### PR TITLE
GitHub 머지 큐 라벨 자동화를 추가한다

### DIFF
--- a/.github/workflows/stacked-pr-merge-queue.yml
+++ b/.github/workflows/stacked-pr-merge-queue.yml
@@ -46,6 +46,7 @@ jobs:
             const labelName = process.env.MERGE_QUEUE_LABEL;
             const targetBranch = process.env.TARGET_BRANCH;
             const mergeMethod = process.env.MERGE_METHOD;
+            const activationPermissions = new Set(["admin", "maintain", "write"]);
 
             function getPullRequestNumber() {
               if (context.eventName === "workflow_dispatch") {
@@ -66,6 +67,34 @@ jobs:
               }
 
               return number;
+            }
+
+            function isPullRequestTargetAction(action) {
+              return context.eventName === "pull_request_target" && context.payload.action === action;
+            }
+
+            function isLabelChangeAction() {
+              return isPullRequestTargetAction("labeled") || isPullRequestTargetAction("unlabeled");
+            }
+
+            function getEventLabelName() {
+              return context.payload.label?.name ?? null;
+            }
+
+            function isRocketLabelRemoval() {
+              return isPullRequestTargetAction("unlabeled") && getEventLabelName() === labelName;
+            }
+
+            function isUnrelatedLabelChange() {
+              return isLabelChangeAction() && getEventLabelName() !== labelName;
+            }
+
+            function isBaseChangedEvent() {
+              return isPullRequestTargetAction("edited") && Boolean(context.payload.changes?.base);
+            }
+
+            function shouldCleanUpForUntrustedSender() {
+              return isPullRequestTargetAction("synchronize");
             }
 
             function getGraphqlErrorMessages(error) {
@@ -100,6 +129,34 @@ jobs:
               return getGraphqlErrorMessages(error).some((message) =>
                 /auto.?merge.*already enabled|already.*auto.?merge/i.test(message),
               );
+            }
+
+            function canActivateMergeQueue(permission) {
+              return activationPermissions.has(String(permission).toLowerCase());
+            }
+
+            async function getSenderPermission() {
+              const sender = context.payload.sender?.login;
+
+              if (!sender) {
+                return "none";
+              }
+
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner,
+                  repo,
+                  username: sender,
+                });
+
+                return data.permission ?? "none";
+              } catch (error) {
+                if (error.status === 404) {
+                  return "none";
+                }
+
+                throw error;
+              }
             }
 
             async function fetchPullRequest(number) {
@@ -283,6 +340,14 @@ jobs:
             }
 
             const pullRequestNumber = getPullRequestNumber();
+
+            if (isUnrelatedLabelChange()) {
+              core.info(
+                `Skipping PR #${pullRequestNumber} because ${context.payload.action} label ${getEventLabelName()} is not ${labelName}.`,
+              );
+              return;
+            }
+
             const pullRequest = await fetchPullRequest(pullRequestNumber);
             const hasLabel = await hasOptInLabel(pullRequestNumber);
 
@@ -304,26 +369,55 @@ jobs:
               return;
             }
 
-            if (pullRequest.baseRefName !== targetBranch) {
-              core.info(
-                `Skipping PR #${pullRequest.number} because its base branch is ${pullRequest.baseRefName}, not ${targetBranch}.`,
-              );
-              return;
-            }
-
-            if (!hasLabel || pullRequest.isDraft) {
-              const reason = !hasLabel
-                ? `it does not have the ${labelName} label`
-                : "it is a draft";
-              core.info(`Cleaning up PR #${pullRequest.number} because ${reason}.`);
+            if (isRocketLabelRemoval()) {
+              core.info(`Cleaning up PR #${pullRequest.number} because the ${labelName} label was removed.`);
               await cleanUpPullRequest(pullRequest);
               return;
             }
 
-            if (!pullRequest.isMergeQueueEnabled) {
-              throw new Error(
-                `PR #${pullRequest.number} targets ${targetBranch}, but GitHub merge queue is not enabled for this branch.`,
+            if (!hasLabel) {
+              core.info(`Skipping PR #${pullRequest.number} because it does not have the ${labelName} label.`);
+              return;
+            }
+
+            if (pullRequest.isDraft) {
+              core.info(`Cleaning up PR #${pullRequest.number} because it is a draft.`);
+              await cleanUpPullRequest(pullRequest);
+              return;
+            }
+
+            const senderPermission = await getSenderPermission();
+            const senderCanActivate = canActivateMergeQueue(senderPermission);
+
+            if (pullRequest.baseRefName !== targetBranch) {
+              if (isPullRequestTargetAction("labeled") && !senderCanActivate) {
+                core.info(
+                  `Skipping PR #${pullRequest.number} because sender ${context.payload.sender?.login ?? "(unknown)"} has ${senderPermission} permission and its base branch is ${pullRequest.baseRefName}, not ${targetBranch}.`,
+                );
+                return;
+              }
+
+              core.info(
+                `Cleaning up PR #${pullRequest.number} because its base branch is ${pullRequest.baseRefName}, not ${targetBranch}.`,
               );
+              await cleanUpPullRequest(pullRequest);
+              return;
+            }
+
+            if (!senderCanActivate) {
+              core.info(
+                `Skipping PR #${pullRequest.number} because sender ${context.payload.sender?.login ?? "(unknown)"} has ${senderPermission} permission, not write access.`,
+              );
+
+              if (shouldCleanUpForUntrustedSender()) {
+                await cleanUpPullRequest(pullRequest);
+              }
+
+              return;
+            }
+
+            if (isBaseChangedEvent()) {
+              core.info(`PR #${pullRequest.number} still targets ${targetBranch} after base edit.`);
             }
 
             if (pullRequest.mergeQueueEntry || pullRequest.isInMergeQueue) {
@@ -331,6 +425,12 @@ jobs:
               const details = entry ? `position ${entry.position}, state ${entry.state}` : "already in queue";
               core.info(`PR #${pullRequest.number} is already in the merge queue (${details}).`);
               return;
+            }
+
+            if (!pullRequest.isMergeQueueEnabled) {
+              throw new Error(
+                `PR #${pullRequest.number} targets ${targetBranch}, but GitHub merge queue is not enabled for this branch.`,
+              );
             }
 
             try {

--- a/.github/workflows/stacked-pr-merge-queue.yml
+++ b/.github/workflows/stacked-pr-merge-queue.yml
@@ -19,7 +19,7 @@ on:
 
 permissions:
   contents: write
-  issues: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -97,6 +97,31 @@ jobs:
               return isPullRequestTargetAction("synchronize");
             }
 
+            function branchPatternMatches(pattern, branch, defaultBranch) {
+              return pattern === "~ALL"
+                || pattern === branch
+                || pattern === `refs/heads/${branch}`
+                || (pattern === "~DEFAULT_BRANCH" && branch === defaultBranch);
+            }
+
+            function rulesetTargetsBranch(ruleset, branch, defaultBranch) {
+              if (ruleset.target !== "branch" || ruleset.enforcement !== "active") {
+                return false;
+              }
+
+              const refName = ruleset.conditions?.ref_name;
+
+              if (!refName) {
+                return true;
+              }
+
+              const includes = refName.include ?? [];
+              const excludes = refName.exclude ?? [];
+
+              return includes.some((pattern) => branchPatternMatches(pattern, branch, defaultBranch))
+                && !excludes.some((pattern) => branchPatternMatches(pattern, branch, defaultBranch));
+            }
+
             function getGraphqlErrorMessages(error) {
               const messages = [];
 
@@ -133,6 +158,35 @@ jobs:
 
             function canActivateMergeQueue(permission) {
               return activationPermissions.has(String(permission).toLowerCase());
+            }
+
+            async function removeOptInLabel(number) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  name: labelName,
+                });
+                core.info(`Removed unauthorized ${labelName} label from PR #${number}.`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`The ${labelName} label was already absent from PR #${number}.`);
+                  return;
+                }
+
+                throw error;
+              }
+            }
+
+            async function addOptInLabel(number) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: number,
+                labels: [labelName],
+              });
+              core.info(`Restored ${labelName} label on PR #${number}.`);
             }
 
             async function getSenderPermission() {
@@ -208,6 +262,43 @@ jobs:
               });
 
               return labels.some((label) => label.name === labelName);
+            }
+
+            async function assertRequiredStatusChecksConfigured() {
+              const { data: repository } = await github.rest.repos.get({ owner, repo });
+              const defaultBranch = repository.default_branch;
+              const { data: rulesets } = await github.request("GET /repos/{owner}/{repo}/rulesets", {
+                owner,
+                repo,
+                per_page: 100,
+              });
+
+              const matchingRulesets = rulesets.filter((ruleset) =>
+                rulesetTargetsBranch(ruleset, targetBranch, defaultBranch),
+              );
+
+              for (const ruleset of matchingRulesets) {
+                const { data: detail } = await github.request("GET /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
+                  owner,
+                  repo,
+                  ruleset_id: ruleset.id,
+                });
+                const requiredStatusChecks = detail.rules?.find(
+                  (rule) => rule.type === "required_status_checks",
+                );
+                const checks = requiredStatusChecks?.parameters?.required_status_checks ?? [];
+
+                if (checks.length > 0) {
+                  core.info(
+                    `Required status checks are configured for ${targetBranch} by ruleset ${detail.name}.`,
+                  );
+                  return;
+                }
+              }
+
+              throw new Error(
+                `No required status checks are configured for ${targetBranch}; refusing to manage merge queue state.`,
+              );
             }
 
             async function dequeuePullRequest(pullRequest) {
@@ -369,7 +460,18 @@ jobs:
               return;
             }
 
+            const senderPermission = await getSenderPermission();
+            const senderCanActivate = canActivateMergeQueue(senderPermission);
+
             if (isRocketLabelRemoval()) {
+              if (!senderCanActivate) {
+                core.info(
+                  `Restoring ${labelName} label on PR #${pullRequest.number} because sender ${context.payload.sender?.login ?? "(unknown)"} has ${senderPermission} permission, not write access.`,
+                );
+                await addOptInLabel(pullRequest.number);
+                return;
+              }
+
               core.info(`Cleaning up PR #${pullRequest.number} because the ${labelName} label was removed.`);
               await cleanUpPullRequest(pullRequest);
               return;
@@ -386,14 +488,12 @@ jobs:
               return;
             }
 
-            const senderPermission = await getSenderPermission();
-            const senderCanActivate = canActivateMergeQueue(senderPermission);
-
             if (pullRequest.baseRefName !== targetBranch) {
               if (isPullRequestTargetAction("labeled") && !senderCanActivate) {
                 core.info(
-                  `Skipping PR #${pullRequest.number} because sender ${context.payload.sender?.login ?? "(unknown)"} has ${senderPermission} permission and its base branch is ${pullRequest.baseRefName}, not ${targetBranch}.`,
+                  `Removing ${labelName} label from PR #${pullRequest.number} because sender ${context.payload.sender?.login ?? "(unknown)"} has ${senderPermission} permission and its base branch is ${pullRequest.baseRefName}, not ${targetBranch}.`,
                 );
+                await removeOptInLabel(pullRequest.number);
                 return;
               }
 
@@ -409,6 +509,11 @@ jobs:
                 `Skipping PR #${pullRequest.number} because sender ${context.payload.sender?.login ?? "(unknown)"} has ${senderPermission} permission, not write access.`,
               );
 
+              if (isPullRequestTargetAction("labeled")) {
+                await removeOptInLabel(pullRequest.number);
+                return;
+              }
+
               if (shouldCleanUpForUntrustedSender()) {
                 await cleanUpPullRequest(pullRequest);
               }
@@ -418,6 +523,13 @@ jobs:
 
             if (isBaseChangedEvent()) {
               core.info(`PR #${pullRequest.number} still targets ${targetBranch} after base edit.`);
+            }
+
+            try {
+              await assertRequiredStatusChecksConfigured();
+            } catch (error) {
+              await cleanUpPullRequest(pullRequest);
+              throw error;
             }
 
             if (pullRequest.mergeQueueEntry || pullRequest.isInMergeQueue) {

--- a/.github/workflows/stacked-pr-merge-queue.yml
+++ b/.github/workflows/stacked-pr-merge-queue.yml
@@ -1,0 +1,352 @@
+name: Stacked PR Merge Queue
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - edited
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to process
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+
+env:
+  MERGE_QUEUE_LABEL: '🚀'
+  TARGET_BRANCH: main
+  MERGE_METHOD: SQUASH
+
+jobs:
+  merge_queue:
+    name: Manage native merge queue opt-in
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Process pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labelName = process.env.MERGE_QUEUE_LABEL;
+            const targetBranch = process.env.TARGET_BRANCH;
+            const mergeMethod = process.env.MERGE_METHOD;
+
+            function getPullRequestNumber() {
+              if (context.eventName === "workflow_dispatch") {
+                const value = core.getInput("pr_number", { required: true });
+                const number = Number(value);
+
+                if (!Number.isInteger(number) || number <= 0) {
+                  throw new Error(`Invalid pull request number: ${value}`);
+                }
+
+                return number;
+              }
+
+              const number = context.payload.pull_request?.number;
+
+              if (!Number.isInteger(number)) {
+                throw new Error("This workflow requires a pull request event or pr_number input.");
+              }
+
+              return number;
+            }
+
+            function getGraphqlErrorMessages(error) {
+              const messages = [];
+
+              if (Array.isArray(error.errors)) {
+                messages.push(...error.errors.map((graphqlError) => graphqlError.message));
+              }
+
+              if (error.message) {
+                messages.push(error.message);
+              }
+
+              return messages.filter(Boolean);
+            }
+
+            function isNotReadyForQueue(error) {
+              return getGraphqlErrorMessages(error).some((message) =>
+                /blocked|check|merge requirements|mergeable|not mergeable|review|required|unstable/i.test(
+                  message,
+                ),
+              );
+            }
+
+            function isAlreadyQueued(error) {
+              return getGraphqlErrorMessages(error).some((message) =>
+                /already.*(merge queue|queued|enqueued)|pull request is already in the merge queue/i.test(message),
+              );
+            }
+
+            function isAutoMergeAlreadyEnabled(error) {
+              return getGraphqlErrorMessages(error).some((message) =>
+                /auto.?merge.*already enabled|already.*auto.?merge/i.test(message),
+              );
+            }
+
+            async function fetchPullRequest(number) {
+              const query = `
+                query PullRequestForMergeQueue($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      id
+                      number
+                      title
+                      url
+                      state
+                      isDraft
+                      baseRefName
+                      headRefOid
+                      isMergeQueueEnabled
+                      isInMergeQueue
+                      mergeStateStatus
+                      mergeQueueEntry {
+                        id
+                        state
+                        position
+                      }
+                      autoMergeRequest {
+                        enabledAt
+                        mergeMethod
+                      }
+                    }
+                  }
+                }
+              `;
+
+              const result = await github.graphql(query, { owner, repo, number });
+              const pullRequest = result.repository?.pullRequest;
+
+              if (!pullRequest) {
+                throw new Error(`Pull request #${number} was not found.`);
+              }
+
+              return pullRequest;
+            }
+
+            async function hasOptInLabel(number) {
+              const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+                owner,
+                repo,
+                issue_number: number,
+                per_page: 100,
+              });
+
+              return labels.some((label) => label.name === labelName);
+            }
+
+            async function dequeuePullRequest(pullRequest) {
+              const entry = pullRequest.mergeQueueEntry;
+
+              if (!entry) {
+                return false;
+              }
+
+              const mutation = `
+                mutation DequeuePullRequest($entryId: ID!) {
+                  dequeuePullRequest(input: { id: $entryId }) {
+                    mergeQueueEntry {
+                      id
+                    }
+                  }
+                }
+              `;
+
+              await github.graphql(mutation, { entryId: entry.id });
+              core.info(`Removed PR #${pullRequest.number} from the merge queue.`);
+              return true;
+            }
+
+            async function disableAutoMerge(pullRequest) {
+              if (!pullRequest.autoMergeRequest) {
+                return false;
+              }
+
+              const mutation = `
+                mutation DisablePullRequestAutoMerge($pullRequestId: ID!) {
+                  disablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest {
+                      number
+                    }
+                  }
+                }
+              `;
+
+              await github.graphql(mutation, { pullRequestId: pullRequest.id });
+              core.info(`Disabled auto-merge for PR #${pullRequest.number}.`);
+              return true;
+            }
+
+            async function cleanUpPullRequest(pullRequest) {
+              const removedFromQueue = await dequeuePullRequest(pullRequest);
+              const disabledAutoMerge = await disableAutoMerge(pullRequest);
+
+              if (!removedFromQueue && !disabledAutoMerge) {
+                core.info(`PR #${pullRequest.number} has no merge queue or auto-merge state to clean up.`);
+              }
+            }
+
+            async function enqueuePullRequest(pullRequest) {
+              const mutation = `
+                mutation EnqueuePullRequest($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
+                  enqueuePullRequest(
+                    input: {
+                      pullRequestId: $pullRequestId
+                      expectedHeadOid: $expectedHeadOid
+                    }
+                  ) {
+                    mergeQueueEntry {
+                      id
+                      state
+                      position
+                    }
+                  }
+                }
+              `;
+
+              const result = await github.graphql(mutation, {
+                pullRequestId: pullRequest.id,
+                expectedHeadOid: pullRequest.headRefOid,
+              });
+
+              const entry = result.enqueuePullRequest.mergeQueueEntry;
+              core.info(`Queued PR #${pullRequest.number} at position ${entry.position} with state ${entry.state}.`);
+            }
+
+            async function enableAutoMerge(pullRequest) {
+              if (pullRequest.autoMergeRequest) {
+                core.info(`PR #${pullRequest.number} already has auto-merge enabled.`);
+                return;
+              }
+
+              const mutation = `
+                mutation EnablePullRequestAutoMerge(
+                  $pullRequestId: ID!
+                  $expectedHeadOid: GitObjectID!
+                  $mergeMethod: PullRequestMergeMethod!
+                ) {
+                  enablePullRequestAutoMerge(
+                    input: {
+                      pullRequestId: $pullRequestId
+                      expectedHeadOid: $expectedHeadOid
+                      mergeMethod: $mergeMethod
+                    }
+                  ) {
+                    pullRequest {
+                      number
+                      autoMergeRequest {
+                        enabledAt
+                        mergeMethod
+                      }
+                    }
+                  }
+                }
+              `;
+
+              try {
+                const result = await github.graphql(mutation, {
+                  pullRequestId: pullRequest.id,
+                  expectedHeadOid: pullRequest.headRefOid,
+                  mergeMethod,
+                });
+
+                const request = result.enablePullRequestAutoMerge.pullRequest.autoMergeRequest;
+                core.info(
+                  `Enabled auto-merge for PR #${pullRequest.number} with method ${request.mergeMethod}.`,
+                );
+              } catch (error) {
+                if (isAutoMergeAlreadyEnabled(error)) {
+                  core.info(`PR #${pullRequest.number} already has auto-merge enabled.`);
+                  return;
+                }
+
+                throw error;
+              }
+            }
+
+            const pullRequestNumber = getPullRequestNumber();
+            const pullRequest = await fetchPullRequest(pullRequestNumber);
+            const hasLabel = await hasOptInLabel(pullRequestNumber);
+
+            core.info(
+              [
+                `PR #${pullRequest.number}: ${pullRequest.title}`,
+                `URL: ${pullRequest.url}`,
+                `State: ${pullRequest.state}`,
+                `Base: ${pullRequest.baseRefName}`,
+                `Draft: ${pullRequest.isDraft}`,
+                `Has ${labelName} label: ${hasLabel}`,
+                `Merge queue enabled: ${pullRequest.isMergeQueueEnabled}`,
+                `Merge state: ${pullRequest.mergeStateStatus}`,
+              ].join("\n"),
+            );
+
+            if (pullRequest.state !== "OPEN") {
+              core.info(`Skipping PR #${pullRequest.number} because it is ${pullRequest.state}.`);
+              return;
+            }
+
+            if (pullRequest.baseRefName !== targetBranch) {
+              core.info(
+                `Skipping PR #${pullRequest.number} because its base branch is ${pullRequest.baseRefName}, not ${targetBranch}.`,
+              );
+              return;
+            }
+
+            if (!hasLabel || pullRequest.isDraft) {
+              const reason = !hasLabel
+                ? `it does not have the ${labelName} label`
+                : "it is a draft";
+              core.info(`Cleaning up PR #${pullRequest.number} because ${reason}.`);
+              await cleanUpPullRequest(pullRequest);
+              return;
+            }
+
+            if (!pullRequest.isMergeQueueEnabled) {
+              throw new Error(
+                `PR #${pullRequest.number} targets ${targetBranch}, but GitHub merge queue is not enabled for this branch.`,
+              );
+            }
+
+            if (pullRequest.mergeQueueEntry || pullRequest.isInMergeQueue) {
+              const entry = pullRequest.mergeQueueEntry;
+              const details = entry ? `position ${entry.position}, state ${entry.state}` : "already in queue";
+              core.info(`PR #${pullRequest.number} is already in the merge queue (${details}).`);
+              return;
+            }
+
+            try {
+              await enqueuePullRequest(pullRequest);
+            } catch (error) {
+              if (isAlreadyQueued(error)) {
+                core.info(`PR #${pullRequest.number} is already in the merge queue.`);
+                return;
+              }
+
+              if (!isNotReadyForQueue(error)) {
+                throw error;
+              }
+
+              core.info(
+                `PR #${pullRequest.number} is not ready for immediate queue entry; enabling auto-merge instead.`,
+              );
+              await enableAutoMerge(pullRequest);
+            }

--- a/.github/workflows/stacked-pr-merge-queue.yml
+++ b/.github/workflows/stacked-pr-merge-queue.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MERGE_QUEUE_LABEL: '🚀'
+  MERGE_QUEUE_LABEL: merge-queue
   TARGET_BRANCH: main
   MERGE_METHOD: SQUASH
 
@@ -81,7 +81,7 @@ jobs:
               return context.payload.label?.name ?? null;
             }
 
-            function isRocketLabelRemoval() {
+            function isMergeQueueLabelRemoval() {
               return isPullRequestTargetAction("unlabeled") && getEventLabelName() === labelName;
             }
 
@@ -422,7 +422,7 @@ jobs:
             const senderPermission = await getSenderPermission();
             const senderCanActivate = canActivateMergeQueue(senderPermission);
 
-            if (isRocketLabelRemoval()) {
+            if (isMergeQueueLabelRemoval()) {
               if (!senderCanActivate) {
                 core.info(
                   `Restoring ${labelName} label on PR #${pullRequest.number} because sender ${context.payload.sender?.login ?? "(unknown)"} has ${senderPermission} permission, not write access.`,

--- a/.github/workflows/stacked-pr-merge-queue.yml
+++ b/.github/workflows/stacked-pr-merge-queue.yml
@@ -97,31 +97,6 @@ jobs:
               return isPullRequestTargetAction("synchronize");
             }
 
-            function branchPatternMatches(pattern, branch, defaultBranch) {
-              return pattern === "~ALL"
-                || pattern === branch
-                || pattern === `refs/heads/${branch}`
-                || (pattern === "~DEFAULT_BRANCH" && branch === defaultBranch);
-            }
-
-            function rulesetTargetsBranch(ruleset, branch, defaultBranch) {
-              if (ruleset.target !== "branch" || ruleset.enforcement !== "active") {
-                return false;
-              }
-
-              const refName = ruleset.conditions?.ref_name;
-
-              if (!refName) {
-                return true;
-              }
-
-              const includes = refName.include ?? [];
-              const excludes = refName.exclude ?? [];
-
-              return includes.some((pattern) => branchPatternMatches(pattern, branch, defaultBranch))
-                && !excludes.some((pattern) => branchPatternMatches(pattern, branch, defaultBranch));
-            }
-
             function getGraphqlErrorMessages(error) {
               const messages = [];
 
@@ -265,35 +240,19 @@ jobs:
             }
 
             async function assertRequiredStatusChecksConfigured() {
-              const { data: repository } = await github.rest.repos.get({ owner, repo });
-              const defaultBranch = repository.default_branch;
-              const { data: rulesets } = await github.request("GET /repos/{owner}/{repo}/rulesets", {
+              const { data: rules } = await github.request("GET /repos/{owner}/{repo}/rules/branches/{branch}", {
                 owner,
                 repo,
+                branch: targetBranch,
                 per_page: 100,
               });
 
-              const matchingRulesets = rulesets.filter((ruleset) =>
-                rulesetTargetsBranch(ruleset, targetBranch, defaultBranch),
-              );
+              const requiredStatusChecks = rules.find((rule) => rule.type === "required_status_checks");
+              const checks = requiredStatusChecks?.parameters?.required_status_checks ?? [];
 
-              for (const ruleset of matchingRulesets) {
-                const { data: detail } = await github.request("GET /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
-                  owner,
-                  repo,
-                  ruleset_id: ruleset.id,
-                });
-                const requiredStatusChecks = detail.rules?.find(
-                  (rule) => rule.type === "required_status_checks",
-                );
-                const checks = requiredStatusChecks?.parameters?.required_status_checks ?? [];
-
-                if (checks.length > 0) {
-                  core.info(
-                    `Required status checks are configured for ${targetBranch} by ruleset ${detail.name}.`,
-                  );
-                  return;
-                }
+              if (checks.length > 0) {
+                core.info(`Required status checks are configured for ${targetBranch}.`);
+                return;
               }
 
               throw new Error(


### PR DESCRIPTION
## 무엇을 변경했는지

- `merge-queue` 라벨이 붙은 `main` 대상 PR을 GitHub native merge queue 대상으로 처리하는 workflow를 추가했습니다.
- 직접 merge하지 않고 `enqueuePullRequest`를 먼저 시도하며, 아직 조건이 충족되지 않은 PR은 auto-merge를 활성화해 GitHub branch rule과 merge queue가 이후 처리를 맡게 했습니다.
- PR base가 `main`이 아니면 queue/auto-merge를 켜지 않고, `merge-queue` 라벨이 붙은 상태에서 이미 켜진 queue/auto-merge 상태는 정리하도록 했습니다.
- `merge-queue` 라벨 제거, draft 전환, non-write sender의 head 변경 재시도 같은 안전하지 않은 상태에서는 auto-merge/queue 상태를 정리합니다.
- unrelated label 이벤트와 `merge-queue` 라벨이 없는 PR은 no-op으로 처리해 수동 auto-merge 상태를 임의로 건드리지 않게 했습니다.
- queue/auto-merge 활성화는 이벤트 sender가 `write`, `maintain`, `admin` 권한을 가진 경우에만 진행하도록 제한했습니다.
- write 권한이 없는 sender가 `merge-queue` 라벨을 붙이면 라벨을 제거하고, `merge-queue` 라벨을 제거하면 라벨을 복구해 라벨 권한이 queue 제어 권한으로 승격되지 않게 했습니다.
- `main`에 실제 적용되는 branch rules에 required status checks가 없으면 queue/auto-merge 상태를 정리하고 workflow를 실패시켜, merge queue가 CI 없이 통과하지 않게 했습니다.

## 왜 변경했는지

Stacked PR 운영에서 사람이 특정 라벨로 merge queue opt-in을 표시하면, 기존 GitHub native merge queue를 통해 순서와 검증을 맡길 수 있게 하기 위해서입니다. GitHub native merge queue는 `main` 대상 PR에서만 기대한 방식으로 동작하므로, 하위 stack PR은 부모 PR이 먼저 merge되어 base가 `main`이 될 때까지 기다려야 합니다.

또한 `pull_request_target`은 base repository 권한으로 실행되므로, 라벨 권한이 merge 권한으로 승격되지 않게 sender 권한을 확인합니다. PR head checkout 없이 `github-script`만 사용해 PR 코드는 실행하지 않습니다.

## 어떻게 확인할 수 있는지

- `pnpm lint:prettier`
- `git diff --check`
- workflow 내 `github-script` 본문 Node 문법 검사
- GitHub GraphQL introspection으로 `enqueuePullRequest`, `dequeuePullRequest`, `enablePullRequestAutoMerge`, `disablePullRequestAutoMerge` input/payload 필드 확인
- GitHub REST branch rules API로 현재 `main`에 required status checks `Lint`, `Semgrep scan`이 적용되어 있음을 확인
- `Lint`, `Semgrep scan` workflow가 `merge_group` 이벤트를 받는지 확인
- repository 설정에서 `allow_auto_merge`, `allow_squash_merge`, `delete_branch_on_merge`가 켜져 있음을 확인
- 서브에이전트 재리뷰에서 액션 가능한 추가 이슈 없음 확인

## 아직 어떤 문제가 남았는지

- `actionlint`가 로컬에 설치되어 있지 않아 별도 actionlint 검증은 하지 못했습니다.
- 실제 repository branch rule에서 `GITHUB_TOKEN`이 merge queue/auto-merge mutation, label update, collaborator permission/branch rules 조회를 허용하는지는 이 PR의 CI 또는 테스트 PR에서 확인해야 합니다.
- 관련 Linear ID 없이 만든 운영 자동화 PR이라 브랜치 이름은 `merge-queue-label-action`으로 두었습니다.
