### PR TITLE
게시글 디테일 페이지 OpenSpec 체인지를 추가한다

### DIFF
--- a/openspec/changes/add-web-post-detail-page/.openspec.yaml
+++ b/openspec/changes/add-web-post-detail-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/add-web-post-detail-page/design.md
+++ b/openspec/changes/add-web-post-detail-page/design.md
@@ -1,0 +1,41 @@
+## Context
+
+PROD-89(게시글 디테일 페이지)는 단건 조회 query(PROD-93)와 작성자 표시 컴포넌트(PROD-97)에 블로킹돼 있다. PR #67(PROD-92)이 `Post`/`PostContent` 타입과 `createPost` mutation을 추가했지만 단건 조회 query는 없고, `PostAuthorProfile`(PR #72)은 아직 머지 전이다. 그래서 블로커와 독립적인 라우트·UI·상태 처리만 더미 데이터로 먼저 구현한다. 순수 프론트엔드(`apps/web`, SvelteKit + mearie GraphQL + Tailwind 시맨틱 토큰)이며, 디자인 기준은 Figma `🧵 Post Detail` 섹션의 anchor 포스트다. 이 변경은 PROD-91의 `(tabs)/@[handle]` 라우트 위에 스택한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 게시글 URL(`/@{handle}/{postId}`)로 단일 게시글 디테일에 직접 접근한다.
+- 작성자 프로필 헤더(`ProfileHero`)가 아니라 단독 게시글 뷰로 렌더한다.
+- Plain Text 본문·작성자·작성 시각을 표시하고, 로딩/오류/없는 게시글/삭제됨 상태가 깨지지 않게 한다.
+- 더미→실데이터 교체 비용이 작도록, 더미를 한 곳에 모으고 상태 분기를 query 필드와 1:1 매핑되게 작성한다.
+
+**Non-Goals:**
+
+- 답글·반응·리포스트·ReplyComposer(Figma 풀 스레드 뷰).
+- 실제 `post` 조회 query 연결(PROD-93)·`PostAuthorProfile` 연결(PROD-97) — 같은 브랜치 후속.
+- 모바일 `(tabs)` 셸 헤더와 back 헤더 통합 — 별도 웹 레이아웃 이슈.
+
+## Decisions
+
+- **URL `/@{handle}/{postId}` (프로필 라우트 하위)**: 대안으로 `/posts/{postId}`(핸들 비의존 평면 경로)를 검토했으나, 작성자 핸들이 URL에 드러나고 프로필 라우트와 일관된 Mastodon식 `/@{handle}/{postId}`를 채택했다.
+- **`+page@(tabs).svelte`로 레이아웃 리셋**: `@[handle]/+layout.svelte`는 모든 하위 라우트에 작성자 `ProfileHero`를 강제로 렌더한다. 게시글 디테일은 단독 뷰여야 하므로 `@(tabs)` 세그먼트로 레이아웃을 `(tabs)` 셸까지 리셋해 ProfileHero를 건너뛰되, 사이드바·하단탭 셸은 유지한다.
+- **로컬 더미 상수**: 이 레포는 loader 파일 없이 컴포넌트 내 인라인 `createQuery`를 쓴다. 그러나 `post` 조회 query가 스키마에 없어 진짜 query를 쓰면 mearie codegen이 깨진다. 따라서 PR #67의 `Post`/`PostContent` shape에 맞춘 로컬 타입·상수를 한 곳에 두고, 상태 분기(`loading`/`error`/null/`state`)는 PROD-93 머지 후 `createQuery` 필드로 1:1 교체되도록 구성한다.
+- **작성자 placeholder**: `PostAuthorProfile`(PR #72)이 머지 전이므로, PROD-91의 `getProfileInitial` 기반 이니셜 아바타 + 표시 이름 + `@handle`로 placeholder를 만들고 `/@{handle}`로 링크한다. PROD-97 머지 후 같은 브랜치에서 컴포넌트로 교체한다.
+- **back 헤더 최소화**: Figma `back_title_action`의 풀 버전(⋯ 메뉴) 대신 이번엔 back 컨트롤만 둔다.
+
+## Risks / Trade-offs
+
+- **모바일 셸 헤더 중복** → `(tabs)` 셸이 모바일에서 햄버거 헤더를 렌더하므로, 본문 상단 back 컨트롤과 시각적으로 중복될 수 있다. 셸 헤더 통합은 별도 웹 레이아웃 이슈로 이연한다.
+- **더미↔실데이터 분기 드리프트** → 더미 단계의 상태 분기가 실제 `createQuery` 필드와 어긋날 위험. 분기 조건을 query 필드명(`loading`/`error`/데이터 null/`state`)에 맞춰 작성하고 주석으로 교체 지점을 표시해 완화한다.
+- **스택 의존(PROD-91)** → base 브랜치(prod-91)가 머지·rewrite되면 rebase가 필요하다. 팀 stacked PR 정책(`memory/commit-pr.md`)의 부모 머지 후 rebase 절차를 따른다.
+
+## Migration Plan
+
+데이터 마이그레이션 없음(프론트엔드 표시 기능). 롤백은 라우트 제거로 충분하며 백엔드 영향 없음.
+
+## Open Questions
+
+- 게시글 단건 조회 query의 최종 형태(`post(id:)` 전용 query vs `node(id:)`)는 PROD-93에서 확정된다. 확정되면 같은 브랜치에서 더미를 교체한다.
+- 모바일 `(tabs)` 셸 헤더 + back 헤더 통합, Figma `back_title_action` 풀 헤더(⋯ 메뉴) 적용은 별도 웹 레이아웃/IA 이슈로 이연.

--- a/openspec/changes/add-web-post-detail-page/proposal.md
+++ b/openspec/changes/add-web-post-detail-page/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+게시글 URL로 단일 게시글을 직접 볼 수 있는 웹 게시글 디테일 페이지가 필요하다(PROD-89). 다만 단건 조회 query(PROD-93)와 작성자 표시 컴포넌트(PROD-97)가 아직 없어, 이번 변경은 **라우트·UI·상태 처리 골격을 더미 데이터 기준으로 먼저 구현**한다. 실제 데이터 조회(`post` query)와 `PostAuthorProfile` 연결은 블로커가 머지된 뒤 **같은 브랜치(prod-89)에서 교체**하며, 더미 상태가 main에 머지되지는 않는다. 이 페이지는 PROD-91이 추가한 핸들 기반 프로필 라우트(`(tabs)/@[handle]`) 위에 얹힌다.
+
+## What Changes
+
+- `apps/web`에 게시글 디테일 라우트 `(tabs)/@[handle]/[postId]`를 추가한다. `/@{handle}/{postId}` 형식으로 접근한다.
+- `+page@(tabs).svelte`로 레이아웃을 `(tabs)` 셸까지 리셋해, 상위 `@[handle]/+layout.svelte`의 작성자 `ProfileHero`를 건너뛰고 단독 게시글 뷰로 렌더한다. 사이드바·하단탭 셸은 유지한다.
+- 게시글 기본 정보(Plain Text 본문, 작성자 표시 이름·핸들, 작성 시각, 공개 범위)를 표시한다. 작성자 영역은 `getProfileInitial` 기반 이니셜 placeholder로 두고, `/@{handle}` 프로필로 링크한다.
+- 상단에 이전 화면으로 돌아가는 간단한 back 컨트롤을 둔다.
+- 로딩·조회 오류·없는 게시글·삭제된 게시글(`state = DELETED`) 상태를 처리하며, 모든 상태에서 상위 `(tabs)` 셸을 유지한다.
+- 데이터는 PR #67(PROD-92)에서 정의된 `Post`/`PostContent` GraphQL shape에 맞춘 로컬 더미 상수 한 곳에서 공급한다. 분기 조건은 향후 `createQuery`의 `loading`/`error`/데이터 null/`state`에 1:1로 매핑되도록 작성한다.
+- (Non-goals) 답글·반응·리포스트·ReplyComposer(Figma 풀 스레드 뷰), 실제 `post` 조회 query 연결(PROD-93 후속·같은 브랜치), `PostAuthorProfile` 컴포넌트 연결(PROD-97 후속·같은 브랜치), 모바일 `(tabs)` 셸 헤더와 back 헤더 통합(별도 웹 레이아웃 이슈)은 본 체인지의 머지 범위 밖이다.
+
+BREAKING 변경 없음.
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `web-app-shell`: 핸들+게시글 ID 기반 디테일 라우트, `(tabs)` 레이아웃 리셋, 게시글 기본 정보 표시, 로딩/오류/없는 게시글/삭제됨 상태 처리, back 내비게이션 요구사항을 추가한다.
+
+## Impact
+
+- 영향 코드(apps/web): `routes/(tabs)/@[handle]/[postId]/+page@(tabs).svelte`(신규).
+- 재사용: `lib/utils/profile.ts`(`getProfileInitial`), `lib/components/TextSkeleton.svelte`(로딩 스켈레톤), 시맨틱 디자인 토큰.
+- 소비 API: 현재 없음(더미). PROD-93 머지 후 `post` 단건 조회 query를 같은 브랜치에서 연결한다. 백엔드 변경 없음.
+- 의존: PROD-91(`(tabs)/@[handle]` 라우트·`profile.ts` 유틸) 위에 스택한다.

--- a/openspec/changes/add-web-post-detail-page/specs/web-app-shell/spec.md
+++ b/openspec/changes/add-web-post-detail-page/specs/web-app-shell/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Handle and post-id based post detail route
+
+웹 앱은 핸들과 게시글 ID를 포함한 URL로 단일 게시글 디테일에 직접 접근할 수 있도록, 프로필 라우트 하위에 게시글 ID 동적 라우트를 제공해야 한다(MUST). 이 라우트는 작성자 프로필 헤더(`ProfileHero`)를 렌더하지 않고 단독 게시글 뷰로 표시해야 하며(MUST), 상위 `(tabs)` 셸(사이드바·하단탭)은 유지해야 한다(MUST).
+
+#### Scenario: Access post by handle and post id URL
+
+- **WHEN** 사용자가 `/@{handle}/{postId}` 형식의 주소로 이동한다
+- **THEN** 시스템은 `(tabs)` 셸 안에서 해당 게시글의 디테일 뷰를 연다
+- **AND** 라우트는 레이아웃을 `(tabs)` 셸까지 리셋해 상위 핸들 라우트의 `ProfileHero`를 표시하지 않는다
+
+### Requirement: Post basic information display
+
+게시글 디테일 페이지는 게시글의 기본 정보를 표시해야 한다(MUST). 표시 항목은 Plain Text 본문, 작성자(표시 이름·핸들), 작성 시각, 공개 범위이며, 색·반경은 시맨틱 디자인 토큰을 사용해 라이트/다크에 대응해야 한다(MUST).
+
+#### Scenario: Display post body and author
+
+- **WHEN** 표시할 활성 게시글이 있다
+- **THEN** 시스템은 Plain Text 본문을 줄바꿈을 보존해 표시하고, 작성자 표시 이름과 `@handle`, 작성 시각, 공개 범위를 표시한다
+- **AND** 작성자 영역은 작성자의 `/@{handle}` 프로필 페이지로 이동할 수 있다
+
+#### Scenario: Author avatar initial fallback
+
+- **WHEN** 작성자에게 아바타 이미지가 없다(스키마 미보유)
+- **THEN** 시스템은 표시 이름(없으면 핸들)의 첫 글자를 대문자로 한 이니셜 아바타를 표시한다
+
+#### Scenario: Missing post content
+
+- **WHEN** 게시글에 표시할 본문 콘텐츠가 없다
+- **THEN** 시스템은 본문 영역을 비워도 레이아웃이 깨지지 않는다
+
+### Requirement: Post detail loading and error states
+
+게시글 디테일 페이지는 로딩, 조회 오류, 없는 게시글, 삭제된 게시글 상태를 처리해야 한다(MUST). 모든 상태에서 상위 `(tabs)` 셸은 유지되어야 한다(MUST).
+
+#### Scenario: Loading state
+
+- **WHEN** 게시글 조회가 진행 중이다
+- **THEN** 시스템은 게시글 형태의 스켈레톤과 스크린리더용 로딩 안내를 표시한다
+
+#### Scenario: Query error
+
+- **WHEN** 게시글 조회가 오류로 실패한다
+- **THEN** 시스템은 오류 안내와 다시 시도 동작을 제공하고, 사이드바·하단탭은 유지한다
+
+#### Scenario: Missing post
+
+- **WHEN** 게시글 ID와 일치하는 게시글이 없다
+- **THEN** 시스템은 인라인 빈 상태("게시글을 찾을 수 없어요")를 표시하고, 사이드바·하단탭은 유지한다
+
+#### Scenario: Deleted post
+
+- **WHEN** 게시글의 상태가 `DELETED`이다
+- **THEN** 시스템은 삭제된 게시글 안내를 표시하고, 본문은 노출하지 않는다
+
+### Requirement: Post detail back navigation
+
+게시글 디테일 페이지는 상단에 이전 화면으로 돌아가는 back 컨트롤을 제공해야 한다(MUST).
+
+#### Scenario: Navigate back
+
+- **WHEN** 사용자가 디테일 페이지 상단의 back 컨트롤을 누른다
+- **THEN** 시스템은 이전 화면으로 돌아간다

--- a/openspec/changes/add-web-post-detail-page/tasks.md
+++ b/openspec/changes/add-web-post-detail-page/tasks.md
@@ -1,0 +1,32 @@
+## 1. 라우트 · 레이아웃
+
+- [ ] 1.1 `(tabs)/@[handle]/[postId]/+page@(tabs).svelte`를 추가해 `/@{handle}/{postId}` 접근을 가능하게 한다
+- [ ] 1.2 `+page@(tabs)` 레이아웃 리셋으로 `@[handle]/+layout.svelte`의 `ProfileHero`를 건너뛰고 `(tabs)` 셸만 유지함을 확인한다
+
+## 2. 게시글 표시 (더미)
+
+- [ ] 2.1 PR #67의 `Post`/`PostContent` shape에 맞춘 로컬 더미 타입·상수를 한 곳에 정의한다
+- [ ] 2.2 Plain Text 본문(`content.bodyText`)을 줄바꿈 보존으로 렌더하고 `content` null을 가드한다
+- [ ] 2.3 작성자 placeholder(`getProfileInitial` 이니셜 + 표시 이름 + `@handle`)를 `/@{handle}`로 링크한다
+- [ ] 2.4 작성 시각(`createdAt`)과 공개 범위(`visibility`) 메타라인을 표시한다
+- [ ] 2.5 상단에 이전 화면으로 돌아가는 back 컨트롤을 둔다
+
+## 3. 상태 처리
+
+- [ ] 3.1 로딩 스켈레톤 + 스크린리더 안내를 표시한다
+- [ ] 3.2 조회 오류 시 안내 + 다시 시도 동작을 제공한다
+- [ ] 3.3 없는 게시글 시 인라인 빈 상태를 표시한다
+- [ ] 3.4 삭제된 게시글(`state = DELETED`) 안내를 표시한다. 모든 상태에서 `(tabs)` 셸을 유지한다
+- [ ] 3.5 분기 조건을 향후 `createQuery`의 `loading`/`error`/데이터 null/`state`에 1:1 매핑되도록 작성한다
+
+## 4. 후속 교체 (같은 prod-89 브랜치, 블로커 머지 후)
+
+- [ ] 4.1 더미 상수 → `post` 단건 조회 `createQuery`로 교체한다 (PROD-93 머지 후)
+- [ ] 4.2 작성자 placeholder → `PostAuthorProfile` + `PostAuthorProfile_profile` fragment로 교체한다 (PROD-97 머지 후)
+- [ ] 4.3 실데이터로 HEAD가 동작하면 Draft → Ready로 전환한다
+
+## 5. 검증
+
+- [ ] 5.1 `pnpm --filter @kosmo/web check`(svelte-check) 통과를 확인한다
+- [ ] 5.2 `pnpm lint:eslint`, `pnpm lint:prettier` 통과를 확인한다
+- [ ] 5.3 `openspec validate add-web-post-detail-page --strict` 통과를 확인한다


### PR DESCRIPTION
Stack: main -> prod-89-openspec -> prod-89 (#75)

> #75에서 리뷰 요청에 따라 OpenSpec 체인지 커밋만 분리한 PR입니다. #75는 이 PR을 base로 스택됩니다.

## 무엇을 변경했는지

- OpenSpec change `add-web-post-detail-page`(proposal/design/tasks/spec delta)를 추가합니다.
- `/@{handle}/{postId}` 형식 URL로 단일 게시글에 접근하는 웹 게시글 디테일 페이지(PROD-89)의 라우트·UI·상태 처리 골격 요구사항을 정의합니다.
- `web-app-shell` capability에 디테일 라우트, `(tabs)` 레이아웃 리셋, 게시글 기본 정보 표시, 로딩/오류/없는 게시글/삭제됨 상태 처리, back 내비게이션 요구사항을 추가합니다.

## 왜 변경했는지

- 구현 PR(#75)에서 스펙 추가와 구현 변경이 한 PR에 섞여 있어, 스펙을 독립적으로 리뷰할 수 있도록 분리해 달라는 리뷰 요청이 있었습니다.
- OpenSpec 체인지를 선행 PR로 두면 스펙 합의와 구현 리뷰를 단계적으로 진행할 수 있습니다.

## 어떻게 확인할 수 있는지

- `pnpm exec openspec validate add-web-post-detail-page --strict`
- diff가 `openspec/changes/add-web-post-detail-page/*` 및 spec delta 파일만 포함하는지 확인합니다.

## 아직 어떤 문제가 남았는지

- 이 PR은 체인지 최초 작성 시점의 스펙입니다. 구현 중 이뤄진 범위 축소(본문 실데이터 연결을 PROD-110으로 분리)와 태스크 진행 체크는 구현 흐름의 일부로 #75에 남아 있습니다.