### PR TITLE
Web E2E 실행이 서로 충돌하지 않게 한다

### DIFF
--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -10,10 +10,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: web-e2e
-  cancel-in-progress: false
-
 jobs:
   web_e2e:
     name: Web E2E
@@ -47,10 +43,7 @@ jobs:
           pnpm --filter @kosmo/app test:storybook
 
       - name: Run Fedify unit tests
-        run: |
-          pnpm db:test:reset
-          pnpm db:test:push
-          pnpm test:fedify
+        run: pnpm test:fedify
 
       - name: Run web E2E tests
         run: pnpm test:e2e
@@ -66,6 +59,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Clean up test Postgres
+      - name: Clean up test database
         if: always()
-        run: node scripts/test-db.mjs down --volumes --remove-orphans
+        run: pnpm db:test:drop

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The test database connection string is defined in `.env.test`:
 DATABASE_URL=postgres://kosmo:kosmo@localhost:54329/kosmo_test
 ```
 
-Use `pnpm db:test:reset` to recreate the container with an empty data directory, and `pnpm db:test:down` to stop it.
+Use `pnpm db:test:reset` to recreate only the default `kosmo_test` database while keeping the shared Postgres server running. Use `pnpm db:test:down` to stop the server, or add `-- --volumes --remove-orphans` when the Docker volume must also be removed.
 
 ## Web E2E
 
@@ -46,4 +46,4 @@ pnpm --filter @kosmo/app exec playwright install chromium
 pnpm test:e2e
 ```
 
-Install Playwright Chromium once, then run the E2E command. The command recreates the test Postgres container, pushes the Drizzle schema, and runs the Playwright specs under `apps/web/e2e`. The Playwright config manages the API server, Expo web export, Hono BFF, and local OIDC mock. It intentionally ignores ambient `DATABASE_URL` values and uses `.env.test` instead, so the reset, schema push, and Playwright servers share the same database. Set `PLAYWRIGHT_BROWSER_CHANNEL` only when you intentionally want to run against another local browser channel such as `chrome`.
+Install Playwright Chromium once, then run the E2E command. The command keeps the Docker Postgres server running, creates a unique `kosmo_test_*` database for the execution, pushes the Drizzle schema, runs the Playwright specs under `apps/web/e2e`, and drops only that database afterward. Concurrent root test commands therefore share the server without sharing schema, fixture state, or local API/web/OIDC ports. An explicit loopback `DATABASE_URL` in the `kosmo_test_*` namespace takes precedence over `.env.test`; other hosts or database names are rejected before destructive test operations. The wrapper derives a port offset from the isolated database name; set `KOSMO_TEST_PORT_OFFSET` only when a specific runner slot needs a fixed offset. The Playwright config manages the API server, Expo web export, Hono BFF, and local OIDC mock. Set `PLAYWRIGHT_BROWSER_CHANNEL` only when you intentionally want to run against another local browser channel such as `chrome`.

--- a/apps/web/e2e/auth-routes.e2e.ts
+++ b/apps/web/e2e/auth-routes.e2e.ts
@@ -7,7 +7,7 @@ import type { APIRequestContext } from '@playwright/test';
 
 const loginCodeVerifierCookie = 'kosmo_oidc_code_verifier';
 const loginStateCookie = 'kosmo_oidc_state';
-const oidcOrigin = 'http://127.0.0.1:4300';
+const oidcOrigin = process.env.PUBLIC_OIDC_ISSUER ?? 'http://127.0.0.1:4300';
 const oidcClientId = process.env.PUBLIC_OIDC_CLIENT_ID ?? 'kosmo-e2e-client';
 const protectedHeadingRoutes = [
   { heading: '홈', path: '/home' },

--- a/apps/web/e2e/db-fixtures.ts
+++ b/apps/web/e2e/db-fixtures.ts
@@ -31,7 +31,7 @@ import { eq } from 'drizzle-orm';
 import { Temporal } from 'temporal-polyfill';
 import type { BrowserContext } from '@playwright/test';
 
-const webOrigin = 'http://127.0.0.1:4173';
+const webOrigin = process.env.PUBLIC_ORIGIN ?? 'http://127.0.0.1:4173';
 let lastPostSeedTimestamp = 0;
 
 type CreateE2ESessionOptions = {
@@ -75,6 +75,7 @@ async function waitForNextPostSeedTimestamp() {
 
 export async function resetE2EDatabase() {
   lastPostSeedTimestamp = 0;
+  assertTestDatabaseUrl();
 
   await pg.unsafe(`
     DO $$
@@ -98,6 +99,18 @@ export async function resetE2EDatabase() {
 
 export async function closeE2EDatabase() {
   await pg.end();
+}
+
+function assertTestDatabaseUrl() {
+  const url = new URL(process.env.DATABASE_URL ?? '');
+  const databaseName = decodeURIComponent(url.pathname.slice(1));
+
+  if (
+    !['127.0.0.1', '[::1]', 'localhost'].includes(url.hostname) ||
+    !/^kosmo_test(?:_[a-z0-9_]+)?$/.test(databaseName)
+  ) {
+    throw new Error(`Refusing to reset non-test database ${url.hostname}/${databaseName}.`);
+  }
 }
 
 export async function createE2ESession(options: CreateE2ESessionOptions = {}) {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,12 +2,18 @@ import { readFileSync } from 'node:fs';
 import { defineConfig } from '@playwright/test';
 
 const host = '127.0.0.1';
-const webPort = 4173;
-const apiPort = 3001;
-const oidcPort = 4300;
+const portOffset = Number(process.env.KOSMO_TEST_PORT_OFFSET ?? 0);
+const webPort = 4173 + portOffset;
+const apiPort = 3001 + portOffset;
+const oidcPort = 4300 + portOffset;
+
+if (!Number.isInteger(portOffset) || portOffset < 0 || portOffset > 60_000) {
+  throw new Error('KOSMO_TEST_PORT_OFFSET must be an integer from 0 to 60000.');
+}
 
 const defaultDatabaseUrl = 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
 const databaseUrl =
+  process.env.DATABASE_URL ??
   readEnvFileValue(new URL('../../.env.test', import.meta.url), 'DATABASE_URL') ??
   defaultDatabaseUrl;
 const apiOrigin = `http://${host}:${apiPort}`;
@@ -18,6 +24,8 @@ const oidcClientSecret = process.env.OIDC_CLIENT_SECRET ?? 'kosmo-e2e-secret';
 const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL;
 
 process.env.DATABASE_URL = databaseUrl;
+process.env.PUBLIC_OIDC_ISSUER = oidcOrigin;
+process.env.PUBLIC_ORIGIN = webOrigin;
 
 function readEnvFileValue(path: URL, key: string) {
   try {

--- a/openspec/changes/isolate-test-databases-per-run/.openspec.yaml
+++ b/openspec/changes/isolate-test-databases-per-run/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-11

--- a/openspec/changes/isolate-test-databases-per-run/decisions.md
+++ b/openspec/changes/isolate-test-databases-per-run/decisions.md
@@ -1,0 +1,58 @@
+## Context
+
+이 결정 기록은 공유 테스트 Postgres에서 workflow run별 데이터베이스를 격리하고, 기존 Drizzle/Fedify/Playwright 경로를 유지하면서 저장소 전역 직렬화를 제거하기 위한 proposal, spec, design을 반영한다.
+
+## Decision Records
+
+### Postgres 서버는 공유하고 database를 실행별로 분리한다
+
+- Status: Accepted
+- Context / Problem: 고정된 `kosmo_test` 데이터베이스와 컨테이너 reset이 동시 테스트 실행을 충돌시킨다.
+- Decision Outcome: 기존 Docker Compose Postgres 서버 하나를 유지하고 각 실행이 `kosmo_test` 네임스페이스의 고유 database를 생성해 사용한다.
+- Alternatives Considered: 실행별 Postgres 컨테이너는 포트와 볼륨 관리가 추가되고, schema 분리는 현재 `public` 기준 truncate와 search path를 바꿔야 하며, Neon은 싱가포르 네트워크 지연과 외부 의존성을 추가하므로 선택하지 않았다.
+- Consequences: 테스트 실행은 Postgres CPU와 I/O를 공유하지만 schema와 데이터 및 파괴적 reset은 격리된다.
+- Confirmation / Follow-up: 두 루트 테스트 명령을 동시에 실행해 서로 다른 database를 사용하고 모두 성공하는지 확인한다.
+
+### Node wrapper가 database 수명 주기와 환경 전달을 소유한다
+
+- Status: Accepted
+- Context / Problem: 자식 프로세스가 부모 shell의 환경을 변경할 수 없으므로 create 명령과 기존 package script를 단순 연결하는 것만으로는 실행별 URL을 전체 테스트 프로세스에 전달할 수 없다.
+- Decision Outcome: `scripts/test-db.mjs run -- <command>`가 database를 생성하고 `DATABASE_URL`을 설정한 자식 명령을 동기 실행한 뒤 database를 정리한다.
+- Alternatives Considered: 임시 env 파일은 동시 실행 시 파일 격리와 정리가 필요하고, 새 라이브러리 도입은 표준 `child_process`와 컨테이너의 PostgreSQL CLI로 해결 가능한 문제에 불필요하다.
+- Consequences: 루트 테스트 명령은 내부 database 전용 명령을 wrapper로 호출하며 명시적 `DATABASE_URL`은 기본값보다 우선한다.
+- Confirmation / Follow-up: 성공 및 실패 자식 명령에서 종료 코드와 database cleanup을 확인한다.
+
+### 파괴적 작업은 loopback 테스트 database로 제한한다
+
+- Status: Accepted
+- Context / Problem: 실행별 URL을 동적으로 처리하면 잘못된 환경변수로 다른 데이터베이스를 truncate하거나 drop할 위험이 있다.
+- Decision Outcome: 대상 host가 `localhost`, `127.0.0.1`, `::1` 중 하나이고 database 이름이 `kosmo_test` 네임스페이스일 때만 reset, truncate, drop을 허용한다.
+- Alternatives Considered: database 이름만 검증하면 원격 서버의 동명 database를 삭제할 수 있고, 별도 확인 플래그는 CI 설정 실수로 우회될 수 있어 선택하지 않았다.
+- Consequences: 원격 테스트 DB는 이 도구의 지원 범위가 아니며 필요하면 별도 설계가 필요하다.
+- Confirmation / Follow-up: 허용되지 않은 host와 database 이름에 대해 명령이 Docker 작업 전에 실패하는지 확인한다.
+
+### Playwright spec 병렬화는 유지하지 않는다
+
+- Status: Accepted
+- Context / Problem: workflow run 간 충돌과 한 run 내부 spec 간 fixture 충돌은 서로 다른 문제다.
+- Decision Outcome: workflow run은 database 단위로 병렬화하되 각 Playwright run의 `workers: 1` 설정은 유지한다.
+- Alternatives Considered: spec별 database 또는 transaction fixture는 현재 변경 범위를 크게 늘리므로 선택하지 않았다.
+- Consequences: 한 workflow 안의 E2E 시간은 그대로지만 여러 workflow의 대기열을 줄일 수 있다.
+- Confirmation / Follow-up: 없음.
+
+### Web E2E 서버 포트도 실행별로 격리한다
+
+- Status: Accepted
+- Context / Problem: database만 분리해도 Playwright가 시작하는 API, web, OIDC mock 서버가 고정 포트를 공유하면 여러 workflow run이 같은 머신에서 동시에 실행될 수 없다.
+- Decision Outcome: test DB wrapper가 database 이름에서 포트 offset을 계산해 전달하고 Playwright가 세 서버의 base port에 동일한 offset을 적용한다. 호출자는 `KOSMO_TEST_PORT_OFFSET`으로 값을 재정의할 수 있다.
+- Alternatives Considered: runner별 고정 포트를 머신 설정에만 두면 저장소 명령을 그대로 병렬 실행할 수 없고, 실행별 컨테이너 네트워크는 현재 규모에 비해 복잡해 선택하지 않았다.
+- Consequences: 테스트 fixture와 OIDC 요청도 계산된 web/OIDC origin을 사용해야 하며 Playwright 내부 worker 수는 그대로 유지된다.
+- Confirmation / Follow-up: 두 Web E2E 루트 명령을 동시에 실행해 bind 충돌 없이 완료되는지 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/isolate-test-databases-per-run/design.md
+++ b/openspec/changes/isolate-test-databases-per-run/design.md
@@ -1,0 +1,47 @@
+## Context
+
+현재 `scripts/test-db.mjs reset`은 공유 Postgres 컨테이너와 볼륨을 제거한 뒤 다시 만들고, Fedify와 Playwright 테스트는 고정된 `kosmo_test` 데이터베이스를 truncate한다. 이 구조는 단일 실행에서는 결정적이지만 같은 self-hosted runner 머신에서 여러 workflow run을 동시에 처리할 수 없다.
+
+Postgres 서버는 기존 Docker Compose 서비스 하나를 계속 사용한다. 테스트 명령을 감싸는 Node 스크립트가 실행 식별자로 고유 데이터베이스 URL과 포트 offset을 만들고, 컨테이너 내부의 `createdb`/`dropdb`를 사용해 데이터베이스만 준비·정리한다. 자식 명령은 해당 URL과 offset을 환경변수로 받아 기존 Drizzle, Fedify, Playwright 경로를 그대로 사용한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 동일한 Postgres 서버에서 여러 테스트 실행의 schema와 데이터를 분리한다.
+- 테스트 실패 시에도 실행 소유 데이터베이스를 정리하고 원래 종료 코드를 보존한다.
+- 로컬 기본 명령은 추가 설정 없이 계속 동작한다.
+- 외부 의존성이나 원격 DB 없이 현재 self-hosted runner 자원을 병렬 활용한다.
+- 동시에 실행된 Web E2E의 API, web, OIDC mock 서버 포트와 origin을 분리한다.
+- 파괴적 작업은 로컬 `kosmo_test` 네임스페이스에만 허용한다.
+
+**Non-Goals:**
+
+- Playwright spec 자체의 `workers: 1` 제한을 해제하지 않는다.
+- Postgres 서버를 실행별 컨테이너나 원격 Neon branch로 분리하지 않는다.
+- 테스트 스키마 적용 방식을 Drizzle migration으로 변경하지 않는다.
+- runner 인스턴스 설치나 머신 수준 자원 제한을 자동화하지 않는다.
+
+## Risks / Trade-offs
+
+- [동시에 실행된 테스트가 Postgres CPU와 I/O를 공유함] → 우선 workflow 간 DB 충돌만 제거하고 runner 슬롯 수는 머신 측정 결과에 따라 제한한다.
+- [취소나 강제 종료로 데이터베이스가 남을 수 있음] → 실행 이름을 `GITHUB_RUN_ID`와 `GITHUB_RUN_ATTEMPT`에서 결정하고 workflow의 `always()` cleanup에서 같은 이름을 다시 삭제한다.
+- [잘못된 URL로 운영 DB를 삭제할 수 있음] → 호스트가 loopback이고 데이터베이스 이름이 `kosmo_test` 네임스페이스인지 생성, truncate, drop 전에 검증한다.
+- [기존 `.env.test`가 명시적 환경변수를 덮어씀] → 환경파일은 누락된 값만 채우고 schema push와 Playwright도 명시적 `DATABASE_URL`을 우선한다.
+- [고유 DB를 사용해도 고정된 E2E 서버 포트가 충돌함] → wrapper가 실행 식별자에서 포트 offset을 만들고 Playwright 및 fixture가 해당 origin을 사용한다. 필요하면 `KOSMO_TEST_PORT_OFFSET`으로 명시적으로 재정의한다.
+- [기존 `reset` 사용자가 컨테이너 재생성을 기대함] → `reset`은 기본 테스트 데이터베이스만 drop/create하도록 바꾸고 전체 서버 제거는 명시적 `down --volumes`로 유지한다.
+
+## Migration Plan
+
+1. 테스트 DB 스크립트에 실행별 database 생성, 자식 명령 실행, 정리 동작을 추가한다.
+2. 루트 테스트 script와 DB 소비자가 전달받은 `DATABASE_URL`을 사용하게 한다.
+3. Playwright의 로컬 서버와 fixture가 실행별 포트 offset으로 만든 origin을 사용하게 한다.
+4. Fedify와 Web E2E를 각각 새 wrapper로 실행하고 실제 Docker Postgres에서 검증한다.
+5. 두 Web E2E 실행을 동시에 수행해 데이터베이스와 포트 충돌이 없는지 검증한다.
+6. workflow의 전역 concurrency group을 제거하고 database cleanup만 남긴다.
+
+롤백 시 workflow 직렬화와 기존 `reset` 기반 package script를 복원하면 된다. 데이터베이스는 테스트 전용 Docker 볼륨에만 존재하므로 데이터 마이그레이션은 필요 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/isolate-test-databases-per-run/proposal.md
+++ b/openspec/changes/isolate-test-databases-per-run/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+현재 테스트 실행은 하나의 `kosmo_test` 데이터베이스와 Postgres 컨테이너 수명 주기를 공유하므로 동시에 실행하면 reset, schema push, truncate가 서로 충돌한다. self-hosted runner의 여유 자원을 활용해 테스트를 병렬 실행하려면 각 실행이 독립적인 데이터베이스를 사용해야 한다.
+
+## What Changes
+
+- 하나의 로컬 Postgres 서버를 여러 테스트 실행이 공유한다.
+- 각 테스트 실행은 고유한 이름의 데이터베이스를 생성하고 해당 데이터베이스에만 스키마와 fixture를 적용한다.
+- 테스트 성공·실패와 관계없이 실행이 소유한 데이터베이스를 정리한다.
+- 외부에서 전달한 테스트 `DATABASE_URL`을 Fedify와 Web E2E 전체에 일관되게 전달한다.
+- Web E2E의 API, web, OIDC mock 포트도 실행별 offset으로 격리한다.
+- 데이터베이스 격리가 완료되면 Web E2E workflow의 저장소 전역 직렬화 제한을 제거한다.
+
+## Capabilities
+
+### New Capabilities
+
+- `isolated-test-database`: 공유 Postgres 서버에서 실행별 테스트 데이터베이스를 안전하게 생성, 사용, 정리하는 동작을 정의한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- 루트 테스트 DB 스크립트와 package script
+- Docker Compose 테스트 Postgres 수명 주기
+- Fedify 및 Playwright 테스트의 `DATABASE_URL` 처리와 삭제 안전장치
+- Playwright가 관리하는 로컬 서버의 포트와 origin 설정
+- Web E2E GitHub Actions concurrency 및 cleanup 단계
+- 로컬 테스트 실행 안내 문서
+- 새 런타임 의존성은 추가하지 않는다.

--- a/openspec/changes/isolate-test-databases-per-run/specs/isolated-test-database/spec.md
+++ b/openspec/changes/isolate-test-databases-per-run/specs/isolated-test-database/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: 실행별 테스트 데이터베이스 격리
+
+테스트 DB 도구는 하나의 Postgres 서버를 공유하면서 각 테스트 실행에 고유한 `kosmo_test_` 접두사 데이터베이스를 생성하여 사용해야 한다(SHALL).
+
+#### Scenario: 두 테스트 실행이 동시에 시작됨
+
+- **WHEN** 서로 다른 실행 식별자를 가진 두 테스트가 동시에 시작된다
+- **THEN** 각 실행은 서로 다른 데이터베이스를 생성하고 상대 실행의 schema, fixture, reset 결과에 영향을 주지 않는다
+
+### Requirement: 명시적인 테스트 데이터베이스 URL 전달
+
+테스트 명령은 호출자가 제공한 `DATABASE_URL`을 기본 테스트 URL보다 우선하고 schema push, Fedify 테스트, Playwright 설정 및 애플리케이션 서버에 동일한 URL을 전달해야 한다(SHALL).
+
+#### Scenario: 실행별 DATABASE_URL이 제공됨
+
+- **WHEN** 테스트 실행이 고유 데이터베이스를 가리키는 `DATABASE_URL`을 제공한다
+- **THEN** 테스트 DB 도구와 모든 DB 사용 테스트 프로세스는 해당 URL만 사용한다
+
+#### Scenario: DATABASE_URL이 제공되지 않음
+
+- **WHEN** 개발자가 별도 환경변수 없이 로컬 테스트 명령을 실행한다
+- **THEN** 테스트 DB 도구는 충돌 가능성이 낮은 실행별 데이터베이스 이름을 생성하고 그 URL로 테스트를 실행한다
+
+### Requirement: 실행 소유 데이터베이스 정리
+
+테스트 실행은 성공 또는 실패 여부와 관계없이 자신이 생성한 데이터베이스의 연결을 종료하고 해당 데이터베이스만 삭제해야 한다(SHALL).
+
+#### Scenario: 테스트가 성공함
+
+- **WHEN** 테스트 명령이 성공적으로 끝난다
+- **THEN** 실행이 생성한 데이터베이스가 삭제되고 공유 Postgres 서버는 계속 실행된다
+
+#### Scenario: 테스트가 실패함
+
+- **WHEN** schema push, Fedify 또는 Playwright 테스트가 실패한다
+- **THEN** 종료 처리에서 실행이 생성한 데이터베이스가 삭제되고 원래 실패 상태가 보존된다
+
+### Requirement: 파괴적 DB 작업 안전장치
+
+테스트 DB 도구와 fixture는 reset, truncate 또는 drop 전에 대상이 허용된 로컬 테스트 서버의 `kosmo_test` 또는 `kosmo_test_*` 네임스페이스 데이터베이스인지 검증해야 한다(MUST).
+
+#### Scenario: 테스트 데이터베이스가 아닌 URL이 제공됨
+
+- **WHEN** 대상 호스트 또는 데이터베이스 이름이 테스트 안전 조건을 만족하지 않는다
+- **THEN** 파괴적 작업을 실행하지 않고 명확한 오류로 실패한다
+
+### Requirement: CI 병렬 실행 허용
+
+Web E2E workflow는 실행별 데이터베이스와 로컬 서버 포트 격리를 사용하고 서로 다른 workflow run을 저장소 전역 잠금으로 직렬화하지 않아야 한다(SHALL).
+
+#### Scenario: 여러 workflow run이 대기 중임
+
+- **WHEN** 둘 이상의 self-hosted runner 슬롯이 사용 가능하다
+- **THEN** workflow run은 각자 고유 데이터베이스와 API, web, OIDC mock 포트를 사용해 동시에 테스트 단계를 실행할 수 있다
+
+### Requirement: 실행별 Web E2E origin 일관성
+
+테스트 DB wrapper는 실행별 포트 offset을 자식 명령에 전달하고 Playwright는 해당 offset으로 API, web, OIDC mock origin을 일관되게 구성해야 한다(SHALL).
+
+#### Scenario: 두 Web E2E 실행이 동시에 시작됨
+
+- **WHEN** 서로 다른 실행 식별자를 가진 두 Web E2E 테스트가 같은 머신에서 동시에 시작된다
+- **THEN** 두 실행의 로컬 서버는 서로 다른 포트에 bind하고 각 테스트 fixture와 OIDC 요청은 자기 실행의 origin을 사용한다

--- a/openspec/changes/isolate-test-databases-per-run/tasks.md
+++ b/openspec/changes/isolate-test-databases-per-run/tasks.md
@@ -1,0 +1,20 @@
+## 1. 테스트 데이터베이스 수명 주기
+
+- [x] 1.1 테스트 DB 스크립트에 loopback 및 `kosmo_test` 네임스페이스 검증을 추가한다.
+- [x] 1.2 공유 Postgres에서 실행별 database를 생성하고 자식 명령 종료 후 삭제하는 `run` 흐름을 구현한다.
+- [x] 1.3 기본 `reset`을 서버 재생성 대신 기본 테스트 database 재생성으로 변경하고 명시적 cleanup 명령을 제공한다.
+
+## 2. 테스트 명령과 CI 연결
+
+- [x] 2.1 루트 package script가 실행별 wrapper 안에서 schema push와 Fedify/Web E2E를 실행하도록 변경한다.
+- [x] 2.2 Fedify와 Playwright가 명시적 `DATABASE_URL`을 우선 사용하고 동일한 안전 조건을 검증하도록 변경한다.
+- [x] 2.3 Web E2E workflow의 전역 concurrency 제한과 공유 Postgres 종료 cleanup을 실행별 database cleanup으로 교체한다.
+- [x] 2.4 README의 로컬 테스트 DB 및 병렬 실행 설명을 새 수명 주기에 맞게 갱신한다.
+- [x] 2.5 테스트 DB wrapper와 Playwright에 실행별 포트 offset을 연결하고 fixture origin을 일치시킨다.
+
+## 3. 검증
+
+- [x] 3.1 허용되지 않은 database URL 거부와 성공·실패 자식 명령의 database cleanup 및 종료 코드 보존을 검증한다.
+- [x] 3.2 Fedify와 Web E2E 루트 명령을 실제 Docker Postgres에서 실행한다.
+- [x] 3.3 두 Web E2E 루트 명령을 동시에 실행해 database와 로컬 서버 포트 충돌 없이 완료되는지 확인한다.
+- [x] 3.4 OpenSpec 및 변경 파일 formatting 검증을 실행한다.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "scripts": {
     "db:test:down": "node scripts/test-db.mjs down",
-    "db:test:push": "set -a && . ./.env.test && set +a && env NODE_OPTIONS='--preserve-symlinks --preserve-symlinks-main' ./packages/core/node_modules/.bin/drizzle-kit push --config packages/core/drizzle.config.ts",
+    "db:test:drop": "node scripts/test-db.mjs drop",
+    "db:test:push": "env DATABASE_URL=\"${DATABASE_URL:-postgres://kosmo:kosmo@localhost:54329/kosmo_test}\" NODE_OPTIONS='--preserve-symlinks --preserve-symlinks-main' ./packages/core/node_modules/.bin/drizzle-kit push --config packages/core/drizzle.config.ts",
     "db:test:reset": "node scripts/test-db.mjs reset",
     "db:test:up": "node scripts/test-db.mjs up",
     "db:bootstrap-local-instance": "pnpm --filter @kosmo/api db:bootstrap-local-instance",
@@ -14,8 +15,10 @@
     "lint:prettier": "prettier --check --ignore-unknown '**/*'",
     "lint:syncpack": "syncpack lint --dependency-types prod,dev,peer",
     "prepare": "husky || true",
-    "test:e2e": "pnpm db:test:reset && pnpm db:test:push && pnpm --filter @kosmo/web test:e2e",
-    "test:fedify": "pnpm --filter @kosmo/fedify test:unit"
+    "test:e2e": "node scripts/test-db.mjs run -- pnpm test:e2e:database",
+    "test:e2e:database": "pnpm db:test:push && pnpm --filter @kosmo/web test:e2e",
+    "test:fedify": "node scripts/test-db.mjs run -- pnpm test:fedify:database",
+    "test:fedify:database": "pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -8,7 +8,7 @@ import type * as FederationModule from './federation';
 import type * as WebFinger from './webfinger';
 
 const publicOrigin = 'http://127.0.0.1:4173';
-const databaseUrl = 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
 
 let db: typeof CoreDb.db;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
@@ -149,7 +149,11 @@ const truncateDatabase = async () => {
 };
 
 const assertTestDatabaseUrl = () => {
-  assert.equal(new URL(process.env.DATABASE_URL ?? '').pathname, '/kosmo_test');
+  const url = new URL(process.env.DATABASE_URL ?? '');
+  const databaseName = decodeURIComponent(url.pathname.slice(1));
+
+  assert.ok(['127.0.0.1', '[::1]', 'localhost'].includes(url.hostname));
+  assert.match(databaseName, /^kosmo_test(?:_[a-z0-9_]+)?$/);
 };
 
 const createRemoteInstance = async () =>

--- a/scripts/test-db.mjs
+++ b/scripts/test-db.mjs
@@ -1,28 +1,90 @@
 import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
 const composeFile = 'docker-compose.test.yml';
 const serviceName = 'postgres';
 const command = process.argv[2];
-const extraArgs = process.argv.slice(3);
+const args = process.argv.slice(3);
+const providedDatabaseUrl = process.env.DATABASE_URL;
 
-if (!command || !['down', 'reset', 'up'].includes(command)) {
-  console.error('Usage: node scripts/test-db.mjs <down|reset|up> [compose args...]');
+if (!command || !['down', 'drop', 'reset', 'run', 'up'].includes(command)) {
+  console.error('Usage: node scripts/test-db.mjs <down|drop|reset|run|up> [-- command...]');
   process.exit(1);
 }
 
 loadEnvFile('.env.test');
 const compose = findCompose();
 
-if (command === 'down') {
-  runCompose(['down', ...extraArgs]);
-} else if (command === 'up') {
-  runCompose(['up', '-d', ...extraArgs]);
-  waitForHealthyService();
-} else {
-  runCompose(['down', '--volumes', '--remove-orphans']);
-  runCompose(['up', '-d', '--force-recreate']);
-  waitForHealthyService();
+try {
+  process.exitCode = main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}
+
+function main() {
+  if (command === 'down') {
+    runCompose(['down', ...args]);
+    return 0;
+  }
+
+  if (command === 'up') {
+    ensurePostgres();
+    return 0;
+  }
+
+  if (command === 'reset') {
+    const databaseUrl = getDefaultDatabaseUrl();
+    assertSafeTestDatabaseUrl(databaseUrl);
+    ensurePostgres();
+    recreateDatabase(getDatabaseName(databaseUrl));
+    return 0;
+  }
+
+  const databaseUrl = getRunDatabaseUrl();
+  assertSafeTestDatabaseUrl(databaseUrl, { isolated: true });
+
+  if (command === 'drop') {
+    if (getContainerId()) {
+      dropDatabase(getDatabaseName(databaseUrl));
+    }
+
+    return 0;
+  }
+
+  const delimiter = args.indexOf('--');
+  const childCommand = delimiter === -1 ? [] : args.slice(delimiter + 1);
+
+  if (childCommand.length === 0) {
+    throw new Error('`run` requires a command after `--`.');
+  }
+
+  ensurePostgres();
+  recreateDatabase(getDatabaseName(databaseUrl));
+
+  let childStatus = 1;
+  let cleanupError;
+
+  try {
+    childStatus = runChild(childCommand, databaseUrl);
+  } finally {
+    try {
+      dropDatabase(getDatabaseName(databaseUrl));
+    } catch (error) {
+      cleanupError = error;
+    }
+  }
+
+  if (cleanupError) {
+    console.error(cleanupError instanceof Error ? cleanupError.message : cleanupError);
+
+    if (childStatus === 0) {
+      return 1;
+    }
+  }
+
+  return childStatus;
 }
 
 function loadEnvFile(path) {
@@ -40,7 +102,66 @@ function loadEnvFile(path) {
 
     const key = trimmed.slice(0, separator);
     const value = trimmed.slice(separator + 1);
-    process.env[key] = value;
+
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function getDefaultDatabaseUrl() {
+  return new URL(process.env.DATABASE_URL ?? '');
+}
+
+function getRunDatabaseUrl() {
+  if (providedDatabaseUrl) {
+    return new URL(providedDatabaseUrl);
+  }
+
+  const url = getDefaultDatabaseUrl();
+  const runId = process.env.GITHUB_RUN_ID;
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? '1';
+  const suffix = runId
+    ? `${runId}_${runAttempt}`
+    : `${process.pid}_${randomUUID().replaceAll('-', '').slice(0, 8)}`;
+
+  url.pathname = `/kosmo_test_${suffix}`;
+  return url;
+}
+
+function getDatabaseName(databaseUrl) {
+  return decodeURIComponent(databaseUrl.pathname.slice(1));
+}
+
+function getPortOffset(databaseName) {
+  if (process.env.KOSMO_TEST_PORT_OFFSET !== undefined) {
+    const offset = Number(process.env.KOSMO_TEST_PORT_OFFSET);
+
+    if (!Number.isInteger(offset) || offset < 0 || offset > 60_000) {
+      throw new Error('KOSMO_TEST_PORT_OFFSET must be an integer from 0 to 60000.');
+    }
+
+    return offset;
+  }
+
+  let hash = 0;
+
+  for (const character of databaseName) {
+    hash = (Math.imul(hash, 31) + character.charCodeAt(0)) >>> 0;
+  }
+
+  return (hash % 5_000) * 10;
+}
+
+function assertSafeTestDatabaseUrl(databaseUrl, { isolated = false } = {}) {
+  const loopbackHosts = new Set(['127.0.0.1', '[::1]', 'localhost']);
+  const databaseName = getDatabaseName(databaseUrl);
+  const databasePattern = isolated ? /^kosmo_test_[a-z0-9_]+$/ : /^kosmo_test(?:_[a-z0-9_]+)?$/;
+
+  if (!loopbackHosts.has(databaseUrl.hostname) || !databasePattern.test(databaseName)) {
+    throw new Error(
+      `Refusing destructive test database operation for ${databaseUrl.hostname}/${databaseName}.`,
+    );
   }
 }
 
@@ -56,8 +177,37 @@ function findCompose() {
     }
   }
 
-  console.error('Neither `docker compose` nor `docker-compose` is available.');
-  process.exit(1);
+  throw new Error('Neither `docker compose` nor `docker-compose` is available.');
+}
+
+function ensurePostgres() {
+  runCompose(['up', '-d']);
+  waitForHealthyService();
+}
+
+function recreateDatabase(databaseName) {
+  dropDatabase(databaseName);
+  runPostgresCommand([
+    'createdb',
+    '--username',
+    process.env.POSTGRES_USER ?? 'kosmo',
+    databaseName,
+  ]);
+}
+
+function dropDatabase(databaseName) {
+  runPostgresCommand([
+    'dropdb',
+    '--if-exists',
+    '--force',
+    '--username',
+    process.env.POSTGRES_USER ?? 'kosmo',
+    databaseName,
+  ]);
+}
+
+function runPostgresCommand(args) {
+  runCompose(['exec', '-T', serviceName, ...args]);
 }
 
 function runCompose(args) {
@@ -71,9 +221,32 @@ function run(command, args, options = {}) {
     ...options,
   });
 
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+  if (result.error) {
+    throw result.error;
   }
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status ?? 1}): ${command} ${args.join(' ')}`);
+  }
+}
+
+function runChild([childCommand, ...childArgs], databaseUrl) {
+  const databaseName = getDatabaseName(databaseUrl);
+  const result = spawnSync(childCommand, childArgs, {
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl.toString(),
+      KOSMO_TEST_PORT_OFFSET: String(getPortOffset(databaseName)),
+    },
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    console.error(result.error);
+    return 1;
+  }
+
+  return result.status ?? 1;
 }
 
 function capture(command, args) {
@@ -83,22 +256,23 @@ function capture(command, args) {
     stdio: ['ignore', 'pipe', 'inherit'],
   });
 
+  if (result.error) {
+    throw result.error;
+  }
+
   if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+    throw new Error(`Command failed (${result.status ?? 1}): ${command} ${args.join(' ')}`);
   }
 
   return result.stdout.trim();
 }
 
+function getContainerId() {
+  return capture(compose.bin, [...compose.args, '-f', composeFile, 'ps', '-q', serviceName]);
+}
+
 function waitForHealthyService() {
-  const containerId = capture(compose.bin, [
-    ...compose.args,
-    '-f',
-    composeFile,
-    'ps',
-    '-q',
-    serviceName,
-  ]);
+  const containerId = getContainerId();
   const deadline = Date.now() + 60_000;
 
   while (Date.now() < deadline) {
@@ -116,6 +290,5 @@ function waitForHealthyService() {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1_000);
   }
 
-  console.error(`${serviceName} did not become healthy within 60 seconds.`);
-  process.exit(1);
+  throw new Error(`${serviceName} did not become healthy within 60 seconds.`);
 }


### PR DESCRIPTION
## 무엇을 변경했는지

- 하나의 Docker Postgres 서버를 유지하면서 테스트 실행마다 고유한 `kosmo_test_*` 데이터베이스를 생성하고 종료 시 해당 데이터베이스만 삭제합니다.
- Web E2E가 시작하는 API, web, OIDC mock 서버에도 실행별 포트 offset을 적용합니다.
- Fedify, Drizzle, Playwright와 fixture가 실행별 `DATABASE_URL` 및 origin을 일관되게 사용하도록 변경했습니다.
- loopback의 테스트 DB 네임스페이스 밖에서는 truncate/drop을 거부합니다.
- Web E2E workflow의 저장소 전역 `concurrency` 그룹을 제거하고 실행별 DB cleanup으로 교체했습니다.
- 설계와 안전 조건, 검증 항목을 OpenSpec change로 기록했습니다.

## 왜 변경했는지

기존 테스트는 고정된 `kosmo_test` 데이터베이스, Postgres 컨테이너 reset, 고정 E2E 포트를 공유해 같은 머신에서 동시에 실행할 수 없었습니다. 이를 피하려고 모든 Web E2E workflow를 하나의 concurrency 그룹으로 직렬화하면서, 새 실행이 기존 pending 실행을 교체 취소해 merge queue required check가 영구 대기하는 문제가 발생했습니다.

이 PR은 공유 자원 충돌 자체를 제거해 [#227](https://github.com/byulmaru/kosmo/pull/227)의 `queue: max` 우회를 대체합니다. pending 실행을 모두 FIFO로 보존하는 대신 각 workflow run이 독립적으로 실행될 수 있게 합니다.

## 어떻게 확인할 수 있는지

- `pnpm test:fedify`와 `pnpm test:e2e` 동시 실행
  - Fedify 8개 통과
  - Web E2E 43개 통과
- `pnpm test:e2e` 두 개 동시 실행
  - 각 실행 43개, 총 86개 통과
  - 임시 테스트 데이터베이스가 남지 않음을 확인
- `pnpm --filter @kosmo/web check`
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `openspec validate isolate-test-databases-per-run --strict`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- 현재 등록된 self-hosted runner 슬롯이 하나라면 GitHub job은 계속 순차 실행됩니다. 실제 workflow 병렬화를 사용하려면 같은 머신에 runner 인스턴스를 하나 더 등록해야 합니다.
- OpenSpec change는 전체 12개 task와 검증을 완료했지만 PR lifecycle과 분리해 아직 archive하지 않았습니다.
