### PR TITLE
dev-50 데이터베이스 기본 키를 UUID 타입으로 전환한다

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,6 @@
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "temporal-polyfill": "^0.3.2",
-        "ulidx": "^2.4.1",
       },
     },
   },
@@ -1396,8 +1395,6 @@
 
     "lan-network": ["lan-network@0.2.1", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A=="],
 
-    "layerr": ["layerr@3.0.0", "", {}, "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA=="],
-
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
@@ -1923,8 +1920,6 @@
     "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
-
-    "ulidx": ["ulidx@2.4.1", "", { "dependencies": { "layerr": "^3.0.0" } }, "sha512-xY7c8LPyzvhvew0Fn+Ek3wBC9STZAuDI/Y5andCKi9AX6/jvfaX45PhsDX8oxgPL0YFp0Jhr8qWMbS/p9375Xg=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/packages/core/db/id.ts
+++ b/packages/core/db/id.ts
@@ -1,16 +1,80 @@
-import { ulid } from 'ulidx';
 import type * as Tables from './tables';
 
-export const TableCode = {
-  Accounts: 'ACCT',
-  AccountProfiles: 'ACPR',
-  Applications: 'APPL',
-  Posts: 'POST',
-  PostContents: 'POCT',
-  Profiles: 'PRFL',
-  ProfileFollows: 'PFLW',
-  Sessions: 'SESS',
-} as const satisfies Record<keyof typeof Tables, Uppercase<string>>;
+export const TableDiscriminator = {
+  Accounts: 0x001,
+  AccountProfiles: 0x002,
+  Applications: 0x003,
+  Posts: 0x004,
+  PostContents: 0x005,
+  Profiles: 0x006,
+  ProfileFollows: 0x007,
+  Sessions: 0x008,
+} as const satisfies Record<keyof typeof Tables, number>;
 
-export const createId = (tableCode: (typeof TableCode)[keyof typeof TableCode]) =>
-  `${tableCode}0${ulid()}`;
+let lastTimestamp = 0;
+let sequence = crypto.getRandomValues(new Uint16Array(1))[0]!;
+
+const assertTableDiscriminator = (tableDiscriminator: number) => {
+  if (
+    !Number.isInteger(tableDiscriminator) ||
+    tableDiscriminator < 0 ||
+    tableDiscriminator > 0xfff
+  ) {
+    throw new RangeError('tableDiscriminator must fit in 12 bits');
+  }
+};
+
+const nextSequence = (timestamp: number) => {
+  if (timestamp === lastTimestamp) {
+    sequence = (sequence + 1) & 0xffff;
+  } else {
+    lastTimestamp = timestamp;
+    sequence = crypto.getRandomValues(new Uint16Array(1))[0]!;
+  }
+
+  return sequence;
+};
+
+const randomBits = (bitLength: bigint) => {
+  const byteLength = Number((bitLength + 7n) / 8n);
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
+  const mask = (1n << bitLength) - 1n;
+
+  return bytes.reduce((value, byte) => (value << 8n) | BigInt(byte), 0n) & mask;
+};
+
+const formatUuid = (bytes: Uint8Array) => {
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+export const createId = (
+  tableDiscriminator: (typeof TableDiscriminator)[keyof typeof TableDiscriminator],
+) => {
+  assertTableDiscriminator(tableDiscriminator);
+
+  const timestamp = Date.now();
+  const bytes = new Uint8Array(16);
+
+  bytes[0] = (timestamp / 0x10000000000) & 0xff;
+  bytes[1] = (timestamp / 0x100000000) & 0xff;
+  bytes[2] = (timestamp / 0x1000000) & 0xff;
+  bytes[3] = (timestamp / 0x10000) & 0xff;
+  bytes[4] = (timestamp / 0x100) & 0xff;
+  bytes[5] = timestamp & 0xff;
+
+  bytes[6] = 0x80 | (tableDiscriminator >> 8);
+  bytes[7] = tableDiscriminator & 0xff;
+
+  const customC = (BigInt(nextSequence(timestamp)) << 46n) | randomBits(46n);
+  bytes[8] = 0x80 | Number((customC >> 56n) & 0x3fn);
+
+  for (let index = 9; index < bytes.length; index += 1) {
+    const shift = BigInt((15 - index) * 8);
+
+    bytes[index] = Number((customC >> shift) & 0xffn);
+  }
+
+  return formatUuid(bytes);
+};

--- a/packages/core/db/id.ts
+++ b/packages/core/db/id.ts
@@ -11,9 +11,6 @@ export const TableDiscriminator = {
   Sessions: 0x008,
 } as const satisfies Record<keyof typeof Tables, number>;
 
-let lastTimestamp = 0;
-let sequence = crypto.getRandomValues(new Uint16Array(1))[0]!;
-
 const assertTableDiscriminator = (tableDiscriminator: number) => {
   if (
     !Number.isInteger(tableDiscriminator) ||
@@ -24,28 +21,8 @@ const assertTableDiscriminator = (tableDiscriminator: number) => {
   }
 };
 
-const nextSequence = (timestamp: number) => {
-  if (timestamp === lastTimestamp) {
-    sequence = (sequence + 1) & 0xffff;
-  } else {
-    lastTimestamp = timestamp;
-    sequence = crypto.getRandomValues(new Uint16Array(1))[0]!;
-  }
-
-  return sequence;
-};
-
-const randomBits = (bitLength: bigint) => {
-  const byteLength = Number((bitLength + 7n) / 8n);
-  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
-  const mask = (1n << bitLength) - 1n;
-
-  return bytes.reduce((value, byte) => (value << 8n) | BigInt(byte), 0n) & mask;
-};
-
 const formatUuid = (bytes: Uint8Array) => {
-  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
-
+  const hex = bytes.toHex();
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 };
 
@@ -67,14 +44,9 @@ export const createId = (
   bytes[6] = 0x80 | (tableDiscriminator >> 8);
   bytes[7] = tableDiscriminator & 0xff;
 
-  const customC = (BigInt(nextSequence(timestamp)) << 46n) | randomBits(46n);
-  bytes[8] = 0x80 | Number((customC >> 56n) & 0x3fn);
-
-  for (let index = 9; index < bytes.length; index += 1) {
-    const shift = BigInt((15 - index) * 8);
-
-    bytes[index] = Number((customC >> shift) & 0xffn);
-  }
+  // 성능 최적화를 위해 9바이트 랜덤을 만든 후 첫 비트만 10으로 만들어줌
+  crypto.getRandomValues(bytes.subarray(8));
+  bytes[8] = 0x80 | (bytes[8] & 0x3f);
 
   return formatUuid(bytes);
 };

--- a/packages/core/db/tables.ts
+++ b/packages/core/db/tables.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm';
-import { index, pgTable, text, unique } from 'drizzle-orm/pg-core';
+import { index, pgTable, text, unique, uuid } from 'drizzle-orm/pg-core';
 import * as Enum from './enums';
-import { createId, TableCode } from './id';
+import { createId, TableDiscriminator } from './id';
 import { datetime } from './types';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
@@ -13,9 +13,9 @@ const createdAt = () =>
 export const Accounts = pgTable(
   'account',
   {
-    id: text('id')
+    id: uuid('id')
       .primaryKey()
-      .$defaultFn(() => createId(TableCode.Accounts)),
+      .$defaultFn(() => createId(TableDiscriminator.Accounts)),
     oidcSubject: text('oidc_subject').notNull(),
     displayName: text('display_name').notNull(),
     state: Enum.accountState('state').notNull(),
@@ -27,13 +27,13 @@ export const Accounts = pgTable(
 export const AccountProfiles = pgTable(
   'account_profile',
   {
-    id: text('id')
+    id: uuid('id')
       .primaryKey()
-      .$defaultFn(() => createId(TableCode.AccountProfiles)),
-    accountId: text('account_id')
+      .$defaultFn(() => createId(TableDiscriminator.AccountProfiles)),
+    accountId: uuid('account_id')
       .notNull()
       .references(() => Accounts.id, { onDelete: 'cascade' }),
-    profileId: text('profile_id')
+    profileId: uuid('profile_id')
       .notNull()
       .references(() => Profiles.id, { onDelete: 'cascade' }),
     role: Enum.accountProfileRole('role').notNull(),
@@ -47,9 +47,9 @@ export const AccountProfiles = pgTable(
 );
 
 export const Applications = pgTable('application', {
-  id: text('id')
+  id: uuid('id')
     .primaryKey()
-    .$defaultFn(() => createId(TableCode.Applications)),
+    .$defaultFn(() => createId(TableDiscriminator.Applications)),
   name: text('name').notNull(),
   createdAt: createdAt(),
 });
@@ -57,15 +57,15 @@ export const Applications = pgTable('application', {
 export const Posts = pgTable(
   'post',
   {
-    id: text('id')
+    id: uuid('id')
       .primaryKey()
-      .$defaultFn(() => createId(TableCode.Posts)),
-    profileId: text('profile_id')
+      .$defaultFn(() => createId(TableDiscriminator.Posts)),
+    profileId: uuid('profile_id')
       .notNull()
       .references(() => Profiles.id),
     visibility: Enum.postVisibility('visibility').notNull(),
     state: Enum.postState('state').notNull(),
-    currentContentId: text('current_content_id').references((): AnyPgColumn => PostContents.id),
+    currentContentId: uuid('current_content_id').references((): AnyPgColumn => PostContents.id),
     createdAt: createdAt(),
     deletedAt: datetime('deleted_at'),
   },
@@ -75,10 +75,10 @@ export const Posts = pgTable(
 export const PostContents = pgTable(
   'post_content',
   {
-    id: text('id')
+    id: uuid('id')
       .primaryKey()
-      .$defaultFn(() => createId(TableCode.PostContents)),
-    postId: text('post_id')
+      .$defaultFn(() => createId(TableDiscriminator.PostContents)),
+    postId: uuid('post_id')
       .notNull()
       .references((): AnyPgColumn => Posts.id),
     bodyText: text('body_text').notNull(),
@@ -92,9 +92,9 @@ export const PostContents = pgTable(
 export const Profiles = pgTable(
   'profile',
   {
-    id: text('id')
+    id: uuid('id')
       .primaryKey()
-      .$defaultFn(() => createId(TableCode.Profiles)),
+      .$defaultFn(() => createId(TableDiscriminator.Profiles)),
     handle: text('handle').notNull(),
     displayName: text('display_name').notNull(),
     bio: text('bio'),
@@ -107,13 +107,13 @@ export const Profiles = pgTable(
 export const ProfileFollows = pgTable(
   'profile_follow',
   {
-    id: text('id')
+    id: uuid('id')
       .primaryKey()
-      .$defaultFn(() => createId(TableCode.ProfileFollows)),
-    followerProfileId: text('follower_profile_id')
+      .$defaultFn(() => createId(TableDiscriminator.ProfileFollows)),
+    followerProfileId: uuid('follower_profile_id')
       .notNull()
       .references(() => Profiles.id, { onDelete: 'cascade' }),
-    followeeProfileId: text('followee_profile_id')
+    followeeProfileId: uuid('followee_profile_id')
       .notNull()
       .references(() => Profiles.id, { onDelete: 'cascade' }),
     state: Enum.followState('state').notNull(),
@@ -130,16 +130,16 @@ export const ProfileFollows = pgTable(
 export const Sessions = pgTable(
   'session',
   {
-    id: text('id')
+    id: uuid('id')
       .primaryKey()
-      .$defaultFn(() => createId(TableCode.Sessions)),
-    accountId: text('account_id')
+      .$defaultFn(() => createId(TableDiscriminator.Sessions)),
+    accountId: uuid('account_id')
       .notNull()
       .references(() => Accounts.id),
-    applicationId: text('application_id')
+    applicationId: uuid('application_id')
       .notNull()
       .references(() => Applications.id),
-    activeProfileId: text('active_profile_id').references(() => Profiles.id),
+    activeProfileId: uuid('active_profile_id').references(() => Profiles.id),
     oidcSessionKey: text('oidc_session_key'),
     token: text('token').unique().notNull(),
     state: Enum.sessionState('state').notNull(),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
-    "temporal-polyfill": "^0.3.2",
-    "ulidx": "^2.4.1"
+    "temporal-polyfill": "^0.3.2"
   }
 }


### PR DESCRIPTION
### 무엇을 변경했는지

- 애플리케이션 레벨에서 UUIDv8 기본 키를 생성하도록 `createId`를 교체
- 테이블별 12비트 구분자를 UUIDv8 `custom_b` 영역에 넣도록 정리
- 모든 DB 기본 키와 관련 외래 키 컬럼을 Drizzle `uuid` 타입으로 변경
- 더 이상 사용하지 않는 `ulidx` 의존성을 제거

### 왜 변경했는지

- 기존 문자열 prefix + ULID 방식 대신 PostgreSQL `uuid` 타입을 사용하는 PK 구조로 맞추기 위해 변경했습니다.
- UUID 생성은 PostgreSQL 함수가 아니라 애플리케이션에서 수행해야 한다는 dev-50 요구사항을 반영했습니다.
- 테이블 구분 정보는 문자열 prefix 대신 UUIDv8의 커스텀 비트 영역에 담도록 했습니다.

### 어떻게 확인할 수 있는지

- `bun run lint:eslint`
- `bunx prettier --check packages/core/db/id.ts packages/core/db/tables.ts packages/core/package.json`
- `bunx tsc --noEmit --ignoreConfig --skipLibCheck --strict --module esnext --moduleResolution bundler --target esnext --types bun packages/core/db/id.ts packages/core/db/tables.ts`
- UUIDv8 샘플 생성 시 version/variant 비트가 맞는지 확인

### 아직 어떤 문제가 남았는지

- 전체 `bunx tsc --noEmit`는 기존 repo의 JSX/alias 설정 문제로 실패합니다.
- 이슈 지시에 따라 DB 마이그레이션은 만들지 않았습니다.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->
