### PR TITLE
WebFinger handle을 local profile actor identifier로 해석한다

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run Fedify unit tests
+        run: |
+          pnpm db:test:reset
+          pnpm db:test:push
+          pnpm test:fedify
+
       - name: Run web E2E tests
         run: pnpm test:e2e
 

--- a/openspec/changes/add-activitypub-actor-discovery/tasks.md
+++ b/openspec/changes/add-activitypub-actor-discovery/tasks.md
@@ -28,7 +28,7 @@
 
 - [x] 4.1 `packages/core`에 runtime local instance resolve helper를 만들고, `PUBLIC_ORIGIN`과 일치하는 configured local instance row를 canonical origin/domain source of truth로 읽어 검증하되 runtime 요청 처리 중 row를 자동 생성하지 않는다.
 - [x] 4.2 `packages/core`에 setup/migration에서 사용할 local instance bootstrap helper를 만들고, configured local instance row를 만들거나 `PUBLIC_ORIGIN`과 일치하는 기존 row를 검증하며, profile backfill 전에 실행되는 setup/migration 흐름에 연결한다.
-- [ ] 4.3 WebFinger `acct:{handle}@{localDomain}`을 local active profile UUID actor identifier로 매핑한다.
+- [x] 4.3 WebFinger `acct:{handle}@{localDomain}`을 local active profile UUID actor identifier로 매핑한다.
 - [x] 4.4 actor dispatcher를 `/ap/actor/{identifier}` URI template에 연결하고 identifier를 raw `profile.id` UUID로 해석한다.
 - [x] 4.5 actor document를 `Person`으로 구성하고 `id`, `preferredUsername`, `name`, `url`, `published`, `inbox`, `outbox`, `publicKey`, `assertionMethods`를 보장한다.
 - [ ] 4.6 WebFinger와 actor document의 성공 content type, canonical subject/id, 404 실패 응답을 구현한다.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:prettier": "prettier --check --ignore-unknown '**/*'",
     "lint:syncpack": "syncpack lint --dependency-types prod,dev,peer",
     "prepare": "husky || true",
-    "test:e2e": "pnpm db:test:reset && pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit && pnpm --filter @kosmo/web test:e2e"
+    "test:e2e": "pnpm db:test:reset && pnpm db:test:push && pnpm --filter @kosmo/web test:e2e",
+    "test:fedify": "pnpm --filter @kosmo/fedify test:unit"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:prettier": "prettier --check --ignore-unknown '**/*'",
     "lint:syncpack": "syncpack lint --dependency-types prod,dev,peer",
     "prepare": "husky || true",
-    "test:e2e": "pnpm db:test:reset && pnpm db:test:push && pnpm --filter @kosmo/web test:e2e"
+    "test:e2e": "pnpm db:test:reset && pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit && pnpm --filter @kosmo/web test:e2e"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/packages/fedify/package.json
+++ b/packages/fedify/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "lint:tsc": "tsc --noEmit",
-    "test:unit": "vitest"
+    "test:unit": "tsx --test src/*.test.ts"
   },
   "dependencies": {
     "@fedify/fedify": "^2.3.0",
@@ -15,6 +15,6 @@
     "drizzle-orm": "1.0.0-beta.22"
   },
   "devDependencies": {
-    "vitest": "^4.1.8"
+    "tsx": "^4.22.4"
   }
 }

--- a/packages/fedify/package.json
+++ b/packages/fedify/package.json
@@ -5,12 +5,16 @@
     ".": "./index.ts"
   },
   "scripts": {
-    "lint:tsc": "tsc --noEmit"
+    "lint:tsc": "tsc --noEmit",
+    "test:unit": "vitest"
   },
   "dependencies": {
     "@fedify/fedify": "^2.3.0",
     "@fedify/vocab": "2.3.0",
     "@kosmo/core": "workspace:*",
     "drizzle-orm": "1.0.0-beta.22"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -2,7 +2,7 @@ import { createFederation, MemoryKvStore } from '@fedify/fedify';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { ensureDrizzleLocalProfileActor } from './local-actor-store';
 import { createLocalProfilePerson } from './local-profile-person';
-import { mapLocalProfileHandle } from './webfinger';
+import { resolveLocalActorIdentifierByHandle } from './webfinger';
 import type { Federation } from '@fedify/fedify';
 
 const federationOrigin = process.env.PUBLIC_ORIGIN;
@@ -34,7 +34,7 @@ federation
       profile: result.profile,
     });
   })
-  .mapHandle(mapLocalProfileHandle)
+  .mapHandle((_context, username) => resolveLocalActorIdentifierByHandle(username))
   .setKeyPairsDispatcher(async (ctx, identifier) => {
     const localInstance = await resolveConfiguredLocalInstance();
     const result = await ensureDrizzleLocalProfileActor({

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -2,6 +2,7 @@ import { createFederation, MemoryKvStore } from '@fedify/fedify';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { ensureDrizzleLocalProfileActor } from './local-actor-store';
 import { createLocalProfilePerson } from './local-profile-person';
+import { mapLocalProfileHandle } from './webfinger';
 import type { Federation } from '@fedify/fedify';
 
 const federationOrigin = process.env.PUBLIC_ORIGIN;
@@ -33,7 +34,7 @@ federation
       profile: result.profile,
     });
   })
-  .mapHandle(() => null)
+  .mapHandle(mapLocalProfileHandle)
   .setKeyPairsDispatcher(async (ctx, identifier) => {
     const localInstance = await resolveConfiguredLocalInstance();
     const result = await ensureDrizzleLocalProfileActor({

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -34,7 +34,11 @@ federation
       profile: result.profile,
     });
   })
-  .mapHandle((_context, username) => resolveLocalActorIdentifierByHandle(username))
+  .mapHandle((context, username) =>
+    context.host === new URL(context.canonicalOrigin).host
+      ? resolveLocalActorIdentifierByHandle(username)
+      : null,
+  )
   .setKeyPairsDispatcher(async (ctx, identifier) => {
     const localInstance = await resolveConfiguredLocalInstance();
     const result = await ensureDrizzleLocalProfileActor({

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -14,6 +14,10 @@ export const federation: Federation<void> = createFederation<void>({
 
 federation
   .setActorDispatcher('/ap/actor/{identifier}', async (ctx, identifier) => {
+    if (ctx.host !== new URL(ctx.canonicalOrigin).host) {
+      return null;
+    }
+
     const localInstance = await resolveConfiguredLocalInstance();
     const result = await ensureDrizzleLocalProfileActor({
       actorUri: ctx.getActorUri(identifier),

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -108,6 +108,21 @@ describe('WebFinger local profile handle mapping', () => {
       ),
     );
   });
+
+  test('rejects WebFinger requests from a non-canonical host', async () => {
+    await createProfile({ handle: 'alice', instanceId: localInstanceId });
+
+    const response = await federation.fetch(
+      new Request(
+        `http://preview.example/.well-known/webfinger?resource=${encodeURIComponent(
+          'acct:alice@preview.example',
+        )}`,
+      ),
+      { contextData: undefined },
+    );
+
+    assert.equal(response.status, 404);
+  });
 });
 
 const truncateDatabase = async () => {

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -1,6 +1,7 @@
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, test } from 'node:test';
 import { InstanceKind, InstanceState, ProfileFollowPolicy, ProfileState } from '@kosmo/core/enums';
 import { normalizeHandle } from '@kosmo/core/utils';
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as FederationModule from './federation';
@@ -16,14 +17,13 @@ let pg: typeof CoreDb.pg;
 let Profiles: typeof CoreDb.Profiles;
 let seedDatabase: typeof CoreSeed.seedDatabase;
 let federation: typeof FederationModule.federation;
-let mapLocalProfileHandle: typeof WebFinger.mapLocalProfileHandle;
 let resolveLocalActorIdentifierByHandle: typeof WebFinger.resolveLocalActorIdentifierByHandle;
 
 describe('WebFinger local profile handle mapping', () => {
   let localInstanceId: string;
   let remoteInstanceId: string;
 
-  beforeAll(async () => {
+  before(async () => {
     process.env.DATABASE_URL ??= databaseUrl;
     process.env.PUBLIC_ORIGIN = publicOrigin;
 
@@ -39,7 +39,6 @@ describe('WebFinger local profile handle mapping', () => {
     Profiles = coreDb.Profiles;
     seedDatabase = seed.seedDatabase;
     federation = federationModule.federation;
-    mapLocalProfileHandle = webfinger.mapLocalProfileHandle;
     resolveLocalActorIdentifierByHandle = webfinger.resolveLocalActorIdentifierByHandle;
 
     await truncateDatabase();
@@ -53,45 +52,39 @@ describe('WebFinger local profile handle mapping', () => {
     await db.delete(Profiles);
   });
 
-  afterAll(async () => {
+  after(async () => {
     await pg.end();
   });
 
   test('returns the active local profile id for a matching handle', async () => {
     const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
 
-    await expect(resolveLocalActorIdentifierByHandle('alice')).resolves.toBe(profile.id);
+    assert.equal(await resolveLocalActorIdentifierByHandle('alice'), profile.id);
   });
 
-  test('normalizes the queried handle before lookup', async () => {
-    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
+  test('returns null when the queried handle is not canonical', async () => {
+    await createProfile({ handle: 'alice', instanceId: localInstanceId });
 
-    await expect(resolveLocalActorIdentifierByHandle(' Alice ')).resolves.toBe(profile.id);
+    assert.equal(await resolveLocalActorIdentifierByHandle(' Alice '), null);
+    assert.equal(await resolveLocalActorIdentifierByHandle('Alice'), null);
   });
 
   test('returns null when the local handle does not exist', async () => {
-    await expect(resolveLocalActorIdentifierByHandle('missing')).resolves.toBeNull();
+    assert.equal(await resolveLocalActorIdentifierByHandle('missing'), null);
   });
 
-  test.each([ProfileState.DISABLED, ProfileState.SUSPENDED])(
-    'returns null when the matching local profile is %s',
-    async (state) => {
+  for (const state of [ProfileState.DISABLED, ProfileState.SUSPENDED]) {
+    test(`returns null when the matching local profile is ${state}`, async () => {
       await createProfile({ handle: 'alice', instanceId: localInstanceId, state });
 
-      await expect(resolveLocalActorIdentifierByHandle('alice')).resolves.toBeNull();
-    },
-  );
+      assert.equal(await resolveLocalActorIdentifierByHandle('alice'), null);
+    });
+  }
 
   test('ignores a matching handle from a non-configured instance', async () => {
     await createProfile({ handle: 'alice', instanceId: remoteInstanceId });
 
-    await expect(resolveLocalActorIdentifierByHandle('alice')).resolves.toBeNull();
-  });
-
-  test('exposes the same lookup as a Fedify handle mapper callback', async () => {
-    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
-
-    await expect(mapLocalProfileHandle({} as never, 'alice')).resolves.toBe(profile.id);
+    assert.equal(await resolveLocalActorIdentifierByHandle('alice'), null);
   });
 
   test('serves a WebFinger JRD for a local active profile handle', async () => {
@@ -106,24 +99,38 @@ describe('WebFinger local profile handle mapping', () => {
       { contextData: undefined },
     );
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toContain('application/jrd+json');
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type') ?? '', /application\/jrd\+json/);
 
     const json = (await response.json()) as {
       subject?: string;
       links?: Array<{ rel?: string; href?: string; type?: string }>;
     };
 
-    expect(json.subject).toBe('acct:alice@127.0.0.1:4173');
-    expect(json.links).toContainEqual({
-      rel: 'self',
-      href: `${publicOrigin}/ap/actor/${profile.id}`,
-      type: 'application/activity+json',
-    });
-    expect(json.links).toContainEqual({
-      rel: 'http://webfinger.net/rel/profile-page',
-      href: `${publicOrigin}/@alice`,
-    });
+    assert.equal(json.subject, 'acct:alice@127.0.0.1:4173');
+    assert.ok(
+      json.links?.some(
+        (link) =>
+          link.rel === 'self' &&
+          link.href === `${publicOrigin}/ap/actor/${profile.id}` &&
+          link.type === 'application/activity+json',
+      ),
+    );
+  });
+
+  test('returns 404 for a non-canonical WebFinger handle', async () => {
+    await createProfile({ handle: 'alice', instanceId: localInstanceId });
+
+    const response = await federation.fetch(
+      new Request(
+        `${publicOrigin}/.well-known/webfinger?resource=${encodeURIComponent(
+          'acct:Alice@127.0.0.1:4173',
+        )}`,
+      ),
+      { contextData: undefined },
+    );
+
+    assert.equal(response.status, 404);
   });
 });
 

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -62,11 +62,11 @@ describe('WebFinger local profile handle mapping', () => {
     assert.equal(await resolveLocalActorIdentifierByHandle('alice'), profile.id);
   });
 
-  test('returns null when the queried handle is not canonical', async () => {
-    await createProfile({ handle: 'alice', instanceId: localInstanceId });
+  test('normalizes the queried handle before lookup', async () => {
+    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
 
-    assert.equal(await resolveLocalActorIdentifierByHandle(' Alice '), null);
-    assert.equal(await resolveLocalActorIdentifierByHandle('Alice'), null);
+    assert.equal(await resolveLocalActorIdentifierByHandle(' Alice '), profile.id);
+    assert.equal(await resolveLocalActorIdentifierByHandle('Alice'), profile.id);
   });
 
   test('returns null when the local handle does not exist', async () => {
@@ -118,19 +118,29 @@ describe('WebFinger local profile handle mapping', () => {
     );
   });
 
-  test('returns 404 for a non-canonical WebFinger handle', async () => {
-    await createProfile({ handle: 'alice', instanceId: localInstanceId });
+  test('serves WebFinger for a normalized profile handle', async () => {
+    const profile = await createProfile({ handle: 'Alice', instanceId: localInstanceId });
 
     const response = await federation.fetch(
       new Request(
         `${publicOrigin}/.well-known/webfinger?resource=${encodeURIComponent(
-          'acct:Alice@127.0.0.1:4173',
+          'acct:alice@127.0.0.1:4173',
         )}`,
       ),
       { contextData: undefined },
     );
 
-    assert.equal(response.status, 404);
+    assert.equal(response.status, 200);
+
+    const json = (await response.json()) as {
+      links?: Array<{ rel?: string; href?: string; type?: string }>;
+    };
+
+    assert.ok(
+      json.links?.some(
+        (link) => link.rel === 'self' && link.href === `${publicOrigin}/ap/actor/${profile.id}`,
+      ),
+    );
   });
 });
 

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -1,0 +1,181 @@
+import { InstanceKind, InstanceState, ProfileFollowPolicy, ProfileState } from '@kosmo/core/enums';
+import { normalizeHandle } from '@kosmo/core/utils';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import type * as CoreDb from '@kosmo/core/db';
+import type * as CoreSeed from '@kosmo/core/db/seed';
+import type * as FederationModule from './federation';
+import type * as WebFinger from './webfinger';
+
+const publicOrigin = 'http://127.0.0.1:4173';
+const databaseUrl = 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+
+let db: typeof CoreDb.db;
+let firstOrThrow: typeof CoreDb.firstOrThrow;
+let Instances: typeof CoreDb.Instances;
+let pg: typeof CoreDb.pg;
+let Profiles: typeof CoreDb.Profiles;
+let seedDatabase: typeof CoreSeed.seedDatabase;
+let federation: typeof FederationModule.federation;
+let mapLocalProfileHandle: typeof WebFinger.mapLocalProfileHandle;
+let resolveLocalActorIdentifierByHandle: typeof WebFinger.resolveLocalActorIdentifierByHandle;
+
+describe('WebFinger local profile handle mapping', () => {
+  let localInstanceId: string;
+  let remoteInstanceId: string;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL ??= databaseUrl;
+    process.env.PUBLIC_ORIGIN = publicOrigin;
+
+    const coreDb = await import('@kosmo/core/db');
+    const federationModule = await import('./federation');
+    const seed = await import('@kosmo/core/db/seed');
+    const webfinger = await import('./webfinger');
+
+    db = coreDb.db;
+    firstOrThrow = coreDb.firstOrThrow;
+    Instances = coreDb.Instances;
+    pg = coreDb.pg;
+    Profiles = coreDb.Profiles;
+    seedDatabase = seed.seedDatabase;
+    federation = federationModule.federation;
+    mapLocalProfileHandle = webfinger.mapLocalProfileHandle;
+    resolveLocalActorIdentifierByHandle = webfinger.resolveLocalActorIdentifierByHandle;
+
+    await truncateDatabase();
+
+    const { localInstance } = await seedDatabase({ publicOrigin });
+    localInstanceId = localInstance.id;
+    remoteInstanceId = await createRemoteInstance();
+  });
+
+  beforeEach(async () => {
+    await db.delete(Profiles);
+  });
+
+  afterAll(async () => {
+    await pg.end();
+  });
+
+  test('returns the active local profile id for a matching handle', async () => {
+    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
+
+    await expect(resolveLocalActorIdentifierByHandle('alice')).resolves.toBe(profile.id);
+  });
+
+  test('normalizes the queried handle before lookup', async () => {
+    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
+
+    await expect(resolveLocalActorIdentifierByHandle(' Alice ')).resolves.toBe(profile.id);
+  });
+
+  test('returns null when the local handle does not exist', async () => {
+    await expect(resolveLocalActorIdentifierByHandle('missing')).resolves.toBeNull();
+  });
+
+  test.each([ProfileState.DISABLED, ProfileState.SUSPENDED])(
+    'returns null when the matching local profile is %s',
+    async (state) => {
+      await createProfile({ handle: 'alice', instanceId: localInstanceId, state });
+
+      await expect(resolveLocalActorIdentifierByHandle('alice')).resolves.toBeNull();
+    },
+  );
+
+  test('ignores a matching handle from a non-configured instance', async () => {
+    await createProfile({ handle: 'alice', instanceId: remoteInstanceId });
+
+    await expect(resolveLocalActorIdentifierByHandle('alice')).resolves.toBeNull();
+  });
+
+  test('exposes the same lookup as a Fedify handle mapper callback', async () => {
+    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
+
+    await expect(mapLocalProfileHandle({} as never, 'alice')).resolves.toBe(profile.id);
+  });
+
+  test('serves a WebFinger JRD for a local active profile handle', async () => {
+    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
+
+    const response = await federation.fetch(
+      new Request(
+        `${publicOrigin}/.well-known/webfinger?resource=${encodeURIComponent(
+          'acct:alice@127.0.0.1:4173',
+        )}`,
+      ),
+      { contextData: undefined },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/jrd+json');
+
+    const json = (await response.json()) as {
+      subject?: string;
+      links?: Array<{ rel?: string; href?: string; type?: string }>;
+    };
+
+    expect(json.subject).toBe('acct:alice@127.0.0.1:4173');
+    expect(json.links).toContainEqual({
+      rel: 'self',
+      href: `${publicOrigin}/ap/actor/${profile.id}`,
+      type: 'application/activity+json',
+    });
+    expect(json.links).toContainEqual({
+      rel: 'http://webfinger.net/rel/profile-page',
+      href: `${publicOrigin}/@alice`,
+    });
+  });
+});
+
+const truncateDatabase = async () => {
+  await pg.unsafe(`
+    DO $$
+    DECLARE
+      truncate_statement text;
+    BEGIN
+      SELECT 'TRUNCATE TABLE ' || string_agg(format('%I.%I', schemaname, tablename), ', ') || ' CASCADE'
+      INTO truncate_statement
+      FROM pg_tables
+      WHERE schemaname = 'public';
+
+      IF truncate_statement IS NOT NULL THEN
+        EXECUTE truncate_statement;
+      END IF;
+    END $$;
+  `);
+};
+
+const createRemoteInstance = async () =>
+  db
+    .insert(Instances)
+    .values({
+      canonicalOrigin: 'https://remote.example',
+      domain: 'remote.example',
+      kind: InstanceKind.ACTIVITYPUB,
+      state: InstanceState.ACTIVE,
+    })
+    .returning({ id: Instances.id })
+    .then(firstOrThrow)
+    .then((instance) => instance.id);
+
+const createProfile = async ({
+  handle,
+  instanceId,
+  state = ProfileState.ACTIVE,
+}: {
+  handle: string;
+  instanceId: string;
+  state?: ProfileState;
+}) =>
+  db
+    .insert(Profiles)
+    .values({
+      displayName: handle,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle,
+      instanceId,
+      normalizedHandle: normalizeHandle(handle),
+      state,
+    })
+    .returning()
+    .then(firstOrThrow);

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -27,19 +27,10 @@ describe('WebFinger local profile handle mapping', () => {
     process.env.DATABASE_URL ??= databaseUrl;
     process.env.PUBLIC_ORIGIN = publicOrigin;
 
-    const coreDb = await import('@kosmo/core/db');
-    const federationModule = await import('./federation');
-    const seed = await import('@kosmo/core/db/seed');
-    const webfinger = await import('./webfinger');
-
-    db = coreDb.db;
-    firstOrThrow = coreDb.firstOrThrow;
-    Instances = coreDb.Instances;
-    pg = coreDb.pg;
-    Profiles = coreDb.Profiles;
-    seedDatabase = seed.seedDatabase;
-    federation = federationModule.federation;
-    resolveLocalActorIdentifierByHandle = webfinger.resolveLocalActorIdentifierByHandle;
+    ({ db, firstOrThrow, Instances, pg, Profiles } = await import('@kosmo/core/db'));
+    ({ federation } = await import('./federation'));
+    ({ seedDatabase } = await import('@kosmo/core/db/seed'));
+    ({ resolveLocalActorIdentifierByHandle } = await import('./webfinger'));
 
     await truncateDatabase();
 

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -117,31 +117,6 @@ describe('WebFinger local profile handle mapping', () => {
       ),
     );
   });
-
-  test('serves WebFinger for a normalized profile handle', async () => {
-    const profile = await createProfile({ handle: 'Alice', instanceId: localInstanceId });
-
-    const response = await federation.fetch(
-      new Request(
-        `${publicOrigin}/.well-known/webfinger?resource=${encodeURIComponent(
-          'acct:alice@127.0.0.1:4173',
-        )}`,
-      ),
-      { contextData: undefined },
-    );
-
-    assert.equal(response.status, 200);
-
-    const json = (await response.json()) as {
-      links?: Array<{ rel?: string; href?: string; type?: string }>;
-    };
-
-    assert.ok(
-      json.links?.some(
-        (link) => link.rel === 'self' && link.href === `${publicOrigin}/ap/actor/${profile.id}`,
-      ),
-    );
-  });
 });
 
 const truncateDatabase = async () => {

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -24,7 +24,7 @@ describe('WebFinger local profile handle mapping', () => {
   let remoteInstanceId: string;
 
   before(async () => {
-    process.env.DATABASE_URL ??= databaseUrl;
+    process.env.DATABASE_URL = databaseUrl;
     process.env.PUBLIC_ORIGIN = publicOrigin;
 
     ({ db, firstOrThrow, Instances, pg, Profiles } = await import('@kosmo/core/db'));
@@ -126,6 +126,8 @@ describe('WebFinger local profile handle mapping', () => {
 });
 
 const truncateDatabase = async () => {
+  assertTestDatabaseUrl();
+
   await pg.unsafe(`
     DO $$
     DECLARE
@@ -141,6 +143,10 @@ const truncateDatabase = async () => {
       END IF;
     END $$;
   `);
+};
+
+const assertTestDatabaseUrl = () => {
+  assert.equal(new URL(process.env.DATABASE_URL ?? '').pathname, '/kosmo_test');
 };
 
 const createRemoteInstance = async () =>

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -110,18 +110,21 @@ describe('WebFinger local profile handle mapping', () => {
   });
 
   test('rejects WebFinger requests from a non-canonical host', async () => {
-    await createProfile({ handle: 'alice', instanceId: localInstanceId });
+    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
 
-    const response = await federation.fetch(
-      new Request(
-        `http://preview.example/.well-known/webfinger?resource=${encodeURIComponent(
-          'acct:alice@preview.example',
-        )}`,
-      ),
-      { contextData: undefined },
-    );
+    for (const resource of [
+      'acct:alice@preview.example',
+      `${publicOrigin}/ap/actor/${profile.id}`,
+    ]) {
+      const response = await federation.fetch(
+        new Request(
+          `http://preview.example/.well-known/webfinger?resource=${encodeURIComponent(resource)}`,
+        ),
+        { contextData: undefined },
+      );
 
-    assert.equal(response.status, 404);
+      assert.equal(response.status, 404);
+    }
   });
 });
 

--- a/packages/fedify/src/webfinger.ts
+++ b/packages/fedify/src/webfinger.ts
@@ -1,0 +1,28 @@
+import { db, first, Profiles } from '@kosmo/core/db';
+import { ProfileState } from '@kosmo/core/enums';
+import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
+import { normalizeHandle } from '@kosmo/core/utils';
+import { and, eq } from 'drizzle-orm';
+import type { ActorHandleMapper } from '@fedify/fedify';
+
+export const resolveLocalActorIdentifierByHandle = async (handle: string) => {
+  const localInstance = await resolveConfiguredLocalInstance();
+
+  const profile = await db
+    .select({ id: Profiles.id })
+    .from(Profiles)
+    .where(
+      and(
+        eq(Profiles.instanceId, localInstance.id),
+        eq(Profiles.state, ProfileState.ACTIVE),
+        eq(Profiles.normalizedHandle, normalizeHandle(handle)),
+      ),
+    )
+    .limit(1)
+    .then(first);
+
+  return profile?.id ?? null;
+};
+
+export const mapLocalProfileHandle: ActorHandleMapper<void> = (_context, username) =>
+  resolveLocalActorIdentifierByHandle(username);

--- a/packages/fedify/src/webfinger.ts
+++ b/packages/fedify/src/webfinger.ts
@@ -1,6 +1,7 @@
 import { db, first, Profiles } from '@kosmo/core/db';
 import { ProfileState } from '@kosmo/core/enums';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
+import { normalizeHandle } from '@kosmo/core/utils';
 import { and, eq } from 'drizzle-orm';
 
 export const resolveLocalActorIdentifierByHandle = async (handle: string) => {
@@ -13,7 +14,7 @@ export const resolveLocalActorIdentifierByHandle = async (handle: string) => {
       and(
         eq(Profiles.instanceId, localInstance.id),
         eq(Profiles.state, ProfileState.ACTIVE),
-        eq(Profiles.handle, handle),
+        eq(Profiles.normalizedHandle, normalizeHandle(handle)),
       ),
     )
     .limit(1)

--- a/packages/fedify/src/webfinger.ts
+++ b/packages/fedify/src/webfinger.ts
@@ -1,9 +1,7 @@
 import { db, first, Profiles } from '@kosmo/core/db';
 import { ProfileState } from '@kosmo/core/enums';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
-import { normalizeHandle } from '@kosmo/core/utils';
 import { and, eq } from 'drizzle-orm';
-import type { ActorHandleMapper } from '@fedify/fedify';
 
 export const resolveLocalActorIdentifierByHandle = async (handle: string) => {
   const localInstance = await resolveConfiguredLocalInstance();
@@ -15,7 +13,7 @@ export const resolveLocalActorIdentifierByHandle = async (handle: string) => {
       and(
         eq(Profiles.instanceId, localInstance.id),
         eq(Profiles.state, ProfileState.ACTIVE),
-        eq(Profiles.normalizedHandle, normalizeHandle(handle)),
+        eq(Profiles.handle, handle),
       ),
     )
     .limit(1)
@@ -23,6 +21,3 @@ export const resolveLocalActorIdentifierByHandle = async (handle: string) => {
 
   return profile?.id ?? null;
 };
-
-export const mapLocalProfileHandle: ActorHandleMapper<void> = (_context, username) =>
-  resolveLocalActorIdentifierByHandle(username);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,9 +309,9 @@ importers:
         specifier: 1.0.0-beta.22
         version: 1.0.0-beta.22(@opentelemetry/api@1.9.1)(postgres@3.4.9)(zod@4.4.3)
     devDependencies:
-      vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.4))
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,10 @@ importers:
       drizzle-orm:
         specifier: 1.0.0-beta.22
         version: 1.0.0-beta.22(@opentelemetry/api@1.9.1)(postgres@3.4.9)(zod@4.4.3)
+    devDependencies:
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.8.4))
 
 packages:
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Fedify `.mapHandle()`로 WebFinger `acct:{handle}@{localDomain}`을 local profile actor identifier로 매핑합니다.
- WebFinger 요청 Host가 configured local Host가 아니면 handle resource와 actor URI resource 모두 404가 되도록 막았습니다.
- Fedify WebFinger 회귀 테스트를 `test:fedify`로 분리하고, Web E2E workflow에서 별도 step으로 실행하게 했습니다.
- OpenSpec task 4.3만 완료로 표시했습니다.

## 왜 변경했는지

local actor document dispatcher가 main에 들어왔으므로, profile handle discovery가 Fedify의 기존 WebFinger 처리 흐름을 통해 actor dispatcher까지 이어지게 합니다. WebFinger JRD는 직접 만들지 않고 Fedify에 맡기되, preview/alias Host에서 canonical local identity가 발견되지 않도록 요청 Host를 제한합니다.

## 어떻게 확인할 수 있는지

- `pnpm db:test:reset`
- `pnpm db:test:push`
- `pnpm test:fedify`
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm exec eslint --max-warnings 0 packages/fedify/src/federation.ts packages/fedify/src/webfinger.ts packages/fedify/src/webfinger.test.ts`
- `pnpm exec prettier --check .github/workflows/web-e2e.yml package.json packages/fedify/package.json packages/fedify/src/federation.ts packages/fedify/src/webfinger.ts packages/fedify/src/webfinger.test.ts pnpm-lock.yaml`
- `pnpm lint:syncpack`
- `pnpm openspec validate add-activitypub-actor-discovery --strict`

## 아직 어떤 문제가 남았는지

- `robin-maki` 재리뷰를 기다립니다.
- WebFinger/actor discovery의 남은 전체 검증은 OpenSpec task 4.6, 4.8, 6.3 범위로 이어집니다.

Stack: `main -> PROD-191`
