### PR TITLE
PROD-184 팔로워 목록 첫 페이지를 연결한다

### DIFF
--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -1,7 +1,93 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
+  import type {
+    ProfileConnectionList_followersProfile$key,
+    ProfileConnectionList_followingProfile$key,
+    ProfileListItem_profile$key,
+  } from '$mearie';
+
   import ProfileConnectionList from './ProfileConnectionList.svelte';
+
+  type FollowState = 'ACCEPTED' | 'PENDING';
+
+  const viewerProfileId = 'viewer-profile';
+
+  const profile = (
+    overrides: Partial<{
+      id: string;
+      displayName: string;
+      handle: string;
+      bio: string | null;
+      viewerFollow: { id: string; state: FollowState } | null;
+    }> = {},
+  ): ProfileListItem_profile$key =>
+    ({
+      __typename: 'Profile',
+      id: 'connection-profile',
+      displayName: '연결된 프로필',
+      handle: 'connected',
+      bio: '팔로우 관계 목록에서 표시되는 프로필입니다.',
+      viewerFollow: null,
+      ...overrides,
+    }) as unknown as ProfileListItem_profile$key;
+
+  const followersProfile = (): ProfileConnectionList_followersProfile$key =>
+    ({
+      __typename: 'Profile',
+      id: 'target-profile',
+      followers: {
+        edges: [
+          {
+            cursor: 'follower-edge-1',
+            node: {
+              __typename: 'ProfileFollow',
+              id: 'follower-follow-1',
+              follower: profile({
+                id: 'follower-1',
+                displayName: '첫 번째 팔로워',
+                handle: 'first-follower',
+              }),
+            },
+          },
+          {
+            cursor: 'follower-edge-2',
+            node: {
+              __typename: 'ProfileFollow',
+              id: 'follower-follow-2',
+              follower: profile({
+                id: 'follower-2',
+                displayName: '두 번째 팔로워',
+                handle: 'second-follower',
+                viewerFollow: { id: 'viewer-follow-2', state: 'ACCEPTED' },
+              }),
+            },
+          },
+        ],
+      },
+    }) as unknown as ProfileConnectionList_followersProfile$key;
+
+  const followingProfile = (): ProfileConnectionList_followingProfile$key =>
+    ({
+      __typename: 'Profile',
+      id: 'target-profile',
+      following: {
+        edges: [
+          {
+            cursor: 'following-edge-1',
+            node: {
+              __typename: 'ProfileFollow',
+              id: 'following-follow-1',
+              followee: profile({
+                id: 'followee-1',
+                displayName: '팔로잉 대상',
+                handle: 'followee',
+              }),
+            },
+          },
+        ],
+      },
+    }) as unknown as ProfileConnectionList_followingProfile$key;
 
   const { Story } = defineMeta({
     title: 'KOSMO/ProfileConnectionList',
@@ -16,22 +102,41 @@
   });
 </script>
 
-<Story name="Playground" args={{ kind: 'followers', loading: false, error: false }} />
+<Story
+  name="Playground"
+  args={{
+    kind: 'followers',
+    followersProfile: followersProfile(),
+    viewerProfileId,
+    loading: false,
+    error: false,
+  }}
+/>
 
-<!-- 팔로워 목록 영역의 상태 전체: 로딩, 오류, 빈 상태. 항목 목록은 PROD-184/185에서 연결한다. -->
+<!-- 팔로워 목록 영역의 상태 전체: 로딩, 오류, 항목 있음, 빈 상태. -->
 <Story name="Followers states" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid w-[600px] gap-8">
     <ProfileConnectionList kind="followers" loading />
     <ProfileConnectionList kind="followers" error onRetry={() => {}} />
+    <ProfileConnectionList
+      kind="followers"
+      followersProfile={followersProfile()}
+      {viewerProfileId}
+    />
     <ProfileConnectionList kind="followers" />
   </div>
 </Story>
 
-<!-- 팔로잉 목록 영역의 상태 전체: 로딩, 오류, 빈 상태. 팔로워와 같은 구조를 공유한다. -->
+<!-- 팔로잉 목록 영역의 상태 전체: 로딩, 오류, 항목 있음, 빈 상태. 팔로워와 같은 구조를 공유한다. -->
 <Story name="Following states" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid w-[600px] gap-8">
     <ProfileConnectionList kind="following" loading />
     <ProfileConnectionList kind="following" error onRetry={() => {}} />
+    <ProfileConnectionList
+      kind="following"
+      followingProfile={followingProfile()}
+      {viewerProfileId}
+    />
     <ProfileConnectionList kind="following" />
   </div>
 </Story>

--- a/apps/web/src/lib/components/ProfileConnectionList.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.svelte
@@ -1,16 +1,26 @@
 <script lang="ts">
+  import { createFragment } from '@mearie/svelte';
+  import { graphql } from '$mearie';
   import type { HTMLAttributes } from 'svelte/elements';
 
+  import type {
+    ProfileConnectionList_followersProfile$key,
+    ProfileConnectionList_followingProfile$key,
+  } from '$mearie';
+
+  import ProfileListItem from './ProfileListItem.svelte';
   import TextSkeleton from './TextSkeleton.svelte';
 
   // 프로필 팔로워/팔로잉 목록 영역. 게시글 목록(PostList)과 같은 상태(로딩/오류/빈) 표현·접근성 패턴을 따른다.
   // 팔로워/팔로잉은 같은 컴포넌트를 `kind`로 분기해 시각/상태 구조를 일치시킨다.
-  // 실제 connection 데이터 연결은 후속(PROD-184/185)에서 fragment prop과 항목 목록 분기를 추가한다.
-  // 데이터 연결 전에는 항목이 없어 기본적으로 빈 상태를 표시한다.
+  // Pagination UI는 별도 이슈로 분리하고 첫 페이지만 조회한다.
   type ConnectionKind = 'followers' | 'following';
 
   type Props = HTMLAttributes<HTMLElement> & {
     kind: ConnectionKind;
+    followersProfile?: ProfileConnectionList_followersProfile$key | null;
+    followingProfile?: ProfileConnectionList_followingProfile$key | null;
+    viewerProfileId?: string | null;
     loading?: boolean;
     error?: boolean;
     onRetry?: () => void;
@@ -18,6 +28,9 @@
 
   let {
     kind,
+    followersProfile = null,
+    followingProfile = null,
+    viewerProfileId = null,
     loading = false,
     error = false,
     onRetry,
@@ -54,6 +67,69 @@
 
   const text = $derived(copy[kind]);
 
+  const followersFragment = createFragment(
+    graphql(`
+      fragment ProfileConnectionList_followersProfile on Profile {
+        id
+        followers(first: 20) {
+          edges {
+            cursor
+            node {
+              id
+              follower {
+                id
+                ...ProfileListItem_profile
+              }
+            }
+          }
+        }
+      }
+    `),
+    () => followersProfile,
+  );
+
+  const followingFragment = createFragment(
+    graphql(`
+      fragment ProfileConnectionList_followingProfile on Profile {
+        id
+        following(first: 20) {
+          edges {
+            cursor
+            node {
+              id
+              followee {
+                id
+                ...ProfileListItem_profile
+              }
+            }
+          }
+        }
+      }
+    `),
+    () => followingProfile,
+  );
+
+  const getConnectionProfiles = () => {
+    if (kind === 'followers') {
+      return (
+        followersFragment.data?.followers.edges.flatMap((edge) =>
+          edge.node.follower ? [{ cursor: edge.cursor, profile: edge.node.follower }] : [],
+        ) ?? []
+      );
+    }
+
+    return (
+      followingFragment.data?.following.edges.flatMap((edge) =>
+        edge.node.followee ? [{ cursor: edge.cursor, profile: edge.node.followee }] : [],
+      ) ?? []
+    );
+  };
+
+  const connectionProfiles = $derived(getConnectionProfiles());
+  const hasConnectionData = $derived(
+    kind === 'followers' ? Boolean(followersFragment.data) : Boolean(followingFragment.data),
+  );
+
   // 첫 화면을 채울 만큼만 반복한다.
   const skeletonItems = [0, 1, 2];
 </script>
@@ -62,7 +138,7 @@
   <h2 class="text-text-primary border-border border-b px-4 pt-2 pb-3 text-base font-bold">
     {text.title}
   </h2>
-  {#if loading}
+  {#if loading && !hasConnectionData}
     <div aria-hidden="true">
       {#each skeletonItems as item (item)}
         <div class="border-border flex items-center gap-3 border-b px-4 py-3">
@@ -77,7 +153,7 @@
       {/each}
     </div>
     <span class="sr-only" role="status">{text.loadingLabel}</span>
-  {:else if error}
+  {:else if error && !hasConnectionData}
     <div class="px-4 py-12 text-center" role="alert">
       <p class="text-text-primary text-base font-semibold">{text.errorTitle}</p>
       <p class="text-text-secondary mt-1 text-sm">잠시 후 다시 시도해주세요.</p>
@@ -91,11 +167,19 @@
         </button>
       {/if}
     </div>
+  {:else if connectionProfiles.length > 0}
+    <div>
+      {#each connectionProfiles as item (item.cursor)}
+        <ProfileListItem
+          profile={item.profile}
+          linked
+          {viewerProfileId}
+          width="wide"
+          class="w-full"
+        />
+      {/each}
+    </div>
   {:else}
-    <!--
-      항목 목록 분기는 후속(PROD-184/185)에서 connection fragment prop과 함께 추가한다.
-      그 전까지는 표시할 항목이 없으므로 빈 상태를 기본으로 표시한다.
-    -->
     <div class="px-4 py-12 text-center">
       <p class="text-text-primary text-base font-semibold">{text.emptyTitle}</p>
       <p class="text-text-secondary mt-1 text-sm">{text.emptyDescription}</p>

--- a/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
@@ -1,9 +1,36 @@
 <script lang="ts">
+  import { page } from '$app/state';
+  import { createQuery } from '@mearie/svelte';
+  import { graphql } from '$mearie';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
 
-  // 팔로워 목록 라우트 골격. 상단 ProfileHero는 상위 @[handle] layout이 렌더한다.
-  // 실제 followers connection 데이터 연결은 후속(PROD-184)에서 추가하며,
-  // 그 전까지는 빈 상태를 표시한다.
+  const query = createQuery(
+    graphql(`
+      query ProfileFollowersPageQuery($handle: String!) {
+        currentSession {
+          id
+          selectedProfile {
+            id
+          }
+        }
+        profileByHandle(handle: $handle) {
+          id
+          ...ProfileConnectionList_followersProfile
+        }
+      }
+    `),
+    () => ({ handle: page.params.handle! }),
+  );
+
+  const profile = $derived(query.data?.profileByHandle ?? null);
+  const viewerProfileId = $derived(query.data?.currentSession?.selectedProfile?.id ?? null);
 </script>
 
-<ProfileConnectionList kind="followers" />
+<ProfileConnectionList
+  kind="followers"
+  followersProfile={profile}
+  {viewerProfileId}
+  loading={query.loading}
+  error={Boolean(query.error)}
+  onRetry={query.refetch}
+/>

--- a/openspec/changes/connect-profile-follow-lists/tasks.md
+++ b/openspec/changes/connect-profile-follow-lists/tasks.md
@@ -1,15 +1,15 @@
 ## 1. 공유 목록 컴포넌트
 
-- [ ] 1.1 `ProfileConnectionList.svelte`가 `Profile.followers(first: 20)`/`Profile.following(first: 20)` fragment prop을 받아 각 edge의 상대 프로필을 `ProfileListItem`으로 렌더하도록 확장한다
-- [ ] 1.2 `viewerProfileId`를 `ProfileListItem`에 전달해 기존 `FollowButton` 표시 정책을 유지한다
-- [ ] 1.3 로딩·오류·빈 상태는 기존 표시 구조를 유지하고, connection 데이터가 있을 때만 항목 목록을 표시한다
-- [ ] 1.4 Storybook에 실제 항목이 있는 followers/following 상태를 추가한다
+- [x] 1.1 `ProfileConnectionList.svelte`가 `Profile.followers(first: 20)`/`Profile.following(first: 20)` fragment prop을 받아 각 edge의 상대 프로필을 `ProfileListItem`으로 렌더하도록 확장한다
+- [x] 1.2 `viewerProfileId`를 `ProfileListItem`에 전달해 기존 `FollowButton` 표시 정책을 유지한다
+- [x] 1.3 로딩·오류·빈 상태는 기존 표시 구조를 유지하고, connection 데이터가 있을 때만 항목 목록을 표시한다
+- [x] 1.4 Storybook에 실제 항목이 있는 followers/following 상태를 추가한다
 
 ## 2. 팔로워 목록 데이터 연결 (PROD-184)
 
-- [ ] 2.1 `/@{handle}/followers` route query에서 `profileByHandle(handle:)`와 `Profile.followers(first: 20).edges[].node.follower`를 조회한다
-- [ ] 2.2 같은 query에서 `currentSession.selectedProfile.id`를 조회해 `viewerProfileId`로 전달한다
-- [ ] 2.3 followers route가 `ProfileConnectionList kind="followers"`에 profile data, loading, error, retry를 연결한다
+- [x] 2.1 `/@{handle}/followers` route query에서 `profileByHandle(handle:)`와 `Profile.followers(first: 20).edges[].node.follower`를 조회한다
+- [x] 2.2 같은 query에서 `currentSession.selectedProfile.id`를 조회해 `viewerProfileId`로 전달한다
+- [x] 2.3 followers route가 `ProfileConnectionList kind="followers"`에 profile data, loading, error, retry를 연결한다
 
 ## 3. 팔로잉 목록 데이터 연결 (PROD-185)
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `/@{handle}/followers` route에서 `Profile.followers(first: 20)` 첫 페이지를 조회하도록 연결했습니다.
- 각 edge의 `node.follower`를 `ProfileConnectionList`를 통해 `ProfileListItem`으로 렌더합니다.
- 기존 `FollowButton` 표시 정책을 유지할 수 있도록 `currentSession.selectedProfile.id`를 `viewerProfileId`로 전달합니다.
- `ProfileConnectionList`에 followers/following connection fragment와 항목 렌더링 분기를 추가하고, Storybook에 항목 있음 상태를 추가했습니다.

## 왜 변경했는지

- 팔로워 목록 route 골격이 실제 follower 데이터를 표시하도록 만들기 위해서입니다.
- shared list 컴포넌트에 항목 렌더링을 먼저 추가해 후속 #167(`prod-185`)에서 following route만 얇게 연결할 수 있게 했습니다.
- 이 PR은 #165(`prod-184-spec`) 위에 쌓이는 PROD-184 구현 PR입니다.

## 어떻게 확인할 수 있는지

- `pnpm -F @kosmo/web check`
- `pnpm exec openspec validate --all --strict`
- `git diff --check`
- 변경 파일 직접 Prettier check
- Storybook `KOSMO / ProfileConnectionList`의 `Followers states`

## 아직 어떤 문제가 남아있는지

- following route 데이터 연결은 #167에서 처리합니다.
- pagination은 PROD-188 범위로 남깁니다.
- active profile 전환 시 목록 viewer 상태 재동기화는 PROD-189 범위로 남깁니다.
- `FollowButton` 책임 경계 재정리는 PROD-170 범위로 남깁니다.
- `ProfileListItem`의 bio 표시 여부/density variant 설계는 [PROD-218](https://linear.app/byulmaru/issue/PROD-218/profilelistitem-bio-표시-여부를-variant로-제어한다)로 분리했습니다.
- Windows에서 `pnpm lint:prettier`는 `'**/*'` glob이 literal로 전달되어 실패합니다.