### PR TITLE
게시글 목록과 상세의 본문 렌더 경로를 일치시킨다

### DIFF
--- a/apps/web/src/lib/components/PostBody.stories.svelte
+++ b/apps/web/src/lib/components/PostBody.stories.svelte
@@ -6,6 +6,8 @@
 
   import type { PostBody_post$key } from '$mearie';
 
+  import { makePost, postBodyCases } from '$lib/stories/postFixtures';
+
   // Storybook은 .storybook/mocks/mearie-svelte.ts에서 createFragment를 패스스루로 모킹하므로
   // 여기서는 평범한 데이터 객체를 fragment ref 자리에 그대로 넘긴다.
   const post = (bodyText: string | null): PostBody_post$key =>
@@ -45,5 +47,20 @@
       )}
     />
     <PostBody post={post(null)} />
+  </div>
+</Story>
+
+<!-- 본문 강조 크기. 같은 공유 fixture를 목록(md 16px)·상세(lg 20px)로 렌더해 의도된 크기 차이만 -->
+<!-- 다르고 나머지 규칙은 같음을 확인한다(PROD-173). -->
+<Story name="Size (목록 md / 상세 lg)" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid w-[600px] gap-8">
+    <div>
+      <div class="text-text-secondary text-xsm mb-1">목록 md (16px)</div>
+      <PostBody post={makePost(postBodyCases[1]) as unknown as PostBody_post$key} size="md" />
+    </div>
+    <div>
+      <div class="text-text-secondary text-xsm mb-1">상세 lg (20px)</div>
+      <PostBody post={makePost(postBodyCases[1]) as unknown as PostBody_post$key} size="lg" />
+    </div>
   </div>
 </Story>

--- a/apps/web/src/lib/components/PostBody.svelte
+++ b/apps/web/src/lib/components/PostBody.svelte
@@ -10,11 +10,16 @@
   // 게시글 본문(TipTap 문서)을 리치 렌더하는 프래그먼트 컴포넌트.
   // 작성자 영역·작성 시각·공개 범위 같은 정보는 PostLayout(상세)·PostListItem(목록)이
   // 담당하므로 여기에는 포함하지 않는다. 본문은 feed·detail 양쪽에서 이 컴포넌트로 통일한다.
-  type Props = HTMLAttributes<HTMLDivElement> & {
+  // size만 의도된 차이(목록 md / 상세 lg)이고, 렌더 규칙은 공유 TipTapRenderer로 동일하다.
+  type Props = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
     post: PostBody_post$key;
+    // 본문 강조 크기. 목록=md / 상세=lg. TipTapRenderer로 그대로 전달한다.
+    size?: 'md' | 'lg';
+    // tailwind-merge가 ClassValue를 받지 못하므로 문자열로 좁힌다.
+    class?: string | null;
   };
 
-  let { post, class: className, ...attributes }: Props = $props();
+  let { post, size = 'md', class: className, ...attributes }: Props = $props();
 
   const postFragment = createFragment(
     graphql(`
@@ -44,5 +49,5 @@
 </script>
 
 {#if document}
-  <TipTapRenderer {...attributes} class={className} {document} />
+  <TipTapRenderer {...attributes} class={className} {size} {document} />
 {/if}

--- a/apps/web/src/lib/components/PostLayout.svelte
+++ b/apps/web/src/lib/components/PostLayout.svelte
@@ -105,7 +105,7 @@
 
   <!-- 본문 + 정보(작성 시각 · 공개 범위). 이후 미디어·투표·액션바가 형제로 쌓인다. -->
   <div class={slots.body()}>
-    <PostBody post={postFragment.data} />
+    <PostBody post={postFragment.data} size="lg" />
     <div class={slots.meta()}>
       <time datetime={postFragment.data.createdAt as string}>{formattedCreatedAt}</time>
       <span aria-hidden="true">·</span>

--- a/apps/web/src/lib/components/PostListItem.svelte
+++ b/apps/web/src/lib/components/PostListItem.svelte
@@ -7,20 +7,29 @@
 
   import type { PostListItem_post$key } from '$mearie';
 
+  import { tv } from '$lib/tv';
   import { getProfileInitial } from '$lib/utils/profile';
 
   import Avatar from './Avatar.svelte';
   import PostBody from './PostBody.svelte';
   import ProfileNameBlock from './ProfileNameBlock.svelte';
 
-  // 게시글 목록 항목(Figma PostCard 67:206). 목록 표현(시간은 헤더 우측 상대시간,
-  // 카드 전체가 상세로 이동)은 이 컴포넌트가 자체 소유한다. 본문은 PostBody로 위임한다.
-  // 카드 전체는 overlay 링크로 상세로 이동한다(아바타·이름은 현재 링크가 아니다).
-  // TODO(PROD-174): feed 작성 시각 소유·레이아웃을 PostLayout처럼 정식화하고,
-  //   PostLayout과 거터·헤더 grid 중복 및 overlay·pointer-events 클릭 모델을 재설계한다
-  //   (아바타·이름 → 프로필 링크 분기 포함).
-  type Props = HTMLAttributes<HTMLElement> & {
+  // 게시글 목록 항목(feed). 본문 배치는 상세 PostLayout과 같은 2×2 grid 골격을 따른다:
+  //
+  //   ┌───────────┬──────────────────────────────┐
+  //   │  Avatar   │  ProfileNameBlock · 상대시각  │  (header)
+  //   ├───────────┼──────────────────────────────┤
+  //   │ ThreadLine│  PostBody                     │  (body)
+  //   └───────────┴──────────────────────────────┘
+  //
+  // PostLayout과 골격을 일치시키되 두 컴포넌트는 별도로 유지한다(목록/상세가 이후 갈릴 수 있음).
+  // feed 고유: 작성 시각은 헤더 우측 상대시간, 본문은 md(상세는 lg), 카드 전체가 overlay 링크로 상세 이동.
+  // TODO(PROD-174): overlay+pointer-events 클릭 모델 재설계, 아바타·이름→프로필 링크 분기,
+  //   feed 시각 소유·책임 모델을 PostLayout과 더 일관되게 정리한다.
+  type Props = Omit<HTMLAttributes<HTMLElement>, 'class'> & {
     post: PostListItem_post$key;
+    // tailwind-merge가 ClassValue를 받지 못하므로 문자열로 좁힌다.
+    class?: string | null;
   };
 
   let { post, class: className, ...attributes }: Props = $props();
@@ -51,38 +60,54 @@
   const initials = $derived(
     getProfileInitial(postFragment.data.profile.displayName, postFragment.data.profile.handle),
   );
+
+  const postListItem = tv({
+    slots: {
+      // feed 카드. overlay 링크가 카드 전체를 상세로 연결한다.
+      card: 'border-border relative border-b px-2 pt-2 pb-4',
+      // 카드 전체를 덮는 overlay 링크. 콘텐츠는 pointer-events-none로 클릭을 여기로 통과시킨다.
+      overlay:
+        'focus-visible:outline-more absolute inset-0 z-0 rounded-md focus-visible:outline-2 focus-visible:outline-offset-2',
+      // PostLayout과 동일한 2열(거터 auto / 콘텐츠 1fr) × 2행 grid. 자동 배치: 아바타 → 헤더 → 스레드 → 본문.
+      // gap-x-3(12px): 거터↔콘텐츠. gap-y-1(4px): 헤더↔본문.
+      grid: 'pointer-events-none relative z-10 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1',
+      avatar: 'self-start',
+      header: 'flex min-w-0 items-start justify-between gap-2',
+      // 거터 col(아바타 폭)을 행 전체 높이로 차지해 이후 스레드 라인 자리를 예약한다(PostLayout 패리티).
+      // feed 아바타는 lg(48px)이므로 거터 폭도 w-12로 맞춘다.
+      thread: 'w-12 self-stretch',
+      body: 'min-w-0',
+      time: 'text-text-secondary shrink-0 text-sm',
+    },
+  });
+
+  const slots = postListItem();
 </script>
 
-<article
-  {...attributes}
-  class={`border-border relative border-b px-2 pt-2 pb-4 ${className ?? ''}`}
->
-  <a
-    class="focus-visible:outline-more absolute inset-0 z-0 rounded-md focus-visible:outline-2 focus-visible:outline-offset-2"
-    href={detailHref}
-  >
+<article {...attributes} class={slots.card({ class: className })}>
+  <a class={slots.overlay()} href={detailHref}>
     <span class="sr-only">@{postFragment.data.profile.handle}의 게시글 상세 보기</span>
   </a>
 
-  <!-- 카드 본문은 overlay 링크 위에 있으나 pointer-events-none으로 클릭을 overlay(상세)로
-       통과시킨다. 아바타·이름 → 프로필 링크 분기는 PROD-174에서 다룬다. -->
-  <div class="pointer-events-none relative z-10 flex items-start gap-3">
-    <div class="shrink-0">
+  <!-- 콘텐츠 grid는 overlay 링크 위(z-10)에 있으나 pointer-events-none으로 클릭을 overlay(상세)로
+       통과시킨다. 아바타·이름 → 프로필 링크 분기와 클릭 모델 재설계는 PROD-174에서 다룬다. -->
+  <div class={slots.grid()}>
+    <div class={slots.avatar()}>
       <Avatar size="lg" {initials} />
     </div>
 
-    <div class="flex min-w-0 flex-1 flex-col gap-1">
-      <div class="flex items-start justify-between gap-2">
-        <ProfileNameBlock profile={postFragment.data.profile} />
-        <time
-          class="text-text-secondary shrink-0 text-sm"
-          datetime={postFragment.data.createdAt as string}
-        >
-          {formattedCreatedAt}
-        </time>
-      </div>
+    <div class={slots.header()}>
+      <ProfileNameBlock profile={postFragment.data.profile} />
+      <time class={slots.time()} datetime={postFragment.data.createdAt as string}>
+        {formattedCreatedAt}
+      </time>
+    </div>
 
-      <PostBody post={postFragment.data} />
+    <!-- 스레드 라인 예약 셀(PostLayout 패리티; 추후 스레드 연결선 자리). -->
+    <div class={slots.thread()} aria-hidden="true"></div>
+
+    <div class={slots.body()}>
+      <PostBody post={postFragment.data} size="md" />
     </div>
   </div>
 </article>

--- a/apps/web/src/lib/components/PostRenderParity.stories.svelte
+++ b/apps/web/src/lib/components/PostRenderParity.stories.svelte
@@ -1,0 +1,48 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import PostLayout from './PostLayout.svelte';
+  import PostListItem from './PostListItem.svelte';
+
+  import type { PostLayout_post$key, PostListItem_post$key } from '$mearie';
+
+  import { makePost, postBodyCases } from '$lib/stories/postFixtures';
+
+  // 목록(PostListItem)·상세(PostLayout)를 같은 fixture로 나란히 렌더해 본문 렌더 규칙이 일치하는지
+  // (문단 간격·빈 문단·긴 단어 wrapping·빈 본문 비렌더) 회귀 비교한다. 의도된 차이는 본문 크기
+  // (목록 md 16px / 상세 lg 20px), 아바타(48/40), 작성 시각 위치(헤더 우측 / 본문 아래)뿐이다(PROD-173).
+  // Storybook이 createFragment를 passthrough로 모킹하므로 superset 객체를 각 fragment ref로 캐스팅한다.
+  const asListItem = (index: number) =>
+    makePost(postBodyCases[index], {
+      id: `parity-list-${index}`,
+    }) as unknown as PostListItem_post$key;
+  const asLayout = (index: number) =>
+    makePost(postBodyCases[index], {
+      id: `parity-detail-${index}`,
+    }) as unknown as PostLayout_post$key;
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/Post/List vs Detail 패리티',
+    component: PostListItem,
+  });
+</script>
+
+<!-- 같은 본문 문서를 목록·상세 컨테이너에 나란히 렌더한다. 본문 규칙(문단 간격·빈 문단·긴 단어
+     wrapping·빈 본문)은 좌우가 같아야 하고, 의도된 차이(본문 크기 md/lg·아바타·시각 위치)만 남는다. -->
+<Story name="본문 렌더 패리티" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid grid-cols-[390px_600px] items-start gap-x-8 gap-y-8">
+    <div class="text-text-secondary text-sm font-bold">목록(feed · 본문 md 16px)</div>
+    <div class="text-text-secondary text-sm font-bold">상세(detail · 본문 lg 20px)</div>
+
+    {#each postBodyCases as bodyCase, index (bodyCase.label)}
+      <div class="self-start">
+        <div class="text-text-secondary text-xsm mb-1">{bodyCase.label}</div>
+        <PostListItem post={asListItem(index)} />
+      </div>
+      <div class="self-start px-4 py-4">
+        <div class="text-text-secondary text-xsm mb-1">{bodyCase.label}</div>
+        <PostLayout post={asLayout(index)} />
+      </div>
+    {/each}
+  </div>
+</Story>

--- a/apps/web/src/lib/components/TipTapRenderer.svelte
+++ b/apps/web/src/lib/components/TipTapRenderer.svelte
@@ -5,11 +5,28 @@
   import type { TipTapDocument } from '@kosmo/core/tiptap';
   import type { HTMLAttributes } from 'svelte/elements';
 
-  type Props = HTMLAttributes<HTMLDivElement> & {
+  import { tv } from '$lib/tv';
+
+  // 본문 강조 크기. 목록(feed)=md(16px) / 상세(detail)=lg(20px). Figma 의도(상세 anchor 본문 강조, PROD-173).
+  // 폰트 크기·줄간격은 Foundation 토큰 유틸리티(text-md/text-lg)를 외곽 wrapper에 적용해 .tiptap-renderer가
+  // 상속한다. 문단 간격·공백 처리 등 그 외 렌더 규칙은 size와 무관하게 공통이다.
+  type Props = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
     document: TipTapDocument;
+    size?: 'md' | 'lg';
+    // tailwind-merge가 ClassValue(숫자·딕셔너리)를 받지 못하므로 문자열로 좁힌다.
+    class?: string | null;
   };
 
-  let { document, class: className, ...attributes }: Props = $props();
+  let { document, size = 'md', class: className, ...attributes }: Props = $props();
+
+  const renderer = tv({
+    variants: {
+      size: {
+        md: 'text-md',
+        lg: 'text-lg',
+      },
+    },
+  });
 
   let editor = $state<Editor | null>(null);
   let editorHost: HTMLDivElement;
@@ -39,16 +56,15 @@
   });
 </script>
 
-<div {...attributes} class={className}>
+<div {...attributes} class={renderer({ size, class: className })}>
   <div bind:this={editorHost}></div>
 </div>
 
 <style>
+  /* 폰트 크기·줄간격은 외곽 wrapper의 text-md/text-lg에서 상속한다(size 변형). */
   :global(.tiptap-renderer) {
     color: var(--color-text-primary);
     font-family: var(--font-body);
-    font-size: var(--text-md);
-    line-height: var(--text-md--line-height);
     white-space: pre-wrap;
     overflow-wrap: anywhere !important;
     outline: none;

--- a/apps/web/src/lib/stories/postFixtures.ts
+++ b/apps/web/src/lib/stories/postFixtures.ts
@@ -1,0 +1,100 @@
+import { createTipTapDocumentFromPlainText } from '@kosmo/core/tiptap';
+import type { TipTapDocument } from '@kosmo/core/tiptap';
+
+// 게시글 본문 회귀 fixture. 목록(PostListItem)·상세(PostLayout)·본문(PostBody) 스토리가 같은 TipTap
+// 문서를 공유해, 본문 렌더 규칙(문단 간격·빈 문단·긴 단어 wrapping·빈 본문 비렌더)을 한 곳에서 검증한다.
+// size 강조(목록 md / 상세 lg)만 의도된 차이로 남는다(PROD-173).
+//
+// makePost가 만드는 객체는 PostListItem_post · PostLayout_post · PostBody_post fragment를 모두 만족하는
+// superset Post shape다. Storybook이 createFragment를 passthrough로 모킹하므로
+// (.storybook/mocks/mearie-svelte.ts) 각 스토리에서 `as unknown as <Fragment>$key`로 캐스팅해 넘긴다.
+
+export type PostBodyCase = {
+  label: string;
+  bodyText: string | null;
+  bodyJson: TipTapDocument | null;
+};
+
+const fromPlainText = (label: string, bodyText: string): PostBodyCase => ({
+  label,
+  bodyText,
+  bodyJson: createTipTapDocumentFromPlainText(bodyText),
+});
+
+const longWord = '긴단어가포함된본문도부모너비를넘지않고줄바꿈되어야합니다'.repeat(3);
+
+// 공유 규칙을 자극하는 정전(canonical) 케이스. 목록·상세가 동일하게 렌더해야 한다.
+export const postBodyCases: PostBodyCase[] = [
+  fromPlainText('짧은 한 줄', '짧은 본문 한 줄.'),
+  fromPlainText(
+    '여러 문단',
+    '본문이 들어가는 자리예요. 내용이 길어지면 여러 줄로 늘어납니다.\n줄바꿈도 문단으로 보존됩니다.\n\n문단 사이 빈 줄도 유지됩니다.',
+  ),
+  {
+    label: '선·후행 빈 문단',
+    bodyText: '앞뒤로 빈 문단이 있어도 본문 규칙이 같아야 합니다.',
+    bodyJson: {
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: '앞뒤로 빈 문단이 있어도 본문 규칙이 같아야 합니다.' }],
+        },
+        { type: 'paragraph' },
+      ],
+    },
+  },
+  {
+    label: '긴 단어 wrapping',
+    bodyText: longWord,
+    bodyJson: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: longWord }] }],
+    },
+  },
+  { label: '빈 본문(렌더 안 함)', bodyText: null, bodyJson: null },
+];
+
+type PostOverrides = {
+  id?: string;
+  createdAt?: string;
+  visibility?: 'PUBLIC' | 'UNLISTED' | 'FOLLOWERS' | 'DIRECT';
+  displayName?: string;
+  handle?: string;
+};
+
+const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+
+// PostListItem_post · PostLayout_post · PostBody_post를 모두 만족하는 superset Post 객체를 만든다.
+export const makePost = (body: PostBodyCase, overrides: PostOverrides = {}) => {
+  const {
+    id = 'story-post',
+    createdAt = minutesAgo(5),
+    visibility = 'PUBLIC',
+    displayName = '코스모 작가',
+    handle = 'kosmo',
+  } = overrides;
+
+  return {
+    __typename: 'Post',
+    id,
+    createdAt,
+    visibility,
+    profile: {
+      __typename: 'Profile',
+      id: `${id}-profile`,
+      handle,
+      displayName,
+    },
+    content:
+      body.bodyJson === null
+        ? null
+        : {
+            __typename: 'PostContent',
+            id: `${id}-content`,
+            bodyJson: body.bodyJson,
+            bodyText: body.bodyText,
+          },
+  };
+};

--- a/apps/web/src/lib/tv.ts
+++ b/apps/web/src/lib/tv.ts
@@ -8,7 +8,7 @@ export const tv = createTV({
   twMergeConfig: {
     extend: {
       theme: {
-        text: ['xsm', 'md'],
+        text: ['xsm', 'md', 'lg'],
         color: [
           'bg',
           'surface',

--- a/apps/web/src/routes/layout.css
+++ b/apps/web/src/routes/layout.css
@@ -19,11 +19,14 @@
   --radius-lg: 16px;
   --radius-xl: 24px;
   /* Foundation font/size 토큰. sm(14)은 Tailwind text-sm과 동일해 생략.
-     lg(20)·xl(24)은 Tailwind 기본(text-lg 18, text-xl 20) 사용처 정리와 함께 후속에서 추가한다. */
+     lg(20)은 게시글 상세 본문 강조에 쓰며 Figma font/size/lg와 일치한다(PROD-173).
+     xl(24)은 Tailwind 기본(text-xl 20) 사용처 정리와 함께 후속에서 추가한다. */
   --text-xsm: 12px;
   --text-xsm--line-height: 16px;
   --text-md: 16px;
   --text-md--line-height: 24px;
+  --text-lg: 20px;
+  --text-lg--line-height: 30px;
   /* 폰트 패밀리. font-sans(UI 기본)=SUIT, font-body(본문)=Pretendard.
      루트 레이아웃이 font-sans를 쓰므로 모든 UI 텍스트가 SUIT를 상속한다. */
   --font-sans:


### PR DESCRIPTION
## 무엇을 변경했는지

- **공유 본문 렌더러에 size 변형 도입.** `PostBody`·`TipTapRenderer`에 `size`(`md`|`lg`) prop을 추가하고, `layout.css @theme`에 `--text-lg`(20px)·`--text-lg--line-height`(30px) Foundation 토큰을 추가했습니다(`$lib/tv.ts` 등록 목록 동기화). 상세(`PostLayout`)는 본문을 `lg`(20px), 목록(`PostListItem`)은 `md`(16px)로 렌더합니다. 폰트 크기·줄간격만 외곽 wrapper의 `text-md`/`text-lg`로 분기하고, 문단 간격·빈 문단·공백 처리·긴 단어 wrapping 등 렌더 규칙은 `.tiptap-renderer` 전역 CSS로 그대로 공유합니다.
- **목록 골격을 상세와 일치.** `PostListItem`을 상세 `PostLayout`과 같은 2×2 grid 골격(아바타 거터 + 헤더 + thread 예약 셀 + 본문=`PostBody`)으로 재구현했습니다. feed 작성 시각(상대시간)은 헤더 우측 슬롯으로 정식화했고, 카드 `<article>` + overlay 링크 래퍼는 유지했습니다. 두 컴포넌트는 **별도로 유지**합니다(이후 목록/상세 골격이 갈릴 수 있어 공유 컴포넌트로 합치지 않음).
- **회귀 가드.** 목록·상세를 같은 fixture로 나란히 렌더하는 `PostRenderParity.stories.svelte`와 공유 fixture(`$lib/stories/postFixtures.ts`)를 추가하고, `PostBody` 스토리에 md/lg 비교를 추가했습니다.

## 왜 변경했는지

리뷰에서 같은 게시글 본문이 목록과 상세에서 다르게 렌더된다는 문제가 제기됐습니다(PROD-173). PR #130(PROD-163) 이후 본문 렌더 경로(`PostBody` → `TipTapRenderer`)는 이미 공유됐지만, 재조사 결과 (1) Figma가 의도한 상세 본문 강조(anchor 20px)가 코드에선 미구현(목록·상세 둘 다 16px)이었고, (2) 바깥 레이아웃이 상세=grid / 목록=flex로 분기돼 거터·헤더·본문 배치가 중복돼 있었습니다. 본문 렌더 규칙은 공유하면서 의도된 차이(상세 본문 강조)만 size 변형으로 명시하고, 목록·상세가 같은 골격으로 본문을 배치하도록 일치시켰습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check` → svelte-check **0 errors / 0 warnings**.
- `pnpm lint:eslint`(max-warnings 0) 통과, 변경 파일 prettier 정리 완료.
- `pnpm --filter @kosmo/web storybook` → `KOSMO/Post/List vs Detail 패리티` 스토리에서 목록(md 16px)·상세(lg 20px)를 같은 fixture로 비교: 본문 규칙(문단 간격·빈 문단·긴 단어 wrapping·빈 본문 비렌더)은 동일하고, 본문 크기·아바타(48/40)·작성 시각 위치(헤더 / 본문 아래)만 의도된 차이로 남습니다. 시각 확인은 로컬 Storybook에서.

## 아직 어떤 문제가 남았는지

- feed 카드 **클릭 모델 재설계**(overlay+`pointer-events` → stretched-link/명시 링크), 아바타·이름 → 프로필 링크 분기, robin-maki의 `PostListItem` 코멘트는 **PROD-174**로 남겼습니다(이번엔 골격만 일치시키고 클릭 모델은 그대로).
- 목록 본문 미리보기 자르기(truncate) 정책은 **PROD-165** 범위입니다.
- `--text-xl`(24px) 토큰과 이름 블록 크기 강조(Figma feed 이름 20px)는 본 PR 범위 밖입니다.
