### PR TITLE
Drizzle Studio 실행 스크립트를 추가한다

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "drizzle:push": "infisical run -- drizzle-kit push",
-    "drizzle:generate": "infisical run -- drizzle-kit generate"
+    "drizzle:generate": "infisical run -- drizzle-kit generate",
+    "drizzle:studio": "infisical run -- drizzle-kit studio"
   },
   "devDependencies": {
     "drizzle-kit": "1.0.0-beta.22"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,8 @@
     "zod": "^4.4.3"
   },
   "scripts": {
-    "drizzle:push": "infisical run -- drizzle-kit push",
     "drizzle:generate": "infisical run -- drizzle-kit generate",
+    "drizzle:push": "infisical run -- drizzle-kit push",
     "drizzle:studio": "infisical run -- drizzle-kit studio"
   },
   "devDependencies": {


### PR DESCRIPTION
## 무엇을 변경했는지

- `@kosmo/core` 패키지에 `drizzle:studio` 스크립트를 추가했습니다.
- 기존 `drizzle:push`, `drizzle:generate`와 동일하게 `infisical run -- drizzle-kit ...` 실행 흐름을 사용합니다.

## 왜 변경했는지

- 로컬에서 Drizzle Studio를 실행할 때 매번 전체 명령을 직접 입력하지 않고, 패키지 스크립트로 일관되게 실행할 수 있게 하기 위함입니다.

## 어떻게 확인할 수 있는지

- `pnpm lint:prettier`
- 커밋 훅에서 staged 파일 대상 `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown` 실행 완료

## 아직 어떤 문제가 남았는지

- 없음