### PR TITLE
dev DB를 Tailscale로 접근할 수 있게 한다

### DIFF
--- a/apps/helm/Chart.yaml
+++ b/apps/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kosmo-web
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: '1.0.0'

--- a/apps/helm/templates/_helpers.tpl
+++ b/apps/helm/templates/_helpers.tpl
@@ -6,6 +6,14 @@
 {{- printf "%s-postgres" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kosmo.postgresTailscaleName" -}}
+{{- printf "%s-postgres-ts" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kosmo.postgresTailscaleHostname" -}}
+{{- printf "%s-%s-postgres" .Release.Name .Values.env | lower | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "kosmo.databaseUrl" -}}
 {{- printf "postgres://kosmo:$(DATABASE_PASSWORD)@%s-rw:5432/kosmo" (include "kosmo.postgresName" .) -}}
 {{- end -}}

--- a/apps/helm/templates/api/httproute.yaml
+++ b/apps/helm/templates/api/httproute.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.apiDomain -}}
 {{- $hostname := trimSuffix "." .Values.apiDomain -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -23,3 +24,4 @@ spec:
       backendRefs:
         - name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
           port: 80
+{{- end }}

--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   instances: 1
+  {{- if eq .Values.env "dev" }}
+  postgresql:
+    pg_hba:
+      - host kosmo kosmo 100.64.0.0/10 trust
+  {{- end }}
   bootstrap:
     initdb:
       database: kosmo

--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -9,11 +9,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   instances: 1
-  {{- if eq .Values.env "dev" }}
-  postgresql:
-    pg_hba:
-      - host kosmo kosmo 100.64.0.0/10 trust
-  {{- end }}
   bootstrap:
     initdb:
       database: kosmo

--- a/apps/helm/templates/postgres-tailscale-service.yaml
+++ b/apps/helm/templates/postgres-tailscale-service.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Values.env "dev" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kosmo.postgresTailscaleName" . }}
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: postgres-tailscale
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    tailscale.com/hostname: {{ include "kosmo.postgresTailscaleHostname" . | quote }}
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    cnpg.io/cluster: {{ include "kosmo.postgresName" . }}
+    cnpg.io/instanceRole: primary
+{{- end }}

--- a/apps/helm/templates/postgres-tailscale-service.yaml
+++ b/apps/helm/templates/postgres-tailscale-service.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     tailscale.com/hostname: {{ include "kosmo.postgresTailscaleHostname" . | quote }}
+    tailscale.com/tags: "tag:dev-database"
 spec:
   type: LoadBalancer
   loadBalancerClass: tailscale

--- a/apps/helm/templates/postgres-tailscale-service.yaml
+++ b/apps/helm/templates/postgres-tailscale-service.yaml
@@ -13,6 +13,7 @@ metadata:
     tailscale.com/tags: "tag:dev-database"
 spec:
   type: LoadBalancer
+  allocateLoadBalancerNodePorts: false
   loadBalancerClass: tailscale
   ports:
     - name: postgres

--- a/apps/helm/templates/web/httproute.yaml
+++ b/apps/helm/templates/web/httproute.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webDomain -}}
 {{- $hostname := trimSuffix "." .Values.webDomain -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -23,3 +24,4 @@ spec:
       backendRefs:
         - name: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" }}
           port: 80
+{{- end }}

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -1,5 +1,3 @@
-env: ''
-webDomain: dev.kos.moe
-apiDomain: dev-api.kos.moe
+env:
 image: ghcr.io/byulmaru/kosmo
 version: latest

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -1,4 +1,4 @@
-env: dev
+env: ''
 webDomain: dev.kos.moe
 apiDomain: dev-api.kos.moe
 image: ghcr.io/byulmaru/kosmo


### PR DESCRIPTION
## 무엇을 변경했는지

- dev 환경에서만 CNPG primary를 가리키는 Tailscale LoadBalancer Service를 생성합니다.
- Tailscale DB hostname은 `kosmo-dev-postgres`로 렌더링하고, Tailscale device tag는 `tag:dev-database`로 지정합니다.
- Tailscale LoadBalancer Service에서 `allocateLoadBalancerNodePorts: false`를 설정해 NodePort 우회 경로를 만들지 않습니다.
- Helm chart 기본 `values.yaml`에는 `env`, `image`, `version`만 남깁니다.
- `env`, `webDomain`, `apiDomain` 값이 명시된 경우에만 dev DB Tailscale Service와 HTTPRoute가 렌더링되게 합니다.
- Helm chart version을 `0.2.1`로 올립니다.

## 왜 변경했는지

로컬 개발 환경에서 dev DB에 직접 접속할 수 있어야 합니다. 운영 DB 접속 구조와 분리하기 위해 이 노출은 `env: dev`일 때만 생성하고, Tailscale 네트워크를 통한 접근으로 제한합니다.

PostgreSQL 인증은 기존 CNPG app user/password를 그대로 유지합니다. Tailscale L3 ingress 경로에서는 PostgreSQL이 원래 tailnet client source IP를 보지 않을 수 있으므로, `pg_hba trust` 기반 passwordless 접속은 이 PR에서 사용하지 않습니다.

Tailscale L3 ingress는 proxy Pod가 Service 내부 ClusterIP로 DNAT하므로 LoadBalancer Service의 NodePort가 필요 없습니다. NodePort가 열리면 Tailnet ACL을 우회하는 별도 접근면이 생길 수 있어 명시적으로 비활성화합니다.

기본 values는 실제 배포값을 암시하지 않도록 비워둡니다. ApplicationSet이 dev 배포에 필요한 `env`, `webDomain`, `apiDomain`, `image`, `version` 값을 명시로 주입합니다.

## 전제 조건

- Tailnet policy에 `tag:dev-database`가 정의되어 있어야 합니다.
- Tailscale Kubernetes Operator가 `tag:dev-database` device를 만들 수 있도록 tag owner가 설정되어 있어야 합니다.
- Tailnet ACL/Grant는 `tag:dev-database` 대상 `tcp:5432` 접근을 의도한 개발자/그룹에게만 허용해야 합니다.
- 이 PR은 ACL/Grant 자체를 변경하지 않습니다. ACL/Grant는 인프라/tailnet policy 쪽에서 별도로 준비되어 있다는 전제입니다.
- ApplicationSet은 `env: dev`, `webDomain`, `apiDomain`을 명시로 넘기므로 dev 배포에서는 HTTPRoute와 DB Tailscale Service가 생성됩니다. 반대로 값을 생략한 수동 Helm 렌더링에서는 생성되지 않습니다.

## 어떻게 확인할 수 있는지

- `helm lint apps/helm`
- `helm template kosmo apps/helm --namespace kosmo-dev`
- `helm template kosmo apps/helm --namespace kosmo-dev --set env=dev --set webDomain=dev.kos.moe --set apiDomain=dev-api.kos.moe`
- `helm template kosmo apps/helm --namespace kosmo-prod --set env=prod`
- `helm template kosmo apps/helm --namespace kosmo-dev --set env=dev --set webDomain=dev.kos.moe --set apiDomain=dev-api.kos.moe | kubectl apply --dry-run=server -f -`
- `pnpm lint:prettier`

## 배포 후 확인할 것

- `kosmo-postgres-ts` Service가 생성되는지 확인합니다.
- Tailscale device가 `tag:dev-database`를 실제로 받았는지 확인합니다.
- Service에 NodePort가 할당되지 않았는지 확인합니다.
- CNPG app user password로 Tailscale hostname을 통해 dev DB에 접속되는지 확인합니다.

```sh
kubectl -n kosmo-dev get svc kosmo-postgres-ts
PASSWORD="$(kubectl -n kosmo-dev get secret kosmo-postgres-app -o jsonpath='{.data.password}' | base64 -d)"
psql "postgres://kosmo:${PASSWORD}@kosmo-dev-postgres.tail1fdd55.ts.net:5432/kosmo"
```

## 아직 어떤 문제가 남았는지

- 현재는 dev DB용 standalone Tailscale Service이므로, Tailscale proxy 자체의 HA는 구성하지 않습니다.
- passwordless DB 접속은 이 PR에서 다루지 않습니다. 필요하면 Vault dynamic DB credentials 또는 PostgreSQL client certificate auth로 별도 설계합니다.
