### PR TITLE
프로필 게시글 목록 connection을 추가한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -147,6 +147,16 @@ enum PostVisibility {
   UNLISTED
 }
 
+type PostsConnection {
+  edges: [PostsConnectionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PostsConnectionEdge {
+  cursor: String!
+  node: Post!
+}
+
 type Profile implements Node {
   bio: String
   createdAt: DateTime!
@@ -158,7 +168,7 @@ type Profile implements Node {
   followingCount: Int!
   handle: String!
   id: ID!
-  posts(after: String, before: String, first: Int, last: Int): ProfilePostsConnection!
+  posts(after: String, before: String, first: Int, last: Int): PostsConnection!
   viewerFollow: ProfileFollow
 }
 
@@ -199,16 +209,6 @@ type ProfileFollowingConnection {
 type ProfileFollowingConnectionEdge {
   cursor: String!
   node: ProfileFollow!
-}
-
-type ProfilePostsConnection {
-  edges: [ProfilePostsConnectionEdge!]!
-  pageInfo: PageInfo!
-}
-
-type ProfilePostsConnectionEdge {
-  cursor: String!
-  node: Post!
 }
 
 enum ProfileState {

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -158,6 +158,7 @@ type Profile implements Node {
   followingCount: Int!
   handle: String!
   id: ID!
+  posts(after: String, before: String, first: Int, last: Int): ProfilePostsConnection!
   viewerFollow: ProfileFollow
 }
 
@@ -198,6 +199,16 @@ type ProfileFollowingConnection {
 type ProfileFollowingConnectionEdge {
   cursor: String!
   node: ProfileFollow!
+}
+
+type ProfilePostsConnection {
+  edges: [ProfilePostsConnectionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ProfilePostsConnectionEdge {
+  cursor: String!
+  node: Post!
 }
 
 enum ProfileState {

--- a/apps/api/src/graphql/resolvers/post/access/visibility.ts
+++ b/apps/api/src/graphql/resolvers/post/access/visibility.ts
@@ -1,19 +1,14 @@
 import { Posts } from '@kosmo/core/db';
-import { eq, inArray, or } from 'drizzle-orm';
-import type { PostVisibility } from '@kosmo/core/enums';
+import { PostState, PostVisibility } from '@kosmo/core/enums';
+import { and, eq, inArray, or } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
-export const postVisibilityAccessWhere = ({
-  ctx,
-  publicVisibilities,
-}: {
-  ctx: UserContext;
-  publicVisibilities: [PostVisibility, ...PostVisibility[]];
-}) => {
-  const publicWhere = inArray(Posts.visibility, publicVisibilities);
-
-  // TODO(PROD-121): Extend this helper with viewer-specific follower/direct access.
-  return ctx.session?.profileId
+export const postVisibilityAccessWhere = ({ ctx }: { ctx: UserContext }) => {
+  const publicWhere = inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]);
+  const visibleWhere = ctx.session?.profileId
     ? or(publicWhere, eq(Posts.profileId, ctx.session.profileId))!
     : publicWhere;
+
+  // TODO(PROD-121): Extend this helper with viewer-specific follower/direct access.
+  return and(eq(Posts.state, PostState.ACTIVE), visibleWhere)!;
 };

--- a/apps/api/src/graphql/resolvers/post/access/visibility.ts
+++ b/apps/api/src/graphql/resolvers/post/access/visibility.ts
@@ -1,0 +1,19 @@
+import { Posts } from '@kosmo/core/db';
+import { eq, inArray, or } from 'drizzle-orm';
+import type { PostVisibility } from '@kosmo/core/enums';
+import type { UserContext } from '@/context';
+
+export const postVisibilityAccessWhere = ({
+  ctx,
+  publicVisibilities,
+}: {
+  ctx: UserContext;
+  publicVisibilities: [PostVisibility, ...PostVisibility[]];
+}) => {
+  const publicWhere = inArray(Posts.visibility, publicVisibilities);
+
+  // TODO(PROD-121): Extend this helper with viewer-specific follower/direct access.
+  return ctx.session?.profileId
+    ? or(publicWhere, eq(Posts.profileId, ctx.session.profileId))!
+    : publicWhere;
+};

--- a/apps/api/src/graphql/resolvers/post/field/index.ts
+++ b/apps/api/src/graphql/resolvers/post/field/index.ts
@@ -1,1 +1,2 @@
 import './post';
+import './profile';

--- a/apps/api/src/graphql/resolvers/post/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/post/field/profile.ts
@@ -1,45 +1,47 @@
 import { db, Posts } from '@kosmo/core/db';
 import { PostState, PostVisibility } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
-import { and, asc, desc, eq, gt, lt, or } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, lt } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
 import { Profile } from '@/graphql/resolvers/profile';
+import { postVisibilityAccessWhere } from '../access/visibility';
 import { Post } from '../ref';
 
 type PostRow = typeof Posts.$inferSelect;
 
 builder.objectFields(Profile, (t) => ({
-  posts: t.connection({
-    type: Post,
-    resolve: (profile, args, ctx) => {
-      const visibilityWhere = ctx.session?.profileId
-        ? or(
-            eq(Posts.visibility, PostVisibility.PUBLIC),
-            eq(Posts.profileId, ctx.session.profileId),
-          )
-        : eq(Posts.visibility, PostVisibility.PUBLIC);
-
-      return resolveCursorConnection<Promise<PostRow[]>>(
-        {
-          args,
-          toCursor: (post) => post.id,
-        },
-        ({ before, after, limit, inverted }) =>
-          db
-            .select()
-            .from(Posts)
-            .where(
-              and(
-                eq(Posts.profileId, profile.id),
-                eq(Posts.state, PostState.ACTIVE),
-                visibilityWhere,
-                before ? gt(Posts.id, before) : undefined,
-                after ? lt(Posts.id, after) : undefined,
-              ),
-            )
-            .orderBy(inverted ? asc(Posts.id) : desc(Posts.id))
-            .limit(limit),
-      );
+  posts: t.connection(
+    {
+      type: Post,
+      resolve: (profile, args, ctx) => {
+        return resolveCursorConnection<Promise<PostRow[]>>(
+          {
+            args,
+            toCursor: (post) => post.id,
+          },
+          ({ before, after, limit, inverted }) =>
+            db
+              .select()
+              .from(Posts)
+              .where(
+                and(
+                  eq(Posts.profileId, profile.id),
+                  eq(Posts.state, PostState.ACTIVE),
+                  postVisibilityAccessWhere({
+                    ctx,
+                    publicVisibilities: [PostVisibility.PUBLIC],
+                  }),
+                  before ? gt(Posts.id, before) : undefined,
+                  after ? lt(Posts.id, after) : undefined,
+                ),
+              )
+              .orderBy(inverted ? asc(Posts.id) : desc(Posts.id))
+              .limit(limit),
+        );
+      },
     },
-  }),
+    {
+      name: 'PostsConnection',
+    },
+  ),
 }));

--- a/apps/api/src/graphql/resolvers/post/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/post/field/profile.ts
@@ -1,0 +1,45 @@
+import { db, Posts } from '@kosmo/core/db';
+import { PostState, PostVisibility } from '@kosmo/core/enums';
+import { resolveCursorConnection } from '@pothos/plugin-relay';
+import { and, asc, desc, eq, gt, lt, or } from 'drizzle-orm';
+import { builder } from '@/graphql/builder';
+import { Profile } from '@/graphql/resolvers/profile';
+import { Post } from '../ref';
+
+type PostRow = typeof Posts.$inferSelect;
+
+builder.objectFields(Profile, (t) => ({
+  posts: t.connection({
+    type: Post,
+    resolve: (profile, args, ctx) => {
+      const visibilityWhere = ctx.session?.profileId
+        ? or(
+            eq(Posts.visibility, PostVisibility.PUBLIC),
+            eq(Posts.profileId, ctx.session.profileId),
+          )
+        : eq(Posts.visibility, PostVisibility.PUBLIC);
+
+      return resolveCursorConnection<Promise<PostRow[]>>(
+        {
+          args,
+          toCursor: (post) => post.id,
+        },
+        ({ before, after, limit, inverted }) =>
+          db
+            .select()
+            .from(Posts)
+            .where(
+              and(
+                eq(Posts.profileId, profile.id),
+                eq(Posts.state, PostState.ACTIVE),
+                visibilityWhere,
+                before ? gt(Posts.id, before) : undefined,
+                after ? lt(Posts.id, after) : undefined,
+              ),
+            )
+            .orderBy(inverted ? asc(Posts.id) : desc(Posts.id))
+            .limit(limit),
+      );
+    },
+  }),
+}));

--- a/apps/api/src/graphql/resolvers/post/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/post/field/profile.ts
@@ -1,5 +1,4 @@
 import { db, Posts } from '@kosmo/core/db';
-import { PostState, PostVisibility } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, gt, lt } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
@@ -26,11 +25,7 @@ builder.objectFields(Profile, (t) => ({
               .where(
                 and(
                   eq(Posts.profileId, profile.id),
-                  eq(Posts.state, PostState.ACTIVE),
-                  postVisibilityAccessWhere({
-                    ctx,
-                    publicVisibilities: [PostVisibility.PUBLIC],
-                  }),
+                  postVisibilityAccessWhere({ ctx }),
                   before ? gt(Posts.id, before) : undefined,
                   after ? lt(Posts.id, after) : undefined,
                 ),

--- a/apps/api/src/graphql/resolvers/post/ref.ts
+++ b/apps/api/src/graphql/resolvers/post/ref.ts
@@ -1,17 +1,10 @@
 import { db, PostContents, Posts, Profiles, TableDiscriminator } from '@kosmo/core/db';
 import { PostState, PostVisibility, ProfileState } from '@kosmo/core/enums';
-import { and, eq, getColumns, inArray, or } from 'drizzle-orm';
+import { and, eq, getColumns, inArray } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
+import { postVisibilityAccessWhere } from './access/visibility';
 
 export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids, ctx) => {
-  // TODO(PROD-121): Replace this PUBLIC/UNLISTED guard with viewer-specific access.
-  const visibilityWhere = ctx.session?.profileId
-    ? or(
-        inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]),
-        eq(Posts.profileId, ctx.session.profileId),
-      )
-    : inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]);
-
   return db
     .select(getColumns(Posts))
     .from(Posts)
@@ -20,7 +13,10 @@ export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids, ctx)
       and(
         inArray(Posts.id, ids),
         eq(Posts.state, PostState.ACTIVE),
-        visibilityWhere,
+        postVisibilityAccessWhere({
+          ctx,
+          publicVisibilities: [PostVisibility.PUBLIC, PostVisibility.UNLISTED],
+        }),
         eq(Profiles.state, ProfileState.ACTIVE),
       ),
     );

--- a/apps/api/src/graphql/resolvers/post/ref.ts
+++ b/apps/api/src/graphql/resolvers/post/ref.ts
@@ -12,11 +12,7 @@ export const Post = createObjectRef('Post', TableDiscriminator.Posts, (ids, ctx)
     .where(
       and(
         inArray(Posts.id, ids),
-        eq(Posts.state, PostState.ACTIVE),
-        postVisibilityAccessWhere({
-          ctx,
-          publicVisibilities: [PostVisibility.PUBLIC, PostVisibility.UNLISTED],
-        }),
+        postVisibilityAccessWhere({ ctx }),
         eq(Profiles.state, ProfileState.ACTIVE),
       ),
     );

--- a/openspec/specs/post/spec.md
+++ b/openspec/specs/post/spec.md
@@ -44,7 +44,7 @@ API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Pr
 #### Scenario: 공개 프로필 게시글 목록 조회
 
 - **WHEN** 현재 active profile이 조회 대상 프로필이 아니거나 인증되지 않은 클라이언트가 프로필의 `posts` connection을 조회한다
-- **THEN** 시스템은 해당 프로필이 작성한 `PUBLIC` 공개 범위의 `ACTIVE` 게시글만 반환한다
+- **THEN** 시스템은 해당 프로필이 작성한 `PUBLIC` 또는 `UNLISTED` 공개 범위의 `ACTIVE` 게시글만 반환한다
 - **AND** 게시글은 최신순으로 정렬된다
 - **AND** connection은 cursor 기반 페이지네이션을 지원한다
 
@@ -63,8 +63,7 @@ API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Pr
 #### Scenario: 프로필 목록에서 숨겨지는 게시글
 
 - **WHEN** 현재 active profile이 조회 대상 프로필이 아니거나 인증되지 않은 클라이언트가 프로필의 `posts` connection을 조회한다
-- **THEN** 시스템은 `UNLISTED`, `FOLLOWERS`, `DIRECT` 공개 범위의 게시글을 반환하지 않는다
-- **AND** `UNLISTED` 게시글은 작성자 본인의 목록 또는 직접 Node 조회에서만 노출될 수 있다
+- **THEN** 시스템은 `FOLLOWERS`, `DIRECT` 공개 범위의 게시글을 반환하지 않는다
 
 ### Requirement: PostContent GraphQL object
 

--- a/openspec/specs/post/spec.md
+++ b/openspec/specs/post/spec.md
@@ -37,6 +37,35 @@ API는 활성 게시글을 GraphQL `Post` Node로 노출해야 하며 작성자 
 - **WHEN** 게시글 상태가 `ACTIVE`가 아니다
 - **THEN** 시스템은 해당 게시글을 GraphQL `Post` object로 노출하지 않는다
 
+### Requirement: 프로필 게시글 목록 connection
+
+API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Profile.posts`로 노출해야 하며, viewer가 작성자인지에 따라 공개 범위를 제한해야 한다(MUST).
+
+#### Scenario: 공개 프로필 게시글 목록 조회
+
+- **WHEN** 현재 active profile이 조회 대상 프로필이 아니거나 인증되지 않은 클라이언트가 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 해당 프로필이 작성한 `PUBLIC` 공개 범위의 `ACTIVE` 게시글만 반환한다
+- **AND** 게시글은 최신순으로 정렬된다
+- **AND** connection은 cursor 기반 페이지네이션을 지원한다
+
+#### Scenario: 작성자 본인의 프로필 게시글 목록 조회
+
+- **WHEN** 현재 active profile이 조회 대상 프로필이고 해당 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 해당 프로필이 작성한 모든 공개 범위의 `ACTIVE` 게시글을 반환한다
+- **AND** 게시글은 최신순으로 정렬된다
+- **AND** connection은 cursor 기반 페이지네이션을 지원한다
+
+#### Scenario: 게시글이 없는 프로필 목록 조회
+
+- **WHEN** 게시글이 없는 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 빈 connection을 반환한다
+
+#### Scenario: 프로필 목록에서 숨겨지는 게시글
+
+- **WHEN** 현재 active profile이 조회 대상 프로필이 아니거나 인증되지 않은 클라이언트가 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 `UNLISTED`, `FOLLOWERS`, `DIRECT` 공개 범위의 게시글을 반환하지 않는다
+- **AND** `UNLISTED` 게시글은 작성자 본인의 목록 또는 직접 Node 조회에서만 노출될 수 있다
+
 ### Requirement: PostContent GraphQL object
 
 API는 게시글의 현재 콘텐츠를 GraphQL `PostContent` Node로 노출하고 TipTap JSON 원본, Plain Text projection, 선택적 스포일러 텍스트를 제공해야 한다(MUST).


### PR DESCRIPTION
## 무엇을 변경했는지

- `Profile.posts` Relay connection을 추가했습니다.
- 타인/비로그인 viewer에게는 해당 프로필의 `PUBLIC`/`UNLISTED`/`ACTIVE` 게시글만 최신순으로 반환합니다.
- 작성자 본인이 자기 프로필의 `posts`를 조회하면 모든 공개 범위의 `ACTIVE` 게시글을 반환합니다.
- `Post` Node loader와 `Profile.posts`가 같은 post access helper를 사용하도록 정리했습니다.
- helper 내부에서 `PostState.ACTIVE`, `PUBLIC`/`UNLISTED` 공개 노출, 작성자 본인 예외를 함께 처리합니다.
- `Profile.posts` connection 타입명을 `PostsConnection`/`PostsConnectionEdge`로 명시했습니다.
- `apps/api/schema.graphql`을 갱신했습니다.
- `openspec/specs/post/spec.md`에 프로필 게시글 목록 connection 계약을 추가하고 `UNLISTED` 노출 정책을 정렬했습니다.

## 왜 변경했는지

- `PROD-120`은 `kos.moe/@test` 같은 프로필 페이지에서 해당 프로필이 작성한 게시글 목록을 가져오기 위한 백엔드 조회 기반입니다.
- 프로필 목록은 X처럼 무한스크롤로 확장될 수 있어 Relay connection 형태가 맞습니다.
- 게시글 노출 조건을 loader와 list resolver가 각각 직접 작성하면, 이후 `FOLLOWERS`/`DIRECT` 정책이 추가될 때 한쪽만 수정되어 보안 정책이 어긋날 위험이 있습니다.
- 공통 helper가 게시글 활성 상태와 visibility 접근 조건을 함께 담당하게 해서 `node(id)`와 `Profile.posts`의 접근 정책이 같은 기준을 따르도록 했습니다.
- 별도 `post(id)` root query는 추가하지 않고, 단건 조회는 기존 `node(id)` 경로를 유지합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc` 통과
- `pnpm lint:eslint` 통과
- `pnpm lint:prettier` 통과
- schema 재생성 확인:
  - `Profile.posts`는 `PostsConnection`을 반환합니다.
  - `PostsConnectionEdge`가 추가되었습니다.
  - `ProfilePostsConnection`/`ProfilePostsConnectionEdge`는 제거되었습니다.
  - `Query.post` 추가 없음

## 아직 어떤 문제가 남았는지

- viewer별 세부 접근 제어, 삭제/숨김/접근 불가 예외 처리는 `PROD-121` 범위입니다.
- 프로필 게시글 목록을 웹 화면에 실제 연결하는 작업은 `PROD-124` 범위입니다.

Linear: PROD-120

Stack: main -> prod-120
