### PR TITLE
Expo 웹 빌드에서 네이티브 바인딩을 찾을 수 있게 한다

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1-alpine AS base
+FROM oven/bun:1.3.13 AS base
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@kosmo/monorepo",
   "private": true,
   "version": "0.0.0",
-  "packageManager": "bun@1.3.9",
+  "packageManager": "bun@1.3.13",
   "scripts": {
     "dev": "infisical run -- bun run --parallel --workspaces dev",
     "lint:eslint": "eslint --max-warnings 0 .",


### PR DESCRIPTION
## 무엇을 변경했는지

- Docker 베이스 이미지를 Alpine 기반 oven/bun:1-alpine에서 Debian 기반 oven/bun:1.3.13으로 변경
- 루트 packageManager의 Bun 버전을 Docker 이미지와 동일한 1.3.13으로 정렬

## 왜 변경했는지

- Alpine 환경에서 @mearie/native 네이티브 바인딩을 찾지 못해 apps/expo의 웹 빌드가 실패했다
- 빌드 컨테이너를 glibc 기반 이미지로 바꿔 Expo 웹 export 중 codegen 단계가 정상 실행되도록 한다

## 어떻게 확인할 수 있는지

- 커밋 훅에서 eslint --fix, prettier --write --ignore-unknown 통과
- Docker 빌드 파이프라인에서 cd apps/expo && bun run build:web 재실행 확인 필요

## 아직 어떤 문제가 남았는지

- CI 또는 Docker 빌드 환경에서 실제 Expo 웹 빌드 성공 여부 확인 필요

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
