### PR TITLE
Cloudflare 관리형 weak cipher 알림을 제외한다

### DIFF
--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -25,10 +25,12 @@ jobs:
       DEFAULT_TARGETS: |
         https://kos.moe
         https://api.kos.moe
+      # Cloudflare controls the edge cipher suites, which cannot be changed on the current plan.
       NUCLEI_ARGS: >-
         -list nuclei-targets.txt
         -jle nuclei.jsonl
         -severity low,medium,high,critical
+        -exclude-id weak-cipher-suites
         -stats
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -25,12 +25,10 @@ jobs:
       DEFAULT_TARGETS: |
         https://kos.moe
         https://api.kos.moe
-      # Cloudflare controls the edge cipher suites, which cannot be changed on the current plan.
       NUCLEI_ARGS: >-
         -list nuclei-targets.txt
         -jle nuclei.jsonl
         -severity low,medium,high,critical
-        -exclude-id weak-cipher-suites
         -stats
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -39,6 +37,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prepare targets
+        id: targets
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_TARGETS: ${{ inputs.targets }}
@@ -46,7 +45,9 @@ jobs:
           script: |
             const fs = require("fs");
 
-            const targets = (process.env.INPUT_TARGETS || process.env.DEFAULT_TARGETS || "")
+            const usesDefaultTargets = !process.env.INPUT_TARGETS;
+            const targetInput = usesDefaultTargets ? process.env.DEFAULT_TARGETS : process.env.INPUT_TARGETS;
+            const targets = (targetInput || "")
               .split(/\r?\n/)
               .map((target) => target.trim())
               .filter(Boolean);
@@ -56,6 +57,7 @@ jobs:
             }
 
             fs.writeFileSync("nuclei-targets.txt", `${targets.join("\n")}\n`);
+            core.setOutput("uses-default-targets", usesDefaultTargets);
             core.info(`Prepared ${targets.length} Nuclei target(s).`);
 
       - name: Run Nuclei
@@ -63,7 +65,10 @@ jobs:
         continue-on-error: true
         uses: projectdiscovery/nuclei-action@cc153d0541e1adf8a42bbe31c0a4fb2376147538 # v3.1.1
         with:
-          args: ${{ env.NUCLEI_ARGS }}
+          # Cloudflare controls the default targets' edge cipher suites on the current plan.
+          args: >-
+            ${{ env.NUCLEI_ARGS }}
+            ${{ steps.targets.outputs.uses-default-targets == 'true' && '-exclude-id weak-cipher-suites' || '' }}
 
       - name: Upload Nuclei artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## 무엇을 변경했는지

- 기본 대상(`kos.moe`, `api.kos.moe`)을 사용하는 Nuclei 실행에서만 `weak-cipher-suites` template ID를 제외했습니다.
- `workflow_dispatch`에서 대상을 직접 입력하면 weak cipher 검사를 포함한 전체 검사를 유지합니다.
- Cloudflare가 현재 요금제의 edge cipher suite를 관리한다는 제외 이유를 workflow에 기록했습니다.
- 다른 심각도와 template, JSON artifact, Job Summary, Slack 알림, 스캔 실행 실패 판정은 그대로 유지합니다.

## 왜 변경했는지

`kos.moe`와 `api.kos.moe`의 TLS 1.0/1.1 weak cipher 결과는 Cloudflare edge 설정에서 발생하며 현재 요금제에서는 저장소나 서비스 설정으로 해소할 수 없습니다. 조치할 수 없는 동일 결과가 정기 Slack 알림을 반복 발생시키므로 기본 대상에 한해 해당 template을 조용히 제외합니다.

- Linear: [PROD-339](https://linear.app/byulmaru/issue/PROD-339/cloudflare-관리형-weak-cipher-nuclei-알림을-제외한다)
- 확인한 실행: [Nuclei #29284638028](https://github.com/byulmaru/kosmo/actions/runs/29284638028)

## 어떻게 확인할 수 있는지

- `pnpm exec prettier --check .github/workflows/nuclei.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nuclei.yml"); puts "YAML OK"'`
- `git diff --check`
- 기본 대상과 사용자 지정 대상의 조건 분기 결과를 Node.js로 확인했습니다.
- ProjectDiscovery 공식 문서에서 `-exclude-id`가 template ID 기반 제외 옵션임을 확인했습니다.

## 아직 어떤 문제가 남았는지

없음.
