### PR TITLE
Docker 빌드에서 pnpm install 캐시를 재사용하게 한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -57,7 +57,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          no-cache-filters: base
+          no-cache-filters: runtime
 
       - name: Save Docker image reference
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM workspace AS deps
 RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
   pnpm install --frozen-lockfile --ignore-scripts --store-dir=/var/cache/pnpm/store
 
-RUN pnpm rebuild
+RUN pnpm rebuild --pending
 
 # pnpm install --ignore-scripts skips this package-name bin link, but app builds invoke it.
 RUN test -e apps/app/node_modules/.bin/relay-compiler \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,24 +9,35 @@ ARG NODE_VERSION
 
 WORKDIR /app
 
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && rm -rf /var/lib/apt/lists/*
+ENV PATH=/pnpm/bin:$PATH
 
 RUN pnpm runtime set node ${NODE_VERSION} -g
 
 FROM base AS workspace
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
-COPY apps ./apps
-COPY packages ./packages
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/app/package.json ./apps/app/package.json
+COPY apps/web/package.json ./apps/web/package.json
+COPY packages/core/package.json ./packages/core/package.json
+COPY packages/fedify/package.json ./packages/fedify/package.json
 
 FROM workspace AS deps
 
 RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
-  pnpm install --frozen-lockfile --store-dir=/var/cache/pnpm/store
+  pnpm install --frozen-lockfile --ignore-scripts --store-dir=/var/cache/pnpm/store
+
+RUN pnpm rebuild
+
+# pnpm install --ignore-scripts skips this package-name bin link, but app builds invoke it.
+RUN test -e apps/app/node_modules/.bin/relay-compiler \
+  || ln -s ../relay-compiler/cli.js apps/app/node_modules/.bin/relay-compiler
 
 FROM deps AS app-build
+
+COPY tsconfig.json ./
+COPY apps ./apps
+COPY packages ./packages
 
 RUN pnpm --filter @kosmo/app build
 RUN find apps/app/dist -type f \( \
@@ -34,7 +45,7 @@ RUN find apps/app/dist -type f \( \
       -o -name '*.mjs' -o -name '*.svg' -o -name '*.ttf' -o -name '*.wasm' \
     \) -exec gzip -9 -n -k {} +
 
-FROM base AS runtime
+FROM workspace AS runtime-files
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
@@ -45,15 +56,10 @@ RUN groupadd --system --gid 10001 app \
   && useradd --system --uid 10001 --gid app --home-dir /app --shell /usr/sbin/nologin app \
   && chown app:app /app
 
-COPY --chown=app:app package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
-COPY --chown=app:app apps/api/package.json ./apps/api/package.json
-COPY --chown=app:app apps/web/package.json ./apps/web/package.json
-COPY --chown=app:app packages/core/package.json ./packages/core/package.json
-COPY --chown=app:app packages/fedify/package.json ./packages/fedify/package.json
-
 RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
   pnpm install --filter @kosmo/api... --filter @kosmo/web... --frozen-lockfile --prod --ignore-scripts --store-dir=/var/cache/pnpm/store
 
+COPY --chown=app:app tsconfig.json ./
 COPY --chown=app:app apps/api ./apps/api
 COPY --chown=app:app drizzle ./drizzle
 COPY --chown=app:app packages/core ./packages/core
@@ -63,6 +69,12 @@ COPY --chown=app:app --from=app-build /app/apps/app/dist ./apps/app/dist
 COPY --chown=app:app docker-entrypoint.sh ./docker-entrypoint.sh
 
 RUN chmod +x ./docker-entrypoint.sh
+
+FROM runtime-files AS runtime
+
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && rm -rf /var/lib/apt/lists/*
 
 USER app
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Dockerfile의 dependency install 입력을 `pnpm-lock.yaml`, `pnpm-workspace.yaml`, 각 workspace `package.json`으로 제한하고, 소스와 `tsconfig.json` 복사는 install 뒤로 옮겼습니다.
- full deps/prod deps install 모두 cache mount target과 `--store-dir`를 `/var/cache/pnpm/store`로 맞췄습니다.
- full deps install은 manifest-only 상태에서 lifecycle prepare가 소스를 요구하지 않도록 `--ignore-scripts` 후 `pnpm rebuild`를 실행하고, app build에 필요한 `relay-compiler` bin 링크를 보정했습니다.
- OS package update는 최종 `runtime` 스테이지의 마지막 레이어로 분리하고, workflow의 `no-cache-filters`를 `base`에서 `runtime`으로 좁혔습니다.

## 왜 변경했는지

기존 workflow의 `no-cache-filters: base`가 모든 stage의 부모인 `base`를 매 빌드 무효화하면서 `pnpm runtime set node`, full deps install, prod deps install 레이어를 매번 새로 만들었습니다. 또한 `deps` stage가 install 전에 전체 `apps`/`packages` 소스를 복사해 lockfile과 dependency manifest가 같아도 일반 소스 변경만으로 full install cache가 깨졌습니다.

이 변경은 보안 업데이트 의도는 유지합니다. `apt-get update && apt-get upgrade`는 최종 `runtime` 스테이지에서 계속 no-cache로 실행되지만, 큰 pnpm install 레이어는 dependency 입력이 바뀔 때만 다시 만들어집니다.

## 어떻게 확인할 수 있는지

- `git diff --check`
- `docker buildx build --check --progress=plain --file Dockerfile .`
- `docker buildx build --progress=plain --file Dockerfile --no-cache-filter runtime .`
- 같은 Buildx 명령을 연속 2회 실행해 두 번째 빌드에서 `deps` full install, `runtime-files` prod install, app build가 모두 `CACHED`이고 최종 `runtime` apt upgrade만 다시 실행되는 것을 확인했습니다.

## 아직 어떤 문제가 남았는지

없음