### PR TITLE
팔로우 목록에서 다음 페이지를 불러올 수 있게 한다

### DIFF
--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -32,11 +32,28 @@
       ...overrides,
     }) as unknown as ProfileListItem_profile$key;
 
-  const followersProfile = (): ProfileConnectionList_followersProfile$key =>
+  const additionalProfileItems = (kind: 'followers' | 'following') => [
+    {
+      cursor: `${kind}-edge-3`,
+      profile: profile({
+        id: `${kind}-page-2-profile`,
+        displayName: '다음 페이지 프로필',
+        handle: `${kind}-next-page`,
+      }),
+    },
+  ];
+
+  const followersProfile = (
+    pageInfo: { hasNextPage: boolean; endCursor: string | null } = {
+      hasNextPage: true,
+      endCursor: 'follower-edge-2',
+    },
+  ): ProfileConnectionList_followersProfile$key =>
     ({
       __typename: 'Profile',
       id: 'target-profile',
       followers: {
+        pageInfo,
         edges: [
           {
             cursor: 'follower-edge-1',
@@ -67,11 +84,17 @@
       },
     }) as unknown as ProfileConnectionList_followersProfile$key;
 
-  const followingProfile = (): ProfileConnectionList_followingProfile$key =>
+  const followingProfile = (
+    pageInfo: { hasNextPage: boolean; endCursor: string | null } = {
+      hasNextPage: true,
+      endCursor: 'following-edge-1',
+    },
+  ): ProfileConnectionList_followingProfile$key =>
     ({
       __typename: 'Profile',
       id: 'target-profile',
       following: {
+        pageInfo,
         edges: [
           {
             cursor: 'following-edge-1',
@@ -88,6 +111,8 @@
         ],
       },
     }) as unknown as ProfileConnectionList_followingProfile$key;
+
+  const lastPageInfo = { hasNextPage: false, endCursor: null };
 
   const { Story } = defineMeta({
     title: 'KOSMO/ProfileConnectionList',
@@ -110,6 +135,7 @@
     viewerProfileId,
     loading: false,
     error: false,
+    onLoadMore: () => {},
   }}
 />
 
@@ -122,8 +148,42 @@
       kind="followers"
       followersProfile={followersProfile()}
       {viewerProfileId}
+      onLoadMore={() => {}}
     />
     <ProfileConnectionList kind="followers" />
+  </div>
+</Story>
+
+<!-- 팔로워 목록의 pagination 상태: 추가 로드 가능, 로딩, 실패, 마지막 페이지. -->
+<Story name="Followers pagination states" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid w-[600px] gap-8">
+    <ProfileConnectionList
+      kind="followers"
+      followersProfile={followersProfile()}
+      {viewerProfileId}
+      onLoadMore={() => {}}
+    />
+    <ProfileConnectionList
+      kind="followers"
+      followersProfile={followersProfile()}
+      {viewerProfileId}
+      loadingNextPage
+      onLoadMore={() => {}}
+    />
+    <ProfileConnectionList
+      kind="followers"
+      followersProfile={followersProfile()}
+      {viewerProfileId}
+      nextPageError
+      onLoadMore={() => {}}
+    />
+    <ProfileConnectionList
+      kind="followers"
+      followersProfile={followersProfile(lastPageInfo)}
+      additionalProfiles={additionalProfileItems('followers')}
+      {viewerProfileId}
+      onLoadMore={() => {}}
+    />
   </div>
 </Story>
 
@@ -136,7 +196,41 @@
       kind="following"
       followingProfile={followingProfile()}
       {viewerProfileId}
+      onLoadMore={() => {}}
     />
     <ProfileConnectionList kind="following" />
+  </div>
+</Story>
+
+<!-- 팔로잉 목록의 pagination 상태: 추가 로드 가능, 로딩, 실패, 마지막 페이지. -->
+<Story name="Following pagination states" asChild parameters={{ controls: { disable: true } }}>
+  <div class="grid w-[600px] gap-8">
+    <ProfileConnectionList
+      kind="following"
+      followingProfile={followingProfile()}
+      {viewerProfileId}
+      onLoadMore={() => {}}
+    />
+    <ProfileConnectionList
+      kind="following"
+      followingProfile={followingProfile()}
+      {viewerProfileId}
+      loadingNextPage
+      onLoadMore={() => {}}
+    />
+    <ProfileConnectionList
+      kind="following"
+      followingProfile={followingProfile()}
+      {viewerProfileId}
+      nextPageError
+      onLoadMore={() => {}}
+    />
+    <ProfileConnectionList
+      kind="following"
+      followingProfile={followingProfile(lastPageInfo)}
+      additionalProfiles={additionalProfileItems('following')}
+      {viewerProfileId}
+      onLoadMore={() => {}}
+    />
   </div>
 </Story>

--- a/apps/web/src/lib/components/ProfileConnectionList.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.svelte
@@ -6,6 +6,7 @@
   import type {
     ProfileConnectionList_followersProfile$key,
     ProfileConnectionList_followingProfile$key,
+    ProfileListItem_profile$key,
   } from '$mearie';
 
   import ProfileListItem from './ProfileListItem.svelte';
@@ -13,27 +14,39 @@
 
   // 프로필 팔로워/팔로잉 목록 영역. 게시글 목록(PostList)과 같은 상태(로딩/오류/빈) 표현·접근성 패턴을 따른다.
   // 팔로워/팔로잉은 같은 컴포넌트를 `kind`로 분기해 시각/상태 구조를 일치시킨다.
-  // Pagination UI는 별도 이슈로 분리하고 첫 페이지만 조회한다.
   type ConnectionKind = 'followers' | 'following';
+  type ConnectionProfileItem = { cursor: string; profile: ProfileListItem_profile$key };
 
   type Props = HTMLAttributes<HTMLElement> & {
     kind: ConnectionKind;
     followersProfile?: ProfileConnectionList_followersProfile$key | null;
     followingProfile?: ProfileConnectionList_followingProfile$key | null;
+    additionalProfiles?: ConnectionProfileItem[];
+    hasNextPage?: boolean | null;
+    endCursor?: string | null;
+    loadingNextPage?: boolean;
+    nextPageError?: boolean;
     viewerProfileId?: string | null;
     loading?: boolean;
     error?: boolean;
     onRetry?: () => void;
+    onLoadMore?: (after: string) => void;
   };
 
   let {
     kind,
     followersProfile = null,
     followingProfile = null,
+    additionalProfiles = [],
+    hasNextPage = null,
+    endCursor = null,
+    loadingNextPage = false,
+    nextPageError = false,
     viewerProfileId = null,
     loading = false,
     error = false,
     onRetry,
+    onLoadMore,
     class: className,
     ...attributes
   }: Props = $props();
@@ -47,6 +60,8 @@
       emptyDescription: string;
       errorTitle: string;
       loadingLabel: string;
+      nextPageErrorTitle: string;
+      loadingNextPageLabel: string;
     }
   > = {
     followers: {
@@ -55,6 +70,8 @@
       emptyDescription: '이 프로필을 팔로우하는 사람이 생기면 여기에 표시돼요.',
       errorTitle: '팔로워 목록을 불러오지 못했어요',
       loadingLabel: '팔로워 목록을 불러오는 중입니다.',
+      nextPageErrorTitle: '팔로워를 더 불러오지 못했어요',
+      loadingNextPageLabel: '팔로워를 더 불러오는 중입니다.',
     },
     following: {
       title: '팔로잉',
@@ -62,6 +79,8 @@
       emptyDescription: '이 프로필이 팔로우하는 사람이 생기면 여기에 표시돼요.',
       errorTitle: '팔로잉 목록을 불러오지 못했어요',
       loadingLabel: '팔로잉 목록을 불러오는 중입니다.',
+      nextPageErrorTitle: '팔로잉을 더 불러오지 못했어요',
+      loadingNextPageLabel: '팔로잉을 더 불러오는 중입니다.',
     },
   };
 
@@ -72,6 +91,10 @@
       fragment ProfileConnectionList_followersProfile on Profile {
         id
         followers(first: 20) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
           edges {
             cursor
             node {
@@ -93,6 +116,10 @@
       fragment ProfileConnectionList_followingProfile on Profile {
         id
         following(first: 20) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
           edges {
             cursor
             node {
@@ -125,10 +152,28 @@
     );
   };
 
-  const connectionProfiles = $derived(getConnectionProfiles());
+  const firstPageProfiles = $derived(getConnectionProfiles());
+  const connectionProfiles = $derived([...firstPageProfiles, ...additionalProfiles]);
   const hasConnectionData = $derived(
     kind === 'followers' ? Boolean(followersFragment.data) : Boolean(followingFragment.data),
   );
+  const firstPageInfo = $derived(
+    kind === 'followers'
+      ? followersFragment.data?.followers.pageInfo
+      : followingFragment.data?.following.pageInfo,
+  );
+  const effectiveHasNextPage = $derived(hasNextPage ?? firstPageInfo?.hasNextPage ?? false);
+  const effectiveEndCursor = $derived(endCursor ?? firstPageInfo?.endCursor ?? null);
+  const showPagination = $derived(Boolean(onLoadMore) && (effectiveHasNextPage || nextPageError));
+  const canLoadMore = $derived(Boolean(effectiveEndCursor) && !loadingNextPage);
+
+  const loadMore = () => {
+    if (!effectiveEndCursor || loadingNextPage) {
+      return;
+    }
+
+    onLoadMore?.(effectiveEndCursor);
+  };
 
   // 첫 화면을 채울 만큼만 반복한다.
   const skeletonItems = [0, 1, 2];
@@ -179,6 +224,28 @@
         />
       {/each}
     </div>
+    {#if showPagination}
+      <div class="border-border border-t px-4 py-4 text-center">
+        {#if nextPageError}
+          <p class="text-text-primary text-sm font-semibold" role="alert">
+            {text.nextPageErrorTitle}
+          </p>
+          <p class="text-text-secondary mt-1 text-sm">잠시 후 다시 시도해주세요.</p>
+        {/if}
+        <button
+          class="border-border text-text-primary mt-3 rounded-lg border px-4 py-2 text-sm font-bold disabled:opacity-45"
+          type="button"
+          disabled={!canLoadMore}
+          aria-busy={loadingNextPage}
+          onclick={loadMore}
+        >
+          {loadingNextPage ? '불러오는 중' : nextPageError ? '다시 시도' : '더 불러오기'}
+        </button>
+        {#if loadingNextPage}
+          <span class="sr-only" role="status">{text.loadingNextPageLabel}</span>
+        {/if}
+      </div>
+    {/if}
   {:else}
     <div class="px-4 py-12 text-center">
       <p class="text-text-primary text-base font-semibold">{text.emptyTitle}</p>

--- a/apps/web/src/lib/profileConnectionPagination.test.ts
+++ b/apps/web/src/lib/profileConnectionPagination.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { appendConnectionPage } from './profileConnectionPagination';
+
+type TestEdge = { cursor: string; node: { id: string } };
+type TestConnection = {
+  edges: TestEdge[];
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+};
+
+describe('appendConnectionPage', () => {
+  test('appends new edges and keeps the latest pageInfo', () => {
+    const current: TestConnection = {
+      edges: [{ cursor: 'cursor-1', node: { id: 'node-1' } }],
+      pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+    };
+    const next: TestConnection = {
+      edges: [{ cursor: 'cursor-2', node: { id: 'node-2' } }],
+      pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+    };
+
+    expect(appendConnectionPage(current, next)).toEqual({
+      edges: [
+        { cursor: 'cursor-1', node: { id: 'node-1' } },
+        { cursor: 'cursor-2', node: { id: 'node-2' } },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+    });
+  });
+});

--- a/apps/web/src/lib/profileConnectionPagination.ts
+++ b/apps/web/src/lib/profileConnectionPagination.ts
@@ -3,6 +3,12 @@ type ConnectionPage<TEdge, TPageInfo> = {
   pageInfo: TPageInfo;
 };
 
+type LoadNextConnectionPageResult<TEdge, TPageInfo> = {
+  connection: ConnectionPage<TEdge, TPageInfo> | null;
+  error: boolean;
+  stale?: boolean;
+};
+
 export const appendConnectionPage = <TEdge, TPageInfo>(
   current: ConnectionPage<TEdge, TPageInfo>,
   next: ConnectionPage<TEdge, TPageInfo>,
@@ -15,9 +21,14 @@ export const loadNextConnectionPage = async <TEdge, TPageInfo>(
   current: ConnectionPage<TEdge, TPageInfo> | null,
   after: string,
   load: (after: string) => Promise<ConnectionPage<TEdge, TPageInfo> | null | undefined>,
-): Promise<{ connection: ConnectionPage<TEdge, TPageInfo> | null; error: boolean }> => {
+  isCurrent = () => true,
+): Promise<LoadNextConnectionPageResult<TEdge, TPageInfo>> => {
   try {
     const next = await load(after);
+
+    if (!isCurrent()) {
+      return { connection: current, error: false, stale: true };
+    }
 
     if (!next) {
       return { connection: current, error: true };
@@ -28,6 +39,10 @@ export const loadNextConnectionPage = async <TEdge, TPageInfo>(
       error: false,
     };
   } catch {
+    if (!isCurrent()) {
+      return { connection: current, error: false, stale: true };
+    }
+
     return { connection: current, error: true };
   }
 };

--- a/apps/web/src/lib/profileConnectionPagination.ts
+++ b/apps/web/src/lib/profileConnectionPagination.ts
@@ -10,3 +10,24 @@ export const appendConnectionPage = <TEdge, TPageInfo>(
   ...next,
   edges: [...current.edges, ...next.edges],
 });
+
+export const loadNextConnectionPage = async <TEdge, TPageInfo>(
+  current: ConnectionPage<TEdge, TPageInfo> | null,
+  after: string,
+  load: (after: string) => Promise<ConnectionPage<TEdge, TPageInfo> | null | undefined>,
+): Promise<{ connection: ConnectionPage<TEdge, TPageInfo> | null; error: boolean }> => {
+  try {
+    const next = await load(after);
+
+    if (!next) {
+      return { connection: current, error: true };
+    }
+
+    return {
+      connection: current ? appendConnectionPage(current, next) : next,
+      error: false,
+    };
+  } catch {
+    return { connection: current, error: true };
+  }
+};

--- a/apps/web/src/lib/profileConnectionPagination.ts
+++ b/apps/web/src/lib/profileConnectionPagination.ts
@@ -1,0 +1,12 @@
+type ConnectionPage<TEdge, TPageInfo> = {
+  edges: readonly TEdge[];
+  pageInfo: TPageInfo;
+};
+
+export const appendConnectionPage = <TEdge, TPageInfo>(
+  current: ConnectionPage<TEdge, TPageInfo>,
+  next: ConnectionPage<TEdge, TPageInfo>,
+): ConnectionPage<TEdge, TPageInfo> => ({
+  ...next,
+  edges: [...current.edges, ...next.edges],
+});

--- a/apps/web/src/lib/profileConnectionPaginationLoader.test.ts
+++ b/apps/web/src/lib/profileConnectionPaginationLoader.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from 'vitest';
+import { loadNextConnectionPage } from './profileConnectionPagination';
+
+type TestEdge = { cursor: string; node: { id: string } };
+type TestConnection = {
+  edges: TestEdge[];
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+};
+
+describe('loadNextConnectionPage', () => {
+  test('loads with the provided cursor and appends the returned connection', async () => {
+    const current: TestConnection = {
+      edges: [{ cursor: 'cursor-1', node: { id: 'node-1' } }],
+      pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+    };
+    const next: TestConnection = {
+      edges: [{ cursor: 'cursor-2', node: { id: 'node-2' } }],
+      pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+    };
+    const load = vi.fn(async () => next);
+
+    await expect(loadNextConnectionPage(current, 'cursor-1', load)).resolves.toEqual({
+      connection: {
+        edges: [
+          { cursor: 'cursor-1', node: { id: 'node-1' } },
+          { cursor: 'cursor-2', node: { id: 'node-2' } },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+      },
+      error: false,
+    });
+    expect(load).toHaveBeenCalledExactlyOnceWith('cursor-1');
+  });
+
+  test('returns the existing connection with an error when loading fails', async () => {
+    const current: TestConnection = {
+      edges: [{ cursor: 'cursor-1', node: { id: 'node-1' } }],
+      pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+    };
+    const load = vi.fn(async () => {
+      throw new Error('network failure');
+    });
+
+    await expect(loadNextConnectionPage(current, 'cursor-1', load)).resolves.toEqual({
+      connection: current,
+      error: true,
+    });
+  });
+});

--- a/apps/web/src/lib/profileConnectionPaginationLoader.test.ts
+++ b/apps/web/src/lib/profileConnectionPaginationLoader.test.ts
@@ -49,4 +49,29 @@ describe('loadNextConnectionPage', () => {
       error: true,
     });
   });
+
+  test('marks the result stale when the route key changes while loading', async () => {
+    const current: TestConnection = {
+      edges: [{ cursor: 'cursor-1', node: { id: 'node-1' } }],
+      pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+    };
+    const next: TestConnection = {
+      edges: [{ cursor: 'cursor-2', node: { id: 'node-2' } }],
+      pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+    };
+    const requestPageKey = 'alice:profile-1';
+    let currentPageKey = requestPageKey;
+    const load = vi.fn(async () => {
+      currentPageKey = 'bob:profile-2';
+      return next;
+    });
+
+    await expect(
+      loadNextConnectionPage(current, 'cursor-1', load, () => currentPageKey === requestPageKey),
+    ).resolves.toEqual({
+      connection: current,
+      error: false,
+      stale: true,
+    });
+  });
 });

--- a/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
@@ -1,36 +1,124 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { createQuery } from '@mearie/svelte';
+  import { createQuery, getClient } from '@mearie/svelte';
   import { graphql } from '$mearie';
+  import type { DataOf } from '@mearie/svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
+  import { appendConnectionPage } from '$lib/profileConnectionPagination';
 
-  const query = createQuery(
-    graphql(`
-      query ProfileFollowersPageQuery($handle: String!) {
-        currentSession {
+  const client = getClient();
+  const queryDocument = graphql(`
+    query ProfileFollowersPageQuery($handle: String!) {
+      currentSession {
+        id
+        selectedProfile {
           id
-          selectedProfile {
-            id
-          }
-        }
-        profileByHandle(handle: $handle) {
-          id
-          ...ProfileConnectionList_followersProfile
         }
       }
-    `),
-    () => ({ handle: page.params.handle! }),
-  );
+      profileByHandle(handle: $handle) {
+        id
+        ...ProfileConnectionList_followersProfile
+      }
+    }
+  `);
+  const nextPageQueryDocument = graphql(`
+    query ProfileFollowersNextPageQuery($handle: String!, $after: String!) {
+      profileByHandle(handle: $handle) {
+        id
+        followers(first: 20, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              id
+              follower {
+                id
+                ...ProfileListItem_profile
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  type NextPageConnection = NonNullable<
+    NonNullable<DataOf<typeof nextPageQueryDocument>['profileByHandle']>['followers']
+  >;
+
+  const query = createQuery(queryDocument, () => ({ handle: page.params.handle! }));
 
   const profile = $derived(query.data?.profileByHandle ?? null);
   const viewerProfileId = $derived(query.data?.currentSession?.selectedProfile?.id ?? null);
+
+  let pageKey = $state<string | null>(null);
+  let paginatedConnection = $state<NextPageConnection | null>(null);
+  let loadingNextPage = $state(false);
+  let nextPageError = $state(false);
+
+  $effect(() => {
+    const nextPageKey = profile ? `${page.params.handle}:${profile.id}` : null;
+
+    if (pageKey !== nextPageKey) {
+      pageKey = nextPageKey;
+      paginatedConnection = null;
+      loadingNextPage = false;
+      nextPageError = false;
+    }
+  });
+
+  const additionalProfiles = $derived(
+    paginatedConnection?.edges.flatMap((edge) =>
+      edge.node.follower ? [{ cursor: edge.cursor, profile: edge.node.follower }] : [],
+    ) ?? [],
+  );
+  const paginatedPageInfo = $derived(paginatedConnection?.pageInfo ?? null);
+
+  const loadMore = async (after: string) => {
+    if (loadingNextPage) {
+      return;
+    }
+
+    loadingNextPage = true;
+    nextPageError = false;
+
+    try {
+      const result = await client.query(nextPageQueryDocument, {
+        handle: page.params.handle!,
+        after,
+      });
+      const nextConnection = result.profileByHandle?.followers;
+
+      if (!nextConnection) {
+        nextPageError = true;
+        return;
+      }
+
+      paginatedConnection = paginatedConnection
+        ? appendConnectionPage(paginatedConnection, nextConnection)
+        : nextConnection;
+    } catch {
+      nextPageError = true;
+    } finally {
+      loadingNextPage = false;
+    }
+  };
 </script>
 
 <ProfileConnectionList
   kind="followers"
   followersProfile={profile}
+  {additionalProfiles}
+  hasNextPage={paginatedPageInfo?.hasNextPage}
+  endCursor={paginatedPageInfo?.endCursor}
+  {loadingNextPage}
+  {nextPageError}
   {viewerProfileId}
   loading={query.loading}
   error={Boolean(query.error)}
   onRetry={query.refetch}
+  onLoadMore={loadMore}
 />

--- a/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
@@ -82,17 +82,28 @@
       return;
     }
 
+    const requestPageKey = pageKey;
+
     loadingNextPage = true;
     nextPageError = false;
 
-    const result = await loadNextConnectionPage(paginatedConnection, after, async (cursor) => {
-      const result = await client.query(nextPageQueryDocument, {
-        handle: page.params.handle!,
-        after: cursor,
-      });
+    const result = await loadNextConnectionPage(
+      paginatedConnection,
+      after,
+      async (cursor) => {
+        const result = await client.query(nextPageQueryDocument, {
+          handle: page.params.handle!,
+          after: cursor,
+        });
 
-      return result.profileByHandle?.followers;
-    });
+        return result.profileByHandle?.followers;
+      },
+      () => pageKey === requestPageKey,
+    );
+
+    if (result.stale) {
+      return;
+    }
 
     paginatedConnection = result.connection;
     nextPageError = result.error;

--- a/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
@@ -4,7 +4,7 @@
   import { graphql } from '$mearie';
   import type { DataOf } from '@mearie/svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
-  import { appendConnectionPage } from '$lib/profileConnectionPagination';
+  import { loadNextConnectionPage } from '$lib/profileConnectionPagination';
 
   const client = getClient();
   const queryDocument = graphql(`
@@ -85,26 +85,18 @@
     loadingNextPage = true;
     nextPageError = false;
 
-    try {
+    const result = await loadNextConnectionPage(paginatedConnection, after, async (cursor) => {
       const result = await client.query(nextPageQueryDocument, {
         handle: page.params.handle!,
-        after,
+        after: cursor,
       });
-      const nextConnection = result.profileByHandle?.followers;
 
-      if (!nextConnection) {
-        nextPageError = true;
-        return;
-      }
+      return result.profileByHandle?.followers;
+    });
 
-      paginatedConnection = paginatedConnection
-        ? appendConnectionPage(paginatedConnection, nextConnection)
-        : nextConnection;
-    } catch {
-      nextPageError = true;
-    } finally {
-      loadingNextPage = false;
-    }
+    paginatedConnection = result.connection;
+    nextPageError = result.error;
+    loadingNextPage = false;
   };
 </script>
 

--- a/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
@@ -4,7 +4,7 @@
   import { graphql } from '$mearie';
   import type { DataOf } from '@mearie/svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
-  import { appendConnectionPage } from '$lib/profileConnectionPagination';
+  import { loadNextConnectionPage } from '$lib/profileConnectionPagination';
 
   const client = getClient();
   const queryDocument = graphql(`
@@ -85,26 +85,18 @@
     loadingNextPage = true;
     nextPageError = false;
 
-    try {
+    const result = await loadNextConnectionPage(paginatedConnection, after, async (cursor) => {
       const result = await client.query(nextPageQueryDocument, {
         handle: page.params.handle!,
-        after,
+        after: cursor,
       });
-      const nextConnection = result.profileByHandle?.following;
 
-      if (!nextConnection) {
-        nextPageError = true;
-        return;
-      }
+      return result.profileByHandle?.following;
+    });
 
-      paginatedConnection = paginatedConnection
-        ? appendConnectionPage(paginatedConnection, nextConnection)
-        : nextConnection;
-    } catch {
-      nextPageError = true;
-    } finally {
-      loadingNextPage = false;
-    }
+    paginatedConnection = result.connection;
+    nextPageError = result.error;
+    loadingNextPage = false;
   };
 </script>
 

--- a/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
@@ -1,36 +1,124 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { createQuery } from '@mearie/svelte';
+  import { createQuery, getClient } from '@mearie/svelte';
   import { graphql } from '$mearie';
+  import type { DataOf } from '@mearie/svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
+  import { appendConnectionPage } from '$lib/profileConnectionPagination';
 
-  const query = createQuery(
-    graphql(`
-      query ProfileFollowingPageQuery($handle: String!) {
-        currentSession {
+  const client = getClient();
+  const queryDocument = graphql(`
+    query ProfileFollowingPageQuery($handle: String!) {
+      currentSession {
+        id
+        selectedProfile {
           id
-          selectedProfile {
-            id
-          }
-        }
-        profileByHandle(handle: $handle) {
-          id
-          ...ProfileConnectionList_followingProfile
         }
       }
-    `),
-    () => ({ handle: page.params.handle! }),
-  );
+      profileByHandle(handle: $handle) {
+        id
+        ...ProfileConnectionList_followingProfile
+      }
+    }
+  `);
+  const nextPageQueryDocument = graphql(`
+    query ProfileFollowingNextPageQuery($handle: String!, $after: String!) {
+      profileByHandle(handle: $handle) {
+        id
+        following(first: 20, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              id
+              followee {
+                id
+                ...ProfileListItem_profile
+              }
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  type NextPageConnection = NonNullable<
+    NonNullable<DataOf<typeof nextPageQueryDocument>['profileByHandle']>['following']
+  >;
+
+  const query = createQuery(queryDocument, () => ({ handle: page.params.handle! }));
 
   const profile = $derived(query.data?.profileByHandle ?? null);
   const viewerProfileId = $derived(query.data?.currentSession?.selectedProfile?.id ?? null);
+
+  let pageKey = $state<string | null>(null);
+  let paginatedConnection = $state<NextPageConnection | null>(null);
+  let loadingNextPage = $state(false);
+  let nextPageError = $state(false);
+
+  $effect(() => {
+    const nextPageKey = profile ? `${page.params.handle}:${profile.id}` : null;
+
+    if (pageKey !== nextPageKey) {
+      pageKey = nextPageKey;
+      paginatedConnection = null;
+      loadingNextPage = false;
+      nextPageError = false;
+    }
+  });
+
+  const additionalProfiles = $derived(
+    paginatedConnection?.edges.flatMap((edge) =>
+      edge.node.followee ? [{ cursor: edge.cursor, profile: edge.node.followee }] : [],
+    ) ?? [],
+  );
+  const paginatedPageInfo = $derived(paginatedConnection?.pageInfo ?? null);
+
+  const loadMore = async (after: string) => {
+    if (loadingNextPage) {
+      return;
+    }
+
+    loadingNextPage = true;
+    nextPageError = false;
+
+    try {
+      const result = await client.query(nextPageQueryDocument, {
+        handle: page.params.handle!,
+        after,
+      });
+      const nextConnection = result.profileByHandle?.following;
+
+      if (!nextConnection) {
+        nextPageError = true;
+        return;
+      }
+
+      paginatedConnection = paginatedConnection
+        ? appendConnectionPage(paginatedConnection, nextConnection)
+        : nextConnection;
+    } catch {
+      nextPageError = true;
+    } finally {
+      loadingNextPage = false;
+    }
+  };
 </script>
 
 <ProfileConnectionList
   kind="following"
   followingProfile={profile}
+  {additionalProfiles}
+  hasNextPage={paginatedPageInfo?.hasNextPage}
+  endCursor={paginatedPageInfo?.endCursor}
+  {loadingNextPage}
+  {nextPageError}
   {viewerProfileId}
   loading={query.loading}
   error={Boolean(query.error)}
   onRetry={query.refetch}
+  onLoadMore={loadMore}
 />

--- a/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
@@ -82,17 +82,28 @@
       return;
     }
 
+    const requestPageKey = pageKey;
+
     loadingNextPage = true;
     nextPageError = false;
 
-    const result = await loadNextConnectionPage(paginatedConnection, after, async (cursor) => {
-      const result = await client.query(nextPageQueryDocument, {
-        handle: page.params.handle!,
-        after: cursor,
-      });
+    const result = await loadNextConnectionPage(
+      paginatedConnection,
+      after,
+      async (cursor) => {
+        const result = await client.query(nextPageQueryDocument, {
+          handle: page.params.handle!,
+          after: cursor,
+        });
 
-      return result.profileByHandle?.following;
-    });
+        return result.profileByHandle?.following;
+      },
+      () => pageKey === requestPageKey,
+    );
+
+    if (result.stale) {
+      return;
+    }
 
     paginatedConnection = result.connection;
     nextPageError = result.error;

--- a/openspec/changes/connect-profile-follow-list-pagination/tasks.md
+++ b/openspec/changes/connect-profile-follow-list-pagination/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Route pagination state
 
-- [ ] 1.1 followers route query에 `after` 변수를 추가하고 첫 페이지와 다음 페이지를 구분해 조회할 수 있게 한다
-- [ ] 1.2 following route query에 `after` 변수를 추가하고 첫 페이지와 다음 페이지를 구분해 조회할 수 있게 한다
-- [ ] 1.3 handle 또는 첫 페이지 대상 profile이 바뀌면 누적 connection state와 다음 페이지 오류 상태를 초기화한다
-- [ ] 1.4 다음 페이지 성공 시 새 edge를 기존 목록 뒤에 connection 순서대로 append하고 최신 `pageInfo`를 보존한다
+- [x] 1.1 followers route query에 `after` 변수를 추가하고 첫 페이지와 다음 페이지를 구분해 조회할 수 있게 한다
+- [x] 1.2 following route query에 `after` 변수를 추가하고 첫 페이지와 다음 페이지를 구분해 조회할 수 있게 한다
+- [x] 1.3 handle 또는 첫 페이지 대상 profile이 바뀌면 누적 connection state와 다음 페이지 오류 상태를 초기화한다
+- [x] 1.4 다음 페이지 성공 시 새 edge를 기존 목록 뒤에 connection 순서대로 append하고 최신 `pageInfo`를 보존한다
 
 ## 2. Shared pagination UI
 
-- [ ] 2.1 `ProfileConnectionList` fragment에 `pageInfo { hasNextPage endCursor }`를 포함한다
-- [ ] 2.2 `ProfileConnectionList`에 다음 페이지 가능 여부, 로딩 여부, 오류 여부, load-more/retry callback props를 추가한다
-- [ ] 2.3 목록 아래에 공통 “더 불러오기” 버튼을 표시하고, 다음 페이지 로딩 중에는 중복 클릭을 막는다
-- [ ] 2.4 마지막 페이지에서는 load-more UI를 숨기고, 다음 페이지 실패 시 기존 목록을 유지한 채 재시도 UI를 표시한다
+- [x] 2.1 `ProfileConnectionList` fragment에 `pageInfo { hasNextPage endCursor }`를 포함한다
+- [x] 2.2 `ProfileConnectionList`에 다음 페이지 가능 여부, 로딩 여부, 오류 여부, load-more/retry callback props를 추가한다
+- [x] 2.3 목록 아래에 공통 “더 불러오기” 버튼을 표시하고, 다음 페이지 로딩 중에는 중복 클릭을 막는다
+- [x] 2.4 마지막 페이지에서는 load-more UI를 숨기고, 다음 페이지 실패 시 기존 목록을 유지한 채 재시도 UI를 표시한다
 
 ## 3. Storybook states
 
-- [ ] 3.1 followers story에 다음 페이지 있음, 다음 페이지 로딩, 다음 페이지 실패, 마지막 페이지 상태를 추가한다
-- [ ] 3.2 following story에 같은 pagination 상태를 추가해 두 목록의 UI 구조가 일치하는지 확인할 수 있게 한다
+- [x] 3.1 followers story에 다음 페이지 있음, 다음 페이지 로딩, 다음 페이지 실패, 마지막 페이지 상태를 추가한다
+- [x] 3.2 following story에 같은 pagination 상태를 추가해 두 목록의 UI 구조가 일치하는지 확인할 수 있게 한다
 
 ## 4. Verification
 
-- [ ] 4.1 `pnpm --filter @kosmo/web check`를 통과시킨다
+- [x] 4.1 `pnpm --filter @kosmo/web check`를 통과시킨다
 - [ ] 4.2 `pnpm lint:prettier`를 통과시킨다
-- [ ] 4.3 팔로워/팔로잉 목록에서 첫 페이지 오류와 다음 페이지 오류가 서로 다른 위치에서 처리되는지 수동 또는 Storybook으로 확인한다
+- [x] 4.3 팔로워/팔로잉 목록에서 첫 페이지 오류와 다음 페이지 오류가 서로 다른 위치에서 처리되는지 수동 또는 Storybook으로 확인한다


### PR DESCRIPTION
## 무엇을 변경했는지

- 팔로워/팔로잉 route에 `after` 기반 다음 페이지 GraphQL query를 추가했습니다.
- 다음 페이지 성공 시 기존 목록 뒤에 edge를 누적하고 최신 `pageInfo`를 유지하도록 공통 helper를 추가했습니다.
- `ProfileConnectionList`에 load-more, 다음 페이지 로딩, 다음 페이지 오류, 마지막 페이지 상태를 표시하는 공통 UI를 연결했습니다.
- 팔로워/팔로잉 Storybook에 다음 페이지 있음, 로딩, 실패, 마지막 페이지 상태를 추가했습니다.
- 실제 20명 초과 계정이 없어도 다음 페이지 loader가 `after` cursor로 호출되고 성공/실패 상태를 반환하는지 unit test로 검증했습니다.

## 왜 변경했는지

- `PROD-188`에서 팔로워/팔로잉 목록이 첫 페이지만 표시되는 문제를 해결하고, OpenSpec PR #173에서 정의한 pagination 동작을 실제 화면에 연결하기 위해서입니다.
- 첫 페이지 오류와 다음 페이지 오류를 분리해, 추가 로드 실패 시 기존 목록은 유지한 채 재시도할 수 있게 했습니다.

## 어떻게 확인했는지

- `pnpm --filter @kosmo/web check`
- `pnpm --filter @kosmo/web test:unit -- --run src/lib/profileConnectionPagination.test.ts src/lib/profileConnectionPaginationLoader.test.ts`
- `pnpm --filter @kosmo/web build-storybook`
- 변경 파일 범위: `pnpm exec prettier --check --ignore-unknown ...`

## 아직 어떤 문제가 남아있는지

- 실제 팔로워/팔로잉이 20명을 초과하는 계정으로 브라우저에서 API round-trip을 수동 확인하지는 못했습니다. 대신 route가 사용하는 loader 단위에서 `after` 전달, append, 오류 유지 동작을 검증했습니다.
- 현재 UX는 cursor 기반 API 위에 수동 “더 불러오기” 버튼을 얹은 형태입니다. 이후 팔로워/팔로잉 목록 UX에는 infinite scroll이 더 적합하다고 판단되면, 이 PR의 후속 작업에서 viewport 관찰 기반 자동 로드로 별도 spec/구현 변경이 필요합니다.
- `pnpm lint:prettier` 전체 명령은 현재 Windows 셸에서 작은따옴표 glob이 그대로 전달되어 실패합니다. 직접 `**/*`로 실행하면 이번 변경 밖의 기존 레포 파일 다수가 포맷 경고로 잡혀, 이번 PR에서는 변경 파일 범위만 Prettier 검증했습니다.