### PR TITLE
PROD-185 팔로잉 목록 첫 페이지를 연결한다

### DIFF
--- a/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
@@ -1,10 +1,36 @@
 <script lang="ts">
+  import { page } from '$app/state';
+  import { createQuery } from '@mearie/svelte';
+  import { graphql } from '$mearie';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
 
-  // 팔로잉 목록 라우트 골격. 상단 ProfileHero는 상위 @[handle] layout이 렌더한다.
-  // 팔로워 목록과 같은 ProfileConnectionList를 재사용해 시각/상태 구조를 일치시킨다.
-  // 실제 following connection 데이터 연결은 후속(PROD-185)에서 추가하며,
-  // 그 전까지는 빈 상태를 표시한다.
+  const query = createQuery(
+    graphql(`
+      query ProfileFollowingPageQuery($handle: String!) {
+        currentSession {
+          id
+          selectedProfile {
+            id
+          }
+        }
+        profileByHandle(handle: $handle) {
+          id
+          ...ProfileConnectionList_followingProfile
+        }
+      }
+    `),
+    () => ({ handle: page.params.handle! }),
+  );
+
+  const profile = $derived(query.data?.profileByHandle ?? null);
+  const viewerProfileId = $derived(query.data?.currentSession?.selectedProfile?.id ?? null);
 </script>
 
-<ProfileConnectionList kind="following" />
+<ProfileConnectionList
+  kind="following"
+  followingProfile={profile}
+  {viewerProfileId}
+  loading={query.loading}
+  error={Boolean(query.error)}
+  onRetry={query.refetch}
+/>

--- a/openspec/changes/connect-profile-follow-lists/tasks.md
+++ b/openspec/changes/connect-profile-follow-lists/tasks.md
@@ -13,9 +13,9 @@
 
 ## 3. 팔로잉 목록 데이터 연결 (PROD-185)
 
-- [ ] 3.1 `/@{handle}/following` route query에서 `profileByHandle(handle:)`와 `Profile.following(first: 20).edges[].node.followee`를 조회한다
-- [ ] 3.2 같은 query에서 `currentSession.selectedProfile.id`를 조회해 `viewerProfileId`로 전달한다
-- [ ] 3.3 following route가 `ProfileConnectionList kind="following"`에 profile data, loading, error, retry를 연결한다
+- [x] 3.1 `/@{handle}/following` route query에서 `profileByHandle(handle:)`와 `Profile.following(first: 20).edges[].node.followee`를 조회한다
+- [x] 3.2 같은 query에서 `currentSession.selectedProfile.id`를 조회해 `viewerProfileId`로 전달한다
+- [x] 3.3 following route가 `ProfileConnectionList kind="following"`에 profile data, loading, error, retry를 연결한다
 
 ## 4. 검증
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `/@{handle}/following` route에서 `Profile.following(first: 20)` 첫 페이지를 조회하도록 연결했습니다.
- 각 edge의 `node.followee`를 `ProfileConnectionList`를 통해 `ProfileListItem`으로 렌더합니다.
- 기존 `FollowButton` 표시 정책을 유지할 수 있도록 `currentSession.selectedProfile.id`를 `viewerProfileId`로 전달합니다.
- OpenSpec PROD-185 task 3.x를 완료 처리했습니다.

## 왜 변경했는지

- 팔로잉 목록 route 골격이 실제 followee 데이터를 표시하도록 만들기 위해서입니다.
- #166에서 추가한 shared list 렌더링 경로를 재사용해 followers/following route의 동작과 상태 표현을 맞추기 위해서입니다.
- 이 PR은 #166(`prod-184`) 위에 쌓이는 PROD-185 구현 PR입니다.

## 어떻게 확인할 수 있는지

- `pnpm -F @kosmo/web check`
- `pnpm exec openspec validate --all --strict`
- `git diff --check`
- 변경 파일 직접 Prettier check
- Storybook `KOSMO / ProfileConnectionList`의 `Following states`

## 아직 어떤 문제가 남아있는지

- pagination은 PROD-188 범위로 남깁니다.
- active profile 전환 시 목록 viewer 상태 재동기화는 PROD-189 범위로 남깁니다.
- `FollowButton` 책임 경계 재정리는 PROD-170 범위로 남깁니다.
- `ProfileListItem`의 bio 표시 여부/density variant 설계는 [PROD-218](https://linear.app/byulmaru/issue/PROD-218/profilelistitem-bio-표시-여부를-variant로-제어한다)로 분리했습니다.
- Windows에서 `pnpm lint:prettier`는 `'**/*'` glob이 literal로 전달되어 실패합니다.