### PR TITLE
Local Reply 작성 흐름의 통합 계약을 정의한다

### DIFF
--- a/openspec/changes/add-local-reply-creation/.openspec.yaml
+++ b/openspec/changes/add-local-reply-creation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-23

--- a/openspec/changes/add-local-reply-creation/decisions.md
+++ b/openspec/changes/add-local-reply-creation/decisions.md
@@ -1,0 +1,61 @@
+## Context
+
+이 기록은 PROD-423이 공유 owner로 확정한 backend·UI·Notification 수직 흐름, Post·Notification canonical 계약, 현재 Reply Parent·thread·Notification 구현 기반을 반영한다.
+
+## Decision Records
+
+### PROD-423을 공유 change owner로 사용한다
+
+- Decision Date: 2026-07-23
+- Decision Class: Derived Contract
+- Authority / Provenance: `PROD-423`, `PROD-424`, `PROD-425`, `PROD-426`
+- Status: Active
+- Context / Problem: Local Reply 생성은 backend, thread UI, Notification/inbox 세 slice가 같은 제외 범위와 통합 완료 기준을 공유하지만 각 이슈만으로는 전체 flow와 archive 책임을 표현할 수 없다.
+- Decision Outcome: PROD-423이 `add-local-reply-creation` 전체를 소유하고 PROD-424는 backend, PROD-425는 UI/thread, PROD-426은 Notification/inbox를 소유한다. PROD-423은 세 slice 완료 후 통합 검증, spec 동기화와 archive를 수행한다.
+- Alternatives Considered: PROD-424의 backend-only change로 제한하면 UI·Notification이 공유하는 생성 계약과 archive gate가 분리된다. 자식별 change를 만들면 같은 사용자 흐름과 제외 범위를 중복 관리해야 한다.
+- Consequences: task와 검증은 이슈별로 분리하되 전체 change는 PROD-423이 archive한다. PROD-460·461·462는 related-only Backlog으로 완료를 막지 않는다.
+- Confirmation / Follow-up: OpenSpec Gate에서 세 자식 계약을 함께 검토하고 PROD-423 통합 task에서 완료를 확인한다.
+
+### Reply 작성은 기존 Post mutation의 nullable Parent 확장이다
+
+- Decision Date: 2026-07-23
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `PROD-424`
+- Status: Active
+- Context / Problem: Reply를 별도 Post type이나 mutation으로 표현할지, 기존 Content·Reply Parent 관계 조합으로 표현할지 결정해야 한다.
+- Decision Outcome: 기존 `createPost`/`CreatePostInput`에 nullable concrete `Post` `replyParentId`를 추가하고 기존 `CreatePostPayload.post`를 유지한다. Parent는 행동 주체 Profile이 조회할 수 있는 contentful Post여야 하며 Reply Visibility는 Parent와 독립적이다. `repostSourceId`는 입력에 추가하지 않는다.
+- Alternatives Considered: 별도 `createReply` mutation은 기존 Post 작성·payload를 중복한다. Parent Visibility 강제는 canonical의 독립 Visibility 계약과 다르다. `repostSourceId`를 함께 받으면 제외된 Reply+Quote 작성이 열린다.
+- Consequences: 기존 client는 입력 생략으로 그대로 동작하고, API는 global ID type·Parent visibility·Content를 write와 같은 transaction에서 검증해야 한다.
+- Confirmation / Follow-up: PROD-424 schema/resolver/integration 테스트에서 일반 Post 회귀, wrong type, hidden/missing/contentless Parent, 독립 Visibility와 rollback을 검증한다.
+
+### Reply UI는 기존 composer와 선행 thread 계약을 재사용한다
+
+- Decision Date: 2026-07-23
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/design/colors.md`, `docs/design/typography.md`, `docs/design/breakpoints.md`, `PROD-425`
+- Status: Active
+- Context / Problem: Reply 작성 화면·상태·payload를 별도로 만들지, 기존 universal Post composer와 thread 조회 계약을 확장할지 결정해야 한다.
+- Decision Outcome: contentful Post의 Reply action은 기존 composer를 Parent 맥락으로 열고 기존 Post fragment·mutation payload를 사용한다. Content 없는 Repost에서는 action을 disabled로 표시하고 callback·composer 진입을 차단한다. 성공 결과는 선행 thread connection 계약을 통해 현재 thread에 반영한다.
+- Alternatives Considered: Reply 전용 composer는 현재 본문·Visibility 상태와 검증을 중복한다. Contentless Repost에 action을 숨기는 방식은 PROD-425의 disabled 표시 계약과 다르다.
+- Consequences: PROD-425 구현은 PROD-422의 thread API/UI가 제공하는 public connection shape을 선행 조건으로 삼고, generated Relay artifact를 commit하지 않는다.
+- Confirmation / Follow-up: PROD-425 component·route/cache 테스트에서 contentful Parent 진입, disabled Repost, pending/error, selected Profile 격리와 성공 thread 반영을 검증한다.
+
+### Reply Notification은 source commit 후 기존 projection에 Best Effort로 추가한다
+
+- Decision Date: 2026-07-23
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/notification.md`, `docs/domain/objects/post.md`, `PROD-426`
+- Status: Active
+- Context / Problem: Reply Notification을 Reply transaction 내에 포함하거나 별도 inbox/storage로 만들면 source 성공 격리 또는 기존 Notification 계약이 깨진다.
+- Decision Outcome: Reply commit 후 같은 request에서 source-only 멱등 Notification 저장 경계를 await/catch한다. Reply kind는 기존 Notification projection·interface·connection·count·Read·badge/cache에 additive로 통합하고, source Reply에서 Parent Author Recipient, Reply Related Post, Reply Author Related Profile을 파생한다.
+- Alternatives Considered: source transaction 내 저장은 Notification 실패가 Reply를 rollback한다. fire-and-forget은 process 종료와 오류 관찰 경계가 불명하다. 별도 Reply inbox/table은 기존 Notification API와 client를 중복한다.
+- Consequences: Notification 저장 실패 시 item이 누락될 수 있지만 Reply는 유지된다. mixed kind visible predicate는 connection limit 전 SQL에서 적용하고 connection·count·Node·Read가 동일한 source 정합성을 사용해야 한다.
+- Confirmation / Follow-up: PROD-426에서 self-reply, invisible result, duplicate/concurrent source, 저장 실패 격리와 mixed inbox/count/Read/Node/client 이동을 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-local-reply-creation/design.md
+++ b/openspec/changes/add-local-reply-creation/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`origin/main` 기준으로 Post table의 nullable Reply Parent self-reference와 core `createPost(replyParentId?)` 저장·rollback 기반은 존재한다. 반면 GraphQL `CreatePostInput`은 `bodyText`와 `visibility`만 받고, 클라이언트 composer와 Post 상세는 Reply 작성 맥락을 모르며, Notification 수직 경계는 Follow kind를 중심으로 구성되어 있다.
+
+PROD-423은 `add-local-reply-creation` 공유 owner로서 PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox를 하나의 사용자 흐름으로 통합한다. Reply 조상·하위 조회와 thread rendering은 `add-post-replies`/PROD-422, 공통 Notification projection·connection·Read·badge는 `add-in-app-notifications`의 선행 기반이다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 기존 Plain Text Post mutation을 nullable Reply Parent 입력으로 확장하고 Parent 권한·Content 검증과 Reply 저장을 원자적으로 수행한다.
+- Post 상세에서 기존 composer를 Reply 맥락으로 재사용하고 성공 결과를 현재 thread cache에 반영한다.
+- Reply Notification을 기존 Notification projection·GraphQL·inbox·Read·badge 흐름에 수직적으로 추가한다.
+- backend, UI, Notification 각 slice를 독립적으로 검증하고 PROD-423에서 전체 flow와 archive gate를 검증한다.
+
+**Non-Goals:**
+
+- Content Warning, Media/Sensitive Media, Mentioned Profile recipient·Mentioned Profiles/DIRECT 작성·조회
+- Reply Parent와 Repost Source를 동시에 입력하는 Reply+Quote 작성
+- ActivityPub Reply, Action Bar 전체 surface rollout, retry/outbox/backfill, Reply Tombstone 후 동기 Notification cleanup
+- `add-post-replies`의 Reply 조상·하위 GraphQL 계약과 thread rendering, `add-in-app-notifications`의 공통 inbox 기반을 다시 설계하는 작업
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `packages/core/services/post.ts`는 Reply Parent를 저장할 수 있지만, API의 `apps/api/src/graphql/resolvers/post/mutation/create.ts`는 Reply Parent를 받지 않고 Parent의 viewer visibility를 검증하지 않는다.
+- Parent visibility 검증과 core write가 서로 다른 connection/transaction에서 수행되면 검증 후 상태 변경 또는 부분 저장 경계가 생길 수 있다.
+- `PostComposer` 성공 처리는 현재 본문 초기화에 초점이 있고, thread connection의 공개 shape은 선행 `add-post-replies` 구현이 제공해야 한다.
+- Notification kind, source predicate, concrete Node loader, connection/count/Read 쿼리와 client item이 Follow 구조에 결합되어 있어, Reply branch를 item 표시만으로 추가하면 hidden item이 page limit·count·Node·Read 간에 다르게 보일 수 있다.
+- Relay generated artifact는 commit하지 않으며, selected Profile 전환은 Environment/Store 재생성을 통해 cache를 격리한다.
+
+### Recommended Approach
+
+1. PROD-424에서 `CreatePostInput`에 nullable `replyParentId: ID`를 추가하고 concrete `Post` global ID를 decode한다. 요청 Profile 기준 Parent visibility/eligibility·Content를 검증한 같은 transaction 내에서 기존 core Reply 저장 경계를 호출하고 기존 `CreatePostPayload.post`를 반환한다.
+2. PROD-425에서 선행 thread API/UI가 merge된 뒤 route가 thread query와 mutation connection context를 소유하게 한다. `PostComposer`에 optional Parent context를 주입하고, 성공 payload를 현재 descendant connection에 정규화·반영하되 전역 Post 목록 membership을 추측하지 않는다.
+3. PROD-426에서 Reply source에서 Recipient·Related Post·Related Profile을 파생하는 멱등 Notification 저장 경계를 추가한다. Reply commit 후 같은 request에서 이 경계를 await/catch하여 source transaction과 격리한다.
+4. Notification visibility predicate를 kind별 source relation에 따라 SQL에서 구성하고 page limit 전에 적용한다. concrete `ReplyNotification` Node, mixed connection/count/Read가 동일 predicate를 사용하게 한 뒤 client의 discriminated item branch를 결과 Reply 이동과 기존 Best Effort Read/cache 경계에 연결한다.
+5. PROD-423에서 Post 상세 Reply 작성 → thread 반영 → Parent Author inbox/count → item 읽음/결과 Reply 이동을 통합 검증한다. 세 자식 계약과 선행 change의 task·delta spec이 모두 맞을 때만 archive한다.
+
+### Allowed Alternatives
+
+- thread 반영은 선행 Reply connection이 제공하는 공식 Relay connection updater 또는 현재 Post 상세의 제한된 targeted refetch를 사용할 수 있다. 두 방식 모두 성공 직후 현재 thread에 결과가 보여야 하고 selected Profile Store 밖을 갱신하면 안 된다.
+- Reply Notification의 kind별 visible SQL은 공통 base predicate와 kind branch를 조합하거나 같은 최종 predicate를 만드는 kind registry로 구성할 수 있다. kind별 메모리 병합으로 pagination 후 filtering하는 방식은 허용하지 않는다.
+
+### Known Traps
+
+- Parent ID를 UUID 문자열로 직접 받아 concrete GraphQL type 검증을 우회하지 않는다.
+- Parent visibility를 검증하지 않거나 요청 Account/selected Profile을 viewer로 삼지 않고, 행동 주체 Profile을 viewer로 사용한다.
+- Reply에 Parent Visibility를 강제하지 않고, `repostSourceId`를 작성 입력에 추가하지 않는다.
+- Content 없는 Repost의 disabled action에 callback을 남겨 composer 진입이 가능하게 만들지 않는다.
+- Notification을 Reply transaction/savepoint에 넣거나 fire-and-forget으로 호출하지 않는다.
+- client에서 hidden Notification을 사후 filtering해 서버 connection·count·Node·Read의 불일치를 감추지 않는다.
+
+## Risks / Trade-offs
+
+- [선행 thread/Notification change가 merge되기 전에 UI 또는 inbox slice를 구현하면 중복 ownership과 재작업이 생김] → PROD-425는 PROD-422, PROD-426은 기존 Notification 기반을 dependency gate로 유지하고 merge된 public contract에 맞춰 구현한다.
+- [Notification이 Best Effort이므로 저장 실패 시 일부 Reply 알림이 누락될 수 있음] → Reply 성공을 우선하고 retry/outbox는 제외하되, 실패 격리 테스트와 관측 가능한 오류 기록을 유지한다.
+- [mixed Notification kind의 SQL predicate가 복잡해짐] → kind별 source 정합성을 공통 visible contract에서 조합하고 connection·count·Node·Read 통합 테스트로 드리프트를 막는다.
+- [mutation 성공 후 targeted refetch를 사용하면 추가 network request가 생김] → 선행 connection의 정렬·cursor 계약을 안전하게 갱신할 updater가 있으면 우선하고, 없을 때만 현재 상세에 제한한다.
+
+## Migration Plan
+
+1. additive GraphQL input·Reply 생성 경계와 테스트를 배포한다. 기존 `replyParentId` 생략 호출은 일반 Post 작성으로 계속 동작한다.
+2. 선행 Reply thread 기반을 확인한 뒤 composer·action·thread cache 통합을 배포한다.
+3. 기존 Notification 기반에 Reply kind, source predicate, API와 client item을 additive로 배포한다. schema enum migration이 필요하면 expand 단계로 먼저 반영한다.
+4. 롤백 시 client/UI 통합과 Reply Notification branch를 역순으로 제거해도 기존 Reply Post 및 Follow Notification 데이터는 유지된다. additive input과 enum 값의 스토리지 contract 제거는 별도 contract 단계 없이 즉시 수행하지 않는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-local-reply-creation/proposal.md
+++ b/openspec/changes/add-local-reply-creation/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Kosmo의 Reply Parent 저장·조회와 thread 표시 기반은 있지만, 사용자가 Local Reply를 작성하고 현재 thread에서 확인하며 Parent Author가 기존 inbox에서 알림을 받는 수직 흐름은 아직 연결되지 않았다. [PROD-423](https://linear.app/byulmaru/issue/PROD-423)이 backend·UI·Notification 자식 계약의 공유 change owner로서 이 흐름을 하나의 `add-local-reply-creation` OpenSpec으로 통합한다.
+
+## What Changes
+
+- 기존 `createPost` 입력에 nullable `replyParentId`를 추가하고, 요청 Profile이 조회할 수 있는 contentful Parent에 현재 지원 본문·Visibility를 가진 일반 Reply를 생성한다.
+- Post 상세의 Reply action에서 기존 composer를 열고, 성공한 Reply를 현재 thread Relay cache에 반영한다. Content 없는 Repost의 action은 표시하되 진입을 차단한다.
+- 다른 Profile의 Post에 Local Reply가 생성되면 Parent Author에게 Reply Notification을 Best Effort로 생성하고, 기존 connection·Unread count·Read·badge/cache·inbox 흐름에 연결한다.
+- Content Warning, Media/Sensitive Media, Mentioned Profile recipient·Mentioned Profiles 작성/조회, Reply+Quote 작성, ActivityPub Reply, Action Bar 전체 rollout, retry/outbox와 동기 cleanup은 제외한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/objects/post.md`, `docs/domain/objects/notification.md`, `docs/domain/policies/post-list.md`, `docs/design/README.md`, `docs/design/colors.md`, `docs/design/typography.md`, `docs/design/breakpoints.md`
+- Linear Contract: [PROD-423](https://linear.app/byulmaru/issue/PROD-423)
+- Linear Implementations: [PROD-424](https://linear.app/byulmaru/issue/PROD-424), [PROD-425](https://linear.app/byulmaru/issue/PROD-425), [PROD-426](https://linear.app/byulmaru/issue/PROD-426)
+
+## Capabilities
+
+### New Capabilities
+
+- `local-reply-creation`: Local Reply 생성 입력, Parent 조회·Content 검증, 원자적 저장과 실패 롤백 계약
+- `post-reply-ui`: 기존 composer를 사용한 Reply 작성 진입, Repost disabled 상태와 thread cache 통합 계약
+- `notification`: Reply source correlation, Best Effort 실패 격리와 기존 Notification API·inbox 통합 계약
+
+### Modified Capabilities
+
+- `post`: Plain Text `createPost` GraphQL 계약이 선택적 Reply Parent를 받고 기존 단일 `Post` payload로 Reply를 반환하도록 확장
+
+## Impact
+
+- Linear: 공유 owner PROD-423과 구현 계약 PROD-424·425·426
+- Core/API: 기존 Reply Parent 저장 경계, Post visibility predicate, `CreatePostInput`, Reply Notification source·concrete Node·visible predicate
+- Universal client: Post 상세 action, 기존 composer mutation, thread Relay cache, Notification inbox item·Read·badge cache
+- Verification: backend service/schema/resolver, client component/route/cache, Notification connection·count·Read·Node와 통합 flow
+- Dependencies: `add-post-replies`의 Reply Parent·thread 기반과 `add-in-app-notifications`의 공통 Notification 기반을 재사용한다.

--- a/openspec/changes/add-local-reply-creation/specs/local-reply-creation/spec.md
+++ b/openspec/changes/add-local-reply-creation/specs/local-reply-creation/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Local Reply 생성 권한과 Parent 검증
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `PROD-423`, `PROD-424` 시스템은 Active Account의 Member이며 Active/Normal Local Profile인 행동 주체에게만, 행동 주체가 조회할 수 있는 contentful Post를 직접 Parent로 참조하는 Local Reply 생성을 허용해야 한다 (MUST).
+
+#### Scenario: 조회 가능한 contentful Parent에 Reply 생성
+
+- **WHEN** 행동 주체가 조회할 수 있는 Active contentful Post의 concrete `Post` global ID와 유효한 `bodyText`, 현재 지원 `visibility`를 제공한다
+- **THEN** 시스템은 Content와 해당 Reply Parent를 가지고 Repost Source는 없는 Active Post를 생성한다
+- **AND** Reply의 Visibility는 Parent의 Visibility와 독립적으로 입력값을 사용한다
+
+#### Scenario: Quote를 Parent로 하는 일반 Reply
+
+- **WHEN** 행동 주체가 조회할 수 있고 Content와 Repost Source를 가진 Quote를 Parent로 제공한다
+- **THEN** 시스템은 Quote를 직접 Reply Parent로 가지고 Repost Source는 없는 일반 Reply를 생성한다
+- **AND** 이 작성 경계는 Reply+Quote를 생성하지 않는다
+
+#### Scenario: 없거나 contentless인 Parent
+
+- **WHEN** `replyParentId`가 없는 Post를 가리키거나 Content 없는 Repost를 가리킨다
+- **THEN** 시스템은 없는 Parent는 `NOT_FOUND`, contentless Parent는 `replyParentId` validation 오류로 거부한다
+- **AND** Post와 PostContent를 남기지 않는다
+
+#### Scenario: 조회할 수 없는 Parent
+
+- **WHEN** Parent가 요청 Profile 기준 Visibility 또는 Eligibility를 통과하지 못한다
+- **THEN** 시스템은 없는 Parent와 구분할 수 없게 생성을 거부한다
+- **AND** Parent 또는 새 Post의 데이터를 노출하지 않는다
+
+#### Scenario: 잘못된 global ID type
+
+- **WHEN** `replyParentId`가 concrete `Post` global ID가 아닌다
+- **THEN** 시스템은 입력 검증 오류로 요청을 거부한다
+- **AND** 다른 Node type의 로더로 재시도하지 않는다
+
+### Requirement: Reply 생성의 원자성
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `PROD-423`, `PROD-424` 시스템은 Parent 조회·Content 검증과 Reply Post·Content·Reply Parent 연결을 하나의 transaction에서 완료해야 한다 (MUST).
+
+#### Scenario: Reply 저장 성공
+
+- **WHEN** Parent 검증과 Reply 저장의 모든 단계가 성공한다
+- **THEN** 새 Post의 `currentContentId`는 새 Content를, `replyParentId`는 입력 Parent를 참조한다
+- **AND** `repostSourceId`는 `null`이다
+
+#### Scenario: transaction 중간 실패
+
+- **WHEN** Parent 검증, Content 생성, Post 관계 연결 중 어느 한 단계가 실패한다
+- **THEN** 시스템은 Reply 생성 transaction 전체를 rollback한다
+- **AND** 부분적인 Post, Content 또는 Reply Parent 관계를 남기지 않는다

--- a/openspec/changes/add-local-reply-creation/specs/notification/spec.md
+++ b/openspec/changes/add-local-reply-creation/specs/notification/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Reply Notification source correlation
+
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/domain/objects/post.md`, `PROD-423`, `PROD-426` 시스템은 Local Profile이 다른 Profile의 Post에 새 Reply를 생성하면 결과 Reply를 source로 하는 Profile-scoped Reply Notification을 Best Effort로 생성해야 한다 (MUST).
+
+#### Scenario: 다른 Profile의 Post에 Reply
+
+- **WHEN** Local Reply transaction이 commit되고 Reply Author와 Parent Author가 다르며 Recipient가 결과 Reply와 Reply Author를 조회할 수 있다
+- **THEN** 시스템은 결과 Reply를 Related Post와 source로, Reply Author를 Related Profile로, Parent Author를 Recipient로 하는 Unread Reply Notification 생성을 시도한다
+- **AND** 이름, handle, Profile 또는 Post snapshot을 kind data에 저장하지 않는다
+
+#### Scenario: self-reply
+
+- **WHEN** Reply Author와 Parent Author가 같다
+- **THEN** 시스템은 Reply 생성 결과를 유지한다
+- **AND** Reply Notification을 생성하지 않는다
+
+#### Scenario: Recipient에게 결과가 보이지 않음
+
+- **WHEN** Parent Author Profile이 결과 Reply 또는 Reply Author Profile을 조회할 수 없다
+- **THEN** 시스템은 Reply Notification을 생성하지 않는다
+
+#### Scenario: 동일 source 재처리
+
+- **WHEN** 같은 결과 Reply source의 Notification 저장 경계가 중복 또는 동시 호출된다
+- **THEN** 같은 Recipient, Reply kind와 source ID의 Notification은 하나만 존재한다
+- **AND** 재처리는 기존 item을 나타내는 성공 또는 동등한 멱등 no-op으로 끝난다
+
+### Requirement: Reply Notification 실패 격리
+
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `PROD-423`, `PROD-426` Reply Notification 생성 실패는 Reply transaction이나 성공 결과를 rollback하거나 실패로 바꾸어서는 안 된다 (MUST NOT).
+
+#### Scenario: Notification 저장 실패
+
+- **WHEN** Reply commit 뒤 같은 request에서 await한 Notification 저장이 실패한다
+- **THEN** 시스템은 Reply와 Reply 생성 성공 결과를 유지한다
+- **AND** 누락 item을 retry, outbox, queue 또는 backfill로 자동 복구하지 않는다
+
+### Requirement: Reply Notification GraphQL과 inbox 통합
+
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `PROD-423`, `PROD-426` API와 클라이언트는 visible Reply Notification을 기존 Notification interface·connection·Unread count·Read·badge/cache·inbox 계약에 통합해야 한다 (MUST).
+
+#### Scenario: Reply Notification concrete object·Node
+
+- **WHEN** GraphQL schema가 Reply kind Notification을 노출한다
+- **THEN** API는 이를 Notification과 Node를 구현하는 concrete `ReplyNotification` object로 resolve한다
+- **AND** object는 Reply Author `profile`과 결과 Reply `post`를 제공한다
+- **AND** concrete global ID로 Node를 조회할 때 row kind, Recipient membership과 visible predicate를 검증하고, 실패하면 다른 type으로 재시도하지 않고 `null`을 반환한다
+
+#### Scenario: visible Recipient inbox
+
+- **WHEN** membership이 있는 Account가 Recipient Profile의 Notification inbox를 조회한다
+- **THEN** visible Reply Notification은 기존 connection 정렬·pagination과 Unread count에 포함된다
+- **AND** inbox item은 Reply Author를 표시하고 결과 Reply 상세로 이동한다
+
+#### Scenario: Read side effect와 이동 분리
+
+- **WHEN** 사용자가 Reply Notification item을 활성화한다
+- **THEN** 클라이언트는 결과 Reply 이동을 즉시 시작한다
+- **AND** Best Effort Read의 pending, 실패 또는 재시도가 이동을 지연·취소·되돌리지 않는다
+- **AND** Read 성공 payload는 item과 Recipient Profile Unread count를 같은 actor Relay Store에서 갱신한다
+
+#### Scenario: selected Profile 격리
+
+- **WHEN** Account가 여러 Profile membership을 가지고 하나의 Recipient Profile inbox를 조회하거나 읽는다
+- **THEN** 시스템은 대상 Profile의 Reply Notification, count, Read와 cache만 반환·갱신한다
+- **AND** 다른 selected Profile의 item, badge 또는 Relay Store를 변경하지 않는다
+
+#### Scenario: unavailable item
+
+- **WHEN** source Reply가 없거나 Recipient·Parent·Author 관계가 저장계약과 다르거나 Recipient 기준 Related Post 또는 Related Profile을 조회할 수 없다
+- **THEN** API는 item을 page limit 전 connection과 Unread count에서 제외한다
+- **AND** Node는 `null`, Read는 `NOT_FOUND`로 처리하며 generic Notification으로 대신 노출하지 않는다

--- a/openspec/changes/add-local-reply-creation/specs/post-reply-ui/spec.md
+++ b/openspec/changes/add-local-reply-creation/specs/post-reply-ui/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: 기존 composer를 사용한 Reply 작성
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/design/colors.md`, `docs/design/typography.md`, `docs/design/breakpoints.md`, `PROD-423`, `PROD-425` 유니버설 클라이언트는 Post 상세의 contentful Post에서 기존 일반 Post composer를 Reply Parent 맥락으로 열고, 현재 composer가 지원하는 본문과 Visibility로 Reply를 제출해야 한다 (MUST).
+
+#### Scenario: contentful Post에서 Reply 진입
+
+- **WHEN** 사용자가 Content를 가진 일반 Post, Reply 또는 Quote의 상세에서 Reply action을 활성화한다
+- **THEN** 클라이언트는 해당 Post를 Parent로 하는 기존 composer를 연다
+- **AND** 제출 mutation에 Parent의 concrete `Post` global ID를 `replyParentId`로 전달한다
+
+#### Scenario: Parent와 독립적인 Visibility
+
+- **WHEN** 사용자가 현재 지원되는 범위에서 Parent와 다른 Visibility를 선택하고 Reply를 제출한다
+- **THEN** 클라이언트는 Parent Visibility를 복사하거나 강제하지 않고 사용자 선택값을 전송한다
+
+#### Scenario: Content 없는 Repost의 disabled Reply action
+
+- **WHEN** Post 상세 대상이 Content 없는 Repost이다
+- **THEN** 클라이언트는 Reply action을 disabled 상태로 표시한다
+- **AND** action callback, composer 진입 또는 create mutation을 실행하지 않는다
+
+#### Scenario: 기존 Post payload 재사용
+
+- **WHEN** Reply mutation이 성공한다
+- **THEN** 클라이언트는 기존 단일 `Post` fragment와 `CreatePostPayload.post`를 사용해 결과를 처리한다
+- **AND** Reply/Repost/Quote Kind enum이나 concrete Post type을 추가하지 않는다
+
+### Requirement: Reply 작성 상태와 thread cache 격리
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `PROD-423`, `PROD-425` 클라이언트는 Reply 작성의 validation·pending·실패·성공 상태를 selected Profile별로 격리하고, 성공한 Reply를 현재 Parent thread에 반영해야 한다 (MUST).
+
+#### Scenario: 성공한 Reply의 thread 반영
+
+- **WHEN** 현재 Post 상세에서 Reply mutation이 성공한다
+- **THEN** 클라이언트는 성공 payload의 Post를 현재 thread Relay cache에 반영한다
+- **AND** 현재 thread의 Parent·조상·하위 Reply 관계를 다른 Post로 평탄화하지 않는다
+
+#### Scenario: validation 또는 network 실패
+
+- **WHEN** Reply 제출이 validation 또는 network 오류로 실패한다
+- **THEN** 클라이언트는 현재 작성 내용과 Parent 맥락을 유지해 재시도할 수 있게 한다
+- **AND** 실패한 Post를 thread cache에 추가하지 않는다
+
+#### Scenario: selected Profile 전환
+
+- **WHEN** Reply 작성 중 selected Profile이 바뀌거나 다른 Profile의 Relay Environment가 활성화된다
+- **THEN** 클라이언트는 이전 Profile의 입력, pending, error, 성공 결과를 새 Profile의 composer나 thread cache에 노출하지 않는다

--- a/openspec/changes/add-local-reply-creation/specs/post/spec.md
+++ b/openspec/changes/add-local-reply-creation/specs/post/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Plain Text post creation
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `PROD-423`, `PROD-424` 로그인했고 active profile이 있는 사용자는 Plain Text UX의 `bodyText` 입력과 선택적 concrete `Post` `replyParentId`로 versioned canonical document의 일반 Post 또는 Reply를 작성할 수 있어야 한다 (MUST).
+
+#### Scenario: Plain Text 게시글 작성 성공
+
+- **WHEN** 로그인한 클라이언트가 active profile이 선택된 상태에서 유효한 `bodyText` 문자열과 `visibility`로 `createPost` mutation을 호출하고 `replyParentId`를 생략한다
+- **THEN** 시스템은 새 `post` 행을 생성한다
+- **AND** 게시글 작성자는 현재 세션의 active profile이다
+- **AND** 게시글 상태는 `ACTIVE`이다
+- **AND** 게시글 공개 범위는 입력받은 `visibility` 값이다
+- **AND** 시스템은 새 `post_content` 행을 생성한다
+- **AND** `post.current_content_id`는 생성된 콘텐츠를 참조한다
+- **AND** `post.reply_parent_id`와 `post.repost_source_id`는 `null`이다
+- **AND** mutation은 `CreatePostPayload.post`로 생성된 `Post`를 반환한다
+
+#### Scenario: Plain Text Reply 작성 성공
+
+- **WHEN** 로그인한 클라이언트가 active profile이 선택된 상태에서 유효한 `bodyText`, `visibility`와 조회 가능한 contentful Parent의 concrete `Post` global ID를 `replyParentId`로 제공한다
+- **THEN** 시스템은 `current_content_id`와 입력 `reply_parent_id`를 가지고 `repost_source_id`는 `null`인 Active Post를 생성한다
+- **AND** Reply의 공개 범위는 Parent와 독립적인 입력 `visibility` 값이다
+- **AND** mutation은 일반 Post와 같은 `CreatePostPayload.post`로 생성된 단일 `Post`를 반환한다
+
+#### Scenario: 본문 저장 형식
+
+- **WHEN** 시스템이 Plain Text 게시글 또는 Reply 콘텐츠를 저장한다
+- **THEN** 시스템은 입력 문자열을 공통 V1 Plain Text 변환 경계에 전달한다
+- **AND** trim과 line-ending normalization 뒤 summary `null`인 V1 canonical PostContent document를 저장한다
+- **AND** trim된 Plain Text가 canonical document에서 다시 동일하게 projection된다
+- **AND** 시스템은 Plain Text 또는 HTML을 별도 canonical 본문으로 저장하지 않는다
+
+#### Scenario: 유효하지 않은 본문
+
+- **WHEN** 클라이언트가 trim 결과가 비어 있거나 summary와 body에서 파생한 authored Plain Text 합계가 500자를 초과하는 입력으로 `createPost` mutation을 호출한다
+- **THEN** 시스템은 validation code를 가진 GraphQL 오류로 요청을 거부한다
+- **AND** 게시글과 게시글 콘텐츠를 생성하지 않는다
+
+#### Scenario: 인증되지 않은 작성 요청
+
+- **WHEN** 인증 session이 없는 클라이언트가 `createPost` mutation을 호출한다
+- **THEN** 시스템은 GraphQL 인증 오류로 요청을 거부한다
+- **AND** 게시글과 게시글 콘텐츠를 생성하지 않는다
+
+#### Scenario: active profile 없는 작성 요청
+
+- **WHEN** 로그인한 클라이언트가 active profile 없이 `createPost` mutation을 호출한다
+- **THEN** 시스템은 GraphQL active profile 인증 scope 오류로 요청을 거부한다
+- **AND** 게시글과 게시글 콘텐츠를 생성하지 않는다

--- a/openspec/changes/add-local-reply-creation/tasks.md
+++ b/openspec/changes/add-local-reply-creation/tasks.md
@@ -1,0 +1,134 @@
+## 1. PROD-424 Reply backend 생성/API
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/decisions/0014-post-structure-relations.md`
+- `PROD-423`
+- `PROD-424`
+
+**Deliverable**
+
+기존 `createPost` GraphQL 계약으로 요청 Profile이 조회할 수 있는 contentful Parent에 현재 지원 본문·Visibility를 가진 Local Reply를 생성하고 기존 `Post` payload를 받는다.
+
+**Guardrails**
+
+- `replyParentId`는 nullable concrete `Post` global ID이며 Parent는 행동 주체 Profile 기준 Visibility·Eligibility와 Content 검증을 통과해야 한다.
+- Reply Visibility는 Parent와 독립적이고 `repostSourceId`는 작성 입력에 추가하지 않는다.
+- Parent 검증과 Post·Content·Reply Parent 저장은 원자적이어야 하며 실패 시 부분 데이터를 남기지 않는다.
+- Content Warning, Media/Sensitive Media, Mentioned Profiles/DIRECT와 Reply+Quote 작성은 포함하지 않는다.
+
+**Verification**
+
+- 일반 Post 작성 회귀와 contentful 일반 Post·Reply·Quote Parent의 Reply 생성을 검증한다.
+- wrong global typename, missing·Tombstone·hidden·contentless Parent, 권한 없는 actor와 transaction rollback을 검증한다.
+- Parent와 다른 현재 지원 Visibility, `currentContentId != null`, 입력 `replyParentId`, `repostSourceId = null`과 기존 Post payload를 검증한다.
+
+- [ ] 1.1 nullable concrete `Post` `replyParentId`를 받는 additive GraphQL 입력·schema 계약을 구현한다.
+- [ ] 1.2 행동 주체와 Parent의 권한·Visibility·Eligibility·Content를 검증하고 원자적 Reply 저장에 연결한다.
+- [ ] 1.3 성공, 독립 Visibility, global ID, Parent 상태·권한과 rollback API integration 테스트를 추가한다.
+- [ ] 1.4 기존 일반 Post 작성·core Reply 테스트와 GraphQL schema check를 통과시킨다.
+
+## 2. PROD-425 Reply 작성 UI/thread 통합
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/design/colors.md`
+- `docs/design/typography.md`
+- `docs/design/breakpoints.md`
+- `PROD-423`
+- `PROD-425`
+
+**Deliverable**
+
+Post 상세의 contentful Parent에서 기존 composer로 Reply를 작성하고 성공한 결과를 현재 thread에서 확인한다.
+
+**Guardrails**
+
+- 기존 composer·`Post` fragment·mutation payload와 PROD-422의 선행 thread 계약을 재사용하고 Reply 전용 composer나 Post Kind/concrete type을 만들지 않는다.
+- Content 없는 Repost의 Reply action은 disabled이며 callback·composer·mutation 진입을 차단한다.
+- Visibility는 Parent와 독립적이며 validation·pending·실패·성공 상태와 Relay cache는 selected Profile별로 격리한다.
+- Reply+Quote 작성, Action Bar 전체 rollout, ActivityPub Reply와 Notification inbox UI는 포함하지 않는다.
+
+**Verification**
+
+- contentful 일반 Post·Reply·Quote의 composer 진입과 contentless Repost disabled 호출 차단을 검증한다.
+- Parent와 다른 Visibility, validation·pending·성공·실패 상태와 selected Profile 전환 격리를 검증한다.
+- 성공 payload가 기존 `Post` fragment로 현재 thread cache에 반영되며 다른 actor Store나 관련 없는 목록을 변경하지 않음을 검증한다.
+
+- [ ] 2.1 PROD-422의 Reply 조상·하위 API와 Post 상세 thread 계약이 merge되었고 이 change와 ownership 중복이 없음을 확인한다.
+- [ ] 2.2 contentful Parent의 Reply action이 기존 composer를 Parent 맥락으로 열고 contentless Repost에서는 진입을 차단하게 연결한다.
+- [ ] 2.3 기존 composer가 `replyParentId`를 포함해 Reply를 제출하고 selected Profile별 입력·pending·error 상태를 격리하게 확장한다.
+- [ ] 2.4 성공한 `Post` payload를 현재 Parent thread에 반영하고 실패 시 입력과 Parent 맥락을 유지한다.
+- [ ] 2.5 Reply 진입·disabled·상태 격리·thread cache 통합 component·route 검증과 Relay compiler/check를 통과시킨다.
+
+## 3. PROD-426 Reply Notification/inbox 통합
+
+**Authority / Provenance**
+
+- `docs/domain/objects/notification.md`
+- `docs/domain/objects/post.md`
+- `PROD-423`
+- `PROD-426`
+
+**Deliverable**
+
+다른 Profile의 Post에 Local Reply가 생성되면 Parent Author가 기존 inbox에서 Reply Author를 보고 결과 Reply로 이동하며, 기존 Unread·Read·badge/cache 흐름을 사용한다.
+
+**Guardrails**
+
+- source와 Related Post는 결과 Reply, Related Profile은 Reply Author, Recipient는 Parent Author에서 파생하고 self-reply와 Recipient에게 보이지 않는 결과는 생성을 억제한다.
+- Notification은 Reply commit 후 Best Effort로 생성하며 저장 실패가 Reply를 rollback하거나 mutation 성공을 실패로 바꾸지 않는다.
+- 기존 Notification projection·interface·connection·count·Read·badge/cache를 확장하고 별도 inbox를 만들지 않는다.
+- duplicate/concurrent source에서 uniqueness를 유지하고 visible filtering을 page limit 전에 적용한다.
+- ActivityPub delivery, retry/outbox/backfill과 Tombstone 후 동기 cleanup은 포함하지 않는다.
+
+**Verification**
+
+- 타인 Post Reply, self-reply, invisible 결과, duplicate/concurrent source와 Notification 저장 실패 격리를 검증한다.
+- source·Related Post·Related Profile·Recipient mapping, concrete `ReplyNotification` Node와 unavailable predicate를 검증한다.
+- mixed connection·Unread count·Read, inbox 표시·Reply 이동·Best Effort Read와 selected Profile cache 격리를 검증한다.
+
+- [ ] 3.1 기존 Notification 기반의 projection·API·client contract가 merge되었고 Reply kind 확장이 공통 계약을 재사용할 수 있음을 확인한다.
+- [ ] 3.2 Reply source에서 Recipient·Related Post·Related Profile을 파생하는 멱등 Notification 저장·visibility 계약을 추가한다.
+- [ ] 3.3 Reply commit 후 Notification 생성을 Best Effort로 연결하고 self-reply·invisible 결과를 억제한다.
+- [ ] 3.4 concrete `ReplyNotification` Node와 mixed visible connection·Unread count·Read 계약을 기존 Notification API에 통합한다.
+- [ ] 3.5 기존 inbox item에 Reply Author 표시, 결과 Reply 이동, Best Effort Read와 selected Profile badge/cache 동기화를 연결한다.
+- [ ] 3.6 source mapping·self-reply·visibility·uniqueness·실패 격리 서비스 검증과 API Node·connection·count·Read integration 테스트를 통과시킨다.
+- [ ] 3.7 inbox 표시·이동·Read·cache·Profile 전환 client 검증과 Relay compiler/check를 통과시킨다.
+
+## 4. PROD-423 통합 검증·OpenSpec 완료
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/notification.md`
+- `docs/domain/policies/post-list.md`
+- `docs/domain/decisions/0014-post-structure-relations.md`
+- `PROD-423`
+- `PROD-424`
+- `PROD-425`
+- `PROD-426`
+
+**Deliverable**
+
+Local Reply 작성에서 thread 반영과 Parent Author Notification inbox·Read·Reply 이동까지의 전체 사용자 흐름을 검증하고 canonical·Linear·OpenSpec을 동기화한 뒤 change를 archive한다.
+
+**Guardrails**
+
+- PROD-424·425·426 전체 Deliverable·Guardrail·Verification과 필수 dependency가 완료되기 전에 change를 archive하지 않는다.
+- PROD-460·461·462와 Reply+Quote·ActivityPub·retry/outbox 범위를 통합 완료 조건으로 승격시키지 않는다.
+- Pull Request readiness와 OpenSpec archive를 별도로 판단한다.
+
+**Verification**
+
+- 두 Local Profile로 Reply 작성 → Parent thread 반영 → Parent Author inbox/count → item Read 및 결과 Reply 이동을 검증한다.
+- self-reply, Parent와 독립 Visibility, contentless Repost disabled, Notification 실패 격리와 selected Profile 전환 회귀를 검증한다.
+- 관련 전체 check, OpenSpec strict validation, task 완료와 canonical delta 동기화 결과를 기록한다.
+
+- [ ] 4.1 PROD-424·425·426의 구현·검증·dependency 완료와 제외 범위 유지를 확인한다.
+- [ ] 4.2 Local Reply 작성·thread·Notification·Read·이동 수직 flow와 필수 회귀 시나리오를 최종 검증한다.
+- [ ] 4.3 구현 결과에 맞게 delta spec, decision, task와 필요한 canonical 문서를 동기화한다.
+- [ ] 4.4 전체 필수 check와 `openspec validate add-local-reply-creation --strict`를 통과시키고 검증 evidence를 기록한다.
+- [ ] 4.5 전체 scope와 task가 완료되고 delta spec이 동기화된 뒤 `add-local-reply-creation`을 archive한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- PROD-423을 공유 owner로 하는 add-local-reply-creation OpenSpec change를 제안했습니다.
- PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox 계약을 별도 capability와 task group으로 나눴습니다.
- Reply+Quote, Content Warning, Media/Sensitive Media, Mentioned Profiles/DIRECT, ActivityPub Reply, retry/outbox를 제외 범위로 고정했습니다.

## 왜 변경했는지

- Local Reply 작성부터 현재 thread 반영, Parent Author 알림과 결과 Reply 이동까지의 수직 흐름이 하나의 공유 계약과 archive gate를 가져야 합니다.
- Reply Parent/thread와 공통 Notification 기반을 재구현하지 않고 진행 중인 선행 change에 의존하도록 ownership을 명확히 해야 합니다.

## 어떻게 확인할 수 있는지

- openspec validate add-local-reply-creation --strict
- pnpm exec prettier --check openspec/changes/add-local-reply-creation/**/*.md openspec/changes/add-local-reply-creation/*.md
- OpenSpec status 5/5 artifacts complete

## 아직 어떤 문제가 남았는지

- 현재 PR은 OpenSpec Gate 검토용이며 구현은 시작하지 않았습니다.
- PROD-425는 PROD-422 thread 기반, PROD-426은 기존 Notification 기반 완료 후 구현해야 합니다.

Linear: https://linear.app/byulmaru/issue/PROD-423