### PR TITLE
iOS 앱을 시뮬레이터에서도 바로 실행할 수 있게 한다

### DIFF
--- a/apps/app/ios/scripts/run.mjs
+++ b/apps/app/ios/scripts/run.mjs
@@ -69,7 +69,6 @@ const readPhysicalDevices = () => {
     const data = JSON.parse(readFileSync(jsonPath, 'utf8'));
     return data.result.devices
       .filter((device) => device.hardwareProperties?.platform === 'iOS')
-      .filter((device) => device.hardwareProperties?.reality === 'physical')
       .filter((device) => ['iPhone', 'iPad'].includes(device.hardwareProperties?.deviceType))
       .map((device) => ({
         type: 'device',
@@ -135,6 +134,8 @@ const ensureSimulatorBooted = (simulator) => {
     run('xcrun', ['simctl', 'boot', simulator.id]);
     run('xcrun', ['simctl', 'bootstatus', simulator.id, '-b']);
   }
+
+  run('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', simulator.id]);
 };
 
 const attachSimulatorDebugger = (simulator, pid) => {

--- a/apps/app/ios/scripts/run.mjs
+++ b/apps/app/ios/scripts/run.mjs
@@ -5,8 +5,8 @@ import { join } from 'node:path';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
 
-const appPath = 'build/DerivedData/Build/Products/Debug-iphoneos/Kosmo.app';
-const executablePath = join(appPath, 'Kosmo');
+const deviceAppPath = 'build/DerivedData/Build/Products/Debug-iphoneos/Kosmo.app';
+const simulatorAppPath = 'build/DerivedData/Build/Products/Debug-iphonesimulator/Kosmo.app';
 const bundleId = 'moe.kos';
 const debug = process.argv.includes('--debug');
 
@@ -15,6 +15,16 @@ const run = (command, args) => {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+};
+
+const readJSONStdout = (command, args) => {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+
+  return JSON.parse(result.stdout);
 };
 
 const runJSON = (command, argsForJSON) => {
@@ -50,7 +60,7 @@ const findProcessID = (value) => {
   return undefined;
 };
 
-const readDevices = () => {
+const readPhysicalDevices = () => {
   const dir = mkdtempSync(join(tmpdir(), 'kosmo-devices-'));
   const jsonPath = join(dir, 'devices.json');
 
@@ -62,6 +72,7 @@ const readDevices = () => {
       .filter((device) => device.hardwareProperties?.reality === 'physical')
       .filter((device) => ['iPhone', 'iPad'].includes(device.hardwareProperties?.deviceType))
       .map((device) => ({
+        type: 'device',
         id: device.identifier,
         name: device.deviceProperties?.name ?? device.identifier,
         model:
@@ -78,30 +89,144 @@ const readDevices = () => {
   }
 };
 
-const devices = await readDevices();
+const readSimulators = () => {
+  const data = readJSONStdout('xcrun', ['simctl', 'list', 'devices', 'available', '--json']);
 
-if (devices.length === 0) {
-  console.error('No physical iOS devices found.');
+  return Object.entries(data.devices ?? {}).flatMap(([runtime, devices]) =>
+    devices
+      .filter((device) => device.isAvailable)
+      .filter((device) => device.deviceTypeIdentifier?.includes('iPhone'))
+      .map((device) => ({
+        type: 'simulator',
+        id: device.udid,
+        name: device.name,
+        model: runtime.replace('com.apple.CoreSimulator.SimRuntime.', '').replaceAll('-', ' '),
+        state: device.state,
+      })),
+  );
+};
+
+const buildApp = (target) => {
+  run('infisical', ['run', '--', 'node', 'scripts/generate-info-plist.mjs']);
+  run('infisical', [
+    'run',
+    '--',
+    'xcodebuild',
+    '-project',
+    'Kosmo.xcodeproj',
+    '-scheme',
+    'Kosmo',
+    '-configuration',
+    'Debug',
+    '-sdk',
+    target.type === 'simulator' ? 'iphonesimulator' : 'iphoneos',
+    '-destination',
+    target.type === 'simulator' ? `platform=iOS Simulator,id=${target.id}` : 'generic/platform=iOS',
+    '-derivedDataPath',
+    'build/DerivedData',
+    'INFOPLIST_FILE=build/Info.plist',
+    '-allowProvisioningUpdates',
+    'build',
+  ]);
+};
+
+const ensureSimulatorBooted = (simulator) => {
+  if (simulator.state !== 'Booted') {
+    run('xcrun', ['simctl', 'boot', simulator.id]);
+    run('xcrun', ['simctl', 'bootstatus', simulator.id, '-b']);
+  }
+};
+
+const attachSimulatorDebugger = (simulator, pid) => {
+  const executablePath = join(simulatorAppPath, 'Kosmo');
+
+  console.log(`Attaching LLDB to ${bundleId} on ${simulator.name} (pid ${pid}).`);
+  run('xcrun', [
+    'lldb',
+    executablePath,
+    '-o',
+    'platform select ios-simulator',
+    '-o',
+    `process attach -p ${pid}`,
+    '-o',
+    'continue',
+  ]);
+};
+
+const launchSimulator = (simulator) => {
+  ensureSimulatorBooted(simulator);
+  run('xcrun', ['simctl', 'install', simulator.id, simulatorAppPath]);
+
+  if (debug) {
+    const result = spawnSync(
+      'xcrun',
+      [
+        'simctl',
+        'launch',
+        '--wait-for-debugger',
+        '--terminate-running-process',
+        simulator.id,
+        bundleId,
+      ],
+      { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] },
+    );
+    if (result.status !== 0) {
+      process.exit(result.status ?? 1);
+    }
+
+    process.stdout.write(result.stdout);
+    const pid = Number(result.stdout.match(/: (\d+)$/m)?.[1]);
+    if (!pid) {
+      console.error('Could not find launched simulator process ID.');
+      process.exit(1);
+    }
+
+    attachSimulatorDebugger(simulator, pid);
+  } else {
+    run('xcrun', [
+      'simctl',
+      'launch',
+      '--terminate-running-process',
+      '--console',
+      simulator.id,
+      bundleId,
+    ]);
+  }
+};
+
+const physicalDevices = await readPhysicalDevices();
+const simulators = readSimulators();
+const targets = [...physicalDevices, ...simulators];
+
+if (targets.length === 0) {
+  console.error('No physical iOS devices or iPhone simulators found.');
   process.exit(1);
 }
 
-console.log('Select an iOS device:');
-devices.forEach((device, index) => {
-  console.log(`${index + 1}. ${device.name} (${device.model}, ${device.state})`);
+console.log('Select an iOS device or simulator:');
+targets.forEach((target, index) => {
+  const label = target.type === 'simulator' ? 'Simulator' : 'Device';
+  console.log(`${index + 1}. ${label}: ${target.name} (${target.model}, ${target.state})`);
 });
 
 const rl = createInterface({ input, output });
 const answer = await rl.question('Device number: ');
 rl.close();
 
-const selected = devices[Number(answer.trim()) - 1];
+const selected = targets[Number(answer.trim()) - 1];
 if (!selected) {
-  console.error('Invalid device selection.');
+  console.error('Invalid iOS target selection.');
   process.exit(1);
 }
 
-run('pnpm', ['run', 'build']);
-run('xcrun', ['devicectl', 'device', 'install', 'app', '--device', selected.id, appPath]);
+buildApp(selected);
+
+if (selected.type === 'simulator') {
+  launchSimulator(selected);
+  process.exit(0);
+}
+
+run('xcrun', ['devicectl', 'device', 'install', 'app', '--device', selected.id, deviceAppPath]);
 
 if (debug) {
   const launchResult = runJSON('xcrun', (jsonPath) => [
@@ -123,6 +248,8 @@ if (debug) {
     console.error('Could not find launched process ID.');
     process.exit(1);
   }
+
+  const executablePath = join(deviceAppPath, 'Kosmo');
 
   console.log(`Attaching LLDB to ${bundleId} on ${selected.name} (pid ${pid}).`);
   run('xcrun', [


### PR DESCRIPTION
## 무엇을 변경했는지

- iOS 실행 스크립트에서 물리 기기와 iPhone 시뮬레이터를 함께 선택할 수 있게 했습니다.
- 선택한 대상이 시뮬레이터이면 `iphonesimulator` SDK와 해당 시뮬레이터 destination으로 빌드합니다.
- 시뮬레이터 대상은 `simctl boot`, `install`, `launch` 경로를 사용하고, 물리 기기는 기존 `devicectl` 경로를 유지합니다.

## 왜 변경했는지

현재 `apps/app/ios/scripts/run.mjs`가 물리 iOS 기기만 대상으로 삼아 로컬 개발 중 iPhone 시뮬레이터에서 앱을 바로 확인할 수 없었습니다. 개발자가 물리 기기 없이도 동일한 `pnpm --dir apps/app/ios run` 흐름으로 iOS 앱을 실행할 수 있게 합니다.

## 어떻게 확인할 수 있는지

- `node --check scripts/run.mjs`
- `printf "17\n" | node scripts/run.mjs`
  - iPhone 15 Pro 시뮬레이터 선택
  - `xcodebuild ... -sdk iphonesimulator ...` 빌드 성공 확인
  - `simctl launch` 결과 `moe.kos: 12415` 확인
- 추가 확인: `xcrun simctl install ... && xcrun simctl launch ... moe.kos` 결과 `moe.kos: 12418` 확인

참고: `lsp_diagnostics`는 로컬에 `typescript-language-server`가 설치되어 있지 않아 실행할 수 없었습니다.

## 아직 어떤 문제가 남았는지

없음

Linear: PROD-75

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
