### PR TITLE
expo를 blue-green rollout으로 배포

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+apps/helm/templates/**/*.yaml

--- a/apps/helm/Chart.yaml
+++ b/apps/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: kosmo-web
 type: application
 version: 0.1.0
-appVersion: "1.0.0"
+appVersion: '1.0.0'

--- a/apps/helm/Chart.yaml
+++ b/apps/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: kosmo-web
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/apps/helm/templates/expo/hpa.yaml
+++ b/apps/helm/templates/expo/hpa.yaml
@@ -1,0 +1,30 @@
+{{- $app := .Values.expo -}}
+{{- if ne (default true $app.enabled) false }}
+{{- if $app.autoscaling.enabled }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ printf "%s-expo" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: {{ printf "%s-expo" .Release.Name | trunc 63 | trimSuffix "-" }}
+  minReplicas: {{ $app.autoscaling.minReplicas }}
+  maxReplicas: {{ $app.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $app.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/apps/helm/templates/expo/infisicalsecret.yaml
+++ b/apps/helm/templates/expo/infisicalsecret.yaml
@@ -1,0 +1,32 @@
+{{- $app := .Values.expo -}}
+{{- if ne (default true $app.enabled) false }}
+{{- if $app.infisical.enabled }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: {{ printf "%s-expo" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  authentication:
+    kubernetesAuth:
+      identityId: {{ $app.infisical.identityId }}
+      autoCreateServiceAccountToken: true
+      serviceAccountRef:
+        name: secret
+        namespace: infisical
+      secretsScope:
+        projectId: {{ $app.infisical.projectId }}
+        envSlug: {{ $app.infisical.envSlug }}
+        secretsPath: /
+  managedKubeSecretReferences:
+    - secretName: {{ $app.infisical.secretName }}
+      secretNamespace: {{ $.Release.Namespace }}
+      creationPolicy: Owner
+{{- end }}
+{{- end }}

--- a/apps/helm/templates/expo/preview-service.yaml
+++ b/apps/helm/templates/expo/preview-service.yaml
@@ -1,0 +1,24 @@
+{{- $app := .Values.expo -}}
+{{- if ne (default true $app.enabled) false }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-expo-preview" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ $app.service.type }}
+  ports:
+    - port: {{ $app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/templates/expo/rollout.yaml
+++ b/apps/helm/templates/expo/rollout.yaml
@@ -1,0 +1,97 @@
+{{- $app := .Values.expo -}}
+{{- if ne (default true $app.enabled) false }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ printf "%s-expo" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if not $app.autoscaling.enabled }}
+  replicas: {{ $app.replicaCount }}
+  {{- end }}
+  strategy:
+    blueGreen:
+      activeService: {{ printf "%s-expo" .Release.Name | trunc 63 | trimSuffix "-" }}
+      previewService: {{ printf "%s-expo-preview" .Release.Name | trunc 63 | trimSuffix "-" }}
+      {{- with $app.rollout.strategy.blueGreen }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: expo
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with $app.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: expo
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with $app.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with $app.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $app.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: expo
+          image: "{{ required "expo.image.repository is required" $app.image.repository }}:{{ $app.image.tag }}"
+          imagePullPolicy: {{ $app.image.pullPolicy }}
+          securityContext:
+            {{- toYaml $app.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ $app.service.targetPort }}
+              protocol: TCP
+          {{- if or $app.infisical.enabled $app.env.secretNames }}
+          envFrom:
+            {{- range $app.env.secretNames }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- if $app.infisical.enabled }}
+            - secretRef:
+                name: {{ $app.infisical.secretName }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ $app.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ $app.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ $app.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ $app.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ $app.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ $app.probes.readiness.periodSeconds }}
+          resources:
+            {{- toYaml $app.resources | nindent 12 }}
+      {{- with $app.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $app.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $app.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/apps/helm/templates/expo/rollout.yaml
+++ b/apps/helm/templates/expo/rollout.yaml
@@ -1,6 +1,10 @@
 {{- $app := .Values.expo -}}
 {{- if ne (default true $app.enabled) false }}
 {{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+{{- $imageRef := printf "%s:%s" $app.image.repository $app.image.tag -}}
+{{- if contains "sha256:" $app.image.tag -}}
+{{- $imageRef = printf "%s@%s" $app.image.repository $app.image.tag -}}
+{{- end -}}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
@@ -49,7 +53,7 @@ spec:
       {{- end }}
       containers:
         - name: expo
-          image: "{{ required "expo.image.repository is required" $app.image.repository }}:{{ $app.image.tag }}"
+          image: {{ $imageRef | quote }}
           imagePullPolicy: {{ $app.image.pullPolicy }}
           securityContext:
             {{- toYaml $app.containerSecurityContext | nindent 12 }}

--- a/apps/helm/templates/expo/service.yaml
+++ b/apps/helm/templates/expo/service.yaml
@@ -1,0 +1,24 @@
+{{- $app := .Values.expo -}}
+{{- if ne (default true $app.enabled) false }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-expo" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ $app.service.type }}
+  ports:
+    - port: {{ $app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -1,0 +1,68 @@
+expo:
+  replicaCount: 1
+  rollout:
+    strategy:
+      blueGreen:
+        autoPromotionEnabled: true
+  image:
+    repository: ghcr.io/byulmaru/kosmo-web
+    tag: latest
+    pullPolicy: Always
+  imagePullSecrets: []
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  probes:
+    liveness:
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    readiness:
+      path: /health
+      initialDelaySeconds: 3
+      periodSeconds: 5
+  env:
+    secretNames: []
+  infisical:
+    enabled: false
+    identityId: ""
+    projectId: ""
+    envSlug: prod
+    secretName: env
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFileSystem: false
+  nodeSelector: {}
+  tolerations:
+    - key: "oci.oraclecloud.com/oke-is-preemptible"
+      operator: "Equal"
+      value: "present"
+      effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: oci.oraclecloud.com/oke-is-preemptible
+                operator: Exists
+                values: []

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -4,6 +4,7 @@ expo:
     strategy:
       blueGreen:
         autoPromotionEnabled: true
+        previewReplicaCount: 1
   image:
     repository: ghcr.io/byulmaru/kosmo-web
     tag: latest

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -38,8 +38,8 @@ expo:
     secretNames: []
   infisical:
     enabled: false
-    identityId: ""
-    projectId: ""
+    identityId: ''
+    projectId: ''
     envSlug: prod
     secretName: env
   podAnnotations: {}
@@ -53,10 +53,10 @@ expo:
     readOnlyRootFileSystem: false
   nodeSelector: {}
   tolerations:
-    - key: "oci.oraclecloud.com/oke-is-preemptible"
-      operator: "Equal"
-      value: "present"
-      effect: "NoSchedule"
+    - key: 'oci.oraclecloud.com/oke-is-preemptible'
+      operator: 'Equal'
+      value: 'present'
+      effect: 'NoSchedule'
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -32,7 +32,7 @@ expo:
       initialDelaySeconds: 5
       periodSeconds: 10
     readiness:
-      path: /health
+      path: /
       initialDelaySeconds: 3
       periodSeconds: 5
   env:


### PR DESCRIPTION
## 변경 사항
- `apps/helm`에 expo 전용 Helm 차트를 추가했습니다.
- Expo 서버 배포 리소스를 `Deployment` 대신 Argo Rollouts `Rollout`으로 구성했습니다.
- active service와 preview service를 분리해 blue-green 배포가 가능하도록 했습니다.
- `app.kubernetes.io/version` 라벨이 digest 기반 이미지 태그에서도 깨지지 않도록 sanitize 로직을 넣었습니다.
- HPA와 InfisicalSecret 템플릿도 expo 폴더 아래로 정리했습니다.

## 중점 리뷰 포인트
- blue-green 전략에서 active/preview service 이름 연결이 의도대로 보이는지
- digest 기반 이미지 태그가 들어와도 Helm 렌더 결과의 Kubernetes 라벨 제약을 만족하는지
- expo 전용 템플릿 폴더 구조가 이후 다른 앱 추가 시에도 무리 없는지
