### PR TITLE
Fedify hook을 SvelteKit 서버에 연결한다

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,0 +1,4 @@
+import { fedifyHook } from '@fedify/sveltekit';
+import { federation } from '@kosmo/fedify';
+
+export const handle = fedifyHook(federation);

--- a/openspec/changes/add-activitypub-actor-discovery/tasks.md
+++ b/openspec/changes/add-activitypub-actor-discovery/tasks.md
@@ -36,7 +36,7 @@
 
 ## 5. Web Integration
 
-- [ ] 5.1 `apps/web/src/hooks.server.ts`에서 `packages/fedify`가 제공하는 federation 구성을 Fedify SvelteKit hook adapter로 SvelteKit `handle`에 연결하고, web hook 본문에는 ActivityPub parsing/응답 조립 로직을 두지 않는다.
+- [x] 5.1 `apps/web/src/hooks.server.ts`에서 `packages/fedify`가 제공하는 federation 구성을 Fedify SvelteKit hook adapter로 SvelteKit `handle`에 연결하고, web hook 본문에는 ActivityPub parsing/응답 조립 로직을 두지 않는다.
 - [ ] 5.2 ActivityPub/WebFinger 요청은 `packages/fedify`가 처리하고 기존 `/health`, `/graphql`, `/login`, `/@{handle}` 요청은 기존 동작을 유지하는지 확인한다.
 - [ ] 5.3 actor URI와 WebFinger JRD가 canonical local origin을 사용하고 request Host에 의존하지 않는지 확인한다.
 


### PR DESCRIPTION
## 무엇을 변경했는지

- SvelteKit 서버 hook에서 `@kosmo/fedify`가 제공하는 federation singleton을 직접 사용하게 했습니다.
- SvelteKit 서버 hook에서 Fedify SvelteKit adapter를 연결했습니다.
- 일반 SvelteKit 요청이 기존 route로 통과하는지 단위 테스트를 추가했습니다.
- OpenSpec `add-activitypub-actor-discovery`의 5.1만 완료 처리했습니다.

## 왜 변경했는지

- ActivityPub/WebFinger 처리를 SvelteKit hook 계층에 연결하기 위한 최소 기반을 마련합니다.
- 실제 actor/WebFinger 성공 응답 구현은 후속 `PROD-190/191` 범위로 남깁니다.

## Stack

- `main -> prod-181`
- PR #150(PROD-176), PR #157(PROD-177)이 main에 merge된 뒤 최신 main 위로 재정렬했습니다.
- 이 PR 생성/재정렬 과정에서 기존 PR #150/#157은 수정하지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm --filter @kosmo/web test:unit -- --run src/hooks.server.test.ts`
- `pnpm --filter @kosmo/web check`
- `pnpm lint:eslint`
- `pnpm exec openspec validate add-activitypub-actor-discovery --strict`

## 아직 어떤 문제가 남았는지

- actor/WebFinger 성공 응답은 아직 구현하지 않았습니다.
- durable KV는 inbox/delivery 범위 전에 별도 이슈에서 정리합니다.
