### PR TITLE
PROD-189 팔로우 목록 프로필 전환 캐시 경계를 넓힌다

### DIFF
--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -35,6 +35,8 @@
         { __typename: 'Query', $field: 'me' },
         { __typename: 'Query', $field: 'homeTimeline' },
         { __typename: 'Profile', $field: 'viewerFollow' },
+        { __typename: 'Profile', $field: 'followers' },
+        { __typename: 'Profile', $field: 'following' },
       );
   };
 


### PR DESCRIPTION
## 무엇을 변경했는지

- active profile 전환 후 실행되는 Mearie cache invalidation 대상에 `Profile.followers`와 `Profile.following`을 추가했습니다.
- 기존 invalidation 대상인 `currentSession`, `me`, `homeTimeline`, `Profile.viewerFollow`는 유지했습니다.
- followers/following route, `ProfileConnectionList`, `ProfileListItem`, `FollowButton` 책임 구조는 변경하지 않았습니다.

## 왜 변경했는지

- 팔로워/팔로잉 목록의 follow button 상태는 현재 selected profile 기준의 `viewerFollow`에 의존합니다.
- 같은 목록 route에 머문 채 active profile을 바꾸면 목록 connection 아래 profile fragment가 이전 viewer 기준 상태를 계속 보여줄 수 있으므로, PROD-109에서 만든 cache invalidation 경계를 목록 connection까지 명시적으로 넓혔습니다.
- `FollowButton`의 viewer/session 책임 재설계는 PROD-170 범위로 남기고, 이번 PR은 active profile 전환 후 목록 화면 재동기화만 다룹니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm exec prettier --check "apps/web/src/routes/(tabs)/+layout.svelte"`
- `git diff --check`
- 브라우저에서 `/@[handle]/followers`, `/@[handle]/following`에 머문 채 active profile을 바꾸는 수동 시나리오 확인
- GitHub Actions: Lint, Semgrep scan, Web E2E 통과

## 아직 어떤 문제가 남았는지

- 없음
- 테스트 코드는 요청에 따라 추가하거나 커밋하지 않았습니다.