### PR TITLE
안드로이드 빌드 경로와 Gradle 설정을 보완한다

### DIFF
--- a/apps/expo/app.json
+++ b/apps/expo/app.json
@@ -13,6 +13,7 @@
       "output": "server"
     },
     "plugins": [
+      "./plugins/with-gradle-parallel-disabled.cjs",
       [
         "expo-router",
         {
@@ -23,6 +24,9 @@
     "experiments": {
       "typedRoutes": true,
       "reactCompiler": true
+    },
+    "android": {
+      "package": "moe.kos"
     }
   }
 }

--- a/apps/expo/plugins/with-gradle-parallel-disabled.cjs
+++ b/apps/expo/plugins/with-gradle-parallel-disabled.cjs
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { withDangerousMod, withGradleProperties } = require('expo/config-plugins');
+
+function upsertProperty(properties, key, value) {
+  const property = properties.find((item) => item.type === 'property' && item.key === key);
+
+  if (property) {
+    property.value = value;
+    return;
+  }
+
+  properties.push({
+    type: 'property',
+    key,
+    value,
+  });
+}
+
+module.exports = function withGradleParallelDisabled(config) {
+  config = withGradleProperties(config, (config) => {
+    upsertProperty(config.modResults, 'org.gradle.parallel', 'false');
+    return config;
+  });
+
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const buildGradlePath = path.join(
+        config.modRequest.projectRoot,
+        '..',
+        '..',
+        'node_modules',
+        'expo-modules-core',
+        'android',
+        'build.gradle',
+      );
+
+      if (!fs.existsSync(buildGradlePath)) {
+        return config;
+      }
+
+      const source = fs.readFileSync(buildGradlePath, 'utf8');
+      const previous = `  afterEvaluate {
+    println("Linking react-native-worklets native libs into expo-modules-core build tasks")
+    println(workletsProject.tasks.getByName("mergeDebugNativeLibs"))
+    println(workletsProject.tasks.getByName("mergeReleaseNativeLibs"))
+    tasks.getByName("buildCMakeDebug").dependsOn(workletsProject.tasks.getByName("mergeDebugNativeLibs"))
+    tasks.getByName("buildCMakeRelWithDebInfo").dependsOn(workletsProject.tasks.getByName("mergeReleaseNativeLibs"))
+  }`;
+      const next = `  afterEvaluate {
+    println("Linking react-native-worklets native libs into expo-modules-core build tasks")
+    def debugWorkletsTask = workletsProject.tasks.findByName("mergeDebugNativeLibs")
+      ?: workletsProject.tasks.findByName("buildCMakeDebug")
+      ?: workletsProject.tasks.findByName("externalNativeBuildDebug")
+    def releaseWorkletsTask = workletsProject.tasks.findByName("mergeReleaseNativeLibs")
+      ?: workletsProject.tasks.findByName("buildCMakeRelWithDebInfo")
+      ?: workletsProject.tasks.findByName("externalNativeBuildRelease")
+
+    if (debugWorkletsTask != null) {
+      tasks.getByName("buildCMakeDebug").dependsOn(debugWorkletsTask)
+    }
+    if (releaseWorkletsTask != null) {
+      tasks.getByName("buildCMakeRelWithDebInfo").dependsOn(releaseWorkletsTask)
+    }
+  }`;
+
+      if (source.includes(previous)) {
+        fs.writeFileSync(buildGradlePath, source.replace(previous, next));
+      }
+
+      const settingsExtensionPath = path.join(
+        config.modRequest.projectRoot,
+        '..',
+        '..',
+        'node_modules',
+        '@react-native',
+        'gradle-plugin',
+        'settings-plugin',
+        'src',
+        'main',
+        'kotlin',
+        'com',
+        'facebook',
+        'react',
+        'ReactSettingsExtension.kt',
+      );
+
+      if (!fs.existsSync(settingsExtensionPath)) {
+        return config;
+      }
+
+      const settingsSource = fs.readFileSync(settingsExtensionPath, 'utf8');
+      const previousSettings = `          ?.associate { deps ->
+            ":\${deps.nameCleansed}" to File(deps.platforms?.android?.sourceDir)
+          } ?: emptyMap()
+    }`;
+      const nextSettings = `          ?.associate { deps ->
+            ":\${deps.nameCleansed}" to normalizeBunAndroidSourceDir(
+                deps.nameCleansed,
+                File(deps.platforms?.android?.sourceDir)
+            )
+          } ?: emptyMap()
+    }
+
+    private fun normalizeBunAndroidSourceDir(projectName: String, sourceDir: File): File {
+      val normalizedPath = sourceDir.path.replace('\\\\', '/')
+      val marker = "/node_modules/.bun/"
+      val nestedPackage = "/node_modules/$projectName/android"
+
+      if (!normalizedPath.contains(marker) || !normalizedPath.endsWith(nestedPackage)) {
+        return sourceDir
+      }
+
+      val rootNodeModulesPath = normalizedPath.substringBefore(marker) + "/node_modules"
+      val hoistedSourceDir = File("$rootNodeModulesPath/$projectName/android")
+      return if (hoistedSourceDir.exists()) hoistedSourceDir else sourceDir
+    }`;
+
+      if (settingsSource.includes(previousSettings)) {
+        fs.writeFileSync(
+          settingsExtensionPath,
+          settingsSource.replace(previousSettings, nextSettings),
+        );
+      }
+
+      return config;
+    },
+  ]);
+};

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,3 @@
 [install]
+linker = "hoisted"
 minimumReleaseAge = 86400 # 1d


### PR DESCRIPTION
## 무엇을 변경했는지

- Expo 앱에 Android Gradle 설정 보정용 config plugin을 추가했습니다.
- Gradle parallel 실행을 비활성화해 Windows 네이티브 빌드 중 Ninja manifest 갱신 경합을 줄이도록 했습니다.
- Bun hoisted linker를 사용하도록 설정해 React Native 네이티브 모듈 경로가 `.bun` 하위의 긴 경로로 잡히는 문제를 완화했습니다.
- Expo/React Native Gradle 플러그인의 일부 node_modules 패치를 config plugin에서 적용하도록 준비했습니다.

## 왜 변경했는지

- `DEV-48` 안드로이드 빌드 에러 해결 작업입니다.
- Windows 환경에서 Bun의 isolated 경로와 CMake/Ninja 경로 길이 제한이 겹치며 `build.ninja`가 반복 갱신되는 문제가 발생했습니다.
- 이후 `react-native-worklets` 및 autolinking Gradle project 경로가 `.bun` 내부로 잡히면서 Android variant 해석이 실패할 수 있어, hoisted 설치와 Gradle 설정 보정을 함께 적용했습니다.

## 어떻게 확인했는지

- config plugin이 Node에서 정상적으로 import되는지 확인했습니다.
- pre-commit hook의 `eslint --fix --no-warn-ignored`와 `prettier --write --ignore-unknown` 통과를 확인했습니다.
- 2026년 4월 30일에 Expo Go 사용이 성공한 것을 확인했습니다.
- 2026년 4월 30일에 `bun expo run:android --device` 실행이 성공한 것을 확인했습니다.

## 아직 어떤 문제가 남아있는지

없음