### PR TITLE
활성 프로필을 선택할 수 있게 한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -26,6 +26,10 @@ type ConflictError implements Error & FieldError {
   message: String!
 }
 
+input CreateProfileInput {
+  handle: String!
+}
+
 union CreateProfileResult = ConflictError | CreateProfileSuccess
 
 type CreateProfileSuccess {
@@ -34,6 +38,10 @@ type CreateProfileSuccess {
 
 """RFC9557 formatted string"""
 scalar DateTime
+
+input DeleteProfileInput {
+  id: ID!
+}
 
 union DeleteProfileResult = DeleteProfileSuccess | NotFoundError | PermissionDeniedError
 
@@ -58,24 +66,10 @@ interface ForbiddenError implements Error {
 }
 
 type Mutation {
-  createProfile(input: MutationCreateProfileInput!): CreateProfileResult!
-  deleteProfile(input: MutationDeleteProfileInput!): DeleteProfileResult!
-  updateProfile(input: MutationUpdateProfileInput!): UpdateProfileResult!
-}
-
-input MutationCreateProfileInput {
-  handle: String!
-}
-
-input MutationDeleteProfileInput {
-  id: ID!
-}
-
-input MutationUpdateProfileInput {
-  bio: String
-  displayName: String
-  followPolicy: ProfileFollowPolicy
-  id: ID!
+  createProfile(input: CreateProfileInput!): CreateProfileResult!
+  deleteProfile(input: DeleteProfileInput!): DeleteProfileResult!
+  selectProfile(input: SelectProfileInput!): SelectProfileResult!
+  updateProfile(input: UpdateProfileInput!): UpdateProfileResult!
 }
 
 interface Node {
@@ -129,6 +123,23 @@ type Query {
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!
   profileByHandle(handle: String!): Profile
+}
+
+input SelectProfileInput {
+  id: ID!
+}
+
+union SelectProfileResult = NotFoundError | SelectProfileSuccess
+
+type SelectProfileSuccess {
+  profile: Profile!
+}
+
+input UpdateProfileInput {
+  bio: String
+  displayName: String
+  followPolicy: ProfileFollowPolicy
+  id: ID!
 }
 
 union UpdateProfileResult = NotFoundError | PermissionDeniedError | UpdateProfileSuccess

--- a/apps/api/src/graphql/builder.ts
+++ b/apps/api/src/graphql/builder.ts
@@ -80,6 +80,11 @@ export const builder = new SchemaBuilder<{
     defaultStrategy: 'all',
     runScopesOnType: true,
   },
+  withInput: {
+    typeOptions: {
+      name: ({ fieldName }) => `${R.capitalize(fieldName)}Input`,
+    },
+  },
 });
 
 builder.queryType({});

--- a/apps/api/src/graphql/resolvers/profile/mutation/index.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/index.ts
@@ -1,3 +1,4 @@
 import './create';
 import './delete';
+import './select';
 import './update';

--- a/apps/api/src/graphql/resolvers/profile/mutation/select.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/select.ts
@@ -1,0 +1,51 @@
+import {
+  AccountProfiles,
+  db,
+  firstOrThrow,
+  firstOrThrowWith,
+  Profiles,
+  Sessions,
+} from '@kosmo/core/db';
+import { ProfileState } from '@kosmo/core/enums';
+import { NotFoundError } from '@kosmo/core/error';
+import { and, eq, getColumns } from 'drizzle-orm';
+import { z } from 'zod';
+import { builder } from '@/graphql/builder';
+import { Profile } from '../ref';
+
+builder.mutationField('selectProfile', (t) =>
+  t.withAuth({ login: true }).fieldWithInput({
+    type: Profile,
+    input: {
+      id: t.input.id({ validate: z.uuid() }),
+    },
+    errors: {
+      types: [NotFoundError],
+      dataField: { name: 'profile' },
+    },
+    resolve: async (_, { input }, ctx) => {
+      const profile = await db
+        .select(getColumns(Profiles))
+        .from(Profiles)
+        .leftJoin(AccountProfiles, and(eq(AccountProfiles.profileId, Profiles.id)))
+        .where(
+          and(
+            eq(Profiles.id, input.id),
+            eq(Profiles.state, ProfileState.ACTIVE),
+            eq(AccountProfiles.accountId, ctx.session.accountId),
+          ),
+        )
+        .limit(1)
+        .then(firstOrThrowWith(() => new NotFoundError('Profile not found')));
+
+      await db
+        .update(Sessions)
+        .set({ activeProfileId: profile.id })
+        .where(eq(Sessions.id, ctx.session.id))
+        .returning()
+        .then(firstOrThrow);
+
+      return profile;
+    },
+  }),
+);


### PR DESCRIPTION
## 무엇을 변경했는지

- 로그인한 계정이 소유한 활성 프로필을 선택하는 `selectProfile` mutation을 추가했습니다.
- 선택한 프로필 ID를 현재 세션의 `activeProfileId`에 저장하도록 했습니다.
- GraphQL `fieldWithInput` 입력 타입명이 `MutationCreateProfileInput` 대신 `CreateProfileInput`처럼 필드명 기반으로 생성되도록 설정했습니다.

## 왜 변경했는지

- 계정에 여러 프로필이 있을 때 클라이언트가 현재 사용할 활성 프로필을 명시적으로 전환할 수 있어야 합니다.
- GraphQL input 타입명을 mutation prefix 없이 정리해 스키마를 더 읽기 쉽게 유지합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- 없음

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->