### PR TITLE
프로필을 생성하고 변경할 수 있게 한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - Use `pnpm` for workspace and dependency management.
 - Use CLI commands for `package.json` dependency changes. Non-dependency fields, such as `scripts`, may be edited directly.
+- Use the Question tool when asking the user to decide between implementation options or unresolved requirements.
 
 ## Review Guidelines
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,11 +15,13 @@
     "@pothos/plugin-relay": "^4.7.0",
     "@pothos/plugin-scope-auth": "^4.1.6",
     "@pothos/plugin-validation": "^4.2.0",
+    "@pothos/plugin-with-input": "^4.1.4",
     "dataloader": "^2.2.3",
     "drizzle-orm": "1.0.0-beta.22",
     "graphql": "^16.13.2",
     "graphql-yoga": "^5.21.0",
     "hono": "^4.12.14",
+    "remeda": "^2.34.1",
     "tsx": "^4.21.0",
     "zod": "^4.4.3"
   }

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -5,7 +5,7 @@ type Account implements Node {
 
 type AccountProfile implements Node {
   id: ID!
-  role: AccountProfileRole
+  role: AccountProfileRole!
 }
 
 enum AccountProfileRole {
@@ -20,26 +20,91 @@ enum AccountState {
   SUSPENDED
 }
 
+type ConflictError implements Error & FieldError {
+  code: String!
+  field: String
+  message: String!
+}
+
+union CreateProfileResult = ConflictError | CreateProfileSuccess
+
+type CreateProfileSuccess {
+  profile: Profile!
+}
+
 """RFC9557 formatted string"""
 scalar DateTime
+
+union DeleteProfileResult = DeleteProfileSuccess | NotFoundError | PermissionDeniedError
+
+type DeleteProfileSuccess {
+  profileId: ID!
+}
+
+interface Error {
+  code: String!
+  message: String!
+}
+
+interface FieldError implements Error {
+  code: String!
+  field: String
+  message: String!
+}
+
+interface ForbiddenError implements Error {
+  code: String!
+  message: String!
+}
+
+type Mutation {
+  createProfile(input: MutationCreateProfileInput!): CreateProfileResult!
+  deleteProfile(input: MutationDeleteProfileInput!): DeleteProfileResult!
+  updateProfile(input: MutationUpdateProfileInput!): UpdateProfileResult!
+}
+
+input MutationCreateProfileInput {
+  handle: String!
+}
+
+input MutationDeleteProfileInput {
+  id: ID!
+}
+
+input MutationUpdateProfileInput {
+  bio: String
+  displayName: String
+  followPolicy: ProfileFollowPolicy
+  id: ID!
+}
 
 interface Node {
   id: ID!
 }
 
+type NotFoundError implements Error {
+  code: String!
+  message: String!
+}
+
+type PermissionDeniedError implements Error & ForbiddenError {
+  code: String!
+  message: String!
+}
+
 type Profile implements Node {
   bio: String
-  createdAt: DateTime
-  displayName: String
-  followPolicy: ProfileFollowPolicy
-  handle: String
+  createdAt: DateTime!
+  displayName: String!
+  followPolicy: ProfileFollowPolicy!
+  handle: String!
   id: ID!
 }
 
 type ProfileFollow implements Node {
-  createdAt: DateTime
+  createdAt: DateTime!
   id: ID!
-  state: ProfileFollowState
+  state: ProfileFollowState!
 }
 
 enum ProfileFollowPolicy {
@@ -64,4 +129,16 @@ type Query {
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!
   profileByHandle(handle: String!): Profile
+}
+
+union UpdateProfileResult = NotFoundError | PermissionDeniedError | UpdateProfileSuccess
+
+type UpdateProfileSuccess {
+  profile: Profile!
+}
+
+type ValidationError implements Error & FieldError {
+  code: String!
+  field: String
+  message: String!
 }

--- a/apps/api/src/graphql/builder.ts
+++ b/apps/api/src/graphql/builder.ts
@@ -1,9 +1,12 @@
+import { ValidationError } from '@kosmo/core/error';
 import SchemaBuilder from '@pothos/core';
 import DataloaderPlugin from '@pothos/plugin-dataloader';
 import ErrorsPlugin from '@pothos/plugin-errors';
 import RelayPlugin from '@pothos/plugin-relay';
 import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
 import ValidationPlugin from '@pothos/plugin-validation';
+import WithInputPlugin from '@pothos/plugin-with-input';
+import * as R from 'remeda';
 import { globalIdMap } from './utils';
 import type { SessionContext, SessionWithProfileContext, UserContext } from '@/context';
 
@@ -27,11 +30,35 @@ export const builder = new SchemaBuilder<{
     };
   };
 }>({
-  plugins: [RelayPlugin, ScopeAuthPlugin, ErrorsPlugin, ValidationPlugin, DataloaderPlugin],
+  plugins: [
+    RelayPlugin,
+    ScopeAuthPlugin,
+    ErrorsPlugin,
+    ValidationPlugin,
+    WithInputPlugin,
+    DataloaderPlugin,
+  ],
   defaultFieldNullability: false,
   defaultInputFieldRequiredness: true,
   errors: {
     defaultTypes: [],
+    defaultResultOptions: {
+      name: ({ fieldName }) => `${R.capitalize(fieldName)}Success`,
+    },
+    defaultUnionOptions: {
+      name: ({ fieldName }) => `${R.capitalize(fieldName)}Result`,
+    },
+  },
+  validation: {
+    validationError: (failure) => {
+      const issue = failure.issues[0];
+      const field = issue?.path
+        ?.map((segment) => (typeof segment === 'object' ? segment.key : segment))
+        .filter((segment) => segment !== 'input')
+        .join('.');
+
+      return new ValidationError(issue?.message, { field: field || undefined });
+    },
   },
   relay: {
     encodeGlobalID: (_, id) => String(id),
@@ -56,6 +83,7 @@ export const builder = new SchemaBuilder<{
 });
 
 builder.queryType({});
+builder.mutationType({});
 
 builder.scalarType('DateTime', {
   description: 'RFC9557 formatted string',

--- a/apps/api/src/graphql/errors.ts
+++ b/apps/api/src/graphql/errors.ts
@@ -1,0 +1,51 @@
+import {
+  ConflictError,
+  NotFoundError,
+  PermissionDeniedError,
+  ValidationError,
+} from '@kosmo/core/error';
+import { builder } from './builder';
+import type { FieldError, KosmoError } from '@kosmo/core/error';
+
+const ErrorInterface = builder.interfaceRef<KosmoError>('Error').implement({
+  fields: (t) => ({
+    message: t.exposeString('message'),
+    code: t.exposeString('code'),
+  }),
+});
+
+const ForbiddenErrorInterface = builder.interfaceRef<KosmoError>('ForbiddenError').implement({
+  interfaces: [ErrorInterface],
+  fields: () => ({}),
+});
+
+const FieldErrorInterface = builder.interfaceRef<FieldError>('FieldError').implement({
+  interfaces: [ErrorInterface],
+  fields: (t) => ({
+    field: t.exposeString('field', { nullable: true }),
+  }),
+});
+
+builder.objectType(ValidationError, {
+  name: 'ValidationError',
+  interfaces: [ErrorInterface, FieldErrorInterface],
+  fields: () => ({}),
+});
+
+builder.objectType(ConflictError, {
+  name: 'ConflictError',
+  interfaces: [ErrorInterface, FieldErrorInterface],
+  fields: () => ({}),
+});
+
+builder.objectType(NotFoundError, {
+  name: 'NotFoundError',
+  interfaces: [ErrorInterface],
+  fields: () => ({}),
+});
+
+builder.objectType(PermissionDeniedError, {
+  name: 'PermissionDeniedError',
+  interfaces: [ErrorInterface, ForbiddenErrorInterface],
+  fields: () => ({}),
+});

--- a/apps/api/src/graphql/resolvers/profile/index.ts
+++ b/apps/api/src/graphql/resolvers/profile/index.ts
@@ -1,3 +1,4 @@
+import './mutation';
 import './query';
 
 export { AccountProfile, Profile, ProfileFollow } from './ref';

--- a/apps/api/src/graphql/resolvers/profile/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/create.ts
@@ -1,0 +1,49 @@
+import { AccountProfiles, db, firstOrThrow, isUniqueViolation, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole, ProfileFollowPolicy } from '@kosmo/core/enums';
+import { ConflictError } from '@kosmo/core/error';
+import { normalizeHandle } from '@kosmo/core/utils';
+import { profileHandleSchema } from '@kosmo/core/validation';
+import { builder } from '@/graphql/builder';
+import { Profile } from '../ref';
+
+builder.mutationField('createProfile', (t) =>
+  t.withAuth({ login: true }).fieldWithInput({
+    type: Profile,
+    input: {
+      handle: t.input.string({ validate: profileHandleSchema }),
+    },
+    errors: {
+      types: [ConflictError],
+      dataField: { name: 'profile' },
+    },
+    resolve: async (_, { input }, ctx) => {
+      return await db.transaction(async (tx) => {
+        const profile = await tx
+          .insert(Profiles)
+          .values({
+            handle: input.handle,
+            normalizedHandle: normalizeHandle(input.handle),
+            displayName: input.handle,
+            followPolicy: ProfileFollowPolicy.OPEN,
+          })
+          .returning()
+          .then(firstOrThrow)
+          .catch((error) => {
+            if (isUniqueViolation(error)) {
+              throw new ConflictError({ field: 'handle' });
+            }
+
+            throw error;
+          });
+
+        await tx.insert(AccountProfiles).values({
+          accountId: ctx.session.accountId,
+          profileId: profile.id,
+          role: AccountProfileRole.OWNER,
+        });
+
+        return profile;
+      });
+    },
+  }),
+);

--- a/apps/api/src/graphql/resolvers/profile/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/delete.ts
@@ -1,0 +1,51 @@
+import { AccountProfiles, db, firstOrThrowWith, Profiles, Sessions } from '@kosmo/core/db';
+import { AccountProfileRole, ProfileState } from '@kosmo/core/enums';
+import { NotFoundError, PermissionDeniedError } from '@kosmo/core/error';
+import { and, eq } from 'drizzle-orm';
+import { builder } from '@/graphql/builder';
+
+builder.mutationField('deleteProfile', (t) =>
+  t.withAuth({ login: true }).fieldWithInput({
+    type: 'ID',
+    input: {
+      id: t.input.id({ required: true }),
+    },
+    errors: {
+      types: [NotFoundError, PermissionDeniedError],
+      dataField: { name: 'profileId' },
+    },
+    resolve: async (_, { input }, ctx) => {
+      const profile = await db
+        .select({ id: Profiles.id, actorRole: AccountProfiles.role })
+        .from(Profiles)
+        .innerJoin(AccountProfiles, eq(AccountProfiles.profileId, Profiles.id))
+        .where(
+          and(
+            eq(Profiles.id, input.id),
+            eq(Profiles.state, ProfileState.ACTIVE),
+            eq(AccountProfiles.accountId, ctx.session.accountId),
+          ),
+        )
+        .limit(1)
+        .then(firstOrThrowWith(() => new NotFoundError('Profile not found')));
+
+      if (profile.actorRole !== AccountProfileRole.OWNER) {
+        throw new PermissionDeniedError('Profile owner permission is required');
+      }
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(Profiles)
+          .set({ state: ProfileState.DISABLED })
+          .where(eq(Profiles.id, input.id));
+
+        await tx
+          .update(Sessions)
+          .set({ activeProfileId: null })
+          .where(eq(Sessions.activeProfileId, input.id));
+      });
+
+      return profile.id;
+    },
+  }),
+);

--- a/apps/api/src/graphql/resolvers/profile/mutation/index.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/index.ts
@@ -1,0 +1,3 @@
+import './create';
+import './delete';
+import './update';

--- a/apps/api/src/graphql/resolvers/profile/mutation/update.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/update.ts
@@ -1,0 +1,60 @@
+import { AccountProfiles, db, firstOrThrow, firstOrThrowWith, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole, ProfileFollowPolicy, ProfileState } from '@kosmo/core/enums';
+import { NotFoundError, PermissionDeniedError } from '@kosmo/core/error';
+import { profileBioSchema, profileDisplayNameSchema } from '@kosmo/core/validation';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { builder } from '@/graphql/builder';
+import { Profile } from '../ref';
+
+builder.mutationField('updateProfile', (t) =>
+  t.withAuth({ login: true }).fieldWithInput({
+    type: Profile,
+    input: {
+      id: t.input.id({ validate: z.uuid() }),
+      displayName: t.input.string({
+        required: false,
+        validate: profileDisplayNameSchema.optional(),
+      }),
+      bio: t.input.string({ required: false, validate: profileBioSchema.optional() }),
+      followPolicy: t.input.field({ type: ProfileFollowPolicy, required: false }),
+    },
+    errors: {
+      types: [NotFoundError, PermissionDeniedError],
+      dataField: { name: 'profile' },
+    },
+    resolve: async (_, { input }, ctx) => {
+      const profile = await db
+        .select({ id: Profiles.id, actorRole: AccountProfiles.role })
+        .from(Profiles)
+        .innerJoin(AccountProfiles, eq(AccountProfiles.profileId, Profiles.id))
+        .where(
+          and(
+            eq(Profiles.id, input.id),
+            eq(Profiles.state, ProfileState.ACTIVE),
+            eq(AccountProfiles.accountId, ctx.session.accountId),
+          ),
+        )
+        .limit(1)
+        .then(firstOrThrowWith(() => new NotFoundError('Profile not found')));
+
+      if (
+        profile.actorRole !== AccountProfileRole.OWNER &&
+        profile.actorRole !== AccountProfileRole.ADMIN
+      ) {
+        throw new PermissionDeniedError('Profile admin permission is required');
+      }
+
+      return await db
+        .update(Profiles)
+        .set({
+          displayName: input.displayName ?? undefined,
+          bio: input.bio,
+          followPolicy: input.followPolicy ?? undefined,
+        })
+        .where(eq(Profiles.id, input.id))
+        .returning()
+        .then(firstOrThrow);
+    },
+  }),
+);

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -1,4 +1,5 @@
 import './enums';
+import './errors';
 import './resolvers';
 
 import { dev } from '@kosmo/core';

--- a/memory/graphql-style.md
+++ b/memory/graphql-style.md
@@ -84,11 +84,53 @@ builder.queryField('me', (t) =>
 
 Mutation도 필드별로 나눈다.
 
-- input type은 해당 mutation 파일 가까이에 둔다.
+- mutation은 기본적으로 `t.withAuth(...).fieldWithInput(...)`로 정의한다.
+- 단순 scalar 검증은 `input` 필드에 `validate`를 직접 붙인다.
+- 여러 필드 조합을 검증해야 하는 경우에만 mutation 파일 안에 inline Zod object schema를 둔다.
+- `packages/core/validation`에는 `handle`, `displayName`, `bio` 같은 재사용 가능한 공통 primitive schema만 둔다. `createProfileInputSchema`처럼 특정 GraphQL mutation input 전체를 core에 공통화하지 않는다.
 - mutation resolver는 권한 확인, 입력 정규화, DB 변경을 수행한다.
+- create mutation처럼 입력을 최소화할 수 있으면 필수 입력만 받고, 나머지 값은 resolver에서 명확한 기본값으로 채운다. 예를 들어 profile 생성은 `handle`만 받고 `displayName`은 `handle`, `followPolicy`는 `OPEN`으로 설정한다.
 - mutation이 Node 타입을 반환할 때 이미 `returning()` 등으로 row를 가지고 있으면 row를 반환해도 된다. 추가 조회가 필요하다면 `id`만 반환한다.
+- delete/disable처럼 반환할 Node가 더 이상 현재 GraphQL 타입의 auth scope를 만족하지 않을 수 있으면 Node 자체를 반환하지 말고 삭제/비활성화된 대상의 `ID` 같은 payload 값을 반환한다.
 - 부분 변경 없이 실패해야 하는 mutation은 transaction을 사용한다.
-- 클라이언트가 분기해야 하는 에러는 `GraphQLError`의 `extensions.code`를 사용한다.
+- Pothos Errors plugin을 사용하고, 클라이언트가 분기해야 하는 에러는 `errors.types`에 명시한다.
+- `errors.dataField`는 `profile`, `profileId`처럼 클라이언트가 받는 성공 payload의 도메인 의미가 드러나는 이름으로 지정한다.
+- builder의 error result/union 기본 이름은 `<FieldName>Success`, `<FieldName>Result` 형태를 사용한다.
+- Zod/Pothos validation 실패는 builder의 `validation.validationError`가 `ValidationError`로 변환한다. mutation별 `errors.types`에는 resolver가 직접 던지는 domain error만 명시한다.
+- 인증 scope 부족은 mutation domain error로 던지지 않고 `t.withAuth({ login: true })` 같은 auth 설정으로 처리한다.
+- 대상 리소스에 대한 권한 부족만 `PermissionDeniedError`로 던진다.
+
+예시:
+
+```ts
+builder.mutationField('createProfile', (t) =>
+  t.withAuth({ login: true }).fieldWithInput({
+    type: Profile,
+    input: {
+      handle: t.input.string({ validate: profileHandleSchema }),
+    },
+    errors: {
+      types: [ConflictError],
+      dataField: { name: 'profile' },
+    },
+    resolve: async (_, { input }, ctx) => {
+      // resolver body
+    },
+  }),
+);
+```
+
+## Error
+
+GraphQL로 노출되는 도메인 에러는 `packages/core/error`에 GraphQL 독립 class로 정의하고, `apps/api/src/graphql/errors.ts`에서 Pothos type/interface로 등록한다.
+
+- 기본 error 계층은 `KosmoError`, `FieldError`, `ValidationError`, `ConflictError`, `NotFoundError`, abstract `ForbiddenError`, `PermissionDeniedError`를 사용한다.
+- `ForbiddenError`는 직접 throw하지 않는 abstract/base class다.
+- `FieldError.field`는 optional이다. 특정 input field에 귀속되는 validation/conflict일 때만 채운다.
+- builder의 `errors.defaultTypes`는 비워두고, 각 field가 노출할 concrete error type을 `errors.types`에 명시한다.
+- validation plugin에서 발생한 입력 검증 오류는 builder 설정에서 첫 issue의 message와 `input`을 제거한 path를 사용해 `ValidationError`로 변환한다.
+- `ValidationError`와 `ConflictError`는 GraphQL `FieldError` interface를 구현한다.
+- `PermissionDeniedError`는 GraphQL `ForbiddenError` interface를 구현한다.
 
 ## Enum
 
@@ -108,7 +150,11 @@ GraphQL enum은 `apps/api/src/graphql/enums.ts`에서 전역 등록한다.
 ## DB 접근
 
 - resolver 코드는 Drizzle query builder를 직접 사용한다.
-- 단건 조회에는 필요하면 `first` 같은 helper를 사용한다.
+- 단건 조회에는 `first`, `firstOrThrow`, `firstOrThrowWith` 같은 helper를 사용한다.
+- 결과 row가 반드시 있어야 하고 없으면 DB/서버 불일치로 보는 5xx 성격의 오류라면 `firstOrThrow`를 사용한다. 예를 들어 insert/update 후 `returning()`이 비는 경우가 이에 해당한다.
+- 결과 row가 없을 수 있고 그 원인이 클라이언트 입력, 권한, 대상 부재 같은 4xx 성격의 도메인 오류라면 `firstOrThrowWith`로 `NotFoundError` 등 명시적 도메인 에러를 던진다.
+- 존재 확인과 actor 권한 조회는 가능하면 join으로 한 번에 처리한다. 예를 들어 profile mutation은 `Profiles`와 `AccountProfiles`를 join해 active profile 존재 여부와 actor role을 같이 조회한 뒤 role을 검사한다.
+- PostgreSQL unique violation 판정은 resolver 로컬 함수로 만들지 않고 `@kosmo/core/db`의 `isUniqueViolation` helper를 사용한다.
 - `createObjectRef`가 만든 loadable Node ref는 batched loading을 제공한다.
 - query, mutation, relationship resolver는 불필요한 추가 조회를 피한다. 이미 row가 있으면 row를 반환하고, ID만 있으면 ID를 반환해 Node loader를 타게 한다.
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@nick-vi/opencode-type-inject", "opencode-pty"],
+  "formatter": {
+    "eslint": {
+      "command": ["pnpm", "exec", "eslint", "--fix", "--no-warn-ignored", "$FILE"],
+      "extensions": [".js", ".mjs", ".svelte", ".ts"]
+    },
+    "prettier": {
+      "command": ["pnpm", "exec", "prettier", "--write", "--ignore-unknown", "$FILE"],
+      "extensions": [
+        ".css",
+        ".graphql",
+        ".html",
+        ".js",
+        ".json",
+        ".md",
+        ".mjs",
+        ".svelte",
+        ".svg",
+        ".ts",
+        ".yaml",
+        ".yml"
+      ]
+    }
+  }
+}

--- a/packages/core/db/utils.ts
+++ b/packages/core/db/utils.ts
@@ -1,4 +1,13 @@
+import { DrizzleQueryError } from 'drizzle-orm';
+
 export const first = <T>(arr: T[]): T | undefined => arr[0];
+
+export const isUniqueViolation = (error: unknown) =>
+  error instanceof DrizzleQueryError &&
+  error.cause &&
+  'code' in error.cause &&
+  error.cause.code === '23505';
+
 export const firstOrThrow = <T>(arr: T[]): T => {
   if (arr.length === 0) {
     throw new Error('Not Found');

--- a/packages/core/error/index.ts
+++ b/packages/core/error/index.ts
@@ -1,0 +1,55 @@
+export type ErrorCode = 'CONFLICT' | 'NOT_FOUND' | 'PERMISSION_DENIED' | 'VALIDATION';
+
+type KosmoErrorOptions = {
+  code: ErrorCode;
+  message: string;
+};
+
+export class KosmoError extends Error {
+  readonly code: ErrorCode;
+
+  constructor({ code, message }: KosmoErrorOptions) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+type FieldErrorOptions = KosmoErrorOptions & {
+  field?: string;
+};
+
+export class FieldError extends KosmoError {
+  readonly field?: string;
+
+  constructor({ field, ...options }: FieldErrorOptions) {
+    super(options);
+    this.field = field;
+  }
+}
+
+export class ValidationError extends FieldError {
+  constructor(message = 'Invalid input', options: { field?: string } = {}) {
+    super({ code: 'VALIDATION', message, field: options.field });
+  }
+}
+
+export class ConflictError extends FieldError {
+  constructor({ message = 'Conflict', field }: { message?: string; field?: string } = {}) {
+    super({ code: 'CONFLICT', message, field });
+  }
+}
+
+export class NotFoundError extends KosmoError {
+  constructor(message = 'Not found') {
+    super({ code: 'NOT_FOUND', message });
+  }
+}
+
+export abstract class ForbiddenError extends KosmoError {}
+
+export class PermissionDeniedError extends ForbiddenError {
+  constructor(message = 'Permission denied') {
+    super({ code: 'PERMISSION_DENIED', message });
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,15 +4,18 @@
   "exports": {
     ".": "./index.ts",
     "./db": "./db/index.ts",
+    "./error": "./error/index.ts",
     "./enums": "./enums.ts",
     "./polyfill": "./polyfill.ts",
-    "./utils": "./utils.ts"
+    "./utils": "./utils.ts",
+    "./validation": "./validation/index.ts"
   },
   "dependencies": {
     "core-js": "^3.49.0",
     "drizzle-orm": "1.0.0-beta.22",
     "postgres": "^3.4.9",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^0.3.2",
+    "zod": "^4.4.3"
   },
   "scripts": {
     "drizzle:push": "infisical run -- drizzle-kit push",

--- a/packages/core/validation/index.ts
+++ b/packages/core/validation/index.ts
@@ -1,0 +1,1 @@
+export * from './profile';

--- a/packages/core/validation/profile.ts
+++ b/packages/core/validation/profile.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const profileHandleSchema = z
+  .string()
+  .trim()
+  .min(3)
+  .max(30)
+  .regex(/^[a-zA-Z0-9_]+$/);
+
+export const profileDisplayNameSchema = z.string().trim().min(1).max(80);
+
+export const profileBioSchema = z.string().trim().max(500).nullable();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@pothos/plugin-validation':
         specifier: ^4.2.0
         version: 4.2.0(@pothos/core@4.12.0(graphql@16.14.0))(graphql@16.14.0)
+      '@pothos/plugin-with-input':
+        specifier: ^4.1.4
+        version: 4.1.4(@pothos/core@4.12.0(graphql@16.14.0))(graphql@16.14.0)
       dataloader:
         specifier: ^2.2.3
         version: 2.2.3
@@ -105,6 +108,9 @@ importers:
       hono:
         specifier: ^4.12.14
         version: 4.12.18
+      remeda:
+        specifier: ^2.34.1
+        version: 2.34.1
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -189,6 +195,9 @@ importers:
       temporal-polyfill:
         specifier: ^0.3.2
         version: 0.3.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       drizzle-kit:
         specifier: 1.0.0-beta.22
@@ -818,6 +827,12 @@ packages:
 
   '@pothos/plugin-validation@4.2.0':
     resolution: {integrity: sha512-iqqlNzHGhTbWIf6dfouMjJfh72gOQEft7gp0Bl0vhW8WNWuOwVmrXrXtF+Lu3hyZuBY7WfQ44jQ41hXjYmqx0g==}
+    peerDependencies:
+      '@pothos/core': '*'
+      graphql: ^16.10.0
+
+  '@pothos/plugin-with-input@4.1.4':
+    resolution: {integrity: sha512-ov8Ufga6lU1PmE0lHt50jpt3G3ypJvHJ0YF2PmjcgWEvJMi/cDhRRKoU2IoB13juBBRE2yo9rS3QhSRUR35iAQ==}
     peerDependencies:
       '@pothos/core': '*'
       graphql: ^16.10.0
@@ -2670,6 +2685,9 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remeda@2.34.1:
+    resolution: {integrity: sha512-k5iIF3lHm2NQ+2bNGDvZTD5jZl/JZkCS6AQOfGjYBd7V4rbb3K5whHvab0/O7CqPI43vYzbnIVCQXQJqmOyI6w==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3649,6 +3667,11 @@ snapshots:
       graphql: 16.14.0
 
   '@pothos/plugin-validation@4.2.0(@pothos/core@4.12.0(graphql@16.14.0))(graphql@16.14.0)':
+    dependencies:
+      '@pothos/core': 4.12.0(graphql@16.14.0)
+      graphql: 16.14.0
+
+  '@pothos/plugin-with-input@4.1.4(@pothos/core@4.12.0(graphql@16.14.0))(graphql@16.14.0)':
     dependencies:
       '@pothos/core': 4.12.0(graphql@16.14.0)
       graphql: 16.14.0
@@ -5378,6 +5401,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  remeda@2.34.1: {}
 
   resolve-from@4.0.0: {}
 


### PR DESCRIPTION
## 무엇을 변경했는지
- 프로필 생성, 수정, 삭제 GraphQL mutation을 추가했습니다.
- Pothos errors, validation, with-input 플러그인을 mutation 흐름에 연결했습니다.
- 공통 도메인 에러와 프로필 입력 검증 schema를 core 패키지에 추가했습니다.
- 프로필 mutation과 에러 처리 스타일을 memory에 정리하고, opencode 설정을 추가했습니다.

## 왜 변경했는지
- 클라이언트가 프로필 생명주기를 GraphQL mutation으로 다룰 수 있게 하기 위해서입니다.
- validation, conflict, not found, permission denied 같은 클라이언트 분기 대상 에러를 GraphQL result union으로 노출하기 위해서입니다.

## 어떻게 확인할 수 있는지
- 

## 아직 어떤 문제가 남았는지
- 없음

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
