### PR TITLE
게시글 connection 타입을 PostConnection으로 통합한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -57,16 +57,6 @@ type FollowProfilePayload {
   profileFollow: ProfileFollow!
 }
 
-type HomeTimelineConnection {
-  edges: [HomeTimelineConnectionEdge!]!
-  pageInfo: PageInfo!
-}
-
-type HomeTimelineConnectionEdge {
-  cursor: String!
-  node: Post!
-}
-
 type Mutation {
   createPost(input: CreatePostInput!): CreatePostPayload!
   createProfile(input: CreateProfileInput!): CreateProfilePayload!
@@ -97,6 +87,16 @@ type Post implements Node {
   visibility: PostVisibility!
 }
 
+type PostConnection {
+  edges: [PostConnectionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PostConnectionEdge {
+  cursor: String!
+  node: Post!
+}
+
 type PostContent implements Node {
   bodyJson: TipTapDocument!
   bodyText: String!
@@ -117,16 +117,6 @@ enum PostVisibility {
   UNLISTED
 }
 
-type PostsConnection {
-  edges: [PostsConnectionEdge!]!
-  pageInfo: PageInfo!
-}
-
-type PostsConnectionEdge {
-  cursor: String!
-  node: Post!
-}
-
 type Profile implements Node {
   bio: String
   createdAt: DateTime!
@@ -138,7 +128,7 @@ type Profile implements Node {
   followingCount: Int!
   handle: String!
   id: ID!
-  posts(after: String, before: String, first: Int, last: Int): PostsConnection!
+  posts(after: String, before: String, first: Int, last: Int): PostConnection!
   relativeHandle: String!
   viewerFollow: ProfileFollow
 }
@@ -190,7 +180,7 @@ enum ProfileState {
 
 type Query {
   currentSession: Session
-  homeTimeline(after: String, before: String, first: Int, last: Int): HomeTimelineConnection
+  homeTimeline(after: String, before: String, first: Int, last: Int): PostConnection
   me: Account
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!

--- a/apps/api/src/graphql/resolvers/post/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/post/field/profile.ts
@@ -4,7 +4,7 @@ import { and, asc, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
 import { Profile } from '@/graphql/resolvers/profile';
 import { postVisibilityAccessWhere } from '../access/visibility';
-import { Post } from '../ref';
+import { Post, PostConnection } from '../ref';
 
 type PostRow = typeof Posts.$inferSelect;
 
@@ -36,8 +36,6 @@ builder.objectFields(Profile, (t) => ({
         );
       },
     },
-    {
-      name: 'PostsConnection',
-    },
+    PostConnection,
   ),
 }));

--- a/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
+++ b/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
@@ -4,7 +4,7 @@ import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, exists, getColumns, gt, lt, or } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
 import { postVisibilityAccessWhere } from '../access/visibility';
-import { Post } from '../ref';
+import { Post, PostConnection } from '../ref';
 
 type PostRow = typeof Posts.$inferSelect;
 
@@ -51,8 +51,6 @@ builder.queryField('homeTimeline', (t) =>
         );
       },
     },
-    {
-      name: 'HomeTimelineConnection',
-    },
+    PostConnection as never,
   ),
 );

--- a/apps/api/src/graphql/resolvers/post/ref.ts
+++ b/apps/api/src/graphql/resolvers/post/ref.ts
@@ -1,6 +1,7 @@
 import { db, PostContents, Posts, Profiles, TableDiscriminator } from '@kosmo/core/db';
 import { PostState, PostVisibility } from '@kosmo/core/enums';
 import { and, eq, getColumns, inArray } from 'drizzle-orm';
+import { builder } from '@/graphql/builder';
 import { createObjectRef } from '@/graphql/utils';
 import { postVisibilityAccessWhere } from './access/visibility';
 
@@ -19,6 +20,16 @@ Post.implement({
     createdAt: t.expose('createdAt', { type: 'DateTime' }),
   }),
 });
+
+export const PostConnection = builder.connectionObject(
+  {
+    type: Post,
+    name: 'PostConnection',
+  },
+  {
+    name: 'PostConnectionEdge',
+  },
+);
 
 export const PostContent = createObjectRef(
   'PostContent',

--- a/apps/web/src/lib/components/PostList.stories.svelte
+++ b/apps/web/src/lib/components/PostList.stories.svelte
@@ -36,9 +36,9 @@
       __typename: 'Profile',
       id: 'story-profile',
       posts: {
-        __typename: 'PostsConnection',
+        __typename: 'PostConnection',
         edges: posts.map((node, index) => ({
-          __typename: 'PostsConnectionEdge',
+          __typename: 'PostConnectionEdge',
           cursor: `story-cursor-${index}`,
           node,
         })),
@@ -47,9 +47,9 @@
 
   const homeTimeline = (...posts: ReturnType<typeof post>[]): PostList_homeTimeline$key =>
     ({
-      __typename: 'HomeTimelineConnection',
+      __typename: 'PostConnection',
       edges: posts.map((node, index) => ({
-        __typename: 'HomeTimelineConnectionEdge',
+        __typename: 'PostConnectionEdge',
         cursor: `story-home-cursor-${index}`,
         node,
       })),

--- a/apps/web/src/lib/components/PostList.svelte
+++ b/apps/web/src/lib/components/PostList.svelte
@@ -49,7 +49,7 @@
 
   const homeTimelineFragment = createFragment(
     graphql(`
-      fragment PostList_homeTimeline on HomeTimelineConnection {
+      fragment PostList_homeTimeline on PostConnection {
         edges {
           cursor
           node {

--- a/openspec/specs/post/spec.md
+++ b/openspec/specs/post/spec.md
@@ -44,7 +44,7 @@ API는 활성 게시글을 GraphQL `Post` Node로 노출해야 하며 작성자 
 
 ### Requirement: 프로필 게시글 목록 connection
 
-API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Profile.posts`로 노출해야 하며, viewer와 작성자의 관계에 따라 공개 범위를 제한해야 한다(MUST).
+API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Profile.posts`로 노출해야 하며, viewer와 작성자의 관계에 따라 공개 범위를 제한해야 한다(MUST). `Profile.posts`는 게시글 node 목록 공용 wrapper인 `PostConnection`을 반환해야 한다(MUST).
 
 #### Scenario: 공개 프로필 게시글 목록 조회
 
@@ -80,7 +80,7 @@ API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Pr
 
 ### Requirement: Home timeline connection
 
-API는 현재 active profile 기준 홈 타임라인을 최신순 Relay connection `Query.homeTimeline`로 노출해야 한다(MUST). active profile이 없거나 인증되지 않은 조회에는 요청을 거부하지 않고 `null`을 반환해야 한다(MUST).
+API는 현재 active profile 기준 홈 타임라인을 최신순 Relay connection `Query.homeTimeline`로 노출해야 한다(MUST). `Query.homeTimeline`은 게시글 node 목록 공용 wrapper인 `PostConnection`을 반환해야 한다(MUST). active profile이 없거나 인증되지 않은 조회에는 요청을 거부하지 않고 `null`을 반환해야 한다(MUST).
 
 #### Scenario: 내 게시글 포함
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `Query.homeTimeline`과 `Profile.posts`가 공용 `PostConnection`/`PostConnectionEdge` wrapper 타입을 사용하게 했습니다.
- `HomeTimelineConnection`과 `PostsConnection` schema 타입을 제거하고 `apps/api/schema.graphql`을 갱신했습니다.
- `PostList_homeTimeline` fragment와 Storybook mock typename을 `PostConnection` 기준으로 정렬했습니다.
- `post` OpenSpec에 두 게시글 connection이 공용 `PostConnection`을 반환한다는 계약을 명시했습니다.

## 왜 변경했는지

`homeTimeline`과 `Profile.posts`는 모두 `Post` node connection이고 현재 edge metadata가 `cursor`와 `node`뿐입니다. 필드별 wrapper 타입을 유지하면 같은 게시글 목록 계약이 타입 이름만 갈라져 프론트엔드 fragment와 schema 계약이 불필요하게 분산됩니다.

## 어떻게 확인할 수 있는지

- `pnpm --dir apps/api exec tsx src/graphql/schema.ts`
- `pnpm --dir apps/web exec mearie generate`
- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --dir apps/web check`
- `pnpm exec openspec validate --all --strict`
- `pnpm lint:eslint`
- 변경 파일 한정 `pnpm exec prettier --check ...`
- schema contract 확인: `PostConnection` 존재, `HomeTimelineConnection`/`PostsConnection` 미존재, `relativeHandle` 유지

참고: `pnpm lint:prettier`는 Windows PowerShell에서 package script의 `''**/*''` glob quote가 그대로 전달되어 실패했습니다. 대신 변경 파일 한정 Prettier check를 PowerShell-compatible quoting으로 실행했습니다.

## 아직 어떤 문제가 남았는지

- 없음

Stack: main -> prod-168