### PR TITLE
dev 배포 전에 DB migration을 실행한다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   restart_dev:
@@ -78,6 +78,15 @@ jobs:
           curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-darwin-${argocd_arch}"
           chmod 555 "${RUNNER_TEMP}/argocd"
           echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
+
+      - name: Sync dev application
+        env:
+          ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          argocd --server "${ARGOCD_SERVER}" --grpc-web app sync kosmo-dev --timeout 600
 
       - name: Restart dev rollouts
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
   pnpm install --filter @kosmo/api... --filter @kosmo/web... --frozen-lockfile --prod --ignore-scripts --store-dir=/var/cache/pnpm/store
 
 COPY --chown=app:app apps/api ./apps/api
+COPY --chown=app:app drizzle ./drizzle
 COPY --chown=app:app packages/core ./packages/core
 COPY --chown=app:app packages/fedify ./packages/fedify
 COPY --chown=app:app apps/web/src/server ./apps/web/src/server

--- a/apps/helm/templates/database-migration-job.yaml
+++ b/apps/helm/templates/database-migration-job.yaml
@@ -1,0 +1,56 @@
+{{- if eq .Values.env "dev" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-db-migrate" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: db-migrate
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.version | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  activeDeadlineSeconds: 600
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: db-migrate
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: db-migrate
+          image: {{ printf "%s:%s" .Values.image .Values.version | quote }}
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - migrate
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-app" (include "kosmo.postgresName" .) | quote }}
+                  key: password
+            - name: DATABASE_URL
+              value: {{ include "kosmo.databaseUrl" . | quote }}
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+{{- end }}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,10 @@ case "${1:-web}" in
     cd /app/apps/api
     exec node --import tsx src/index.ts
     ;;
+  migrate)
+    cd /app/packages/core
+    exec node --import tsx db/migrate.ts
+    ;;
   *)
     echo "Unknown app: $1" >&2
     exit 1

--- a/memory/script.md
+++ b/memory/script.md
@@ -36,3 +36,11 @@
 - `.codex/environments/environment.toml`의 setup script는 `mise trust`와 `pnpm install` 전에 원격 `refs/heads/main`을 `refs/remotes/origin/main`으로 fetch하고, 해당 ref의 commit OID를 확정한 뒤 로컬 `main` worktree 또는 `main` ref를 fast-forward로 최신화한다.
 - 새 Codex worktree의 현재 HEAD가 fetch된 `origin/main` commit의 조상인 경우에는 현재 worktree도 해당 commit까지 fast-forward하거나 detached HEAD를 해당 commit으로 옮긴다.
 - 로컬 `main`이 `origin/main`으로 fast-forward될 수 없는 상태라면 setup에서 자동 갱신을 거부하고 실패시킨다.
+
+## Dev database migrations
+
+- dev 배포는 `Deploy Dev`가 `kosmo-dev` 애플리케이션을 full sync하고, dev 전용 Argo CD `PreSync` Job이 같은 `latest` 런타임 이미지의 `migrate` entrypoint를 실행한 뒤 기존 API/web Rollout을 restart한다. sync나 migration이 실패하면 restart하지 않는다.
+- migration runner는 Drizzle history와 PostgreSQL advisory lock을 사용한다. `Deploy Dev` 실행도 취소하지 않고 직렬화하므로 동일 DB에 migration을 동시에 적용하지 않는다.
+- dev migration은 기존 dev DB와 credential을 그대로 사용하고 데이터를 reset하지 않는다. dev downtime은 허용한다.
+- 로컬에서는 `pnpm --filter @kosmo/core db:migrate`로 같은 runner를 실행한다. 런타임 이미지에는 `drizzle/` migration 파일이 포함된다.
+- production의 immutable image, expand/contract, backup/rollback/approval gate와 배포 smoke는 PROD-269 후속 범위이며 dev 계약을 그대로 production에 적용하지 않는다.

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-12

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/decisions.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/decisions.md
@@ -1,0 +1,63 @@
+## Context
+
+이 기록은 PROD-280의 Linear 범위, `dev-database-migrations` spec, 현재 Docker Build → Deploy Dev → Argo Rollout restart 경로와 사용자 논의를 반영한다. dev는 `latest`와 허용된 downtime을 유지하고, production migration 정책은 PROD-269가 별도로 소유한다.
+
+## Decision Records
+
+### Dev는 `latest` image와 downtime 허용 정책을 유지한다
+
+- Decision Date: 2026-07-12
+- Status: Accepted
+- Context / Problem: production에서는 migration과 workload를 같은 immutable release로 묶어야 하지만 현재 dev는 빠른 반복을 위해 `latest` restart를 사용하고 downtime이 문제되지 않는다.
+- Decision Outcome: PROD-280은 dev의 `latest` image reference를 유지하고 migration 직후 기존 workload가 잠시 실패할 수 있음을 허용한다. 기존 data는 reset하지 않고 version-controlled migration으로 보존한다.
+- Alternatives Considered: dev도 SHA/digest로 전환하는 방식은 production release identity 설계와 결합돼 현재 범위를 키운다. DB reset은 migration 보존 계약을 검증하지 못하고 기존 dev data를 불필요하게 버린다.
+- Consequences: dev는 무중단과 rollback compatibility를 보장하지 않는다. migration과 restart는 한 직렬 workflow에서 최대한 가깝게 실행한다.
+- Confirmation / Follow-up: production immutable image와 expand/contract는 PROD-269에서 결정한다.
+
+### 같은 runtime image의 독립 migration command와 Job을 사용한다
+
+- Decision Date: 2026-07-12
+- Status: Accepted
+- Context / Problem: app startup migration은 pod 수만큼 경쟁하고 initContainer는 rollout 중 모든 pod에서 반복되며, 별도 migration image는 같은 release의 code와 SQL이 어긋날 수 있다.
+- Decision Outcome: runtime image에 migration SQL과 `migrate` command를 포함하고, Argo CD가 app container와 분리된 단일 Kubernetes Job으로 실행한다.
+- Alternatives Considered: startup migration과 initContainer는 중복 실행과 rollout 결합 때문에 제외한다. 별도 image는 build/promotion surface를 늘린다. GitHub runner에서 직접 DB에 연결하면 cluster-local DB credential과 network 경계를 CI에 노출한다.
+- Consequences: Dockerfile과 entrypoint가 migration runtime도 소유한다. Job은 workload와 같은 image와 DB secret을 사용한다.
+- Confirmation / Follow-up: container command, Helm render와 disposable PostgreSQL 실행으로 검증한다.
+
+### GitHub Actions가 full sync를 시작하고 Argo PreSync가 rollout을 gate한다
+
+- Decision Date: 2026-07-12
+- Status: Accepted
+- Context / Problem: 현재 Deploy Dev는 Argo Rollout restart action만 실행하므로 hook이 실행될 application sync 경계가 없다.
+- Decision Outcome: Docker Build 완료 workflow가 `argocd app sync kosmo-dev`를 실행하고, `PreSync` migration Job 성공 뒤에만 기존 API/web restart action을 실행한다. migration-aware deploy는 취소하지 않고 직렬화한다.
+- Alternatives Considered: GitHub Actions가 Kubernetes Job을 직접 생성하면 cluster credential과 imperative manifest 관리가 추가된다. `PostSync` destructive migration은 rollback 대상 workload를 깨뜨린다. selective sync는 hook을 실행하지 않는다.
+- Consequences: Argo sync 실패가 workflow 실패로 전파되고 restart step은 실행되지 않는다. 현재 Argo application이 full sync hook을 실행할 수 있어야 한다.
+- Confirmation / Follow-up: workflow ordering과 실패 short-circuit를 정적 검증하고 dev 최초 배포에서 hook 실행을 확인한다.
+
+### Drizzle history와 PostgreSQL advisory lock만 사용한다
+
+- Decision Date: 2026-07-12
+- Status: Accepted
+- Context / Problem: 설치된 Drizzle migrator는 pending migration과 history transaction을 처리하지만 concurrent runner coordination을 제공하지 않는다.
+- Decision Outcome: 별도 migration history system을 만들지 않고 Drizzle `__drizzle_migrations`를 사용한다. runner는 단일 connection session에서 `pg_try_advisory_lock`을 획득하고 실패하면 즉시 종료한다.
+- Alternatives Considered: custom history/checksum table은 Drizzle 기능을 중복한다. blocking lock은 잘못 시작된 Job이 무기한 대기할 수 있다. lock 없이 Job 수만 1로 제한하면 서로 다른 deploy run 간 경쟁을 막지 못한다.
+- Consequences: migration runner connection pool은 1이고 lock key는 repository에서 고정한다. Job은 자동 retry하지 않는다.
+- Confirmation / Follow-up: 최초 적용, no-op 재실행과 lock contention을 test PostgreSQL에서 검증한다.
+
+### 배포 후 smoke는 포함하지 않는다
+
+- Decision Date: 2026-07-12
+- Status: Accepted
+- Context / Problem: 현재 `/health`는 변경된 domain column을 확인하지 않고, 인증된 end-to-end smoke는 test identity와 실제 data mutation을 요구한다.
+- Decision Outcome: PROD-280의 배포 성공 조건은 migration Job 성공과 Argo sync/restart command 성공으로 제한한다.
+- Alternatives Considered: `/health`만 추가 호출하면 DB schema compatibility 근거가 약하다. 게시글 작성 smoke는 이번 최소 migration 경계를 넘어선다.
+- Consequences: 배포 후 사용자 흐름 검증은 기존 CI와 수동 dev 확인에 남는다.
+- Confirmation / Follow-up: 실제 필요가 확인되면 별도 issue로 read-only readiness 또는 deploy smoke를 설계한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/design.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/design.md
@@ -1,0 +1,47 @@
+## Context
+
+현재 Docker image는 API/web server만 실행하고 `drizzle/` migration directory를 runtime stage에 포함하지 않는다. Deploy Dev workflow는 Docker Build 성공 후 Argo CD resource action으로 `latest` API/web Rollout을 restart하며, full sync나 DB migration을 실행하지 않는다. dev의 API/web active·preview workload는 같은 CloudNativePG database를 사용한다.
+
+PROD-280은 production용 무중단 expand/contract 체계를 도입하지 않고, downtime이 허용된 dev에서 version-controlled migration을 workload restart 전에 적용하는 최소 배포 경계를 만든다. runtime은 이미 production dependency로 `drizzle-orm`, `postgres`와 `tsx`를 포함하므로 별도 migration image나 `drizzle-kit` production dependency를 추가하지 않는다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 동일한 dev runtime image가 `migrate` command로 image 안의 SQL migration을 적용한다.
+- Drizzle history와 단일 PostgreSQL advisory lock을 사용해 재실행과 동시 실행을 안전하게 처리한다.
+- Argo CD `PreSync` Job 실패가 rollout restart를 차단한다.
+- dev `latest` image 정책과 기존 Argo Rollout resource action을 유지한다.
+- PROD-267 migration을 data reset 없이 적용할 실행 경계를 제공한다.
+
+**Non-Goals:**
+
+- production immutable image, zero-downtime expand/transition/contract와 rollback window.
+- app DB role과 별도의 production DDL credential.
+- backup/restore, automatic rollback과 배포 후 smoke/E2E.
+- migration SQL 생성 방식 또는 domain schema 변경.
+
+## Risks / Trade-offs
+
+- [`latest`가 migration과 workload 사이에 바뀔 수 있음] → Deploy Dev를 environment 단위로 직렬화하고 Docker Build 성공 직후 full sync와 restart를 한 workflow에서 수행한다. production의 immutable identity 문제는 PROD-269에 남긴다.
+- [GitHub workflow 취소 후 Argo hook이 남을 수 있음] → `cancel-in-progress`를 끄고 PostgreSQL advisory lock으로 겹친 runner가 SQL을 실행하지 못하게 한다.
+- [Drizzle migrator history만으로 동시 실행을 막지 못함] → connection pool을 1로 제한한 session에서 `pg_try_advisory_lock`을 먼저 획득하고 실패 시 즉시 종료한다.
+- [Migration SQL 실패] → Drizzle의 PostgreSQL transaction과 실패 exit status를 사용하며 Argo `PreSync` 실패가 이후 restart step을 차단한다.
+- [파괴적 migration 직후 기존 dev workload가 실패할 수 있음] → dev downtime을 허용하고 migration 성공 직후 새 `latest` workload를 restart한다. production에서는 허용하지 않는다.
+- [Argo selective sync는 hook을 실행하지 않음] → Deploy Dev가 resource 선택 없이 application full sync를 호출한다.
+- [Job 자동 retry가 논리 오류를 반복함] → `backoffLimit: 0`, `restartPolicy: Never`와 제한된 실행 시간을 사용한다.
+
+## Migration Plan
+
+1. runtime image에 `drizzle/`을 복사하고 `migrate` entrypoint를 추가한다.
+2. runner는 `DATABASE_URL`, image 안 migration directory와 단일 connection을 사용해 advisory lock을 획득한 뒤 Drizzle migrator를 실행한다.
+3. Helm chart에 dev workload와 같은 image/DB secret을 사용하는 `PreSync` Job을 추가한다.
+4. Deploy Dev를 직렬화하고 `argocd app sync kosmo-dev` 성공 후에만 API/web restart action을 실행한다.
+5. disposable test database에서 최초 적용, no-op 재실행, 실패와 lock contention을 검증하고 Helm render와 workflow 순서를 확인한다.
+6. PROD-280을 PROD-267보다 먼저 머지한다. 이후 PROD-267 merge의 Docker Build가 새 migration runner로 pending Plain Text cutover migration을 적용한다.
+
+Rollback은 PROD-280 코드와 Job/workflow를 revert하는 방식이다. 이미 적용된 domain migration은 자동으로 되돌리지 않으며, schema/data rollback은 각 migration의 별도 운영 판단에 따른다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/proposal.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+현재 dev 배포는 `main`의 Docker image build가 성공하면 `latest` image를 사용하는 API와 web Rollout만 restart하고, 새 Drizzle migration을 실제 PostgreSQL에 적용하지 않는다. 파괴적 schema 변경이 포함된 PROD-267을 데이터 reset 없이 배포하고 이후 migration 누락으로 새 workload가 깨지는 일을 막으려면, DB migration 성공을 dev rollout의 선행 조건으로 만들어야 한다.
+
+Linear: [PROD-280](https://linear.app/byulmaru/issue/PROD-280/dev-배포-전에-drizzle-migration-job을-실행한다)
+
+## What Changes
+
+- runtime image가 version control의 Drizzle SQL migration을 포함하고 독립적인 `migrate` command로 pending migration을 적용한다.
+- migration runner는 Drizzle migration history를 사용하고 PostgreSQL advisory lock으로 동시 실행을 거부한다.
+- Helm chart에 app startup 및 initContainer와 분리된 단일 Argo CD `PreSync` migration Job을 추가한다.
+- Deploy Dev workflow는 Docker Build 성공 후 Argo CD full sync로 migration을 완료하고, 성공한 경우에만 기존 API/web Rollout restart를 실행한다.
+- migration-aware dev deploy를 직렬화해 실행 중 workflow를 새 배포가 취소하지 않게 한다.
+- dev는 기존 `latest` image 정책과 허용된 짧은 downtime을 유지하며 DB data를 reset하지 않는다.
+- production immutable release, expand/transition/contract 승인, backup/restore와 배포 후 smoke는 포함하지 않는다.
+
+## Capabilities
+
+### New Capabilities
+
+- `dev-database-migrations`: dev workload rollout 전에 pending Drizzle migration을 단일 실행하고 실패 시 rollout을 차단하는 배포 계약.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- Runtime: `Dockerfile`, `docker-entrypoint.sh`, production dependency로 제공되는 Drizzle migrator와 SQL migration directory.
+- Deployment: `apps/helm`의 `PreSync` Job, DB secret 사용 경계, `.github/workflows/deploy-dev.yml`의 sync/restart 순서와 concurrency.
+- Database: Drizzle `__drizzle_migrations` history와 PostgreSQL advisory lock; 기존 domain table과 migration SQL 내용은 변경하지 않는다.
+- Verification: migration runner unit/integration, Helm render, workflow ordering, existing lint/format/OpenSpec validation.

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/specs/dev-database-migrations/spec.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/specs/dev-database-migrations/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Runtime migration command
+
+dev에 배포되는 runtime image는 애플리케이션 server 시작과 분리된 명시적 migration command로 image에 포함된 Drizzle SQL migration을 대상 PostgreSQL에 적용해야 한다(MUST).
+
+#### Scenario: Pending migration 적용
+
+- **WHEN** runtime migration command가 미적용 migration이 있는 dev database를 대상으로 실행된다
+- **THEN** 시스템은 migration을 version control 순서대로 적용한다
+- **AND** 시스템은 성공적으로 적용된 migration을 Drizzle migration history에 기록한다
+- **AND** 시스템은 기존 domain data를 reset하거나 schema 전체를 재생성하지 않는다
+
+#### Scenario: Pending migration 없는 실행
+
+- **WHEN** runtime migration command가 모든 migration이 적용된 dev database를 대상으로 실행된다
+- **THEN** 시스템은 domain schema와 data를 변경하지 않고 성공한다
+
+#### Scenario: Migration 실패
+
+- **WHEN** SQL migration이 실패한다
+- **THEN** migration command는 실패 exit status를 반환한다
+- **AND** 실패한 migration을 적용 완료로 기록하지 않는다
+
+### Requirement: Migration 단일 실행
+
+시스템은 PostgreSQL advisory lock을 사용해 같은 database에서 migration runner가 동시에 하나만 migration을 실행하도록 보장해야 한다(MUST).
+
+#### Scenario: Lock 획득 성공
+
+- **WHEN** 실행 중인 다른 migration runner가 없는 상태에서 runner가 시작된다
+- **THEN** runner는 migration 전용 advisory lock을 획득한다
+- **AND** migration 완료 또는 database session 종료 시 lock을 해제한다
+
+#### Scenario: 동시 runner 거부
+
+- **WHEN** 다른 runner가 migration advisory lock을 보유한 상태에서 새 runner가 시작된다
+- **THEN** 새 runner는 lock 해제를 기다리지 않고 migration을 중복 실행하지 않는다
+- **AND** 새 runner는 명시적인 실패 exit status를 반환한다
+
+### Requirement: Dev PreSync migration Job
+
+dev Helm release는 API 또는 web container의 startup/initContainer와 분리된 단일 Kubernetes Job으로 runtime migration command를 실행해야 한다(MUST).
+
+#### Scenario: Argo full sync의 migration 선행 실행
+
+- **WHEN** dev application에 Argo CD full sync가 시작된다
+- **THEN** Argo CD는 application resource sync 전에 migration Job을 `PreSync` hook으로 실행한다
+- **AND** Job은 dev workload와 같은 `latest` image reference를 사용한다
+- **AND** Job은 단일 Pod에서 재시작 없이 migration command를 실행한다
+
+#### Scenario: Migration Job 실패
+
+- **WHEN** migration Job이 실패한다
+- **THEN** Argo CD sync는 실패한다
+- **AND** dev deployment workflow는 API와 web Rollout restart를 실행하지 않는다
+
+### Requirement: Migration-gated dev rollout
+
+Deploy Dev workflow는 Docker Build 성공 후 migration을 포함한 Argo CD full sync를 완료하고, 성공한 경우에만 API와 web Rollout을 restart해야 한다(MUST).
+
+#### Scenario: Migration 성공 후 rollout
+
+- **WHEN** Docker Build가 성공하고 Argo CD full sync와 migration Job이 성공한다
+- **THEN** deployment workflow는 `kosmo-api`와 `kosmo-web` Rollout restart를 실행한다
+
+#### Scenario: Dev deploy 직렬 실행
+
+- **WHEN** migration-aware dev deployment가 실행 중인 동안 새 Docker Build가 완료된다
+- **THEN** 시스템은 실행 중 deployment를 취소하지 않는다
+- **AND** 같은 environment의 migration-aware deployment를 동시에 실행하지 않는다
+
+#### Scenario: Dev downtime 허용
+
+- **WHEN** 기존 workload와 호환되지 않는 migration을 dev에 적용한다
+- **THEN** 시스템은 migration과 새 `latest` workload restart 사이의 일시적인 dev 오류를 허용한다
+- **AND** 시스템은 production 수준의 무중단 호환 또는 rollback 보장을 이 dev workflow에서 제공하지 않는다

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/tasks.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/tasks.md
@@ -1,0 +1,16 @@
+## 1. Runtime migration command
+
+- [x] 1.1 Add a minimal PostgreSQL migration runner that validates `DATABASE_URL`, uses one session, acquires a non-blocking advisory lock and invokes the installed Drizzle migrator against the repository migration directory.
+- [x] 1.2 Add disposable PostgreSQL coverage for first apply, history-backed no-op rerun, migration failure and concurrent advisory lock rejection.
+- [x] 1.3 Include the `drizzle/` directory in the production runtime image and add a `migrate` entrypoint without adding `drizzle-kit` to production dependencies.
+
+## 2. Argo migration gate
+
+- [x] 2.1 Add a Helm `PreSync` migration Job that uses the release image and existing dev database secret with one Pod, no automatic retry, a bounded deadline and non-root security context.
+- [x] 2.2 Add deterministic Helm render coverage for the migration hook annotations, image, command, database environment, retry and deadline policy.
+
+## 3. Dev deployment orchestration and verification
+
+- [x] 3.1 Serialize Deploy Dev runs and run an Argo CD application full sync before the existing API/web Rollout restart actions so migration failure prevents restart.
+- [x] 3.2 Update project deployment/script memory with the dev migration command, PreSync gate, `latest` downtime boundary and deferred production/smoke scope.
+- [x] 3.3 Run migration integration, Helm render, workflow order, TypeScript, lint/format and strict OpenSpec validation, then confirm no application startup or initContainer migration path was introduced.

--- a/openspec/specs/dev-database-migrations/spec.md
+++ b/openspec/specs/dev-database-migrations/spec.md
@@ -1,0 +1,83 @@
+# dev-database-migrations Specification
+
+## Purpose
+
+dev 환경에서 Drizzle SQL migration을 애플리케이션 rollout보다 먼저 단일 실행하고, migration 실패 시 새 workload restart를 차단하는 배포 계약을 정의한다.
+
+## Requirements
+
+### Requirement: Runtime migration command
+
+dev에 배포되는 runtime image는 애플리케이션 server 시작과 분리된 명시적 migration command로 image에 포함된 Drizzle SQL migration을 대상 PostgreSQL에 적용해야 한다(MUST).
+
+#### Scenario: Pending migration 적용
+
+- **WHEN** runtime migration command가 미적용 migration이 있는 dev database를 대상으로 실행된다
+- **THEN** 시스템은 migration을 version control 순서대로 적용한다
+- **AND** 시스템은 성공적으로 적용된 migration을 Drizzle migration history에 기록한다
+- **AND** 시스템은 기존 domain data를 reset하거나 schema 전체를 재생성하지 않는다
+
+#### Scenario: Pending migration 없는 실행
+
+- **WHEN** runtime migration command가 모든 migration이 적용된 dev database를 대상으로 실행된다
+- **THEN** 시스템은 domain schema와 data를 변경하지 않고 성공한다
+
+#### Scenario: Migration 실패
+
+- **WHEN** SQL migration이 실패한다
+- **THEN** migration command는 실패 exit status를 반환한다
+- **AND** 실패한 migration을 적용 완료로 기록하지 않는다
+
+### Requirement: Migration 단일 실행
+
+시스템은 PostgreSQL advisory lock을 사용해 같은 database에서 migration runner가 동시에 하나만 migration을 실행하도록 보장해야 한다(MUST).
+
+#### Scenario: Lock 획득 성공
+
+- **WHEN** 실행 중인 다른 migration runner가 없는 상태에서 runner가 시작된다
+- **THEN** runner는 migration 전용 advisory lock을 획득한다
+- **AND** migration 완료 또는 database session 종료 시 lock을 해제한다
+
+#### Scenario: 동시 runner 거부
+
+- **WHEN** 다른 runner가 migration advisory lock을 보유한 상태에서 새 runner가 시작된다
+- **THEN** 새 runner는 lock 해제를 기다리지 않고 migration을 중복 실행하지 않는다
+- **AND** 새 runner는 명시적인 실패 exit status를 반환한다
+
+### Requirement: Dev PreSync migration Job
+
+dev Helm release는 API 또는 web container의 startup/initContainer와 분리된 단일 Kubernetes Job으로 runtime migration command를 실행해야 한다(MUST).
+
+#### Scenario: Argo full sync의 migration 선행 실행
+
+- **WHEN** dev application에 Argo CD full sync가 시작된다
+- **THEN** Argo CD는 application resource sync 전에 migration Job을 `PreSync` hook으로 실행한다
+- **AND** Job은 dev workload와 같은 `latest` image reference를 사용한다
+- **AND** Job은 단일 Pod에서 재시작 없이 migration command를 실행한다
+
+#### Scenario: Migration Job 실패
+
+- **WHEN** migration Job이 실패한다
+- **THEN** Argo CD sync는 실패한다
+- **AND** dev deployment workflow는 API와 web Rollout restart를 실행하지 않는다
+
+### Requirement: Migration-gated dev rollout
+
+Deploy Dev workflow는 Docker Build 성공 후 migration을 포함한 Argo CD full sync를 완료하고, 성공한 경우에만 API와 web Rollout을 restart해야 한다(MUST).
+
+#### Scenario: Migration 성공 후 rollout
+
+- **WHEN** Docker Build가 성공하고 Argo CD full sync와 migration Job이 성공한다
+- **THEN** deployment workflow는 `kosmo-api`와 `kosmo-web` Rollout restart를 실행한다
+
+#### Scenario: Dev deploy 직렬 실행
+
+- **WHEN** migration-aware dev deployment가 실행 중인 동안 새 Docker Build가 완료된다
+- **THEN** 시스템은 실행 중 deployment를 취소하지 않는다
+- **AND** 같은 environment의 migration-aware deployment를 동시에 실행하지 않는다
+
+#### Scenario: Dev downtime 허용
+
+- **WHEN** 기존 workload와 호환되지 않는 migration을 dev에 적용한다
+- **THEN** 시스템은 migration과 새 `latest` workload restart 사이의 일시적인 dev 오류를 허용한다
+- **AND** 시스템은 production 수준의 무중단 호환 또는 rollback 보장을 이 dev workflow에서 제공하지 않는다

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:syncpack": "syncpack lint --dependency-types prod,dev,peer",
     "prepare": "husky || true",
     "test": "pnpm --recursive --workspace-concurrency=1 --if-present test",
+    "test:dev-deployment": "node --test scripts/dev-deployment.test.mjs",
     "test:e2e": "node scripts/test-db.mjs run -- pnpm test:e2e:database",
     "test:e2e:database": "pnpm db:test:push && pnpm --filter @kosmo/web test:e2e",
     "test:fedify": "node scripts/test-db.mjs run -- pnpm test:fedify:database",

--- a/packages/core/db/migrate.test.ts
+++ b/packages/core/db/migrate.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import postgres from 'postgres';
+import { migrationLock, runDatabaseMigrations } from './migrate';
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required for migration integration tests.');
+}
+
+async function migrationFolder(name: string, sql: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'kosmo-migrations-'));
+  const migration = join(root, name);
+  await mkdir(migration);
+  await writeFile(join(migration, 'migration.sql'), sql);
+  return root;
+}
+
+test('마이그레이션을 한 번만 적용하고 동시 실행을 거부하며 실패를 롤백한다', async () => {
+  const control = postgres(databaseUrl, { max: 1 });
+  const validMigrations = await migrationFolder(
+    '20260712000000_valid',
+    'CREATE TABLE migration_probe (id integer PRIMARY KEY);',
+  );
+  const invalidMigrations = await migrationFolder(
+    '20260712000001_invalid',
+    'CREATE TABLE invalid_migration (',
+  );
+
+  try {
+    await control.unsafe('DROP SCHEMA IF EXISTS drizzle CASCADE; DROP SCHEMA public CASCADE;');
+    await control.unsafe('CREATE SCHEMA public;');
+
+    await runDatabaseMigrations({ databaseUrl, migrationsFolder: validMigrations });
+    assert.equal(
+      (
+        await control<{ tableName: string | null }[]>`
+        SELECT to_regclass('public.migration_probe')::text AS "tableName"
+      `
+      )[0]?.tableName,
+      'migration_probe',
+    );
+    assert.equal(
+      (
+        await control<
+          { count: number }[]
+        >`SELECT count(*)::int AS count FROM drizzle.__drizzle_migrations`
+      )[0]?.count,
+      1,
+    );
+
+    await runDatabaseMigrations({ databaseUrl, migrationsFolder: validMigrations });
+    assert.equal(
+      (
+        await control<
+          { count: number }[]
+        >`SELECT count(*)::int AS count FROM drizzle.__drizzle_migrations`
+      )[0]?.count,
+      1,
+    );
+
+    await control`SELECT pg_advisory_lock(${migrationLock[0]}, ${migrationLock[1]})`;
+    await assert.rejects(
+      runDatabaseMigrations({ databaseUrl, migrationsFolder: validMigrations }),
+      /Another database migration is already running/,
+    );
+    await control`SELECT pg_advisory_unlock(${migrationLock[0]}, ${migrationLock[1]})`;
+
+    await control.unsafe('DROP SCHEMA IF EXISTS drizzle CASCADE; DROP SCHEMA public CASCADE;');
+    await control.unsafe('CREATE SCHEMA public;');
+    await assert.rejects(
+      runDatabaseMigrations({ databaseUrl, migrationsFolder: invalidMigrations }),
+    );
+    assert.equal(
+      (
+        await control<
+          { count: number }[]
+        >`SELECT count(*)::int AS count FROM drizzle.__drizzle_migrations`
+      )[0]?.count,
+      0,
+    );
+    assert.equal(
+      (
+        await control<{ tableName: string | null }[]>`
+        SELECT to_regclass('public.invalid_migration')::text AS "tableName"
+      `
+      )[0]?.tableName,
+      null,
+    );
+  } finally {
+    await control.end({ timeout: 5 });
+    await rm(validMigrations, { force: true, recursive: true });
+    await rm(invalidMigrations, { force: true, recursive: true });
+  }
+});

--- a/packages/core/db/migrate.ts
+++ b/packages/core/db/migrate.ts
@@ -1,0 +1,57 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import postgres from 'postgres';
+
+// ASCII: "KOSM", "MIGR"
+export const migrationLock = [0x4b4f534d, 0x4d494752] as const;
+
+export async function runDatabaseMigrations({
+  databaseUrl = process.env.DATABASE_URL,
+  migrationsFolder = join(dirname(fileURLToPath(import.meta.url)), '../../../drizzle'),
+}: {
+  databaseUrl?: string;
+  migrationsFolder?: string;
+} = {}): Promise<void> {
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required to run database migrations.');
+  }
+
+  const client = postgres(databaseUrl, {
+    max: 1,
+    connection: {
+      idle_in_transaction_session_timeout: 30 * 1000,
+      lock_timeout: 10 * 1000,
+      statement_timeout: 10 * 60 * 1000,
+    },
+  });
+  let lockAcquired = false;
+
+  try {
+    const [lock] = await client<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(${migrationLock[0]}, ${migrationLock[1]}) AS acquired
+    `;
+
+    if (!lock?.acquired) {
+      throw new Error('Another database migration is already running.');
+    }
+
+    lockAcquired = true;
+    await migrate(drizzle({ client }), { migrationsFolder });
+  } finally {
+    if (lockAcquired) {
+      await client`
+        SELECT pg_advisory_unlock(${migrationLock[0]}, ${migrationLock[1]})
+      `;
+    }
+
+    await client.end({ timeout: 5 });
+  }
+}
+
+const entrypointUrl = process.argv[1] ? pathToFileURL(process.argv[1]).href : undefined;
+
+if (entrypointUrl === import.meta.url) {
+  await runDatabaseMigrations();
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,12 +27,16 @@
     "drizzle-orm": "1.0.0-beta.22",
     "postgres": "^3.4.9",
     "temporal-polyfill": "^0.3.2",
+    "tsx": "^4.22.4",
     "zod": "^4.4.3"
   },
   "scripts": {
+    "db:migrate": "node --import tsx db/migrate.ts",
     "drizzle:generate": "node ../../scripts/vault-run.mjs -- drizzle-kit generate",
     "drizzle:push": "node ../../scripts/vault-run.mjs -- drizzle-kit push",
-    "drizzle:studio": "node ../../scripts/vault-run.mjs -- drizzle-kit studio"
+    "drizzle:studio": "node ../../scripts/vault-run.mjs -- drizzle-kit studio",
+    "test": "pnpm test:migrate",
+    "test:migrate": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/core exec node --import tsx --test db/migrate.test.ts"
   },
   "devDependencies": {
     "drizzle-kit": "1.0.0-beta.22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       temporal-polyfill:
         specifier: ^0.3.2
         version: 0.3.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -6120,6 +6123,7 @@ packages:
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/scripts/dev-deployment.test.mjs
+++ b/scripts/dev-deployment.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('dev 차트는 제한된 PreSync 마이그레이션 Job을 렌더링한다', () => {
+  const result = spawnSync('helm', ['template', 'kosmo-dev', 'apps/helm', '--set', 'env=dev'], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const job = result.stdout
+    .split('---')
+    .find((document) => document.includes('database-migration-job.yaml'));
+
+  assert.ok(job, 'the dev chart must render the database migration Job');
+  assert.match(job, /argocd\.argoproj\.io\/hook: PreSync/);
+  assert.match(job, /argocd\.argoproj\.io\/hook-delete-policy: BeforeHookCreation,HookSucceeded/);
+  assert.match(job, /argocd\.argoproj\.io\/sync-wave: "-1"/);
+  assert.match(job, /image: "ghcr\.io\/byulmaru\/kosmo:latest"/);
+  assert.match(job, /args:\s+- migrate/);
+  assert.match(job, /name: DATABASE_URL/);
+  assert.match(job, /backoffLimit: 0/);
+  assert.match(job, /activeDeadlineSeconds: 600/);
+  assert.match(job, /restartPolicy: Never/);
+  assert.doesNotMatch(job, /initContainers:/);
+});
+
+test('dev가 아닌 차트는 마이그레이션 Job을 렌더링하지 않는다', () => {
+  const result = spawnSync('helm', ['template', 'kosmo', 'apps/helm'], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /database-migration-job\.yaml/);
+});
+
+test('Deploy Dev는 실행을 직렬화하고 전체 sync 후 Rollout을 재시작한다', async () => {
+  const workflow = await readFile('.github/workflows/deploy-dev.yml', 'utf8');
+  const sync = workflow.indexOf('app sync kosmo-dev --timeout 600');
+  const restart = workflow.indexOf('app actions run kosmo-dev restart');
+
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.ok(sync >= 0, 'Deploy Dev must perform a full application sync');
+  assert.ok(restart > sync, 'rollout restart must happen after a successful sync');
+  assert.doesNotMatch(workflow.slice(sync, restart), /--resource(?:-name)?\b/);
+});


### PR DESCRIPTION
## 무엇을 변경했나요?

- `@kosmo/core`에 Drizzle migration runner와 `migrate` runtime entrypoint를 추가했습니다.
- PostgreSQL advisory lock으로 동시 migration을 즉시 거부하고, Drizzle history로 재실행을 no-op 처리합니다.
- dev Helm release에 같은 `latest` 이미지와 기존 DB credential을 쓰는 Argo CD `PreSync` Job을 추가했습니다.
- `Deploy Dev`를 직렬화하고 `kosmo-dev` full sync가 성공한 뒤에만 API/web Rollout을 restart하도록 순서를 바꿨습니다.
- PROD-280 OpenSpec의 전체 task를 완료하고 `dev-database-migrations` canonical spec을 동기화한 뒤 change를 아카이브했습니다.

## 왜 필요한가요?

현재 dev 배포는 이미지를 빌드한 뒤 workload만 restart하므로, 저장소의 Drizzle SQL migration을 배포 전에 적용할 실행 경로가 없습니다. 특히 #224처럼 schema 변경이 있는 배포는 새 애플리케이션과 DB 계약이 어긋날 수 있습니다.

이번 PR은 dev 환경에 한해 `full sync → PreSync migration Job → Rollout restart`를 배포 성공 경계로 만듭니다. 기존 dev DB는 reset하지 않으며, dev downtime은 허용합니다.

- Linear: [PROD-280](https://linear.app/byulmaru/issue/PROD-280/dev-배포-전에-drizzle-migration-job을-실행한다)
- 상위 범위: [PROD-269](https://linear.app/byulmaru/issue/PROD-269)
- 이 PR이 #224보다 먼저 merge되어야 합니다.

## 어떻게 확인했나요?

- `pnpm --filter @kosmo/core test:migrate`
  - 최초 적용
  - history 기반 no-op 재실행
  - advisory lock 경합 거부
  - 실패 migration rollback 및 history 미기록
- `pnpm test:dev-deployment`
  - dev 전용 Helm hook 렌더
  - PreSync/image/command/credential/retry/deadline 계약
  - full sync 이후 restart 순서
- 신규 migration TypeScript 파일 strict typecheck
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm lint:syncpack`
- `helm lint apps/helm --set env=dev`
- `pnpm exec openspec validate --all --strict`
- runtime Docker image build 후 실제 PostgreSQL에 전체 migration 적용 및 두 번째 no-op 실행

## 아직 남은 문제는 무엇인가요?

- production immutable image, expand/contract, backup/rollback, approval gate는 PROD-269 후속 범위입니다.
- 배포 smoke는 이번 범위에서 제외했습니다.
- 실제 dev Argo sync는 merge 후 배포 workflow에서 처음 실행됩니다.