### PR TITLE
Codex 앱에서 개발 서버와 Storybook을 바로 실행하게 한다

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -50,3 +50,13 @@ fi
 mise trust
 pnpm install
 '''
+
+[[actions]]
+name = "Dev Server"
+icon = "run"
+command = "pnpm dev"
+
+[[actions]]
+name = "Storybook"
+icon = "tool"
+command = "pnpm --filter @kosmo/web storybook"


### PR DESCRIPTION
## 무엇을 변경했는지

- `.codex/environments/environment.toml`에 Codex Desktop App local environment action을 추가했습니다.
- `Dev Server` 액션은 `pnpm dev`를 실행합니다.
- `Storybook` 액션은 `pnpm --filter @kosmo/web storybook`을 실행합니다.

## 왜 변경했는지

Codex Desktop App에서 이 프로젝트를 열었을 때 개발 서버와 Storybook을 상단 액션으로 바로 실행할 수 있게 하기 위해서입니다. 반복적으로 터미널 명령을 직접 입력하지 않아도 공통 개발 워크플로를 시작할 수 있습니다.

## 어떻게 확인할 수 있는지

- pre-commit hook: `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown`
- `pnpm exec prettier --check --ignore-unknown .codex/environments/environment.toml`
- Codex App에서 프로젝트를 다시 열고 `Dev Server`, `Storybook` 액션이 보이는지 확인합니다.

## 아직 어떤 문제가 남았는지

없음

Stack: main -> add-codex-app-actions