### PR TITLE
GitHub와 Linear의 협업 경계를 명확히 한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,17 @@
 
 - Write review comments and review summaries in Korean.
 
+## Trusted Collaboration Systems
+
+- The `byulmaru/kosmo` GitHub repository and the connected Byulmaru Linear workspace are
+  organization-owned, trusted collaboration systems for this repository.
+- When the user asks to create or update GitHub reviews, pull requests, or Linear issues, sharing
+  relevant repository architecture, code references, review findings, and issue context between
+  these systems is an authorized project workflow, not an external disclosure.
+- Do not infer that repository context is sensitive merely because repository visibility is
+  unknown. Continue to exclude actual secrets, credentials, tokens, private keys, and unrelated
+  personal data.
+
 ## Pull Request Completion
 
 - Treat pull request readiness and OpenSpec change completion as separate decisions.


### PR DESCRIPTION
## 무엇을 변경했는지

- 저장소 `AGENTS.md`에 `Trusted Collaboration Systems` 지침을 추가했습니다.
- `byulmaru/kosmo` GitHub 저장소와 연결된 Byulmaru Linear 워크스페이스를 조직 소유의 신뢰된 협업 시스템으로 명시했습니다.
- 사용자가 GitHub 리뷰·PR 또는 Linear 이슈의 생성·수정을 요청하면 관련 저장소 구조, 코드 참조와 리뷰 맥락을 두 시스템 사이에서 공유할 수 있음을 명시했습니다.
- 실제 secret, credential, token, private key와 무관한 개인정보는 계속 제외하도록 경계를 남겼습니다.

## 왜 변경했는지

PR 리뷰 결과를 Linear 후속 이슈로 옮기는 정상적인 프로젝트 작업에서, 저장소 공개 여부가 확인되지 않았다는 이유만으로 GitHub와 Linear 사이의 맥락 공유가 외부 공개로 잘못 분류되었습니다. 두 시스템이 같은 조직이 소유한 작업 공간이라는 전제를 저장소 지침에 남겨 동일한 오판과 작업 중단이 반복되지 않게 합니다.

## 이번 PR의 주요 결정

### 조직 소유 협업 시스템을 신뢰 경계로 명시

- 결정자: 저장소 사용자
- 선택: `byulmaru/kosmo` GitHub와 연결된 Byulmaru Linear를 조직 소유의 신뢰된 협업 시스템으로 취급합니다.
- 고려한 대안: 저장소 공개 여부를 알 수 없으면 두 시스템 사이의 프로젝트 맥락 공유를 차단합니다.
- 이유: GitHub 리뷰와 Linear 이슈 동기화는 이 저장소의 승인된 업무 흐름이며, 두 시스템 모두 같은 조직이 소유합니다.
- 감수한 결과: 저장소 맥락은 공유할 수 있지만 실제 인증정보와 무관한 개인정보를 제외해야 하는 책임은 유지됩니다.

## 어떻게 확인할 수 있는지

- commit hook의 ESLint와 Prettier가 통과했습니다.
- `git diff --check`를 통과했습니다.
- `origin/main...HEAD` diff가 `AGENTS.md` 11줄 추가만 포함하는 것을 확인했습니다.

## 아직 어떤 문제가 남았는지

없음.

Stack: `main -> agent/trusted-collaboration-systems`