### PR TITLE
우측 레일에 글 작성 위젯을 추가한다

### DIFF
--- a/apps/web/src/lib/components/RightRail.stories.svelte
+++ b/apps/web/src/lib/components/RightRail.stories.svelte
@@ -1,0 +1,15 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import RightRail from './RightRail.svelte';
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/RightRail',
+    component: RightRail,
+    parameters: {
+      layout: 'padded',
+    },
+  });
+</script>
+
+<Story name="Default" />

--- a/apps/web/src/lib/components/RightRail.stories.svelte
+++ b/apps/web/src/lib/components/RightRail.stories.svelte
@@ -2,6 +2,16 @@
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import RightRail from './RightRail.svelte';
+  import type { RightRail_profile$key } from '$mearie';
+
+  // Storybook은 .storybook/mocks/mearie-svelte.ts에서 createFragment를 패스스루로 모킹하므로
+  // 여기서는 평범한 데이터 객체를 fragment ref 자리에 그대로 넘긴다.
+  const profile = {
+    __typename: 'Profile',
+    id: 'profile-1',
+    displayName: '코스모 작가',
+    handle: 'kosmo',
+  } as unknown as RightRail_profile$key;
 
   const { Story } = defineMeta({
     title: 'KOSMO/RightRail',
@@ -12,4 +22,9 @@
   });
 </script>
 
-<Story name="Default" />
+<Story
+  name="Default"
+  args={{
+    profile,
+  }}
+/>

--- a/apps/web/src/lib/components/RightRail.svelte
+++ b/apps/web/src/lib/components/RightRail.svelte
@@ -26,9 +26,8 @@
     <div class="text-text-primary flex items-center gap-2">
       <ImageIcon size={20} />
       <TriangleAlertIcon size={20} />
-      <span class="flex-1"></span>
       <span
-        class="bg-primary text-text-primary flex h-8 w-30 items-center justify-center rounded-sm text-sm font-bold"
+        class="bg-primary text-text-primary ml-auto flex h-8 w-30 items-center justify-center rounded-sm text-sm font-bold"
       >
         게시
       </span>

--- a/apps/web/src/lib/components/RightRail.svelte
+++ b/apps/web/src/lib/components/RightRail.svelte
@@ -5,7 +5,7 @@
   import PostVisibilityIcon from './PostVisibilityIcon.svelte';
 
   // TODO: 글 작성 위젯은 디자인(05 Screens - Web / RightRail) 모양만 잡아둔 정적 placeholder다.
-  // 후속 이슈에서 PostComposer 연결로 교체한다.
+  // PROD-131에서 PostComposer 연결로 교체한다.
 </script>
 
 <div class="flex w-full flex-col gap-4">

--- a/apps/web/src/lib/components/RightRail.svelte
+++ b/apps/web/src/lib/components/RightRail.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { PostVisibility } from '@kosmo/core/enums';
+  import { ChevronDownIcon, ImageIcon, PlusIcon, TriangleAlertIcon, XIcon } from '@lucide/svelte';
+  import Avatar from './Avatar.svelte';
+  import PostVisibilityIcon from './PostVisibilityIcon.svelte';
+
+  // TODO: 아래 위젯들은 디자인(05 Screens - Web / RightRail) 모양만 잡아둔 정적 placeholder다.
+  // 글 작성 위젯은 PostComposer 연결로, 태그 타임라인 위젯은 실데이터 연결로 후속 이슈에서 교체한다.
+  const placeholderTags = ['일러스트', '팬아트', '웹소설', '커미션'];
+</script>
+
+<div class="flex w-full flex-col gap-4">
+  <div class="border-border bg-card flex flex-col gap-3 rounded-lg border p-4" aria-hidden="true">
+    <div class="flex items-center justify-between">
+      <Avatar size="sm" />
+      <div
+        class="border-text-primary text-text-primary flex items-center gap-1.5 rounded-full border px-3 py-2 text-xsm font-bold"
+      >
+        <PostVisibilityIcon visibility={PostVisibility.PUBLIC} size={12} />
+        공개
+        <ChevronDownIcon size={12} />
+      </div>
+    </div>
+
+    <p class="text-text-secondary pt-1 pb-3 text-sm">지금 그리고 있는 작업을 공유해 보세요…</p>
+
+    <div class="text-text-primary flex items-center gap-2">
+      <ImageIcon size={20} />
+      <TriangleAlertIcon size={20} />
+      <span class="flex-1"></span>
+      <span
+        class="bg-primary text-text-primary flex h-8 w-30 items-center justify-center rounded-sm text-sm font-bold"
+      >
+        게시
+      </span>
+    </div>
+  </div>
+
+  <div class="border-border bg-card flex flex-col gap-2 rounded-lg border p-4">
+    <p class="text-text-primary text-md font-semibold">태그 타임라인</p>
+    <p class="text-text-secondary text-xsm">선택한 태그만 해시태그 타임라인에 보여요</p>
+
+    <ul class="flex flex-wrap gap-2 pt-1" aria-hidden="true">
+      {#each placeholderTags as tag (tag)}
+        <li
+          class="bg-surface text-text-secondary flex items-center gap-1.5 rounded-full py-1 pr-1.5 pl-2.5 text-xsm font-medium"
+        >
+          {tag}
+          <XIcon size={12} />
+        </li>
+      {/each}
+    </ul>
+
+    <div class="text-more flex items-center gap-1 pt-1 text-xsm" aria-hidden="true">
+      <PlusIcon size={16} />
+      태그 추가
+    </div>
+  </div>
+</div>

--- a/apps/web/src/lib/components/RightRail.svelte
+++ b/apps/web/src/lib/components/RightRail.svelte
@@ -1,36 +1,25 @@
 <script lang="ts">
-  import { PostVisibility } from '@kosmo/core/enums';
-  import { ChevronDownIcon, ImageIcon, TriangleAlertIcon } from '@lucide/svelte';
-  import Avatar from './Avatar.svelte';
-  import PostVisibilityIcon from './PostVisibilityIcon.svelte';
+  import { graphql } from '$mearie';
+  import { createFragment } from '@mearie/svelte';
+  import PostComposer from './PostComposer.svelte';
+  import type { RightRail_profile$key } from '$mearie';
 
-  // TODO: 글 작성 위젯은 디자인(05 Screens - Web / RightRail) 모양만 잡아둔 정적 placeholder다.
-  // PROD-131에서 PostComposer 연결로 교체한다.
+  type Props = {
+    profile: RightRail_profile$key;
+  };
+
+  let { profile }: Props = $props();
+
+  const profileFragment = createFragment(
+    graphql(`
+      fragment RightRail_profile on Profile {
+        ...PostComposer_profile
+      }
+    `),
+    () => profile,
+  );
 </script>
 
 <div class="flex w-full flex-col gap-4">
-  <div class="border-border bg-card flex flex-col gap-3 rounded-lg border p-4" aria-hidden="true">
-    <div class="flex items-center justify-between">
-      <Avatar size="sm" />
-      <div
-        class="border-text-primary text-text-primary flex items-center gap-1.5 rounded-full border px-3 py-2 text-xsm font-bold"
-      >
-        <PostVisibilityIcon visibility={PostVisibility.PUBLIC} size={12} />
-        공개
-        <ChevronDownIcon size={12} />
-      </div>
-    </div>
-
-    <p class="text-text-secondary pt-1 pb-3 text-sm">지금 그리고 있는 작업을 공유해 보세요…</p>
-
-    <div class="text-text-primary flex items-center gap-2">
-      <ImageIcon size={20} />
-      <TriangleAlertIcon size={20} />
-      <span
-        class="bg-primary text-text-primary ml-auto flex h-8 w-30 items-center justify-center rounded-sm text-sm font-bold"
-      >
-        게시
-      </span>
-    </div>
-  </div>
+  <PostComposer profile={profileFragment.data} />
 </div>

--- a/apps/web/src/lib/components/RightRail.svelte
+++ b/apps/web/src/lib/components/RightRail.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import { PostVisibility } from '@kosmo/core/enums';
-  import { ChevronDownIcon, ImageIcon, PlusIcon, TriangleAlertIcon, XIcon } from '@lucide/svelte';
+  import { ChevronDownIcon, ImageIcon, TriangleAlertIcon } from '@lucide/svelte';
   import Avatar from './Avatar.svelte';
   import PostVisibilityIcon from './PostVisibilityIcon.svelte';
 
-  // TODO: 아래 위젯들은 디자인(05 Screens - Web / RightRail) 모양만 잡아둔 정적 placeholder다.
-  // 글 작성 위젯은 PostComposer 연결로, 태그 타임라인 위젯은 실데이터 연결로 후속 이슈에서 교체한다.
-  const placeholderTags = ['일러스트', '팬아트', '웹소설', '커미션'];
+  // TODO: 글 작성 위젯은 디자인(05 Screens - Web / RightRail) 모양만 잡아둔 정적 placeholder다.
+  // 후속 이슈에서 PostComposer 연결로 교체한다.
 </script>
 
 <div class="flex w-full flex-col gap-4">
@@ -33,27 +32,6 @@
       >
         게시
       </span>
-    </div>
-  </div>
-
-  <div class="border-border bg-card flex flex-col gap-2 rounded-lg border p-4">
-    <p class="text-text-primary text-md font-semibold">태그 타임라인</p>
-    <p class="text-text-secondary text-xsm">선택한 태그만 해시태그 타임라인에 보여요</p>
-
-    <ul class="flex flex-wrap gap-2 pt-1" aria-hidden="true">
-      {#each placeholderTags as tag (tag)}
-        <li
-          class="bg-surface text-text-secondary flex items-center gap-1.5 rounded-full py-1 pr-1.5 pl-2.5 text-xsm font-medium"
-        >
-          {tag}
-          <XIcon size={12} />
-        </li>
-      {/each}
-    </ul>
-
-    <div class="text-more flex items-center gap-1 pt-1 text-xsm" aria-hidden="true">
-      <PlusIcon size={16} />
-      태그 추가
     </div>
   </div>
 </div>

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import BottomTabBar from '$lib/components/BottomTabBar.svelte';
+  import RightRail from '$lib/components/RightRail.svelte';
   import SidebarNavigation from '$lib/components/SidebarNavigation.svelte';
 
   let { children } = $props();
@@ -70,8 +71,11 @@
     <BottomTabBar onMenuClick={openDrawer} />
   </div>
 
-  <!-- 우측 레일 자리: 위젯은 PROD-113에서 채운다 -->
-  <div class="hidden lg:block"></div>
+  <div class="hidden lg:block">
+    <div class="sticky top-0 pt-4 pl-6">
+      <RightRail />
+    </div>
+  </div>
 
   {#if drawerOpen}
     <div class="fixed inset-0 z-40 lg:hidden" role="presentation">

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -1,9 +1,27 @@
 <script lang="ts">
+  import { graphql } from '$mearie';
+  import { createQuery } from '@mearie/svelte';
   import BottomTabBar from '$lib/components/BottomTabBar.svelte';
   import RightRail from '$lib/components/RightRail.svelte';
   import SidebarNavigation from '$lib/components/SidebarNavigation.svelte';
 
   let { children } = $props();
+
+  const query = createQuery(
+    graphql(`
+      query TabsLayoutQuery {
+        currentSession {
+          id
+          selectedProfile {
+            id
+            ...RightRail_profile
+          }
+        }
+      }
+    `),
+  );
+
+  const selectedProfile = $derived(query.data?.currentSession?.selectedProfile ?? null);
 
   let drawerOpen = $state(false);
   let swipeStartX = $state<number | null>(null);
@@ -73,7 +91,17 @@
 
   <div class="border-border hidden border-l lg:block">
     <div class="sticky top-0 pt-4 pl-6">
-      <RightRail />
+      {#if query.loading}
+        <div class="border-border bg-card grid gap-3 rounded-lg border p-4" aria-hidden="true">
+          <div class="bg-surface size-8 animate-pulse rounded-full"></div>
+          <div class="bg-surface h-24 animate-pulse rounded-md"></div>
+          <div class="flex justify-end">
+            <div class="bg-surface h-8 w-30 animate-pulse rounded-sm"></div>
+          </div>
+        </div>
+      {:else if selectedProfile}
+        <RightRail profile={selectedProfile} />
+      {/if}
     </div>
   </div>
 

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -71,7 +71,7 @@
     <BottomTabBar onMenuClick={openDrawer} />
   </div>
 
-  <div class="hidden lg:block">
+  <div class="border-border hidden border-l lg:block">
     <div class="sticky top-0 pt-4 pl-6">
       <RightRail />
     </div>


### PR DESCRIPTION
## 무엇을 변경했는지

- `RightRail.svelte` 추가: 우측 레일에서 main에 머지된 `PostComposer`(#88)를 렌더한다. `RightRail_profile` fragment를 선언해 `PostComposer_profile`을 spread하는 중첩 fragment 패턴을 따른다.
- `(tabs)/+layout.svelte`에 `TabsLayoutQuery`(`currentSession.selectedProfile`)를 colocate하고, 우측 컬럼(sticky, `border-l` 경계선)에서 로딩 중엔 스켈레톤, 선택 프로필이 있을 때만 `RightRail`을 렌더한다. 비로그인·프로필 미선택·오류 상태는 빈 레일로 둔다.
- `RightRail.stories.svelte`: mock profile로 `KOSMO/RightRail` 스토리 제공.

## 왜 변경했는지

- PROD-113: 3분할 레이아웃 셸(PROD-112, #100)이 확보한 우측 컬럼이 빈 상태라 우측 레일을 채운다.
- 처음엔 피그마 디자인 모양의 정적 placeholder로 구현했으나, 리뷰 의견(PostComposer가 이미 main에 있으니 바로 연결하자)을 반영해 실제 작성 위젯으로 교체했다. 이에 따라 후속 이슈 PROD-131은 이 이슈의 duplicate로 정리한다.
- 피그마의 TagFilterCard는 예시용 시안이라 레일에 표시하지 않는다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`(0 errors), `pnpm lint:eslint` 통과, Storybook 빌드 통과.
- `pnpm dev` 후 데스크톱 너비(lg 이상)에서: 로그인+프로필 선택 시 우측 레일에서 글 작성·게시, 로딩 스켈레톤, 비로그인 시 빈 레일, 스크롤 시 sticky 유지.

## 아직 어떤 문제가 남았는지

- 좁은 lg 뷰포트(우측 트랙이 290px까지 줄어드는 구간)에서 PostComposer 푸터(공개범위 버튼·게시 버튼 각 min-w 120px + 글자수)가 가용 폭을 살짝 초과할 수 있다. 1440 기준은 여유 있음. 반응형 정밀화는 PROD-114, 피그마 컴팩트 ComposeWidget(320w) 디자인 정렬은 후속으로 남긴다.
- 좌측 경계선은 `SidebarNavigation` 내부의 하드코딩 `#eaeaea`, 우측은 `border-border` 토큰으로 색 출처가 다르다(값은 동일). 사이드바 쪽 정렬은 PROD-127 범위.
- 프로필 전환 시 `Session.selectedProfile` 캐시 동기화 이슈(PROD-130)는 이 레일에도 동일하게 적용되는 기존 문제다.
