### PR TITLE
프로필 목록 Item이 실제 Profile 데이터를 표시하게 한다

### DIFF
--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -1,7 +1,23 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
+  import type { ProfileListItem_profile$key } from '$mearie';
+
   import ProfileListItem from './ProfileListItem.svelte';
+
+  // 실제 Mearie fragment ref 대신 표시 필드만 담은 mock 객체를 캐스팅해 넘긴다.
+  // (Storybook은 .storybook/mocks의 createFragment가 data getter로 그대로 돌려준다.)
+  const profile = (
+    overrides: Partial<{ displayName: string; handle: string; bio: string | null }> = {},
+  ): ProfileListItem_profile$key =>
+    ({
+      __typename: 'Profile',
+      id: 'story-profile',
+      displayName: '사용자 이름',
+      handle: 'handle@kos.mo',
+      bio: null,
+      ...overrides,
+    }) as unknown as ProfileListItem_profile$key;
 
   const { Story } = defineMeta({
     title: 'KOSMO/ProfileListItem',
@@ -23,24 +39,25 @@
 <Story
   name="Playground"
   args={{
+    profile: profile(),
     state: 'follow',
-    name: '사용자 이름',
-    handle: '@handle@kos.mo',
-    bio: '',
     width: 'compact',
   }}
 />
 
 <Story name="States" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid gap-3">
-    <ProfileListItem state="follow" />
-    <ProfileListItem state="following" />
-    <ProfileListItem state="follow" width="wide" handle="@user@kos.moe" />
+    <ProfileListItem state="follow" profile={profile()} />
+    <ProfileListItem state="following" profile={profile()} />
+    <ProfileListItem
+      state="follow"
+      width="wide"
+      profile={profile({ displayName: '코스모 사용자', handle: 'user@kos.moe' })}
+    />
     <ProfileListItem
       state="following"
       width="wide"
-      handle="@user@kos.moe"
-      bio="한 줄 소개가 들어가는 자리"
+      profile={profile({ handle: 'user@kos.moe', bio: '한 줄 소개가 들어가는 자리' })}
     />
   </div>
 </Story>
@@ -50,10 +67,15 @@
     <ProfileListItem
       state="follow"
       width="wide"
-      name="아주 긴 표시 이름이 들어가서 한 줄을 넘기면 잘려야 한다"
-      handle="@super-long-handle-that-overflows@really-long-instance.example.com"
-      bio="긴 한 줄 소개가 들어가서 컨테이너 폭을 넘기면 말줄임으로 잘려야 한다"
+      profile={profile({
+        displayName: '아주 긴 표시 이름이 들어가서 한 줄을 넘기면 잘려야 한다',
+        handle: 'super-long-handle-that-overflows@really-long-instance.example.com',
+        bio: '긴 한 줄 소개가 들어가서 컨테이너 폭을 넘기면 말줄임으로 잘려야 한다',
+      })}
     />
-    <ProfileListItem state="follow" name="최소 정보" handle="@user@kos.moe" />
+    <ProfileListItem
+      state="follow"
+      profile={profile({ displayName: '최소 정보', handle: 'user@kos.moe' })}
+    />
   </div>
 </Story>

--- a/apps/web/src/lib/components/ProfileListItem.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.svelte
@@ -1,27 +1,40 @@
 <script lang="ts">
+  import { graphql } from '$mearie';
+  import { createFragment } from '@mearie/svelte';
+  import { getProfileInitial } from '$lib/utils/profile';
   import type { HTMLAttributes } from 'svelte/elements';
+
+  import type { ProfileListItem_profile$key } from '$mearie';
 
   import Avatar from './Avatar.svelte';
 
   type ProfileListItemState = 'follow' | 'following';
 
   type ProfileListItemProps = HTMLAttributes<HTMLDivElement> & {
+    profile: ProfileListItem_profile$key;
     state?: ProfileListItemState;
-    name?: string;
-    handle?: string;
-    bio?: string;
     width?: 'compact' | 'wide';
   };
 
   let {
+    profile,
     state = 'follow',
-    name = '사용자 이름',
-    handle = '@handle@kos.mo',
-    bio = '',
     width = 'compact',
     class: className = '',
     ...rest
   }: ProfileListItemProps = $props();
+
+  const fragment = createFragment(
+    graphql(`
+      fragment ProfileListItem_profile on Profile {
+        id
+        displayName
+        handle
+        bio
+      }
+    `),
+    () => profile,
+  );
 
   const following = $derived(state === 'following');
   const buttonLabel = $derived(following ? '팔로잉' : '팔로우');
@@ -33,12 +46,12 @@
   data-state={state}
   class={`border-border bg-card flex min-h-16 items-center gap-3 border-b px-4 ${widthClass} ${className}`}
 >
-  <Avatar size="md" initials="K" />
+  <Avatar size="md" initials={getProfileInitial(fragment.data.displayName, fragment.data.handle)} />
   <div class="min-w-0 flex-1">
-    <p class="text-text-primary m-0 truncate text-sm font-bold">{name}</p>
-    <p class="text-text-secondary m-0 truncate text-xs">{handle}</p>
-    {#if bio}
-      <p class="text-text-primary m-0 mt-1 truncate text-xs">{bio}</p>
+    <p class="text-text-primary m-0 truncate text-sm font-bold">{fragment.data.displayName}</p>
+    <p class="text-text-secondary m-0 truncate text-xs">@{fragment.data.handle}</p>
+    {#if fragment.data.bio}
+      <p class="text-text-primary m-0 mt-1 truncate text-xs">{fragment.data.bio}</p>
     {/if}
   </div>
   <!-- 정적 팔로우 버튼 placeholder. 실제 FollowButton 연결은 PROD-156에서 처리한다. -->


### PR DESCRIPTION
## 무엇을 변경했는지

- `ProfileListItem`이 정적 스칼라 props(`name`/`handle`/`bio`) 대신 GraphQL `Profile` fragment를 소비하도록 전환했다.
  - Mearie fragment colocation 패턴으로 `ProfileListItem_profile` fragment(`id`, `displayName`, `handle`, `bio`)를 컴포넌트에 colocate.
  - prop 타입은 `$mearie`의 생성 타입 `ProfileListItem_profile$key`를 사용(`PostListItem`과 동일 패턴).
  - 아바타는 별도 이미지 필드가 없어 `getProfileInitial(displayName, handle)` 이니셜 폴백을 사용.
  - handle은 표시 계층에서 `@`를 붙여 렌더(`@{handle}`) — 기존 `ProfileHero`/`PostAuthorProfile`과 동일.
- 레이아웃 props(`width`)와 정적 팔로우 버튼 placeholder(`state`)는 그대로 유지(실제 `FollowButton` 연결은 PROD-156).
- Storybook story를 mock fragment ref(factory + cast)로 전환하고, 긴 표시 이름·긴 handle·bio 없음 등 layout edge case를 포함.

## 왜 변경했는지

- 검색 결과(PROD-154)와 향후 팔로워/팔로잉/추천 목록이 동일한 "프로필 목록 Item"으로 실제 `Profile` 데이터를 표시할 수 있어야 한다.
- 선행 작업(PROD-152, #127)이 정리한 Item 경계 위에, 실데이터 연결과 후속 팔로우/검색 연결이 붙기 쉬운 fragment 경계를 만든다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check` (svelte-kit sync + svelte-check) 통과: 0 errors / 0 warnings.
- `mearie generate`로 `ProfileListItem_profile$key` 타입 생성 확인.
- Storybook(`KOSMO/ProfileListItem`)에서 Playground / States / Edge cases로 긴 이름·긴 handle·bio 없음 상태의 truncate·표시를 시각 확인 가능(브라우저 확인은 리뷰어/작성자 직접).

## 아직 어떤 문제가 남았는지

- 팔로우 버튼은 정적 placeholder로 남아 있다. 실제 `FollowButton`(`...FollowButton_profile`) 연결은 **PROD-156**에서 처리.
- 검색 결과 화면에서 이 Item을 `profileByHandle` 결과와 연결하는 작업은 **PROD-154**에서 처리.
