### PR TITLE
개인 북마크 목록 화면을 제공한다

### DIFF
--- a/apps/app/.storybook/mocks/react-relay.tsx
+++ b/apps/app/.storybook/mocks/react-relay.tsx
@@ -12,6 +12,7 @@ type RelayMockValue = {
   paginationError?: string | boolean;
   paginationLoading?: boolean;
   paginationResponse?: unknown;
+  paginationResponses?: StoryOperationResponse[];
   operationResponses?: Record<string, StoryOperationResponse | StoryOperationResponse[]>;
   queryData?: unknown;
 };
@@ -30,6 +31,7 @@ export function RelayStoryProvider({
   paginationError,
   paginationLoading,
   paginationResponse,
+  paginationResponses,
   operationResponses,
   queryData,
 }: PropsWithChildren<RelayMockValue>) {
@@ -42,6 +44,7 @@ export function RelayStoryProvider({
       paginationError,
       paginationLoading,
       paginationResponse,
+      paginationResponses,
       operationResponses,
       queryData,
     }),
@@ -53,6 +56,7 @@ export function RelayStoryProvider({
       paginationError,
       paginationLoading,
       paginationResponse,
+      paginationResponses,
       operationResponses,
       queryData,
     ],
@@ -71,8 +75,11 @@ export function RelayStoryProvider({
 }
 
 function createStoryEnvironment(mock: RelayMockValue, environmentIndex: number): Environment {
+  let paginationResponseIndex = 0;
   return new Environment({
-    network: Network.create((request) => executeStoryOperation(request, mock, environmentIndex)),
+    network: Network.create((request) =>
+      executeStoryOperation(request, mock, environmentIndex, () => paginationResponseIndex++),
+    ),
     store: new Store(new RecordSource()),
   });
 }
@@ -81,6 +88,7 @@ function executeStoryOperation(
   request: RequestParameters,
   mock: RelayMockValue,
   environmentIndex: number,
+  nextPaginationResponseIndex: () => number,
 ): Promise<GraphQLResponse> {
   if (request.operationKind === 'mutation') {
     if (mock.mutationError) {
@@ -97,6 +105,16 @@ function executeStoryOperation(
   }
 
   if (request.name.endsWith('NextPageQuery')) {
+    const configuredResponse =
+      mock.paginationResponses?.[
+        Math.min(nextPaginationResponseIndex(), mock.paginationResponses.length - 1)
+      ];
+    if (configuredResponse?.error) {
+      return Promise.reject(new Error(configuredResponse.error));
+    }
+    if (configuredResponse) {
+      return Promise.resolve({ data: (configuredResponse.data ?? {}) as GraphQLResponse['data'] });
+    }
     if (mock.paginationError) {
       return Promise.reject(
         new Error(

--- a/apps/app/.storybook/preview.tsx
+++ b/apps/app/.storybook/preview.tsx
@@ -27,6 +27,7 @@ const preview: Preview = {
               paginationError={relay.paginationError}
               paginationLoading={relay.paginationLoading}
               paginationResponse={relay.paginationResponse}
+              paginationResponses={relay.paginationResponses}
               operationResponses={relay.operationResponses}
               queryData={relay.data}
             >

--- a/apps/app/src/app/(tabs)/(protected)/bookmarks.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/bookmarks.tsx
@@ -21,10 +21,10 @@ const BookmarksQuery = graphql`
 
 export default function BookmarksScreen() {
   const { revision } = useRelayActor();
-  const { selectedProfileId } = useSession();
+  const { selectedProfileId, status } = useSession();
   const [fetchKey, setFetchKey] = useState(0);
 
-  if (!selectedProfileId) {
+  if (status !== 'error' && !selectedProfileId) {
     return <BookmarkList profileRequired />;
   }
 

--- a/apps/app/src/app/(tabs)/(protected)/bookmarks.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/bookmarks.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import { BookmarkConnectionList } from '@/components/bookmark/BookmarkConnectionList';
+import { BookmarkList } from '@/components/bookmark/BookmarkList';
+import { RouteBoundary } from '@/components/RouteBoundary';
+import { useRelayActor } from '@/relay/RelayActorProvider';
+import { useSession } from '@/session/SessionProvider';
+import type { BookmarksPageQuery } from './__generated__/BookmarksPageQuery.graphql';
+
+const BookmarksQuery = graphql`
+  query BookmarksPageQuery {
+    currentSession {
+      id
+      selectedProfile {
+        id
+        ...BookmarkConnectionList_profile
+      }
+    }
+  }
+`;
+
+export default function BookmarksScreen() {
+  const { revision } = useRelayActor();
+  const { selectedProfileId } = useSession();
+  const [fetchKey, setFetchKey] = useState(0);
+
+  if (!selectedProfileId) {
+    return <BookmarkList profileRequired />;
+  }
+
+  return (
+    <RouteBoundary
+      error={(retry) => <BookmarkList error onRetry={retry} />}
+      key={`${revision}:${selectedProfileId}`}
+      loading={<BookmarkList loading />}
+      onRetry={() => setFetchKey((key) => key + 1)}
+      title="북마크 목록을 불러오지 못했어요"
+    >
+      <BookmarksContent fetchKey={`${revision}:${selectedProfileId}:${fetchKey}`} />
+    </RouteBoundary>
+  );
+}
+
+function BookmarksContent({ fetchKey }: { fetchKey: string }) {
+  const data = useLazyLoadQuery<BookmarksPageQuery>(
+    BookmarksQuery,
+    {},
+    { fetchKey, fetchPolicy: 'store-and-network' },
+  );
+  const profile = data.currentSession?.selectedProfile ?? null;
+
+  return profile ? <BookmarkConnectionList profile={profile} /> : <BookmarkList profileRequired />;
+}

--- a/apps/app/src/components/bookmark/BookmarkConnectionList.tsx
+++ b/apps/app/src/components/bookmark/BookmarkConnectionList.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+import { graphql, usePaginationFragment } from 'react-relay';
+import { BookmarkList } from './BookmarkList';
+import type { BookmarkConnectionList_profile$key } from './__generated__/BookmarkConnectionList_profile.graphql';
+import type { BookmarkConnectionListNextPageQuery } from './__generated__/BookmarkConnectionListNextPageQuery.graphql';
+
+const bookmarkConnectionFragment = graphql`
+  fragment BookmarkConnectionList_profile on Profile
+  @argumentDefinitions(count: { type: "Int", defaultValue: 20 }, cursor: { type: "String" })
+  @refetchable(queryName: "BookmarkConnectionListNextPageQuery") {
+    id
+    bookmarks(first: $count, after: $cursor) @connection(key: "BookmarkConnectionList_bookmarks") {
+      edges {
+        node {
+          id
+          post {
+            ...PostListItem_post @alias(as: "listItem")
+          }
+        }
+      }
+    }
+  }
+`;
+
+type BookmarkConnectionListProps = {
+  profile: BookmarkConnectionList_profile$key;
+};
+
+export function BookmarkConnectionList({ profile }: BookmarkConnectionListProps) {
+  const pagination = usePaginationFragment<
+    BookmarkConnectionListNextPageQuery,
+    BookmarkConnectionList_profile$key
+  >(bookmarkConnectionFragment, profile);
+  const profileId = pagination.data.id;
+  const [loadError, setLoadError] = useState(false);
+  const profileIdRef = useRef(profileId);
+  profileIdRef.current = profileId;
+  useEffect(() => {
+    setLoadError(false);
+  }, [profileId]);
+  const items = pagination.data.bookmarks.edges.flatMap(({ node }) =>
+    node.post?.listItem ? [{ id: node.id, post: node.post.listItem }] : [],
+  );
+
+  const loadMore = () => {
+    if (pagination.isLoadingNext) {
+      return;
+    }
+    setLoadError(false);
+    pagination.loadNext(20, {
+      onComplete: (error) => {
+        if (profileIdRef.current === profileId) {
+          setLoadError(Boolean(error));
+        }
+      },
+    });
+  };
+
+  return (
+    <BookmarkList
+      error={loadError}
+      hasNext={pagination.hasNext}
+      isLoadingMore={pagination.isLoadingNext}
+      items={items}
+      onLoadMore={loadMore}
+      onRetry={loadMore}
+    />
+  );
+}

--- a/apps/app/src/components/bookmark/BookmarkList.tsx
+++ b/apps/app/src/components/bookmark/BookmarkList.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { PostListItem } from '@/components/post/PostListItem';
 import { Button } from '@/components/ui/Button';
 import { Skeleton } from '@/components/ui/StateView';
@@ -94,10 +94,10 @@ export function BookmarkList({
   }
 
   return (
-    <View style={styles.root}>
+    <ScrollView contentContainerStyle={styles.root} testID="bookmark-list-scroll">
       <BookmarkListTitle />
       {content}
-    </View>
+    </ScrollView>
   );
 }
 
@@ -172,7 +172,7 @@ function BookmarkListState({
 }
 
 const styles = StyleSheet.create({
-  root: { width: '100%' },
+  root: { flexGrow: 1, width: '100%' },
   titleBar: { justifyContent: 'center', minHeight: 43, paddingHorizontal: spacing.lg },
   title: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
   skeletonItem: {

--- a/apps/app/src/components/bookmark/BookmarkList.tsx
+++ b/apps/app/src/components/bookmark/BookmarkList.tsx
@@ -17,6 +17,7 @@ export type BookmarkListProps = {
   loading?: boolean;
   onLoadMore?: () => void;
   onRetry?: () => void;
+  profileRequired?: boolean;
 };
 
 export function BookmarkList({
@@ -27,11 +28,19 @@ export function BookmarkList({
   loading = false,
   onLoadMore,
   onRetry,
+  profileRequired = false,
 }: BookmarkListProps): React.JSX.Element {
   const hasData = items.length > 0;
   let content: ReactNode;
 
-  if (loading && !hasData) {
+  if (profileRequired) {
+    content = (
+      <BookmarkListState
+        description="북마크를 보려면 사용할 프로필을 먼저 선택해주세요."
+        title="프로필이 필요해요"
+      />
+    );
+  } else if (loading && !hasData) {
     content = <BookmarkListSkeleton />;
   } else if (error && !hasData) {
     content = (
@@ -55,7 +64,14 @@ export function BookmarkList({
         {items.map((item) => (
           <PostListItem key={item.id} post={item.post} />
         ))}
-        {hasNext && onLoadMore ? (
+        {error ? (
+          <BookmarkListState
+            alert
+            description="기존 북마크는 그대로 유지돼요."
+            onRetry={onRetry}
+            title="북마크를 더 불러오지 못했어요"
+          />
+        ) : hasNext && onLoadMore ? (
           <View style={styles.pagination}>
             <Button
               aria-busy={isLoadingMore}

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -59,7 +59,7 @@ const navigation: NavigationItem[] = [
   { href: '/search', Icon: Search, label: '검색' },
   { href: '/notifications', Icon: Bell, label: '알림' },
   { href: '/menu', Icon: UserRound, label: '프로필', profile: true },
-  { href: '/menu', Icon: Bookmark, label: '북마크' },
+  { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
   { href: '/menu', Icon: UserRoundPlus, label: '팔로워 요청' },
   { href: '/menu', Icon: Settings, label: '프로필 설정' },
 ];

--- a/apps/app/src/stories/Bookmarks.stories.tsx
+++ b/apps/app/src/stories/Bookmarks.stories.tsx
@@ -2,10 +2,14 @@ import { useState } from 'react';
 import { Text } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { expect, userEvent, within } from 'storybook/test';
+import { BookmarkConnectionList } from '@/components/bookmark/BookmarkConnectionList';
 import { BookmarkList } from '@/components/bookmark/BookmarkList';
+import { Button } from '@/components/ui/Button';
 import { post, profile } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { BookmarksIntegrationStoriesQuery as BookmarksIntegrationStoriesQueryType } from './__generated__/BookmarksIntegrationStoriesQuery.graphql';
+import type { BookmarksProfileSwitchStoriesQuery as BookmarksProfileSwitchStoriesQueryType } from './__generated__/BookmarksProfileSwitchStoriesQuery.graphql';
 import type { BookmarksStoriesQuery as BookmarksStoriesQueryType } from './__generated__/BookmarksStoriesQuery.graphql';
 
 const author = profile({
@@ -18,6 +22,60 @@ const targetPosts = [
   post({ bodyText: '첫 번째로 저장한 게시글입니다.', id: 'bookmark-target-1', profile: author }),
   post({ bodyText: '두 번째로 저장한 게시글입니다.', id: 'bookmark-target-2', profile: author }),
 ];
+const bookmarkOwner = {
+  ...profile({ id: 'bookmark-owner' }),
+  bookmarks: {
+    edges: [
+      {
+        cursor: 'bookmark-cursor-2',
+        node: { __typename: 'Bookmark', id: 'bookmark-2', post: targetPosts[0] },
+      },
+      {
+        cursor: 'bookmark-cursor-1',
+        node: { __typename: 'Bookmark', id: 'bookmark-1', post: targetPosts[1] },
+      },
+      {
+        cursor: 'bookmark-cursor-null',
+        node: { __typename: 'Bookmark', id: 'bookmark-null', post: null },
+      },
+    ],
+    pageInfo: { endCursor: 'bookmark-cursor-1', hasNextPage: true },
+  },
+};
+const bookmarkNextPage = {
+  node: {
+    ...bookmarkOwner,
+    bookmarks: {
+      edges: [
+        {
+          cursor: 'bookmark-cursor-0',
+          node: {
+            __typename: 'Bookmark',
+            id: 'bookmark-0',
+            post: post({
+              bodyText: '세 번째로 저장한 게시글입니다.',
+              id: 'bookmark-target-3',
+              profile: author,
+            }),
+          },
+        },
+      ],
+      pageInfo: { endCursor: 'bookmark-cursor-0', hasNextPage: false },
+    },
+  },
+};
+const bookmarkOtherOwner = {
+  ...profile({ id: 'bookmark-owner-b' }),
+  bookmarks: {
+    edges: [
+      {
+        cursor: 'bookmark-b-cursor-1',
+        node: { __typename: 'Bookmark', id: 'bookmark-b-1', post: targetPosts[0] },
+      },
+    ],
+    pageInfo: { endCursor: 'bookmark-b-cursor-1', hasNextPage: true },
+  },
+};
 
 const BookmarksStoriesQuery = graphql`
   query BookmarksStoriesQuery($ids: [ID!]!) {
@@ -30,6 +88,65 @@ const BookmarksStoriesQuery = graphql`
     }
   }
 `;
+
+const BookmarksIntegrationStoriesQuery = graphql`
+  query BookmarksIntegrationStoriesQuery {
+    node(id: "bookmark-owner") {
+      __typename
+      ... on Profile {
+        ...BookmarkConnectionList_profile @alias(as: "bookmarkConnection")
+      }
+    }
+  }
+`;
+
+const BookmarksProfileSwitchStoriesQuery = graphql`
+  query BookmarksProfileSwitchStoriesQuery {
+    first: node(id: "bookmark-owner") {
+      __typename
+      ... on Profile {
+        ...BookmarkConnectionList_profile @alias(as: "bookmarkConnection")
+      }
+    }
+    second: node(id: "bookmark-owner-b") {
+      __typename
+      ... on Profile {
+        ...BookmarkConnectionList_profile @alias(as: "bookmarkConnection")
+      }
+    }
+  }
+`;
+
+function BookmarkConnectionStory() {
+  const data = useLazyLoadQuery<BookmarksIntegrationStoriesQueryType>(
+    BookmarksIntegrationStoriesQuery,
+    {},
+  );
+  if (data.node?.__typename !== 'Profile' || !data.node.bookmarkConnection) {
+    throw new Error('Missing Bookmark connection Profile fixture.');
+  }
+  return <BookmarkConnectionList profile={data.node.bookmarkConnection} />;
+}
+
+function BookmarkConnectionProfileSwitchStory() {
+  const data = useLazyLoadQuery<BookmarksProfileSwitchStoriesQueryType>(
+    BookmarksProfileSwitchStoriesQuery,
+    {},
+  );
+  const [selectedProfile, setSelectedProfile] = useState<'first' | 'second'>('first');
+  const profile = data[selectedProfile];
+  if (profile?.__typename !== 'Profile' || !profile.bookmarkConnection) {
+    throw new Error('Missing Bookmark connection Profile switch fixture.');
+  }
+  return (
+    <>
+      <Button onPress={() => setSelectedProfile('second')} tone="secondary">
+        B 프로필로 전환
+      </Button>
+      <BookmarkConnectionList profile={profile.bookmarkConnection} />
+    </>
+  );
+}
 
 function useBookmarkItems() {
   const data = useLazyLoadQuery<BookmarksStoriesQueryType>(BookmarksStoriesQuery, {
@@ -131,6 +248,51 @@ export const NextPageLoading: Story = {
     const button = within(canvasElement).getByRole('button', { name: '불러오는 중' });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('aria-busy', 'true');
+  },
+};
+
+export const ConnectionNextPageFailureRetrySucceeds: Story = {
+  parameters: {
+    relay: {
+      data: { node: bookmarkOwner },
+      paginationResponses: [
+        { error: '다음 페이지를 불러오지 못했습니다.' },
+        { data: bookmarkNextPage },
+      ],
+    },
+  },
+  render: () => <BookmarkConnectionStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getAllByRole('article')).toHaveLength(2);
+    await userEvent.click(canvas.getByRole('button', { name: '더 불러오기' }));
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
+      '북마크를 더 불러오지 못했어요',
+    );
+    expect(canvas.getAllByRole('article')).toHaveLength(2);
+    await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
+    await expect(canvas.findAllByRole('article')).resolves.toHaveLength(3);
+    expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+
+export const ConnectionProfileSwitchClearsPaginationError: Story = {
+  parameters: {
+    relay: {
+      data: { first: bookmarkOwner, second: bookmarkOtherOwner },
+      paginationResponses: [{ error: '다음 페이지를 불러오지 못했습니다.' }],
+    },
+  },
+  render: () => <BookmarkConnectionProfileSwitchStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '더 불러오기' }));
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
+      '북마크를 더 불러오지 못했어요',
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'B 프로필로 전환' }));
+    expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    expect(canvas.getByRole('button', { name: '더 불러오기' })).toBeVisible();
   },
 };
 

--- a/apps/app/src/stories/Bookmarks.stories.tsx
+++ b/apps/app/src/stories/Bookmarks.stories.tsx
@@ -9,7 +9,7 @@ import { BookmarkConnectionList } from '@/components/bookmark/BookmarkConnection
 import { BookmarkList } from '@/components/bookmark/BookmarkList';
 import { Button } from '@/components/ui/Button';
 import { useRelayActor } from '@/relay/RelayActorProvider';
-import { SessionProvider } from '@/session/SessionProvider';
+import { SessionErrorProvider, SessionProvider } from '@/session/SessionProvider';
 import { post, profile } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -166,6 +166,14 @@ function BookmarksRouteStory() {
     <SessionProvider>
       <BookmarksScreen />
     </SessionProvider>
+  );
+}
+
+function SessionErrorBookmarksRoute() {
+  return (
+    <SessionErrorProvider>
+      <BookmarksScreen />
+    </SessionErrorProvider>
   );
 }
 
@@ -440,6 +448,26 @@ export const NoSelectedProfileSkipsBookmarkQuery: Story = {
     await expect(within(canvasElement).findByText('프로필이 필요해요')).resolves.toBeVisible();
   },
   render: () => <BookmarksRouteStory />,
+};
+
+export const SessionErrorStillUsesBookmarkQuery: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        BookmarksPageQuery: {
+          data: {
+            currentSession: { id: 'bookmark-session', selectedProfile: bookmarkOwner },
+          },
+        },
+      },
+    },
+  },
+  render: () => <SessionErrorBookmarksRoute />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findAllByRole('article')).resolves.toHaveLength(2);
+    expect(canvas.queryByText('프로필이 필요해요')).not.toBeInTheDocument();
+  },
 };
 
 export const InitialRouteErrorAndRetry: Story = {

--- a/apps/app/src/stories/Bookmarks.stories.tsx
+++ b/apps/app/src/stories/Bookmarks.stories.tsx
@@ -1,6 +1,6 @@
 import { usePathname } from 'expo-router';
 import { useState } from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { expect, spyOn, userEvent, within } from 'storybook/test';
 import ProtectedLayout from '@/app/(tabs)/(protected)/_layout';
@@ -244,6 +244,26 @@ function LoadingMoreCatalog() {
   );
 }
 
+function ScrollableListCatalog() {
+  const items = useBookmarkItems();
+  const [loadCount, setLoadCount] = useState(0);
+  const longItems = Array.from({ length: 12 }, (_, index) => ({
+    id: `bookmark-scroll-${index}`,
+    post: items[index % items.length]!.post,
+  }));
+
+  return (
+    <View style={{ height: 320 }}>
+      <Text testID="bookmark-scroll-load-count">load:{loadCount}</Text>
+      <BookmarkList
+        hasNext
+        items={longItems}
+        onLoadMore={() => setLoadCount((count) => count + 1)}
+      />
+    </View>
+  );
+}
+
 const meta = {
   component: StateCatalog,
   parameters: {
@@ -291,6 +311,20 @@ export const NextPageLoading: Story = {
     const button = within(canvasElement).getByRole('button', { name: '불러오는 중' });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('aria-busy', 'true');
+  },
+};
+
+export const LongListScrollsToPagination: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  render: () => <ScrollableListCatalog />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const scroller = canvas.getByTestId('bookmark-list-scroll');
+    expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+    scroller.scrollTop = scroller.scrollHeight;
+    expect(scroller.scrollTop).toBeGreaterThan(0);
+    await userEvent.click(canvas.getByRole('button', { name: '더 불러오기' }));
+    expect(canvas.getByTestId('bookmark-scroll-load-count')).toHaveTextContent('load:1');
   },
 };
 

--- a/apps/app/src/stories/Bookmarks.stories.tsx
+++ b/apps/app/src/stories/Bookmarks.stories.tsx
@@ -33,11 +33,11 @@ const bookmarkOwner = {
     edges: [
       {
         cursor: 'bookmark-cursor-2',
-        node: { __typename: 'Bookmark', id: 'bookmark-2', post: targetPosts[0] },
+        node: { __typename: 'Bookmark', id: 'bookmark-2', post: targetPosts[1] },
       },
       {
         cursor: 'bookmark-cursor-1',
-        node: { __typename: 'Bookmark', id: 'bookmark-1', post: targetPosts[1] },
+        node: { __typename: 'Bookmark', id: 'bookmark-1', post: targetPosts[0] },
       },
       {
         cursor: 'bookmark-cursor-null',
@@ -58,7 +58,7 @@ const bookmarkNextPage = {
             __typename: 'Bookmark',
             id: 'bookmark-0',
             post: post({
-              bodyText: '세 번째로 저장한 게시글입니다.',
+              bodyText: '더 이전에 저장한 게시글입니다.',
               id: 'bookmark-target-3',
               profile: author,
             }),
@@ -377,7 +377,10 @@ export const SelectedProfileRoute: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findAllByRole('article')).resolves.toHaveLength(2);
+    const articles = await canvas.findAllByRole('article');
+    expect(articles).toHaveLength(2);
+    expect(articles[0]).toHaveTextContent('두 번째로 저장한 게시글입니다.');
+    expect(articles[1]).toHaveTextContent('첫 번째로 저장한 게시글입니다.');
     expect(
       canvasElement.querySelector('a[href="/@space-writer/bookmark-target-1"]'),
     ).toBeInTheDocument();

--- a/apps/app/src/stories/Bookmarks.stories.tsx
+++ b/apps/app/src/stories/Bookmarks.stories.tsx
@@ -1,10 +1,15 @@
+import { usePathname } from 'expo-router';
 import { useState } from 'react';
 import { Text } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, spyOn, userEvent, within } from 'storybook/test';
+import ProtectedLayout from '@/app/(tabs)/(protected)/_layout';
+import BookmarksScreen from '@/app/(tabs)/(protected)/bookmarks';
 import { BookmarkConnectionList } from '@/components/bookmark/BookmarkConnectionList';
 import { BookmarkList } from '@/components/bookmark/BookmarkList';
 import { Button } from '@/components/ui/Button';
+import { useRelayActor } from '@/relay/RelayActorProvider';
+import { SessionProvider } from '@/session/SessionProvider';
 import { post, profile } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -70,7 +75,15 @@ const bookmarkOtherOwner = {
     edges: [
       {
         cursor: 'bookmark-b-cursor-1',
-        node: { __typename: 'Bookmark', id: 'bookmark-b-1', post: targetPosts[0] },
+        node: {
+          __typename: 'Bookmark',
+          id: 'bookmark-b-1',
+          post: post({
+            bodyText: 'B 프로필로 저장한 게시글입니다.',
+            id: 'bookmark-target-b',
+            profile: author,
+          }),
+        },
       },
     ],
     pageInfo: { endCursor: 'bookmark-b-cursor-1', hasNextPage: true },
@@ -145,6 +158,36 @@ function BookmarkConnectionProfileSwitchStory() {
       </Button>
       <BookmarkConnectionList profile={profile.bookmarkConnection} />
     </>
+  );
+}
+
+function BookmarksRouteStory() {
+  return (
+    <SessionProvider>
+      <BookmarksScreen />
+    </SessionProvider>
+  );
+}
+
+function ActorResetBookmarksRoute() {
+  const { resetActor } = useRelayActor();
+
+  return (
+    <>
+      <Button onPress={() => resetActor('bookmark-owner-b')}>프로필 전환</Button>
+      <BookmarksRouteStory />
+    </>
+  );
+}
+
+function GuestBookmarkRoute() {
+  const pathname = usePathname();
+
+  return (
+    <SessionProvider>
+      <ProtectedLayout />
+      <Text testID="bookmark-route-pathname">{pathname}</Text>
+    </SessionProvider>
   );
 }
 
@@ -312,4 +355,153 @@ export const WebCenterColumn: Story = {
     expect(canvas.queryByRole('tab')).not.toBeInTheDocument();
   },
   render: () => <PopulatedList />,
+};
+
+export const SelectedProfileRoute: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        BookmarksPageQuery: {
+          data: {
+            currentSession: { id: 'bookmark-session', selectedProfile: bookmarkOwner },
+          },
+        },
+        SessionProviderQuery: {
+          data: {
+            currentSession: { id: 'bookmark-session', selectedProfile: bookmarkOwner },
+            me: { id: 'bookmark-account', name: 'bookmark-account' },
+          },
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findAllByRole('article')).resolves.toHaveLength(2);
+    expect(
+      canvasElement.querySelector('a[href="/@space-writer/bookmark-target-1"]'),
+    ).toBeInTheDocument();
+  },
+  render: () => <BookmarksRouteStory />,
+};
+
+export const NoSelectedProfileSkipsBookmarkQuery: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        BookmarksPageQuery: { error: 'Bookmark query must not run without a selected Profile.' },
+        SessionProviderQuery: {
+          data: {
+            currentSession: { id: 'bookmark-session', selectedProfile: null },
+            me: { id: 'bookmark-account', name: 'bookmark-account' },
+          },
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).findByText('프로필이 필요해요')).resolves.toBeVisible();
+  },
+  render: () => <BookmarksRouteStory />,
+};
+
+export const InitialRouteErrorAndRetry: Story = {
+  beforeEach: () => {
+    const originalError = console.error;
+    const errorSpy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      const isExpectedRouteError = args.some((argument) =>
+        argument instanceof Error
+          ? argument.message === '북마크 목록을 불러오지 못했습니다.'
+          : typeof argument === 'string' && argument.includes('북마크 목록을 불러오지 못했습니다.'),
+      );
+
+      if (!isExpectedRouteError) {
+        originalError(...args);
+      }
+    });
+
+    return () => errorSpy.mockRestore();
+  },
+  parameters: {
+    relay: {
+      operationResponses: {
+        BookmarksPageQuery: { error: '북마크 목록을 불러오지 못했습니다.' },
+        SessionProviderQuery: {
+          data: {
+            currentSession: { id: 'bookmark-session', selectedProfile: bookmarkOwner },
+            me: { id: 'bookmark-account', name: 'bookmark-account' },
+          },
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
+      '북마크 목록을 불러오지 못했어요',
+    );
+    await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
+    await expect(canvas.findByText('북마크 목록을 불러오는 중입니다.')).resolves.toBeVisible();
+  },
+  render: () => <BookmarksRouteStory />,
+};
+
+export const ActorResetUsesNextProfileConnection: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        BookmarksPageQuery: [
+          {
+            data: { currentSession: { id: 'bookmark-session-a', selectedProfile: bookmarkOwner } },
+          },
+          {
+            data: {
+              currentSession: { id: 'bookmark-session-b', selectedProfile: bookmarkOtherOwner },
+            },
+          },
+        ],
+        SessionProviderQuery: [
+          {
+            data: {
+              currentSession: { id: 'bookmark-session-a', selectedProfile: bookmarkOwner },
+              me: { id: 'bookmark-account', name: 'bookmark-account' },
+            },
+          },
+          {
+            data: {
+              currentSession: { id: 'bookmark-session-b', selectedProfile: bookmarkOtherOwner },
+              me: { id: 'bookmark-account', name: 'bookmark-account' },
+            },
+          },
+        ],
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByText('첫 번째로 저장한 게시글입니다.')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '프로필 전환' }));
+    await expect(canvas.findByText('B 프로필로 저장한 게시글입니다.')).resolves.toBeVisible();
+    expect(canvas.queryByText('첫 번째로 저장한 게시글입니다.')).not.toBeInTheDocument();
+  },
+  render: () => <ActorResetBookmarksRoute />,
+};
+
+export const ProtectedLayoutRedirectsGuestFromBookmarkPath: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        SessionProviderQuery: {
+          data: { currentSession: null, me: null },
+        },
+      },
+    },
+    router: { pathname: '/bookmarks' },
+  },
+  play: async ({ canvasElement }) => {
+    await expect(
+      within(canvasElement).findByTestId('bookmark-route-pathname'),
+    ).resolves.toHaveTextContent('/');
+  },
+  render: () => <GuestBookmarkRoute />,
 };

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -156,11 +156,22 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const SharedNavigation: Story = {};
+export const SharedNavigation: Story = {
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole('link', { name: '북마크' })).toHaveAttribute('href', '/bookmarks');
+  },
+};
 
 export const BottomNavigation: Story = { render: () => <BottomNavigationStory /> };
 
-export const CompactSidebar: Story = { render: () => <CompactSidebarStory /> };
+export const CompactSidebar: Story = {
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole('link', { name: '북마크' })).toHaveAttribute('href', '/bookmarks');
+  },
+  render: () => <CompactSidebarStory />,
+};
 
 export const FollowUpdatesBothProfileCounts: Story = {
   parameters: {
@@ -585,6 +596,17 @@ function unreadBadgeParameters(count: number) {
 export const UniversalMobile: Story = {
   globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
   parameters: universalParameters,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByRole('link', { name: '북마크' })).not.toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: '메뉴 열기' }));
+    const page = within(canvasElement.ownerDocument.body);
+    const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
+    expect(within(drawer).getByRole('link', { name: '북마크' })).toHaveAttribute(
+      'href',
+      '/bookmarks',
+    );
+  },
   render: () => (
     <View style={{ height: 844 }}>
       <UniversalShellStory />

--- a/openspec/changes/add-profile-bookmarks/decisions.md
+++ b/openspec/changes/add-profile-bookmarks/decisions.md
@@ -78,6 +78,30 @@
 - Consequences: guest는 `/`로 이동하고, 선택 Profile이 없으면 목록 query를 실행하지 않는다. Bookmark action adapter와 production Post surface는 `PROD-432/433/434`가 별도로 소유한다.
 - Confirmation / Follow-up: `PROD-421`에서 세 플랫폼 route parity, guest/no-Profile, Profile 전환과 connection 격리를 검증한다.
 
+### 공용 SidebarNavigation으로 Bookmark 진입점 통일
+
+- Decision Date: 2026-07-23
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-421`, 2026-07-23 사용자 결정
+- Status: Active
+- Context / Problem: Web full·compact sidebar와 mobile drawer가 같은 `SidebarNavigation`을 사용하지만 Bookmark 항목은 현재 일반 `/menu` placeholder를 가리킨다. Mobile bottom tab은 홈·검색·글쓰기·알림·Profile의 다섯 항목을 고정으로 제공한다.
+- Decision Outcome: Web full·compact sidebar와 mobile drawer의 공용 Bookmark 메뉴 항목을 모두 canonical `/bookmarks` route로 연결한다. Mobile은 기존 메뉴 drawer를 Bookmark 진입점으로 사용하며 bottom tab이나 별도 header 버튼을 추가하지 않는다.
+- Alternatives Considered: Bookmark bottom tab 추가 — 기존 다섯 항목의 shell 계약과 배치를 바꾸므로 채택하지 않는다. Mobile header에 별도 Bookmark 버튼 추가 — drawer의 공용 메뉴와 진입 계약을 중복하므로 채택하지 않는다. `/menu` placeholder 유지 — canonical route로 직접 이동하지 못하므로 채택하지 않는다.
+- Consequences: `SidebarNavigation`의 단일 Bookmark 항목이 Web과 mobile에서 같은 route를 제공한다. Drawer는 기존 `onNavigate` 흐름으로 이동 뒤 닫히며, 다른 `/menu` placeholder 항목과 bottom tab 구성은 이 결정에서 바꾸지 않는다.
+- Confirmation / Follow-up: `PROD-421` task 7.3에서 Web full·compact sidebar와 mobile drawer의 href·이동을 검증하고, task 7.4에서 세 플랫폼 route parity를 확인한다.
+
+### Bookmark 다음 페이지 실패 시 기존 목록 유지
+
+- Decision Date: 2026-07-23
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-421`, 2026-07-23 사용자 결정
+- Status: Active
+- Context / Problem: 첫 목록 요청 실패와 기존 edge를 표시한 뒤의 다음 페이지 요청 실패는 보존할 수 있는 사용자 데이터가 다르다. 다음 페이지 실패를 전체 error 화면으로 바꾸면 이미 조회한 Bookmark를 불필요하게 숨긴다.
+- Decision Outcome: 첫 목록 요청이 실패하고 표시할 edge가 없으면 전체 목록 error·retry 상태를 표시한다. 기존 edge가 있는 상태에서 다음 페이지 요청이 실패하면 기존 Post 카드를 유지하고 목록 아래에 `북마크를 더 불러오지 못했어요` alert와 `다시 시도` action을 표시한다. 재시도는 같은 connection의 다음 cursor를 다시 요청하며 성공하면 pagination error를 지운다.
+- Alternatives Considered: 다음 페이지 실패 때 전체 목록 교체 — 이미 성공한 edge를 숨겨 채택하지 않는다. 오류를 표시하지 않고 load-more action만 유지 — 실패와 재시도 의미를 사용자에게 전달하지 못해 채택하지 않는다. 자동 재시도 — 요청 횟수와 실패 상태를 숨기므로 채택하지 않는다.
+- Consequences: `BookmarkList`는 items가 있는 error 상태에서도 Post 카드를 유지하고 pagination error·retry를 렌더링해야 한다. Relay connection edge와 cursor를 수동으로 지우거나 재구성하지 않는다.
+- Confirmation / Follow-up: `PROD-421` task 7.2에서 실제 `loadNext` error state를 presentation props에 연결하고, task 7.4에서 기존 edge 유지·alert·재시도 성공을 검증한다.
+
 ### Post.viewerBookmark viewer-relative 조회 계약
 
 - Decision Date: 2026-07-23
@@ -164,9 +188,7 @@
 
 ## Remaining Decisions
 
-- **PROD-421 — mobile navigation entry:** `/bookmarks` route는 고정하되 sidebar 외 mobile shell에서의 정확한 진입 control은 구현 전에 확정한다.
-
-위 Remaining Decisions는 `PROD-408`의 생성 mutation, `PROD-409`의 삭제 mutation, `PROD-410`의 owner connection·Bookmark Node·nullable Target·pagination 계약과 `PROD-420`의 `Post.viewerBookmark` 계약을 바꾸지 않는다. 각 owner 이슈에 착수하기 전 관련 결정을 `Decision Records`에 추가하고 사용자 승인을 받아야 한다.
+없음.
 
 ## Superseded Decisions
 

--- a/openspec/changes/add-profile-bookmarks/design.md
+++ b/openspec/changes/add-profile-bookmarks/design.md
@@ -47,7 +47,7 @@ Bookmark의 도메인 계약은 `docs/domain/objects/bookmark.md`와 Accepted AD
 4. **PROD-410 목록**: 현재 선택된 Profile의 `Profile.bookmarks` owner-only connection query에서 Bookmark와 Target Post·작성자 Profile·Instance를 결합하고 기존 Post 가시성 predicate를 SQL `WHERE`에 적용한 뒤 UUIDv7 ID-only cursor, order, limit을 적용한다. `Bookmark`는 Owner만 조회하는 Relay Node로 두고, Owner가 숨겨진 Target의 관계도 관리할 수 있도록 `Bookmark.post`는 nullable로 둔다. 개별 Node의 숨겨진 Target은 `null`, 목록의 같은 Bookmark edge는 결과 제외로 처리한다. 다른 Profile의 connection은 일반적인 권한 거부, 비Owner Node 조회는 `null`로 정규화한다.
 5. **PROD-420 viewer-relative 조회 API**: nullable `Post.viewerBookmark`를 추가하고 request-scoped batch loader가 현재 selected Profile과 요청 Post ID들에 해당하는 Bookmark만 조회하게 한다. guest, selected Profile 없음과 미저장 상태는 `null`로 정규화하고 여러 Post 조회에서 N+1을 만들지 않는다.
 6. **PROD-452 목록 presentation**: 실제 Bookmark connection 없이 loading·error·empty·populated와 추가 로딩 상태를 props로 제공하고 fixture로 검증한다. populated 상태는 기존 `PostListItem` fragment를 그대로 렌더링해 Profile·Post canonical Link를 유지한다. Storybook은 Relay mock fixture로 fragment ref를 만들고, error retry와 mock pagination callback만 presentation 상호작용으로 검증한다.
-7. **PROD-421 목록 route 통합**: `/bookmarks` route의 selected Profile fragment에 `@refetchable`·`@connection` pagination 계약을 두고 PROD-452 presentation에 실제 상태와 edge를 전달한다. 선택 Profile이 없으면 query를 실행하지 않고, Profile 전환 뒤에는 새 connection/cursor를 사용한다. 현재 `/menu` placeholder인 사이드바 Bookmark 항목을 canonical route로 연결하고 mobile 진입 경계도 함께 검증한다.
+7. **PROD-421 목록 route 통합**: `/bookmarks` route의 selected Profile fragment에 `@refetchable`·`@connection` pagination 계약을 두고 PROD-452 presentation에 실제 상태와 edge를 전달한다. 선택 Profile이 없으면 query를 실행하지 않고, Profile 전환 뒤에는 새 connection/cursor를 사용한다. 다음 페이지 요청이 실패하면 기존 edge를 유지한 채 목록 아래에 retry를 제공한다. Web full·compact sidebar와 mobile drawer가 공유하는 `SidebarNavigation`의 Bookmark 항목을 `/menu` placeholder에서 canonical route로 바꾸며, mobile bottom tab이나 별도 header 버튼은 추가하지 않는다.
 8. **PROD-391 통합**: 저장 → 생성 → `Post.viewerBookmark`/목록 조회 → Target 숨김·재노출 → 삭제를 하나의 계약 흐름으로 검증하고, 모든 구현 이슈의 검증 증거와 canonical/OpenSpec 정합성을 확인한 뒤 archive한다.
 
 ### Allowed Alternatives
@@ -86,4 +86,4 @@ Bookmark의 도메인 계약은 `docs/domain/objects/bookmark.md`와 Accepted AD
 
 ## Open Questions
 
-- **PROD-421**: desktop sidebar 외 mobile shell에서 `/bookmarks`로 들어가는 정확한 navigation entry를 확정해야 한다.
+없음.

--- a/openspec/changes/add-profile-bookmarks/specs/bookmark/spec.md
+++ b/openspec/changes/add-profile-bookmarks/specs/bookmark/spec.md
@@ -207,6 +207,8 @@ Owner가 개별 Bookmark Node를 조회할 때 `Bookmark.post`는 nullable이어
 
 **Authority / Provenance:** `docs/domain/objects/bookmark.md`, `PROD-391`, `PROD-421` — 클라이언트는 유효한 세션과 선택 Profile이 있는 사용자에게 개인 Bookmark 목록 화면을 제공해야 한다(MUST). 화면은 최신순 pagination과 Target Post 이동을 지원하고(MUST), loading·error·empty 상태를 구분해야 하며(MUST), 서버가 숨긴 Target Post를 별도 경로로 복원하거나 노출하지 않아야 한다(MUST NOT).
 
+**Authority / Provenance:** `PROD-421`, 2026-07-23 사용자 결정 — 다음 페이지 요청이 실패하면 클라이언트는 이미 표시한 Bookmark edge를 유지해야 하며(MUST), 목록 아래에 실패 alert와 같은 다음 cursor를 다시 요청하는 retry action을 제공해야 한다(MUST).
+
 #### Scenario: Bookmark 목록을 탐색함
 
 - **WHEN** 선택 Profile에 조회 가능한 Bookmark가 있다
@@ -217,6 +219,13 @@ Owner가 개별 Bookmark Node를 조회할 때 `Bookmark.post`는 nullable이어
 
 - **WHEN** 선택 Profile에 표시할 Bookmark가 없다
 - **THEN** 클라이언트는 loading 또는 error와 구분되는 비공개 목록의 empty 상태를 표시한다
+
+#### Scenario: 다음 페이지 요청이 실패함
+
+- **WHEN** 클라이언트가 기존 Bookmark를 표시한 상태에서 다음 페이지 요청에 실패한다
+- **THEN** 클라이언트는 기존 Bookmark 카드를 계속 표시한다
+- **AND** 목록 아래에 `북마크를 더 불러오지 못했어요` alert와 `다시 시도` action을 표시한다
+- **AND** 사용자가 재시도하면 같은 connection의 다음 cursor를 다시 요청한다
 
 #### Scenario: 선택 Profile별 목록을 격리함
 

--- a/openspec/changes/add-profile-bookmarks/specs/universal-expo-client/spec.md
+++ b/openspec/changes/add-profile-bookmarks/specs/universal-expo-client/spec.md
@@ -31,6 +31,12 @@ Android, iOS, Web 클라이언트는 `/bookmarks` route에 같은 공용 route·
 - **WHEN** 사용자가 Android, iOS 또는 Web에서 `/bookmarks`를 연다
 - **THEN** 각 플랫폼은 같은 공용 Bookmark 목록 route와 Relay query 계약을 사용한다
 
+#### Scenario: Navigate from the mobile Bookmark menu
+
+- **WHEN** 사용자가 Android, iOS 또는 mobile layout의 Web에서 메뉴 drawer의 Bookmark 항목을 선택한다
+- **THEN** 시스템은 canonical `/bookmarks` route로 이동한다
+- **AND** Bookmark 전용 bottom tab이나 별도 header action을 요구하지 않는다
+
 #### Scenario: Isolate Bookmark pagination by Profile
 
 - **WHEN** 사용자가 선택 Profile을 바꾼 뒤 `/bookmarks` 목록을 조회한다

--- a/openspec/changes/add-profile-bookmarks/specs/web-app-shell/spec.md
+++ b/openspec/changes/add-profile-bookmarks/specs/web-app-shell/spec.md
@@ -40,6 +40,11 @@
 - **WHEN** 유효한 세션과 선택 Profile이 있는 사용자가 `/bookmarks`로 이동한다
 - **THEN** 시스템은 `(tabs)` 셸을 유지하며 선택 Profile의 개인 Bookmark 목록 화면을 표시한다
 
+#### Scenario: Navigate from the Web Bookmark menu
+
+- **WHEN** 사용자가 Web full 또는 compact sidebar의 Bookmark 메뉴 항목을 선택한다
+- **THEN** 시스템은 `/menu`를 경유하지 않고 canonical `/bookmarks` route로 이동한다
+
 #### Scenario: Open without a selected Profile
 
 - **WHEN** 유효한 세션은 있지만 선택 Profile이 없는 사용자가 `/bookmarks`로 이동한다

--- a/openspec/changes/add-profile-bookmarks/tasks.md
+++ b/openspec/changes/add-profile-bookmarks/tasks.md
@@ -193,13 +193,14 @@ Owner Profile이 조회 가능한 Target의 Bookmark를 안정적인 최신순 c
 - PROD-452의 목록 presentation을 재사용하고 기존 Post 카드의 canonical navigation을 Bookmark 전용 callback으로 대체하지 않는다.
 - selected Profile이 없으면 목록 query를 실행하지 않고, Profile 전환 뒤 이전 edge·cursor를 재사용하지 않는다.
 - 서버가 숨긴 Target Post를 client fallback으로 복원하거나 노출하지 않는다.
-- mobile navigation entry는 구현 전에 Remaining Decisions에서 확정한다.
+- 다음 페이지 요청이 실패하면 기존 Post 카드를 유지하고 목록 아래에 alert와 retry action을 제공한다.
+- Web full·compact sidebar와 mobile drawer는 공용 `SidebarNavigation`의 Bookmark 항목을 `/bookmarks`로 연결하고, mobile bottom tab이나 별도 header 버튼을 추가하지 않는다.
 
 **Verification**
 
-- guest redirect, no-selected-Profile, loading·error·retry·empty·pagination, Target 이동, Profile 격리, mobile entry와 Web direct navigation을 route/component integration 수준에서 검증한다.
+- guest redirect, no-selected-Profile, loading·initial error·empty·pagination, 다음 페이지 실패 시 기존 edge 유지·retry, Target 이동, Profile 격리, mobile entry와 Web direct navigation을 route/component integration 수준에서 검증한다.
 
-- [ ] 7.1 mobile shell의 `/bookmarks` navigation entry를 사용자와 확정하고 specs·decisions에 반영한다.
+- [x] 7.1 Web full·compact sidebar와 mobile drawer의 공용 Bookmark 메뉴를 `/bookmarks`로 연결하고 bottom tab은 유지하기로 사용자와 확정해 specs·decisions에 반영한다.
 - [ ] 7.2 selected Profile별 pagination connection과 PROD-452 presentation을 연결하는 공용 Bookmark 목록 route를 구현한다.
 - [ ] 7.3 desktop·mobile navigation entry와 기존 Post 카드의 canonical detail Link가 shell/router 정책으로 동작하게 한다.
 - [ ] 7.4 세 플랫폼 route parity와 실제 connection의 목록 상태·pagination·Profile 격리·direct navigation 검증을 추가하고 관련 check를 통과시킨다.

--- a/openspec/changes/add-profile-bookmarks/tasks.md
+++ b/openspec/changes/add-profile-bookmarks/tasks.md
@@ -201,9 +201,9 @@ Owner Profile이 조회 가능한 Target의 Bookmark를 안정적인 최신순 c
 - guest redirect, no-selected-Profile, loading·initial error·empty·pagination, 다음 페이지 실패 시 기존 edge 유지·retry, Target 이동, Profile 격리, mobile entry와 Web direct navigation을 route/component integration 수준에서 검증한다.
 
 - [x] 7.1 Web full·compact sidebar와 mobile drawer의 공용 Bookmark 메뉴를 `/bookmarks`로 연결하고 bottom tab은 유지하기로 사용자와 확정해 specs·decisions에 반영한다.
-- [ ] 7.2 selected Profile별 pagination connection과 PROD-452 presentation을 연결하는 공용 Bookmark 목록 route를 구현한다.
-- [ ] 7.3 desktop·mobile navigation entry와 기존 Post 카드의 canonical detail Link가 shell/router 정책으로 동작하게 한다.
-- [ ] 7.4 세 플랫폼 route parity와 실제 connection의 목록 상태·pagination·Profile 격리·direct navigation 검증을 추가하고 관련 check를 통과시킨다.
+- [x] 7.2 selected Profile별 pagination connection과 PROD-452 presentation을 연결하는 공용 Bookmark 목록 route를 구현한다.
+- [x] 7.3 desktop·mobile navigation entry와 기존 Post 카드의 canonical detail Link가 shell/router 정책으로 동작하게 한다.
+- [x] 7.4 세 플랫폼 route parity와 실제 connection의 목록 상태·pagination·Profile 격리·direct navigation 검증을 추가하고 관련 check를 통과시킨다.
 
 ## 8. PROD-391 Bookmark 계약 통합 검증과 archive
 


### PR DESCRIPTION
## 무엇을 변경했는지

- 선택된 Profile만 자신의 `Profile.bookmarks` connection을 조회하는 공용 `/bookmarks` 보호 route를 추가했습니다.
- nullable Target은 목록에서 제외하고 PROD-452의 `BookmarkList`와 기존 `PostListItem` canonical Link를 그대로 재사용했습니다.
- 다음 페이지 실패 때 기존 카드를 유지하고 alert와 retry를 제공하며, 재시도 성공 시 같은 connection에 다음 edge를 추가합니다.
- selected Profile이 없을 때 query를 시작하지 않고, Profile/Relay actor 전환 뒤 이전 edge·cursor·오류 상태를 재사용하지 않게 했습니다.
- Web full·compact sidebar와 mobile drawer의 Bookmark 메뉴를 `/bookmarks`로 연결하고 기존 mobile BottomTab은 유지했습니다.
- 서버가 제공하는 최신순 edge를 그대로 렌더링하며, 나중에 저장한 Bookmark가 위에 오는 순서를 route Story에서 명시적으로 검증했습니다.
- navigation과 pagination failure 결정을 `add-profile-bookmarks` OpenSpec에 반영했습니다.

## 왜 변경했는지

선택된 Profile이 Android·iOS·Web의 공용 Expo route에서 자신의 개인 Bookmark를 최신순으로 탐색하고, 기존 Post 표면과 동일한 navigation으로 Target Post를 열 수 있게 하기 위해서입니다.

PR #317은 merge됐고, 이 브랜치는 최신 `main` 위로 재정렬했습니다.

## 이번 PR의 주요 결정

### Bookmark 진입점

- Web full·compact sidebar와 mobile drawer의 공용 Bookmark 항목을 `/bookmarks`로 연결합니다.
- mobile BottomTab이나 별도 header action은 추가하지 않습니다.
- Bookmark 외 기존 `/menu` placeholder는 유지합니다.

### 최신순 표시

- API의 기존 UUIDv7 `id DESC` connection 순서를 클라이언트가 재정렬하지 않고 보존합니다.
- 같은 millisecond 안의 절대 생성 순서는 추가 ordering key 없이 기존 canonical 계약을 유지합니다.
- Story fixture와 route interaction은 나중 저장한 항목이 이전 저장 항목보다 위에 표시되는 일반 동작을 검증합니다.

### 다음 페이지 실패

- 이미 불러온 카드는 유지하고 목록 아래에 alert와 retry action을 표시합니다.
- 성공한 retry는 같은 Relay connection에 다음 edge를 추가하고 alert를 지웁니다.
- 첫 요청 실패는 전체 목록 error/retry 상태로 유지합니다.

### Profile 격리

- selected Profile 부재 시 Bookmark query 전에 Profile-required 상태를 반환합니다.
- Relay actor revision과 Profile ID를 route/query 경계에 포함하고, 늦은 pagination callback이 다른 Profile 오류 상태를 바꾸지 못하게 합니다.

Durable decision과 대안·결과는 `openspec/changes/add-profile-bookmarks/decisions.md`에 기록했습니다. 새 API/DB 계약, Bookmark action, 공개 목록, Folder/Collection은 추가하지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check` — Relay compiler·TypeScript 통과
- `pnpm --filter @kosmo/app test:unit` — 29/29 통과
- `pnpm --filter @kosmo/app build-storybook` — 정적 빌드 통과
- `pnpm --filter @kosmo/app test:storybook` — 9 files, 86/86 통과
- `pnpm exec openspec validate add-profile-bookmarks --strict` — 통과
- `pnpm run "/^lint:.*/"` — workspace lint 통과
- `git diff --check` — 통과
- Web 1440/1024에서 600px CenterColumn과 43px TitleBar를 확인했습니다.
- full·compact sidebar와 mobile drawer의 `/bookmarks`, mobile BottomTab의 Bookmark 미추가를 확인했습니다.
- 독립 구현 리뷰를 통과했고, rebase 후 `range-diff`에서 네 커밋의 patch 동일성을 확인했습니다.
- GitHub Lint·Semgrep·Test가 모두 통과했고 unresolved review thread는 없습니다.

## 아직 어떤 문제가 남았는지

- Storybook은 Web renderer이므로 Android/iOS 실제 runtime과 `kosmo://` custom-scheme deep link는 실행하지 않았습니다. 공용 route/source, Relay compile과 TypeScript 정합성까지만 확인했습니다.
- 초기 요청 실패 story는 retry 후 loading 재진입까지 확인하며, 성공 목록 복구는 별도 assertion하지 않습니다. 다음 페이지 실패 → retry 성공 → edge append·alert 해제는 검증했습니다.
- Storybook build에는 Node `module.register()` deprecation과 500 kB 초과 chunk 경고가 있으나 빌드와 테스트는 성공했습니다.
- PROD-391의 최종 vertical flow와 OpenSpec archive(group 8)는 이 PR 범위가 아니며 완료 처리하지 않습니다.
- 이 PR은 사용자 확인 전까지 Draft를 유지합니다.
