### PR TITLE
로컬 환경 setup 첫 실행 ref 복구를 안정화한다

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -8,12 +8,14 @@ set -eu
 
 cd "${CODEX_WORKTREE_PATH:?CODEX_WORKTREE_PATH is required}"
 
-git fetch origin refs/heads/main:refs/remotes/origin/main
+remote_main_ref=refs/remotes/origin/main
 
-if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+git fetch origin +refs/heads/main:"$remote_main_ref"
+
+remote_main_commit="$(git rev-parse --verify "$remote_main_ref^{commit}")" || {
   echo "origin/main was not fetched; verify the remote default branch before continuing." >&2
   exit 1
-fi
+}
 
 main_worktree="$(
   git worktree list --porcelain |
@@ -24,24 +26,24 @@ main_worktree="$(
 )"
 
 if [ -n "$main_worktree" ]; then
-  git -C "$main_worktree" merge --ff-only origin/main
+  git -C "$main_worktree" merge --ff-only "$remote_main_commit"
 elif git show-ref --verify --quiet refs/heads/main; then
-  if git merge-base --is-ancestor main origin/main; then
-    git branch --force main origin/main
+  if git merge-base --is-ancestor refs/heads/main "$remote_main_commit"; then
+    git branch --force main "$remote_main_commit"
   else
     echo "main is not a fast-forward of origin/main; refusing to update automatically." >&2
     exit 1
   fi
 else
-  git branch main origin/main
+  git branch main "$remote_main_ref"
 fi
 
 current_branch="$(git branch --show-current || true)"
-if git merge-base --is-ancestor HEAD origin/main; then
+if git merge-base --is-ancestor HEAD "$remote_main_commit"; then
   if [ -n "$current_branch" ]; then
-    git merge --ff-only origin/main
+    git merge --ff-only "$remote_main_commit"
   else
-    git switch --detach origin/main
+    git switch --detach "$remote_main_commit"
   fi
 fi
 

--- a/memory/script.md
+++ b/memory/script.md
@@ -11,6 +11,6 @@
 
 ## Codex worktree setup
 
-- `.codex/environments/environment.toml`의 setup script는 `mise trust`와 `pnpm install` 전에 원격 `refs/heads/main`을 `refs/remotes/origin/main`으로 non-forcing fetch하고, 해당 ref가 실제로 생겼는지 검증한 뒤 로컬 `main` worktree 또는 `main` ref를 fast-forward로 최신화한다.
-- 새 Codex worktree의 현재 HEAD가 `origin/main`의 조상인 경우에는 현재 worktree도 `origin/main`까지 fast-forward하거나 detached HEAD를 `origin/main`으로 옮긴다.
+- `.codex/environments/environment.toml`의 setup script는 `mise trust`와 `pnpm install` 전에 원격 `refs/heads/main`을 `refs/remotes/origin/main`으로 fetch하고, 해당 ref의 commit OID를 확정한 뒤 로컬 `main` worktree 또는 `main` ref를 fast-forward로 최신화한다.
+- 새 Codex worktree의 현재 HEAD가 fetch된 `origin/main` commit의 조상인 경우에는 현재 worktree도 해당 commit까지 fast-forward하거나 detached HEAD를 해당 commit으로 옮긴다.
 - 로컬 `main`이 `origin/main`으로 fast-forward될 수 없는 상태라면 setup에서 자동 갱신을 거부하고 실패시킨다.


### PR DESCRIPTION
## 무엇을 변경했는지

- Codex 로컬 환경 setup에서 `origin/main` 축약 ref를 반복 참조하지 않고, fetch 직후 전체 ref의 commit OID를 확정해 사용하도록 변경했습니다.
- 첫 실행에서 `refs/remotes/origin/main`이 없거나 `origin/HEAD`가 dangling인 상태여도 `refs/heads/main`을 `refs/remotes/origin/main`으로 직접 복구하도록 했습니다.
- 관련 `memory/script.md`의 setup 동작 설명을 새 방식에 맞게 갱신했습니다.

## 왜 변경했는지

- 기존 setup은 재시도 후에는 성공해도, 첫 worktree 생성 시점의 원격 ref 상태가 비어 있거나 불안정하면 `origin/main` 해석에 실패할 수 있었습니다.
- 실패한 첫 setup을 사용자가 수동으로 재시도하지 않아도, 새 worktree 생성 직후 한 번에 setup이 통과하도록 하기 위한 변경입니다.

## 어떻게 확인할 수 있는지

- 임시 clone에서 `refs/remotes/origin/main`을 삭제하고 `origin/HEAD`만 해당 ref를 가리키는 dangling 상태를 만든 뒤, 수정된 Git setup 구간이 한 번에 `origin/main`을 복구하고 성공하는지 확인했습니다.
- `git diff --check`
- `pnpm install`
- 커밋 훅의 `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown` 통과

## 아직 어떤 문제가 남았는지

- `mise trust`는 사용자 전역 mise 신뢰 저장소를 영구 변경하는 단계라 자동 승인 환경에서 직접 검증하지 않았습니다.
- 이 작업에는 별도 Linear 이슈 ID가 제공되지 않아, 브랜치는 예외적으로 설명형 이름을 사용했습니다.