### PR TITLE
개발 스크립트 비밀값을 Vault에서 주입한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,26 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Get secrets from Infisical
-        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995 # v1.0.16
-        with:
-          method: oidc
-          domain: https://${{ secrets.INFISICAL_HOST }}
-          identity-id: ${{ secrets.INFISICAL_MACHINE_IDENTITY_ID }}
-          project-slug: kosmo
-          env-slug: prod
-
-      - name: Prepare web build env
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          env | while IFS='=' read -r name value; do
-            if [[ "$name" == PUBLIC_* ]]; then
-              printf '%s=%q\n' "$name" "$value"
-            fi
-          done | sort > .web-build.env
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -75,11 +55,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            PUBLIC_ENV_HASH=${{ hashFiles('.web-build.env') }}
           no-cache-filters: base
-          secret-files: |
-            web_build_env=.web-build.env
 
       - name: Select image tag for Trivy
         id: trivy-image

--- a/.infisical.json
+++ b/.infisical.json
@@ -1,5 +1,0 @@
-{
-  "workspaceId": "8e05f8b4-604a-4a3e-a4f2-77a89a8318be",
-  "defaultEnvironment": "local",
-  "gitBranchToEnvironmentMapping": null
-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,7 @@ RUN pnpm install --frozen-lockfile
 
 FROM deps AS web-build
 
-ARG PUBLIC_ENV_HASH
-
-RUN --mount=type=secret,id=web_build_env,required=true,mode=0400 \
-  : "${PUBLIC_ENV_HASH}" \
-  && set -a \
-  && . /run/secrets/web_build_env \
-  && set +a \
-  && pnpm --filter @kosmo/web build
+RUN pnpm --filter @kosmo/web build
 
 FROM base AS runtime
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 AWS Terraform root is documented in [apps/terraform/README.md](apps/terraform/README.md).
 
+## Development Secrets
+
+Dev scripts load environment variables from Vault through `scripts/vault-run.mjs`.
+Install the Vault CLI and set `VAULT_ADDR`; if needed, the wrapper runs
+`vault login -method=oidc` before reading secrets. Use normal workspace scripts
+such as `pnpm dev`. The default secret path is
+`secret/kubernetes/kosmo/local`; use
+`node scripts/vault-run.mjs --env dev -- pnpm --recursive --parallel --if-present dev`
+or `node scripts/vault-run.mjs --secret-path secret/kubernetes/kosmo/dev -- <command>`
+to point at another path.
+
 ## Test Postgres
 
 Run a local PostgreSQL instance for tests with Docker Compose:

--- a/apps/app/android/package.json
+++ b/apps/app/android/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "infisical run -- ./gradlew assembleDebug",
+    "build": "node ../../../scripts/vault-run.mjs -- ./gradlew assembleDebug",
     "run": "node scripts/run.mjs",
     "run:debug": "node scripts/run.mjs --debug"
   }

--- a/apps/app/ios/package.json
+++ b/apps/app/ios/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "infisical run -- node scripts/generate-info-plist.mjs && infisical run -- xcodebuild -project Kosmo.xcodeproj -scheme Kosmo -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS' -derivedDataPath build/DerivedData INFOPLIST_FILE=build/Info.plist -allowProvisioningUpdates build",
+    "build": "node ../../../scripts/vault-run.mjs -- node scripts/generate-info-plist.mjs && node ../../../scripts/vault-run.mjs -- xcodebuild -project Kosmo.xcodeproj -scheme Kosmo -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS' -derivedDataPath build/DerivedData INFOPLIST_FILE=build/Info.plist -allowProvisioningUpdates build",
     "run": "node scripts/run.mjs",
     "run:debug": "node scripts/run.mjs --debug"
   }

--- a/apps/app/ios/scripts/run.mjs
+++ b/apps/app/ios/scripts/run.mjs
@@ -106,9 +106,9 @@ const readSimulators = () => {
 };
 
 const buildApp = (target) => {
-  run('infisical', ['run', '--', 'node', 'scripts/generate-info-plist.mjs']);
-  run('infisical', [
-    'run',
+  run('node', ['../../../scripts/vault-run.mjs', '--', 'node', 'scripts/generate-info-plist.mjs']);
+  run('node', [
+    '../../../scripts/vault-run.mjs',
     '--',
     'xcodebuild',
     '-project',

--- a/memory/script.md
+++ b/memory/script.md
@@ -5,7 +5,8 @@
 - `pnpm-workspace.yaml`은 package manager mismatch 처리를 `ignore`로 둬 pnpm이 sandbox 내부에서 `packageManager`에 명시된 pnpm 자체를 자동 fetch하지 않게 한다.
 - sandbox 실패나 fallback 실행으로 workspace 안에 `.pnpm-store/`가 생길 수 있으므로 git, Prettier, ESLint ignore 대상으로 둔다.
 - `pnpm --recursive --parallel --if-present <script>`는 루트 패키지의 `<script>`를 재귀 실행하지 않고, workspace 패키지들의 해당 script를 실행한다.
-- 루트 `dev` 스크립트가 `infisical run -- pnpm --recursive --parallel --if-present dev`처럼 workspace script 실행을 감싸는 구조여도, 이것만으로 루트 `dev`가 자기 자신을 무한 재귀 호출한다고 판단하면 안 된다.
+- 루트 `dev` 스크립트가 `node scripts/vault-run.mjs -- pnpm --recursive --parallel --if-present dev`처럼 workspace script 실행을 감싸는 구조여도, 이것만으로 루트 `dev`가 자기 자신을 무한 재귀 호출한다고 판단하면 안 된다.
+- `scripts/vault-run.mjs`는 Vault CLI의 현재 인증 상태를 사용해 기본 `secret/kubernetes/kosmo/local` 값을 env로 주입하고, 토큰 조회가 실패하면 `vault login -method=oidc`를 실행한다. 다른 path가 필요하면 wrapper CLI 옵션 `--env <name>` 또는 `--secret-path <path>`를 `-- <command>` 앞에 둔다.
 - 관련 리뷰를 작성하거나 수정할 때는 실제 재현 로그 없이 재귀 실행을 단정하지 않는다.
 - 루트 script 래퍼 구조를 바꾸는 경우, 이 메모의 전제가 여전히 맞는지 확인하고 변경 사항을 업데이트한다.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "db:test:reset": "node scripts/test-db.mjs reset",
     "db:test:up": "node scripts/test-db.mjs up",
     "db:bootstrap-local-instance": "pnpm --filter @kosmo/api db:bootstrap-local-instance",
-    "dev": "infisical run -- pnpm --recursive --parallel --if-present dev",
+    "dev": "node scripts/vault-run.mjs -- pnpm --recursive --parallel --if-present dev",
     "lint:eslint": "eslint --max-warnings 0 .",
     "lint:prettier": "prettier --check --ignore-unknown '**/*'",
     "lint:syncpack": "syncpack lint --dependency-types prod,dev,peer",
@@ -19,6 +19,8 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@fission-ai/openspec": "^1.3.1",
+    "@optique/core": "^1.1.1",
+    "@optique/run": "^1.1.1",
     "@types/node": "^25.6.2",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,9 +28,9 @@
     "zod": "^4.4.3"
   },
   "scripts": {
-    "drizzle:generate": "infisical run -- drizzle-kit generate",
-    "drizzle:push": "infisical run -- drizzle-kit push",
-    "drizzle:studio": "infisical run -- drizzle-kit studio"
+    "drizzle:generate": "node ../../scripts/vault-run.mjs -- drizzle-kit generate",
+    "drizzle:push": "node ../../scripts/vault-run.mjs -- drizzle-kit push",
+    "drizzle:studio": "node ../../scripts/vault-run.mjs -- drizzle-kit studio"
   },
   "devDependencies": {
     "drizzle-kit": "1.0.0-beta.22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
       '@fission-ai/openspec':
         specifier: ^1.3.1
         version: 1.3.1(@types/node@25.6.2)
+      '@optique/core':
+        specifier: ^1.1.1
+        version: 1.1.1
+      '@optique/run':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@types/node':
         specifier: ^25.6.2
         version: 25.6.2
@@ -1107,6 +1113,14 @@ packages:
   '@opentelemetry/semantic-conventions@1.41.1':
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
+
+  '@optique/core@1.1.1':
+    resolution: {integrity: sha512-tbZLdH5wEnh8IRG8KTmWPZCKHLmD4bXigoPdzoSUVi+V46qZTNEaTdqtR7EuEwhbPI0KQjLSYRZCxFTdr9OZkA==}
+    engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
+
+  '@optique/run@1.1.1':
+    resolution: {integrity: sha512-jSZeuiljDEWYkQ67bVDucRknzFVwiSH1j4ho2jFWfcdMMa+WDRSfZA3GZoHA8zKj0Bf6UbJ+FMs/2IReQ0KYNQ==}
+    engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
@@ -5504,6 +5518,12 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@optique/core@1.1.1': {}
+
+  '@optique/run@1.1.1':
+    dependencies:
+      '@optique/core': 1.1.1
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     optional: true

--- a/scripts/vault-run.mjs
+++ b/scripts/vault-run.mjs
@@ -1,0 +1,104 @@
+import { spawnSync } from 'node:child_process';
+import {
+  argument,
+  message,
+  multiple,
+  object,
+  option,
+  optional,
+  string,
+  withDefault,
+} from '@optique/core';
+import { run } from '@optique/run';
+
+const config = run(
+  object({
+    env: withDefault(
+      option('--env', string({ metavar: 'NAME' }), {
+        description: message`Vault environment name under secret/kubernetes/kosmo/.`,
+      }),
+      'local',
+    ),
+    secretPath: optional(
+      option('--secret-path', string({ metavar: 'PATH' }), {
+        description: message`Full Vault KV path. Overrides --env.`,
+      }),
+    ),
+    command: multiple(
+      argument(string({ metavar: 'COMMAND' }), {
+        description: message`Command to run with Vault values in the environment.`,
+      }),
+    ),
+  }),
+  {
+    help: 'option',
+    programName: 'vault-run',
+  },
+);
+const command = config.command;
+const secretPath = config.secretPath ?? `secret/kubernetes/kosmo/${config.env}`;
+
+if (command.length === 0) {
+  console.error('Usage: vault-run [--env <name>] [--secret-path <path>] -- <command> [args...]');
+  process.exit(1);
+}
+
+const tokenLookup = spawnSync('vault', ['token', 'lookup', '-format=json'], {
+  stdio: 'ignore',
+});
+
+if (tokenLookup.error) {
+  console.error(`Failed to run vault: ${tokenLookup.error.message}`);
+  process.exit(1);
+}
+
+if (tokenLookup.status !== 0) {
+  const login = spawnSync('vault', ['login', '-method=oidc'], { stdio: 'inherit' });
+
+  if (login.error) {
+    console.error(`Failed to run vault: ${login.error.message}`);
+    process.exit(1);
+  }
+
+  if (login.status !== 0) {
+    process.exit(login.status ?? 1);
+  }
+}
+
+const vault = spawnSync('vault', ['kv', 'get', '-format=json', secretPath], {
+  encoding: 'utf8',
+});
+
+if (vault.error) {
+  console.error(`Failed to run vault: ${vault.error.message}`);
+  process.exit(1);
+}
+
+if (vault.status !== 0) {
+  process.stderr.write(vault.stderr);
+  process.exit(vault.status ?? 1);
+}
+
+const payload = JSON.parse(vault.stdout);
+const vaultData = payload.data ?? {};
+const data =
+  typeof vaultData.data === 'object' && vaultData.data !== null && 'metadata' in vaultData
+    ? vaultData.data
+    : vaultData;
+const env = { ...process.env };
+
+for (const [key, value] of Object.entries(data)) {
+  env[key] = String(value);
+}
+
+const result = spawnSync(command[0], command.slice(1), {
+  env,
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(`Failed to run ${command[0]}: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## 무엇을 변경했는지

- Infisical 기반 개발 스크립트 래퍼를 제거하고 `scripts/vault-run.mjs`를 추가했습니다.
- `vault-run`은 Optique로 `--env`, `--secret-path`, 실행 명령을 파싱하고, Vault CLI로 secret을 읽어 하위 명령 환경변수로 주입합니다.
- Vault 토큰 조회가 실패하면 `vault login -method=oidc`를 실행한 뒤 secret을 다시 읽습니다.
- Docker/CI에서 더 이상 필요하지 않은 빌드 타임 public env secret 주입을 제거했습니다.
- `.infisical.json`을 삭제하고 관련 README 및 script memory를 갱신했습니다.

## 왜 변경했는지

운영 서버에서는 이미 Vault 기반 Secret이 환경변수로 주입되지만, 로컬 개발 스크립트는 여전히 Infisical에 의존하고 있었습니다. 개발 흐름도 Vault를 source of truth로 맞추고, secret 선택은 환경변수가 아니라 wrapper CLI 옵션으로 명시하도록 변경했습니다.

## 어떻게 확인할 수 있는지

- `node --check scripts/vault-run.mjs`
- `node scripts/vault-run.mjs --help`
- `pnpm lint:prettier`
- `pnpm --filter @kosmo/web build`
- `git diff --check`
- commit hook에서 `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown` 실행
- 로컬에서 Vault OIDC 로그인과 secret read 확인

## 아직 어떤 문제가 남았는지

없음

Stack: `main -> agent/vault-dev-secrets`