### PR TITLE
구현 자기 검토와 외부 PR 리뷰 코치 스킬을 공유한다

### DIFF
--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-review-coach
-description: Inspect GitHub pull requests as the human reviewer’s evidence-gathering and drafting partner. Orchestrate parallel review subagents, using a ponytail simplification pass when available, while the main agent maps implementation responsibilities and execution flow. Compare updated heads, separate confirmed findings from suspicions, ask the user to decide ambiguous policy, draft detailed junior-friendly Korean review comments, publish only after explicit approval, and resolve only feedback actually reflected in code. When the current thread already contains an active PR review and reviewed head, treat follow-up review requests or skill invocations as re-reviews of that PR without asking for its number again. Use for PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
+description: Inspect GitHub pull requests as the human reviewer’s evidence-gathering and drafting partner. Delegate a bounded correctness review and add a parallel ponytail simplification pass when available, while the main agent maps implementation responsibilities and execution flow. Compare updated heads, separate confirmed findings from suspicions, ask the user to decide ambiguous policy, draft detailed junior-friendly Korean review comments, publish only after explicit approval, and resolve only feedback actually reflected in code. When the current thread already contains an active PR review and reviewed head, treat follow-up review requests or skill invocations as re-reviews of that PR without asking for its number again. Use for PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
 ---
 
 # GitHub Review Coach
@@ -32,18 +32,17 @@ Treat the user as the reviewer and final decision-maker. Act as the reviewer’s
 
 Use thread-aware GitHub reads when resolution or inline context matters. Do not infer current state from a flat comment list.
 
-### 2. Start parallel evidence review
+### 2. Start delegated evidence review
 
-After fixing the target, base SHA, head SHA, and repository guidance, always spawn at least two review subagents in parallel before drawing conclusions.
+After fixing the target, base SHA, head SHA, and repository guidance, spawn one review subagent before drawing conclusions.
 
 - Assign one subagent a bounded correctness surface such as contracts, authorization, transactions, persistence, concurrency, fixtures, tests, or unresolved-thread regressions.
-- When the `ponytail:ponytail-review` skill is available, assign one subagent to apply it only to find deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
-- When the ponytail skill is unavailable, assign that subagent another non-overlapping responsibility or execution-flow slice and continue the review.
-- Divide work by independent responsibility or execution-flow slices. Do not assign overlapping whole-PR rereads merely to increase agent count.
+- When the `ponytail:ponytail-review` skill is available, spawn a second subagent in parallel and assign it to find only deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
+- When the ponytail skill is unavailable, continue with the single correctness subagent.
+- When multiple subagents run, divide work by independent responsibility or execution-flow slices. Do not assign overlapping whole-PR rereads merely to increase agent count.
 - Give every subagent the same repository, PR number, base SHA, head SHA, applicable guidance, and a bounded question.
 - Require exact file/line evidence, the path or invariant checked, confirmed findings separated from suspicions, the smallest relevant validation and its result, and an explicit no-finding result when the assigned surface is sound.
 - Forbid subagents from GitHub writes, code edits, product-policy decisions, severity decisions, and final review recommendations.
-- If agent capacity prevents at least two parallel review subagents, report that the required review protocol is incomplete instead of silently falling back to a single-agent review.
 
 While they run, the main agent must independently trace and share a compact responsibility map and execution-flow summary. Do not wait idle and do not delegate this synthesis. The main agent owns freshness checks, final verification, deduplication, severity, drafting, and every GitHub write.
 

--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: gh-review-coach
+description: Inspect GitHub pull requests as the human reviewer’s evidence-gathering and drafting partner. Orchestrate parallel review subagents, including a mandatory ponytail simplification pass, while the main agent maps implementation responsibilities and execution flow. Compare updated heads, separate confirmed findings from suspicions, ask the user to decide ambiguous policy, draft detailed junior-friendly Korean review comments, publish only after explicit approval, and resolve only feedback actually reflected in code. When the current thread already contains an active PR review and reviewed head, treat follow-up review requests or skill invocations as re-reviews of that PR without asking for its number again. Use for PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
+---
+
+# GitHub Review Coach
+
+## Role
+
+Treat the user as the reviewer and final decision-maker. Act as the reviewer’s research, reasoning, and drafting partner.
+
+- Inspect and explain before writing to GitHub.
+- When this thread already contains one active PR review, treat a later review request or skill invocation as a re-review of that same PR by default.
+- Do not ask for the PR number or URL again unless the earlier target is missing, genuinely ambiguous, closed and replaced, or the user explicitly switches targets.
+- Do not publish, reply, resolve, approve, or request changes merely because the user says “리뷰해줘.”
+- Publish only after explicit instructions such as “댓글 달아,” “리젝해,” “approve해,” or equivalent.
+- Present uncertain policy or design choices to the user instead of silently deciding them.
+- Follow repository instructions and review memories before this skill when they are more specific.
+
+## Review Workflow
+
+### 1. Establish the exact review state
+
+1. Resolve the repository and PR from the existing thread context first.
+2. If this thread already reviewed one PR, reuse that PR number and the last reviewed head and proceed directly as a re-review.
+3. Ask for a PR number or URL only when no usable prior target exists or multiple targets are plausible.
+4. Fetch the current base SHA and head SHA.
+5. Read applicable `AGENTS.md`, repository review guidance, specs, and domain memories.
+6. Fetch the PR diff, metadata, existing reviews, replies, and thread resolution state.
+7. Compare the last reviewed SHA with the new head before rereading the whole PR.
+8. Record the newly reviewed head SHA for the next re-review.
+
+Use thread-aware GitHub reads when resolution or inline context matters. Do not infer current state from a flat comment list.
+
+### 2. Start parallel evidence review
+
+After fixing the target, base SHA, head SHA, and repository guidance, always spawn at least two review subagents in parallel before drawing conclusions.
+
+- Assign one subagent a bounded correctness surface such as contracts, authorization, transactions, persistence, concurrency, fixtures, tests, or unresolved-thread regressions.
+- Require one subagent to load and apply the `ponytail:ponytail-review` skill only to find deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
+- Divide work by independent responsibility or execution-flow slices. Do not assign overlapping whole-PR rereads merely to increase agent count.
+- Give every subagent the same repository, PR number, base SHA, head SHA, applicable guidance, and a bounded question.
+- Require exact file/line evidence, the path or invariant checked, confirmed findings separated from suspicions, the smallest relevant validation and its result, and an explicit no-finding result when the assigned surface is sound.
+- Forbid subagents from GitHub writes, code edits, product-policy decisions, severity decisions, and final review recommendations.
+- If agent capacity or the ponytail skill is unavailable, report that the required review protocol is incomplete instead of silently falling back to a single-agent review.
+
+While they run, the main agent must independently trace and share a compact responsibility map and execution-flow summary. Do not wait idle and do not delegate this synthesis. The main agent owns freshness checks, final verification, deduplication, severity, drafting, and every GitHub write.
+
+### 3. Trace behavior and ownership
+
+The main agent owns the end-to-end implementation map. Trace the changed flow through callers and downstream consumers in execution order:
+
+`entry point -> application action -> domain policy -> transaction/persistence -> side effect -> response/consumer`
+
+For each boundary, identify its owner, input, output, invariant, and changed files. Summarize at least:
+
+- the trigger or public entry point;
+- the application action or orchestration layer;
+- the module that owns each domain policy and authorization decision;
+- validation and transaction boundaries;
+- persistence, cache, queue, or external side effects;
+- returned values and downstream consumers;
+- tests that exercise each important path.
+
+Then check:
+
+- which module owns the domain action;
+- where policy, authorization, validation, transaction, and persistence responsibilities live;
+- whether API-specific details leak into core/domain services;
+- whether a public service is a full application action or a low-level DB primitive;
+- whether transaction boundaries permit the operations that must be atomic;
+- whether specs, API contracts, DB invariants, caches, and tests agree;
+- whether fixtures create states that production code cannot create;
+- whether concurrency logic has a deterministic concurrency test;
+- whether unused code anticipates a future PR without a current caller;
+- whether the PR has accumulated unrelated changes with different reasons or verification methods.
+
+Prefer the smallest relevant check that can disprove or confirm a concern. Do not run broad test suites merely to appear thorough.
+
+### 4. Reconcile and classify evidence
+
+Treat subagent reports as evidence, not conclusions. Verify their cited lines against the shared head SHA. Merge duplicates only when they have the same root cause and requested fix, and preserve independently actionable fixes. A ponytail observation is not a blocker without a concrete current cost, absent caller, duplicated behavior, or scope/verification mismatch.
+
+If the head changes, identify the affected responsibility slices and rerun those checks before publishing. Never reuse evidence against a different head without verification.
+
+Separate the review into four groups:
+
+1. **Addressed feedback**: the requested behavior is actually present in the current code.
+2. **Confirmed findings**: code, spec, test, or reproducible behavior proves the problem.
+3. **Suspicions and decisions**: the concern depends on product policy, intended layering, or acceptable scope.
+4. **Scope concerns**: independent changes should move to separate PRs.
+
+Show this classification to the user before posting. Ask concise questions for every decision that materially changes the requested fix.
+
+When code and spec disagree, do not assume the spec is correct. Explain the consequence of changing either side and ask which contract the user wants.
+
+### 5. Recommend PR splits when scope expands
+
+Recommend splitting when the PR combines changes that have different:
+
+- business reasons;
+- responsibility owners;
+- rollback risks;
+- test strategies;
+- delivery dependencies.
+
+Propose concrete slices rather than saying only “this PR is too large.” State what files, behaviors, specs, and tests belong to each slice.
+
+Do not keep speculative helpers, options, or abstractions solely for a later PR. Add them with the real caller and exact transaction requirements.
+
+### 6. Draft junior-friendly comments
+
+Write in Korean when the repository or user prefers Korean. Use the following order:
+
+1. **Priority and short title**
+2. **What the current code does**
+3. **Why that causes a problem**
+4. **A concrete example or execution order**
+5. **What to change**
+6. **Whether it blocks this PR or may move to a follow-up**
+
+Explain unfamiliar terms in plain language. Use `transaction`, `loader`, `fixture`, or `idempotency` only when useful, and immediately connect the term to the observable behavior.
+
+Anchor comments to the tightest changed line. Avoid preference-only feedback. Combine comments that share one root cause, but keep independently actionable fixes separate.
+
+Use repository priority rules when available. Otherwise:
+
+- `P1`: merge-blocking behavior, security, data, or API contract defect;
+- `P2`: structural or correctness risk that should be fixed now but may be split with explicit ownership;
+- `P3`: lower-risk design or maintainability improvement;
+- `P5`: trivial cleanup.
+
+### 7. Get explicit approval before publishing
+
+Before a GitHub write:
+
+1. Show the proposed findings and open questions.
+2. Incorporate the user’s policy decisions.
+3. Re-fetch the PR head.
+4. If the head changed, stop and re-check the affected lines before publishing.
+5. State the exact PR and intended action.
+
+Decide the review body before submission. A submitted empty review body may not be editable later.
+
+- Use an empty body when inline comments are sufficient and repository rules prefer it.
+- Include a detailed body in the initial submission when requesting a PR split or explaining an overarching blocker.
+
+### 8. Clean up threads accurately
+
+- Resolve only feedback whose requested behavior is actually reflected in the current code or conclusively answered.
+- Do not resolve a thread merely because the author replied or moved code.
+- Keep new and unaddressed findings unresolved.
+- After publishing, verify the review state, inline comment count, body, resolved/unresolved thread state, and clean local workspace.
+
+## Output Before Publishing
+
+Return:
+
+1. the reviewed base SHA and head SHA, plus the head-to-head change summary;
+2. the implementation summary by responsibility and ordered execution flow;
+3. subagent coverage, relevant validations, and any disagreements or no-finding reports;
+4. which previous feedback is addressed;
+5. confirmed findings ordered by severity;
+6. suspicions and questions for the user;
+7. proposed inline comments and review body;
+8. the recommended review action: approve, comment, or request changes.
+
+## Output After Publishing
+
+Return:
+
+- the review state and link;
+- the number of inline comments;
+- which earlier threads were resolved;
+- which findings remain open;
+- whether any local files or git state changed.

--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-review-coach
-description: Inspect GitHub pull requests as the human reviewer’s evidence-gathering and drafting partner. Orchestrate parallel review subagents, including a mandatory ponytail simplification pass, while the main agent maps implementation responsibilities and execution flow. Compare updated heads, separate confirmed findings from suspicions, ask the user to decide ambiguous policy, draft detailed junior-friendly Korean review comments, publish only after explicit approval, and resolve only feedback actually reflected in code. When the current thread already contains an active PR review and reviewed head, treat follow-up review requests or skill invocations as re-reviews of that PR without asking for its number again. Use for PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
+description: Inspect GitHub pull requests as the human reviewer’s evidence-gathering and drafting partner. Orchestrate parallel review subagents, using a ponytail simplification pass when available, while the main agent maps implementation responsibilities and execution flow. Compare updated heads, separate confirmed findings from suspicions, ask the user to decide ambiguous policy, draft detailed junior-friendly Korean review comments, publish only after explicit approval, and resolve only feedback actually reflected in code. When the current thread already contains an active PR review and reviewed head, treat follow-up review requests or skill invocations as re-reviews of that PR without asking for its number again. Use for PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
 ---
 
 # GitHub Review Coach
@@ -37,12 +37,13 @@ Use thread-aware GitHub reads when resolution or inline context matters. Do not 
 After fixing the target, base SHA, head SHA, and repository guidance, always spawn at least two review subagents in parallel before drawing conclusions.
 
 - Assign one subagent a bounded correctness surface such as contracts, authorization, transactions, persistence, concurrency, fixtures, tests, or unresolved-thread regressions.
-- Require one subagent to load and apply the `ponytail:ponytail-review` skill only to find deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
+- When the `ponytail:ponytail-review` skill is available, assign one subagent to apply it only to find deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
+- When the ponytail skill is unavailable, assign that subagent another non-overlapping responsibility or execution-flow slice and continue the review.
 - Divide work by independent responsibility or execution-flow slices. Do not assign overlapping whole-PR rereads merely to increase agent count.
 - Give every subagent the same repository, PR number, base SHA, head SHA, applicable guidance, and a bounded question.
 - Require exact file/line evidence, the path or invariant checked, confirmed findings separated from suspicions, the smallest relevant validation and its result, and an explicit no-finding result when the assigned surface is sound.
 - Forbid subagents from GitHub writes, code edits, product-policy decisions, severity decisions, and final review recommendations.
-- If agent capacity or the ponytail skill is unavailable, report that the required review protocol is incomplete instead of silently falling back to a single-agent review.
+- If agent capacity prevents at least two parallel review subagents, report that the required review protocol is incomplete instead of silently falling back to a single-agent review.
 
 While they run, the main agent must independently trace and share a compact responsibility map and execution-flow summary. Do not wait idle and do not delegate this synthesis. The main agent owns freshness checks, final verification, deduplication, severity, drafting, and every GitHub write.
 

--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: gh-review-coach
-description: Inspect GitHub pull requests as the human reviewer’s evidence-gathering and drafting partner. Delegate a bounded correctness review and add a parallel ponytail simplification pass when available, while the main agent maps implementation responsibilities and execution flow. Compare updated heads, separate confirmed findings from suspicions, ask the user to decide ambiguous policy, draft detailed junior-friendly Korean review comments, publish only after explicit approval, and resolve only feedback actually reflected in code. When the current thread already contains an active PR review and reviewed head, treat follow-up review requests or skill invocations as re-reviews of that PR without asking for its number again. Use for PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
+description: Review implementation work before publication or inspect another author’s GitHub pull request as the human decision-maker’s evidence-gathering partner. Distinguish implementation self-review from external PR review using user intent, thread provenance, PR authorship, and Linear ownership; delegate bounded correctness and optional ponytail passes while the main agent maps responsibilities, execution flow, public contracts, production callers, and test-only seams. Use for implementation self-review, PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
 ---
 
 # GitHub Review Coach
 
 ## Role
 
-Treat the user as the reviewer and final decision-maker. Act as the reviewer’s research, reasoning, and drafting partner.
+Treat the user as the final decision-maker. First distinguish whether the user is validating owned implementation work or reviewing another owner’s PR.
 
-- Inspect and explain before writing to GitHub.
+- In implementation self-review, inspect the intended local change, help fix authorized in-scope findings, record important human decisions, and report publication readiness. Never approve the user’s own PR.
+- In external PR review, remain read-only until the user explicitly authorizes a GitHub write. Act as the reviewer’s research, reasoning, and drafting partner.
+- Inspect and explain before any mutation.
 - When this thread already contains one active PR review, treat a later review request or skill invocation as a re-review of that same PR by default.
 - Do not ask for the PR number or URL again unless the earlier target is missing, genuinely ambiguous, closed and replaced, or the user explicitly switches targets.
 - Do not publish, reply, resolve, approve, or request changes merely because the user says “리뷰해줘.”
@@ -19,7 +21,32 @@ Treat the user as the reviewer and final decision-maker. Act as the reviewer’s
 
 ## Review Workflow
 
-### 1. Establish the exact review state
+### 1. Determine the review mode and owner
+
+Classify the task as **implementation self-review** or **external PR review** before fixing the review target.
+
+Use evidence in this order:
+
+1. the user’s explicit intent;
+2. whether the current thread implemented the change;
+3. the assignee of the linked Linear implementation issue;
+4. the PR author and authenticated GitHub user;
+5. branch name, commit authorship, and prior task context.
+
+Resolve the linked Linear issue from explicit references, branch name, PR title, or PR body. Treat PR author and Linear assignee as ownership evidence, not absolute truth: bots, pair work, delegated publication, and shared branches can differ. If ownership signals conflict and the mode changes whether code may be edited or GitHub feedback may be published, ask the user which role they intend.
+
+State the selected mode and evidence. Do not infer that a user wants external review publication merely because a PR exists.
+
+### 2. Establish the exact review state
+
+For implementation self-review:
+
+1. Identify the intended base or parent PR and the owned Linear issue.
+2. Capture committed changes from the merge base plus staged, unstaged, and relevant untracked files.
+3. Include changed specs, decisions, repository memory, generated artifacts, and validations in the snapshot.
+4. Record an exact snapshot identity and prefer to keep it stable while delegated review is running.
+
+For external PR review:
 
 1. Resolve the repository and PR from the existing thread context first.
 2. If this thread already reviewed one PR, reuse that PR number and the last reviewed head and proceed directly as a re-review.
@@ -32,21 +59,21 @@ Treat the user as the reviewer and final decision-maker. Act as the reviewer’s
 
 Use thread-aware GitHub reads when resolution or inline context matters. Do not infer current state from a flat comment list.
 
-### 2. Start delegated evidence review
+### 3. Start delegated evidence review
 
-After fixing the target, base SHA, head SHA, and repository guidance, spawn one review subagent before drawing conclusions.
+After fixing the review mode, exact snapshot, ownership evidence, and repository guidance, spawn one review subagent before drawing conclusions.
 
 - Assign one subagent a bounded correctness surface such as contracts, authorization, transactions, persistence, concurrency, fixtures, tests, or unresolved-thread regressions.
 - When the `ponytail:ponytail-review` skill is available, spawn a second subagent in parallel and assign it to find only deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
 - When the ponytail skill is unavailable, continue with the single correctness subagent.
 - When multiple subagents run, divide work by independent responsibility or execution-flow slices. Do not assign overlapping whole-PR rereads merely to increase agent count.
-- Give every subagent the same repository, PR number, base SHA, head SHA, applicable guidance, and a bounded question.
+- Give every subagent the same repository, review mode, exact snapshot, applicable guidance, and a bounded question. For external review include PR number, base SHA, and head SHA. For self-review provide raw artifacts rather than implementation rationale or the expected conclusion.
 - Require exact file/line evidence, the path or invariant checked, confirmed findings separated from suspicions, the smallest relevant validation and its result, and an explicit no-finding result when the assigned surface is sound.
 - Forbid subagents from GitHub writes, code edits, product-policy decisions, severity decisions, and final review recommendations.
 
 While they run, the main agent must independently trace and share a compact responsibility map and execution-flow summary. Do not wait idle and do not delegate this synthesis. The main agent owns freshness checks, final verification, deduplication, severity, drafting, and every GitHub write.
 
-### 3. Trace behavior and ownership
+### 4. Trace behavior and ownership
 
 The main agent owns the end-to-end implementation map. Trace the changed flow through callers and downstream consumers in execution order:
 
@@ -72,16 +99,29 @@ Then check:
 - whether specs, API contracts, DB invariants, caches, and tests agree;
 - whether fixtures create states that production code cannot create;
 - whether concurrency logic has a deterministic concurrency test;
-- whether unused code anticipates a future PR without a current caller;
 - whether the PR has accumulated unrelated changes with different reasons or verification methods.
+
+#### Audit public contracts and test seams
+
+List every new or widened function parameter, callback, interface, evaluator, options object, factory, and exported type. For each one, identify:
+
+- current production and test-only callers, plus default and injected execution paths;
+- whether multiple concrete runtime implementations and a current replacement requirement exist now;
+- which invariant a caller can bypass by passing a no-op, forced allow/deny, or replacement implementation.
+
+Do not treat a future issue or an OpenSpec mention as a current caller. Prefer changing the owning function when concrete policy arrives over adding a speculative port, strategy, evaluator, default-allow function, or callback now. Add an abstraction with its real caller and exact composition requirements.
+
+Tests must validate the exported default production wiring. A test that injects a fake callback proves only the behavior of that injected path unless the same composition boundary exists in production. Flag states, failures, or policy results that tests can create but production cannot reach. Keep fault injection in test fixtures, test-side mocking, or a non-public internal boundary rather than widening a public application action solely for test convenience.
+
+Treat a mandatory application lifecycle exposed as an optional or replaceable callback as an ownership defect. If `action(input, noop)` can skip a MUST side effect or `create(source, forcedAllow)` can bypass centrally owned policy, the public contract contradicts the invariant it claims to enforce.
 
 Prefer the smallest relevant check that can disprove or confirm a concern. Do not run broad test suites merely to appear thorough.
 
-### 4. Reconcile and classify evidence
+### 5. Reconcile and classify evidence
 
-Treat subagent reports as evidence, not conclusions. Verify their cited lines against the shared head SHA. Merge duplicates only when they have the same root cause and requested fix, and preserve independently actionable fixes. A ponytail observation is not a blocker without a concrete current cost, absent caller, duplicated behavior, or scope/verification mismatch.
+Treat subagent reports as evidence, not conclusions. Verify their cited lines against the exact reviewed snapshot; in external review, this includes the shared head SHA. Merge duplicates only when they have the same root cause and requested fix, and preserve independently actionable fixes. A ponytail observation is not a blocker without a concrete current cost, absent caller, duplicated behavior, or scope/verification mismatch.
 
-If the head changes, identify the affected responsibility slices and rerun those checks before publishing. Never reuse evidence against a different head without verification.
+If the snapshot changes, record the delta, preserve evidence for unaffected responsibility slices, and rerun only checks whose files, callers, invariants, or decisions changed. Restart the whole review only when the base, review mode, ownership, or a broad rewrite makes prior evidence unreliable. Never reuse evidence against a changed snapshot without this verification.
 
 Separate the review into four groups:
 
@@ -92,9 +132,9 @@ Separate the review into four groups:
 
 Show this classification to the user before posting. Ask concise questions for every decision that materially changes the requested fix.
 
-When code and spec disagree, do not assume the spec is correct. Explain the consequence of changing either side and ask which contract the user wants.
+When code and spec disagree, do not assume the spec is correct. Code and spec may also agree on a premature abstraction or test-only escape hatch; agreement alone does not prove the design is necessary. Explain the consequence of changing each and ask which contract the user wants.
 
-### 5. Recommend PR splits when scope expands
+### 6. Recommend PR splits when scope expands
 
 Recommend splitting when the PR combines changes that have different:
 
@@ -106,9 +146,19 @@ Recommend splitting when the PR combines changes that have different:
 
 Propose concrete slices rather than saying only “this PR is too large.” State what files, behaviors, specs, and tests belong to each slice.
 
-Do not keep speculative helpers, options, or abstractions solely for a later PR. Add them with the real caller and exact transaction requirements.
+### 7. Record implementation self-review decisions
 
-### 6. Draft junior-friendly comments
+After classifying self-review findings, distinguish a defect fix from a newly chosen important alternative. A choice is important when it changes observable behavior, public contracts, data, security, compatibility, rollout, reversibility, ownership, scope, dependencies, or the direction later implementations must follow.
+
+- Update Linear first when scope, ownership, deliverables, blockers, or issue relationships change.
+- Update OpenSpec `decisions.md` before code when a durable choice or public contract shared by implementation slices changes. Record superseded decisions instead of silently overwriting them.
+- Record important implementation choices within accepted contracts in the PR body with decision-maker, choice, alternatives, reason, consequences, and links.
+- Update applicable `memory/*.md` only for reusable repository conventions, and `docs/design/*.md` for documented product or UI design decisions.
+- Do not invent a decision, rationale, or decision-maker. Ask the user when a material choice remains open. Do not create ceremonial records when the implementation merely follows an accepted decision.
+
+Return a decision ledger with new decisions and their recorded locations, accepted decisions applied unchanged, and unresolved decisions. After self-review fixes, apply the snapshot-change rule above before declaring publication readiness.
+
+### 8. Draft junior-friendly external review comments
 
 Write in Korean when the repository or user prefers Korean. Use the following order:
 
@@ -125,12 +175,12 @@ Anchor comments to the tightest changed line. Avoid preference-only feedback. Co
 
 Use repository priority rules when available. Otherwise:
 
-- `P1`: merge-blocking behavior, security, data, or API contract defect;
+- `P1`: merge-blocking behavior, security, data, or API contract defect. This includes a public API that makes the PR’s mandatory invariant optional or bypassable, or a test-only input that can disable a required lifecycle in production.
 - `P2`: structural or correctness risk that should be fixed now but may be split with explicit ownership;
 - `P3`: lower-risk design or maintainability improvement;
 - `P5`: trivial cleanup.
 
-### 7. Get explicit approval before publishing
+### 9. Get explicit approval before publishing external feedback
 
 Before a GitHub write:
 
@@ -145,14 +195,29 @@ Decide the review body before submission. A submitted empty review body may not 
 - Use an empty body when inline comments are sufficient and repository rules prefer it.
 - Include a detailed body in the initial submission when requesting a PR split or explaining an overarching blocker.
 
-### 8. Clean up threads accurately
+### 10. Clean up external review threads accurately
 
 - Resolve only feedback whose requested behavior is actually reflected in the current code or conclusively answered.
 - Do not resolve a thread merely because the author replied or moved code.
 - Keep new and unaddressed findings unresolved.
 - After publishing, verify the review state, inline comment count, body, resolved/unresolved thread state, and clean local workspace.
 
-## Output Before Publishing
+## Output For Implementation Self-Review
+
+Return:
+
+1. the selected mode, ownership evidence, and reviewed local snapshot;
+2. the implementation summary by responsibility and ordered execution flow;
+3. subagent coverage, validations, and disagreements or no-finding reports;
+4. confirmed findings, including public-contract and test-seam analysis;
+5. fixes applied within the user’s authorized scope;
+6. the decision ledger and actual record locations;
+7. remaining questions, deferred work, and risks;
+8. the readiness result: ready to publish, fixes required, user decision required, or blocked.
+
+Do not return `APPROVE`, submit a GitHub review, or treat self-review as an approval of the user’s own PR.
+
+## Output Before External Review Publishing
 
 Return:
 
@@ -165,7 +230,7 @@ Return:
 7. proposed inline comments and review body;
 8. the recommended review action: approve, comment, or request changes.
 
-## Output After Publishing
+## Output After External Review Publishing
 
 Return:
 

--- a/.codex/skills/gh-review-coach/agents/openai.yaml
+++ b/.codex/skills/gh-review-coach/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: 'GitHub Review Coach'
-  short_description: 'PR 리뷰 증거 수집과 한국어 피드백 초안 작성'
-  default_prompt: 'Use $gh-review-coach to inspect this pull request and prepare an evidence-backed Korean review draft.'
+  short_description: '구현 자기 검토와 외부 PR 리뷰를 증거 기반으로 지원'
+  default_prompt: 'Use $gh-review-coach to determine the review mode, inspect the implementation evidence, and prepare the appropriate readiness or external review result.'

--- a/.codex/skills/gh-review-coach/agents/openai.yaml
+++ b/.codex/skills/gh-review-coach/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'GitHub Review Coach'
+  short_description: 'PR 리뷰 증거 수집과 한국어 피드백 초안 작성'
+  default_prompt: 'Use $gh-review-coach to inspect this pull request and prepare an evidence-backed Korean review draft.'


### PR DESCRIPTION
## 무엇을 변경했는지

- 개인 `gh-review-coach`를 `.codex/skills/gh-review-coach/`의 레포지토리 로컬 스킬로 추가했습니다.
- 사용자의 명시적 의도, 현재 스레드의 구현 이력, PR author와 연결된 Linear 이슈 assignee를 근거로 구현 자기 리뷰와 외부 PR 리뷰 모드를 구분합니다.
- 자기 리뷰는 committed·staged·unstaged·관련 untracked 변경을 포함한 exact snapshot을 검토하고, 중요한 사람의 결정을 기존 Linear/OpenSpec/PR/memory/design 기록 위치와 Decision ledger로 연결합니다.
- 외부 리뷰는 고정된 PR base/head와 review thread를 읽기 전용으로 검토하고, 명시적 승인 전에는 GitHub write나 코드 수정을 하지 않습니다.
- 새 callback·interface·evaluator·options·exported type의 production caller와 test-only caller를 구분하고, 테스트 편의를 위한 공개 계약 확장과 미래 caller만을 위한 speculative abstraction을 검사합니다.
- Codex UI에서 두 모드를 설명하도록 `agents/openai.yaml`을 갱신했습니다.

## 왜 변경했는지

Kosmo 구현자가 게시 전에 자신의 작업을 독립 검토하는 경우와 reviewer가 다른 사람의 PR을 검토하는 경우는 같은 증거 수집 절차를 공유하지만, 검토 기준점·수정 권한·결정 기록·최종 결과가 다릅니다.

또한 실제 적용에서 테스트가 production 기본 경로 대신 주입된 가짜 경로만 검증하거나, 후속 정책을 이유로 현재 caller 없는 evaluator와 callback을 공개 계약에 먼저 추가하는 문제를 기존 스킬이 충분히 드러내지 못했습니다. 공유 스킬이 실제 caller, 책임 소유권과 production wiring을 명시적으로 검사하게 합니다.

관련 이슈: [PROD-373](https://linear.app/byulmaru/issue/PROD-373)

## 이번 PR의 주요 결정

### 자기 리뷰와 외부 리뷰를 하나의 스킬 안에서 모드로 구분한다

- 결정자: @robin-maki
- 선택: 공통 책임·실행 흐름 및 delegated evidence 절차를 공유하고, 모드별 snapshot·권한·출력을 분기합니다.
- 고려한 대안: 자기 리뷰와 외부 리뷰를 별도 스킬로 분리, 기존 외부 PR 리뷰만 유지.
- 이유: 핵심 분석 절차는 같고 finding 이후의 수정·게시 권한과 결과만 다르므로 하나의 스킬에서 중복 없이 관리할 수 있습니다.
- 감수한 결과: 리뷰 시작 시 모드와 소유권을 먼저 판정해야 합니다.

### 리뷰 소유권은 의도와 실제 작업 메타데이터를 함께 사용한다

- 결정자: @robin-maki
- 선택: 사용자 의도와 스레드 구현 이력을 우선하고 Linear assignee와 PR author를 추가 증거로 사용합니다. 증거가 충돌하고 권한이 달라지면 사용자에게 확인합니다.
- 고려한 대안: PR author만 사용, Linear assignee만 사용, 대화 문맥만 사용.
- 이유: bot publication, pair work와 delegated branch에서는 단일 메타데이터가 실제 구현 소유자를 나타내지 않을 수 있습니다.
- 감수한 결과: 연결된 Linear 이슈와 인증된 GitHub 사용자를 추가로 조회할 수 있습니다.

### 테스트는 production 공개 계약을 넓히지 않는다

- 결정자: @robin-maki
- 선택: test-only caller가 사용하는 callback·evaluator와 미래 이슈만을 위한 abstraction을 finding 후보로 다루고, 실제 정책은 concrete caller와 함께 소유 함수에 추가합니다.
- 고려한 대안: fault injection을 위해 public action에 optional callback을 제공, 후속 정책용 port를 미리 추가.
- 이유: 테스트가 검증해야 할 production invariant를 오히려 선택 가능하게 만들고, production에서 도달할 수 없는 injected path만 테스트할 수 있기 때문입니다.
- 감수한 결과: fault injection은 test fixture, test-side mocking 또는 비공개 내부 경계에서 해결해야 합니다.

### snapshot 변경은 영향 범위만 재검토한다

- 결정자: @robin-maki
- 선택: snapshot delta가 생기면 영향받지 않은 증거는 유지하고 관련 파일·caller·invariant·decision slice만 재검토합니다.
- 고려한 대안: 변경이 생길 때마다 전체 리뷰 폐기 후 재실행.
- 이유: 작은 후속 수정까지 전체 검토를 반복하지 않으면서도 stale evidence 사용을 막을 수 있습니다.
- 감수한 결과: base, mode, ownership 변경이나 광범위 rewrite에서는 전체 재검토가 필요합니다.

## 어떻게 확인할 수 있는지

- `quick_validate.py .codex/skills/gh-review-coach`: 통과
- `prettier --check` 대상 SKILL.md와 openai.yaml: 통과
- `git diff --check`: 통과
- commit hook의 ESLint 및 Prettier: 통과
- 자기 리뷰 forward-test에서 PR author·Linear assignee 기반 모드 판정, Decision ledger와 snapshot delta 재사용을 확인하고, working tree 증거를 HEAD SHA로만 검증하던 문제를 exact reviewed snapshot 기준으로 수정

## 아직 어떤 문제가 남았는지

없음.
