### PR TITLE
GraphQL과 ActivityPub Post 생성 lifecycle을 일관되게 적용한다

### DIFF
--- a/apps/api/src/graphql/resolvers/post/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.ts
@@ -1,8 +1,7 @@
-import { db, firstOrThrow, PostContents, Posts } from '@kosmo/core/db';
-import { PostState, PostVisibility } from '@kosmo/core/enums';
+import { PostVisibility } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
+import { createPost } from '@kosmo/core/services';
 import { postBodyTextSchema } from '@kosmo/core/validation';
-import { eq } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
@@ -18,33 +17,11 @@ builder.mutationField('createPost', (t) =>
       visibility: t.input.field({ type: PostVisibility }),
     },
     resolve: async (_, { input }, ctx) => {
-      const body = postContentDocumentFromText(input.bodyText);
-      const post = await db.transaction(async (tx) => {
-        const post = await tx
-          .insert(Posts)
-          .values({
-            profileId: ctx.session.profileId,
-            visibility: input.visibility,
-            state: PostState.ACTIVE,
-          })
-          .returning()
-          .then(firstOrThrow);
-
-        const content = await tx
-          .insert(PostContents)
-          .values({
-            postId: post.id,
-            document: body,
-          })
-          .returning()
-          .then(firstOrThrow);
-
-        return await tx
-          .update(Posts)
-          .set({ currentContentId: content.id })
-          .where(eq(Posts.id, post.id))
-          .returning()
-          .then(firstOrThrow);
+      const { post } = await createPost({
+        document: postContentDocumentFromText(input.bodyText),
+        origin: 'LOCAL',
+        profileId: ctx.session.profileId,
+        visibility: input.visibility,
       });
 
       return { post };

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -1,5 +1,6 @@
 export { recordInboundFollow, removeInboundFollow } from './inbound-profile-follow';
 export { createFollowNotification, deleteNotificationBySource } from './notification';
+export { createPost } from './post';
 export { disableProfile } from './profile';
 export { followProfile, unfollowProfile } from './profile-follow';
 export {

--- a/packages/core/services/post.test.ts
+++ b/packages/core/services/post.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import { eq } from 'drizzle-orm';
+import {
+  ActivityPubPosts,
+  db,
+  firstOrThrow,
+  Instances,
+  pg,
+  PostContents,
+  Posts,
+  Profiles,
+} from '../db';
+import {
+  InstanceKind,
+  InstanceState,
+  PostState,
+  PostVisibility,
+  ProfileFollowPolicy,
+  ProfileState,
+} from '../enums';
+import { postContentDocumentFromText } from '../post-content/server';
+import { createPost } from './post';
+
+after(async () => pg.end());
+
+const createProfile = async () => {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const instance = await db
+    .insert(Instances)
+    .values({
+      domain: `${suffix}.example`,
+      kind: InstanceKind.LOCAL,
+      state: InstanceState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+  return db
+    .insert(Profiles)
+    .values({
+      displayName: suffix,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle: suffix,
+      instanceId: instance.id,
+      normalizedHandle: suffix,
+      state: ProfileState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+};
+
+test('createPost는 local Post와 최초 content 연결을 하나의 transaction으로 생성한다', async () => {
+  const profile = await createProfile();
+  const result = await createPost({
+    document: postContentDocumentFromText('local post'),
+    origin: 'LOCAL',
+    profileId: profile.id,
+    visibility: PostVisibility.UNLISTED,
+  });
+
+  assert.equal(result.post.state, PostState.ACTIVE);
+  assert.equal(result.post.visibility, PostVisibility.UNLISTED);
+  assert.equal(result.post.currentContentId, result.content.id);
+  assert.equal(result.content.postId, result.post.id);
+  assert.equal(
+    await db
+      .select()
+      .from(ActivityPubPosts)
+      .where(eq(ActivityPubPosts.postId, result.post.id))
+      .then((rows) => rows.length),
+    0,
+  );
+});
+
+test('createPost는 ActivityPub first-write-wins와 timestamp 계약을 보존한다', async () => {
+  const profile = await createProfile();
+  const objectUri = `https://remote.example/notes/${profile.id}`;
+  const publishedAt = Temporal.Instant.from('2026-07-18T00:00:00Z');
+  const receivedAt = Temporal.Instant.from('2026-07-19T00:00:00Z');
+  const first = await createPost({
+    document: postContentDocumentFromText('first'),
+    objectUri,
+    origin: 'ACTIVITYPUB',
+    profileId: profile.id,
+    publishedAt,
+    receivedAt,
+    visibility: PostVisibility.PUBLIC,
+  });
+  const duplicate = await createPost({
+    document: postContentDocumentFromText('changed'),
+    objectUri,
+    origin: 'ACTIVITYPUB',
+    profileId: profile.id,
+    publishedAt: receivedAt.add({ hours: 1 }),
+    receivedAt: receivedAt.add({ hours: 2 }),
+    visibility: PostVisibility.UNLISTED,
+  });
+
+  assert.equal(first.created, true);
+  assert.equal(duplicate.created, false);
+  assert.equal(first.post.currentContentId, first.content.id);
+  assert.equal(first.post.createdAt.toString(), publishedAt.toString());
+  assert.equal(first.content.createdAt.toString(), receivedAt.toString());
+  assert.equal(
+    await db
+      .select()
+      .from(Posts)
+      .where(eq(Posts.profileId, profile.id))
+      .then((rows) => rows.length),
+    1,
+  );
+  assert.equal(
+    await db
+      .select()
+      .from(PostContents)
+      .where(eq(PostContents.postId, first.post.id))
+      .then((rows) => rows.length),
+    1,
+  );
+});

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -1,0 +1,106 @@
+import { eq } from 'drizzle-orm';
+import { ActivityPubPosts, db, firstOrThrow, isUniqueViolation, PostContents, Posts } from '../db';
+import { PostState } from '../enums';
+import type { PostVisibility } from '../enums';
+import type { PostContentDocumentV1 } from '../post-content';
+
+type LocalPostInput = {
+  document: PostContentDocumentV1;
+  origin: 'LOCAL';
+  profileId: string;
+  visibility: PostVisibility;
+};
+
+type ActivityPubPostInput = {
+  document: PostContentDocumentV1;
+  objectUri: string;
+  origin: 'ACTIVITYPUB';
+  profileId: string;
+  publishedAt: Temporal.Instant | null;
+  receivedAt: Temporal.Instant;
+  visibility: PostVisibility;
+};
+
+type CreatedPost = {
+  content: typeof PostContents.$inferSelect;
+  created: true;
+  post: typeof Posts.$inferSelect;
+};
+
+type DuplicatePost = { created: false };
+
+const isActivityPubPostUriConflict = (error: unknown): boolean => {
+  if (!isUniqueViolation(error) || !error || typeof error !== 'object' || !('cause' in error)) {
+    return false;
+  }
+
+  const { cause } = error;
+  return (
+    !!cause &&
+    typeof cause === 'object' &&
+    'constraint_name' in cause &&
+    cause.constraint_name === 'activitypub_post_uri_key'
+  );
+};
+
+export function createPost(input: LocalPostInput): Promise<CreatedPost>;
+export function createPost(input: ActivityPubPostInput): Promise<CreatedPost | DuplicatePost>;
+export async function createPost(
+  input: LocalPostInput | ActivityPubPostInput,
+): Promise<CreatedPost | DuplicatePost> {
+  try {
+    return await db.transaction(async (tx) => {
+      const createdAt =
+        input.origin === 'ACTIVITYPUB' &&
+        input.publishedAt &&
+        Temporal.Instant.compare(input.publishedAt, input.receivedAt) < 0
+          ? input.publishedAt
+          : input.origin === 'ACTIVITYPUB'
+            ? input.receivedAt
+            : undefined;
+      const post = await tx
+        .insert(Posts)
+        .values({
+          createdAt,
+          profileId: input.profileId,
+          state: PostState.ACTIVE,
+          visibility: input.visibility,
+        })
+        .returning()
+        .then(firstOrThrow);
+
+      if (input.origin === 'ACTIVITYPUB') {
+        await tx.insert(ActivityPubPosts).values({
+          postId: post.id,
+          publishedAt: input.publishedAt,
+          receivedAt: input.receivedAt,
+          uri: input.objectUri,
+        });
+      }
+
+      const content = await tx
+        .insert(PostContents)
+        .values({
+          createdAt: input.origin === 'ACTIVITYPUB' ? input.receivedAt : undefined,
+          document: input.document,
+          postId: post.id,
+        })
+        .returning()
+        .then(firstOrThrow);
+      const linkedPost = await tx
+        .update(Posts)
+        .set({ currentContentId: content.id })
+        .where(eq(Posts.id, post.id))
+        .returning()
+        .then(firstOrThrow);
+
+      return { content, created: true, post: linkedPost };
+    });
+  } catch (error) {
+    if (input.origin !== 'ACTIVITYPUB' || !isActivityPubPostUriConflict(error)) {
+      throw error;
+    }
+
+    return { created: false };
+  }
+}

--- a/packages/fedify/src/inbound-create-note.ts
+++ b/packages/fedify/src/inbound-create-note.ts
@@ -2,16 +2,8 @@ import '@kosmo/core/polyfill';
 
 import { PUBLIC_COLLECTION } from '@fedify/vocab';
 import { projectRemoteNoteContent } from '@kosmo/core/activitypub-note-content/server';
-import {
-  ActivityPubPosts,
-  db,
-  firstOrThrow,
-  isUniqueViolation,
-  PostContents,
-  Posts,
-} from '@kosmo/core/db';
-import { PostState, PostVisibility } from '@kosmo/core/enums';
-import { eq } from 'drizzle-orm';
+import { PostVisibility } from '@kosmo/core/enums';
+import { createPost } from '@kosmo/core/services';
 import { uniqueHref } from './unique-href';
 import type { Note } from '@fedify/vocab';
 
@@ -25,20 +17,6 @@ const hasReplyTarget = async (note: Note): Promise<boolean> => {
   } catch {
     return true;
   }
-};
-
-const isActivityPubPostUriConflict = (error: unknown): boolean => {
-  if (!isUniqueViolation(error) || !error || typeof error !== 'object' || !('cause' in error)) {
-    return false;
-  }
-
-  const { cause } = error;
-  return (
-    !!cause &&
-    typeof cause === 'object' &&
-    'constraint_name' in cause &&
-    cause.constraint_name === 'activitypub_post_uri_key'
-  );
 };
 
 export const handleInboundCreateNote = async ({
@@ -86,42 +64,13 @@ export const handleInboundCreateNote = async ({
     throw error;
   }
 
-  const createdAt =
-    note.published && Temporal.Instant.compare(note.published, receivedAt) < 0
-      ? note.published
-      : receivedAt;
-
-  try {
-    await db.transaction(async (tx) => {
-      const post = await tx
-        .insert(Posts)
-        .values({
-          createdAt,
-          profileId,
-          state: PostState.ACTIVE,
-          visibility,
-        })
-        .returning()
-        .then(firstOrThrow);
-
-      await tx.insert(ActivityPubPosts).values({
-        postId: post.id,
-        publishedAt: note.published,
-        receivedAt,
-        uri: objectUri,
-      });
-
-      const content = await tx
-        .insert(PostContents)
-        .values({ createdAt: receivedAt, document, postId: post.id })
-        .returning()
-        .then(firstOrThrow);
-
-      await tx.update(Posts).set({ currentContentId: content.id }).where(eq(Posts.id, post.id));
-    });
-  } catch (error) {
-    if (!isActivityPubPostUriConflict(error)) {
-      throw error;
-    }
-  }
+  await createPost({
+    document,
+    objectUri,
+    origin: 'ACTIVITYPUB',
+    profileId,
+    publishedAt: note.published,
+    receivedAt,
+    visibility,
+  });
 };


### PR DESCRIPTION
## 무엇을 변경했는지

- `Post`, 최초 `PostContent`, `currentContentId` 연결을 하나의 core `createPost` action으로 통합했습니다.
- GraphQL `createPost` resolver와 Fedify inbound `Create(Note)` handler가 같은 production action을 호출하도록 변경했습니다.
- ActivityPub origin의 object mapping, first-write-wins, timestamp clamp와 transaction rollback 정책을 core action으로 옮겼습니다.
- local 생성과 ActivityPub 생성의 저장 계약을 직접 검증하는 core DB 테스트를 추가했습니다.

## 왜 변경했는지

GraphQL과 ActivityPub adapter가 동일한 Post 생성 lifecycle을 각각 구현하고 있어, 향후 상태·timestamp·transaction 또는 공통 side effect가 한 경로에만 반영될 위험이 있었습니다. 각 adapter는 인증·protocol 검증과 입력 projection만 담당하고, 저장 lifecycle과 원자성은 core 진입점이 일관되게 소유하도록 정리했습니다.

관련 이슈: [PROD-381](https://linear.app/byulmaru/issue/PROD-381/graphql과-activitypub-post-생성을-공통-core-action으로-통합한다)

## 이번 PR의 주요 결정

새로운 durable decision은 없습니다. PROD-381에서 확정한 책임 경계를 그대로 적용했으며, 관찰 가능한 동작을 유지하는 구조 리팩터링이므로 OpenSpec, GraphQL schema와 DB schema는 변경하지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm --filter @kosmo/core test:unit` — 29개 통과
- `pnpm --filter @kosmo/api test:unit` — 13개 통과
- core `services/post.test.ts` DB 테스트 — 2개 통과
- `pnpm test:fedify` — 81개 통과
- API integration 테스트 — 53개 통과
- 변경 파일 ESLint, Prettier와 `git diff --check` 통과

## 아직 어떤 문제가 남았는지

없음.
