### PR TITLE
API 컨테이너가 읽기 전용 pnpm 상태 DB에 막히지 않게 한다

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,4 +14,8 @@ if [ "${app}" = "web" ]; then
   exec node build/index.js
 fi
 
+if [ "${app}" = "api" ]; then
+  exec node --import tsx src/index.ts
+fi
+
 exec pnpm start


### PR DESCRIPTION
## 무엇을 변경했는지

- Docker entrypoint에서 `api` 앱을 실행할 때 `pnpm start`를 거치지 않고 `node --import tsx src/index.ts`를 직접 실행하게 했습니다.
- `web` 실행 경로와 알 수 없는 앱에 대한 기존 fallback은 유지했습니다.

## 왜 변경했는지

- 런타임 컨테이너는 `USER app`으로 실행되며, `pnpm start` 호출 중 pnpm 내부 SQLite 상태 DB에 쓰기를 시도하면 `attempt to write a readonly database` 오류가 발생할 수 있습니다.
- API 서버 실행에는 패키지 매니저가 필요하지 않으므로 런타임 경로에서 pnpm을 우회해 권한 문제를 제거합니다.

## 어떻게 확인할 수 있는지

- `sh -n docker-entrypoint.sh`
- `pnpm --filter @kosmo/api lint:tsc`
- 임시 web build secret과 `PUBLIC_ENV_HASH=verify`로 `docker build --secret id=web_build_env,src=<temp> --build-arg PUBLIC_ENV_HASH=verify -t kosmo-entrypoint-verify:latest .`
- `docker run -d --name kosmo-entrypoint-verify -p 127.0.0.1:18080:3000 -e PORT=3000 -e DATABASE_URL=postgres://user:pass@127.0.0.1:5432/kosmo kosmo-entrypoint-verify:latest api` 후 `curl -fsS http://127.0.0.1:18080/health`가 `{"status":"ok"}` 응답

## 아직 어떤 문제가 남았는지

- 없음

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
