### PR TITLE
pnpm global virtual store를 비활성화한다

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,8 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: sha256-73TRSDJq106kpeKThE6wEN53UHNvyo2VmC6fNDIAVYU=
-
 importers:
 
   .:
@@ -171,7 +169,7 @@ importers:
         version: 1.1.1
       mearie:
         specifier: ^0.1.7
-        version: 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
+        version: 0.1.7(jiti@2.7.0)(magicast@0.5.2)
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
@@ -4674,20 +4672,19 @@ snapshots:
       '@types/react': 19.2.15
       react: 19.2.6
 
-  '@mearie/cli@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)':
+  '@mearie/cli@0.1.7(jiti@2.7.0)(magicast@0.5.2)':
     dependencies:
-      '@mearie/codegen': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/codegen': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
       citty: 0.2.2
     transitivePeerDependencies:
-      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget
       - jiti
       - magicast
 
-  '@mearie/codegen@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)':
+  '@mearie/codegen@0.1.7(jiti@2.7.0)(magicast@0.5.2)':
     dependencies:
       '@logtape/logtape': 2.0.7
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
@@ -4695,10 +4692,8 @@ snapshots:
       '@mearie/shared': 0.4.0
       picocolors: 1.1.1
       picomatch: 4.0.4
-      svelte: 5.55.7(@typescript-eslint/types@8.59.2)
       tinyglobby: 0.2.16
     transitivePeerDependencies:
-      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget
@@ -4750,12 +4745,11 @@ snapshots:
       '@mearie/core': 0.6.7
       svelte: 5.55.7(@typescript-eslint/types@8.59.2)
 
-  '@mearie/vite@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)':
+  '@mearie/vite@0.1.7(jiti@2.7.0)(magicast@0.5.2)':
     dependencies:
-      '@mearie/codegen': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/codegen': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
     transitivePeerDependencies:
-      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget
@@ -6815,14 +6809,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mearie@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2):
+  mearie@0.1.7(jiti@2.7.0)(magicast@0.5.2):
     dependencies:
-      '@mearie/cli': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/cli': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/shared': 0.4.0
-      '@mearie/vite': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/vite': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
     transitivePeerDependencies:
-      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: sha256-73TRSDJq106kpeKThE6wEN53UHNvyo2VmC6fNDIAVYU=
+
 importers:
 
   .:
@@ -169,7 +171,7 @@ importers:
         version: 1.1.1
       mearie:
         specifier: ^0.1.7
-        version: 0.1.7(jiti@2.7.0)(magicast@0.5.2)
+        version: 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
@@ -4672,19 +4674,20 @@ snapshots:
       '@types/react': 19.2.15
       react: 19.2.6
 
-  '@mearie/cli@0.1.7(jiti@2.7.0)(magicast@0.5.2)':
+  '@mearie/cli@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)':
     dependencies:
-      '@mearie/codegen': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/codegen': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
       citty: 0.2.2
     transitivePeerDependencies:
+      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget
       - jiti
       - magicast
 
-  '@mearie/codegen@0.1.7(jiti@2.7.0)(magicast@0.5.2)':
+  '@mearie/codegen@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)':
     dependencies:
       '@logtape/logtape': 2.0.7
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
@@ -4692,8 +4695,10 @@ snapshots:
       '@mearie/shared': 0.4.0
       picocolors: 1.1.1
       picomatch: 4.0.4
+      svelte: 5.55.7(@typescript-eslint/types@8.59.2)
       tinyglobby: 0.2.16
     transitivePeerDependencies:
+      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget
@@ -4745,11 +4750,12 @@ snapshots:
       '@mearie/core': 0.6.7
       svelte: 5.55.7(@typescript-eslint/types@8.59.2)
 
-  '@mearie/vite@0.1.7(jiti@2.7.0)(magicast@0.5.2)':
+  '@mearie/vite@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)':
     dependencies:
-      '@mearie/codegen': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/codegen': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
     transitivePeerDependencies:
+      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget
@@ -6809,13 +6815,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mearie@0.1.7(jiti@2.7.0)(magicast@0.5.2):
+  mearie@0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2):
     dependencies:
-      '@mearie/cli': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/cli': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/config': 0.1.2(jiti@2.7.0)(magicast@0.5.2)
       '@mearie/shared': 0.4.0
-      '@mearie/vite': 0.1.7(jiti@2.7.0)(magicast@0.5.2)
+      '@mearie/vite': 0.1.7(@typescript-eslint/types@8.59.2)(jiti@2.7.0)(magicast@0.5.2)
     transitivePeerDependencies:
+      - '@typescript-eslint/types'
       - chokidar
       - dotenv
       - giget

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,13 +2,9 @@ packages:
   - apps/*
   - packages/*
 
-enableGlobalVirtualStore: true
+enableGlobalVirtualStore: false
 pmOnFail: ignore
 minimumReleaseAge: 4320
-packageExtensions:
-  '@mearie/codegen@0.1.7':
-    dependencies:
-      svelte: '*'
 allowBuilds:
   '@fission-ai/openspec': true
   '@tailwindcss/oxide': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,10 @@ packages:
 enableGlobalVirtualStore: true
 pmOnFail: ignore
 minimumReleaseAge: 4320
+packageExtensions:
+  '@mearie/codegen@0.1.7':
+    dependencies:
+      svelte: '*'
 allowBuilds:
   '@fission-ai/openspec': true
   '@tailwindcss/oxide': true


### PR DESCRIPTION
## 무엇을 변경했는지

- `pnpm-workspace.yaml`에서 `enableGlobalVirtualStore`를 `false`로 변경했습니다.
- `@mearie/codegen`용 `packageExtensions` 보강은 제거했습니다.
- 최종 PR diff는 workspace 설정 1줄 변경만 남도록 정리했습니다.

## 왜 변경했는지

- Docker Build workflow에서 `@mearie/codegen`이 `svelte/compiler`를 해석하지 못한 원인은 pnpm global virtual store 레이아웃에서 패키지 위치 기준 ESM import가 앱의 `svelte`까지 닿지 못한 것이었습니다.
- `enableGlobalVirtualStore`는 [#54](https://github.com/byulmaru/kosmo/pull/54)에서 worktree 설치 비용을 줄이기 위해 활성화됐습니다.
- 이후 Windows 환경의 pnpm `node_modules` 심볼릭 링크 문제가 반복되어 [PROD-83](https://linear.app/byulmaru/issue/PROD-83/개발환경-dockerdev-container-기반-로컬-개발-환경-검토)에서 Docker/Dev Container/WSL 기반 개발 환경 검토가 열렸습니다.
- 해당 방향에 맞춰 특정 패키지만 우회하기보다 workspace 설정 자체에서 global virtual store를 비활성화합니다.

## 어떻게 확인할 수 있는지

- `pnpm install --frozen-lockfile --no-optimistic-repeat-install`
- `pnpm --filter @kosmo/web build`
- Docker Build workflow 수동 실행 성공: https://github.com/byulmaru/kosmo/actions/runs/26569477375

## 아직 어떤 문제가 남았는지

- workflow에서 Node.js 20 기반 Actions deprecation 경고가 표시되지만, 이번 빌드 실패와는 별도 후속 정리 대상입니다.
- `pnpm peers check`는 기존 `@eslint/js@10.0.1` / `eslint@9.39.4` peer mismatch로 실패합니다. 이번 변경으로 새로 생긴 문제는 아닙니다.

Linear: PROD-83