### PR TITLE
게시글 본문 길이 정책을 core에서 공유한다

### DIFF
--- a/apps/web/src/lib/components/Dropdown.stories.svelte
+++ b/apps/web/src/lib/components/Dropdown.stories.svelte
@@ -54,9 +54,7 @@
 <Story name="Default" asChild parameters={{ controls: { disable: true } }}>
   <div class="flex min-h-52 items-start justify-center p-8">
     <Dropdown.Root>
-      <Dropdown.Trigger>
-        <Button variant="secondary">메뉴</Button>
-      </Dropdown.Trigger>
+      <Dropdown.Trigger>메뉴</Dropdown.Trigger>
 
       <Dropdown.Content aria-label="작업 메뉴">
         {#each menuItems as item}
@@ -72,21 +70,42 @@
   </div>
 </Story>
 
-<Story name="Selected Item" asChild parameters={{ controls: { disable: true } }}>
+<Story name="Active Item" asChild parameters={{ controls: { disable: true } }}>
   <div class="flex min-h-52 items-start justify-center p-8">
     <Dropdown.Root>
-      <Dropdown.Trigger>
-        <Button variant="secondary">정렬</Button>
-      </Dropdown.Trigger>
+      <Dropdown.Trigger>정렬</Dropdown.Trigger>
 
       <Dropdown.Content aria-label="정렬 메뉴">
         {#each sortItems as item}
           <Dropdown.Item
-            selected={item.value === selectedSort}
+            active={item.value === selectedSort}
             onclick={() => {
               selectedSort = item.value;
             }}
           >
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>
+
+<Story name="Snippet Trigger" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        {#snippet child({ props })}
+          <Button variant="secondary" {...props}>프로필 작업</Button>
+        {/snippet}
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="프로필 작업 메뉴">
+        {#each menuItems as item}
+          <Dropdown.Item>
             <span class="grid min-w-0 gap-0.5">
               <span class="text-text-primary text-sm font-bold">{item.label}</span>
               <span class="text-text-secondary text-xs leading-4">{item.description}</span>

--- a/apps/web/src/lib/components/Dropdown.stories.svelte
+++ b/apps/web/src/lib/components/Dropdown.stories.svelte
@@ -1,0 +1,99 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import * as Dropdown from './Dropdown';
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/Dropdown',
+    tags: ['autodocs'],
+    parameters: {
+      layout: 'centered',
+    },
+  });
+</script>
+
+<script lang="ts">
+  import Button from './Button.svelte';
+
+  const menuItems = [
+    {
+      label: '프로필 열기',
+      description: '선택한 프로필 페이지로 이동합니다.',
+    },
+    {
+      label: '알림 설정',
+      description: '이 항목의 알림 방식을 조정합니다.',
+    },
+    {
+      label: '목록에서 숨기기',
+      description: '현재 목록에서만 항목을 숨깁니다.',
+    },
+  ];
+
+  const sortItems = [
+    {
+      value: 'recent',
+      label: '최신순',
+      description: '가장 최근 항목부터 표시합니다.',
+    },
+    {
+      value: 'popular',
+      label: '인기순',
+      description: '반응이 많은 항목부터 표시합니다.',
+    },
+    {
+      value: 'oldest',
+      label: '오래된순',
+      description: '오래된 항목부터 표시합니다.',
+    },
+  ];
+
+  let selectedSort = $state('recent');
+</script>
+
+<Story name="Default" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        <Button variant="secondary">메뉴</Button>
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="작업 메뉴">
+        {#each menuItems as item}
+          <Dropdown.Item>
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>
+
+<Story name="Selected Item" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        <Button variant="secondary">정렬</Button>
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="정렬 메뉴">
+        {#each sortItems as item}
+          <Dropdown.Item
+            selected={item.value === selectedSort}
+            onclick={() => {
+              selectedSort = item.value;
+            }}
+          >
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>

--- a/apps/web/src/lib/components/Dropdown/Content.svelte
+++ b/apps/web/src/lib/components/Dropdown/Content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { cn } from 'tailwind-variants';
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+  let {
+    ref = $bindable(null),
+    sideOffset = 4,
+    portalProps,
+    class: className,
+    ...restProps
+  }: DropdownMenuPrimitive.ContentProps & {
+    portalProps?: DropdownMenuPrimitive.PortalProps;
+  } = $props();
+</script>
+
+<DropdownMenuPrimitive.Portal {...portalProps}>
+  <DropdownMenuPrimitive.Content
+    bind:ref
+    data-slot="dropdown-menu-content"
+    {sideOffset}
+    class={cn(
+      'border-border bg-card text-text-primary z-50 min-w-64 overflow-hidden rounded-md border p-1 shadow-[0_10px_24px_rgba(0,0,0,0.12)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+      className,
+    )}
+    {...restProps}
+  />
+</DropdownMenuPrimitive.Portal>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
-  import { cn } from 'tailwind-variants';
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+  import { cn, tv, type VariantProps } from 'tailwind-variants';
 
-  type Props = DropdownMenuPrimitive.ItemProps & {
-    active?: boolean;
-  };
+  const dropdownItem = tv({
+    base: 'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-45',
+    variants: {
+      active: {
+        true: 'bg-primary/45 hover:bg-primary/55 focus:bg-primary/55 data-[highlighted]:bg-primary/55',
+        false: 'bg-card hover:bg-surface focus:bg-surface data-[highlighted]:bg-surface',
+      },
+    },
+    defaultVariants: {
+      active: false,
+    },
+  });
+
+  type Props = DropdownMenuPrimitive.ItemProps & VariantProps<typeof dropdownItem>;
 
   let { ref = $bindable(null), active = false, class: className, ...restProps }: Props = $props();
 </script>
@@ -13,9 +24,6 @@
   bind:ref
   data-slot="dropdown-menu-item"
   data-active={active ? '' : undefined}
-  class={cn(
-    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm bg-card px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[active]:bg-primary/45 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface hover:data-[active]:bg-primary/55 focus:data-[active]:bg-primary/55 data-[highlighted]:data-[active]:bg-primary/55',
-    className,
-  )}
+  class={cn(dropdownItem({ active }), className)}
   {...restProps}
 />

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,27 +1,22 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
-  import type { HTMLButtonAttributes } from 'svelte/elements';
+  import { cn } from 'tailwind-variants';
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
-  type Props = HTMLButtonAttributes & {
+  type Props = DropdownMenuPrimitive.ItemProps & {
     selected?: boolean;
-    children: Snippet;
   };
 
-  let {
-    selected = false,
-    children,
-    class: className = '',
-    type = 'button',
-    ...rest
-  }: Props = $props();
+  let { ref = $bindable(null), selected = false, class: className, ...restProps }: Props = $props();
 </script>
 
-<button
-  {...rest}
-  {type}
-  role="option"
-  aria-selected={selected}
-  class={`text-text-primary flex w-full items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-more ${selected ? 'bg-primary/45' : 'bg-card'} ${className}`}
->
-  {@render children()}
-</button>
+<DropdownMenuPrimitive.Item
+  bind:ref
+  data-slot="dropdown-menu-item"
+  data-selected={selected ? '' : undefined}
+  class={cn(
+    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
+    selected ? 'bg-primary/45' : 'bg-card',
+    className,
+  )}
+  {...restProps}
+/>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -14,8 +14,7 @@
   data-slot="dropdown-menu-item"
   data-active={active ? '' : undefined}
   class={cn(
-    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
-    active ? 'bg-primary/45' : 'bg-card',
+    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm bg-card px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[active]:bg-primary/45 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface hover:data-[active]:bg-primary/55 focus:data-[active]:bg-primary/55 data-[highlighted]:data-[active]:bg-primary/55',
     className,
   )}
   {...restProps}

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  type Props = HTMLButtonAttributes & {
+    selected?: boolean;
+    children: Snippet;
+  };
+
+  let {
+    selected = false,
+    children,
+    class: className = '',
+    type = 'button',
+    ...rest
+  }: Props = $props();
+</script>
+
+<button
+  {...rest}
+  {type}
+  role="option"
+  aria-selected={selected}
+  class={`text-text-primary flex w-full items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-more ${selected ? 'bg-primary/45' : 'bg-card'} ${className}`}
+>
+  {@render children()}
+</button>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -3,19 +3,19 @@
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
   type Props = DropdownMenuPrimitive.ItemProps & {
-    selected?: boolean;
+    active?: boolean;
   };
 
-  let { ref = $bindable(null), selected = false, class: className, ...restProps }: Props = $props();
+  let { ref = $bindable(null), active = false, class: className, ...restProps }: Props = $props();
 </script>
 
 <DropdownMenuPrimitive.Item
   bind:ref
   data-slot="dropdown-menu-item"
-  data-selected={selected ? '' : undefined}
+  data-active={active ? '' : undefined}
   class={cn(
     'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
-    selected ? 'bg-primary/45' : 'bg-card',
+    active ? 'bg-primary/45' : 'bg-card',
     className,
   )}
   {...restProps}

--- a/apps/web/src/lib/components/Dropdown/Trigger.svelte
+++ b/apps/web/src/lib/components/Dropdown/Trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+  let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />

--- a/apps/web/src/lib/components/Dropdown/Trigger.svelte
+++ b/apps/web/src/lib/components/Dropdown/Trigger.svelte
@@ -1,7 +1,29 @@
 <script lang="ts">
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
-  let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+  import Button from '../Button.svelte';
+
+  let {
+    ref = $bindable(null),
+    child: childSnippet,
+    children,
+    ...restProps
+  }: DropdownMenuPrimitive.TriggerProps = $props();
 </script>
 
-<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />
+{#if childSnippet}
+  <DropdownMenuPrimitive.Trigger
+    bind:ref
+    data-slot="dropdown-menu-trigger"
+    child={childSnippet}
+    {...restProps}
+  />
+{:else}
+  <DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps}>
+    {#snippet child({ props })}
+      <Button variant="secondary" {...props}>
+        {@render children?.()}
+      </Button>
+    {/snippet}
+  </DropdownMenuPrimitive.Trigger>
+{/if}

--- a/apps/web/src/lib/components/Dropdown/index.ts
+++ b/apps/web/src/lib/components/Dropdown/index.ts
@@ -1,7 +1,7 @@
-import { DropdownMenu as DropdownMentPrimitive } from 'bits-ui';
+import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 import Content from './Content.svelte';
 import Item from './Item.svelte';
 import Trigger from './Trigger.svelte';
 
-const Root = DropdownMentPrimitive.Root;
+const Root = DropdownMenuPrimitive.Root;
 export { Content, Item, Root, Trigger };

--- a/apps/web/src/lib/components/Dropdown/index.ts
+++ b/apps/web/src/lib/components/Dropdown/index.ts
@@ -1,0 +1,7 @@
+import { DropdownMenu as DropdownMentPrimitive } from 'bits-ui';
+import Content from './Content.svelte';
+import Item from './Item.svelte';
+import Trigger from './Trigger.svelte';
+
+const Root = DropdownMentPrimitive.Root;
+export { Content, Item, Root, Trigger };

--- a/packages/core/validation/post.ts
+++ b/packages/core/validation/post.ts
@@ -1,35 +1,31 @@
 import { z } from 'zod';
 import { parseTipTapDocumentContent } from '../tiptap';
 
-export const postBodyTipTapDocumentSchema = z.unknown().transform((value, ctx) => {
+export const postBodyMaxLength = 500;
+
+export const postBodyTipTapDocumentSchema = z.unknown().superRefine((value, ctx) => {
   try {
-    const { document, plainText } = parseTipTapDocumentContent(value);
+    const { plainText } = parseTipTapDocumentContent(value);
 
     if (plainText.length === 0) {
       ctx.addIssue({
         code: 'custom',
-        message: 'Post body is required',
+        message: '본문을 입력해주세요.',
       });
 
-      return z.NEVER;
+      return;
     }
 
-    if (plainText.length > 5000) {
+    if (plainText.length > postBodyMaxLength) {
       ctx.addIssue({
         code: 'custom',
-        message: 'Post body must be at most 5000 characters',
+        message: `본문은 ${postBodyMaxLength.toLocaleString('ko-KR')}자까지 작성할 수 있어요.`,
       });
-
-      return z.NEVER;
     }
-
-    return document;
   } catch {
     ctx.addIssue({
       code: 'custom',
-      message: 'Invalid TipTap document',
+      message: '유효하지 않은 본문 형식입니다.',
     });
-
-    return z.NEVER;
   }
 });


### PR DESCRIPTION
Stack: `main` -> `prod-87-dropdown` -> `prod-87-post-validation`

## 무엇을 변경했는지
- 게시글 본문 최대 길이를 `postBodyMaxLength = 500`으로 core validation에서 export합니다.
- TipTap 문서 validation을 transform 결과에 의존하지 않고 `superRefine`으로 검증하게 바꿉니다.
- 빈 본문, 길이 초과, 잘못된 문서 형식 오류 메시지를 한국어로 맞춥니다.

## 왜 변경했는지
- 게시글 본문 길이 제한은 프론트와 백엔드가 공유해야 하는 정책이므로 core에 두어 같은 기준을 사용하게 합니다.
- 프론트 컴포넌트가 별도 상수를 들고 있으면 제한값 변경 시 drift가 생길 수 있습니다.

## 어떻게 확인할 수 있는지
- `pnpm --filter @kosmo/web check`
- `git diff --check`

## 아직 어떤 문제가 남았는지
- 없음