### PR TITLE
게시글 디테일에서 실제 게시글을 보여준다

### DIFF
--- a/apps/web/src/lib/graphql/client.ts
+++ b/apps/web/src/lib/graphql/client.ts
@@ -5,7 +5,7 @@ export const client = createClient({
   schema,
   exchanges: [
     dedupExchange(),
-    cacheExchange(),
+    cacheExchange({ fetchPolicy: 'cache-and-network' }),
     httpExchange({
       url: '/graphql',
     }),

--- a/apps/web/src/routes/(tabs)/@[handle]/[postId]/+page@(tabs).svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/[postId]/+page@(tabs).svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import { createQuery } from '@mearie/svelte';
-  import type { FragmentRefs } from '@mearie/svelte';
   import { graphql } from '$mearie';
   import PostAuthorProfile from '$lib/components/PostAuthorProfile.svelte';
   import PostBody from '$lib/components/PostBody.svelte';
@@ -15,49 +15,42 @@
   // 강제로 렌더하므로, 게시글 디테일은 그 레이아웃을 건너뛰고 사이드바·하단탭만 유지한다.
 
   const handle = $derived(page.params.handle ?? '');
+  const postId = $derived(page.params.postId ?? '');
 
-  // 작성자 영역: 라우트 핸들이 곧 작성자이므로 `profileByHandle`로 실데이터를 가져온다.
-  // 로딩·오류·없는 게시글 상태도 이 query에 매핑한다(`@[handle]/+layout.svelte`와 같은 패턴).
-  const authorQuery = createQuery(
+  // 게시글은 `Post`가 `Node`를 구현하므로 별도 query 없이 `node(id)` 단건 조회로 가져온다
+  // (PROD-93 범위 변경). 작성자도 `post.profile`에서 함께 가져와 URL 핸들에 의존하지 않는다.
+  const postQuery = createQuery(
     graphql(`
-      query PostDetailAuthorQuery($handle: String!) {
-        profileByHandle(handle: $handle) {
-          id
-          ...PostAuthorProfile_profile
+      query PostDetailQuery($postId: ID!) {
+        node(id: $postId) {
+          __typename
+          ... on Post {
+            id
+            state
+            profile {
+              id
+              handle
+              ...PostAuthorProfile_profile
+            }
+            ...PostBody_post
+          }
         }
       }
     `),
-    () => ({ handle }),
+    () => ({ postId }),
   );
 
-  const author = $derived(authorQuery.data?.profileByHandle ?? null);
+  // 없는 게시글뿐 아니라 다른 타입의 Node ID로 접근한 경우도 "없음"으로 본다.
+  const post = $derived(postQuery.data?.node?.__typename === 'Post' ? postQuery.data.node : null);
 
-  // TODO(PROD-110): 단건 조회 query(PROD-93) 머지 후 아래 본문 더미를 createQuery로 교체한다.
-  //   const postQuery = createQuery(
-  //     graphql(`query PostDetailQuery($id: ID!) {
-  //       post(id: $id) { state profile { id ...PostAuthorProfile_profile } ...PostBody_post }
-  //     }`),
-  //     () => ({ id: page.params.postId }),
-  //   );
-  // 그때 작성자는 `post.profile`에서 오고, 상태 분기에 postQuery.loading/error와
-  // post null, post.state를 합류시킨다. 본문 상태별 화면은 Storybook `KOSMO/PostBody`에서 본다.
-  //
-  // 더미는 실쿼리 결과와 같은 모양으로 둔다: route에서 직접 읽는 `state`는 객체 필드로 두고,
-  // 본문·메타는 `PostBody_post` fragment ref로 `PostBody`에 넘긴다.
-  type PostDetail = FragmentRefs<'PostBody_post'> & { state: 'ACTIVE' | 'DELETED' };
-  const post: PostDetail | null = {
-    __typename: 'Post',
-    id: 'dummy-post',
-    state: 'ACTIVE',
-    content: {
-      __typename: 'PostContent',
-      id: 'dummy-post-content',
-      bodyText:
-        '본문이 들어가는 자리예요. 내용이 길어지면 여러 줄로 늘어납니다.\n줄바꿈도 그대로 보존됩니다.',
-    },
-    createdAt: '2026-04-27T21:14:00.000Z',
-    visibility: 'PUBLIC',
-  } as unknown as PostDetail;
+  // URL 핸들이 실제 작성자 핸들과 다르면(작성자의 핸들 변경 후 옛 URL, 위조 핸들 URL)
+  // 정식 URL로 정규화한다. postId가 source of truth이므로 게시글은 그대로 두고
+  // 주소만 replaceState로 바꿔 히스토리에 잘못된 핸들이 남지 않게 한다.
+  $effect(() => {
+    if (post && post.profile.handle !== handle) {
+      void goto(`/@${post.profile.handle}/${postId}`, { replaceState: true });
+    }
+  });
 </script>
 
 <!--
@@ -90,7 +83,7 @@
     <h1 class="text-text-primary text-lg font-bold">게시글</h1>
   </header>
 
-  {#if authorQuery.loading}
+  {#if postQuery.loading}
     <div class="flex items-start gap-3 px-4 py-4" aria-hidden="true">
       <div class="w-10 shrink-0">
         <div class="border-border bg-surface size-10 animate-pulse rounded-full border"></div>
@@ -108,23 +101,28 @@
       </div>
     </div>
     <span class="sr-only" role="status">게시글을 불러오는 중입니다.</span>
-  {:else if authorQuery.error}
+  {:else if postQuery.error}
     <div class="px-4 py-12 text-center" role="alert">
       <p class="text-text-primary text-base font-semibold">게시글을 불러오지 못했어요</p>
       <p class="text-text-secondary mt-1 text-sm">잠시 후 다시 시도해주세요.</p>
       <button
         class="border-border text-text-primary mt-4 rounded-lg border px-4 py-2 text-sm font-bold"
         type="button"
-        onclick={() => authorQuery.refetch()}
+        onclick={() => postQuery.refetch()}
       >
         다시 시도
       </button>
     </div>
-  {:else if !author || !post}
+  {:else if !post}
     <div class="px-4 py-12 text-center">
       <p class="text-text-primary text-base font-semibold">게시글을 찾을 수 없어요</p>
       <p class="text-text-secondary mt-1 text-sm">이미 삭제되었거나 존재하지 않는 게시글이에요.</p>
     </div>
+    <!--
+      삭제됨 분기는 현재 백엔드 node loader가 ACTIVE 게시글만 반환해 실쿼리로는 도달하지
+      않는다(삭제 게시글은 null → 위 "없음" 분기). 백엔드가 삭제 상태를 구분해 노출하는
+      PROD-121 대비로 분기만 선제 유지한다.
+    -->
   {:else if post.state === 'DELETED'}
     <div class="px-4 py-12 text-center">
       <p class="text-text-primary text-base font-semibold">삭제된 게시글이에요</p>
@@ -132,7 +130,7 @@
     </div>
   {:else}
     <article class="px-4 py-4">
-      <PostAuthorProfile profile={author} href={`/@${handle}`}>
+      <PostAuthorProfile profile={post.profile} href={`/@${post.profile.handle}`}>
         <PostBody class="mt-1.5" {post} />
       </PostAuthorProfile>
     </article>

--- a/memory/frontend-svelte.md
+++ b/memory/frontend-svelte.md
@@ -25,8 +25,8 @@
 
 ## Mearie Cache And Mutations
 
-- `cacheExchange`의 `fetchPolicy`는 client(`apps/web/src/lib/graphql/client.ts`) 생성 시 한 번 고정되는 전역 상수이고 기본값은 `cache-first`다. `createQuery` options로 per-query override가 되지 않는다(이 버전 기준).
-- `cache-first`에서 쿼리가 정규화 캐시로 완전히 denormalize되면 네트워크를 타지 않는다. 따라서 `query.refetch()`도 캐시에 데이터가 있으면 네트워크 요청을 보내지 않고 stale 캐시를 다시 내보낸다. mutation 이후 UI 갱신을 부모 `refetch()`에 의존하면 안 된다.
+- `cacheExchange`의 `fetchPolicy`는 client(`apps/web/src/lib/graphql/client.ts`) 생성 시 한 번 고정되는 전역 상수이고, 이 repo는 `cache-and-network`를 사용한다(쿼리 실행 시 캐시를 즉시 내보내고 백그라운드 네트워크 재요청으로 갱신, PROD-110 리뷰 결정). mearie 문서에는 per-operation fetch policy(`useQuery` 세 번째 인자)가 있으나 0.6.7 기준 미구현이다 — 문서-구현 불일치이므로 per-query override를 시도하지 않는다.
+- `cache-and-network`에서도 캐시 갱신은 쿼리가 새로 실행될 때(마운트, 변수 변경, `refetch()`) 일어난다. 화면이 떠 있는 동안 다른 곳에서 일어난 변경이 저절로 반영되지는 않으므로, mutation 이후 UI 갱신을 부모 `refetch()`에 의존하지 말고 아래 응답 기반 정규화 갱신을 우선한다.
 - mutation 후 화면을 갱신하려면 응답에 **영향받는 엔티티의 `id`와 변경된 필드를 실어와** 정규화 캐시가 자동 갱신되게 한다. 예: follow/unfollow는 대상 `Profile`의 `viewerFollow`와 `followersCount`를 응답에서 선택한다.
 - delete/해제 mutation은 삭제된 관계 row의 `id`만으로 부모 링크를 끊지 못한다. `Profile.viewerFollow`를 `null`로 만들려면 success payload에 영향받는 부모 엔티티(예: `UnfollowProfileSuccess.profile`)를 노출하고 클라이언트가 그 필드를 다시 선택해야 한다.
 - 정규화로 안 되는 경우의 escape hatch로 `client.extension('cache').invalidate(...)`가 있으나(대상을 stale 처리해 네트워크 refetch 유발), 가능하면 응답 기반 정규화 갱신을 우선한다.


### PR DESCRIPTION
PROD-110

## 무엇을 변경했는지

- 게시글 디테일 라우트(`apps/web/src/routes/(tabs)/@[handle]/[postId]/+page@(tabs).svelte`)의 본문 더미 상수를 `node(id)` 단건 조회 실쿼리로 교체했다.
- 작성자 영역도 별도 `profileByHandle` 쿼리 대신 같은 쿼리의 `post.profile`에서 가져오도록 통합했다. 디테일 페이지의 네트워크 요청이 1회로 줄어든다.
- 로딩/오류/없음 상태 분기를 `postQuery.loading`/`error`/`node === null`에 합류시켰다. 다른 타입의 Node ID로 접근한 경우도 "없음"으로 처리한다.
- URL 핸들이 실제 작성자 핸들과 다르면 정식 URL(`/@{실제핸들}/{postId}`)로 `replaceState` redirect한다.

## 왜 변경했는지

- PROD-89에서 조회 기반이 없어 본문을 더미로 남겨 두었고(`TODO(PROD-110)`), 차단 이슈 PROD-119/PROD-93(#95, #96)이 main에 머지되어 실데이터 연결이 가능해졌다.
- **redirect 설계**: 핸들 불일치를 "없음 처리"하면 작성자가 핸들을 바꾼 뒤 기존에 공유된 URL이 전부 깨지고, "무시하고 렌더"하면 주소창·공유 URL에 잘못된(또는 위조된) 핸들이 남는다. postId를 source of truth로 두고 정식 URL로 정규화하면 옛 URL이 계속 동작하면서 위조 핸들 URL도 정식 주소로 수렴한다. 히스토리에 잘못된 핸들이 남지 않도록 `replaceState`를 사용했다.

## 어떻게 확인할 수 있는지

확인 완료:

- 자동 검사: `pnpm --filter web check`(svelte-check 0 errors), `pnpm lint:eslint`, prettier 통과.
- API 실쿼리(curl, 로컬 dev): ① 실제 게시글 ID → `Post`의 본문·작성 시각·공개 범위·작성자 반환 ② 형식은 유효하지만 존재하지 않는 ID → `node: null`(화면의 "찾을 수 없어요" 분기) ③ 임의 문자열 ID → `Unknown global id type code` GraphQL 오류(화면의 오류+다시 시도 분기, 아래 남은 문제 참고).
- SSR: 디테일 URL 직접 접근 시 로딩 스켈레톤까지 서버 렌더되고 데이터는 클라이언트에서 합류한다.

브라우저 수동 확인 필요(클라이언트 사이드 동작):

- 실제 게시글 URL 직접 접근 → 본문·작성 시각·공개 범위 표시
- 잘못된 핸들 + 유효한 postId(예: `/@아무핸들/{실제 postId}`) → 정식 URL로 주소창 정규화(redirect는 `$effect`+`goto`라 브라우저에서만 동작)
- API 중단 → 오류 + 다시 시도

## 아직 어떤 문제가 남았는지

- 삭제됨(`DELETED`) 분기는 현재 백엔드 node loader가 ACTIVE만 반환해 실쿼리로는 도달하지 않는다(삭제 게시글은 null → "없음" 분기). 백엔드가 삭제 상태를 구분해 노출하는 PROD-121 대비로 분기만 선제 유지했다. 따라서 이 분기는 이번 PR에서 실쿼리 기준으로 검증할 수 없고, PROD-121에서 검증한다.
- UUID discriminator가 깨진 잘못된 형식의 postId는 백엔드 `decodeGlobalID`가 throw하므로 "없음"이 아니라 오류 상태로 표시된다(위 curl ③에서 재현 확인). 백엔드 예외 정리는 PROD-121 범위.
- 비공개(FOLLOWERS/DIRECT) 게시글은 본인 외 null → "찾을 수 없어요"로 표시된다(이번 사이클 정책과 일치).
