### PR TITLE
Helm 배포 후속 설정을 보정한다

### DIFF
--- a/applicationset.yaml
+++ b/applicationset.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       name: 'kosmo-{{env}}'
     spec:
+      project: default
       source:
         repoURL: https://github.com/byulmaru/kosmo.git
         targetRevision: main

--- a/apps/helm/templates/api/rollout.yaml
+++ b/apps/helm/templates/api/rollout.yaml
@@ -33,6 +33,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
             capabilities:
               drop:
                 - ALL

--- a/apps/helm/templates/web/rollout.yaml
+++ b/apps/helm/templates/web/rollout.yaml
@@ -33,6 +33,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
## 무엇을 변경했는지

- ApplicationSet의 Argo CD project를 `default`로 명시했습니다.
- web/api Rollout 컨테이너 securityContext에 `runAsUser: 10001`, `runAsGroup: 10001`을 추가했습니다.

## 왜 변경했는지

#201이 머지된 뒤 ApplicationSet에서 `project`를 완전히 제거하면 Argo CD Application spec 계약에 맞지 않습니다. 별도 AppProject를 쓰지 않는 현재 구성에서는 `default` project를 명시해야 합니다.

또한 Dockerfile은 `USER app`처럼 문자열 user를 사용하지만 Kubernetes는 `runAsNonRoot: true`만으로 문자열 user가 non-root인지 검증할 수 없어 Pod 생성이 실패합니다. Dockerfile에서 `app` user/group을 UID/GID `10001`로 생성하므로 Rollout에도 같은 numeric user/group을 명시했습니다.

## 어떻게 확인할 수 있는지

- `pnpm lint:prettier`
- `helm lint apps/helm`
- `helm template kosmo apps/helm --namespace kosmo-dev`

## 아직 어떤 문제가 남았는지

없음