### PR TITLE
팔로워/팔로잉 목록 페이지네이션 스펙을 분리한다

### DIFF
--- a/openspec/changes/connect-profile-follow-list-pagination/.openspec.yaml
+++ b/openspec/changes/connect-profile-follow-list-pagination/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/connect-profile-follow-list-pagination/design.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/design.md
@@ -1,0 +1,45 @@
+## Context
+
+팔로워/팔로잉 목록 라우트와 `ProfileConnectionList`는 이미 `Profile.followers(first: 20)`와 `Profile.following(first: 20)` 첫 페이지를 표시한다. 선행 OpenSpec change인 `connect-profile-follow-lists`는 첫 페이지 연결까지만 다루고 pagination을 명시적으로 제외했으므로, 이 변경은 그 위에 쌓이는 후속 범위다.
+
+API는 이미 Relay-style connection 인자(`first`, `after`, `before`, `last`)와 `PageInfo`를 제공한다. 따라서 서버 schema/resolver 변경 없이 웹 route query 변수와 목록 컴포넌트 상태를 확장하면 된다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 팔로워/팔로잉 두 목록에서 `pageInfo.hasNextPage`와 `pageInfo.endCursor`를 기준으로 다음 페이지를 불러온다.
+- 두 목록이 같은 pagination UI, 로딩, 실패, 재시도, 마지막 페이지 처리를 공유한다.
+- 다음 페이지 요청이 실패해도 이미 표시된 목록은 유지한다.
+- 추가 페이지 항목도 기존 `ProfileListItem`/`FollowButton` 정책과 connection edge 순서를 유지한다.
+
+**Non-Goals:**
+
+- API GraphQL connection, resolver, schema 변경.
+- follow/unfollow mutation 동작 변경.
+- active profile 전환 시 기존 목록 항목 viewer 상태 재동기화(PROD-189).
+- `FollowButton`의 viewer/session 책임 경계 재설계(PROD-170).
+- 무한 스크롤 또는 viewport 관찰 기반 자동 로드.
+
+## Decisions
+
+- route query가 `after` 변수를 소유하고, `ProfileConnectionList`는 pagination 상태와 load-more callback을 props로 받는다.
+  - 이유: GraphQL query document와 변수는 route에 colocate하는 기존 패턴을 유지하고, 목록 컴포넌트는 표시와 상태 UI를 공유하는 책임에 집중한다.
+  - 대안: `ProfileConnectionList`가 직접 query를 실행할 수 있지만, route별 handle 변수와 current session query가 컴포넌트 내부로 섞인다.
+
+- 다음 페이지 결과는 route state에 누적하고, 목록 컴포넌트에는 현재 누적된 connection shape를 넘긴다.
+  - 이유: Mearie normalized cache가 connection append 정책을 자동으로 제공한다는 repo 내 선례가 없다. 명시적으로 누적하면 실패/재시도와 중복 클릭 상태를 route에서 제어할 수 있다.
+  - 대안: cache merge 정책에 의존할 수 있다면 코드가 짧아질 수 있지만, 현재 repo에는 fetch-more 패턴이 없고 동작 검증 부담이 커진다.
+
+- pagination UI는 수동 “더 불러오기” 버튼으로 시작한다.
+  - 이유: 접근성이 명확하고, 실패 후 같은 버튼으로 재시도 상태를 표현하기 쉽다. 무한 스크롤보다 테스트와 수동 검증 범위가 작다.
+  - 대안: viewport 진입 시 자동 로드는 사용자가 목록 끝에 도달하기 전에 데이터를 가져올 수 있지만, 관찰자 cleanup, 중복 요청, 오류 복구 UX가 추가된다.
+
+- 첫 페이지 전체 오류와 다음 페이지 오류를 분리한다.
+  - 이유: 첫 페이지 오류는 기존 인라인 오류 상태를 그대로 사용하고, 다음 페이지 오류는 기존 목록 아래에서 재시도해야 이미 본 항목이 사라지지 않는다.
+
+## Risks / Trade-offs
+
+- Mearie query 재실행 시 첫 페이지 데이터가 갱신되면 route의 누적 목록과 최신 첫 페이지가 어긋날 수 있음 → handle 또는 첫 페이지 profile id가 바뀌면 누적 상태를 초기화하고, 추가 페이지는 현재 `endCursor` 기준으로만 붙인다.
+- follow/unfollow로 관계 수나 목록 membership이 바뀌어도 pagination 누적 목록이 즉시 재정렬/삭제되지 않을 수 있음 → 이번 범위는 기존 `ProfileListItem`/`FollowButton` 정책 유지로 제한하고, 관계 목록 membership 동기화는 별도 후속으로 남긴다.
+- 두 route의 pagination state 코드가 유사해 중복이 생길 수 있음 → 이번 PR은 두 route가 각각 필요한 connection만 조회하는 기존 구조를 유지한다. 구현 중 중복이 과도하면 route-local helper를 검토하되, GraphQL document colocation을 깨지 않는다.

--- a/openspec/changes/connect-profile-follow-list-pagination/design.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-팔로워/팔로잉 목록 라우트와 `ProfileConnectionList`는 이미 `Profile.followers(first: 20)`와 `Profile.following(first: 20)` 첫 페이지를 표시한다. 선행 OpenSpec change인 `connect-profile-follow-lists`는 첫 페이지 연결까지만 다루고 pagination을 명시적으로 제외했으므로, 이 변경은 그 위에 쌓이는 후속 범위다.
+팔로워/팔로잉 목록 라우트와 `ProfileConnectionList`는 이미 `Profile.followers(first: 20)`와 `Profile.following(first: 20)` 첫 페이지를 표시한다. 선행 OpenSpec change인 `connect-profile-follow-lists`는 첫 페이지 연결 계약만 다루고 첫 페이지 이후 pagination을 후속 change로 남기므로, 이 변경은 그 위에 쌓이는 후속 범위다.
 
 API는 이미 Relay-style connection 인자(`first`, `after`, `before`, `last`)와 `PageInfo`를 제공한다. 따라서 서버 schema/resolver 변경 없이 웹 route query 변수와 목록 컴포넌트 상태를 확장하면 된다.
 

--- a/openspec/changes/connect-profile-follow-list-pagination/proposal.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+팔로워/팔로잉 목록은 이미 GraphQL connection 첫 페이지를 표시하지만, 관계 수가 20개를 넘으면 사용자가 나머지 목록을 탐색할 수 없다. API가 cursor pagination과 `pageInfo`를 제공하므로, 웹 목록 화면이 다음 페이지 로드를 연결해 긴 관계 목록을 끝까지 볼 수 있게 한다.
+
+## What Changes
+
+- `/@{handle}/followers`와 `/@{handle}/following` 목록에서 `pageInfo.hasNextPage`와 `pageInfo.endCursor`를 사용해 다음 페이지를 불러온다.
+- 두 목록은 같은 pagination UI와 상태 처리를 공유한다.
+- 다음 페이지 로딩 중에는 중복 클릭을 막고 진행 중 상태를 표시한다.
+- 마지막 페이지에서는 추가 로드 동작을 노출하지 않는다.
+- 다음 페이지 조회가 실패하면 기존 목록은 유지하고, 같은 위치에서 재시도할 수 있게 한다.
+- 이 변경은 follow/unfollow mutation, active profile 전환 재동기화, `FollowButton` 책임 재설계, 서버 GraphQL connection 계약 변경을 포함하지 않는다.
+
+## Capabilities
+
+### New Capabilities
+
+- 없음
+
+### Modified Capabilities
+
+- `web-app-shell`: 팔로워/팔로잉 목록 라우트가 connection 첫 페이지뿐 아니라 `pageInfo` 기반 다음 페이지 로드를 제공해야 한다는 요구사항을 추가한다.
+
+## Impact
+
+- `openspec/specs/web-app-shell/spec.md`
+- `apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte`
+- `apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte`
+- `apps/web/src/lib/components/ProfileConnectionList.svelte`
+- `apps/web/src/lib/components/ProfileConnectionList.stories.svelte`
+- API schema/resolver 변경 없음: 기존 `Profile.followers(after:, first:)`, `Profile.following(after:, first:)`, `PageInfo` 계약을 사용한다.

--- a/openspec/changes/connect-profile-follow-list-pagination/specs/web-app-shell/spec.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/specs/web-app-shell/spec.md
@@ -1,3 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Profile connection list data rendering
+
+팔로워·팔로잉 목록 라우트는 해당 프로필의 follow connection 첫 페이지를 조회해 프로필 항목 목록을 렌더해야 한다(MUST). `/@{handle}/followers`는 `Profile.followers(first: 20).edges[].node.follower`를 `ProfileListItem`으로 표시해야 하며(MUST), `/@{handle}/following`은 `Profile.following(first: 20).edges[].node.followee`를 `ProfileListItem`으로 표시해야 한다(MUST). 두 목록은 connection이 반환한 edge 순서를 그대로 렌더하고 클라이언트에서 별도 정렬하지 않아야 한다(MUST NOT). 각 항목은 기존 `ProfileListItem`/`FollowButton` 정책을 따라 프로필 정보와 가능한 follow action을 표시해야 한다(MUST). 이 요구사항은 첫 페이지 렌더링 계약을 정의하며, 첫 페이지 이후의 pagination 동작은 `Profile connection list pagination` 요구사항에서 정의한다.
+
+#### Scenario: Render followers from connection
+
+- **WHEN** 사용자가 `/@{handle}/followers`에 접근하고 `Profile.followers(first: 20)`가 edge를 반환한다
+- **THEN** 시스템은 각 edge의 `node.follower` 프로필을 `ProfileListItem`으로 표시한다
+- **AND** 팔로워 목록 영역은 상위 프로필 헤더 아래에 유지된다
+
+#### Scenario: Render following from connection
+
+- **WHEN** 사용자가 `/@{handle}/following`에 접근하고 `Profile.following(first: 20)`가 edge를 반환한다
+- **THEN** 시스템은 각 edge의 `node.followee` 프로필을 `ProfileListItem`으로 표시한다
+- **AND** 팔로잉 목록 영역은 상위 프로필 헤더 아래에 유지된다
+
+#### Scenario: Preserve empty state after data connection
+
+- **WHEN** 팔로워 또는 팔로잉 connection 첫 페이지가 edge를 반환하지 않는다
+- **THEN** 시스템은 기존 목록 종류별 빈 상태를 표시한다
+
+#### Scenario: Preserve connection order
+
+- **WHEN** 팔로워 또는 팔로잉 connection 첫 페이지가 여러 edge를 반환한다
+- **THEN** 시스템은 connection edge가 반환된 순서대로 목록 항목을 표시한다
+- **AND** 클라이언트는 항목을 별도 기준으로 재정렬하지 않는다
+
+#### Scenario: Preserve list item follow policy
+
+- **WHEN** 비로그인 사용자, 선택 프로필이 없는 사용자, 또는 자기 프로필 항목이 팔로워·팔로잉 목록을 본다
+- **THEN** 시스템은 새 follow action 정책을 만들지 않고 기존 `ProfileListItem`/`FollowButton` 정책에 따라 action을 표시하거나 숨긴다
+
 ## ADDED Requirements
 
 ### Requirement: Profile connection list pagination

--- a/openspec/changes/connect-profile-follow-list-pagination/specs/web-app-shell/spec.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/specs/web-app-shell/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Profile connection list pagination
+
+팔로워·팔로잉 목록 라우트는 connection 첫 페이지 이후에도 `pageInfo` 기반 다음 페이지 로드를 제공해야 한다(MUST). `/@{handle}/followers`는 `Profile.followers(first: 20, after: <endCursor>)`로 다음 팔로워 페이지를 조회해야 하며(MUST), `/@{handle}/following`은 `Profile.following(first: 20, after: <endCursor>)`로 다음 팔로잉 페이지를 조회해야 한다(MUST). 추가 페이지 항목은 기존 목록 뒤에 connection edge 순서대로 붙어야 하며(MUST), 클라이언트는 항목을 별도 기준으로 재정렬하지 않아야 한다(MUST NOT). 두 목록은 같은 pagination UI와 상태 표현을 공유해야 한다(MUST).
+
+#### Scenario: Load next followers page
+
+- **WHEN** 사용자가 `/@{handle}/followers`에서 첫 페이지를 보고 있고 `pageInfo.hasNextPage`가 `true`이다
+- **THEN** 시스템은 다음 페이지를 불러오는 동작을 제공한다
+- **AND** 사용자가 그 동작을 실행하면 `pageInfo.endCursor`를 `after`로 사용해 다음 팔로워 페이지를 조회한다
+- **AND** 새 팔로워 항목은 기존 팔로워 목록 뒤에 connection edge 순서대로 추가된다
+
+#### Scenario: Load next following page
+
+- **WHEN** 사용자가 `/@{handle}/following`에서 첫 페이지를 보고 있고 `pageInfo.hasNextPage`가 `true`이다
+- **THEN** 시스템은 다음 페이지를 불러오는 동작을 제공한다
+- **AND** 사용자가 그 동작을 실행하면 `pageInfo.endCursor`를 `after`로 사용해 다음 팔로잉 페이지를 조회한다
+- **AND** 새 팔로잉 항목은 기존 팔로잉 목록 뒤에 connection edge 순서대로 추가된다
+
+#### Scenario: Prevent duplicate next-page requests
+
+- **WHEN** 다음 페이지 요청이 진행 중이다
+- **THEN** 시스템은 같은 목록에서 중복 추가 로드 요청을 실행하지 않는다
+- **AND** 사용자에게 추가 로드가 진행 중임을 버튼 상태 또는 보조 기술 상태로 알려야 한다
+
+#### Scenario: Hide load action on last page
+
+- **WHEN** 현재 connection의 `pageInfo.hasNextPage`가 `false`이다
+- **THEN** 시스템은 다음 페이지를 불러오는 동작을 제공하지 않는다
+
+#### Scenario: Retry failed next-page request
+
+- **WHEN** 첫 페이지 항목이 표시된 상태에서 다음 페이지 요청이 실패한다
+- **THEN** 시스템은 기존 목록 항목을 유지한다
+- **AND** 목록 아래에 다음 페이지를 불러오지 못했다는 오류와 재시도 동작을 표시한다
+- **AND** 사용자가 재시도하면 실패했던 cursor 기준으로 다음 페이지 요청을 다시 실행한다
+
+#### Scenario: Preserve first-page error behavior
+
+- **WHEN** 첫 페이지 조회가 실패했고 표시할 기존 목록 데이터가 없다
+- **THEN** 시스템은 기존 팔로워·팔로잉 목록 오류 상태와 다시 시도 동작을 표시한다
+- **AND** 다음 페이지 오류 UI를 별도로 표시하지 않는다

--- a/openspec/changes/connect-profile-follow-list-pagination/specs/web-app-shell/spec.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/specs/web-app-shell/spec.md
@@ -1,37 +1,3 @@
-## MODIFIED Requirements
-
-### Requirement: Profile connection list data rendering
-
-팔로워·팔로잉 목록 라우트는 해당 프로필의 follow connection 첫 페이지를 조회해 프로필 항목 목록을 렌더해야 한다(MUST). `/@{handle}/followers`는 `Profile.followers(first: 20).edges[].node.follower`를 `ProfileListItem`으로 표시해야 하며(MUST), `/@{handle}/following`은 `Profile.following(first: 20).edges[].node.followee`를 `ProfileListItem`으로 표시해야 한다(MUST). 두 목록은 connection이 반환한 edge 순서를 그대로 렌더하고 클라이언트에서 별도 정렬하지 않아야 한다(MUST NOT). 각 항목은 기존 `ProfileListItem`/`FollowButton` 정책을 따라 프로필 정보와 가능한 follow action을 표시해야 한다(MUST). 이 요구사항은 첫 페이지 렌더링 계약을 정의하며, 첫 페이지 이후의 pagination 동작은 `Profile connection list pagination` 요구사항에서 정의한다.
-
-#### Scenario: Render followers from connection
-
-- **WHEN** 사용자가 `/@{handle}/followers`에 접근하고 `Profile.followers(first: 20)`가 edge를 반환한다
-- **THEN** 시스템은 각 edge의 `node.follower` 프로필을 `ProfileListItem`으로 표시한다
-- **AND** 팔로워 목록 영역은 상위 프로필 헤더 아래에 유지된다
-
-#### Scenario: Render following from connection
-
-- **WHEN** 사용자가 `/@{handle}/following`에 접근하고 `Profile.following(first: 20)`가 edge를 반환한다
-- **THEN** 시스템은 각 edge의 `node.followee` 프로필을 `ProfileListItem`으로 표시한다
-- **AND** 팔로잉 목록 영역은 상위 프로필 헤더 아래에 유지된다
-
-#### Scenario: Preserve empty state after data connection
-
-- **WHEN** 팔로워 또는 팔로잉 connection 첫 페이지가 edge를 반환하지 않는다
-- **THEN** 시스템은 기존 목록 종류별 빈 상태를 표시한다
-
-#### Scenario: Preserve connection order
-
-- **WHEN** 팔로워 또는 팔로잉 connection 첫 페이지가 여러 edge를 반환한다
-- **THEN** 시스템은 connection edge가 반환된 순서대로 목록 항목을 표시한다
-- **AND** 클라이언트는 항목을 별도 기준으로 재정렬하지 않는다
-
-#### Scenario: Preserve list item follow policy
-
-- **WHEN** 비로그인 사용자, 선택 프로필이 없는 사용자, 또는 자기 프로필 항목이 팔로워·팔로잉 목록을 본다
-- **THEN** 시스템은 새 follow action 정책을 만들지 않고 기존 `ProfileListItem`/`FollowButton` 정책에 따라 action을 표시하거나 숨긴다
-
 ## ADDED Requirements
 
 ### Requirement: Profile connection list pagination

--- a/openspec/changes/connect-profile-follow-list-pagination/tasks.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/tasks.md
@@ -1,0 +1,24 @@
+## 1. Route pagination state
+
+- [ ] 1.1 followers route query에 `after` 변수를 추가하고 첫 페이지와 다음 페이지를 구분해 조회할 수 있게 한다
+- [ ] 1.2 following route query에 `after` 변수를 추가하고 첫 페이지와 다음 페이지를 구분해 조회할 수 있게 한다
+- [ ] 1.3 handle 또는 첫 페이지 대상 profile이 바뀌면 누적 connection state와 다음 페이지 오류 상태를 초기화한다
+- [ ] 1.4 다음 페이지 성공 시 새 edge를 기존 목록 뒤에 connection 순서대로 append하고 최신 `pageInfo`를 보존한다
+
+## 2. Shared pagination UI
+
+- [ ] 2.1 `ProfileConnectionList` fragment에 `pageInfo { hasNextPage endCursor }`를 포함한다
+- [ ] 2.2 `ProfileConnectionList`에 다음 페이지 가능 여부, 로딩 여부, 오류 여부, load-more/retry callback props를 추가한다
+- [ ] 2.3 목록 아래에 공통 “더 불러오기” 버튼을 표시하고, 다음 페이지 로딩 중에는 중복 클릭을 막는다
+- [ ] 2.4 마지막 페이지에서는 load-more UI를 숨기고, 다음 페이지 실패 시 기존 목록을 유지한 채 재시도 UI를 표시한다
+
+## 3. Storybook states
+
+- [ ] 3.1 followers story에 다음 페이지 있음, 다음 페이지 로딩, 다음 페이지 실패, 마지막 페이지 상태를 추가한다
+- [ ] 3.2 following story에 같은 pagination 상태를 추가해 두 목록의 UI 구조가 일치하는지 확인할 수 있게 한다
+
+## 4. Verification
+
+- [ ] 4.1 `pnpm --filter @kosmo/web check`를 통과시킨다
+- [ ] 4.2 `pnpm lint:prettier`를 통과시킨다
+- [ ] 4.3 팔로워/팔로잉 목록에서 첫 페이지 오류와 다음 페이지 오류가 서로 다른 위치에서 처리되는지 수동 또는 Storybook으로 확인한다

--- a/openspec/changes/connect-profile-follow-lists/specs/web-app-shell/spec.md
+++ b/openspec/changes/connect-profile-follow-lists/specs/web-app-shell/spec.md
@@ -26,7 +26,7 @@
 
 ### Requirement: Profile connection list data rendering
 
-팔로워·팔로잉 목록 라우트는 해당 프로필의 follow connection 첫 페이지를 조회해 프로필 항목 목록을 렌더해야 한다(MUST). `/@{handle}/followers`는 `Profile.followers(first: 20).edges[].node.follower`를 `ProfileListItem`으로 표시해야 하며(MUST), `/@{handle}/following`은 `Profile.following(first: 20).edges[].node.followee`를 `ProfileListItem`으로 표시해야 한다(MUST). 두 목록은 connection이 반환한 edge 순서를 그대로 렌더하고 클라이언트에서 별도 정렬하지 않아야 한다(MUST NOT). 각 항목은 기존 `ProfileListItem`/`FollowButton` 정책을 따라 프로필 정보와 가능한 follow action을 표시해야 한다(MUST). 이 요구사항은 첫 페이지 렌더링만 포함하며, pagination은 포함하지 않는다(MUST NOT).
+팔로워·팔로잉 목록 라우트는 해당 프로필의 follow connection 첫 페이지를 조회해 프로필 항목 목록을 렌더해야 한다(MUST). `/@{handle}/followers`는 `Profile.followers(first: 20).edges[].node.follower`를 `ProfileListItem`으로 표시해야 하며(MUST), `/@{handle}/following`은 `Profile.following(first: 20).edges[].node.followee`를 `ProfileListItem`으로 표시해야 한다(MUST). 두 목록은 connection이 반환한 edge 순서를 그대로 렌더하고 클라이언트에서 별도 정렬하지 않아야 한다(MUST NOT). 각 항목은 기존 `ProfileListItem`/`FollowButton` 정책을 따라 프로필 정보와 가능한 follow action을 표시해야 한다(MUST). 이 요구사항은 첫 페이지 렌더링 계약만 정의하며, 첫 페이지 이후의 pagination 동작은 후속 change에서 별도 요구사항으로 정의한다.
 
 #### Scenario: Render followers from connection
 


### PR DESCRIPTION
## 무엇을 변경했는지

- PROD-188용 OpenSpec change `connect-profile-follow-list-pagination`을 추가했습니다.
- 팔로워/팔로잉 목록의 `pageInfo` 기반 다음 페이지 로드 요구사항, 설계, 작업 체크리스트를 분리했습니다.

## 왜 변경했는지

- 구현 PR과 스펙 PR을 분리해 리뷰 범위를 작게 유지하기 위해서입니다.
- 현재 목록은 첫 페이지 이후 관계를 탐색할 수 없으므로, 구현 전에 pagination 요구사항과 제외 범위를 명확히 합니다.

## 어떻게 확인할 수 있는지

- `pnpm exec openspec validate connect-profile-follow-list-pagination`
- pre-commit hook: `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown`

## 아직 어떤 문제가 남았는지

- 실제 UI/GraphQL 구현은 후속 stacked PR에서 진행합니다.
- Stack: main -> prod-188