### PR TITLE
TipTap 글쓰기 화면 OpenSpec을 추가한다

### DIFF
--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,5 +1,6 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
+/// <reference types="vite/client" />
+import '../.mearie/graphql.d.ts';
+
 declare global {
   namespace App {
     // interface Error {}
@@ -9,5 +10,4 @@ declare global {
     // interface Platform {}
   }
 }
-
 export {};

--- a/apps/web/src/lib/graphql/client.ts
+++ b/apps/web/src/lib/graphql/client.ts
@@ -2,7 +2,6 @@ import { cacheExchange, createClient, dedupExchange, httpExchange } from '@meari
 import { schema } from '$mearie';
 
 export const client = createClient({
-  // @ts-expect-error 왜지??
   schema,
   exchanges: [
     dedupExchange(),

--- a/apps/web/src/routes/(tabs)/@[handle]/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/+layout.svelte
@@ -23,7 +23,7 @@
         }
       }
     `),
-    () => ({ handle: page.params.handle }),
+    () => ({ handle: page.params.handle! }),
   );
 
   const profile = $derived(query.data?.profileByHandle ?? null);

--- a/memory/frontend-svelte.md
+++ b/memory/frontend-svelte.md
@@ -16,6 +16,8 @@
 ## Fragment Components
 
 - GraphQL 데이터를 소비하는 컴포넌트는 개별 scalar props를 나열하지 말고 Mearie가 생성한 `{FragmentName}$key` 타입을 받는다.
+- `@mearie/svelte`의 `FragmentRefs<'FragmentName'>` helper를 fragment prop 타입으로 쓰지 않는다. Mearie 공식 fragment guide의 `$key` prop 타입 패턴을 따른다.
+- generated fragment `$key` 타입은 `$mearie`에서 type-only import한다.
 - 컴포넌트 내부에서 `$mearie`의 `graphql(...)`와 `createFragment(..., () => props.<name>)`를 사용한다.
 - fragment typing을 피하려고 container/view를 나누지 않는다. 실제 책임 분리가 없다면 수동 타입 선언만 늘고 fragment의 장점이 사라진다.
 - 컴포넌트가 필요한 데이터는 자신이 fragment로 선언한다.
@@ -52,5 +54,6 @@
 - backend error `message`를 사용자 UI에 그대로 노출할지, error type/code로 분기할지, generic 한국어 fallback을 쓸지는 아직 확정된 정책이 아니다.
 - 리뷰에서는 `message` 노출 자체를 곧바로 위반으로 단정하지 말고, 해당 흐름의 사용자 문구 정책이 정해져 있는지 먼저 확인한다. 정책이 정해진 뒤에는 컴포넌트마다 ad hoc 처리하지 말고 공통 error handling boundary나 helper로 모은다.
 - handle에 `@`를 붙일지 같은 표시 정책은 컴포넌트마다 ad hoc 처리하지 않는다. API boundary나 공통 formatting helper에서 정한다.
+- Lucide 아이콘을 import할 때는 반드시 `GlobeIcon`, `ExampleIcon`처럼 `Icon` suffix가 붙은 이름만 사용한다.
 - Figma/OpenSpec의 수치와 Tailwind class 수치가 다르면 코드 또는 spec을 같은 PR에서 정렬한다.
 - 긴 표시 이름, 긴 handle, 비어 있는 값 등 layout edge case를 story에 포함한다.

--- a/openspec/changes/add-plain-text-post-writing-screen/.openspec.yaml
+++ b/openspec/changes/add-plain-text-post-writing-screen/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/add-plain-text-post-writing-screen/design.md
+++ b/openspec/changes/add-plain-text-post-writing-screen/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`PROD-92` 브랜치에는 `createPost(input: { content, visibility }): CreatePostResult!` GraphQL mutation, `Post`/`PostContent` object, `PostVisibility` enum, `TipTapDocument` scalar가 추가되어 있다. 성공 payload는 `CreatePostSuccess { post }`이며, 웹 앱에는 `/compose` 탭과 하단 탭 navigation은 있지만 현재는 안내 문구만 표시한다.
+
+웹 클라이언트는 Mearie/Svelte GraphQL client를 사용하며, `SidebarNavigation`에서 `createQuery`/`createMutation` 패턴으로 현재 세션의 선택 프로필과 계정 프로필 목록을 이미 조회한다. 최신 main의 프론트엔드 규칙은 GraphQL query, mutation, fragment document를 실제로 사용하는 `.svelte` 파일에 colocate하고, 하위 컴포넌트가 데이터를 소비하면 fragment spread로 연결하도록 요구한다. 작성 UI는 TipTap editor를 사용하고, 제출 시 editor가 가진 TipTap `doc` JSON을 `createPost` mutation의 `content` 입력에 그대로 전달한다.
+
+최신 main에는 게시글 작성자 표시용 `PostAuthorProfile` 컴포넌트가 추가되어 있고, 이 컴포넌트는 `Profile` fragment ref를 props로 받는다. 새 글 작성 컴포넌트가 선택 프로필을 표시할 때는 별도 one-off author UI를 만들기보다 이 컴포넌트를 재사용하고, 부모 query document 안에서 해당 fragment를 spread한다.
+
+기존 `byulmaru/kosmo-old` 작성 화면은 공개 범위 selector를 제공했다. 옵션은 `PUBLIC`, `UNLISTED`, `FOLLOWER`, `DIRECT` 순서였고, 한국어 라벨은 각각 “공개”, “조용한 공개”, “팔로워만”, “언급한 계정만”이었다. 현재 새 enum은 `FOLLOWER` 대신 `FOLLOWERS`를 사용하므로 같은 의미를 `FOLLOWERS`로 매핑한다. `kosmo-old`는 프로필 기본 공개 범위가 없을 때 `UNLISTED`를 fallback으로 사용했다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 로그인한 사용자가 선택된 프로필로 게시글을 작성할 수 있는 TipTap 기반 작성 컴포넌트를 구현한다.
+- `/compose`는 현재 세션의 선택 프로필을 조회하고, 선택 프로필이 없으면 작성 컴포넌트를 렌더링하지 않는다.
+- 게시글 공개 범위 selector를 제공하고 선택한 `PostVisibility` 값을 mutation에 전달한다.
+- 공백을 trim한 본문이 비어 있거나 500자를 초과하면 제출 버튼을 비활성화한다.
+- TipTap editor의 `doc` JSON을 그대로 사용해 `createPost` mutation을 호출한다.
+- 제출 중과 실패 상태를 화면에서 확인할 수 있게 한다.
+- 성공 후 별도 완료 패널이나 경로 이동 없이 editor 본문과 공개 범위를 초기화한다.
+
+**Non-Goals:**
+
+- 게시글 상세 페이지, 피드 목록, timeline pagination 구현.
+- `createPost` API 계약 변경 또는 서버 검증 정책 변경.
+- 이미지/첨부, 인용, 리포스트, 공개 범위별 세부 authorization 정책.
+- 작성 중 임시 저장, 자동 저장, offline queue.
+
+## Decisions
+
+1. 작성 페이지에서 `currentSession.selectedProfile`을 직접 조회한다.
+
+   사이드바가 같은 정보를 이미 조회하지만, 작성 가능 여부는 `/compose` 페이지의 핵심 상태이다. 페이지가 독립적으로 현재 선택 프로필을 조회하면 모바일 drawer가 열리지 않은 상태에서도 빈 프로필/로딩/오류 상태를 명확히 렌더링할 수 있다. 대안으로 사이드바 상태를 전역 store로 공유할 수 있지만, 현재 앱에는 그런 전역 session store가 없고 이 변경의 범위를 키운다.
+
+2. 작성 본문은 TipTap editor 문서를 source of truth로 둔다.
+
+   서버는 TipTap `Document`/`Paragraph`/`Text` subset을 검증한다. 클라이언트도 TipTap editor에서 생성된 `doc` JSON을 그대로 제출하면 브라우저에서 보이는 문서 구조와 API 저장 입력이 일치한다. 별도의 문자열 projection을 만들고 다시 TipTap JSON으로 변환하는 방식은 editor와 저장 입력 사이의 drift를 만들 수 있으므로 사용하지 않는다.
+
+3. 기본 본문 검증은 클라이언트와 서버에서 모두 수행한다.
+
+   웹 화면은 trim 기준 빈 본문과 500자 초과에서 제출 버튼을 비활성화해 불필요한 mutation 호출을 줄인다. 빈 본문은 별도 오류 메시지를 표시하지 않고 비활성화 상태만 제공한다. 서버 검증은 source of truth로 유지되므로 클라이언트 검증을 우회한 요청도 `createPost`에서 거부된다. 서버 오류 메시지는 사용자가 이해할 수 있는 작성 실패 상태로 표시한다.
+
+4. 공개 범위 selector는 `kosmo-old`의 옵션과 라벨을 새 enum에 맞춰 제공한다.
+
+   사용자는 `PUBLIC`, `UNLISTED`, `FOLLOWERS`, `DIRECT` 중 하나를 선택할 수 있어야 한다. 라벨과 설명은 `kosmo-old`의 한국어 문구를 따르되, old의 `FOLLOWER` enum 이름은 현재 API의 `FOLLOWERS`로 매핑한다. 공개 범위 선택은 별도 route나 modal보다 작성 폼 내부의 compact selector로 둔다. 대안으로 `PUBLIC`을 고정할 수 있지만, 기존 제품 흐름과 사용자의 명시 요구사항을 충족하지 못한다.
+
+5. 기본 공개 범위는 `UNLISTED`로 둔다.
+
+   현재 새 API의 `Profile`에는 `kosmo-old`의 `config.defaultPostVisibility`에 해당하는 필드가 없다. 따라서 이번 구현에서는 `kosmo-old`의 fallback과 동일하게 초기 선택을 `UNLISTED`로 둔다. 프로필별 기본 공개 범위가 후속 API로 추가되면 `/compose` query에서 해당 값을 받아 초기 선택에 반영할 수 있다.
+
+6. 작성 성공 후에는 폼만 초기화한다.
+
+   현재 범위에는 게시글 상세 route나 피드 갱신 흐름이 없다. 따라서 mutation 성공은 editor 본문을 비우고 공개 범위를 기본값인 `UNLISTED`로 되돌리는 것으로 처리한다. 별도 성공 패널을 만들거나 생성된 게시글 경로로 이동하지 않는다.
+
+7. GraphQL document는 실제 사용하는 component에 colocate한다.
+
+   최신 main의 `memory/frontend-svelte.md`는 GraphQL operation을 실제 사용하는 Svelte 파일에 두고, GraphQL 데이터를 소비하는 컴포넌트는 fragment ref를 받도록 정한다. 따라서 `/compose/+page.svelte`는 현재 세션 query를 colocate하고, 새 글 작성 컴포넌트는 선택 프로필 fragment와 `createPost` mutation을 colocate한다. 작성자 표시는 `PostAuthorProfile`을 재사용하고, 부모 query selection에 `PostAuthorProfile_profile` fragment spread를 포함한다. 별도 `.ts` GraphQL document 파일이나 수동 author props 복제는 만들지 않는다.
+
+## Risks / Trade-offs
+
+- [Risk] `createPost`의 성공 결과는 `CreatePostSuccess { post }` union payload이지만, 인증 scope와 validation 실패는 GraphQL client 오류로 전달될 수 있다. → [Mitigation] 웹 mutation 호출은 `CreatePostSuccess` 분기와 예외/GraphQL client 오류를 모두 처리해 작성 실패 메시지로 매핑한다.
+- [Risk] 성공 후 생성된 게시글을 즉시 확인하는 화면이 없다. → [Mitigation] 이번 변경은 작성 컴포넌트와 mutation 제출에 집중하고, 상세 route나 피드 갱신은 후속 게시글 표시 흐름에서 다룬다.
+- [Risk] `DIRECT` 라벨은 언급 기능을 전제로 하지만 이번 변경은 mention UX를 구현하지 않는다. → [Mitigation] 이번 변경은 API enum 선택과 전달만 다루고, mention parsing 또는 수신자 안내는 후속 요구사항에서 다룬다.

--- a/openspec/changes/add-plain-text-post-writing-screen/proposal.md
+++ b/openspec/changes/add-plain-text-post-writing-screen/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+현재 웹 앱의 글쓰기 탭은 안내 문구만 표시하고 있어 사용자가 게시글을 실제로 작성할 수 없다. `PROD-92`에서 게시글 작성 GraphQL mutation과 TipTap 문서 저장 계약이 준비되었으므로, 이번 변경은 로그인한 사용자가 선택된 프로필로 TipTap 기반 게시글을 작성하는 웹 화면 흐름을 추가한다.
+
+## What Changes
+
+- 웹 `/compose` 탭을 TipTap 기반 게시글 작성 폼으로 전환한다.
+- 작성 본문은 TipTap editor로 입력하고 editor의 TipTap `doc` JSON을 `createPost` mutation에 전달한다.
+- `kosmo-old`의 작성 화면을 참고해 게시글 공개 범위 선택을 제공한다.
+- 선택된 프로필이 없는 상태, 빈 본문, 길이 초과, mutation 실패를 화면에서 처리한다.
+- 작성 중에는 제출 중 상태와 중복 제출 방지를 제공한다.
+- 작성 성공 후 별도 완료 패널이나 경로 이동 없이 작성 폼을 초기화한다.
+- 이미지, 첨부, 리치 텍스트 편집, 인용, 리포스트, 게시글 상세/목록 API 구현은 이번 범위에서 제외한다.
+
+## Capabilities
+
+### New Capabilities
+
+- 없음.
+
+### Modified Capabilities
+
+- `post`: 웹 클라이언트의 TipTap 기반 게시글 작성 화면, 공개 범위 선택, 선택 프로필 기반 작성 흐름, 작성 성공 후 초기화와 실패 상태 표시 요구사항을 추가한다.
+
+## Impact
+
+- `apps/web`: `/compose` 페이지, GraphQL `createPost` mutation 사용, 공개 범위 선택 UI, TipTap editor 본문 검증, 제출/오류 UI.
+- `apps/web/src/lib/components`: TipTap editor와 공개 범위 선택을 포함한 새 글 작성 컴포넌트, 기존 `Button` 등 폼 컴포넌트 재사용 또는 필요한 최소 조정.
+- `apps/api/schema.graphql`: `PROD-92`에서 추가된 `createPost`, `Post`, `PostContent`, `PostVisibility`, `TipTapDocument` 계약을 클라이언트에서 사용한다.
+- `openspec`: `post` delta spec, 설계 문서, 구현 task 추가.

--- a/openspec/changes/add-plain-text-post-writing-screen/specs/post/spec.md
+++ b/openspec/changes/add-plain-text-post-writing-screen/specs/post/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: TipTap post composer screen
+
+웹 앱은 `/compose` 탭에서 TipTap 기반 게시글 작성 화면을 제공해야 한다(MUST).
+
+#### Scenario: 작성 폼 표시
+
+- **WHEN** 로그인한 사용자가 `/compose` 탭을 연다
+- **THEN** 시스템은 TipTap editor 본문 입력 영역과 제출 버튼을 표시한다
+- **AND** 시스템은 게시글 공개 범위 selector를 표시한다
+- **AND** 본문 입력 영역은 여러 줄 본문을 입력할 수 있다
+- **AND** 제출 버튼은 작성 본문이 유효하지 않거나 제출 중일 때 비활성화된다
+
+#### Scenario: 인증되지 않은 사용자
+
+- **WHEN** 인증 session이 없는 사용자가 `/compose` 탭을 연다
+- **THEN** 시스템은 게시글을 작성하려면 로그인이 필요하다는 상태를 표시한다
+- **AND** 시스템은 `createPost` mutation을 호출하지 않는다
+
+#### Scenario: 선택 프로필이 없는 사용자
+
+- **WHEN** 로그인했지만 active profile이 선택되지 않은 사용자가 `/compose` 탭을 연다
+- **THEN** 시스템은 게시글 작성에 사용할 프로필을 선택해야 한다는 상태를 표시한다
+- **AND** 시스템은 제출 동작을 비활성화한다
+- **AND** 시스템은 `createPost` mutation을 호출하지 않는다
+
+### Requirement: Post visibility selection
+
+웹 앱은 TipTap 게시글 작성 폼에서 게시글 공개 범위를 선택할 수 있게 해야 한다(MUST).
+
+#### Scenario: 공개 범위 옵션 표시
+
+- **WHEN** 사용자가 `/compose` 작성 폼을 본다
+- **THEN** 시스템은 `PUBLIC`, `UNLISTED`, `FOLLOWERS`, `DIRECT` 공개 범위 옵션을 표시한다
+- **AND** `PUBLIC` 옵션은 “공개”와 “모두가 볼 수 있어요.” 설명을 표시한다
+- **AND** `UNLISTED` 옵션은 “조용한 공개”와 “모두가 볼 수 있지만 검색되지 않아요.” 설명을 표시한다
+- **AND** `FOLLOWERS` 옵션은 “팔로워만”과 “팔로워만 볼 수 있어요.” 설명을 표시한다
+- **AND** `DIRECT` 옵션은 “언급한 계정만”과 “이 글에서 언급한 계정만 볼 수 있어요.” 설명을 표시한다
+
+#### Scenario: 기본 공개 범위
+
+- **WHEN** 작성 폼이 처음 표시되고 프로필 기본 공개 범위 값이 제공되지 않는다
+- **THEN** 시스템은 `UNLISTED`를 기본 공개 범위로 선택한다
+
+#### Scenario: 공개 범위 변경
+
+- **WHEN** 사용자가 공개 범위 selector에서 다른 공개 범위 옵션을 선택한다
+- **THEN** 시스템은 작성 폼의 선택 공개 범위를 사용자가 선택한 값으로 갱신한다
+- **AND** 시스템은 현재 선택된 공개 범위를 제출 전 화면에서 확인할 수 있게 표시한다
+
+### Requirement: TipTap post submission
+
+웹 앱은 유효한 TipTap editor 문서 JSON을 `createPost` mutation으로 제출해 게시글을 작성해야 한다(MUST).
+
+#### Scenario: TipTap 게시글 작성 성공
+
+- **WHEN** 로그인했고 active profile이 선택된 사용자가 유효한 TipTap editor 본문으로 작성 폼을 제출한다
+- **THEN** 시스템은 TipTap editor의 `doc` JSON을 `content` 값으로 설정한다
+- **AND** 시스템은 `visibility` 값을 사용자가 선택한 공개 범위로 설정해 `createPost` mutation을 호출한다
+- **AND** 시스템은 제출 중 상태를 표시하고 중복 제출을 방지한다
+- **AND** mutation 성공 후 editor 본문과 공개 범위 선택을 기본값으로 초기화한다
+- **AND** 시스템은 생성된 게시글 확인 패널을 표시하지 않고 생성된 게시글 경로로 이동하지 않는다
+
+#### Scenario: 빈 본문 제출 방지
+
+- **WHEN** 사용자가 공백만 있거나 비어 있는 본문으로 작성 폼을 제출한다
+- **THEN** 시스템은 제출 버튼을 비활성화한다
+- **AND** 시스템은 빈 본문 오류 메시지를 표시하지 않는다
+- **AND** 시스템은 `createPost` mutation을 호출하지 않는다
+
+#### Scenario: 너무 긴 본문 제출
+
+- **WHEN** 사용자가 500자를 초과하는 editor 본문으로 작성 폼을 제출한다
+- **THEN** 시스템은 제출 버튼을 비활성화한다
+- **AND** 시스템은 `createPost` mutation을 호출하지 않는다
+
+#### Scenario: 작성 실패 표시
+
+- **WHEN** `createPost` mutation이 인증, active profile, validation, 네트워크 오류 중 하나로 실패한다
+- **THEN** 시스템은 작성 실패 상태와 사용자가 이해할 수 있는 오류 메시지를 표시한다
+- **AND** 시스템은 사용자가 본문을 수정하거나 다시 제출할 수 있게 유지한다

--- a/openspec/changes/add-plain-text-post-writing-screen/specs/post/spec.md
+++ b/openspec/changes/add-plain-text-post-writing-screen/specs/post/spec.md
@@ -6,7 +6,7 @@
 
 #### Scenario: 작성 폼 표시
 
-- **WHEN** 로그인한 사용자가 `/compose` 탭을 연다
+- **WHEN** 로그인했고 active profile이 선택된 사용자가 `/compose` 탭을 연다
 - **THEN** 시스템은 TipTap editor 본문 입력 영역과 제출 버튼을 표시한다
 - **AND** 시스템은 게시글 공개 범위 selector를 표시한다
 - **AND** 본문 입력 영역은 여러 줄 본문을 입력할 수 있다

--- a/openspec/changes/add-plain-text-post-writing-screen/tasks.md
+++ b/openspec/changes/add-plain-text-post-writing-screen/tasks.md
@@ -1,0 +1,23 @@
+## 1. GraphQL 흐름
+
+- [ ] 1.1 `/compose/+page.svelte`에 현재 세션과 선택 프로필을 조회하는 GraphQL query를 colocate한다.
+- [ ] 1.2 새 글 작성 컴포넌트에 선택 프로필 fragment와 `createPost` mutation을 colocate한다.
+- [ ] 1.3 TipTap editor의 `doc` JSON과 사용자가 선택한 공개 범위를 mutation 입력에 연결한다.
+
+## 2. 작성 화면 상태
+
+- [ ] 2.1 TipTap editor, 공개 범위 selector, 남은 글자 수 indicator, 게시 버튼을 포함한 새 글 작성 컴포넌트를 구현한다.
+- [ ] 2.2 `kosmo-old`를 참고해 `PUBLIC`, `UNLISTED`, `FOLLOWERS`, `DIRECT` 공개 범위 selector와 라벨/설명을 구현한다.
+- [ ] 2.3 공개 범위 기본값을 `UNLISTED`로 두고, 사용자가 선택한 값을 `createPost` mutation 입력에 연결한다.
+- [ ] 2.4 인증 없음, 세션 로딩, 선택 프로필 없음 상태를 화면에서 구분하고 선택 프로필이 없으면 작성 컴포넌트를 렌더링하지 않는다.
+- [ ] 2.5 trim 기준 빈 본문과 500자 초과 본문에서 게시 버튼을 비활성화하고 mutation 호출을 막는다.
+- [ ] 2.6 mutation 제출 중 상태를 표시하고 중복 제출을 방지한다.
+- [ ] 2.7 mutation 실패를 작성 실패 메시지로 표시하고 사용자가 본문을 유지한 채 다시 제출할 수 있게 한다.
+- [ ] 2.8 mutation 성공 후 별도 완료 패널이나 경로 이동 없이 editor 본문과 공개 범위를 기본값으로 초기화한다.
+- [ ] 2.9 선택 프로필 표시는 최신 main의 `PostAuthorProfile` fragment spread로 재사용한다.
+
+## 3. 검증
+
+- [ ] 3.1 Mearie/Svelte 타입 생성 또는 동기화가 필요한 경우 실행해 GraphQL operation 타입을 최신화한다.
+- [ ] 3.2 `pnpm --filter @kosmo/web check`로 Svelte 타입 검증을 통과시킨다.
+- [ ] 3.3 로컬 웹 앱에서 `/compose` 화면의 공개 범위 선택, 로딩, 선택 프로필 없음, 빈 본문/500자 초과 버튼 비활성화, 성공 초기화, 실패 상태가 레이아웃 깨짐 없이 표시되는지 확인한다.


### PR DESCRIPTION
Stack: main -> prod-87

## 무엇을 변경했는지

- `add-plain-text-post-writing-screen` OpenSpec 변경안을 추가했다.
- `/compose` 첫 사용처와 별도로, 선택 프로필 fragment를 받는 TipTap 기반 새 글 작성 컴포넌트 요구사항을 정리했다.
- editor의 TipTap `doc` JSON을 `createPost` mutation 입력으로 전달하는 흐름을 문서화했다.
- 공개 범위 selector는 `kosmo-old` 라벨을 참고하되 현재 enum의 `FOLLOWERS`에 맞춰 문서화했다.
- trim 기준 빈 본문과 500자 초과 본문은 mutation 호출 없이 게시 버튼 비활성화로 막도록 명시했다.
- 작성 성공 후 별도 완료 패널이나 경로 이동 없이 editor 본문과 공개 범위를 기본값으로 초기화하도록 정리했다.

## 왜 변경했는지

- `createPost` GraphQL mutation과 TipTap 문서 저장 계약이 준비되어 웹 글쓰기 구현을 시작할 수 있게 됐다.
- 구현 전에 작성 컴포넌트 경계, GraphQL colocation, 공개 범위 선택, 검증, 성공/실패 처리를 OpenSpec으로 고정해 PR 범위를 명확히 하려는 목적이다.

## 어떻게 확인할 수 있는지

- `CI=true pnpm exec openspec validate add-plain-text-post-writing-screen --strict --no-interactive`
- 커밋 시 `lint-staged` pre-commit hook 통과

## 아직 어떤 문제가 남았는지

- 이 PR은 OpenSpec 단계이며 실제 구현은 후속 stacked PR에서 다룬다.
