### PR TITLE
Mearie generated 타입을 앱 전역에서 인식하게 한다

### DIFF
--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,5 +1,6 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
+/// <reference types="vite/client" />
+import '../.mearie/graphql.d.ts';
+
 declare global {
   namespace App {
     // interface Error {}
@@ -9,5 +10,4 @@ declare global {
     // interface Platform {}
   }
 }
-
 export {};

--- a/apps/web/src/lib/graphql/client.ts
+++ b/apps/web/src/lib/graphql/client.ts
@@ -2,7 +2,6 @@ import { cacheExchange, createClient, dedupExchange, httpExchange } from '@meari
 import { schema } from '$mearie';
 
 export const client = createClient({
-  // @ts-expect-error 왜지??
   schema,
   exchanges: [
     dedupExchange(),

--- a/apps/web/src/routes/(tabs)/@[handle]/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/+layout.svelte
@@ -23,7 +23,7 @@
         }
       }
     `),
-    () => ({ handle: page.params.handle }),
+    () => ({ handle: page.params.handle! }),
   );
 
   const profile = $derived(query.data?.profileByHandle ?? null);

--- a/memory/frontend-svelte.md
+++ b/memory/frontend-svelte.md
@@ -16,6 +16,8 @@
 ## Fragment Components
 
 - GraphQL 데이터를 소비하는 컴포넌트는 개별 scalar props를 나열하지 말고 Mearie가 생성한 `{FragmentName}$key` 타입을 받는다.
+- `@mearie/svelte`의 `FragmentRefs<'FragmentName'>` helper를 fragment prop 타입으로 쓰지 않는다. Mearie 공식 fragment guide의 `$key` prop 타입 패턴을 따른다.
+- generated fragment `$key` 타입은 `$mearie`에서 type-only import한다.
 - 컴포넌트 내부에서 `$mearie`의 `graphql(...)`와 `createFragment(..., () => props.<name>)`를 사용한다.
 - fragment typing을 피하려고 container/view를 나누지 않는다. 실제 책임 분리가 없다면 수동 타입 선언만 늘고 fragment의 장점이 사라진다.
 - 컴포넌트가 필요한 데이터는 자신이 fragment로 선언한다.
@@ -52,5 +54,6 @@
 - backend error `message`를 사용자 UI에 그대로 노출할지, error type/code로 분기할지, generic 한국어 fallback을 쓸지는 아직 확정된 정책이 아니다.
 - 리뷰에서는 `message` 노출 자체를 곧바로 위반으로 단정하지 말고, 해당 흐름의 사용자 문구 정책이 정해져 있는지 먼저 확인한다. 정책이 정해진 뒤에는 컴포넌트마다 ad hoc 처리하지 말고 공통 error handling boundary나 helper로 모은다.
 - handle에 `@`를 붙일지 같은 표시 정책은 컴포넌트마다 ad hoc 처리하지 않는다. API boundary나 공통 formatting helper에서 정한다.
+- Lucide 아이콘을 import할 때는 반드시 `GlobeIcon`, `ExampleIcon`처럼 `Icon` suffix가 붙은 이름만 사용한다.
 - Figma/OpenSpec의 수치와 Tailwind class 수치가 다르면 코드 또는 spec을 같은 PR에서 정렬한다.
 - 긴 표시 이름, 긴 handle, 비어 있는 값 등 layout edge case를 story에 포함한다.


### PR DESCRIPTION
Stack: `prod-87` -> `prod-87-cleanup`

## 무엇을 변경했는지
- `app.d.ts`에서 Vite client 타입과 Mearie generated GraphQL 타입을 참조합니다.
- GraphQL client에서 더 이상 필요하지 않은 `@ts-expect-error`를 제거합니다.
- profile handle route parameter가 nullable로 흘러가지 않도록 타입을 보정합니다.
- Mearie fragment `$key` 타입과 Lucide `Icon` suffix import 규칙을 frontend memory에 기록합니다.

## 왜 변경했는지
- 이후 글쓰기 컴포넌트에서 Mearie fragment `$key` 타입을 직접 사용해야 하므로 generated 타입을 앱 전역에서 안정적으로 인식해야 합니다.
- 기능 PR에 타입 설정과 코딩 스타일 정리가 섞이면 리뷰 범위가 커지므로 선행 정리 PR로 분리했습니다.

## 어떻게 확인할 수 있는지
- `pnpm --filter @kosmo/web check`
- `git diff --check`

## 아직 어떤 문제가 남았는지
- 없음