### PR TITLE
[PROD-99] GitHub Actions를 self-hosted 러너로 전환한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get secrets from Infisical
-        uses: Infisical/secrets-action@v1.0.15
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
         with:
           method: oidc
           domain: https://${{ secrets.INFISICAL_HOST }}
@@ -46,11 +46,11 @@ jobs:
           done | sort > .web-build.env
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile
@@ -93,7 +93,7 @@ jobs:
       - name: Run Trivy image scan
         id: trivy
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_PLATFORM: linux/arm64
         with:
@@ -107,7 +107,7 @@ jobs:
           severity: HIGH,CRITICAL
 
       - name: Upload Trivy report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: trivy-report
@@ -117,7 +117,7 @@ jobs:
 
       - name: Notify Slack about Trivy findings
         if: always() && env.SLACK_WEBHOOK_URL != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,8 +51,19 @@ jobs:
           set -euo pipefail
 
           docker_config="$RUNNER_TEMP/docker-config"
+          docker_context="$(docker context show 2>/dev/null || true)"
           mkdir -p "$docker_config"
-          printf '{"auths":{}}\n' > "$docker_config/config.json"
+          if [[ -d "$HOME/.docker/contexts" ]]; then
+            cp -R "$HOME/.docker/contexts" "$docker_config/contexts"
+          fi
+          DOCKER_CONTEXT_NAME="$docker_context" node -e '
+            const fs = require("fs");
+            const config = { auths: {} };
+            if (process.env.DOCKER_CONTEXT_NAME) {
+              config.currentContext = process.env.DOCKER_CONTEXT_NAME;
+            }
+            fs.writeFileSync(`${process.env.RUNNER_TEMP}/docker-config/config.json`, `${JSON.stringify(config)}\n`);
+          '
           printf 'DOCKER_CONFIG=%s\n' "$docker_config" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,14 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Connect Tailnet
-        uses: tailscale/github-action@v4
-        with:
-          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          audience: ${{ secrets.TAILSCALE_AUDIENCE }}
-          tags: tag:github-actions
-          ping: ${{ secrets.INFISICAL_HOST }}
-
       - name: Get secrets from Infisical
         uses: Infisical/secrets-action@v1.0.15
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   docker_build:
     name: Docker Build
-    runs-on: ubuntu-24.04-arm
+    runs-on: [self-hosted, ARM64]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,7 @@ jobs:
     name: Docker Build
     runs-on: [self-hosted, ARM64]
     env:
+      DOCKER_CONFIG: ${{ runner.temp }}/docker-config
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
@@ -44,6 +45,14 @@ jobs:
               printf '%s=%q\n' "$name" "$value"
             fi
           done | sort > .web-build.env
+
+      - name: Prepare Docker config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$DOCKER_CONFIG"
+          printf '{"auths":{}}\n' > "$DOCKER_CONFIG/config.json"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,7 +19,6 @@ jobs:
     name: Docker Build
     runs-on: [self-hosted, ARM64]
     env:
-      DOCKER_CONFIG: ${{ runner.temp }}/docker-config
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
     steps:
@@ -51,8 +50,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          mkdir -p "$DOCKER_CONFIG"
-          printf '{"auths":{}}\n' > "$DOCKER_CONFIG/config.json"
+          docker_config="$RUNNER_TEMP/docker-config"
+          mkdir -p "$docker_config"
+          printf '{"auths":{}}\n' > "$docker_config/config.json"
+          printf 'DOCKER_CONFIG=%s\n' "$docker_config" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,27 +45,6 @@ jobs:
             fi
           done | sort > .web-build.env
 
-      - name: Prepare Docker config
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          docker_config="$RUNNER_TEMP/docker-config"
-          docker_context="$(docker context show 2>/dev/null || true)"
-          mkdir -p "$docker_config"
-          if [[ -d "$HOME/.docker/contexts" ]]; then
-            cp -R "$HOME/.docker/contexts" "$docker_config/contexts"
-          fi
-          DOCKER_CONTEXT_NAME="$docker_context" node -e '
-            const fs = require("fs");
-            const config = { auths: {} };
-            if (process.env.DOCKER_CONTEXT_NAME) {
-              config.currentContext = process.env.DOCKER_CONTEXT_NAME;
-            }
-            fs.writeFileSync(`${process.env.RUNNER_TEMP}/docker-config/config.json`, `${JSON.stringify(config)}\n`);
-          '
-          printf 'DOCKER_CONFIG=%s\n' "$docker_config" >> "$GITHUB_ENV"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: arc-b-4x
+    runs-on: [self-hosted]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   nuclei:
     name: Nuclei scan
-    runs-on: arc-b-4x
+    runs-on: [self-hosted]
     env:
       DEFAULT_TARGETS: |
         https://kos.moe

--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prepare targets
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_TARGETS: ${{ inputs.targets }}
         with:
@@ -59,12 +59,12 @@ jobs:
       - name: Run Nuclei
         id: nuclei
         continue-on-error: true
-        uses: projectdiscovery/nuclei-action@v3.1.1
+        uses: projectdiscovery/nuclei-action@cc153d0541e1adf8a42bbe31c0a4fb2376147538 # v3.1.1
         with:
           args: ${{ env.NUCLEI_ARGS }}
 
       - name: Upload Nuclei artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: nuclei-report
@@ -76,7 +76,7 @@ jobs:
 
       - name: Notify Slack
         if: always() && env.SLACK_WEBHOOK_URL != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           mise_toml: |
             [tools]
@@ -57,7 +57,7 @@ jobs:
             --output=semgrep.json
 
       - name: Upload Semgrep report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: semgrep-report
@@ -67,7 +67,7 @@ jobs:
 
       - name: Comment findings on PR
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");
@@ -160,7 +160,7 @@ jobs:
 
       - name: Notify Slack
         if: always() && env.SLACK_WEBHOOK_URL != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,22 +37,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Prepare Python tool cache
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          python_tool_cache="$RUNNER_TEMP/python-tool-cache"
-          mkdir -p "$python_tool_cache"
-          {
-            printf 'RUNNER_TOOL_CACHE=%s\n' "$python_tool_cache"
-            printf 'AGENT_TOOLSDIRECTORY=%s\n' "$python_tool_cache"
-          } >> "$GITHUB_ENV"
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+      - name: Set up mise
+        uses: jdx/mise-action@v4
 
       - name: Install Semgrep
         run: python -m pip install --upgrade semgrep

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@v4
+        with:
+          mise_toml: |
+            [tools]
+            python = "3.12"
 
       - name: Install Semgrep
         run: python -m pip install --upgrade semgrep

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
+          cache: false
           mise_toml: |
             [tools]
             python = "3.12"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   semgrep:
     name: Semgrep scan
-    runs-on: arc-b-4x
+    runs-on: [self-hosted]
     if: github.actor != 'dependabot[bot]'
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,6 +37,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Prepare Python tool cache
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python_tool_cache="$RUNNER_TEMP/python-tool-cache"
+          mkdir -p "$python_tool_cache"
+          {
+            printf 'RUNNER_TOOL_CACHE=%s\n' "$python_tool_cache"
+            printf 'AGENT_TOOLSDIRECTORY=%s\n' "$python_tool_cache"
+          } >> "$GITHUB_ENV"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 node = "26.2.0"
 pnpm = "11.1.0"
+python = "3.12"

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,3 @@
 [tools]
 node = "26.2.0"
 pnpm = "11.1.0"
-python = "3.12"


### PR DESCRIPTION
## 요약

- GitHub Actions 워크플로의 러너를 self-hosted 러너로 전환합니다.
- Docker Build 워크플로는 ARM64 self-hosted 러너에서 실행되도록 `runs-on: [self-hosted, ARM64]`로 지정합니다.
- Docker Build에서 Infisical 접근 전 Tailnet 연결 step을 제거합니다.
- Semgrep은 `actions/setup-python` 대신 workflow-local `mise_toml`로 Python 3.12를 설치해 macOS self-hosted runner의 hostedtoolcache 권한 문제를 피합니다.
- 워크플로에서 사용하는 외부 GitHub Actions를 최신 tag의 commit SHA로 고정하고, `mise-action`의 GitHub cache를 꺼 self-hosted runner의 로컬 캐시를 우선 사용합니다.

## 배경

PROD-99 작업입니다. 기존 GitHub-hosted/ARC 러너 대신 Mac mini self-hosted runner에서 CI와 Docker build를 실행하기 위한 변경입니다.

Stack: `main -> PROD-99`

## 검증

- `pnpm lint:prettier`
- Lint 통과: https://github.com/byulmaru/kosmo/actions/runs/27424262388
- Semgrep 통과: https://github.com/byulmaru/kosmo/actions/runs/27424262363
- Docker Build workflow dispatch 성공: https://github.com/byulmaru/kosmo/actions/runs/27403010184

## 운영 메모

- `jiyu-mac-mini` 호스트에서 Docker가 macOS keychain credential helper를 타지 않도록 Rancher Desktop의 `docker-credential-osxkeychain` symlink를 비활성화했습니다.
- 비활성화된 symlink 백업: `/Users/jiyu/.rd/bin/docker-credential-osxkeychain.disabled.20260612170243`
- Docker config는 `currentContext: rancher-desktop`를 유지하고, `credsStore`/`credHelpers` 없이 동작하도록 확인했습니다.