### PR TITLE
백엔드에서 Drizzle DB 연결을 사용할 수 있게 한다

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@kosmo/env": "workspace:*",
+    "@kosmo/core": "workspace:*",
     "@pothos/core": "^4.12.0",
     "graphql": "^16.13.2",
     "graphql-yoga": "^5.21.0",

--- a/apps/api/src/graphql/index.ts
+++ b/apps/api/src/graphql/index.ts
@@ -1,4 +1,4 @@
-import { dev } from '@kosmo/env';
+import { dev } from '@kosmo/core';
 import { createYoga, useExecutionCancellation } from 'graphql-yoga';
 import { Hono } from 'hono';
 import { schema } from './schema';

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -1,6 +1,6 @@
 import './resolvers';
 
-import { dev } from '@kosmo/env';
+import { dev } from '@kosmo/core';
 import { builder } from './builder';
 
 export const schema = builder.toSchema();

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     "apps/api": {
       "name": "@kosmo/api",
       "dependencies": {
-        "@kosmo/env": "workspace:*",
+        "@kosmo/core": "workspace:*",
         "@pothos/core": "^4.12.0",
         "graphql": "^16.13.2",
         "graphql-yoga": "^5.21.0",
@@ -73,10 +73,12 @@
         "tailwindcss": "^4.2.2",
       },
     },
-    "packages/env": {
-      "name": "@kosmo/env",
+    "packages/core": {
+      "name": "@kosmo/core",
       "dependencies": {
-        "zod": "^4.3.6",
+        "drizzle-orm": "^0.45.2",
+        "temporal-polyfill": "^0.3.2",
+        "ulidx": "^2.4.1",
       },
     },
   },
@@ -478,7 +480,7 @@
 
     "@kosmo/api": ["@kosmo/api@workspace:apps/api"],
 
-    "@kosmo/env": ["@kosmo/env@workspace:packages/env"],
+    "@kosmo/core": ["@kosmo/core@workspace:packages/core"],
 
     "@kosmo/expo": ["@kosmo/expo@workspace:apps/expo"],
 
@@ -948,6 +950,8 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -1341,6 +1345,8 @@
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "lan-network": ["lan-network@0.2.1", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A=="],
+
+    "layerr": ["layerr@3.0.0", "", {}, "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
@@ -1806,6 +1812,10 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "temporal-polyfill": ["temporal-polyfill@0.3.2", "", { "dependencies": { "temporal-spec": "0.3.1" } }, "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg=="],
+
+    "temporal-spec": ["temporal-spec@0.3.1", "", {}, "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw=="],
+
     "terminal-link": ["terminal-link@2.1.1", "", { "dependencies": { "ansi-escapes": "^4.2.1", "supports-hyperlinks": "^2.0.0" } }, "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ=="],
 
     "terser": ["terser@5.46.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ=="],
@@ -1855,6 +1865,8 @@
     "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
+
+    "ulidx": ["ulidx@2.4.1", "", { "dependencies": { "layerr": "^3.0.0" } }, "sha512-xY7c8LPyzvhvew0Fn+Ek3wBC9STZAuDI/Y5andCKi9AX6/jvfaX45PhsDX8oxgPL0YFp0Jhr8qWMbS/p9375Xg=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
@@ -1950,7 +1962,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -2129,8 +2141,6 @@
     "ora/strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
-
-    "prettier-plugin-brace-style/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,3 @@
+- `packages/core/enums.ts`, `packages/core/db/enums.ts`, `packages/core/db/id.ts`, `packages/core/db/tables.ts`의 schema export는 단수 엔티티명 기준으로 사전순 정렬한다.
+  - export 이름이 복수형이어도 정렬할 때는 복수형 suffix를 제외한다.
+  - 예: `Accounts`는 `Account`로 보므로 `AccountProfiles`보다 앞에 둔다.

--- a/packages/core/db/enums.ts
+++ b/packages/core/db/enums.ts
@@ -1,0 +1,13 @@
+import { pgEnum } from 'drizzle-orm/pg-core';
+import * as Enum from '../enums';
+
+const createPgEnum = <T extends string>(enumName: string, values: Record<T, T>) =>
+  pgEnum(enumName, Object.values(values) as [T, ...T[]]);
+
+export const accountProfileRole = createPgEnum('account_profile_role', Enum.AccountProfileRole);
+export const accountState = createPgEnum('account_state', Enum.AccountState);
+export const followPolicy = createPgEnum('follow_policy', Enum.FollowPolicy);
+export const followState = createPgEnum('follow_state', Enum.FollowState);
+export const postState = createPgEnum('post_state', Enum.PostState);
+export const postVisibility = createPgEnum('post_visibility', Enum.PostVisibility);
+export const sessionState = createPgEnum('session_state', Enum.SessionState);

--- a/packages/core/db/id.ts
+++ b/packages/core/db/id.ts
@@ -1,0 +1,16 @@
+import { ulid } from 'ulidx';
+import type * as Tables from './tables';
+
+export const TableCode = {
+  Accounts: 'ACCT',
+  AccountProfiles: 'ACPR',
+  Applications: 'APPL',
+  Posts: 'POST',
+  PostContents: 'POCT',
+  Profiles: 'PRFL',
+  ProfileFollows: 'PFLW',
+  Sessions: 'SESS',
+} as const satisfies Record<keyof typeof Tables, Uppercase<string>>;
+
+export const createId = (tableCode: (typeof TableCode)[keyof typeof TableCode]) =>
+  `${tableCode}0${ulid()}`;

--- a/packages/core/db/index.ts
+++ b/packages/core/db/index.ts
@@ -1,0 +1,13 @@
+import { drizzle } from 'drizzle-orm/bun-sql';
+import * as schema from './tables';
+import type { PgDatabase, PgTransaction } from 'drizzle-orm/pg-core';
+
+export * from './id';
+export * from './tables';
+export * from './utils';
+
+export const db = drizzle(Bun.env.DATABASE_URL, { schema });
+
+export type Database = typeof db;
+export type Transaction =
+  Database extends PgDatabase<infer T, infer U, infer V> ? PgTransaction<T, U, V> : never;

--- a/packages/core/db/tables.ts
+++ b/packages/core/db/tables.ts
@@ -1,0 +1,151 @@
+import { sql } from 'drizzle-orm';
+import { index, pgTable, text, unique } from 'drizzle-orm/pg-core';
+import * as Enum from './enums';
+import { createId, TableCode } from './id';
+import { datetime } from './types';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
+
+const createdAt = () =>
+  datetime('created_at')
+    .notNull()
+    .default(sql`now()`);
+
+export const Accounts = pgTable(
+  'account',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableCode.Accounts)),
+    oidcSubject: text('oidc_subject').notNull(),
+    displayName: text('display_name').notNull(),
+    state: Enum.accountState('state').notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [unique().on(table.oidcSubject)],
+);
+
+export const AccountProfiles = pgTable(
+  'account_profile',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableCode.AccountProfiles)),
+    accountId: text('account_id')
+      .notNull()
+      .references(() => Accounts.id, { onDelete: 'cascade' }),
+    profileId: text('profile_id')
+      .notNull()
+      .references(() => Profiles.id, { onDelete: 'cascade' }),
+    role: Enum.accountProfileRole('role').notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    unique().on(table.accountId, table.profileId),
+    index().on(table.accountId),
+    index().on(table.profileId),
+  ],
+);
+
+export const Applications = pgTable('application', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => createId(TableCode.Applications)),
+  name: text('name').notNull(),
+  createdAt: createdAt(),
+});
+
+export const Posts = pgTable(
+  'post',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableCode.Posts)),
+    profileId: text('profile_id')
+      .notNull()
+      .references(() => Profiles.id),
+    visibility: Enum.postVisibility('visibility').notNull(),
+    state: Enum.postState('state').notNull(),
+    currentContentId: text('current_content_id').references((): AnyPgColumn => PostContents.id),
+    createdAt: createdAt(),
+    deletedAt: datetime('deleted_at'),
+  },
+  (table) => [index().on(table.profileId, table.id.desc())],
+);
+
+export const PostContents = pgTable(
+  'post_content',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableCode.PostContents)),
+    postId: text('post_id')
+      .notNull()
+      .references((): AnyPgColumn => Posts.id),
+    bodyText: text('body_text').notNull(),
+    bodyHtml: text('body_html'),
+    spoilerText: text('spoiler_text'),
+    createdAt: createdAt(),
+  },
+  (table) => [index().on(table.postId)],
+);
+
+export const Profiles = pgTable(
+  'profile',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableCode.Profiles)),
+    handle: text('handle').notNull(),
+    displayName: text('display_name').notNull(),
+    bio: text('bio'),
+    followPolicy: Enum.followPolicy('follow_policy').notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [unique().on(table.handle)],
+);
+
+export const ProfileFollows = pgTable(
+  'profile_follow',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableCode.ProfileFollows)),
+    followerProfileId: text('follower_profile_id')
+      .notNull()
+      .references(() => Profiles.id, { onDelete: 'cascade' }),
+    followeeProfileId: text('followee_profile_id')
+      .notNull()
+      .references(() => Profiles.id, { onDelete: 'cascade' }),
+    state: Enum.followState('state').notNull(),
+    createdAt: createdAt(),
+    respondedAt: datetime('responded_at'),
+  },
+  (table) => [
+    unique().on(table.followerProfileId, table.followeeProfileId),
+    index().on(table.followeeProfileId, table.state),
+    index().on(table.followerProfileId, table.state),
+  ],
+);
+
+export const Sessions = pgTable(
+  'session',
+  {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableCode.Sessions)),
+    accountId: text('account_id')
+      .notNull()
+      .references(() => Accounts.id),
+    applicationId: text('application_id')
+      .notNull()
+      .references(() => Applications.id),
+    activeProfileId: text('active_profile_id').references(() => Profiles.id),
+    oidcSessionKey: text('oidc_session_key'),
+    token: text('token').unique().notNull(),
+    state: Enum.sessionState('state').notNull(),
+    issuedAt: datetime('issued_at').notNull(),
+    lastUsedAt: datetime('last_used_at').notNull(),
+    expiresAt: datetime('expires_at').notNull(),
+  },
+  (table) => [index().on(table.accountId), index().on(table.state, table.expiresAt)],
+);

--- a/packages/core/db/types.ts
+++ b/packages/core/db/types.ts
@@ -1,0 +1,8 @@
+import { customType } from 'drizzle-orm/pg-core';
+import { Temporal } from 'temporal-polyfill';
+
+export const datetime = customType<{ data: Temporal.Instant; driverData: Date }>({
+  dataType: () => 'timestamp with time zone',
+  fromDriver: (value) => Temporal.Instant.fromEpochMilliseconds(value.getTime()),
+  toDriver: (value) => new Date(value.epochMilliseconds),
+});

--- a/packages/core/db/utils.ts
+++ b/packages/core/db/utils.ts
@@ -1,0 +1,18 @@
+export const first = <T>(arr: T[]): T | undefined => arr[0];
+export const firstOrThrow = <T>(arr: T[]): T => {
+  if (arr.length === 0) {
+    throw new Error('Not Found');
+  }
+
+  return arr[0];
+};
+
+export const firstOrThrowWith = (errorThrower: () => unknown) => {
+  return <T>(arr: T[]): T => {
+    if (arr.length === 0) {
+      throw errorThrower();
+    }
+
+    return arr[0];
+  };
+};

--- a/packages/core/enums.ts
+++ b/packages/core/enums.ts
@@ -1,0 +1,47 @@
+export const AccountProfileRole = {
+  OWNER: 'OWNER',
+  ADMIN: 'ADMIN',
+  MEMBER: 'MEMBER',
+} as const;
+export type AccountProfileRole = keyof typeof AccountProfileRole;
+
+export const AccountState = {
+  ACTIVE: 'ACTIVE',
+  DISABLED: 'DISABLED',
+  SUSPENDED: 'SUSPENDED',
+} as const;
+export type AccountState = keyof typeof AccountState;
+
+export const FollowPolicy = {
+  OPEN: 'OPEN',
+  APPROVAL_REQUIRED: 'APPROVAL_REQUIRED',
+} as const;
+export type FollowPolicy = keyof typeof FollowPolicy;
+
+export const FollowState = {
+  PENDING: 'PENDING',
+  ACCEPTED: 'ACCEPTED',
+  REJECTED: 'REJECTED',
+} as const;
+export type FollowState = keyof typeof FollowState;
+
+export const PostState = {
+  ACTIVE: 'ACTIVE',
+  DELETED: 'DELETED',
+} as const;
+export type PostState = keyof typeof PostState;
+
+export const PostVisibility = {
+  PUBLIC: 'PUBLIC',
+  UNLISTED: 'UNLISTED',
+  FOLLOWERS: 'FOLLOWERS',
+  DIRECT: 'DIRECT',
+} as const;
+export type PostVisibility = keyof typeof PostVisibility;
+
+export const SessionState = {
+  ACTIVE: 'ACTIVE',
+  REVOKED: 'REVOKED',
+  EXPIRED: 'EXPIRED',
+} as const;
+export type SessionState = keyof typeof SessionState;

--- a/packages/core/env.d.ts
+++ b/packages/core/env.d.ts
@@ -1,0 +1,5 @@
+declare module 'bun' {
+  interface Env {
+    DATABASE_URL: string;
+  }
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,7 +1,2 @@
-import { z } from 'zod';
-
-const schema = z.object({});
-
-export const env = schema.parse(process.env);
 export const stack = process.env.STACK ?? 'dev';
 export const dev = process.env.NODE_ENV !== 'production';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@kosmo/core",
+  "exports": {
+    ".": "./index.ts",
+    "./db": "./db/index.ts",
+    "./enums": "./enums.ts"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.45.2",
+    "temporal-polyfill": "^0.3.2",
+    "ulidx": "^2.4.1"
+  }
+}

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@kosmo/env",
-  "dependencies": {
-    "zod": "^4.3.6"
-  }
-}


### PR DESCRIPTION
### 무엇을 변경했는지

- `@kosmo/env` 패키지를 `@kosmo/core`로 대체하고 API의 환경 플래그 import 경로를 갱신했습니다.
- `@kosmo/core/db`에서 Bun SQL 기반 Drizzle 클라이언트를 초기화하고 DB 타입/조회 유틸을 노출했습니다.
- DEV-40 설계를 바탕으로 초기 enum/table schema와 `{TableCode}0{ULID}` ID 생성 규칙을 추가했습니다.
- core DB 파일의 정렬 규칙을 `packages/core/AGENTS.md`에 문서화했습니다.

### 왜 변경했는지

- API 서버가 개발용 PostgreSQL에 연결할 공통 DB 진입점이 필요했습니다.
- DB 연결 코드와 schema 정의를 core 패키지에 모아 이후 resolver, migration, seed 작업에서 같은 타입과 테이블 정의를 재사용할 수 있게 하려는 변경입니다.
- 기존 `@kosmo/env`의 역할을 `@kosmo/core`로 흡수해 환경 플래그와 DB 코드가 같은 서버 공통 패키지에서 관리되도록 정리했습니다.

### 어떻게 확인할 수 있는지

- `bun run --cwd apps/api lint:tsc`
- `bun run lint:eslint`
- 변경 파일 대상 Prettier check 통과
- PR 생성 전 `dev-31` 브랜치를 원격에 push했고, 현재 HEAD 기준 작업트리가 PR 변경과 분리되어 있습니다.

### 아직 어떤 문제가 남았는지

- 실제 DB 접속 확인은 `DATABASE_URL`이 설정된 개발 DB 환경에서 서버 실행으로 추가 확인이 필요합니다.
- migration/drizzle-kit 설정과 실제 schema 반영은 후속 작업으로 남겼습니다.

Linear: DEV-31