### PR TITLE
홈과 프로필 타임라인 E2E를 추가한다

### DIFF
--- a/apps/web/e2e/db-fixtures.ts
+++ b/apps/web/e2e/db-fixtures.ts
@@ -7,6 +7,9 @@ import {
   firstOrThrow,
   Instances,
   pg,
+  PostContents,
+  Posts,
+  ProfileFollows,
   Profiles,
   Sessions,
 } from '@kosmo/core/db';
@@ -14,13 +17,22 @@ import { seedDatabase } from '@kosmo/core/db/seed';
 import {
   AccountProfileRole,
   AccountState,
+  PostState,
+  PostVisibility,
   ProfileFollowPolicy,
   ProfileState,
   SessionState,
 } from '@kosmo/core/enums';
+import {
+  createTipTapDocumentFromPlainText,
+  extractPlainTextFromTipTapDocument,
+} from '@kosmo/core/tiptap';
+import { eq } from 'drizzle-orm';
+import { Temporal } from 'temporal-polyfill';
 import type { BrowserContext } from '@playwright/test';
 
 const webOrigin = 'http://127.0.0.1:4173';
+let lastPostSeedTimestamp = 0;
 
 type CreateE2ESessionOptions = {
   accountState?: AccountState;
@@ -32,7 +44,38 @@ type CreateE2ESessionOptions = {
   token?: string;
 };
 
+type CreateE2EProfileOptions = {
+  displayName?: string;
+  followPolicy?: ProfileFollowPolicy;
+  handle?: string;
+  state?: ProfileState;
+};
+
+type CreateE2EFollowOptions = {
+  createdAt?: string;
+  followeeProfileId: string;
+  followerProfileId: string;
+};
+
+type CreateE2EPostOptions = {
+  body?: string;
+  createdAt?: string;
+  profileId: string;
+  state?: PostState;
+  visibility?: PostVisibility;
+};
+
+const toInstant = (value?: string) => (value ? Temporal.Instant.from(value) : undefined);
+
+async function waitForNextPostSeedTimestamp() {
+  while (Date.now() <= lastPostSeedTimestamp) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
 export async function resetE2EDatabase() {
+  lastPostSeedTimestamp = 0;
+
   await pg.unsafe(`
     DO $$
     DECLARE
@@ -111,6 +154,83 @@ export async function createE2ESession(options: CreateE2ESessionOptions = {}) {
     .then(firstOrThrow);
 
   return { account, profile, session, token };
+}
+
+export async function createE2EProfile(options: CreateE2EProfileOptions = {}) {
+  const suffix = randomUUID().slice(0, 8);
+  const displayName = options.displayName ?? `E2E Profile ${suffix}`;
+  const handle = options.handle ?? `e2e-profile-${suffix}`;
+  const instance = await db.select().from(Instances).limit(1).then(firstOrThrow);
+
+  return await db
+    .insert(Profiles)
+    .values({
+      displayName,
+      followPolicy: options.followPolicy ?? ProfileFollowPolicy.OPEN,
+      handle,
+      instanceId: instance.id,
+      normalizedHandle: handle.toLowerCase(),
+      state: options.state ?? ProfileState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+}
+
+export async function createE2EFollow(options: CreateE2EFollowOptions) {
+  const createdAt = toInstant(options.createdAt);
+
+  return await db
+    .insert(ProfileFollows)
+    .values({
+      followeeProfileId: options.followeeProfileId,
+      followerProfileId: options.followerProfileId,
+      ...(createdAt ? { createdAt } : {}),
+    })
+    .returning()
+    .then(firstOrThrow);
+}
+
+export async function createE2EPost(options: CreateE2EPostOptions) {
+  const bodyJson = createTipTapDocumentFromPlainText(options.body ?? '');
+  const bodyText = extractPlainTextFromTipTapDocument(bodyJson);
+  const createdAt = toInstant(options.createdAt);
+
+  await waitForNextPostSeedTimestamp();
+
+  const post = await db.transaction(async (tx) => {
+    const post = await tx
+      .insert(Posts)
+      .values({
+        profileId: options.profileId,
+        state: options.state ?? PostState.ACTIVE,
+        visibility: options.visibility ?? PostVisibility.PUBLIC,
+        ...(createdAt ? { createdAt } : {}),
+      })
+      .returning()
+      .then(firstOrThrow);
+
+    const content = await tx
+      .insert(PostContents)
+      .values({
+        bodyJson,
+        bodyText,
+        postId: post.id,
+        ...(createdAt ? { createdAt } : {}),
+      })
+      .returning()
+      .then(firstOrThrow);
+
+    return await tx
+      .update(Posts)
+      .set({ currentContentId: content.id })
+      .where(eq(Posts.id, post.id))
+      .returning()
+      .then(firstOrThrow);
+  });
+
+  lastPostSeedTimestamp = Date.now();
+
+  return post;
 }
 
 export async function setE2ESessionCookie(context: BrowserContext, token: string) {

--- a/apps/web/e2e/timelines.e2e.ts
+++ b/apps/web/e2e/timelines.e2e.ts
@@ -1,0 +1,226 @@
+import {
+  createE2EFollow,
+  createE2EPost,
+  createE2EProfile,
+  createE2ESession,
+  resetE2EDatabase,
+  setE2ESessionCookie,
+} from './db-fixtures';
+import { expect, test } from './fixtures';
+import type { Page } from '@playwright/test';
+
+const minute = 60_000;
+const day = 24 * 60 * minute;
+
+function isoAgo(milliseconds: number) {
+  return new Date(Date.now() - milliseconds).toISOString();
+}
+
+function formatDateLabel(iso: string) {
+  return new Date(iso)
+    .toLocaleString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
+    .replace(/\.$/, '');
+}
+
+async function expectPostOrder(page: Page, bodies: string[]) {
+  const bodyLinks = page.getByRole('link').filter({ hasText: /^E2E timeline/ });
+
+  await expect(bodyLinks).toHaveCount(bodies.length);
+  await expect(bodyLinks).toHaveText(bodies);
+}
+
+test.beforeEach(async () => {
+  await resetE2EDatabase();
+});
+
+test('홈 타임라인은 본인 글과 팔로우한 프로필 글만 최신순으로 보여준다', async ({
+  context,
+  page,
+}) => {
+  const viewer = await createE2ESession({
+    displayName: 'E2E Timeline Viewer',
+    handle: 'e2e-timeline-viewer',
+  });
+  const followedProfile = await createE2EProfile({
+    displayName: 'E2E Followed Writer',
+    handle: 'e2e-followed-writer',
+  });
+  const unfollowedProfile = await createE2EProfile({
+    displayName: 'E2E Hidden Writer',
+    handle: 'e2e-hidden-writer',
+  });
+  const viewerPostTime = isoAgo(10 * minute);
+  const followedPostTime = isoAgo(2 * minute);
+  const oldFollowedPostTime = isoAgo(2 * day);
+
+  await createE2EFollow({
+    followerProfileId: viewer.profile!.id,
+    followeeProfileId: followedProfile.id,
+  });
+  await createE2EPost({
+    profileId: followedProfile.id,
+    body: 'E2E timeline followed old body',
+    createdAt: oldFollowedPostTime,
+  });
+  await createE2EPost({
+    profileId: viewer.profile!.id,
+    body: 'E2E timeline viewer body',
+    createdAt: viewerPostTime,
+  });
+  await createE2EPost({
+    profileId: followedProfile.id,
+    body: 'E2E timeline followed latest body',
+    createdAt: followedPostTime,
+  });
+  await createE2EPost({
+    profileId: unfollowedProfile.id,
+    body: 'E2E timeline hidden body',
+    createdAt: isoAgo(minute),
+  });
+  await setE2ESessionCookie(context, viewer.token);
+
+  await page.goto('/home');
+
+  await expect(page.getByRole('heading', { name: '홈' })).toBeVisible();
+  await expectPostOrder(page, [
+    'E2E timeline followed latest body',
+    'E2E timeline viewer body',
+    'E2E timeline followed old body',
+  ]);
+  await expect(page.getByText('E2E timeline hidden body')).toHaveCount(0);
+  await expect(
+    page.getByRole('link', { name: 'E2E Followed Writer @e2e-followed-writer' }),
+  ).toHaveCount(2);
+  await expect(
+    page.getByRole('link', { name: 'E2E Timeline Viewer @e2e-timeline-viewer' }),
+  ).toHaveCount(1);
+  await expect(page.getByRole('link', { name: /분 전|시간 전|지금/ }).first()).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: formatDateLabel(oldFollowedPostTime) }),
+  ).toBeVisible();
+  await expect(page.getByText('게시글 목록을 불러오는 중입니다.')).toHaveCount(0);
+  await expect(page.getByText('아직 게시글이 없어요')).toHaveCount(0);
+});
+
+test('프로필 게시글 목록은 해당 프로필이 작성한 글만 보여준다', async ({ context, page }) => {
+  const viewer = await createE2ESession({
+    displayName: 'E2E Profile Viewer',
+    handle: 'e2e-profile-viewer',
+  });
+  const targetProfile = await createE2EProfile({
+    displayName: 'E2E Profile Writer',
+    handle: 'e2e-profile-writer',
+  });
+
+  await createE2EPost({
+    profileId: targetProfile.id,
+    body: 'E2E timeline profile older body',
+    createdAt: isoAgo(90 * minute),
+  });
+  await createE2EPost({
+    profileId: targetProfile.id,
+    body: 'E2E timeline profile latest body',
+    createdAt: isoAgo(3 * minute),
+  });
+  await createE2EPost({
+    profileId: viewer.profile!.id,
+    body: 'E2E timeline other profile body',
+    createdAt: isoAgo(minute),
+  });
+  await setE2ESessionCookie(context, viewer.token);
+
+  await page.goto('/@e2e-profile-writer');
+
+  await expect(page.getByRole('link', { name: /E2E Profile Writer/ }).first()).toContainText(
+    '@e2e-profile-writer',
+  );
+  await expectPostOrder(page, [
+    'E2E timeline profile latest body',
+    'E2E timeline profile older body',
+  ]);
+  await expect(page.getByText('E2E timeline other profile body')).toHaveCount(0);
+});
+
+test('게시글이 없는 홈과 프로필 목록은 빈 상태를 보여준다', async ({ context, page }) => {
+  const viewer = await createE2ESession({
+    displayName: 'E2E Empty Viewer',
+    handle: 'e2e-empty-viewer',
+  });
+  const emptyProfile = await createE2EProfile({
+    displayName: 'E2E Empty Profile',
+    handle: 'e2e-empty-profile',
+  });
+
+  await setE2ESessionCookie(context, viewer.token);
+
+  await page.goto('/home');
+  await expect(page.getByRole('heading', { name: '홈' })).toBeVisible();
+  await expect(page.getByText('아직 게시글이 없어요')).toBeVisible();
+
+  await page.goto(`/@${emptyProfile.handle}`);
+  await expect(page.getByText('아직 게시글이 없어요')).toBeVisible();
+});
+
+test('빈 본문과 긴 본문 게시글도 목록 항목으로 렌더한다', async ({ context, page }) => {
+  const viewer = await createE2ESession({
+    displayName: 'E2E Body Viewer',
+    handle: 'e2e-body-viewer',
+  });
+  const longBody = `E2E timeline long body ${'긴 본문 '.repeat(80)}`;
+
+  await createE2EPost({
+    profileId: viewer.profile!.id,
+    body: '',
+    createdAt: isoAgo(4 * minute),
+  });
+  await createE2EPost({
+    profileId: viewer.profile!.id,
+    body: longBody,
+    createdAt: isoAgo(2 * minute),
+  });
+  await setE2ESessionCookie(context, viewer.token);
+
+  await page.goto('/home');
+
+  await expect(page.getByRole('article')).toHaveCount(2);
+  await expect(page.getByText('E2E timeline long body')).toBeVisible();
+  await expect(page.getByRole('link', { name: /E2E Body Viewer/ }).first()).toContainText(
+    '@e2e-body-viewer',
+  );
+});
+
+test('프로필 게시글 목록 오류 상태는 다시 시도를 제공한다', async ({ context, page }) => {
+  let profilePostsRequestCount = 0;
+  const viewer = await createE2ESession({
+    displayName: 'E2E Profile Error Viewer',
+    handle: 'e2e-profile-error-viewer',
+  });
+  const targetProfile = await createE2EProfile({
+    displayName: 'E2E Profile Error Target',
+    handle: 'e2e-profile-error-target',
+  });
+
+  await setE2ESessionCookie(context, viewer.token);
+  await page.route('**/graphql', async (route) => {
+    const body = route.request().postData() ?? '';
+
+    if (body.includes('ProfilePostListPageQuery')) {
+      profilePostsRequestCount += 1;
+      await route.fulfill({
+        contentType: 'application/json',
+        status: 500,
+        body: JSON.stringify({ errors: [{ message: 'E2E forced profile posts error' }] }),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await page.goto(`/@${targetProfile.handle}`);
+
+  await expect(page.getByRole('alert')).toContainText('게시글 목록을 불러오지 못했어요');
+  const previousCount = profilePostsRequestCount;
+  await page.getByRole('button', { name: '다시 시도' }).click();
+  await expect.poll(() => profilePostsRequestCount).toBeGreaterThan(previousCount);
+});


### PR DESCRIPTION
Stack: main -> PROD-232 -> PROD-229

## 무엇을 변경했는지
- `apps/web/e2e/db-fixtures.ts`에 E2E 프로필, 팔로우, 게시글 seed helper를 추가했습니다.
- 게시글 seed에서 `createdAt`을 지정할 수 있게 해 최신순과 시간 표시 검증을 안정화했습니다.
- `apps/web/e2e/timelines.e2e.ts`를 추가해 홈 타임라인과 프로필 게시글 목록의 필터링, 최신순 정렬, 작성자/본문/시간 표시, 빈 상태, 긴 본문/빈 본문, 오류 후 다시 시도 흐름을 검증했습니다.

## 왜 변경했는지
- PROD-229 범위인 홈과 프로필 타임라인의 사용자 가시 동작을 E2E로 고정하기 위해서입니다.
- 본인 글, 팔로우한 프로필 글, 팔로우하지 않은 프로필 글이 섞이는 조건에서 목록 노출 계약을 회귀 테스트로 남깁니다.

## 어떻게 확인할 수 있는지
- `pnpm --filter @kosmo/web test:e2e -- timelines.e2e.ts` 통과: 5 passed.
- `pnpm --filter @kosmo/web exec prettier --check e2e/db-fixtures.ts e2e/timelines.e2e.ts` 통과.
- `git diff --check -- apps\web\e2e\db-fixtures.ts apps\web\e2e\timelines.e2e.ts` 통과.
- `pnpm test:e2e`는 Windows PowerShell에서 루트 스크립트의 POSIX `set -a` 사용 때문에 실행 자체가 실패했습니다.
- 수동으로 테스트 DB reset/schema push 후 `pnpm --filter @kosmo/web test:e2e`를 실행했을 때 새 `timelines.e2e.ts`는 통과했지만, 기존 `auth-routes.e2e.ts`에서 `chrome-error://chromewebdata/`, `ERR_CONNECTION_REFUSED` 계열 실패가 남았습니다. `auth-routes.e2e.ts` 단독 실행도 webServer health 대기에서 timeout이 발생했습니다.

## 아직 어떤 문제가 남았는지
- 전체 E2E는 기존 auth route/webServer 기동 문제 때문에 이 브랜치에서 clean 상태를 확인하지 못했습니다.
- 홈 타임라인의 GraphQL 오류 주입은 현재 `HomePageQuery`가 세션/프로필/타임라인을 함께 조회해 오류 시 `PostList` 오류 상태까지 도달하지 않아 제외했고, 프로필 게시글 목록에서 오류 상태와 다시 시도 재요청을 검증했습니다.
- pagination/더 불러오기, 게시글 작성 후 캐시 갱신, follow/unfollow mutation 자체, 인증/보호 라우트, 스크린샷 기반 시각 회귀, ActivityPub remote post 동작은 이번 PR 범위에서 제외했습니다.