### PR TITLE
프로필 핸들 오류 원인을 사용자가 이해할 수 있게 한다

### DIFF
--- a/apps/api/src/graphql/resolvers/profile/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/create.ts
@@ -30,7 +30,7 @@ builder.mutationField('createProfile', (t) =>
           .then(firstOrThrow)
           .catch((error) => {
             if (isUniqueViolation(error)) {
-              throw new ConflictError({ field: 'handle' });
+              throw new ConflictError({ message: '이미 사용 중인 핸들이에요.', field: 'handle' });
             }
 
             throw error;

--- a/apps/web/src/lib/components/SidebarNavigation.svelte
+++ b/apps/web/src/lib/components/SidebarNavigation.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { profileHandleSchema } from '@kosmo/core/validation';
   import { createMutation, createQuery } from '@mearie/svelte';
   import { graphql } from '$mearie';
   import type { DataOf } from '@mearie/svelte';
@@ -138,6 +139,18 @@
 
   const formatCount = (count: number) => new Intl.NumberFormat('ko-KR').format(count);
 
+  const getProfileHandleError = (handle: string) => {
+    if (!handle) {
+      return '프로필 핸들을 입력해주세요.';
+    }
+
+    const result = profileHandleSchema.safeParse(handle);
+
+    return result.success
+      ? null
+      : (result.error.issues[0]?.message ?? '프로필 핸들 형식을 확인해주세요.');
+  };
+
   const creatingOrSwitching = $derived(profileActionLoading || profileQuery.loading);
   const sidebarProfiles = $derived(profilesOverride ?? profileQuery.data?.me?.profiles ?? []);
   const sidebarActiveProfile = $derived(
@@ -185,8 +198,14 @@
     event.preventDefault();
 
     const handle = newProfileHandle.trim();
-    if (!handle || creatingOrSwitching) {
-      profileCreationError = handle ? null : '프로필 핸들을 입력해주세요.';
+
+    if (creatingOrSwitching) {
+      return;
+    }
+
+    const handleError = getProfileHandleError(handle);
+    if (handleError) {
+      profileCreationError = handleError;
       return;
     }
 
@@ -396,6 +415,8 @@
                 class="min-w-0 flex-1 rounded-lg border border-[#d4d4d8] px-3 py-2 text-sm outline-none transition placeholder:text-[#a1a1aa] focus:border-[#111111]"
                 name="handle"
                 autocomplete="off"
+                aria-describedby={`profile-handle-help-${surface}`}
+                aria-invalid={profileCreationError ? 'true' : undefined}
                 placeholder="새 프로필 핸들"
                 disabled={creatingOrSwitching}
                 bind:value={newProfileHandle}
@@ -408,6 +429,9 @@
                 만들기
               </button>
             </div>
+            <p id={`profile-handle-help-${surface}`} class="px-1 text-xs leading-4 text-[#777777]">
+              영문, 숫자, 밑줄(_)만 사용할 수 있어요.
+            </p>
             {#if profileCreationError}
               <p class="px-1 text-xs leading-4 text-red-600">{profileCreationError}</p>
             {/if}

--- a/packages/core/validation/profile.ts
+++ b/packages/core/validation/profile.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 export const profileHandleSchema = z
   .string()
   .trim()
-  .min(3)
-  .max(30)
-  .regex(/^[a-zA-Z0-9_]+$/);
+  .min(3, '핸들은 3자 이상 입력해주세요.')
+  .max(30, '핸들은 30자 이하로 입력해주세요.')
+  .regex(/^[a-zA-Z0-9_]+$/, '핸들은 영문, 숫자, 밑줄(_)만 사용할 수 있어요.');
 
 export const profileDisplayNameSchema = z.string().trim().min(1).max(80);
 


### PR DESCRIPTION
## 무엇을 변경했는지

- 프로필 핸들 Zod 스키마에 사용자용 검증 메시지를 추가했습니다.
- 프로필 생성 폼에서 서버와 동일한 `profileHandleSchema`로 submit 전 클라이언트 검증을 수행하게 했습니다.
- 유효하지 않은 핸들은 GraphQL 요청 전에 막고 입력창 아래에 원인 메시지를 표시하게 했습니다.
- 중복 핸들 생성 실패 시 `이미 사용 중인 핸들이에요.` 메시지를 반환하게 했습니다.
- 프로필 핸들 입력 도움말과 `aria-invalid`, `aria-describedby`를 추가했습니다.

## 왜 변경했는지

한글이나 특수문자가 포함된 핸들을 입력하면 GraphQL validation error가 발생하고, 사용자에게 `1 error(s) occurred` 같은 기술적인 메시지가 표시됐습니다.

사용자가 입력값을 어떻게 고쳐야 하는지 바로 이해할 수 있도록, 클라이언트에서 먼저 검증하고 일반 사용자에게 필요한 수준의 안내 문구를 보여주도록 변경했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm --filter @kosmo/api lint:tsc`

## 아직 어떤 문제가 남았는지

없음