### PR TITLE
Helm 차트에 Expo Ingress와 Certificate 리소스를 추가

### DIFF
--- a/apps/helm/templates/certificate.yaml
+++ b/apps/helm/templates/certificate.yaml
@@ -1,11 +1,13 @@
 {{- $certificate := .Values.certificate -}}
 {{- if $certificate.enabled }}
+{{- $defaultSecretName := printf "%s-expo-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $secretName := default $defaultSecretName $certificate.secretName -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ $certificate.secretName }}
+  name: {{ $secretName }}
 spec:
-  secretName: {{ $certificate.secretName }}
+  secretName: {{ $secretName }}
   issuerRef:
     name: {{ $certificate.issuerRef.name }}
     kind: {{ $certificate.issuerRef.kind }}

--- a/apps/helm/templates/certificate.yaml
+++ b/apps/helm/templates/certificate.yaml
@@ -1,6 +1,6 @@
 {{- $certificate := .Values.certificate -}}
 {{- if $certificate.enabled }}
-{{- $defaultSecretName := printf "%s-expo-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $defaultSecretName := printf "%s-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- $secretName := default $defaultSecretName $certificate.secretName -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/apps/helm/templates/certificate.yaml
+++ b/apps/helm/templates/certificate.yaml
@@ -1,0 +1,14 @@
+{{- $certificate := .Values.certificate -}}
+{{- if $certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $certificate.secretName }}
+spec:
+  secretName: {{ $certificate.secretName }}
+  issuerRef:
+    name: {{ $certificate.issuerRef.name }}
+    kind: {{ $certificate.issuerRef.kind }}
+  dnsNames:
+    {{- toYaml $certificate.dnsNames | nindent 4 }}
+{{- end }}

--- a/apps/helm/templates/expo/ingress.yaml
+++ b/apps/helm/templates/expo/ingress.yaml
@@ -1,5 +1,6 @@
 {{- $app := .Values.expo -}}
 {{- if and (ne (default true $app.enabled) false) $app.ingress.enabled }}
+{{- $certificate := .Values.certificate -}}
 {{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
 {{- $defaultTlsSecretName := printf "%s-expo-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
 apiVersion: networking.k8s.io/v1
@@ -20,13 +21,20 @@ spec:
   {{- with $app.ingress.className }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- with $app.ingress.tls }}
+  {{- if $app.ingress.tls }}
   tls:
-    {{- range $tls := . }}
+    {{- range $tls := $app.ingress.tls }}
     - hosts:
         {{- toYaml $tls.hosts | nindent 8 }}
       secretName: {{ default $defaultTlsSecretName $tls.secretName }}
     {{- end }}
+  {{- else if $certificate.enabled }}
+  tls:
+    - hosts:
+        {{- range $host := $app.ingress.hosts }}
+        - {{ $host.host }}
+        {{- end }}
+      secretName: {{ default $defaultTlsSecretName $certificate.secretName }}
   {{- end }}
   rules:
     {{- range $host := $app.ingress.hosts }}

--- a/apps/helm/templates/expo/ingress.yaml
+++ b/apps/helm/templates/expo/ingress.yaml
@@ -2,7 +2,7 @@
 {{- if and (ne (default true $app.enabled) false) $app.ingress.enabled }}
 {{- $certificate := .Values.certificate -}}
 {{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
-{{- $defaultTlsSecretName := printf "%s-expo-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $defaultTlsSecretName := printf "%s-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/apps/helm/templates/expo/ingress.yaml
+++ b/apps/helm/templates/expo/ingress.yaml
@@ -1,0 +1,41 @@
+{{- $app := .Values.expo -}}
+{{- if and (ne (default true $app.enabled) false) $app.ingress.enabled }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-expo" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: expo
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with $app.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $app.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $app.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $host := $app.ingress.hosts }}
+    - host: {{ $host.host | quote }}
+      http:
+        paths:
+          {{- range $path := $host.paths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType }}
+            backend:
+              service:
+                name: {{ printf "%s-expo" $.Release.Name | trunc 63 | trimSuffix "-" }}
+                port:
+                  number: {{ $app.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/apps/helm/templates/expo/ingress.yaml
+++ b/apps/helm/templates/expo/ingress.yaml
@@ -1,6 +1,7 @@
 {{- $app := .Values.expo -}}
 {{- if and (ne (default true $app.enabled) false) $app.ingress.enabled }}
 {{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+{{- $defaultTlsSecretName := printf "%s-expo-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -21,7 +22,11 @@ spec:
   {{- end }}
   {{- with $app.ingress.tls }}
   tls:
-    {{- toYaml . | nindent 4 }}
+    {{- range $tls := . }}
+    - hosts:
+        {{- toYaml $tls.hosts | nindent 8 }}
+      secretName: {{ default $defaultTlsSecretName $tls.secretName }}
+    {{- end }}
   {{- end }}
   rules:
     {{- range $host := $app.ingress.hosts }}

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -23,10 +23,7 @@ expo:
         paths:
           - path: /
             pathType: Prefix
-    tls:
-      - hosts:
-          - kos.moe
-        secretName: certificate
+    tls: []
   resources:
     requests:
       cpu: 100m
@@ -82,7 +79,7 @@ expo:
 
 certificate:
   enabled: false
-  secretName: certificate
+  secretName: ''
   issuerRef:
     name: cert-issuer
     kind: ClusterIssuer

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -14,6 +14,19 @@ expo:
     type: ClusterIP
     port: 80
     targetPort: 8080
+  ingress:
+    enabled: false
+    className: nginx
+    annotations: {}
+    hosts:
+      - host: kos.moe
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - kos.moe
+        secretName: certificate
   resources:
     requests:
       cpu: 100m
@@ -66,3 +79,12 @@ expo:
               - key: oci.oraclecloud.com/oke-is-preemptible
                 operator: Exists
                 values: []
+
+certificate:
+  enabled: false
+  secretName: certificate
+  issuerRef:
+    name: cert-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - kos.moe


### PR DESCRIPTION
## 변경 사항
- `apps/helm/templates/expo/ingress.yaml`을 추가해 Expo 서비스 앞단 Ingress 리소스를 Helm 템플릿으로 생성하도록 했습니다.
- `apps/helm/templates/certificate.yaml`을 추가해 cert-manager `Certificate` 리소스를 Helm 템플릿으로 생성하도록 했습니다.
- `apps/helm/values.yaml`에 ingress와 certificate 설정값을 추가해 host, TLS, issuer, secret 이름을 values로 제어할 수 있게 했습니다.
- Ingress와 Certificate가 동일한 TLS secret 이름을 공유하도록 기본값과 렌더링 로직을 맞췄습니다.

## 중점 리뷰 포인트
- Ingress가 현재 `expo` 서비스/rollout 네이밍 규칙과 일관되게 연결되는지
- `certificate.enabled`, `expo.ingress.enabled`, `expo.ingress.tls` 조합에서 TLS가 의도한 형태로 렌더링되는지
- 환경별 values override에서 host, dnsNames, issuer, secretName을 무리 없이 덮어쓸 수 있는지