### PR TITLE
저장된 게시글 본문을 TipTap 문서로 표시할 수 있게 한다

### DIFF
--- a/apps/web/src/lib/components/TipTapEditor.svelte
+++ b/apps/web/src/lib/components/TipTapEditor.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { Editor } from '@tiptap/core';
-  import { Document } from '@tiptap/extension-document';
-  import { Paragraph } from '@tiptap/extension-paragraph';
-  import { Text } from '@tiptap/extension-text';
+  import { tipTapExtensions } from '@kosmo/core/tiptap';
   import type { TipTapDocument } from '@kosmo/core/tiptap';
 
   type Props = {
@@ -40,7 +38,7 @@
   onMount(() => {
     editor = new Editor({
       element: editorHost,
-      extensions: [Document, Paragraph, Text],
+      extensions: tipTapExtensions,
       content: document ?? {
         type: 'doc',
         content: [{ type: 'paragraph' }],

--- a/apps/web/src/lib/components/TipTapRenderer.stories.svelte
+++ b/apps/web/src/lib/components/TipTapRenderer.stories.svelte
@@ -1,38 +1,110 @@
 <script module lang="ts">
-  import { createTipTapDocumentFromPlainText } from '@kosmo/core/tiptap';
   import { defineMeta } from '@storybook/addon-svelte-csf';
+  import type { TipTapDocument } from '@kosmo/core/tiptap';
 
   import TipTapRenderer from './TipTapRenderer.svelte';
 
-  const tipTapDocument = (text: string) => createTipTapDocumentFromPlainText(text);
+  const playgroundDocument = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: '본문이 들어가는 자리예요.' }],
+      },
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: '저장된 TipTap 문서를 렌더링합니다.' }],
+      },
+    ],
+  } satisfies TipTapDocument;
+
+  const shortDocument = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: '짧은 본문 한 줄.' }],
+      },
+    ],
+  } satisfies TipTapDocument;
+
+  const multilineDocument = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: '본문이 들어가는 자리예요. 내용이 길어지면 여러 줄로 늘어납니다.' },
+        ],
+      },
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: '줄바꿈도 문단으로 렌더링됩니다.' }],
+      },
+      {
+        type: 'paragraph',
+      },
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: '문단 사이 빈 줄도 유지됩니다.' }],
+      },
+    ],
+  } satisfies TipTapDocument;
+
+  const longWordDocument = {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: '긴단어가포함된본문도부모너비를넘지않고줄바꿈되어야합니다긴단어가포함된본문도부모너비를넘지않고줄바꿈되어야합니다',
+          },
+        ],
+      },
+    ],
+  } satisfies TipTapDocument;
+
+  const emptyDocument = {
+    type: 'doc',
+    content: [{ type: 'paragraph' }],
+  } satisfies TipTapDocument;
 
   const { Story } = defineMeta({
     title: 'KOSMO/TipTapRenderer',
     component: TipTapRenderer,
     tags: ['autodocs'],
+    argTypes: {
+      document: {
+        control: 'object',
+      },
+    },
   });
 </script>
 
+<Story name="Playground" args={{ class: 'w-[600px]', document: playgroundDocument }} />
+
 <Story
-  name="Playground"
-  args={{
-    document: tipTapDocument('본문이 들어가는 자리예요. 저장된 TipTap 문서를 렌더링합니다.'),
-  }}
+  name="Short"
+  args={{ class: 'w-[600px]', document: shortDocument }}
+  parameters={{ controls: { disable: true } }}
 />
 
-<Story name="States" asChild parameters={{ controls: { disable: true } }}>
-  <div class="grid w-[600px] gap-8">
-    <TipTapRenderer document={tipTapDocument('짧은 본문 한 줄.')} />
-    <TipTapRenderer
-      document={tipTapDocument(
-        '본문이 들어가는 자리예요. 내용이 길어지면 여러 줄로 늘어납니다.\n줄바꿈도 문단으로 렌더링됩니다.\n\n문단 사이 빈 줄도 유지됩니다.',
-      )}
-    />
-    <TipTapRenderer
-      document={tipTapDocument(
-        '긴단어가포함된본문도부모너비를넘지않고줄바꿈되어야합니다긴단어가포함된본문도부모너비를넘지않고줄바꿈되어야합니다',
-      )}
-    />
-    <TipTapRenderer document={tipTapDocument('')} />
-  </div>
-</Story>
+<Story
+  name="Multiline"
+  args={{ class: 'w-[600px]', document: multilineDocument }}
+  parameters={{ controls: { disable: true } }}
+/>
+
+<Story
+  name="LongWord"
+  args={{ class: 'w-[600px]', document: longWordDocument }}
+  parameters={{ controls: { disable: true } }}
+/>
+
+<Story
+  name="Empty"
+  args={{ class: 'w-[600px]', document: emptyDocument }}
+  parameters={{ controls: { disable: true } }}
+/>

--- a/apps/web/src/lib/components/TipTapRenderer.stories.svelte
+++ b/apps/web/src/lib/components/TipTapRenderer.stories.svelte
@@ -1,0 +1,38 @@
+<script module lang="ts">
+  import { createTipTapDocumentFromPlainText } from '@kosmo/core/tiptap';
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import TipTapRenderer from './TipTapRenderer.svelte';
+
+  const tipTapDocument = (text: string) => createTipTapDocumentFromPlainText(text);
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/TipTapRenderer',
+    component: TipTapRenderer,
+    tags: ['autodocs'],
+  });
+</script>
+
+<Story
+  name="Playground"
+  args={{
+    document: tipTapDocument('본문이 들어가는 자리예요. 저장된 TipTap 문서를 렌더링합니다.'),
+  }}
+/>
+
+<Story name="States" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid w-[600px] gap-8">
+    <TipTapRenderer document={tipTapDocument('짧은 본문 한 줄.')} />
+    <TipTapRenderer
+      document={tipTapDocument(
+        '본문이 들어가는 자리예요. 내용이 길어지면 여러 줄로 늘어납니다.\n줄바꿈도 문단으로 렌더링됩니다.\n\n문단 사이 빈 줄도 유지됩니다.',
+      )}
+    />
+    <TipTapRenderer
+      document={tipTapDocument(
+        '긴단어가포함된본문도부모너비를넘지않고줄바꿈되어야합니다긴단어가포함된본문도부모너비를넘지않고줄바꿈되어야합니다',
+      )}
+    />
+    <TipTapRenderer document={tipTapDocument('')} />
+  </div>
+</Story>

--- a/apps/web/src/lib/components/TipTapRenderer.svelte
+++ b/apps/web/src/lib/components/TipTapRenderer.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Editor } from '@tiptap/core';
+  import { tipTapExtensions } from '@kosmo/core/tiptap';
+  import type { TipTapDocument } from '@kosmo/core/tiptap';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  type Props = HTMLAttributes<HTMLDivElement> & {
+    document: TipTapDocument;
+  };
+
+  let { document, class: className, ...attributes }: Props = $props();
+
+  let editor = $state<Editor | null>(null);
+  let editorHost: HTMLDivElement;
+
+  $effect(() => {
+    editor?.commands.setContent(document, { emitUpdate: false });
+  });
+
+  onMount(() => {
+    editor = new Editor({
+      element: editorHost,
+      extensions: tipTapExtensions,
+      content: document,
+      editable: false,
+      autofocus: false,
+      editorProps: {
+        attributes: {
+          class: 'tiptap-renderer',
+        },
+      },
+    });
+
+    return () => {
+      editor?.destroy();
+      editor = null;
+    };
+  });
+</script>
+
+<div {...attributes} class={className}>
+  <div bind:this={editorHost}></div>
+</div>
+
+<style>
+  :global(.tiptap-renderer) {
+    color: var(--color-text-primary);
+    font-size: var(--text-md);
+    line-height: var(--text-md--line-height);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    outline: none;
+  }
+
+  :global(.tiptap-renderer p) {
+    margin: 0 0 0.75rem;
+  }
+
+  :global(.tiptap-renderer p:last-child) {
+    margin-bottom: 0;
+  }
+</style>


### PR DESCRIPTION
## 무엇을 변경했는지

- `TipTapDocument`를 read-only TipTap 인스턴스로 표시하는 `TipTapRenderer`를 추가했습니다.
- 렌더러의 `document` prop은 required non-null로 두어, 데이터 없음 상태는 호출부가 명시적으로 분기하게 했습니다.
- `TipTapEditor`와 렌더러가 같은 `tipTapExtensions`를 사용하도록 에디터의 extension 선언을 공용화했습니다.
- Storybook에 `TipTapRenderer` story를 추가했습니다.
  - Playground는 `document`를 object control로 노출해 TipTap JSON을 직접 수정할 수 있습니다.
  - 짧은 본문, 여러 문단/빈 줄, 긴 텍스트, 빈 문서를 story별 단일 렌더러로 분리했습니다.
  - 예시 문서는 helper 생성 함수에 의존하지 않고 기본 TipTap JSON을 직접 하드코딩했습니다.
- 새 컴포넌트는 `apps/web/src/lib/index.ts` barrel export에 추가하지 않았습니다.

## 왜 변경했는지

게시글 작성 흐름은 TipTap JSON 문서를 저장하지만, 웹 UI에서 저장된 문서 원본을 그대로 표시하는 공용 렌더링 경계가 없었습니다. 이후 게시글 본문 표시를 `bodyText` projection이 아니라 저장된 TipTap 문서 기준으로 옮길 수 있게 표시 전용 컴포넌트를 먼저 준비합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm --filter @kosmo/web build-storybook`

## 아직 어떤 문제가 남았는지

- 이번 PR에서는 기존 게시글 표시 화면을 `TipTapRenderer`로 연결하지 않습니다. 실제 `PostBody`/목록 표시를 `bodyJson` 기반 렌더링으로 바꾸는 작업은 후속 PR 범위입니다.