### PR TITLE
Windows에서 drizzle-kit이 스키마 파일을 찾게 한다

### DIFF
--- a/packages/core/drizzle.config.ts
+++ b/packages/core/drizzle.config.ts
@@ -4,9 +4,14 @@ import { defineConfig } from 'drizzle-kit';
 
 const configDir = dirname(fileURLToPath(import.meta.url));
 
+// drizzle-kit feeds each schema path straight into `glob`, which treats `\` as an
+// escape character. On Windows `join` produces backslash paths, so the glob matches
+// nothing ("No schema files found"). Normalize to forward slashes to keep matching.
+const schemaPath = (...segments: string[]) => join(configDir, ...segments).replaceAll('\\', '/');
+
 export default defineConfig({
   dialect: 'postgresql',
-  schema: [join(configDir, 'db/tables.ts'), join(configDir, 'db/enums.ts')],
+  schema: [schemaPath('db/tables.ts'), schemaPath('db/enums.ts')],
   out: join(configDir, '../../drizzle'),
   dbCredentials: {
     url: process.env.DATABASE_URL!,


### PR DESCRIPTION
## 무엇을 변경했는지

- `packages/core/drizzle.config.ts`에서 스키마 경로를 forward slash로 정규화하는 `schemaPath()` 헬퍼를 추가하고, `schema` 배열이 이를 거치도록 변경했다.
- 동작 변화는 Windows에 한정된다. macOS/Linux에서는 바꿀 역슬래시가 없어 사실상 no-op이다.

## 왜 변경했는지

- Windows에서 `pnpm run drizzle:studio`(및 `drizzle:generate`, `drizzle:push`)가 스키마 파일이 실제로 존재함에도 `No schema files found`로 실패했다.
- 원인: drizzle-kit(`bin.cjs`)의 `prepareFilenames`는 각 스키마 경로를 그대로 `glob.sync()`에 넘긴다. 기존 config는 `path.join(...)`으로 경로를 만들어 Windows에서 역슬래시 경로(`C:\Users\...\db\tables.ts`)가 되는데, `glob`은 `\`를 이스케이프 문자로 해석하므로 어떤 파일과도 매칭되지 않았다.
- macOS/Linux는 `join`이 슬래시(`/`)를 생성해 정상 동작했기 때문에 그동안 드러나지 않았다.

## 어떻게 확인할 수 있는지

- 패치된 config로 `drizzle-kit export`(스키마만 읽고 DB 불필요)를 실행하면 모든 enum/table DDL이 정상 출력되고 종료 코드 0.
- 패치 전 동일 명령은 `No schema files found`로 실패함을 확인했다.
- `pnpm run drizzle:studio`는 Postgres와 infisical로 주입되는 `DATABASE_URL`이 떠 있는 환경에서 정상 기동된다(DB 연결 자체는 미검증).

## 아직 어떤 문제가 남았는지

- 없음.

---

Linear: PROD-171
