### PR TITLE
pnpm 버전 전환 fetch를 우회한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
 .turbo
+.pnpm-store/
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,6 @@ apps/helm/templates/**/*.yaml
 apps/web/build/
 apps/web/.svelte-kit
 apps/web/.mearie
+.pnpm-store/
 pnpm-lock.yaml
 schema.graphql

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,6 +65,7 @@ const config = ts.config(
       '**/node_modules/**',
       '**/dist/**',
       '**/.mearie/**',
+      '**/.pnpm-store/**',
       '**/.svelte-kit/**',
       '**/build/**',
     ],

--- a/memory/script.md
+++ b/memory/script.md
@@ -2,6 +2,8 @@
 
 ## pnpm workspace scripts
 
+- `pnpm-workspace.yaml`은 package manager mismatch 처리를 `ignore`로 둬 pnpm이 sandbox 내부에서 `packageManager`에 명시된 pnpm 자체를 자동 fetch하지 않게 한다.
+- sandbox 실패나 fallback 실행으로 workspace 안에 `.pnpm-store/`가 생길 수 있으므로 git, Prettier, ESLint ignore 대상으로 둔다.
 - `pnpm --recursive --parallel --if-present <script>`는 루트 패키지의 `<script>`를 재귀 실행하지 않고, workspace 패키지들의 해당 script를 실행한다.
 - 루트 `dev` 스크립트가 `infisical run -- pnpm --recursive --parallel --if-present dev`처럼 workspace script 실행을 감싸는 구조여도, 이것만으로 루트 `dev`가 자기 자신을 무한 재귀 호출한다고 판단하면 안 된다.
 - 관련 리뷰를 작성하거나 수정할 때는 실제 재현 로그 없이 재귀 실행을 단정하지 않는다.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/*
 
 enableGlobalVirtualStore: true
+pmOnFail: ignore
 minimumReleaseAge: 4320
 allowBuilds:
   '@fission-ai/openspec': true


### PR DESCRIPTION
## 무엇을 변경했는지

- `pnpm-workspace.yaml`에 `pmOnFail: ignore`를 추가해 package manager mismatch 처리에서 pnpm 버전 자동 다운로드를 시도하지 않게 했습니다.
- fallback store가 workspace 안에 생겨도 추적/검사되지 않도록 `.pnpm-store/`를 git, Prettier, ESLint ignore에 추가했습니다.
- 관련 pnpm 실행 전제를 `memory/script.md`에 기록했습니다.

## 왜 변경했는지

Codex sandbox 안에서 pnpm이 `packageManager`의 pnpm 버전을 자동으로 가져오려 하면 네트워크/쓰기 제한 때문에 `fetch failed`가 발생하고, 실패 과정에서 `.pnpm-store/`가 workspace에 생길 수 있습니다. 이미 있는 workspace pnpm 설정에 mismatch 처리 정책을 추가해 버전 전환 fetch를 우회하고, 부산물이 생겨도 도구가 스캔하지 않게 방어선을 추가했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --version`
- `pnpm config get pm-on-fail --location project`
- `git check-ignore -v .pnpm-store .pnpm-store/v11/index.db`
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- 없음