### PR TITLE
팔로워 목록 라우트 골격과 공유 상태 컴포넌트를 추가한다

### DIFF
--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -1,0 +1,37 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import ProfileConnectionList from './ProfileConnectionList.svelte';
+
+  const { Story } = defineMeta({
+    title: 'KOSMO/ProfileConnectionList',
+    component: ProfileConnectionList,
+    tags: ['autodocs'],
+    argTypes: {
+      kind: {
+        control: 'radio',
+        options: ['followers', 'following'],
+      },
+    },
+  });
+</script>
+
+<Story name="Playground" args={{ kind: 'followers', loading: false, error: false }} />
+
+<!-- 팔로워 목록 영역의 상태 전체: 로딩, 오류, 빈 상태. 항목 목록은 PROD-184/185에서 연결한다. -->
+<Story name="Followers states" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid w-[600px] gap-8">
+    <ProfileConnectionList kind="followers" loading />
+    <ProfileConnectionList kind="followers" error onRetry={() => {}} />
+    <ProfileConnectionList kind="followers" />
+  </div>
+</Story>
+
+<!-- 팔로잉 목록 영역의 상태 전체: 로딩, 오류, 빈 상태. 팔로워와 같은 구조를 공유한다. -->
+<Story name="Following states" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid w-[600px] gap-8">
+    <ProfileConnectionList kind="following" loading />
+    <ProfileConnectionList kind="following" error onRetry={() => {}} />
+    <ProfileConnectionList kind="following" />
+  </div>
+</Story>

--- a/apps/web/src/lib/components/ProfileConnectionList.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  import TextSkeleton from './TextSkeleton.svelte';
+
+  // 프로필 팔로워/팔로잉 목록 영역. 게시글 목록(PostList)과 같은 상태(로딩/오류/빈) 표현·접근성 패턴을 따른다.
+  // 팔로워/팔로잉은 같은 컴포넌트를 `kind`로 분기해 시각/상태 구조를 일치시킨다.
+  // 실제 connection 데이터 연결은 후속(PROD-184/185)에서 fragment prop과 항목 목록 분기를 추가한다.
+  // 데이터 연결 전에는 항목이 없어 기본적으로 빈 상태를 표시한다.
+  type ConnectionKind = 'followers' | 'following';
+
+  type Props = HTMLAttributes<HTMLElement> & {
+    kind: ConnectionKind;
+    loading?: boolean;
+    error?: boolean;
+    onRetry?: () => void;
+  };
+
+  let {
+    kind,
+    loading = false,
+    error = false,
+    onRetry,
+    class: className,
+    ...attributes
+  }: Props = $props();
+
+  // 목록 종류별 표시 문구를 컴포넌트 안에 모아 두 라우트가 같은 카피를 공유하게 한다.
+  const copy: Record<
+    ConnectionKind,
+    {
+      title: string;
+      emptyTitle: string;
+      emptyDescription: string;
+      errorTitle: string;
+      loadingLabel: string;
+    }
+  > = {
+    followers: {
+      title: '팔로워',
+      emptyTitle: '아직 팔로워가 없어요',
+      emptyDescription: '이 프로필을 팔로우하는 사람이 생기면 여기에 표시돼요.',
+      errorTitle: '팔로워 목록을 불러오지 못했어요',
+      loadingLabel: '팔로워 목록을 불러오는 중입니다.',
+    },
+    following: {
+      title: '팔로잉',
+      emptyTitle: '아직 팔로잉이 없어요',
+      emptyDescription: '이 프로필이 팔로우하는 사람이 생기면 여기에 표시돼요.',
+      errorTitle: '팔로잉 목록을 불러오지 못했어요',
+      loadingLabel: '팔로잉 목록을 불러오는 중입니다.',
+    },
+  };
+
+  const text = $derived(copy[kind]);
+
+  // 첫 화면을 채울 만큼만 반복한다.
+  const skeletonItems = [0, 1, 2];
+</script>
+
+<section {...attributes} class={className}>
+  <h2 class="text-text-primary border-border border-b px-4 pt-2 pb-3 text-base font-bold">
+    {text.title}
+  </h2>
+  {#if loading}
+    <div aria-hidden="true">
+      {#each skeletonItems as item (item)}
+        <div class="border-border flex items-center gap-3 border-b px-4 py-3">
+          <div
+            class="border-border bg-surface size-10 shrink-0 animate-pulse rounded-full border"
+          ></div>
+          <div class="flex min-w-0 flex-1 flex-col gap-2">
+            <TextSkeleton width="md" />
+            <TextSkeleton width="sm" />
+          </div>
+        </div>
+      {/each}
+    </div>
+    <span class="sr-only" role="status">{text.loadingLabel}</span>
+  {:else if error}
+    <div class="px-4 py-12 text-center" role="alert">
+      <p class="text-text-primary text-base font-semibold">{text.errorTitle}</p>
+      <p class="text-text-secondary mt-1 text-sm">잠시 후 다시 시도해주세요.</p>
+      {#if onRetry}
+        <button
+          class="border-border text-text-primary mt-4 rounded-lg border px-4 py-2 text-sm font-bold"
+          type="button"
+          onclick={onRetry}
+        >
+          다시 시도
+        </button>
+      {/if}
+    </div>
+  {:else}
+    <!--
+      항목 목록 분기는 후속(PROD-184/185)에서 connection fragment prop과 함께 추가한다.
+      그 전까지는 표시할 항목이 없으므로 빈 상태를 기본으로 표시한다.
+    -->
+    <div class="px-4 py-12 text-center">
+      <p class="text-text-primary text-base font-semibold">{text.emptyTitle}</p>
+      <p class="text-text-secondary mt-1 text-sm">{text.emptyDescription}</p>
+    </div>
+  {/if}
+</section>

--- a/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
+
+  // 팔로워 목록 라우트 골격. 상단 ProfileHero는 상위 @[handle] layout이 렌더한다.
+  // 실제 followers connection 데이터 연결은 후속(PROD-184)에서 추가하며,
+  // 그 전까지는 빈 상태를 표시한다.
+</script>
+
+<ProfileConnectionList kind="followers" />

--- a/openspec/changes/add-profile-follow-list-routes/tasks.md
+++ b/openspec/changes/add-profile-follow-list-routes/tasks.md
@@ -1,12 +1,12 @@
 ## 1. 공유 상태 컴포넌트 (PROD-179)
 
-- [ ] 1.1 `ProfileConnectionList.svelte`를 신설해 `kind`(followers/following)별 제목과 로딩·오류·빈 상태를 `PostList` 패턴으로 구성한다(`loading`/`error`/`onRetry` props, 데이터 연결은 후속 주석)
-- [ ] 1.2 `ProfileConnectionList.stories.svelte`에 followers·following × 로딩/오류/빈 상태를 노출한다
+- [x] 1.1 `ProfileConnectionList.svelte`를 신설해 `kind`(followers/following)별 제목과 로딩·오류·빈 상태를 `PostList` 패턴으로 구성한다(`loading`/`error`/`onRetry` props, 데이터 연결은 후속 주석)
+- [x] 1.2 `ProfileConnectionList.stories.svelte`에 followers·following × 로딩/오류/빈 상태를 노출한다
 
 ## 2. 팔로워 목록 라우트 (PROD-179)
 
-- [ ] 2.1 `(tabs)/@[handle]/followers/+page.svelte`를 신설해 `ProfileConnectionList kind="followers"`를 렌더한다(쿼리 없음 → 빈 상태)
-- [ ] 2.2 `ProfileHero` 유지(`(tabs)` 셸 리셋 없음)와 라우트 직접 접근 시 깨지지 않음을 확인한다
+- [x] 2.1 `(tabs)/@[handle]/followers/+page.svelte`를 신설해 `ProfileConnectionList kind="followers"`를 렌더한다(쿼리 없음 → 빈 상태)
+- [x] 2.2 `ProfileHero` 유지(`(tabs)` 셸 리셋 없음)와 라우트 직접 접근 시 깨지지 않음을 확인한다
 
 ## 3. 팔로잉 목록 라우트 (PROD-180)
 


### PR DESCRIPTION
## 무엇을 변경했는지

- 공유 상태 컴포넌트 `ProfileConnectionList.svelte`를 신설했다. `kind`(followers/following)별 제목과 로딩 스켈레톤·인라인 오류(재시도)·인라인 빈 상태를 게시글 목록(`PostList`) 패턴으로 구성한다.
- `(tabs)/@[handle]/followers/+page.svelte` 라우트를 추가해 `ProfileConnectionList kind="followers"`를 렌더한다. 상단 `ProfileHero`는 상위 `@[handle]` layout이 유지하며, 게시글 상세처럼 `(tabs)` 셸까지 리셋하지 않는다.
- `ProfileConnectionList.stories.svelte`로 followers·following × 로딩/오류/빈 상태를 카탈로그한다.

## 왜 변경했는지

- 프로필 카운트의 팔로워 목록 진입점 링크(PROD-217, 상위 스택 #159/#161)가 가리킬 `/@{handle}/followers` 라우트가 필요하다. 실제 데이터 연결(PROD-184) 전에 라우트·상태 골격을 먼저 만들어, 진입점이 빈 목록 화면으로 동작하게 한다.

## 어떻게 확인할 수 있는지

- `pnpm -F @kosmo/web check` 통과(0 errors / 0 warnings), prettier 통과.
- `/@{handle}/followers` 직접 접근 시 `ProfileHero` + "팔로워" 제목 + 빈 상태("아직 팔로워가 없어요")가 표시되고 화면이 깨지지 않는다. (시각 확인은 사용자)
- Storybook `KOSMO/ProfileConnectionList`의 Followers/Following states에서 로딩·오류·빈 상태를 확인.

## 남은 문제

- 항목 목록 렌더링 + 실제 followers connection 데이터 연결은 PROD-184(후속). 현재는 데이터 미연결로 기본 빈 상태가 노출되는 것이 의도된 동작이다.
- 팔로잉 라우트는 다음 PR `prod-180`에서 같은 컴포넌트를 재사용해 추가하고, 거기서 OpenSpec change를 archive한다.

---

Stack: `main` → `prod-178-spec`(#148) → `prod-178`(#149) → `prod-179-spec`(#152) → **`prod-179`**(#153) → `prod-180`(#154) → `prod-217-spec`(#159) → `prod-217`(#161)

Linear: PROD-179
