### PR TITLE
Codex setup이 mise의 pnpm 버전을 사용하게 한다

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -48,6 +48,7 @@ if git merge-base --is-ancestor HEAD "$remote_main_commit"; then
 fi
 
 mise trust
+eval "$(mise env -s bash)"
 pnpm install
 '''
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Codex 로컬 환경 setup에서 `mise trust` 직후 `mise env`를 현재 셸에 적용합니다.
- 이후의 `pnpm install`과 setup 완료 후 실행되는 액션이 `mise.toml`의 pnpm 11.10.0을 사용하게 합니다.

## 왜 변경했는지

기존 setup은 `mise trust`만 실행해 비대화형 setup 셸의 PATH를 갱신하지 않았습니다. 그 결과 PATH에 남아 있던 pnpm 10.13.1이 `packageManager`의 11.10.0으로 자체 전환하려다 `~/Library/pnpm/.tools`에서 ENOENT로 실패했습니다.

Linear: [PROD-353](https://linear.app/byulmaru/issue/PROD-353/codex-로컬-환경에서-mise-pnpm을-활성화한다)

## 이번 PR의 주요 결정

### setup 셸의 mise 환경을 지속해서 활성화한다

- 결정자: @robin-maki
- 선택: `eval "$(mise env -s bash)"`로 setup 셸의 PATH를 갱신합니다.
- 고려한 대안: `mise exec -- pnpm install`로 설치 명령만 감쌉니다.
- 이유: 설치뿐 아니라 setup 완료 시 캡처되는 환경과 후속 Dev Server·Storybook 액션에도 동일한 pnpm 버전이 필요합니다.
- 감수한 결과: setup 스크립트가 mise의 Bash용 환경 출력 형식에 의존합니다.
- 관련 근거: [PROD-353](https://linear.app/byulmaru/issue/PROD-353/codex-로컬-환경에서-mise-pnpm을-활성화한다)

## 어떻게 확인할 수 있는지

- 비대화형 Bash에서 `command -v pnpm`이 mise의 pnpm 11.10.0 경로를 가리키는지 확인했습니다.
- `pnpm --version`이 11.10.0을 출력하는지 확인했습니다.
- `pnpm install`이 성공하는지 확인했습니다.
- 캡처된 PATH만 사용한 새 셸에서도 pnpm 11.10.0이 유지되는지 확인했습니다.
- pre-commit ESLint 및 Prettier 검사를 통과했습니다.

## 아직 어떤 문제가 남았는지

없음.

Stack: main -> PROD-353