### PR TITLE
dev 배포가 개발 도메인과 시크릿 환경을 사용하게 한다

### DIFF
--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -19,7 +19,7 @@ web:
     className: nginx
     annotations: {}
     hosts:
-      - host: kos.moe
+      - host: dev.kos.moe
         paths:
           - path: /
             pathType: Prefix
@@ -92,7 +92,7 @@ api:
     className: nginx
     annotations: {}
     hosts:
-      - host: api.kos.moe
+      - host: dev-api.kos.moe
         paths:
           - path: /
             pathType: Prefix
@@ -153,10 +153,12 @@ certificate:
   dnsNames:
     - kos.moe
     - api.kos.moe
+    - dev.kos.moe
+    - dev-api.kos.moe
 
 infisical:
   enabled: true
   identityId: '953a7c79-6486-44d6-a6be-04dd7eda1853'
   projectId: '8e05f8b4-604a-4a3e-a4f2-77a89a8318be'
-  envSlug: prod
+  envSlug: dev
   secretName: env


### PR DESCRIPTION
## 무엇을 변경했는지

- Helm 기본 values의 web ingress host를 `dev.kos.moe`로 변경했습니다.
- Helm 기본 values의 api ingress host를 `dev-api.kos.moe`로 변경했습니다.
- cert-manager Certificate DNS 이름에 `dev.kos.moe`, `dev-api.kos.moe`를 추가했습니다.
- Infisical Secret의 `envSlug`를 `prod`에서 `dev`로 변경했습니다.

## 왜 변경했는지

ApplicationSet이 `main`의 `apps/helm` chart를 `kosmo-dev` namespace에 배포하고 있어서, 기본 values가 dev 배포 대상과 맞아야 합니다. ingress와 Infisical 환경을 dev 기준으로 맞춰 개발 배포가 production 도메인과 production secret을 참조하지 않게 합니다.

## 어떻게 확인할 수 있는지

- `pnpm lint:prettier`
- `ruby -e 'require "yaml"; YAML.load_file("apps/helm/values.yaml"); puts "apps/helm/values.yaml YAML OK"'`
- `apps/helm/templates/web/ingress.yaml`, `apps/helm/templates/api/ingress.yaml`, `apps/helm/templates/certificate.yaml`, `apps/helm/templates/infisicalsecret.yaml`에서 변경된 values 참조 경로를 확인했습니다.

## 아직 어떤 문제가 남았는지

- 로컬 환경에 `helm` CLI가 없어 `helm lint apps/helm`과 `helm template kosmo apps/helm`은 실행하지 못했습니다.
- `certificate.dnsNames`에 기존 `kos.moe`, `api.kos.moe`를 유지했습니다. dev 인증서에 prod 도메인 SAN을 함께 두는 것이 의도인지 배포 전에 확인이 필요합니다.