### PR TITLE
iOS 시뮬레이터 빌드를 독립 CI 검사로 연결한다

### DIFF
--- a/.github/workflows/native-ios.yml
+++ b/.github/workflows/native-ios.yml
@@ -1,0 +1,63 @@
+name: Native iOS
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native_ios:
+    name: Native iOS
+    runs-on: [self-hosted, macOS]
+    env:
+      CI: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Ensure generated iOS project remains untracked
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -n "$(git ls-files apps/app/ios)" ]]; then
+            echo "::error::apps/app/ios must remain generated and untracked."
+            git ls-files apps/app/ios
+            exit 1
+          fi
+
+          if ! git check-ignore -q apps/app/ios/; then
+            echo "::error::apps/app/ios must stay ignored so Expo CNG output does not become source of truth."
+            exit 1
+          fi
+
+      - name: Set up mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build iOS simulator app
+        run: pnpm --filter @kosmo/app build:ios
+
+      - name: Upload Native iOS logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-ios-logs
+          path: apps/app/.native-build/ios
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Clean up generated iOS state
+        if: always()
+        run: rm -rf apps/app/ios apps/app/.native-build/ios

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ playwright-report
 test-results
 **/__generated__/
 apps/app/.expo/
+apps/app/.native-build/
 apps/app/dist/
 apps/app/storybook-static/
 apps/app/android/

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -19,6 +19,27 @@ Native OIDC uses Expo AuthSession with the `kosmo://login/callback` redirect. Re
 
 Native projects are generated with `expo prebuild --clean`; they are not source-of-truth files.
 
+## Native iOS build
+
+`apps/app/ios` is generated Expo CNG output and must remain untracked. Reproduce the
+unsigned simulator build with:
+
+```sh
+pnpm --filter @kosmo/app build:ios
+```
+
+The script runs Relay compilation, a clean `expo prebuild --clean --platform ios`,
+and an unsigned `xcodebuild` for the iPhone simulator SDK. It preflights the selected
+Xcode developer directory and version, accepted Xcode license, iPhone simulator SDK,
+and CocoaPods path/version before compiling. Set `KOSMO_KEEP_IOS_BUILD=1` when you
+need to inspect the generated `apps/app/ios` project after a local run.
+
+The `Native iOS` CI check runs on a self-hosted macOS runner for `pull_request`,
+`merge_group`, and `workflow_dispatch`. The runner must have Xcode selected with
+`xcode-select`, an accepted Xcode license, initialized Xcode first-launch simulator
+support, the iPhone simulator SDK, CocoaPods, mise, and pnpm. Failure logs are written
+under `apps/app/.native-build/ios` and uploaded by CI when the check fails.
+
 ## Validation
 
 ```sh

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "android": "expo run:android",
     "build": "pnpm export:web",
+    "build:ios": "bash scripts/build-ios-simulator.sh",
     "build-storybook": "storybook build --disable-telemetry",
     "check": "pnpm relay && tsc --noEmit",
     "dev": "pnpm relay && expo start --port 5173",

--- a/apps/app/scripts/build-ios-simulator.sh
+++ b/apps/app/scripts/build-ios-simulator.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${APP_DIR}/../.." && pwd)"
+LOG_DIR="${KOSMO_IOS_BUILD_LOG_DIR:-${APP_DIR}/.native-build/ios}"
+DERIVED_DATA_PATH="${APP_DIR}/ios/DerivedData"
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  set +e
+
+  if [[ "${KOSMO_KEEP_IOS_BUILD:-0}" == "1" ]]; then
+    log "Keeping generated iOS project because KOSMO_KEEP_IOS_BUILD=1"
+    return
+  fi
+
+  rm -rf "${APP_DIR}/ios"
+}
+
+trap 'status=$?; cleanup; exit "${status}"' EXIT
+
+require_command() {
+  local command_name="$1"
+  local install_hint="$2"
+
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    fail "${command_name} is required. ${install_hint}"
+  fi
+}
+
+ensure_generated_ios_project_is_untracked() {
+  local tracked_files
+
+  tracked_files="$(git -C "${REPO_ROOT}" ls-files apps/app/ios)"
+  if [[ -n "${tracked_files}" ]]; then
+    printf '%s\n' "${tracked_files}" >&2
+    fail "apps/app/ios must remain generated and untracked."
+  fi
+
+  if ! git -C "${REPO_ROOT}" check-ignore -q apps/app/ios/; then
+    fail "apps/app/ios must stay ignored so Expo CNG output does not become source of truth."
+  fi
+}
+
+preflight_xcode() {
+  require_command xcodebuild "Install Xcode on the macOS runner and select it with xcode-select."
+  require_command xcrun "Install Xcode command line tools with the selected Xcode."
+
+  local developer_dir
+  if [[ -n "${DEVELOPER_DIR:-}" ]]; then
+    developer_dir="${DEVELOPER_DIR}"
+    log "DEVELOPER_DIR override: ${developer_dir}"
+  else
+    developer_dir="$(xcode-select -p 2>/dev/null)" ||
+      fail "No Xcode developer directory is selected. Run sudo xcode-select -s /Applications/Xcode.app/Contents/Developer."
+    log "xcode-select developer directory: ${developer_dir}"
+  fi
+
+  [[ -d "${developer_dir}" ]] ||
+    fail "Selected Xcode developer directory does not exist: ${developer_dir}"
+
+  local license_output
+  local license_status
+  set +e
+  license_output="$(xcodebuild -license check 2>&1)"
+  license_status=$?
+  set -e
+
+  if [[ "${license_status}" -ne 0 ]]; then
+    printf '%s\n' "${license_output}" >&2
+    if [[ "${license_output}" == *"requires Xcode"* ]] ||
+      [[ "${license_output}" == *"command line tools instance"* ]]; then
+      fail "xcodebuild requires a full Xcode installation. Select Xcode with sudo xcode-select -s /Applications/Xcode.app/Contents/Developer."
+    fi
+
+    fail "Xcode license is not accepted. Run sudo xcodebuild -license accept on the runner."
+  fi
+
+  local xcode_version_output
+  local xcode_version_status
+  set +e
+  xcode_version_output="$(xcodebuild -version 2>&1)"
+  xcode_version_status=$?
+  set -e
+
+  if [[ "${xcode_version_status}" -ne 0 ]]; then
+    printf '%s\n' "${xcode_version_output}" >&2
+    fail "xcodebuild could not run with ${developer_dir}. Select a full Xcode installation, not Command Line Tools."
+  fi
+
+  log "Xcode version:"
+  printf '%s\n' "${xcode_version_output}"
+
+  local sdk_path
+  sdk_path="$(xcrun --sdk iphonesimulator --show-sdk-path 2>/dev/null)" ||
+    fail "iPhone simulator SDK is not available from the selected Xcode."
+
+  local sdk_version
+  sdk_version="$(xcrun --sdk iphonesimulator --show-sdk-version 2>/dev/null)" ||
+    fail "Could not determine the iPhone simulator SDK version."
+
+  log "iPhone simulator SDK: ${sdk_version} (${sdk_path})"
+  xcodebuild -showsdks >"${LOG_DIR}/xcode-sdks.txt"
+
+  local simulator_runtimes_output
+  local simulator_runtimes_status
+  set +e
+  simulator_runtimes_output="$(xcrun simctl list runtimes 2>&1)"
+  simulator_runtimes_status=$?
+  set -e
+
+  printf '%s\n' "${simulator_runtimes_output}" >"${LOG_DIR}/simulator-runtimes.txt"
+
+  if [[ "${simulator_runtimes_status}" -ne 0 ]]; then
+    printf '%s\n' "${simulator_runtimes_output}" >&2
+    fail "iOS simulator support is not initialized for the selected Xcode. Run xcodebuild -runFirstLaunch on the runner."
+  fi
+
+  if ! printf '%s\n' "${simulator_runtimes_output}" |
+    grep -Eq 'com\.apple\.CoreSimulator\.SimRuntime\.iOS|^[[:space:]]*iOS[[:space:]][0-9]'; then
+    printf '%s\n' "${simulator_runtimes_output}" >&2
+    fail "No iOS simulator runtime is installed. Install one with xcodebuild -downloadPlatform iOS or Xcode > Settings > Components."
+  fi
+}
+
+preflight_cocoapods() {
+  require_command pod "Install CocoaPods on the macOS runner, for example with brew install cocoapods."
+
+  local pod_path
+  pod_path="$(command -v pod)"
+  local pod_version
+  pod_version="$(pod --version 2>&1)" ||
+    fail "CocoaPods exists at ${pod_path}, but pod --version failed: ${pod_version}"
+
+  log "CocoaPods: ${pod_version} (${pod_path})"
+}
+
+run_logged() {
+  local log_name="$1"
+  shift
+
+  log "$*"
+  "$@" 2>&1 | tee "${LOG_DIR}/${log_name}.log"
+}
+
+run_logged_to_file() {
+  local log_name="$1"
+  shift
+
+  local log_file="${LOG_DIR}/${log_name}.log"
+
+  log "$*"
+  set +e
+  "$@" >"${log_file}" 2>&1
+  local status=$?
+  set -e
+
+  if [[ "${status}" -ne 0 ]]; then
+    printf 'error: command failed with exit code %s. Last 200 log lines from %s:\n' "${status}" "${log_file}" >&2
+    tail -n 200 "${log_file}" >&2 || true
+    return "${status}"
+  fi
+
+  log "Log saved to ${log_file}"
+}
+
+main() {
+  cd "${APP_DIR}"
+  rm -rf "${LOG_DIR}"
+  mkdir -p "${LOG_DIR}"
+
+  preflight_xcode
+  ensure_generated_ios_project_is_untracked
+  preflight_cocoapods
+
+  log "Cleaning generated iOS project and local DerivedData"
+  rm -rf ios "${DERIVED_DATA_PATH}"
+
+  run_logged relay pnpm relay
+  run_logged expo-prebuild pnpm exec expo prebuild --clean --platform ios
+
+  [[ -d ios/Kosmo.xcworkspace ]] ||
+    fail "Expo prebuild did not produce ios/Kosmo.xcworkspace."
+
+  log "Removing any generated-project DerivedData before xcodebuild"
+  rm -rf "${DERIVED_DATA_PATH}"
+
+  run_logged_to_file xcodebuild \
+    xcodebuild \
+    -workspace ios/Kosmo.xcworkspace \
+    -scheme Kosmo \
+    -configuration Debug \
+    -sdk iphonesimulator \
+    -destination "generic/platform=iOS Simulator" \
+    -derivedDataPath "${DERIVED_DATA_PATH}" \
+    CODE_SIGNING_ALLOWED=NO \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGN_IDENTITY= \
+    build
+}
+
+main "$@"


### PR DESCRIPTION
## 무엇을 변경했는지

- `apps/app`에 clean Expo CNG iOS prebuild와 코드 서명 없는 simulator `xcodebuild`를 실행하는 `build:ios` 스크립트를 추가했습니다.
- 선택된 Xcode 경로/버전, Xcode license, iPhone simulator SDK와 runtime, CocoaPods을 사전에 확인하고 실패 로그를 남기도록 했습니다.
- Android와 분리된 `Native iOS` GitHub Actions check를 `pull_request`, `merge_group`, `workflow_dispatch`에 연결하고 concurrency, 실패 로그 업로드, generated iOS 정리를 추가했습니다.
- `apps/app/ios`와 빌드 로그는 generated/untracked 상태를 유지하도록 했습니다.

## 왜 변경했는지

Expo CNG, CocoaPods, iOS 네이티브 컴파일 단계의 회귀를 Android와 독립적으로 조기에 감지해야 합니다. 이 검사는 device build와 코드 서명 설정까지 요구하지 않고 simulator SDK 컴파일 가능 여부를 확인합니다.

## 어떻게 확인할 수 있는지

- `mise exec pnpm@11.10.0 -- pnpm install --frozen-lockfile`
- `mise exec pnpm@11.10.0 -- pnpm --filter @kosmo/app build:ios`
- `bash -n apps/app/scripts/build-ios-simulator.sh`
- `pnpm exec prettier --check --ignore-unknown .gitignore apps/app/package.json apps/app/README.md .github/workflows/native-ios.yml apps/app/scripts/build-ios-simulator.sh`
- YAML 파싱 및 `git diff --check`
- pre-commit의 ESLint와 Prettier

## 아직 어떤 문제가 남았는지

없음. device build, 코드 서명, Fastlane 및 배포 연동은 이 이슈 범위에서 의도적으로 제외했습니다.

Stack: main -> PROD-302
