### PR TITLE
보안 스캔 결과를 GitHub Checks에서 확인할 수 있게 한다

### DIFF
--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -74,9 +74,11 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      - name: Notify Slack
-        if: always() && env.SLACK_WEBHOOK_URL != ''
+      - name: Report Nuclei findings
+        if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NUCLEI_STATUS: ${{ steps.nuclei.outcome }}
         with:
           script: |
             const fs = require("fs");
@@ -86,7 +88,7 @@ jobs:
             const targets = fs.existsSync("nuclei-targets.txt")
               ? fs.readFileSync("nuclei-targets.txt", "utf8").split(/\r?\n/).filter(Boolean)
               : [];
-            const status = "${{ steps.nuclei.outcome }}";
+            const status = process.env.NUCLEI_STATUS;
 
             const findings = fs.existsSync(reportPath)
               ? fs.readFileSync(reportPath, "utf8")
@@ -102,11 +104,6 @@ jobs:
                   }
                 })
               : [];
-
-            if (findings.length === 0 && status !== "failure") {
-              core.info("No Nuclei findings detected. Skipping Slack notification.");
-              return;
-            }
 
             const counts = findings.reduce((acc, finding) => {
               const severity = finding.info?.severity ?? finding.severity ?? "unknown";
@@ -124,6 +121,37 @@ jobs:
             const omitted = findings.length > topFindings.length
               ? `\n...and ${findings.length - topFindings.length} more finding(s).`
               : "";
+
+            const summary = [
+              "## Nuclei scan",
+              "",
+              `Targets: ${targets.map((target) => `\`${target}\``).join(", ") || "none"}`,
+              `Status: \`${status}\``,
+              "",
+              "| Severity | Count |",
+              "| --- | ---: |",
+              `| Critical | ${counts.critical ?? 0} |`,
+              `| High | ${counts.high ?? 0} |`,
+              `| Medium | ${counts.medium ?? 0} |`,
+              `| Low | ${counts.low ?? 0} |`,
+              `| Info | ${counts.info ?? 0} |`,
+              "",
+              "### Findings",
+              "",
+              findings.length > 0
+                ? topFindings.join("\n") + omitted
+                : status === "failure"
+                  ? "The Nuclei scan failed before producing findings."
+                  : "No findings were detected.",
+              "",
+              `Full report: [nuclei-report artifact](${runUrl})`,
+            ].join("\n");
+
+            await core.summary.addRaw(summary).write();
+
+            if (!process.env.SLACK_WEBHOOK_URL || (findings.length === 0 && status !== "failure")) {
+              return;
+            }
 
             const payload = {
               text: [

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -50,6 +48,7 @@ jobs:
         id: semgrep
         continue-on-error: true
         run: |
+          # shellcheck disable=SC2086
           semgrep scan \
             $SEMGREP_CONFIGS \
             --json \
@@ -64,19 +63,19 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Comment findings on PR
-        if: github.event_name == 'pull_request' && always()
+      - name: Report Semgrep findings
+        if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require("fs");
 
-            const marker = "<!-- semgrep-scan-report -->";
             const reportPath = "semgrep.json";
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
+            const hasReport = fs.existsSync(reportPath);
             let results = [];
-            if (fs.existsSync(reportPath)) {
+            if (hasReport) {
               const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
               results = report.results ?? [];
             }
@@ -97,11 +96,33 @@ jobs:
             }, {});
 
             const summary = [
-              `- Total: ${results.length}`,
-              `- ERROR: ${counts.ERROR ?? 0}`,
-              `- WARNING: ${counts.WARNING ?? 0}`,
-              `- INFO: ${counts.INFO ?? 0}`,
-            ].join("\n");
+              ["Severity", "Count"],
+              ["ERROR", String(counts.ERROR ?? 0)],
+              ["WARNING", String(counts.WARNING ?? 0)],
+              ["INFO", String(counts.INFO ?? 0)],
+            ];
+
+            const annotationCounts = { ERROR: 0, WARNING: 0, INFO: 0 };
+            for (const result of results) {
+              const severity = result.extra?.severity ?? "INFO";
+              const path = result.path;
+              const line = Number(result.start?.line);
+              if (!path || !Number.isInteger(line) || (annotationCounts[severity] ?? 10) >= 10) {
+                continue;
+              }
+
+              const rule = result.check_id ?? "Semgrep finding";
+              const message = (result.extra?.message ?? rule).replace(/\s+/g, " ").trim();
+              const properties = { file: path, startLine: line, title: rule };
+              if (severity === "ERROR") {
+                core.error(message, properties);
+              } else if (severity === "WARNING") {
+                core.warning(message, properties);
+              } else {
+                core.notice(message, properties);
+              }
+              annotationCounts[severity] += 1;
+            }
 
             const maxFindings = 30;
             const findingLines = results.slice(0, maxFindings).map((result, index) => {
@@ -110,7 +131,8 @@ jobs:
               const severity = result.extra?.severity ?? "UNKNOWN";
               const rule = result.check_id ?? "(unknown rule)";
               const message = (result.extra?.message ?? "").replace(/\s+/g, " ").trim();
-              return `${index + 1}. \`${severity}\` [${path}:${line}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${context.payload.pull_request.head.sha}/${path}#L${line}) - \`${rule}\`${message ? `\n   ${message}` : ""}`;
+              const sha = context.payload.pull_request?.head?.sha ?? context.sha;
+              return `${index + 1}. \`${severity}\` [${path}:${line}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/${sha}/${path}#L${line}) - \`${rule}\`${message ? `\n   ${message}` : ""}`;
             });
 
             const truncated = results.length > maxFindings
@@ -118,44 +140,28 @@ jobs:
               : "";
 
             const body = [
-              marker,
-              "## Semgrep security scan result",
+              "## Semgrep security scan",
               "",
-              summary,
+              `Status: \`${{ steps.semgrep.outcome }}\``,
               "",
-              results.length > 0
-                ? findingLines.join("\n") + truncated
-                : "No findings were detected.",
+              "### Summary",
+              "",
+              "| Severity | Count |",
+              "| --- | ---: |",
+              ...summary.slice(1).map(([severity, count]) => `| ${severity} | ${count} |`),
+              "",
+              "### Findings",
+              "",
+              !hasReport
+                ? "No Semgrep report was produced."
+                : results.length > 0
+                  ? findingLines.join("\n") + truncated
+                  : "No findings were detected.",
               "",
               `Full report: [semgrep-report artifact](${runUrl})`,
             ].join("\n");
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find((comment) =>
-              comment.user?.type === "Bot" && comment.body?.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+            await core.summary.addRaw(body).write();
 
       - name: Notify Slack
         if: always() && env.SLACK_WEBHOOK_URL != ''

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -103,11 +103,12 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      - name: Notify Slack about Trivy findings
-        if: always() && env.SLACK_WEBHOOK_URL != ''
+      - name: Report Trivy findings
+        if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TRIVY_IMAGE_REF: ${{ steps.image.outputs.image-ref }}
+          TRIVY_STATUS: ${{ steps.trivy.outcome }}
         with:
           script: |
             const fs = require("fs");
@@ -116,19 +117,9 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const imageRef = process.env.TRIVY_IMAGE_REF;
 
-            if (!fs.existsSync(reportPath)) {
-              core.info("No Trivy report was produced. Skipping Slack notification.");
-              return;
-            }
-
-            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-            const vulnerabilities = (report.Results ?? [])
-              .flatMap((result) => result.Vulnerabilities ?? []);
-
-            if (vulnerabilities.length === 0) {
-              core.info("No Trivy findings detected. Skipping Slack notification.");
-              return;
-            }
+            const hasReport = fs.existsSync(reportPath);
+            const report = hasReport ? JSON.parse(fs.readFileSync(reportPath, "utf8")) : {};
+            const vulnerabilities = (report.Results ?? []).flatMap((result) => result.Vulnerabilities ?? []);
 
             const counts = vulnerabilities.reduce((acc, vulnerability) => {
               const severity = vulnerability.Severity ?? "UNKNOWN";
@@ -148,6 +139,34 @@ jobs:
             const omitted = vulnerabilities.length > topFindings.length
               ? `\n...and ${vulnerabilities.length - topFindings.length} more finding(s).`
               : "";
+
+            const summary = [
+              "## Trivy image scan",
+              "",
+              `Image: \`${imageRef || "unknown"}\``,
+              `Status: \`${process.env.TRIVY_STATUS}\``,
+              "",
+              "| Severity | Count |",
+              "| --- | ---: |",
+              `| CRITICAL | ${counts.CRITICAL ?? 0} |`,
+              `| HIGH | ${counts.HIGH ?? 0} |`,
+              "",
+              "### Findings",
+              "",
+              !hasReport
+                ? "No Trivy report was produced."
+                : topFindings.length > 0
+                  ? topFindings.join("\n") + omitted
+                  : "No findings were detected.",
+              "",
+              `Full report: [trivy-report artifact](${runUrl})`,
+            ].join("\n");
+
+            await core.summary.addRaw(summary).write();
+
+            if (!process.env.SLACK_WEBHOOK_URL || !hasReport || vulnerabilities.length === 0) {
+              return;
+            }
 
             const sourceRef = context.eventName === "workflow_run"
               ? context.payload.workflow_run.head_branch


### PR DESCRIPTION
Linear: [PROD-290](https://linear.app/byulmaru/issue/PROD-290/보안-스캔-결과를-github-checks에서-확인할-수-있게-한다)

## 무엇을 변경했는지

- Semgrep의 PR 일반 댓글을 제거하고, 우선순위 높은 결과를 소스 줄의 GitHub Actions annotation으로 표시합니다.
- Semgrep 결과 건수와 상위 30개 발견 사항을 Job Summary에 표시합니다.
- Trivy 이미지 취약점과 Nuclei URL 스캔의 심각도별 건수 및 상위 10개 결과를 Job Summary에 표시합니다.
- 전체 JSON artifact와 기존 Slack 알림, 스캐너 실행 실패 판정은 유지합니다.
- Semgrep 워크플로에서 더 이상 필요하지 않은 `issues: write`, `pull-requests: write` 권한을 제거합니다.

## 왜 변경했는지

현재 Semgrep 결과는 PR 일반 댓글에 길게 표시되고, Trivy와 Nuclei 결과는 artifact나 Slack을 열어야 확인할 수 있어 코드 리뷰 흐름에서 발견 사항과 전체 상태를 파악하기 어렵습니다. 소스 위치가 있는 결과는 해당 줄에, 전체 요약은 Check 실행 결과에 표시해 검토 동선을 줄입니다.

저장소의 향후 비공개 전환은 구현 방식의 제약입니다. 유료 GitHub Code Security가 필요한 SARIF 대신 GitHub Actions 기본 annotation과 Job Summary를 사용해 저장소 공개 범위와 관계없이 같은 표시 방식을 유지합니다.

## 어떻게 확인할 수 있는지

- `actionlint`
- `pnpm lint:prettier`
- `git diff --check`
- PR의 Lint, Test, Semgrep workflow 성공
- Semgrep workflow의 `Report Semgrep findings` step 성공

## 아직 어떤 문제가 남았는지

- GitHub Actions는 한 step에서 error와 warning annotation을 각각 10개까지만 표시하므로, 초과 결과는 Job Summary와 artifact에서 확인해야 합니다.
- Trivy와 Nuclei 결과에는 저장소 소스 경로가 없어 인라인 annotation 대신 Job Summary에 표시합니다.