### PR TITLE
DB 락을 중대한 동시성 보호에만 사용한다

### DIFF
--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -41,6 +41,7 @@
 
 - API와 BFF가 공유하는 server business use case는 `packages/core/services`가 소유한다. GraphQL resolver와 HTTP route는 transport validation과 actor context를 처리한 뒤 service를 호출한다.
 - service는 production database implementation이 하나인 현재 구조에서 `getDatabaseConnection(tx)`로 optional transaction 또는 shared `db`를 선택한다. 여러 DB 작업을 원자적으로 수행하는 service는 선택한 connection에서 transaction 경계를 열어, caller transaction이 있으면 savepoint로 합류하고 없으면 shared `db`에서 transaction을 시작한다. test seam이나 복수 implementation 요구 없이 generic `Database`를 전달하는 추상화는 만들지 않는다.
+- 명시적 비관적 DB 락은 동시성 위반이 금전 거래처럼 심각하고 되돌리기 어려운 피해를 만드는 use case에만 사용한다. 팔로우 요청처럼 드문 race의 영향이 작고 복구 가능한 social interaction은 락으로 완전 직렬화하지 않으며, 상세 판단과 리뷰 근거는 `memory/database-design.md`의 Runtime Locking Policy를 따른다.
 - `packages/core/db`는 DB client, schema, relation과 DB 전용 utility를 소유하고 account/session 생성 같은 application transaction은 소유하지 않는다.
 - OIDC discovery와 code exchange처럼 transport 또는 protocol-specific 검증은 API/BFF 경계에 남기고, core service에는 검증된 identity와 business input만 전달한다.
 

--- a/memory/database-design.md
+++ b/memory/database-design.md
@@ -120,6 +120,26 @@ Drizzle query policy:
 - Define database foreign keys in `packages/core/db/tables.ts` with `.references()`; relation metadata is not a substitute for database constraints.
 - If a future change adopts the relational query API, introduce only the relation definitions required by concrete query paths and update this policy in the same change.
 
+## Runtime Locking Policy
+
+- Application use cases must not add explicit pessimistic locks such as `SELECT ... FOR UPDATE`, table locks,
+  or advisory locks merely to make every concurrent outcome perfectly serialized.
+- Use an explicit lock only when a concrete race can violate a critical invariant and the resulting damage is severe or
+  difficult to reverse, such as duplicate financial settlement, overspending a balance, or another transaction with
+  equivalent correctness requirements.
+- Prefer database constraints, atomic conditional `INSERT`/`UPDATE`/`DELETE`, upsert/conflict handling, idempotency
+  keys, and bounded retry before considering a lock. A short transaction and the locks PostgreSQL acquires inherently
+  while executing normal DML are not prohibited by this policy.
+- Social interactions whose rare race is benign or repairable should favor availability and simpler code over strict
+  serialization. In particular, Follow Request creation, acceptance, rejection, or cancellation must not lock the
+  participant Profile or Follow Request rows solely to preserve perfect request consistency; use uniqueness and atomic
+  writes and tolerate a harmless concurrent winner instead.
+- A PR that introduces an explicit lock must explain the protected invariant, the exact race and user/business impact,
+  why constraint/atomic/idempotent approaches are insufficient, the smallest lock scope and stable acquisition order,
+  and how lock duration, deadlock, timeout, and concurrent behavior were verified.
+- Infrastructure coordination locks with a separate operational purpose, such as the migration runner advisory lock,
+  are reviewed under that workflow and are not precedent for adding locks to product use cases.
+
 ## Base Table Responsibilities
 
 - `account`: maps an OIDC account to a kosmo internal account. Authentication secrets remain owned by the OIDC server.
@@ -193,6 +213,10 @@ Thumbnail policy:
 - Are CDN URL and Object Storage key responsibilities kept separate?
 - Are ActivityPub/AT Protocol detail tables deferred until implementation needs are concrete?
 - Is the MVP schema small while preserving expensive-to-change boundaries?
+- Does each explicit application lock protect a documented critical invariant whose failure would cause severe or
+  difficult-to-reverse harm?
+- Could a constraint, atomic conditional write, conflict handling, idempotency, or bounded retry replace the lock?
+- Are benign social races, especially Follow Request races, handled without explicit pessimistic locking?
 
 ## Response Shape For Reviews
 


### PR DESCRIPTION
## 무엇을 변경했는지

- 런타임 비즈니스 로직에서 명시적 비관적 DB 락을 허용하는 기준을 문서화했습니다.
- 팔로우 요청처럼 드문 동시성 충돌의 영향이 작고 복구 가능한 소셜 상호작용은 락 없이 처리하도록 명시했습니다.
- 제약조건, 원자적 조건부 쓰기, 충돌 처리, 멱등성, 제한된 재시도를 락보다 먼저 검토하도록 했습니다.
- 락을 도입하는 PR에서 보호할 불변식, 실패 영향, 대안이 불충분한 이유, 락 범위·순서·검증을 설명하도록 리뷰 체크리스트를 추가했습니다.

## 왜 변경했는지

PR에서 정합성을 완전히 직렬화하기 위해 DB 락을 과도하게 사용하는 경향을 줄이기 위함입니다. 락은 경합, 지연, 데드락과 구현 복잡성을 늘리므로 동시성 위반이 심각하고 되돌리기 어려운 피해를 만드는 경우에만 사용해야 합니다.

## 이번 PR의 주요 결정

### 명시적 비관적 락의 허용 범위를 중대한 불변식으로 제한

- 결정자: @robin-maki
- 선택: 금전 거래처럼 동시성 위반이 심각하고 복구하기 어려운 경우에만 명시적 비관적 락을 사용합니다. 팔로우 요청은 락으로 완전 직렬화하지 않습니다.
- 고려한 대안: 모든 관계 상태 변경을 명시적 락으로 직렬화
- 이유: 팔로우 요청의 일시적 정합성 충돌은 영향이 작고 복구 가능하지만, 락의 경합·데드락·복잡성 비용은 지속적으로 발생합니다.
- 감수한 결과: 일부 소셜 상호작용에서는 동시 요청 중 하나가 충돌 처리되거나 드문 일시적 불일치가 발생할 수 있습니다.
- 관련 근거: `memory/database-design.md`의 Runtime Locking Policy

## 어떻게 확인할 수 있는지

- `git diff --check origin/main...HEAD` 통과
- Prettier는 로컬 pnpm 11.10.0 실행 파일이 누락되어 실행하지 못했습니다.
- Markdown 문서만 변경되어 런타임 테스트 대상은 없습니다.

## 아직 어떤 문제가 남았는지

없음