### PR TITLE
API 서버를 Helm으로 배포한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,6 +20,9 @@ jobs:
           - app: expo
             dockerfile: ./apps/expo/Dockerfile
             image_suffix: web
+          - app: api
+            dockerfile: ./apps/api/Dockerfile
+            image_suffix: api
 
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@
 - The canonical project skill directory is `.skills`. Agent-specific directories should reference it rather than keeping separate copies.
 - Make speculative commits frequently so intermediate hypotheses, pivots, and recovery points are preserved.
 
+## Review Guidelines
+
+- Write review comments and review summaries in Korean.
+
 ## `package.json` Changes
 
 - Use `bun add`, `bun remove`, `bun add --dev`, or other `bun`-based CLI commands for manifest updates.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,10 @@ import { yoga } from './graphql';
 
 const app = new Hono();
 
+app.get('/health', (c) => {
+  return c.json({ status: 'ok' });
+});
+
 app.route('/graphql', yoga);
 
 export default app;

--- a/apps/helm/templates/api/hpa.yaml
+++ b/apps/helm/templates/api/hpa.yaml
@@ -1,0 +1,30 @@
+{{- $app := .Values.api -}}
+{{- if ne (default true $app.enabled) false }}
+{{- if $app.autoscaling.enabled }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  minReplicas: {{ $app.autoscaling.minReplicas }}
+  maxReplicas: {{ $app.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $app.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/apps/helm/templates/api/infisicalsecret.yaml
+++ b/apps/helm/templates/api/infisicalsecret.yaml
@@ -1,0 +1,32 @@
+{{- $app := .Values.api -}}
+{{- if ne (default true $app.enabled) false }}
+{{- if $app.infisical.enabled }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  authentication:
+    kubernetesAuth:
+      identityId: {{ $app.infisical.identityId }}
+      autoCreateServiceAccountToken: true
+      serviceAccountRef:
+        name: secret
+        namespace: infisical
+      secretsScope:
+        projectId: {{ $app.infisical.projectId }}
+        envSlug: {{ $app.infisical.envSlug }}
+        secretsPath: /
+  managedKubeSecretReferences:
+    - secretName: {{ $app.infisical.secretName }}
+      secretNamespace: {{ $.Release.Namespace }}
+      creationPolicy: Owner
+{{- end }}
+{{- end }}

--- a/apps/helm/templates/api/ingress.yaml
+++ b/apps/helm/templates/api/ingress.yaml
@@ -1,0 +1,54 @@
+{{- $app := .Values.api -}}
+{{- if and (ne (default true $app.enabled) false) $app.ingress.enabled }}
+{{- $certificate := .Values.certificate -}}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+{{- $defaultTlsSecretName := printf "%s-tls" .Release.Name | trunc 63 | trimSuffix "-" -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with $app.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $app.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if $app.ingress.tls }}
+  tls:
+    {{- range $tls := $app.ingress.tls }}
+    - hosts:
+        {{- toYaml $tls.hosts | nindent 8 }}
+      secretName: {{ default $defaultTlsSecretName $tls.secretName }}
+    {{- end }}
+  {{- else if $certificate.enabled }}
+  tls:
+    - hosts:
+        {{- range $host := $app.ingress.hosts }}
+        - {{ $host.host }}
+        {{- end }}
+      secretName: {{ default $defaultTlsSecretName $certificate.secretName }}
+  {{- end }}
+  rules:
+    {{- range $host := $app.ingress.hosts }}
+    - host: {{ $host.host | quote }}
+      http:
+        paths:
+          {{- range $path := $host.paths }}
+          - path: {{ $path.path }}
+            pathType: {{ $path.pathType }}
+            backend:
+              service:
+                name: {{ printf "%s-api" $.Release.Name | trunc 63 | trimSuffix "-" }}
+                port:
+                  number: {{ $app.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/apps/helm/templates/api/preview-service.yaml
+++ b/apps/helm/templates/api/preview-service.yaml
@@ -1,0 +1,24 @@
+{{- $app := .Values.api -}}
+{{- if ne (default true $app.enabled) false }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-api-preview" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ $app.service.type }}
+  ports:
+    - port: {{ $app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/templates/api/rollout.yaml
+++ b/apps/helm/templates/api/rollout.yaml
@@ -1,0 +1,101 @@
+{{- $app := .Values.api -}}
+{{- if ne (default true $app.enabled) false }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+{{- $imageRef := printf "%s:%s" $app.image.repository $app.image.tag -}}
+{{- if contains "sha256:" $app.image.tag -}}
+{{- $imageRef = printf "%s@%s" $app.image.repository $app.image.tag -}}
+{{- end -}}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  {{- if not $app.autoscaling.enabled }}
+  replicas: {{ $app.replicaCount }}
+  {{- end }}
+  strategy:
+    blueGreen:
+      activeService: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+      previewService: {{ printf "%s-api-preview" .Release.Name | trunc 63 | trimSuffix "-" }}
+      {{- with $app.rollout.strategy.blueGreen }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with $app.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: api
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with $app.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with $app.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $app.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api
+          image: {{ $imageRef | quote }}
+          imagePullPolicy: {{ $app.image.pullPolicy }}
+          securityContext:
+            {{- toYaml $app.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ $app.service.targetPort }}
+              protocol: TCP
+          {{- if or $app.infisical.enabled $app.env.secretNames }}
+          envFrom:
+            {{- range $app.env.secretNames }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- if $app.infisical.enabled }}
+            - secretRef:
+                name: {{ $app.infisical.secretName }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ $app.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ $app.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ $app.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ $app.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ $app.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ $app.probes.readiness.periodSeconds }}
+          resources:
+            {{- toYaml $app.resources | nindent 12 }}
+      {{- with $app.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $app.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $app.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/apps/helm/templates/api/service.yaml
+++ b/apps/helm/templates/api/service.yaml
@@ -1,0 +1,24 @@
+{{- $app := .Values.api -}}
+{{- if ne (default true $app.enabled) false }}
+{{- $versionLabel := regexReplaceAll "[^A-Za-z0-9_.-]" $app.image.tag "-" | trunc 63 | trimAll "-" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ $versionLabel | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ $app.service.type }}
+  ports:
+    - port: {{ $app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -77,6 +77,85 @@ expo:
                 operator: Exists
                 values: []
 
+api:
+  replicaCount: 1
+  rollout:
+    strategy:
+      blueGreen:
+        autoPromotionEnabled: true
+        previewReplicaCount: 1
+  image:
+    repository: ghcr.io/byulmaru/kosmo-api
+    tag: latest
+    pullPolicy: Always
+  imagePullSecrets: []
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
+  ingress:
+    enabled: true
+    className: nginx
+    annotations: {}
+    hosts:
+      - host: api.kos.moe
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  probes:
+    liveness:
+      path: /graphql
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    readiness:
+      path: /graphql
+      initialDelaySeconds: 3
+      periodSeconds: 5
+  env:
+    secretNames: []
+  infisical:
+    enabled: false
+    identityId: ''
+    projectId: ''
+    envSlug: prod
+    secretName: env
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector: {}
+  tolerations:
+    - key: 'oci.oraclecloud.com/oke-is-preemptible'
+      operator: 'Equal'
+      value: 'present'
+      effect: 'NoSchedule'
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: oci.oraclecloud.com/oke-is-preemptible
+                operator: Exists
+                values: []
+
 certificate:
   enabled: true
   secretName: ''
@@ -85,3 +164,4 @@ certificate:
     kind: ClusterIssuer
   dnsNames:
     - kos.moe
+    - api.kos.moe

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -117,11 +117,11 @@ api:
     targetCPUUtilizationPercentage: 80
   probes:
     liveness:
-      path: /graphql
+      path: /health
       initialDelaySeconds: 5
       periodSeconds: 10
     readiness:
-      path: /graphql
+      path: /health
       initialDelaySeconds: 3
       periodSeconds: 5
   env:


### PR DESCRIPTION
## 변경 사항
- `apps/helm` 차트에 `api`용 Rollout, Service, Ingress, HPA, InfisicalSecret 템플릿을 추가했습니다.
- 기본 values에 `api.kos.moe` 호스트, `ghcr.io/byulmaru/kosmo-api` 이미지, `/graphql` probe 경로를 추가했습니다.
- Docker build workflow에 `api` 이미지를 추가해 Helm 배포가 실제 배포 가능한 이미지로 이어지게 했습니다.
- 공유 TLS 인증서에 `api.kos.moe` SAN을 추가했습니다.

## 지금까지 된 것
- `helm template kosmo apps/helm` 렌더링이 통과합니다.
- `api.kos.moe` Ingress와 `kosmo-api` Rollout/Service가 생성됩니다.
- GitHub Actions가 `ghcr.io/byulmaru/kosmo-api` 이미지를 빌드하도록 설정했습니다.

## 아직 안 된 것
- 실제 클러스터 반영과 DNS 연결 확인은 아직 하지 않았습니다.
- 운영 환경용 secret 주입은 기본값에서 비활성화 상태입니다.

## 중점 리뷰 포인트
- `api`도 `expo`와 같은 shared certificate/blue-green 구조를 쓰는 것이 운영상 적절한지 봐주세요.
- `/graphql`를 liveness/readiness probe로 쓰는 선택이 현재 API 특성에 맞는지 확인 부탁드립니다.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
