### PR TITLE
[PROD-454] 우측 컴포저 레일의 강제 스크롤바 제거

### DIFF
--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -49,6 +49,11 @@ const webStickyRail = {
   top: 0,
 } as unknown as ViewStyle;
 
+const webRightRailOverflow = {
+  overflowX: 'hidden',
+  overflowY: 'auto',
+} as unknown as ViewStyle;
+
 const webStickyHeader = {
   position: 'sticky',
   top: 0,
@@ -208,7 +213,14 @@ function UniversalShellContent({ revision }: { revision: number }) {
         </View>
 
         {full ? (
-          <View style={[styles.rightRail, web && webStickyRail, { borderColor: theme.border }]}>
+          <View
+            style={[
+              styles.rightRail,
+              web && webStickyRail,
+              web && webRightRailOverflow,
+              { borderColor: theme.border },
+            ]}
+          >
             {profile ? <RightRail profile={profile} /> : null}
           </View>
         ) : null}
@@ -258,7 +270,6 @@ const styles = StyleSheet.create({
   nativeRoute: { flex: 1 },
   webMobileRoute: { paddingBottom: 56 },
   rightRail: {
-    overflow: 'scroll',
     paddingLeft: spacing.xl,
     paddingTop: spacing.lg,
     width: 350,

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -659,16 +659,25 @@ export const UniversalFull: Story = {
   parameters: universalParameters,
   play: async ({ canvasElement }) => {
     const view = canvasElement.ownerDocument.defaultView;
-    let rail: HTMLElement | null = within(canvasElement).getByRole('navigation', {
+    const canvas = within(canvasElement);
+    let leftRail: HTMLElement | null = canvas.getByRole('navigation', {
       name: '주요 메뉴',
     });
 
-    while (rail && view?.getComputedStyle(rail).position !== 'sticky') {
-      rail = rail.parentElement;
+    while (leftRail && view?.getComputedStyle(leftRail).position !== 'sticky') {
+      leftRail = leftRail.parentElement;
     }
 
-    expect(rail).not.toBeNull();
-    expect(rail?.getBoundingClientRect().height).toBeLessThanOrEqual(view?.innerHeight ?? 0);
+    const rightRail = canvas.getByLabelText('새 게시글 작성').parentElement;
+    const rightRailStyle = rightRail ? view?.getComputedStyle(rightRail) : undefined;
+
+    expect(leftRail).not.toBeNull();
+    expect(leftRail?.getBoundingClientRect().height).toBeLessThanOrEqual(view?.innerHeight ?? 0);
+    expect(rightRail).not.toBeNull();
+    expect(rightRailStyle?.position).toBe('sticky');
+    expect(rightRailStyle?.overflowX).toBe('hidden');
+    expect(rightRailStyle?.overflowY).toBe('auto');
+    expect(rightRail?.scrollWidth ?? 1).toBeLessThanOrEqual(rightRail?.clientWidth ?? 0);
   },
   render: () => (
     <View style={{ height: 1800 }}>

--- a/openspec/changes/add-web-app-shell-sticky-rails/specs/web-app-shell/spec.md
+++ b/openspec/changes/add-web-app-shell-sticky-rails/specs/web-app-shell/spec.md
@@ -44,6 +44,22 @@
 - **THEN** 해당 rail은 document scroll과 별도로 내부 overflow를 처리할 수 있다
 - **AND** rail 내부 overflow는 중앙 `main`을 internal scroller로 바꾸는 요구사항이 아니다
 
+### Requirement: Conditional right rail overflow
+
+**Authority / Provenance:** `docs/design/breakpoints.md`의 스크롤 소유권 계약과 [PROD-454](https://linear.app/byulmaru/issue/PROD-454/web-우측-컴포저-레일의-강제-스크롤바-표시를-제거한다)의 기대 결과·완료 조건에서 파생한다. Web 풀 3열 레이아웃의 우측 rail은 콘텐츠가 viewport 안에 들어오는 동안 overflow 정책만으로 가로·세로 scrollbar track, gutter 또는 corner를 강제로 만들어서는 안 된다(MUST NOT). 우측 rail은 가로 overflow를 허용해서는 안 되며(MUST NOT), 콘텐츠가 viewport보다 길어지면 세로 방향으로 계속 접근할 수 있어야 한다(MUST). 이 조건부 rail overflow는 document/window의 기본 scroll ownership과 grid flow 안의 sticky 배치를 유지해야 한다(MUST).
+
+#### Scenario: Do not force scrollbar chrome for a short right rail
+
+- **WHEN** Web 풀 3열 레이아웃의 우측 rail 콘텐츠가 viewport 안에 들어온다
+- **THEN** rail의 overflow 정책은 가로·세로 scrollbar track, gutter 또는 corner를 강제로 만들지 않는다
+- **AND** 우측 rail에 가로 overflow가 생기지 않는다
+
+#### Scenario: Keep a long right rail vertically accessible
+
+- **WHEN** Web 풀 3열 레이아웃의 우측 rail 콘텐츠가 viewport 높이보다 길다
+- **THEN** 사용자는 rail 내부의 긴 콘텐츠에 세로 방향으로 접근할 수 있다
+- **AND** 중앙 route는 document/window scroll을 기본으로 유지하며 우측 rail은 grid flow 안에서 sticky로 남는다
+
 ### Requirement: Mobile bottom tab overlap policy
 
 모바일 하단 탭은 safe-area를 포함한 fixed bottom chrome으로 유지되어야 한다(MUST). `(tabs)` 라우트 콘텐츠는 fixed bottom tab과 safe-area에 가려지지 않도록 하단 padding 또는 scroll padding을 제공해야 한다(MUST). 이 변경은 하단 탭 IA를 바꾸지 않아야 한다(MUST NOT).

--- a/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
+++ b/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
@@ -20,7 +20,7 @@
 - [x] 3.1 `md` 이상 좌측 sidebar/icon rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
 - [x] 3.2 `SidebarNavigation`과 mobile drawer의 public props/API를 유지하고, sticky shell 안에서 필요한 height/overflow class만 보정한다.
 - [x] 3.3 `xl` 이상 우측 rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
-- [x] 3.4 우측 rail 내용이 viewport보다 길어질 때만 rail 내부 overflow가 가능하도록 구조를 둔다.
+- [ ] 3.4 `PROD-454`: 우측 rail 내용이 viewport보다 길어질 때만 rail 내부 세로 overflow가 가능하도록 하고, 짧은 rail에서는 강제 scrollbar chrome과 가로 overflow를 만들지 않는다.
 - [x] 3.5 좌우 rail을 `position: fixed` layer로 빼지 않는다. fixed가 필요하다고 판단되면 후속 change로 분리한다.
 
 ## 4. Route 호환성과 bottom tab
@@ -46,3 +46,4 @@
 - [ ] 6.4 구현 PR에서 `/home`, `/search`, `/notifications`, `/menu`, `/compose`, 프로필/팔로우 목록/게시글 상세 route를 smoke로 확인한다. 현재 fresh browser route smoke는 보호 route 리다이렉트와 공개 프로필 계열 렌더링까지만 확인했다.
 - [ ] 6.5 구현 PR에서 drawer open/close, bottom tab, icon rail/full sidebar, RightRail 위치, 검색 `noScroll`, 게시글 상세 sticky header를 확인한다. 현재 viewport smoke는 document scroll, bottom tab fixed, icon rail/full sidebar, RightRail 위치까지 확인했다.
 - [x] 6.6 반응형 앱 내비게이션 E2E suite 전체는 구현하지 않고, 필요 검증은 `PROD-233` 후속 범위로 남긴다.
+- [ ] 6.7 `PROD-454`: `UniversalFull` Storybook browser test와 Chrome `xl+` smoke에서 짧은 RightRail의 조건부 overflow, 가로 overflow 부재와 sticky 배치를 확인한다.

--- a/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
+++ b/openspec/changes/add-web-app-shell-sticky-rails/tasks.md
@@ -20,7 +20,7 @@
 - [x] 3.1 `md` 이상 좌측 sidebar/icon rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
 - [x] 3.2 `SidebarNavigation`과 mobile drawer의 public props/API를 유지하고, sticky shell 안에서 필요한 height/overflow class만 보정한다.
 - [x] 3.3 `xl` 이상 우측 rail wrapper를 grid flow 안에서 `sticky top-0`와 viewport height 경계로 유지한다.
-- [ ] 3.4 `PROD-454`: 우측 rail 내용이 viewport보다 길어질 때만 rail 내부 세로 overflow가 가능하도록 하고, 짧은 rail에서는 강제 scrollbar chrome과 가로 overflow를 만들지 않는다.
+- [x] 3.4 `PROD-454`: 우측 rail 내용이 viewport보다 길어질 때만 rail 내부 세로 overflow가 가능하도록 하고, 짧은 rail에서는 강제 scrollbar chrome과 가로 overflow를 만들지 않는다.
 - [x] 3.5 좌우 rail을 `position: fixed` layer로 빼지 않는다. fixed가 필요하다고 판단되면 후속 change로 분리한다.
 
 ## 4. Route 호환성과 bottom tab
@@ -46,4 +46,4 @@
 - [ ] 6.4 구현 PR에서 `/home`, `/search`, `/notifications`, `/menu`, `/compose`, 프로필/팔로우 목록/게시글 상세 route를 smoke로 확인한다. 현재 fresh browser route smoke는 보호 route 리다이렉트와 공개 프로필 계열 렌더링까지만 확인했다.
 - [ ] 6.5 구현 PR에서 drawer open/close, bottom tab, icon rail/full sidebar, RightRail 위치, 검색 `noScroll`, 게시글 상세 sticky header를 확인한다. 현재 viewport smoke는 document scroll, bottom tab fixed, icon rail/full sidebar, RightRail 위치까지 확인했다.
 - [x] 6.6 반응형 앱 내비게이션 E2E suite 전체는 구현하지 않고, 필요 검증은 `PROD-233` 후속 범위로 남긴다.
-- [ ] 6.7 `PROD-454`: `UniversalFull` Storybook browser test와 Chrome `xl+` smoke에서 짧은 RightRail의 조건부 overflow, 가로 overflow 부재와 sticky 배치를 확인한다.
+- [x] 6.7 `PROD-454`: `UniversalFull` Storybook browser test와 Chrome `xl+` smoke에서 짧은 RightRail의 조건부 overflow, 가로 overflow 부재와 sticky 배치를 확인한다.


### PR DESCRIPTION
## 배경

- Linear: https://linear.app/byulmaru/issue/PROD-454/web-우측-컴포저-레일의-강제-스크롤바-표시를-제거한다
- 관련 계약: PROD-219, OpenSpec add-web-app-shell-sticky-rails
- Web 우측 sticky rail에 overflow: scroll이 적용되어, 브라우저/로컬 스크롤바 표시 방식에 따라 컴포저 오른쪽과 아래에 불필요한 트랙 및 코너가 보일 수 있었습니다.

## 변경 내용

- 전체 Web 우측 rail의 가로 overflow를 숨기고 세로 overflow만 실제로 필요할 때 허용합니다.
- UniversalFull Storybook play에 sticky, computed overflow, 가로 확장 방지 회귀 검증을 추가했습니다.
- active OpenSpec delta spec에 PROD-454의 short/long rail 조건부 overflow requirement와 Linear provenance를 추가했습니다.
- 실제 Chrome smoke 후 OpenSpec task 3.4와 6.7을 완료 처리했습니다.

## 범위 밖

- breakpoint 구조 및 rail 폭
- PostComposer 내부 UI
- GraphQL/API
- 전역 scrollbar CSS
- PROD-233의 광범위한 responsive E2E

## 검증

- TDD RED: 기존 구현에서 UniversalFull의 overflowX 기대값 hidden, 실제값 scroll로 실패 확인
- pnpm --filter @kosmo/app test:storybook -- --runInBand --testNamePattern="UniversalFull" (7 files, 48/48 통과)
- pnpm --filter @kosmo/app check (Relay compiler + tsc 통과)
- pnpm exec openspec validate add-web-app-shell-sticky-rails --strict (통과)
- git diff --check (통과)
- 게시 전 구현 정확성 재리뷰: 승인 가능, findings 없음
- 게시 전 저장소 지침·계약 재리뷰: 승인 가능, findings 없음
- GitHub Lint, Semgrep, Test: 모두 성공

기존 Relay connection warning 2건은 동일하게 남아 있으며 이번 변경과 무관합니다.

## Chrome xl+ smoke

macOS Google Chrome 150, 1400x900에서 확인했습니다.

- 짧은 rail: sticky, overflow-x hidden, overflow-y auto, clientWidth = scrollWidth = 350
- rail 오른쪽과 아래에 강제 scrollbar track/corner 없음
- window를 600px 스크롤한 뒤에도 rail top = 0, documentElement가 scroll owner
- 1200px 긴 콘텐츠 조건에서 clientHeight 900, scrollHeight 1526, scrollTop 0에서 200으로 이동
- compact 900px와 mobile 390px에서 우측 composer rail 미표시 유지

## 판단 기록

PROD-219와 docs/design/breakpoints.md의 document scroll 계약, Linear PROD-454의 조건부 overflow 완료 조건을 그대로 적용했습니다. 새 제품 정책은 추가하지 않았고, Web 전체 우측 rail에만 최소 overflow 제약을 적용했습니다. active OpenSpec의 다른 기존 미완료 작업은 이 PR 범위가 아니므로 change를 archive하지 않습니다.