### PR TITLE
Docker 이미지 빌드 시간을 줄인다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,19 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - .dockerignore
-      - .github/workflows/docker-build.yml
-      - Dockerfile
-      - docker-entrypoint.sh
-      - package.json
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
-      - tsconfig.json
-      - apps/api/**
-      - apps/app/**
-      - apps/web/**
-      - packages/**
 
 permissions:
   contents: read

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,19 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths:
+      - .dockerignore
+      - .github/workflows/docker-build.yml
+      - Dockerfile
+      - docker-entrypoint.sh
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - tsconfig.json
+      - apps/api/**
+      - apps/app/**
+      - apps/web/**
+      - packages/**
 
 permissions:
   contents: read
@@ -27,6 +40,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          name: kosmo-${{ runner.name }}
+          keep-state: true
+          cache-binary: false
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -64,6 +81,26 @@ jobs:
           image_ref="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)"
           echo "image-ref=${image_ref}" >> "${GITHUB_OUTPUT}"
 
+      - name: Find local Trivy
+        id: trivy-binary
+        shell: bash
+        run: |
+          trivy_dir="${RUNNER_TOOL_CACHE}/kosmo-trivy-v0.70.0/trivy-bin"
+          echo "${trivy_dir}" >> "${GITHUB_PATH}"
+          if [[ -x "${trivy_dir}/trivy" ]]; then
+            echo "installed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "installed=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Install Trivy
+        if: steps.trivy-binary.outputs.installed != 'true'
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
+        with:
+          version: v0.70.0
+          cache: false
+          path: ${{ runner.tool_cache }}/kosmo-trivy-v0.70.0
+
       - name: Run Trivy image scan
         id: trivy
         continue-on-error: true
@@ -79,6 +116,9 @@ jobs:
           vuln-type: os,library
           scanners: vuln
           severity: HIGH,CRITICAL
+          cache: false
+          cache-dir: ${{ runner.tool_cache }}/kosmo-trivy-cache
+          skip-setup-trivy: true
 
       - name: Upload Trivy report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
-          name: kosmo-${{ runner.name }}
-          keep-state: true
+          name: kosmo
+          cleanup: false
           cache-binary: false
 
       - name: Log in to GHCR

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ COPY packages ./packages
 
 FROM workspace AS deps
 
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/pnpm/store \
+  pnpm install --frozen-lockfile --store-dir=/pnpm/store
 
 FROM deps AS app-build
 
@@ -50,7 +51,8 @@ COPY --chown=app:app apps/web/package.json ./apps/web/package.json
 COPY --chown=app:app packages/core/package.json ./packages/core/package.json
 COPY --chown=app:app packages/fedify/package.json ./packages/fedify/package.json
 
-RUN pnpm install --filter @kosmo/api... --filter @kosmo/web... --frozen-lockfile --prod --ignore-scripts
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/pnpm/store \
+  pnpm install --filter @kosmo/api... --filter @kosmo/web... --frozen-lockfile --prod --ignore-scripts --store-dir=/pnpm/store
 
 COPY --chown=app:app apps/api ./apps/api
 COPY --chown=app:app packages/core ./packages/core

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ COPY packages ./packages
 
 FROM workspace AS deps
 
-RUN --mount=type=cache,id=kosmo-pnpm-store,target=/pnpm/store \
-  pnpm install --frozen-lockfile --store-dir=/pnpm/store
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  pnpm install --frozen-lockfile --store-dir=/var/cache/pnpm/store
 
 FROM deps AS app-build
 
@@ -51,8 +51,8 @@ COPY --chown=app:app apps/web/package.json ./apps/web/package.json
 COPY --chown=app:app packages/core/package.json ./packages/core/package.json
 COPY --chown=app:app packages/fedify/package.json ./packages/fedify/package.json
 
-RUN --mount=type=cache,id=kosmo-pnpm-store,target=/pnpm/store \
-  pnpm install --filter @kosmo/api... --filter @kosmo/web... --frozen-lockfile --prod --ignore-scripts --store-dir=/pnpm/store
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  pnpm install --filter @kosmo/api... --filter @kosmo/web... --frozen-lockfile --prod --ignore-scripts --store-dir=/var/cache/pnpm/store
 
 COPY --chown=app:app apps/api ./apps/api
 COPY --chown=app:app packages/core ./packages/core


### PR DESCRIPTION
## 무엇을 변경했는지

- 같은 기기에 등록된 세 self-hosted runner가 고정 Buildx builder `kosmo`를 공유하도록 했습니다.
- job 종료 시 builder를 제거하지 않도록 `cleanup: false`를 설정해 동시 빌드 중 다른 job이 builder를 제거하는 경쟁을 막았습니다.
- Buildx 바이너리의 GitHub Actions cache 사용을 비활성화했습니다.
- Trivy 바이너리와 취약점 DB는 runner별 tool cache에서 재사용하고 GitHub Actions cache 왕복을 제거했습니다.
- 빌드 및 런타임 `pnpm install`이 공용 BuildKit builder의 로컬 pnpm store cache를 공유하도록 했습니다.
- OS 패키지를 매번 갱신하는 기존 `no-cache-filters: base` 정책과 모든 `main` push에서 빌드하는 트리거 범위는 유지했습니다.

## 왜 변경했는지

모든 Actions runner가 이름만 다르고 같은 기기와 Docker daemon을 사용하므로 GitHub 원격 cache를 내려받고 다시 업로드하는 비용이 로컬 상태 재사용보다 컸습니다. runner 이름별 builder는 BuildKit 캐시를 세 벌로 나누므로 고정 persistent builder를 사용합니다.

BuildKit은 동일 daemon에서 동시 빌드를 처리할 수 있습니다. setup action의 job cleanup이 공용 builder를 제거하는 lifecycle 경쟁을 만들지 않도록 builder를 계속 유지합니다. Trivy DB는 동시 갱신 경계를 분리하기 위해 runner별 tool cache를 유지합니다.

파일 경로 allowlist는 미래에 새 빌드 입력이 추가될 때 이미지 빌드가 조용히 누락될 수 있으므로 사용하지 않습니다.

## 어떻게 확인했는지

로컬 검증:

- `pnpm exec prettier --check .github/workflows/docker-build.yml`
- `actionlint .github/workflows/docker-build.yml`
- `git diff --check`
- `docker buildx build --check --file Dockerfile .`
- `CI=true pnpm install --frozen-lockfile`

실제 Actions 검증:

- 첫 실행에서 `/pnpm/store` cache mount가 `pnpm runtime set node`의 Node 런타임을 가리는 문제를 발견했고, cache 경로를 `/var/cache/pnpm/store`로 분리해 수정했습니다.
- [cold 실행](https://github.com/byulmaru/kosmo/actions/runs/29158128409): 성공, 총 3분 57초, Trivy 설치 8초, DB 약 100 MiB 다운로드를 포함한 스캔 59초.
- [같은 runner의 warm 실행](https://github.com/byulmaru/kosmo/actions/runs/29158298393): 성공, 총 3분 24초, Trivy 설치 skip, DB 다운로드 없음, 스캔 40초.
- 두 실행 모두 `jiyu-mac-mini`에 배정됐으며 Buildx 준비는 1초, 이미지 build/push는 2분 16초였습니다.
- Trivy는 `cache: false`로 실행됐고 실제 cache restore/save 및 post-job cache 업로드가 없었습니다.

## 아직 어떤 문제가 남았는지

- Trivy 바이너리와 DB는 runner 등록별 tool cache이므로 나머지 두 runner 등록도 최초 한 번은 cold 실행이 필요합니다.
- `trivy-action`의 composite dependency 때문에 job 준비 중 `actions/cache` action 코드 자체는 다운로드되지만, cache 데이터 restore/save는 실행되지 않습니다.
- persistent builder의 디스크 사용량은 BuildKit GC에 맡기며, 필요하면 `docker buildx du --builder kosmo`로 확인해야 합니다.
- 미래 빌드 입력 누락을 막기 위해 이미지와 무관한 `main` 변경에서도 Docker Build는 계속 실행됩니다.

Stack: `main -> agent/optimize-docker-build`