### PR TITLE
프로필 목록의 팔로우 액션 책임을 분리한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -131,7 +131,7 @@ type Profile implements Node {
   posts(after: String, before: String, first: Int, last: Int): PostConnection!
   relativeHandle: String!
   viewerFollow: ProfileFollow
-  viewerState: ProfileViewerState!
+  viewerState: ProfileViewerState
 }
 
 type ProfileFollow implements Node {
@@ -180,10 +180,7 @@ enum ProfileState {
 }
 
 type ProfileViewerState {
-  authenticated: Boolean!
-  canMutate: Boolean!
   follow: ProfileFollow
-  hasSelectedProfile: Boolean!
   isSelf: Boolean!
 }
 

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -131,6 +131,7 @@ type Profile implements Node {
   posts(after: String, before: String, first: Int, last: Int): PostConnection!
   relativeHandle: String!
   viewerFollow: ProfileFollow
+  viewerState: ProfileViewerState!
 }
 
 type ProfileFollow implements Node {
@@ -176,6 +177,14 @@ enum ProfileState {
   ACTIVE
   DISABLED
   SUSPENDED
+}
+
+type ProfileViewerState {
+  authenticated: Boolean!
+  canMutate: Boolean!
+  follow: ProfileFollow
+  hasSelectedProfile: Boolean!
+  isSelf: Boolean!
 }
 
 type Query {

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -12,6 +12,15 @@ type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
 
 const FollowerProfiles = alias(Profiles, 'profile_follow_connection_follower_profile');
 const FolloweeProfiles = alias(Profiles, 'profile_follow_connection_followee_profile');
+const ProfileViewerState = builder.simpleObject('ProfileViewerState', {
+  fields: (field) => ({
+    authenticated: field.boolean(),
+    hasSelectedProfile: field.boolean(),
+    isSelf: field.boolean(),
+    canMutate: field.boolean(),
+    follow: field.field({ type: ProfileFollow, nullable: true }),
+  }),
+});
 
 builder.objectFields(ProfileFollow, (t) => ({
   follower: t.field({
@@ -135,5 +144,20 @@ builder.objectFields(Profile, (t) => ({
     type: ProfileFollow,
     nullable: true,
     resolve: (profile, _, ctx) => viewerFollowLoader(ctx).load(profile.id),
+  }),
+  viewerState: t.field({
+    type: ProfileViewerState,
+    resolve: async (profile, _, ctx) => {
+      const viewerProfileId = ctx.session?.profileId ?? null;
+      const isSelf = Boolean(viewerProfileId && viewerProfileId === profile.id);
+
+      return {
+        authenticated: Boolean(ctx.session),
+        hasSelectedProfile: Boolean(viewerProfileId),
+        isSelf,
+        canMutate: Boolean(viewerProfileId && !isSelf),
+        follow: await viewerFollowLoader(ctx).load(profile.id),
+      };
+    },
   }),
 }));

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -142,19 +142,15 @@ builder.objectFields(Profile, (t) => ({
     nullable: true,
     resolve: (profile, _, ctx) => viewerFollowLoader(ctx).load(profile.id),
   }),
-  viewerState: t.field({
+  viewerState: t.withAuth({ usingProfile: true }).field({
     type: ProfileViewerState,
     nullable: true,
+    unauthorizedResolver: () => null,
     resolve: async (profile, _, ctx) => {
-      const viewerProfileId = ctx.session?.profileId ?? null;
-      if (!viewerProfileId) {
-        return null;
-      }
-
-      const isSelf = Boolean(viewerProfileId && viewerProfileId === profile.id);
+      const viewerProfileId = ctx.session.profileId;
 
       return {
-        isSelf,
+        isSelf: viewerProfileId === profile.id,
         follow: await viewerFollowLoader(ctx).load(profile.id),
       };
     },

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -14,10 +14,7 @@ const FollowerProfiles = alias(Profiles, 'profile_follow_connection_follower_pro
 const FolloweeProfiles = alias(Profiles, 'profile_follow_connection_followee_profile');
 const ProfileViewerState = builder.simpleObject('ProfileViewerState', {
   fields: (field) => ({
-    authenticated: field.boolean(),
-    hasSelectedProfile: field.boolean(),
     isSelf: field.boolean(),
-    canMutate: field.boolean(),
     follow: field.field({ type: ProfileFollow, nullable: true }),
   }),
 });
@@ -147,15 +144,17 @@ builder.objectFields(Profile, (t) => ({
   }),
   viewerState: t.field({
     type: ProfileViewerState,
+    nullable: true,
     resolve: async (profile, _, ctx) => {
       const viewerProfileId = ctx.session?.profileId ?? null;
+      if (!viewerProfileId) {
+        return null;
+      }
+
       const isSelf = Boolean(viewerProfileId && viewerProfileId === profile.id);
 
       return {
-        authenticated: Boolean(ctx.session),
-        hasSelectedProfile: Boolean(viewerProfileId),
         isSelf,
-        canMutate: Boolean(viewerProfileId && !isSelf),
         follow: await viewerFollowLoader(ctx).load(profile.id),
       };
     },

--- a/apps/web/src/lib/components/FollowButton.stories.svelte
+++ b/apps/web/src/lib/components/FollowButton.stories.svelte
@@ -7,19 +7,13 @@
 
   type FollowState = 'ACCEPTED' | 'PENDING' | 'REJECTED';
   type ViewerState = {
-    authenticated: boolean;
-    hasSelectedProfile: boolean;
     isSelf: boolean;
-    canMutate: boolean;
     follow: { id: string; state: FollowState } | null;
   };
 
   const targetProfileId = 'target-profile';
   const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
-    authenticated: true,
-    hasSelectedProfile: true,
     isSelf: false,
-    canMutate: true,
     follow: null,
     ...overrides,
   });
@@ -28,7 +22,7 @@
   // 여기서는 평범한 데이터 객체를 fragment ref 자리에 그대로 넘긴다.
   const profile = (
     id: string,
-    viewerState: ViewerState = defaultViewerState(),
+    viewerState: ViewerState | null = defaultViewerState(),
   ): FollowButton_profile$key =>
     ({
       __typename: 'Profile',
@@ -91,38 +85,12 @@
       />
     </section>
     <section class="grid gap-1">
-      <p class="text-text-secondary m-0">프로필 미선택</p>
-      <FollowButton
-        profile={profile(
-          'missing-viewer-profile',
-          defaultViewerState({ hasSelectedProfile: false, canMutate: false }),
-        )}
-      />
-    </section>
-    <section class="grid gap-1">
-      <p class="text-text-secondary m-0">비로그인</p>
-      <FollowButton
-        profile={profile(
-          'guest-profile',
-          defaultViewerState({
-            authenticated: false,
-            hasSelectedProfile: false,
-            canMutate: false,
-          }),
-        )}
-      />
-    </section>
-    <section class="grid gap-1">
-      <p class="text-text-secondary m-0">권한 없음</p>
-      <FollowButton
-        profile={profile('blocked-profile', defaultViewerState({ canMutate: false }))}
-      />
+      <p class="text-text-secondary m-0">viewerState 없음</p>
+      <FollowButton profile={profile('missing-viewer-profile', null)} />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">본인 프로필에서는 버튼이 렌더링되지 않음</p>
-      <FollowButton
-        profile={profile('self-profile', defaultViewerState({ isSelf: true, canMutate: false }))}
-      />
+      <FollowButton profile={profile('self-profile', defaultViewerState({ isSelf: true }))} />
     </section>
   </div>
 </Story>

--- a/apps/web/src/lib/components/FollowButton.stories.svelte
+++ b/apps/web/src/lib/components/FollowButton.stories.svelte
@@ -1,37 +1,46 @@
 <script module lang="ts">
-  import type { FragmentRefs } from '@mearie/svelte';
   import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import type { FollowButton_profile$key } from '$mearie';
 
   import FollowButton from './FollowButton.svelte';
 
   type FollowState = 'ACCEPTED' | 'PENDING' | 'REJECTED';
+  type ViewerState = {
+    authenticated: boolean;
+    hasSelectedProfile: boolean;
+    isSelf: boolean;
+    canMutate: boolean;
+    follow: { id: string; state: FollowState } | null;
+  };
 
-  const viewerProfileId = 'viewer-profile';
   const targetProfileId = 'target-profile';
+  const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
+    authenticated: true,
+    hasSelectedProfile: true,
+    isSelf: false,
+    canMutate: true,
+    follow: null,
+    ...overrides,
+  });
 
   // Storybook은 .storybook/mocks/mearie-svelte.ts에서 createFragment를 패스스루로 모킹하므로
   // 여기서는 평범한 데이터 객체를 fragment ref 자리에 그대로 넘긴다.
   const profile = (
     id: string,
-    viewerFollow: { id: string; state: FollowState } | null = null,
-  ): FragmentRefs<'FollowButton_profile'> =>
+    viewerState: ViewerState = defaultViewerState(),
+  ): FollowButton_profile$key =>
     ({
       __typename: 'Profile',
       id,
-      viewerFollow,
-    }) as unknown as FragmentRefs<'FollowButton_profile'>;
+      viewerState,
+    }) as unknown as FollowButton_profile$key;
 
   const { Story } = defineMeta({
     title: 'KOSMO/FollowButton',
     component: FollowButton,
     tags: ['autodocs'],
     argTypes: {
-      authenticated: {
-        control: 'boolean',
-      },
-      canMutate: {
-        control: 'boolean',
-      },
       size: {
         control: 'radio',
         options: ['sm', 'md', 'lg'],
@@ -44,9 +53,6 @@
   name="Playground"
   args={{
     profile: profile(targetProfileId),
-    viewerProfileId,
-    authenticated: true,
-    canMutate: true,
     size: 'sm',
   }}
 />
@@ -55,44 +61,68 @@
   <div class="grid gap-4 text-sm">
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">팔로우 가능</p>
-      <FollowButton profile={profile('followable-profile')} {viewerProfileId} />
+      <FollowButton profile={profile('followable-profile')} />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">팔로잉</p>
       <FollowButton
-        profile={profile('followed-profile', { id: 'follow-accepted', state: 'ACCEPTED' })}
-        {viewerProfileId}
+        profile={profile(
+          'followed-profile',
+          defaultViewerState({ follow: { id: 'follow-accepted', state: 'ACCEPTED' } }),
+        )}
       />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">요청 중</p>
       <FollowButton
-        profile={profile('pending-profile', { id: 'follow-pending', state: 'PENDING' })}
-        {viewerProfileId}
+        profile={profile(
+          'pending-profile',
+          defaultViewerState({ follow: { id: 'follow-pending', state: 'PENDING' } }),
+        )}
       />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">거절 후 재요청 가능</p>
       <FollowButton
-        profile={profile('rejected-profile', { id: 'follow-rejected', state: 'REJECTED' })}
-        {viewerProfileId}
+        profile={profile(
+          'rejected-profile',
+          defaultViewerState({ follow: { id: 'follow-rejected', state: 'REJECTED' } }),
+        )}
       />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">프로필 미선택</p>
-      <FollowButton profile={profile('missing-viewer-profile')} viewerProfileId={null} />
+      <FollowButton
+        profile={profile(
+          'missing-viewer-profile',
+          defaultViewerState({ hasSelectedProfile: false, canMutate: false }),
+        )}
+      />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">비로그인</p>
-      <FollowButton profile={profile('guest-profile')} {viewerProfileId} authenticated={false} />
+      <FollowButton
+        profile={profile(
+          'guest-profile',
+          defaultViewerState({
+            authenticated: false,
+            hasSelectedProfile: false,
+            canMutate: false,
+          }),
+        )}
+      />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">권한 없음</p>
-      <FollowButton profile={profile('blocked-profile')} {viewerProfileId} canMutate={false} />
+      <FollowButton
+        profile={profile('blocked-profile', defaultViewerState({ canMutate: false }))}
+      />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">본인 프로필에서는 버튼이 렌더링되지 않음</p>
-      <FollowButton profile={profile(viewerProfileId)} {viewerProfileId} />
+      <FollowButton
+        profile={profile('self-profile', defaultViewerState({ isSelf: true, canMutate: false }))}
+      />
     </section>
   </div>
 </Story>

--- a/apps/web/src/lib/components/FollowButton.svelte
+++ b/apps/web/src/lib/components/FollowButton.svelte
@@ -9,10 +9,7 @@
     fragment FollowButton_profile on Profile {
       id
       viewerState {
-        authenticated
-        hasSelectedProfile
         isSelf
-        canMutate
         follow {
           id
           state
@@ -66,24 +63,14 @@
   let errorMessage = $state<string | null>(null);
 
   const viewerState = $derived(profileFragment.data.viewerState);
-  const viewerFollow = $derived(viewerState.follow);
+  const viewerFollow = $derived(viewerState?.follow ?? null);
   const isFollowing = $derived(viewerFollow?.state === 'ACCEPTED');
   // TODO: 승인 플로우가 추가되면 PENDING/REJECTED 전이를 실제 mutation 결과로 검증한다.
   const isPending = $derived(viewerFollow?.state === 'PENDING');
-  const unavailableReason = $derived(
-    !viewerState.authenticated
-      ? '로그인 후 팔로우할 수 있습니다.'
-      : !viewerState.hasSelectedProfile
-        ? '프로필을 선택한 뒤 팔로우할 수 있습니다.'
-        : !viewerState.canMutate
-          ? '이 프로필을 팔로우할 권한이 없습니다.'
-          : null,
-  );
-  const disabled = $derived(loading || Boolean(unavailableReason));
-  const message = $derived(errorMessage ?? unavailableReason);
+  const disabled = $derived(loading);
 
   const toggleFollow = async () => {
-    if (disabled) {
+    if (disabled || !viewerState || viewerState.isSelf) {
       return;
     }
 
@@ -107,8 +94,7 @@
   };
 </script>
 
-{#if !viewerState.isSelf}
-  <!-- 안내문이 버튼보다 넓어도 버튼은 우측 끝에 붙도록 items-end로 정렬한다. -->
+{#if viewerState && !viewerState.isSelf}
   <div class={`inline-flex flex-col items-end gap-1 ${className}`}>
     <Button
       variant={isFollowing || isPending ? 'secondary' : 'primary'}
@@ -120,12 +106,9 @@
     >
       {loading ? '처리 중' : isPending ? '요청 중' : isFollowing ? '팔로잉' : '팔로우'}
     </Button>
-    {#if message}
-      <p
-        class="text-text-secondary m-0 max-w-56 text-right text-xs leading-4"
-        role={errorMessage ? 'alert' : undefined}
-      >
-        {message}
+    {#if errorMessage}
+      <p class="text-text-secondary m-0 max-w-56 text-right text-xs leading-4" role="alert">
+        {errorMessage}
       </p>
     {/if}
   </div>

--- a/apps/web/src/lib/components/FollowButton.svelte
+++ b/apps/web/src/lib/components/FollowButton.svelte
@@ -1,32 +1,34 @@
 <script lang="ts">
   import { createFragment, createMutation } from '@mearie/svelte';
   import { graphql } from '$mearie';
-  import type { FragmentRefs } from '@mearie/svelte';
+  import type { FollowButton_profile$key } from '$mearie';
 
   import Button from './Button.svelte';
 
   const followButtonProfileFragment = graphql(`
     fragment FollowButton_profile on Profile {
       id
-      viewerFollow {
-        id
-        state
+      viewerState {
+        authenticated
+        hasSelectedProfile
+        isSelf
+        canMutate
+        follow {
+          id
+          state
+        }
       }
     }
   `);
 
   type Props = {
-    profile: FragmentRefs<'FollowButton_profile'>;
-    viewerProfileId?: string | null;
-    authenticated?: boolean;
-    canMutate?: boolean;
-    disabledReason?: string | null;
+    profile: FollowButton_profile$key;
     size?: 'sm' | 'md' | 'lg';
     class?: string;
   };
 
-  // followee/profile에 viewerFollow와 followersCount를 함께 선택해, mutation 응답만으로
-  // normalized cache의 Profile.viewerFollow / followersCount가 갱신되게 한다(별도 refetch 불필요).
+  // followee/profile에 viewerState와 followersCount를 함께 선택해, mutation 응답만으로
+  // normalized cache의 Profile.viewerState / followersCount가 갱신되게 한다(별도 refetch 불필요).
   const followProfileMutation = graphql(`
     mutation FollowButtonFollowProfile($id: ID!) {
       followProfile(input: { id: $id }) {
@@ -34,12 +36,8 @@
           id
           state
           followee {
-            id
             followersCount
-            viewerFollow {
-              id
-              state
-            }
+            ...FollowButton_profile
           }
         }
       }
@@ -51,26 +49,14 @@
       unfollowProfile(input: { id: $id }) {
         profileFollowId
         profile {
-          id
           followersCount
-          viewerFollow {
-            id
-            state
-          }
+          ...FollowButton_profile
         }
       }
     }
   `);
 
-  let {
-    profile,
-    viewerProfileId = null,
-    authenticated = true,
-    canMutate = true,
-    disabledReason = null,
-    size = 'sm',
-    class: className = '',
-  }: Props = $props();
+  let { profile, size = 'sm', class: className = '' }: Props = $props();
 
   const [followProfile] = createMutation(followProfileMutation);
   const [unfollowProfile] = createMutation(unfollowProfileMutation);
@@ -79,19 +65,19 @@
   let loading = $state(false);
   let errorMessage = $state<string | null>(null);
 
-  const viewerFollow = $derived(profileFragment.data.viewerFollow);
+  const viewerState = $derived(profileFragment.data.viewerState);
+  const viewerFollow = $derived(viewerState.follow);
   const isFollowing = $derived(viewerFollow?.state === 'ACCEPTED');
   // TODO: 승인 플로우가 추가되면 PENDING/REJECTED 전이를 실제 mutation 결과로 검증한다.
   const isPending = $derived(viewerFollow?.state === 'PENDING');
   const unavailableReason = $derived(
-    disabledReason ??
-      (!authenticated
-        ? '로그인 후 팔로우할 수 있습니다.'
-        : !viewerProfileId
-          ? '프로필을 선택한 뒤 팔로우할 수 있습니다.'
-          : !canMutate
-            ? '이 프로필을 팔로우할 권한이 없습니다.'
-            : null),
+    !viewerState.authenticated
+      ? '로그인 후 팔로우할 수 있습니다.'
+      : !viewerState.hasSelectedProfile
+        ? '프로필을 선택한 뒤 팔로우할 수 있습니다.'
+        : !viewerState.canMutate
+          ? '이 프로필을 팔로우할 권한이 없습니다.'
+          : null,
   );
   const disabled = $derived(loading || Boolean(unavailableReason));
   const message = $derived(errorMessage ?? unavailableReason);
@@ -121,7 +107,7 @@
   };
 </script>
 
-{#if !(viewerProfileId && viewerProfileId === profileFragment.data.id)}
+{#if !viewerState.isSelf}
   <!-- 안내문이 버튼보다 넓어도 버튼은 우측 끝에 붙도록 items-end로 정렬한다. -->
   <div class={`inline-flex flex-col items-end gap-1 ${className}`}>
     <Button

--- a/apps/web/src/lib/components/FollowButton.viewerState.test.ts
+++ b/apps/web/src/lib/components/FollowButton.viewerState.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { compile } from 'svelte/compiler';
+import { describe, expect, test } from 'vitest';
+
+const componentSource = readFileSync('src/lib/components/FollowButton.svelte', 'utf8');
+
+describe('FollowButton viewer state boundary', () => {
+  test('uses only relationship state from Profile.viewerState', () => {
+    expect.assertions(8);
+
+    const compiled = compile(componentSource, {
+      generate: 'client',
+      dev: true,
+      filename: 'FollowButton.svelte',
+    }).js.code;
+
+    expect(componentSource).toContain('viewerState');
+    expect(componentSource).toContain('isSelf');
+    expect(componentSource).toContain('follow {');
+    expect(componentSource).not.toContain('authenticated');
+    expect(componentSource).not.toContain('hasSelectedProfile');
+    expect(componentSource).not.toContain('canMutate');
+    expect(componentSource).not.toContain('unavailableReason');
+    expect(compiled).not.toContain('로그인 후 팔로우할 수 있습니다.');
+  });
+});

--- a/apps/web/src/lib/components/ProfileConnectionList.snippet.test.ts
+++ b/apps/web/src/lib/components/ProfileConnectionList.snippet.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, test } from 'vitest';
 
 const componentSource = readFileSync('src/lib/components/ProfileConnectionList.svelte', 'utf8');
 
-describe('ProfileConnectionList action snippet', () => {
-  test('passes the rendered profile action to ProfileListItem as a named action snippet', () => {
-    expect.assertions(2);
+describe('ProfileConnectionList profile row boundary', () => {
+  test('keeps follow action ownership inside ProfileListItem instead of passing an action snippet', () => {
+    expect.assertions(4);
 
     const compiled = compile(componentSource, {
       generate: 'client',
@@ -14,9 +14,9 @@ describe('ProfileConnectionList action snippet', () => {
       filename: 'ProfileConnectionList.svelte',
     }).js.code;
 
-    expect(compiled).toMatch(
-      /ProfileListItem\(\$\$anchor, \{[\s\S]*?action,\s*\$\$slots: \{ action: true \}/,
-    );
+    expect(componentSource).not.toContain('FollowButton_profile');
+    expect(componentSource).not.toContain('action?: Snippet');
+    expect(compiled).not.toMatch(/\$\$slots: \{ action: true \}/);
     expect(compiled).not.toMatch(/ProfileListItem\(\$\$anchor, \{[\s\S]*?children:/);
   });
 });

--- a/apps/web/src/lib/components/ProfileConnectionList.snippet.test.ts
+++ b/apps/web/src/lib/components/ProfileConnectionList.snippet.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { compile } from 'svelte/compiler';
+import { describe, expect, test } from 'vitest';
+
+const componentSource = readFileSync('src/lib/components/ProfileConnectionList.svelte', 'utf8');
+
+describe('ProfileConnectionList action snippet', () => {
+  test('passes the rendered profile action to ProfileListItem as a named action snippet', () => {
+    expect.assertions(2);
+
+    const compiled = compile(componentSource, {
+      generate: 'client',
+      dev: true,
+      filename: 'ProfileConnectionList.svelte',
+    }).js.code;
+
+    expect(compiled).toMatch(
+      /ProfileListItem\(\$\$anchor, \{[\s\S]*?action,\s*\$\$slots: \{ action: true \}/,
+    );
+    expect(compiled).not.toMatch(/ProfileListItem\(\$\$anchor, \{[\s\S]*?children:/);
+  });
+});

--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -1,5 +1,4 @@
 <script module lang="ts">
-  import type { FragmentRefs } from '@mearie/svelte';
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import type {
@@ -8,13 +7,25 @@
     ProfileListItem_profile$key,
   } from '$mearie';
 
-  import FollowButton from './FollowButton.svelte';
   import ProfileConnectionList from './ProfileConnectionList.svelte';
 
   type FollowState = 'ACCEPTED' | 'PENDING';
-  type ProfileActionMock = ProfileListItem_profile$key & FragmentRefs<'FollowButton_profile'>;
+  type ViewerState = {
+    authenticated: boolean;
+    hasSelectedProfile: boolean;
+    isSelf: boolean;
+    canMutate: boolean;
+    follow: { id: string; state: FollowState } | null;
+  };
 
-  const viewerProfileId = 'viewer-profile';
+  const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
+    authenticated: true,
+    hasSelectedProfile: true,
+    isSelf: false,
+    canMutate: true,
+    follow: null,
+    ...overrides,
+  });
 
   const profile = (
     overrides: Partial<{
@@ -23,7 +34,7 @@
       handle: string;
       relativeHandle: string;
       bio: string | null;
-      viewerFollow: { id: string; state: FollowState } | null;
+      viewerState: ViewerState;
     }> = {},
   ): ProfileListItem_profile$key =>
     ({
@@ -33,28 +44,14 @@
       handle: 'connected',
       relativeHandle: '@connected',
       bio: '팔로우 관계 목록에서 표시되는 프로필입니다.',
-      viewerFollow: null,
+      viewerState: defaultViewerState(),
       ...overrides,
     }) as unknown as ProfileListItem_profile$key;
-
-  const actionProfile = (
-    overrides: Partial<{
-      id: string;
-      displayName: string;
-      handle: string;
-      relativeHandle: string;
-      bio: string | null;
-      viewerFollow: { id: string; state: FollowState } | null;
-    }> = {},
-  ): ProfileActionMock => profile(overrides) as unknown as ProfileActionMock;
-
-  const followTarget = (item: ProfileListItem_profile$key): FragmentRefs<'FollowButton_profile'> =>
-    item as unknown as FragmentRefs<'FollowButton_profile'>;
 
   const additionalProfileItems = (kind: 'followers' | 'following') => [
     {
       cursor: `${kind}-edge-3`,
-      profile: actionProfile({
+      profile: profile({
         id: `${kind}-page-2-profile`,
         displayName: '다음 페이지 프로필',
         handle: `${kind}-next-page`,
@@ -97,7 +94,9 @@
                 displayName: '두 번째 팔로워',
                 handle: 'second-follower',
                 relativeHandle: '@second-follower',
-                viewerFollow: { id: 'viewer-follow-2', state: 'ACCEPTED' },
+                viewerState: defaultViewerState({
+                  follow: { id: 'viewer-follow-2', state: 'ACCEPTED' },
+                }),
               }),
             },
           },
@@ -169,11 +168,7 @@
       kind="followers"
       followersProfile={followersProfile()}
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList kind="followers" />
   </div>
 </Story>
@@ -185,41 +180,25 @@
       kind="followers"
       followersProfile={followersProfile()}
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile()}
       loadingNextPage
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile()}
       nextPageError
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile(lastPageInfo)}
       additionalProfiles={additionalProfileItems('followers')}
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
   </div>
 </Story>
 
@@ -232,11 +211,7 @@
       kind="following"
       followingProfile={followingProfile()}
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList kind="following" />
   </div>
 </Story>
@@ -248,40 +223,24 @@
       kind="following"
       followingProfile={followingProfile()}
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile()}
       loadingNextPage
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile()}
       nextPageError
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile(lastPageInfo)}
       additionalProfiles={additionalProfileItems('following')}
       onLoadMore={() => {}}
-    >
-      {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </ProfileConnectionList>
+    />
   </div>
 </Story>

--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -1,4 +1,5 @@
 <script module lang="ts">
+  import type { FragmentRefs } from '@mearie/svelte';
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import type {
@@ -7,9 +8,11 @@
     ProfileListItem_profile$key,
   } from '$mearie';
 
+  import FollowButton from './FollowButton.svelte';
   import ProfileConnectionList from './ProfileConnectionList.svelte';
 
   type FollowState = 'ACCEPTED' | 'PENDING';
+  type ProfileActionMock = ProfileListItem_profile$key & FragmentRefs<'FollowButton_profile'>;
 
   const viewerProfileId = 'viewer-profile';
 
@@ -34,10 +37,24 @@
       ...overrides,
     }) as unknown as ProfileListItem_profile$key;
 
+  const actionProfile = (
+    overrides: Partial<{
+      id: string;
+      displayName: string;
+      handle: string;
+      relativeHandle: string;
+      bio: string | null;
+      viewerFollow: { id: string; state: FollowState } | null;
+    }> = {},
+  ): ProfileActionMock => profile(overrides) as unknown as ProfileActionMock;
+
+  const followTarget = (item: ProfileListItem_profile$key): FragmentRefs<'FollowButton_profile'> =>
+    item as unknown as FragmentRefs<'FollowButton_profile'>;
+
   const additionalProfileItems = (kind: 'followers' | 'following') => [
     {
       cursor: `${kind}-edge-3`,
-      profile: profile({
+      profile: actionProfile({
         id: `${kind}-page-2-profile`,
         displayName: '다음 페이지 프로필',
         handle: `${kind}-next-page`,
@@ -137,7 +154,6 @@
   args={{
     kind: 'followers',
     followersProfile: followersProfile(),
-    viewerProfileId,
     loading: false,
     error: false,
     onLoadMore: () => {},
@@ -152,9 +168,12 @@
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile()}
-      {viewerProfileId}
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList kind="followers" />
   </div>
 </Story>
@@ -165,30 +184,42 @@
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile()}
-      {viewerProfileId}
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile()}
-      {viewerProfileId}
       loadingNextPage
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile()}
-      {viewerProfileId}
       nextPageError
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList
       kind="followers"
       followersProfile={followersProfile(lastPageInfo)}
       additionalProfiles={additionalProfileItems('followers')}
-      {viewerProfileId}
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
   </div>
 </Story>
 
@@ -200,9 +231,12 @@
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile()}
-      {viewerProfileId}
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList kind="following" />
   </div>
 </Story>
@@ -213,29 +247,41 @@
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile()}
-      {viewerProfileId}
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile()}
-      {viewerProfileId}
       loadingNextPage
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile()}
-      {viewerProfileId}
       nextPageError
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
     <ProfileConnectionList
       kind="following"
       followingProfile={followingProfile(lastPageInfo)}
       additionalProfiles={additionalProfileItems('following')}
-      {viewerProfileId}
       onLoadMore={() => {}}
-    />
+    >
+      {#snippet action(profile: ProfileListItem_profile$key)}
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+      {/snippet}
+    </ProfileConnectionList>
   </div>
 </Story>

--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -171,7 +171,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList kind="followers" />
@@ -187,7 +187,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList
@@ -197,7 +197,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList
@@ -207,7 +207,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList
@@ -217,7 +217,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
   </div>
@@ -234,7 +234,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList kind="following" />
@@ -250,7 +250,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList
@@ -260,7 +260,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList
@@ -270,7 +270,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
     <ProfileConnectionList
@@ -280,7 +280,7 @@
       onLoadMore={() => {}}
     >
       {#snippet action(profile: ProfileListItem_profile$key)}
-        <FollowButton profile={followTarget(profile)} {viewerProfileId} />
+        <FollowButton profile={followTarget(profile)} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </ProfileConnectionList>
   </div>

--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -11,18 +11,12 @@
 
   type FollowState = 'ACCEPTED' | 'PENDING';
   type ViewerState = {
-    authenticated: boolean;
-    hasSelectedProfile: boolean;
     isSelf: boolean;
-    canMutate: boolean;
     follow: { id: string; state: FollowState } | null;
   };
 
   const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
-    authenticated: true,
-    hasSelectedProfile: true,
     isSelf: false,
-    canMutate: true,
     follow: null,
     ...overrides,
   });
@@ -34,7 +28,7 @@
       handle: string;
       relativeHandle: string;
       bio: string | null;
-      viewerState: ViewerState;
+      viewerState: ViewerState | null;
     }> = {},
   ): ProfileListItem_profile$key =>
     ({

--- a/apps/web/src/lib/components/ProfileConnectionList.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { createFragment } from '@mearie/svelte';
   import { graphql } from '$mearie';
-  import type { FragmentRefs } from '@mearie/svelte';
   import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
   import type {
+    FollowButton_profile$key,
     ProfileConnectionList_followersProfile$key,
     ProfileConnectionList_followingProfile$key,
     ProfileListItem_profile$key,
@@ -17,8 +17,7 @@
   // 프로필 팔로워/팔로잉 목록 영역. 게시글 목록(PostList)과 같은 상태(로딩/오류/빈) 표현·접근성 패턴을 따른다.
   // 팔로워/팔로잉은 같은 컴포넌트를 `kind`로 분기해 시각/상태 구조를 일치시킨다.
   type ConnectionKind = 'followers' | 'following';
-  type ProfileConnectionActionProfile = ProfileListItem_profile$key &
-    FragmentRefs<'FollowButton_profile'>;
+  type ProfileConnectionActionProfile = ProfileListItem_profile$key & FollowButton_profile$key;
   type ConnectionProfileItem = { cursor: string; profile: ProfileConnectionActionProfile };
 
   type Props = HTMLAttributes<HTMLElement> & {
@@ -222,13 +221,15 @@
     <div>
       {#each connectionProfiles as item (item.cursor)}
         {@const actionSnippet = action}
-        <ProfileListItem profile={item.profile} linked width="wide" class="w-full">
-          {#if actionSnippet}
+        {#if actionSnippet}
+          <ProfileListItem profile={item.profile} linked width="wide" class="w-full">
             {#snippet action()}
               {@render actionSnippet(item.profile)}
             {/snippet}
-          {/if}
-        </ProfileListItem>
+          </ProfileListItem>
+        {:else}
+          <ProfileListItem profile={item.profile} linked width="wide" class="w-full" />
+        {/if}
       {/each}
     </div>
     {#if showPagination}

--- a/apps/web/src/lib/components/ProfileConnectionList.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { createFragment } from '@mearie/svelte';
   import { graphql } from '$mearie';
-  import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
   import type {
-    FollowButton_profile$key,
     ProfileConnectionList_followersProfile$key,
     ProfileConnectionList_followingProfile$key,
     ProfileListItem_profile$key,
@@ -17,8 +15,7 @@
   // 프로필 팔로워/팔로잉 목록 영역. 게시글 목록(PostList)과 같은 상태(로딩/오류/빈) 표현·접근성 패턴을 따른다.
   // 팔로워/팔로잉은 같은 컴포넌트를 `kind`로 분기해 시각/상태 구조를 일치시킨다.
   type ConnectionKind = 'followers' | 'following';
-  type ProfileConnectionActionProfile = ProfileListItem_profile$key & FollowButton_profile$key;
-  type ConnectionProfileItem = { cursor: string; profile: ProfileConnectionActionProfile };
+  type ConnectionProfileItem = { cursor: string; profile: ProfileListItem_profile$key };
 
   type Props = HTMLAttributes<HTMLElement> & {
     kind: ConnectionKind;
@@ -29,7 +26,6 @@
     endCursor?: string | null;
     loadingNextPage?: boolean;
     nextPageError?: boolean;
-    action?: Snippet<[profile: ProfileConnectionActionProfile]>;
     loading?: boolean;
     error?: boolean;
     onRetry?: () => void;
@@ -45,7 +41,6 @@
     endCursor = null,
     loadingNextPage = false,
     nextPageError = false,
-    action,
     loading = false,
     error = false,
     onRetry,
@@ -105,7 +100,6 @@
               follower {
                 id
                 ...ProfileListItem_profile
-                ...FollowButton_profile
               }
             }
           }
@@ -131,7 +125,6 @@
               followee {
                 id
                 ...ProfileListItem_profile
-                ...FollowButton_profile
               }
             }
           }
@@ -220,16 +213,7 @@
   {:else if connectionProfiles.length > 0}
     <div>
       {#each connectionProfiles as item (item.cursor)}
-        {@const actionSnippet = action}
-        {#if actionSnippet}
-          <ProfileListItem profile={item.profile} linked width="wide" class="w-full">
-            {#snippet action()}
-              {@render actionSnippet(item.profile)}
-            {/snippet}
-          </ProfileListItem>
-        {:else}
-          <ProfileListItem profile={item.profile} linked width="wide" class="w-full" />
-        {/if}
+        <ProfileListItem profile={item.profile} linked width="wide" class="w-full" />
       {/each}
     </div>
     {#if showPagination}

--- a/apps/web/src/lib/components/ProfileConnectionList.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { createFragment } from '@mearie/svelte';
   import { graphql } from '$mearie';
+  import type { FragmentRefs } from '@mearie/svelte';
+  import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
   import type {
@@ -15,7 +17,9 @@
   // 프로필 팔로워/팔로잉 목록 영역. 게시글 목록(PostList)과 같은 상태(로딩/오류/빈) 표현·접근성 패턴을 따른다.
   // 팔로워/팔로잉은 같은 컴포넌트를 `kind`로 분기해 시각/상태 구조를 일치시킨다.
   type ConnectionKind = 'followers' | 'following';
-  type ConnectionProfileItem = { cursor: string; profile: ProfileListItem_profile$key };
+  type ProfileConnectionActionProfile = ProfileListItem_profile$key &
+    FragmentRefs<'FollowButton_profile'>;
+  type ConnectionProfileItem = { cursor: string; profile: ProfileConnectionActionProfile };
 
   type Props = HTMLAttributes<HTMLElement> & {
     kind: ConnectionKind;
@@ -26,7 +30,7 @@
     endCursor?: string | null;
     loadingNextPage?: boolean;
     nextPageError?: boolean;
-    viewerProfileId?: string | null;
+    action?: Snippet<[profile: ProfileConnectionActionProfile]>;
     loading?: boolean;
     error?: boolean;
     onRetry?: () => void;
@@ -42,7 +46,7 @@
     endCursor = null,
     loadingNextPage = false,
     nextPageError = false,
-    viewerProfileId = null,
+    action,
     loading = false,
     error = false,
     onRetry,
@@ -102,6 +106,7 @@
               follower {
                 id
                 ...ProfileListItem_profile
+                ...FollowButton_profile
               }
             }
           }
@@ -127,6 +132,7 @@
               followee {
                 id
                 ...ProfileListItem_profile
+                ...FollowButton_profile
               }
             }
           }
@@ -215,13 +221,14 @@
   {:else if connectionProfiles.length > 0}
     <div>
       {#each connectionProfiles as item (item.cursor)}
-        <ProfileListItem
-          profile={item.profile}
-          linked
-          {viewerProfileId}
-          width="wide"
-          class="w-full"
-        />
+        {@const actionSnippet = action}
+        <ProfileListItem profile={item.profile} linked width="wide" class="w-full">
+          {#if actionSnippet}
+            {#snippet action()}
+              {@render actionSnippet(item.profile)}
+            {/snippet}
+          {/if}
+        </ProfileListItem>
       {/each}
     </div>
     {#if showPagination}

--- a/apps/web/src/lib/components/ProfileHero.stories.svelte
+++ b/apps/web/src/lib/components/ProfileHero.stories.svelte
@@ -28,10 +28,7 @@
     __typename: 'Profile',
     id: 'target-profile',
     viewerState: {
-      authenticated: true,
-      hasSelectedProfile: true,
       isSelf: false,
-      canMutate: true,
       follow: null,
     },
   } as unknown as FollowButton_profile$key;

--- a/apps/web/src/lib/components/ProfileHero.stories.svelte
+++ b/apps/web/src/lib/components/ProfileHero.stories.svelte
@@ -4,6 +4,7 @@
   import FollowButton from './FollowButton.svelte';
   import ProfileHero from './ProfileHero.svelte';
   import type { FragmentRefs } from '@mearie/svelte';
+  import type { FollowButton_profile$key } from '$mearie';
 
   // 스토리북은 .storybook/mocks/mearie-svelte.ts에서 createFragment를 패스스루로 모킹하므로
   // 여기서는 평범한 데이터 객체를 fragment ref 자리에 그대로 넘긴다.
@@ -22,13 +23,18 @@
     bio: null,
   } as unknown as ProfileRef;
 
-  // 라우트가 action 슬롯에 넣는 팔로우 버튼 예시. 대상 프로필 id와 viewerProfileId가 달라 버튼이 노출된다.
-  const followViewerProfileId = 'viewer-profile';
+  // 라우트가 hero action 슬롯에 넣는 팔로우 버튼 예시. 버튼 정책은 FollowButton의 Profile.viewerState가 판단한다.
   const followTarget = {
     __typename: 'Profile',
     id: 'target-profile',
-    viewerFollow: null,
-  } as unknown as FragmentRefs<'FollowButton_profile'>;
+    viewerState: {
+      authenticated: true,
+      hasSelectedProfile: true,
+      isSelf: false,
+      canMutate: true,
+      follow: null,
+    },
+  } as unknown as FollowButton_profile$key;
 
   const { Story } = defineMeta({
     title: 'KOSMO/ProfileHero',
@@ -56,7 +62,7 @@
 <Story name="With action" asChild>
   <ProfileHero profile={sampleProfile}>
     {#snippet action()}
-      <FollowButton profile={followTarget} viewerProfileId={followViewerProfileId} />
+      <FollowButton profile={followTarget} />
     {/snippet}
   </ProfileHero>
 </Story>

--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -1,16 +1,27 @@
 <script module lang="ts">
-  import type { FragmentRefs } from '@mearie/svelte';
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import type { ProfileListItem_profile$key } from '$mearie';
 
-  import FollowButton from './FollowButton.svelte';
   import ProfileListItem from './ProfileListItem.svelte';
 
   type FollowState = 'ACCEPTED' | 'PENDING';
+  type ViewerState = {
+    authenticated: boolean;
+    hasSelectedProfile: boolean;
+    isSelf: boolean;
+    canMutate: boolean;
+    follow: { id: string; state: FollowState } | null;
+  };
 
-  const viewerProfileId = 'viewer-profile';
-  const missingViewerProfileId: string | null = null;
+  const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
+    authenticated: true,
+    hasSelectedProfile: true,
+    isSelf: false,
+    canMutate: true,
+    follow: null,
+    ...overrides,
+  });
 
   // 실제 Mearie fragment ref 대신 표시 필드만 담은 mock 객체를 캐스팅해 넘긴다.
   // (Storybook은 .storybook/mocks의 createFragment가 data getter로 그대로 돌려준다.)
@@ -21,7 +32,7 @@
       handle: string;
       relativeHandle: string;
       bio: string | null;
-      viewerFollow: { id: string; state: FollowState } | null;
+      viewerState: ViewerState;
     }> = {},
   ): ProfileListItem_profile$key =>
     ({
@@ -31,17 +42,9 @@
       handle: 'handle',
       relativeHandle: '@handle@kos.mo',
       bio: null,
-      viewerFollow: null,
+      viewerState: defaultViewerState(),
       ...overrides,
     }) as unknown as ProfileListItem_profile$key;
-
-  const followTarget = (
-    overrides: Partial<{
-      id: string;
-      viewerFollow: { id: string; state: FollowState } | null;
-    }> = {},
-  ): FragmentRefs<'FollowButton_profile'> =>
-    profile(overrides) as unknown as FragmentRefs<'FollowButton_profile'>;
 
   const { Story } = defineMeta({
     title: 'KOSMO/ProfileListItem',
@@ -68,86 +71,65 @@
   <div class="grid gap-4 text-sm">
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">팔로우 가능</p>
-      <ProfileListItem profile={profile({ id: 'followable-profile' })}>
-        {#snippet action()}
-          <FollowButton
-            profile={followTarget({ id: 'followable-profile' })}
-            {viewerProfileId}
-            class="shrink-0"
-          />
-        {/snippet}
-      </ProfileListItem>
+      <ProfileListItem profile={profile({ id: 'followable-profile' })} />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">팔로잉</p>
       <ProfileListItem
         profile={profile({
           id: 'followed-profile',
-          viewerFollow: { id: 'follow-accepted', state: 'ACCEPTED' },
+          viewerState: defaultViewerState({
+            follow: { id: 'follow-accepted', state: 'ACCEPTED' },
+          }),
         })}
-      >
-        {#snippet action()}
-          <FollowButton
-            profile={followTarget({
-              id: 'followed-profile',
-              viewerFollow: { id: 'follow-accepted', state: 'ACCEPTED' },
-            })}
-            {viewerProfileId}
-            class="shrink-0"
-          />
-        {/snippet}
-      </ProfileListItem>
+      />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">요청 중</p>
       <ProfileListItem
         profile={profile({
           id: 'pending-profile',
-          viewerFollow: { id: 'follow-pending', state: 'PENDING' },
+          viewerState: defaultViewerState({
+            follow: { id: 'follow-pending', state: 'PENDING' },
+          }),
         })}
-      >
-        {#snippet action()}
-          <FollowButton
-            profile={followTarget({
-              id: 'pending-profile',
-              viewerFollow: { id: 'follow-pending', state: 'PENDING' },
-            })}
-            {viewerProfileId}
-            class="shrink-0"
-          />
-        {/snippet}
-      </ProfileListItem>
+      />
     </section>
   </div>
 </Story>
 
-<Story name="Hidden action states" asChild parameters={{ controls: { disable: true } }}>
+<Story name="Viewer states" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid gap-4 text-sm">
     <section class="grid gap-1">
-      <p class="text-text-secondary m-0">비로그인 공개 조회 또는 선택 프로필 없음</p>
-      <ProfileListItem profile={profile({ id: 'guest-profile' })}>
-        {#snippet action()}
-          {#if missingViewerProfileId}
-            <FollowButton
-              profile={followTarget({ id: 'guest-profile' })}
-              viewerProfileId={missingViewerProfileId}
-              class="shrink-0"
-            />
-          {/if}
-        {/snippet}
-      </ProfileListItem>
+      <p class="text-text-secondary m-0">프로필 미선택</p>
+      <ProfileListItem
+        profile={profile({
+          id: 'missing-viewer-profile',
+          viewerState: defaultViewerState({ hasSelectedProfile: false, canMutate: false }),
+        })}
+      />
+    </section>
+    <section class="grid gap-1">
+      <p class="text-text-secondary m-0">비로그인 공개 조회</p>
+      <ProfileListItem
+        profile={profile({
+          id: 'guest-profile',
+          viewerState: defaultViewerState({
+            authenticated: false,
+            hasSelectedProfile: false,
+            canMutate: false,
+          }),
+        })}
+      />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">본인 프로필</p>
-      <ProfileListItem profile={profile({ id: viewerProfileId })}>
-        {#snippet action()}
-          <FollowButton
-            profile={followTarget({ id: viewerProfileId })}
-            {viewerProfileId}
-            class="shrink-0"
-          />
-        {/snippet}
-      </ProfileListItem>
+      <ProfileListItem
+        profile={profile({
+          id: 'self-profile',
+          viewerState: defaultViewerState({ isSelf: true, canMutate: false }),
+        })}
+      />
     </section>
   </div>
 </Story>
@@ -156,15 +138,7 @@
   <ProfileListItem
     profile={profile({ id: 'linked-profile', handle: 'user', relativeHandle: '@user@kos.moe' })}
     linked
-  >
-    {#snippet action()}
-      <FollowButton
-        profile={followTarget({ id: 'linked-profile' })}
-        {viewerProfileId}
-        class="shrink-0"
-      />
-    {/snippet}
-  </ProfileListItem>
+  />
 </Story>
 
 <Story name="Edge cases" asChild parameters={{ controls: { disable: true } }}>
@@ -178,15 +152,7 @@
         relativeHandle: '@super-long-handle-that-overflows@really-long-instance.example.com',
         bio: '긴 한 줄 소개가 들어가서 컨테이너 폭을 넘기면 말줄임으로 잘려야 한다',
       })}
-    >
-      {#snippet action()}
-        <FollowButton
-          profile={followTarget({ id: 'long-profile' })}
-          {viewerProfileId}
-          class="shrink-0"
-        />
-      {/snippet}
-    </ProfileListItem>
+    />
     <ProfileListItem
       profile={profile({
         id: 'minimal-profile',

--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -7,18 +7,12 @@
 
   type FollowState = 'ACCEPTED' | 'PENDING';
   type ViewerState = {
-    authenticated: boolean;
-    hasSelectedProfile: boolean;
     isSelf: boolean;
-    canMutate: boolean;
     follow: { id: string; state: FollowState } | null;
   };
 
   const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
-    authenticated: true,
-    hasSelectedProfile: true,
     isSelf: false,
-    canMutate: true,
     follow: null,
     ...overrides,
   });
@@ -32,7 +26,7 @@
       handle: string;
       relativeHandle: string;
       bio: string | null;
-      viewerState: ViewerState;
+      viewerState: ViewerState | null;
     }> = {},
   ): ProfileListItem_profile$key =>
     ({
@@ -101,24 +95,11 @@
 <Story name="Viewer states" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid gap-4 text-sm">
     <section class="grid gap-1">
-      <p class="text-text-secondary m-0">프로필 미선택</p>
+      <p class="text-text-secondary m-0">viewerState 없음</p>
       <ProfileListItem
         profile={profile({
           id: 'missing-viewer-profile',
-          viewerState: defaultViewerState({ hasSelectedProfile: false, canMutate: false }),
-        })}
-      />
-    </section>
-    <section class="grid gap-1">
-      <p class="text-text-secondary m-0">비로그인 공개 조회</p>
-      <ProfileListItem
-        profile={profile({
-          id: 'guest-profile',
-          viewerState: defaultViewerState({
-            authenticated: false,
-            hasSelectedProfile: false,
-            canMutate: false,
-          }),
+          viewerState: null,
         })}
       />
     </section>
@@ -127,7 +108,7 @@
       <ProfileListItem
         profile={profile({
           id: 'self-profile',
-          viewerState: defaultViewerState({ isSelf: true, canMutate: false }),
+          viewerState: defaultViewerState({ isSelf: true }),
         })}
       />
     </section>

--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -10,6 +10,7 @@
   type FollowState = 'ACCEPTED' | 'PENDING';
 
   const viewerProfileId = 'viewer-profile';
+  const missingViewerProfileId: string | null = null;
 
   // 실제 Mearie fragment ref 대신 표시 필드만 담은 mock 객체를 캐스팅해 넘긴다.
   // (Storybook은 .storybook/mocks의 createFragment가 data getter로 그대로 돌려준다.)
@@ -69,7 +70,11 @@
       <p class="text-text-secondary m-0">팔로우 가능</p>
       <ProfileListItem profile={profile({ id: 'followable-profile' })}>
         {#snippet action()}
-          <FollowButton profile={followTarget({ id: 'followable-profile' })} {viewerProfileId} />
+          <FollowButton
+            profile={followTarget({ id: 'followable-profile' })}
+            {viewerProfileId}
+            class="shrink-0"
+          />
         {/snippet}
       </ProfileListItem>
     </section>
@@ -88,6 +93,7 @@
               viewerFollow: { id: 'follow-accepted', state: 'ACCEPTED' },
             })}
             {viewerProfileId}
+            class="shrink-0"
           />
         {/snippet}
       </ProfileListItem>
@@ -107,6 +113,7 @@
               viewerFollow: { id: 'follow-pending', state: 'PENDING' },
             })}
             {viewerProfileId}
+            class="shrink-0"
           />
         {/snippet}
       </ProfileListItem>
@@ -118,13 +125,27 @@
   <div class="grid gap-4 text-sm">
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">비로그인 공개 조회 또는 선택 프로필 없음</p>
-      <ProfileListItem profile={profile({ id: 'guest-profile' })} />
+      <ProfileListItem profile={profile({ id: 'guest-profile' })}>
+        {#snippet action()}
+          {#if missingViewerProfileId}
+            <FollowButton
+              profile={followTarget({ id: 'guest-profile' })}
+              viewerProfileId={missingViewerProfileId}
+              class="shrink-0"
+            />
+          {/if}
+        {/snippet}
+      </ProfileListItem>
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">본인 프로필</p>
       <ProfileListItem profile={profile({ id: viewerProfileId })}>
         {#snippet action()}
-          <FollowButton profile={followTarget({ id: viewerProfileId })} {viewerProfileId} />
+          <FollowButton
+            profile={followTarget({ id: viewerProfileId })}
+            {viewerProfileId}
+            class="shrink-0"
+          />
         {/snippet}
       </ProfileListItem>
     </section>
@@ -137,7 +158,11 @@
     linked
   >
     {#snippet action()}
-      <FollowButton profile={followTarget({ id: 'linked-profile' })} {viewerProfileId} />
+      <FollowButton
+        profile={followTarget({ id: 'linked-profile' })}
+        {viewerProfileId}
+        class="shrink-0"
+      />
     {/snippet}
   </ProfileListItem>
 </Story>
@@ -153,7 +178,15 @@
         relativeHandle: '@super-long-handle-that-overflows@really-long-instance.example.com',
         bio: '긴 한 줄 소개가 들어가서 컨테이너 폭을 넘기면 말줄임으로 잘려야 한다',
       })}
-    />
+    >
+      {#snippet action()}
+        <FollowButton
+          profile={followTarget({ id: 'long-profile' })}
+          {viewerProfileId}
+          class="shrink-0"
+        />
+      {/snippet}
+    </ProfileListItem>
     <ProfileListItem
       profile={profile({
         id: 'minimal-profile',

--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -1,8 +1,10 @@
 <script module lang="ts">
+  import type { FragmentRefs } from '@mearie/svelte';
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import type { ProfileListItem_profile$key } from '$mearie';
 
+  import FollowButton from './FollowButton.svelte';
   import ProfileListItem from './ProfileListItem.svelte';
 
   type FollowState = 'ACCEPTED' | 'PENDING';
@@ -32,6 +34,14 @@
       ...overrides,
     }) as unknown as ProfileListItem_profile$key;
 
+  const followTarget = (
+    overrides: Partial<{
+      id: string;
+      viewerFollow: { id: string; state: FollowState } | null;
+    }> = {},
+  ): FragmentRefs<'FollowButton_profile'> =>
+    profile(overrides) as unknown as FragmentRefs<'FollowButton_profile'>;
+
   const { Story } = defineMeta({
     title: 'KOSMO/ProfileListItem',
     component: ProfileListItem,
@@ -49,7 +59,6 @@
   name="Playground"
   args={{
     profile: profile(),
-    viewerProfileId,
     width: 'compact',
   }}
 />
@@ -58,7 +67,11 @@
   <div class="grid gap-4 text-sm">
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">팔로우 가능</p>
-      <ProfileListItem profile={profile({ id: 'followable-profile' })} {viewerProfileId} />
+      <ProfileListItem profile={profile({ id: 'followable-profile' })}>
+        {#snippet action()}
+          <FollowButton profile={followTarget({ id: 'followable-profile' })} {viewerProfileId} />
+        {/snippet}
+      </ProfileListItem>
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">팔로잉</p>
@@ -67,8 +80,17 @@
           id: 'followed-profile',
           viewerFollow: { id: 'follow-accepted', state: 'ACCEPTED' },
         })}
-        {viewerProfileId}
-      />
+      >
+        {#snippet action()}
+          <FollowButton
+            profile={followTarget({
+              id: 'followed-profile',
+              viewerFollow: { id: 'follow-accepted', state: 'ACCEPTED' },
+            })}
+            {viewerProfileId}
+          />
+        {/snippet}
+      </ProfileListItem>
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">요청 중</p>
@@ -77,8 +99,17 @@
           id: 'pending-profile',
           viewerFollow: { id: 'follow-pending', state: 'PENDING' },
         })}
-        {viewerProfileId}
-      />
+      >
+        {#snippet action()}
+          <FollowButton
+            profile={followTarget({
+              id: 'pending-profile',
+              viewerFollow: { id: 'follow-pending', state: 'PENDING' },
+            })}
+            {viewerProfileId}
+          />
+        {/snippet}
+      </ProfileListItem>
     </section>
   </div>
 </Story>
@@ -87,11 +118,15 @@
   <div class="grid gap-4 text-sm">
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">비로그인 공개 조회 또는 선택 프로필 없음</p>
-      <ProfileListItem profile={profile({ id: 'guest-profile' })} viewerProfileId={null} />
+      <ProfileListItem profile={profile({ id: 'guest-profile' })} />
     </section>
     <section class="grid gap-1">
       <p class="text-text-secondary m-0">본인 프로필</p>
-      <ProfileListItem profile={profile({ id: viewerProfileId })} {viewerProfileId} />
+      <ProfileListItem profile={profile({ id: viewerProfileId })}>
+        {#snippet action()}
+          <FollowButton profile={followTarget({ id: viewerProfileId })} {viewerProfileId} />
+        {/snippet}
+      </ProfileListItem>
     </section>
   </div>
 </Story>
@@ -100,15 +135,17 @@
   <ProfileListItem
     profile={profile({ id: 'linked-profile', handle: 'user', relativeHandle: '@user@kos.moe' })}
     linked
-    {viewerProfileId}
-  />
+  >
+    {#snippet action()}
+      <FollowButton profile={followTarget({ id: 'linked-profile' })} {viewerProfileId} />
+    {/snippet}
+  </ProfileListItem>
 </Story>
 
 <Story name="Edge cases" asChild parameters={{ controls: { disable: true } }}>
   <div class="grid gap-3">
     <ProfileListItem
       width="wide"
-      {viewerProfileId}
       profile={profile({
         id: 'long-profile',
         displayName: '아주 긴 표시 이름이 들어가서 한 줄을 넘기면 잘려야 한다',
@@ -118,7 +155,6 @@
       })}
     />
     <ProfileListItem
-      {viewerProfileId}
       profile={profile({
         id: 'minimal-profile',
         displayName: '최소 정보',

--- a/apps/web/src/lib/components/ProfileListItem.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.svelte
@@ -3,17 +3,16 @@
   import { createFragment } from '@mearie/svelte';
   import { tv } from '$lib/tv';
   import { getProfileInitial } from '$lib/utils/profile';
-  import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
   import type { ProfileListItem_profile$key } from '$mearie';
 
   import Avatar from './Avatar.svelte';
+  import FollowButton from './FollowButton.svelte';
 
   type ProfileListItemProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
     profile: ProfileListItem_profile$key;
     linked?: boolean;
-    action?: Snippet;
     width?: 'compact' | 'wide';
     class?: string | null;
   };
@@ -21,7 +20,6 @@
   let {
     profile,
     linked = false,
-    action,
     width = 'compact',
     class: className = null,
     ...rest
@@ -48,6 +46,7 @@
         handle
         relativeHandle
         bio
+        ...FollowButton_profile
       }
     `),
     () => profile,
@@ -89,5 +88,5 @@
       </div>
     </div>
   {/if}
-  {@render action?.()}
+  <FollowButton profile={fragment.data} class="shrink-0" />
 </div>

--- a/apps/web/src/lib/components/ProfileListItem.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.svelte
@@ -89,7 +89,5 @@
       </div>
     </div>
   {/if}
-  {#if action}
-    <div class="shrink-0">{@render action()}</div>
-  {/if}
+  {@render action?.()}
 </div>

--- a/apps/web/src/lib/components/ProfileListItem.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.svelte
@@ -3,17 +3,17 @@
   import { createFragment } from '@mearie/svelte';
   import { tv } from '$lib/tv';
   import { getProfileInitial } from '$lib/utils/profile';
+  import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
   import type { ProfileListItem_profile$key } from '$mearie';
 
   import Avatar from './Avatar.svelte';
-  import FollowButton from './FollowButton.svelte';
 
   type ProfileListItemProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
     profile: ProfileListItem_profile$key;
     linked?: boolean;
-    viewerProfileId?: string | null;
+    action?: Snippet;
     width?: 'compact' | 'wide';
     class?: string | null;
   };
@@ -21,7 +21,7 @@
   let {
     profile,
     linked = false,
-    viewerProfileId = null,
+    action,
     width = 'compact',
     class: className = null,
     ...rest
@@ -48,7 +48,6 @@
         handle
         relativeHandle
         bio
-        ...FollowButton_profile
       }
     `),
     () => profile,
@@ -90,7 +89,7 @@
       </div>
     </div>
   {/if}
-  {#if viewerProfileId}
-    <FollowButton profile={fragment.data} {viewerProfileId} class="shrink-0" />
+  {#if action}
+    <div class="shrink-0">{@render action()}</div>
   {/if}
 </div>

--- a/apps/web/src/lib/components/Search/SearchResults.stories.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.stories.svelte
@@ -1,11 +1,12 @@
 <script module lang="ts">
-  import type { FragmentRefs } from '@mearie/svelte';
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import type { ProfileListItem_profile$key } from '$mearie';
+  import type { FollowButton_profile$key, ProfileListItem_profile$key } from '$mearie';
 
   import FollowButton from '../FollowButton.svelte';
   import SearchResults from './SearchResults.svelte';
+
+  type SearchResultMock = ProfileListItem_profile$key & FollowButton_profile$key;
 
   const viewerProfileId = 'viewer-profile';
 
@@ -18,7 +19,7 @@
       bio: string | null;
       viewerFollow: { id: string; state: 'ACCEPTED' | 'PENDING' } | null;
     }> = {},
-  ): ProfileListItem_profile$key =>
+  ): SearchResultMock =>
     ({
       __typename: 'Profile',
       id: 'searched-profile',
@@ -28,15 +29,7 @@
       bio: '코스모에서 만나는 첫 프로필',
       viewerFollow: null,
       ...overrides,
-    }) as unknown as ProfileListItem_profile$key;
-
-  const followTarget = (
-    overrides: Partial<{
-      id: string;
-      viewerFollow: { id: string; state: 'ACCEPTED' | 'PENDING' } | null;
-    }> = {},
-  ): FragmentRefs<'FollowButton_profile'> =>
-    profile(overrides) as unknown as FragmentRefs<'FollowButton_profile'>;
+    }) as unknown as SearchResultMock;
 
   const { Story } = defineMeta({
     title: 'KOSMO/SearchResults',
@@ -60,8 +53,8 @@
     <SearchResults query="별마루" loading />
     <SearchResults query="별마루" error onRetry={() => {}} />
     <SearchResults query="별마루" profile={profile()}>
-      {#snippet action()}
-        <FollowButton profile={followTarget()} {viewerProfileId} />
+      {#snippet action(profile)}
+        <FollowButton {profile} {viewerProfileId} class="shrink-0" />
       {/snippet}
     </SearchResults>
     <SearchResults query="없는핸들" />

--- a/apps/web/src/lib/components/Search/SearchResults.stories.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.stories.svelte
@@ -7,18 +7,12 @@
 
   type FollowState = 'ACCEPTED' | 'PENDING';
   type ViewerState = {
-    authenticated: boolean;
-    hasSelectedProfile: boolean;
     isSelf: boolean;
-    canMutate: boolean;
     follow: { id: string; state: FollowState } | null;
   };
 
   const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
-    authenticated: true,
-    hasSelectedProfile: true,
     isSelf: false,
-    canMutate: true,
     follow: null,
     ...overrides,
   });
@@ -30,7 +24,7 @@
       handle: string;
       relativeHandle: string;
       bio: string | null;
-      viewerState: ViewerState;
+      viewerState: ViewerState | null;
     }> = {},
   ): ProfileListItem_profile$key =>
     ({

--- a/apps/web/src/lib/components/Search/SearchResults.stories.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.stories.svelte
@@ -1,14 +1,27 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
-  import type { FollowButton_profile$key, ProfileListItem_profile$key } from '$mearie';
+  import type { ProfileListItem_profile$key } from '$mearie';
 
-  import FollowButton from '../FollowButton.svelte';
   import SearchResults from './SearchResults.svelte';
 
-  type SearchResultMock = ProfileListItem_profile$key & FollowButton_profile$key;
+  type FollowState = 'ACCEPTED' | 'PENDING';
+  type ViewerState = {
+    authenticated: boolean;
+    hasSelectedProfile: boolean;
+    isSelf: boolean;
+    canMutate: boolean;
+    follow: { id: string; state: FollowState } | null;
+  };
 
-  const viewerProfileId = 'viewer-profile';
+  const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
+    authenticated: true,
+    hasSelectedProfile: true,
+    isSelf: false,
+    canMutate: true,
+    follow: null,
+    ...overrides,
+  });
 
   const profile = (
     overrides: Partial<{
@@ -17,9 +30,9 @@
       handle: string;
       relativeHandle: string;
       bio: string | null;
-      viewerFollow: { id: string; state: 'ACCEPTED' | 'PENDING' } | null;
+      viewerState: ViewerState;
     }> = {},
-  ): SearchResultMock =>
+  ): ProfileListItem_profile$key =>
     ({
       __typename: 'Profile',
       id: 'searched-profile',
@@ -27,9 +40,9 @@
       handle: 'byulmaru',
       relativeHandle: '@byulmaru',
       bio: '코스모에서 만나는 첫 프로필',
-      viewerFollow: null,
+      viewerState: defaultViewerState(),
       ...overrides,
-    }) as unknown as SearchResultMock;
+    }) as unknown as ProfileListItem_profile$key;
 
   const { Story } = defineMeta({
     title: 'KOSMO/SearchResults',
@@ -52,11 +65,7 @@
     <SearchResults />
     <SearchResults query="별마루" loading />
     <SearchResults query="별마루" error onRetry={() => {}} />
-    <SearchResults query="별마루" profile={profile()}>
-      {#snippet action(profile)}
-        <FollowButton {profile} {viewerProfileId} class="shrink-0" />
-      {/snippet}
-    </SearchResults>
+    <SearchResults query="별마루" profile={profile()} />
     <SearchResults query="없는핸들" />
   </div>
 </Story>

--- a/apps/web/src/lib/components/Search/SearchResults.stories.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.stories.svelte
@@ -1,8 +1,10 @@
 <script module lang="ts">
+  import type { FragmentRefs } from '@mearie/svelte';
   import { defineMeta } from '@storybook/addon-svelte-csf';
 
   import type { ProfileListItem_profile$key } from '$mearie';
 
+  import FollowButton from '../FollowButton.svelte';
   import SearchResults from './SearchResults.svelte';
 
   const viewerProfileId = 'viewer-profile';
@@ -28,6 +30,14 @@
       ...overrides,
     }) as unknown as ProfileListItem_profile$key;
 
+  const followTarget = (
+    overrides: Partial<{
+      id: string;
+      viewerFollow: { id: string; state: 'ACCEPTED' | 'PENDING' } | null;
+    }> = {},
+  ): FragmentRefs<'FollowButton_profile'> =>
+    profile(overrides) as unknown as FragmentRefs<'FollowButton_profile'>;
+
   const { Story } = defineMeta({
     title: 'KOSMO/SearchResults',
     component: SearchResults,
@@ -40,7 +50,6 @@
   args={{
     query: '별마루',
     profile: profile(),
-    viewerProfileId,
   }}
 />
 
@@ -50,7 +59,11 @@
     <SearchResults />
     <SearchResults query="별마루" loading />
     <SearchResults query="별마루" error onRetry={() => {}} />
-    <SearchResults query="별마루" profile={profile()} {viewerProfileId} />
+    <SearchResults query="별마루" profile={profile()}>
+      {#snippet action()}
+        <FollowButton profile={followTarget()} {viewerProfileId} />
+      {/snippet}
+    </SearchResults>
     <SearchResults query="없는핸들" />
   </div>
 </Story>

--- a/apps/web/src/lib/components/Search/SearchResults.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ProfileListItem_profile$key } from '$mearie';
+  import type { FollowButton_profile$key, ProfileListItem_profile$key } from '$mearie';
   import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
@@ -7,10 +7,11 @@
   import TextSkeleton from '../TextSkeleton.svelte';
 
   // 사람(프로필) 탭의 검색 상태 영역.
+  type SearchResultActionProfile = ProfileListItem_profile$key & FollowButton_profile$key;
   type Props = HTMLAttributes<HTMLElement> & {
     query?: string;
-    profile?: ProfileListItem_profile$key | null;
-    action?: Snippet;
+    profile?: SearchResultActionProfile | null;
+    action?: Snippet<[profile: SearchResultActionProfile]>;
     loading?: boolean;
     error?: boolean;
     onRetry?: () => void;
@@ -42,7 +43,16 @@
       </p>
     </div>
   {:else if profile}
-    <ProfileListItem {profile} linked {action} width="wide" class="w-full" />
+    {@const actionSnippet = action}
+    {#if actionSnippet}
+      <ProfileListItem {profile} linked width="wide" class="w-full">
+        {#snippet action()}
+          {@render actionSnippet(profile)}
+        {/snippet}
+      </ProfileListItem>
+    {:else}
+      <ProfileListItem {profile} linked width="wide" class="w-full" />
+    {/if}
   {:else if loading}
     <div aria-hidden="true">
       {#each skeletonItems as item (item)}

--- a/apps/web/src/lib/components/Search/SearchResults.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
-  import type { FollowButton_profile$key, ProfileListItem_profile$key } from '$mearie';
-  import type { Snippet } from 'svelte';
+  import type { ProfileListItem_profile$key } from '$mearie';
   import type { HTMLAttributes } from 'svelte/elements';
 
   import ProfileListItem from '../ProfileListItem.svelte';
   import TextSkeleton from '../TextSkeleton.svelte';
 
   // 사람(프로필) 탭의 검색 상태 영역.
-  type SearchResultActionProfile = ProfileListItem_profile$key & FollowButton_profile$key;
   type Props = HTMLAttributes<HTMLElement> & {
     query?: string;
-    profile?: SearchResultActionProfile | null;
-    action?: Snippet<[profile: SearchResultActionProfile]>;
+    profile?: ProfileListItem_profile$key | null;
     loading?: boolean;
     error?: boolean;
     onRetry?: () => void;
@@ -20,7 +17,6 @@
   let {
     query = '',
     profile = null,
-    action,
     loading = false,
     error = false,
     onRetry,
@@ -43,16 +39,7 @@
       </p>
     </div>
   {:else if profile}
-    {@const actionSnippet = action}
-    {#if actionSnippet}
-      <ProfileListItem {profile} linked width="wide" class="w-full">
-        {#snippet action()}
-          {@render actionSnippet(profile)}
-        {/snippet}
-      </ProfileListItem>
-    {:else}
-      <ProfileListItem {profile} linked width="wide" class="w-full" />
-    {/if}
+    <ProfileListItem {profile} linked width="wide" class="w-full" />
   {:else if loading}
     <div aria-hidden="true">
       {#each skeletonItems as item (item)}

--- a/apps/web/src/lib/components/Search/SearchResults.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ProfileListItem_profile$key } from '$mearie';
+  import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
   import ProfileListItem from '../ProfileListItem.svelte';
@@ -9,7 +10,7 @@
   type Props = HTMLAttributes<HTMLElement> & {
     query?: string;
     profile?: ProfileListItem_profile$key | null;
-    viewerProfileId?: string | null;
+    action?: Snippet;
     loading?: boolean;
     error?: boolean;
     onRetry?: () => void;
@@ -18,7 +19,7 @@
   let {
     query = '',
     profile = null,
-    viewerProfileId = null,
+    action,
     loading = false,
     error = false,
     onRetry,
@@ -41,7 +42,7 @@
       </p>
     </div>
   {:else if profile}
-    <ProfileListItem {profile} linked {viewerProfileId} width="wide" class="w-full" />
+    <ProfileListItem {profile} linked {action} width="wide" class="w-full" />
   {:else if loading}
     <div aria-hidden="true">
       {#each skeletonItems as item (item)}

--- a/apps/web/src/routes/(tabs)/(protected)/search/+page.svelte
+++ b/apps/web/src/routes/(tabs)/(protected)/search/+page.svelte
@@ -159,9 +159,9 @@
         onRetry={peopleQuery.refetch}
         class="w-full"
       >
-        {#snippet action()}
-          {#if viewerProfileId && searchedProfile}
-            <FollowButton profile={searchedProfile} {viewerProfileId} class="shrink-0" />
+        {#snippet action(profile)}
+          {#if viewerProfileId}
+            <FollowButton {profile} {viewerProfileId} class="shrink-0" />
           {/if}
         {/snippet}
       </SearchResults>

--- a/apps/web/src/routes/(tabs)/(protected)/search/+page.svelte
+++ b/apps/web/src/routes/(tabs)/(protected)/search/+page.svelte
@@ -5,7 +5,6 @@
   import { page } from '$app/state';
   import { graphql } from '$mearie';
   import { createQuery } from '@mearie/svelte';
-  import FollowButton from '$lib/components/FollowButton.svelte';
   import RecentSearches from '$lib/components/Search/RecentSearches.svelte';
   import SearchBar from '$lib/components/Search/SearchBar.svelte';
   import SearchResults from '$lib/components/Search/SearchResults.svelte';
@@ -26,25 +25,11 @@
   const activeTab = $derived(parseSearchTab(page.url.searchParams.get('tab')));
   const shouldSearchPeople = $derived(activeTab === SearchTab.PEOPLE && trimmedQuery.length > 0);
 
-  const sessionQuery = createQuery(
-    graphql(`
-      query SearchPageSessionQuery {
-        currentSession {
-          id
-          selectedProfile {
-            id
-          }
-        }
-      }
-    `),
-  );
-
   const peopleQuery = createQuery(
     graphql(`
       query SearchPeopleByHandlePageQuery($handle: String!) {
         profileByHandle(handle: $handle) {
           ...ProfileListItem_profile
-          ...FollowButton_profile
         }
       }
     `),
@@ -52,7 +37,6 @@
     () => ({ skip: !shouldSearchPeople }),
   );
   const searchedProfile = $derived(peopleQuery.data?.profileByHandle ?? null);
-  const viewerProfileId = $derived(sessionQuery.data?.currentSession?.selectedProfile?.id ?? null);
 
   // 단계 구분(검색바 포커스 기준):
   // - input  : 검색바 포커스 = 입력 중 → 최근 검색 노출
@@ -158,13 +142,7 @@
         error={shouldSearchPeople && Boolean(peopleQuery.error)}
         onRetry={peopleQuery.refetch}
         class="w-full"
-      >
-        {#snippet action(profile)}
-          {#if viewerProfileId}
-            <FollowButton {profile} {viewerProfileId} class="shrink-0" />
-          {/if}
-        {/snippet}
-      </SearchResults>
+      />
     {:else}
       <div class="px-4 py-12 text-center">
         <p class="text-text-primary text-base font-semibold">준비 중인 검색이에요</p>

--- a/apps/web/src/routes/(tabs)/(protected)/search/+page.svelte
+++ b/apps/web/src/routes/(tabs)/(protected)/search/+page.svelte
@@ -5,6 +5,7 @@
   import { page } from '$app/state';
   import { graphql } from '$mearie';
   import { createQuery } from '@mearie/svelte';
+  import FollowButton from '$lib/components/FollowButton.svelte';
   import RecentSearches from '$lib/components/Search/RecentSearches.svelte';
   import SearchBar from '$lib/components/Search/SearchBar.svelte';
   import SearchResults from '$lib/components/Search/SearchResults.svelte';
@@ -43,6 +44,7 @@
       query SearchPeopleByHandlePageQuery($handle: String!) {
         profileByHandle(handle: $handle) {
           ...ProfileListItem_profile
+          ...FollowButton_profile
         }
       }
     `),
@@ -152,12 +154,17 @@
       <SearchResults
         query={queryParam}
         profile={searchedProfile}
-        {viewerProfileId}
         loading={shouldSearchPeople && peopleQuery.loading}
         error={shouldSearchPeople && Boolean(peopleQuery.error)}
         onRetry={peopleQuery.refetch}
         class="w-full"
-      />
+      >
+        {#snippet action()}
+          {#if viewerProfileId && searchedProfile}
+            <FollowButton profile={searchedProfile} {viewerProfileId} class="shrink-0" />
+          {/if}
+        {/snippet}
+      </SearchResults>
     {:else}
       <div class="px-4 py-12 text-center">
         <p class="text-text-primary text-base font-semibold">준비 중인 검색이에요</p>

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -35,7 +35,6 @@
         { __typename: 'Query', $field: 'me' },
         { __typename: 'Query', $field: 'homeTimeline' },
         { __typename: 'Profile', $field: 'viewerState' },
-        { __typename: 'Profile', $field: 'viewerFollow' },
       );
   };
 

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -34,6 +34,7 @@
         { __typename: 'Query', $field: 'currentSession' },
         { __typename: 'Query', $field: 'me' },
         { __typename: 'Query', $field: 'homeTimeline' },
+        { __typename: 'Profile', $field: 'viewerState' },
         { __typename: 'Profile', $field: 'viewerFollow' },
       );
   };

--- a/apps/web/src/routes/(tabs)/@[handle]/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/+layout.svelte
@@ -10,12 +10,6 @@
   const query = createQuery(
     graphql(`
       query ProfileLayoutQuery($handle: String!) {
-        currentSession {
-          id
-          selectedProfile {
-            id
-          }
-        }
         profileByHandle(handle: $handle) {
           id
           ...ProfileHero_profile
@@ -27,9 +21,6 @@
   );
 
   const profile = $derived(query.data?.profileByHandle ?? null);
-  // currentSession이 null이면 비로그인. selectedProfile은 본인 프로필 식별과 미선택 안내에 쓰인다.
-  const authenticated = $derived(Boolean(query.data?.currentSession));
-  const viewerProfileId = $derived(query.data?.currentSession?.selectedProfile?.id ?? null);
 </script>
 
 <!--
@@ -65,7 +56,7 @@
   {:else}
     <ProfileHero {profile}>
       {#snippet action()}
-        <FollowButton {profile} {viewerProfileId} {authenticated} />
+        <FollowButton {profile} />
       {/snippet}
     </ProfileHero>
     {@render children()}

--- a/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
@@ -3,6 +3,7 @@
   import { createQuery, getClient } from '@mearie/svelte';
   import { graphql } from '$mearie';
   import type { DataOf } from '@mearie/svelte';
+  import FollowButton from '$lib/components/FollowButton.svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
   import { loadNextConnectionPage } from '$lib/profileConnectionPagination';
 
@@ -37,6 +38,7 @@
               follower {
                 id
                 ...ProfileListItem_profile
+                ...FollowButton_profile
               }
             }
           }
@@ -119,9 +121,14 @@
   endCursor={paginatedPageInfo?.endCursor}
   {loadingNextPage}
   {nextPageError}
-  {viewerProfileId}
   loading={query.loading}
   error={Boolean(query.error)}
   onRetry={query.refetch}
   onLoadMore={loadMore}
-/>
+>
+  {#snippet action(profile)}
+    {#if viewerProfileId}
+      <FollowButton {profile} {viewerProfileId} class="shrink-0" />
+    {/if}
+  {/snippet}
+</ProfileConnectionList>

--- a/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/followers/+page.svelte
@@ -3,19 +3,12 @@
   import { createQuery, getClient } from '@mearie/svelte';
   import { graphql } from '$mearie';
   import type { DataOf } from '@mearie/svelte';
-  import FollowButton from '$lib/components/FollowButton.svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
   import { loadNextConnectionPage } from '$lib/profileConnectionPagination';
 
   const client = getClient();
   const queryDocument = graphql(`
     query ProfileFollowersPageQuery($handle: String!) {
-      currentSession {
-        id
-        selectedProfile {
-          id
-        }
-      }
       profileByHandle(handle: $handle) {
         id
         ...ProfileConnectionList_followersProfile
@@ -38,7 +31,6 @@
               follower {
                 id
                 ...ProfileListItem_profile
-                ...FollowButton_profile
               }
             }
           }
@@ -54,7 +46,6 @@
   const query = createQuery(queryDocument, () => ({ handle: page.params.handle! }));
 
   const profile = $derived(query.data?.profileByHandle ?? null);
-  const viewerProfileId = $derived(query.data?.currentSession?.selectedProfile?.id ?? null);
 
   let pageKey = $state<string | null>(null);
   let paginatedConnection = $state<NextPageConnection | null>(null);
@@ -125,10 +116,4 @@
   error={Boolean(query.error)}
   onRetry={query.refetch}
   onLoadMore={loadMore}
->
-  {#snippet action(profile)}
-    {#if viewerProfileId}
-      <FollowButton {profile} {viewerProfileId} class="shrink-0" />
-    {/if}
-  {/snippet}
-</ProfileConnectionList>
+/>

--- a/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
@@ -3,19 +3,12 @@
   import { createQuery, getClient } from '@mearie/svelte';
   import { graphql } from '$mearie';
   import type { DataOf } from '@mearie/svelte';
-  import FollowButton from '$lib/components/FollowButton.svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
   import { loadNextConnectionPage } from '$lib/profileConnectionPagination';
 
   const client = getClient();
   const queryDocument = graphql(`
     query ProfileFollowingPageQuery($handle: String!) {
-      currentSession {
-        id
-        selectedProfile {
-          id
-        }
-      }
       profileByHandle(handle: $handle) {
         id
         ...ProfileConnectionList_followingProfile
@@ -38,7 +31,6 @@
               followee {
                 id
                 ...ProfileListItem_profile
-                ...FollowButton_profile
               }
             }
           }
@@ -54,7 +46,6 @@
   const query = createQuery(queryDocument, () => ({ handle: page.params.handle! }));
 
   const profile = $derived(query.data?.profileByHandle ?? null);
-  const viewerProfileId = $derived(query.data?.currentSession?.selectedProfile?.id ?? null);
 
   let pageKey = $state<string | null>(null);
   let paginatedConnection = $state<NextPageConnection | null>(null);
@@ -125,10 +116,4 @@
   error={Boolean(query.error)}
   onRetry={query.refetch}
   onLoadMore={loadMore}
->
-  {#snippet action(profile)}
-    {#if viewerProfileId}
-      <FollowButton {profile} {viewerProfileId} class="shrink-0" />
-    {/if}
-  {/snippet}
-</ProfileConnectionList>
+/>

--- a/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
+++ b/apps/web/src/routes/(tabs)/@[handle]/following/+page.svelte
@@ -3,6 +3,7 @@
   import { createQuery, getClient } from '@mearie/svelte';
   import { graphql } from '$mearie';
   import type { DataOf } from '@mearie/svelte';
+  import FollowButton from '$lib/components/FollowButton.svelte';
   import ProfileConnectionList from '$lib/components/ProfileConnectionList.svelte';
   import { loadNextConnectionPage } from '$lib/profileConnectionPagination';
 
@@ -37,6 +38,7 @@
               followee {
                 id
                 ...ProfileListItem_profile
+                ...FollowButton_profile
               }
             }
           }
@@ -119,9 +121,14 @@
   endCursor={paginatedPageInfo?.endCursor}
   {loadingNextPage}
   {nextPageError}
-  {viewerProfileId}
   loading={query.loading}
   error={Boolean(query.error)}
   onRetry={query.refetch}
   onLoadMore={loadMore}
-/>
+>
+  {#snippet action(profile)}
+    {#if viewerProfileId}
+      <FollowButton {profile} {viewerProfileId} class="shrink-0" />
+    {/if}
+  {/snippet}
+</ProfileConnectionList>

--- a/openspec/specs/profile/spec.md
+++ b/openspec/specs/profile/spec.md
@@ -175,6 +175,15 @@ API는 프로필 간 visible follow 관계를 GraphQL에서 조회할 수 있어
 - **AND** 반환된 관계는 `ACCEPTED`, `PENDING`, `REJECTED` 상태를 포함할 수 있다
 - **AND** follow 관계가 없으면 없음으로 응답한다
 
+#### Scenario: Read viewer state
+
+- **WHEN** 클라이언트가 활성 프로필의 `viewerState`를 조회한다
+- **THEN** 시스템은 현재 요청에 유효한 세션이 있는지 `authenticated`로 반환한다
+- **AND** 현재 세션에 active profile이 선택되어 있는지 `hasSelectedProfile`로 반환한다
+- **AND** 조회 대상 프로필이 viewer active profile 자신인지 `isSelf`로 반환한다
+- **AND** viewer가 대상 프로필의 follow 상태를 바꿀 수 있는지 `canMutate`로 반환한다
+- **AND** viewer active profile이 대상 프로필을 follow하는 관계가 있으면 `follow`로 반환하고, 없으면 없음으로 응답한다
+
 #### Scenario: Read ProfileFollow profiles
 
 - **WHEN** 클라이언트가 `ProfileFollow.follower` 또는 `ProfileFollow.followee`를 조회한다

--- a/openspec/specs/profile/spec.md
+++ b/openspec/specs/profile/spec.md
@@ -178,10 +178,9 @@ API는 프로필 간 visible follow 관계를 GraphQL에서 조회할 수 있어
 #### Scenario: Read viewer state
 
 - **WHEN** 클라이언트가 활성 프로필의 `viewerState`를 조회한다
-- **THEN** 시스템은 현재 요청에 유효한 세션이 있는지 `authenticated`로 반환한다
-- **AND** 현재 세션에 active profile이 선택되어 있는지 `hasSelectedProfile`로 반환한다
+- **THEN** 시스템은 현재 요청에 active profile이 선택되어 있으면 viewer-relative 상태를 반환한다
+- **AND** 현재 요청에 active profile이 없으면 없음으로 응답한다
 - **AND** 조회 대상 프로필이 viewer active profile 자신인지 `isSelf`로 반환한다
-- **AND** viewer가 대상 프로필의 follow 상태를 바꿀 수 있는지 `canMutate`로 반환한다
 - **AND** viewer active profile이 대상 프로필을 follow하는 관계가 있으면 `follow`로 반환하고, 없으면 없음으로 응답한다
 
 #### Scenario: Read ProfileFollow profiles


### PR DESCRIPTION
## 무엇을 변경했는지

- `ProfileListItem`, `SearchResults`, `ProfileConnectionList`에서 `viewerProfileId`를 제거하고 `action` snippet으로 우측 액션 영역을 받도록 정리했습니다.
- 검색 결과, 팔로워 목록, 팔로잉 목록 route가 선택 프로필 상태를 보고 `FollowButton`을 action으로 주입하도록 변경했습니다.
- 검색/팔로우 목록 GraphQL fragment에서 `FollowButton_profile`을 action을 렌더링하는 경계에서 함께 조회하도록 맞췄습니다.
- `ProfileConnectionList`가 action snippet을 `ProfileListItem`의 named `action`으로 직접 전달하도록 분기 구조를 조정했습니다.
- action이 비어 있는 경우 빈 우측 wrapper가 남지 않도록 `ProfileListItem`의 action 렌더링 경계를 정리했습니다.
- 관련 Storybook을 새 action-slot API 기준으로 갱신하고, Svelte compiler 기반 회귀 테스트를 추가했습니다.

## 왜 변경했는지

- 목록 표시 컴포넌트가 로그인/선택 프로필 상태와 팔로우 정책까지 알면 재사용 경계가 흐려집니다.
- 팔로우/언팔로우 정책은 `FollowButton`에 남기고, 표시 컴포넌트는 프로필 목록 렌더링만 담당하게 해서 검색 결과와 팔로워/팔로잉 목록의 책임을 분리합니다.
- 최신 `main`에 추가된 `ProfileConnectionList`와 followers/following routes까지 같은 방식으로 정리해 이후 목록 화면 확장 시 세션 상태 전파가 컴포넌트 내부로 새지 않게 합니다.
- Svelte named snippet은 조건문 안에 선언되면 자식 컴포넌트의 named prop이 아니라 기본 `children`으로 컴파일될 수 있어, 이를 회귀 테스트로 고정했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm --filter @kosmo/web exec vitest --run src/lib/components/ProfileConnectionList.snippet.test.ts --project server`
- `pnpm --filter @kosmo/web exec vitest --run --project server`
- `pnpm --filter @kosmo/web build-storybook`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `rg -n "viewerProfileId" apps/web/src/lib/components/ProfileListItem.svelte apps/web/src/lib/components/Search/SearchResults.svelte apps/web/src/lib/components/ProfileConnectionList.svelte` 결과 없음

## 아직 어떤 문제가 남았는지

- Draft PR이라 GitHub CI 결과와 실제 브라우저 수동 확인은 PR에서 이어서 확인해야 합니다.

Stack: `main -> prod-170`