### PR TITLE
폼 검증을 네이티브 validity와 연결한다

### DIFF
--- a/apps/web/src/lib/form.svelte.ts
+++ b/apps/web/src/lib/form.svelte.ts
@@ -1,0 +1,149 @@
+import type { Action } from 'svelte/action';
+import type { z } from 'zod';
+
+type PathSegment = {
+  key: PropertyKey;
+};
+
+const stringifyPath = (path: readonly (PropertyKey | PathSegment)[]) =>
+  path
+    .map((p) => (typeof p === 'number' ? `[${p}]` : `.${p.toString()}`))
+    .join('')
+    .slice(1);
+
+export class FormValidationError extends Error {
+  path: string | null;
+
+  constructor({ path, message }: { path?: string | undefined | null; message: string }) {
+    super(message);
+    this.path = path ? path.split('input.', 2)[1] : null;
+  }
+}
+
+type CreateFormParams<
+  Input extends Record<string, unknown>,
+  Output extends Record<string, unknown>,
+> = {
+  schema: z.ZodType<Output, Input>;
+  onSubmit?: (data: z.output<z.ZodType<Output, Input>>) => Promise<void>;
+  onError?: (error: Error) => void;
+};
+
+export const createForm = <
+  Input extends Record<string, unknown>,
+  Output extends Record<string, unknown>,
+>({
+  schema,
+  onSubmit,
+  onError,
+}: CreateFormParams<Input, Output>) => {
+  let formElement: HTMLFormElement | undefined;
+
+  const action: Action<HTMLFormElement> = (node) => {
+    formElement = node;
+    let submitted = false;
+
+    $effect(() => {
+      const parseFormData = () => {
+        const formData = new FormData(node);
+        const parsed = schema.safeParse(Object.fromEntries(formData));
+        const inputIssues: Record<string, string[]> = {};
+
+        if (!parsed.success) {
+          for (const issue of parsed.error.issues) {
+            const name = stringifyPath(issue.path);
+            inputIssues[name] ??= [];
+            inputIssues[name].push(issue.message);
+          }
+        }
+
+        for (const inputNode of node.querySelectorAll<
+          HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+        >('input, select, textarea')) {
+          const name = inputNode.name;
+
+          inputNode.setCustomValidity(inputIssues[name]?.join('\n') ?? '');
+        }
+
+        node.reportValidity();
+
+        return parsed.success ? parsed.data : false;
+      };
+
+      const handleSubmit = (event: Event) => {
+        submitted = true;
+        const parsed = parseFormData();
+        event.preventDefault();
+
+        if (parsed) {
+          const submitButtonNode = node.querySelector('button[type="submit"]');
+          if (submitButtonNode instanceof HTMLButtonElement) {
+            submitButtonNode.setAttribute('aria-busy', 'true');
+            submitButtonNode.disabled = true;
+          }
+
+          if (onSubmit) {
+            onSubmit(parsed)
+              .catch((error) => {
+                if (error instanceof FormValidationError) {
+                  const inputNode = node.querySelector(`[name="${error.path}"]`);
+                  if (
+                    inputNode instanceof HTMLInputElement ||
+                    inputNode instanceof HTMLSelectElement ||
+                    inputNode instanceof HTMLTextAreaElement
+                  ) {
+                    inputNode.setCustomValidity(error.message);
+                    inputNode.reportValidity();
+                    return;
+                  }
+                }
+
+                if (onError) {
+                  onError(error);
+                } else {
+                  throw error;
+                }
+              })
+              .finally(() => {
+                if (submitButtonNode instanceof HTMLButtonElement) {
+                  submitButtonNode.removeAttribute('aria-busy');
+                  submitButtonNode.disabled = false;
+                }
+              });
+          }
+        }
+      };
+
+      const handleInput = () => {
+        if (submitted) {
+          parseFormData();
+        }
+      };
+
+      node.addEventListener('submit', handleSubmit);
+      node.addEventListener('input', handleInput, { capture: true });
+
+      return () => {
+        node.removeEventListener('submit', handleSubmit);
+        node.removeEventListener('input', handleInput, { capture: true });
+      };
+    });
+  };
+
+  return {
+    enhance: action,
+
+    submit: () => {
+      formElement?.requestSubmit();
+    },
+
+    reset: () => {
+      formElement?.reset();
+    },
+  };
+};
+
+export type Form<
+  Input extends Record<string, unknown>,
+  Output extends Record<string, unknown>,
+> = ReturnType<typeof createForm<Input, Output>>;


### PR DESCRIPTION
Stack: `main` -> `prod-87-post-validation` -> `prod-87-form-helper`

## 무엇을 변경했는지
- Svelte action 기반 `createForm` helper를 추가합니다.
- Zod schema parse 결과를 form control의 `setCustomValidity`에 연결합니다.
- submit 중 submit button의 `aria-busy`와 disabled 상태를 관리합니다.
- 서버/submit 단계 validation error를 특정 field validity로 되돌릴 수 있는 `FormValidationError`를 추가합니다.

## 왜 변경했는지
- PostComposer에서 validation을 ad hoc 이벤트 처리로 흩뿌리지 않고, 기존 native form validation 흐름에 맞춰 재사용하기 위해 분리했습니다.
- 후속 입력 폼에서도 같은 zod/native validity 연결을 반복 구현하지 않게 하기 위한 기반입니다.

## 어떻게 확인할 수 있는지
- `pnpm --filter @kosmo/web check`
- `git diff --check`

## 아직 어떤 문제가 남았는지
- 이 PR은 helper만 추가합니다. 실제 적용은 후속 PostComposer PR에서 확인합니다.