### PR TITLE
새 글 작성 컴포넌트를 추가한다

### DIFF
--- a/apps/web/src/lib/components/Dropdown.stories.svelte
+++ b/apps/web/src/lib/components/Dropdown.stories.svelte
@@ -54,9 +54,7 @@
 <Story name="Default" asChild parameters={{ controls: { disable: true } }}>
   <div class="flex min-h-52 items-start justify-center p-8">
     <Dropdown.Root>
-      <Dropdown.Trigger>
-        <Button variant="secondary">메뉴</Button>
-      </Dropdown.Trigger>
+      <Dropdown.Trigger>메뉴</Dropdown.Trigger>
 
       <Dropdown.Content aria-label="작업 메뉴">
         {#each menuItems as item}
@@ -72,21 +70,42 @@
   </div>
 </Story>
 
-<Story name="Selected Item" asChild parameters={{ controls: { disable: true } }}>
+<Story name="Active Item" asChild parameters={{ controls: { disable: true } }}>
   <div class="flex min-h-52 items-start justify-center p-8">
     <Dropdown.Root>
-      <Dropdown.Trigger>
-        <Button variant="secondary">정렬</Button>
-      </Dropdown.Trigger>
+      <Dropdown.Trigger>정렬</Dropdown.Trigger>
 
       <Dropdown.Content aria-label="정렬 메뉴">
         {#each sortItems as item}
           <Dropdown.Item
-            selected={item.value === selectedSort}
+            active={item.value === selectedSort}
             onclick={() => {
               selectedSort = item.value;
             }}
           >
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>
+
+<Story name="Snippet Trigger" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        {#snippet child({ props })}
+          <Button variant="secondary" {...props}>프로필 작업</Button>
+        {/snippet}
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="프로필 작업 메뉴">
+        {#each menuItems as item}
+          <Dropdown.Item>
             <span class="grid min-w-0 gap-0.5">
               <span class="text-text-primary text-sm font-bold">{item.label}</span>
               <span class="text-text-secondary text-xs leading-4">{item.description}</span>

--- a/apps/web/src/lib/components/Dropdown.stories.svelte
+++ b/apps/web/src/lib/components/Dropdown.stories.svelte
@@ -1,0 +1,99 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import * as Dropdown from './Dropdown';
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/Dropdown',
+    tags: ['autodocs'],
+    parameters: {
+      layout: 'centered',
+    },
+  });
+</script>
+
+<script lang="ts">
+  import Button from './Button.svelte';
+
+  const menuItems = [
+    {
+      label: '프로필 열기',
+      description: '선택한 프로필 페이지로 이동합니다.',
+    },
+    {
+      label: '알림 설정',
+      description: '이 항목의 알림 방식을 조정합니다.',
+    },
+    {
+      label: '목록에서 숨기기',
+      description: '현재 목록에서만 항목을 숨깁니다.',
+    },
+  ];
+
+  const sortItems = [
+    {
+      value: 'recent',
+      label: '최신순',
+      description: '가장 최근 항목부터 표시합니다.',
+    },
+    {
+      value: 'popular',
+      label: '인기순',
+      description: '반응이 많은 항목부터 표시합니다.',
+    },
+    {
+      value: 'oldest',
+      label: '오래된순',
+      description: '오래된 항목부터 표시합니다.',
+    },
+  ];
+
+  let selectedSort = $state('recent');
+</script>
+
+<Story name="Default" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        <Button variant="secondary">메뉴</Button>
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="작업 메뉴">
+        {#each menuItems as item}
+          <Dropdown.Item>
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>
+
+<Story name="Selected Item" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        <Button variant="secondary">정렬</Button>
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="정렬 메뉴">
+        {#each sortItems as item}
+          <Dropdown.Item
+            selected={item.value === selectedSort}
+            onclick={() => {
+              selectedSort = item.value;
+            }}
+          >
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>

--- a/apps/web/src/lib/components/Dropdown/Content.svelte
+++ b/apps/web/src/lib/components/Dropdown/Content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { cn } from 'tailwind-variants';
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+  let {
+    ref = $bindable(null),
+    sideOffset = 4,
+    portalProps,
+    class: className,
+    ...restProps
+  }: DropdownMenuPrimitive.ContentProps & {
+    portalProps?: DropdownMenuPrimitive.PortalProps;
+  } = $props();
+</script>
+
+<DropdownMenuPrimitive.Portal {...portalProps}>
+  <DropdownMenuPrimitive.Content
+    bind:ref
+    data-slot="dropdown-menu-content"
+    {sideOffset}
+    class={cn(
+      'border-border bg-card text-text-primary z-50 min-w-64 overflow-hidden rounded-md border p-1 shadow-[0_10px_24px_rgba(0,0,0,0.12)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+      className,
+    )}
+    {...restProps}
+  />
+</DropdownMenuPrimitive.Portal>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
-  import { cn } from 'tailwind-variants';
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+  import { cn, tv, type VariantProps } from 'tailwind-variants';
 
-  type Props = DropdownMenuPrimitive.ItemProps & {
-    active?: boolean;
-  };
+  const dropdownItem = tv({
+    base: 'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-45',
+    variants: {
+      active: {
+        true: 'bg-primary/45 hover:bg-primary/55 focus:bg-primary/55 data-[highlighted]:bg-primary/55',
+        false: 'bg-card hover:bg-surface focus:bg-surface data-[highlighted]:bg-surface',
+      },
+    },
+    defaultVariants: {
+      active: false,
+    },
+  });
+
+  type Props = DropdownMenuPrimitive.ItemProps & VariantProps<typeof dropdownItem>;
 
   let { ref = $bindable(null), active = false, class: className, ...restProps }: Props = $props();
 </script>
@@ -13,9 +24,6 @@
   bind:ref
   data-slot="dropdown-menu-item"
   data-active={active ? '' : undefined}
-  class={cn(
-    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm bg-card px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[active]:bg-primary/45 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface hover:data-[active]:bg-primary/55 focus:data-[active]:bg-primary/55 data-[highlighted]:data-[active]:bg-primary/55',
-    className,
-  )}
+  class={cn(dropdownItem({ active }), className)}
   {...restProps}
 />

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,27 +1,22 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
-  import type { HTMLButtonAttributes } from 'svelte/elements';
+  import { cn } from 'tailwind-variants';
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
-  type Props = HTMLButtonAttributes & {
+  type Props = DropdownMenuPrimitive.ItemProps & {
     selected?: boolean;
-    children: Snippet;
   };
 
-  let {
-    selected = false,
-    children,
-    class: className = '',
-    type = 'button',
-    ...rest
-  }: Props = $props();
+  let { ref = $bindable(null), selected = false, class: className, ...restProps }: Props = $props();
 </script>
 
-<button
-  {...rest}
-  {type}
-  role="option"
-  aria-selected={selected}
-  class={`text-text-primary flex w-full items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-more ${selected ? 'bg-primary/45' : 'bg-card'} ${className}`}
->
-  {@render children()}
-</button>
+<DropdownMenuPrimitive.Item
+  bind:ref
+  data-slot="dropdown-menu-item"
+  data-selected={selected ? '' : undefined}
+  class={cn(
+    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
+    selected ? 'bg-primary/45' : 'bg-card',
+    className,
+  )}
+  {...restProps}
+/>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -14,8 +14,7 @@
   data-slot="dropdown-menu-item"
   data-active={active ? '' : undefined}
   class={cn(
-    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
-    active ? 'bg-primary/45' : 'bg-card',
+    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm bg-card px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[active]:bg-primary/45 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface hover:data-[active]:bg-primary/55 focus:data-[active]:bg-primary/55 data-[highlighted]:data-[active]:bg-primary/55',
     className,
   )}
   {...restProps}

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  type Props = HTMLButtonAttributes & {
+    selected?: boolean;
+    children: Snippet;
+  };
+
+  let {
+    selected = false,
+    children,
+    class: className = '',
+    type = 'button',
+    ...rest
+  }: Props = $props();
+</script>
+
+<button
+  {...rest}
+  {type}
+  role="option"
+  aria-selected={selected}
+  class={`text-text-primary flex w-full items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-more ${selected ? 'bg-primary/45' : 'bg-card'} ${className}`}
+>
+  {@render children()}
+</button>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -3,19 +3,19 @@
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
   type Props = DropdownMenuPrimitive.ItemProps & {
-    selected?: boolean;
+    active?: boolean;
   };
 
-  let { ref = $bindable(null), selected = false, class: className, ...restProps }: Props = $props();
+  let { ref = $bindable(null), active = false, class: className, ...restProps }: Props = $props();
 </script>
 
 <DropdownMenuPrimitive.Item
   bind:ref
   data-slot="dropdown-menu-item"
-  data-selected={selected ? '' : undefined}
+  data-active={active ? '' : undefined}
   class={cn(
     'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
-    selected ? 'bg-primary/45' : 'bg-card',
+    active ? 'bg-primary/45' : 'bg-card',
     className,
   )}
   {...restProps}

--- a/apps/web/src/lib/components/Dropdown/Trigger.svelte
+++ b/apps/web/src/lib/components/Dropdown/Trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+  let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />

--- a/apps/web/src/lib/components/Dropdown/Trigger.svelte
+++ b/apps/web/src/lib/components/Dropdown/Trigger.svelte
@@ -1,7 +1,29 @@
 <script lang="ts">
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
-  let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+  import Button from '../Button.svelte';
+
+  let {
+    ref = $bindable(null),
+    child: childSnippet,
+    children,
+    ...restProps
+  }: DropdownMenuPrimitive.TriggerProps = $props();
 </script>
 
-<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />
+{#if childSnippet}
+  <DropdownMenuPrimitive.Trigger
+    bind:ref
+    data-slot="dropdown-menu-trigger"
+    child={childSnippet}
+    {...restProps}
+  />
+{:else}
+  <DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps}>
+    {#snippet child({ props })}
+      <Button variant="secondary" {...props}>
+        {@render children?.()}
+      </Button>
+    {/snippet}
+  </DropdownMenuPrimitive.Trigger>
+{/if}

--- a/apps/web/src/lib/components/Dropdown/index.ts
+++ b/apps/web/src/lib/components/Dropdown/index.ts
@@ -1,7 +1,7 @@
-import { DropdownMenu as DropdownMentPrimitive } from 'bits-ui';
+import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 import Content from './Content.svelte';
 import Item from './Item.svelte';
 import Trigger from './Trigger.svelte';
 
-const Root = DropdownMentPrimitive.Root;
+const Root = DropdownMenuPrimitive.Root;
 export { Content, Item, Root, Trigger };

--- a/apps/web/src/lib/components/Dropdown/index.ts
+++ b/apps/web/src/lib/components/Dropdown/index.ts
@@ -1,0 +1,7 @@
+import { DropdownMenu as DropdownMentPrimitive } from 'bits-ui';
+import Content from './Content.svelte';
+import Item from './Item.svelte';
+import Trigger from './Trigger.svelte';
+
+const Root = DropdownMentPrimitive.Root;
+export { Content, Item, Root, Trigger };

--- a/apps/web/src/lib/components/PostComposer.stories.svelte
+++ b/apps/web/src/lib/components/PostComposer.stories.svelte
@@ -1,0 +1,30 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import PostComposer from './PostComposer.svelte';
+  import type { PostComposer_profile$key } from '$mearie';
+
+  // Storybook은 .storybook/mocks/mearie-svelte.ts에서 createFragment를 패스스루로 모킹하므로
+  // 여기서는 평범한 데이터 객체를 fragment ref 자리에 그대로 넘긴다.
+  const profile = {
+    __typename: 'Profile',
+    id: 'profile-1',
+    displayName: '코스모 작가',
+    handle: 'kosmo',
+  } as unknown as PostComposer_profile$key;
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/PostComposer',
+    component: PostComposer,
+    parameters: {
+      layout: 'padded',
+    },
+  });
+</script>
+
+<Story
+  name="Default"
+  args={{
+    profile,
+  }}
+/>

--- a/apps/web/src/lib/components/PostComposer.svelte
+++ b/apps/web/src/lib/components/PostComposer.svelte
@@ -86,11 +86,14 @@
   const handleSubmit = async (event: SubmitEvent) => {
     event.preventDefault();
 
-    if (!editor || editor.isEmpty) {
+    if (submitting || !editor || editor.isEmpty) {
       return;
     }
 
-    const data = await createPost({
+    submitting = true;
+    errorMessage = null;
+
+    await createPost({
       input: {
         content: tipTapDocument,
         visibility: selectedVisibility,

--- a/apps/web/src/lib/components/PostComposer.svelte
+++ b/apps/web/src/lib/components/PostComposer.svelte
@@ -93,18 +93,19 @@
     submitting = true;
     errorMessage = null;
 
-    await createPost({
-      input: {
-        content: tipTapDocument,
-        visibility: selectedVisibility,
-      },
-    })
-      .then(() => {
-        resetEditor();
-      })
-      .finally(() => {
-        submitting = false;
+    try {
+      await createPost({
+        input: {
+          content: tipTapDocument,
+          visibility: selectedVisibility,
+        },
       });
+      resetEditor();
+    } catch {
+      errorMessage = '게시글을 작성하지 못했습니다.';
+    } finally {
+      submitting = false;
+    }
   };
 </script>
 
@@ -140,10 +141,14 @@
     <div class="flex min-w-0 items-center gap-2">
       <Dropdown.Root>
         <Dropdown.Trigger>
-          <Button variant="secondary" class="flex gap-1 text-sm">
-            <PostVisibilityIcon visibility={selectedVisibility} class="shrink-0" />
-            <span class="truncate">{visibilityOptions[selectedVisibility].label}</span>
-          </Button>
+          {#snippet child({ props })}
+            <Button variant="secondary" {...props}>
+              <span class="flex min-w-0 items-center gap-1">
+                <PostVisibilityIcon visibility={selectedVisibility} class="shrink-0" size={16} />
+                <span class="truncate">{visibilityOptions[selectedVisibility].label}</span>
+              </span>
+            </Button>
+          {/snippet}
         </Dropdown.Trigger>
 
         <Dropdown.Content aria-label="게시글 공개 설정">

--- a/apps/web/src/lib/components/PostComposer.svelte
+++ b/apps/web/src/lib/components/PostComposer.svelte
@@ -73,7 +73,6 @@
   let selectedVisibility = $state<PostVisibility>(PostVisibility.UNLISTED);
   let editorFocused = $state(false);
   let submitting = $state(false);
-  let validationMessage = $state<string | null>(null);
   let errorMessage = $state<string | null>(null);
 
   const resetEditor = () => {
@@ -119,7 +118,7 @@
   </header>
 
   <div
-    class={`relative min-h-40 rounded-md border bg-bg transition-colors ${validationMessage ? 'border-danger' : editorFocused ? 'border-primary' : 'border-border'}`}
+    class={`relative min-h-40 rounded-md border bg-bg transition-colors ${errorMessage ? 'border-danger' : editorFocused ? 'border-primary' : 'border-border'}`}
   >
     <TipTapEditor
       placeholder="무슨 일이 일어나고 있나요?"
@@ -131,9 +130,9 @@
     />
   </div>
 
-  {#if validationMessage || errorMessage}
+  {#if errorMessage}
     <p class="text-danger m-0 text-sm leading-5" role="alert">
-      {validationMessage ?? errorMessage}
+      {errorMessage}
     </p>
   {/if}
 

--- a/apps/web/src/lib/components/PostComposer.svelte
+++ b/apps/web/src/lib/components/PostComposer.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+  import { graphql } from '$mearie';
+  import { createFragment, createMutation } from '@mearie/svelte';
+  import { PostVisibility } from '@kosmo/core/enums';
+  import { postBodyMaxLength } from '@kosmo/core/validation';
+  import Button from './Button.svelte';
+  import * as Dropdown from './Dropdown';
+  import PostAuthorProfile from './PostAuthorProfile.svelte';
+  import PostVisibilityIcon from './PostVisibilityIcon.svelte';
+  import TipTapEditor from './TipTapEditor.svelte';
+  import type { Editor } from '@tiptap/core';
+  import type { TipTapDocument } from '@kosmo/core/tiptap';
+  import type { PostComposer_profile$key } from '$mearie';
+
+  const postVisibilitySchemaValues = [
+    PostVisibility.PUBLIC,
+    PostVisibility.UNLISTED,
+    PostVisibility.FOLLOWERS,
+    PostVisibility.DIRECT,
+  ] as const;
+
+  type VisibilityOption = {
+    label: string;
+    description: string;
+  };
+
+  const visibilityOptions = {
+    [PostVisibility.PUBLIC]: {
+      label: '공개',
+      description: '모두가 볼 수 있어요.',
+    },
+    [PostVisibility.UNLISTED]: {
+      label: '조용한 공개',
+      description: '모두가 볼 수 있지만 검색되지 않아요.',
+    },
+    [PostVisibility.FOLLOWERS]: {
+      label: '팔로워만',
+      description: '팔로워만 볼 수 있어요.',
+    },
+    [PostVisibility.DIRECT]: {
+      label: '언급한 계정만',
+      description: '이 글에서 언급한 계정만 볼 수 있어요.',
+    },
+  } satisfies Record<PostVisibility, VisibilityOption>;
+
+  type Props = {
+    profile: PostComposer_profile$key;
+  };
+
+  let { profile }: Props = $props();
+
+  const profileFragment = createFragment(
+    graphql(`
+      fragment PostComposer_profile on Profile {
+        ...PostAuthorProfile_profile
+      }
+    `),
+    () => profile,
+  );
+  const [createPost] = createMutation(
+    graphql(`
+      mutation PostComposerCreatePost($input: CreatePostInput!) {
+        createPost(input: $input) {
+          __typename
+        }
+      }
+    `),
+  );
+
+  let editor = $state<Editor | null>(null);
+  let bodyText = $state('');
+  let tipTapDocument = $state<TipTapDocument | null>(null);
+  let selectedVisibility = $state<PostVisibility>(PostVisibility.UNLISTED);
+  let editorFocused = $state(false);
+  let submitting = $state(false);
+  let validationMessage = $state<string | null>(null);
+  let errorMessage = $state<string | null>(null);
+
+  const resetEditor = () => {
+    editor?.commands.setContent({ type: 'doc', content: [{ type: 'paragraph' }] });
+    selectedVisibility = PostVisibility.UNLISTED;
+    editor?.commands.focus();
+    errorMessage = null;
+  };
+
+  const handleSubmit = async (event: SubmitEvent) => {
+    event.preventDefault();
+
+    if (!editor || editor.isEmpty) {
+      return;
+    }
+
+    const data = await createPost({
+      input: {
+        content: tipTapDocument,
+        visibility: selectedVisibility,
+      },
+    })
+      .then(() => {
+        resetEditor();
+      })
+      .finally(() => {
+        submitting = false;
+      });
+  };
+</script>
+
+<form
+  class="border-border bg-card grid w-full gap-4 rounded-md border p-4"
+  aria-label="새 게시글 작성"
+  onsubmit={handleSubmit}
+>
+  <header class="min-w-0">
+    <PostAuthorProfile class="min-w-0" profile={profileFragment.data} />
+  </header>
+
+  <div
+    class={`relative min-h-40 rounded-md border bg-bg transition-colors ${validationMessage ? 'border-danger' : editorFocused ? 'border-primary' : 'border-border'}`}
+  >
+    <TipTapEditor
+      placeholder="무슨 일이 일어나고 있나요?"
+      editable={!submitting}
+      bind:editor
+      bind:bodyText
+      bind:document={tipTapDocument}
+      bind:focused={editorFocused}
+    />
+  </div>
+
+  {#if validationMessage || errorMessage}
+    <p class="text-danger m-0 text-sm leading-5" role="alert">
+      {validationMessage ?? errorMessage}
+    </p>
+  {/if}
+
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex min-w-0 items-center gap-2">
+      <Dropdown.Root>
+        <Dropdown.Trigger>
+          <Button variant="secondary" class="flex gap-1 text-sm">
+            <PostVisibilityIcon visibility={selectedVisibility} class="shrink-0" />
+            <span class="truncate">{visibilityOptions[selectedVisibility].label}</span>
+          </Button>
+        </Dropdown.Trigger>
+
+        <Dropdown.Content aria-label="게시글 공개 설정">
+          {#each postVisibilitySchemaValues as visibility}
+            <Dropdown.Item
+              active={visibility === selectedVisibility}
+              onclick={() => {
+                selectedVisibility = visibility;
+              }}
+            >
+              <PostVisibilityIcon
+                {visibility}
+                class="text-text-secondary mt-0.5 shrink-0"
+                size={16}
+                strokeWidth={2}
+              />
+              <span class="grid min-w-0 gap-0.5">
+                <span class="text-text-primary text-sm font-bold">
+                  {visibilityOptions[visibility].label}
+                </span>
+                <span class="text-text-secondary text-xs leading-4">
+                  {visibilityOptions[visibility].description}
+                </span>
+              </span>
+            </Dropdown.Item>
+          {/each}
+        </Dropdown.Content>
+      </Dropdown.Root>
+    </div>
+
+    <div class="flex items-center justify-end gap-2">
+      <p
+        class={`m-0 text-xs ${bodyText.length > postBodyMaxLength ? 'text-danger' : 'text-text-secondary'}`}
+        aria-live="polite"
+      >
+        {(postBodyMaxLength - bodyText.length).toLocaleString('ko-KR')}
+      </p>
+
+      <Button
+        class="shrink-0"
+        type="submit"
+        disabled={submitting || bodyText.length === 0 || bodyText.length > postBodyMaxLength}
+        aria-busy={submitting}
+      >
+        {submitting ? '게시 중' : '게시'}
+      </Button>
+    </div>
+  </div>
+</form>

--- a/apps/web/src/lib/components/PostVisibilityIcon.svelte
+++ b/apps/web/src/lib/components/PostVisibilityIcon.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { PostVisibility } from '@kosmo/core/enums';
+  import { AtSignIcon, GlobeIcon, LockIcon, MoonIcon } from '@lucide/svelte';
+  import type { IconProps } from '@lucide/svelte';
+  import type { Component } from 'svelte';
+
+  const POST_VISIBILITY_ICON = {
+    [PostVisibility.PUBLIC]: GlobeIcon,
+    [PostVisibility.UNLISTED]: MoonIcon,
+    [PostVisibility.FOLLOWERS]: LockIcon,
+    [PostVisibility.DIRECT]: AtSignIcon,
+  } satisfies Record<PostVisibility, Component>;
+
+  const { visibility, ...restProps }: { visibility: PostVisibility } & IconProps = $props();
+  const PostVisibilityIcon = $derived(POST_VISIBILITY_ICON[visibility]);
+</script>
+
+<PostVisibilityIcon {...restProps} />

--- a/apps/web/src/lib/components/TipTapEditor.svelte
+++ b/apps/web/src/lib/components/TipTapEditor.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Editor } from '@tiptap/core';
+  import { Document } from '@tiptap/extension-document';
+  import { Paragraph } from '@tiptap/extension-paragraph';
+  import { Text } from '@tiptap/extension-text';
+  import type { TipTapDocument } from '@kosmo/core/tiptap';
+
+  type Props = {
+    placeholder?: string;
+    editable?: boolean;
+    editor?: Editor | null;
+    bodyText?: string;
+    document?: TipTapDocument | null;
+    focused?: boolean;
+    onUpdate?: () => void;
+  };
+
+  let {
+    placeholder = '',
+    editable = true,
+    editor = $bindable<Editor | null>(null),
+    bodyText = $bindable(''),
+    document = $bindable<TipTapDocument | null>(null),
+    focused = $bindable(false),
+    onUpdate,
+  }: Props = $props();
+
+  let editorHost: HTMLDivElement;
+
+  const syncEditorState = () => {
+    bodyText = editor?.getText({ blockSeparator: '\n' }).trim() ?? '';
+    document = (editor?.getJSON() as TipTapDocument | undefined) ?? null;
+  };
+
+  $effect(() => {
+    editor?.setEditable(editable);
+  });
+
+  onMount(() => {
+    editor = new Editor({
+      element: editorHost,
+      extensions: [Document, Paragraph, Text],
+      content: document ?? {
+        type: 'doc',
+        content: [{ type: 'paragraph' }],
+      },
+      autofocus: false,
+      editorProps: {
+        attributes: {
+          class: 'post-composer-editor',
+          'aria-label': '게시글 본문',
+        },
+        handleDOMEvents: {
+          focus: () => {
+            focused = true;
+            return false;
+          },
+          blur: () => {
+            focused = false;
+            syncEditorState();
+            return false;
+          },
+        },
+      },
+      onUpdate: () => {
+        syncEditorState();
+        onUpdate?.();
+      },
+    });
+
+    syncEditorState();
+    onUpdate?.();
+
+    return () => {
+      editor?.destroy();
+      editor = null;
+    };
+  });
+</script>
+
+<div class="relative">
+  {#if placeholder && bodyText.length === 0}
+    <p class="text-text-secondary pointer-events-none absolute left-4 top-4 m-0 text-base">
+      {placeholder}
+    </p>
+  {/if}
+  <div bind:this={editorHost}></div>
+</div>
+
+<style>
+  :global(.post-composer-editor) {
+    min-height: 10rem;
+    padding: 1rem;
+    color: var(--color-text-primary);
+    font-size: 1rem;
+    line-height: 1.625;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    outline: none;
+  }
+
+  :global(.post-composer-editor p) {
+    margin: 0 0 0.75rem;
+  }
+
+  :global(.post-composer-editor p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/apps/web/src/lib/index.ts
+++ b/apps/web/src/lib/index.ts
@@ -9,6 +9,7 @@ export { default as ImagePlaceholder } from './components/ImagePlaceholder.svelt
 export { default as NotificationItem } from './components/NotificationItem.svelte';
 export { default as PostAuthorProfile } from './components/PostAuthorProfile.svelte';
 export { default as PostBody } from './components/PostBody.svelte';
+export { default as PostComposer } from './components/PostComposer.svelte';
 export { default as PostList } from './components/PostList.svelte';
 export { default as SearchBar } from './components/SearchBar.svelte';
 export { default as SearchTabs } from './components/SearchTabs.svelte';

--- a/apps/web/src/routes/layout.css
+++ b/apps/web/src/routes/layout.css
@@ -1,10 +1,5 @@
 @import 'tailwindcss';
 
-svg.lucide-icon {
-  width: 1em;
-  height: 1em;
-}
-
 @theme {
   --color-bg: #ffffff;
   --color-surface: #f6f6f6;

--- a/apps/web/src/routes/layout.css
+++ b/apps/web/src/routes/layout.css
@@ -1,5 +1,10 @@
 @import 'tailwindcss';
 
+svg.lucide-icon {
+  width: 1em;
+  height: 1em;
+}
+
 @theme {
   --color-bg: #ffffff;
   --color-surface: #f6f6f6;

--- a/packages/core/validation/post.ts
+++ b/packages/core/validation/post.ts
@@ -1,35 +1,31 @@
 import { z } from 'zod';
 import { parseTipTapDocumentContent } from '../tiptap';
 
-export const postBodyTipTapDocumentSchema = z.unknown().transform((value, ctx) => {
+export const postBodyMaxLength = 500;
+
+export const postBodyTipTapDocumentSchema = z.unknown().superRefine((value, ctx) => {
   try {
-    const { document, plainText } = parseTipTapDocumentContent(value);
+    const { plainText } = parseTipTapDocumentContent(value);
 
     if (plainText.length === 0) {
       ctx.addIssue({
         code: 'custom',
-        message: 'Post body is required',
+        message: '본문을 입력해주세요.',
       });
 
-      return z.NEVER;
+      return;
     }
 
-    if (plainText.length > 5000) {
+    if (plainText.length > postBodyMaxLength) {
       ctx.addIssue({
         code: 'custom',
-        message: 'Post body must be at most 5000 characters',
+        message: `본문은 ${postBodyMaxLength.toLocaleString('ko-KR')}자까지 작성할 수 있어요.`,
       });
-
-      return z.NEVER;
     }
-
-    return document;
   } catch {
     ctx.addIssue({
       code: 'custom',
-      message: 'Invalid TipTap document',
+      message: '유효하지 않은 본문 형식입니다.',
     });
-
-    return z.NEVER;
   }
 });


### PR DESCRIPTION
Stack: `main` -> `prod-87-dropdown` -> `prod-87-post-validation` -> `prod-87-post-composer`

## 무엇을 변경했는지
- `PostComposer` 컴포넌트를 추가하고 `Profile` fragment ref를 prop으로 받게 합니다.
- TipTap editor 책임을 `TipTapEditor` 컴포넌트로 분리합니다.
- 공개 범위별 Lucide 아이콘 선택을 `PostVisibilityIcon` 컴포넌트로 분리합니다.
- 공개 설정 Dropdown, 남은 글자수 인디케이터, 게시 버튼을 작성 폼 하단에 배치합니다.
- Storybook story와 library export를 추가합니다.

## 왜 변경했는지
- `/compose` 화면 전환보다 재사용 가능한 새 글 작성 컴포넌트가 이번 작업의 중심이므로, route 연결과 분리해 컴포넌트 자체를 먼저 검토할 수 있게 했습니다.
- 작성자 프로필 표시, TipTap 입력, 공개 범위 선택, 본문 길이 제한을 하나의 독립 컴포넌트 계약으로 묶기 위한 변경입니다.

## 어떻게 확인할 수 있는지
- `pnpm --filter @kosmo/web check`
- `git diff --check`
- Storybook `KOSMO/PostComposer` story에서 기본 렌더링을 확인할 수 있습니다.

## 아직 어떤 문제가 남았는지
- 이 PR에서는 `/compose` route에 아직 연결하지 않습니다. route 상태 처리는 후속 PR에서 확인합니다.