### PR TITLE
프로필 목록 Item에서 팔로우 액션을 사용할 수 있게 한다

### DIFF
--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -5,7 +5,7 @@
 
   import ProfileListItem from './ProfileListItem.svelte';
 
-  type FollowState = 'ACCEPTED' | 'PENDING' | 'REJECTED';
+  type FollowState = 'ACCEPTED' | 'PENDING';
 
   const viewerProfileId = 'viewer-profile';
 
@@ -74,16 +74,6 @@
         profile={profile({
           id: 'pending-profile',
           viewerFollow: { id: 'follow-pending', state: 'PENDING' },
-        })}
-        {viewerProfileId}
-      />
-    </section>
-    <section class="grid gap-1">
-      <p class="text-text-secondary m-0">거절 후 재요청 가능</p>
-      <ProfileListItem
-        profile={profile({
-          id: 'rejected-profile',
-          viewerFollow: { id: 'follow-rejected', state: 'REJECTED' },
         })}
         {viewerProfileId}
       />

--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -5,17 +5,28 @@
 
   import ProfileListItem from './ProfileListItem.svelte';
 
+  type FollowState = 'ACCEPTED' | 'PENDING' | 'REJECTED';
+
+  const viewerProfileId = 'viewer-profile';
+
   // 실제 Mearie fragment ref 대신 표시 필드만 담은 mock 객체를 캐스팅해 넘긴다.
   // (Storybook은 .storybook/mocks의 createFragment가 data getter로 그대로 돌려준다.)
   const profile = (
-    overrides: Partial<{ displayName: string; handle: string; bio: string | null }> = {},
+    overrides: Partial<{
+      id: string;
+      displayName: string;
+      handle: string;
+      bio: string | null;
+      viewerFollow: { id: string; state: FollowState } | null;
+    }> = {},
   ): ProfileListItem_profile$key =>
     ({
       __typename: 'Profile',
-      id: 'story-profile',
+      id: 'target-profile',
       displayName: '사용자 이름',
       handle: 'handle@kos.mo',
       bio: null,
+      viewerFollow: null,
       ...overrides,
     }) as unknown as ProfileListItem_profile$key;
 
@@ -24,10 +35,6 @@
     component: ProfileListItem,
     tags: ['autodocs'],
     argTypes: {
-      state: {
-        control: 'radio',
-        options: ['follow', 'following'],
-      },
       width: {
         control: 'radio',
         options: ['compact', 'wide'],
@@ -40,42 +47,78 @@
   name="Playground"
   args={{
     profile: profile(),
-    state: 'follow',
+    viewerProfileId,
     width: 'compact',
   }}
 />
 
 <Story name="States" asChild parameters={{ controls: { disable: true } }}>
-  <div class="grid gap-3">
-    <ProfileListItem state="follow" profile={profile()} />
-    <ProfileListItem state="following" profile={profile()} />
-    <ProfileListItem
-      state="follow"
-      width="wide"
-      profile={profile({ displayName: '코스모 사용자', handle: 'user@kos.moe' })}
-    />
-    <ProfileListItem
-      state="following"
-      width="wide"
-      profile={profile({ handle: 'user@kos.moe', bio: '한 줄 소개가 들어가는 자리' })}
-    />
+  <div class="grid gap-4 text-sm">
+    <section class="grid gap-1">
+      <p class="text-text-secondary m-0">팔로우 가능</p>
+      <ProfileListItem profile={profile({ id: 'followable-profile' })} {viewerProfileId} />
+    </section>
+    <section class="grid gap-1">
+      <p class="text-text-secondary m-0">팔로잉</p>
+      <ProfileListItem
+        profile={profile({
+          id: 'followed-profile',
+          viewerFollow: { id: 'follow-accepted', state: 'ACCEPTED' },
+        })}
+        {viewerProfileId}
+      />
+    </section>
+    <section class="grid gap-1">
+      <p class="text-text-secondary m-0">요청 중</p>
+      <ProfileListItem
+        profile={profile({
+          id: 'pending-profile',
+          viewerFollow: { id: 'follow-pending', state: 'PENDING' },
+        })}
+        {viewerProfileId}
+      />
+    </section>
+    <section class="grid gap-1">
+      <p class="text-text-secondary m-0">거절 후 재요청 가능</p>
+      <ProfileListItem
+        profile={profile({
+          id: 'rejected-profile',
+          viewerFollow: { id: 'follow-rejected', state: 'REJECTED' },
+        })}
+        {viewerProfileId}
+      />
+    </section>
+  </div>
+</Story>
+
+<Story name="Hidden action states" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid gap-4 text-sm">
+    <section class="grid gap-1">
+      <p class="text-text-secondary m-0">비로그인 공개 조회 또는 선택 프로필 없음</p>
+      <ProfileListItem profile={profile({ id: 'guest-profile' })} viewerProfileId={null} />
+    </section>
+    <section class="grid gap-1">
+      <p class="text-text-secondary m-0">본인 프로필</p>
+      <ProfileListItem profile={profile({ id: viewerProfileId })} {viewerProfileId} />
+    </section>
   </div>
 </Story>
 
 <Story name="Edge cases" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid gap-3">
     <ProfileListItem
-      state="follow"
       width="wide"
+      {viewerProfileId}
       profile={profile({
+        id: 'long-profile',
         displayName: '아주 긴 표시 이름이 들어가서 한 줄을 넘기면 잘려야 한다',
         handle: 'super-long-handle-that-overflows@really-long-instance.example.com',
         bio: '긴 한 줄 소개가 들어가서 컨테이너 폭을 넘기면 말줄임으로 잘려야 한다',
       })}
     />
     <ProfileListItem
-      state="follow"
-      profile={profile({ displayName: '최소 정보', handle: 'user@kos.moe' })}
+      {viewerProfileId}
+      profile={profile({ id: 'minimal-profile', displayName: '최소 정보', handle: 'user@kos.moe' })}
     />
   </div>
 </Story>

--- a/apps/web/src/lib/components/ProfileListItem.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.svelte
@@ -7,18 +7,17 @@
   import type { ProfileListItem_profile$key } from '$mearie';
 
   import Avatar from './Avatar.svelte';
-
-  type ProfileListItemState = 'follow' | 'following';
+  import FollowButton from './FollowButton.svelte';
 
   type ProfileListItemProps = HTMLAttributes<HTMLDivElement> & {
     profile: ProfileListItem_profile$key;
-    state?: ProfileListItemState;
+    viewerProfileId?: string | null;
     width?: 'compact' | 'wide';
   };
 
   let {
     profile,
-    state = 'follow',
+    viewerProfileId = null,
     width = 'compact',
     class: className = '',
     ...rest
@@ -31,19 +30,20 @@
         displayName
         handle
         bio
+        ...FollowButton_profile
       }
     `),
     () => profile,
   );
 
-  const following = $derived(state === 'following');
-  const buttonLabel = $derived(following ? '팔로잉' : '팔로우');
   const widthClass = $derived(width === 'wide' ? 'w-[390px]' : 'w-[358px]');
+  const showFollowButton = $derived(
+    Boolean(viewerProfileId && viewerProfileId !== fragment.data.id),
+  );
 </script>
 
 <div
   {...rest}
-  data-state={state}
   class={`border-border bg-card flex min-h-16 items-center gap-3 border-b px-4 ${widthClass} ${className}`}
 >
   <Avatar size="md" initials={getProfileInitial(fragment.data.displayName, fragment.data.handle)} />
@@ -54,11 +54,7 @@
       <p class="text-text-primary m-0 mt-1 truncate text-xs">{fragment.data.bio}</p>
     {/if}
   </div>
-  <!-- 정적 팔로우 버튼 placeholder. 실제 FollowButton 연결은 PROD-156에서 처리한다. -->
-  <button
-    class={`h-[27px] min-w-[58px] rounded-full px-3 text-xs font-bold ${following ? 'bg-surface text-text-primary' : 'bg-text-primary text-bg'}`}
-    type="button"
-  >
-    {buttonLabel}
-  </button>
+  {#if showFollowButton}
+    <FollowButton profile={fragment.data} {viewerProfileId} class="shrink-0" />
+  {/if}
 </div>

--- a/apps/web/src/lib/components/ProfileListItem.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { graphql } from '$mearie';
   import { createFragment } from '@mearie/svelte';
+  import { tv } from '$lib/tv';
   import { getProfileInitial } from '$lib/utils/profile';
   import type { HTMLAttributes } from 'svelte/elements';
 
@@ -9,19 +10,33 @@
   import Avatar from './Avatar.svelte';
   import FollowButton from './FollowButton.svelte';
 
-  type ProfileListItemProps = HTMLAttributes<HTMLDivElement> & {
+  type ProfileListItemProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
     profile: ProfileListItem_profile$key;
     viewerProfileId?: string | null;
     width?: 'compact' | 'wide';
+    class?: string | null;
   };
 
   let {
     profile,
     viewerProfileId = null,
     width = 'compact',
-    class: className = '',
+    class: className = null,
     ...rest
   }: ProfileListItemProps = $props();
+
+  const profileListItem = tv({
+    base: 'border-border bg-card flex min-h-16 items-center gap-3 border-b px-4',
+    variants: {
+      width: {
+        compact: 'w-[358px]',
+        wide: 'w-[390px]',
+      },
+    },
+    defaultVariants: {
+      width: 'compact',
+    },
+  });
 
   const fragment = createFragment(
     graphql(`
@@ -35,14 +50,9 @@
     `),
     () => profile,
   );
-
-  const widthClass = $derived(width === 'wide' ? 'w-[390px]' : 'w-[358px]');
 </script>
 
-<div
-  {...rest}
-  class={`border-border bg-card flex min-h-16 items-center gap-3 border-b px-4 ${widthClass} ${className}`}
->
+<div {...rest} class={profileListItem({ width, class: className })}>
   <Avatar size="md" initials={getProfileInitial(fragment.data.displayName, fragment.data.handle)} />
   <div class="min-w-0 flex-1">
     <p class="text-text-primary m-0 truncate text-sm font-bold">{fragment.data.displayName}</p>

--- a/apps/web/src/lib/components/ProfileListItem.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.svelte
@@ -37,9 +37,6 @@
   );
 
   const widthClass = $derived(width === 'wide' ? 'w-[390px]' : 'w-[358px]');
-  const showFollowButton = $derived(
-    Boolean(viewerProfileId && viewerProfileId !== fragment.data.id),
-  );
 </script>
 
 <div
@@ -54,7 +51,7 @@
       <p class="text-text-primary m-0 mt-1 truncate text-xs">{fragment.data.bio}</p>
     {/if}
   </div>
-  {#if showFollowButton}
+  {#if viewerProfileId}
     <FollowButton profile={fragment.data} {viewerProfileId} class="shrink-0" />
   {/if}
 </div>


### PR DESCRIPTION
## 무엇을 변경했는지

- `ProfileListItem`의 정적 팔로우 placeholder를 기존 `FollowButton` 연결로 교체했습니다.
- `ProfileListItem_profile` fragment에 `...FollowButton_profile`을 합성해 팔로우 상태와 mutation에 필요한 데이터를 같은 item 경계에서 소비하게 했습니다.
- `ProfileListItem`은 선택 프로필이 있을 때만 `FollowButton`을 렌더링하고, 본인 프로필 숨김은 기존 `FollowButton` 책임으로 유지했습니다.
- Storybook 상태를 실제 `viewerFollow` 값 기준으로 팔로우 가능/팔로잉/요청 중/숨김 상태를 확인할 수 있게 갱신했습니다.

## 왜 변경했는지

- 검색 결과와 향후 팔로워/팔로잉 목록에서 같은 프로필 목록 Item이 표시 정보와 팔로우 액션을 함께 처리해야 합니다.
- 팔로우 API와 mutation은 이미 `FollowButton`에 구현돼 있으므로, 목록 Item은 해당 경계를 재사용해 중복 mutation 구현 없이 액션을 연결합니다.
- 자기 자신 숨김 정책은 `FollowButton` 한 곳에 남겨 같은 버튼을 쓰는 프로필 헤더와 목록 Item의 동작이 갈라지지 않게 했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`

## 아직 어떤 문제가 남았는지

- 검색 결과 화면에서 이 Item을 실제 `profileByHandle` 결과와 연결하는 작업은 PROD-154에서 진행합니다.

Stack: main -> prod-156