### PR TITLE
모듈이 전체 테스트 계약을 소유하게 한다

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Web E2E
+name: Test
 
 on:
   pull_request:
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  web_e2e:
-    name: Web E2E
+  test:
+    name: Test
     runs-on: [self-hosted]
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,44 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  unit_test:
-    name: Unit Test
-    runs-on: [self-hosted]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          cache: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run unit tests
-        run: pnpm test:unit
-
-  typescript:
-    name: TypeScript
-    runs-on: [self-hosted]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          cache: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check TypeScript
-        run: pnpm check
-
-  storybook:
-    name: Storybook
+  test:
+    name: Test
     runs-on: [self-hosted]
     steps:
       - name: Checkout repository
@@ -63,57 +27,8 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm --filter @kosmo/app exec playwright install chromium
 
-      - name: Build and test the app Storybook
-        run: pnpm test:storybook
-
-  fedify:
-    name: Fedify
-    runs-on: [self-hosted]
-    env:
-      DATABASE_URL: >-
-        postgres://kosmo:kosmo@localhost:54329/kosmo_test_${{ github.run_id }}_${{ github.run_attempt }}_fedify
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          cache: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run Fedify unit tests
-        run: pnpm test:fedify
-
-      - name: Clean up test database
-        if: always()
-        run: pnpm db:test:drop
-
-  web_e2e:
-    name: Web E2E
-    runs-on: [self-hosted]
-    env:
-      DATABASE_URL: >-
-        postgres://kosmo:kosmo@localhost:54329/kosmo_test_${{ github.run_id }}_${{ github.run_attempt }}_web_e2e
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          cache: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright Chromium
-        run: pnpm --filter @kosmo/app exec playwright install chromium
-
-      - name: Run web E2E tests
-        run: pnpm test:e2e
+      - name: Run module tests
+        run: pnpm test
 
       - name: Upload Playwright artifacts
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test
+  unit_test:
+    name: Unit Test
     runs-on: [self-hosted]
     steps:
       - name: Checkout repository
@@ -24,24 +24,93 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run app and web unit tests
-        run: |
-          pnpm --filter @kosmo/app test:unit
-          pnpm --filter @kosmo/web test:unit
+      - name: Run unit tests
+        run: pnpm test:unit
 
-      - name: Check web TypeScript
-        run: pnpm --filter @kosmo/web check
+  typescript:
+    name: TypeScript
+    runs-on: [self-hosted]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check TypeScript
+        run: pnpm check
+
+  storybook:
+    name: Storybook
+    runs-on: [self-hosted]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
         run: pnpm --filter @kosmo/app exec playwright install chromium
 
       - name: Build and test the app Storybook
-        run: |
-          pnpm --filter @kosmo/app build-storybook
-          pnpm --filter @kosmo/app test:storybook
+        run: pnpm test:storybook
+
+  fedify:
+    name: Fedify
+    runs-on: [self-hosted]
+    env:
+      DATABASE_URL: >-
+        postgres://kosmo:kosmo@localhost:54329/kosmo_test_${{ github.run_id }}_${{ github.run_attempt }}_fedify
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run Fedify unit tests
         run: pnpm test:fedify
+
+      - name: Clean up test database
+        if: always()
+        run: pnpm db:test:drop
+
+  web_e2e:
+    name: Web E2E
+    runs-on: [self-hosted]
+    env:
+      DATABASE_URL: >-
+        postgres://kosmo:kosmo@localhost:54329/kosmo_test_${{ github.run_id }}_${{ github.run_attempt }}_web_e2e
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @kosmo/app exec playwright install chromium
 
       - name: Run web E2E tests
         run: pnpm test:e2e

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node --import tsx src/index.ts",
     "lint:tsc": "tsc --noEmit",
+    "test": "pnpm lint:tsc && pnpm test:unit",
     "test:unit": "NODE_ENV=production node --import tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -18,6 +18,7 @@
     "relay:watch": "relay-compiler --watch",
     "start": "expo start",
     "storybook:dev": "storybook dev -p 6006 --disable-telemetry",
+    "test": "pnpm check && pnpm test:unit && pnpm build-storybook && pnpm test:storybook",
     "test:storybook": "vitest run --project=storybook",
     "test:unit": "node --import tsx --test 'src/**/*.test.ts'",
     "web": "expo start --web --port 5173"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "check": "tsc --noEmit",
     "dev": "PORT=5174 tsx watch src/server/index.ts",
     "start": "tsx src/server/index.ts",
-    "test": "pnpm test:unit && pnpm test:e2e",
+    "test": "pnpm check && pnpm test:unit && pnpm --workspace-root test:e2e",
     "test:e2e": "playwright test --pass-with-no-tests",
     "test:unit": "vitest run"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "db:test:reset": "node scripts/test-db.mjs reset",
     "db:test:up": "node scripts/test-db.mjs up",
     "db:bootstrap-local-instance": "pnpm --filter @kosmo/api db:bootstrap-local-instance",
-    "check": "pnpm --filter @kosmo/app check && pnpm --filter @kosmo/web check",
+    "check": "pnpm --recursive --parallel --if-present check",
     "dev": "node scripts/vault-run.mjs -- pnpm --recursive --parallel --if-present dev",
     "lint:eslint": "eslint --max-warnings 0 .",
     "lint:prettier": "prettier --check --ignore-unknown '**/*'",
@@ -20,8 +20,8 @@
     "test:e2e:database": "pnpm db:test:push && pnpm --filter @kosmo/web test:e2e",
     "test:fedify": "node scripts/test-db.mjs run -- pnpm test:fedify:database",
     "test:fedify:database": "pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit",
-    "test:storybook": "pnpm --filter @kosmo/app build-storybook && pnpm --filter @kosmo/app test:storybook",
-    "test:unit": "pnpm --filter @kosmo/api test:unit && pnpm --filter @kosmo/app test:unit && pnpm --filter @kosmo/web test:unit"
+    "test:storybook": "pnpm --recursive --parallel --if-present build-storybook && pnpm --recursive --parallel --if-present test:storybook",
+    "test:unit": "pnpm --recursive --parallel --if-present --filter '!@kosmo/fedify' test:unit"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -10,18 +10,16 @@
     "db:test:reset": "node scripts/test-db.mjs reset",
     "db:test:up": "node scripts/test-db.mjs up",
     "db:bootstrap-local-instance": "pnpm --filter @kosmo/api db:bootstrap-local-instance",
-    "check": "pnpm --recursive --parallel --if-present check",
     "dev": "node scripts/vault-run.mjs -- pnpm --recursive --parallel --if-present dev",
     "lint:eslint": "eslint --max-warnings 0 .",
     "lint:prettier": "prettier --check --ignore-unknown '**/*'",
     "lint:syncpack": "syncpack lint --dependency-types prod,dev,peer",
     "prepare": "husky || true",
+    "test": "pnpm --recursive --workspace-concurrency=1 --if-present test",
     "test:e2e": "node scripts/test-db.mjs run -- pnpm test:e2e:database",
     "test:e2e:database": "pnpm db:test:push && pnpm --filter @kosmo/web test:e2e",
     "test:fedify": "node scripts/test-db.mjs run -- pnpm test:fedify:database",
-    "test:fedify:database": "pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit",
-    "test:storybook": "pnpm --recursive --parallel --if-present build-storybook && pnpm --recursive --parallel --if-present test:storybook",
-    "test:unit": "pnpm --recursive --parallel --if-present --filter '!@kosmo/fedify' test:unit"
+    "test:fedify:database": "pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "db:test:reset": "node scripts/test-db.mjs reset",
     "db:test:up": "node scripts/test-db.mjs up",
     "db:bootstrap-local-instance": "pnpm --filter @kosmo/api db:bootstrap-local-instance",
+    "check": "pnpm --filter @kosmo/app check && pnpm --filter @kosmo/web check",
     "dev": "node scripts/vault-run.mjs -- pnpm --recursive --parallel --if-present dev",
     "lint:eslint": "eslint --max-warnings 0 .",
     "lint:prettier": "prettier --check --ignore-unknown '**/*'",
@@ -18,7 +19,9 @@
     "test:e2e": "node scripts/test-db.mjs run -- pnpm test:e2e:database",
     "test:e2e:database": "pnpm db:test:push && pnpm --filter @kosmo/web test:e2e",
     "test:fedify": "node scripts/test-db.mjs run -- pnpm test:fedify:database",
-    "test:fedify:database": "pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit"
+    "test:fedify:database": "pnpm db:test:push && pnpm --filter @kosmo/fedify test:unit",
+    "test:storybook": "pnpm --filter @kosmo/app build-storybook && pnpm --filter @kosmo/app test:storybook",
+    "test:unit": "pnpm --filter @kosmo/api test:unit && pnpm --filter @kosmo/app test:unit && pnpm --filter @kosmo/web test:unit"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/packages/fedify/package.json
+++ b/packages/fedify/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "lint:tsc": "tsc --noEmit",
+    "test": "pnpm lint:tsc && pnpm --workspace-root test:fedify",
     "test:unit": "tsx --test src/*.test.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Linear: [PROD-279](https://linear.app/byulmaru/issue/PROD-279/모듈별-테스트-계약을-root-test-workflow에서-실행한다)

## 무엇을 변경했는지

- `.github/workflows/web-e2e.yml`을 `.github/workflows/test.yml`로 정리하고 하나의 `Test` job/check만 실행합니다.
- root `test`는 `pnpm --recursive --workspace-concurrency=1 --if-present test`로 각 모듈의 `test`를 순차 실행합니다.
- 각 모듈이 자신의 전체 테스트 계약을 소유합니다.
  - API: TypeScript + unit
  - App: TypeScript/Relay + unit + Storybook build/test
  - Web: TypeScript + unit + 격리된 DB의 Web E2E
  - Fedify: TypeScript + 격리된 DB의 Fedify test
- Web/Fedify 모듈은 기존 root DB wrapper를 호출하고, wrapper는 모듈의 하위 test script를 호출해 순환을 피합니다.
- `pull_request`, `merge_group`, `workflow_dispatch` trigger와 self-hosted runner를 유지합니다.

## 왜 변경했는지

기존 workflow는 어떤 테스트를 실행할지 CI 파일에서 직접 나열해 모듈의 실제 테스트 계약과 쉽게 어긋날 수 있었습니다. 실제로 API unit과 app TypeScript가 누락되어 있었고 check 이름도 전체 범위를 설명하지 못했습니다.

각 모듈의 `test`가 타입 검사와 모든 테스트를 소유하면 로컬과 CI가 동일한 진입점을 사용하고, 새 테스트 종류를 추가할 때 해당 모듈만 변경하면 됩니다. CI 자체는 하나의 `Test` check로 유지합니다.

이 변경은 PROD-267 / PR #224와 독립된 tooling-only 작업이며 해당 브랜치와 구현 diff를 수정하지 않습니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/test.yml`
- 변경된 모든 `package.json`의 JSON 파싱
- `git diff --check`
- GitHub Actions:
  - `Test` 성공 — 2분 9초
  - `Lint` 성공 — 36초
  - `Semgrep scan` 성공 — 35초
- root `pnpm test`에서 API/App/Web/Fedify의 타입 검사와 전체 test가 순차 실행됐습니다.
- Web/Fedify DB wrapper의 schema push, test, cleanup이 충돌 없이 완료됐습니다.

## ruleset 전환 절차와 결과

1. 이전 required checks를 유지한 채 이 PR에서 새 단일 `Test` check의 생성·성공을 확인했습니다.
2. 전환 직전에 ruleset 전체 값과 main merge queue 0건을 재확인했습니다.
3. 다른 ruleset 설정을 보존한 단일 update로 required checks를 `Lint`, `Semgrep scan`, `Test`로 교체했습니다.
4. 별도 readback으로 최종 required checks와 이 PR의 CLEAN 상태를 확인했습니다.
5. 전환 후 main merge queue는 계속 0건입니다.

## 영향 범위

- 기존 open PR은 `Test` 결과가 없어 전환 직후 일시적으로 차단됩니다.
- 실제로 PR #224는 기존 `Web E2E` 결과만 있어 현재 BLOCKED입니다.
- 이 PR merge 후 기존 PR 브랜치에 최신 `main`을 반영하면 새 `Test` workflow를 실행할 수 있습니다.
- `merge_group` trigger는 유지했습니다. 실제 merge queue 실행은 이 PR이 queue에 들어갈 때 `Test`를 보고하는지 확인해야 합니다.

## 아직 어떤 문제가 남았는지

- 리뷰 후 이 PR을 merge queue에 넣을 때 `merge_group`의 `Test` 생성 확인이 필요합니다.
- 기존 open PR은 이 PR merge 후 최신 `main` 반영과 `Test` 실행이 필요합니다.