### PR TITLE
Web E2E 대기 실행이 merge queue에서 취소되지 않게 한다

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -12,6 +12,7 @@ permissions:
 
 concurrency:
   group: web-e2e
+  queue: max
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## 무엇을 변경했는지

- Web E2E workflow-level `concurrency`에 `queue: max`를 추가했습니다.
- 기존 전역 `web-e2e` 그룹과 `cancel-in-progress: false`는 유지해 Web E2E를 계속 한 번에 하나씩 실행합니다.

## 왜 변경했는지

기본 concurrency queue는 pending run을 하나만 보존합니다. Web E2E가 실행 중인 동안 새 merge-group run이 연달아 들어오면 뒤의 run이 기존 pending run을 취소해 required check가 영구히 대기하는 문제가 있었습니다.

GitHub가 공식 지원하는 `queue: max`를 사용하면 같은 그룹의 pending run을 최대 100개까지 보존하고 직렬로 처리하므로 merge queue 진입 순서에서 Web E2E가 교체 취소되지 않습니다.

## 어떻게 확인할 수 있는지

- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/web-e2e.yml")'`
- `git diff --check`
- GitHub Actions 최신 workflow syntax에서 `queue: max`와 `cancel-in-progress: false` 조합을 확인했습니다.
- GitHub가 PR의 Web E2E run `29161330060`을 workflow-level `pending`으로 정상 등록했습니다.
- 새 PR run이 들어온 뒤에도 기존 main push run `29161263565`가 함께 `pending`으로 유지되어 복수 pending 보존을 확인했습니다.

로컬 `actionlint` 1.7.12는 2026년 5월 추가된 `queue` 키를 아직 알지 못해 해당 키만 schema 오류로 보고합니다. 최신 문법을 사용하는 GitHub 자체 workflow parser에서는 정상 등록됐습니다.

## 아직 어떤 문제가 남았는지

- 기존 PR #223의 취소된 run이나 merge queue 상태는 이 PR에서 수정하거나 재실행하지 않습니다.
