### PR TITLE
권한이 있는 Profile의 알림 목록을 제공한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -113,6 +113,16 @@ interface Notification implements Node {
   readAt: DateTime
 }
 
+type NotificationConnection {
+  edges: [NotificationConnectionEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NotificationConnectionEdge {
+  cursor: String!
+  node: Notification!
+}
+
 type PageInfo {
   endCursor: String
   hasNextPage: Boolean!
@@ -174,6 +184,7 @@ type Profile implements Node {
   handle: String!
   id: ID!
   instance: ProfileInstance!
+  notifications(after: String, before: String, first: Int, last: Int): NotificationConnection!
   posts(after: String, before: String, first: Int, last: Int): PostConnection!
   relativeHandle: String!
   unreadNotificationCount: Int!

--- a/apps/api/src/graphql/resolvers/notification/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/notification/field/profile.ts
@@ -1,6 +1,7 @@
 import { AccountProfiles, db, Notifications, ProfileFollows } from '@kosmo/core/db';
 import { PermissionDeniedError } from '@kosmo/core/error';
-import { and, count, eq, isNull } from 'drizzle-orm';
+import { resolveCursorConnection } from '@pothos/plugin-relay';
+import { and, asc, count, desc, eq, getColumns, gt, isNull, lt } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
 import { Profile } from '@/graphql/resolvers/profile';
 import {
@@ -9,25 +10,75 @@ import {
   NotificationRelatedProfiles,
   visibleFollowNotificationWhere,
 } from '../access/visibility';
+import { Notification, NotificationConnection } from '../ref';
+import type { FollowNotificationRow } from '../ref';
+
+const requireProfileNotificationMembership = async (accountId: string, profileId: string) => {
+  const membership = await db
+    .select({ id: AccountProfiles.id })
+    .from(AccountProfiles)
+    .where(and(eq(AccountProfiles.accountId, accountId), eq(AccountProfiles.profileId, profileId)))
+    .limit(1);
+
+  if (membership.length === 0) {
+    throw new PermissionDeniedError('Profile membership is required');
+  }
+};
+
+builder.objectField(Profile, 'notifications', (t) =>
+  t.withAuth({ login: true }).connection(
+    {
+      type: Notification,
+      resolve: async (profile, args, ctx) => {
+        await requireProfileNotificationMembership(ctx.session.accountId, profile.id);
+
+        return resolveCursorConnection<Promise<FollowNotificationRow[]>>(
+          {
+            args,
+            toCursor: (notification) => notification.id,
+          },
+          ({ before, after, limit, inverted }) =>
+            db
+              .select({
+                ...getColumns(Notifications),
+                profileId: ProfileFollows.followerProfileId,
+              })
+              .from(Notifications)
+              .innerJoin(ProfileFollows, eq(ProfileFollows.id, Notifications.sourceId))
+              .innerJoin(
+                NotificationRecipientProfiles,
+                eq(NotificationRecipientProfiles.id, Notifications.recipientProfileId),
+              )
+              .innerJoin(
+                NotificationRelatedProfiles,
+                eq(NotificationRelatedProfiles.id, ProfileFollows.followerProfileId),
+              )
+              .innerJoin(
+                NotificationRelatedInstances,
+                eq(NotificationRelatedInstances.id, NotificationRelatedProfiles.instanceId),
+              )
+              .where(
+                and(
+                  eq(Notifications.recipientProfileId, profile.id),
+                  visibleFollowNotificationWhere({ ctx }),
+                  before ? gt(Notifications.id, before) : undefined,
+                  after ? lt(Notifications.id, after) : undefined,
+                ),
+              )
+              .orderBy(inverted ? asc(Notifications.id) : desc(Notifications.id))
+              .limit(limit),
+        );
+      },
+    },
+    NotificationConnection as never,
+  ),
+);
 
 builder.objectField(Profile, 'unreadNotificationCount', (t) =>
   t.withAuth({ login: true }).field({
     type: 'Int',
     resolve: async (profile, _, ctx) => {
-      const membership = await db
-        .select({ id: AccountProfiles.id })
-        .from(AccountProfiles)
-        .where(
-          and(
-            eq(AccountProfiles.accountId, ctx.session.accountId),
-            eq(AccountProfiles.profileId, profile.id),
-          ),
-        )
-        .limit(1);
-
-      if (membership.length === 0) {
-        throw new PermissionDeniedError('Profile membership is required');
-      }
+      await requireProfileNotificationMembership(ctx.session.accountId, profile.id);
 
       const [result] = await db
         .select({ count: count() })

--- a/apps/api/src/graphql/resolvers/notification/ref.ts
+++ b/apps/api/src/graphql/resolvers/notification/ref.ts
@@ -28,6 +28,16 @@ Notification.implement({
   resolveType: (notification) => notificationNodeType(notification.kind),
 });
 
+export const NotificationConnection = builder.connectionObject(
+  {
+    type: Notification,
+    name: 'NotificationConnection',
+  },
+  {
+    name: 'NotificationConnectionEdge',
+  },
+);
+
 export const FollowNotification = createObjectRef<FollowNotificationRow>(
   'FollowNotification',
   async (ids, ctx) => {

--- a/apps/api/src/graphql/schema.test.ts
+++ b/apps/api/src/graphql/schema.test.ts
@@ -89,7 +89,16 @@ test('exposes Notification interface and FollowNotification without raw storage 
   );
   assert.equal(notificationNodeType('FOLLOW'), 'FollowNotification');
   assert.equal(notificationNodeType('UNSUPPORTED'), null);
+  assert.equal(String(profile.getFields().notifications?.type), 'NotificationConnection!');
   assert.equal(String(profile.getFields().unreadNotificationCount?.type), 'Int!');
+
+  const connection = schema.getType('NotificationConnection');
+  const edge = schema.getType('NotificationConnectionEdge');
+  assert.ok(isObjectType(connection));
+  assert.ok(isObjectType(edge));
+  assert.equal(String(connection.getFields().pageInfo.type), 'PageInfo!');
+  assert.equal(String(edge.getFields().cursor.type), 'String!');
+  assert.equal(String(edge.getFields().node.type), 'Notification!');
 });
 
 test('exposes the typed Notification Read mutation payload', () => {

--- a/apps/api/tests/integration/graphql/notification.test.ts
+++ b/apps/api/tests/integration/graphql/notification.test.ts
@@ -410,7 +410,6 @@ describe('Notification GraphQL Node boundary', () => {
     const first = await loadNotificationConnection(profileId, auth.token, { first: 2 });
     assertNoGraphQLErrors(first);
     const firstConnection = first.data?.node?.notifications;
-    assert.equal(firstConnection?.edges.length, 2);
     assert.deepEqual(
       firstConnection?.edges.map(({ node }) => node.id),
       [newest.id, read.id].map((id) => encodeGlobalId('FollowNotification', id)),
@@ -438,12 +437,6 @@ describe('Notification GraphQL Node boundary', () => {
       encodeGlobalId('Profile', oldestRelated.id),
     );
     assert.equal(secondConnection?.pageInfo.hasNextPage, false);
-    assert.deepEqual(
-      [...(firstConnection?.edges ?? []), ...(secondConnection?.edges ?? [])].map(
-        ({ node }) => node.id,
-      ),
-      [newest.id, read.id, oldest.id].map((id) => encodeGlobalId('FollowNotification', id)),
-    );
   });
 
   test('does not infer a Notification type from a mismatched concrete global ID', async () => {
@@ -747,7 +740,6 @@ const loadNotificationConnection = (
               node {
                 __typename
                 id
-                createdAt
                 readAt
                 ... on FollowNotification { profile { id } }
               }

--- a/apps/api/tests/integration/graphql/notification.test.ts
+++ b/apps/api/tests/integration/graphql/notification.test.ts
@@ -285,6 +285,167 @@ describe('Notification GraphQL Node boundary', () => {
     assert.deepEqual(inactiveResult.data?.nodes, [null]);
   });
 
+  test('lists notifications for every membership role without using the selected Profile', async () => {
+    const auth = await createAuthenticatedSession();
+    const profileIds: string[] = [];
+
+    for (const role of Object.values(AccountProfileRole)) {
+      const recipient = await createProfile(`list-recipient-${role.toLowerCase()}`);
+      const related = await createProfile(`list-related-${role.toLowerCase()}`);
+      await addMembership(auth.account.id, recipient.id, role);
+      await createFollowNotification(recipient.id, related.id);
+      profileIds.push(encodeGlobalId('Profile', recipient.id));
+    }
+
+    for (const profileId of profileIds) {
+      const result = await loadNotificationConnection(profileId, auth.token, { first: 10 });
+      assertNoGraphQLErrors(result);
+      assert.equal(result.data?.node?.notifications.edges.length, 1);
+      assert.equal(
+        result.data?.node?.notifications.edges[0]?.node.__typename,
+        'FollowNotification',
+      );
+    }
+
+    await db
+      .update(Sessions)
+      .set({ activeProfileId: null })
+      .where(eq(Sessions.id, auth.session.id));
+    const withoutSelection = await loadNotificationConnection(profileIds[0]!, auth.token, {
+      first: 10,
+    });
+    assertNoGraphQLErrors(withoutSelection);
+    assert.equal(withoutSelection.data?.node?.notifications.edges.length, 1);
+
+    const unrelated = await createAuthenticatedSession();
+    const withoutMembership = await loadNotificationConnection(profileIds[0]!, unrelated.token, {
+      first: 10,
+    });
+    assert.equal(withoutMembership.data?.node, null);
+    assert.equal(withoutMembership.errors?.[0]?.extensions?.code, 'PERMISSION_DENIED');
+
+    const unauthenticated = await loadNotificationConnection(profileIds[0]!, undefined, {
+      first: 10,
+    });
+    assert.equal(unauthenticated.data?.node, null);
+    assert.equal(unauthenticated.errors?.[0]?.extensions?.code, 'PERMISSION_DENIED');
+
+    const inactiveRecipient = await createProfile('list-inactive-recipient');
+    const inactiveRelated = await createProfile('list-inactive-related');
+    await addMembership(auth.account.id, inactiveRecipient.id, AccountProfileRole.OWNER);
+    await createFollowNotification(inactiveRecipient.id, inactiveRelated.id);
+    await db
+      .update(Profiles)
+      .set({ state: ProfileState.DISABLED })
+      .where(eq(Profiles.id, inactiveRecipient.id));
+    const inactiveResult = await loadNotificationConnection(
+      encodeGlobalId('Profile', inactiveRecipient.id),
+      auth.token,
+      { first: 10 },
+    );
+    assertNoGraphQLErrors(inactiveResult);
+    assert.equal(inactiveResult.data?.node, null);
+  });
+
+  test('paginates visible notifications by ID after filtering hidden rows', async () => {
+    const auth = await createAuthenticatedSession();
+    const recipient = await createProfile('page-recipient');
+    await addMembership(auth.account.id, recipient.id, AccountProfileRole.OWNER);
+
+    const newestRelated = await createProfile('page-newest-related');
+    const newest = await createFollowNotification(
+      recipient.id,
+      newestRelated.id,
+      '00000000-0000-8006-8000-000000000900',
+    );
+
+    await db.insert(Notifications).values({
+      id: '00000000-0000-8006-8000-000000000800',
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: recipient.id,
+      sourceId: crypto.randomUUID(),
+    });
+
+    const readRelated = await createProfile('page-read-related');
+    const read = await createFollowNotification(
+      recipient.id,
+      readRelated.id,
+      '00000000-0000-8006-8000-000000000700',
+    );
+    const readResult = await markNotificationRead(
+      encodeGlobalId('FollowNotification', read.id),
+      auth.token,
+    );
+    assertNoGraphQLErrors(readResult);
+
+    const actualFollowee = await createProfile('page-actual-followee');
+    const mismatchRelated = await createProfile('page-mismatch-related');
+    const mismatchSource = await createFollow(actualFollowee.id, mismatchRelated.id);
+    await db.insert(Notifications).values({
+      id: '00000000-0000-8006-8000-000000000600',
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: recipient.id,
+      sourceId: mismatchSource.id,
+    });
+
+    const oldestRelated = await createProfile('page-oldest-related');
+    const oldest = await createFollowNotification(
+      recipient.id,
+      oldestRelated.id,
+      '00000000-0000-8006-8000-000000000500',
+    );
+
+    const hiddenRelated = await createProfile('page-hidden-related');
+    await createFollowNotification(
+      recipient.id,
+      hiddenRelated.id,
+      '00000000-0000-8006-8000-000000000400',
+    );
+    await db
+      .update(Profiles)
+      .set({ state: ProfileState.SUSPENDED })
+      .where(eq(Profiles.id, hiddenRelated.id));
+
+    const profileId = encodeGlobalId('Profile', recipient.id);
+    const first = await loadNotificationConnection(profileId, auth.token, { first: 2 });
+    assertNoGraphQLErrors(first);
+    const firstConnection = first.data?.node?.notifications;
+    assert.equal(firstConnection?.edges.length, 2);
+    assert.deepEqual(
+      firstConnection?.edges.map(({ node }) => node.id),
+      [newest.id, read.id].map((id) => encodeGlobalId('FollowNotification', id)),
+    );
+    assert.equal(
+      firstConnection?.edges[1]?.node.profile.id,
+      encodeGlobalId('Profile', readRelated.id),
+    );
+    assert.ok(firstConnection?.edges[1]?.node.readAt);
+    assert.equal(firstConnection?.pageInfo.hasNextPage, true);
+    assert.equal(firstConnection?.pageInfo.endCursor, firstConnection?.edges[1]?.cursor);
+
+    const second = await loadNotificationConnection(profileId, auth.token, {
+      after: firstConnection?.pageInfo.endCursor,
+      first: 2,
+    });
+    assertNoGraphQLErrors(second);
+    const secondConnection = second.data?.node?.notifications;
+    assert.deepEqual(
+      secondConnection?.edges.map(({ node }) => node.id),
+      [encodeGlobalId('FollowNotification', oldest.id)],
+    );
+    assert.equal(
+      secondConnection?.edges[0]?.node.profile.id,
+      encodeGlobalId('Profile', oldestRelated.id),
+    );
+    assert.equal(secondConnection?.pageInfo.hasNextPage, false);
+    assert.deepEqual(
+      [...(firstConnection?.edges ?? []), ...(secondConnection?.edges ?? [])].map(
+        ({ node }) => node.id,
+      ),
+      [newest.id, read.id, oldest.id].map((id) => encodeGlobalId('FollowNotification', id)),
+    );
+  });
+
   test('does not infer a Notification type from a mismatched concrete global ID', async () => {
     const auth = await createAuthenticatedSession();
     const recipient = await createProfile('mismatched-recipient');
@@ -527,6 +688,11 @@ type NotificationNode = {
   profile: { id: string };
 };
 
+type NotificationConnection = {
+  edges: Array<{ cursor: string; node: NotificationNode }>;
+  pageInfo: { endCursor: string | null; hasNextPage: boolean };
+};
+
 type ProfileNode = { __typename: 'Profile'; id: string };
 
 type GraphQLResult<TData> = {
@@ -565,6 +731,35 @@ const loadNodes = async (ids: string[], token: string) => {
   assertNoGraphQLErrors(result);
   return result.data!.nodes;
 };
+
+const loadNotificationConnection = (
+  id: string,
+  token: string | undefined,
+  variables: { after?: string | null; first: number },
+) =>
+  requestGraphQL<{ node: { notifications: NotificationConnection } | null }>(
+    `query ProfileNotifications($id: ID!, $first: Int!, $after: String) {
+      node(id: $id) {
+        ... on Profile {
+          notifications(first: $first, after: $after) {
+            edges {
+              cursor
+              node {
+                __typename
+                id
+                createdAt
+                readAt
+                ... on FollowNotification { profile { id } }
+              }
+            }
+            pageInfo { endCursor hasNextPage }
+          }
+        }
+      }
+    }`,
+    { id, ...variables },
+    token,
+  );
 
 const markNotificationRead = (id: string, token?: string) =>
   requestGraphQL<{

--- a/openspec/changes/add-in-app-notifications/tasks.md
+++ b/openspec/changes/add-in-app-notifications/tasks.md
@@ -20,8 +20,8 @@
 
 ## 4. PROD-352 권한이 있는 Profile의 알림 목록 API를 제공한다
 
-- [ ] 4.1 `Profile.notifications`에 membership 권한과 공통 visible predicate를 SQL page limit 전에 적용한 `id DESC` opaque cursor connection을 구현한다.
-- [ ] 4.2 API test로 FOLLOW concrete resolution, membership·비선택 Profile, inactive Recipient, ID keyset page 경계와 hidden source·Recipient mismatch·Related Profile의 pre-limit filtering을 검증한다.
+- [x] 4.1 `Profile.notifications`에 membership 권한과 공통 visible predicate를 SQL page limit 전에 적용한 `id DESC` opaque cursor connection을 구현한다.
+- [x] 4.2 API test로 FOLLOW concrete resolution, membership·비선택 Profile, inactive Recipient, ID keyset page 경계와 hidden source·Recipient mismatch·Related Profile의 pre-limit filtering을 검증한다.
 
 ## 5. PROD-351 권한이 있는 Profile의 visible Unread count API를 제공한다
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `Profile.notifications: NotificationConnection!` GraphQL connection을 추가했습니다.
- Account-Profile membership을 명시적으로 확인하고 공통 visible predicate를 SQL page limit 전에 적용했습니다.
- Notification ID 기준의 opaque cursor와 `id DESC` keyset pagination을 사용합니다.
- FOLLOW item의 Related Profile을 non-null로 함께 반환합니다.
- membership role 전체, selected Profile 비의존, 비인증·무권한, inactive Recipient를 검증했습니다.
- 고정 UUID와 hidden row를 교차 배치해 pre-limit filtering, 두 페이지 경계, 중복·누락 방지를 검증했습니다.
- Read 처리된 visible item이 목록에 남고 `readAt`을 반환하는지 검증했습니다.
- OpenSpec `add-in-app-notifications`의 PROD-352 task 4.1·4.2를 완료 처리했습니다.

## 왜 변경했는지

[PROD-352](https://linear.app/byulmaru/issue/PROD-352/권한이-있는-profile의-알림-목록-api를-제공한다)에 따라 로그인 Account가 membership을 가진 Profile의 visible Notification을 안정적으로 페이지 조회할 수 있어야 합니다. hidden item을 조회 후 버리지 않아 page 크기와 cursor 경계를 일관되게 유지합니다.

## 이번 PR의 주요 결정

없음. 승인된 OpenSpec `add-in-app-notifications`의 membership 권한, unavailable item 숨김, UUID ID cursor 결정을 변경 없이 적용했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --filter @kosmo/api test:unit` — 12개 통과
- targeted Notification integration test — 12개 통과
- `pnpm --filter @kosmo/api test:integration` — 43개 통과
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `openspec validate add-in-app-notifications --strict`
- `git diff --check`
- 서브에이전트 반복 리뷰 3회
  - `ponytail-review`: 최종 `Lean already. Ship.`
  - 정확성 리뷰: 최종 `수정사항 없음.`

## 아직 어떤 문제가 남았는지

이번 PR 범위에서 남은 문제는 없습니다. UI, Relay cache, source lifecycle과 전체 OpenSpec archive는 후속 이슈가 소유합니다.