### PR TITLE
프로필 팔로우 수 표시 순서를 팔로잉→팔로워로 정정하는 스펙을 정한다

### DIFF
--- a/openspec/changes/fix-profile-follow-count-order/proposal.md
+++ b/openspec/changes/fix-profile-follow-count-order/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+현재 프로필 헤더(`ProfileHero`)와 사이드바(`SidebarNavigation`)의 팔로우 수가 의도와 반대 순서(`팔로워 → 팔로잉`)로 표시된다. 팔로워/팔로잉 목록 페이지를 추가하기 전에 표시 순서를 `팔로잉 → 팔로워`로 바로잡는다. (Linear PROD-178)
+
+## What Changes
+
+- 팔로우 수 표시 순서를 `팔로잉 → 팔로워`로 정정한다(`ProfileHero`, `SidebarNavigation` 모두).
+- 카운트 값과 라벨이 어긋나지 않도록(팔로잉=followingCount, 팔로워=followersCount) 맞춘다.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `web-app-shell`: 프로필 기본 정보 표시의 팔로우 수 순서를 `팔로잉 → 팔로워`로 수정한다(MODIFIED `Profile basic information display`).
+
+## Impact
+
+- `apps/web/src/lib/components/ProfileHero.svelte` — 카운트 표시 순서 정정
+- `apps/web/src/lib/components/SidebarNavigation.svelte` — 카운트 표시 순서 정정
+- GraphQL fragment/스키마, API 영향 없음(`followersCount`·`followingCount`는 이미 조회 중)
+
+## Out of Scope
+
+- 팔로잉/팔로워 수에서 목록 라우트로 가는 진입점 링크 연결 — 별도 변경(목록 라우트 골격이 머지된 뒤 진행)
+- 팔로잉/팔로워 목록 페이지(라우트·상태 UI·데이터 연결) 구현 — PROD-179/180/184/185
+- ActivityPub followers/following collection 연동
+- `SidebarNavigation` 기존 raw hex 색상의 디자인 토큰 마이그레이션

--- a/openspec/changes/fix-profile-follow-count-order/specs/web-app-shell/spec.md
+++ b/openspec/changes/fix-profile-follow-count-order/specs/web-app-shell/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Profile basic information display
+
+프로필 페이지는 조회된 프로필의 기본 정보를 표시해야 한다(MUST). 표시 항목은 커버 영역, 아바타, 표시 이름, 핸들, bio, 팔로잉/팔로워 수이며, 팔로우 수는 `팔로잉 → 팔로워` 순서로 표시해야 한다(MUST). 색·반경은 시맨틱 디자인 토큰을 사용해 라이트/다크에 대응해야 한다(MUST).
+
+#### Scenario: Display loaded profile
+
+- **WHEN** 핸들로 조회한 활성 프로필이 있다
+- **THEN** 시스템은 커버 밴드, 아바타, 표시 이름, `@handle`, bio(있을 때), 팔로잉/팔로워 수를 표시한다
+- **AND** 팔로우 수는 팔로잉을 먼저, 팔로워를 나중에 표시한다
+
+#### Scenario: Avatar initial fallback
+
+- **WHEN** 프로필에 아바타 이미지가 없다(스키마 미보유)
+- **THEN** 시스템은 표시 이름(없으면 핸들)의 첫 글자를 대문자로 한 이니셜 아바타를 표시한다
+
+#### Scenario: Compact follow counts
+
+- **WHEN** 팔로워 또는 팔로잉 수를 표시한다
+- **THEN** 시스템은 1000 이상의 값을 compact 표기(예: `1.2k`)로 보여준다

--- a/openspec/changes/fix-profile-follow-count-order/tasks.md
+++ b/openspec/changes/fix-profile-follow-count-order/tasks.md
@@ -1,0 +1,10 @@
+## 1. 표시 순서 정정
+
+- [ ] 1.1 `ProfileHero.svelte`의 팔로우 수를 `팔로잉 → 팔로워` 순서로 바꾼다
+- [ ] 1.2 `SidebarNavigation.svelte`의 활성 프로필 팔로우 수를 `팔로잉 → 팔로워` 순서로 바꾼다
+- [ ] 1.3 두 컴포넌트 모두 카운트 값과 라벨이 어긋나지 않게(팔로잉=followingCount, 팔로워=followersCount) 확인한다
+
+## 2. 검증
+
+- [ ] 2.1 `pnpm -F @kosmo/web check`와 prettier를 통과시킨다
+- [ ] 2.2 프로필 페이지에서 순서가 `팔로잉 → 팔로워`인지 헤더·사이드바 모두 확인한다(시각 확인은 사용자)


### PR DESCRIPTION
## 무엇을 변경했는지

- OpenSpec change `fix-profile-follow-count-order`(capability `web-app-shell`)를 추가했다.
  - **MODIFIED `Profile basic information display`**: 프로필 기본 정보 표시의 팔로우 수 순서를 `팔로잉 → 팔로워`로 정정.
- 메인 스펙(`openspec/specs/`)은 아직 수정하지 않았다. 델타는 `openspec/changes/`에만 두고, 구현 PR(#149)에서 archive할 때 반영한다.

## 왜 변경했는지

- 현재 헤더/사이드바의 팔로우 수가 의도와 반대 순서(`팔로워 → 팔로잉`)로 보인다.
- 팔로워/팔로잉 목록 페이지를 추가하기 전에 표시 순서를 먼저 바로잡기 위함. (Linear PROD-178)

## 범위 변경 (리뷰 반영)

- 당초 이 스펙에 함께 있던 **목록 진입점 링크(`Follow count entry-point links`)는 분리**했다. 링크 대상 라우트(`/@{handle}/following`·`/@{handle}/followers`)가 더 위 스택에서 생기므로, 링크를 라우트보다 먼저 머지하면 동작하지 않는 링크를 머지하게 되기 때문(#148 리뷰 지적).
- 진입점 링크는 라우트 골격(#154 `prod-180`) 위 별도 스택으로 옮겼다 → 스펙 #159, 구현 #161 (Linear PROD-217).

## 어떻게 확인할 수 있는지

- `openspec validate fix-profile-follow-count-order --strict` → `valid`
- `prettier --check` (변경 md) 통과
- 실제 컴포넌트 동작은 구현 PR(#149)에서 검증.

## 스택

- 스펙 단독 PR. 구현(컴포넌트 순서 정정 + change archive)은 #149(`prod-178`, base `prod-178-spec`).
