### PR TITLE
웹앱 셸을 document scroll + sticky rail 구조로 조정한다

### DIFF
--- a/apps/web/src/lib/components/SidebarNavigation.svelte
+++ b/apps/web/src/lib/components/SidebarNavigation.svelte
@@ -219,7 +219,7 @@
 {/snippet}
 
 <aside
-  class={`flex h-full flex-col bg-white text-[#111111] ${
+  class={`flex h-full min-h-0 flex-col bg-white text-[#111111] ${
     surface === 'drawer'
       ? 'w-80 overflow-hidden rounded-r-2xl shadow-[4px_0_4px_rgba(0,0,0,0.4)]'
       : 'w-full border-r border-[#eaeaea]'
@@ -229,7 +229,7 @@
     <div class="flex h-full w-full flex-col xl:hidden">{@render collapsedRail()}</div>
   {/if}
 
-  <div class={`h-full w-full flex-col ${surface === 'drawer' ? 'flex' : 'hidden xl:flex'}`}>
+  <div class={`h-full min-h-0 w-full flex-col ${surface === 'drawer' ? 'flex' : 'hidden xl:flex'}`}>
     <section
       class="relative z-20 h-[260px] w-80 shrink-0 overflow-visible"
       aria-label="활성 프로필"
@@ -304,7 +304,7 @@
     </section>
 
     <section
-      class="relative z-0 flex min-h-0 flex-1 flex-col justify-between border-t border-[#eaeaea] bg-white p-4"
+      class="relative z-0 flex min-h-0 flex-1 flex-col justify-between overflow-y-auto border-t border-[#eaeaea] bg-white p-4"
     >
       <nav class="flex w-[264px] flex-col gap-1" aria-label="주요 메뉴">
         {#each navItems as item}

--- a/apps/web/src/routes/(tabs)/+layout.svelte
+++ b/apps/web/src/routes/(tabs)/+layout.svelte
@@ -101,7 +101,7 @@
 <div
   class="min-h-screen md:grid md:justify-center md:grid-cols-[5rem_minmax(0,600px)] xl:grid-cols-[20rem_minmax(0,600px)_minmax(290px,350px)]"
 >
-  <div class="hidden md:block" inert={shellInert}>
+  <div class="hidden md:sticky md:top-0 md:block md:h-dvh md:self-start" inert={shellInert}>
     <SidebarNavigation
       query={query.data}
       loading={query.loading}
@@ -138,7 +138,7 @@
   </div>
 
   <div class="border-border hidden border-l xl:block" inert={shellInert}>
-    <div class="sticky top-0 pt-4 pl-6">
+    <div class="sticky top-0 h-dvh overflow-y-auto pt-4 pl-6">
       {#if query.loading}
         <div class="border-border bg-card grid gap-3 rounded-lg border p-4" aria-hidden="true">
           <div class="bg-surface size-8 animate-pulse rounded-full"></div>

--- a/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
+++ b/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
@@ -1,48 +1,48 @@
 ## 1. 최신 기준 재확인
 
-- [ ] 1.1 최신 `main` 기준으로 `apps/web/src/routes/(tabs)/+layout.svelte`의 shell grid, mobile header, main, right rail wrapper 구조를 확인한다.
-- [ ] 1.2 최신 `main` 기준으로 `apps/web/src/lib/components/BottomTabBar.svelte`의 fixed bottom tab, safe-area padding, 표시 breakpoint를 확인한다.
-- [ ] 1.3 최신 `main` 기준으로 `apps/web/src/lib/components/SidebarNavigation.svelte`의 mobile drawer, `md`~`xl` icon rail, `xl+` full sidebar 분기를 확인한다.
-- [ ] 1.4 최신 `main` 기준으로 프로필/게시글 상세 route wrapper가 document scroll + sticky rails에서 추가 layout 리팩터링 없이 호환되는지 확인한다.
-- [ ] 1.5 최신 `main` 기준으로 `openspec/specs/web-app-shell/spec.md`와 `docs/design/breakpoints.md`가 `md`/`xl` 3단계 기준과 어긋나지 않는지 확인한다.
-- [ ] 1.6 기존 active `add-web-app-shell-internal-scroll` change가 이 change로 대체되어야 하는 범위인지 확인한다.
+- [x] 1.1 최신 `main` 기준으로 `apps/web/src/routes/(tabs)/+layout.svelte`의 shell grid, mobile header, main, right rail wrapper 구조를 확인한다.
+- [x] 1.2 최신 `main` 기준으로 `apps/web/src/lib/components/BottomTabBar.svelte`의 fixed bottom tab, safe-area padding, 표시 breakpoint를 확인한다.
+- [x] 1.3 최신 `main` 기준으로 `apps/web/src/lib/components/SidebarNavigation.svelte`의 mobile drawer, `md`~`xl` icon rail, `xl+` full sidebar 분기를 확인한다.
+- [x] 1.4 최신 `main` 기준으로 프로필/게시글 상세 route wrapper가 document scroll + sticky rails에서 추가 layout 리팩터링 없이 호환되는지 확인한다.
+- [x] 1.5 최신 `main` 기준으로 `openspec/specs/web-app-shell/spec.md`와 `docs/design/breakpoints.md`가 `md`/`xl` 3단계 기준과 어긋나지 않는지 확인한다.
+- [x] 1.6 기존 active `add-web-app-shell-internal-scroll` change가 이 change로 대체되어야 하는 범위인지 확인한다.
 
 ## 2. Document scroll shell 유지
 
-- [ ] 2.1 `(tabs)` 최상위 shell이 document/window scroll을 막지 않도록 `h-dvh`, `overflow-hidden`, 중앙 `overflow-y-auto` 기반 internal scroller 구조를 제거하거나 도입하지 않는다.
-- [ ] 2.2 중앙 `main`은 route content wrapper로 유지하고, 별도 scroll owner가 되지 않게 한다.
-- [ ] 2.3 shell chrome wheel 이벤트를 중앙 피드로 전달하는 custom wheel forwarding을 추가하지 않는다.
-- [ ] 2.4 일반 route 이동과 back/forward는 SvelteKit/browser document scroll 정책을 따르게 하고, internal scroller용 scroll restoration helper를 만들지 않는다.
-- [ ] 2.5 검색 화면의 `noScroll`/`data-sveltekit-noscroll`/focus 동작이 기존 document scroll 기준으로 유지되는지 확인한다.
+- [x] 2.1 `(tabs)` 최상위 shell이 document/window scroll을 막지 않도록 `h-dvh`, `overflow-hidden`, 중앙 `overflow-y-auto` 기반 internal scroller 구조를 제거하거나 도입하지 않는다.
+- [x] 2.2 중앙 `main`은 route content wrapper로 유지하고, 별도 scroll owner가 되지 않게 한다.
+- [x] 2.3 shell chrome wheel 이벤트를 중앙 피드로 전달하는 custom wheel forwarding을 추가하지 않는다.
+- [x] 2.4 일반 route 이동과 back/forward는 SvelteKit/browser document scroll 정책을 따르게 하고, internal scroller용 scroll restoration helper를 만들지 않는다.
+- [x] 2.5 검색 화면의 `noScroll`/`data-sveltekit-noscroll`/focus 동작이 기존 document scroll 기준으로 유지되는지 확인한다.
 
 ## 3. Sticky rail 배치
 
-- [ ] 3.1 `md` 이상 좌측 sidebar/icon rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
-- [ ] 3.2 `SidebarNavigation`과 mobile drawer의 public props/API를 유지하고, sticky shell 안에서 필요한 height/overflow class만 보정한다.
-- [ ] 3.3 `xl` 이상 우측 rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
-- [ ] 3.4 우측 rail 내용이 viewport보다 길어질 때만 rail 내부 overflow가 가능하도록 구조를 둔다.
-- [ ] 3.5 좌우 rail을 `position: fixed` layer로 빼지 않는다. fixed가 필요하다고 판단되면 후속 change로 분리한다.
+- [x] 3.1 `md` 이상 좌측 sidebar/icon rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
+- [x] 3.2 `SidebarNavigation`과 mobile drawer의 public props/API를 유지하고, sticky shell 안에서 필요한 height/overflow class만 보정한다.
+- [x] 3.3 `xl` 이상 우측 rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
+- [x] 3.4 우측 rail 내용이 viewport보다 길어질 때만 rail 내부 overflow가 가능하도록 구조를 둔다.
+- [x] 3.5 좌우 rail을 `position: fixed` layer로 빼지 않는다. fixed가 필요하다고 판단되면 후속 change로 분리한다.
 
 ## 4. Route 호환성과 bottom tab
 
-- [ ] 4.1 `/home`, `/search`, `/notifications`, `/menu`, `/compose`가 document scroll + sticky rails 구조에서 기존 폭과 정렬을 유지하는지 확인한다.
-- [ ] 4.2 `/@{handle}`, `/@{handle}/followers`, `/@{handle}/following`, `/@{handle}/{postId}`가 document scroll + sticky rails 구조에서 레이아웃 깨짐 없이 렌더링되는지 확인한다.
-- [ ] 4.3 프로필/게시글 상세의 `-mx-6 -mt-8` padding 상쇄 결합은 유지 우선으로 확인하고, 깨지는 경우에만 route wrapper를 최소 보정한다.
-- [ ] 4.4 모바일 bottom tab은 fixed chrome으로 유지하고, content 하단이 tab/safe-area에 가려지지 않도록 padding 또는 scroll padding을 확인한다.
-- [ ] 4.5 `PROD-220` 하단바 겹침이 이 구조 안에서 함께 해소되는지 확인하고, 이슈 처리 여부를 구현 PR 설명에 남긴다.
+- [ ] 4.1 `/home`, `/search`, `/notifications`, `/menu`, `/compose`가 document scroll + sticky rails 구조에서 기존 폭과 정렬을 유지하는지 확인한다. Fresh browser context에서는 보호 route가 `/`로 리다이렉트되어, 로그인 세션 smoke가 남아 있다.
+- [x] 4.2 `/@{handle}`, `/@{handle}/followers`, `/@{handle}/following`, `/@{handle}/{postId}`가 document scroll + sticky rails 구조에서 레이아웃 깨짐 없이 렌더링되는지 확인한다.
+- [x] 4.3 프로필/게시글 상세의 `-mx-6 -mt-8` padding 상쇄 결합은 유지 우선으로 확인하고, 깨지는 경우에만 route wrapper를 최소 보정한다.
+- [x] 4.4 모바일 bottom tab은 fixed chrome으로 유지하고, content 하단이 tab/safe-area에 가려지지 않도록 padding 또는 scroll padding을 확인한다.
+- [ ] 4.5 `PROD-220` 하단바 겹침이 이 구조 안에서 함께 해소되는지 확인하고, 이슈 처리 여부를 구현 PR 설명에 남긴다. 로그인 세션 `/home` smoke 후 확정한다.
 
 ## 5. 문서 정렬
 
-- [ ] 5.1 `openspec/changes/add-web-app-shell-sticky-rails`가 document scroll + sticky rails 요구사항과 일치하는지 확인한다.
-- [ ] 5.2 기존 `openspec/changes/add-web-app-shell-internal-scroll` active change를 제거해 상충하는 scroll ownership 스펙이 동시에 남지 않게 한다.
-- [ ] 5.3 `docs/design/breakpoints.md`의 scroll ownership 정책이 sticky rails 방향과 일치하는지 확인한다.
-- [ ] 5.4 `PROD-233`은 변경된 shell 기준의 반응형 내비게이션 E2E 후속 작업으로 남긴다.
+- [x] 5.1 `openspec/changes/add-web-app-shell-sticky-rails`가 document scroll + sticky rails 요구사항과 일치하는지 확인한다.
+- [x] 5.2 기존 `openspec/changes/add-web-app-shell-internal-scroll` active change를 제거해 상충하는 scroll ownership 스펙이 동시에 남지 않게 한다.
+- [x] 5.3 `docs/design/breakpoints.md`의 scroll ownership 정책이 sticky rails 방향과 일치하는지 확인한다.
+- [x] 5.4 `PROD-233`은 변경된 shell 기준의 반응형 내비게이션 E2E 후속 작업으로 남긴다.
 
 ## 6. 검증
 
-- [ ] 6.1 `pnpm exec openspec validate add-web-app-shell-sticky-rails --strict`를 통과시킨다.
-- [ ] 6.2 구현 PR에서 `pnpm -F @kosmo/web check`를 통과시킨다.
-- [ ] 6.3 구현 PR에서 모바일 1개, `md`~`xl` 1개, `xl+` 1개 viewport를 smoke로 확인한다.
-- [ ] 6.4 구현 PR에서 `/home`, `/search`, `/notifications`, `/menu`, `/compose`, 프로필/팔로우 목록/게시글 상세 route를 smoke로 확인한다.
-- [ ] 6.5 구현 PR에서 drawer open/close, bottom tab, icon rail/full sidebar, RightRail 위치, 검색 `noScroll`, 게시글 상세 sticky header를 확인한다.
-- [ ] 6.6 반응형 앱 내비게이션 E2E suite 전체는 구현하지 않고, 필요 검증은 `PROD-233` 후속 범위로 남긴다.
+- [x] 6.1 `pnpm exec openspec validate add-web-app-shell-sticky-rails --strict`를 통과시킨다.
+- [x] 6.2 구현 PR에서 `pnpm -F @kosmo/web check`를 통과시킨다.
+- [x] 6.3 구현 PR에서 모바일 1개, `md`~`xl` 1개, `xl+` 1개 viewport를 smoke로 확인한다.
+- [ ] 6.4 구현 PR에서 `/home`, `/search`, `/notifications`, `/menu`, `/compose`, 프로필/팔로우 목록/게시글 상세 route를 smoke로 확인한다. 현재 fresh browser route smoke는 보호 route 리다이렉트와 공개 프로필 계열 렌더링까지만 확인했다.
+- [ ] 6.5 구현 PR에서 drawer open/close, bottom tab, icon rail/full sidebar, RightRail 위치, 검색 `noScroll`, 게시글 상세 sticky header를 확인한다. 현재 viewport smoke는 document scroll, bottom tab fixed, icon rail/full sidebar, RightRail 위치까지 확인했다.
+- [x] 6.6 반응형 앱 내비게이션 E2E suite 전체는 구현하지 않고, 필요 검증은 `PROD-233` 후속 범위로 남긴다.

--- a/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
+++ b/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
@@ -13,7 +13,7 @@
 - [x] 2.2 중앙 `main`은 route content wrapper로 유지하고, 별도 scroll owner가 되지 않게 한다.
 - [x] 2.3 shell chrome wheel 이벤트를 중앙 피드로 전달하는 custom wheel forwarding을 추가하지 않는다.
 - [x] 2.4 일반 route 이동과 back/forward는 SvelteKit/browser document scroll 정책을 따르게 하고, internal scroller용 scroll restoration helper를 만들지 않는다.
-- [x] 2.5 검색 화면의 `noScroll`/`data-sveltekit-noscroll`/focus 동작이 기존 document scroll 기준으로 유지되는지 확인한다.
+- [ ] 2.5 검색 화면의 `noScroll`/`data-sveltekit-noscroll`/focus 동작이 기존 document scroll 기준으로 유지되는지 확인한다. 로그인 세션 smoke에서 확인한다.
 
 ## 3. Sticky rail 배치
 


### PR DESCRIPTION
## 무엇을 변경했는지

- #191(`prod-219-sticky-rails-spec`) 위에 쌓인 구현 PR로 정리했습니다.
- `(tabs)` 셸의 document/window scroll 흐름은 유지하고, 중앙 `main`을 별도 internal scroller로 만들지 않습니다.
- `md+` 좌측 sidebar/icon rail wrapper를 grid flow 안에서 `sticky top-0 h-dvh`로 유지하게 했습니다.
- `xl+` 우측 rail wrapper도 grid flow 안의 `sticky top-0 h-dvh` column으로 두고, rail content가 길어질 때만 내부 overflow가 가능하게 했습니다.
- `SidebarNavigation`/drawer public props는 유지하고, full sidebar 영역이 sticky rail 높이 안에서 필요한 경우 내부 overflow를 가질 수 있도록 class만 보정했습니다.
- `add-web-app-shell-sticky-rails` OpenSpec `tasks.md`를 구현/검증 현황에 맞춰 갱신했습니다.

Stack: `main` → #191 `prod-219-sticky-rails-spec` → #189 `prod-219`

## 왜 변경했는지

- internal scroll shell은 피드 바깥 shell 영역에서 자연스럽게 스크롤하기 어렵고, wheel forwarding은 조작감이 어색했습니다.
- document scroll을 유지하면 sidebar, 우측 rail, 빈 레이아웃 영역 위에서도 브라우저 기본 scroll 흐름이 동작합니다.
- 지금은 `fixed` rail보다 grid flow와 column 폭 계산을 보존하는 sticky rail이 더 작은 변경입니다. fixed 전환은 sticky 구현 후 실제 필요가 확인되면 후속으로 분리합니다.

## 어떻게 확인할 수 있는지

- `pnpm exec openspec validate add-web-app-shell-sticky-rails --strict`
- `pnpm -F @kosmo/web check`
- GitHub Actions
  - Lint
  - Web E2E
  - Semgrep scan
- 로컬 dev 서버 응답 확인
  - `http://localhost:5173/home` → 200
  - `http://localhost:3000/graphql` `{ __typename }` → 200
- Chrome DevTools Protocol smoke
  - viewport: 390x844, 1024x768, 1440x900
  - public routes: `/@prod219-smoke`, `/@prod219-smoke/followers`, `/@prod219-smoke/following`, `/@prod219-smoke/post-smoke`
  - 확인 내용: document scroll 발생, `main.scrollTop` 유지, `md+` 좌측 rail top 유지, `xl+` 우측 rail top 유지, 모바일 bottom tab fixed/bottom 정렬
- 로그인 세션 수동 smoke 확인(작성자 확인)
  - `/home`, `/search`, `/notifications`, `/menu`, `/compose`
  - drawer open/close
  - bottom tab, icon rail/full sidebar, RightRail 위치
  - 검색 query-only `noScroll`
  - 게시글 상세 sticky header
  - PROD-220 하단바 겹침 회귀 여부

## 아직 어떤 문제가 남았는지

- #191 Change PR이 먼저 merge되어야 합니다.
- PROD-233의 반응형 내비게이션 E2E suite 작성은 후속 범위로 남깁니다.
