### PR TITLE
여러 진입점이 공유하는 core service 책임 경계를 명확히 한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # kosmo
 
+## Architecture
+
+- [Core service boundary](docs/architecture/core-services.md)
+- [Domain model and policies](docs/domain/README.md)
+
 ## Infrastructure
 
 AWS Terraform root is documented in [apps/terraform/README.md](apps/terraform/README.md).

--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -2,15 +2,16 @@
 
 ## 목적과 의존 방향
 
-`packages/core/services`는 GraphQL API, Web BFF, ActivityPub handler와 worker가 공유하는 application
-action 경계다. 진입점이 달라도 같은 도메인 정책, transaction, persistence와 멱등성 결과를 보장한다.
+`packages/core/services`는 GraphQL API, Web BFF, ActivityPub handler와 worker가 공유하는
+state-changing application action 경계다. 진입점이 달라도 같은 도메인 정책, transaction, persistence와
+멱등성 결과를 보장한다.
 
-의존 방향은 항상 진입점에서 core로 향한다.
+의존 방향은 항상 진입점에서 core로 향한다. 상태를 바꾸지 않는 조회는 application action이 아니므로
+`packages/core/services`를 거치지 않는다.
 
 ```text
-GraphQL / BFF / ActivityPub / worker
-  -> packages/core/services
-    -> packages/core/db
+Mutation / state-changing entry -> packages/core/services -> packages/core/db
+Read query / loader -------------------------------------> packages/core/db
 ```
 
 core는 GraphQL context·payload·Global ID, HTTP session, ActivityPub object처럼 특정 진입점에서만 의미가
@@ -18,11 +19,11 @@ core는 GraphQL context·payload·Global ID, HTTP session, ActivityPub object처
 
 ## 책임
 
-| 계층                                                            | 책임                                                                                           |
-| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| GraphQL resolver, HTTP route, ActivityPub handler, worker entry | transport 입력 해석, caller·actor 인증, protocol별 권한 증거 검증, 외부 ID와 응답·오류 mapping |
-| `packages/core/services`                                        | 검증된 actor와 business input에 대한 공통 domain policy, transaction, persistence와 멱등성     |
-| `packages/core/db`                                              | DB client, schema, migration 지원과 DB 전용 utility                                            |
+| 계층                                                            | 책임                                                                                       |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| GraphQL resolver, HTTP route, ActivityPub handler, worker entry | transport 입력 해석, caller·actor 인증, 조회·loader, 외부 ID와 응답·오류 mapping           |
+| `packages/core/services`                                        | 검증된 actor와 business input에 대한 공통 domain policy, transaction, persistence와 멱등성 |
+| `packages/core/db`                                              | DB client, schema, migration 지원과 DB 전용 utility                                        |
 
 Account session이나 ActivityPub signature처럼 actor identity를 신뢰하기 위한 증거는 진입점이 검증한다.
 Post.Author, Source visibility와 lifecycle처럼 검증된 actor와 domain object 사이의 공통 권한은 core가
@@ -47,6 +48,8 @@ ingress는 signature와 Remote actor를 검증한다. 두 진입점은 검증된
 - GraphQL은 core 결과를 schema 타입과 payload로 mapping하고, presentation에만 필요한 값은
   resolver·loader에서 조합한다. 어떤 값이 모든 caller가 알아야 하는 domain outcome일 때만 core
   반환값에 포함한다.
+- read-only query, lookup, list와 loader는 진입점의 query 계층에서 DB와 공유 조회 policy를 사용한다.
+  계층을 맞추기 위한 pass-through core service를 만들지 않는다.
 - 여러 DB 변경이 원자적이어야 하면 core action이 transaction 경계를 소유한다. 실제 caller
   transaction과 합류해야 할 때만 optional transaction을 받는다.
 - core는 공통 domain error를 반환하고 각 진입점이 외부 오류 표현으로 mapping한다.

--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -1,0 +1,116 @@
+# Core 서비스 경계
+
+## 존재 이유
+
+`packages/core`는 특정 transport나 protocol의 요청을 처리하기 위한 계층이 아니다. GraphQL API, Web BFF,
+ActivityPub handler와 worker처럼 서로 다른 진입점이 같은 Kosmo business use case를 실행할 때, 도메인
+불변식과 transaction 동작이 진입점마다 달라지지 않도록 공유하는 server business logic 경계다.
+
+이 경계의 목적은 코드를 단순히 재사용하는 것이 아니라 다음을 한곳에서 보장하는 것이다.
+
+- 같은 행동이 어느 진입점에서 호출돼도 동일한 도메인 결과를 만든다.
+- 여러 DB 변경이 하나의 transaction으로 commit되거나 rollback된다.
+- uniqueness, idempotency와 concurrency 결과가 caller마다 달라지지 않는다.
+- transport, session 또는 federation protocol이 바뀌어도 domain action의 public contract는 유지된다.
+
+## 책임 구분
+
+| 계층                                                            | 소유하는 책임                                                                                                                                          | 소유하지 않는 책임                                                                         |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| GraphQL resolver, HTTP route, ActivityPub handler, worker entry | transport input 해석, 인증된 caller와 actor 확인, protocol별 권한 증거 검증, 외부 ID 변환, 응답·오류 mapping                                           | 공통 domain transaction을 직접 복제하는 일                                                 |
+| `packages/core/services`                                        | 검증된 actor identity와 business input을 받는 application action, 공통 domain policy, transaction, persistence orchestration, uniqueness와 idempotency | GraphQL context, HTTP session, OIDC exchange, ActivityPub signature나 Activity object 해석 |
+| `packages/core/db`                                              | DB client, schema, migration 지원과 DB 전용 utility                                                                                                    | application use case와 transport별 authorization                                           |
+
+진입점은 core service를 호출하기 전에 자기 protocol에서만 의미가 있는 사실을 검증한다.
+
+- Local GraphQL mutation은 Active Account, selected Profile membership과 Local actor context를 검증한다.
+- ActivityPub ingress는 서명, remote actor, Activity actor/object/recipient와 federation 수신 정책을 검증한다.
+- Worker는 job provenance와 실행 권한을 검증한다.
+
+core service는 이렇게 검증된 actor와 business input을 받아 모든 caller가 공유하는 Profile/Post lifecycle,
+관계 구조, visibility·eligibility, 저장과 멱등성 규칙을 적용한다.
+
+이 구분은 core가 authorization을 하지 않는다는 뜻이 아니다. Account session, ActivityPub signature처럼
+actor identity를 신뢰하기 위한 caller별 증거는 진입점이 검증하고, Post.Author, 관계 Owner, Source
+visibility처럼 검증된 actor와 domain object 사이의 공통 권한은 core가 검증한다.
+
+## Actor와 Account
+
+기본 소셜 행동 주체는 `Profile`이다. `Account`는 Local 요청에서 Profile을 선택하고 그 Profile의
+Owner/Member임을 증명하는 인증·권한 사실이지, 모든 소셜 action의 보편적인 actor가 아니다. Remote
+ActivityPub Profile에는 Kosmo Account membership이 없다.
+
+따라서 public core action에 `accountId`를 추가해도 되는 것은 Account 자체가 domain participant이거나,
+transaction commit 시점의 Account 권한을 다시 확인하는 것이 그 action의 명시된 불변식일 때뿐이다. 현재
+GraphQL caller의 session 검증을 core에서 반복하기 위한 목적으로 `accountId`를 요구하지 않는다.
+
+`InstanceKind.LOCAL`도 같은 원칙을 따른다. 현재 caller가 Local GraphQL이라는 이유만으로 공통 action이
+Local Profile만 허용하면, 검증된 Remote Profile이 같은 domain action을 수행해야 할 때 공통 경계를 재사용할
+수 없다. Locality가 action 자체의 의미인 경우에만 core contract에 포함하고, 그렇지 않으면 각 진입점이
+자기 actor origin을 검증한다. Profile이나 Instance의 공통 lifecycle·safety 정책은 caller 종류와 무관하게
+적용되는 범위에서 core가 계속 검증할 수 있다.
+
+## 공통 action 흐름
+
+같은 domain action에 Local과 ActivityPub 진입점이 있다면 다음 형태를 사용한다.
+
+```text
+Local GraphQL
+  -> Account/session/selected Profile/Locality 검증
+  -> verified actor Profile + business input
+                                      \
+                                       -> core service
+                                      /   -> 공통 domain policy
+ActivityPub                          /    -> transaction/persistence
+  -> signature/actor/object 검증    /     -> uniqueness/idempotency
+  -> verified actor Profile + input
+```
+
+예를 들어 Repost 생성의 Local mutation은 Account와 membership을 검증하고, ActivityPub ingress는
+`Announce`와 Remote actor를 검증한다. 두 진입점은 검증된 `actorProfileId`와 `sourcePostId`를 같은 core
+action에 전달하며, core는 Repost 구조, Source 정책, derived visibility와 멱등 저장을 공유한다.
+
+이번 slice가 한 진입점만 구현한다는 사실은 공통 action을 그 진입점 전용으로 만들어도 된다는 뜻이 아니다.
+반대로 실제 공유 책임이 아직 확인되지 않았다면 미래 caller를 가정한 evaluator, callback, generic port나
+대체 implementation을 선제 추가하지 않는다.
+
+## Public contract 규칙
+
+- core service input에는 DB identity와 domain input을 사용한다. GraphQL global ID, HTTP request/session,
+  ActivityPub Activity object를 그대로 전달하지 않는다.
+- caller별 인증 결과를 boolean이나 강제 allow/deny callback으로 전달하지 않는다. 진입점은 자기 책임을
+  완료한 뒤 검증된 identity를 전달한다.
+- 여러 DB 작업이 원자적이어야 하면 service가 transaction 경계를 소유한다.
+- 기존 caller transaction과 조합해야 하는 concrete 요구가 있으면 optional transaction을 받아 savepoint로
+  합류할 수 있다.
+- 공통 domain 오류는 core가 반환하고, GraphQL error extension이나 ActivityPub 응답 같은 외부 표현은
+  진입점이 mapping한다.
+- action이 의도적으로 Local-only이거나 특정 protocol에 종속된다면 upstream contract에 그 이유와 실제
+  caller를 명시한다.
+
+## 테스트 책임
+
+- 진입점 integration test는 Account/session/membership, Locality, ActivityPub signature와 actor/object처럼
+  caller별 인증·protocol 조건을 검증한다.
+- core service test는 검증된 actor 입력에서 공통 domain policy, transaction rollback, persistence,
+  uniqueness와 idempotency를 검증한다.
+- core test를 위해 production에 없는 authorization callback이나 대체 implementation을 public contract에
+  추가하지 않는다.
+- 여러 production 진입점이 같은 action을 사용할 때는 각 진입점이 같은 core default wiring을 호출하는지
+  확인한다.
+
+## 계약 문서와의 관계
+
+`docs/domain`은 행동 주체, 권한, 조건과 결과 같은 제품·도메인 계약을 정의한다. Linear issue는 전달 범위와
+검증 책임을 정하고, OpenSpec은 이를 구현 slice로 번역한다. Local GraphQL 행동에 필요한 조건이 적혀 있다는
+이유만으로 OpenSpec이 그 조건을 공통 core action의 caller 제한으로 옮겨서는 안 된다.
+
+OpenSpec에서 core 책임을 정할 때는 다음을 확인한다.
+
+1. 이 조건이 모든 현재·예정 production caller에 공통인 domain invariant인가?
+2. 아니면 특정 transport, session 또는 protocol이 actor를 신뢰하기 위한 증거인가?
+3. core public input이 caller-specific identity나 protocol object를 요구하게 되지는 않는가?
+4. 후속 caller가 같은 action을 사용하려면 가짜 Account를 만들거나 검증을 우회해야 하지는 않는가?
+
+두 번째 또는 네 번째에 해당하면 해당 검증은 진입점이 소유하고, core에는 검증된 actor identity와 business
+input만 전달한다.

--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -1,116 +1,65 @@
 # Core 서비스 경계
 
-## 존재 이유
+## 목적과 의존 방향
 
-`packages/core`는 특정 transport나 protocol의 요청을 처리하기 위한 계층이 아니다. GraphQL API, Web BFF,
-ActivityPub handler와 worker처럼 서로 다른 진입점이 같은 Kosmo business use case를 실행할 때, 도메인
-불변식과 transaction 동작이 진입점마다 달라지지 않도록 공유하는 server business logic 경계다.
+`packages/core/services`는 GraphQL API, Web BFF, ActivityPub handler와 worker가 공유하는 application
+action 경계다. 진입점이 달라도 같은 도메인 정책, transaction, persistence와 멱등성 결과를 보장한다.
 
-이 경계의 목적은 코드를 단순히 재사용하는 것이 아니라 다음을 한곳에서 보장하는 것이다.
-
-- 같은 행동이 어느 진입점에서 호출돼도 동일한 도메인 결과를 만든다.
-- 여러 DB 변경이 하나의 transaction으로 commit되거나 rollback된다.
-- uniqueness, idempotency와 concurrency 결과가 caller마다 달라지지 않는다.
-- transport, session 또는 federation protocol이 바뀌어도 domain action의 public contract는 유지된다.
-
-## 책임 구분
-
-| 계층                                                            | 소유하는 책임                                                                                                                                          | 소유하지 않는 책임                                                                         |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| GraphQL resolver, HTTP route, ActivityPub handler, worker entry | transport input 해석, 인증된 caller와 actor 확인, protocol별 권한 증거 검증, 외부 ID 변환, 응답·오류 mapping                                           | 공통 domain transaction을 직접 복제하는 일                                                 |
-| `packages/core/services`                                        | 검증된 actor identity와 business input을 받는 application action, 공통 domain policy, transaction, persistence orchestration, uniqueness와 idempotency | GraphQL context, HTTP session, OIDC exchange, ActivityPub signature나 Activity object 해석 |
-| `packages/core/db`                                              | DB client, schema, migration 지원과 DB 전용 utility                                                                                                    | application use case와 transport별 authorization                                           |
-
-진입점은 core service를 호출하기 전에 자기 protocol에서만 의미가 있는 사실을 검증한다.
-
-- Local GraphQL mutation은 Active Account, selected Profile membership과 Local actor context를 검증한다.
-- ActivityPub ingress는 서명, remote actor, Activity actor/object/recipient와 federation 수신 정책을 검증한다.
-- Worker는 job provenance와 실행 권한을 검증한다.
-
-core service는 이렇게 검증된 actor와 business input을 받아 모든 caller가 공유하는 Profile/Post lifecycle,
-관계 구조, visibility·eligibility, 저장과 멱등성 규칙을 적용한다.
-
-이 구분은 core가 authorization을 하지 않는다는 뜻이 아니다. Account session, ActivityPub signature처럼
-actor identity를 신뢰하기 위한 caller별 증거는 진입점이 검증하고, Post.Author, 관계 Owner, Source
-visibility처럼 검증된 actor와 domain object 사이의 공통 권한은 core가 검증한다.
-
-## Actor와 Account
-
-기본 소셜 행동 주체는 `Profile`이다. `Account`는 Local 요청에서 Profile을 선택하고 그 Profile의
-Owner/Member임을 증명하는 인증·권한 사실이지, 모든 소셜 action의 보편적인 actor가 아니다. Remote
-ActivityPub Profile에는 Kosmo Account membership이 없다.
-
-따라서 public core action에 `accountId`를 추가해도 되는 것은 Account 자체가 domain participant이거나,
-transaction commit 시점의 Account 권한을 다시 확인하는 것이 그 action의 명시된 불변식일 때뿐이다. 현재
-GraphQL caller의 session 검증을 core에서 반복하기 위한 목적으로 `accountId`를 요구하지 않는다.
-
-`InstanceKind.LOCAL`도 같은 원칙을 따른다. 현재 caller가 Local GraphQL이라는 이유만으로 공통 action이
-Local Profile만 허용하면, 검증된 Remote Profile이 같은 domain action을 수행해야 할 때 공통 경계를 재사용할
-수 없다. Locality가 action 자체의 의미인 경우에만 core contract에 포함하고, 그렇지 않으면 각 진입점이
-자기 actor origin을 검증한다. Profile이나 Instance의 공통 lifecycle·safety 정책은 caller 종류와 무관하게
-적용되는 범위에서 core가 계속 검증할 수 있다.
-
-## 공통 action 흐름
-
-같은 domain action에 Local과 ActivityPub 진입점이 있다면 다음 형태를 사용한다.
+의존 방향은 항상 진입점에서 core로 향한다.
 
 ```text
-Local GraphQL
-  -> Account/session/selected Profile/Locality 검증
-  -> verified actor Profile + business input
-                                      \
-                                       -> core service
-                                      /   -> 공통 domain policy
-ActivityPub                          /    -> transaction/persistence
-  -> signature/actor/object 검증    /     -> uniqueness/idempotency
-  -> verified actor Profile + input
+GraphQL / BFF / ActivityPub / worker
+  -> packages/core/services
+    -> packages/core/db
 ```
 
-예를 들어 Repost 생성의 Local mutation은 Account와 membership을 검증하고, ActivityPub ingress는
-`Announce`와 Remote actor를 검증한다. 두 진입점은 검증된 `actorProfileId`와 `sourcePostId`를 같은 core
-action에 전달하며, core는 Repost 구조, Source 정책, derived visibility와 멱등 저장을 공유한다.
+core는 GraphQL context·payload·Global ID, HTTP session, ActivityPub object처럼 특정 진입점에서만 의미가
+있는 타입이나 표현을 알지 않는다.
 
-이번 slice가 한 진입점만 구현한다는 사실은 공통 action을 그 진입점 전용으로 만들어도 된다는 뜻이 아니다.
-반대로 실제 공유 책임이 아직 확인되지 않았다면 미래 caller를 가정한 evaluator, callback, generic port나
-대체 implementation을 선제 추가하지 않는다.
+## 책임
 
-## Public contract 규칙
+| 계층                                                            | 책임                                                                                           |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| GraphQL resolver, HTTP route, ActivityPub handler, worker entry | transport 입력 해석, caller·actor 인증, protocol별 권한 증거 검증, 외부 ID와 응답·오류 mapping |
+| `packages/core/services`                                        | 검증된 actor와 business input에 대한 공통 domain policy, transaction, persistence와 멱등성     |
+| `packages/core/db`                                              | DB client, schema, migration 지원과 DB 전용 utility                                            |
 
-- core service input에는 DB identity와 domain input을 사용한다. GraphQL global ID, HTTP request/session,
-  ActivityPub Activity object를 그대로 전달하지 않는다.
-- caller별 인증 결과를 boolean이나 강제 allow/deny callback으로 전달하지 않는다. 진입점은 자기 책임을
-  완료한 뒤 검증된 identity를 전달한다.
-- 여러 DB 작업이 원자적이어야 하면 service가 transaction 경계를 소유한다.
-- 기존 caller transaction과 조합해야 하는 concrete 요구가 있으면 optional transaction을 받아 savepoint로
-  합류할 수 있다.
-- 공통 domain 오류는 core가 반환하고, GraphQL error extension이나 ActivityPub 응답 같은 외부 표현은
-  진입점이 mapping한다.
-- action이 의도적으로 Local-only이거나 특정 protocol에 종속된다면 upstream contract에 그 이유와 실제
-  caller를 명시한다.
+Account session이나 ActivityPub signature처럼 actor identity를 신뢰하기 위한 증거는 진입점이 검증한다.
+Post.Author, Source visibility와 lifecycle처럼 검증된 actor와 domain object 사이의 공통 권한은 core가
+검증한다.
 
-## 테스트 책임
+## Actor와 caller별 조건
 
-- 진입점 integration test는 Account/session/membership, Locality, ActivityPub signature와 actor/object처럼
-  caller별 인증·protocol 조건을 검증한다.
-- core service test는 검증된 actor 입력에서 공통 domain policy, transaction rollback, persistence,
-  uniqueness와 idempotency를 검증한다.
-- core test를 위해 production에 없는 authorization callback이나 대체 implementation을 public contract에
-  추가하지 않는다.
-- 여러 production 진입점이 같은 action을 사용할 때는 각 진입점이 같은 core default wiring을 호출하는지
-  확인한다.
+기본 소셜 actor는 `Profile`이다. `Account`와 `InstanceKind.LOCAL`은 Local GraphQL 요청의 인증
+조건이지 모든 소셜 action의 공통 조건이 아니다. Account 자체가 domain participant이거나 Locality가
+action의 의미일 때만 core contract에 포함한다.
 
-## 계약 문서와의 관계
+예를 들어 Local Repost mutation은 session과 selected Profile membership을 검증하고, ActivityPub
+ingress는 signature와 Remote actor를 검증한다. 두 진입점은 검증된 `actorProfileId`와
+`sourcePostId`를 같은 core action에 전달하고, core는 Source 정책, visibility와 멱등 저장을 처리한다.
 
-`docs/domain`은 행동 주체, 권한, 조건과 결과 같은 제품·도메인 계약을 정의한다. Linear issue는 전달 범위와
-검증 책임을 정하고, OpenSpec은 이를 구현 slice로 번역한다. Local GraphQL 행동에 필요한 조건이 적혀 있다는
-이유만으로 OpenSpec이 그 조건을 공통 core action의 caller 제한으로 옮겨서는 안 된다.
+## Public contract
 
-OpenSpec에서 core 책임을 정할 때는 다음을 확인한다.
+- input은 검증된 DB identity와 domain input으로 구성한다. caller별 인증 결과를 boolean, callback 또는
+  protocol object로 전달하지 않는다.
+- 반환값은 action의 transport-neutral domain 결과다. GraphQL payload, object ref, connection이나
+  resolver 편의에만 필요한 조회 결과를 반환하도록 core contract를 바꾸지 않는다.
+- GraphQL은 core 결과를 schema 타입과 payload로 mapping하고, presentation에만 필요한 값은
+  resolver·loader에서 조합한다. 어떤 값이 모든 caller가 알아야 하는 domain outcome일 때만 core
+  반환값에 포함한다.
+- 여러 DB 변경이 원자적이어야 하면 core action이 transaction 경계를 소유한다. 실제 caller
+  transaction과 합류해야 할 때만 optional transaction을 받는다.
+- core는 공통 domain error를 반환하고 각 진입점이 외부 오류 표현으로 mapping한다.
+- 실제 caller 없이 evaluator, callback, generic port나 대체 implementation을 미리 추가하지 않는다.
 
-1. 이 조건이 모든 현재·예정 production caller에 공통인 domain invariant인가?
-2. 아니면 특정 transport, session 또는 protocol이 actor를 신뢰하기 위한 증거인가?
-3. core public input이 caller-specific identity나 protocol object를 요구하게 되지는 않는가?
-4. 후속 caller가 같은 action을 사용하려면 가짜 Account를 만들거나 검증을 우회해야 하지는 않는가?
+## 테스트와 계약
 
-두 번째 또는 네 번째에 해당하면 해당 검증은 진입점이 소유하고, core에는 검증된 actor identity와 business
-input만 전달한다.
+- 진입점 integration test는 session, membership, Locality, signature와 actor/object처럼 caller별 조건을
+  검증한다.
+- core test는 공통 domain policy, transaction rollback, persistence, uniqueness와 idempotency를
+  검증한다.
+- 테스트만을 위해 production에 없는 우회 가능한 public contract를 추가하지 않는다.
+
+`docs/domain`은 도메인 계약, Linear는 전달 범위, OpenSpec은 구현 slice를 정의한다. 조건을 core로 옮기기
+전에 모든 production caller에 공통인 domain invariant인지, 특정 caller의 인증 조건인지, core가
+transport-specific 입력이나 반환값에 의존하게 되는지를 확인한다.

--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -17,6 +17,10 @@ Read query / loader -------------------------------------> packages/core/db
 core는 GraphQL context·payload·Global ID, HTTP session, ActivityPub object처럼 특정 진입점에서만 의미가
 있는 타입이나 표현을 알지 않는다.
 
+Protocol별 post-commit side effect는 진입점이나 delivery 계층이 core의 commit 결과를 받아 처리한다. 현재
+`followProfile`과 `unfollowProfile`이 commit 뒤 `@kosmo/fedify`를 직접 호출하는 경로는 기존 예외이며,
+새 action에서 반복할 기준이 아니다.
+
 ## 책임
 
 | 계층                                                            | 책임                                                                                       |
@@ -35,9 +39,9 @@ Post.Author, Source visibility와 lifecycle처럼 검증된 actor와 domain obje
 조건이지 모든 소셜 action의 공통 조건이 아니다. Account 자체가 domain participant이거나 Locality가
 action의 의미일 때만 core contract에 포함한다.
 
-예를 들어 Local Repost mutation은 session과 selected Profile membership을 검증하고, ActivityPub
-ingress는 signature와 Remote actor를 검증한다. 두 진입점은 검증된 `actorProfileId`와
-`sourcePostId`를 같은 core action에 전달하고, core는 Source 정책, visibility와 멱등 저장을 처리한다.
+현재 Repost caller인 Local mutation은 session과 selected Profile membership을 검증한 뒤 core action에
+`actorProfileId`와 `sourcePostId`를 전달한다. 향후 ActivityPub Repost ingress가 생기면 signature와
+Remote actor 검증 뒤 같은 action을 재사용할 수 있지만, ingress와 delivery는 현재 Repost 범위가 아니다.
 
 ## Public contract
 

--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -39,7 +39,19 @@
 
 ## Core Services
 
-- API와 BFF가 공유하는 server business use case는 `packages/core/services`가 소유한다. GraphQL resolver와 HTTP route는 transport validation과 actor context를 처리한 뒤 service를 호출한다.
+- GraphQL API, Web BFF, ActivityPub handler와 worker가 공유하는 server business use case는
+  `packages/core/services`가 소유한다. GraphQL resolver, HTTP route와 ActivityPub handler는 각
+  transport·protocol의 인증과 actor context를 처리한 뒤 service를 호출한다. 상세 책임은
+  `docs/architecture/core-services.md`를 따른다.
+- Local GraphQL의 Account/session/selected Profile membership과 Locality, ActivityPub의
+  signature/actor/object/recipient 검증처럼 caller마다 다른 권한 증거는 진입점이 소유한다. core service에는
+  검증된 actor identity와 business input만 전달한다.
+- 기본 소셜 행동 주체는 Profile이다. Account 자체가 domain participant이거나 commit 시점의 Account 권한
+  재검증이 명시된 불변식인 경우가 아니라면, GraphQL context 검증을 반복하기 위해 core public action에
+  `accountId`를 추가하지 않는다. 현재 caller가 Local이라는 이유만으로 공통 action에
+  `InstanceKind.LOCAL`을 강제하지 않는다.
+- core service는 caller들이 공유하는 Profile/Post lifecycle, 관계 구조, visibility·eligibility, domain
+  error, transaction, persistence, uniqueness와 idempotency를 소유한다.
 - service는 production database implementation이 하나인 현재 구조에서 `getDatabaseConnection(tx)`로 optional transaction 또는 shared `db`를 선택한다. 여러 DB 작업을 원자적으로 수행하는 service는 선택한 connection에서 transaction 경계를 열어, caller transaction이 있으면 savepoint로 합류하고 없으면 shared `db`에서 transaction을 시작한다. test seam이나 복수 implementation 요구 없이 generic `Database`를 전달하는 추상화는 만들지 않는다.
 - 명시적 비관적 DB 락은 동시성 위반이 금전 거래처럼 심각하고 되돌리기 어려운 피해를 만드는 use case에만 사용한다. 팔로우 요청처럼 드문 race의 영향이 작고 복구 가능한 social interaction은 락으로 완전 직렬화하지 않으며, 상세 판단과 리뷰 근거는 `memory/database-design.md`의 Runtime Locking Policy를 따른다.
 - `packages/core/db`는 DB client, schema, relation과 DB 전용 utility를 소유하고 account/session 생성 같은 application transaction은 소유하지 않는다.

--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -39,9 +39,10 @@
 
 ## Core Services
 
-- GraphQL API, Web BFF, ActivityPub handler와 worker가 공유하는 server business use case는
-  `packages/core/services`가 소유한다. GraphQL resolver, HTTP route와 ActivityPub handler는 각
-  transport·protocol의 인증과 actor context를 처리한 뒤 service를 호출한다. 상세 책임은
+- 의존 방향은 GraphQL API, Web BFF, ActivityPub handler, worker에서 `packages/core/services`로 향하고,
+  core는 `packages/core/db`에 의존한다. core가 특정 진입점의 타입이나 표현에 의존하게 하지 않는다.
+- 진입점은 transport·protocol의 인증과 actor context를 처리하고, core는 검증된 actor와 business input에
+  대한 공통 domain policy, transaction, persistence와 멱등성을 처리한다. 상세 책임은
   `docs/architecture/core-services.md`를 따른다.
 - Local GraphQL의 Account/session/selected Profile membership과 Locality, ActivityPub의
   signature/actor/object/recipient 검증처럼 caller마다 다른 권한 증거는 진입점이 소유한다. core service에는
@@ -52,6 +53,9 @@
   `InstanceKind.LOCAL`을 강제하지 않는다.
 - core service는 caller들이 공유하는 Profile/Post lifecycle, 관계 구조, visibility·eligibility, domain
   error, transaction, persistence, uniqueness와 idempotency를 소유한다.
+- core는 transport-neutral domain 결과만 반환한다. GraphQL payload, object ref, connection이나
+  resolver 편의에만 필요한 조회 결과는 resolver·loader에서 조합하고, 모든 caller가 알아야 하는 domain
+  outcome일 때만 core 반환값에 포함한다.
 - service는 production database implementation이 하나인 현재 구조에서 `getDatabaseConnection(tx)`로 optional transaction 또는 shared `db`를 선택한다. 여러 DB 작업을 원자적으로 수행하는 service는 선택한 connection에서 transaction 경계를 열어, caller transaction이 있으면 savepoint로 합류하고 없으면 shared `db`에서 transaction을 시작한다. test seam이나 복수 implementation 요구 없이 generic `Database`를 전달하는 추상화는 만들지 않는다.
 - 명시적 비관적 DB 락은 동시성 위반이 금전 거래처럼 심각하고 되돌리기 어려운 피해를 만드는 use case에만 사용한다. 팔로우 요청처럼 드문 race의 영향이 작고 복구 가능한 social interaction은 락으로 완전 직렬화하지 않으며, 상세 판단과 리뷰 근거는 `memory/database-design.md`의 Runtime Locking Policy를 따른다.
 - `packages/core/db`는 DB client, schema, relation과 DB 전용 utility를 소유하고 account/session 생성 같은 application transaction은 소유하지 않는다.

--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -39,8 +39,9 @@
 
 ## Core Services
 
-- 의존 방향은 GraphQL API, Web BFF, ActivityPub handler, worker에서 `packages/core/services`로 향하고,
-  core는 `packages/core/db`에 의존한다. core가 특정 진입점의 타입이나 표현에 의존하게 하지 않는다.
+- state-changing 진입점은 `packages/core/services`에, core service는 `packages/core/db`에 의존한다.
+  read-only query와 loader는 service를 거치지 않고 query 계층에서 DB와 공유 조회 policy를 사용한다.
+  core가 특정 진입점의 타입이나 표현에 의존하게 하지 않는다.
 - 진입점은 transport·protocol의 인증과 actor context를 처리하고, core는 검증된 actor와 business input에
   대한 공통 domain policy, transaction, persistence와 멱등성을 처리한다. 상세 책임은
   `docs/architecture/core-services.md`를 따른다.

--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -57,6 +57,8 @@
 - core는 transport-neutral domain 결과만 반환한다. GraphQL payload, object ref, connection이나
   resolver 편의에만 필요한 조회 결과는 resolver·loader에서 조합하고, 모든 caller가 알아야 하는 domain
   outcome일 때만 core 반환값에 포함한다.
+- protocol별 post-commit side effect는 진입점이나 delivery 계층이 처리한다. 현재
+  `followProfile`/`unfollowProfile`의 core -> Fedify 호출은 기존 예외이며 새 action에서 반복하지 않는다.
 - service는 production database implementation이 하나인 현재 구조에서 `getDatabaseConnection(tx)`로 optional transaction 또는 shared `db`를 선택한다. 여러 DB 작업을 원자적으로 수행하는 service는 선택한 connection에서 transaction 경계를 열어, caller transaction이 있으면 savepoint로 합류하고 없으면 shared `db`에서 transaction을 시작한다. test seam이나 복수 implementation 요구 없이 generic `Database`를 전달하는 추상화는 만들지 않는다.
 - 명시적 비관적 DB 락은 동시성 위반이 금전 거래처럼 심각하고 되돌리기 어려운 피해를 만드는 use case에만 사용한다. 팔로우 요청처럼 드문 race의 영향이 작고 복구 가능한 social interaction은 락으로 완전 직렬화하지 않으며, 상세 판단과 리뷰 근거는 `memory/database-design.md`의 Runtime Locking Policy를 따른다.
 - `packages/core/db`는 DB client, schema, relation과 DB 전용 utility를 소유하고 account/session 생성 같은 application transaction은 소유하지 않는다.


### PR DESCRIPTION
## 변경

- state-changing 진입점은 `core service → DB`, read-only query·loader는 service를 거치지 않고 DB와 공유 조회 policy를 사용하도록 경계를 문서화했습니다.
- caller별 인증과 core의 공통 domain policy·transaction·persistence 책임을 구분했습니다.
- core는 transport-neutral 결과만 반환하고, GraphQL payload·object ref·connection 등 presentation 값은 resolver·loader가 조합하도록 명시했습니다.
- README와 `memory/coding-style.md`를 같은 원칙으로 맞췄습니다.

## 배경

PR #320 리뷰에서 GraphQL caller의 Account·Locality 조건과 GraphQL에 필요한 반환값이 공통 core contract로 역류할 수 있음을 확인했습니다. 진입점이 core에 의존하고 core는 특정 transport를 알지 않는다는 반복 적용 원칙을 남기는 문서 PR입니다.

관련 리뷰: https://github.com/byulmaru/kosmo/pull/320#discussion_r3635805800

런타임 동작과 DB/API 계약 변경은 없습니다.

## 검증

- `prettier --check README.md docs/architecture/core-services.md memory/coding-style.md`
- `git diff --check`