### PR TITLE
저장된 원격 작성자 Post의 GraphQL authorization 회귀를 검증한다

### DIFF
--- a/apps/api/tests/integration/graphql/profile.test.ts
+++ b/apps/api/tests/integration/graphql/profile.test.ts
@@ -292,7 +292,7 @@ describe('GraphQL remote profile boundary', () => {
     });
   });
 
-  test('applies parent authorization to stored remote Post surfaces without network reads', async () => {
+  test('applies parent authorization to stored remote Post surfaces without network reads', async (t) => {
     const auth = await createAuthenticatedSession();
     const activeInstance = await createRemoteInstance();
     const unresponsiveInstance = await createRemoteInstance({
@@ -335,45 +335,50 @@ describe('GraphQL remote profile boundary', () => {
       { followerProfileId: auth.profile.id, followeeProfileId: activeAuthor.id },
       { followerProfileId: auth.profile.id, followeeProfileId: unresponsiveAuthor.id },
       { followerProfileId: auth.profile.id, followeeProfileId: suspendedAuthor.id },
+      { followerProfileId: auth.profile.id, followeeProfileId: inactiveAuthor.id },
     ]);
-    const originalFetch = globalThis.fetch;
-    let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls += 1;
+    const fetchMock = t.mock.method(globalThis, 'fetch', () => {
       throw new Error('GraphQL materialized Post reads must not use fetch');
-    }) as typeof fetch;
+    });
 
-    try {
-      const result = await requestGraphQL<{
-        activeCurrent: { id: string } | null;
-        activeHistorical: { id: string } | null;
-        activePost: { id: string } | null;
-        activeProfile: { posts: { edges: Array<{ node: { id: string } }> } } | null;
-        homeTimeline: { edges: Array<{ node: { id: string } }> } | null;
-        inactivePost: { id: string } | null;
-        inactivePostContent: { id: string } | null;
-        inactiveProfileContent: { id: string } | null;
-        inactiveProfilePost: { id: string } | null;
-        suspendedContent: { id: string } | null;
-        suspendedPost: { id: string } | null;
-        suspendedProfile: { posts: { edges: unknown[] } } | null;
-        unresponsiveCurrent: { id: string } | null;
-        unresponsiveHistorical: { id: string } | null;
-        unresponsivePost: { id: string } | null;
-        unresponsiveProfile: {
-          posts: { edges: Array<{ node: { id: string } }> };
-        } | null;
-      }>(
-        `query RemotePostAuthorization(
+    const result = await requestGraphQL<{
+      activeCurrent: { id: string } | null;
+      activeHistorical: { id: string } | null;
+      activePost: { id: string } | null;
+      activeProfile: { posts: { edges: Array<{ node: { id: string } }> } } | null;
+      homeTimeline: { edges: Array<{ node: { id: string } }> } | null;
+      inactivePost: { id: string } | null;
+      inactivePostContent: { id: string } | null;
+      inactivePostHistorical: { id: string } | null;
+      inactiveProfile: { posts: { edges: unknown[] } } | null;
+      inactiveProfileContent: { id: string } | null;
+      inactiveProfileHistorical: { id: string } | null;
+      inactiveProfilePost: { id: string } | null;
+      suspendedContent: { id: string } | null;
+      suspendedHistorical: { id: string } | null;
+      suspendedPost: { id: string } | null;
+      suspendedProfile: { posts: { edges: unknown[] } } | null;
+      unresponsiveCurrent: { id: string } | null;
+      unresponsiveHistorical: { id: string } | null;
+      unresponsivePost: { id: string } | null;
+      unresponsiveProfile: {
+        posts: { edges: Array<{ node: { id: string } }> };
+      } | null;
+    }>(
+      `query RemotePostAuthorization(
           $activeContentId: ID!
           $activeHistoricalId: ID!
           $activePostId: ID!
           $activeProfileId: ID!
           $inactivePostContentId: ID!
+          $inactivePostHistoricalId: ID!
           $inactivePostId: ID!
           $inactiveProfileContentId: ID!
+          $inactiveProfileHistoricalId: ID!
+          $inactiveProfileId: ID!
           $inactiveProfilePostId: ID!
           $suspendedContentId: ID!
+          $suspendedHistoricalId: ID!
           $suspendedPostId: ID!
           $suspendedProfileId: ID!
           $unresponsiveContentId: ID!
@@ -399,72 +404,112 @@ describe('GraphQL remote profile boundary', () => {
           }
           suspendedPost: node(id: $suspendedPostId) { ... on Post { id } }
           suspendedContent: node(id: $suspendedContentId) { ... on PostContent { id } }
+          suspendedHistorical: node(id: $suspendedHistoricalId) {
+            ... on PostContent { id }
+          }
           suspendedProfile: node(id: $suspendedProfileId) {
+            ... on Profile { posts(first: 10) { edges { node { id } } } }
+          }
+          inactiveProfile: node(id: $inactiveProfileId) {
             ... on Profile { posts(first: 10) { edges { node { id } } } }
           }
           inactiveProfilePost: node(id: $inactiveProfilePostId) { ... on Post { id } }
           inactiveProfileContent: node(id: $inactiveProfileContentId) {
             ... on PostContent { id }
           }
+          inactiveProfileHistorical: node(id: $inactiveProfileHistoricalId) {
+            ... on PostContent { id }
+          }
           inactivePost: node(id: $inactivePostId) { ... on Post { id } }
           inactivePostContent: node(id: $inactivePostContentId) {
             ... on PostContent { id }
           }
+          inactivePostHistorical: node(id: $inactivePostHistoricalId) {
+            ... on PostContent { id }
+          }
           homeTimeline(first: 10) { edges { node { id } } }
         }`,
-        {
-          activeContentId: globalId('PostContent', active.current.id),
-          activeHistoricalId: globalId('PostContent', active.historical.id),
-          activePostId: globalId('Post', active.post.id),
-          activeProfileId: globalId('Profile', activeAuthor.id),
-          inactivePostContentId: globalId('PostContent', inactivePost.current.id),
-          inactivePostId: globalId('Post', inactivePost.post.id),
-          inactiveProfileContentId: globalId('PostContent', inactiveProfile.current.id),
-          inactiveProfilePostId: globalId('Post', inactiveProfile.post.id),
-          suspendedContentId: globalId('PostContent', suspended.current.id),
-          suspendedPostId: globalId('Post', suspended.post.id),
-          suspendedProfileId: globalId('Profile', suspendedAuthor.id),
-          unresponsiveContentId: globalId('PostContent', unresponsive.current.id),
-          unresponsiveHistoricalId: globalId('PostContent', unresponsive.historical.id),
-          unresponsivePostId: globalId('Post', unresponsive.post.id),
-          unresponsiveProfileId: globalId('Profile', unresponsiveAuthor.id),
-        },
-        auth.token,
-      );
+      {
+        activeContentId: globalId('PostContent', active.current.id),
+        activeHistoricalId: globalId('PostContent', active.historical.id),
+        activePostId: globalId('Post', active.post.id),
+        activeProfileId: globalId('Profile', activeAuthor.id),
+        inactivePostContentId: globalId('PostContent', inactivePost.current.id),
+        inactivePostHistoricalId: globalId('PostContent', inactivePost.historical.id),
+        inactivePostId: globalId('Post', inactivePost.post.id),
+        inactiveProfileContentId: globalId('PostContent', inactiveProfile.current.id),
+        inactiveProfileHistoricalId: globalId('PostContent', inactiveProfile.historical.id),
+        inactiveProfileId: globalId('Profile', inactiveAuthor.id),
+        inactiveProfilePostId: globalId('Post', inactiveProfile.post.id),
+        suspendedContentId: globalId('PostContent', suspended.current.id),
+        suspendedHistoricalId: globalId('PostContent', suspended.historical.id),
+        suspendedPostId: globalId('Post', suspended.post.id),
+        suspendedProfileId: globalId('Profile', suspendedAuthor.id),
+        unresponsiveContentId: globalId('PostContent', unresponsive.current.id),
+        unresponsiveHistoricalId: globalId('PostContent', unresponsive.historical.id),
+        unresponsivePostId: globalId('Post', unresponsive.post.id),
+        unresponsiveProfileId: globalId('Profile', unresponsiveAuthor.id),
+      },
+      auth.token,
+    );
 
-      assertNoGraphQLErrors(result);
-      assert.deepEqual(result.data, {
-        activeCurrent: { id: globalId('PostContent', active.current.id) },
-        activeHistorical: { id: globalId('PostContent', active.historical.id) },
-        activePost: { id: globalId('Post', active.post.id) },
-        activeProfile: {
-          posts: { edges: [{ node: { id: globalId('Post', active.post.id) } }] },
-        },
-        homeTimeline: {
-          edges: [unresponsive, active]
-            .sort((a, b) => b.post.id.localeCompare(a.post.id))
-            .map(({ post }) => ({ node: { id: globalId('Post', post.id) } })),
-        },
-        inactivePost: null,
-        inactivePostContent: null,
-        inactiveProfileContent: null,
-        inactiveProfilePost: null,
-        suspendedContent: null,
-        suspendedPost: null,
-        suspendedProfile: null,
-        unresponsiveCurrent: { id: globalId('PostContent', unresponsive.current.id) },
-        unresponsiveHistorical: {
-          id: globalId('PostContent', unresponsive.historical.id),
-        },
-        unresponsivePost: { id: globalId('Post', unresponsive.post.id) },
-        unresponsiveProfile: {
-          posts: { edges: [{ node: { id: globalId('Post', unresponsive.post.id) } }] },
-        },
-      });
-      assert.equal(fetchCalls, 0);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    const anonymous = await requestGraphQL<{
+      post: { id: string } | null;
+      profile: { posts: { edges: Array<{ node: { id: string } }> } } | null;
+    }>(
+      `query AnonymousRemotePost($postId: ID!, $profileId: ID!) {
+        post: node(id: $postId) { ... on Post { id } }
+        profile: node(id: $profileId) {
+          ... on Profile { posts(first: 10) { edges { node { id } } } }
+        }
+      }`,
+      {
+        postId: globalId('Post', active.post.id),
+        profileId: globalId('Profile', activeAuthor.id),
+      },
+    );
+
+    assertNoGraphQLErrors(result);
+    assertNoGraphQLErrors(anonymous);
+    assert.deepEqual(anonymous.data, {
+      post: { id: globalId('Post', active.post.id) },
+      profile: {
+        posts: { edges: [{ node: { id: globalId('Post', active.post.id) } }] },
+      },
+    });
+    assert.deepEqual(result.data, {
+      activeCurrent: { id: globalId('PostContent', active.current.id) },
+      activeHistorical: { id: globalId('PostContent', active.historical.id) },
+      activePost: { id: globalId('Post', active.post.id) },
+      activeProfile: {
+        posts: { edges: [{ node: { id: globalId('Post', active.post.id) } }] },
+      },
+      homeTimeline: {
+        edges: [unresponsive, active]
+          .sort((a, b) => b.post.id.localeCompare(a.post.id))
+          .map(({ post }) => ({ node: { id: globalId('Post', post.id) } })),
+      },
+      inactivePost: null,
+      inactivePostContent: null,
+      inactivePostHistorical: null,
+      inactiveProfile: null,
+      inactiveProfileContent: null,
+      inactiveProfileHistorical: null,
+      inactiveProfilePost: null,
+      suspendedContent: null,
+      suspendedHistorical: null,
+      suspendedPost: null,
+      suspendedProfile: null,
+      unresponsiveCurrent: { id: globalId('PostContent', unresponsive.current.id) },
+      unresponsiveHistorical: {
+        id: globalId('PostContent', unresponsive.historical.id),
+      },
+      unresponsivePost: { id: globalId('Post', unresponsive.post.id) },
+      unresponsiveProfile: {
+        posts: { edges: [{ node: { id: globalId('Post', unresponsive.post.id) } }] },
+      },
+    });
+    assert.equal(fetchMock.mock.callCount(), 0);
   });
 
   test('includes established remote followees and excludes other remote authors from home', async () => {
@@ -479,7 +524,7 @@ describe('GraphQL remote profile boundary', () => {
       instanceId: activeInstance.id,
     });
     const active = await createPostWithContents({ profileId: activeFollowee.id });
-    const unrelated = await createPostWithContents({ profileId: nonFollowee.id });
+    await createPostWithContents({ profileId: nonFollowee.id });
     await db.insert(ProfileFollows).values({
       followerProfileId: auth.profile.id,
       followeeProfileId: activeFollowee.id,
@@ -499,12 +544,6 @@ describe('GraphQL remote profile boundary', () => {
     assert.deepEqual(result.data?.homeTimeline?.edges, [
       { node: { id: globalId('Post', active.post.id) } },
     ]);
-    assert.equal(
-      result.data?.homeTimeline?.edges.some(
-        (edge) => edge.node.id === globalId('Post', unrelated.post.id),
-      ),
-      false,
-    );
   });
 
   test('preserves local visibility and Post ID cursor pagination', async () => {

--- a/apps/api/tests/integration/graphql/profile.test.ts
+++ b/apps/api/tests/integration/graphql/profile.test.ts
@@ -292,129 +292,326 @@ describe('GraphQL remote profile boundary', () => {
     });
   });
 
-  test('reads stored active remote posts through the general visibility policy', async () => {
-    const remoteInstance = await createRemoteInstance();
-    const remote = await createProfile({
-      handle: 'remote-post-author',
-      instanceId: remoteInstance.id,
-    });
-    const post = await db
-      .insert(Posts)
-      .values({
-        profileId: remote.id,
-        state: PostState.ACTIVE,
-        visibility: PostVisibility.PUBLIC,
-      })
-      .returning()
-      .then(firstOrThrow);
-
-    const result = await requestGraphQL<{
-      post: { id: string } | null;
-      node: { posts: { edges: Array<{ node: { id: string } }> } } | null;
-    }>(
-      `query StoredRemotePosts($postId: ID!, $profileId: ID!) {
-        post: node(id: $postId) { ... on Post { id } }
-        node(id: $profileId) {
-          ... on Profile { posts(first: 10) { edges { node { id } } } }
-        }
-      }`,
-      { postId: globalId('Post', post.id), profileId: globalId('Profile', remote.id) },
-    );
-
-    assertNoGraphQLErrors(result);
-    assert.deepEqual(result.data, {
-      post: { id: globalId('Post', post.id) },
-      node: { posts: { edges: [{ node: { id: globalId('Post', post.id) } }] } },
-    });
-  });
-
-  test('hides suspended-instance posts from Node and home timeline', async () => {
+  test('applies parent authorization to stored remote Post surfaces without network reads', async () => {
     const auth = await createAuthenticatedSession();
+    const activeInstance = await createRemoteInstance();
+    const unresponsiveInstance = await createRemoteInstance({
+      domain: 'unresponsive.example',
+      state: InstanceState.UNRESPONSIVE,
+    });
     const suspendedInstance = await createRemoteInstance({
       domain: 'suspended.example',
       state: InstanceState.SUSPENDED,
     });
-    const suspended = await createProfile({
-      handle: 'suspended',
+    const activeAuthor = await createProfile({
+      handle: 'active-author',
+      instanceId: activeInstance.id,
+    });
+    const unresponsiveAuthor = await createProfile({
+      handle: 'unresponsive-author',
+      instanceId: unresponsiveInstance.id,
+    });
+    const suspendedAuthor = await createProfile({
+      handle: 'suspended-author',
       instanceId: suspendedInstance.id,
     });
-    const suspendedPost = await db
-      .insert(Posts)
-      .values({
-        profileId: suspended.id,
-        state: PostState.ACTIVE,
-        visibility: PostVisibility.PUBLIC,
-      })
-      .returning()
-      .then(firstOrThrow);
+    const inactiveAuthor = await createProfile({
+      handle: 'inactive-author',
+      instanceId: activeInstance.id,
+      state: ProfileState.DISABLED,
+    });
+    const active = await createPostWithContents({ profileId: activeAuthor.id });
+    const unresponsive = await createPostWithContents({
+      profileId: unresponsiveAuthor.id,
+      visibility: PostVisibility.UNLISTED,
+    });
+    const suspended = await createPostWithContents({ profileId: suspendedAuthor.id });
+    const inactiveProfile = await createPostWithContents({ profileId: inactiveAuthor.id });
+    const inactivePost = await createPostWithContents({
+      profileId: activeAuthor.id,
+      state: PostState.DELETED,
+    });
+    await db.insert(ProfileFollows).values([
+      { followerProfileId: auth.profile.id, followeeProfileId: activeAuthor.id },
+      { followerProfileId: auth.profile.id, followeeProfileId: unresponsiveAuthor.id },
+      { followerProfileId: auth.profile.id, followeeProfileId: suspendedAuthor.id },
+    ]);
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (() => {
+      fetchCalls += 1;
+      throw new Error('GraphQL materialized Post reads must not use fetch');
+    }) as typeof fetch;
+
+    try {
+      const result = await requestGraphQL<{
+        activeCurrent: { id: string } | null;
+        activeHistorical: { id: string } | null;
+        activePost: { id: string } | null;
+        activeProfile: { posts: { edges: Array<{ node: { id: string } }> } } | null;
+        homeTimeline: { edges: Array<{ node: { id: string } }> } | null;
+        inactivePost: { id: string } | null;
+        inactivePostContent: { id: string } | null;
+        inactiveProfileContent: { id: string } | null;
+        inactiveProfilePost: { id: string } | null;
+        suspendedContent: { id: string } | null;
+        suspendedPost: { id: string } | null;
+        suspendedProfile: { posts: { edges: unknown[] } } | null;
+        unresponsiveCurrent: { id: string } | null;
+        unresponsiveHistorical: { id: string } | null;
+        unresponsivePost: { id: string } | null;
+        unresponsiveProfile: {
+          posts: { edges: Array<{ node: { id: string } }> };
+        } | null;
+      }>(
+        `query RemotePostAuthorization(
+          $activeContentId: ID!
+          $activeHistoricalId: ID!
+          $activePostId: ID!
+          $activeProfileId: ID!
+          $inactivePostContentId: ID!
+          $inactivePostId: ID!
+          $inactiveProfileContentId: ID!
+          $inactiveProfilePostId: ID!
+          $suspendedContentId: ID!
+          $suspendedPostId: ID!
+          $suspendedProfileId: ID!
+          $unresponsiveContentId: ID!
+          $unresponsiveHistoricalId: ID!
+          $unresponsivePostId: ID!
+          $unresponsiveProfileId: ID!
+        ) {
+          activePost: node(id: $activePostId) { ... on Post { id } }
+          activeCurrent: node(id: $activeContentId) { ... on PostContent { id } }
+          activeHistorical: node(id: $activeHistoricalId) { ... on PostContent { id } }
+          activeProfile: node(id: $activeProfileId) {
+            ... on Profile { posts(first: 10) { edges { node { id } } } }
+          }
+          unresponsivePost: node(id: $unresponsivePostId) { ... on Post { id } }
+          unresponsiveCurrent: node(id: $unresponsiveContentId) {
+            ... on PostContent { id }
+          }
+          unresponsiveHistorical: node(id: $unresponsiveHistoricalId) {
+            ... on PostContent { id }
+          }
+          unresponsiveProfile: node(id: $unresponsiveProfileId) {
+            ... on Profile { posts(first: 10) { edges { node { id } } } }
+          }
+          suspendedPost: node(id: $suspendedPostId) { ... on Post { id } }
+          suspendedContent: node(id: $suspendedContentId) { ... on PostContent { id } }
+          suspendedProfile: node(id: $suspendedProfileId) {
+            ... on Profile { posts(first: 10) { edges { node { id } } } }
+          }
+          inactiveProfilePost: node(id: $inactiveProfilePostId) { ... on Post { id } }
+          inactiveProfileContent: node(id: $inactiveProfileContentId) {
+            ... on PostContent { id }
+          }
+          inactivePost: node(id: $inactivePostId) { ... on Post { id } }
+          inactivePostContent: node(id: $inactivePostContentId) {
+            ... on PostContent { id }
+          }
+          homeTimeline(first: 10) { edges { node { id } } }
+        }`,
+        {
+          activeContentId: globalId('PostContent', active.current.id),
+          activeHistoricalId: globalId('PostContent', active.historical.id),
+          activePostId: globalId('Post', active.post.id),
+          activeProfileId: globalId('Profile', activeAuthor.id),
+          inactivePostContentId: globalId('PostContent', inactivePost.current.id),
+          inactivePostId: globalId('Post', inactivePost.post.id),
+          inactiveProfileContentId: globalId('PostContent', inactiveProfile.current.id),
+          inactiveProfilePostId: globalId('Post', inactiveProfile.post.id),
+          suspendedContentId: globalId('PostContent', suspended.current.id),
+          suspendedPostId: globalId('Post', suspended.post.id),
+          suspendedProfileId: globalId('Profile', suspendedAuthor.id),
+          unresponsiveContentId: globalId('PostContent', unresponsive.current.id),
+          unresponsiveHistoricalId: globalId('PostContent', unresponsive.historical.id),
+          unresponsivePostId: globalId('Post', unresponsive.post.id),
+          unresponsiveProfileId: globalId('Profile', unresponsiveAuthor.id),
+        },
+        auth.token,
+      );
+
+      assertNoGraphQLErrors(result);
+      assert.deepEqual(result.data, {
+        activeCurrent: { id: globalId('PostContent', active.current.id) },
+        activeHistorical: { id: globalId('PostContent', active.historical.id) },
+        activePost: { id: globalId('Post', active.post.id) },
+        activeProfile: {
+          posts: { edges: [{ node: { id: globalId('Post', active.post.id) } }] },
+        },
+        homeTimeline: {
+          edges: [unresponsive, active]
+            .sort((a, b) => b.post.id.localeCompare(a.post.id))
+            .map(({ post }) => ({ node: { id: globalId('Post', post.id) } })),
+        },
+        inactivePost: null,
+        inactivePostContent: null,
+        inactiveProfileContent: null,
+        inactiveProfilePost: null,
+        suspendedContent: null,
+        suspendedPost: null,
+        suspendedProfile: null,
+        unresponsiveCurrent: { id: globalId('PostContent', unresponsive.current.id) },
+        unresponsiveHistorical: {
+          id: globalId('PostContent', unresponsive.historical.id),
+        },
+        unresponsivePost: { id: globalId('Post', unresponsive.post.id) },
+        unresponsiveProfile: {
+          posts: { edges: [{ node: { id: globalId('Post', unresponsive.post.id) } }] },
+        },
+      });
+      assert.equal(fetchCalls, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('includes established remote followees and excludes other remote authors from home', async () => {
+    const auth = await createAuthenticatedSession();
+    const activeInstance = await createRemoteInstance();
+    const activeFollowee = await createProfile({
+      handle: 'active-followee',
+      instanceId: activeInstance.id,
+    });
+    const nonFollowee = await createProfile({
+      handle: 'non-followee',
+      instanceId: activeInstance.id,
+    });
+    const active = await createPostWithContents({ profileId: activeFollowee.id });
+    const unrelated = await createPostWithContents({ profileId: nonFollowee.id });
     await db.insert(ProfileFollows).values({
       followerProfileId: auth.profile.id,
-      followeeProfileId: suspended.id,
+      followeeProfileId: activeFollowee.id,
     });
 
     const result = await requestGraphQL<{
-      suspendedPost: { id: string } | null;
-      homeTimeline: { edges: unknown[] } | null;
+      homeTimeline: { edges: Array<{ node: { id: string } }> } | null;
     }>(
-      `query HiddenSuspendedPosts($suspendedPostId: ID!) {
-        suspendedPost: node(id: $suspendedPostId) {
-          ... on Post { id }
-        }
+      `query RemoteFolloweeHome {
         homeTimeline(first: 10) { edges { node { id } } }
       }`,
-      { suspendedPostId: globalId('Post', suspendedPost.id) },
+      {},
       auth.token,
     );
 
     assertNoGraphQLErrors(result);
-    assert.deepEqual(result.data, {
-      suspendedPost: null,
-      homeTimeline: { edges: [] },
-    });
+    assert.deepEqual(result.data?.homeTimeline?.edges, [
+      { node: { id: globalId('Post', active.post.id) } },
+    ]);
+    assert.equal(
+      result.data?.homeTimeline?.edges.some(
+        (edge) => edge.node.id === globalId('Post', unrelated.post.id),
+      ),
+      false,
+    );
   });
 
-  test('hides suspended-instance post contents from Node', async () => {
-    const suspendedInstance = await createRemoteInstance({
-      domain: 'suspended.example',
-      state: InstanceState.SUSPENDED,
+  test('preserves local visibility and Post ID cursor pagination', async () => {
+    const author = await createAuthenticatedSession();
+    const follower = await createAuthenticatedSession();
+    await db.insert(ProfileFollows).values({
+      followerProfileId: follower.profile.id,
+      followeeProfileId: author.profile.id,
     });
-    const suspended = await createProfile({
-      handle: 'suspended',
-      instanceId: suspendedInstance.id,
+    const oldest = await createPostWithContents({
+      id: '00000000-0001-8004-8000-000000000001',
+      profileId: author.profile.id,
+      visibility: PostVisibility.PUBLIC,
     });
-    const suspendedPost = await db
-      .insert(Posts)
-      .values({
-        profileId: suspended.id,
-        state: PostState.ACTIVE,
-        visibility: PostVisibility.PUBLIC,
-      })
-      .returning()
-      .then(firstOrThrow);
-    const suspendedContent = await db
-      .insert(PostContents)
-      .values({
-        document: postContentDocumentFromText('suspended content'),
-        postId: suspendedPost.id,
-      })
-      .returning()
-      .then(firstOrThrow);
+    const middle = await createPostWithContents({
+      id: '00000000-0002-8004-8000-000000000002',
+      profileId: author.profile.id,
+      visibility: PostVisibility.UNLISTED,
+    });
+    const newest = await createPostWithContents({
+      id: '00000000-0003-8004-8000-000000000003',
+      profileId: author.profile.id,
+      visibility: PostVisibility.FOLLOWERS,
+    });
+    const direct = await createPostWithContents({
+      id: '00000000-0004-8004-8000-000000000004',
+      profileId: author.profile.id,
+      visibility: PostVisibility.DIRECT,
+    });
 
-    const result = await requestGraphQL<{
-      suspendedContent: { id: string } | null;
+    const anonymous = await requestGraphQL<{
+      node: {
+        posts: {
+          edges: Array<{ cursor: string; node: { id: string } }>;
+          pageInfo: { endCursor: string | null; hasNextPage: boolean };
+        };
+      } | null;
     }>(
-      `query HiddenSuspendedPostContents($suspendedContentId: ID!) {
-        suspendedContent: node(id: $suspendedContentId) {
-          ... on PostContent { id }
+      `query LocalPublicPage($profileId: ID!) {
+        node(id: $profileId) {
+          ... on Profile {
+            posts(first: 1) {
+              edges { cursor node { id } }
+              pageInfo { endCursor hasNextPage }
+            }
+          }
         }
       }`,
-      { suspendedContentId: globalId('PostContent', suspendedContent.id) },
+      { profileId: globalId('Profile', author.profile.id) },
     );
 
-    assertNoGraphQLErrors(result);
-    assert.deepEqual(result.data, {
-      suspendedContent: null,
-    });
+    assertNoGraphQLErrors(anonymous);
+    assert.deepEqual(
+      anonymous.data?.node?.posts.edges.map((edge) => edge.node.id),
+      [globalId('Post', middle.post.id)],
+    );
+    assert.equal(anonymous.data?.node?.posts.pageInfo.hasNextPage, true);
+    const endCursor = anonymous.data?.node?.posts.pageInfo.endCursor;
+    assert.equal(typeof endCursor, 'string');
+
+    const nextPage = await requestGraphQL<{
+      node: { posts: { edges: Array<{ node: { id: string } }> } } | null;
+    }>(
+      `query LocalPublicNextPage($after: String!, $profileId: ID!) {
+        node(id: $profileId) {
+          ... on Profile { posts(first: 1, after: $after) { edges { node { id } } } }
+        }
+      }`,
+      { after: endCursor, profileId: globalId('Profile', author.profile.id) },
+    );
+    const followerView = await requestGraphQL<{
+      node: { posts: { edges: Array<{ node: { id: string } }> } | null } | null;
+    }>(
+      `query LocalFollowerPosts($profileId: ID!) {
+        node(id: $profileId) {
+          ... on Profile { posts(first: 10) { edges { node { id } } } }
+        }
+      }`,
+      { profileId: globalId('Profile', author.profile.id) },
+      follower.token,
+    );
+    const authorView = await requestGraphQL<{
+      node: { posts: { edges: Array<{ node: { id: string } }> } | null } | null;
+    }>(
+      `query LocalAuthorPosts($profileId: ID!) {
+        node(id: $profileId) {
+          ... on Profile { posts(first: 10) { edges { node { id } } } }
+        }
+      }`,
+      { profileId: globalId('Profile', author.profile.id) },
+      author.token,
+    );
+
+    assertNoGraphQLErrors(nextPage);
+    assertNoGraphQLErrors(followerView);
+    assertNoGraphQLErrors(authorView);
+    assert.deepEqual(nextPage.data?.node?.posts.edges, [
+      { node: { id: globalId('Post', oldest.post.id) } },
+    ]);
+    assert.deepEqual(
+      followerView.data?.node?.posts?.edges.map((edge) => edge.node.id),
+      [newest, middle, oldest].map(({ post }) => globalId('Post', post.id)),
+    );
+    assert.deepEqual(
+      authorView.data?.node?.posts?.edges.map((edge) => edge.node.id),
+      [direct, newest, middle, oldest].map(({ post }) => globalId('Post', post.id)),
+    );
   });
 
   test('includes active profiles from another local instance in an account profile list', async () => {
@@ -957,6 +1154,37 @@ const createProfile = async ({
     })
     .returning()
     .then(firstOrThrow);
+
+const createPostWithContents = async ({
+  id,
+  profileId,
+  state = PostState.ACTIVE,
+  visibility = PostVisibility.PUBLIC,
+}: {
+  id?: string;
+  profileId: string;
+  state?: PostState;
+  visibility?: PostVisibility;
+}) => {
+  const post = await db
+    .insert(Posts)
+    .values({ ...(id === undefined ? {} : { id }), profileId, state, visibility })
+    .returning()
+    .then(firstOrThrow);
+  const [historical, current] = await db
+    .insert(PostContents)
+    .values([
+      { document: postContentDocumentFromText('historical content'), postId: post.id },
+      { document: postContentDocumentFromText('current content'), postId: post.id },
+    ])
+    .returning();
+
+  assert.ok(historical);
+  assert.ok(current);
+  await db.update(Posts).set({ currentContentId: current.id }).where(eq(Posts.id, post.id));
+
+  return { current, historical, post };
+};
 
 const createAuthenticatedSession = async () => {
   const account = await db


### PR DESCRIPTION
## 무엇을 변경했는지

- ActivityPub mapping이나 ingestion을 거치지 않은 PostgreSQL fixture로 원격 작성자 Profile/Post/PostContent를 직접 저장합니다.
- Post Node, current/historical PostContent Node, Profile.posts와 homeTimeline의 기존 GraphQL authorization을 검증합니다.
- ACTIVE/UNRESPONSIVE instance의 공개 Post 허용과 SUSPENDED instance, inactive author, inactive Post 제외를 검증합니다.
- established remote followee 포함, non-followee 제외, local visibility와 Post.id DESC cursor pagination을 회귀 검증합니다.
- GraphQL read 중 remote fetch가 발생하지 않는지 실패 spy로 확인합니다.

## 왜 변경했는지

[PROD-257](https://linear.app/byulmaru/issue/PROD-257) PR #212가 저장된 remote Profile/Post에 적용되는 DB-only GraphQL read path를 구현했습니다. [PROD-262](https://linear.app/byulmaru/issue/PROD-262)는 향후 ingestion으로 같은 DB row가 생성되더라도 기존 authorization을 우회하지 않도록 이 read-path 보안 계약을 독립적으로 고정합니다.

이 PR은 실제 ActivityPub Note projection이나 Post materialization을 검증하지 않습니다. PR #249의 remote content projection, PR #256의 object mapping, PR #273의 Create(Note) validation과 PROD-261의 atomic materialization은 별도 구현 범위입니다.

## 이번 PR의 주요 결정

없음. 승인된 PROD-354 OpenSpec의 GraphQL DB-only read 결정과 PROD-262 테스트 전용 범위를 변경 없이 적용했습니다. resolver, visibility predicate, GraphQL schema와 production code는 변경하지 않습니다.

## 어떻게 확인할 수 있는지

- API PostgreSQL GraphQL 통합 테스트: 31개 통과
- API unit/schema 테스트: 9개 통과
- API TypeScript typecheck 통과
- ESLint 통과
- Prettier 통과
- `openspec validate add-activitypub-remote-post-ingestion --strict` 통과
- GraphQL schema 및 공유 OpenSpec diff 없음

## 아직 어떤 문제가 남았는지

- PR #249 remote Note content projection은 아직 main에 병합되지 않았습니다.
- PR #256 object mapping과 PR #273 Create(Note) validation도 아직 main에 병합되지 않았습니다.
- PROD-261이 실제 atomic materialization을 구현한 뒤, PROD-256 최종 통합 게이트에서 실제 materialized row smoke test와 OpenSpec archive를 수행합니다.