### PR TITLE
프로필 전환 후 팔로우 버튼 상태를 다시 동기화한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -202,6 +202,7 @@ input SelectProfileInput {
 
 type SelectProfilePayload {
   profile: Profile!
+  session: Session!
 }
 
 type Session implements Node {

--- a/apps/api/src/graphql/resolvers/profile/mutation/select.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/select.ts
@@ -11,6 +11,7 @@ import { NotFoundError } from '@kosmo/core/error';
 import { and, eq, getColumns } from 'drizzle-orm';
 import { z } from 'zod';
 import { builder } from '@/graphql/builder';
+import { Session } from '@/graphql/resolvers/session/ref';
 import { Profile } from '../ref';
 
 builder.mutationField('selectProfile', (t) =>
@@ -18,6 +19,7 @@ builder.mutationField('selectProfile', (t) =>
     type: builder.simpleObject('SelectProfilePayload', {
       fields: (field) => ({
         profile: field.field({ type: Profile }),
+        session: field.field({ type: Session }),
       }),
     }),
     input: {
@@ -45,7 +47,9 @@ builder.mutationField('selectProfile', (t) =>
         .returning()
         .then(firstOrThrow);
 
-      return { profile };
+      ctx.session.profileId = profile.id;
+
+      return { profile, session: ctx.session.id };
     },
   }),
 );

--- a/apps/web/src/lib/components/ProfileSwitcher.svelte
+++ b/apps/web/src/lib/components/ProfileSwitcher.svelte
@@ -53,6 +53,14 @@
           handle
           displayName
         }
+        session {
+          id
+          selectedProfile {
+            id
+            handle
+            displayName
+          }
+        }
       }
     }
   `);

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -34,6 +34,7 @@
         { __typename: 'Query', $field: 'currentSession' },
         { __typename: 'Query', $field: 'me' },
         { __typename: 'Query', $field: 'homeTimeline' },
+        { __typename: 'Profile', $field: 'viewerFollow' },
       );
   };
 

--- a/openspec/specs/profile/spec.md
+++ b/openspec/specs/profile/spec.md
@@ -124,6 +124,8 @@ API는 활성 프로필만 GraphQL profile object로 노출해야 한다(MUST).
 - **WHEN** 로그인한 계정이 자신과 연결된 활성 프로필 선택을 요청한다
 - **THEN** 시스템은 현재 세션의 active profile을 해당 프로필로 변경한다
 - **AND** mutation은 `SelectProfilePayload.profile`로 선택된 `Profile`을 반환한다
+- **AND** mutation은 `SelectProfilePayload.session`으로 현재 `Session`을 반환한다
+- **AND** 반환된 `Session.selectedProfile`은 선택된 프로필을 가리켜 클라이언트 캐시가 active profile 변경을 동기화할 수 있다
 
 #### Scenario: Select missing or inaccessible profile
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Replacement for accidentally squash-merged PR #146.
- Stack: `main -> prod-108 (#102) -> prod-109` 구조를 복구했습니다.
- `selectProfile`을 #102의 `SelectProfilePayload` Simple Object 흐름에 맞추고, 응답에 `profile`과 `session`을 함께 포함했습니다.
- `ProfileSwitcher`의 프로필 전환 mutation에서 `session.selectedProfile`을 함께 선택해 `currentSession.selectedProfile` 정규화 캐시가 갱신되게 했습니다.
- active profile 전환 후 `Profile.viewerFollow`를 invalidate해 `profileByHandle` 경로로 조회되지 않은 Profile의 우측 포스팅 레이아웃도 새 selected profile 기준으로 다시 조회되게 했습니다.
- OpenSpec `profile` 스펙의 active profile selection 시나리오를 새 응답 계약에 맞춰 갱신했습니다.

## 왜 변경했는지

- 같은 화면에 머문 상태에서 사이드바로 active profile을 바꾸면, follow 상태와 본인 여부가 이전 profile 기준 캐시에 남을 수 있었습니다.
- 서버 mutation 응답, 프론트 정규화 캐시, 명시적 invalidation 범위를 함께 맞춰 화면 상태와 실제 서버 상태가 어긋나지 않게 합니다.
- PR #102가 GraphQL mutation 오류 처리와 payload 스타일을 바꾸므로, PROD-109도 그 스타일 위에서 작은 동작 변경만 남기도록 정렬했습니다.

## 어떻게 확인할 수 있는지

- `CI=true pnpm install --frozen-lockfile`
- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --filter @kosmo/web check`
- `pnpm lint:eslint`
- `pnpm exec prettier --check apps/api/src/graphql/resolvers/profile/mutation/select.ts apps/web/src/lib/components/ProfileSwitcher.svelte 'apps/web/src/routes/(tabs)/+layout.svelte' apps/api/schema.graphql openspec/specs/profile/spec.md`
- `pnpm --filter @kosmo/api exec tsx -e "import(\"./src/graphql/schema.ts\").then(() => console.log(\"schema ok\"))"`
- `openspec validate --all`
- `git diff origin/prod-108...HEAD`

## 아직 어떤 문제가 남았는지

- 팔로워/팔로잉 목록의 active profile 전환 재동기화는 이 PR 범위 밖이며 `PROD-189`에서 별도로 처리합니다.