### PR TITLE
홈 타임라인 상태 UI를 Storybook에서 확인하게 한다

### DIFF
--- a/apps/web/src/lib/components/PostList.stories.svelte
+++ b/apps/web/src/lib/components/PostList.stories.svelte
@@ -4,7 +4,7 @@
 
   import PostList from './PostList.svelte';
 
-  import type { PostList_profile$key } from '$mearie';
+  import type { PostList_homeTimeline$key, PostList_profile$key } from '$mearie';
 
   // Storybook은 .storybook/mocks/mearie-svelte.ts에서 createFragment를 패스스루로 모킹하므로
   // 여기서는 평범한 데이터 객체를 fragment ref 자리에 그대로 넘긴다.
@@ -45,6 +45,16 @@
       },
     }) as unknown as PostList_profile$key;
 
+  const homeTimeline = (...posts: ReturnType<typeof post>[]): PostList_homeTimeline$key =>
+    ({
+      __typename: 'HomeTimelineConnection',
+      edges: posts.map((node, index) => ({
+        __typename: 'HomeTimelineConnectionEdge',
+        cursor: `story-home-cursor-${index}`,
+        node,
+      })),
+    }) as unknown as PostList_homeTimeline$key;
+
   const longBody =
     '프로필 게시글 목록은 실제 query 결과의 TipTap 문서를 항목 렌더러에 전달합니다. ' +
     '긴 본문 접힘 처리는 PROD-138에서 다루며, 지금은 목록 컨테이너가 데이터를 그대로 전달합니다. '.repeat(
@@ -55,6 +65,12 @@
     post('short', '짧은 게시글 본문입니다.'),
     post('long', longBody, minutesAgo(90)),
     post('empty', null, minutesAgo(180)),
+  );
+
+  const multiplePostsHomeTimeline = homeTimeline(
+    post('home-own', '홈 타임라인에는 내가 쓴 글과 팔로우한 프로필의 글이 함께 표시됩니다.'),
+    post('home-followee', '팔로우한 프로필의 최근 글입니다.', minutesAgo(30)),
+    post('home-empty', null, minutesAgo(120)),
   );
 
   const { Story } = defineMeta({
@@ -81,5 +97,15 @@
     <PostList error onRetry={() => {}} />
     <PostList profile={profile()} />
     <PostList profile={multiplePostsProfile} />
+  </div>
+</Story>
+
+<!-- 홈 타임라인 영역의 상태 전체: 로딩 스켈레톤, 오류, 게시글 없음, 게시글 있음. -->
+<Story name="Home timeline states" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid w-[600px] gap-8">
+    <PostList loading />
+    <PostList error onRetry={() => {}} />
+    <PostList homeTimeline={homeTimeline()} />
+    <PostList homeTimeline={multiplePostsHomeTimeline} />
   </div>
 </Story>


### PR DESCRIPTION
## 무엇을 변경했는지

- `PostList` Storybook에 `homeTimeline` fragment mock을 추가했습니다.
- `Home timeline states` 스토리에서 로딩, 오류, 빈 상태, 게시글 있음 상태를 한 화면에서 확인할 수 있게 했습니다.
- 기존 `/home` 실제 데이터 연결과 `PostList` 공용 상태 UI는 유지했습니다.

## 왜 변경했는지

- PROD-150의 상태 UI는 #124(PROD-151)에서 `/home`과 `PostList` 통합으로 기능적으로 이미 충족된 상태였습니다.
- 다만 Storybook이 프로필 목록 상태만 명시적으로 보여주고 홈 타임라인 상태는 별도 확인 지점이 없어, 완료 기준을 더 명확히 만족하도록 보강했습니다.
- 따라서 이번 PR은 새 UI 로직을 추가하기보다 PROD-150 마감 근거를 Storybook에서 리뷰 가능하게 만드는 변경입니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `pnpm --filter @kosmo/web build-storybook`

## 아직 남은 문제

- 액션 바, 리액션, 이미지/링크 프리뷰는 PROD-150 제외 범위로 다루지 않았습니다.
- 실제 홈 타임라인 데이터 연결은 #124(PROD-151)에서 완료됐습니다.

Stack: main -> prod-150

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
