### PR TITLE
재사용 가능한 Dropdown primitive를 main에 반영한다

### DIFF
--- a/apps/web/src/lib/components/Dropdown.stories.svelte
+++ b/apps/web/src/lib/components/Dropdown.stories.svelte
@@ -54,9 +54,7 @@
 <Story name="Default" asChild parameters={{ controls: { disable: true } }}>
   <div class="flex min-h-52 items-start justify-center p-8">
     <Dropdown.Root>
-      <Dropdown.Trigger>
-        <Button variant="secondary">메뉴</Button>
-      </Dropdown.Trigger>
+      <Dropdown.Trigger>메뉴</Dropdown.Trigger>
 
       <Dropdown.Content aria-label="작업 메뉴">
         {#each menuItems as item}
@@ -72,21 +70,42 @@
   </div>
 </Story>
 
-<Story name="Selected Item" asChild parameters={{ controls: { disable: true } }}>
+<Story name="Active Item" asChild parameters={{ controls: { disable: true } }}>
   <div class="flex min-h-52 items-start justify-center p-8">
     <Dropdown.Root>
-      <Dropdown.Trigger>
-        <Button variant="secondary">정렬</Button>
-      </Dropdown.Trigger>
+      <Dropdown.Trigger>정렬</Dropdown.Trigger>
 
       <Dropdown.Content aria-label="정렬 메뉴">
         {#each sortItems as item}
           <Dropdown.Item
-            selected={item.value === selectedSort}
+            active={item.value === selectedSort}
             onclick={() => {
               selectedSort = item.value;
             }}
           >
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>
+
+<Story name="Snippet Trigger" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        {#snippet child({ props })}
+          <Button variant="secondary" {...props}>프로필 작업</Button>
+        {/snippet}
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="프로필 작업 메뉴">
+        {#each menuItems as item}
+          <Dropdown.Item>
             <span class="grid min-w-0 gap-0.5">
               <span class="text-text-primary text-sm font-bold">{item.label}</span>
               <span class="text-text-secondary text-xs leading-4">{item.description}</span>

--- a/apps/web/src/lib/components/Dropdown.stories.svelte
+++ b/apps/web/src/lib/components/Dropdown.stories.svelte
@@ -1,0 +1,99 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import * as Dropdown from './Dropdown';
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/Dropdown',
+    tags: ['autodocs'],
+    parameters: {
+      layout: 'centered',
+    },
+  });
+</script>
+
+<script lang="ts">
+  import Button from './Button.svelte';
+
+  const menuItems = [
+    {
+      label: '프로필 열기',
+      description: '선택한 프로필 페이지로 이동합니다.',
+    },
+    {
+      label: '알림 설정',
+      description: '이 항목의 알림 방식을 조정합니다.',
+    },
+    {
+      label: '목록에서 숨기기',
+      description: '현재 목록에서만 항목을 숨깁니다.',
+    },
+  ];
+
+  const sortItems = [
+    {
+      value: 'recent',
+      label: '최신순',
+      description: '가장 최근 항목부터 표시합니다.',
+    },
+    {
+      value: 'popular',
+      label: '인기순',
+      description: '반응이 많은 항목부터 표시합니다.',
+    },
+    {
+      value: 'oldest',
+      label: '오래된순',
+      description: '오래된 항목부터 표시합니다.',
+    },
+  ];
+
+  let selectedSort = $state('recent');
+</script>
+
+<Story name="Default" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        <Button variant="secondary">메뉴</Button>
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="작업 메뉴">
+        {#each menuItems as item}
+          <Dropdown.Item>
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>
+
+<Story name="Selected Item" asChild parameters={{ controls: { disable: true } }}>
+  <div class="flex min-h-52 items-start justify-center p-8">
+    <Dropdown.Root>
+      <Dropdown.Trigger>
+        <Button variant="secondary">정렬</Button>
+      </Dropdown.Trigger>
+
+      <Dropdown.Content aria-label="정렬 메뉴">
+        {#each sortItems as item}
+          <Dropdown.Item
+            selected={item.value === selectedSort}
+            onclick={() => {
+              selectedSort = item.value;
+            }}
+          >
+            <span class="grid min-w-0 gap-0.5">
+              <span class="text-text-primary text-sm font-bold">{item.label}</span>
+              <span class="text-text-secondary text-xs leading-4">{item.description}</span>
+            </span>
+          </Dropdown.Item>
+        {/each}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  </div>
+</Story>

--- a/apps/web/src/lib/components/Dropdown/Content.svelte
+++ b/apps/web/src/lib/components/Dropdown/Content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { cn } from 'tailwind-variants';
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+  let {
+    ref = $bindable(null),
+    sideOffset = 4,
+    portalProps,
+    class: className,
+    ...restProps
+  }: DropdownMenuPrimitive.ContentProps & {
+    portalProps?: DropdownMenuPrimitive.PortalProps;
+  } = $props();
+</script>
+
+<DropdownMenuPrimitive.Portal {...portalProps}>
+  <DropdownMenuPrimitive.Content
+    bind:ref
+    data-slot="dropdown-menu-content"
+    {sideOffset}
+    class={cn(
+      'border-border bg-card text-text-primary z-50 min-w-64 overflow-hidden rounded-md border p-1 shadow-[0_10px_24px_rgba(0,0,0,0.12)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+      className,
+    )}
+    {...restProps}
+  />
+</DropdownMenuPrimitive.Portal>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
-  import { cn } from 'tailwind-variants';
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+  import { cn, tv, type VariantProps } from 'tailwind-variants';
 
-  type Props = DropdownMenuPrimitive.ItemProps & {
-    active?: boolean;
-  };
+  const dropdownItem = tv({
+    base: 'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-45',
+    variants: {
+      active: {
+        true: 'bg-primary/45 hover:bg-primary/55 focus:bg-primary/55 data-[highlighted]:bg-primary/55',
+        false: 'bg-card hover:bg-surface focus:bg-surface data-[highlighted]:bg-surface',
+      },
+    },
+    defaultVariants: {
+      active: false,
+    },
+  });
+
+  type Props = DropdownMenuPrimitive.ItemProps & VariantProps<typeof dropdownItem>;
 
   let { ref = $bindable(null), active = false, class: className, ...restProps }: Props = $props();
 </script>
@@ -13,9 +24,6 @@
   bind:ref
   data-slot="dropdown-menu-item"
   data-active={active ? '' : undefined}
-  class={cn(
-    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm bg-card px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[active]:bg-primary/45 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface hover:data-[active]:bg-primary/55 focus:data-[active]:bg-primary/55 data-[highlighted]:data-[active]:bg-primary/55',
-    className,
-  )}
+  class={cn(dropdownItem({ active }), className)}
   {...restProps}
 />

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,27 +1,22 @@
 <script lang="ts">
-  import type { Snippet } from 'svelte';
-  import type { HTMLButtonAttributes } from 'svelte/elements';
+  import { cn } from 'tailwind-variants';
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
-  type Props = HTMLButtonAttributes & {
+  type Props = DropdownMenuPrimitive.ItemProps & {
     selected?: boolean;
-    children: Snippet;
   };
 
-  let {
-    selected = false,
-    children,
-    class: className = '',
-    type = 'button',
-    ...rest
-  }: Props = $props();
+  let { ref = $bindable(null), selected = false, class: className, ...restProps }: Props = $props();
 </script>
 
-<button
-  {...rest}
-  {type}
-  role="option"
-  aria-selected={selected}
-  class={`text-text-primary flex w-full items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-more ${selected ? 'bg-primary/45' : 'bg-card'} ${className}`}
->
-  {@render children()}
-</button>
+<DropdownMenuPrimitive.Item
+  bind:ref
+  data-slot="dropdown-menu-item"
+  data-selected={selected ? '' : undefined}
+  class={cn(
+    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
+    selected ? 'bg-primary/45' : 'bg-card',
+    className,
+  )}
+  {...restProps}
+/>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -14,8 +14,7 @@
   data-slot="dropdown-menu-item"
   data-active={active ? '' : undefined}
   class={cn(
-    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
-    active ? 'bg-primary/45' : 'bg-card',
+    'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm bg-card px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[active]:bg-primary/45 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface hover:data-[active]:bg-primary/55 focus:data-[active]:bg-primary/55 data-[highlighted]:data-[active]:bg-primary/55',
     className,
   )}
   {...restProps}

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  type Props = HTMLButtonAttributes & {
+    selected?: boolean;
+    children: Snippet;
+  };
+
+  let {
+    selected = false,
+    children,
+    class: className = '',
+    type = 'button',
+    ...rest
+  }: Props = $props();
+</script>
+
+<button
+  {...rest}
+  {type}
+  role="option"
+  aria-selected={selected}
+  class={`text-text-primary flex w-full items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors hover:bg-surface focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-more ${selected ? 'bg-primary/45' : 'bg-card'} ${className}`}
+>
+  {@render children()}
+</button>

--- a/apps/web/src/lib/components/Dropdown/Item.svelte
+++ b/apps/web/src/lib/components/Dropdown/Item.svelte
@@ -3,19 +3,19 @@
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
   type Props = DropdownMenuPrimitive.ItemProps & {
-    selected?: boolean;
+    active?: boolean;
   };
 
-  let { ref = $bindable(null), selected = false, class: className, ...restProps }: Props = $props();
+  let { ref = $bindable(null), active = false, class: className, ...restProps }: Props = $props();
 </script>
 
 <DropdownMenuPrimitive.Item
   bind:ref
   data-slot="dropdown-menu-item"
-  data-selected={selected ? '' : undefined}
+  data-active={active ? '' : undefined}
   class={cn(
     'text-text-primary flex w-full cursor-default items-start gap-2 rounded-sm px-3 py-2.5 text-left text-sm transition-colors outline-none hover:bg-surface focus:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-45 data-[highlighted]:bg-surface',
-    selected ? 'bg-primary/45' : 'bg-card',
+    active ? 'bg-primary/45' : 'bg-card',
     className,
   )}
   {...restProps}

--- a/apps/web/src/lib/components/Dropdown/Trigger.svelte
+++ b/apps/web/src/lib/components/Dropdown/Trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+  let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />

--- a/apps/web/src/lib/components/Dropdown/Trigger.svelte
+++ b/apps/web/src/lib/components/Dropdown/Trigger.svelte
@@ -1,7 +1,29 @@
 <script lang="ts">
   import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 
-  let { ref = $bindable(null), ...restProps }: DropdownMenuPrimitive.TriggerProps = $props();
+  import Button from '../Button.svelte';
+
+  let {
+    ref = $bindable(null),
+    child: childSnippet,
+    children,
+    ...restProps
+  }: DropdownMenuPrimitive.TriggerProps = $props();
 </script>
 
-<DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps} />
+{#if childSnippet}
+  <DropdownMenuPrimitive.Trigger
+    bind:ref
+    data-slot="dropdown-menu-trigger"
+    child={childSnippet}
+    {...restProps}
+  />
+{:else}
+  <DropdownMenuPrimitive.Trigger bind:ref data-slot="dropdown-menu-trigger" {...restProps}>
+    {#snippet child({ props })}
+      <Button variant="secondary" {...props}>
+        {@render children?.()}
+      </Button>
+    {/snippet}
+  </DropdownMenuPrimitive.Trigger>
+{/if}

--- a/apps/web/src/lib/components/Dropdown/index.ts
+++ b/apps/web/src/lib/components/Dropdown/index.ts
@@ -1,7 +1,7 @@
-import { DropdownMenu as DropdownMentPrimitive } from 'bits-ui';
+import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 import Content from './Content.svelte';
 import Item from './Item.svelte';
 import Trigger from './Trigger.svelte';
 
-const Root = DropdownMentPrimitive.Root;
+const Root = DropdownMenuPrimitive.Root;
 export { Content, Item, Root, Trigger };

--- a/apps/web/src/lib/components/Dropdown/index.ts
+++ b/apps/web/src/lib/components/Dropdown/index.ts
@@ -1,0 +1,7 @@
+import { DropdownMenu as DropdownMentPrimitive } from 'bits-ui';
+import Content from './Content.svelte';
+import Item from './Item.svelte';
+import Trigger from './Trigger.svelte';
+
+const Root = DropdownMentPrimitive.Root;
+export { Content, Item, Root, Trigger };


### PR DESCRIPTION
기존 #85가 잘못된 base(`prod-87-post-validation`)에서 merged 처리되어 `main`에는 Dropdown 변경이 실제로 들어가지 않은 상태입니다. 이 PR은 같은 Dropdown 변경을 최신 `main` 위에 다시 올려 실제 trunk에 반영하기 위한 대체 PR입니다.

Stack: `main` -> `prod-87-dropdown`

## 무엇을 변경했는지

- Dropdown을 `Root`, `Trigger`, `Content`, `Item` 컴포넌트 구조로 추가합니다.
- `bits-ui` DropdownMenu primitive를 감싸 trigger, positioning, open 상태 관리를 재사용 가능한 메뉴 primitive로 제공합니다.
- trigger는 호출부가 넘기는 버튼/요소를 유지하고, Dropdown primitive가 클릭 이벤트와 메뉴 열림 상태를 처리하게 합니다.
- Dropdown content와 item의 기본 스타일, active item 상태를 제공합니다.
- `KOSMO/Dropdown` Storybook story를 추가해 기본 메뉴와 active item 상태를 확인할 수 있게 했습니다.

## 왜 변경했는지

- 특정 기능 UI와 분리된 Dropdown primitive를 먼저 제공해, 후속 사용처에서 같은 메뉴 구조와 스타일을 재사용할 수 있게 하기 위함입니다.
- 호출부가 trigger 버튼을 직접 구성하되 접근성, positioning, open 상태 관리는 공통 컴포넌트가 맡도록 경계를 정리합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `git diff --check`
- Storybook `KOSMO/Dropdown`에서 기본 메뉴와 active item 상태를 확인할 수 있습니다.

## 아직 어떤 문제가 남았는지

- 이 PR에서는 Dropdown 사용처를 추가하지 않습니다. 실제 기능 UI 연결은 후속 PR에서 확인합니다.