### PR TITLE
권한이 있는 Profile의 읽지 않은 알림 수를 제공한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -166,6 +166,7 @@ type Profile implements Node {
   instance: ProfileInstance!
   posts(after: String, before: String, first: Int, last: Int): PostConnection!
   relativeHandle: String!
+  unreadNotificationCount: Int!
   viewerFollow: ProfileFollow
   viewerState: ProfileViewerState
 }

--- a/apps/api/src/graphql/resolvers/notification/field/index.ts
+++ b/apps/api/src/graphql/resolvers/notification/field/index.ts
@@ -1,1 +1,2 @@
 import './follow-notification';
+import './profile';

--- a/apps/api/src/graphql/resolvers/notification/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/notification/field/profile.ts
@@ -1,0 +1,59 @@
+import { AccountProfiles, db, Notifications, ProfileFollows } from '@kosmo/core/db';
+import { PermissionDeniedError } from '@kosmo/core/error';
+import { and, count, eq, isNull } from 'drizzle-orm';
+import { builder } from '@/graphql/builder';
+import { Profile } from '@/graphql/resolvers/profile';
+import {
+  NotificationRecipientProfiles,
+  NotificationRelatedInstances,
+  NotificationRelatedProfiles,
+  visibleFollowNotificationWhere,
+} from '../access/visibility';
+
+builder.objectField(Profile, 'unreadNotificationCount', (t) =>
+  t.withAuth({ login: true }).field({
+    type: 'Int',
+    resolve: async (profile, _, ctx) => {
+      const membership = await db
+        .select({ id: AccountProfiles.id })
+        .from(AccountProfiles)
+        .where(
+          and(
+            eq(AccountProfiles.accountId, ctx.session.accountId),
+            eq(AccountProfiles.profileId, profile.id),
+          ),
+        )
+        .limit(1);
+
+      if (membership.length === 0) {
+        throw new PermissionDeniedError('Profile membership is required');
+      }
+
+      const [result] = await db
+        .select({ count: count() })
+        .from(Notifications)
+        .innerJoin(ProfileFollows, eq(ProfileFollows.id, Notifications.sourceId))
+        .innerJoin(
+          NotificationRecipientProfiles,
+          eq(NotificationRecipientProfiles.id, Notifications.recipientProfileId),
+        )
+        .innerJoin(
+          NotificationRelatedProfiles,
+          eq(NotificationRelatedProfiles.id, ProfileFollows.followerProfileId),
+        )
+        .innerJoin(
+          NotificationRelatedInstances,
+          eq(NotificationRelatedInstances.id, NotificationRelatedProfiles.instanceId),
+        )
+        .where(
+          and(
+            eq(Notifications.recipientProfileId, profile.id),
+            isNull(Notifications.readAt),
+            visibleFollowNotificationWhere({ ctx }),
+          ),
+        );
+
+      return result?.count ?? 0;
+    },
+  }),
+);

--- a/apps/api/src/graphql/schema.test.ts
+++ b/apps/api/src/graphql/schema.test.ts
@@ -67,8 +67,10 @@ test('rejects empty and over-500-character Plain Text before creating a post', a
 test('exposes Notification interface and FollowNotification without raw storage fields', () => {
   const notification = schema.getType('Notification');
   const followNotification = schema.getType('FollowNotification');
+  const profile = schema.getType('Profile');
 
   assert.ok(isObjectType(followNotification));
+  assert.ok(isObjectType(profile));
   assert.deepEqual(
     followNotification.getInterfaces().map(({ name }) => name),
     ['Node', 'Notification'],
@@ -87,6 +89,7 @@ test('exposes Notification interface and FollowNotification without raw storage 
   );
   assert.equal(notificationNodeType('FOLLOW'), 'FollowNotification');
   assert.equal(notificationNodeType('UNSUPPORTED'), null);
+  assert.equal(String(profile.getFields().unreadNotificationCount?.type), 'Int!');
 });
 
 test('rejects legacy raw UUID and unknown typename Node IDs', async () => {

--- a/apps/api/tests/integration/graphql/notification.test.ts
+++ b/apps/api/tests/integration/graphql/notification.test.ts
@@ -179,6 +179,112 @@ describe('Notification GraphQL Node boundary', () => {
     );
   });
 
+  test('counts unread notifications for every membership role without using the selected Profile', async () => {
+    const auth = await createAuthenticatedSession();
+    const profileIds: string[] = [];
+
+    for (const role of Object.values(AccountProfileRole)) {
+      const recipient = await createProfile(`count-recipient-${role.toLowerCase()}`);
+      const related = await createProfile(`count-related-${role.toLowerCase()}`);
+      await addMembership(auth.account.id, recipient.id, role);
+      await createFollowNotification(recipient.id, related.id);
+      profileIds.push(encodeGlobalId('Profile', recipient.id));
+    }
+
+    const selectedElsewhere = await loadUnreadNotificationCounts(profileIds, auth.token);
+    assertNoGraphQLErrors(selectedElsewhere);
+    assert.deepEqual(
+      selectedElsewhere.data?.nodes.map((profile) => profile?.unreadNotificationCount),
+      profileIds.map(() => 1),
+    );
+
+    await db
+      .update(Sessions)
+      .set({ activeProfileId: null })
+      .where(eq(Sessions.id, auth.session.id));
+    const withoutSelection = await loadUnreadNotificationCounts(profileIds, auth.token);
+    assertNoGraphQLErrors(withoutSelection);
+    assert.deepEqual(
+      withoutSelection.data?.nodes.map((profile) => profile?.unreadNotificationCount),
+      profileIds.map(() => 1),
+    );
+
+    const unrelated = await createAuthenticatedSession();
+    const withoutMembership = await loadUnreadNotificationCounts(profileIds, unrelated.token);
+    assert.deepEqual(
+      withoutMembership.data?.nodes,
+      profileIds.map(() => null),
+    );
+    assert.equal(withoutMembership.errors?.length, profileIds.length);
+    assert.ok(
+      withoutMembership.errors?.every(({ extensions }) => extensions?.code === 'PERMISSION_DENIED'),
+    );
+
+    const unauthenticated = await loadUnreadNotificationCounts([profileIds[0]!]);
+    assert.deepEqual(unauthenticated.data?.nodes, [null]);
+    assert.equal(unauthenticated.errors?.[0]?.extensions?.code, 'PERMISSION_DENIED');
+  });
+
+  test('counts only visible unread notifications', async () => {
+    const auth = await createAuthenticatedSession();
+    const recipient = await createProfile('count-visible-recipient');
+    await addMembership(auth.account.id, recipient.id, AccountProfileRole.OWNER);
+
+    const visibleRelated = await createProfile('count-visible-related');
+    await createFollowNotification(recipient.id, visibleRelated.id);
+    const readRelated = await createProfile('count-read-related');
+    const readNotification = await createFollowNotification(recipient.id, readRelated.id);
+    await db
+      .update(Notifications)
+      .set({ readAt: Temporal.Now.instant() })
+      .where(eq(Notifications.id, readNotification.id));
+
+    await db.insert(Notifications).values({
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: recipient.id,
+      sourceId: crypto.randomUUID(),
+    });
+
+    const actualFollowee = await createProfile('count-actual-followee');
+    const mismatchRelated = await createProfile('count-mismatch-related');
+    const mismatchSource = await createFollow(actualFollowee.id, mismatchRelated.id);
+    await db.insert(Notifications).values({
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: recipient.id,
+      sourceId: mismatchSource.id,
+    });
+
+    const hiddenRelated = await createProfile('count-hidden-related');
+    await createFollowNotification(recipient.id, hiddenRelated.id);
+    await db
+      .update(Profiles)
+      .set({ state: ProfileState.SUSPENDED })
+      .where(eq(Profiles.id, hiddenRelated.id));
+
+    const result = await loadUnreadNotificationCounts(
+      [encodeGlobalId('Profile', recipient.id)],
+      auth.token,
+    );
+    assertNoGraphQLErrors(result);
+    assert.equal(result.data?.nodes[0]?.unreadNotificationCount, 1);
+
+    const inactiveRecipient = await createProfile('count-inactive-recipient');
+    const inactiveRelated = await createProfile('count-inactive-related');
+    await addMembership(auth.account.id, inactiveRecipient.id, AccountProfileRole.OWNER);
+    await createFollowNotification(inactiveRecipient.id, inactiveRelated.id);
+    await db
+      .update(Profiles)
+      .set({ state: ProfileState.DISABLED })
+      .where(eq(Profiles.id, inactiveRecipient.id));
+
+    const inactiveResult = await loadUnreadNotificationCounts(
+      [encodeGlobalId('Profile', inactiveRecipient.id)],
+      auth.token,
+    );
+    assertNoGraphQLErrors(inactiveResult);
+    assert.deepEqual(inactiveResult.data?.nodes, [null]);
+  });
+
   test('does not infer a Notification type from a mismatched concrete global ID', async () => {
     const auth = await createAuthenticatedSession();
     const recipient = await createProfile('mismatched-recipient');
@@ -310,6 +416,19 @@ const loadNodes = async (ids: string[], token: string) => {
   assertNoGraphQLErrors(result);
   return result.data!.nodes;
 };
+
+const loadUnreadNotificationCounts = (ids: string[], token?: string) =>
+  requestGraphQL<{
+    nodes: Array<{ id: string; unreadNotificationCount: number } | null>;
+  }>(
+    `query NotificationUnreadCounts($ids: [ID!]!) {
+      nodes(ids: $ids) {
+        ... on Profile { id unreadNotificationCount }
+      }
+    }`,
+    { ids },
+    token,
+  );
 
 const assertNoGraphQLErrors = (result: GraphQLResult<unknown>) => {
   assert.equal(result.errors, undefined, JSON.stringify(result.errors));

--- a/openspec/changes/add-in-app-notifications/tasks.md
+++ b/openspec/changes/add-in-app-notifications/tasks.md
@@ -25,7 +25,7 @@
 
 ## 5. PROD-351 권한이 있는 Profile의 visible Unread count API를 제공한다
 
-- [ ] 5.1 `Profile.unreadNotificationCount`에 membership 권한과 공통 visible predicate 및 `read_at IS NULL`을 적용한다.
+- [x] 5.1 `Profile.unreadNotificationCount`에 membership 권한과 공통 visible predicate 및 `read_at IS NULL`을 적용한다.
 - [ ] 5.2 API test로 membership·비선택 Profile과 inactive Recipient·missing source·Recipient mismatch·hidden Related Profile·read item 제외를 검증한다.
 
 ## 6. PROD-350 권한이 있는 Profile의 Notification Read mutation을 제공한다

--- a/openspec/changes/add-in-app-notifications/tasks.md
+++ b/openspec/changes/add-in-app-notifications/tasks.md
@@ -26,7 +26,7 @@
 ## 5. PROD-351 권한이 있는 Profile의 visible Unread count API를 제공한다
 
 - [x] 5.1 `Profile.unreadNotificationCount`에 membership 권한과 공통 visible predicate 및 `read_at IS NULL`을 적용한다.
-- [ ] 5.2 API test로 membership·비선택 Profile과 inactive Recipient·missing source·Recipient mismatch·hidden Related Profile·read item 제외를 검증한다.
+- [x] 5.2 API test로 membership·비선택 Profile과 inactive Recipient·missing source·Recipient mismatch·hidden Related Profile·read item 제외를 검증한다.
 
 ## 6. PROD-350 권한이 있는 Profile의 Notification Read mutation을 제공한다
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `Profile.unreadNotificationCount: Int!` GraphQL 필드를 추가했습니다.
- Account-Profile membership을 명시적으로 확인하고 기존 Follow Notification visible SQL predicate와 `read_at IS NULL`을 count 쿼리에 함께 적용했습니다.
- generated schema와 schema unit test를 갱신했습니다.
- membership role 전체, selected Profile 부재, 비인증·무권한, read item과 unavailable item을 검증하는 DB integration test를 추가했습니다.
- OpenSpec `add-in-app-notifications`의 PROD-351 작업 5.1·5.2를 완료 처리했습니다.

## 왜 변경했는지

[PROD-351](https://linear.app/byulmaru/issue/PROD-351/권한이-있는-profile의-visible-unread-count-api를-제공한다)에 따라 로그인 Account가 membership을 가진 Profile의 visible unread Notification 수를 서버에서 일관되게 조회할 수 있어야 합니다. hidden item을 애플리케이션에서 차감하지 않고 목록·Node와 같은 SQL visibility 경계를 재사용합니다.

## 이번 PR의 주요 결정

없음. 승인된 OpenSpec `add-in-app-notifications`의 [membership 권한과 unavailable item 숨김 결정](https://github.com/byulmaru/kosmo/blob/main/openspec/changes/add-in-app-notifications/decisions.md)을 변경 없이 적용했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --filter @kosmo/api test:unit` — 10개 통과
- Notification DB integration test — 6개 통과
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm exec openspec validate add-in-app-notifications --strict`
- GraphQL schema 재생성 및 `git diff --check`

## 아직 어떤 문제가 남았는지

이번 PR 범위에서 남은 문제는 없습니다. 알림 목록, Read mutation, UI badge와 OpenSpec archive는 각각의 후속 이슈가 소유합니다.