### PR TITLE
게시글 Node 조회 공개 범위를 제한한다

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,9 @@
 apps/helm/templates/**/*.yaml
+apps/app/android/.gradle/
+apps/app/android/build/
+apps/app/ios/.build/
+apps/app/ios/build/
+apps/app/ios/DerivedData/
 apps/web/build/
 apps/web/storybook-static/
 apps/web/.svelte-kit

--- a/apps/api/src/graphql/resolvers/post/ref.ts
+++ b/apps/api/src/graphql/resolvers/post/ref.ts
@@ -1,10 +1,17 @@
 import { db, PostContents, Posts, Profiles, TableDiscriminator } from '@kosmo/core/db';
 import { PostState, PostVisibility, ProfileState } from '@kosmo/core/enums';
-import { and, eq, getColumns, inArray } from 'drizzle-orm';
+import { and, eq, getColumns, inArray, or } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
 
-export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids) => {
+export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids, ctx) => {
   // TODO(PROD-121): Replace this PUBLIC/UNLISTED guard with viewer-specific access.
+  const visibilityWhere = ctx.session?.profileId
+    ? or(
+        inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]),
+        eq(Posts.profileId, ctx.session.profileId),
+      )
+    : inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]);
+
   return db
     .select(getColumns(Posts))
     .from(Posts)
@@ -13,7 +20,7 @@ export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids) => {
       and(
         inArray(Posts.id, ids),
         eq(Posts.state, PostState.ACTIVE),
-        inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]),
+        visibilityWhere,
         eq(Profiles.state, ProfileState.ACTIVE),
       ),
     );

--- a/apps/api/src/graphql/resolvers/post/ref.ts
+++ b/apps/api/src/graphql/resolvers/post/ref.ts
@@ -4,8 +4,7 @@ import { and, eq, getColumns, inArray } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
 
 export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids) => {
-  // TODO(PROD-102): Apply viewer-specific visibility checks. PUBLIC and UNLISTED
-  // are readable by ID, while FOLLOWERS and DIRECT need restricted access.
+  // TODO(PROD-121): Replace this PUBLIC/UNLISTED guard with viewer-specific access.
   return db
     .select(getColumns(Posts))
     .from(Posts)
@@ -14,6 +13,7 @@ export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids) => {
       and(
         inArray(Posts.id, ids),
         eq(Posts.state, PostState.ACTIVE),
+        inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]),
         eq(Profiles.state, ProfileState.ACTIVE),
       ),
     );
@@ -31,7 +31,7 @@ export const PostContent = createObjectRef(
   'PostContent',
   TableDiscriminator.PostContents,
   (ids) => {
-    // TODO(PROD-102): Prevent direct PostContent node loads from bypassing the parent
+    // TODO(PROD-121): Prevent direct PostContent node loads from bypassing the parent
     // post's state and visibility policy. Historical content remains loadable.
     return db.select().from(PostContents).where(inArray(PostContents.id, ids));
   },

--- a/openspec/specs/post/spec.md
+++ b/openspec/specs/post/spec.md
@@ -21,9 +21,14 @@ API는 활성 게시글을 GraphQL `Post` Node로 노출해야 하며 작성자 
 - **WHEN** 클라이언트가 `PUBLIC` 또는 `UNLISTED` 공개 범위의 활성 게시글 Node를 조회한다
 - **THEN** 시스템은 `Post` object를 반환한다
 
-#### Scenario: 비공개 게시글 object 조회
+#### Scenario: 작성자 본인의 비공개 게시글 object 조회
 
-- **WHEN** 클라이언트가 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 게시글 Node를 조회한다
+- **WHEN** 현재 active profile이 게시글 작성자이고 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 `Post` object를 반환한다
+
+#### Scenario: 작성자가 아닌 viewer의 비공개 게시글 object 조회
+
+- **WHEN** 현재 active profile이 게시글 작성자가 아니거나 인증되지 않은 클라이언트가 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 게시글 Node를 조회한다
 - **THEN** 시스템은 해당 게시글을 GraphQL `Post` object로 노출하지 않는다
 - **AND** viewer 기준 세부 접근 제어는 후속 변경에서 정의한다
 

--- a/openspec/specs/post/spec.md
+++ b/openspec/specs/post/spec.md
@@ -16,6 +16,17 @@ API는 활성 게시글을 GraphQL `Post` Node로 노출해야 하며 작성자 
 - **AND** `profile`은 게시글 작성자 프로필을 가리킨다
 - **AND** `content`는 게시글의 현재 콘텐츠를 가리킨다
 
+#### Scenario: 공개 게시글 object 조회
+
+- **WHEN** 클라이언트가 `PUBLIC` 또는 `UNLISTED` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 `Post` object를 반환한다
+
+#### Scenario: 비공개 게시글 object 조회
+
+- **WHEN** 클라이언트가 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 게시글 Node를 조회한다
+- **THEN** 시스템은 해당 게시글을 GraphQL `Post` object로 노출하지 않는다
+- **AND** viewer 기준 세부 접근 제어는 후속 변경에서 정의한다
+
 #### Scenario: 비활성 게시글 object 조회
 
 - **WHEN** 게시글 상태가 `ACTIVE`가 아니다


### PR DESCRIPTION
## 무엇을 변경했는지

- `Post` Node 로더가 `PUBLIC`/`UNLISTED` 게시글만 반환하도록 제한했습니다.
- `FOLLOWERS`/`DIRECT` 게시글은 이번 범위에서 `node(id)` 조회 결과로 노출되지 않게 했습니다.
- 접근 제어 후속 TODO를 현재 분리된 이슈인 `PROD-121` 기준으로 정리했습니다.
- `openspec/specs/post/spec.md`에 공개/비공개 게시글 Node 조회 계약을 반영했습니다.
- 로컬 네이티브 빌드 산출물이 전체 Prettier 검사 대상에 포함되지 않도록 `.prettierignore`를 보강했습니다.

## 왜 변경했는지

- `PROD-119`는 게시글 상세 화면이 `node(id)`로 조회할 수 있는 `Post` 타입 필드를 정리하는 작업입니다.
- 별도 `post(id)` root query는 기존 리뷰 피드백대로 추가하지 않습니다. `Post`가 이미 `Node`를 구현하므로 단건 조회는 `node(id)`로 처리합니다.
- viewer별 세부 접근 제어는 `PROD-121`에서 다루지만, 이번 사이클에서는 비공개 게시글이 권한 없는 viewer에게 노출되지 않도록 최소 가드가 필요합니다.
- Xcode/Android 빌드 산출물은 Git ignore 대상이지만 루트 Prettier ignore에는 없어서, 로컬 전체 포맷 검사가 불안정했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc` 통과
- `pnpm lint:eslint` 통과
- `pnpm lint:prettier` 통과
- schema 재생성 확인: `Query.post` 추가 없음, `Profile.posts` 추가 없음, `schema.graphql` diff 없음

## 아직 어떤 문제가 남았는지

- `PostContent` 직접 Node 조회가 부모 게시글 visibility를 우회하지 못하게 막는 작업은 `PROD-121` 범위입니다.
- 프로필 게시글 무한스크롤 목록(`Profile.posts`)은 `PROD-120` 범위입니다.

Linear: PROD-119

Stack: main -> prod-119
