### PR TITLE
병합 이후 중복 CI 검사를 생략한다

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,6 @@ name: Lint
 on:
   pull_request:
   merge_group:
-  push:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,8 +3,6 @@ name: Semgrep
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -3,8 +3,6 @@ name: Web E2E
 on:
   pull_request:
   merge_group:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 무엇을 변경했는지

- `Lint`, `Semgrep`, `Web E2E` 워크플로에서 `push: main` 트리거를 제거했습니다.
- PR과 Merge Queue의 `merge_group` 검증은 그대로 유지했습니다.
- Semgrep과 Web E2E의 수동 실행 경로도 유지했습니다.

## 왜 변경했는지

현재 `main` ruleset은 `Lint`, `Semgrep scan`, `Web E2E`를 모두 필수 체크로 요구합니다. 세 검사는 병합 전에 이미 통과하므로, 병합 직후 동일한 변경을 다시 검사할 필요가 없습니다. 중복 실행을 줄여 self-hosted runner 사용량과 피드백 대기열을 줄입니다.

## 어떻게 확인할 수 있는지

- GitHub ruleset `14949708`에서 세 필수 체크 확인
- `pnpm exec prettier --check .github/workflows/lint.yml .github/workflows/semgrep.yml .github/workflows/web-e2e.yml`
- `actionlint -ignore 'SC2086' .github/workflows/lint.yml .github/workflows/semgrep.yml .github/workflows/web-e2e.yml`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- 저장소를 프라이빗으로 전환해 GitHub 네이티브 Merge Queue를 사용하지 못하게 될 때는, strict required checks 또는 Mergify 같은 대체 큐를 먼저 구성한 뒤 `merge_group` 트리거를 정리해야 합니다.
- `actionlint`의 `SC2086` 제외는 기존 Semgrep의 `$SEMGREP_CONFIGS` 비인용 경고이며 이번 변경에서 새로 발생한 문제는 아닙니다.

Stack: `main` → `agent/skip-post-merge-ci`