### PR TITLE
dev Postgres PDB를 비활성화한다

### DIFF
--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   instances: 1
+{{- if eq .Values.env "dev" }}
+  enablePDB: false
+{{- end }}
   bootstrap:
     initdb:
       database: kosmo


### PR DESCRIPTION
## 무엇을 변경했는지

- Helm Postgres Cluster 템플릿에서 `env: dev`일 때만 `enablePDB: false`를 렌더링합니다.
- prod 환경에서는 `enablePDB` 필드를 렌더링하지 않아 CloudNativePG 기본 PDB 동작을 그대로 사용합니다.

## 왜 변경했는지

- dev 환경에서는 단일 인스턴스 운영 중 PDB 제약이 유지보수 작업을 방해할 수 있어 낮춥니다.
- prod 환경은 기본 PDB 정책을 유지해야 하므로 별도 값을 넣지 않습니다.

## 어떻게 확인할 수 있는지

- `helm template kosmo apps/helm --set env=dev`
- `helm template kosmo apps/helm --set env=prod`
- `helm lint apps/helm`

## 아직 어떤 문제가 남았는지

없음

Stack: `main` -> `agent/dev-postgres-pdb`