### PR TITLE
Reaction 추가 입력을 허용 타입 계약에 맞춘다

### DIFF
--- a/docs/domain/objects/reaction.md
+++ b/docs/domain/objects/reaction.md
@@ -40,10 +40,10 @@ Reaction은 Profile이 Post에 남기는 유니코드 이모지 반응이다.
 
 ## 행동
 
-| 행동          | 행동 주체 Profile | 대상 객체 | 입력값      | 권한                               | 조건                                                                                              | 결과                |
-| ------------- | ----------------- | --------- | ----------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------- |
-| Reaction 추가 | Profile           | Reaction  | Post, Emoji | `Account.Active`, `Profile.Member` | 행동 주체가 Active/Normal Local Profile이고 Post 조회 정책을 통과하며 같은 조합의 Reaction이 없다 | Reaction이 생성된다 |
-| Reaction 삭제 | Profile           | Reaction  | 없음        | `Account.Active`, `Reaction.Owner` | Reaction이 존재한다                                                                               | Reaction이 제거된다 |
+| 행동          | 행동 주체 Profile | 대상 객체 | 입력값              | 권한                               | 조건                                                                                              | 결과                |
+| ------------- | ----------------- | --------- | ------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------- |
+| Reaction 추가 | Profile           | Reaction  | Post, Reaction Type | `Account.Active`, `Profile.Member` | 행동 주체가 Active/Normal Local Profile이고 Post 조회 정책을 통과하며 같은 조합의 Reaction이 없다 | Reaction이 생성된다 |
+| Reaction 삭제 | Profile           | Reaction  | 없음                | `Account.Active`, `Reaction.Owner` | Reaction이 존재한다                                                                               | Reaction이 제거된다 |
 
 ## 권한
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Reaction 객체의 `Reaction 추가` 입력값을 `Post, Emoji`에서 `Post, Reaction Type`으로 변경했습니다.

## 왜 변경했는지

#292에서 초기 허용 Reaction Type 6개를 확정했지만 행동 표의 입력값은 일반 `Emoji`로 남아 있어, downstream 구현이 임의의 이모지를 허용하는 계약으로 해석할 수 있었습니다. #292 머지 직전 생성된 [리뷰 지적](https://github.com/byulmaru/kosmo/pull/292#discussion_r3612452163)을 반영해 속성 검증 정책과 Mutation 입력 계약을 일치시킵니다.

## 이번 PR의 주요 결정

없음. #292에서 승인된 Reaction Type 계약을 행동 입력값에 그대로 반영했습니다.

## 어떻게 확인할 수 있는지

- `pnpm lint:prettier`
- 객체 문서 구조 검증 스크립트
- `git diff --check`

모든 검사를 통과했습니다.

## 아직 어떤 문제가 남았는지

없음.