### PR TITLE
리뷰 코멘트에도 에이전트 footer가 붙지 않게 한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,4 @@
 
 ## Claude-specific
 
-- Do not append a "Generated with Claude Code" (or similar agent) footer to PR bodies. The author of record is the human running the agent; if agent involvement must be recorded, note it in Linear.
+- Do not append a "Generated with Claude Code" (or similar agent) footer to PR bodies, review comments, or review summaries. The author of record is the human running the agent; if agent involvement must be recorded, note it in Linear.


### PR DESCRIPTION
## 무엇을 변경했는지

- CLAUDE.md의 "Generated with Claude Code" footer 금지 규칙의 적용 범위를 PR 본문에서 리뷰 코멘트·리뷰 요약까지로 확장했습니다.

## 왜 변경했는지

- 기존 규칙은 PR 본문만 명시하고 있어, 에이전트 리뷰 스킬 템플릿이 리뷰 코멘트에 footer를 붙이는 것을 막지 못했습니다.
- 기록상 작성자는 에이전트를 실행한 사람이라는 기존 원칙을 리뷰에도 동일하게 적용합니다.

## 어떻게 확인할 수 있는지

- 문서 한 줄 수정이라 CLAUDE.md diff 확인으로 충분합니다.

## 아직 어떤 문제가 남았는지

- 없음