### PR TITLE
동적 정규식으로 인한 Semgrep 경고를 제거한다

### DIFF
--- a/apps/web/src/server/app.test.ts
+++ b/apps/web/src/server/app.test.ts
@@ -580,7 +580,11 @@ describe('runtime routing', () => {
 });
 
 const getCookieValue = (setCookie: string, name: string) => {
-  const value = new RegExp(`(?:^|,\\s*)${name}=([^;,]+)`).exec(setCookie)?.[1];
+  const cookie = setCookie
+    .split(',')
+    .map((part) => part.trimStart())
+    .find((part) => part.startsWith(`${name}=`));
+  const value = cookie?.slice(name.length + 1).split(';', 1)[0];
 
   if (!value) {
     throw new Error(`Missing ${name} cookie`);

--- a/apps/web/src/server/app.test.ts
+++ b/apps/web/src/server/app.test.ts
@@ -120,7 +120,8 @@ describe('browser login', () => {
     });
     const location = new URL(response.headers.get('location') ?? '');
     const setCookie = response.headers.get('set-cookie') ?? '';
-    const verifier = getCookieValue(response.headers, 'kosmo_oidc_code_verifier');
+    const cookies = responseCookies(response.headers);
+    const verifier = cookies.kosmo_oidc_code_verifier;
 
     expect(response.status).toBe(302);
     expect(location.origin + location.pathname).toBe('https://id.example/oauth/authorize');
@@ -131,7 +132,7 @@ describe('browser login', () => {
       redirect_uri: 'https://kos.moe/login/callback',
       response_type: 'code',
       scope: 'openid profile',
-      state: getCookieValue(response.headers, 'kosmo_oidc_state'),
+      state: cookies.kosmo_oidc_state,
     });
     expect(setCookie).toContain('Max-Age=600');
     expect(setCookie).toContain('Path=/login/callback');
@@ -159,16 +160,17 @@ describe('browser login', () => {
   test('uses the public origin when TLS terminates before the Node server', async () => {
     vi.stubEnv('PUBLIC_ORIGIN', 'https://kos.moe');
     const login = await app.request('http://web:8080/login');
-    const loginCookies = login.headers.get('set-cookie') ?? '';
+    const setCookie = login.headers.get('set-cookie') ?? '';
+    const cookies = responseCookies(login.headers);
     const loginLocation = new URL(login.headers.get('location') ?? '');
-    const state = getCookieValue(login.headers, 'kosmo_oidc_state');
+    const state = cookies.kosmo_oidc_state;
     const callback = await app.request(`http://web:8080/login/callback?code=code&state=${state}`, {
-      headers: { cookie: cookieHeader(login.headers) },
+      headers: { cookie: cookieHeader(cookies) },
     });
     const [, callbackUrl, checks] = authorizationCodeGrant.mock.calls[0] ?? [];
 
     expect(loginLocation.searchParams.get('redirect_uri')).toBe('https://kos.moe/login/callback');
-    expect(loginCookies).toContain('Secure');
+    expect(setCookie).toContain('Secure');
     expect(callbackUrl).toBeInstanceOf(URL);
     expect((callbackUrl as URL).origin + (callbackUrl as URL).pathname).toBe(
       'https://kos.moe/login/callback',
@@ -179,11 +181,12 @@ describe('browser login', () => {
 
   test('exchanges a valid callback and sets the existing session cookie', async () => {
     const login = await app.request('https://kos.moe/login');
-    const state = getCookieValue(login.headers, 'kosmo_oidc_state');
-    const verifier = getCookieValue(login.headers, 'kosmo_oidc_code_verifier');
+    const cookies = responseCookies(login.headers);
+    const state = cookies.kosmo_oidc_state;
+    const verifier = cookies.kosmo_oidc_code_verifier;
     const response = await app.request(
       `https://kos.moe/login/callback?code=oidc-code&state=${state}`,
-      { headers: { cookie: cookieHeader(login.headers) } },
+      { headers: { cookie: cookieHeader(cookies) } },
     );
     const [, callbackUrl, checks] = authorizationCodeGrant.mock.calls[0] ?? [];
     const setCookie = response.headers.get('set-cookie') ?? '';
@@ -212,12 +215,13 @@ describe('browser login', () => {
 
   test('rejects a non-browser redirect before token exchange', async () => {
     const login = await app.request('https://kos.moe/login');
-    const state = getCookieValue(login.headers, 'kosmo_oidc_state');
+    const cookies = responseCookies(login.headers);
+    const state = cookies.kosmo_oidc_state;
     const response = await app.request(
       `https://kos.moe/login/callback?code=oidc-code&state=${state}&redirect_uri=${encodeURIComponent(
         'kosmo://login/callback',
       )}`,
-      { headers: { cookie: cookieHeader(login.headers) } },
+      { headers: { cookie: cookieHeader(cookies) } },
     );
 
     expect(response.status).toBe(400);
@@ -578,20 +582,12 @@ describe('runtime routing', () => {
   });
 });
 
-const getCookieValue = (headers: Headers, name: string) => {
-  const value = headers
-    .getSetCookie()
-    .map((cookie) => parse(cookie, name)[name])
-    .find(Boolean);
+const responseCookies = (headers: Headers) =>
+  Object.fromEntries(
+    headers.getSetCookie().flatMap((cookie) => Object.entries(parse(cookie)).slice(0, 1)),
+  );
 
-  if (!value) {
-    throw new Error(`Missing ${name} cookie`);
-  }
-
-  return value;
-};
-
-const cookieHeader = (headers: Headers) =>
-  ['kosmo_oidc_state', 'kosmo_oidc_code_verifier']
-    .map((name) => `${name}=${getCookieValue(headers, name)}`)
+const cookieHeader = (cookies: Record<string, string>) =>
+  Object.entries(cookies)
+    .map(([name, value]) => `${name}=${value}`)
     .join('; ');

--- a/apps/web/src/server/app.test.ts
+++ b/apps/web/src/server/app.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { gunzipSync, gzipSync } from 'node:zlib';
+import { parse } from 'hono/utils/cookie';
 import { Configuration, enableNonRepudiationChecks, ResponseBodyError } from 'openid-client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { federation } from '@kosmo/fedify';
@@ -119,7 +120,7 @@ describe('browser login', () => {
     });
     const location = new URL(response.headers.get('location') ?? '');
     const setCookie = response.headers.get('set-cookie') ?? '';
-    const verifier = getCookieValue(setCookie, 'kosmo_oidc_code_verifier');
+    const verifier = getCookieValue(response.headers, 'kosmo_oidc_code_verifier');
 
     expect(response.status).toBe(302);
     expect(location.origin + location.pathname).toBe('https://id.example/oauth/authorize');
@@ -130,7 +131,7 @@ describe('browser login', () => {
       redirect_uri: 'https://kos.moe/login/callback',
       response_type: 'code',
       scope: 'openid profile',
-      state: getCookieValue(setCookie, 'kosmo_oidc_state'),
+      state: getCookieValue(response.headers, 'kosmo_oidc_state'),
     });
     expect(setCookie).toContain('Max-Age=600');
     expect(setCookie).toContain('Path=/login/callback');
@@ -160,9 +161,9 @@ describe('browser login', () => {
     const login = await app.request('http://web:8080/login');
     const loginCookies = login.headers.get('set-cookie') ?? '';
     const loginLocation = new URL(login.headers.get('location') ?? '');
-    const state = getCookieValue(loginCookies, 'kosmo_oidc_state');
+    const state = getCookieValue(login.headers, 'kosmo_oidc_state');
     const callback = await app.request(`http://web:8080/login/callback?code=code&state=${state}`, {
-      headers: { cookie: cookieHeader(loginCookies) },
+      headers: { cookie: cookieHeader(login.headers) },
     });
     const [, callbackUrl, checks] = authorizationCodeGrant.mock.calls[0] ?? [];
 
@@ -178,12 +179,11 @@ describe('browser login', () => {
 
   test('exchanges a valid callback and sets the existing session cookie', async () => {
     const login = await app.request('https://kos.moe/login');
-    const loginCookies = login.headers.get('set-cookie') ?? '';
-    const state = getCookieValue(loginCookies, 'kosmo_oidc_state');
-    const verifier = getCookieValue(loginCookies, 'kosmo_oidc_code_verifier');
+    const state = getCookieValue(login.headers, 'kosmo_oidc_state');
+    const verifier = getCookieValue(login.headers, 'kosmo_oidc_code_verifier');
     const response = await app.request(
       `https://kos.moe/login/callback?code=oidc-code&state=${state}`,
-      { headers: { cookie: cookieHeader(loginCookies) } },
+      { headers: { cookie: cookieHeader(login.headers) } },
     );
     const [, callbackUrl, checks] = authorizationCodeGrant.mock.calls[0] ?? [];
     const setCookie = response.headers.get('set-cookie') ?? '';
@@ -212,13 +212,12 @@ describe('browser login', () => {
 
   test('rejects a non-browser redirect before token exchange', async () => {
     const login = await app.request('https://kos.moe/login');
-    const loginCookies = login.headers.get('set-cookie') ?? '';
-    const state = getCookieValue(loginCookies, 'kosmo_oidc_state');
+    const state = getCookieValue(login.headers, 'kosmo_oidc_state');
     const response = await app.request(
       `https://kos.moe/login/callback?code=oidc-code&state=${state}&redirect_uri=${encodeURIComponent(
         'kosmo://login/callback',
       )}`,
-      { headers: { cookie: cookieHeader(loginCookies) } },
+      { headers: { cookie: cookieHeader(login.headers) } },
     );
 
     expect(response.status).toBe(400);
@@ -579,12 +578,11 @@ describe('runtime routing', () => {
   });
 });
 
-const getCookieValue = (setCookie: string, name: string) => {
-  const cookie = setCookie
-    .split(',')
-    .map((part) => part.trimStart())
-    .find((part) => part.startsWith(`${name}=`));
-  const value = cookie?.slice(name.length + 1).split(';', 1)[0];
+const getCookieValue = (headers: Headers, name: string) => {
+  const value = headers
+    .getSetCookie()
+    .map((cookie) => parse(cookie, name)[name])
+    .find(Boolean);
 
   if (!value) {
     throw new Error(`Missing ${name} cookie`);
@@ -593,7 +591,7 @@ const getCookieValue = (setCookie: string, name: string) => {
   return value;
 };
 
-const cookieHeader = (setCookie: string) =>
+const cookieHeader = (headers: Headers) =>
   ['kosmo_oidc_state', 'kosmo_oidc_code_verifier']
-    .map((name) => `${name}=${getCookieValue(setCookie, name)}`)
+    .map((name) => `${name}=${getCookieValue(headers, name)}`)
     .join('; ');


### PR DESCRIPTION
## 무엇을 변경했는지

- Web 서버 테스트의 `Set-Cookie` 값 추출 로직에서 동적으로 생성하던 정규식을 제거했습니다.
- `Headers.getSetCookie()`로 응답 쿠키를 분리하고 Hono의 `parse`로 값을 읽도록 변경했습니다.

## 왜 변경했는지

테스트 헬퍼가 쿠키 이름을 `RegExp` 생성자에 삽입해 Semgrep의 `detect-non-literal-regexp` 경고가 발생했습니다. 플랫폼 API와 이미 설치된 Hono 쿠키 파서를 사용해 동적 정규식 없이 같은 동작을 구현하고 보안 스캔 경고의 원인을 제거합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web exec vitest run src/server/app.test.ts`
- `pnpm --filter @kosmo/web check`
- `pnpm exec prettier --check apps/web/src/server/app.test.ts`
- 커밋 훅의 ESLint 및 Prettier 통과

로컬 Python shim에 버전이 설정되지 않아 CI의 Semgrep 전체 스캔은 실행하지 못했으며, Draft PR CI에서 확인합니다.

## 아직 어떤 문제가 남았는지

없음
