### PR TITLE
로그인 후 기존 프로필로 바로 홈에 진입하게 한다

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,6 +41,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "bits-ui": "^2.18.1",
     "cookie": "^1.1.1",
+    "drizzle-orm": "1.0.0-beta.22",
     "mearie": "^0.1.7",
     "playwright": "^1.59.1",
     "pretendard": "^1.3.9",

--- a/apps/web/src/routes/login/callback/+server.ts
+++ b/apps/web/src/routes/login/callback/+server.ts
@@ -1,6 +1,17 @@
 import { sessionName } from '@kosmo/core';
-import { Accounts, db, firstOrThrow, Sessions } from '@kosmo/core/db';
-import { AccountState, SessionState } from '@kosmo/core/enums';
+import {
+  AccountProfiles,
+  Accounts,
+  and,
+  db,
+  desc,
+  eq,
+  first,
+  firstOrThrow,
+  Profiles,
+  Sessions,
+} from '@kosmo/core/db';
+import { AccountState, ProfileState, SessionState } from '@kosmo/core/enums';
 import { error, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { env } from '$env/dynamic/private';
@@ -82,10 +93,23 @@ export const GET: RequestHandler = async ({ cookies, url }) => {
       .returning({ id: Accounts.id })
       .then(firstOrThrow);
 
+    const activeProfile = await tx
+      .select({ id: Profiles.id })
+      .from(Profiles)
+      .innerJoin(
+        AccountProfiles,
+        and(eq(AccountProfiles.profileId, Profiles.id), eq(AccountProfiles.accountId, account.id)),
+      )
+      .where(eq(Profiles.state, ProfileState.ACTIVE))
+      .orderBy(desc(Profiles.id))
+      .limit(1)
+      .then(first);
+
     const session = await tx
       .insert(Sessions)
       .values({
         accountId: account.id,
+        activeProfileId: activeProfile?.id ?? null,
         oidcSessionKey: tokenJson.access_token,
         state: SessionState.ACTIVE,
         token: createSessionToken(),

--- a/apps/web/src/routes/login/callback/+server.ts
+++ b/apps/web/src/routes/login/callback/+server.ts
@@ -2,10 +2,7 @@ import { sessionName } from '@kosmo/core';
 import {
   AccountProfiles,
   Accounts,
-  and,
   db,
-  desc,
-  eq,
   first,
   firstOrThrow,
   Profiles,
@@ -13,6 +10,7 @@ import {
 } from '@kosmo/core/db';
 import { AccountState, ProfileState, SessionState } from '@kosmo/core/enums';
 import { error, redirect } from '@sveltejs/kit';
+import { and, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { env } from '$env/dynamic/private';
 import { env as publicEnv } from '$env/dynamic/public';

--- a/packages/core/db/index.ts
+++ b/packages/core/db/index.ts
@@ -8,7 +8,6 @@ export * from './id';
 export * from './relations';
 export * from './tables';
 export * from './utils';
-export { and, desc, eq } from 'drizzle-orm';
 
 export const pg = postgres(process.env.DATABASE_URL!, {
   max: 20,

--- a/packages/core/db/index.ts
+++ b/packages/core/db/index.ts
@@ -8,6 +8,7 @@ export * from './id';
 export * from './relations';
 export * from './tables';
 export * from './utils';
+export { and, desc, eq } from 'drizzle-orm';
 
 export const pg = postgres(process.env.DATABASE_URL!, {
   max: 20,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       cookie:
         specifier: ^1.1.1
         version: 1.1.1
+      drizzle-orm:
+        specifier: 1.0.0-beta.22
+        version: 1.0.0-beta.22(postgres@3.4.9)(zod@4.4.3)
       mearie:
         specifier: ^0.1.7
         version: 0.1.7(jiti@2.7.0)(magicast@0.5.2)


### PR DESCRIPTION
# 로그인 후 기존 프로필로 바로 홈에 진입하게 한다

Stack: `main -> prod-140`

Linear: [PROD-140](https://linear.app/byulmaru/issue/PROD-140/로그인-세션에-기존-프로필-자동-선택)

## 무엇을 변경했는지

- 로그인 콜백에서 계정 upsert 후 해당 계정의 ACTIVE 프로필을 1개 조회합니다.
- ACTIVE 프로필이 있으면 시간순 ID 정렬 기준 최신 프로필을 새 세션의 `activeProfileId`로 저장합니다.
- ACTIVE 프로필이 없으면 기존처럼 선택 프로필 없이 세션을 생성합니다.
- 로그인 콜백이 DB 조건식을 직접 조립하므로 `@kosmo/web`에 `drizzle-orm` 의존성을 명시합니다.

## 왜 변경했는지

- 기존 프로필이 있는 사용자가 다시 로그인했을 때 새 세션의 active profile이 비어 있으면 `/home`에서 불필요하게 프로필 없음 온보딩을 볼 수 있습니다.
- 세션 생성 시 기존 프로필을 자동 선택하면 재로그인 사용자는 바로 홈 타임라인 흐름으로 진입할 수 있습니다.
- 프로필이 없는 계정의 온보딩 흐름은 그대로 유지합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm lint:syncpack`
- 기존 ACTIVE 프로필이 있는 계정으로 로컬 OIDC 재로그인 확인: 새 세션의 `activeProfileId`가 최신 ACTIVE 프로필 ID와 일치
- 프로필이 없는 계정으로 로컬 OIDC 로그인 확인: 프로필 수 0개, 새 세션의 `activeProfileId`는 `null`

## 아직 어떤 문제가 남았는지

- 없음
