### PR TITLE
Web E2E 고정 포트 충돌을 방지한다

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: web-e2e-test-db
+  group: web-e2e
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: web-e2e-test-db
+  cancel-in-progress: false
 
 jobs:
   web_e2e:


### PR DESCRIPTION
## 무엇을 변경했는지

- Web E2E 워크플로의 concurrency group을 `web-e2e`로 고정했습니다.
- 실행 중인 워크플로는 취소하지 않고 다음 실행이 대기하도록 설정했습니다.

## 왜 변경했는지

기존 concurrency group은 PR 번호나 ref를 포함해 서로 다른 PR과 브랜치의 Web E2E 실행을 동시에 허용했습니다. self-hosted runner에서 테스트 PostgreSQL `54329`뿐 아니라 API, BFF, OIDC mock 서버가 고정 포트를 공유하므로 실행이 겹치면 포트 충돌과 테스트 상태 간섭이 발생할 수 있습니다.

PR #217의 run `29156877783` / job `86555333993`에서는 Playwright webServer 기동 전에 OIDC mock 서버 포트와 충돌해 `http://127.0.0.1:4300/health is already used` 오류가 발생했습니다. 기존 서버를 재사용하면 stale OIDC 서버를 사용할 수 있으므로 `reuseExistingServer`는 변경하지 않습니다.

## 어떻게 확인할 수 있는지

- `pnpm exec prettier --check .github/workflows/web-e2e.yml`
- `actionlint .github/workflows/web-e2e.yml`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- GitHub concurrency는 기본적으로 실행 중인 run 1개와 대기 중인 run 1개만 유지하므로, 실행이 몰리면 더 오래된 pending run은 새 pending run으로 교체될 수 있습니다.
- 이 PR을 merge한 뒤 PR #217의 Web E2E를 rerun해 실제 self-hosted runner에서 충돌이 해소됐는지 확인해야 합니다.
- PR #217의 Native Build 실패(Android SDK/`ANDROID_HOME` 미설정)는 별도 원인이며 이 PR 범위에 포함하지 않습니다.

Stack: main -> fix-web-e2e-concurrency
