### PR TITLE
기본 Helm 배포에 Ingress와 Certificate를 포함

### DIFF
--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -15,7 +15,7 @@ expo:
     port: 80
     targetPort: 8080
   ingress:
-    enabled: false
+    enabled: true
     className: nginx
     annotations: {}
     hosts:
@@ -78,7 +78,7 @@ expo:
                 values: []
 
 certificate:
-  enabled: false
+  enabled: true
   secretName: ''
   issuerRef:
     name: cert-issuer


### PR DESCRIPTION
## 변경 사항
- Helm 차트 기본값에서 `expo.ingress.enabled`를 `true`로 바꿔 기본 배포에 Ingress가 포함되도록 했습니다.
- Helm 차트 기본값에서 `certificate.enabled`를 `true`로 바꿔 기본 배포에 cert-manager `Certificate`가 포함되도록 했습니다.
- 기본 `values.yaml`만으로도 Expo 서비스 앞단 TLS 리소스가 함께 렌더링되도록 기본 배포 구성을 맞췄습니다.

## 논의할 점
- 기본 배포에서 Ingress와 Certificate를 항상 생성하는 것이 모든 환경에 맞는지 추가 확인이 필요합니다.

## 중점 리뷰 포인트
- 기본값만 사용했을 때 Ingress와 Certificate가 의도한 환경에서 바로 생성돼도 되는지
- 환경별 override 없이도 host, issuer, dnsNames 기본값이 운영 환경과 충돌하지 않는지
- Argo CD 기준 기본 배포에 새 리소스가 포함되어도 기존 배포 흐름과 충돌이 없는지