### PR TITLE
윈도우에서 깨지는 CLAUDE.md 심볼릭링크를 @AGENTS.md import로 교체한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## 무엇을 변경했는지

- `CLAUDE.md`를 심볼릭링크(mode `120000` → `AGENTS.md`)에서 일반 파일(mode `100644`)로 바꾸고, 내용을 `@AGENTS.md` import 한 줄로 둔다.
- `AGENTS.md`는 원본 그대로 유지한다(Codex 등 다른 도구가 직접 읽음).

## 왜 변경했는지

- `CLAUDE.md`가 git에 심볼릭링크로 저장되어 있어 mac/Linux에서는 정상 동작하지만, 윈도우 체크아웃은 `core.symlinks=false`라 링크가 풀리지 않고 `AGENTS.md`라는 9바이트 텍스트가 든 일반 파일로 깨진다.
- 그 결과 윈도우 작업자는 Claude Code가 AGENTS.md 지침을 자동으로 로드하지 못했다.
- `@AGENTS.md`는 Claude Code의 import 기능이라 파일시스템 symlink에 의존하지 않으므로 mac/윈도우/리눅스에서 동일하게 동작한다.

## 어떻게 확인할 수 있는지

- `git ls-files -s CLAUDE.md`가 `100644`(일반 파일)을 보여주는지 확인했다.
- `git show HEAD --stat`에 `mode change 120000 => 100644 CLAUDE.md`가 기록된다.
- 윈도우 환경에서 다음 Claude Code 세션부터 AGENTS.md 본문이 프로젝트 지침으로 로드되는지 확인 필요.

## 아직 어떤 문제가 남았는지

- 없음.

Linear: PROD-101