### PR TITLE
av 실패 시 Git 기반 스택 PR 운영 절차를 문서화한다

### DIFF
--- a/memory/commit-pr.md
+++ b/memory/commit-pr.md
@@ -44,8 +44,14 @@
   - `gh pr view --json number,title,headRefName,baseRefName,isDraft,state,url`
 - 스택을 재작성하기 전에는 현재 브랜치 위치를 복구 가능한 백업 브랜치로 남긴다.
   - `git branch backup/<branch>-<timestamp> <branch>`
+- 여러 층을 다시 쓰는 작업에서는 각 브랜치의 직전 부모 tip을 잃지 않도록 영향받는 하위 브랜치 tip을 모두 먼저 백업한다.
+- `git rebase --onto <new-base> <old-base> <branch>`의 `<old-base>`는 항상 해당 브랜치가 기존에 쌓여 있던 직전 부모의 이전 tip이어야 한다.
 - rebase 또는 reparent 후에는 `git range-diff`나 `git log --graph`로 의도한 커밋만 이동했는지 확인한다.
-- 공유 브랜치를 다시 push할 때는 `git push --force-with-lease`만 사용한다.
+- 공유 브랜치를 다시 push할 때는 branch별 expected remote SHA를 지정한 `--force-with-lease=<branch>:<expected-remote-sha>`만 사용한다.
+  - rebase 전에 `git fetch origin` 후 `git rev-parse origin/<branch>`로 `<expected-remote-sha>`를 기록한다.
+  - rebase 전에 `git merge-base --is-ancestor origin/<branch> <branch>`로 로컬 브랜치가 원격 head를 포함하는지 확인한다.
+  - 원격 head가 로컬에 포함되어 있지 않으면 force-push하지 않는다. `git log --oneline <branch>..origin/<branch>`로 원격-only 커밋을 확인하고, 필요한 커밋을 먼저 통합한 뒤 다시 진행한다.
+  - 기본 `git push --force-with-lease`는 직전 `fetch`로 갱신된 원격 추적 ref를 기준으로 삼을 수 있어, 로컬에 포함하지 않은 원격 변경을 덮어쓸 수 있으므로 fallback 절차에서는 사용하지 않는다.
 
 ### 새 스택 브랜치 만들기
 
@@ -88,42 +94,52 @@
 
 - 부모 브랜치가 force-push나 rebase로 다시 쓰일 수 있는 fallback 상황에서는 자식 브랜치의 기존 base였던 부모 tip을 먼저 백업 ref나 commit SHA로 남긴다.
   - `<old-parent-tip>`은 자식 브랜치가 쌓여 있던 이전 부모 tip이며, fetch/pull/rebase로 ref가 이동하기 전에 `git rev-parse <parent-branch>` 또는 `git rev-parse origin/<parent-branch>`로 확인한다.
+  - `<old-parent-tip>`은 자식 브랜치 히스토리에 포함된 경계 커밋이어야 하므로, 의심스러우면 `git merge-base --is-ancestor <old-parent-tip> <child-branch>`로 확인한다.
   - `git branch backup/<parent-branch>-before-update-<timestamp> <old-parent-tip>`
   - `git branch backup/<child-branch>-before-parent-update-<timestamp> <child-branch>`
   - `git branch backup/<grandchild-branch>-before-parent-update-<timestamp> <grandchild-branch>`
 - 부모 브랜치가 push된 최신 상태라면 자식 고유 커밋만 새 부모 브랜치 위로 rebase한다.
   - `git fetch origin`
   - `git switch <child-branch>`
+  - `git rev-parse origin/<child-branch>`로 `<expected-child-remote-sha>`를 기록
+  - `git merge-base --is-ancestor origin/<child-branch> <child-branch>`
   - `git rebase --onto origin/<parent-branch> backup/<parent-branch>-before-update-<timestamp> <child-branch>`
-  - `git push --force-with-lease`
+  - `git push --force-with-lease=<child-branch>:<expected-child-remote-sha> origin <child-branch>`
 - 자식 PR이 또 다른 PR의 부모라면, 그 아래 브랜치도 갱신된 직전 부모 브랜치 위로 차례대로 rebase한다.
   - `git switch <grandchild-branch>`
+  - `git rev-parse origin/<grandchild-branch>`로 `<expected-grandchild-remote-sha>`를 기록
+  - `git merge-base --is-ancestor origin/<grandchild-branch> <grandchild-branch>`
   - `git rebase --onto <child-branch> backup/<child-branch>-before-parent-update-<timestamp> <grandchild-branch>`
-  - `git push --force-with-lease`
+  - `git push --force-with-lease=<grandchild-branch>:<expected-grandchild-remote-sha> origin <grandchild-branch>`
   - `gh pr edit <grandchild-branch> --base <child-branch>`
-- 더 깊은 스택도 같은 규칙을 반복한다. 예를 들어 `main -> A -> B -> C -> D`에서 `A`가 rewrite되면 `B`는 갱신된 `A` 위로 옮기고, `C`는 갱신된 `B` 위로, `D`는 갱신된 `C` 위로 옮긴다.
+- 더 깊은 스택도 같은 규칙을 반복한다. 예를 들어 `main -> A -> B -> C -> D`에서 `A`가 rewrite되면 `B`는 갱신된 `A` 위로 옮기고, `C`는 갱신된 `B` 위로, `D`는 갱신된 `C` 위로 옮긴다. 이때 `C`의 old-base는 rewrite 전 `B` tip이고, `D`의 old-base는 rewrite 전 `C` tip이다.
 - 부모 브랜치가 fast-forward로만 변경됐다는 점이 확실할 때는 `git rebase origin/<parent-branch>`도 동작하지만, 부모가 rewrite됐거나 확실하지 않으면 사용하지 않는다.
 - `git rebase origin/<parent-branch>`는 `<upstream>`만 지정하는 형태라 old-base 경계를 받지 못한다. 부모가 rewrite된 뒤 이 명령을 쓰면 기존 부모 커밋까지 자식 브랜치에서 replay되어 충돌하거나 자식 PR diff에 부모 변경이 섞일 수 있다.
 - 충돌 해결 후에는 `git status`, 관련 테스트, `git log --graph`를 확인한다.
 
 ### 부모 PR이 squash merge된 뒤 자식 PR 이어가기
 
-- 부모 PR이 squash merge되면 먼저 rebase 경계로 사용할 기존 branch tip을 백업 ref나 commit SHA로 남긴다.
+- 부모 PR을 squash merge하기 전, 또는 merge 직후 부모 ref를 삭제하거나 prune하기 전에 rebase 경계로 사용할 기존 branch tip을 백업 ref나 commit SHA로 남긴다.
   - 이 백업은 작업 중인 파일을 보관하기 위한 것이 아니라, `git rebase --onto`의 `<old-base>` 기준점을 잃지 않기 위한 것이다.
   - `git stash`는 uncommitted worktree/index 변경 보관용이므로 이 기준점을 대체하지 못한다.
   - `git branch backup/<merged-parent>-before-squash-<timestamp> <merged-parent>`
   - `git branch backup/<child-branch>-before-squash-<timestamp> <child-branch>`
   - `git branch backup/<grandchild-branch>-before-squash-<timestamp> <grandchild-branch>`
+- 이미 부모 ref가 삭제됐다면 먼저 local reflog, PR commit 목록, 또는 남아 있는 descendant 히스토리에서 이전 부모 tip을 복구해 백업한 뒤 진행한다.
 - squash merge된 PR의 직계 자식만 최신 `main` 위로 옮긴다.
   - `git fetch origin`
   - `git switch <child-branch>`
+  - `git rev-parse origin/<child-branch>`로 `<expected-child-remote-sha>`를 기록
+  - `git merge-base --is-ancestor origin/<child-branch> <child-branch>`
   - `git rebase --onto origin/main backup/<merged-parent>-before-squash-<timestamp> <child-branch>`
-  - `git push --force-with-lease`
+  - `git push --force-with-lease=<child-branch>:<expected-child-remote-sha> origin <child-branch>`
   - `gh pr edit <child-branch> --base main`
 - 손자 이하 브랜치도 결과적으로 새 `main`을 포함하도록 다시 써진다. 다만 `main` 위로 직접 옮기지 않고, 갱신된 직전 부모 브랜치 위로 차례대로 옮긴다.
   - `git switch <grandchild-branch>`
+  - `git rev-parse origin/<grandchild-branch>`로 `<expected-grandchild-remote-sha>`를 기록
+  - `git merge-base --is-ancestor origin/<grandchild-branch> <grandchild-branch>`
   - `git rebase --onto <child-branch> backup/<child-branch>-before-squash-<timestamp> <grandchild-branch>`
-  - `git push --force-with-lease`
+  - `git push --force-with-lease=<grandchild-branch>:<expected-grandchild-remote-sha> origin <grandchild-branch>`
   - `gh pr edit <grandchild-branch> --base <child-branch>`
 - 더 깊은 스택도 같은 규칙을 반복한다. 예를 들어 `main -> A -> B -> C -> D`에서 `A`가 squash merge되면 `B`만 `origin/main` 위로 옮기고, `C`는 갱신된 `B` 위로, `D`는 갱신된 `C` 위로 옮긴다. 이 과정을 끝내면 `C`와 `D`도 새 `main` 위의 히스토리를 갖지만, PR base는 각각 `B`, `C`로 유지된다.
 - 3층 이상 스택의 맨 위 브랜치에서 `git rebase --onto origin/main <merged-parent> <top-branch>`를 바로 실행하면 중간 PR의 커밋까지 맨 위 PR에 포함될 수 있으므로 사용하지 않는다.
@@ -131,13 +147,27 @@
 ### Reparent 하기
 
 - PR의 부모를 바꿔야 하면 local ancestry와 GitHub PR base를 같이 바꾼다. 이때도 현재 브랜치가 쌓여 있던 기존 부모 tip을 rebase 경계로 남긴다.
+  - `<old-parent-tip>`은 현재 브랜치가 기존에 쌓여 있던 직전 부모의 이전 tip이며, fetch/pull/rebase로 ref가 이동하기 전에 기록한다.
+  - 의심스러우면 `git merge-base --is-ancestor <old-parent-tip> <branch>`로 `<old-parent-tip>`이 현재 브랜치 히스토리에 포함된 경계인지 확인한다.
   - `git branch backup/<old-parent-branch>-before-reparent-<timestamp> <old-parent-tip>`
   - `git branch backup/<branch>-before-reparent-<timestamp> <branch>`
+  - `git branch backup/<child-branch>-before-reparent-<timestamp> <child-branch>`
+  - `git branch backup/<grandchild-branch>-before-reparent-<timestamp> <grandchild-branch>`
   - `git fetch origin`
   - `git switch <branch>`
+  - `git rev-parse origin/<branch>`로 `<expected-branch-remote-sha>`를 기록
+  - `git merge-base --is-ancestor origin/<branch> <branch>`
   - `git rebase --onto origin/<new-parent-branch> backup/<old-parent-branch>-before-reparent-<timestamp> <branch>`
-  - `git push --force-with-lease`
+  - `git push --force-with-lease=<branch>:<expected-branch-remote-sha> origin <branch>`
   - `gh pr edit <branch> --base <new-parent-branch>`
+- reparent한 브랜치가 또 다른 PR의 부모라면, 하위 브랜치들도 갱신된 직전 부모 브랜치 위로 차례대로 rebase한다.
+  - `git switch <child-branch>`
+  - `git rev-parse origin/<child-branch>`로 `<expected-child-remote-sha>`를 기록
+  - `git merge-base --is-ancestor origin/<child-branch> <child-branch>`
+  - `git rebase --onto <branch> backup/<branch>-before-reparent-<timestamp> <child-branch>`
+  - `git push --force-with-lease=<child-branch>:<expected-child-remote-sha> origin <child-branch>`
+  - `gh pr edit <child-branch> --base <branch>`
+- 더 깊은 하위 브랜치도 같은 규칙을 반복한다. 각 단계의 old-base는 해당 브랜치가 기존에 쌓여 있던 직전 부모의 reparent 전 tip이며, 이 old-base로 쓸 직전 부모 tip도 첫 rebase 전에 백업해 둔다.
 - 기존 부모 브랜치가 rewrite됐거나 rewrite 여부가 불확실하면 `origin/<old-parent-branch>`를 old-base로 직접 쓰지 않는다.
 - reparent 후에는 `gh pr view --json headRefName,baseRefName,url`로 GitHub base가 맞는지 확인한다.
 

--- a/memory/commit-pr.md
+++ b/memory/commit-pr.md
@@ -13,6 +13,7 @@
 - 최종 머지는 PR 내용 기준의 squash merge를 전제로 하므로, 커밋 히스토리 정리보다 PR의 기능적 일관성과 리뷰 가능성을 더 우선한다.
 - 브랜치 이름은 관련 Linear 이슈 ID를 그대로 사용한다.
 - 브랜치 생성, 커밋 생성, PR 생성은 기본적으로 Aviator CLI(`av`)를 사용한다.
+- 현재 워크트리에서 Aviator CLI(`av`)가 반복적으로 실패하거나 스택 메타데이터가 불안정하면, 작업을 멈추지 않고 Git/GitHub CLI fallback flow를 사용한다.
 - 기존 PR 제목/본문/상태 등 PR 편집은 Aviator CLI(`av pr --edit`) 대신 GitHub CLI(`gh`)를 사용한다.
 - Aviator CLI(`av`)가 설치되어 있지 않다면 커밋/PR 작업을 계속하기 전에 설치를 권장한다.
 
@@ -27,6 +28,130 @@
 - 이미 열린 PR의 제목/본문/상태를 편집할 때는 `gh pr edit` 같은 GitHub CLI 명령을 사용한다.
 - 브랜치 정리가 필요할 때는 `av sync --ff-trunk --rebase-to-trunk --prune`으로 로컬 브랜치 스택을 정리한다.
 - 별도 이유가 없다면 같은 목적을 위해 `git switch -c`, `git commit`, `gh pr create`를 직접 쓰지 않는다.
+- 단, `av`가 현재 워크트리에서 반복 실패하는 상황에서는 아래 Git fallback 명령을 우선한다.
+
+## Git Fallback Flow When `av` Fails
+
+이 fallback은 `av`의 숨은 스택 메타데이터 대신 Git 브랜치 ancestry와 GitHub PR base를 source of truth로 삼는다.
+
+### 공통 확인
+
+- 작업 전 항상 현재 위치와 변경 범위를 확인한다.
+  - `git status --short --branch`
+  - `git branch --show-current`
+  - `git log --oneline --graph --decorate --all -n 30`
+- PR이 이미 있거나 스택 base를 확인해야 하면 GitHub의 PR base를 확인한다.
+  - `gh pr view --json number,title,headRefName,baseRefName,isDraft,state,url`
+- 스택을 재작성하기 전에는 현재 브랜치 위치를 복구 가능한 백업 브랜치로 남긴다.
+  - `git branch backup/<branch>-<timestamp> <branch>`
+- rebase 또는 reparent 후에는 `git range-diff`나 `git log --graph`로 의도한 커밋만 이동했는지 확인한다.
+- 공유 브랜치를 다시 push할 때는 `git push --force-with-lease`만 사용한다.
+
+### 새 스택 브랜치 만들기
+
+- 첫 PR 브랜치는 최신 trunk에서 만든다.
+  - `git fetch origin`
+  - `git switch main`
+  - `git pull --ff-only`
+  - `git switch -c <Linear issue ID>`
+- 후속 PR 브랜치는 부모 브랜치에서 만든다.
+  - `git fetch origin`
+  - `git switch <parent-branch>`
+  - `git pull --ff-only origin <parent-branch>`
+  - `git switch -c <Linear issue ID>`
+- 브랜치 이름은 fallback에서도 관련 Linear 이슈 ID를 그대로 사용한다.
+
+### 커밋 만들기
+
+- 변경 범위를 확인한 뒤 필요한 파일만 staging한다.
+  - `git status --short`
+  - `git diff`
+  - `git add <paths>`
+  - `git diff --cached`
+  - `git commit -m "<message>"`
+- 커밋 메시지는 투기적 체크포인트로 충분히 식별 가능하게 쓴다.
+- 의도하지 않은 사용자 변경이 섞이면 staging하지 않고 남겨둔다.
+
+### 스택 PR 열기
+
+- 원격 브랜치를 먼저 올린다.
+  - `git push -u origin HEAD`
+- 첫 PR은 `main`을 base로 연다.
+  - `gh pr create --draft --base main --head <branch> --title "<Korean title>" --body "<Korean body>"`
+- 후속 PR은 부모 브랜치를 base로 연다.
+  - `gh pr create --draft --base <parent-branch> --head <branch> --title "<Korean title>" --body "<Korean body>"`
+- PR 본문에는 스택 위치를 명시한다.
+  - `Stack: main -> <parent-branch> -> <this-branch>`
+- 이미 열린 PR의 base가 틀리면 `gh pr edit <branch-or-pr-number> --base <parent-branch>`로 고친다.
+
+### 부모 브랜치 변경을 자식 브랜치에 반영하기
+
+- 부모 브랜치가 force-push나 rebase로 다시 쓰일 수 있는 fallback 상황에서는 자식 브랜치의 기존 base였던 부모 tip을 먼저 백업 ref나 commit SHA로 남긴다.
+  - `<old-parent-tip>`은 자식 브랜치가 쌓여 있던 이전 부모 tip이며, fetch/pull/rebase로 ref가 이동하기 전에 `git rev-parse <parent-branch>` 또는 `git rev-parse origin/<parent-branch>`로 확인한다.
+  - `git branch backup/<parent-branch>-before-update-<timestamp> <old-parent-tip>`
+  - `git branch backup/<child-branch>-before-parent-update-<timestamp> <child-branch>`
+  - `git branch backup/<grandchild-branch>-before-parent-update-<timestamp> <grandchild-branch>`
+- 부모 브랜치가 push된 최신 상태라면 자식 고유 커밋만 새 부모 브랜치 위로 rebase한다.
+  - `git fetch origin`
+  - `git switch <child-branch>`
+  - `git rebase --onto origin/<parent-branch> backup/<parent-branch>-before-update-<timestamp> <child-branch>`
+  - `git push --force-with-lease`
+- 자식 PR이 또 다른 PR의 부모라면, 그 아래 브랜치도 갱신된 직전 부모 브랜치 위로 차례대로 rebase한다.
+  - `git switch <grandchild-branch>`
+  - `git rebase --onto <child-branch> backup/<child-branch>-before-parent-update-<timestamp> <grandchild-branch>`
+  - `git push --force-with-lease`
+  - `gh pr edit <grandchild-branch> --base <child-branch>`
+- 더 깊은 스택도 같은 규칙을 반복한다. 예를 들어 `main -> A -> B -> C -> D`에서 `A`가 rewrite되면 `B`는 갱신된 `A` 위로 옮기고, `C`는 갱신된 `B` 위로, `D`는 갱신된 `C` 위로 옮긴다.
+- 부모 브랜치가 fast-forward로만 변경됐다는 점이 확실할 때는 `git rebase origin/<parent-branch>`도 동작하지만, 부모가 rewrite됐거나 확실하지 않으면 사용하지 않는다.
+- `git rebase origin/<parent-branch>`는 `<upstream>`만 지정하는 형태라 old-base 경계를 받지 못한다. 부모가 rewrite된 뒤 이 명령을 쓰면 기존 부모 커밋까지 자식 브랜치에서 replay되어 충돌하거나 자식 PR diff에 부모 변경이 섞일 수 있다.
+- 충돌 해결 후에는 `git status`, 관련 테스트, `git log --graph`를 확인한다.
+
+### 부모 PR이 squash merge된 뒤 자식 PR 이어가기
+
+- 부모 PR이 squash merge되면 먼저 rebase 경계로 사용할 기존 branch tip을 백업 ref나 commit SHA로 남긴다.
+  - 이 백업은 작업 중인 파일을 보관하기 위한 것이 아니라, `git rebase --onto`의 `<old-base>` 기준점을 잃지 않기 위한 것이다.
+  - `git stash`는 uncommitted worktree/index 변경 보관용이므로 이 기준점을 대체하지 못한다.
+  - `git branch backup/<merged-parent>-before-squash-<timestamp> <merged-parent>`
+  - `git branch backup/<child-branch>-before-squash-<timestamp> <child-branch>`
+  - `git branch backup/<grandchild-branch>-before-squash-<timestamp> <grandchild-branch>`
+- squash merge된 PR의 직계 자식만 최신 `main` 위로 옮긴다.
+  - `git fetch origin`
+  - `git switch <child-branch>`
+  - `git rebase --onto origin/main backup/<merged-parent>-before-squash-<timestamp> <child-branch>`
+  - `git push --force-with-lease`
+  - `gh pr edit <child-branch> --base main`
+- 손자 이하 브랜치도 결과적으로 새 `main`을 포함하도록 다시 써진다. 다만 `main` 위로 직접 옮기지 않고, 갱신된 직전 부모 브랜치 위로 차례대로 옮긴다.
+  - `git switch <grandchild-branch>`
+  - `git rebase --onto <child-branch> backup/<child-branch>-before-squash-<timestamp> <grandchild-branch>`
+  - `git push --force-with-lease`
+  - `gh pr edit <grandchild-branch> --base <child-branch>`
+- 더 깊은 스택도 같은 규칙을 반복한다. 예를 들어 `main -> A -> B -> C -> D`에서 `A`가 squash merge되면 `B`만 `origin/main` 위로 옮기고, `C`는 갱신된 `B` 위로, `D`는 갱신된 `C` 위로 옮긴다. 이 과정을 끝내면 `C`와 `D`도 새 `main` 위의 히스토리를 갖지만, PR base는 각각 `B`, `C`로 유지된다.
+- 3층 이상 스택의 맨 위 브랜치에서 `git rebase --onto origin/main <merged-parent> <top-branch>`를 바로 실행하면 중간 PR의 커밋까지 맨 위 PR에 포함될 수 있으므로 사용하지 않는다.
+
+### Reparent 하기
+
+- PR의 부모를 바꿔야 하면 local ancestry와 GitHub PR base를 같이 바꾼다. 이때도 현재 브랜치가 쌓여 있던 기존 부모 tip을 rebase 경계로 남긴다.
+  - `git branch backup/<old-parent-branch>-before-reparent-<timestamp> <old-parent-tip>`
+  - `git branch backup/<branch>-before-reparent-<timestamp> <branch>`
+  - `git fetch origin`
+  - `git switch <branch>`
+  - `git rebase --onto origin/<new-parent-branch> backup/<old-parent-branch>-before-reparent-<timestamp> <branch>`
+  - `git push --force-with-lease`
+  - `gh pr edit <branch> --base <new-parent-branch>`
+- 기존 부모 브랜치가 rewrite됐거나 rewrite 여부가 불확실하면 `origin/<old-parent-branch>`를 old-base로 직접 쓰지 않는다.
+- reparent 후에는 `gh pr view --json headRefName,baseRefName,url`로 GitHub base가 맞는지 확인한다.
+
+### 스택 상태 보기
+
+- 로컬 커밋 관계는 Git graph로 본다.
+  - `git log --oneline --graph --decorate --all --date-order -n 80`
+- PR 체인은 각 PR의 base/head로 본다.
+  - `gh pr list --state open --json number,title,headRefName,baseRefName,isDraft,url`
+
+### fallback 종료
+
+- `av`가 다시 정상화되기 전까지는 같은 스택에서 `av reorder`, `av reparent`, `av sync`와 Git fallback rebase를 섞지 않는다.
+- `av`를 다시 쓰려면 먼저 열린 PR의 base/head와 로컬 브랜치 ancestry가 일치하는지 확인한 뒤, 별도 정리 작업으로 전환한다.
 
 ## Commit Policy
 
@@ -52,6 +177,8 @@
 - 브랜치 순서를 재구성하거나, 커밋을 다른 브랜치로 옮기거나, 스택 단위로 정리해야 할 때는 `av reorder`를 사용한다.
 - `av reorder`는 스택 전체를 대상으로 동작하므로, 단순 커밋 순서 조정뿐 아니라 브랜치 간 커밋 이동이 필요한 경우에도 우선 고려한다.
 - 브랜치 구조가 틀어졌을 때 임의의 `git rebase -i`로 개별 브랜치를 손대기보다 Aviator 스택 명령을 우선 사용한다.
+- 단, `av`가 현재 워크트리에서 실패하는 동안에는 Git fallback flow를 예외 정책으로 사용한다.
+- fallback 중에는 GitHub PR base가 리뷰 순서를 결정하므로, 모든 stacked PR의 `baseRefName`이 의도한 부모 브랜치를 가리키는지 확인한다.
 
 ## PR Policy
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `av`가 현재 워크트리에서 반복 실패하거나 스택 메타데이터가 불안정할 때 사용할 Git/GitHub CLI fallback flow를 `memory/commit-pr.md`에 추가했습니다.
- Git branch ancestry와 GitHub PR base를 source of truth로 삼는 운영 원칙을 명시했습니다.
- `git rebase --onto <new-base> <old-base> <branch>`의 `<old-base>`는 항상 해당 브랜치가 기존에 쌓여 있던 직전 부모의 이전 tip이어야 한다는 공통 원칙을 추가했습니다.
- 공유 브랜치를 다시 push할 때 기본 `git push --force-with-lease` 대신 branch별 expected remote SHA를 지정한 `--force-with-lease=<branch>:<expected-remote-sha>`를 쓰도록 보강했습니다.
- force-push 전 원격 head가 로컬 브랜치에 포함되어 있는지 확인하고, 원격-only 커밋이 있으면 먼저 통합하도록 명시했습니다.
- 새 스택 브랜치 생성, 커밋, PR 생성, 부모 브랜치 변경 반영, reparent, 스택 상태 확인 절차를 정리했습니다.
- 부모 브랜치가 force-push/rebase로 다시 쓰인 경우 `git rebase origin/<parent-branch>` 대신 이전 부모 tip을 경계로 둔 `git rebase --onto origin/<parent-branch> <old-parent-tip> <child-branch>`를 사용하도록 보강했습니다.
- 부모 변경 반영 절차에서도 자식 PR 아래에 열린 후속 PR이 있으면 손자 이하 브랜치를 갱신된 직전 부모 위로 순차 rebase하도록 보강했습니다.
- squash merge 전이나 부모 ref 삭제/prune 전에 기존 부모 tip을 백업하고, 이미 ref가 삭제된 경우 reflog/PR commit/descendant history에서 복구하도록 보강했습니다.
- reparent 절차에서도 기존 부모가 rewrite됐거나 불확실한 경우 `origin/<old-parent-branch>`를 old-base로 직접 쓰지 않고, reparent 전 기존 부모 tip 백업 ref를 경계로 쓰도록 보강했습니다.
- reparent된 브랜치 아래에 열린 후속 PR도 갱신된 직전 부모 위로 순차 rebase하도록 보강했습니다.
- `git stash`와 백업 ref/commit SHA의 역할 차이를 명시했습니다.

## 왜 변경했는지

- 현재 워크트리에서 `av` CLI가 계속 실패하는 상황에서도 팀의 stacked PR 흐름을 멈추지 않기 위해 Git 기반 fallback 절차가 필요했습니다.
- 부모 브랜치가 rewrite된 뒤 old-base 경계 없이 rebase하면 기존 부모 커밋이 자식 PR diff에 섞일 수 있어, 안전한 `--onto` 기준을 문서화했습니다.
- 기본 `--force-with-lease`는 직전 `fetch`로 갱신된 원격 추적 ref를 기준으로 삼을 수 있어, 로컬에 포함하지 않은 원격 변경을 덮어쓸 위험이 있으므로 expected SHA 기반 lease를 문서화했습니다.
- 자식 브랜치만 갱신하면 그 아래 PR diff에 이전 자식 커밋이 섞일 수 있어, descendant 브랜치까지 순차 갱신하는 규칙을 추가했습니다.
- squash merge 후 부모 ref를 잃으면 old-base 경계를 복구하기 어려워질 수 있어, merge 전 백업과 복구 절차를 명확히 했습니다.
- reparent 중에도 같은 old-base 경계 문제가 생길 수 있어, reparent 절차의 기준과 하위 브랜치 갱신 절차를 명확히 했습니다.

## 어떻게 확인할 수 있는지

- `git diff --check origin/main...HEAD`
- `pnpm exec prettier --check --ignore-unknown memory/commit-pr.md`
- pre-commit hook 실행: `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown`
- 서브에이전트 반복 리뷰: 마지막 리뷰에서 액션 가능한 문제 없음 확인

## 아직 어떤 문제가 남았는지

- 관련 Linear 이슈 ID가 없어 브랜치 이름은 GitHub publish fallback 규칙에 따라 `codex/git-stacking-fallback-flow`를 사용했습니다.
- 로컬 `gh` 토큰이 invalid 상태라 PR 생성과 본문 갱신은 GitHub connector로 진행했습니다.
- 이 세션에서는 1Password signing agent에 연결할 수 없어 커밋은 `commit.gpgsign=false`로 생성했습니다.