### PR TITLE
EKS worker node용 VPC 네트워크 기반을 추가한다

### DIFF
--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -39,6 +39,8 @@ Terraform plan은 다음 네트워크 리소스를 생성한다.
 
 현재 구성은 비용을 줄이기 위해 NAT Gateway를 1개만 둔다. 장점은 시간당 NAT Gateway 비용과 Elastic IP 수가 최소화된다는 점이다. 단점은 NAT Gateway가 위치한 AZ 또는 해당 public subnet 경로에 장애가 나면 다른 AZ의 private subnet도 outbound 인터넷/AWS API 접근에 영향을 받을 수 있고, 다른 AZ의 private subnet에서 NAT Gateway로 나가는 트래픽은 cross-AZ 데이터 전송 비용이 발생할 수 있다는 점이다.
 
+Elastic IP는 외부 서비스 allowlist를 위한 운영 요구사항으로 둔 것이 아니라, AWS public NAT Gateway가 Internet Gateway를 통해 IPv4 인터넷 egress를 제공하기 위해 필요한 주소다. 고정 egress IP 자체가 필요 없는 AWS API 접근은 VPC endpoint로 대체할 수 있지만, container registry나 OS package repository처럼 일반 인터넷 egress가 필요한 경로까지 제거하려면 별도 mirror/cache 또는 egress proxy 설계가 필요하다.
+
 운영 가용성을 우선하면 AZ마다 NAT Gateway를 1개씩 두고, 각 private route table이 같은 AZ의 NAT Gateway를 바라보게 바꾼다. 이 대안은 NAT Gateway 시간당 비용과 처리 비용이 AZ 수만큼 늘지만, AZ 단위 장애와 cross-AZ NAT 트래픽 비용을 줄인다. kosmo의 초기 EKS 전환은 비용 민감도가 높고 트래픽 규모가 작다는 전제로 단일 NAT Gateway를 선택한다.
 
 ## Security group 경계

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -18,7 +18,8 @@
 - node group 설정은 외부 변수로 열어 두지 않는다. 여러 node group의 구성, On-Demand/Spot 비율, instance type, min/desired/max size는 PROD-205에서 실제 Terraform 코드로 정의한다.
 - VPC CIDR은 `10.40.0.0/16`으로 고정한다. AWS VPC의 단일 IPv4 CIDR block은 `/16`이 가장 넓은 범위다.
 - public subnet은 NAT Gateway와 load balancer 배치를 위한 공간이므로 `10.40.0.0/24`, `10.40.1.0/24`를 사용한다.
-- private subnet은 EKS 기본 VPC CNI에서 node와 pod IP를 함께 소비하므로 public subnet보다 크게 잡아 `10.40.16.0/20`, `10.40.32.0/20`을 사용한다. Kubernetes Service ClusterIP는 EKS service CIDR에서 배정되므로 VPC subnet IP를 소비하지 않는다.
+- private subnet은 worker node와 AWS load balancer/NAT 경로가 소비하는 cloud network 주소 공간으로 보고 `10.40.10.0/24`, `10.40.11.0/24`를 사용한다.
+- Kubernetes pod/service IP는 AWS subnet 주소 공간과 분리하는 것을 목표로 한다. AWS ENI 기반 pod IP 할당은 pod가 subnet IP를 직접 소비해 cloud portability를 낮추므로 기본 전제로 두지 않는다. Cilium 같은 CNI를 쓰더라도 cluster-pool/overlay 등 Kubernetes 내부 pod CIDR을 별도로 관리하는 모드를 우선 검토한다.
 - CIDR 변경은 route, subnet, EKS node placement에 직접 영향을 주므로 일반 입력 변수로 열지 않는다. `/16`보다 큰 IPv4 공간이 필요하면 VPC secondary CIDR block, VPC CNI custom networking, 또는 IPv6 적용을 별도 이슈로 설계한다.
 - AZ는 현재 AWS 계정과 region에서 opt-in 없이 사용할 수 있는 availability zone 중 앞의 2개를 사용한다.
 - EKS worker node는 private subnet에 배치한다. public subnet은 NAT Gateway와 이후 public load balancer가 필요할 때만 사용한다.
@@ -59,6 +60,8 @@ private-only endpoint 전환은 다음 조건이 갖춰진 뒤에 한다.
 ## OKE 복귀 영향
 
 이 Terraform root는 AWS 전용 VPC, NAT Gateway, EKS security group을 만든다. OKE로 복귀할 경우 애플리케이션 Kubernetes manifest와 container image는 재사용할 수 있지만, 네트워크 IaC는 OCI VCN/subnet/NAT gateway/security list 또는 NSG 구성으로 다시 매핑해야 한다. AWS Load Balancer Controller용 subnet tag와 EKS security group 경계는 OKE에 직접 대응하지 않으므로, 복귀 계획에서는 Kubernetes 계층과 cloud network 계층을 분리해서 폐기 순서를 잡는다.
+
+Kubernetes 위에서 운영하는 ingress, service mesh, network policy, workload manifest는 cloud network subnet CIDR에 의존하지 않게 유지한다. CNI는 가능한 한 pod CIDR을 AWS ENI/subnet에 직접 묶지 않는 구성을 우선 검토하고, cloud-specific load balancer와 storage integration은 교체 가능한 경계로 둔다.
 
 ## State backend
 

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -1,12 +1,12 @@
 # kosmo Terraform
 
-이 디렉터리는 AWS EKS 전환을 위한 Terraform root다. PROD-198 범위에서는 실제 AWS 리소스를 만들지 않고, 이후 VPC/EKS/node group/CSI/Argo CD 이슈가 채울 수 있는 root, backend, provider, 변수, 출력 인터페이스만 준비한다.
+이 디렉터리는 AWS EKS 전환을 위한 Terraform root다. PROD-201 범위에서는 EKS worker node를 private subnet에 배치할 수 있는 2 AZ VPC, public/private subnet, 단일 NAT Gateway, route table, EKS용 security group을 준비한다.
 
 ## 범위
 
-- 포함: Terraform CLI/provider 버전 고정, AWS provider 설정, S3 backend partial configuration, 변수/출력 구조, init/plan 절차.
-- 제외: VPC, subnet, NAT Gateway, security group, EKS cluster, node group, CSI driver, Kubernetes/Helm provider, Argo CD bootstrap.
-- 제외된 리소스는 각각 PROD-201, PROD-204, PROD-205, PROD-210, PROD-212에서 추가한다.
+- 포함: Terraform CLI/provider 버전 고정, AWS provider 설정, S3 backend partial configuration, 변수/출력 구조, VPC, subnet, NAT Gateway, route table, EKS cluster/node security group, init/plan 절차.
+- 제외: EKS cluster, node group, CSI driver, Kubernetes/Helm provider, Argo CD bootstrap.
+- 제외된 리소스는 각각 PROD-204, PROD-205, PROD-210, PROD-212에서 추가한다.
 
 ## 기본 결정
 
@@ -15,6 +15,46 @@
 - cluster name은 `kosmo`로 고정한다. cluster name 변경은 replacement 성격이 강하므로 외부 변수로 열어 두지 않는다.
 - Kubernetes version 기본값은 `1.36`이다. 이 값은 스캐폴딩 기본값이며 EKS cluster를 실제 생성하는 PROD-204에서 AWS EKS 지원 상태와 add-on 호환성을 다시 확인한다.
 - node group 설정은 외부 변수로 열어 두지 않는다. 여러 node group의 구성, On-Demand/Spot 비율, instance type, min/desired/max size는 PROD-205에서 실제 Terraform 코드로 정의한다.
+- VPC CIDR 기본값은 `10.40.0.0/16`이다. public subnet은 `10.40.0.0/24`, `10.40.1.0/24`, private subnet은 `10.40.10.0/24`, `10.40.11.0/24`를 기본값으로 사용한다.
+- AZ는 현재 AWS 계정과 region에서 opt-in 없이 사용할 수 있는 availability zone 중 앞의 2개를 사용한다.
+- EKS worker node는 private subnet에 배치한다. public subnet은 NAT Gateway와 이후 public load balancer가 필요할 때만 사용한다.
+
+## 네트워크 구성
+
+Terraform plan은 다음 네트워크 리소스를 생성한다.
+
+- VPC 1개, DNS support/hostname 활성화.
+- public subnet 2개, private subnet 2개. 각 subnet은 EKS와 AWS load balancer discovery용 Kubernetes tag를 가진다.
+- Internet Gateway 1개와 public route table 1개.
+- Elastic IP 1개와 NAT Gateway 1개. NAT Gateway는 첫 번째 public subnet에 둔다.
+- private route table은 private subnet마다 1개씩 만들지만, 현재는 둘 다 동일한 NAT Gateway로 `0.0.0.0/0`을 보낸다. 이후 AZ별 NAT Gateway로 바꿀 때 각 route table의 NAT 대상만 나눌 수 있게 하기 위해서다.
+- EKS cluster security group 1개와 worker node security group 1개.
+
+## NAT Gateway trade-off
+
+현재 구성은 비용을 줄이기 위해 NAT Gateway를 1개만 둔다. 장점은 시간당 NAT Gateway 비용과 Elastic IP 수가 최소화된다는 점이다. 단점은 NAT Gateway가 위치한 AZ 또는 해당 public subnet 경로에 장애가 나면 다른 AZ의 private subnet도 outbound 인터넷/AWS API 접근에 영향을 받을 수 있고, 다른 AZ의 private subnet에서 NAT Gateway로 나가는 트래픽은 cross-AZ 데이터 전송 비용이 발생할 수 있다는 점이다.
+
+운영 가용성을 우선하면 AZ마다 NAT Gateway를 1개씩 두고, 각 private route table이 같은 AZ의 NAT Gateway를 바라보게 바꾼다. 이 대안은 NAT Gateway 시간당 비용과 처리 비용이 AZ 수만큼 늘지만, AZ 단위 장애와 cross-AZ NAT 트래픽 비용을 줄인다. kosmo의 초기 EKS 전환은 비용 민감도가 높고 트래픽 규모가 작다는 전제로 단일 NAT Gateway를 선택한다.
+
+## Security group 경계
+
+`kosmo-eks-cluster` security group은 후속 EKS cluster control plane ENI에 연결할 그룹이다. worker node security group에서 Kubernetes API HTTPS 트래픽을 받을 수 있고, worker node의 HTTPS webhook과 kubelet `10250`으로 나갈 수 있다.
+
+`kosmo-eks-nodes` security group은 private subnet의 worker node에 연결할 그룹이다. 같은 node group 내부 통신은 허용하고, control plane에서 들어오는 HTTPS와 kubelet 트래픽만 명시적으로 허용한다. outbound는 private node가 NAT Gateway를 통해 AWS API, container registry, OS package repository에 접근해야 하므로 IPv4 전체 egress를 허용한다. pod-to-pod 정책은 이 security group 대신 Kubernetes NetworkPolicy 또는 CNI 정책으로 다룬다.
+
+## EKS endpoint 운영
+
+PROD-204에서 EKS cluster를 만들 때 초기값은 public endpoint를 켜는 구성이 현실적이다. 아직 VPN, bastion, private admin path가 없기 때문에 private-only endpoint로 시작하면 장애 대응과 배포 경로가 막힐 수 있다. public endpoint를 쓰더라도 cluster API 접근 CIDR은 운영자 고정 IP 또는 CI egress IP로 좁히는 것을 기본으로 한다.
+
+private-only endpoint 전환은 다음 조건이 갖춰진 뒤에 한다.
+
+- 운영자가 VPC 내부 경로로 Kubernetes API에 접근할 수 있다.
+- CI/CD가 VPC 내부 runner, VPN, 또는 승인된 network path를 통해 cluster API에 접근할 수 있다.
+- Argo CD bootstrap 이후에도 emergency kubectl 접근 절차가 문서화되어 있다.
+
+## OKE 복귀 영향
+
+이 Terraform root는 AWS 전용 VPC, NAT Gateway, EKS security group을 만든다. OKE로 복귀할 경우 애플리케이션 Kubernetes manifest와 container image는 재사용할 수 있지만, 네트워크 IaC는 OCI VCN/subnet/NAT gateway/security list 또는 NSG 구성으로 다시 매핑해야 한다. AWS Load Balancer Controller용 subnet tag와 EKS security group 경계는 OKE에 직접 대응하지 않으므로, 복귀 계획에서는 Kubernetes 계층과 cloud network 계층을 분리해서 폐기 순서를 잡는다.
 
 ## State backend
 
@@ -31,7 +71,7 @@ use_lockfile = true
 
 `use_lockfile = true`로 S3 native lockfile을 사용한다. DynamoDB 기반 locking은 쓰지 않는다.
 
-기본 checkout 상태에서는 backend를 활성화하지 않는다. 이렇게 해야 조직 공용 S3 bucket 값이 없어도 `terraform init -backend=false`, `terraform validate`, `terraform plan`으로 스캐폴딩을 검증할 수 있다. S3 backend를 쓸 때는 `backend.s3.tf.example`을 커밋하지 않는 `backend.s3.tf`로 복사한다.
+기본 checkout 상태에서는 backend를 활성화하지 않는다. 이렇게 해야 조직 공용 S3 bucket 값이 없어도 `terraform init -backend=false`와 `terraform validate`를 실행할 수 있다. `terraform plan`은 실제 AWS availability zone 조회와 리소스 계획을 포함하므로 AWS 인증이 필요하다. S3 backend를 쓸 때는 `backend.s3.tf.example`을 커밋하지 않는 `backend.s3.tf`로 복사한다.
 
 ## 민감 값 규칙
 
@@ -73,7 +113,7 @@ cp terraform.tfvars.example terraform.tfvars
 $EDITOR terraform.tfvars
 ```
 
-현재 root에는 실제 리소스가 없으므로 `terraform.tfvars` 없이도 validate와 plan이 가능해야 한다.
+기본 CIDR을 쓰면 `terraform.tfvars` 없이도 validate가 가능하다. plan은 availability zone 조회와 AWS 리소스 계획을 위해 AWS 인증이 필요하다.
 
 ## Toolchain
 
@@ -94,4 +134,4 @@ terraform validate
 terraform plan -input=false -lock=false
 ```
 
-현재 plan은 실제 AWS 리소스 생성을 포함하지 않는다. 후속 이슈에서 리소스가 추가되면 plan 결과에 비용 발생 리소스와 운영 trade-off를 함께 문서화한다.
+현재 plan은 VPC, subnet, Elastic IP, NAT Gateway, route, security group 생성을 포함한다. NAT Gateway와 Elastic IP는 비용 발생 리소스이므로 실제 apply 전에 단일 NAT Gateway 비용/가용성 trade-off가 현재 운영 기대와 맞는지 다시 확인한다.

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -16,8 +16,9 @@
 - AWS resource name prefix는 cluster name에서 파생한다. 별도 변수로 열면 같은 cluster의 이름 체계가 갈라질 수 있고 prefix 변경도 replacement 성격이 강하므로 입력값으로 받지 않는다.
 - Kubernetes version 기본값은 `1.36`이다. 이 값은 스캐폴딩 기본값이며 EKS cluster를 실제 생성하는 PROD-204에서 AWS EKS 지원 상태와 add-on 호환성을 다시 확인한다.
 - node group 설정은 외부 변수로 열어 두지 않는다. 여러 node group의 구성, On-Demand/Spot 비율, instance type, min/desired/max size는 PROD-205에서 실제 Terraform 코드로 정의한다.
-- VPC CIDR은 `10.40.0.0/16`으로 고정한다. AWS VPC의 단일 IPv4 CIDR block은 `/16`이 가장 넓은 범위이므로, Kubernetes pod IP 소모를 고려해 private subnet을 크게 배정한다.
-- public subnet은 `10.40.0.0/20`, `10.40.16.0/20`, private subnet은 `10.40.64.0/18`, `10.40.128.0/18`을 사용한다.
+- VPC CIDR은 `10.40.0.0/16`으로 고정한다. AWS VPC의 단일 IPv4 CIDR block은 `/16`이 가장 넓은 범위다.
+- public subnet은 NAT Gateway와 load balancer 배치를 위한 공간이므로 `10.40.0.0/24`, `10.40.1.0/24`를 사용한다.
+- private subnet은 EKS 기본 VPC CNI에서 node와 pod IP를 함께 소비하므로 public subnet보다 크게 잡아 `10.40.16.0/20`, `10.40.32.0/20`을 사용한다. Kubernetes Service ClusterIP는 EKS service CIDR에서 배정되므로 VPC subnet IP를 소비하지 않는다.
 - CIDR 변경은 route, subnet, EKS node placement에 직접 영향을 주므로 일반 입력 변수로 열지 않는다. `/16`보다 큰 IPv4 공간이 필요하면 VPC secondary CIDR block, VPC CNI custom networking, 또는 IPv6 적용을 별도 이슈로 설계한다.
 - AZ는 현재 AWS 계정과 region에서 opt-in 없이 사용할 수 있는 availability zone 중 앞의 2개를 사용한다.
 - EKS worker node는 private subnet에 배치한다. public subnet은 NAT Gateway와 이후 public load balancer가 필요할 때만 사용한다.

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -13,9 +13,12 @@
 - AWS region 기본값은 `ap-northeast-2`다.
 - Terraform root는 환경별로 나누지 않고 단일 kosmo 클러스터만 관리한다.
 - cluster name은 `kosmo`로 고정한다. cluster name 변경은 replacement 성격이 강하므로 외부 변수로 열어 두지 않는다.
+- AWS resource name prefix는 cluster name에서 파생한다. 별도 변수로 열면 같은 cluster의 이름 체계가 갈라질 수 있고 prefix 변경도 replacement 성격이 강하므로 입력값으로 받지 않는다.
 - Kubernetes version 기본값은 `1.36`이다. 이 값은 스캐폴딩 기본값이며 EKS cluster를 실제 생성하는 PROD-204에서 AWS EKS 지원 상태와 add-on 호환성을 다시 확인한다.
 - node group 설정은 외부 변수로 열어 두지 않는다. 여러 node group의 구성, On-Demand/Spot 비율, instance type, min/desired/max size는 PROD-205에서 실제 Terraform 코드로 정의한다.
-- VPC CIDR 기본값은 `10.40.0.0/16`이다. public subnet은 `10.40.0.0/24`, `10.40.1.0/24`, private subnet은 `10.40.10.0/24`, `10.40.11.0/24`를 기본값으로 사용한다.
+- VPC CIDR은 `10.40.0.0/16`으로 고정한다. AWS VPC의 단일 IPv4 CIDR block은 `/16`이 가장 넓은 범위이므로, Kubernetes pod IP 소모를 고려해 private subnet을 크게 배정한다.
+- public subnet은 `10.40.0.0/20`, `10.40.16.0/20`, private subnet은 `10.40.64.0/18`, `10.40.128.0/18`을 사용한다.
+- CIDR 변경은 route, subnet, EKS node placement에 직접 영향을 주므로 일반 입력 변수로 열지 않는다. `/16`보다 큰 IPv4 공간이 필요하면 VPC secondary CIDR block, VPC CNI custom networking, 또는 IPv6 적용을 별도 이슈로 설계한다.
 - AZ는 현재 AWS 계정과 region에서 opt-in 없이 사용할 수 있는 availability zone 중 앞의 2개를 사용한다.
 - EKS worker node는 private subnet에 배치한다. public subnet은 NAT Gateway와 이후 public load balancer가 필요할 때만 사용한다.
 
@@ -113,7 +116,7 @@ cp terraform.tfvars.example terraform.tfvars
 $EDITOR terraform.tfvars
 ```
 
-기본 CIDR을 쓰면 `terraform.tfvars` 없이도 validate가 가능하다. plan은 availability zone 조회와 AWS 리소스 계획을 위해 AWS 인증이 필요하다.
+네트워크 CIDR은 코드에서 고정하므로 `terraform.tfvars` 없이도 validate가 가능하다. plan은 availability zone 조회와 AWS 리소스 계획을 위해 AWS 인증이 필요하다.
 
 ## Toolchain
 

--- a/apps/terraform/network.tf
+++ b/apps/terraform/network.tf
@@ -58,8 +58,8 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name                                           = each.value.name
-    Tier                                           = "public"
+    Name                                          = each.value.name
+    Tier                                          = "public"
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"
     "kubernetes.io/role/elb"                      = "1"
   }
@@ -73,8 +73,8 @@ resource "aws_subnet" "private" {
   cidr_block        = each.value.cidr_block
 
   tags = {
-    Name                                           = each.value.name
-    Tier                                           = "private"
+    Name                                          = each.value.name
+    Tier                                          = "private"
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"             = "1"
   }

--- a/apps/terraform/network.tf
+++ b/apps/terraform/network.tf
@@ -12,7 +12,7 @@ locals {
   network_availability_zones      = slice(data.aws_availability_zones.available.names, 0, local.network_availability_zone_count)
   vpc_cidr_block                  = "10.40.0.0/16"
   public_subnet_cidr_blocks       = ["10.40.0.0/24", "10.40.1.0/24"]
-  private_subnet_cidr_blocks      = ["10.40.16.0/20", "10.40.32.0/20"]
+  private_subnet_cidr_blocks      = ["10.40.10.0/24", "10.40.11.0/24"]
 
   public_subnets = {
     for index, cidr_block in local.public_subnet_cidr_blocks : "public-${index + 1}" => {

--- a/apps/terraform/network.tf
+++ b/apps/terraform/network.tf
@@ -10,9 +10,12 @@ data "aws_availability_zones" "available" {
 locals {
   network_availability_zone_count = 2
   network_availability_zones      = slice(data.aws_availability_zones.available.names, 0, local.network_availability_zone_count)
+  vpc_cidr_block                  = "10.40.0.0/16"
+  public_subnet_cidr_blocks       = ["10.40.0.0/20", "10.40.16.0/20"]
+  private_subnet_cidr_blocks      = ["10.40.64.0/18", "10.40.128.0/18"]
 
   public_subnets = {
-    for index, cidr_block in var.public_subnet_cidrs : "public-${index + 1}" => {
+    for index, cidr_block in local.public_subnet_cidr_blocks : "public-${index + 1}" => {
       availability_zone = local.network_availability_zones[index]
       cidr_block        = cidr_block
       name              = "${local.name_prefix}-public-${index + 1}"
@@ -20,7 +23,7 @@ locals {
   }
 
   private_subnets = {
-    for index, cidr_block in var.private_subnet_cidrs : "private-${index + 1}" => {
+    for index, cidr_block in local.private_subnet_cidr_blocks : "private-${index + 1}" => {
       availability_zone = local.network_availability_zones[index]
       cidr_block        = cidr_block
       name              = "${local.name_prefix}-private-${index + 1}"
@@ -29,7 +32,7 @@ locals {
 }
 
 resource "aws_vpc" "main" {
-  cidr_block           = var.vpc_cidr
+  cidr_block           = local.vpc_cidr_block
   enable_dns_hostnames = true
   enable_dns_support   = true
 

--- a/apps/terraform/network.tf
+++ b/apps/terraform/network.tf
@@ -11,8 +11,8 @@ locals {
   network_availability_zone_count = 2
   network_availability_zones      = slice(data.aws_availability_zones.available.names, 0, local.network_availability_zone_count)
   vpc_cidr_block                  = "10.40.0.0/16"
-  public_subnet_cidr_blocks       = ["10.40.0.0/20", "10.40.16.0/20"]
-  private_subnet_cidr_blocks      = ["10.40.64.0/18", "10.40.128.0/18"]
+  public_subnet_cidr_blocks       = ["10.40.0.0/24", "10.40.1.0/24"]
+  private_subnet_cidr_blocks      = ["10.40.16.0/20", "10.40.32.0/20"]
 
   public_subnets = {
     for index, cidr_block in local.public_subnet_cidr_blocks : "public-${index + 1}" => {

--- a/apps/terraform/network.tf
+++ b/apps/terraform/network.tf
@@ -1,0 +1,145 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+locals {
+  network_availability_zone_count = 2
+  network_availability_zones      = slice(data.aws_availability_zones.available.names, 0, local.network_availability_zone_count)
+
+  public_subnets = {
+    for index, cidr_block in var.public_subnet_cidrs : "public-${index + 1}" => {
+      availability_zone = local.network_availability_zones[index]
+      cidr_block        = cidr_block
+      name              = "${local.name_prefix}-public-${index + 1}"
+    }
+  }
+
+  private_subnets = {
+    for index, cidr_block in var.private_subnet_cidrs : "private-${index + 1}" => {
+      availability_zone = local.network_availability_zones[index]
+      cidr_block        = cidr_block
+      name              = "${local.name_prefix}-private-${index + 1}"
+    }
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = local.name_prefix
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-igw"
+  }
+}
+
+resource "aws_subnet" "public" {
+  for_each = local.public_subnets
+
+  vpc_id                  = aws_vpc.main.id
+  availability_zone       = each.value.availability_zone
+  cidr_block              = each.value.cidr_block
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name                                           = each.value.name
+    Tier                                           = "public"
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
+  }
+}
+
+resource "aws_subnet" "private" {
+  for_each = local.private_subnets
+
+  vpc_id            = aws_vpc.main.id
+  availability_zone = each.value.availability_zone
+  cidr_block        = each.value.cidr_block
+
+  tags = {
+    Name                                           = each.value.name
+    Tier                                           = "private"
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  }
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "${local.name_prefix}-nat"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public["public-1"].id
+
+  tags = {
+    Name = "${local.name_prefix}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-public"
+    Tier = "public"
+  }
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  for_each = aws_subnet.private
+
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-${each.key}"
+    Tier = "private"
+  }
+}
+
+resource "aws_route" "private_nat" {
+  for_each = aws_route_table.private
+
+  route_table_id         = each.value.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.main.id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private[each.key].id
+}

--- a/apps/terraform/outputs.tf
+++ b/apps/terraform/outputs.tf
@@ -13,6 +13,56 @@ output "kubernetes_version" {
   value       = var.kubernetes_version
 }
 
+output "vpc_id" {
+  description = "ID of the VPC prepared for EKS."
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr_block" {
+  description = "IPv4 CIDR block of the VPC prepared for EKS."
+  value       = aws_vpc.main.cidr_block
+}
+
+output "availability_zones" {
+  description = "Availability zones used by the public and private subnets."
+  value       = local.network_availability_zones
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs keyed by Terraform subnet slot."
+  value       = { for key, subnet in aws_subnet.public : key => subnet.id }
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs keyed by Terraform subnet slot. Worker nodes should use these subnets."
+  value       = { for key, subnet in aws_subnet.private : key => subnet.id }
+}
+
+output "nat_gateway_id" {
+  description = "Single NAT Gateway ID shared by private subnet route tables."
+  value       = aws_nat_gateway.main.id
+}
+
+output "public_route_table_id" {
+  description = "Public route table ID associated with all public subnets."
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_ids" {
+  description = "Private route table IDs keyed by private subnet slot."
+  value       = { for key, route_table in aws_route_table.private : key => route_table.id }
+}
+
+output "eks_cluster_security_group_id" {
+  description = "Security group ID intended for the future EKS cluster control plane."
+  value       = aws_security_group.eks_cluster.id
+}
+
+output "eks_node_security_group_id" {
+  description = "Security group ID intended for the future EKS worker nodes."
+  value       = aws_security_group.eks_nodes.id
+}
+
 output "name_prefix" {
   description = "Shared name prefix for later AWS resources."
   value       = local.name_prefix

--- a/apps/terraform/security-groups.tf
+++ b/apps/terraform/security-groups.tf
@@ -1,0 +1,80 @@
+resource "aws_security_group" "eks_cluster" {
+  name        = "${local.name_prefix}-eks-cluster"
+  description = "Network boundary for the future EKS control plane interfaces."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-eks-cluster"
+    Role = "eks-cluster"
+  }
+}
+
+resource "aws_security_group" "eks_nodes" {
+  name        = "${local.name_prefix}-eks-nodes"
+  description = "Network boundary for private EKS worker nodes."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-eks-nodes"
+    Role = "eks-nodes"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "cluster_from_nodes_https" {
+  security_group_id            = aws_security_group.eks_cluster.id
+  referenced_security_group_id = aws_security_group.eks_nodes.id
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+  description                  = "Allow worker nodes to reach the Kubernetes API endpoint."
+}
+
+resource "aws_vpc_security_group_egress_rule" "cluster_to_nodes_https" {
+  security_group_id            = aws_security_group.eks_cluster.id
+  referenced_security_group_id = aws_security_group.eks_nodes.id
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+  description                  = "Allow the control plane to reach node HTTPS webhooks."
+}
+
+resource "aws_vpc_security_group_egress_rule" "cluster_to_nodes_kubelet" {
+  security_group_id            = aws_security_group.eks_cluster.id
+  referenced_security_group_id = aws_security_group.eks_nodes.id
+  ip_protocol                  = "tcp"
+  from_port                    = 10250
+  to_port                      = 10250
+  description                  = "Allow the control plane to reach kubelet on worker nodes."
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nodes_from_cluster_https" {
+  security_group_id            = aws_security_group.eks_nodes.id
+  referenced_security_group_id = aws_security_group.eks_cluster.id
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+  description                  = "Allow control plane HTTPS traffic to worker nodes."
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nodes_from_cluster_kubelet" {
+  security_group_id            = aws_security_group.eks_nodes.id
+  referenced_security_group_id = aws_security_group.eks_cluster.id
+  ip_protocol                  = "tcp"
+  from_port                    = 10250
+  to_port                      = 10250
+  description                  = "Allow control plane kubelet traffic to worker nodes."
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nodes_from_self" {
+  security_group_id            = aws_security_group.eks_nodes.id
+  referenced_security_group_id = aws_security_group.eks_nodes.id
+  ip_protocol                  = "-1"
+  description                  = "Allow worker nodes and pods on nodes to communicate within the node group."
+}
+
+resource "aws_vpc_security_group_egress_rule" "nodes_to_internet" {
+  security_group_id = aws_security_group.eks_nodes.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Allow private worker nodes to reach AWS APIs and package registries through NAT."
+}

--- a/apps/terraform/terraform.tfvars.example
+++ b/apps/terraform/terraform.tfvars.example
@@ -1,5 +1,14 @@
-aws_region         = "ap-northeast-2"
-kubernetes_version = "1.36"
+aws_region           = "ap-northeast-2"
+kubernetes_version   = "1.36"
+vpc_cidr             = "10.40.0.0/16"
+public_subnet_cidrs  = [
+  "10.40.0.0/24",
+  "10.40.1.0/24",
+]
+private_subnet_cidrs = [
+  "10.40.10.0/24",
+  "10.40.11.0/24",
+]
 
 tags = {
   Service = "kosmo"

--- a/apps/terraform/terraform.tfvars.example
+++ b/apps/terraform/terraform.tfvars.example
@@ -1,14 +1,5 @@
 aws_region           = "ap-northeast-2"
 kubernetes_version   = "1.36"
-vpc_cidr             = "10.40.0.0/16"
-public_subnet_cidrs  = [
-  "10.40.0.0/24",
-  "10.40.1.0/24",
-]
-private_subnet_cidrs = [
-  "10.40.10.0/24",
-  "10.40.11.0/24",
-]
 
 tags = {
   Service = "kosmo"

--- a/apps/terraform/variables.tf
+++ b/apps/terraform/variables.tf
@@ -15,45 +15,6 @@ variable "kubernetes_version" {
   }
 }
 
-variable "vpc_cidr" {
-  type        = string
-  description = "IPv4 CIDR block for the kosmo EKS VPC."
-  default     = "10.40.0.0/16"
-
-  validation {
-    condition     = can(cidrnetmask(var.vpc_cidr))
-    error_message = "vpc_cidr must be a valid IPv4 CIDR block."
-  }
-}
-
-variable "public_subnet_cidrs" {
-  type        = list(string)
-  description = "Two public subnet IPv4 CIDR blocks, one per availability zone."
-  default     = ["10.40.0.0/24", "10.40.1.0/24"]
-
-  validation {
-    condition = (
-      length(var.public_subnet_cidrs) == 2 &&
-      alltrue([for cidr in var.public_subnet_cidrs : can(cidrnetmask(cidr))])
-    )
-    error_message = "public_subnet_cidrs must contain exactly two valid IPv4 CIDR blocks."
-  }
-}
-
-variable "private_subnet_cidrs" {
-  type        = list(string)
-  description = "Two private subnet IPv4 CIDR blocks for EKS worker nodes, one per availability zone."
-  default     = ["10.40.10.0/24", "10.40.11.0/24"]
-
-  validation {
-    condition = (
-      length(var.private_subnet_cidrs) == 2 &&
-      alltrue([for cidr in var.private_subnet_cidrs : can(cidrnetmask(cidr))])
-    )
-    error_message = "private_subnet_cidrs must contain exactly two valid IPv4 CIDR blocks."
-  }
-}
-
 variable "tags" {
   type        = map(string)
   description = "Additional tags merged into all AWS resources."

--- a/apps/terraform/variables.tf
+++ b/apps/terraform/variables.tf
@@ -15,8 +15,47 @@ variable "kubernetes_version" {
   }
 }
 
+variable "vpc_cidr" {
+  type        = string
+  description = "IPv4 CIDR block for the kosmo EKS VPC."
+  default     = "10.40.0.0/16"
+
+  validation {
+    condition     = can(cidrnetmask(var.vpc_cidr))
+    error_message = "vpc_cidr must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Two public subnet IPv4 CIDR blocks, one per availability zone."
+  default     = ["10.40.0.0/24", "10.40.1.0/24"]
+
+  validation {
+    condition = (
+      length(var.public_subnet_cidrs) == 2 &&
+      alltrue([for cidr in var.public_subnet_cidrs : can(cidrnetmask(cidr))])
+    )
+    error_message = "public_subnet_cidrs must contain exactly two valid IPv4 CIDR blocks."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Two private subnet IPv4 CIDR blocks for EKS worker nodes, one per availability zone."
+  default     = ["10.40.10.0/24", "10.40.11.0/24"]
+
+  validation {
+    condition = (
+      length(var.private_subnet_cidrs) == 2 &&
+      alltrue([for cidr in var.private_subnet_cidrs : can(cidrnetmask(cidr))])
+    )
+    error_message = "private_subnet_cidrs must contain exactly two valid IPv4 CIDR blocks."
+  }
+}
+
 variable "tags" {
   type        = map(string)
-  description = "Additional tags merged into all AWS resources once resources are added."
+  description = "Additional tags merged into all AWS resources."
   default     = {}
 }


### PR DESCRIPTION
## 무엇을 변경했는지

- EKS 전환용 Terraform root에 2 AZ VPC, public/private subnet, Internet Gateway, 단일 NAT Gateway, route table 구성을 추가했습니다.
- 후속 EKS cluster/node group에서 참조할 cluster/node security group과 출력값을 추가했습니다.
- CIDR과 resource name prefix를 일반 입력 변수로 열지 않고 코드에서 고정했습니다.
- public/private subnet은 모두 AZ별 `/24`로 두고, pod/service IP는 AWS subnet 주소 공간에 묶지 않는 전제를 README에 명시했습니다.
- README에 NAT Gateway 1개 구성의 비용/가용성 trade-off, Elastic IP가 public NAT Gateway의 IPv4 egress 요건이라는 점, public endpoint 사용 범위, private-only endpoint 전환 조건, OKE 복귀 영향, CIDR/prefix 고정 이유를 정리했습니다.

## 왜 변경했는지

PROD-201은 EKS worker node를 private subnet에 둘 수 있는 네트워크 기반과 security group 경계를 먼저 마련하는 작업입니다. 이후 EKS cluster, node group, CSI, Argo CD 작업이 같은 VPC/subnet/security group 출력을 기준으로 이어질 수 있게 합니다.

리뷰 반영으로, 한 번만 쓰이고 운영자가 바꿀 가능성이 낮은 CIDR 입력 변수는 제거했습니다. 또한 kosmo의 목표가 Kubernetes 위 인프라를 최대한 cloud-portable하게 유지하는 것이므로, AWS ENI 기반 pod IP 할당을 기본 전제로 두지 않고 Cilium cluster-pool/overlay처럼 pod CIDR을 Kubernetes/CNI 계층에서 별도로 관리하는 방향을 문서화했습니다.

NAT의 Elastic IP는 외부 allowlist용 고정 egress IP 정책이 아니라, AWS public NAT Gateway가 Internet Gateway로 IPv4 egress를 제공하기 위해 필요한 주소로 설명했습니다. AWS API egress는 후속으로 VPC endpoint를 붙이면 NAT 의존도를 줄일 수 있지만, 일반 인터넷 egress를 없애려면 mirror/cache 또는 egress proxy 설계가 별도로 필요합니다.

## 어떻게 확인할 수 있는지

- `git diff --check`
- `git diff --check origin/main..HEAD`
- commit hook: `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown`

`terraform fmt`, `terraform validate`, `terraform plan`은 아직 실행하지 못했습니다. 로컬 `apps/terraform/mise.toml`이 trust되지 않은 상태이고, trust 설정 변경은 별도 명시 승인이 필요한 로컬 보안 설정 변경이라 이번 작업에서는 수행하지 않았습니다. `terraform plan`은 AWS availability zone 조회와 리소스 계획 때문에 AWS 인증도 필요합니다.

## 아직 어떤 문제가 남았는지

- 실제 apply 전에 `terraform init -backend=false`, `terraform validate`, `terraform plan -input=false -lock=false`를 실행해 provider 수준 검증과 plan 결과를 확인해야 합니다.
- PROD-204/PROD-205에서 EKS cluster와 node group을 만들 때 CNI/IPAM 모드를 확정해야 합니다. 기본 방향은 pod/service CIDR을 cloud subnet CIDR에 직접 묶지 않는 구성입니다.
- PROD-204에서 public endpoint CIDR 제한과 private-only endpoint 전환 조건을 다시 확정해야 합니다.

Stack: `main -> prod-201`