### PR TITLE
PR에서는 Docker 이미지 빌드를 건너뛴다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,12 +1,6 @@
 name: Docker Build
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
## 변경 사항
- `docker-build` 워크플로우에서 `pull_request` 트리거를 제거했습니다.
- PR 생성/업데이트 시에는 Docker Buildx와 이미지 빌드 단계가 아예 실행되지 않도록 정리했습니다.
- Docker 이미지는 `main` 브랜치 푸시와 수동 실행에서만 빌드되도록 유지했습니다.

## 중점 리뷰 포인트
- PR 이벤트에서 `Docker Build` 워크플로우가 더 이상 나타나지 않는지
- `main` 브랜치 푸시와 `workflow_dispatch` 경로에서는 기존처럼 이미지 빌드가 유지되는지