### PR TITLE
Follow 알림 저장 경계를 제공한다

### DIFF
--- a/openspec/changes/add-in-app-notifications/tasks.md
+++ b/openspec/changes/add-in-app-notifications/tasks.md
@@ -7,10 +7,10 @@
 
 ## 2. PROD-274 Follow Notification의 source·Recipient 저장 경계를 제공한다
 
-- [ ] 2.1 established `ProfileFollow`에서 Followee Recipient와 Follower Related Profile을 파생하고 Local Recipient만 허용하는 source-only create 경계를 구현한다.
-- [ ] 2.2 `kind=FOLLOW`, `source_id=ProfileFollow.id`, `recipient_profile_id=Followee.id`, `data={}`인 row를 저장하고 existing source·Recipient 또는 concurrent unique conflict를 기존 item 성공이나 idempotent no-op으로 정규화한다.
-- [ ] 2.3 `(kind, source_id)`를 받는 idempotent delete 경계를 구현하고 이미 없는 row도 성공한 no-op으로 정규화한다.
-- [ ] 2.4 service/data-access test로 정확한 파생, Remote Recipient 거부, Local/Remote Follower, 동일 source 재호출, concurrent create와 반복 delete를 검증하고 target package check를 통과시킨다.
+- [x] 2.1 established `ProfileFollow`에서 Followee Recipient와 Follower Related Profile을 파생하고 Local Recipient만 허용하는 source-only create 경계를 구현한다.
+- [x] 2.2 `kind=FOLLOW`, `source_id=ProfileFollow.id`, `recipient_profile_id=Followee.id`, `data={}`인 row를 저장하고 existing source·Recipient 또는 concurrent unique conflict를 기존 item 성공이나 idempotent no-op으로 정규화한다.
+- [x] 2.3 `(kind, source_id)`를 받는 idempotent delete 경계를 구현하고 이미 없는 row도 성공한 no-op으로 정규화한다.
+- [x] 2.4 service/data-access test로 정확한 파생, Remote Recipient 거부, Local/Remote Follower, 동일 source 재호출, concurrent create와 반복 delete를 검증하고 target package check를 통과시킨다.
 
 ## 3. PROD-275 권한이 있는 Profile의 알림 목록·읽음·Unread count API를 제공한다
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "test:migrate": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/core exec node --import tsx --test db/migrate.test.ts",
     "test:migration": "cd ../.. && node scripts/test-db.mjs run -- node --test --test-concurrency=1 'packages/core/db/*.migration.test.mjs'",
     "test:services": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/core test:services:database",
-    "test:services:database": "cd ../.. && pnpm db:test:push && pnpm --filter @kosmo/core exec node --import tsx --test --test-concurrency=1 services/inbound-profile-follow.test.ts services/profile-follow.test.ts services/profile.test.ts",
+    "test:services:database": "cd ../.. && pnpm db:test:push && pnpm --filter @kosmo/core exec node --import tsx --test --test-concurrency=1 'services/*.test.ts'",
     "test:unit": "node --import tsx --test 'post-content/**/*.test.ts'"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,11 +35,12 @@
     "drizzle:generate": "node ../../scripts/vault-run.mjs -- drizzle-kit generate",
     "drizzle:push": "node ../../scripts/vault-run.mjs -- drizzle-kit push",
     "drizzle:studio": "node ../../scripts/vault-run.mjs -- drizzle-kit studio",
-    "test": "pnpm test:unit && pnpm test:migrate && pnpm test:migration && pnpm test:services",
+    "test": "pnpm test:unit && pnpm test:migrate && pnpm test:migration && pnpm test:services:database",
     "test:migrate": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/core exec node --import tsx --test db/migrate.test.ts",
     "test:migration": "cd ../.. && node scripts/test-db.mjs run -- node --test --test-concurrency=1 'packages/core/db/*.migration.test.mjs'",
-    "test:services": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/core test:services:database",
-    "test:services:database": "cd ../.. && pnpm db:test:push && pnpm --filter @kosmo/core exec node --import tsx --test --test-concurrency=1 'services/*.test.ts'",
+    "test:services": "node --import tsx --test --test-concurrency=1 'services/*.test.ts'",
+    "test:services:database": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/core test:services:isolated",
+    "test:services:isolated": "cd ../.. && pnpm db:test:push && pnpm --filter @kosmo/core test:services",
     "test:unit": "node --import tsx --test 'post-content/**/*.test.ts'"
   },
   "devDependencies": {

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -1,4 +1,5 @@
 export { recordInboundFollow, removeInboundFollow } from './inbound-profile-follow';
+export { createFollowNotification, deleteNotificationBySource } from './notification';
 export { disableProfile } from './profile';
 export { followProfile, unfollowProfile } from './profile-follow';
 export { createOidcSession } from './session';

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -1,17 +1,7 @@
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
 import { eq, inArray, or } from 'drizzle-orm';
-import {
-  createId,
-  db,
-  firstOrThrow,
-  Instances,
-  Notifications,
-  pg,
-  ProfileFollows,
-  Profiles,
-  TableDiscriminator,
-} from '../db';
+import { db, firstOrThrow, Instances, Notifications, pg, ProfileFollows, Profiles } from '../db';
 import { InstanceKind, InstanceState, NotificationKind, ProfileFollowPolicy } from '../enums';
 import { NotFoundError } from '../error';
 import { createFollowNotification, deleteNotificationBySource } from './notification';
@@ -119,7 +109,7 @@ test('Follow 알림은 Remote Recipient source를 거부한다', async () => {
 });
 
 test('Follow 알림은 존재하지 않거나 삭제된 source를 거부한다', async () => {
-  const missingSourceId = createId(TableDiscriminator.ProfileFollows);
+  const missingSourceId = crypto.randomUUID();
   await assert.rejects(createFollowNotification(missingSourceId), NotFoundError);
   assert.deepEqual(await readNotifications(missingSourceId), []);
 

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -1,7 +1,17 @@
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
 import { eq, inArray, or } from 'drizzle-orm';
-import { db, firstOrThrow, Instances, Notifications, pg, ProfileFollows, Profiles } from '../db';
+import {
+  createId,
+  db,
+  firstOrThrow,
+  Instances,
+  Notifications,
+  pg,
+  ProfileFollows,
+  Profiles,
+  TableDiscriminator,
+} from '../db';
 import { InstanceKind, InstanceState, NotificationKind, ProfileFollowPolicy } from '../enums';
 import { NotFoundError } from '../error';
 import { createFollowNotification, deleteNotificationBySource } from './notification';
@@ -68,7 +78,7 @@ test('Follow 알림은 source에서 Local Recipient와 Related Profile을 파생
     followeeProfileId: followee.id,
   });
 
-  await createFollowNotification(profileFollow);
+  await createFollowNotification(profileFollow.id);
 
   const [notification] = await readNotifications(profileFollow.id);
   assert.ok(notification);
@@ -88,7 +98,7 @@ test('Follow 알림은 materialize된 Remote Follower도 같은 mapping으로 �
     followeeProfileId: followee.id,
   });
 
-  await createFollowNotification(profileFollow);
+  await createFollowNotification(profileFollow.id);
 
   const [notification] = await readNotifications(profileFollow.id);
   assert.equal(notification?.recipientProfileId, followee.id);
@@ -104,7 +114,24 @@ test('Follow 알림은 Remote Recipient source를 거부한다', async () => {
     .returning()
     .then(firstOrThrow);
 
-  await assert.rejects(createFollowNotification(profileFollow), NotFoundError);
+  await assert.rejects(createFollowNotification(profileFollow.id), NotFoundError);
+  assert.deepEqual(await readNotifications(profileFollow.id), []);
+});
+
+test('Follow 알림은 존재하지 않거나 삭제된 source를 거부한다', async () => {
+  const missingSourceId = createId(TableDiscriminator.ProfileFollows);
+  await assert.rejects(createFollowNotification(missingSourceId), NotFoundError);
+  assert.deepEqual(await readNotifications(missingSourceId), []);
+
+  const follower = await createProfile();
+  const followee = await createProfile();
+  const { profileFollow } = await followProfile({
+    followerProfileId: follower.id,
+    followeeProfileId: followee.id,
+  });
+  await unfollowProfile({ followerProfileId: follower.id, followeeProfileId: followee.id });
+
+  await assert.rejects(createFollowNotification(profileFollow.id), NotFoundError);
   assert.deepEqual(await readNotifications(profileFollow.id), []);
 });
 
@@ -117,12 +144,12 @@ test('Follow 알림 생성과 삭제는 반복 및 동시 호출에 idempotent�
   });
 
   await Promise.all([
-    createFollowNotification(profileFollow),
-    createFollowNotification(profileFollow),
+    createFollowNotification(profileFollow.id),
+    createFollowNotification(profileFollow.id),
   ]);
   assert.equal((await readNotifications(profileFollow.id)).length, 1);
 
-  await createFollowNotification(profileFollow);
+  await createFollowNotification(profileFollow.id);
   assert.equal((await readNotifications(profileFollow.id)).length, 1);
 
   await deleteNotificationBySource(NotificationKind.FOLLOW, profileFollow.id);
@@ -137,7 +164,7 @@ test('Unfollow 뒤 Re-follow는 새 source ID로 새 알림을 저장한다', as
     followerProfileId: follower.id,
     followeeProfileId: followee.id,
   });
-  await createFollowNotification(firstFollow.profileFollow);
+  await createFollowNotification(firstFollow.profileFollow.id);
 
   const deleted = await unfollowProfile({
     followerProfileId: follower.id,
@@ -150,7 +177,7 @@ test('Unfollow 뒤 Re-follow는 새 source ID로 새 알림을 저장한다', as
     followerProfileId: follower.id,
     followeeProfileId: followee.id,
   });
-  await createFollowNotification(secondFollow.profileFollow);
+  await createFollowNotification(secondFollow.profileFollow.id);
 
   assert.notEqual(secondFollow.profileFollow.id, firstFollow.profileFollow.id);
   assert.deepEqual(await readNotifications(firstFollow.profileFollow.id), []);

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -10,7 +10,7 @@ import { followProfile, unfollowProfile } from './profile-follow';
 const instanceIds: string[] = [];
 const profileIds: string[] = [];
 
-const createProfile = async (kind = InstanceKind.LOCAL) => {
+const createProfile = async (kind: InstanceKind = InstanceKind.LOCAL) => {
   const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const instance = await db
     .insert(Instances)
@@ -116,11 +116,13 @@ test('Follow 알림 생성과 삭제는 반복 및 동시 호출에 idempotent�
     followeeProfileId: followee.id,
   });
 
-  await createFollowNotification(profileFollow);
   await Promise.all([
     createFollowNotification(profileFollow),
     createFollowNotification(profileFollow),
   ]);
+  assert.equal((await readNotifications(profileFollow.id)).length, 1);
+
+  await createFollowNotification(profileFollow);
   assert.equal((await readNotifications(profileFollow.id)).length, 1);
 
   await deleteNotificationBySource(NotificationKind.FOLLOW, profileFollow.id);

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import { eq, inArray, or } from 'drizzle-orm';
+import { db, firstOrThrow, Instances, Notifications, pg, ProfileFollows, Profiles } from '../db';
+import { InstanceKind, InstanceState, NotificationKind, ProfileFollowPolicy } from '../enums';
+import { NotFoundError } from '../error';
+import { createFollowNotification, deleteNotificationBySource } from './notification';
+import { followProfile, unfollowProfile } from './profile-follow';
+
+const instanceIds: string[] = [];
+const profileIds: string[] = [];
+
+const createProfile = async (kind = InstanceKind.LOCAL) => {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const instance = await db
+    .insert(Instances)
+    .values({
+      domain: `${suffix}.example`,
+      kind,
+      state: InstanceState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  instanceIds.push(instance.id);
+
+  const profile = await db
+    .insert(Profiles)
+    .values({
+      displayName: suffix,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle: suffix,
+      instanceId: instance.id,
+      normalizedHandle: suffix,
+    })
+    .returning()
+    .then(firstOrThrow);
+  profileIds.push(profile.id);
+  return profile;
+};
+
+const readNotifications = (sourceId: string) =>
+  db.select().from(Notifications).where(eq(Notifications.sourceId, sourceId));
+
+after(async () => {
+  if (profileIds.length > 0) {
+    await db.delete(Notifications).where(inArray(Notifications.recipientProfileId, profileIds));
+    await db
+      .delete(ProfileFollows)
+      .where(
+        or(
+          inArray(ProfileFollows.followerProfileId, profileIds),
+          inArray(ProfileFollows.followeeProfileId, profileIds),
+        ),
+      );
+    await db.delete(Profiles).where(inArray(Profiles.id, profileIds));
+  }
+  if (instanceIds.length > 0) {
+    await db.delete(Instances).where(inArray(Instances.id, instanceIds));
+  }
+  await pg.end();
+});
+
+test('Follow 알림은 source에서 Local Recipient와 Related Profile을 파생한다', async () => {
+  const follower = await createProfile();
+  const followee = await createProfile();
+  const { profileFollow } = await followProfile({
+    followerProfileId: follower.id,
+    followeeProfileId: followee.id,
+  });
+
+  await createFollowNotification(profileFollow);
+
+  const [notification] = await readNotifications(profileFollow.id);
+  assert.ok(notification);
+  assert.equal(notification.kind, NotificationKind.FOLLOW);
+  assert.equal(notification.sourceId, profileFollow.id);
+  assert.equal(notification.recipientProfileId, profileFollow.followeeProfileId);
+  assert.equal(profileFollow.followerProfileId, follower.id);
+  assert.deepEqual(notification.data, {});
+  assert.equal(notification.readAt, null);
+});
+
+test('Follow 알림은 materialize된 Remote Follower도 같은 mapping으로 저장한다', async () => {
+  const follower = await createProfile(InstanceKind.ACTIVITYPUB);
+  const followee = await createProfile();
+  const { profileFollow } = await followProfile({
+    followerProfileId: follower.id,
+    followeeProfileId: followee.id,
+  });
+
+  await createFollowNotification(profileFollow);
+
+  const [notification] = await readNotifications(profileFollow.id);
+  assert.equal(notification?.recipientProfileId, followee.id);
+  assert.equal(profileFollow.followerProfileId, follower.id);
+});
+
+test('Follow 알림은 Remote Recipient source를 거부한다', async () => {
+  const follower = await createProfile();
+  const followee = await createProfile(InstanceKind.ACTIVITYPUB);
+  const profileFollow = await db
+    .insert(ProfileFollows)
+    .values({ followerProfileId: follower.id, followeeProfileId: followee.id })
+    .returning()
+    .then(firstOrThrow);
+
+  await assert.rejects(createFollowNotification(profileFollow), NotFoundError);
+  assert.deepEqual(await readNotifications(profileFollow.id), []);
+});
+
+test('Follow 알림 생성과 삭제는 반복 및 동시 호출에 idempotent하다', async () => {
+  const follower = await createProfile();
+  const followee = await createProfile();
+  const { profileFollow } = await followProfile({
+    followerProfileId: follower.id,
+    followeeProfileId: followee.id,
+  });
+
+  await createFollowNotification(profileFollow);
+  await Promise.all([
+    createFollowNotification(profileFollow),
+    createFollowNotification(profileFollow),
+  ]);
+  assert.equal((await readNotifications(profileFollow.id)).length, 1);
+
+  await deleteNotificationBySource(NotificationKind.FOLLOW, profileFollow.id);
+  await deleteNotificationBySource(NotificationKind.FOLLOW, profileFollow.id);
+  assert.deepEqual(await readNotifications(profileFollow.id), []);
+});
+
+test('Unfollow 뒤 Re-follow는 새 source ID로 새 알림을 저장한다', async () => {
+  const follower = await createProfile();
+  const followee = await createProfile();
+  const firstFollow = await followProfile({
+    followerProfileId: follower.id,
+    followeeProfileId: followee.id,
+  });
+  await createFollowNotification(firstFollow.profileFollow);
+
+  const deleted = await unfollowProfile({
+    followerProfileId: follower.id,
+    followeeProfileId: followee.id,
+  });
+  assert.equal(deleted.profileFollowId, firstFollow.profileFollow.id);
+  await deleteNotificationBySource(NotificationKind.FOLLOW, firstFollow.profileFollow.id);
+
+  const secondFollow = await followProfile({
+    followerProfileId: follower.id,
+    followeeProfileId: followee.id,
+  });
+  await createFollowNotification(secondFollow.profileFollow);
+
+  assert.notEqual(secondFollow.profileFollow.id, firstFollow.profileFollow.id);
+  assert.deepEqual(await readNotifications(firstFollow.profileFollow.id), []);
+  assert.equal((await readNotifications(secondFollow.profileFollow.id)).length, 1);
+});

--- a/packages/core/services/notification.ts
+++ b/packages/core/services/notification.ts
@@ -1,35 +1,32 @@
 import { and, eq } from 'drizzle-orm';
-import { db, firstOrThrowWith, Instances, Notifications, Profiles } from '../db';
+import { db, firstOrThrowWith, Instances, Notifications, ProfileFollows, Profiles } from '../db';
 import { InstanceKind, NotificationKind } from '../enums';
 import { NotFoundError } from '../error';
-import type { ProfileFollows } from '../db';
 
-type ProfileFollowSource = Pick<
-  typeof ProfileFollows.$inferSelect,
-  'id' | 'followerProfileId' | 'followeeProfileId'
->;
+export const createFollowNotification = async (sourceId: string): Promise<void> =>
+  db.transaction(async (tx) => {
+    const source = await tx
+      .select({ id: ProfileFollows.id, recipientProfileId: ProfileFollows.followeeProfileId })
+      .from(ProfileFollows)
+      .innerJoin(Profiles, eq(Profiles.id, ProfileFollows.followeeProfileId))
+      .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+      .where(and(eq(ProfileFollows.id, sourceId), eq(Instances.kind, InstanceKind.LOCAL)))
+      .limit(1)
+      .for('key share', { of: ProfileFollows })
+      .then(firstOrThrowWith(() => new NotFoundError('Profile follow not found')));
 
-export const createFollowNotification = async (source: ProfileFollowSource): Promise<void> => {
-  await db
-    .select({ id: Profiles.id })
-    .from(Profiles)
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .where(and(eq(Profiles.id, source.followeeProfileId), eq(Instances.kind, InstanceKind.LOCAL)))
-    .limit(1)
-    .then(firstOrThrowWith(() => new NotFoundError('Profile not found')));
-
-  await db
-    .insert(Notifications)
-    .values({
-      data: {},
-      kind: NotificationKind.FOLLOW,
-      recipientProfileId: source.followeeProfileId,
-      sourceId: source.id,
-    })
-    .onConflictDoNothing({
-      target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
-    });
-};
+    await tx
+      .insert(Notifications)
+      .values({
+        data: {},
+        kind: NotificationKind.FOLLOW,
+        recipientProfileId: source.recipientProfileId,
+        sourceId: source.id,
+      })
+      .onConflictDoNothing({
+        target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
+      });
+  });
 
 export const deleteNotificationBySource = async (
   kind: NotificationKind,

--- a/packages/core/services/notification.ts
+++ b/packages/core/services/notification.ts
@@ -3,30 +3,28 @@ import { db, firstOrThrowWith, Instances, Notifications, ProfileFollows, Profile
 import { InstanceKind, NotificationKind } from '../enums';
 import { NotFoundError } from '../error';
 
-export const createFollowNotification = async (sourceId: string): Promise<void> =>
-  db.transaction(async (tx) => {
-    const source = await tx
-      .select({ id: ProfileFollows.id, recipientProfileId: ProfileFollows.followeeProfileId })
-      .from(ProfileFollows)
-      .innerJoin(Profiles, eq(Profiles.id, ProfileFollows.followeeProfileId))
-      .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-      .where(and(eq(ProfileFollows.id, sourceId), eq(Instances.kind, InstanceKind.LOCAL)))
-      .limit(1)
-      .for('key share', { of: ProfileFollows })
-      .then(firstOrThrowWith(() => new NotFoundError('Profile follow not found')));
+export const createFollowNotification = async (sourceId: string): Promise<void> => {
+  const source = await db
+    .select({ id: ProfileFollows.id, recipientProfileId: ProfileFollows.followeeProfileId })
+    .from(ProfileFollows)
+    .innerJoin(Profiles, eq(Profiles.id, ProfileFollows.followeeProfileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(and(eq(ProfileFollows.id, sourceId), eq(Instances.kind, InstanceKind.LOCAL)))
+    .limit(1)
+    .then(firstOrThrowWith(() => new NotFoundError('Profile follow not found')));
 
-    await tx
-      .insert(Notifications)
-      .values({
-        data: {},
-        kind: NotificationKind.FOLLOW,
-        recipientProfileId: source.recipientProfileId,
-        sourceId: source.id,
-      })
-      .onConflictDoNothing({
-        target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
-      });
-  });
+  await db
+    .insert(Notifications)
+    .values({
+      data: {},
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: source.recipientProfileId,
+      sourceId: source.id,
+    })
+    .onConflictDoNothing({
+      target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
+    });
+};
 
 export const deleteNotificationBySource = async (
   kind: NotificationKind,

--- a/packages/core/services/notification.ts
+++ b/packages/core/services/notification.ts
@@ -1,0 +1,41 @@
+import { and, eq } from 'drizzle-orm';
+import { db, firstOrThrowWith, Instances, Notifications, Profiles } from '../db';
+import { InstanceKind, NotificationKind } from '../enums';
+import { NotFoundError } from '../error';
+import type { ProfileFollows } from '../db';
+
+type ProfileFollowSource = Pick<
+  typeof ProfileFollows.$inferSelect,
+  'id' | 'followerProfileId' | 'followeeProfileId'
+>;
+
+export const createFollowNotification = async (source: ProfileFollowSource): Promise<void> => {
+  await db
+    .select({ id: Profiles.id })
+    .from(Profiles)
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(and(eq(Profiles.id, source.followeeProfileId), eq(Instances.kind, InstanceKind.LOCAL)))
+    .limit(1)
+    .then(firstOrThrowWith(() => new NotFoundError('Profile not found')));
+
+  await db
+    .insert(Notifications)
+    .values({
+      data: {},
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: source.followeeProfileId,
+      sourceId: source.id,
+    })
+    .onConflictDoNothing({
+      target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
+    });
+};
+
+export const deleteNotificationBySource = async (
+  kind: NotificationKind,
+  sourceId: string,
+): Promise<void> => {
+  await db
+    .delete(Notifications)
+    .where(and(eq(Notifications.kind, kind), eq(Notifications.sourceId, sourceId)));
+};


### PR DESCRIPTION
## 무엇을 변경했나요

- established `ProfileFollow` source에서 Followee를 Recipient로 파생하는 Follow 알림 저장 경계를 추가했습니다.
- Local Recipient만 허용하고, 동일 source의 반복·최초 동시 생성은 idempotent no-op으로 정규화했습니다.
- `(kind, source_id)` 기준 idempotent 삭제 경계와 Local/Remote Follower, Remote Recipient 거부, Unfollow 뒤 Re-follow 테스트를 추가했습니다.
- 검증 근거에 따라 OpenSpec `add-in-app-notifications`의 PROD-274 tasks 2.1~2.4를 완료 처리했습니다.

## 왜 변경했나요

PROD-325에서 병합된 Notification 단일 projection 위에 Follow source의 저장·정리 계약을 제공해, 후속 PROD-276이 ProfileFollow action commit 이후 안전하게 연결할 수 있게 합니다.

## 이번 PR의 주요 결정

없음. 승인된 OpenSpec 결정을 변경 없이 적용했습니다.

- 관련 근거: `openspec/changes/add-in-app-notifications/decisions.md`의 source identity, source lifecycle, Remote compatibility 결정

## 어떻게 확인할 수 있나요

- `env POSTGRES_PORT=54339 DATABASE_URL=postgres://kosmo:kosmo@localhost:54339/kosmo_test_prod274 pnpm --filter @kosmo/core test`
- `env POSTGRES_PORT=54339 DATABASE_URL=postgres://kosmo:kosmo@localhost:54339/kosmo_test_prod274 pnpm test`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm exec openspec validate add-in-app-notifications --strict`
- 서브에이전트 반복 리뷰 2회
  - correctness: 1차 테스트 동시성 경로 지적 반영, 2차 수정사항 없음
  - Fedify/Serena: 1차 TypeScript diagnostics 지적 반영, 2차 diagnostics 0건·Fedify 중복 비관련
  - ponytail-review: 두 차례 모두 `Lean already. Ship.`

## 아직 어떤 문제가 남았나요

- ProfileFollow action 연결과 Notification-side 실패 격리는 PROD-276이 소유합니다.
- source-only cleanup index는 승인된 결정에 따라 이번 범위에 추가하지 않았습니다.