### PR TITLE
API 서버 Docker 실행 경로를 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+node_modules
+.expo
+dist

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,14 +7,10 @@ ENV HOST=0.0.0.0
 ENV PORT=8080
 
 COPY package.json bun.lock tsconfig.json ./
-COPY apps/api/package.json ./apps/api/package.json
-COPY apps/expo/package.json ./apps/expo/package.json
-COPY packages/env/package.json ./packages/env/package.json
+COPY apps ./apps
+COPY packages ./packages
 
 RUN bun install --frozen-lockfile --production --filter '@kosmo/api'
-
-COPY apps/api ./apps/api
-COPY packages ./packages
 
 WORKDIR /app/apps/api
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,10 +7,14 @@ ENV HOST=0.0.0.0
 ENV PORT=8080
 
 COPY package.json bun.lock tsconfig.json ./
-COPY apps/api ./apps/api
-COPY packages ./packages
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/expo/package.json ./apps/expo/package.json
+COPY packages/env/package.json ./packages/env/package.json
 
 RUN bun install --frozen-lockfile --production --filter '@kosmo/api'
+
+COPY apps/api ./apps/api
+COPY packages ./packages
 
 WORKDIR /app/apps/api
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,19 +7,13 @@ ENV HOST=0.0.0.0
 ENV PORT=8080
 
 COPY package.json bun.lock tsconfig.json ./
-COPY apps/api/package.json ./apps/api/package.json
-COPY apps/api/tsconfig.json ./apps/api/tsconfig.json
-COPY packages/env/package.json ./packages/env/package.json
+COPY apps/api ./apps/api
+COPY packages ./packages
 
-RUN bun install --frozen-lockfile --production
-
-COPY apps/api/schema.graphql ./apps/api/schema.graphql
-COPY apps/api/src ./apps/api/src
-COPY packages/env ./packages/env
-COPY schema.graphql ./schema.graphql
+RUN bun install --frozen-lockfile --production --filter '@kosmo/api'
 
 WORKDIR /app/apps/api
 
 EXPOSE 8080
 
-CMD ["bun", "run", "src/index.ts"]
+CMD ["bun", "run", "start"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,25 @@
+FROM oven/bun:1-alpine AS base
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=8080
+
+COPY package.json bun.lock tsconfig.json ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/api/tsconfig.json ./apps/api/tsconfig.json
+COPY packages/env/package.json ./packages/env/package.json
+
+RUN bun install --frozen-lockfile --production
+
+COPY apps/api/schema.graphql ./apps/api/schema.graphql
+COPY apps/api/src ./apps/api/src
+COPY packages/env ./packages/env
+COPY schema.graphql ./schema.graphql
+
+WORKDIR /app/apps/api
+
+EXPOSE 8080
+
+CMD ["bun", "run", "src/index.ts"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,6 +2,7 @@
   "name": "@kosmo/api",
   "scripts": {
     "dev": "bun run --hot src/index.ts",
+    "start": "bun run src/index.ts",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/expo/Dockerfile.dockerignore
+++ b/apps/expo/Dockerfile.dockerignore
@@ -1,6 +1,0 @@
-.git
-.github
-node_modules
-apps/expo/.expo
-apps/expo/dist
-apps/expo/.git


### PR DESCRIPTION
## 변경 사항
- `apps/api`를 Bun 기반으로 실행하는 Dockerfile을 추가했습니다.
- 루트 컨텍스트 기준으로 Docker build를 돌릴 수 있도록 `.dockerignore`를 루트로 통합했습니다.
- `apps/expo` 전용 Docker ignore 파일은 제거해 두 앱이 같은 컨텍스트 규칙을 쓰게 했습니다.

## 지금까지 된 것
- `apps/api/Dockerfile`로 API 런타임 경로를 정의했습니다.
- 루트 `.dockerignore`로 공통 제외 규칙을 정리했습니다.

## 아직 안 된 것
- 실제 `docker build -f apps/api/Dockerfile .` 실행 검증은 아직 하지 않았습니다.
- 배포 환경 변수와 이미지 배포 파이프라인 연결은 후속 작업이 필요합니다.

## 중점 리뷰 포인트
- 루트 컨텍스트 기반 Docker build 방식이 현재 워크스페이스 구조와 배포 방식에 맞는지 봐주세요.
- `apps/expo`도 루트 `.dockerignore`만으로 충분한지 확인 부탁드립니다.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"dev-32","parentHead":"61bbc39a9c81d67a7a5803b5cb781d86471c0ff1","parentPull":10,"trunk":"main"}
```
-->
