### PR TITLE
Codex worktree setup에서 origin/main을 안정적으로 복구한다

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -8,7 +8,7 @@ set -eu
 
 cd "${CODEX_WORKTREE_PATH:?CODEX_WORKTREE_PATH is required}"
 
-git fetch origin +refs/heads/main:refs/remotes/origin/main
+git fetch origin refs/heads/main:refs/remotes/origin/main
 
 if ! git show-ref --verify --quiet refs/remotes/origin/main; then
   echo "origin/main was not fetched; verify the remote default branch before continuing." >&2

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -8,7 +8,12 @@ set -eu
 
 cd "${CODEX_WORKTREE_PATH:?CODEX_WORKTREE_PATH is required}"
 
-git fetch origin main:refs/remotes/origin/main
+git fetch origin +refs/heads/main:refs/remotes/origin/main
+
+if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+  echo "origin/main was not fetched; verify the remote default branch before continuing." >&2
+  exit 1
+fi
 
 main_worktree="$(
   git worktree list --porcelain |

--- a/memory/script.md
+++ b/memory/script.md
@@ -11,6 +11,6 @@
 
 ## Codex worktree setup
 
-- `.codex/environments/environment.toml`의 setup script는 `mise trust`와 `pnpm install` 전에 원격 `refs/heads/main`을 `refs/remotes/origin/main`으로 fetch하고, 해당 ref가 실제로 생겼는지 검증한 뒤 로컬 `main` worktree 또는 `main` ref를 fast-forward로 최신화한다.
+- `.codex/environments/environment.toml`의 setup script는 `mise trust`와 `pnpm install` 전에 원격 `refs/heads/main`을 `refs/remotes/origin/main`으로 non-forcing fetch하고, 해당 ref가 실제로 생겼는지 검증한 뒤 로컬 `main` worktree 또는 `main` ref를 fast-forward로 최신화한다.
 - 새 Codex worktree의 현재 HEAD가 `origin/main`의 조상인 경우에는 현재 worktree도 `origin/main`까지 fast-forward하거나 detached HEAD를 `origin/main`으로 옮긴다.
 - 로컬 `main`이 `origin/main`으로 fast-forward될 수 없는 상태라면 setup에서 자동 갱신을 거부하고 실패시킨다.

--- a/memory/script.md
+++ b/memory/script.md
@@ -11,6 +11,6 @@
 
 ## Codex worktree setup
 
-- `.codex/environments/environment.toml`의 setup script는 `mise trust`와 `pnpm install` 전에 `origin/main`을 fetch하고, 로컬 `main` worktree 또는 `main` ref를 fast-forward로 최신화한다.
+- `.codex/environments/environment.toml`의 setup script는 `mise trust`와 `pnpm install` 전에 원격 `refs/heads/main`을 `refs/remotes/origin/main`으로 fetch하고, 해당 ref가 실제로 생겼는지 검증한 뒤 로컬 `main` worktree 또는 `main` ref를 fast-forward로 최신화한다.
 - 새 Codex worktree의 현재 HEAD가 `origin/main`의 조상인 경우에는 현재 worktree도 `origin/main`까지 fast-forward하거나 detached HEAD를 `origin/main`으로 옮긴다.
 - 로컬 `main`이 `origin/main`으로 fast-forward될 수 없는 상태라면 setup에서 자동 갱신을 거부하고 실패시킨다.


### PR DESCRIPTION
## 무엇을 변경했는지

- Codex 로컬 환경 setup에서 원격 `refs/heads/main`을 `refs/remotes/origin/main`으로 명시 fetch하도록 수정했습니다.
- fetch 직후 `origin/main` ref가 실제로 존재하는지 확인하고, 없으면 명확한 오류 메시지로 중단하게 했습니다.
- setup 동작 변경을 `memory/script.md`의 Codex worktree setup 메모리에 반영했습니다.

## 왜 변경했는지

- 기존 `git fetch origin main:refs/remotes/origin/main` 명령이 현재 원격 상태에서 `origin/main`을 삭제하는 동작을 재현했습니다.
- 이후 setup이 `git merge-base ... origin/main`을 실행하면서 `fatal: Not a valid object name origin/main`으로 실패했습니다.
- 원격 head ref를 명시하면 삭제된 원격 추적 ref를 다시 만들 수 있어, 새 Codex worktree의 환경 설정이 main ref 누락 때문에 실패하지 않습니다.

## 어떻게 확인할 수 있는지

- 서브에이전트 리뷰: 발견된 문제 없음
- 기존 fetch 명령으로 `origin/main` 삭제 동작 재현 확인
- 수정된 fetch 명령으로 `origin/main`이 `87a4508cc4a07da5faa78e29259c049fda71b8d5`로 복구되는지 확인
- 수정된 setup 경로를 현재 복구 워크트리에서 실행해 `mise trust`와 `pnpm install`까지 성공 확인
- `git diff --check`
- 커밋 훅의 `lint-staged` 실행 통과

## 아직 어떤 문제가 남았는지

없음