### PR TITLE
타이포그래피 문서에 Figma 작업 환경 폰트 대치 섹션을 추가한다

### DIFF
--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -10,6 +10,19 @@
 - Foundation 변수 컬렉션에 폰트 패밀리 변수가 없으므로 Figma에서는 폰트를 직접 지정한다.
 - Figma에서는 SUIT/Pretendard 미설치로 각각 Inter / Noto Sans KR로 대치 표기한다. 구현 시에는 Inter→SUIT, Noto Sans KR→Pretendard로 매핑한다.
 
+## Figma 작업 환경에서의 폰트 대치
+
+브랜드 폰트인 **SUIT**(UI)와 **Pretendard Variable**(본문)은 현재 Figma 작업 환경에 설치되어 있지 않다. 해당 패밀리로 지정된 텍스트는 편집 시 "폰트를 불러올 수 없음" 오류가 난다. 그래서 Figma 디자인 작업에서는 다음 폰트로 대치한다.
+
+| 용도 | 브랜드 폰트(스펙)   | Figma 작업 대치 폰트 |
+| ---- | ------------------- | -------------------- |
+| UI   | SUIT                | **Inter**            |
+| 본문 | Pretendard Variable | **Noto Sans KR**     |
+
+- 새 Figma 화면/컴포넌트는 위 대치 폰트로 만든다. 기존 화면도 대부분 Inter / Noto Sans KR로 작업돼 있다.
+- 이는 **Figma 작업 환경 한정 대치**다. 코드·실서비스는 그대로 SUIT·Pretendard Variable을 사용하며 브랜드 결정은 바뀌지 않는다.
+- 로고처럼 SUIT로 지정하려던 요소도 Figma에서는 Inter로 표기한다(로고 에셋 확정 전까지는 대문자 "K").
+
 ## 웹 구현 (apps/web)
 
 - 두 폰트는 **npm 패키지로 관리**한다(`pretendard`, `@sun-typeface/suit`, 둘 다 Variable). 각 패키지가 제공하는 `@font-face` CSS를 `+layout.svelte`(앱)와 `.storybook/preview.ts`(Storybook)에서 import하면 Vite가 woff2를 번들해 자체 origin에서 제공한다(외부 CDN 런타임 의존 없음, git에 폰트 바이너리 미커밋). 패키지 버전은 `package.json`으로 관리한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- `docs/design/typography.md`에 `## Figma 작업 환경에서의 폰트 대치` 섹션을 추가했다.
  - 브랜드 폰트 SUIT(UI) / Pretendard Variable(본문)이 Figma 작업 환경에 미설치라 편집 시 "폰트를 불러올 수 없음" 오류가 나는 배경을 명시.
  - Figma 작업용 대치 폰트 매핑(UI=Inter, 본문=Noto Sans KR)을 표로 정리.
  - 대치는 Figma 작업 환경 한정이며 코드·실서비스는 그대로 SUIT·Pretendard Variable을 쓴다는 점, 로고 표기 규칙(에셋 확정 전 대문자 "K")을 함께 기재.
- 기존 한 줄 요약 bullet은 그대로 두고 상세 섹션만 덧붙였다.

## 왜 변경했는지

기존 문서에는 Figma 폰트 대치가 한 줄로만 적혀 있어, 왜 대치가 필요한지(미설치로 인한 로드 오류)와 대치 범위(Figma 한정, 브랜드 결정 불변)가 드러나지 않았다. Figma 디자인 작업자가 매번 같은 혼란을 겪지 않도록 배경과 매핑을 문서로 고정한다.

## 어떻게 확인할 수 있는지

- 문서 변경이므로 빌드/런타임 영향 없음.
- `prettier --write docs/design/typography.md`로 포맷 정규화 완료(표 정렬 변화 없음).
- PR diff로 섹션 추가만 있는지 확인.

## 아직 어떤 문제가 남았는지

없음.

---

Linear: PROD-166 (https://linear.app/byulmaru/issue/PROD-166)
