### PR TITLE
사이드바가 shell 프로필 조회를 재사용하게 한다

### DIFF
--- a/apps/web/src/lib/components/SidebarNavigation.svelte
+++ b/apps/web/src/lib/components/SidebarNavigation.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { profileHandleSchema } from '@kosmo/core/validation';
-  import { createMutation, createQuery } from '@mearie/svelte';
+  import { createFragment, createMutation } from '@mearie/svelte';
   import { graphql } from '$mearie';
   import { formatCount, getProfileInitial } from '$lib/utils/profile';
   import type { DataOf } from '@mearie/svelte';
+  import type { SidebarNavigation_query$key } from '$mearie';
 
   type Props = {
+    query?: SidebarNavigation_query$key | null;
+    loading?: boolean;
+    error?: boolean;
     surface?: 'desktop' | 'drawer';
     onNavigate?: () => void;
+    onProfileStateChanged?: () => void;
   };
 
-  const sidebarProfilesQuery = graphql(`
-    query SidebarProfilesQuery {
+  const sidebarNavigationFragment = graphql(`
+    fragment SidebarNavigation_query on Query {
       currentSession {
         selectedProfile {
           id
@@ -76,10 +81,17 @@
     }
   `);
 
-  type SidebarProfilesData = DataOf<typeof sidebarProfilesQuery>;
-  type ProfileSummary = NonNullable<SidebarProfilesData['me']>['profiles'][number];
+  type SidebarNavigationData = DataOf<typeof sidebarNavigationFragment>;
+  type ProfileSummary = NonNullable<SidebarNavigationData['me']>['profiles'][number];
 
-  let { surface = 'desktop', onNavigate = () => {} }: Props = $props();
+  let {
+    query = null,
+    loading = false,
+    error = false,
+    surface = 'desktop',
+    onNavigate = () => {},
+    onProfileStateChanged = () => {},
+  }: Props = $props();
 
   const navItems = [
     { href: '/', label: '홈', path: 'M3 10.5 12 3l9 7.5V21h-6v-6H9v6H3z' },
@@ -111,7 +123,7 @@
     },
   ];
 
-  const profileQuery = createQuery(sidebarProfilesQuery);
+  const sidebarNavigation = createFragment(sidebarNavigationFragment, () => query);
   const [selectSidebarProfile] = createMutation(selectSidebarProfileMutation);
   const [createSidebarProfile] = createMutation(createSidebarProfileMutation);
   let profileError = $state<string | null>(null);
@@ -147,10 +159,10 @@
       : (result.error.issues[0]?.message ?? '프로필 핸들 형식을 확인해주세요.');
   };
 
-  const creatingOrSwitching = $derived(profileActionLoading || profileQuery.loading);
-  const sidebarProfiles = $derived(profilesOverride ?? profileQuery.data?.me?.profiles ?? []);
+  const creatingOrSwitching = $derived(profileActionLoading || loading);
+  const sidebarProfiles = $derived(profilesOverride ?? sidebarNavigation.data?.me?.profiles ?? []);
   const sidebarActiveProfile = $derived(
-    selectedProfileOverride ?? profileQuery.data?.currentSession?.selectedProfile ?? null,
+    selectedProfileOverride ?? sidebarNavigation.data?.currentSession?.selectedProfile ?? null,
   );
 
   const openProfileSwitcher = () => {
@@ -182,7 +194,7 @@
         data.selectProfile.profile;
       profileSwitcherOpen = false;
       profileCreationOpen = false;
-      profileQuery.refetch();
+      onProfileStateChanged();
     } catch (error) {
       profileError = error instanceof Error ? error.message : '프로필을 전환하지 못했습니다.';
     } finally {
@@ -231,7 +243,7 @@
       selectedProfileOverride = createdProfile;
       profileSwitcherOpen = false;
       profileCreationOpen = false;
-      profileQuery.refetch();
+      onProfileStateChanged();
     } catch (error) {
       profileCreationError =
         error instanceof Error ? error.message : '프로필을 생성하지 못했습니다.';
@@ -304,7 +316,7 @@
           >
         </div>
       </div>
-    {:else if profileQuery.data && sidebarProfiles.length > 0}
+    {:else if sidebarNavigation.data && sidebarProfiles.length > 0}
       <div class="absolute left-5 top-[54px] flex w-[280px] items-start justify-between">
         <div
           class="flex size-24 items-center justify-center rounded-full bg-zinc-200 text-3xl font-bold text-zinc-500 shadow-[1px_1px_2px_rgba(0,0,0,0.25)]"
@@ -358,7 +370,7 @@
           </svg>
         </button>
         <p class="text-sm leading-[19.6px] text-[#777777]">
-          {profileQuery.loading ? '프로필을 불러오는 중입니다.' : '새 프로필을 만들어 시작하세요.'}
+          {loading ? '프로필을 불러오는 중입니다.' : '새 프로필을 만들어 시작하세요.'}
         </p>
       </div>
     {/if}
@@ -557,9 +569,9 @@
       전환 중
     {/if}
 
-    {#if profileQuery.loading}
+    {#if loading}
       프로필을 불러오는 중입니다.
-    {:else if profileQuery.error}
+    {:else if error}
       프로필을 불러오지 못했습니다.
     {:else if sidebarProfiles.length === 0}
       사용 가능한 프로필이 없습니다.

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import { graphql } from '$mearie';
-  import { createQuery } from '@mearie/svelte';
+  import { createQuery, getClient } from '@mearie/svelte';
   import BottomTabBar from '$lib/components/BottomTabBar.svelte';
   import RightRail from '$lib/components/RightRail.svelte';
   import SidebarNavigation from '$lib/components/SidebarNavigation.svelte';
 
   let { children } = $props();
 
+  const client = getClient();
   const query = createQuery(
     graphql(`
       query TabsLayoutQuery {
+        ...SidebarNavigation_query
         currentSession {
           id
           selectedProfile {
@@ -22,6 +24,15 @@
   );
 
   const selectedProfile = $derived(query.data?.currentSession?.selectedProfile ?? null);
+
+  const invalidateSidebarNavigationData = () => {
+    client
+      .extension('cache')
+      .invalidate(
+        { __typename: 'Query', $field: 'currentSession' },
+        { __typename: 'Query', $field: 'me' },
+      );
+  };
 
   let drawerOpen = $state(false);
   let swipeStartX = $state<number | null>(null);
@@ -63,7 +74,12 @@
   class="min-h-screen lg:grid lg:grid-cols-[20rem_minmax(0,600px)_minmax(290px,350px)] lg:justify-center"
 >
   <div class="hidden lg:block">
-    <SidebarNavigation />
+    <SidebarNavigation
+      query={query.data}
+      loading={query.loading}
+      error={Boolean(query.error)}
+      onProfileStateChanged={invalidateSidebarNavigationData}
+    />
   </div>
 
   <div class="grid min-h-screen grid-rows-[auto_1fr_auto] lg:grid-rows-[1fr]">
@@ -114,7 +130,14 @@
         onclick={closeDrawer}
       ></button>
       <div id="mobile-sidebar" class="absolute inset-y-0 left-0 max-w-[85vw]">
-        <SidebarNavigation surface="drawer" onNavigate={closeDrawer} />
+        <SidebarNavigation
+          query={query.data}
+          loading={query.loading}
+          error={Boolean(query.error)}
+          surface="drawer"
+          onNavigate={closeDrawer}
+          onProfileStateChanged={invalidateSidebarNavigationData}
+        />
       </div>
     </div>
   {/if}


### PR DESCRIPTION
# 사이드바가 shell 프로필 조회를 재사용하게 한다

Linear: PROD-136

## 무엇을 변경했는지

- `SidebarNavigation`의 자체 `SidebarProfilesQuery` 실행을 제거하고, `SidebarNavigation_query` fragment를 통해 부모가 넘긴 route query 결과를 읽도록 바꿨습니다.
- `(tabs)/+layout.svelte`의 기존 `TabsLayoutQuery`에 `...SidebarNavigation_query`를 함께 spread해 데스크톱 사이드바와 모바일 drawer가 같은 query 결과를 재사용하게 했습니다.
- 프로필 전환/생성 mutation 성공 후에는 기존 즉시 반영 override를 유지하면서, `currentSession`과 `me` query field를 cache invalidate해 route shell 데이터가 다시 동기화되도록 했습니다.

## 왜 변경했는지

- 같은 `(tabs)` shell 안에서 route layout과 `SidebarNavigation`이 프로필/세션 데이터를 따로 조회하면서 불필요한 프로필 관련 GraphQL 요청이 추가로 나갈 수 있었습니다.
- 사이드바가 필요한 데이터 목록은 fragment로 컴포넌트에 colocate하고, 실제 조회는 route shell이 한 번만 담당하게 하면 데스크톱/모바일 surface가 같은 데이터를 공유할 수 있습니다.
- 이 구조가 프로젝트의 Mearie fragment 패턴과 더 잘 맞고, 이후 shell 데이터 소유권을 이해하기 쉬워집니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm lint:eslint`
- 브라우저에서 `(tabs)` shell 진입 시 `SidebarProfilesQuery`가 더 이상 별도 요청으로 실행되지 않는지 Network 탭에서 확인합니다.
- 데스크톱 사이드바와 모바일 drawer에서 프로필 전환/생성 후 활성 프로필 표시와 프로필 메뉴 링크가 유지되는지 확인합니다.

## 아직 어떤 문제가 남았는지

- 자동 검증은 통과했지만, 브라우저 Network 탭과 실제 프로필 전환/생성 플로우의 수동 확인은 아직 추가로 진행해야 합니다.
