### PR TITLE
Superpowers 문서 산출물이 Git 변경에 섞이지 않게 한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ apps/app/ios/
 
 # Figma MCP 등 에이전트 도구가 레포 루트에 떨어뜨리는 임시 산출물(스크린샷 등).
 .tmp-*
+
+# 로컬 Superpowers 설계·계획 문서는 에이전트가 생성한 산출물입니다.
+/docs/superpowers/


### PR DESCRIPTION
## 무엇을 변경했는지

- 루트 `.gitignore`에 `/docs/superpowers/` 규칙을 추가했습니다.
- 이 규칙이 로컬 Superpowers 설계·계획 문서용임을 설명하는 주석을 추가했습니다.
- 기존에 추적 중인 `docs/superpowers/plans/2026-07-20-notification-row-hover-background.md`는 삭제하거나 untrack하지 않았습니다.

## 왜 변경했는지

Superpowers 스킬이 만드는 `docs/superpowers/specs/`와 `docs/superpowers/plans/` 문서는 이 저장소에서 로컬 에이전트 작업 산출물로 취급합니다. 새 산출물이 Git 변경에 섞이지 않도록 저장소 루트의 해당 디렉터리를 제외합니다.

- Linear: [PROD-455](https://linear.app/byulmaru/issue/PROD-455/superpowers-%EB%AC%B8%EC%84%9C-%EC%82%B0%EC%B6%9C%EB%AC%BC%EC%9D%84-git-%EC%B6%94%EC%A0%81%EC%97%90%EC%84%9C-%EC%A0%9C%EC%99%B8%ED%95%9C%EB%8B%A4)
- 관련 선례: [PROD-86](https://linear.app/byulmaru/issue/PROD-86/add-gitignore-patterns-for-figma-mcp-temporary-files)

## 이번 PR의 주요 결정

### Superpowers 문서 디렉터리 전체를 제외한다

- 결정자: 사용자
- 선택: plans/specs를 개별 나열하지 않고 `/docs/superpowers/` 전체를 ignore합니다.
- 고려한 대안: `plans/`와 `specs/`만 개별 제외하거나, `.worktrees/`까지 함께 제외하는 방식
- 이유: Superpowers가 만드는 문서 산출물의 저장 경계를 가장 단순하고 명확하게 표현합니다.
- 감수한 결과: 기존 추적 파일에는 ignore 규칙이 소급 적용되지 않으며, 이번 PR에서도 해당 파일을 추적 상태로 유지합니다.
- 관련 근거: PROD-455의 승인된 범위

## 어떻게 확인할 수 있는지

- `pnpm test` 통과
  - PostgreSQL migration·service 테스트
  - Fedify 테스트
  - Storybook build·테스트
  - Web E2E 49개 포함
- `git check-ignore -v --no-index docs/superpowers/plans/example.md docs/superpowers/specs/example.md`에서 두 경로 모두 `/docs/superpowers/` 규칙에 매칭됨을 확인했습니다.
- `git check-ignore -v --no-index docs/other/example.md`가 매칭되지 않음을 확인했습니다.
- `git ls-files docs/superpowers/plans/2026-07-20-notification-row-hover-background.md`로 기존 문서의 추적 상태 유지를 확인했습니다.
- `git diff --check HEAD^ HEAD` 통과

## 아직 어떤 문제가 남았는지

구현상 남은 문제는 없습니다. 사용자 요청에 따라 Draft 상태로 열어 리뷰와 CI 결과를 확인합니다.

Stack: main -> prod-455
