### PR TITLE
main 빌드 성공 후 dev 배포를 갱신한다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,12 +19,12 @@ jobs:
     name: Restart Dev Rollouts
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted]
+    env:
+      ARGOCD_SERVER: https://argocd-aws.tail1fdd55.ts.net
     steps:
       - name: Get Argo CD token
         id: argocd-token
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
         with:
           script: |
             const runtimeToken = process.env.ACTIONS_RUNTIME_TOKEN;
@@ -32,7 +32,7 @@ jobs:
             const server = process.env.ARGOCD_SERVER;
 
             if (!server) {
-              throw new Error("ARGOCD_SERVER repository variable is required.");
+              throw new Error("ARGOCD_SERVER is required.");
             }
 
             if (!runtimeToken || !idTokenUrl) {
@@ -113,7 +113,6 @@ jobs:
       - name: Restart dev rollouts
         env:
           ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
-          ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
           ARGOCD_OPTS: --grpc-web
         shell: bash
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,12 +30,10 @@ jobs:
             const githubToken = await core.getIDToken();
             core.setSecret(githubToken);
 
-            const baseUrl = process.env.ARGOCD_SERVER.replace(/\/$/, "");
-            const dexTokenResponse = await fetch(`${baseUrl}/api/dex/token`, {
+            const response = await fetch(`${process.env.ARGOCD_SERVER.replace(/\/$/, "")}/api/dex/token`, {
               method: "POST",
               headers: {
                 authorization: `Basic ${Buffer.from("argo-cd-cli:").toString("base64")}`,
-                "content-type": "application/x-www-form-urlencoded",
               },
               body: new URLSearchParams({
                 connector_id: "github-actions",
@@ -47,11 +45,11 @@ jobs:
               }),
             });
 
-            if (!dexTokenResponse.ok) {
-              throw new Error(`Dex token exchange failed: ${dexTokenResponse.status} ${await dexTokenResponse.text()}`);
+            if (!response.ok) {
+              throw new Error(`Dex token exchange failed: ${response.status} ${await response.text()}`);
             }
 
-            const dexToken = (await dexTokenResponse.json()).access_token;
+            const { access_token: dexToken } = await response.json();
             if (!dexToken) {
               throw new Error("Dex token response did not include an access token.");
             }

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,7 +20,6 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, macOS]
     env:
-      ARGOCD_BASE_URL: https://argocd-aws.tail1fdd55.ts.net
       ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net
     steps:
       - name: Get Argo CD token
@@ -31,7 +30,7 @@ jobs:
             const githubToken = await core.getIDToken();
             core.setSecret(githubToken);
 
-            const response = await fetch(`${process.env.ARGOCD_BASE_URL.replace(/\/$/, "")}/api/dex/token`, {
+            const response = await fetch(`https://${process.env.ARGOCD_SERVER}/api/dex/token`, {
               method: "POST",
               headers: {
                 authorization: `Basic ${Buffer.from("argo-cd-cli:").toString("base64")}`,

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,128 @@
+name: Deploy Dev
+
+on:
+  workflow_run:
+    workflows: [Docker Build]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-main
+  cancel-in-progress: true
+
+jobs:
+  restart_dev:
+    name: Restart Dev Rollouts
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: [self-hosted]
+    steps:
+      - name: Get Argo CD token
+        id: argocd-token
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
+        with:
+          script: |
+            const runtimeToken = process.env.ACTIONS_RUNTIME_TOKEN;
+            const idTokenUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+            const server = process.env.ARGOCD_SERVER;
+
+            if (!server) {
+              throw new Error("ARGOCD_SERVER repository variable is required.");
+            }
+
+            if (!runtimeToken || !idTokenUrl) {
+              throw new Error("GitHub Actions OIDC environment is unavailable.");
+            }
+
+            const githubTokenResponse = await fetch(idTokenUrl, {
+              method: "POST",
+              headers: {
+                authorization: `bearer ${runtimeToken}`,
+                accept: "application/json; api-version=2.0",
+                "content-type": "application/json",
+              },
+              body: "{}",
+            });
+
+            if (!githubTokenResponse.ok) {
+              throw new Error(`GitHub OIDC token request failed: ${githubTokenResponse.status} ${await githubTokenResponse.text()}`);
+            }
+
+            const githubToken = (await githubTokenResponse.json()).value;
+            if (!githubToken) {
+              throw new Error("GitHub OIDC token response did not include a token.");
+            }
+            core.setSecret(githubToken);
+
+            const baseUrl = /^https?:\/\//.test(server) ? server.replace(/\/$/, "") : `https://${server}`;
+            const dexTokenResponse = await fetch(`${baseUrl}/api/dex/token`, {
+              method: "POST",
+              headers: {
+                authorization: `Basic ${Buffer.from("argo-cd-cli:").toString("base64")}`,
+                "content-type": "application/x-www-form-urlencoded",
+              },
+              body: new URLSearchParams({
+                connector_id: "github-actions",
+                grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+                scope: "openid email profile federated:id",
+                requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+                subject_token: githubToken,
+                subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
+              }),
+            });
+
+            if (!dexTokenResponse.ok) {
+              throw new Error(`Dex token exchange failed: ${dexTokenResponse.status} ${await dexTokenResponse.text()}`);
+            }
+
+            const dexToken = (await dexTokenResponse.json()).access_token;
+            if (!dexToken) {
+              throw new Error("Dex token response did not include an access token.");
+            }
+
+            core.setSecret(dexToken);
+            core.setOutput("token", dexToken);
+
+      - name: Install Argo CD CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if command -v argocd >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          case "$(uname -m)" in
+            x86_64) argocd_arch=amd64 ;;
+            aarch64 | arm64) argocd_arch=arm64 ;;
+            *)
+              echo "::error::Unsupported runner architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
+
+          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-${argocd_arch}"
+          chmod 555 "${RUNNER_TEMP}/argocd"
+          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
+
+      - name: Restart dev rollouts
+        env:
+          ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
+          ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
+          ARGOCD_OPTS: --grpc-web
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for rollout in kosmo-web kosmo-api; do
+            argocd app actions run kosmo-dev restart \
+              --group argoproj.io \
+              --kind Rollout \
+              --namespace kosmo-dev \
+              --resource-name "${rollout}"
+          done

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,39 +27,10 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const runtimeToken = process.env.ACTIONS_RUNTIME_TOKEN;
-            const idTokenUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-            const server = process.env.ARGOCD_SERVER;
-
-            if (!server) {
-              throw new Error("ARGOCD_SERVER is required.");
-            }
-
-            if (!runtimeToken || !idTokenUrl) {
-              throw new Error("GitHub Actions OIDC environment is unavailable.");
-            }
-
-            const githubTokenResponse = await fetch(idTokenUrl, {
-              method: "POST",
-              headers: {
-                authorization: `bearer ${runtimeToken}`,
-                accept: "application/json; api-version=2.0",
-                "content-type": "application/json",
-              },
-              body: "{}",
-            });
-
-            if (!githubTokenResponse.ok) {
-              throw new Error(`GitHub OIDC token request failed: ${githubTokenResponse.status} ${await githubTokenResponse.text()}`);
-            }
-
-            const githubToken = (await githubTokenResponse.json()).value;
-            if (!githubToken) {
-              throw new Error("GitHub OIDC token response did not include a token.");
-            }
+            const githubToken = await core.getIDToken();
             core.setSecret(githubToken);
 
-            const baseUrl = /^https?:\/\//.test(server) ? server.replace(/\/$/, "") : `https://${server}`;
+            const baseUrl = process.env.ARGOCD_SERVER.replace(/\/$/, "");
             const dexTokenResponse = await fetch(`${baseUrl}/api/dex/token`, {
               method: "POST",
               headers: {

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -18,9 +18,10 @@ jobs:
   restart_dev:
     name: Restart Dev Rollouts
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, macOS]
     env:
-      ARGOCD_SERVER: https://argocd-aws.tail1fdd55.ts.net
+      ARGOCD_BASE_URL: https://argocd-aws.tail1fdd55.ts.net
+      ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net
     steps:
       - name: Get Argo CD token
         id: argocd-token
@@ -30,7 +31,7 @@ jobs:
             const githubToken = await core.getIDToken();
             core.setSecret(githubToken);
 
-            const response = await fetch(`${process.env.ARGOCD_SERVER.replace(/\/$/, "")}/api/dex/token`, {
+            const response = await fetch(`${process.env.ARGOCD_BASE_URL.replace(/\/$/, "")}/api/dex/token`, {
               method: "POST",
               headers: {
                 authorization: `Basic ${Buffer.from("argo-cd-cli:").toString("base64")}`,
@@ -75,20 +76,19 @@ jobs:
               ;;
           esac
 
-          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-${argocd_arch}"
+          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-darwin-${argocd_arch}"
           chmod 555 "${RUNNER_TEMP}/argocd"
           echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
 
       - name: Restart dev rollouts
         env:
           ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
-          ARGOCD_OPTS: --grpc-web
         shell: bash
         run: |
           set -euo pipefail
 
           for rollout in kosmo-web kosmo-api; do
-            argocd app actions run kosmo-dev restart \
+            argocd --server "${ARGOCD_SERVER}" --grpc-web app actions run kosmo-dev restart \
               --group argoproj.io \
               --kind Rollout \
               --namespace kosmo-dev \

--- a/applicationset.yaml
+++ b/applicationset.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       name: 'kosmo-{{env}}'
     spec:
-      project: default
+      project: kosmo
       source:
         repoURL: https://github.com/byulmaru/kosmo.git
         targetRevision: main


### PR DESCRIPTION
## 무엇을 변경했는지

- `Docker Build` 워크플로가 `main`에서 성공한 뒤 실행되는 `Deploy Dev` 워크플로를 추가했습니다.
- GitHub Actions OIDC 토큰을 Argo CD Dex 토큰으로 교환한 뒤 Argo CD CLI로 `kosmo-dev` 앱의 web/api Rollout restart action을 실행합니다.
- Argo CD 서버 주소를 `https://argocd-aws.tail1fdd55.ts.net`로 설정했습니다.
- 새 Argo CD RBAC 대상에 맞게 ApplicationSet 템플릿의 project를 `default`에서 `kosmo`로 변경했습니다.

## 왜 변경했는지

- dev 환경은 아직 `latest` 이미지를 따라가는 구조라, `main` 빌드가 GHCR에 새 이미지를 push한 뒤 Pod를 다시 띄워야 최신 이미지가 적용됩니다.
- Kubernetes API 권한을 GitHub Actions에 주지 않고, Argo CD에 추가된 application action 권한만 사용하도록 범위를 좁혔습니다.

## 어떻게 확인할 수 있는지

- `pnpm lint:prettier`
- 로컬에 `actionlint`가 없어 workflow 정적 검사는 실행하지 못했습니다.

## 아직 어떤 문제가 남았는지

- Argo CD 쪽에 `kosmo` AppProject와 GitHub Actions OIDC/RBAC 설정이 먼저 적용되어 있어야 합니다.