### PR TITLE
Post에서 Repost 수와 현재 Profile의 Active Repost를 조회한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -218,6 +218,7 @@ type Post implements Node {
   replyAncestors: [Post!]!
   replyDescendants(after: String, before: String, first: Int, last: Int): PostConnection!
   replyParent: Post
+  repostCount: Int!
   repostSource: Post
   state: PostState!
   viewerBookmark: Bookmark

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -222,6 +222,7 @@ type Post implements Node {
   repostSource: Post
   state: PostState!
   viewerBookmark: Bookmark
+  viewerRepost: Post
   visibility: PostVisibility!
 }
 

--- a/apps/api/src/graphql/resolvers/post/field/post.ts
+++ b/apps/api/src/graphql/resolvers/post/field/post.ts
@@ -1,5 +1,6 @@
 import { builder } from '@/graphql/builder';
 import { Profile } from '@/graphql/resolvers/profile';
+import { repostCountLoader } from '../loader/repost';
 import { Post, PostContent } from '../ref';
 
 builder.objectFields(Post, (t) => ({
@@ -21,5 +22,8 @@ builder.objectFields(Post, (t) => ({
     type: Post,
     nullable: true,
     resolve: (post) => post.repostSourceId,
+  }),
+  repostCount: t.int({
+    resolve: async (post, _, ctx) => (await repostCountLoader(ctx).load(post.id))?.count ?? 0,
   }),
 }));

--- a/apps/api/src/graphql/resolvers/post/field/post.ts
+++ b/apps/api/src/graphql/resolvers/post/field/post.ts
@@ -1,6 +1,6 @@
 import { builder } from '@/graphql/builder';
 import { Profile } from '@/graphql/resolvers/profile';
-import { repostCountLoader } from '../loader/repost';
+import { repostCountLoader, viewerRepostLoader } from '../loader/repost';
 import { Post, PostContent } from '../ref';
 
 builder.objectFields(Post, (t) => ({
@@ -25,5 +25,10 @@ builder.objectFields(Post, (t) => ({
   }),
   repostCount: t.int({
     resolve: async (post, _, ctx) => (await repostCountLoader(ctx).load(post.id))?.count ?? 0,
+  }),
+  viewerRepost: t.field({
+    type: Post,
+    nullable: true,
+    resolve: (post, _, ctx) => viewerRepostLoader(ctx).load(post.id),
   }),
 }));

--- a/apps/api/src/graphql/resolvers/post/loader/repost.ts
+++ b/apps/api/src/graphql/resolvers/post/loader/repost.ts
@@ -1,6 +1,6 @@
 import { db, Instances, Posts, Profiles } from '@kosmo/core/db';
 import { PostState } from '@kosmo/core/enums';
-import { and, count, eq, inArray, isNull } from 'drizzle-orm';
+import { and, count, eq, getColumns, inArray, isNull } from 'drizzle-orm';
 import { visibleProfileWhere } from '@/profile/visibility';
 import type { UserContext } from '@/context';
 
@@ -8,6 +8,8 @@ type RepostCountRow = {
   repostSourceId: string | null;
   count: number;
 };
+
+export type PostRow = typeof Posts.$inferSelect;
 
 export const repostCountLoader = (ctx: UserContext) =>
   ctx.loader<string, RepostCountRow, string, true>({
@@ -33,4 +35,29 @@ export const repostCountLoader = (ctx: UserContext) =>
         )
         .groupBy(Posts.repostSourceId),
     key: (row) => row?.repostSourceId ?? null,
+  });
+
+export const viewerRepostLoader = (ctx: UserContext) =>
+  ctx.loader<string, PostRow, string, true>({
+    name: 'post.viewerRepost',
+    nullable: true,
+    load: async (sourceIds) => {
+      if (!ctx.session?.profileId) {
+        return [];
+      }
+
+      return db
+        .select(getColumns(Posts))
+        .from(Posts)
+        .where(
+          and(
+            eq(Posts.profileId, ctx.session.profileId),
+            inArray(Posts.repostSourceId, sourceIds),
+            eq(Posts.state, PostState.ACTIVE),
+            isNull(Posts.currentContentId),
+            isNull(Posts.replyParentId),
+          ),
+        );
+    },
+    key: (post) => post?.repostSourceId ?? null,
   });

--- a/apps/api/src/graphql/resolvers/post/loader/repost.ts
+++ b/apps/api/src/graphql/resolvers/post/loader/repost.ts
@@ -1,0 +1,36 @@
+import { db, Instances, Posts, Profiles } from '@kosmo/core/db';
+import { PostState } from '@kosmo/core/enums';
+import { and, count, eq, inArray, isNull } from 'drizzle-orm';
+import { visibleProfileWhere } from '@/profile/visibility';
+import type { UserContext } from '@/context';
+
+type RepostCountRow = {
+  repostSourceId: string | null;
+  count: number;
+};
+
+export const repostCountLoader = (ctx: UserContext) =>
+  ctx.loader<string, RepostCountRow, string, true>({
+    name: 'post.repostCount',
+    nullable: true,
+    load: async (sourceIds) =>
+      db
+        .select({
+          repostSourceId: Posts.repostSourceId,
+          count: count(),
+        })
+        .from(Posts)
+        .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+        .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+        .where(
+          and(
+            inArray(Posts.repostSourceId, sourceIds),
+            eq(Posts.state, PostState.ACTIVE),
+            isNull(Posts.currentContentId),
+            isNull(Posts.replyParentId),
+            visibleProfileWhere({ profile: Profiles, instance: Instances }),
+          ),
+        )
+        .groupBy(Posts.repostSourceId),
+    key: (row) => row?.repostSourceId ?? null,
+  });

--- a/apps/api/src/graphql/schema.test.ts
+++ b/apps/api/src/graphql/schema.test.ts
@@ -12,6 +12,13 @@ test('Post는 nullable Repost Source를 제공한다', () => {
   assert.equal(String(post.getFields().repostSource?.type), 'Post');
 });
 
+test('exposes viewer-independent Repost count on Post', () => {
+  const post = schema.getType('Post');
+
+  assert.ok(isObjectType(post));
+  assert.equal(String(post.getFields().repostCount?.type), 'Int!');
+});
+
 test('exposes the versioned PostContent document and Plain Text composer contract', () => {
   const postContent = schema.getType('PostContent');
   const createPostInput = schema.getType('CreatePostInput');

--- a/apps/api/src/graphql/schema.test.ts
+++ b/apps/api/src/graphql/schema.test.ts
@@ -12,11 +12,12 @@ test('Post는 nullable Repost Source를 제공한다', () => {
   assert.equal(String(post.getFields().repostSource?.type), 'Post');
 });
 
-test('exposes viewer-independent Repost count on Post', () => {
+test('exposes viewer-independent Repost count and selected Profile Repost on Post', () => {
   const post = schema.getType('Post');
 
   assert.ok(isObjectType(post));
   assert.equal(String(post.getFields().repostCount?.type), 'Int!');
+  assert.equal(String(post.getFields().viewerRepost?.type), 'Post');
 });
 
 test('exposes the versioned PostContent document and Plain Text composer contract', () => {

--- a/apps/api/tests/integration/graphql/post-repost-count.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost-count.test.ts
@@ -217,6 +217,52 @@ describe('Post Repost 상태 GraphQL 경계', () => {
     assert.equal(deletedProfileAResult.data?.nodes[0]?.viewerRepost, null);
     assert.equal(deletedProfileAResult.data?.nodes[0]?.repostCount, 1);
   });
+
+  test('Repost가 없는 조회 가능한 Source Post의 repostCount를 0으로 반환한다', async () => {
+    const sourceAuthor = await createProfile('zero-count-source-author');
+    const source = await createContentPost(sourceAuthor.id, 'zero-count-source');
+
+    const result = await requestRepostState([source.id]);
+
+    assertNoGraphQLErrors(result);
+    assert.deepEqual(result.data?.nodes, [
+      { id: encodeGlobalId('Post', source.id), repostCount: 0, viewerRepost: null },
+    ]);
+  });
+
+  test('같은 Session에서 selected Profile 전환 후 viewerRepost identity를 갱신한다', async () => {
+    const sourceAuthor = await createProfile('profile-transition-source-author');
+    const source = await createContentPost(sourceAuthor.id, 'profile-transition-source');
+    const profileA = await createProfile('profile-transition-a');
+    const profileB = await createProfile('profile-transition-b');
+    const viewer = await createAuthenticatedSession({ activeProfileId: profileA.id });
+    await db.insert(AccountProfiles).values({
+      accountId: viewer.accountId,
+      profileId: profileB.id,
+      role: AccountProfileRole.OWNER,
+    });
+    const repostA = await createRepost(profileA.id, source.id);
+    const repostB = await createRepost(profileB.id, source.id);
+
+    const beforeTransition = await requestRepostState([source.id], viewer.token);
+    assertNoGraphQLErrors(beforeTransition);
+    assert.equal(
+      beforeTransition.data?.nodes[0]?.viewerRepost?.id,
+      encodeGlobalId('Post', repostA.id),
+    );
+
+    await db
+      .update(Sessions)
+      .set({ activeProfileId: profileB.id })
+      .where(eq(Sessions.id, viewer.sessionId));
+
+    const afterTransition = await requestRepostState([source.id], viewer.token);
+    assertNoGraphQLErrors(afterTransition);
+    assert.equal(
+      afterTransition.data?.nodes[0]?.viewerRepost?.id,
+      encodeGlobalId('Post', repostB.id),
+    );
+  });
 });
 
 const createProfile = (
@@ -299,7 +345,7 @@ const createAuthenticatedSession = async ({
   activeProfileId,
 }: {
   activeProfileId: string | null;
-}): Promise<{ accountId: string; token: string }> => {
+}): Promise<{ accountId: string; sessionId: string; token: string }> => {
   const suffix = crypto.randomUUID();
   const account = await db
     .insert(Accounts)
@@ -314,13 +360,17 @@ const createAuthenticatedSession = async ({
     });
   }
   const token = `token-${suffix}`;
-  await db.insert(Sessions).values({
-    accountId: account.id,
-    activeProfileId,
-    state: SessionState.ACTIVE,
-    token,
-  });
-  return { accountId: account.id, token };
+  const session = await db
+    .insert(Sessions)
+    .values({
+      accountId: account.id,
+      activeProfileId,
+      state: SessionState.ACTIVE,
+      token,
+    })
+    .returning()
+    .then(firstOrThrow);
+  return { accountId: account.id, sessionId: session.id, token };
 };
 
 const requestRepostState = (sourceIds: string[], token?: string) =>

--- a/apps/api/tests/integration/graphql/post-repost-count.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost-count.test.ts
@@ -5,6 +5,8 @@ import { after, before, beforeEach, describe, test } from 'node:test';
 import {
   AccountProfileRole,
   AccountState,
+  InstanceKind,
+  InstanceState,
   PostState,
   PostVisibility,
   ProfileFollowPolicy,
@@ -17,7 +19,7 @@ import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { encodeGlobalId } from '../../../src/graphql/global-id';
 import type * as CoreDb from '@kosmo/core/db';
-import type { Env } from '../../../src/context';
+import type { deriveContext as DeriveContext, Env } from '../../../src/context';
 
 const publicOrigin = 'http://127.0.0.1:4173';
 const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
@@ -26,19 +28,41 @@ let AccountProfiles: typeof CoreDb.AccountProfiles;
 let Accounts: typeof CoreDb.Accounts;
 let db: typeof CoreDb.db;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
+let Instances: typeof CoreDb.Instances;
 let pg: typeof CoreDb.pg;
 let PostContents: typeof CoreDb.PostContents;
 let Posts: typeof CoreDb.Posts;
 let Profiles: typeof CoreDb.Profiles;
 let Sessions: typeof CoreDb.Sessions;
 let app: Hono<Env>;
+let deriveContext: typeof DeriveContext;
 let localInstanceId: string;
 
 type ProfileRow = typeof CoreDb.Profiles.$inferSelect;
 type PostRow = typeof CoreDb.Posts.$inferSelect;
+type LoaderBatchRecord = Map<string, number[]>;
 type GraphQLResult<TData> = {
   data?: TData;
   errors?: Array<{ message: string }>;
+};
+
+let loaderBatches: LoaderBatchRecord;
+
+const trackLoaderBatches = <Context extends Awaited<ReturnType<typeof deriveContext>>>(
+  context: Context,
+) => {
+  const originalLoader = context.loader;
+  context.loader = ((params: { name: string; load: (keys: unknown[]) => Promise<unknown[]> }) =>
+    originalLoader({
+      ...params,
+      load: async (keys: unknown[]) => {
+        const keyCounts = loaderBatches.get(params.name) ?? [];
+        keyCounts.push(keys.length);
+        loaderBatches.set(params.name, keyCounts);
+        return params.load(keys);
+      },
+    } as never)) as typeof context.loader;
+  return context;
 };
 
 describe('Post Repost 상태 GraphQL 경계', () => {
@@ -47,25 +71,36 @@ describe('Post Repost 상태 GraphQL 경계', () => {
     process.env.NODE_ENV = 'production';
     process.env.PUBLIC_ORIGIN = publicOrigin;
 
-    ({ AccountProfiles, Accounts, db, firstOrThrow, pg, PostContents, Posts, Profiles, Sessions } =
-      await import('@kosmo/core/db'));
+    ({
+      AccountProfiles,
+      Accounts,
+      db,
+      firstOrThrow,
+      Instances,
+      pg,
+      PostContents,
+      Posts,
+      Profiles,
+      Sessions,
+    } = await import('@kosmo/core/db'));
     const { seedDatabase } = await import('@kosmo/core/db/seed');
 
     await truncateDatabase();
     const { localInstance } = await seedDatabase({ publicOrigin });
     localInstanceId = localInstance.id;
 
-    const { deriveContext } = await import('../../../src/context');
+    ({ deriveContext } = await import('../../../src/context'));
     const { yoga } = await import('../../../src/graphql');
     app = new Hono<Env>();
     app.use('*', async (c, next) => {
-      c.set('context', await deriveContext(c));
+      c.set('context', trackLoaderBatches(await deriveContext(c)));
       return next();
     });
     app.route('/graphql', yoga);
   });
 
   beforeEach(async () => {
+    loaderBatches = new Map();
     await resetFixtures();
   });
 
@@ -103,11 +138,32 @@ describe('Post Repost 상태 GraphQL 경계', () => {
       (await createProfile('inactive-reposter', { state: ProfileState.DISABLED })).id,
       sourceA.id,
     );
+    const suspendedInstance = await createSuspendedInstance('suspended-reposter.example');
+    await createRepost(
+      (await createProfile('suspended-instance-reposter', { instanceId: suspendedInstance.id })).id,
+      sourceA.id,
+    );
     await createRepost((await createProfile('reply-reposter')).id, sourceA.id, {
       replyParentId: sourceA.id,
     });
     await createRepost((await createProfile('source-b-reposter')).id, sourceB.id);
     await createRepost((await createProfile('quote-reposter')).id, quote.id);
+
+    loaderBatches.clear();
+    const batchingResult = await requestRepostState([sourceA.id, sourceB.id], viewerA.token);
+    assertNoGraphQLErrors(batchingResult);
+    assert.deepEqual(loaderBatches.get('post.repostCount'), [2]);
+    assert.deepEqual(loaderBatches.get('post.viewerRepost'), [2]);
+    assert.deepEqual(batchingResult.data?.nodes, [
+      {
+        id: encodeGlobalId('Post', sourceA.id),
+        repostCount: 2,
+        viewerRepost: { id: encodeGlobalId('Post', repostA.id) },
+      },
+      { id: encodeGlobalId('Post', sourceB.id), repostCount: 1, viewerRepost: null },
+    ]);
+
+    loaderBatches.clear();
 
     const [
       anonymousResult,
@@ -165,7 +221,10 @@ describe('Post Repost 상태 GraphQL 경계', () => {
 
 const createProfile = (
   handle: string,
-  { state = ProfileState.ACTIVE }: { state?: ProfileState } = {},
+  {
+    instanceId = localInstanceId,
+    state = ProfileState.ACTIVE,
+  }: { instanceId?: string; state?: ProfileState } = {},
 ): Promise<ProfileRow> =>
   db
     .insert(Profiles)
@@ -173,10 +232,17 @@ const createProfile = (
       displayName: handle,
       followPolicy: ProfileFollowPolicy.OPEN,
       handle,
-      instanceId: localInstanceId,
+      instanceId,
       normalizedHandle: normalizeHandle(handle),
       state,
     })
+    .returning()
+    .then(firstOrThrow);
+
+const createSuspendedInstance = (domain: string) =>
+  db
+    .insert(Instances)
+    .values({ domain, kind: InstanceKind.ACTIVITYPUB, state: InstanceState.SUSPENDED })
     .returning()
     .then(firstOrThrow);
 

--- a/apps/api/tests/integration/graphql/post-repost-count.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost-count.test.ts
@@ -41,7 +41,7 @@ type GraphQLResult<TData> = {
   errors?: Array<{ message: string }>;
 };
 
-describe('Post repostCount GraphQL 경계', () => {
+describe('Post Repost 상태 GraphQL 경계', () => {
   before(async () => {
     process.env.DATABASE_URL = databaseUrl;
     process.env.NODE_ENV = 'production';
@@ -73,17 +73,22 @@ describe('Post repostCount GraphQL 경계', () => {
     await pg.end();
   });
 
-  test('모든 viewer에게 eligible direct Repost만 같은 수로 반환한다', async () => {
+  test('모든 viewer에게 eligible direct Repost 수와 현재 Profile의 Repost를 반환한다', async () => {
     const sourceAuthor = await createProfile('source-author');
     const sourceA = await createContentPost(sourceAuthor.id, 'source A');
     const sourceB = await createContentPost(sourceAuthor.id, 'source B');
     const viewerAProfile = await createProfile('viewer-a');
     const viewerBProfile = await createProfile('viewer-b');
+    const viewerWithoutRepostProfile = await createProfile('viewer-without-repost');
     const viewerA = await createAuthenticatedSession({ activeProfileId: viewerAProfile.id });
     const viewerB = await createAuthenticatedSession({ activeProfileId: viewerBProfile.id });
+    const viewerWithoutRepost = await createAuthenticatedSession({
+      activeProfileId: viewerWithoutRepostProfile.id,
+    });
+    const noSelectedProfile = await createAuthenticatedSession({ activeProfileId: null });
 
-    await createRepost((await createProfile('reposter-a')).id, sourceA.id);
-    await createRepost((await createProfile('reposter-b')).id, sourceA.id);
+    const repostA = await createRepost(viewerAProfile.id, sourceA.id);
+    const repostB = await createRepost(viewerBProfile.id, sourceA.id);
     const quote = await createRepost((await createProfile('quoter')).id, sourceA.id);
     const quoteContent = await db
       .insert(PostContents)
@@ -104,27 +109,57 @@ describe('Post repostCount GraphQL 경계', () => {
     await createRepost((await createProfile('source-b-reposter')).id, sourceB.id);
     await createRepost((await createProfile('quote-reposter')).id, quote.id);
 
-    const [anonymous, viewerAResult, viewerBResult] = await Promise.all([
-      requestRepostCounts([sourceA.id, sourceB.id]),
-      requestRepostCounts([sourceA.id, sourceB.id], viewerA.token),
-      requestRepostCounts([sourceA.id, sourceB.id], viewerB.token),
+    const [
+      anonymousResult,
+      profileAResult,
+      profileBResult,
+      profileWithoutRepostResult,
+      noSelectedProfileResult,
+    ] = await Promise.all([
+      requestRepostState([sourceA.id, sourceB.id]),
+      requestRepostState([sourceA.id, sourceB.id], viewerA.token),
+      requestRepostState([sourceA.id, sourceB.id], viewerB.token),
+      requestRepostState([sourceA.id, sourceB.id], viewerWithoutRepost.token),
+      requestRepostState([sourceA.id, sourceB.id], noSelectedProfile.token),
     ]);
 
-    assertNoGraphQLErrors(anonymous);
-    assertNoGraphQLErrors(viewerAResult);
-    assertNoGraphQLErrors(viewerBResult);
-    assert.deepEqual(anonymous.data?.nodes, [
-      { id: encodeGlobalId('Post', sourceA.id), repostCount: 2 },
-      { id: encodeGlobalId('Post', sourceB.id), repostCount: 1 },
+    assertNoGraphQLErrors(anonymousResult);
+    assertNoGraphQLErrors(profileAResult);
+    assertNoGraphQLErrors(profileBResult);
+    assertNoGraphQLErrors(profileWithoutRepostResult);
+    assertNoGraphQLErrors(noSelectedProfileResult);
+    assert.deepEqual(anonymousResult.data?.nodes, [
+      { id: encodeGlobalId('Post', sourceA.id), repostCount: 2, viewerRepost: null },
+      { id: encodeGlobalId('Post', sourceB.id), repostCount: 1, viewerRepost: null },
     ]);
-    assert.deepEqual(viewerAResult.data?.nodes, anonymous.data?.nodes);
-    assert.deepEqual(viewerBResult.data?.nodes, anonymous.data?.nodes);
+    assert.equal(
+      profileAResult.data?.nodes[0]?.viewerRepost?.id,
+      encodeGlobalId('Post', repostA.id),
+    );
+    assert.equal(
+      profileBResult.data?.nodes[0]?.viewerRepost?.id,
+      encodeGlobalId('Post', repostB.id),
+    );
+    assert.equal(profileWithoutRepostResult.data?.nodes[0]?.viewerRepost, null);
+    assert.equal(noSelectedProfileResult.data?.nodes[0]?.viewerRepost, null);
+    assert.equal(anonymousResult.data?.nodes[0]?.viewerRepost, null);
+    assert.equal(
+      profileAResult.data?.nodes[0]?.repostCount,
+      profileBResult.data?.nodes[0]?.repostCount,
+    );
 
-    const quoteCount = await requestRepostCounts([quote.id]);
-    assertNoGraphQLErrors(quoteCount);
-    assert.deepEqual(quoteCount.data?.nodes, [
-      { id: encodeGlobalId('Post', quote.id), repostCount: 1 },
+    const quoteState = await requestRepostState([quote.id]);
+    assertNoGraphQLErrors(quoteState);
+    assert.deepEqual(quoteState.data?.nodes, [
+      { id: encodeGlobalId('Post', quote.id), repostCount: 1, viewerRepost: null },
     ]);
+
+    await db.update(Posts).set({ state: PostState.DELETED }).where(eq(Posts.id, repostA.id));
+
+    const deletedProfileAResult = await requestRepostState([sourceA.id], viewerA.token);
+    assertNoGraphQLErrors(deletedProfileAResult);
+    assert.equal(deletedProfileAResult.data?.nodes[0]?.viewerRepost, null);
+    assert.equal(deletedProfileAResult.data?.nodes[0]?.repostCount, 1);
   });
 });
 
@@ -222,13 +257,18 @@ const createAuthenticatedSession = async ({
   return { accountId: account.id, token };
 };
 
-const requestRepostCounts = (sourceIds: string[], token?: string) =>
-  requestGraphQL<{ nodes: Array<{ id: string; repostCount: number } | null> }>(
-    `query RepostCounts($sourceIds: [ID!]!) {
+const requestRepostState = (sourceIds: string[], token?: string) =>
+  requestGraphQL<{
+    nodes: Array<{ id: string; repostCount: number; viewerRepost: { id: string } | null } | null>;
+  }>(
+    `query RepostState($sourceIds: [ID!]!) {
       nodes(ids: $sourceIds) {
         ... on Post {
           id
           repostCount
+          viewerRepost {
+            id
+          }
         }
       }
     }`,

--- a/apps/api/tests/integration/graphql/post-repost-count.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost-count.test.ts
@@ -1,0 +1,284 @@
+import '@kosmo/core/polyfill';
+
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, test } from 'node:test';
+import {
+  AccountProfileRole,
+  AccountState,
+  PostState,
+  PostVisibility,
+  ProfileFollowPolicy,
+  ProfileState,
+  SessionState,
+} from '@kosmo/core/enums';
+import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
+import { normalizeHandle } from '@kosmo/core/utils';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { encodeGlobalId } from '../../../src/graphql/global-id';
+import type * as CoreDb from '@kosmo/core/db';
+import type { Env } from '../../../src/context';
+
+const publicOrigin = 'http://127.0.0.1:4173';
+const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+
+let AccountProfiles: typeof CoreDb.AccountProfiles;
+let Accounts: typeof CoreDb.Accounts;
+let db: typeof CoreDb.db;
+let firstOrThrow: typeof CoreDb.firstOrThrow;
+let pg: typeof CoreDb.pg;
+let PostContents: typeof CoreDb.PostContents;
+let Posts: typeof CoreDb.Posts;
+let Profiles: typeof CoreDb.Profiles;
+let Sessions: typeof CoreDb.Sessions;
+let app: Hono<Env>;
+let localInstanceId: string;
+
+type ProfileRow = typeof CoreDb.Profiles.$inferSelect;
+type PostRow = typeof CoreDb.Posts.$inferSelect;
+type GraphQLResult<TData> = {
+  data?: TData;
+  errors?: Array<{ message: string }>;
+};
+
+describe('Post repostCount GraphQL 경계', () => {
+  before(async () => {
+    process.env.DATABASE_URL = databaseUrl;
+    process.env.NODE_ENV = 'production';
+    process.env.PUBLIC_ORIGIN = publicOrigin;
+
+    ({ AccountProfiles, Accounts, db, firstOrThrow, pg, PostContents, Posts, Profiles, Sessions } =
+      await import('@kosmo/core/db'));
+    const { seedDatabase } = await import('@kosmo/core/db/seed');
+
+    await truncateDatabase();
+    const { localInstance } = await seedDatabase({ publicOrigin });
+    localInstanceId = localInstance.id;
+
+    const { deriveContext } = await import('../../../src/context');
+    const { yoga } = await import('../../../src/graphql');
+    app = new Hono<Env>();
+    app.use('*', async (c, next) => {
+      c.set('context', await deriveContext(c));
+      return next();
+    });
+    app.route('/graphql', yoga);
+  });
+
+  beforeEach(async () => {
+    await resetFixtures();
+  });
+
+  after(async () => {
+    await pg.end();
+  });
+
+  test('모든 viewer에게 eligible direct Repost만 같은 수로 반환한다', async () => {
+    const sourceAuthor = await createProfile('source-author');
+    const sourceA = await createContentPost(sourceAuthor.id, 'source A');
+    const sourceB = await createContentPost(sourceAuthor.id, 'source B');
+    const viewerAProfile = await createProfile('viewer-a');
+    const viewerBProfile = await createProfile('viewer-b');
+    const viewerA = await createAuthenticatedSession({ activeProfileId: viewerAProfile.id });
+    const viewerB = await createAuthenticatedSession({ activeProfileId: viewerBProfile.id });
+
+    await createRepost((await createProfile('reposter-a')).id, sourceA.id);
+    await createRepost((await createProfile('reposter-b')).id, sourceA.id);
+    const quote = await createRepost((await createProfile('quoter')).id, sourceA.id);
+    const quoteContent = await db
+      .insert(PostContents)
+      .values({ document: postContentDocumentFromText('quote'), postId: quote.id })
+      .returning()
+      .then(firstOrThrow);
+    await db.update(Posts).set({ currentContentId: quoteContent.id }).where(eq(Posts.id, quote.id));
+    await createRepost((await createProfile('deleted-reposter')).id, sourceA.id, {
+      state: PostState.DELETED,
+    });
+    await createRepost(
+      (await createProfile('inactive-reposter', { state: ProfileState.DISABLED })).id,
+      sourceA.id,
+    );
+    await createRepost((await createProfile('reply-reposter')).id, sourceA.id, {
+      replyParentId: sourceA.id,
+    });
+    await createRepost((await createProfile('source-b-reposter')).id, sourceB.id);
+    await createRepost((await createProfile('quote-reposter')).id, quote.id);
+
+    const [anonymous, viewerAResult, viewerBResult] = await Promise.all([
+      requestRepostCounts([sourceA.id, sourceB.id]),
+      requestRepostCounts([sourceA.id, sourceB.id], viewerA.token),
+      requestRepostCounts([sourceA.id, sourceB.id], viewerB.token),
+    ]);
+
+    assertNoGraphQLErrors(anonymous);
+    assertNoGraphQLErrors(viewerAResult);
+    assertNoGraphQLErrors(viewerBResult);
+    assert.deepEqual(anonymous.data?.nodes, [
+      { id: encodeGlobalId('Post', sourceA.id), repostCount: 2 },
+      { id: encodeGlobalId('Post', sourceB.id), repostCount: 1 },
+    ]);
+    assert.deepEqual(viewerAResult.data?.nodes, anonymous.data?.nodes);
+    assert.deepEqual(viewerBResult.data?.nodes, anonymous.data?.nodes);
+
+    const quoteCount = await requestRepostCounts([quote.id]);
+    assertNoGraphQLErrors(quoteCount);
+    assert.deepEqual(quoteCount.data?.nodes, [
+      { id: encodeGlobalId('Post', quote.id), repostCount: 1 },
+    ]);
+  });
+});
+
+const createProfile = (
+  handle: string,
+  { state = ProfileState.ACTIVE }: { state?: ProfileState } = {},
+): Promise<ProfileRow> =>
+  db
+    .insert(Profiles)
+    .values({
+      displayName: handle,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle,
+      instanceId: localInstanceId,
+      normalizedHandle: normalizeHandle(handle),
+      state,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+const createContentPost = async (
+  profileId: string,
+  bodyText: string,
+  { state = PostState.ACTIVE }: { state?: PostState } = {},
+): Promise<PostRow> => {
+  const post = await db
+    .insert(Posts)
+    .values({ profileId, state, visibility: PostVisibility.PUBLIC })
+    .returning()
+    .then(firstOrThrow);
+  const content = await db
+    .insert(PostContents)
+    .values({ document: postContentDocumentFromText(bodyText), postId: post.id })
+    .returning()
+    .then(firstOrThrow);
+  return db
+    .update(Posts)
+    .set({ currentContentId: content.id })
+    .where(eq(Posts.id, post.id))
+    .returning()
+    .then(firstOrThrow);
+};
+
+const createRepost = (
+  profileId: string,
+  repostSourceId: string,
+  {
+    currentContentId = null,
+    replyParentId = null,
+    state = PostState.ACTIVE,
+  }: {
+    currentContentId?: string | null;
+    replyParentId?: string | null;
+    state?: PostState;
+  } = {},
+): Promise<PostRow> =>
+  db
+    .insert(Posts)
+    .values({
+      currentContentId,
+      profileId,
+      replyParentId,
+      repostSourceId,
+      state,
+      visibility: PostVisibility.PUBLIC,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+const createAuthenticatedSession = async ({
+  activeProfileId,
+}: {
+  activeProfileId: string | null;
+}): Promise<{ accountId: string; token: string }> => {
+  const suffix = crypto.randomUUID();
+  const account = await db
+    .insert(Accounts)
+    .values({ displayName: suffix, oidcSubject: suffix, state: AccountState.ACTIVE })
+    .returning()
+    .then(firstOrThrow);
+  if (activeProfileId) {
+    await db.insert(AccountProfiles).values({
+      accountId: account.id,
+      profileId: activeProfileId,
+      role: AccountProfileRole.OWNER,
+    });
+  }
+  const token = `token-${suffix}`;
+  await db.insert(Sessions).values({
+    accountId: account.id,
+    activeProfileId,
+    state: SessionState.ACTIVE,
+    token,
+  });
+  return { accountId: account.id, token };
+};
+
+const requestRepostCounts = (sourceIds: string[], token?: string) =>
+  requestGraphQL<{ nodes: Array<{ id: string; repostCount: number } | null> }>(
+    `query RepostCounts($sourceIds: [ID!]!) {
+      nodes(ids: $sourceIds) {
+        ... on Post {
+          id
+          repostCount
+        }
+      }
+    }`,
+    { sourceIds: sourceIds.map((id) => encodeGlobalId('Post', id)) },
+    token,
+  );
+
+const requestGraphQL = async <TData>(
+  query: string,
+  variables: Record<string, unknown>,
+  token?: string,
+): Promise<GraphQLResult<TData>> => {
+  const headers = new Headers({ 'content-type': 'application/json' });
+  if (token) {
+    headers.set('authorization', `Bearer ${token}`);
+  }
+  const response = await app.request('/graphql', {
+    body: JSON.stringify({ query, variables }),
+    headers,
+    method: 'POST',
+  });
+  assert.equal(response.status, 200);
+  return (await response.json()) as GraphQLResult<TData>;
+};
+
+const assertNoGraphQLErrors = (result: GraphQLResult<unknown>) => {
+  assert.equal(result.errors, undefined, JSON.stringify(result.errors));
+};
+
+const resetFixtures = async () => {
+  await db.update(Posts).set({ currentContentId: null });
+  await db.delete(PostContents);
+  await db.delete(Sessions);
+  await db.delete(Posts);
+  await db.delete(AccountProfiles);
+  await db.delete(Accounts);
+  await db.delete(Profiles);
+};
+
+const truncateDatabase = async () => {
+  const url = new URL(process.env.DATABASE_URL ?? '');
+  assert.ok(['127.0.0.1', '[::1]', 'localhost'].includes(url.hostname));
+  assert.match(decodeURIComponent(url.pathname.slice(1)), /^kosmo_test(?:_[a-z0-9_]+)?$/);
+  await pg.unsafe(`
+    DO $$
+    DECLARE truncate_statement text;
+    BEGIN
+      SELECT 'TRUNCATE TABLE ' || string_agg(format('%I.%I', schemaname, tablename), ', ') || ' CASCADE'
+      INTO truncate_statement FROM pg_tables WHERE schemaname = 'public';
+      IF truncate_statement IS NOT NULL THEN EXECUTE truncate_statement; END IF;
+    END $$;
+  `);
+};

--- a/openspec/changes/add-post-reposts/tasks.md
+++ b/openspec/changes/add-post-reposts/tasks.md
@@ -123,8 +123,8 @@ Post가 모든 viewer에게 같은 direct Active Repost count와 현재 selected
 
 - 서로 다른 viewer의 동일 count, Quote/Tombstone 제외, selected Profile 전환·부재와 active Repost identity를 batched GraphQL integration test로 검증한다.
 
-- [ ] 4.1 viewer-independent `repostCount`와 selected Profile별 nullable `viewerRepost`를 batched query 경계로 제공한다.
-- [ ] 4.2 count membership, actor 격리, selected Profile 부재와 N+1 회귀 검증을 추가하고 API check를 통과시킨다.
+- [x] 4.1 viewer-independent `repostCount`와 selected Profile별 nullable `viewerRepost`를 batched query 경계로 제공한다.
+- [x] 4.2 count membership, actor 격리, selected Profile 부재와 N+1 회귀 검증을 추가하고 API check를 통과시킨다.
 
 ## 5. PROD-430 Home과 Profile Post List Repost 후보 정책
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `Post.repostCount: Int!`를 추가해 모든 viewer에게 동일한 direct Active Repost 수를 제공합니다.
- `Post.viewerRepost: Post`를 추가해 현재 selected Profile이 만든 Active Repost identity를 nullable Post로 제공합니다.
- 두 필드는 request-scoped DataLoader를 사용해 여러 Source Post를 한 query로 batch 조회합니다.
- Quote, Tombstone, Reply Parent가 있는 Post, 비활성 Profile 및 suspended Instance 작성자의 Repost를 count에서 제외합니다.
- 익명·selected Profile 부재·서로 다른 Profile·Repost 삭제 시나리오와 실제 2-key batching을 PostgreSQL 기반 GraphQL integration test로 검증했습니다.
- OpenSpec의 PROD-403 task 4.1과 4.2만 완료 처리했습니다.

## 왜 변경했는지

[PROD-403](https://linear.app/byulmaru/issue/PROD-403/repostcount와-현재-profile의-active-repost를-조회한다)은 Post Action Bar가 Repost 수와 현재 selected Profile의 Active Repost 상태를 GraphQL에서 조회할 수 있는 계약을 요구합니다.

이 PR은 viewer별 관계에 따라 달라지지 않는 공통 count와 selected Profile별 identity를 기존 Post Node 경계에 제공합니다.

## 이번 PR의 주요 결정

### Repost 수는 viewer와 무관하게 계산한다

- 결정자: @yeeun-uwu
- 선택: count membership에 viewer별 Post Visibility, Profile Block, Mute 조건을 적용하지 않습니다.
- 고려한 대안: 일반 Post 조회와 동일한 viewer별 visibility predicate 적용
- 이유: PROD-403과 OpenSpec이 모든 viewer에게 동일한 direct Active Repost 수를 요구합니다.
- 감수한 결과: Source Post에 접근할 수 있는 viewer는 개인별 관계와 무관하게 동일한 count를 봅니다. Source Post 자체의 기존 접근 제어는 유지됩니다.
- 관련 근거: `openspec/changes/add-post-reposts/specs/repost/spec.md`

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api test` — PASS, 24/24
- `pnpm --filter @kosmo/api run test:integration` — PASS, 110/110
- `pnpm lint:eslint` — PASS
- `pnpm lint:prettier` — PASS
- `pnpm exec openspec validate add-post-reposts --strict` — PASS
- `pnpm exec openspec validate --all --strict` — PASS, 32/32
- `git diff --check` — PASS
- 저장소 지침 포함·제외 독립 리뷰 — Critical/Important/Minor findings 없음
- rebase 전후 `git range-diff` — 최신 `main`의 Repost mutation·Reply 조회 계약 보존 외 PROD-403 의미 변경 없음

## 아직 어떤 문제가 남았는지

- 생성·취소 mutation, Post Action UI와 목록 후보 정책은 이 PR 범위에 포함하지 않습니다.
- 대규모 Post 데이터에서 aggregate query plan은 아직 별도로 측정하지 않았습니다.
- shared `add-post-reposts` OpenSpec change는 다른 구현 task가 남아 있어 archive하지 않습니다.
