### PR TITLE
팔로우 요청과 팔로잉 관계를 분리한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -139,18 +139,11 @@ type ProfileFollow implements Node {
   followee: Profile
   follower: Profile
   id: ID!
-  state: ProfileFollowState!
 }
 
 enum ProfileFollowPolicy {
   APPROVAL_REQUIRED
   OPEN
-}
-
-enum ProfileFollowState {
-  ACCEPTED
-  PENDING
-  REJECTED
 }
 
 type ProfileFollowersConnection {

--- a/apps/api/src/graphql/enums.ts
+++ b/apps/api/src/graphql/enums.ts
@@ -12,5 +12,4 @@ createEnumRef('AccountProfileRole');
 createEnumRef('PostState');
 createEnumRef('PostVisibility');
 createEnumRef('ProfileFollowPolicy');
-createEnumRef('ProfileFollowState');
 createEnumRef('ProfileState');

--- a/apps/api/src/graphql/resolvers/post/access/visibility.ts
+++ b/apps/api/src/graphql/resolvers/post/access/visibility.ts
@@ -1,11 +1,11 @@
 import { db, Posts, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { PostState, PostVisibility, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
+import { PostState, PostVisibility, ProfileState } from '@kosmo/core/enums';
 import { and, eq, exists, inArray, or } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
 export const postVisibilityAccessWhere = ({ ctx }: { ctx: UserContext }) => {
   const publicWhere = inArray(Posts.visibility, [PostVisibility.PUBLIC, PostVisibility.UNLISTED]);
-  const acceptedFollowerWhere = ctx.session?.profileId
+  const followerWhere = ctx.session?.profileId
     ? and(
         eq(Posts.visibility, PostVisibility.FOLLOWERS),
         exists(
@@ -16,14 +16,13 @@ export const postVisibilityAccessWhere = ({ ctx }: { ctx: UserContext }) => {
               and(
                 eq(ProfileFollows.followerProfileId, ctx.session.profileId),
                 eq(ProfileFollows.followeeProfileId, Posts.profileId),
-                eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
               ),
             ),
         ),
       )
     : undefined;
   const visibleWhere = ctx.session?.profileId
-    ? or(publicWhere, eq(Posts.profileId, ctx.session.profileId), acceptedFollowerWhere)!
+    ? or(publicWhere, eq(Posts.profileId, ctx.session.profileId), followerWhere)!
     : publicWhere;
 
   // TODO(PROD-121): Extend this helper with DIRECT access once recipient policy exists.

--- a/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
+++ b/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
@@ -1,5 +1,4 @@
 import { db, Posts, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { ProfileFollowState } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, exists, getColumns, gt, lt, or } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
@@ -15,7 +14,7 @@ builder.queryField('homeTimeline', (t) =>
       nullable: true,
       unauthorizedResolver: () => null,
       resolve: (_, args, ctx) => {
-        const acceptedFolloweeWhere = exists(
+        const followeeWhere = exists(
           db
             .select({ id: ProfileFollows.id })
             .from(ProfileFollows)
@@ -23,7 +22,6 @@ builder.queryField('homeTimeline', (t) =>
               and(
                 eq(ProfileFollows.followerProfileId, ctx.session.profileId),
                 eq(ProfileFollows.followeeProfileId, Posts.profileId),
-                eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
               ),
             ),
         );
@@ -40,7 +38,7 @@ builder.queryField('homeTimeline', (t) =>
               .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
               .where(
                 and(
-                  or(eq(Posts.profileId, ctx.session.profileId), acceptedFolloweeWhere),
+                  or(eq(Posts.profileId, ctx.session.profileId), followeeWhere),
                   postVisibilityAccessWhere({ ctx }),
                   before ? gt(Posts.id, before) : undefined,
                   after ? lt(Posts.id, after) : undefined,

--- a/apps/api/src/graphql/resolvers/profile/access/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/access/follow.ts
@@ -1,5 +1,5 @@
 import { ProfileFollows } from '@kosmo/core/db';
-import { ProfileFollowPolicy, ProfileFollowState, ProfileState } from '@kosmo/core/enums';
+import { ProfileFollowPolicy, ProfileState } from '@kosmo/core/enums';
 import { and, eq, or } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 import type { UserContext } from '@/context';
@@ -18,8 +18,7 @@ export const profileFollowAccessWhere = ({
   followerProfile: ProfileFollowAccessProfile;
   followeeProfile: ProfileFollowAccessProfile;
 }) => {
-  const publicAcceptedWhere = and(
-    eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
+  const publicFollowWhere = and(
     eq(followerProfile.followPolicy, ProfileFollowPolicy.OPEN),
     eq(followeeProfile.followPolicy, ProfileFollowPolicy.OPEN),
   )!;
@@ -27,9 +26,9 @@ export const profileFollowAccessWhere = ({
     ? or(
         eq(ProfileFollows.followerProfileId, ctx.session.profileId),
         eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
-        publicAcceptedWhere,
+        publicFollowWhere,
       )
-    : publicAcceptedWhere;
+    : publicFollowWhere;
 
   return and(
     eq(followerProfile.state, ProfileState.ACTIVE),

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,5 +1,5 @@
 import { db, first, ProfileFollows, Profiles } from '@kosmo/core/db';
-import { ProfileFollowState, ProfileState } from '@kosmo/core/enums';
+import { ProfileState } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, count, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
@@ -50,7 +50,6 @@ builder.objectFields(Profile, (t) => ({
             .where(
               and(
                 eq(ProfileFollows.followeeProfileId, profile.id),
-                eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
                 before ? gt(ProfileFollows.id, before) : undefined,
                 after ? lt(ProfileFollows.id, after) : undefined,
                 profileFollowAccessWhere({
@@ -83,7 +82,6 @@ builder.objectFields(Profile, (t) => ({
             .where(
               and(
                 eq(ProfileFollows.followerProfileId, profile.id),
-                eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
                 before ? gt(ProfileFollows.id, before) : undefined,
                 after ? lt(ProfileFollows.id, after) : undefined,
                 profileFollowAccessWhere({
@@ -109,7 +107,6 @@ builder.objectFields(Profile, (t) => ({
         .where(
           and(
             eq(ProfileFollows.followeeProfileId, profile.id),
-            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
             eq(FollowerProfiles.state, ProfileState.ACTIVE),
           ),
         )
@@ -128,7 +125,6 @@ builder.objectFields(Profile, (t) => ({
         .where(
           and(
             eq(ProfileFollows.followerProfileId, profile.id),
-            eq(ProfileFollows.state, ProfileFollowState.ACCEPTED),
             eq(FolloweeProfiles.state, ProfileState.ACTIVE),
           ),
         )

--- a/apps/api/src/graphql/resolvers/profile/mutation/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/follow.ts
@@ -7,7 +7,7 @@ import {
   ProfileFollows,
   Profiles,
 } from '@kosmo/core/db';
-import { ProfileFollowState, ProfileState } from '@kosmo/core/enums';
+import { ProfileFollowPolicy, ProfileState } from '@kosmo/core/enums';
 import { ConflictError, NotFoundError } from '@kosmo/core/error';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
@@ -26,7 +26,7 @@ builder.mutationField('followProfile', (t) =>
     },
     resolve: async (_, { input }, ctx) => {
       const targetProfile = await db
-        .select({ id: Profiles.id })
+        .select({ id: Profiles.id, followPolicy: Profiles.followPolicy })
         .from(Profiles)
         .where(and(eq(Profiles.id, input.id), eq(Profiles.state, ProfileState.ACTIVE)))
         .limit(1)
@@ -49,13 +49,12 @@ builder.mutationField('followProfile', (t) =>
         .then(first);
 
       if (existingFollow) {
-        if (existingFollow.state === ProfileFollowState.ACCEPTED) {
-          return { profileFollow: existingFollow };
-        }
+        return { profileFollow: existingFollow };
+      }
 
-        // PENDING/REJECTED 재요청 정책은 후속 pending 승인 플로우에서 결정한다.
+      if (targetProfile.followPolicy !== ProfileFollowPolicy.OPEN) {
         throw new ConflictError({
-          message: 'Profile follow already exists with unsupported state',
+          message: 'Profile requires follow request',
           field: 'id',
         });
       }
@@ -65,7 +64,6 @@ builder.mutationField('followProfile', (t) =>
         .values({
           followerProfileId: ctx.session.profileId,
           followeeProfileId: targetProfile.id,
-          state: ProfileFollowState.ACCEPTED,
         })
         .returning()
         .then(firstOrThrow)
@@ -86,12 +84,12 @@ builder.mutationField('followProfile', (t) =>
             .limit(1)
             .then(first);
 
-          if (concurrentFollow?.state === ProfileFollowState.ACCEPTED) {
+          if (concurrentFollow) {
             return concurrentFollow;
           }
 
           throw new ConflictError({
-            message: 'Profile follow already exists with unsupported state',
+            message: 'Profile follow could not be created',
             field: 'id',
           });
         });

--- a/apps/api/src/graphql/resolvers/profile/ref.ts
+++ b/apps/api/src/graphql/resolvers/profile/ref.ts
@@ -1,10 +1,5 @@
 import { AccountProfiles, db, Profiles, TableDiscriminator } from '@kosmo/core/db';
-import {
-  AccountProfileRole,
-  ProfileFollowPolicy,
-  ProfileFollowState,
-  ProfileState,
-} from '@kosmo/core/enums';
+import { AccountProfileRole, ProfileFollowPolicy, ProfileState } from '@kosmo/core/enums';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { and, eq, inArray } from 'drizzle-orm';
 import { createObjectRef } from '@/graphql/utils';
@@ -69,9 +64,6 @@ export const ProfileFollow = createObjectRef(
 
 ProfileFollow.implement({
   fields: (t) => ({
-    state: t.expose('state', {
-      type: ProfileFollowState,
-    }),
     createdAt: t.expose('createdAt', {
       type: 'DateTime',
     }),

--- a/apps/web/src/lib/components/FollowButton.stories.svelte
+++ b/apps/web/src/lib/components/FollowButton.stories.svelte
@@ -5,10 +5,9 @@
 
   import FollowButton from './FollowButton.svelte';
 
-  type FollowState = 'ACCEPTED' | 'PENDING' | 'REJECTED';
   type ViewerState = {
     isSelf: boolean;
-    follow: { id: string; state: FollowState } | null;
+    follow: { id: string } | null;
   };
 
   const targetProfileId = 'target-profile';
@@ -62,25 +61,7 @@
       <FollowButton
         profile={profile(
           'followed-profile',
-          defaultViewerState({ follow: { id: 'follow-accepted', state: 'ACCEPTED' } }),
-        )}
-      />
-    </section>
-    <section class="grid gap-1">
-      <p class="text-text-secondary m-0">요청 중</p>
-      <FollowButton
-        profile={profile(
-          'pending-profile',
-          defaultViewerState({ follow: { id: 'follow-pending', state: 'PENDING' } }),
-        )}
-      />
-    </section>
-    <section class="grid gap-1">
-      <p class="text-text-secondary m-0">거절 후 재요청 가능</p>
-      <FollowButton
-        profile={profile(
-          'rejected-profile',
-          defaultViewerState({ follow: { id: 'follow-rejected', state: 'REJECTED' } }),
+          defaultViewerState({ follow: { id: 'follow-accepted' } }),
         )}
       />
     </section>

--- a/apps/web/src/lib/components/FollowButton.svelte
+++ b/apps/web/src/lib/components/FollowButton.svelte
@@ -12,7 +12,6 @@
         isSelf
         follow {
           id
-          state
         }
       }
     }
@@ -31,7 +30,6 @@
       followProfile(input: { id: $id }) {
         profileFollow {
           id
-          state
           followee {
             followersCount
             ...FollowButton_profile
@@ -64,9 +62,7 @@
 
   const viewerState = $derived(profileFragment.data.viewerState);
   const viewerFollow = $derived(viewerState?.follow ?? null);
-  const isFollowing = $derived(viewerFollow?.state === 'ACCEPTED');
-  // TODO: 승인 플로우가 추가되면 PENDING/REJECTED 전이를 실제 mutation 결과로 검증한다.
-  const isPending = $derived(viewerFollow?.state === 'PENDING');
+  const isFollowing = $derived(Boolean(viewerFollow));
   const disabled = $derived(loading);
 
   const toggleFollow = async () => {
@@ -80,7 +76,7 @@
     errorMessage = null;
 
     try {
-      if (isFollowing || isPending) {
+      if (isFollowing) {
         await unfollowProfile({ id: targetProfileId });
         return;
       }
@@ -97,14 +93,14 @@
 {#if viewerState && !viewerState.isSelf}
   <div class={`inline-flex flex-col items-end gap-1 ${className}`}>
     <Button
-      variant={isFollowing || isPending ? 'secondary' : 'primary'}
+      variant={isFollowing ? 'secondary' : 'primary'}
       {size}
       {disabled}
       aria-busy={loading}
       aria-pressed={isFollowing}
       onclick={toggleFollow}
     >
-      {loading ? '처리 중' : isPending ? '요청 중' : isFollowing ? '팔로잉' : '팔로우'}
+      {loading ? '처리 중' : isFollowing ? '팔로잉' : '팔로우'}
     </Button>
     {#if errorMessage}
       <p class="text-text-secondary m-0 max-w-56 text-right text-xs leading-4" role="alert">

--- a/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
+++ b/apps/web/src/lib/components/ProfileConnectionList.stories.svelte
@@ -9,10 +9,9 @@
 
   import ProfileConnectionList from './ProfileConnectionList.svelte';
 
-  type FollowState = 'ACCEPTED' | 'PENDING';
   type ViewerState = {
     isSelf: boolean;
-    follow: { id: string; state: FollowState } | null;
+    follow: { id: string } | null;
   };
 
   const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
@@ -89,7 +88,7 @@
                 handle: 'second-follower',
                 relativeHandle: '@second-follower',
                 viewerState: defaultViewerState({
-                  follow: { id: 'viewer-follow-2', state: 'ACCEPTED' },
+                  follow: { id: 'viewer-follow-2' },
                 }),
               }),
             },

--- a/apps/web/src/lib/components/ProfileListItem.stories.svelte
+++ b/apps/web/src/lib/components/ProfileListItem.stories.svelte
@@ -5,10 +5,9 @@
 
   import ProfileListItem from './ProfileListItem.svelte';
 
-  type FollowState = 'ACCEPTED' | 'PENDING';
   type ViewerState = {
     isSelf: boolean;
-    follow: { id: string; state: FollowState } | null;
+    follow: { id: string } | null;
   };
 
   const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({
@@ -73,18 +72,7 @@
         profile={profile({
           id: 'followed-profile',
           viewerState: defaultViewerState({
-            follow: { id: 'follow-accepted', state: 'ACCEPTED' },
-          }),
-        })}
-      />
-    </section>
-    <section class="grid gap-1">
-      <p class="text-text-secondary m-0">요청 중</p>
-      <ProfileListItem
-        profile={profile({
-          id: 'pending-profile',
-          viewerState: defaultViewerState({
-            follow: { id: 'follow-pending', state: 'PENDING' },
+            follow: { id: 'follow-accepted' },
           }),
         })}
       />

--- a/apps/web/src/lib/components/Search/SearchResults.stories.svelte
+++ b/apps/web/src/lib/components/Search/SearchResults.stories.svelte
@@ -5,10 +5,9 @@
 
   import SearchResults from './SearchResults.svelte';
 
-  type FollowState = 'ACCEPTED' | 'PENDING';
   type ViewerState = {
     isSelf: boolean;
-    follow: { id: string; state: FollowState } | null;
+    follow: { id: string } | null;
   };
 
   const defaultViewerState = (overrides: Partial<ViewerState> = {}): ViewerState => ({

--- a/memory/database-design.md
+++ b/memory/database-design.md
@@ -31,9 +31,9 @@ Use this memory when designing or reviewing the kosmo PostgreSQL/Drizzle databas
 
 ## Kosmo Schema Direction
 
-- The initial schema should focus on the minimum SNS backbone: `account`, `application`, `session`, `profile`, `account_profile`, `post`, `post_content`, and `profile_follow`.
+- The initial schema should focus on the minimum SNS backbone: `account`, `application`, `session`, `profile`, `account_profile`, `post`, `post_content`, `profile_follow`, and `profile_follow_request`.
 - Defer fluid UX/policy areas to later migrations: profile tags, themes, ActivityPub detail tables, AT Protocol caches, moderation, notifications, block/mute, and media processing.
-- Reflect expensive-to-change boundaries early: account-profile N:N, post content versioning, and profile-follow directionality.
+- Reflect expensive-to-change boundaries early: account-profile N:N, post content versioning, profile-follow directionality, and separation between established follows and follow requests.
 - Keep DB internal IDs, external API IDs, Object Storage keys, and CDN URLs as separate responsibilities.
 
 ## Naming
@@ -67,23 +67,27 @@ Kosmo UUID v8 type-code policy:
 - Decode IDs only through a shared `decodeIdType(id)` utility.
 - Store IDs as PostgreSQL `uuid`, not as string prefixes.
 
-Initial type-code examples:
+Current type-code registry examples. The source of truth is `TableDiscriminator` in `packages/core/db/id.ts`.
 
-| Code | Table                | Description                          |
-| ---: | -------------------- | ------------------------------------ |
-|  `0` | `account`            | Login unit mapped to an OIDC account |
-|  `1` | `application`        | App/client connecting to kosmo       |
-|  `2` | `application_secret` | Application secret                   |
-|  `3` | `session`            | Account and application session      |
-|  `4` | `profile`            | Social profile                       |
-|  `5` | `account_profile`    | Account-profile relationship         |
-|  `6` | `post`               | Post metadata                        |
-|  `7` | `post_content`       | Post body revision                   |
-|  `8` | `profile_follow`     | Profile follow relationship          |
-|  `9` | `file_object`        | Object Storage file                  |
-| `10` | `media_asset`        | Uploaded logical media               |
-| `11` | `media_variant`      | Thumbnail/preview derived file       |
-| `12` | `post_media`         | Post-media relationship              |
+| Code | Table                       | Description                          |
+| ---: | --------------------------- | ------------------------------------ |
+|  `1` | `account`                   | Login unit mapped to an OIDC account |
+|  `2` | `account_profile`           | Account-profile relationship         |
+|  `3` | `application`               | App/client connecting to kosmo       |
+|  `4` | `post`                      | Post metadata                        |
+|  `5` | `post_content`              | Post body revision                   |
+|  `6` | `profile`                   | Social profile                       |
+|  `7` | `profile_follow`            | Established profile follow           |
+|  `8` | `session`                   | Account and application session      |
+|  `9` | `application_authorization` | OAuth application authorization      |
+| `10` | `oauth_authorization_code`  | OAuth authorization code             |
+| `11` | `oauth_token`               | OAuth access/refresh token           |
+| `12` | `file`                      | Object Storage file                  |
+| `13` | `media`                     | Uploaded or remote logical media     |
+| `14` | `instance`                  | Local or remote service instance     |
+| `15` | `activitypub_actor`         | ActivityPub actor details            |
+| `16` | `activitypub_actor_key`     | ActivityPub actor key                |
+| `17` | `profile_follow_request`    | Profile follow request lifecycle     |
 
 Relay global ID options:
 
@@ -135,7 +139,8 @@ Drizzle relation schema policy:
 - `account_profile`: account-profile N:N relationship and role.
 - `post`: post metadata, visibility, state, and current content pointer.
 - `post_content`: body revision, storing a plain-text projection plus TipTap JSON body, optional HTML/spoiler render fields, and eventually `(post_id, revision_number)` uniqueness when revisioning lands.
-- `profile_follow`: follower/followee direction and pending/accepted/rejected state.
+- `profile_follow`: established follower/followee direction only; row existence means the follow relationship is active.
+- `profile_follow_request`: pending follower/followee request direction before a follow relationship is established. The row itself means the request is pending; accepted or rejected requests are removed instead of stored with a state.
 
 ## Media And Files
 

--- a/openspec/changes/split-profile-follow-requests/.openspec.yaml
+++ b/openspec/changes/split-profile-follow-requests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-01

--- a/openspec/changes/split-profile-follow-requests/decisions.md
+++ b/openspec/changes/split-profile-follow-requests/decisions.md
@@ -1,0 +1,40 @@
+## Context
+
+이 결정 기록은 `split-profile-follow-requests` proposal, data-model/profile/post/api-platform delta, design.md를 반영한다. 핵심 변경은 `ProfileFollow`를 성립된 팔로잉 관계 전용 모델로 축소하고, 팔로우 요청 상태를 별도 저장 모델로 분리하는 것이다.
+
+## Decision Records
+
+### ProfileFollow는 상태 없는 팔로잉 관계로 유지한다
+
+- Status: Accepted
+- Context / Problem: `ProfileFollow.state`가 있으면 follow graph, count, timeline, visibility 코드가 모두 `ACCEPTED` 상태를 반복해서 필터링하고, `PENDING`/`REJECTED` 요청 상태까지 같은 GraphQL 타입으로 노출된다.
+- Decision Outcome: `profile_follow` row의 존재 자체를 성립된 팔로우 관계로 해석하고, `ProfileFollow.state`와 `respondedAt` 책임을 제거한다.
+- Alternatives Considered: `ProfileFollowState`를 `ACCEPTED` 하나만 남기는 방법은 상태 컬럼이 사실상 boolean marker가 되어 도메인 경계를 흐린다. 기존 상태 enum을 유지하고 loader에서 pending/rejected만 숨기는 방법은 API 표면과 저장 모델이 계속 요청 상태를 공유한다.
+- Consequences: GraphQL 클라이언트는 `viewerFollow` 존재 여부로 팔로잉 상태를 판단한다. followers/following count와 followers-only post 접근은 `profile_follow` 존재 조건으로 단순화된다.
+- Confirmation / Follow-up: generated GraphQL schema에 `ProfileFollow.state`와 `ProfileFollowState`가 없어야 한다.
+
+### 팔로우 요청은 ProfileFollowRequest 저장 모델로 분리한다
+
+- Status: Accepted
+- Context / Problem: 승인 대기는 팔로잉 관계가 아니라 관계를 만들기 전의 요청 lifecycle이다. 요청이 승인되거나 거절되면 대기 상태가 끝나므로 request row가 더 이상 필요하지 않다.
+- Decision Outcome: `profile_follow_request` 테이블은 상태 컬럼 없이 요청 방향과 생성 시각만 저장한다. 동일 follower/followee pair의 request row는 하나만 허용하고, row 존재 자체를 대기 중인 요청으로 해석한다. 승인 시 `profile_follow`를 만들고 request row를 삭제하며, 거절 시에도 request row를 삭제한다.
+- Alternatives Considered: 요청 상태를 `profile_follow`에 계속 두는 방법은 이번 변경의 목적과 충돌한다. `ProfileFollowRequestState` enum을 별도로 두는 방법은 pending-only request row에 불필요한 상태 모델을 만든다. 요청 테이블을 후속 변경까지 미루는 방법은 지금 `ProfileFollowState` 제거 후 후속 구현에서 다시 저장 경계를 설계해야 한다.
+- Consequences: 이번 변경에서 테이블은 추가되지만 공개 GraphQL request API는 열지 않는다. 후속 요청 플로우는 pair당 단일 pending request row와 승인/거절 시 삭제 정책을 기준으로 mutation/query를 설계한다.
+- Confirmation / Follow-up: `ProfileFollowRequest` GraphQL Node, 요청 목록, 승인/거절 mutation은 후속 OpenSpec change에서 정의한다.
+
+### 승인 필요 프로필 follow는 요청 플로우 전까지 거부한다
+
+- Status: Accepted
+- Context / Problem: `APPROVAL_REQUIRED` 대상에 즉시 `ProfileFollow`를 만들면 승인 정책을 우회한다. 하지만 요청 생성 mutation은 아직 범위 밖이다.
+- Decision Outcome: `followProfile`은 `OPEN` 대상만 즉시 follow를 만들고, `APPROVAL_REQUIRED` 대상은 conflict 오류로 거부한다.
+- Alternatives Considered: 임시로 `ProfileFollowRequest` row를 만드는 방법은 요청 생성 로직을 부분 구현하게 되어 API payload와 UI 상태가 불명확하다. 기존처럼 즉시 follow를 만드는 방법은 제품 정책을 깨뜨린다.
+- Consequences: request UI가 생기기 전에는 승인 필요 프로필을 follow할 수 없다. FollowButton의 pending 상태도 이번 변경에서는 제거된다.
+- Confirmation / Follow-up: 후속 요청 mutation이 추가되면 FollowButton 문구와 cache update shape를 다시 정렬한다.
+
+## Remaining Decisions
+
+- ActivityPub follow request와 local approval request를 같은 테이블로 통합할지, federation 전용 lifecycle 테이블을 둘지 결정해야 한다.
+
+## Superseded Decisions
+
+- `ProfileFollow`가 `ACCEPTED`, `PENDING`, `REJECTED` 상태를 모두 포함할 수 있다는 기존 GraphQL 계약은 `ProfileFollow`는 성립된 팔로잉 관계만 표현한다는 계약으로 대체된다.

--- a/openspec/changes/split-profile-follow-requests/design.md
+++ b/openspec/changes/split-profile-follow-requests/design.md
@@ -1,0 +1,46 @@
+## Context
+
+현재 `profile_follow`는 `state = ACCEPTED | PENDING | REJECTED`와 `responded_at`을 가져 실제 팔로잉 관계와 요청 상태를 한 테이블에 섞어 표현한다. 구현상 follow request 생성/승인/거절 mutation은 아직 없고, `followProfile`은 즉시 `ACCEPTED` row를 만들며 목록, 카운트, 타임라인, followers-only 게시글 접근은 모두 `ACCEPTED` 필터를 반복한다.
+
+이번 변경은 `ProfileFollow`를 “성립된 팔로잉 관계”로 축소한다. 대기 중인 요청은 새 `profile_follow_request` 테이블의 row 존재로만 표현하고, 공개 GraphQL request API와 승인 플로우는 후속 변경으로 남긴다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `profile_follow`에서 `state`와 `responded_at` 책임을 제거한다.
+- `profile_follow_request` Drizzle table, relations, table discriminator를 추가한다.
+- `ProfileFollow` GraphQL 타입에서 `state` 필드를 제거하고, viewer follow와 follow connection은 row 존재 여부로 판단한다.
+- post visibility와 home timeline의 accepted-state 조건을 follow row 존재 조건으로 단순화한다.
+- web fragments와 FollowButton UI를 binary follow 상태에 맞춘다.
+- OpenSpec delta와 generated GraphQL schema를 코드와 정렬한다.
+
+**Non-Goals:**
+
+- 팔로우 요청 생성/승인/거절 mutation 추가.
+- `ProfileFollowRequest` GraphQL Node, query, connection, notification UI 노출.
+- 기존 운영 DB의 pending/rejected 데이터 마이그레이션 정책 확정. 현재 코드에는 해당 row 생성 경로가 없다.
+- ActivityPub remote follow request 정책 변경.
+
+## Risks / Trade-offs
+
+- [Risk] `APPROVAL_REQUIRED` 프로필을 `followProfile`로 즉시 팔로우하면 요청 정책을 우회할 수 있다. → 요청 플로우가 구현되기 전까지 `APPROVAL_REQUIRED` 대상은 conflict 오류로 거부하고 `ProfileFollow`를 만들지 않는다.
+- [Risk] `ProfileFollow.state` 제거는 GraphQL 클라이언트 fragments와 Storybook mock을 깨뜨린다. → web fragments에서 `state` 선택을 제거하고 버튼 상태를 `viewerFollow` 존재 여부로 계산한다.
+- [Risk] 기존 DB에 `PENDING`/`REJECTED` row가 있으면 Drizzle push만으로 의미 보존이 어렵다. → 현재 제품 코드에는 생성 경로가 없음을 전제로 하며, 운영 데이터가 발견되면 별도 데이터 마이그레이션 change에서 `profile_follow_request`로 이관한다.
+- [Risk] 요청 테이블을 API 없이 추가하면 당장 사용되지 않는 schema가 생긴다. → follow/request 도메인 경계를 미리 고정해 `profile_follow`의 상태 의존 구현이 더 퍼지는 것을 막는다.
+
+## Migration Plan
+
+1. core enum에서 `ProfileFollowState`를 제거한다.
+2. Drizzle schema에서 `ProfileFollows.state/respondedAt`를 제거하고 상태 없는 `ProfileFollowRequests`를 추가한다.
+3. Drizzle relations와 table discriminator를 갱신한다.
+4. API resolver에서 `ProfileFollowState` import와 state 필터를 제거한다.
+5. `followProfile`은 기존 follow가 있으면 멱등 반환하고, `OPEN` 대상만 새 follow를 만든다. `APPROVAL_REQUIRED` 대상은 후속 요청 플로우 전까지 conflict로 거부한다.
+6. web GraphQL fragments, FollowButton 상태, Storybook mock을 binary follow 모델로 정리한다.
+7. GraphQL schema를 재생성하고 타입체크/포맷 검사를 실행한다.
+
+Rollback은 같은 범위의 Drizzle schema와 GraphQL fragments를 이전 상태로 되돌리는 방식으로 처리한다. 실제 운영 DB에 이미 적용된 뒤에는 `profile_follow_request` 제거와 `profile_follow.state` 복구가 데이터 손실 가능성을 가지므로 별도 rollback migration 검토가 필요하다.
+
+## Open Questions
+
+- `APPROVAL_REQUIRED` 프로필의 FollowButton 문구를 “요청”으로 바꾸는 시점은 request mutation이 생기는 후속 UI change에서 결정한다.

--- a/openspec/changes/split-profile-follow-requests/proposal.md
+++ b/openspec/changes/split-profile-follow-requests/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`profile_follow`가 실제 팔로잉 관계와 승인 대기/거절 요청 상태를 동시에 표현하고 있어 조회, 카운트, 타임라인 접근 정책이 모두 `ACCEPTED` 상태 필터에 의존한다. 팔로우 관계는 이미 성립한 관계만 나타내고, 승인 흐름은 별도 요청 테이블로 분리해 도메인 경계를 명확히 한다.
+
+## What Changes
+
+- **BREAKING** `ProfileFollow`는 더 이상 `state`를 갖지 않고, 존재 자체가 팔로잉 관계를 의미한다.
+- `profile_follow` 테이블에서 `state`와 `responded_at` 책임을 제거한다.
+- `profile_follow_request` 테이블을 추가해 대기 중인 요청의 follower/followee 방향과 생성 시각을 저장할 수 있게 한다.
+- 기존 follow graph, followers/following count, followers-only post visibility, home timeline 조건을 `ACCEPTED` 상태 대신 `profile_follow` row 존재 여부로 판단한다.
+- 공개 GraphQL 팔로우 요청 mutation/query는 이번 범위에서 열지 않는다. 요청 생성/승인/거절 로직은 후속 변경에서 정의한다.
+
+## Capabilities
+
+### New Capabilities
+
+- 없음
+
+### Modified Capabilities
+
+- `data-model`: `profile_follow`를 팔로잉 관계 전용 테이블로 바꾸고 `profile_follow_request` 저장 모델을 추가한다.
+- `profile`: GraphQL `ProfileFollow`와 follow graph 요구사항에서 상태 기반 표현을 제거한다.
+- `post`: 팔로워 공개 게시글과 홈 타임라인 접근 조건을 accepted 상태가 아닌 팔로우 관계 존재 여부로 바꾼다.
+- `api-platform`: GraphQL enum 등록 대상에서 더 이상 노출되지 않는 `ProfileFollowState`를 제거한다.
+
+## Impact
+
+- `packages/core`: enum, Drizzle table, relations, table discriminator, DB 접근 타입.
+- `apps/api`: GraphQL enum 등록, `ProfileFollow` ref/loader/field, follow/unfollow mutation, post visibility, home timeline, generated schema.
+- `apps/web`: `ProfileFollow.state`를 선택하던 fragments, FollowButton UI 상태, Storybook mock.
+- OpenSpec: `data-model`, `profile`, `post`, `api-platform` delta.

--- a/openspec/changes/split-profile-follow-requests/specs/api-platform/spec.md
+++ b/openspec/changes/split-profile-follow-requests/specs/api-platform/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: GraphQL enum registration
+
+API는 GraphQL schema에서 노출되는 core enum을 schema 생성 전에 등록해야 한다(MUST).
+
+#### Scenario: Build enum schema
+
+- **WHEN** GraphQL schema가 생성된다
+- **THEN** 시스템은 현재 API가 노출하는 core enum을 GraphQL enum으로 등록한다
+- **AND** 현재 등록 대상은 `AccountState`, `AccountProfileRole`, `PostState`, `PostVisibility`, `ProfileFollowPolicy`, `ProfileState`이다

--- a/openspec/changes/split-profile-follow-requests/specs/data-model/spec.md
+++ b/openspec/changes/split-profile-follow-requests/specs/data-model/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: 팔로우 요청 저장
+
+시스템은 승인 기반 팔로우 흐름을 위해 팔로워와 팔로위 방향을 명시하는 대기 중인 프로필 간 팔로우 요청을 팔로우 관계와 별도 테이블에 저장해야 한다(MUST).
+
+#### Scenario: 팔로우 요청 생성
+
+- **WHEN** 한 프로필이 승인 필요한 다른 프로필에게 팔로우 요청을 보낸다
+- **THEN** 시스템은 `profile_follow_request`에 `follower_profile_id`, `followee_profile_id`, 생성 시각을 저장한다
+- **AND** `profile_follow_request` 행의 존재 자체가 대기 중인 요청을 의미한다
+- **AND** 동일한 팔로워와 팔로위 조합의 요청은 중복될 수 없다
+- **AND** 팔로워 또는 팔로위 프로필이 삭제되면 팔로우 요청도 함께 삭제된다
+
+#### Scenario: 팔로우 요청 승인
+
+- **WHEN** 팔로우 요청이 승인된다
+- **THEN** 시스템은 `ProfileFollow` 관계를 생성한다
+- **AND** 해당 `profile_follow_request` 행을 삭제한다
+- **AND** 승인 상태 값을 저장하지 않는다
+
+#### Scenario: 팔로우 요청 거절
+
+- **WHEN** 팔로우 요청이 거절된다
+- **THEN** 시스템은 해당 `profile_follow_request` 행을 삭제한다
+- **AND** 거절 상태 값을 저장하지 않는다
+
+## MODIFIED Requirements
+
+### Requirement: UUID 기반 테이블 식별자
+
+시스템은 주요 도메인 테이블의 기본 키를 PostgreSQL `uuid` 값으로 저장하고, 애플리케이션에서 생성한 시간 정렬 가능 ID에 테이블 식별자를 포함해야 한다(MUST).
+
+#### Scenario: 새 도메인 행 생성
+
+- **WHEN** `account`, `account_profile`, `application`, `application_authorization`, `file`, `media`, `oauth_authorization_code`, `oauth_token`, `post`, `post_content`, `profile`, `profile_follow`, `profile_follow_request`, `session` 행이 생성된다
+- **THEN** 시스템은 해당 테이블의 `TableDiscriminator` 값을 포함한 UUID 문자열을 기본 키로 생성한다
+- **AND** 테이블 식별자는 12비트 범위 안에 있어야 한다
+
+### Requirement: 팔로우 관계 저장
+
+시스템은 팔로워와 팔로위 방향을 명시하는 성립된 프로필 간 팔로우 관계를 저장해야 한다(MUST).
+
+#### Scenario: 팔로우 관계 생성
+
+- **WHEN** 한 프로필이 다른 프로필을 팔로우한다
+- **THEN** 시스템은 `profile_follow`에 `follower_profile_id`, `followee_profile_id`, 생성 시각을 저장한다
+- **AND** `profile_follow` 행의 존재 자체가 성립된 팔로우 관계를 의미한다
+- **AND** 동일한 팔로워와 팔로위 조합은 중복될 수 없다
+- **AND** 팔로워 또는 팔로위 프로필이 삭제되면 팔로우 관계도 함께 삭제된다
+
+### Requirement: 열거형 상태 값
+
+시스템은 도메인 상태와 정책 값을 제한된 enum 값으로 저장해야 한다(MUST).
+
+#### Scenario: enum 값 사용
+
+- **WHEN** 계정, 프로필, 세션, OAuth token, 애플리케이션, 게시물, 계정-프로필 역할, 미디어가 저장된다
+- **THEN** 시스템은 core enum에 정의된 값만 저장해야 한다
+- **AND** 지원 값은 `AccountState`, `ProfileState`, `SessionState`, `OAuthTokenState`, `ApplicationState`, `ApplicationType`, `PostState`, `PostVisibility`, `ProfileFollowPolicy`, `AccountProfileRole`, `MediaSource`에 정의된 값으로 제한된다

--- a/openspec/changes/split-profile-follow-requests/specs/post/spec.md
+++ b/openspec/changes/split-profile-follow-requests/specs/post/spec.md
@@ -1,0 +1,109 @@
+## MODIFIED Requirements
+
+### Requirement: Post GraphQL object
+
+API는 활성 게시글을 GraphQL `Post` Node로 노출해야 하며 작성자 프로필, 현재 콘텐츠, 공개 범위, 상태, 생성 시각을 제공해야 한다(MUST).
+
+#### Scenario: 활성 게시글 object 조회
+
+- **WHEN** 클라이언트가 노출 가능한 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 `Post` object를 반환한다
+- **AND** `Post`는 `id`, `profile`, `content`, `visibility`, `state`, `createdAt` 필드를 포함한다
+- **AND** `profile`은 게시글 작성자 프로필을 가리킨다
+- **AND** `content`는 게시글의 현재 콘텐츠를 가리킨다
+
+#### Scenario: 공개 게시글 object 조회
+
+- **WHEN** 클라이언트가 `PUBLIC` 또는 `UNLISTED` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 `Post` object를 반환한다
+
+#### Scenario: 작성자 본인의 비공개 게시글 object 조회
+
+- **WHEN** 현재 active profile이 게시글 작성자이고 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 `Post` object를 반환한다
+
+#### Scenario: follower의 팔로워 공개 게시글 object 조회
+
+- **WHEN** 현재 active profile이 게시글 작성자를 팔로우하고 `FOLLOWERS` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 `Post` object를 반환한다
+
+#### Scenario: 접근 권한 없는 viewer의 비공개 게시글 object 조회
+
+- **WHEN** 인증되지 않았거나, 현재 active profile이 게시글 작성자가 아니고 게시글 작성자를 팔로우하지 않는 클라이언트가 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 게시글 Node를 조회한다
+- **THEN** 시스템은 해당 게시글을 GraphQL `Post` object로 노출하지 않는다
+- **AND** `DIRECT` viewer 기준 세부 접근 제어는 후속 변경에서 정의한다
+
+#### Scenario: 비활성 게시글 object 조회
+
+- **WHEN** 게시글 상태가 `ACTIVE`가 아니다
+- **THEN** 시스템은 해당 게시글을 GraphQL `Post` object로 노출하지 않는다
+
+### Requirement: 프로필 게시글 목록 connection
+
+API는 프로필이 작성한 활성 게시글을 최신순 Relay connection `Profile.posts`로 노출해야 하며, viewer와 작성자의 관계에 따라 공개 범위를 제한해야 한다(MUST). `Profile.posts`는 게시글 node 목록 공용 wrapper인 `PostConnection`을 반환해야 한다(MUST).
+
+#### Scenario: 공개 프로필 게시글 목록 조회
+
+- **WHEN** 인증되지 않았거나 현재 active profile이 조회 대상 프로필을 팔로우하지 않는 클라이언트가 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 해당 프로필이 작성한 `PUBLIC` 또는 `UNLISTED` 공개 범위의 `ACTIVE` 게시글만 반환한다
+- **AND** 게시글은 최신순으로 정렬된다
+- **AND** connection은 cursor 기반 페이지네이션을 지원한다
+
+#### Scenario: 작성자 본인의 프로필 게시글 목록 조회
+
+- **WHEN** 현재 active profile이 조회 대상 프로필이고 해당 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 해당 프로필이 작성한 모든 공개 범위의 `ACTIVE` 게시글을 반환한다
+- **AND** 게시글은 최신순으로 정렬된다
+- **AND** connection은 cursor 기반 페이지네이션을 지원한다
+
+#### Scenario: follower의 프로필 게시글 목록 조회
+
+- **WHEN** 현재 active profile이 조회 대상 프로필을 팔로우하고 해당 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 해당 프로필이 작성한 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 공개 범위의 `ACTIVE` 게시글을 반환한다
+- **AND** `DIRECT` 공개 범위의 게시글은 반환하지 않는다
+- **AND** 게시글은 최신순으로 정렬된다
+- **AND** connection은 cursor 기반 페이지네이션을 지원한다
+
+#### Scenario: 게시글이 없는 프로필 목록 조회
+
+- **WHEN** 게시글이 없는 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 빈 connection을 반환한다
+
+#### Scenario: 프로필 목록에서 숨겨지는 게시글
+
+- **WHEN** 인증되지 않았거나 현재 active profile이 조회 대상 프로필을 팔로우하지 않는 클라이언트가 프로필의 `posts` connection을 조회한다
+- **THEN** 시스템은 `FOLLOWERS`, `DIRECT` 공개 범위의 게시글을 반환하지 않는다
+
+### Requirement: Home timeline connection
+
+API는 현재 active profile 기준 홈 타임라인을 최신순 Relay connection `Query.homeTimeline`로 노출해야 한다(MUST). `Query.homeTimeline`은 게시글 node 목록 공용 wrapper인 `PostConnection`을 반환해야 한다(MUST). active profile이 없거나 인증되지 않은 조회에는 요청을 거부하지 않고 `null`을 반환해야 한다(MUST).
+
+#### Scenario: 내 게시글 포함
+
+- **WHEN** active profile이 있는 인증자가 `homeTimeline` connection을 조회한다
+- **THEN** 시스템은 현재 active profile이 작성한 `ACTIVE` 게시글을 반환한다
+- **AND** 게시글은 최신순으로 정렬된다
+- **AND** connection은 첫 페이지 조회에 사용할 수 있어야 한다
+
+#### Scenario: followee 게시글 포함
+
+- **WHEN** active profile이 있는 인증자가 `homeTimeline` connection을 조회하고 현재 active profile이 다른 활성 프로필을 팔로우한다
+- **THEN** 시스템은 해당 followee가 작성한 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 공개 범위의 `ACTIVE` 게시글을 반환한다
+- **AND** `DIRECT` 공개 범위의 게시글은 반환하지 않는다
+- **AND** 게시글은 최신순으로 정렬된다
+
+#### Scenario: 비팔로우 게시글 제외
+
+- **WHEN** active profile이 있는 인증자가 `homeTimeline` connection을 조회하고 현재 active profile이 작성자를 팔로우하지 않는다
+- **THEN** 시스템은 해당 작성자의 게시글을 반환하지 않는다
+
+#### Scenario: 역방향 팔로워 게시글 제외
+
+- **WHEN** active profile이 있는 인증자가 `homeTimeline` connection을 조회하고 다른 프로필이 현재 active profile을 팔로우하지만 현재 active profile은 그 프로필을 팔로우하지 않는다
+- **THEN** 시스템은 해당 팔로워의 게시글을 반환하지 않는다
+
+#### Scenario: active profile 없는 홈 타임라인 조회
+
+- **WHEN** 인증되지 않았거나 active profile이 없는 클라이언트가 `homeTimeline` connection을 조회한다
+- **THEN** 시스템은 요청을 거부하지 않고 `homeTimeline` 필드로 `null`을 반환한다
+- **AND** GraphQL 인증 오류를 발생시키지 않는다

--- a/openspec/changes/split-profile-follow-requests/specs/profile/spec.md
+++ b/openspec/changes/split-profile-follow-requests/specs/profile/spec.md
@@ -1,0 +1,99 @@
+## MODIFIED Requirements
+
+### Requirement: Profile follow graph
+
+API는 프로필 간 visible follow 관계를 GraphQL에서 조회할 수 있어야 한다(MUST).
+
+#### Scenario: Read followers
+
+- **WHEN** 클라이언트가 활성 프로필의 followers connection을 조회한다
+- **THEN** 시스템은 해당 프로필을 followee로 하고 follower 프로필도 활성 상태인 follow 관계 중 viewer가 볼 수 있는 관계를 반환한다
+- **AND** 각 edge의 node는 해당 `ProfileFollow`이다
+
+#### Scenario: Read following
+
+- **WHEN** 클라이언트가 활성 프로필의 following connection을 조회한다
+- **THEN** 시스템은 해당 프로필을 follower로 하고 followee 프로필도 활성 상태인 follow 관계 중 viewer가 볼 수 있는 관계를 반환한다
+- **AND** 각 edge의 node는 해당 `ProfileFollow`이다
+
+#### Scenario: Count follows
+
+- **WHEN** 클라이언트가 활성 프로필의 followersCount 또는 followingCount를 조회한다
+- **THEN** 시스템은 상대 프로필도 활성 상태인 follow 관계만 집계한다
+
+#### Scenario: Read public follow
+
+- **WHEN** 클라이언트가 자기 active profile과 관련되지 않은 follow 관계를 조회한다
+- **THEN** 시스템은 follower와 followee 프로필이 모두 활성 상태이고 `followPolicy`가 `OPEN`인 경우에만 해당 `ProfileFollow`를 반환한다
+
+#### Scenario: Read own follow relationship
+
+- **WHEN** active profile이 있는 인증자가 자기 active profile이 follower 또는 followee인 follow 관계를 조회한다
+- **THEN** 시스템은 follower와 followee 프로필이 활성 상태이면 해당 `ProfileFollow`를 반환한다
+
+#### Scenario: Read viewer follow
+
+- **WHEN** active profile이 있는 인증자가 다른 활성 프로필에 대한 viewer follow 관계를 조회한다
+- **THEN** 시스템은 viewer active profile이 대상 프로필을 follow하는 `ProfileFollow` 관계를 반환한다
+- **AND** follow 관계가 없으면 없음으로 응답한다
+
+#### Scenario: Read ProfileFollow profiles
+
+- **WHEN** 클라이언트가 `ProfileFollow.follower` 또는 `ProfileFollow.followee`를 조회한다
+- **THEN** 시스템은 관계의 follower profile 또는 followee profile이 노출 가능한 활성 프로필이면 반환한다
+- **AND** 해당 프로필이 노출 가능하지 않으면 없음으로 응답한다
+
+### Requirement: Follow profile mutation
+
+active profile이 있는 인증자는 다른 활성 공개 프로필을 즉시 follow할 수 있어야 한다(MUST).
+
+#### Scenario: Follow open active profile
+
+- **WHEN** active profile이 있는 인증자가 `followPolicy`가 `OPEN`인 다른 활성 프로필 follow를 요청한다
+- **THEN** 시스템은 follow 관계를 생성한다
+- **AND** mutation은 `FollowProfilePayload.profileFollow`로 생성된 `ProfileFollow`를 반환한다
+
+#### Scenario: Follow profile idempotently
+
+- **WHEN** active profile이 있는 인증자가 이미 follow 중인 프로필 follow를 요청한다
+- **THEN** 시스템은 `FollowProfilePayload.profileFollow`로 기존 `ProfileFollow`를 반환한다
+- **AND** 오류로 처리하지 않는다
+
+#### Scenario: Reject unsupported approval-required follow
+
+- **WHEN** active profile이 있는 인증자가 `followPolicy`가 `APPROVAL_REQUIRED`인 활성 프로필 follow를 요청하고 팔로우 요청 생성 플로우가 아직 제공되지 않는다
+- **THEN** 시스템은 conflict code를 가진 GraphQL 오류로 요청을 거부한다
+- **AND** `ProfileFollow` 관계를 생성하지 않는다
+
+#### Scenario: Prevent self follow
+
+- **WHEN** active profile이 있는 인증자가 자기 자신 follow를 요청한다
+- **THEN** 시스템은 conflict code를 가진 GraphQL 오류로 요청을 거부한다
+
+#### Scenario: Follow missing profile
+
+- **WHEN** active profile이 있는 인증자가 없는 대상 프로필 또는 비활성인 대상 프로필 follow를 요청한다
+- **THEN** 시스템은 profile not found 오류를 반환한다
+
+### Requirement: Unfollow profile mutation
+
+active profile이 있는 인증자는 기존 follow 관계를 해제할 수 있어야 한다(MUST).
+`UnfollowProfilePayload`는 삭제된 follow ID와 함께, 클라이언트 캐시 갱신을 위해 갱신된 대상 `Profile`을 포함한다.
+
+#### Scenario: Unfollow active profile
+
+- **WHEN** active profile이 있는 인증자가 follow 중인 활성 프로필 unfollow를 요청한다
+- **THEN** 시스템은 해당 follow 관계를 제거한다
+- **AND** mutation은 `UnfollowProfilePayload.profileFollowId`로 삭제된 `ProfileFollow` ID를 반환한다
+- **AND** 갱신된 viewer follow 상태와 팔로워 수를 가진 대상 `Profile`을 함께 반환한다
+
+#### Scenario: Unfollow profile idempotently
+
+- **WHEN** active profile이 있는 인증자가 follow 관계가 없는 활성 프로필 unfollow를 요청한다
+- **THEN** 시스템은 오류로 처리하지 않는다
+- **AND** `profileFollowId`가 `null`이고 대상 `Profile`을 포함한 `UnfollowProfilePayload`를 반환한다
+
+#### Scenario: Unfollow missing profile
+
+- **WHEN** active profile이 있는 인증자가 없는 대상 프로필 또는 비활성인 대상 프로필 unfollow를 요청한다
+- **THEN** 시스템은 profile not found 오류를 반환한다

--- a/openspec/changes/split-profile-follow-requests/tasks.md
+++ b/openspec/changes/split-profile-follow-requests/tasks.md
@@ -1,0 +1,25 @@
+## 1. Core schema
+
+- [x] 1.1 core enum에서 `ProfileFollowState`를 제거한다.
+- [x] 1.2 `ProfileFollows`에서 `state`와 `respondedAt` 컬럼/인덱스를 제거하고 follow 관계용 인덱스를 정리한다.
+- [x] 1.3 `ProfileFollowRequests` 테이블, table discriminator, Drizzle relations를 추가한다.
+- [x] 1.4 관련 memory 문서에서 profile follow/request 저장 책임을 갱신한다.
+
+## 2. API behavior
+
+- [x] 2.1 `ProfileFollow` GraphQL 타입과 enum 등록에서 follow state 노출을 제거한다.
+- [x] 2.2 follow graph loader, followers/following connection, count resolver를 follow row 존재 기준으로 수정한다.
+- [x] 2.3 `followProfile` mutation을 기존 follow 멱등 반환, `OPEN` 대상 생성, `APPROVAL_REQUIRED` 대상 conflict 정책에 맞게 수정한다.
+- [x] 2.4 post visibility와 home timeline 조건에서 accepted state 필터를 제거한다.
+
+## 3. Web client
+
+- [x] 3.1 FollowButton fragment와 mutations에서 `ProfileFollow.state` 선택을 제거한다.
+- [x] 3.2 FollowButton 상태 계산과 문구를 binary follow 모델로 정리한다.
+- [x] 3.3 ProfileListItem/ProfileConnectionList/Search Storybook mock에서 pending/rejected follow state를 제거한다.
+
+## 4. Generated schema and validation
+
+- [x] 4.1 `apps/api/schema.graphql`을 재생성한다.
+- [x] 4.2 OpenSpec 변경 산출물을 검증한다.
+- [x] 4.3 관련 TypeScript/Svelte 타입체크와 포맷 검사를 실행한다.

--- a/packages/core/db/enums.ts
+++ b/packages/core/db/enums.ts
@@ -23,6 +23,5 @@ export const oauthTokenState = createPgEnum('oauth_token_state', Enum.OAuthToken
 export const postState = createPgEnum('post_state', Enum.PostState);
 export const postVisibility = createPgEnum('post_visibility', Enum.PostVisibility);
 export const profileFollowPolicy = createPgEnum('profile_follow_policy', Enum.ProfileFollowPolicy);
-export const profileFollowState = createPgEnum('profile_follow_state', Enum.ProfileFollowState);
 export const profileState = createPgEnum('profile_state', Enum.ProfileState);
 export const sessionState = createPgEnum('session_state', Enum.SessionState);

--- a/packages/core/db/id.ts
+++ b/packages/core/db/id.ts
@@ -16,6 +16,7 @@ export const TableDiscriminator = {
   PostContents: 0x005,
   Profiles: 0x006,
   ProfileFollows: 0x007,
+  ProfileFollowRequests: 0x011,
   Sessions: 0x008,
 } as const satisfies Record<keyof typeof Tables, number>;
 

--- a/packages/core/db/relations.ts
+++ b/packages/core/db/relations.ts
@@ -137,10 +137,20 @@ export const relations = defineRelations(tables, (r) => ({
       to: r.ProfileFollows.followerProfileId,
       alias: 'profile_follow_follower',
     }),
+    followerFollowRequests: r.many.ProfileFollowRequests({
+      from: r.Profiles.id,
+      to: r.ProfileFollowRequests.followerProfileId,
+      alias: 'profile_follow_request_follower',
+    }),
     followeeFollows: r.many.ProfileFollows({
       from: r.Profiles.id,
       to: r.ProfileFollows.followeeProfileId,
       alias: 'profile_follow_followee',
+    }),
+    followeeFollowRequests: r.many.ProfileFollowRequests({
+      from: r.Profiles.id,
+      to: r.ProfileFollowRequests.followeeProfileId,
+      alias: 'profile_follow_request_followee',
     }),
     instance: r.one.Instances({
       from: r.Profiles.instanceId,
@@ -167,6 +177,20 @@ export const relations = defineRelations(tables, (r) => ({
       to: r.Profiles.id,
       optional: false,
       alias: 'profile_follow_follower',
+    }),
+  },
+  ProfileFollowRequests: {
+    followeeProfile: r.one.Profiles({
+      from: r.ProfileFollowRequests.followeeProfileId,
+      to: r.Profiles.id,
+      optional: false,
+      alias: 'profile_follow_request_followee',
+    }),
+    followerProfile: r.one.Profiles({
+      from: r.ProfileFollowRequests.followerProfileId,
+      to: r.Profiles.id,
+      optional: false,
+      alias: 'profile_follow_request_follower',
     }),
   },
   Sessions: {

--- a/packages/core/db/tables.ts
+++ b/packages/core/db/tables.ts
@@ -309,14 +309,33 @@ export const ProfileFollows = pgTable(
     followeeProfileId: uuid('followee_profile_id')
       .notNull()
       .references(() => Profiles.id, { onDelete: 'cascade' }),
-    state: Enum.profileFollowState('state').notNull(),
     createdAt: createdAt(),
-    respondedAt: datetime('responded_at'),
   },
   (table) => [
     unique().on(table.followerProfileId, table.followeeProfileId),
-    index().on(table.followeeProfileId, table.state),
-    index().on(table.followerProfileId, table.state),
+    index().on(table.followeeProfileId),
+    index().on(table.followerProfileId),
+  ],
+);
+
+export const ProfileFollowRequests = pgTable(
+  'profile_follow_request',
+  {
+    id: uuid('id')
+      .primaryKey()
+      .$defaultFn(() => createId(TableDiscriminator.ProfileFollowRequests)),
+    followerProfileId: uuid('follower_profile_id')
+      .notNull()
+      .references(() => Profiles.id, { onDelete: 'cascade' }),
+    followeeProfileId: uuid('followee_profile_id')
+      .notNull()
+      .references(() => Profiles.id, { onDelete: 'cascade' }),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    unique().on(table.followerProfileId, table.followeeProfileId),
+    index().on(table.followeeProfileId),
+    index().on(table.followerProfileId),
   ],
 );
 

--- a/packages/core/enums.ts
+++ b/packages/core/enums.ts
@@ -54,13 +54,6 @@ export const MediaSource = {
 } as const;
 export type MediaSource = keyof typeof MediaSource;
 
-export const ProfileFollowState = {
-  PENDING: 'PENDING',
-  ACCEPTED: 'ACCEPTED',
-  REJECTED: 'REJECTED',
-} as const;
-export type ProfileFollowState = keyof typeof ProfileFollowState;
-
 export const OAuthTokenState = {
   ACTIVE: 'ACTIVE',
   REVOKED: 'REVOKED',


### PR DESCRIPTION
## 무엇을 변경했는지

- `ProfileFollow`를 성립된 팔로잉 관계 전용 모델로 정리하고 `state`/`ProfileFollowState` 노출을 제거했습니다.
- 대기 중인 팔로우 요청을 표현하는 `profile_follow_request` 테이블을 추가했습니다. 이 테이블은 상태 컬럼 없이 row 존재 자체가 pending request를 의미하고, follower/followee pair는 unique입니다.
- followers/following, count, home timeline, followers-only visibility 조건을 `ACCEPTED` 상태 필터 대신 follow row 존재 기준으로 단순화했습니다.
- web `FollowButton`과 Storybook mock에서 `viewerFollow.state` 의존을 제거했습니다.
- OpenSpec delta(`split-profile-follow-requests`)와 DB 설계 memory를 새 모델에 맞게 추가/갱신했습니다.

## 왜 변경했는지

`profile_follow`가 실제 팔로잉 관계와 pending request 상태를 동시에 표현하면서 조회, 카운트, 접근 정책이 모두 `ACCEPTED` 필터에 의존하고 있었습니다. 팔로잉 관계와 팔로우 요청의 lifecycle을 분리해 GraphQL/API 계약과 DB 모델을 더 단순하게 만들기 위한 변경입니다.

## 어떻게 확인할 수 있는지

- `pnpm exec openspec validate "split-profile-follow-requests"`
- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --filter @kosmo/web check`
- `pnpm lint:prettier`
- `pnpm lint:eslint`
- `git diff --check`
- 서브에이전트 리뷰 2회 반복: 최초 DB/API 리뷰 지적 반영 후 최신 정책 기준 재리뷰에서 문제 없음 확인

## 아직 어떤 문제가 남았는지

- 공개 팔로우 요청 생성/승인/거절 mutation과 UI는 후속 변경에서 구현해야 합니다.
- 이번 변경에서는 `APPROVAL_REQUIRED` 대상 `followProfile` 호출을 conflict로 거부합니다.

Stack: main -> split-profile-follow-requests
