### PR TITLE
나중 결정이 우선되도록 OpenSpec 결정 날짜를 기록한다

### DIFF
--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -42,6 +42,7 @@
 - OpenSpec과 구현은 root field, object field, payload, error type, connection, UI 수치 단위가 서로 맞아야 한다.
 - 코드가 spec과 다르면 어느 쪽이 source of truth인지 정하고 같은 PR에서 정렬한다.
 - 현재 범위에서 의도적으로 미룬 정책은 코드 주석이나 OpenSpec의 decision artifact(`decisions.md`가 있으면 그 파일, 없으면 `design.md` 또는 관련 artifact)의 남은 결정으로 검색 가능하게 남긴다.
+- OpenSpec decision record에는 `YYYY-MM-DD` 형식의 결정 날짜를 기록한다. 결정이 충돌하면 더 최신 날짜를 따르고, 같은 날짜에 바뀌면 새 기록이 대체하는 이전 기록을 명시한다.
 - 장기적으로 유지될 규칙은 task-specific skill보다 `memory/`에 남긴다.
 
 ## Runtime And Tooling

--- a/openspec/schemas/spec-driven-decisions/schema.yaml
+++ b/openspec/schemas/spec-driven-decisions/schema.yaml
@@ -117,6 +117,7 @@ artifacts:
       Sections:
       - **Context**: Briefly state the proposal/spec/design inputs this decision log reflects.
       - **Decision Records**: Accepted or proposed choices. For each decision include:
+        - decision date in `YYYY-MM-DD` format
         - status
         - context/problem
         - decision outcome
@@ -127,6 +128,7 @@ artifacts:
       - **Superseded Decisions**: Choices replaced during the change. Include what replaced them and why. Use "없음." if there are none.
 
       Keep decisions separate from tasks and design notes. design.md can explain the implementation approach, but decisions.md is the durable decision record agents should read before implementation. Use one section per decision rather than one long mixed bullet list.
+      Append decision records in chronological order. When records conflict, the decision with the later date wins. If a decision changes on the same date, the later record MUST explicitly identify the earlier record it supersedes.
     requires:
       - design
 

--- a/openspec/schemas/spec-driven-decisions/templates/decisions.md
+++ b/openspec/schemas/spec-driven-decisions/templates/decisions.md
@@ -6,6 +6,7 @@
 
 ### <decision title>
 
+- Decision Date: YYYY-MM-DD
 - Status: Accepted
 - Context / Problem: <what issue required a decision>
 - Decision Outcome: <chosen option and why>


### PR DESCRIPTION
## 무엇을 변경했는지

- `spec-driven-decisions`의 각 decision record에 `Decision Date: YYYY-MM-DD`를 필수 항목으로 추가했습니다.
- 서로 충돌하는 결정은 더 최신 날짜가 우선하도록 하고, 같은 날짜에 변경되면 새 기록이 이전 기록을 명시적으로 supersede하도록 생성 지침을 보강했습니다.
- 같은 정책을 저장소의 coding-style memory에도 반영했습니다.

## 왜 변경했는지

결정 날짜가 없으면 과거 결정과 이후 결정이 충돌할 때 어느 쪽이 최신 맥락을 반영한 결정인지 구분하기 어렵습니다. 이후 결정은 기존 결정을 고려해 내려졌다는 전제에 맞춰, decision log에서 최신 결정을 안정적으로 식별할 수 있게 합니다.

## 어떻게 확인할 수 있는지

- `openspec schema validate spec-driven-decisions --verbose`
- `pnpm lint:prettier`
- `git diff --check`
- commit hook의 ESLint 및 Prettier

## 아직 어떤 문제가 남았는지

기존 `decisions.md`의 과거 결정 날짜는 정확한 시점을 추정해서 기록하지 않도록 소급 변경하지 않았습니다.

Stack: `main -> agent/record-openspec-decision-date`