### PR TITLE
OpenTelemetry Core 보안 취약점을 패치한다

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@opentelemetry/sdk-metrics@<2.8.0': ^2.8.0
   cookie@<0.7.0: ^0.7.0
   esbuild@<0.28.1: ^0.28.1
 
@@ -1079,23 +1080,11 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
   '@opentelemetry/core@2.8.0':
     resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/resources@2.7.1':
-    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/resources@2.8.0':
     resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
@@ -1103,8 +1092,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-metrics@2.7.1':
-    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+  '@opentelemetry/sdk-metrics@2.8.0':
+    resolution: {integrity: sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
@@ -5042,7 +5031,7 @@ snapshots:
       '@logtape/logtape': 2.2.1
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       byte-encodings: 1.0.11
@@ -5490,20 +5479,9 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.41.1
-
   '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.41.1
-
-  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
@@ -5512,11 +5490,11 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,6 @@ allowBuilds:
   esbuild: true
   unrs-resolver: true
 minimumReleaseAgeExclude:
-  - cookie@0.7.0
   - esbuild@0.28.1
   - '@esbuild/aix-ppc64@0.28.1'
   - '@esbuild/android-arm@0.28.1'
@@ -47,8 +46,8 @@ minimumReleaseAgeExclude:
   - '@esbuild/win32-ia32@0.28.1'
   - '@esbuild/win32-x64@0.28.1'
   - ws@8.21.0
-  - js-yaml@4.1.2
   - hono@4.12.25
 overrides:
+  '@opentelemetry/sdk-metrics@<2.8.0': ^2.8.0
   cookie@<0.7.0: ^0.7.0
   esbuild@<0.28.1: ^0.28.1


### PR DESCRIPTION
## 무엇을 변경했는지

- `pnpm-workspace.yaml`에 `@opentelemetry/sdk-metrics@<2.8.0`을 2.8.0 라인으로 해석하는 override만 남겼습니다.
- `pnpm-lock.yaml`에서 `@opentelemetry/sdk-metrics`, `@opentelemetry/resources`, `@opentelemetry/core` 경로가 모두 2.8.0으로 수렴하도록 갱신했습니다.
- Dependabot alert #25의 대상인 `@opentelemetry/core@2.7.1` lockfile 항목을 제거했습니다.
- 현재 lockfile에 없는 `minimumReleaseAgeExclude` 예외인 `cookie@0.7.0`, `js-yaml@4.1.2`를 제거했습니다.

## 왜 변경했는지

Dependabot alert #25가 `@opentelemetry/core`의 W3C Baggage propagation 관련 메모리 할당 취약점(GHSA-8988-4f7v-96qf, CVE-2026-54285)을 보고하고 있습니다. 취약 범위는 `< 2.8.0`이고, 현재 lockfile에서는 `@fedify/fedify` 아래 `@opentelemetry/sdk-metrics@2.7.1` 경로가 `@opentelemetry/core@2.7.1`을 끌고 와 알림이 열린 상태였습니다.

`@fedify/fedify@2.3.1`도 `@opentelemetry/sdk-metrics`를 정확히 `2.7.1`로 pin하고 있어 직접 update만으로는 알림이 닫히지 않습니다. 그래서 pin된 `sdk-metrics`만 override하고, 그 하위 `core`/`resources`는 `sdk-metrics@2.8.0`의 정상 dependency graph로 따라가게 했습니다.

## 어떻게 확인할 수 있는지

- `pnpm install --frozen-lockfile --lockfile-only --store-dir .pnpm-store`
- `CI=true pnpm install --frozen-lockfile --store-dir .pnpm-store`
- `pnpm lint:syncpack`
- `pnpm lint:prettier`
- `pnpm why @opentelemetry/core --recursive`에서 `@opentelemetry/core@2.8.0` 단일 버전만 확인
- `rg -n "@opentelemetry/(core|resources|sdk-metrics)@2\.7\.1|@opentelemetry/(core|resources|sdk-metrics): 2\.7\.1" pnpm-lock.yaml` 결과 없음

## 아직 어떤 문제가 남았는지

없음