### PR TITLE
Claude가 PR 본문에 생성 푸터를 넣지 않게 한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 @AGENTS.md
+
+## Claude-specific
+
+- Do not append a "Generated with Claude Code" (or similar agent) footer to PR bodies. The author of record is the human running the agent; if agent involvement must be recorded, note it in Linear.


### PR DESCRIPTION
## 무엇을 변경했는지

- `CLAUDE.md`에 Claude 전용 규칙 추가: PR 본문에 "Generated with Claude Code" 류 생성 푸터를 넣지 않는다.

## 왜 변경했는지

- 에이전트 귀속은 git trailer나 PR 본문이 아니라 사람(작성자)과 Linear로 관리한다는 팀 방침에 맞춘다.
- `AGENTS.md`는 Codex 등 다른 에이전트도 공유하므로, Claude에만 해당하는 규칙은 `CLAUDE.md`에 둔다.

## 어떻게 확인할 수 있는지

- 문서 변경. 이후 Claude Code가 여는 PR 본문에 생성 푸터가 없으면 된다.

## 아직 어떤 문제가 남았는지

- 없음.
