### PR TITLE
Trivy OpenSSL CVE가 런타임 이미지에 남지 않게 한다

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM oven/bun:1.3.13 AS base
 
 WORKDIR /app
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends --only-upgrade libssl3t64 openssl-provider-legacy \
+  && rm -rf /var/lib/apt/lists/*
+
 FROM base AS workspace
 
 COPY package.json bun.lock tsconfig.json ./


### PR DESCRIPTION
## 무엇을 변경했는지

- Docker `base` stage에서 `libssl3t64`, `openssl-provider-legacy` 패키지만 `--only-upgrade` 하도록 추가했습니다.
- `base`를 상속하는 `deps`, `expo-build`, `runtime` stage가 모두 fixed OpenSSL 패키지를 사용하도록 했습니다.
- apt metadata가 이미지에 남지 않도록 업그레이드 후 `/var/lib/apt/lists/*`를 정리했습니다.

## 왜 변경했는지

- GitHub Actions run 25246209032의 Trivy report에서 Debian 13.4 기반 이미지의 OpenSSL 관련 OS 패키지 취약점이 발견되었습니다.
- 발견된 패키지의 설치 버전은 `3.5.5-1~deb13u1`이고, fixed version은 `3.5.5-1~deb13u2`입니다.
- 영향을 받은 CVE는 `CVE-2026-31789`, `CVE-2026-28387`, `CVE-2026-28388`, `CVE-2026-28389`, `CVE-2026-28390`입니다.

## 어떻게 확인했는지

- Trivy artifact `trivy-report`를 확인해 취약점 대상이 JS 의존성이 아니라 Debian OS package임을 확인했습니다.
- 로컬 환경에는 Docker/Trivy가 없어 이미지 재빌드 후 재스캔은 수행하지 못했습니다.
- 이 PR의 GitHub Actions Docker build 이후 Trivy report에서 해당 CVE가 해소되는지 확인이 필요합니다.

## 아직 어떤 문제가 남아있는지

- GitHub Actions에서 새 이미지가 빌드된 뒤 Trivy report 재확인이 필요합니다.

Linear: DEV-51