### PR TITLE
Docker 빌드에서 GitHub 캐시를 쓰지 않게 한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,8 +77,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             PUBLIC_ENV_HASH=${{ hashFiles('.web-build.env') }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           no-cache-filters: base
           secret-files: |
             web_build_env=.web-build.env


### PR DESCRIPTION
## 무엇을 변경했는지

- Docker Build 워크플로우의 Buildx GitHub Actions cache backend 설정을 제거했습니다.
- `cache-from: type=gha`, `cache-to: type=gha,mode=max`를 제거해 Docker 빌드가 GitHub Cache API에 캐시를 내려받거나 업로드하지 않게 했습니다.
- 기존 `no-cache-filters: base`와 secret 기반 web build env 전달은 그대로 유지했습니다.

## 왜 변경했는지

셀프호스트 러너에서 Docker 빌드를 실행할 때 GitHub 원격 캐시 다운로드/업로드 비용이 캐시 이득보다 커질 수 있습니다. 이 PR은 러너가 GitHub Actions cache backend를 쓰지 않게 해서 원격 캐시 왕복 시간을 제거합니다.

Stack: `main -> codex/disable-github-actions-cache`

## 어떻게 확인할 수 있는지

- `pnpm exec prettier --check .github/workflows/docker-build.yml`
- `rg -n "type=gha|actions/cache|cache-from|cache-to|restore-keys|key:" .github Dockerfile package.json pnpm-workspace.yaml mise.toml` 결과 없음

## 아직 어떤 문제가 남았는지

실제 self-hosted runner의 wall-clock 개선 정도는 PR/배포 워크플로우 실행 결과로 확인해야 합니다.