### PR TITLE
프로필 게시글 목록에 TipTap 본문 렌더러 연결

### DIFF
--- a/apps/web/src/lib/components/PostList.stories.svelte
+++ b/apps/web/src/lib/components/PostList.stories.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { createTipTapDocumentFromPlainText } from '@kosmo/core/tiptap';
 
   import PostList from './PostList.svelte';
 
@@ -15,7 +16,12 @@
     content:
       bodyText === null
         ? null
-        : { __typename: 'PostContent', id: `story-post-content-${id}`, bodyText },
+        : {
+            __typename: 'PostContent',
+            id: `story-post-content-${id}`,
+            bodyJson: createTipTapDocumentFromPlainText(bodyText),
+            bodyText,
+          },
     createdAt,
     profile: {
       __typename: 'Profile',
@@ -40,8 +46,8 @@
     }) as unknown as PostList_profile$key;
 
   const longBody =
-    '프로필 게시글 목록은 이제 실제 query 결과를 받아 항목을 렌더합니다. ' +
-    '긴 본문은 PostListItem의 더보기 동작으로 접혀야 하므로, 목록 컨테이너에서는 데이터를 그대로 전달합니다. '.repeat(
+    '프로필 게시글 목록은 실제 query 결과의 TipTap 문서를 항목 렌더러에 전달합니다. ' +
+    '긴 본문 접힘 처리는 PROD-138에서 다루며, 지금은 목록 컨테이너가 데이터를 그대로 전달합니다. '.repeat(
       4,
     );
 
@@ -61,7 +67,7 @@
 <Story
   name="Playground"
   args={{
-    profile: profile(post('playground', '프로필에 올라온 게시글 본문입니다.')),
+    profile: profile(post('playground', '프로필에 올라온 TipTap 게시글 본문입니다.')),
     loading: false,
   }}
 />

--- a/apps/web/src/lib/components/PostList.svelte
+++ b/apps/web/src/lib/components/PostList.svelte
@@ -8,8 +8,8 @@
   import PostListItem from './PostListItem.svelte';
   import TextSkeleton from './TextSkeleton.svelte';
 
-  // 프로필 게시글 목록(PROD-124). Pagination UI는 별도 이슈로 분리하고 첫 페이지만
-  // 조회한다. 항목 본문은 TipTap 렌더러 대신 PostListItem의 plain text fragment를 사용한다.
+  // 프로필 게시글 목록. Pagination UI는 별도 이슈로 분리하고 첫 페이지만 조회한다.
+  // 항목 본문은 PostListItem의 TipTap 렌더러 fragment를 통해 렌더한다.
   type Props = HTMLAttributes<HTMLElement> & {
     profile?: PostList_profile$key | null;
     loading?: boolean;

--- a/apps/web/src/lib/components/PostListItem.stories.svelte
+++ b/apps/web/src/lib/components/PostListItem.stories.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
+  import { createTipTapDocumentFromPlainText } from '@kosmo/core/tiptap';
 
   import PostListItem from './PostListItem.svelte';
 
@@ -21,7 +22,12 @@
       content:
         bodyText === null
           ? null
-          : { __typename: 'PostContent', id: 'story-post-content', bodyText },
+          : {
+              __typename: 'PostContent',
+              id: 'story-post-content',
+              bodyJson: createTipTapDocumentFromPlainText(bodyText),
+              bodyText,
+            },
       createdAt,
       profile: {
         __typename: 'Profile',
@@ -32,11 +38,10 @@
     }) as unknown as PostListItem_post$key;
 
   const longBody =
-    '긴 본문은 목록에서 200자까지만 보이고 더보기 버튼이 나타납니다. ' +
-    '이 문장은 잘림 동작을 확인하기 위해 일부러 길게 이어 붙였습니다. '.repeat(6) +
-    '\n잘린 이후의 내용은 펼치기 전에는 보이지 않아야 합니다.\n마지막 줄입니다.';
+    '긴 본문도 목록 항목에서 원본 TipTap 문서를 그대로 렌더링합니다. ' +
+    '접힘 처리는 PROD-138에서 문서 구조를 보존하는 방식으로 별도 구현합니다. '.repeat(6) +
+    '\n여러 문단도 원본 문서 형태로 렌더링되어야 합니다.\n마지막 줄입니다.';
 
-  // 글자 수는 200자 이하지만 줄바꿈이 10줄을 넘는 본문 — 줄 상한으로 잘려야 한다.
   const manyLinesBody = Array.from({ length: 14 }, (_, index) => `${index + 1}번째 줄`).join('\n');
 
   const { Story } = defineMeta({
@@ -48,7 +53,7 @@
 
 <Story name="Playground" args={{ post: post('목록 항목 본문이 들어가는 자리예요.') }} />
 
-<!-- 본문 길이별 잘림 상태. 200자 초과(또는 10줄 초과) 본문은 잘리고 "더보기..." 버튼이 보여야 한다. -->
+<!-- 본문 상태: 짧은 본문, 긴 본문, 여러 문단, 빈 본문. 접힘 처리는 PROD-138에서 다룬다. -->
 <Story name="Body states" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid w-[390px]">
     <PostListItem post={post('짧은 본문 한 줄.')} />

--- a/apps/web/src/lib/components/PostListItem.svelte
+++ b/apps/web/src/lib/components/PostListItem.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
   import { formatTimelineTimestamp } from '@kosmo/core/datetime';
+  import { tipTapDocumentSchema } from '@kosmo/core/tiptap';
+  import type { TipTapDocument } from '@kosmo/core/tiptap';
   import { graphql } from '$mearie';
   import { createFragment } from '@mearie/svelte';
-  import { tick } from 'svelte';
-  import { Temporal } from 'temporal-polyfill';
   import type { HTMLAttributes } from 'svelte/elements';
+  import { Temporal } from 'temporal-polyfill';
 
   import type { PostListItem_post$key } from '$mearie';
 
   import PostAuthorProfile from './PostAuthorProfile.svelte';
+  import TipTapRenderer from './TipTapRenderer.svelte';
 
   // 게시글 목록 항목(Figma PostCard 67:206). 디테일(`PostBody`)과 달리 목록 표현을
-  // 따른다: 시간은 헤더 우측(24시간 미만 상대시간, 이상 날짜), 본문은 클램프.
+  // 따른다: 시간은 헤더 우측(24시간 미만 상대시간, 이상 날짜), 본문은 TipTap 원본
+  // 문서 그대로 렌더한다.
   // 카드 전체는 디테일로 이동하고, 카드 내부 컨트롤은 pointer-events-auto로
   // overlay 링크보다 우선한다.
   type Props = HTMLAttributes<HTMLElement> & {
@@ -26,6 +29,7 @@
         id
         content {
           id
+          bodyJson
           bodyText
         }
         createdAt
@@ -46,37 +50,20 @@
   );
   const detailHref = $derived(`/@${postFragment.data.profile.handle}/${postFragment.data.id}`);
 
-  // 본문 미리보기와 "더보기..."(Figma ExpandButton 67:515) 인라인 펼침. 펼친 뒤
-  // 다시 접는 동작은 Figma에 없어 두지 않는다.
-  // 잘림 기준은 렌더 측정 없이 본문 텍스트로 판정한다: 200자 초과 또는 줄바꿈 10줄
-  // 초과 중 하나라도 해당하면 자른다(글자 수 기준은 팀 결정값, Figma에 명시 없음).
-  // 줄 상한은 글자 수는 적어도 줄바꿈이 많은 본문이 목록을 길게 차지하지 않게 한다.
-  const BODY_PREVIEW_MAX_CHARS = 200;
-  const BODY_PREVIEW_MAX_LINES = 10;
-
-  let expanded = $state(false);
-  let bodyElement = $state<HTMLParagraphElement>();
-
   const fullBody = $derived(postFragment.data.content?.bodyText ?? '');
-  const previewBody = $derived.by(() => {
-    const preview = fullBody.split('\n').slice(0, BODY_PREVIEW_MAX_LINES).join('\n');
-    // surrogate pair(이모지 등)를 자르지 않도록 코드 포인트 단위로 센다.
-    const characters = [...preview];
-    if (characters.length <= BODY_PREVIEW_MAX_CHARS) {
-      return preview;
+  const fullDocument = $derived.by<TipTapDocument | null>(() => {
+    const content = postFragment.data.content;
+    if (!content) {
+      return null;
     }
-    return characters.slice(0, BODY_PREVIEW_MAX_CHARS).join('');
-  });
-  // 잘려나간 부분이 공백뿐이면(예: 꼬리 줄바꿈) 펼쳐도 차이가 없으므로 자르지 않는다.
-  const clamped = $derived(fullBody.slice(previewBody.length).trim() !== '');
 
-  // 더보기 버튼은 펼치면 DOM에서 사라지므로, 포커스가 document로 떨어지지 않게
-  // 펼쳐진 본문으로 옮긴다.
-  const expand = async () => {
-    expanded = true;
-    await tick();
-    bodyElement?.focus();
-  };
+    const parsedDocument = tipTapDocumentSchema.safeParse(content.bodyJson);
+    if (parsedDocument.success) {
+      return parsedDocument.data;
+    }
+
+    return null;
+  });
 </script>
 
 <article
@@ -98,26 +85,10 @@
         </time>
       {/snippet}
 
-      {#if fullBody}
-        <!-- tabindex는 펼침 시 -1로만 설정되는 programmatic focus 대상이다(탭 순서에
-             들어가지 않음). 정적 분석이 동적 값을 음수로 판별하지 못해 경고를 끈다. -->
-        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-        <p
-          bind:this={bodyElement}
-          class="text-text-primary text-md font-body focus-visible:outline-more mt-2 rounded-md break-words whitespace-pre-wrap focus-visible:outline-2 focus-visible:outline-offset-2"
-          tabindex={expanded ? -1 : undefined}
-        >
-          {#if expanded || !clamped}{fullBody}{:else}{previewBody}…{/if}
-        </p>
-        {#if clamped && !expanded}
-          <button
-            class="text-more text-md focus-visible:outline-more pointer-events-auto block rounded-md text-left font-bold focus-visible:outline-2 focus-visible:outline-offset-2"
-            onclick={expand}
-            type="button"
-          >
-            더보기...
-          </button>
-        {/if}
+      {#if fullDocument && fullBody}
+        <div class="mt-2">
+          <TipTapRenderer document={fullDocument} />
+        </div>
       {/if}
     </PostAuthorProfile>
   </div>

--- a/apps/web/src/lib/components/TipTapRenderer.svelte
+++ b/apps/web/src/lib/components/TipTapRenderer.svelte
@@ -50,7 +50,7 @@
     font-size: var(--text-md);
     line-height: var(--text-md--line-height);
     white-space: pre-wrap;
-    overflow-wrap: anywhere;
+    overflow-wrap: anywhere !important;
     outline: none;
   }
 


### PR DESCRIPTION
## 요약

- 프로필 게시글 목록 항목의 GraphQL fragment에 `content.bodyJson`을 추가했습니다.
- `PostListItem`에서 `bodyText` 기반 본문 렌더링과 접힘/더보기 처리를 제거하고, `bodyJson` 원본 TipTap 문서를 `TipTapRenderer`에 전달하도록 바꿨습니다.
- Storybook mock 데이터에 TipTap `bodyJson`을 포함하고, 접힘 처리는 후속 이슈 `PROD-138` 범위로 분리했습니다.

## 검증

- `pnpm --filter @kosmo/web check`
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm --filter @kosmo/web build`

## 관련

- PROD-133
- 후속: PROD-138