### PR TITLE
팔로우 버튼 View의 파생 상태를 Fragment 기반으로 제거한다

### DIFF
--- a/apps/web/src/lib/components/FollowButton.stories.svelte
+++ b/apps/web/src/lib/components/FollowButton.stories.svelte
@@ -8,10 +8,17 @@
     component: FollowButtonView,
     tags: ['autodocs'],
     argTypes: {
-      authenticated: {
+      variant: {
+        control: 'radio',
+        options: ['primary', 'secondary'],
+      },
+      disabled: {
         control: 'boolean',
       },
-      canMutate: {
+      loading: {
+        control: 'boolean',
+      },
+      pressed: {
         control: 'boolean',
       },
       size: {
@@ -23,82 +30,57 @@
 </script>
 
 <script lang="ts">
-  const targetProfileId = '00000000-0000-4000-8000-000000000090';
-  const viewerProfileId = '00000000-0000-4000-8000-000000000001';
-  const acceptedFollow = {
-    id: '00000000-0000-4000-8000-000000000100',
-    state: 'ACCEPTED' as const,
-  };
-  const pendingFollow = {
-    id: '00000000-0000-4000-8000-000000000101',
-    state: 'PENDING' as const,
-  };
-
-  const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-  const followAction = async () => {
-    await wait(400);
-    return acceptedFollow;
-  };
-  const unfollowAction = async () => {
-    await wait(400);
-  };
-  const failingFollowAction = async () => {
-    await wait(400);
-    throw new Error('팔로우 요청에 실패했습니다. 잠시 후 다시 시도해주세요.');
-  };
+  const noop = () => {};
 </script>
 
 <Story
   name="Playground"
   args={{
-    targetProfileId,
-    viewerProfileId,
-    viewerFollow: null,
-    authenticated: true,
-    canMutate: true,
+    hidden: false,
+    label: '팔로우',
+    variant: 'primary',
+    disabled: false,
+    loading: false,
+    pressed: false,
+    message: null,
     size: 'sm',
-    followAction,
-    unfollowAction,
+    onclick: noop,
   }}
 />
 
 <Story name="States" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid gap-4">
-    <FollowButtonView {targetProfileId} {viewerProfileId} {followAction} {unfollowAction} />
+    <FollowButtonView label="팔로우" variant="primary" onclick={noop} />
+    <FollowButtonView label="팔로잉" variant="secondary" pressed onclick={noop} />
+    <FollowButtonView label="요청 중" variant="secondary" onclick={noop} />
+    <FollowButtonView label="처리 중" variant="primary" loading disabled onclick={noop} />
     <FollowButtonView
-      {targetProfileId}
-      {viewerProfileId}
-      viewerFollow={acceptedFollow}
-      {followAction}
-      {unfollowAction}
+      label="팔로우"
+      variant="primary"
+      disabled
+      message="프로필을 선택한 뒤 팔로우할 수 있습니다."
+      onclick={noop}
     />
     <FollowButtonView
-      {targetProfileId}
-      {viewerProfileId}
-      viewerFollow={pendingFollow}
-      {followAction}
-      {unfollowAction}
-    />
-    <FollowButtonView {targetProfileId} viewerProfileId={null} {followAction} {unfollowAction} />
-    <FollowButtonView
-      {targetProfileId}
-      {viewerProfileId}
-      authenticated={false}
-      {followAction}
-      {unfollowAction}
+      label="팔로우"
+      variant="primary"
+      disabled
+      message="로그인 후 팔로우할 수 있습니다."
+      onclick={noop}
     />
     <FollowButtonView
-      {targetProfileId}
-      {viewerProfileId}
-      canMutate={false}
-      {followAction}
-      {unfollowAction}
+      label="팔로우"
+      variant="primary"
+      disabled
+      message="이 프로필을 팔로우할 권한이 없습니다."
+      onclick={noop}
     />
     <FollowButtonView
-      {targetProfileId}
-      {viewerProfileId}
-      followAction={failingFollowAction}
-      {unfollowAction}
+      label="팔로우"
+      variant="primary"
+      message="팔로우 요청에 실패했습니다. 잠시 후 다시 시도해주세요."
+      messageRole="alert"
+      onclick={noop}
     />
   </div>
 </Story>

--- a/apps/web/src/lib/components/FollowButton.svelte
+++ b/apps/web/src/lib/components/FollowButton.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { createMutation } from '@mearie/svelte';
+  import { createFragment, createMutation } from '@mearie/svelte';
   import { graphql } from '$mearie';
+  import type { FragmentRefs } from '@mearie/svelte';
 
   import FollowButtonView, { type ViewerFollow } from './FollowButtonView.svelte';
 
   type Props = {
-    targetProfileId: string;
+    profile: FragmentRefs<'FollowButton_profile'>;
     viewerProfileId?: string | null;
-    viewerFollow?: ViewerFollow | null;
     authenticated?: boolean;
     canMutate?: boolean;
     disabledReason?: string | null;
@@ -15,6 +15,16 @@
     class?: string;
     onFollowChange?: (viewerFollow: ViewerFollow | null) => void;
   };
+
+  const followButtonProfileFragment = graphql(`
+    fragment FollowButton_profile on Profile {
+      id
+      viewerFollow {
+        id
+        state
+      }
+    }
+  `);
 
   const followProfileMutation = graphql(`
     mutation FollowButtonFollowProfile($id: ID!) {
@@ -48,9 +58,8 @@
   `);
 
   let {
-    targetProfileId,
+    profile,
     viewerProfileId = null,
-    viewerFollow = null,
     authenticated = true,
     canMutate = true,
     disabledReason = null,
@@ -61,6 +70,39 @@
 
   const [followProfile] = createMutation(followProfileMutation);
   const [unfollowProfile] = createMutation(unfollowProfileMutation);
+  const profileFragment = createFragment(followButtonProfileFragment, () => profile);
+
+  let overrideProfileId = $state<string | null>(null);
+  let followOverride = $state<ViewerFollow | null>(null);
+  let loading = $state(false);
+  let errorMessage = $state<string | null>(null);
+
+  const getTargetProfileId = () => profileFragment.data.id;
+  const getViewerFollow = () =>
+    overrideProfileId === getTargetProfileId() ? followOverride : profileFragment.data.viewerFollow;
+  const isFollowing = () => getViewerFollow()?.state === 'ACCEPTED';
+  const isPending = () => getViewerFollow()?.state === 'PENDING';
+  const isSelf = () => Boolean(viewerProfileId && viewerProfileId === getTargetProfileId());
+  const getUnavailableReason = () =>
+    disabledReason ??
+    (!authenticated
+      ? '로그인 후 팔로우할 수 있습니다.'
+      : !viewerProfileId
+        ? '프로필을 선택한 뒤 팔로우할 수 있습니다.'
+        : !canMutate
+          ? '이 프로필을 팔로우할 권한이 없습니다.'
+          : null);
+  const getDisabled = () => loading || Boolean(getUnavailableReason());
+  const getLabel = () =>
+    loading ? '처리 중' : isPending() ? '요청 중' : isFollowing() ? '팔로잉' : '팔로우';
+  const getVariant = () => (isFollowing() || isPending() ? 'secondary' : 'primary');
+  const getMessage = () => errorMessage ?? getUnavailableReason();
+
+  const setFollow = (nextFollow: ViewerFollow | null) => {
+    overrideProfileId = getTargetProfileId();
+    followOverride = nextFollow;
+    onFollowChange?.(nextFollow);
+  };
 
   const followAction = async (id: string) => {
     const data = await followProfile({ id });
@@ -77,18 +119,43 @@
       throw new Error(data.unfollowProfile.message);
     }
   };
+
+  const toggleFollow = async () => {
+    if (getDisabled()) {
+      return;
+    }
+
+    const targetProfileId = getTargetProfileId();
+
+    loading = true;
+    errorMessage = null;
+
+    try {
+      if (isFollowing() || isPending()) {
+        await unfollowAction(targetProfileId);
+        setFollow(null);
+        return;
+      }
+
+      setFollow(await followAction(targetProfileId));
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : '팔로우 상태를 변경하지 못했습니다.';
+    } finally {
+      loading = false;
+    }
+  };
 </script>
 
 <FollowButtonView
-  {targetProfileId}
-  {viewerProfileId}
-  {viewerFollow}
-  {authenticated}
-  {canMutate}
-  {disabledReason}
+  hidden={isSelf()}
+  label={getLabel()}
+  variant={getVariant()}
+  disabled={getDisabled()}
+  {loading}
+  pressed={isFollowing()}
+  message={getMessage()}
+  messageRole={errorMessage ? 'alert' : undefined}
   {size}
   class={className}
-  {onFollowChange}
-  {followAction}
-  {unfollowAction}
+  onclick={toggleFollow}
 />

--- a/apps/web/src/lib/components/FollowButtonView.svelte
+++ b/apps/web/src/lib/components/FollowButtonView.svelte
@@ -9,120 +9,42 @@
   };
 
   type Props = {
-    targetProfileId: string;
-    viewerProfileId?: string | null;
-    viewerFollow?: ViewerFollow | null;
-    authenticated?: boolean;
-    canMutate?: boolean;
-    disabledReason?: string | null;
+    hidden?: boolean;
+    label: string;
+    variant: 'primary' | 'secondary';
+    disabled?: boolean;
+    loading?: boolean;
+    pressed?: boolean;
+    message?: string | null;
+    messageRole?: 'alert' | 'status';
     size?: 'sm' | 'md' | 'lg';
     class?: string;
-    onFollowChange?: (viewerFollow: ViewerFollow | null) => void;
-    followAction: (targetProfileId: string) => Promise<ViewerFollow>;
-    unfollowAction: (targetProfileId: string) => Promise<void>;
+    onclick: () => void;
   };
 
   let {
-    targetProfileId,
-    viewerProfileId = null,
-    viewerFollow = null,
-    authenticated = true,
-    canMutate = true,
-    disabledReason = null,
+    hidden = false,
+    label,
+    variant,
+    disabled = false,
+    loading = false,
+    pressed = false,
+    message = null,
+    messageRole,
     size = 'sm',
     class: className = '',
-    onFollowChange,
-    followAction,
-    unfollowAction,
+    onclick,
   }: Props = $props();
-
-  let currentFollow = $state<ViewerFollow | null>(null);
-  let loading = $state(false);
-  let errorMessage = $state<string | null>(null);
-  let syncedPropKey = $state<string | null>(null);
-
-  const propKey = $derived(
-    [targetProfileId, viewerProfileId, viewerFollow?.id, viewerFollow?.state].join(':'),
-  );
-
-  $effect(() => {
-    if (syncedPropKey === propKey) {
-      return;
-    }
-
-    currentFollow = viewerFollow;
-    errorMessage = null;
-    syncedPropKey = propKey;
-  });
-
-  const isSelf = $derived(Boolean(viewerProfileId && viewerProfileId === targetProfileId));
-  const isFollowing = $derived(currentFollow?.state === 'ACCEPTED');
-  const isPending = $derived(currentFollow?.state === 'PENDING');
-  const hidden = $derived(isSelf);
-  const unavailableReason = $derived(
-    disabledReason ??
-      (!authenticated
-        ? '로그인 후 팔로우할 수 있습니다.'
-        : !viewerProfileId
-          ? '프로필을 선택한 뒤 팔로우할 수 있습니다.'
-          : !canMutate
-            ? '이 프로필을 팔로우할 권한이 없습니다.'
-            : null),
-  );
-  const disabled = $derived(loading || Boolean(unavailableReason));
-  const label = $derived(
-    loading ? '처리 중' : isPending ? '요청 중' : isFollowing ? '팔로잉' : '팔로우',
-  );
-  const buttonVariant = $derived(isFollowing || isPending ? 'secondary' : 'primary');
-  const statusMessage = $derived(errorMessage ?? unavailableReason);
-
-  const setFollow = (nextFollow: ViewerFollow | null) => {
-    currentFollow = nextFollow;
-    onFollowChange?.(nextFollow);
-  };
-
-  const toggleFollow = async () => {
-    if (disabled) {
-      return;
-    }
-
-    loading = true;
-    errorMessage = null;
-
-    try {
-      if (isFollowing || isPending) {
-        await unfollowAction(targetProfileId);
-        setFollow(null);
-        return;
-      }
-
-      setFollow(await followAction(targetProfileId));
-    } catch (error) {
-      errorMessage = error instanceof Error ? error.message : '팔로우 상태를 변경하지 못했습니다.';
-    } finally {
-      loading = false;
-    }
-  };
 </script>
 
 {#if !hidden}
   <div class={`inline-flex flex-col items-start gap-1 ${className}`}>
-    <Button
-      variant={buttonVariant}
-      {size}
-      {disabled}
-      aria-busy={loading}
-      aria-pressed={isFollowing}
-      onclick={toggleFollow}
-    >
+    <Button {variant} {size} {disabled} aria-busy={loading} aria-pressed={pressed} {onclick}>
       {label}
     </Button>
-    {#if statusMessage}
-      <p
-        class="text-text-secondary m-0 max-w-56 text-xs leading-4"
-        role={errorMessage ? 'alert' : undefined}
-      >
-        {statusMessage}
+    {#if message}
+      <p class="text-text-secondary m-0 max-w-56 text-xs leading-4" role={messageRole}>
+        {message}
       </p>
     {/if}
   </div>


### PR DESCRIPTION
## 무엇을 변경했는지

- `FollowButton`에 `FollowButton_profile` Fragment를 추가했습니다.
- `Profile.id`와 `Profile.viewerFollow`를 Fragment에서 읽도록 변경했습니다.
- 팔로우 상태 override와 버튼 UI 계산을 `FollowButton` 컨테이너로 옮겼습니다.
- `FollowButtonView`에서 불필요한 `$derived`, `currentFollow`, prop sync `$effect`, `syncedPropKey`를 제거했습니다.
- `FollowButtonView`는 계산된 UI props만 받는 dumb component로 단순화했습니다.
- Storybook은 GraphQL client 없이 `FollowButtonView`를 직접 렌더하는 구조를 유지했습니다.

## 왜 변경했는지

프로젝트 전반에서 Fragment를 사용하는 방향에 맞춰, feature 컴포넌트가 필요한 데이터를 Fragment로 선언하도록 정리하기 위해서입니다.

기존 `FollowButtonView`는 `viewerFollow` prop을 다시 local state와 `$derived` 값으로 재구성하면서 prop/state 동기화 코드가 필요했습니다. 이 구조에서는 stale prop이 로컬 상태를 덮지 않도록 별도 동기화 키까지 관리해야 했습니다.

Fragment를 사용하는 `FollowButton` 컨테이너가 원본 데이터를 읽고 버튼에 필요한 UI props를 계산하면, View 컴포넌트는 파생 상태와 동기화 로직을 직접 가질 필요가 없습니다. 이 PR의 목적은 Fragment 도입 자체가 아니라, 그 방식에 맞춰 View의 불필요한 `$derived`와 prop/state 동기화를 제거하는 것입니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm --filter @kosmo/web build-storybook`
- Storybook의 `KOSMO/FollowButton`에서 팔로우, 팔로잉, 요청 중, 로딩, 비활성, 실패 상태를 확인합니다.

## 아직 어떤 문제가 남았는지

- 이 PR은 PROD-90 위에 쌓인 리팩터링 PR입니다. PROD-90이 먼저 머지되어야 합니다.
- 프로필 페이지에 실제로 버튼을 배치하는 작업은 별도 후속 이슈에서 처리합니다.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"PROD-90","parentHead":"2914a33ee5a690fbcbcd0bb04ebf8b4a17ea13b4","parentPull":73,"trunk":"main"}
```
-->