### PR TITLE
ProfileFollow 조회 권한을 일관되게 적용한다

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "@pothos/plugin-with-input": "^4.1.4",
     "dataloader": "^2.2.3",
     "drizzle-orm": "1.0.0-beta.22",
+    "fast-json-stable-stringify": "^2.1.0",
     "graphql": "^16.13.2",
     "graphql-yoga": "^5.21.0",
     "hono": "^4.12.14",

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -1,10 +1,35 @@
 import { AccountProfiles, Accounts, db, first, Profiles, Sessions } from '@kosmo/core/db';
 import { AccountState, ProfileState, SessionState } from '@kosmo/core/enums';
+import DataLoader from 'dataloader';
 import { and, eq } from 'drizzle-orm';
+import stringify from 'fast-json-stable-stringify';
+import * as R from 'remeda';
 import type { Context as HonoContext } from 'hono';
+
+type LoaderParams<Key, Result, SortKey, Nullability extends boolean, Many extends boolean> = {
+  name: string;
+  nullable?: Nullability;
+  many?: Many;
+  key: (
+    value: Nullability extends true ? Result | null : Result,
+  ) => Nullability extends true ? SortKey | null : SortKey;
+  load: (keys: Key[]) => Promise<Result[]>;
+};
 
 type DefaultContext = {
   ip?: string;
+  loader: <
+    Key = string,
+    Result = unknown,
+    SortKey = Key,
+    Nullability extends boolean = false,
+    Many extends boolean = false,
+    MaybeResult = Nullability extends true ? Result | null : Result,
+    FinalResult = Many extends true ? MaybeResult[] : MaybeResult,
+  >(
+    params: LoaderParams<Key, Result, SortKey, Nullability, Many>,
+  ) => DataLoader<Key, FinalResult, string>;
+  $loaders: Map<string, DataLoader<unknown, unknown>>;
 };
 
 export type SessionContext = {
@@ -30,7 +55,44 @@ export type Env = {
 };
 
 export const deriveContext = async (c: ServerContext): Promise<Context> => {
-  const ctx: Context = {};
+  const ctx: Context = {
+    loader: ({ name, nullable, many, load, key }) => {
+      const cached = ctx.$loaders.get(name);
+      if (cached) {
+        return cached as never;
+      }
+
+      const loader = new DataLoader(
+        async (keys) => {
+          const rows = await load(keys as never);
+          const values = R.groupBy(rows, (row) => stringify(key(row as never)));
+
+          return keys.map((key) => {
+            const value = values[stringify(key)];
+            if (value?.length) {
+              return many ? value : value[0];
+            }
+
+            if (nullable) {
+              return null;
+            }
+
+            if (many) {
+              return [];
+            }
+
+            return new Error(`DataLoader(${name}): Missing key`);
+          });
+        },
+        { cache: false },
+      );
+
+      ctx.$loaders.set(name, loader);
+
+      return loader as never;
+    },
+    $loaders: new Map(),
+  };
 
   const accessToken = c.req.header('Authorization')?.match(/^Bearer (.+)$/)?.[1];
   if (accessToken) {

--- a/apps/api/src/graphql/resolvers/profile/access/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/access/follow.ts
@@ -1,18 +1,27 @@
-import { ProfileFollows, Profiles } from '@kosmo/core/db';
+import { ProfileFollows } from '@kosmo/core/db';
 import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
 import { and, eq, or } from 'drizzle-orm';
-import { alias } from 'drizzle-orm/pg-core';
-import type { SQL } from 'drizzle-orm';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 import type { UserContext } from '@/context';
 
-export const ProfileFollowFollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
-export const ProfileFollowFolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
+type ProfileFollowAccessProfile = {
+  followPolicy: AnyPgColumn;
+  state: AnyPgColumn;
+};
 
-export const profileFollowAccessWhere = (ctx: UserContext, where: (SQL | undefined)[] = []) => {
+export const profileFollowAccessWhere = ({
+  ctx,
+  followerProfile,
+  followeeProfile,
+}: {
+  ctx: UserContext;
+  followerProfile: ProfileFollowAccessProfile;
+  followeeProfile: ProfileFollowAccessProfile;
+}) => {
   const publicAcceptedWhere = and(
     eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-    eq(ProfileFollowFollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
-    eq(ProfileFollowFolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+    eq(followerProfile.followPolicy, ProfileFollowPolicy.OPEN),
+    eq(followeeProfile.followPolicy, ProfileFollowPolicy.OPEN),
   )!;
   const visibleWhere = ctx.session?.profileId
     ? or(
@@ -23,9 +32,8 @@ export const profileFollowAccessWhere = (ctx: UserContext, where: (SQL | undefin
     : publicAcceptedWhere;
 
   return and(
-    ...where,
-    eq(ProfileFollowFollowerProfiles.state, ProfileState.ACTIVE),
-    eq(ProfileFollowFolloweeProfiles.state, ProfileState.ACTIVE),
+    eq(followerProfile.state, ProfileState.ACTIVE),
+    eq(followeeProfile.state, ProfileState.ACTIVE),
     visibleWhere,
   )!;
 };

--- a/apps/api/src/graphql/resolvers/profile/access/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/access/follow.ts
@@ -1,0 +1,31 @@
+import { ProfileFollows, Profiles } from '@kosmo/core/db';
+import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
+import { and, eq, or } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { UserContext } from '@/context';
+
+export const ProfileFollowFollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
+export const ProfileFollowFolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
+
+export const profileFollowAccessWhere = (ctx: UserContext, where: (SQL | undefined)[] = []) => {
+  const publicAcceptedWhere = and(
+    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+    eq(ProfileFollowFollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+    eq(ProfileFollowFolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+  )!;
+  const visibleWhere = ctx.session?.profileId
+    ? or(
+        eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+        eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
+        publicAcceptedWhere,
+      )
+    : publicAcceptedWhere;
+
+  return and(
+    ...where,
+    eq(ProfileFollowFollowerProfiles.state, ProfileState.ACTIVE),
+    eq(ProfileFollowFolloweeProfiles.state, ProfileState.ACTIVE),
+    visibleWhere,
+  )!;
+};

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,8 +1,8 @@
 import { resolveOffsetConnection } from '@pothos/plugin-relay';
 import { builder } from '@/graphql/builder';
 import {
-  readableAcceptedProfileFollowCountLoader,
-  readableAcceptedProfileFollowPageLoader,
+  acceptedProfileFollowCountLoader,
+  acceptedProfileFollowPageLoader,
   viewerFollowLoader,
 } from '../loader/follow';
 import { Profile, ProfileFollow } from '../ref';
@@ -29,14 +29,14 @@ builder.objectFields(Profile, (t) => ({
           args,
           totalCount:
             (
-              await readableAcceptedProfileFollowCountLoader(ctx).load({
+              await acceptedProfileFollowCountLoader(ctx).load({
                 direction: 'followers',
                 profileId: profile.id,
               })
             )?.value ?? 0,
         },
         ({ limit, offset }) =>
-          readableAcceptedProfileFollowPageLoader(ctx).load({
+          acceptedProfileFollowPageLoader(ctx).load({
             direction: 'followers',
             profileId: profile.id,
             limit,
@@ -53,14 +53,14 @@ builder.objectFields(Profile, (t) => ({
           args,
           totalCount:
             (
-              await readableAcceptedProfileFollowCountLoader(ctx).load({
+              await acceptedProfileFollowCountLoader(ctx).load({
                 direction: 'following',
                 profileId: profile.id,
               })
             )?.value ?? 0,
         },
         ({ limit, offset }) =>
-          readableAcceptedProfileFollowPageLoader(ctx).load({
+          acceptedProfileFollowPageLoader(ctx).load({
             direction: 'following',
             profileId: profile.id,
             limit,
@@ -71,7 +71,7 @@ builder.objectFields(Profile, (t) => ({
   }),
   followersCount: t.int({
     resolve: (profile, _, ctx) =>
-      readableAcceptedProfileFollowCountLoader(ctx)
+      acceptedProfileFollowCountLoader(ctx)
         .load({
           direction: 'followers',
           profileId: profile.id,
@@ -80,7 +80,7 @@ builder.objectFields(Profile, (t) => ({
   }),
   followingCount: t.int({
     resolve: (profile, _, ctx) =>
-      readableAcceptedProfileFollowCountLoader(ctx)
+      acceptedProfileFollowCountLoader(ctx)
         .load({
           direction: 'following',
           profileId: profile.id,

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,13 +1,10 @@
-import { db, ProfileFollows } from '@kosmo/core/db';
+import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
 import { ProfileFollowState } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
-import { asc, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
+import { and, asc, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { builder } from '@/graphql/builder';
-import {
-  profileFollowAccessWhere,
-  ProfileFollowFolloweeProfiles,
-  ProfileFollowFollowerProfiles,
-} from '../access/follow';
+import { profileFollowAccessWhere } from '../access/follow';
 import {
   acceptedProfileFollowersCountLoader,
   acceptedProfileFollowingCountLoader,
@@ -16,6 +13,9 @@ import {
 import { Profile, ProfileFollow } from '../ref';
 
 type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
+
+const FollowerProfiles = alias(Profiles, 'profile_follow_connection_follower_profile');
+const FolloweeProfiles = alias(Profiles, 'profile_follow_connection_followee_profile');
 
 builder.objectFields(ProfileFollow, (t) => ({
   follower: t.field({
@@ -43,21 +43,20 @@ builder.objectFields(Profile, (t) => ({
           return await db
             .select(getColumns(ProfileFollows))
             .from(ProfileFollows)
-            .innerJoin(
-              ProfileFollowFollowerProfiles,
-              eq(ProfileFollowFollowerProfiles.id, ProfileFollows.followerProfileId),
-            )
-            .innerJoin(
-              ProfileFollowFolloweeProfiles,
-              eq(ProfileFollowFolloweeProfiles.id, ProfileFollows.followeeProfileId),
-            )
+            .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+            .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
             .where(
-              profileFollowAccessWhere(ctx, [
+              and(
                 eq(ProfileFollows.followeeProfileId, profile.id),
                 eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
                 before ? gt(ProfileFollows.id, before) : undefined,
                 after ? lt(ProfileFollows.id, after) : undefined,
-              ]),
+                profileFollowAccessWhere({
+                  ctx,
+                  followerProfile: FollowerProfiles,
+                  followeeProfile: FolloweeProfiles,
+                }),
+              ),
             )
             .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
             .limit(limit);
@@ -77,21 +76,20 @@ builder.objectFields(Profile, (t) => ({
           return await db
             .select(getColumns(ProfileFollows))
             .from(ProfileFollows)
-            .innerJoin(
-              ProfileFollowFollowerProfiles,
-              eq(ProfileFollowFollowerProfiles.id, ProfileFollows.followerProfileId),
-            )
-            .innerJoin(
-              ProfileFollowFolloweeProfiles,
-              eq(ProfileFollowFolloweeProfiles.id, ProfileFollows.followeeProfileId),
-            )
+            .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+            .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
             .where(
-              profileFollowAccessWhere(ctx, [
+              and(
                 eq(ProfileFollows.followerProfileId, profile.id),
                 eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
                 before ? gt(ProfileFollows.id, before) : undefined,
                 after ? lt(ProfileFollows.id, after) : undefined,
-              ]),
+                profileFollowAccessWhere({
+                  ctx,
+                  followerProfile: FollowerProfiles,
+                  followeeProfile: FolloweeProfiles,
+                }),
+              ),
             )
             .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
             .limit(limit);

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,15 +1,11 @@
-import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { ProfileFollowState } from '@kosmo/core/enums';
+import { db, first, ProfileFollows, Profiles } from '@kosmo/core/db';
+import { ProfileFollowState, ProfileState } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
-import { and, asc, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
+import { and, asc, count, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { builder } from '@/graphql/builder';
 import { profileFollowAccessWhere } from '../access/follow';
-import {
-  acceptedProfileFollowersCountLoader,
-  acceptedProfileFollowingCountLoader,
-  viewerFollowLoader,
-} from '../loader/follow';
+import { viewerFollowLoader } from '../loader/follow';
 import { Profile, ProfileFollow } from '../ref';
 
 type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
@@ -98,16 +94,40 @@ builder.objectFields(Profile, (t) => ({
     },
   }),
   followersCount: t.int({
-    resolve: (profile, _, ctx) =>
-      acceptedProfileFollowersCountLoader(ctx)
-        .load(profile.id)
-        .then((row) => row?.value ?? 0),
+    resolve: async (profile) => {
+      const row = await db
+        .select({ value: count() })
+        .from(ProfileFollows)
+        .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+        .where(
+          and(
+            eq(ProfileFollows.followeeProfileId, profile.id),
+            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+            eq(FollowerProfiles.state, ProfileState.ACTIVE),
+          ),
+        )
+        .then(first);
+
+      return row?.value ?? 0;
+    },
   }),
   followingCount: t.int({
-    resolve: (profile, _, ctx) =>
-      acceptedProfileFollowingCountLoader(ctx)
-        .load(profile.id)
-        .then((row) => row?.value ?? 0),
+    resolve: async (profile) => {
+      const row = await db
+        .select({ value: count() })
+        .from(ProfileFollows)
+        .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+        .where(
+          and(
+            eq(ProfileFollows.followerProfileId, profile.id),
+            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+            eq(FolloweeProfiles.state, ProfileState.ACTIVE),
+          ),
+        )
+        .then(first);
+
+      return row?.value ?? 0;
+    },
   }),
   viewerFollow: t.field({
     type: ProfileFollow,

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,9 +1,13 @@
-import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
+import { db, ProfileFollows } from '@kosmo/core/db';
+import { ProfileFollowState } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
-import { and, asc, desc, eq, getColumns, gt, lt, or } from 'drizzle-orm';
-import { alias } from 'drizzle-orm/pg-core';
+import { asc, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
+import {
+  profileFollowAccessWhere,
+  ProfileFollowFolloweeProfiles,
+  ProfileFollowFollowerProfiles,
+} from '../access/follow';
 import {
   acceptedProfileFollowersCountLoader,
   acceptedProfileFollowingCountLoader,
@@ -12,9 +16,6 @@ import {
 import { Profile, ProfileFollow } from '../ref';
 
 type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
-
-const FollowerProfiles = alias(Profiles, 'profile_follow_connection_follower_profile');
-const FolloweeProfiles = alias(Profiles, 'profile_follow_connection_followee_profile');
 
 builder.objectFields(ProfileFollow, (t) => ({
   follower: t.field({
@@ -39,34 +40,24 @@ builder.objectFields(Profile, (t) => ({
           toCursor: (profileFollow) => profileFollow.id,
         },
         async ({ before, after, limit, inverted }) => {
-          const publicAcceptedWhere = and(
-            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-            eq(FollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
-            eq(FolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
-          )!;
-          const visibleWhere = ctx.session?.profileId
-            ? or(
-                eq(ProfileFollows.followerProfileId, ctx.session.profileId),
-                eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
-                publicAcceptedWhere,
-              )
-            : publicAcceptedWhere;
-
           return await db
             .select(getColumns(ProfileFollows))
             .from(ProfileFollows)
-            .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
-            .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+            .innerJoin(
+              ProfileFollowFollowerProfiles,
+              eq(ProfileFollowFollowerProfiles.id, ProfileFollows.followerProfileId),
+            )
+            .innerJoin(
+              ProfileFollowFolloweeProfiles,
+              eq(ProfileFollowFolloweeProfiles.id, ProfileFollows.followeeProfileId),
+            )
             .where(
-              and(
+              profileFollowAccessWhere(ctx, [
                 eq(ProfileFollows.followeeProfileId, profile.id),
                 eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
                 before ? gt(ProfileFollows.id, before) : undefined,
                 after ? lt(ProfileFollows.id, after) : undefined,
-                eq(FollowerProfiles.state, ProfileState.ACTIVE),
-                eq(FolloweeProfiles.state, ProfileState.ACTIVE),
-                visibleWhere,
-              ),
+              ]),
             )
             .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
             .limit(limit);
@@ -83,34 +74,24 @@ builder.objectFields(Profile, (t) => ({
           toCursor: (profileFollow) => profileFollow.id,
         },
         async ({ before, after, limit, inverted }) => {
-          const publicAcceptedWhere = and(
-            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-            eq(FollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
-            eq(FolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
-          )!;
-          const visibleWhere = ctx.session?.profileId
-            ? or(
-                eq(ProfileFollows.followerProfileId, ctx.session.profileId),
-                eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
-                publicAcceptedWhere,
-              )
-            : publicAcceptedWhere;
-
           return await db
             .select(getColumns(ProfileFollows))
             .from(ProfileFollows)
-            .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
-            .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+            .innerJoin(
+              ProfileFollowFollowerProfiles,
+              eq(ProfileFollowFollowerProfiles.id, ProfileFollows.followerProfileId),
+            )
+            .innerJoin(
+              ProfileFollowFolloweeProfiles,
+              eq(ProfileFollowFolloweeProfiles.id, ProfileFollows.followeeProfileId),
+            )
             .where(
-              and(
+              profileFollowAccessWhere(ctx, [
                 eq(ProfileFollows.followerProfileId, profile.id),
                 eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
                 before ? gt(ProfileFollows.id, before) : undefined,
                 after ? lt(ProfileFollows.id, after) : undefined,
-                eq(FollowerProfiles.state, ProfileState.ACTIVE),
-                eq(FolloweeProfiles.state, ProfileState.ACTIVE),
-                visibleWhere,
-              ),
+              ]),
             )
             .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
             .limit(limit);

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -95,6 +95,7 @@ builder.objectFields(Profile, (t) => ({
   }),
   followersCount: t.int({
     resolve: async (profile) => {
+      // TODO: follower 수를 Profile DB 컬럼으로 옮기면 이 count 쿼리를 제거한다.
       const row = await db
         .select({ value: count() })
         .from(ProfileFollows)
@@ -113,6 +114,7 @@ builder.objectFields(Profile, (t) => ({
   }),
   followingCount: t.int({
     resolve: async (profile) => {
+      // TODO: following 수를 Profile DB 컬럼으로 옮기면 이 count 쿼리를 제거한다.
       const row = await db
         .select({ value: count() })
         .from(ProfileFollows)

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,14 +1,20 @@
+import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
+import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
+import { and, asc, desc, eq, getColumns, gt, lt, or } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { builder } from '@/graphql/builder';
 import {
   acceptedProfileFollowersCountLoader,
   acceptedProfileFollowingCountLoader,
-  selectAcceptedProfileFollowers,
-  selectAcceptedProfileFollowing,
   viewerFollowLoader,
 } from '../loader/follow';
 import { Profile, ProfileFollow } from '../ref';
-import type { ProfileFollowRow } from '../loader/follow';
+
+type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
+
+const FollowerProfiles = alias(Profiles, 'profile_follow_connection_follower_profile');
+const FolloweeProfiles = alias(Profiles, 'profile_follow_connection_followee_profile');
 
 builder.objectFields(ProfileFollow, (t) => ({
   follower: t.field({
@@ -32,13 +38,39 @@ builder.objectFields(Profile, (t) => ({
           args,
           toCursor: (profileFollow) => profileFollow.id,
         },
-        async ({ before, after, limit, inverted }) =>
-          await selectAcceptedProfileFollowers(ctx, profile.id, {
-            before,
-            after,
-            limit,
-            inverted,
-          }),
+        async ({ before, after, limit, inverted }) => {
+          const publicAcceptedWhere = and(
+            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+            eq(FollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+            eq(FolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+          )!;
+          const visibleWhere = ctx.session?.profileId
+            ? or(
+                eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+                eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
+                publicAcceptedWhere,
+              )
+            : publicAcceptedWhere;
+
+          return await db
+            .select(getColumns(ProfileFollows))
+            .from(ProfileFollows)
+            .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+            .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+            .where(
+              and(
+                eq(ProfileFollows.followeeProfileId, profile.id),
+                eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+                before ? gt(ProfileFollows.id, before) : undefined,
+                after ? lt(ProfileFollows.id, after) : undefined,
+                eq(FollowerProfiles.state, ProfileState.ACTIVE),
+                eq(FolloweeProfiles.state, ProfileState.ACTIVE),
+                visibleWhere,
+              ),
+            )
+            .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
+            .limit(limit);
+        },
       );
     },
   }),
@@ -50,13 +82,39 @@ builder.objectFields(Profile, (t) => ({
           args,
           toCursor: (profileFollow) => profileFollow.id,
         },
-        async ({ before, after, limit, inverted }) =>
-          await selectAcceptedProfileFollowing(ctx, profile.id, {
-            before,
-            after,
-            limit,
-            inverted,
-          }),
+        async ({ before, after, limit, inverted }) => {
+          const publicAcceptedWhere = and(
+            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+            eq(FollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+            eq(FolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+          )!;
+          const visibleWhere = ctx.session?.profileId
+            ? or(
+                eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+                eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
+                publicAcceptedWhere,
+              )
+            : publicAcceptedWhere;
+
+          return await db
+            .select(getColumns(ProfileFollows))
+            .from(ProfileFollows)
+            .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+            .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+            .where(
+              and(
+                eq(ProfileFollows.followerProfileId, profile.id),
+                eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+                before ? gt(ProfileFollows.id, before) : undefined,
+                after ? lt(ProfileFollows.id, after) : undefined,
+                eq(FollowerProfiles.state, ProfileState.ACTIVE),
+                eq(FolloweeProfiles.state, ProfileState.ACTIVE),
+                visibleWhere,
+              ),
+            )
+            .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
+            .limit(limit);
+        },
       );
     },
   }),

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,4 +1,4 @@
-import { resolveOffsetConnection } from '@pothos/plugin-relay';
+import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { builder } from '@/graphql/builder';
 import {
   acceptedProfileFollowersCountLoader,
@@ -8,6 +8,7 @@ import {
   viewerFollowLoader,
 } from '../loader/follow';
 import { Profile, ProfileFollow } from '../ref';
+import type { ProfileFollowRow } from '../loader/follow';
 
 builder.objectFields(ProfileFollow, (t) => ({
   follower: t.field({
@@ -26,15 +27,17 @@ builder.objectFields(Profile, (t) => ({
   followers: t.connection({
     type: ProfileFollow,
     resolve: async (profile, args, ctx) => {
-      return resolveOffsetConnection(
+      return resolveCursorConnection<Promise<ProfileFollowRow[]>>(
         {
           args,
-          totalCount: (await acceptedProfileFollowersCountLoader(ctx).load(profile.id))?.value ?? 0,
+          toCursor: (profileFollow) => profileFollow.id,
         },
-        ({ limit, offset }) =>
-          selectAcceptedProfileFollowers(ctx, profile.id, {
+        async ({ before, after, limit, inverted }) =>
+          await selectAcceptedProfileFollowers(ctx, profile.id, {
+            before,
+            after,
             limit,
-            offset,
+            inverted,
           }),
       );
     },
@@ -42,15 +45,17 @@ builder.objectFields(Profile, (t) => ({
   following: t.connection({
     type: ProfileFollow,
     resolve: async (profile, args, ctx) => {
-      return resolveOffsetConnection(
+      return resolveCursorConnection<Promise<ProfileFollowRow[]>>(
         {
           args,
-          totalCount: (await acceptedProfileFollowingCountLoader(ctx).load(profile.id))?.value ?? 0,
+          toCursor: (profileFollow) => profileFollow.id,
         },
-        ({ limit, offset }) =>
-          selectAcceptedProfileFollowing(ctx, profile.id, {
+        async ({ before, after, limit, inverted }) =>
+          await selectAcceptedProfileFollowing(ctx, profile.id, {
+            before,
+            after,
             limit,
-            offset,
+            inverted,
           }),
       );
     },

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,21 +1,11 @@
-import { db, first, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { ProfileFollowState, ProfileState } from '@kosmo/core/enums';
 import { resolveOffsetConnection } from '@pothos/plugin-relay';
-import { and, count, desc, eq, getColumns } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
+import {
+  readableAcceptedProfileFollowCountLoader,
+  readableAcceptedProfileFollowPageLoader,
+  viewerFollowLoader,
+} from '../loader/follow';
 import { Profile, ProfileFollow } from '../ref';
-import type { SQL } from 'drizzle-orm';
-
-const countFollows = async (where: SQL, joinOn: SQL) => {
-  const row = await db
-    .select({ value: count() })
-    .from(ProfileFollows)
-    .innerJoin(Profiles, joinOn)
-    .where(where)
-    .then(first);
-
-  return row?.value ?? 0;
-};
 
 builder.objectFields(ProfileFollow, (t) => ({
   follower: t.field({
@@ -33,95 +23,73 @@ builder.objectFields(ProfileFollow, (t) => ({
 builder.objectFields(Profile, (t) => ({
   followers: t.connection({
     type: ProfileFollow,
-    resolve: async (profile, args) => {
-      const joinOn = eq(Profiles.id, ProfileFollows.followerProfileId);
-      const where = and(
-        eq(ProfileFollows.followeeProfileId, profile.id),
-        eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-        eq(Profiles.state, ProfileState.ACTIVE),
-      )!;
-
+    resolve: async (profile, args, ctx) => {
       return resolveOffsetConnection(
-        { args, totalCount: await countFollows(where, joinOn) },
+        {
+          args,
+          totalCount:
+            (
+              await readableAcceptedProfileFollowCountLoader(ctx).load({
+                direction: 'followers',
+                profileId: profile.id,
+              })
+            )?.value ?? 0,
+        },
         ({ limit, offset }) =>
-          db
-            .select(getColumns(ProfileFollows))
-            .from(ProfileFollows)
-            .innerJoin(Profiles, joinOn)
-            .where(where)
-            .orderBy(desc(ProfileFollows.id))
-            .limit(limit)
-            .offset(offset),
+          readableAcceptedProfileFollowPageLoader(ctx).load({
+            direction: 'followers',
+            profileId: profile.id,
+            limit,
+            offset,
+          }),
       );
     },
   }),
   following: t.connection({
     type: ProfileFollow,
-    resolve: async (profile, args) => {
-      const joinOn = eq(Profiles.id, ProfileFollows.followeeProfileId);
-      const where = and(
-        eq(ProfileFollows.followerProfileId, profile.id),
-        eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-        eq(Profiles.state, ProfileState.ACTIVE),
-      )!;
-
+    resolve: async (profile, args, ctx) => {
       return resolveOffsetConnection(
-        { args, totalCount: await countFollows(where, joinOn) },
+        {
+          args,
+          totalCount:
+            (
+              await readableAcceptedProfileFollowCountLoader(ctx).load({
+                direction: 'following',
+                profileId: profile.id,
+              })
+            )?.value ?? 0,
+        },
         ({ limit, offset }) =>
-          db
-            .select(getColumns(ProfileFollows))
-            .from(ProfileFollows)
-            .innerJoin(Profiles, joinOn)
-            .where(where)
-            .orderBy(desc(ProfileFollows.id))
-            .limit(limit)
-            .offset(offset),
+          readableAcceptedProfileFollowPageLoader(ctx).load({
+            direction: 'following',
+            profileId: profile.id,
+            limit,
+            offset,
+          }),
       );
     },
   }),
   followersCount: t.int({
-    resolve: (profile) =>
-      countFollows(
-        and(
-          eq(ProfileFollows.followeeProfileId, profile.id),
-          eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-          eq(Profiles.state, ProfileState.ACTIVE),
-        )!,
-        eq(Profiles.id, ProfileFollows.followerProfileId),
-      ),
+    resolve: (profile, _, ctx) =>
+      readableAcceptedProfileFollowCountLoader(ctx)
+        .load({
+          direction: 'followers',
+          profileId: profile.id,
+        })
+        .then((row) => row?.value ?? 0),
   }),
   followingCount: t.int({
-    resolve: (profile) =>
-      countFollows(
-        and(
-          eq(ProfileFollows.followerProfileId, profile.id),
-          eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-          eq(Profiles.state, ProfileState.ACTIVE),
-        )!,
-        eq(Profiles.id, ProfileFollows.followeeProfileId),
-      ),
+    resolve: (profile, _, ctx) =>
+      readableAcceptedProfileFollowCountLoader(ctx)
+        .load({
+          direction: 'following',
+          profileId: profile.id,
+        })
+        .then((row) => row?.value ?? 0),
   }),
   viewerFollow: t.field({
     type: ProfileFollow,
     nullable: true,
-    resolve: async (profile, _, ctx) => {
-      if (!ctx.session?.profileId) {
-        return null;
-      }
-
-      const follow = await db
-        .select({ id: ProfileFollows.id })
-        .from(ProfileFollows)
-        .where(
-          and(
-            eq(ProfileFollows.followerProfileId, ctx.session.profileId),
-            eq(ProfileFollows.followeeProfileId, profile.id),
-          ),
-        )
-        .limit(1)
-        .then(first);
-
-      return follow?.id ?? null;
-    },
+    resolve: (profile, _, ctx) => viewerFollowLoader(ctx).load(profile.id),
   }),
 }));

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,8 +1,10 @@
 import { resolveOffsetConnection } from '@pothos/plugin-relay';
 import { builder } from '@/graphql/builder';
 import {
-  acceptedProfileFollowCountLoader,
-  acceptedProfileFollowPageLoader,
+  acceptedProfileFollowersCountLoader,
+  acceptedProfileFollowingCountLoader,
+  selectAcceptedProfileFollowers,
+  selectAcceptedProfileFollowing,
   viewerFollowLoader,
 } from '../loader/follow';
 import { Profile, ProfileFollow } from '../ref';
@@ -27,18 +29,10 @@ builder.objectFields(Profile, (t) => ({
       return resolveOffsetConnection(
         {
           args,
-          totalCount:
-            (
-              await acceptedProfileFollowCountLoader(ctx).load({
-                direction: 'followers',
-                profileId: profile.id,
-              })
-            )?.value ?? 0,
+          totalCount: (await acceptedProfileFollowersCountLoader(ctx).load(profile.id))?.value ?? 0,
         },
         ({ limit, offset }) =>
-          acceptedProfileFollowPageLoader(ctx).load({
-            direction: 'followers',
-            profileId: profile.id,
+          selectAcceptedProfileFollowers(ctx, profile.id, {
             limit,
             offset,
           }),
@@ -51,18 +45,10 @@ builder.objectFields(Profile, (t) => ({
       return resolveOffsetConnection(
         {
           args,
-          totalCount:
-            (
-              await acceptedProfileFollowCountLoader(ctx).load({
-                direction: 'following',
-                profileId: profile.id,
-              })
-            )?.value ?? 0,
+          totalCount: (await acceptedProfileFollowingCountLoader(ctx).load(profile.id))?.value ?? 0,
         },
         ({ limit, offset }) =>
-          acceptedProfileFollowPageLoader(ctx).load({
-            direction: 'following',
-            profileId: profile.id,
+          selectAcceptedProfileFollowing(ctx, profile.id, {
             limit,
             offset,
           }),
@@ -71,20 +57,14 @@ builder.objectFields(Profile, (t) => ({
   }),
   followersCount: t.int({
     resolve: (profile, _, ctx) =>
-      acceptedProfileFollowCountLoader(ctx)
-        .load({
-          direction: 'followers',
-          profileId: profile.id,
-        })
+      acceptedProfileFollowersCountLoader(ctx)
+        .load(profile.id)
         .then((row) => row?.value ?? 0),
   }),
   followingCount: t.int({
     resolve: (profile, _, ctx) =>
-      acceptedProfileFollowCountLoader(ctx)
-        .load({
-          direction: 'following',
-          profileId: profile.id,
-        })
+      acceptedProfileFollowingCountLoader(ctx)
+        .load(profile.id)
         .then((row) => row?.value ?? 0),
   }),
   viewerFollow: t.field({

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -1,0 +1,238 @@
+import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
+import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
+import { and, count, eq, getColumns, gt, inArray, lte, or, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { UserContext } from '@/context';
+
+export type ProfileFollowConnectionDirection = 'followers' | 'following';
+
+type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
+
+type ProfileFollowCountKey = {
+  direction: ProfileFollowConnectionDirection;
+  profileId: string;
+};
+
+type ProfileFollowCountRow = ProfileFollowCountKey & {
+  value: number;
+};
+
+type ProfileFollowPageKey = ProfileFollowCountKey & {
+  limit: number;
+  offset: number;
+};
+
+type ProfileFollowPageRow = ProfileFollowPageKey & ProfileFollowRow;
+
+const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
+const FolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
+
+const ownerProfileIdColumn = (direction: ProfileFollowConnectionDirection) =>
+  direction === 'followers' ? ProfileFollows.followeeProfileId : ProfileFollows.followerProfileId;
+
+const readableProfileFollowWhere = (
+  ctx: UserContext,
+  {
+    acceptedOnly = false,
+    where = [],
+  }: { acceptedOnly?: boolean; where?: (SQL | undefined)[] } = {},
+) => {
+  const publicAcceptedWhere = and(
+    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+    eq(FollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+    eq(FolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
+  )!;
+  const visibleWhere = ctx.session?.profileId
+    ? or(
+        eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+        eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
+        publicAcceptedWhere,
+      )
+    : publicAcceptedWhere;
+
+  return and(
+    ...where,
+    acceptedOnly ? eq(ProfileFollows.state, ProfileFollowState.ACCEPTED) : undefined,
+    eq(FollowerProfiles.state, ProfileState.ACTIVE),
+    eq(FolloweeProfiles.state, ProfileState.ACTIVE),
+    visibleWhere,
+  )!;
+};
+
+const readableProfileFollows = (
+  ctx: UserContext,
+  options?: Parameters<typeof readableProfileFollowWhere>[1],
+) =>
+  db
+    .select(getColumns(ProfileFollows))
+    .from(ProfileFollows)
+    .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+    .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+    .where(readableProfileFollowWhere(ctx, options));
+
+export const readableAcceptedProfileFollowCountLoader = (ctx: UserContext) =>
+  ctx.loader<ProfileFollowCountKey, ProfileFollowCountRow, ProfileFollowCountKey, true>({
+    name: 'profileFollow.acceptedCount',
+    nullable: true,
+    load: async (keys) => {
+      const rows: ProfileFollowCountRow[] = [];
+
+      for (const direction of ['followers', 'following'] as const) {
+        const profileIds = keys
+          .filter((key) => key.direction === direction)
+          .map((key) => key.profileId);
+
+        if (!profileIds.length) {
+          continue;
+        }
+
+        const readableFollows = readableProfileFollows(ctx, {
+          acceptedOnly: true,
+          where: [inArray(ownerProfileIdColumn(direction), [...new Set(profileIds)])],
+        }).as('readable_profile_follows');
+        const ownerColumn =
+          direction === 'followers'
+            ? readableFollows.followeeProfileId
+            : readableFollows.followerProfileId;
+        const counts = await db
+          .select({
+            profileId: ownerColumn,
+            value: count(),
+          })
+          .from(readableFollows)
+          .groupBy(ownerColumn);
+
+        rows.push(
+          ...counts.map((row) => ({ direction, profileId: row.profileId, value: row.value })),
+        );
+      }
+
+      return rows;
+    },
+    key: (row) => row && { direction: row.direction, profileId: row.profileId },
+  });
+
+export const readableAcceptedProfileFollowPageLoader = (ctx: UserContext) =>
+  ctx.loader<ProfileFollowPageKey, ProfileFollowPageRow, ProfileFollowPageKey, false, true>({
+    name: 'profileFollow.acceptedPage',
+    many: true,
+    load: async (keys) => {
+      const rows: ProfileFollowPageRow[] = [];
+      const groups = new Map<string, ProfileFollowPageKey[]>();
+
+      for (const key of keys) {
+        const groupKey = `${key.direction}:${key.offset}:${key.limit}`;
+        const group = groups.get(groupKey);
+        if (group) {
+          group.push(key);
+        } else {
+          groups.set(groupKey, [key]);
+        }
+      }
+
+      for (const group of groups.values()) {
+        const [{ direction, limit, offset }] = group;
+        const readableFollows = readableProfileFollows(ctx, {
+          acceptedOnly: true,
+          where: [
+            inArray(ownerProfileIdColumn(direction), [
+              ...new Set(group.map((key) => key.profileId)),
+            ]),
+          ],
+        }).as('readable_profile_follows');
+        const ownerColumn =
+          direction === 'followers'
+            ? readableFollows.followeeProfileId
+            : readableFollows.followerProfileId;
+        const position = sql<number>`row_number() over (
+          partition by ${ownerColumn}
+          order by ${readableFollows.id} desc
+        )`.as('position');
+
+        const rankedProfileFollows = db
+          .select({
+            ownerProfileId: ownerColumn,
+            position,
+            id: readableFollows.id,
+            followerProfileId: readableFollows.followerProfileId,
+            followeeProfileId: readableFollows.followeeProfileId,
+            state: readableFollows.state,
+            createdAt: readableFollows.createdAt,
+            respondedAt: readableFollows.respondedAt,
+          })
+          .from(readableFollows)
+          .as('ranked_profile_follows');
+
+        const page = await db
+          .select()
+          .from(rankedProfileFollows)
+          .where(
+            and(
+              gt(rankedProfileFollows.position, offset),
+              lte(rankedProfileFollows.position, offset + limit),
+            ),
+          )
+          .orderBy(rankedProfileFollows.ownerProfileId, rankedProfileFollows.position);
+
+        rows.push(
+          ...page.map((row) => ({
+            direction,
+            profileId: row.ownerProfileId,
+            limit,
+            offset,
+            id: row.id,
+            followerProfileId: row.followerProfileId,
+            followeeProfileId: row.followeeProfileId,
+            state: row.state,
+            createdAt: row.createdAt,
+            respondedAt: row.respondedAt,
+          })),
+        );
+      }
+
+      return rows;
+    },
+    key: (row) => ({
+      direction: row.direction,
+      profileId: row.profileId,
+      limit: row.limit,
+      offset: row.offset,
+    }),
+  });
+
+export const viewerFollowLoader = (ctx: UserContext) =>
+  ctx.loader<string, ProfileFollowRow, string, true>({
+    name: 'profileFollow.viewerFollow',
+    nullable: true,
+    load: async (ids) => {
+      if (!ctx.session?.profileId) {
+        return [];
+      }
+
+      return await db
+        .select()
+        .from(ProfileFollows)
+        .where(
+          and(
+            eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+            inArray(ProfileFollows.followeeProfileId, ids),
+          ),
+        );
+    },
+    key: (profileFollow) => profileFollow?.followeeProfileId ?? null,
+  });
+
+const readableProfileFollowLoader = (ctx: UserContext) =>
+  ctx.loader<string, ProfileFollowRow, string, true>({
+    name: 'profileFollow.readable',
+    nullable: true,
+    load: (ids) => readableProfileFollows(ctx, { where: [inArray(ProfileFollows.id, ids)] }),
+    key: (profileFollow) => profileFollow?.id ?? null,
+  });
+
+export const loadReadableProfileFollowsByIds = async (ids: string[], ctx: UserContext) => {
+  const rows = await readableProfileFollowLoader(ctx).loadMany(ids);
+
+  return rows.filter((row): row is ProfileFollowRow => row !== null && !(row instanceof Error));
+};

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -49,7 +49,7 @@ export const acceptedProfileFollowersCountLoader = (ctx: UserContext) =>
         .where(
           and(
             eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-            inArray(ProfileFollows.followeeProfileId, [...new Set(keys)]),
+            inArray(ProfileFollows.followeeProfileId, keys),
             profileFollowAccessWhere({
               ctx,
               followerProfile: FollowerProfiles,
@@ -78,7 +78,7 @@ export const acceptedProfileFollowingCountLoader = (ctx: UserContext) =>
         .where(
           and(
             eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-            inArray(ProfileFollows.followerProfileId, [...new Set(keys)]),
+            inArray(ProfileFollows.followerProfileId, keys),
             profileFollowAccessWhere({
               ctx,
               followerProfile: FollowerProfiles,

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -1,6 +1,6 @@
 import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
 import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
-import { and, asc, count, desc, eq, getColumns, gt, inArray, lt, or } from 'drizzle-orm';
+import { and, count, eq, getColumns, inArray, or } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
 import type { UserContext } from '@/context';
@@ -10,13 +10,6 @@ export type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
 type ProfileFollowCountRow = {
   profileId: string;
   value: number;
-};
-
-type ProfileFollowCursorPage = {
-  before?: string;
-  after?: string;
-  inverted: boolean;
-  limit: number;
 };
 
 const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
@@ -96,34 +89,6 @@ export const acceptedProfileFollowingCountLoader = (ctx: UserContext) =>
     },
     key: (row) => row?.profileId ?? null,
   });
-
-export const selectAcceptedProfileFollowers = (
-  ctx: UserContext,
-  profileId: string,
-  { before, after, inverted, limit }: ProfileFollowCursorPage,
-) =>
-  profileFollowQuery(ctx, [
-    eq(ProfileFollows.followeeProfileId, profileId),
-    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-    before ? gt(ProfileFollows.id, before) : undefined,
-    after ? lt(ProfileFollows.id, after) : undefined,
-  ])
-    .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
-    .limit(limit);
-
-export const selectAcceptedProfileFollowing = (
-  ctx: UserContext,
-  profileId: string,
-  { before, after, inverted, limit }: ProfileFollowCursorPage,
-) =>
-  profileFollowQuery(ctx, [
-    eq(ProfileFollows.followerProfileId, profileId),
-    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-    before ? gt(ProfileFollows.id, before) : undefined,
-    after ? lt(ProfileFollows.id, after) : undefined,
-  ])
-    .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
-    .limit(limit);
 
 export const viewerFollowLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -38,18 +38,26 @@ export const acceptedProfileFollowersCountLoader = (ctx: UserContext) =>
     name: 'profileFollow.acceptedFollowersCount',
     nullable: true,
     load: async (keys) => {
-      const profileFollowRows = profileFollowQuery(ctx, [
-        eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-        inArray(ProfileFollows.followeeProfileId, [...new Set(keys)]),
-      ]).as('profile_follow_rows');
-
       return await db
         .select({
-          profileId: profileFollowRows.followeeProfileId,
+          profileId: ProfileFollows.followeeProfileId,
           value: count(),
         })
-        .from(profileFollowRows)
-        .groupBy(profileFollowRows.followeeProfileId);
+        .from(ProfileFollows)
+        .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+        .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+        .where(
+          and(
+            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+            inArray(ProfileFollows.followeeProfileId, [...new Set(keys)]),
+            profileFollowAccessWhere({
+              ctx,
+              followerProfile: FollowerProfiles,
+              followeeProfile: FolloweeProfiles,
+            }),
+          ),
+        )
+        .groupBy(ProfileFollows.followeeProfileId);
     },
     key: (row) => row?.profileId ?? null,
   });
@@ -59,18 +67,26 @@ export const acceptedProfileFollowingCountLoader = (ctx: UserContext) =>
     name: 'profileFollow.acceptedFollowingCount',
     nullable: true,
     load: async (keys) => {
-      const profileFollowRows = profileFollowQuery(ctx, [
-        eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-        inArray(ProfileFollows.followerProfileId, [...new Set(keys)]),
-      ]).as('profile_follow_rows');
-
       return await db
         .select({
-          profileId: profileFollowRows.followerProfileId,
+          profileId: ProfileFollows.followerProfileId,
           value: count(),
         })
-        .from(profileFollowRows)
-        .groupBy(profileFollowRows.followerProfileId);
+        .from(ProfileFollows)
+        .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+        .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+        .where(
+          and(
+            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+            inArray(ProfileFollows.followerProfileId, [...new Set(keys)]),
+            profileFollowAccessWhere({
+              ctx,
+              followerProfile: FollowerProfiles,
+              followeeProfile: FolloweeProfiles,
+            }),
+          ),
+        )
+        .groupBy(ProfileFollows.followerProfileId);
     },
     key: (row) => row?.profileId ?? null,
   });

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -2,30 +2,12 @@ import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
 import { and, eq, getColumns, inArray } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { profileFollowAccessWhere } from '../access/follow';
-import type { SQL } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
 export type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
 
 const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
 const FolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
-
-const profileFollowQuery = (ctx: UserContext, where?: (SQL | undefined)[]) =>
-  db
-    .select(getColumns(ProfileFollows))
-    .from(ProfileFollows)
-    .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
-    .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
-    .where(
-      and(
-        ...(where ?? []),
-        profileFollowAccessWhere({
-          ctx,
-          followerProfile: FollowerProfiles,
-          followeeProfile: FolloweeProfiles,
-        }),
-      ),
-    );
 
 export const viewerFollowLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({
@@ -49,16 +31,25 @@ export const viewerFollowLoader = (ctx: UserContext) =>
     key: (profileFollow) => profileFollow?.followeeProfileId ?? null,
   });
 
-const profileFollowByIdLoader = (ctx: UserContext) =>
+export const profileFollowByIdLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({
     name: 'profileFollow.byId',
     nullable: true,
-    load: (ids) => profileFollowQuery(ctx, [inArray(ProfileFollows.id, ids)]),
+    load: (ids) =>
+      db
+        .select(getColumns(ProfileFollows))
+        .from(ProfileFollows)
+        .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+        .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+        .where(
+          and(
+            inArray(ProfileFollows.id, ids),
+            profileFollowAccessWhere({
+              ctx,
+              followerProfile: FollowerProfiles,
+              followeeProfile: FolloweeProfiles,
+            }),
+          ),
+        ),
     key: (profileFollow) => profileFollow?.id ?? null,
   });
-
-export const loadProfileFollowsByIds = async (ids: string[], ctx: UserContext) => {
-  const rows = await profileFollowByIdLoader(ctx).loadMany(ids);
-
-  return rows.filter((row): row is ProfileFollowRow => row !== null && !(row instanceof Error));
-};

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -1,17 +1,11 @@
 import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { ProfileFollowState } from '@kosmo/core/enums';
-import { and, count, eq, getColumns, inArray } from 'drizzle-orm';
+import { and, eq, getColumns, inArray } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { profileFollowAccessWhere } from '../access/follow';
 import type { SQL } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
 export type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
-
-type ProfileFollowCountRow = {
-  profileId: string;
-  value: number;
-};
 
 const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
 const FolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
@@ -32,64 +26,6 @@ const profileFollowQuery = (ctx: UserContext, where?: (SQL | undefined)[]) =>
         }),
       ),
     );
-
-export const acceptedProfileFollowersCountLoader = (ctx: UserContext) =>
-  ctx.loader<string, ProfileFollowCountRow, string, true>({
-    name: 'profileFollow.acceptedFollowersCount',
-    nullable: true,
-    load: async (keys) => {
-      return await db
-        .select({
-          profileId: ProfileFollows.followeeProfileId,
-          value: count(),
-        })
-        .from(ProfileFollows)
-        .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
-        .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
-        .where(
-          and(
-            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-            inArray(ProfileFollows.followeeProfileId, keys),
-            profileFollowAccessWhere({
-              ctx,
-              followerProfile: FollowerProfiles,
-              followeeProfile: FolloweeProfiles,
-            }),
-          ),
-        )
-        .groupBy(ProfileFollows.followeeProfileId);
-    },
-    key: (row) => row?.profileId ?? null,
-  });
-
-export const acceptedProfileFollowingCountLoader = (ctx: UserContext) =>
-  ctx.loader<string, ProfileFollowCountRow, string, true>({
-    name: 'profileFollow.acceptedFollowingCount',
-    nullable: true,
-    load: async (keys) => {
-      return await db
-        .select({
-          profileId: ProfileFollows.followerProfileId,
-          value: count(),
-        })
-        .from(ProfileFollows)
-        .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
-        .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
-        .where(
-          and(
-            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-            inArray(ProfileFollows.followerProfileId, keys),
-            profileFollowAccessWhere({
-              ctx,
-              followerProfile: FollowerProfiles,
-              followeeProfile: FolloweeProfiles,
-            }),
-          ),
-        )
-        .groupBy(ProfileFollows.followerProfileId);
-    },
-    key: (row) => row?.profileId ?? null,
-  });
 
 export const viewerFollowLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -31,7 +31,7 @@ const FolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
 const ownerProfileIdColumn = (direction: ProfileFollowConnectionDirection) =>
   direction === 'followers' ? ProfileFollows.followeeProfileId : ProfileFollows.followerProfileId;
 
-const readableProfileFollowWhere = (
+const profileFollowAccessWhere = (
   ctx: UserContext,
   {
     acceptedOnly = false,
@@ -60,18 +60,18 @@ const readableProfileFollowWhere = (
   )!;
 };
 
-const readableProfileFollows = (
+const profileFollowQuery = (
   ctx: UserContext,
-  options?: Parameters<typeof readableProfileFollowWhere>[1],
+  options?: Parameters<typeof profileFollowAccessWhere>[1],
 ) =>
   db
     .select(getColumns(ProfileFollows))
     .from(ProfileFollows)
     .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
     .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
-    .where(readableProfileFollowWhere(ctx, options));
+    .where(profileFollowAccessWhere(ctx, options));
 
-export const readableAcceptedProfileFollowCountLoader = (ctx: UserContext) =>
+export const acceptedProfileFollowCountLoader = (ctx: UserContext) =>
   ctx.loader<ProfileFollowCountKey, ProfileFollowCountRow, ProfileFollowCountKey, true>({
     name: 'profileFollow.acceptedCount',
     nullable: true,
@@ -87,20 +87,20 @@ export const readableAcceptedProfileFollowCountLoader = (ctx: UserContext) =>
           continue;
         }
 
-        const readableFollows = readableProfileFollows(ctx, {
+        const profileFollowRows = profileFollowQuery(ctx, {
           acceptedOnly: true,
           where: [inArray(ownerProfileIdColumn(direction), [...new Set(profileIds)])],
-        }).as('readable_profile_follows');
+        }).as('profile_follow_rows');
         const ownerColumn =
           direction === 'followers'
-            ? readableFollows.followeeProfileId
-            : readableFollows.followerProfileId;
+            ? profileFollowRows.followeeProfileId
+            : profileFollowRows.followerProfileId;
         const counts = await db
           .select({
             profileId: ownerColumn,
             value: count(),
           })
-          .from(readableFollows)
+          .from(profileFollowRows)
           .groupBy(ownerColumn);
 
         rows.push(
@@ -113,7 +113,7 @@ export const readableAcceptedProfileFollowCountLoader = (ctx: UserContext) =>
     key: (row) => row && { direction: row.direction, profileId: row.profileId },
   });
 
-export const readableAcceptedProfileFollowPageLoader = (ctx: UserContext) =>
+export const acceptedProfileFollowPageLoader = (ctx: UserContext) =>
   ctx.loader<ProfileFollowPageKey, ProfileFollowPageRow, ProfileFollowPageKey, false, true>({
     name: 'profileFollow.acceptedPage',
     many: true,
@@ -133,35 +133,35 @@ export const readableAcceptedProfileFollowPageLoader = (ctx: UserContext) =>
 
       for (const group of groups.values()) {
         const [{ direction, limit, offset }] = group;
-        const readableFollows = readableProfileFollows(ctx, {
+        const profileFollowRows = profileFollowQuery(ctx, {
           acceptedOnly: true,
           where: [
             inArray(ownerProfileIdColumn(direction), [
               ...new Set(group.map((key) => key.profileId)),
             ]),
           ],
-        }).as('readable_profile_follows');
+        }).as('profile_follow_rows');
         const ownerColumn =
           direction === 'followers'
-            ? readableFollows.followeeProfileId
-            : readableFollows.followerProfileId;
+            ? profileFollowRows.followeeProfileId
+            : profileFollowRows.followerProfileId;
         const position = sql<number>`row_number() over (
           partition by ${ownerColumn}
-          order by ${readableFollows.id} desc
+          order by ${profileFollowRows.id} desc
         )`.as('position');
 
         const rankedProfileFollows = db
           .select({
             ownerProfileId: ownerColumn,
             position,
-            id: readableFollows.id,
-            followerProfileId: readableFollows.followerProfileId,
-            followeeProfileId: readableFollows.followeeProfileId,
-            state: readableFollows.state,
-            createdAt: readableFollows.createdAt,
-            respondedAt: readableFollows.respondedAt,
+            id: profileFollowRows.id,
+            followerProfileId: profileFollowRows.followerProfileId,
+            followeeProfileId: profileFollowRows.followeeProfileId,
+            state: profileFollowRows.state,
+            createdAt: profileFollowRows.createdAt,
+            respondedAt: profileFollowRows.respondedAt,
           })
-          .from(readableFollows)
+          .from(profileFollowRows)
           .as('ranked_profile_follows');
 
         const page = await db
@@ -223,16 +223,16 @@ export const viewerFollowLoader = (ctx: UserContext) =>
     key: (profileFollow) => profileFollow?.followeeProfileId ?? null,
   });
 
-const readableProfileFollowLoader = (ctx: UserContext) =>
+const profileFollowByIdLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({
-    name: 'profileFollow.readable',
+    name: 'profileFollow.byId',
     nullable: true,
-    load: (ids) => readableProfileFollows(ctx, { where: [inArray(ProfileFollows.id, ids)] }),
+    load: (ids) => profileFollowQuery(ctx, { where: [inArray(ProfileFollows.id, ids)] }),
     key: (profileFollow) => profileFollow?.id ?? null,
   });
 
-export const loadReadableProfileFollowsByIds = async (ids: string[], ctx: UserContext) => {
-  const rows = await readableProfileFollowLoader(ctx).loadMany(ids);
+export const loadProfileFollowsByIds = async (ids: string[], ctx: UserContext) => {
+  const rows = await profileFollowByIdLoader(ctx).loadMany(ids);
 
   return rows.filter((row): row is ProfileFollowRow => row !== null && !(row instanceof Error));
 };

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -1,7 +1,11 @@
-import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
-import { and, count, eq, getColumns, inArray, or } from 'drizzle-orm';
-import { alias } from 'drizzle-orm/pg-core';
+import { db, ProfileFollows } from '@kosmo/core/db';
+import { ProfileFollowState } from '@kosmo/core/enums';
+import { and, count, eq, getColumns, inArray } from 'drizzle-orm';
+import {
+  profileFollowAccessWhere,
+  ProfileFollowFolloweeProfiles,
+  ProfileFollowFollowerProfiles,
+} from '../access/follow';
 import type { SQL } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
@@ -12,40 +16,18 @@ type ProfileFollowCountRow = {
   value: number;
 };
 
-const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
-const FolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
-
-const profileFollowAccessWhere = (ctx: UserContext, where: (SQL | undefined)[] = []) => {
-  const publicAcceptedWhere = and(
-    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
-    eq(FollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
-    eq(FolloweeProfiles.followPolicy, ProfileFollowPolicy.OPEN),
-  )!;
-  const visibleWhere = ctx.session?.profileId
-    ? or(
-        eq(ProfileFollows.followerProfileId, ctx.session.profileId),
-        eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
-        publicAcceptedWhere,
-      )
-    : publicAcceptedWhere;
-
-  return and(
-    ...where,
-    eq(FollowerProfiles.state, ProfileState.ACTIVE),
-    eq(FolloweeProfiles.state, ProfileState.ACTIVE),
-    visibleWhere,
-  )!;
-};
-
-const profileFollowQuery = (
-  ctx: UserContext,
-  where?: Parameters<typeof profileFollowAccessWhere>[1],
-) =>
+const profileFollowQuery = (ctx: UserContext, where?: (SQL | undefined)[]) =>
   db
     .select(getColumns(ProfileFollows))
     .from(ProfileFollows)
-    .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
-    .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+    .innerJoin(
+      ProfileFollowFollowerProfiles,
+      eq(ProfileFollowFollowerProfiles.id, ProfileFollows.followerProfileId),
+    )
+    .innerJoin(
+      ProfileFollowFolloweeProfiles,
+      eq(ProfileFollowFolloweeProfiles.id, ProfileFollows.followeeProfileId),
+    )
     .where(profileFollowAccessWhere(ctx, where));
 
 export const acceptedProfileFollowersCountLoader = (ctx: UserContext) =>

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -1,20 +1,22 @@
 import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
 import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
-import { and, count, desc, eq, getColumns, inArray, or } from 'drizzle-orm';
+import { and, asc, count, desc, eq, getColumns, gt, inArray, lt, or } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
-type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
+export type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
 
 type ProfileFollowCountRow = {
   profileId: string;
   value: number;
 };
 
-type ProfileFollowPage = {
+type ProfileFollowCursorPage = {
+  before?: string;
+  after?: string;
+  inverted: boolean;
   limit: number;
-  offset: number;
 };
 
 const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
@@ -98,28 +100,30 @@ export const acceptedProfileFollowingCountLoader = (ctx: UserContext) =>
 export const selectAcceptedProfileFollowers = (
   ctx: UserContext,
   profileId: string,
-  { limit, offset }: ProfileFollowPage,
+  { before, after, inverted, limit }: ProfileFollowCursorPage,
 ) =>
   profileFollowQuery(ctx, [
     eq(ProfileFollows.followeeProfileId, profileId),
     eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+    before ? gt(ProfileFollows.id, before) : undefined,
+    after ? lt(ProfileFollows.id, after) : undefined,
   ])
-    .orderBy(desc(ProfileFollows.id))
-    .limit(limit)
-    .offset(offset);
+    .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
+    .limit(limit);
 
 export const selectAcceptedProfileFollowing = (
   ctx: UserContext,
   profileId: string,
-  { limit, offset }: ProfileFollowPage,
+  { before, after, inverted, limit }: ProfileFollowCursorPage,
 ) =>
   profileFollowQuery(ctx, [
     eq(ProfileFollows.followerProfileId, profileId),
     eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+    before ? gt(ProfileFollows.id, before) : undefined,
+    after ? lt(ProfileFollows.id, after) : undefined,
   ])
-    .orderBy(desc(ProfileFollows.id))
-    .limit(limit)
-    .offset(offset);
+    .orderBy(inverted ? asc(ProfileFollows.id) : desc(ProfileFollows.id))
+    .limit(limit);
 
 export const viewerFollowLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -1,11 +1,8 @@
-import { db, ProfileFollows } from '@kosmo/core/db';
+import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
 import { ProfileFollowState } from '@kosmo/core/enums';
 import { and, count, eq, getColumns, inArray } from 'drizzle-orm';
-import {
-  profileFollowAccessWhere,
-  ProfileFollowFolloweeProfiles,
-  ProfileFollowFollowerProfiles,
-} from '../access/follow';
+import { alias } from 'drizzle-orm/pg-core';
+import { profileFollowAccessWhere } from '../access/follow';
 import type { SQL } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
@@ -16,19 +13,25 @@ type ProfileFollowCountRow = {
   value: number;
 };
 
+const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
+const FolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
+
 const profileFollowQuery = (ctx: UserContext, where?: (SQL | undefined)[]) =>
   db
     .select(getColumns(ProfileFollows))
     .from(ProfileFollows)
-    .innerJoin(
-      ProfileFollowFollowerProfiles,
-      eq(ProfileFollowFollowerProfiles.id, ProfileFollows.followerProfileId),
-    )
-    .innerJoin(
-      ProfileFollowFolloweeProfiles,
-      eq(ProfileFollowFolloweeProfiles.id, ProfileFollows.followeeProfileId),
-    )
-    .where(profileFollowAccessWhere(ctx, where));
+    .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+    .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
+    .where(
+      and(
+        ...(where ?? []),
+        profileFollowAccessWhere({
+          ctx,
+          followerProfile: FollowerProfiles,
+          followeeProfile: FolloweeProfiles,
+        }),
+      ),
+    );
 
 export const acceptedProfileFollowersCountLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowCountRow, string, true>({

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -1,43 +1,26 @@
 import { db, ProfileFollows, Profiles } from '@kosmo/core/db';
 import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
-import { and, count, eq, getColumns, gt, inArray, lte, or, sql } from 'drizzle-orm';
+import { and, count, desc, eq, getColumns, inArray, or } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
-export type ProfileFollowConnectionDirection = 'followers' | 'following';
-
 type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
 
-type ProfileFollowCountKey = {
-  direction: ProfileFollowConnectionDirection;
+type ProfileFollowCountRow = {
   profileId: string;
-};
-
-type ProfileFollowCountRow = ProfileFollowCountKey & {
   value: number;
 };
 
-type ProfileFollowPageKey = ProfileFollowCountKey & {
+type ProfileFollowPage = {
   limit: number;
   offset: number;
 };
 
-type ProfileFollowPageRow = ProfileFollowPageKey & ProfileFollowRow;
-
 const FollowerProfiles = alias(Profiles, 'profile_follow_follower_profile');
 const FolloweeProfiles = alias(Profiles, 'profile_follow_followee_profile');
 
-const ownerProfileIdColumn = (direction: ProfileFollowConnectionDirection) =>
-  direction === 'followers' ? ProfileFollows.followeeProfileId : ProfileFollows.followerProfileId;
-
-const profileFollowAccessWhere = (
-  ctx: UserContext,
-  {
-    acceptedOnly = false,
-    where = [],
-  }: { acceptedOnly?: boolean; where?: (SQL | undefined)[] } = {},
-) => {
+const profileFollowAccessWhere = (ctx: UserContext, where: (SQL | undefined)[] = []) => {
   const publicAcceptedWhere = and(
     eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
     eq(FollowerProfiles.followPolicy, ProfileFollowPolicy.OPEN),
@@ -53,7 +36,6 @@ const profileFollowAccessWhere = (
 
   return and(
     ...where,
-    acceptedOnly ? eq(ProfileFollows.state, ProfileFollowState.ACCEPTED) : undefined,
     eq(FollowerProfiles.state, ProfileState.ACTIVE),
     eq(FolloweeProfiles.state, ProfileState.ACTIVE),
     visibleWhere,
@@ -62,144 +44,82 @@ const profileFollowAccessWhere = (
 
 const profileFollowQuery = (
   ctx: UserContext,
-  options?: Parameters<typeof profileFollowAccessWhere>[1],
+  where?: Parameters<typeof profileFollowAccessWhere>[1],
 ) =>
   db
     .select(getColumns(ProfileFollows))
     .from(ProfileFollows)
     .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
     .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, ProfileFollows.followeeProfileId))
-    .where(profileFollowAccessWhere(ctx, options));
+    .where(profileFollowAccessWhere(ctx, where));
 
-export const acceptedProfileFollowCountLoader = (ctx: UserContext) =>
-  ctx.loader<ProfileFollowCountKey, ProfileFollowCountRow, ProfileFollowCountKey, true>({
-    name: 'profileFollow.acceptedCount',
+export const acceptedProfileFollowersCountLoader = (ctx: UserContext) =>
+  ctx.loader<string, ProfileFollowCountRow, string, true>({
+    name: 'profileFollow.acceptedFollowersCount',
     nullable: true,
     load: async (keys) => {
-      const rows: ProfileFollowCountRow[] = [];
+      const profileFollowRows = profileFollowQuery(ctx, [
+        eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+        inArray(ProfileFollows.followeeProfileId, [...new Set(keys)]),
+      ]).as('profile_follow_rows');
 
-      for (const direction of ['followers', 'following'] as const) {
-        const profileIds = keys
-          .filter((key) => key.direction === direction)
-          .map((key) => key.profileId);
-
-        if (!profileIds.length) {
-          continue;
-        }
-
-        const profileFollowRows = profileFollowQuery(ctx, {
-          acceptedOnly: true,
-          where: [inArray(ownerProfileIdColumn(direction), [...new Set(profileIds)])],
-        }).as('profile_follow_rows');
-        const ownerColumn =
-          direction === 'followers'
-            ? profileFollowRows.followeeProfileId
-            : profileFollowRows.followerProfileId;
-        const counts = await db
-          .select({
-            profileId: ownerColumn,
-            value: count(),
-          })
-          .from(profileFollowRows)
-          .groupBy(ownerColumn);
-
-        rows.push(
-          ...counts.map((row) => ({ direction, profileId: row.profileId, value: row.value })),
-        );
-      }
-
-      return rows;
+      return await db
+        .select({
+          profileId: profileFollowRows.followeeProfileId,
+          value: count(),
+        })
+        .from(profileFollowRows)
+        .groupBy(profileFollowRows.followeeProfileId);
     },
-    key: (row) => row && { direction: row.direction, profileId: row.profileId },
+    key: (row) => row?.profileId ?? null,
   });
 
-export const acceptedProfileFollowPageLoader = (ctx: UserContext) =>
-  ctx.loader<ProfileFollowPageKey, ProfileFollowPageRow, ProfileFollowPageKey, false, true>({
-    name: 'profileFollow.acceptedPage',
-    many: true,
+export const acceptedProfileFollowingCountLoader = (ctx: UserContext) =>
+  ctx.loader<string, ProfileFollowCountRow, string, true>({
+    name: 'profileFollow.acceptedFollowingCount',
+    nullable: true,
     load: async (keys) => {
-      const rows: ProfileFollowPageRow[] = [];
-      const groups = new Map<string, ProfileFollowPageKey[]>();
+      const profileFollowRows = profileFollowQuery(ctx, [
+        eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+        inArray(ProfileFollows.followerProfileId, [...new Set(keys)]),
+      ]).as('profile_follow_rows');
 
-      for (const key of keys) {
-        const groupKey = `${key.direction}:${key.offset}:${key.limit}`;
-        const group = groups.get(groupKey);
-        if (group) {
-          group.push(key);
-        } else {
-          groups.set(groupKey, [key]);
-        }
-      }
-
-      for (const group of groups.values()) {
-        const [{ direction, limit, offset }] = group;
-        const profileFollowRows = profileFollowQuery(ctx, {
-          acceptedOnly: true,
-          where: [
-            inArray(ownerProfileIdColumn(direction), [
-              ...new Set(group.map((key) => key.profileId)),
-            ]),
-          ],
-        }).as('profile_follow_rows');
-        const ownerColumn =
-          direction === 'followers'
-            ? profileFollowRows.followeeProfileId
-            : profileFollowRows.followerProfileId;
-        const position = sql<number>`row_number() over (
-          partition by ${ownerColumn}
-          order by ${profileFollowRows.id} desc
-        )`.as('position');
-
-        const rankedProfileFollows = db
-          .select({
-            ownerProfileId: ownerColumn,
-            position,
-            id: profileFollowRows.id,
-            followerProfileId: profileFollowRows.followerProfileId,
-            followeeProfileId: profileFollowRows.followeeProfileId,
-            state: profileFollowRows.state,
-            createdAt: profileFollowRows.createdAt,
-            respondedAt: profileFollowRows.respondedAt,
-          })
-          .from(profileFollowRows)
-          .as('ranked_profile_follows');
-
-        const page = await db
-          .select()
-          .from(rankedProfileFollows)
-          .where(
-            and(
-              gt(rankedProfileFollows.position, offset),
-              lte(rankedProfileFollows.position, offset + limit),
-            ),
-          )
-          .orderBy(rankedProfileFollows.ownerProfileId, rankedProfileFollows.position);
-
-        rows.push(
-          ...page.map((row) => ({
-            direction,
-            profileId: row.ownerProfileId,
-            limit,
-            offset,
-            id: row.id,
-            followerProfileId: row.followerProfileId,
-            followeeProfileId: row.followeeProfileId,
-            state: row.state,
-            createdAt: row.createdAt,
-            respondedAt: row.respondedAt,
-          })),
-        );
-      }
-
-      return rows;
+      return await db
+        .select({
+          profileId: profileFollowRows.followerProfileId,
+          value: count(),
+        })
+        .from(profileFollowRows)
+        .groupBy(profileFollowRows.followerProfileId);
     },
-    key: (row) => ({
-      direction: row.direction,
-      profileId: row.profileId,
-      limit: row.limit,
-      offset: row.offset,
-    }),
+    key: (row) => row?.profileId ?? null,
   });
+
+export const selectAcceptedProfileFollowers = (
+  ctx: UserContext,
+  profileId: string,
+  { limit, offset }: ProfileFollowPage,
+) =>
+  profileFollowQuery(ctx, [
+    eq(ProfileFollows.followeeProfileId, profileId),
+    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+  ])
+    .orderBy(desc(ProfileFollows.id))
+    .limit(limit)
+    .offset(offset);
+
+export const selectAcceptedProfileFollowing = (
+  ctx: UserContext,
+  profileId: string,
+  { limit, offset }: ProfileFollowPage,
+) =>
+  profileFollowQuery(ctx, [
+    eq(ProfileFollows.followerProfileId, profileId),
+    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+  ])
+    .orderBy(desc(ProfileFollows.id))
+    .limit(limit)
+    .offset(offset);
 
 export const viewerFollowLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({
@@ -227,7 +147,7 @@ const profileFollowByIdLoader = (ctx: UserContext) =>
   ctx.loader<string, ProfileFollowRow, string, true>({
     name: 'profileFollow.byId',
     nullable: true,
-    load: (ids) => profileFollowQuery(ctx, { where: [inArray(ProfileFollows.id, ids)] }),
+    load: (ids) => profileFollowQuery(ctx, [inArray(ProfileFollows.id, ids)]),
     key: (profileFollow) => profileFollow?.id ?? null,
   });
 

--- a/apps/api/src/graphql/resolvers/profile/ref.ts
+++ b/apps/api/src/graphql/resolvers/profile/ref.ts
@@ -47,11 +47,7 @@ AccountProfile.implement({
 export const ProfileFollow = createObjectRef(
   'ProfileFollow',
   TableDiscriminator.ProfileFollows,
-  async (ids, ctx) => {
-    const loader = profileFollowByIdLoader(ctx);
-
-    return Promise.all(ids.map((id) => loader.load(id)));
-  },
+  (ids, ctx) => profileFollowByIdLoader(ctx).loadMany(ids),
 );
 
 ProfileFollow.implement({

--- a/apps/api/src/graphql/resolvers/profile/ref.ts
+++ b/apps/api/src/graphql/resolvers/profile/ref.ts
@@ -7,7 +7,8 @@ import {
 } from '@kosmo/core/enums';
 import { and, eq, inArray } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
-import { loadProfileFollowsByIds } from './loader/follow';
+import { profileFollowByIdLoader } from './loader/follow';
+import type { ProfileFollowRow } from './loader/follow';
 
 export const Profile = createObjectRef('Profile', TableDiscriminator.Profiles, (ids) =>
   db
@@ -47,7 +48,11 @@ AccountProfile.implement({
 export const ProfileFollow = createObjectRef(
   'ProfileFollow',
   TableDiscriminator.ProfileFollows,
-  (ids, ctx) => loadProfileFollowsByIds(ids, ctx),
+  async (ids, ctx) => {
+    const rows = await profileFollowByIdLoader(ctx).loadMany(ids);
+
+    return rows.filter((row): row is ProfileFollowRow => row !== null && !(row instanceof Error));
+  },
 );
 
 ProfileFollow.implement({

--- a/apps/api/src/graphql/resolvers/profile/ref.ts
+++ b/apps/api/src/graphql/resolvers/profile/ref.ts
@@ -7,7 +7,7 @@ import {
 } from '@kosmo/core/enums';
 import { and, eq, inArray } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
-import { loadReadableProfileFollowsByIds } from './loader/follow';
+import { loadProfileFollowsByIds } from './loader/follow';
 
 export const Profile = createObjectRef('Profile', TableDiscriminator.Profiles, (ids) =>
   db
@@ -47,7 +47,7 @@ AccountProfile.implement({
 export const ProfileFollow = createObjectRef(
   'ProfileFollow',
   TableDiscriminator.ProfileFollows,
-  (ids, ctx) => loadReadableProfileFollowsByIds(ids, ctx),
+  (ids, ctx) => loadProfileFollowsByIds(ids, ctx),
 );
 
 ProfileFollow.implement({

--- a/apps/api/src/graphql/resolvers/profile/ref.ts
+++ b/apps/api/src/graphql/resolvers/profile/ref.ts
@@ -47,7 +47,11 @@ AccountProfile.implement({
 export const ProfileFollow = createObjectRef(
   'ProfileFollow',
   TableDiscriminator.ProfileFollows,
-  (ids, ctx) => profileFollowByIdLoader(ctx).loadMany(ids),
+  async (ids, ctx) => {
+    const loader = profileFollowByIdLoader(ctx);
+
+    return Promise.all(ids.map((id) => loader.load(id)));
+  },
 );
 
 ProfileFollow.implement({

--- a/apps/api/src/graphql/resolvers/profile/ref.ts
+++ b/apps/api/src/graphql/resolvers/profile/ref.ts
@@ -8,7 +8,6 @@ import {
 import { and, eq, inArray } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
 import { profileFollowByIdLoader } from './loader/follow';
-import type { ProfileFollowRow } from './loader/follow';
 
 export const Profile = createObjectRef('Profile', TableDiscriminator.Profiles, (ids) =>
   db
@@ -48,11 +47,7 @@ AccountProfile.implement({
 export const ProfileFollow = createObjectRef(
   'ProfileFollow',
   TableDiscriminator.ProfileFollows,
-  async (ids, ctx) => {
-    const rows = await profileFollowByIdLoader(ctx).loadMany(ids);
-
-    return rows.filter((row): row is ProfileFollowRow => row !== null && !(row instanceof Error));
-  },
+  (ids, ctx) => profileFollowByIdLoader(ctx).loadMany(ids),
 );
 
 ProfileFollow.implement({

--- a/apps/api/src/graphql/resolvers/profile/ref.ts
+++ b/apps/api/src/graphql/resolvers/profile/ref.ts
@@ -1,4 +1,4 @@
-import { AccountProfiles, db, ProfileFollows, Profiles, TableDiscriminator } from '@kosmo/core/db';
+import { AccountProfiles, db, Profiles, TableDiscriminator } from '@kosmo/core/db';
 import {
   AccountProfileRole,
   ProfileFollowPolicy,
@@ -7,6 +7,7 @@ import {
 } from '@kosmo/core/enums';
 import { and, eq, inArray } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
+import { loadReadableProfileFollowsByIds } from './loader/follow';
 
 export const Profile = createObjectRef('Profile', TableDiscriminator.Profiles, (ids) =>
   db
@@ -46,7 +47,7 @@ AccountProfile.implement({
 export const ProfileFollow = createObjectRef(
   'ProfileFollow',
   TableDiscriminator.ProfileFollows,
-  (ids) => db.select().from(ProfileFollows).where(inArray(ProfileFollows.id, ids)),
+  (ids, ctx) => loadReadableProfileFollowsByIds(ids, ctx),
 );
 
 ProfileFollow.implement({

--- a/apps/api/src/graphql/utils.ts
+++ b/apps/api/src/graphql/utils.ts
@@ -4,11 +4,22 @@ import type { UserContext } from '@/context';
 
 export const globalIdMap = new Map<number, string>();
 
+type LoadableRow<T> = T | null | Error;
+
 const alignByIds = <T extends { id: string }>(
   ids: readonly string[],
-  rows: readonly T[],
+  rows: readonly LoadableRow<T>[],
 ): (T | null)[] => {
-  const rowsById = new Map(rows.map((row) => [row.id, row]));
+  const rowsById = new Map<string, T>();
+  for (const row of rows) {
+    if (row instanceof Error) {
+      throw row;
+    }
+
+    if (row) {
+      rowsById.set(row.id, row);
+    }
+  }
 
   return ids.map((id) => rowsById.get(id) ?? null);
 };
@@ -16,7 +27,7 @@ const alignByIds = <T extends { id: string }>(
 export const createObjectRef = <TRow extends { id: string }>(
   name: string,
   discriminator: (typeof TableDiscriminator)[keyof typeof TableDiscriminator],
-  load: (ids: string[], ctx: UserContext) => Promise<TRow[]>,
+  load: (ids: string[], ctx: UserContext) => Promise<readonly LoadableRow<TRow>[]>,
 ) => {
   globalIdMap.set(discriminator, name);
 

--- a/apps/api/src/graphql/utils.ts
+++ b/apps/api/src/graphql/utils.ts
@@ -4,27 +4,21 @@ import type { UserContext } from '@/context';
 
 export const globalIdMap = new Map<number, string>();
 
-type LoadableRow<T> = T | null | Error;
+type LoadableRow<T> = T | null;
 
 const alignByIds = <T extends { id: string }>(
   ids: readonly string[],
   rows: readonly LoadableRow<T>[],
 ): LoadableRow<T>[] => {
   const rowsById = new Map<string, T>();
-  const errorsByIndex = new Map<number, Error>();
 
-  for (const [index, row] of rows.entries()) {
-    if (row instanceof Error) {
-      errorsByIndex.set(index, row);
-      continue;
-    }
-
+  for (const row of rows) {
     if (row) {
       rowsById.set(row.id, row);
     }
   }
 
-  return ids.map((id, index) => errorsByIndex.get(index) ?? rowsById.get(id) ?? null);
+  return ids.map((id) => rowsById.get(id) ?? null);
 };
 
 export const createObjectRef = <TRow extends { id: string }>(

--- a/apps/api/src/graphql/utils.ts
+++ b/apps/api/src/graphql/utils.ts
@@ -9,11 +9,14 @@ type LoadableRow<T> = T | null | Error;
 const alignByIds = <T extends { id: string }>(
   ids: readonly string[],
   rows: readonly LoadableRow<T>[],
-): (T | null)[] => {
+): LoadableRow<T>[] => {
   const rowsById = new Map<string, T>();
-  for (const row of rows) {
+  const errorsByIndex = new Map<number, Error>();
+
+  for (const [index, row] of rows.entries()) {
     if (row instanceof Error) {
-      throw row;
+      errorsByIndex.set(index, row);
+      continue;
     }
 
     if (row) {
@@ -21,7 +24,7 @@ const alignByIds = <T extends { id: string }>(
     }
   }
 
-  return ids.map((id) => rowsById.get(id) ?? null);
+  return ids.map((id, index) => errorsByIndex.get(index) ?? rowsById.get(id) ?? null);
 };
 
 export const createObjectRef = <TRow extends { id: string }>(

--- a/apps/api/src/graphql/utils.ts
+++ b/apps/api/src/graphql/utils.ts
@@ -4,15 +4,19 @@ import type { UserContext } from '@/context';
 
 export const globalIdMap = new Map<number, string>();
 
-type LoadableRow<T> = T | null;
+type LoadableRow<T> = T | null | Error;
 
 const alignByIds = <T extends { id: string }>(
   ids: readonly string[],
   rows: readonly LoadableRow<T>[],
-): LoadableRow<T>[] => {
+): (T | null)[] => {
   const rowsById = new Map<string, T>();
 
   for (const row of rows) {
+    if (row instanceof Error) {
+      throw row;
+    }
+
     if (row) {
       rowsById.set(row.id, row);
     }

--- a/openspec/specs/profile/spec.md
+++ b/openspec/specs/profile/spec.md
@@ -132,24 +132,39 @@ API는 활성 프로필만 GraphQL profile object로 노출해야 한다(MUST).
 
 ### Requirement: Profile follow graph
 
-API는 프로필 간 accepted follow 관계를 GraphQL에서 조회할 수 있어야 한다(MUST).
+API는 프로필 간 visible follow 관계를 GraphQL에서 조회할 수 있어야 한다(MUST).
 
 #### Scenario: Read accepted followers
 
 - **WHEN** 클라이언트가 활성 프로필의 followers connection을 조회한다
-- **THEN** 시스템은 해당 프로필을 followee로 하고 follower 프로필도 활성 상태인 `ACCEPTED` follow 관계를 반환한다
+- **THEN** 시스템은 해당 프로필을 followee로 하고 follower 프로필도 활성 상태인 `ACCEPTED` follow 관계 중 viewer가 볼 수 있는 관계를 반환한다
 - **AND** 각 edge의 node는 해당 `ProfileFollow`이다
 
 #### Scenario: Read accepted following
 
 - **WHEN** 클라이언트가 활성 프로필의 following connection을 조회한다
-- **THEN** 시스템은 해당 프로필을 follower로 하고 followee 프로필도 활성 상태인 `ACCEPTED` follow 관계를 반환한다
+- **THEN** 시스템은 해당 프로필을 follower로 하고 followee 프로필도 활성 상태인 `ACCEPTED` follow 관계 중 viewer가 볼 수 있는 관계를 반환한다
 - **AND** 각 edge의 node는 해당 `ProfileFollow`이다
 
 #### Scenario: Count accepted follows
 
 - **WHEN** 클라이언트가 활성 프로필의 followersCount 또는 followingCount를 조회한다
-- **THEN** 시스템은 `ACCEPTED` follow 관계 중 상대 프로필도 활성 상태인 관계만 집계한다
+- **THEN** 시스템은 `ACCEPTED` follow 관계 중 상대 프로필도 활성 상태이고 viewer가 볼 수 있는 관계만 집계한다
+
+#### Scenario: Read public accepted follow
+
+- **WHEN** 클라이언트가 자기 active profile과 관련되지 않은 `ACCEPTED` follow 관계를 조회한다
+- **THEN** 시스템은 follower와 followee 프로필이 모두 활성 상태이고 `followPolicy`가 `OPEN`인 경우에만 해당 `ProfileFollow`를 반환한다
+
+#### Scenario: Read own follow relationship
+
+- **WHEN** active profile이 있는 인증자가 자기 active profile이 follower 또는 followee인 follow 관계를 조회한다
+- **THEN** 시스템은 follower와 followee 프로필이 활성 상태이면 follow 정책과 상태에 관계없이 해당 `ProfileFollow`를 반환한다
+
+#### Scenario: Hide follow request from unrelated viewer
+
+- **WHEN** 클라이언트가 자기 active profile과 관련되지 않은 `PENDING` 또는 `REJECTED` follow 관계를 조회한다
+- **THEN** 시스템은 해당 `ProfileFollow`를 반환하지 않는다
 
 #### Scenario: Read viewer follow
 

--- a/openspec/specs/profile/spec.md
+++ b/openspec/specs/profile/spec.md
@@ -149,7 +149,7 @@ API는 프로필 간 visible follow 관계를 GraphQL에서 조회할 수 있어
 #### Scenario: Count accepted follows
 
 - **WHEN** 클라이언트가 활성 프로필의 followersCount 또는 followingCount를 조회한다
-- **THEN** 시스템은 `ACCEPTED` follow 관계 중 상대 프로필도 활성 상태이고 viewer가 볼 수 있는 관계만 집계한다
+- **THEN** 시스템은 `ACCEPTED` follow 관계 중 상대 프로필도 활성 상태인 관계만 집계한다
 
 #### Scenario: Read public accepted follow
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       drizzle-orm:
         specifier: 1.0.0-beta.22
         version: 1.0.0-beta.22(postgres@3.4.9)(zod@4.4.3)
+      fast-json-stable-stringify:
+        specifier: ^2.1.0
+        version: 2.1.0
       graphql:
         specifier: ^16.13.2
         version: 16.14.0


### PR DESCRIPTION
## 무엇을 변경했는지

- `ProfileFollow` 조회 권한 조건을 공용 loader 조건으로 모았습니다.
- 자기 active profile이 follower 또는 followee인 관계는 항상 조회 가능하게 하고, 그 외 accepted follow는 양쪽 프로필이 모두 공개 팔로우 정책일 때만 보이도록 제한했습니다.
- follow request 성격의 `PENDING`/`REJECTED` 관계는 자기 active profile이 관련된 경우에만 노출되게 했습니다.
- followers/following connection과 count, `viewerFollow`, Node ref 조회가 같은 loader 경로를 타도록 정리했습니다.
- loader key 직렬화는 kosmo-old 패턴과 맞춰 `fast-json-stable-stringify`를 직접 사용하게 했습니다.
- Profile OpenSpec에 visible follow 관계 요구사항을 반영했습니다.

## 왜 변경했는지

ProfileFollow를 제한 없이 조회할 수 있으면 공개되지 않은 follow 관계나 follow request가 GraphQL Node 조회 및 관계 필드에서 노출될 수 있습니다. 권한 조건을 각 resolver에 흩뿌리면 누락 위험이 커지므로, DataLoader 기반 조회 경로에 공통 조건을 두어 N+1을 줄이면서 동일한 접근 제한을 적용하도록 했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm exec openspec validate --specs --strict --no-interactive`
- `git diff --check`

## 아직 어떤 문제가 남았는지

없음