### PR TITLE
게시글을 조회하고 프로필 게시글 목록을 볼 수 있게 한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -158,6 +158,7 @@ type Profile implements Node {
   followingCount: Int!
   handle: String!
   id: ID!
+  posts(after: String, before: String, first: Int, last: Int): ProfilePostsConnection!
   viewerFollow: ProfileFollow
 }
 
@@ -200,6 +201,16 @@ type ProfileFollowingConnectionEdge {
   node: ProfileFollow!
 }
 
+type ProfilePostsConnection {
+  edges: [ProfilePostsConnectionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ProfilePostsConnectionEdge {
+  cursor: String!
+  node: Post!
+}
+
 enum ProfileState {
   ACTIVE
   DISABLED
@@ -211,6 +222,7 @@ type Query {
   me: Account
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!
+  post(id: ID!): Post
   profileByHandle(handle: String!): Profile
 }
 

--- a/apps/api/src/graphql/resolvers/post/field/index.ts
+++ b/apps/api/src/graphql/resolvers/post/field/index.ts
@@ -1,1 +1,2 @@
 import './post';
+import './profile';

--- a/apps/api/src/graphql/resolvers/post/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/post/field/profile.ts
@@ -1,0 +1,39 @@
+import { db, Posts } from '@kosmo/core/db';
+import { PostState } from '@kosmo/core/enums';
+import { resolveCursorConnection } from '@pothos/plugin-relay';
+import { and, asc, desc, eq, gt, lt } from 'drizzle-orm';
+import { builder } from '@/graphql/builder';
+import { Profile } from '@/graphql/resolvers/profile';
+import { Post } from '../ref';
+
+type PostRow = typeof Posts.$inferSelect;
+
+builder.objectFields(Profile, (t) => ({
+  posts: t.connection({
+    type: Post,
+    // 부모 profile은 이미 활성 상태로 로드되어 있어 profile.state를 다시 검사하지 않는다.
+    // (profile_id, id desc) 인덱스를 활용해 최신순 cursor 페이지네이션한다.
+    // TODO(PROD-102): viewer 기준 공개 범위(UNLISTED 목록 제외, FOLLOWERS/DIRECT 제한)를 적용한다.
+    resolve: (profile, args) =>
+      resolveCursorConnection<Promise<PostRow[]>>(
+        {
+          args,
+          toCursor: (post) => post.id,
+        },
+        ({ before, after, limit, inverted }) =>
+          db
+            .select()
+            .from(Posts)
+            .where(
+              and(
+                eq(Posts.profileId, profile.id),
+                eq(Posts.state, PostState.ACTIVE),
+                before ? gt(Posts.id, before) : undefined,
+                after ? lt(Posts.id, after) : undefined,
+              ),
+            )
+            .orderBy(inverted ? asc(Posts.id) : desc(Posts.id))
+            .limit(limit),
+      ),
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/post/index.ts
+++ b/apps/api/src/graphql/resolvers/post/index.ts
@@ -1,4 +1,5 @@
 import './field';
 import './mutation';
+import './query';
 
 export { Post, PostContent } from './ref';

--- a/apps/api/src/graphql/resolvers/post/query/index.ts
+++ b/apps/api/src/graphql/resolvers/post/query/index.ts
@@ -1,0 +1,1 @@
+import './post';

--- a/apps/api/src/graphql/resolvers/post/query/post.ts
+++ b/apps/api/src/graphql/resolvers/post/query/post.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { builder } from '@/graphql/builder';
+import { Post } from '../ref';
+
+builder.queryField('post', (t) =>
+  t.field({
+    type: Post,
+    nullable: true,
+    args: {
+      id: t.arg.id({ validate: z.uuid() }),
+    },
+    // Post Node 로더가 state=ACTIVE + 작성자 profile.state=ACTIVE를 적용한다.
+    // 없는/비활성 게시글은 로더에서 걸러져 null이 된다.
+    // TODO(PROD-102): viewer 기준 공개 범위(FOLLOWERS/DIRECT) 제한은 로더에서 강화한다.
+    resolve: (_, args) => args.id,
+  }),
+);

--- a/openspec/changes/add-post-read-graphql/.openspec.yaml
+++ b/openspec/changes/add-post-read-graphql/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/add-post-read-graphql/design.md
+++ b/openspec/changes/add-post-read-graphql/design.md
@@ -1,0 +1,44 @@
+## Context
+
+PROD-92(PR #67)가 `Post`/`PostContent` loadable Node 타입, `Post.profile`/`Post.content` 필드, `createPost` mutation을 추가했다. `Post` Node 로더는 `state=ACTIVE`이고 작성자 `profile.state=ACTIVE`인 게시글만 로드한다. 다만 게시글을 다시 조회하는 query나 프로필별 목록은 아직 없다.
+
+이번 PROD-93은 작성된 게시글을 다시 읽는 조회 경로만 추가한다. 단건 상세는 기존 `Post` Node 로더에 위임하고, 목록은 `(profile_id, id desc)` 인덱스를 활용한 cursor 기반 connection으로 제공한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- ID로 단일 활성 게시글을 조회하는 `post(id: ID!): Post` query를 추가한다.
+- `Profile.posts` Relay connection으로 프로필 게시글을 최신순(`id desc`)으로 페이지네이션한다.
+- 없는/비활성 게시글과 비활성 프로필 게시글을 조회에서 제외한다.
+
+**Non-Goals:**
+
+- viewer 기준 공개 범위 접근 제어(`FOLLOWERS`/`DIRECT` 제한, `UNLISTED` 목록 제외) — `PROD-102`.
+- `PostContent` Node 직접 로드 시 부모 게시글 정책 우회 차단 — `PROD-102`.
+- 홈 타임라인, 팔로잉 기반 피드, 검색.
+- 게시글 수 집계 필드, 답글/thread, 리포스트.
+- GraphQL resolver 자동 테스트 — `PROD-102`.
+
+## Decisions
+
+1. 단건 조회 query는 기존 `Post` Node 로더에 위임한다.
+
+   `post(id: ID!)` query는 입력 ID를 그대로 반환하고 `Post` loadable Node ref가 로딩한다. 로더가 이미 `state=ACTIVE` + 작성자 `profile.state=ACTIVE` 조건을 적용하므로, 없는/비활성 게시글은 자연히 `null`이 된다. 글로벌 ID는 UUID 자체이고 타입 코드가 UUID에 내장되어 있어 추가 decode가 필요 없다. `node(id:)`와 동일한 로딩 경로를 재사용하므로 공개 범위 정책을 한 곳(로더)에서 강화할 수 있다(`PROD-102`).
+
+2. 목록은 `Profile.posts` Relay connection으로 제공하고 cursor는 게시글 ID를 사용한다.
+
+   `profile/field/follow.ts`의 `resolveCursorConnection` 패턴을 따른다. UUID v7은 시간 정렬되므로 `id desc` 정렬이 최신순과 일치하고 `(profile_id, id desc)` 인덱스를 그대로 활용한다. 부모 `profile`은 이미 활성 상태로 로드되어 있어 목록 쿼리에서 profile 상태를 다시 검사하지 않는다.
+
+3. 목록 필드는 게시글 도메인 모듈에 둔다.
+
+   `Profile.posts`는 Profile 타입 필드이지만 게시글 관계를 노출하므로, `Account.profiles`를 profile 모듈에 두는 규칙과 동일하게 `post/field/profile.ts`에 둔다.
+
+4. 공개 범위 접근 제어는 이번 변경에서 적용하지 않는다.
+
+   PROD-92가 `Post`/`PostContent` Node 로더에 `TODO(PROD-102)`로 공개 범위 정책을 미뤘다. PROD-93 목록도 동일하게 `state=ACTIVE`만 필터하고 공개 범위와 무관하게 노출한다. `FOLLOWERS`/`DIRECT` viewer 제한과 `UNLISTED` 목록 제외는 `PROD-102`가 로더와 목록에 일관되게 적용한다.
+
+## Risks / Trade-offs
+
+- `PROD-102` 적용 전까지 `Profile.posts` 목록과 `post(id)` 단건 조회는 `FOLLOWERS`/`DIRECT` 게시글도 노출한다. 의도적으로 `PROD-102`까지 미룬 제약이며, 두 이슈는 같은 사이클 stacked PR로 진행한다.
+- 게시글 수 집계 필드(`postsCount`)는 이번 범위에서 제외한다. 필요 시 follower count와 동일한 후속 최적화로 추가한다.

--- a/openspec/changes/add-post-read-graphql/proposal.md
+++ b/openspec/changes/add-post-read-graphql/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+PROD-92에서 게시글 작성 mutation과 `Post`/`PostContent` GraphQL Node 타입을 추가했지만, 작성된 게시글을 다시 조회하는 query는 아직 없다. 프로필 게시글 목록(PROD-88)과 게시글 디테일 페이지(PROD-89)가 같은 조회 기반을 필요로 하므로, 게시글 조회 GraphQL query를 백엔드 작업으로 먼저 추가한다.
+
+## What Changes
+
+- ID로 단일 활성 게시글을 조회하는 `post(id: ID!): Post` query를 추가한다.
+- 프로필이 작성한 활성 게시글을 최신순으로 페이지네이션하는 `Profile.posts` Relay connection을 추가한다.
+- 없는 게시글, 비활성(`ACTIVE`가 아닌) 게시글, 비활성 프로필 게시글은 조회 결과에서 제외한다.
+- 게시글이 없는 프로필은 빈 connection을 반환한다.
+- viewer 기준 공개 범위 접근 제어(`FOLLOWERS`/`DIRECT` 제한, `UNLISTED` 목록 제외)는 이번 변경 범위에서 제외하고 `PROD-102`로 미룬다. 목록은 `state=ACTIVE` 게시글을 공개 범위와 무관하게 노출한다.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `post`: 작성된 게시글을 조회하는 단건 query와 프로필별 게시글 목록 connection 계약을 추가한다.
+
+## Impact
+
+- `apps/api/src/graphql/resolvers/post/query`: 단건 게시글 조회 query 추가
+- `apps/api/src/graphql/resolvers/post/field`: `Profile.posts` connection 필드 추가
+- `apps/api/schema.graphql`: `post` query, `Profile.posts` connection, `PostConnection`/`PostEdge` 타입 반영

--- a/openspec/changes/add-post-read-graphql/specs/post/spec.md
+++ b/openspec/changes/add-post-read-graphql/specs/post/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Post 단건 조회 query
+
+API는 ID로 단일 활성 게시글을 조회하는 `post` query를 제공해야 하며, 조회 가능한 게시글이 없으면 `null`을 반환해야 한다(MUST).
+
+#### Scenario: 활성 게시글 단건 조회
+
+- **WHEN** 클라이언트가 활성 게시글의 ID로 `post` query를 호출한다
+- **THEN** 시스템은 해당 `Post` object를 반환한다
+
+#### Scenario: 없는 게시글 단건 조회
+
+- **WHEN** 클라이언트가 존재하지 않는 ID로 `post` query를 호출한다
+- **THEN** 시스템은 `null`을 반환한다
+
+#### Scenario: 비활성 게시글 단건 조회
+
+- **WHEN** 클라이언트가 상태가 `ACTIVE`가 아니거나 작성자 프로필이 비활성인 게시글의 ID로 `post` query를 호출한다
+- **THEN** 시스템은 `null`을 반환한다
+
+### Requirement: 프로필 게시글 목록 connection
+
+API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Profile.posts`로 노출해야 한다(MUST).
+
+#### Scenario: 프로필 게시글 목록 조회
+
+- **WHEN** 클라이언트가 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 해당 프로필이 작성한 `state`가 `ACTIVE`인 게시글만 반환한다
+- **AND** 게시글은 생성 시각 기준 최신순으로 정렬된다
+- **AND** connection은 cursor 기반 페이지네이션을 지원한다
+
+#### Scenario: 게시글이 없는 프로필 목록 조회
+
+- **WHEN** 게시글이 없는 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 빈 connection을 반환한다
+
+#### Scenario: 공개 범위 필터 미적용
+
+- **WHEN** 클라이언트가 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 게시글 공개 범위(`visibility`)와 무관하게 `state`가 `ACTIVE`인 게시글을 노출한다
+- **AND** viewer 기준 공개 범위 접근 제어는 이 변경에서 적용하지 않는다

--- a/openspec/changes/add-post-read-graphql/tasks.md
+++ b/openspec/changes/add-post-read-graphql/tasks.md
@@ -1,0 +1,22 @@
+## 1. Spec
+
+- [x] 1.1 `post` capability에 게시글 단건 조회 query와 프로필 게시글 목록 connection delta spec을 작성한다.
+- [x] 1.2 OpenSpec 변경안을 strict mode로 검증한다.
+
+## 2. GraphQL Query
+
+- [ ] 2.1 ID로 단일 활성 게시글을 조회하는 `post(id: ID!): Post` query를 추가한다.
+- [ ] 2.2 없는/비활성 게시글은 기존 `Post` Node 로더에 위임해 `null`을 반환한다.
+
+## 3. Profile Posts Connection
+
+- [ ] 3.1 `Profile.posts` Relay connection을 `post/field/profile.ts`에 추가한다.
+- [ ] 3.2 `state=ACTIVE` 게시글을 `id desc` 최신순으로 cursor 페이지네이션한다.
+- [ ] 3.3 게시글이 없는 프로필은 빈 connection을 반환한다.
+
+## 4. Verification
+
+- [x] 4.1 GraphQL schema를 생성하고 `schema.graphql` diff를 확인한다.
+- [x] 4.2 API TypeScript 타입체크를 실행한다.
+- [x] 4.3 ESLint/Prettier 검증을 실행한다.
+- [ ] 4.4 테스트 DB에서 수동 GraphQL 목록/단건/`null` 케이스를 확인한다. (Docker 미실행으로 보류)


### PR DESCRIPTION
## 무엇을 변경했는지

- ID로 단일 활성 게시글을 조회하는 `post(id: ID!): Post` query를 추가했습니다.
- 프로필이 작성한 활성 게시글을 최신순으로 페이지네이션하는 `Profile.posts` Relay connection을 추가했습니다.
- 단건 조회는 기존 `Post` Node 로더(`state=ACTIVE` + 작성자 `profile.state=ACTIVE`)에 위임해, 없는/비활성 게시글은 `null`을 반환합니다.
- 목록은 `(profile_id, id desc)` 인덱스를 활용해 `state=ACTIVE` 게시글을 cursor 기반으로 조회하며, `profile/field/follow.ts`의 `resolveCursorConnection` 패턴을 따릅니다.
- `apps/api/schema.graphql`에 `post` query, `Profile.posts`, `ProfilePostsConnection`/`ProfilePostsConnectionEdge` 타입을 반영했습니다.
- OpenSpec 변경안 `add-post-read-graphql`(post capability delta: 단건 조회 query, 프로필 게시글 목록 connection)을 추가했습니다.

## 왜 변경했는지

- 프로필 게시글 목록(PROD-88)과 게시글 디테일 페이지(PROD-89)가 같은 조회 기반을 필요로 합니다. 두 프론트엔드 작업의 백엔드 의존성을 먼저 제공합니다.
- PROD-92에서 `Post`/`PostContent` 타입과 작성 mutation은 추가됐지만 작성된 게시글을 다시 읽는 조회 query가 없었습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc` 타입체크 통과.
- dev 실행으로 `schema.graphql` 재생성 → `Query.post(id: ID!): Post`, `Profile.posts: ProfilePostsConnection!` 반영 확인(diff 포함).
- `eslint`/`prettier` 통과.
- 런타임 GraphQL 검증(테스트 DB 시드 후 목록/단건/`null`)은 로컬 Docker 미실행으로 **보류**했습니다. 재현 절차:
  - `pnpm db:test:up && pnpm db:test:push`
  - dev 서버 기동 후 `profileByHandle(handle){ posts(first: 10){ edges{ cursor node{ id createdAt content{ bodyText } } } pageInfo{ hasNextPage endCursor } } } }`로 목록·페이지네이션 확인
  - `post(id){ id createdAt profile{ handle } content{ bodyText spoilerText } }`로 단건 확인, 없는/`DELETED` id → `null` 확인

## 아직 어떤 문제가 남았는지

- viewer 기준 공개 범위 접근 제어(`FOLLOWERS`/`DIRECT` 제한, `UNLISTED` 목록 제외)는 이 PR 범위에서 제외했습니다. `PROD-102`가 `Post`/`PostContent` Node 로더와 목록에 일관되게 적용합니다. 현재 목록은 공개 범위와 무관하게 `state=ACTIVE` 게시글을 노출합니다.
- GraphQL resolver 자동 테스트도 `PROD-102` 범위입니다.
- 런타임 GraphQL 수동 검증 미수행(위 재현 명령 참고).

Stack: main -> prod-93