### PR TITLE
pre-commit 훅이 pnpm으로 lint-staged를 실행하게 한다

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bunx lint-staged
+pnpm lint-staged


### PR DESCRIPTION
## 무엇을 변경했는지

- `.husky/pre-commit`에서 `bunx lint-staged` 대신 `pnpm lint-staged`를 실행하게 변경했습니다.

## 왜 변경했는지

- 이 워크스페이스는 `pnpm`을 표준 패키지 매니저로 사용하므로 pre-commit 훅도 동일한 실행 경로를 사용하게 맞췄습니다.

## 어떻게 확인할 수 있는지

- `pnpm lint-staged`

## 아직 어떤 문제가 남았는지

- 없음

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
