### PR TITLE
프로필의 instance 소속을 필수로 보장한다

### DIFF
--- a/packages/core/db/relations.ts
+++ b/packages/core/db/relations.ts
@@ -154,6 +154,7 @@ export const relations = defineRelations(tables, (r) => ({
     }),
     instance: r.one.Instances({
       from: r.Profiles.instanceId,
+      optional: false,
       to: r.Instances.id,
     }),
     media: r.many.Media({ from: r.Profiles.id, to: r.Media.profileId }),

--- a/packages/core/db/tables.ts
+++ b/packages/core/db/tables.ts
@@ -285,7 +285,9 @@ export const Profiles = pgTable(
     id: uuid('id')
       .primaryKey()
       .$defaultFn(() => createId(TableDiscriminator.Profiles)),
-    instanceId: uuid('instance_id').references(() => Instances.id),
+    instanceId: uuid('instance_id')
+      .notNull()
+      .references(() => Instances.id),
     state: Enum.profileState('state').notNull().default('ACTIVE'),
     handle: text('handle').notNull(),
     normalizedHandle: text('normalized_handle').notNull(),


### PR DESCRIPTION
## 무엇을 변경했는지

- `profile.instance_id`를 Drizzle schema에서 `NOT NULL`로 전환했습니다.
- `Profiles.instance` relation을 `optional: false`로 정렬했습니다.
- 새 migration 체계나 API 동작은 추가하지 않고 기존 local instance bootstrap/backfill 경로를 재사용합니다.

## 왜 변경했는지

PROD-182에서 기존 profile을 configured local instance에 연결하는 bootstrap/backfill을 먼저 배포했습니다. 이제 모든 profile이 instance를 갖는 계약을 DB와 타입에 반영해 `(instance_id, normalized_handle)` unique가 NULL 때문에 우회되지 않도록 합니다.

## 어떻게 확인할 수 있는지

정적·회귀 검증:
- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm --filter @kosmo/web check`
- `pnpm lint:eslint`
- `pnpm test:e2e`: 36개 통과
- `openspec validate add-activitypub-actor-discovery --strict`

단계형 DB 업그레이드 검증:
- nullable 기준 disposable DB에 legacy NULL profile 1건을 만들었습니다.
- 기존 `db:bootstrap-local-instance` 실행 후 NULL 0건과 configured local instance 연결을 확인했습니다.
- `pnpm db:test:push --explain`이 `ALTER TABLE "profile" ALTER COLUMN "instance_id" SET NOT NULL`만 생성하는 것을 확인했습니다.
- 실제 push 후 `information_schema.columns.is_nullable = 'NO'`를 확인했습니다.
- instance 없는 insert는 PostgreSQL `23502`, 같은 instance/handle 중복은 `23505`를 반환했습니다.
- 다른 instance의 같은 handle은 2건이 공존하는 것을 확인했습니다.
- fresh DB reset → push → bootstrap → 전체 E2E 경로도 통과했습니다.

## 운영 적용 런북

1. contract 배포 전에 환경별 `db:bootstrap-local-instance`를 실행합니다.
2. `profile.instance_id IS NULL`이 0건인지 확인합니다. NULL이 남거나 configured local instance 검증이 실패하면 중단합니다.
3. `pnpm db:test:push --explain`과 같은 환경별 explain 명령으로 `SET NOT NULL` 변경과 lock 영향을 검토합니다.
4. 실제 push 후 `information_schema.columns.is_nullable = 'NO'`인지 재확인합니다.
5. 애플리케이션 롤백 시 DB constraint는 유지하고 이전 nullable schema로 다시 push하지 않습니다.

## 아직 어떤 문제가 남았는지

- 실제 운영 DB 적용은 이 PR 범위에 포함하지 않습니다.
- profile 규모가 큰 환경에서는 `ALTER TABLE` 적용 전 lock 영향을 별도로 확인해야 합니다.
- OpenSpec verification task 6.1은 이 PR보다 범위가 넓으므로 완료 처리하지 않았습니다.

Stack: main -> prod-224

Linear: PROD-224