### PR TITLE
Terraform 기반 AWS 인프라 root를 준비한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,15 @@ dist
 playwright-report
 test-results
 
+# Terraform local working files and environment-specific inputs.
+**/.terraform/
+**/backend.hcl
+**/backend.s3.tf
+**/*.tfvars
+**/*.tfvars.json
+**/*.tfstate
+**/*.tfstate.*
+**/*.tfplan
+
 # Figma MCP 등 에이전트 도구가 레포 루트에 떨어뜨리는 임시 산출물(스크린샷 등).
 .tmp-*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # kosmo
 
+## Infrastructure
+
+AWS Terraform root is documented in [apps/terraform/README.md](apps/terraform/README.md).
+
 ## Test Postgres
 
 Run a local PostgreSQL instance for tests with Docker Compose:

--- a/apps/terraform/.terraform.lock.hcl
+++ b/apps/terraform/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.51.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
+    "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
+    "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
+    "zh:190a46da0c69082b74da48238ce134d2fc9893e09122ac249c5689f88eab7e13",
+    "zh:1b312a4b53fa3cf731f95e674c033865feea5455f163b86136f2614424637293",
+    "zh:2b319814806222c5aba196b1a78756a6b36dc5c91f85edda349234d8a2f20a6a",
+    "zh:2bddf92c8efc6ad445a2eb8a0e5f88742a0596392c3a4ebc350ebb4105a4a96d",
+    "zh:3bef0c4f675c09034ff017cf899977b1765b2c0b3d1e489bcb06a5fcac316e2d",
+    "zh:47c46b5aa22199638fed5c93b195bbfd1182a1408edad4e5c39d4a73a04493f6",
+    "zh:5f808699650f6db961964466c77f5a581eab142a91c2e54810bb09b6f2fcd3f2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ada97e6be10164f452e278c23412b8597698a9c95ffb68fe83629d63d85906f3",
+    "zh:c4d73a91810d8dbcf9abbd431d41fcceebb48f8b6fd3c28a84bb3c6ed08be2e9",
+    "zh:c63ec875d38fc557b16b0b2b0ab1c7635852799453113240e21a52409de94a71",
+    "zh:cdd0209a755fc3aa14855aa013dae4b166a2fc7f6d3cbb673f7ff2142f5b63a2",
+    "zh:e5e665a27290391fd1bffc093ab68b596f6c507785be2e3f0949fab4fd6aec1b",
+    "zh:f6c42046a31d65eff2793737656b38931f90318b53661046bb84326cd4cb558f",
+  ]
+}

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -75,6 +75,16 @@ $EDITOR terraform.tfvars
 
 현재 root에는 실제 리소스가 없으므로 `terraform.tfvars` 없이도 validate와 plan이 가능해야 한다.
 
+## Toolchain
+
+Terraform CLI는 이 디렉터리의 `mise.toml`에서만 고정한다. repo root의 `mise.toml`에는 Terraform을 넣지 않아 web/api 작업에서 불필요하게 Terraform을 설치하지 않게 한다.
+
+```sh
+cd apps/terraform
+mise trust
+mise install
+```
+
 ## 검증
 
 ```sh

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -14,7 +14,7 @@
 - Terraform root는 환경별로 나누지 않고 단일 kosmo 클러스터만 관리한다.
 - cluster name은 `kosmo`로 고정한다. cluster name 변경은 replacement 성격이 강하므로 외부 변수로 열어 두지 않는다.
 - Kubernetes version 기본값은 `1.36`이다. 이 값은 스캐폴딩 기본값이며 EKS cluster를 실제 생성하는 PROD-204에서 AWS EKS 지원 상태와 add-on 호환성을 다시 확인한다.
-- node group은 `node_groups = {}` 인터페이스만 둔다. On-Demand/Spot 비율, instance type, min/desired/max size는 PROD-205에서 결정한다.
+- node group 설정은 외부 변수로 열어 두지 않는다. 여러 node group의 구성, On-Demand/Spot 비율, instance type, min/desired/max size는 PROD-205에서 실제 Terraform 코드로 정의한다.
 
 ## State backend
 

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -81,7 +81,7 @@ Terraform CLI는 이 디렉터리의 `mise.toml`에서만 고정한다. repo roo
 
 ```sh
 cd apps/terraform
-mise trust
+mise trust --all
 mise install
 ```
 

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -1,0 +1,87 @@
+# kosmo Terraform
+
+이 디렉터리는 AWS EKS 전환을 위한 Terraform root다. PROD-198 범위에서는 실제 AWS 리소스를 만들지 않고, 이후 VPC/EKS/node group/CSI/Argo CD 이슈가 채울 수 있는 root, backend, provider, 변수, 출력 인터페이스만 준비한다.
+
+## 범위
+
+- 포함: Terraform CLI/provider 버전 고정, AWS provider 설정, S3 backend partial configuration, 변수/출력 구조, init/plan 절차.
+- 제외: VPC, subnet, NAT Gateway, security group, EKS cluster, node group, CSI driver, Kubernetes/Helm provider, Argo CD bootstrap.
+- 제외된 리소스는 각각 PROD-201, PROD-204, PROD-205, PROD-210, PROD-212에서 추가한다.
+
+## 기본 결정
+
+- AWS region 기본값은 `ap-northeast-2`다.
+- Terraform root는 환경별로 나누지 않고 단일 kosmo 클러스터만 관리한다.
+- cluster name은 `kosmo`로 고정한다. cluster name 변경은 replacement 성격이 강하므로 외부 변수로 열어 두지 않는다.
+- Kubernetes version 기본값은 `1.36`이다. 이 값은 스캐폴딩 기본값이며 EKS cluster를 실제 생성하는 PROD-204에서 AWS EKS 지원 상태와 add-on 호환성을 다시 확인한다.
+- node group은 `node_groups = {}` 인터페이스만 둔다. On-Demand/Spot 비율, instance type, min/desired/max size는 PROD-205에서 결정한다.
+
+## State backend
+
+장기 state는 조직 공용 S3 bucket에 저장한다. bucket은 이 root에서 만들지 않으며, 이미 존재하거나 별도 운영 절차로 준비되어 있어야 한다. Terraform root는 환경별로 갈라지지 않으므로 S3 object key는 kosmo 프로젝트 단위로만 구분한다.
+
+예시:
+
+```hcl
+bucket       = "byulmaru-terraform-state"
+key          = "kosmo/terraform.tfstate"
+region       = "ap-northeast-2"
+use_lockfile = true
+```
+
+`use_lockfile = true`로 S3 native lockfile을 사용한다. DynamoDB 기반 locking은 쓰지 않는다.
+
+기본 checkout 상태에서는 backend를 활성화하지 않는다. 이렇게 해야 조직 공용 S3 bucket 값이 없어도 `terraform init -backend=false`, `terraform validate`, `terraform plan`으로 스캐폴딩을 검증할 수 있다. S3 backend를 쓸 때는 `backend.s3.tf.example`을 커밋하지 않는 `backend.s3.tf`로 복사한다.
+
+## 민감 값 규칙
+
+커밋하지 않는 파일:
+
+- `backend.hcl`
+- `backend.s3.tf`
+- `*.tfvars`
+- `*.tfstate`, `*.tfstate.*`
+- `*.tfplan`
+- `.terraform/`
+- AWS credential, kubeconfig, Argo CD secret
+
+AWS 인증은 `AWS_PROFILE` 또는 표준 AWS 환경 변수(`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`)로만 주입한다. credential 값을 Terraform 변수, backend config, plan 파일에 넣지 않는다.
+
+## 초기화
+
+provider lockfile을 만들거나 backend 없이 정적 검증만 할 때:
+
+```sh
+terraform init -backend=false
+```
+
+S3 backend로 실제 초기화할 때:
+
+```sh
+cp backend.s3.tf.example backend.s3.tf
+cp backend.hcl.example backend.hcl
+$EDITOR backend.hcl
+AWS_PROFILE=<profile> terraform init -backend-config=backend.hcl
+```
+
+`backend.hcl`에는 실제 조직 공용 state bucket 이름을 넣는다. bucket 이름은 전역 유일한 AWS 리소스 이름이므로 예시 값을 그대로 사용하지 않는다.
+
+## 변수 예시
+
+```sh
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+```
+
+현재 root에는 실제 리소스가 없으므로 `terraform.tfvars` 없이도 validate와 plan이 가능해야 한다.
+
+## 검증
+
+```sh
+terraform fmt -check
+terraform init -backend=false
+terraform validate
+terraform plan -input=false -lock=false
+```
+
+현재 plan은 실제 AWS 리소스 생성을 포함하지 않는다. 후속 이슈에서 리소스가 추가되면 plan 결과에 비용 발생 리소스와 운영 trade-off를 함께 문서화한다.

--- a/apps/terraform/backend.hcl.example
+++ b/apps/terraform/backend.hcl.example
@@ -1,0 +1,4 @@
+bucket       = "byulmaru-terraform-state"
+key          = "kosmo/terraform.tfstate"
+region       = "ap-northeast-2"
+use_lockfile = true

--- a/apps/terraform/backend.s3.tf.example
+++ b/apps/terraform/backend.s3.tf.example
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/apps/terraform/backend.tf
+++ b/apps/terraform/backend.tf
@@ -1,0 +1,3 @@
+# This root intentionally uses Terraform's default local backend until the
+# organization S3 state bucket is configured locally. Copy backend.s3.tf.example
+# to backend.s3.tf to enable the partial S3 backend.

--- a/apps/terraform/locals.tf
+++ b/apps/terraform/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  cluster_name = "kosmo"
+  name_prefix  = local.cluster_name
+
+  tags = merge(
+    {
+      ManagedBy = "terraform"
+      Project   = "kosmo"
+    },
+    var.tags,
+  )
+}

--- a/apps/terraform/mise.toml
+++ b/apps/terraform/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+terraform = "1.15.6"

--- a/apps/terraform/outputs.tf
+++ b/apps/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "aws_region" {
+  description = "AWS region configured for this Terraform root."
+  value       = var.aws_region
+}
+
+output "cluster_name" {
+  description = "EKS cluster name candidate for the later cluster resource."
+  value       = local.cluster_name
+}
+
+output "kubernetes_version" {
+  description = "Kubernetes minor version candidate for the later EKS cluster."
+  value       = var.kubernetes_version
+}
+
+output "name_prefix" {
+  description = "Shared name prefix for later AWS resources."
+  value       = local.name_prefix
+}
+
+output "tags" {
+  description = "Default tags that will be applied to AWS resources."
+  value       = local.tags
+}

--- a/apps/terraform/providers.tf
+++ b/apps/terraform/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/apps/terraform/terraform.tfvars.example
+++ b/apps/terraform/terraform.tfvars.example
@@ -1,8 +1,6 @@
 aws_region         = "ap-northeast-2"
 kubernetes_version = "1.36"
 
-node_groups = {}
-
 tags = {
   Service = "kosmo"
 }

--- a/apps/terraform/terraform.tfvars.example
+++ b/apps/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+aws_region         = "ap-northeast-2"
+kubernetes_version = "1.36"
+
+node_groups = {}
+
+tags = {
+  Service = "kosmo"
+}

--- a/apps/terraform/variables.tf
+++ b/apps/terraform/variables.tf
@@ -15,18 +15,6 @@ variable "kubernetes_version" {
   }
 }
 
-variable "node_groups" {
-  type = map(object({
-    capacity_type  = optional(string)
-    instance_types = optional(list(string))
-    min_size       = optional(number)
-    desired_size   = optional(number)
-    max_size       = optional(number)
-  }))
-  description = "Worker node group interface placeholder. Concrete sizing and capacity choices belong to PROD-205."
-  default     = {}
-}
-
 variable "tags" {
   type        = map(string)
   description = "Additional tags merged into all AWS resources once resources are added."

--- a/apps/terraform/variables.tf
+++ b/apps/terraform/variables.tf
@@ -10,8 +10,8 @@ variable "kubernetes_version" {
   default     = "1.36"
 
   validation {
-    condition     = can(regex("^1\\.[0-9]+$", var.kubernetes_version))
-    error_message = "kubernetes_version must be a Kubernetes minor version such as 1.36."
+    condition     = can(regex("^[0-9]+\\.[0-9]+$", var.kubernetes_version))
+    error_message = "kubernetes_version must be a Kubernetes minor version in major.minor format, such as 1.36 or 2.0."
   }
 }
 

--- a/apps/terraform/variables.tf
+++ b/apps/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region used for the temporary EKS execution environment."
+  default     = "ap-northeast-2"
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes minor version candidate for EKS; re-check this in PROD-204 before creating the cluster."
+  default     = "1.36"
+
+  validation {
+    condition     = can(regex("^1\\.[0-9]+$", var.kubernetes_version))
+    error_message = "kubernetes_version must be a Kubernetes minor version such as 1.36."
+  }
+}
+
+variable "node_groups" {
+  type = map(object({
+    capacity_type  = optional(string)
+    instance_types = optional(list(string))
+    min_size       = optional(number)
+    desired_size   = optional(number)
+    max_size       = optional(number)
+  }))
+  description = "Worker node group interface placeholder. Concrete sizing and capacity choices belong to PROD-205."
+  default     = {}
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags merged into all AWS resources once resources are added."
+  default     = {}
+}

--- a/apps/terraform/versions.tf
+++ b/apps/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.15"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,3 @@
 [tools]
 node = "26.3.0"
 pnpm = "11.6.0"
-terraform = "1.15.6"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
 node = "26.3.0"
 pnpm = "11.6.0"
+terraform = "1.15.6"


### PR DESCRIPTION
## 무엇을 변경했는지

- `apps/terraform`에 AWS Terraform root 스캐폴딩을 추가했습니다.
- Terraform `1.15.6`, AWS provider `6.51.0` 기준으로 provider 버전과 lockfile을 고정했습니다.
- 조직 공용 S3 state bucket을 쓰는 backend 예시와 실제 backend/TFVars/state/plan 파일 ignore 규칙을 추가했습니다.
- 단일 kosmo 클러스터 전제를 반영해 cluster name은 `kosmo` local 값으로 고정하고, 환경별 Terraform root 분리는 두지 않았습니다.

## 왜 변경했는지

PROD-198은 AWS EKS 전환을 위한 첫 Terraform root를 준비하는 작업입니다. 이번 PR은 실제 AWS 리소스를 만들지 않고, 후속 VPC/EKS/node group/CSI/Argo CD 이슈가 같은 root 위에서 이어질 수 있도록 backend, provider, 변수, 출력, 문서 경계를 먼저 정리합니다.

## 어떻게 확인할 수 있는지

- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`
- `terraform plan -input=false -lock=false`
- `pnpm lint:prettier`
- `terraform providers lock -platform=darwin_arm64`

## 아직 어떤 문제가 남았는지

- 실제 조직 공용 S3 state bucket 이름은 `backend.hcl`에서 로컬/CI별로 지정해야 합니다.
- VPC/NAT/보안 그룹은 PROD-201, EKS cluster/add-ons는 PROD-204, node group은 PROD-205에서 추가합니다.

Stack: main -> prod-198