### PR TITLE
Repost 삭제 기능 구현

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -106,6 +106,14 @@ type DeleteBookmarkPayload {
   post: Post
 }
 
+input DeletePostInput {
+  id: ID!
+}
+
+type DeletePostPayload {
+  postId: ID!
+}
+
 input DeleteProfileInput {
   id: ID!
 }
@@ -171,6 +179,7 @@ type Mutation {
   createPost(input: CreatePostInput!): CreatePostPayload!
   createProfile(input: CreateProfileInput!): CreateProfilePayload!
   deleteBookmark(input: DeleteBookmarkInput!): DeleteBookmarkPayload!
+  deletePost(input: DeletePostInput!): DeletePostPayload!
   deleteProfile(input: DeleteProfileInput!): DeleteProfilePayload!
   deleteReaction(input: DeleteReactionInput!): DeleteReactionPayload!
   exchangeNativeOidcSession(input: ExchangeNativeOidcSessionInput!): ExchangeNativeOidcSessionPayload!

--- a/apps/api/src/graphql/resolvers/post/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/delete.ts
@@ -1,0 +1,26 @@
+import { deletePost } from '@kosmo/core/services';
+import { builder } from '@/graphql/builder';
+import { Post } from '../ref';
+
+builder.mutationField('deletePost', (t) =>
+  t.withAuth({ usingProfile: true }).fieldWithInput({
+    type: builder.simpleObject('DeletePostPayload', {
+      fields: (field) => ({
+        postId: field.globalID({
+          resolve: (payload) => ({
+            id: (payload as { postId: string }).postId,
+            type: Post,
+          }),
+        }),
+      }),
+    }),
+    input: {
+      id: t.input.globalID({ for: Post }),
+    },
+    resolve: (_, { input }, ctx) =>
+      deletePost({
+        actorProfileId: ctx.session.profileId,
+        postId: input.id.id,
+      }),
+  }),
+);

--- a/apps/api/src/graphql/resolvers/post/mutation/index.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/index.ts
@@ -1,2 +1,3 @@
 import './create';
+import './delete';
 import './repost';

--- a/apps/api/src/graphql/schema.test.ts
+++ b/apps/api/src/graphql/schema.test.ts
@@ -120,6 +120,20 @@ test('exposes the idempotent Repost creation contract', () => {
   assert.equal(payload.getFields().created, undefined);
 });
 
+test('exposes the ID-based idempotent Post delete contract', () => {
+  const mutation = schema.getMutationType();
+  const input = schema.getType('DeletePostInput');
+  const payload = schema.getType('DeletePostPayload');
+
+  assert.equal(String(mutation?.getFields().deletePost?.type), 'DeletePostPayload!');
+  assert.ok(isInputObjectType(input));
+  assert.equal(String(input.getFields().id.type), 'ID!');
+  assert.ok(isObjectType(payload));
+  assert.equal(String(payload.getFields().postId.type), 'ID!');
+  assert.equal(payload.getFields().post, undefined);
+  assert.equal(payload.getFields().deleted, undefined);
+});
+
 test('exposes the Bookmark mutation and relationship contract', () => {
   const mutation = schema.getMutationType();
   const createInput = schema.getType('CreateBookmarkInput');

--- a/apps/api/tests/integration/graphql/post-repost.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { normalizeHandle } from '@kosmo/core/utils';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { encodeGlobalId as globalId } from '../../../src/graphql/global-id';
 import type * as CoreDb from '@kosmo/core/db';
@@ -198,6 +198,116 @@ describe('GraphQL Repost', () => {
 
     assert.ok(result.errors?.[0]);
   });
+
+  test('deletePost는 Author Repost를 멱등 Tombstone 처리하고 새 Repost를 허용한다', async () => {
+    const auth = await createAuthenticatedSession();
+    const source = await createContentPost(auth.profile.id);
+    await requestRepost(source.id, auth.token);
+    const repost = await db
+      .select()
+      .from(Posts)
+      .where(and(eq(Posts.profileId, auth.profile.id), eq(Posts.repostSourceId, source.id)))
+      .then(firstOrThrow);
+
+    const first = await requestDelete(repost.id, auth.token);
+    assertNoGraphQLErrors(first);
+    assert.deepEqual(first.data?.deletePost, { postId: globalId('Post', repost.id) });
+
+    const deleted = await db.select().from(Posts).where(eq(Posts.id, repost.id)).then(firstOrThrow);
+    assert.equal(deleted.state, PostState.DELETED);
+    assert.ok(deleted.deletedAt);
+    assert.equal(deleted.repostSourceId, source.id);
+
+    const repeated = await requestDelete(repost.id, auth.token);
+    assertNoGraphQLErrors(repeated);
+    assert.deepEqual(repeated.data?.deletePost, first.data?.deletePost);
+    const repeatedDeletedAt = await db
+      .select({ deletedAt: Posts.deletedAt })
+      .from(Posts)
+      .where(eq(Posts.id, repost.id))
+      .then(firstOrThrow);
+    assert.equal(repeatedDeletedAt.deletedAt?.toString(), deleted.deletedAt.toString());
+
+    assert.equal(
+      await db
+        .select()
+        .from(Posts)
+        .where(
+          and(
+            eq(Posts.repostSourceId, source.id),
+            eq(Posts.state, PostState.ACTIVE),
+            isNull(Posts.currentContentId),
+          ),
+        )
+        .then((rows) => rows.length),
+      0,
+    );
+
+    const recreated = await requestRepost(source.id, auth.token);
+    assertNoGraphQLErrors(recreated);
+    assert.notEqual(recreated.data?.repostPost.repost.id, globalId('Post', repost.id));
+  });
+
+  test('동시 deletePost는 같은 postId로 수렴하고 최초 Tombstone만 기록한다', async () => {
+    const auth = await createAuthenticatedSession();
+    const source = await createContentPost(auth.profile.id);
+    await requestRepost(source.id, auth.token);
+    const repost = await db
+      .select()
+      .from(Posts)
+      .where(and(eq(Posts.profileId, auth.profile.id), eq(Posts.repostSourceId, source.id)))
+      .then(firstOrThrow);
+
+    const concurrent = await Promise.all(
+      Array.from({ length: 4 }, () => requestDelete(repost.id, auth.token)),
+    );
+    concurrent.forEach(assertNoGraphQLErrors);
+    assert.deepEqual(
+      concurrent.map((result) => result.data?.deletePost.postId),
+      Array.from({ length: 4 }, () => globalId('Post', repost.id)),
+    );
+
+    const stored = await db.select().from(Posts).where(eq(Posts.id, repost.id)).then(firstOrThrow);
+    assert.equal(stored.state, PostState.DELETED);
+    assert.ok(stored.deletedAt);
+  });
+
+  test('deletePost는 비Author와 비로그인 요청을 거부한다', async () => {
+    const author = await createAuthenticatedSession();
+    const other = await createAuthenticatedSession();
+    const source = await createContentPost(author.profile.id);
+    await requestRepost(source.id, author.token);
+    const repost = await db
+      .select()
+      .from(Posts)
+      .where(and(eq(Posts.profileId, author.profile.id), eq(Posts.repostSourceId, source.id)))
+      .then(firstOrThrow);
+
+    for (const token of [other.token, undefined]) {
+      const result = await requestDelete(repost.id, token);
+      assert.equal(result.errors?.[0]?.extensions?.code, 'PERMISSION_DENIED');
+    }
+
+    const stored = await db
+      .select({ state: Posts.state })
+      .from(Posts)
+      .where(eq(Posts.id, repost.id))
+      .then(firstOrThrow);
+    assert.equal(stored.state, PostState.ACTIVE);
+  });
+
+  test('deletePost는 Post가 아닌 concrete global ID를 거부한다', async () => {
+    const auth = await createAuthenticatedSession();
+    const result = await requestGraphQL<{ deletePost: { postId: string } }>(
+      `mutation DeletePost($input: DeletePostInput!) {
+        deletePost(input: $input) { postId }
+      }`,
+      { input: { id: globalId('Profile', auth.profile.id) } },
+      auth.token,
+    );
+
+    assert.ok(result.errors?.[0]);
+  });
 });
 
 type PostNode = {
@@ -223,6 +333,15 @@ const requestRepost = (sourceId: string, token?: string) =>
       }
     }`,
     { input: { sourceId: globalId('Post', sourceId) } },
+    token,
+  );
+
+const requestDelete = (postId: string, token?: string) =>
+  requestGraphQL<{ deletePost: { postId: string } }>(
+    `mutation DeletePost($input: DeletePostInput!) {
+      deletePost(input: $input) { postId }
+    }`,
+    { input: { id: globalId('Post', postId) } },
     token,
   );
 

--- a/apps/api/tests/integration/graphql/post-repost.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost.test.ts
@@ -199,7 +199,7 @@ describe('GraphQL Repost', () => {
     assert.ok(result.errors?.[0]);
   });
 
-  test('deletePost는 삭제한 Repost의 concrete global ID를 반환한다', async () => {
+  test('deletePost는 GraphQL 경로에서 Repost를 Tombstone 처리하고 상태를 갱신한다', async () => {
     const auth = await createAuthenticatedSession();
     const source = await createContentPost(auth.profile.id);
     await requestRepost(source.id, auth.token);
@@ -212,6 +212,40 @@ describe('GraphQL Repost', () => {
     const first = await requestDelete(repost.id, auth.token);
     assertNoGraphQLErrors(first);
     assert.deepEqual(first.data?.deletePost, { postId: globalId('Post', repost.id) });
+
+    const deleted = await db
+      .select({ deletedAt: Posts.deletedAt, state: Posts.state })
+      .from(Posts)
+      .where(eq(Posts.id, repost.id))
+      .then(firstOrThrow);
+    assert.equal(deleted.state, PostState.DELETED);
+    assert.ok(deleted.deletedAt);
+
+    const sourceState = await requestGraphQL<{
+      nodes: Array<{
+        id: string;
+        repostCount: number;
+        viewerRepost: { id: string } | null;
+      } | null>;
+    }>(
+      `query RepostState($ids: [ID!]!) {
+        nodes(ids: $ids) {
+          ... on Post {
+            id
+            repostCount
+            viewerRepost { id }
+          }
+        }
+      }`,
+      { ids: [globalId('Post', source.id)] },
+      auth.token,
+    );
+    assertNoGraphQLErrors(sourceState);
+    assert.deepEqual(sourceState.data?.nodes[0], {
+      id: globalId('Post', source.id),
+      repostCount: 0,
+      viewerRepost: null,
+    });
   });
 
   test('deletePost는 비Author와 비로그인 요청을 거부한다', async () => {

--- a/apps/api/tests/integration/graphql/post-repost.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { normalizeHandle } from '@kosmo/core/utils';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { encodeGlobalId as globalId } from '../../../src/graphql/global-id';
 import type * as CoreDb from '@kosmo/core/db';
@@ -199,7 +199,7 @@ describe('GraphQL Repost', () => {
     assert.ok(result.errors?.[0]);
   });
 
-  test('deletePost는 Author Repost를 멱등 Tombstone 처리하고 새 Repost를 허용한다', async () => {
+  test('deletePost는 삭제한 Repost의 concrete global ID를 반환한다', async () => {
     const auth = await createAuthenticatedSession();
     const source = await createContentPost(auth.profile.id);
     await requestRepost(source.id, auth.token);
@@ -212,64 +212,6 @@ describe('GraphQL Repost', () => {
     const first = await requestDelete(repost.id, auth.token);
     assertNoGraphQLErrors(first);
     assert.deepEqual(first.data?.deletePost, { postId: globalId('Post', repost.id) });
-
-    const deleted = await db.select().from(Posts).where(eq(Posts.id, repost.id)).then(firstOrThrow);
-    assert.equal(deleted.state, PostState.DELETED);
-    assert.ok(deleted.deletedAt);
-    assert.equal(deleted.repostSourceId, source.id);
-
-    const repeated = await requestDelete(repost.id, auth.token);
-    assertNoGraphQLErrors(repeated);
-    assert.deepEqual(repeated.data?.deletePost, first.data?.deletePost);
-    const repeatedDeletedAt = await db
-      .select({ deletedAt: Posts.deletedAt })
-      .from(Posts)
-      .where(eq(Posts.id, repost.id))
-      .then(firstOrThrow);
-    assert.equal(repeatedDeletedAt.deletedAt?.toString(), deleted.deletedAt.toString());
-
-    assert.equal(
-      await db
-        .select()
-        .from(Posts)
-        .where(
-          and(
-            eq(Posts.repostSourceId, source.id),
-            eq(Posts.state, PostState.ACTIVE),
-            isNull(Posts.currentContentId),
-          ),
-        )
-        .then((rows) => rows.length),
-      0,
-    );
-
-    const recreated = await requestRepost(source.id, auth.token);
-    assertNoGraphQLErrors(recreated);
-    assert.notEqual(recreated.data?.repostPost.repost.id, globalId('Post', repost.id));
-  });
-
-  test('동시 deletePost는 같은 postId로 수렴하고 최초 Tombstone만 기록한다', async () => {
-    const auth = await createAuthenticatedSession();
-    const source = await createContentPost(auth.profile.id);
-    await requestRepost(source.id, auth.token);
-    const repost = await db
-      .select()
-      .from(Posts)
-      .where(and(eq(Posts.profileId, auth.profile.id), eq(Posts.repostSourceId, source.id)))
-      .then(firstOrThrow);
-
-    const concurrent = await Promise.all(
-      Array.from({ length: 4 }, () => requestDelete(repost.id, auth.token)),
-    );
-    concurrent.forEach(assertNoGraphQLErrors);
-    assert.deepEqual(
-      concurrent.map((result) => result.data?.deletePost.postId),
-      Array.from({ length: 4 }, () => globalId('Post', repost.id)),
-    );
-
-    const stored = await db.select().from(Posts).where(eq(Posts.id, repost.id)).then(firstOrThrow);
-    assert.equal(stored.state, PostState.DELETED);
-    assert.ok(stored.deletedAt);
   });
 
   test('deletePost는 비Author와 비로그인 요청을 거부한다', async () => {

--- a/openspec/changes/add-post-reposts/tasks.md
+++ b/openspec/changes/add-post-reposts/tasks.md
@@ -182,9 +182,9 @@ Repost Author가 기존 Post 삭제 행동으로 Active Repost를 멱등 Tombsto
 
 - 정상·반복·동시 삭제, 권한 실패, `postId` payload, count 감소, partial unique 해제와 재Repost를 core/API integration test로 검증한다.
 
-- [ ] 6.1 Author·Active 상태를 확인하고 Post를 멱등 Tombstone 처리하는 공통 삭제 core action을 구현한다.
-- [ ] 6.2 `deletePost` mutation과 `DeletePostPayload.postId`를 concrete Post global ID 계약에 맞춰 제공한다.
-- [ ] 6.3 Tombstone·권한·동시성·count·재Repost와 GraphQL payload 검증을 추가하고 core/API check를 통과시킨다.
+- [x] 6.1 Author·Active 상태를 확인하고 Post를 멱등 Tombstone 처리하는 공통 삭제 core action을 구현한다.
+- [x] 6.2 `deletePost` mutation과 `DeletePostPayload.postId`를 concrete Post global ID 계약에 맞춰 제공한다.
+- [x] 6.3 Tombstone·권한·동시성·count·재Repost와 GraphQL payload 검증을 추가하고 core/API check를 통과시킨다.
 
 ## 7. PROD-453 Repost/Quote presentation UI
 

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -4,7 +4,8 @@ export {
   createReactionNotification,
   deleteNotificationBySource,
 } from './notification';
-export { createPost, repostPost } from './post';
+export { createPost, deletePost, repostPost } from './post';
+export { createPost, deletePost, repostPost } from './post';
 export { disableProfile } from './profile';
 export { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
 export {

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -5,7 +5,6 @@ export {
   deleteNotificationBySource,
 } from './notification';
 export { createPost, deletePost, repostPost } from './post';
-export { createPost, deletePost, repostPost } from './post';
 export { disableProfile } from './profile';
 export { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
 export {

--- a/packages/core/services/post-repost.test.ts
+++ b/packages/core/services/post-repost.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { db, firstOrThrow, Instances, pg, Posts, ProfileFollows, Profiles } from '../db';
 import {
   InstanceKind,
@@ -12,7 +12,7 @@ import {
 } from '../enums';
 import { NotFoundError, PermissionDeniedError, ValidationError } from '../error';
 import { postContentDocumentFromText } from '../post-content/server';
-import { createPost, repostPost } from './post';
+import { createPost, deletePost, repostPost } from './post';
 
 after(async () => pg.end());
 
@@ -273,4 +273,140 @@ test('repostPost는 caller transaction rollback에 합류한다', async () => {
       .then((rows) => rows.length),
     0,
   );
+});
+
+test('deletePost는 Author의 Repost를 Tombstone 처리하고 새 Repost를 허용한다', async () => {
+  const actor = await createProfile();
+  const source = await createContentPost(actor.profile.id);
+  const repost = await repostPost({
+    actorProfileId: actor.profile.id,
+    sourcePostId: source.id,
+  });
+
+  assert.deepEqual(await deletePost({ actorProfileId: actor.profile.id, postId: repost.id }), {
+    postId: repost.id,
+  });
+
+  const deleted = await db.select().from(Posts).where(eq(Posts.id, repost.id)).then(firstOrThrow);
+  assert.equal(deleted.state, PostState.DELETED);
+  assert.ok(deleted.deletedAt);
+  assert.equal(deleted.repostSourceId, source.id);
+  assert.equal(
+    await db
+      .select()
+      .from(Posts)
+      .where(
+        and(
+          eq(Posts.repostSourceId, source.id),
+          eq(Posts.state, PostState.ACTIVE),
+          isNull(Posts.currentContentId),
+        ),
+      )
+      .then((rows) => rows.length),
+    0,
+  );
+
+  const recreated = await repostPost({
+    actorProfileId: actor.profile.id,
+    sourcePostId: source.id,
+  });
+  assert.notEqual(recreated.id, repost.id);
+  assert.equal(recreated.state, PostState.ACTIVE);
+});
+
+test('deletePost의 반복·동시 호출은 최초 삭제 시각을 보존하며 멱등 성공한다', async () => {
+  const actor = await createProfile();
+  const source = await createContentPost(actor.profile.id);
+  const repost = await repostPost({
+    actorProfileId: actor.profile.id,
+    sourcePostId: source.id,
+  });
+  const input = { actorProfileId: actor.profile.id, postId: repost.id };
+
+  const concurrent = await Promise.all(Array.from({ length: 4 }, () => deletePost(input)));
+  assert.deepEqual(
+    concurrent,
+    Array.from({ length: 4 }, () => ({ postId: repost.id })),
+  );
+
+  const firstDeletedAt = await db
+    .select({ deletedAt: Posts.deletedAt })
+    .from(Posts)
+    .where(eq(Posts.id, repost.id))
+    .then(firstOrThrow)
+    .then(({ deletedAt }) => deletedAt);
+  assert.ok(firstDeletedAt);
+
+  assert.deepEqual(await deletePost(input), { postId: repost.id });
+  const repeatedDeletedAt = await db
+    .select({ deletedAt: Posts.deletedAt })
+    .from(Posts)
+    .where(eq(Posts.id, repost.id))
+    .then(firstOrThrow)
+    .then(({ deletedAt }) => deletedAt);
+  assert.equal(repeatedDeletedAt?.toString(), firstDeletedAt.toString());
+});
+
+test('deletePost는 다른 Author의 Post를 거부하고 누락 Post를 숨긴다', async () => {
+  const author = await createProfile();
+  const other = await createProfile();
+  const post = await createContentPost(author.profile.id);
+
+  await assert.rejects(
+    deletePost({ actorProfileId: other.profile.id, postId: post.id }),
+    (error) => error instanceof PermissionDeniedError && error.code === 'PERMISSION_DENIED',
+  );
+  await assert.rejects(
+    deletePost({ actorProfileId: author.profile.id, postId: crypto.randomUUID() }),
+    (error) => error instanceof NotFoundError && error.code === 'NOT_FOUND',
+  );
+
+  const stored = await db
+    .select({ state: Posts.state })
+    .from(Posts)
+    .where(eq(Posts.id, post.id))
+    .then(firstOrThrow);
+  assert.equal(stored.state, PostState.ACTIVE);
+});
+
+test('deletePost는 대상 Quote만 삭제하고 별도 Active Repost는 유지한다', async () => {
+  const actor = await createProfile();
+  const source = await createContentPost(actor.profile.id);
+  const quote = await createContentPost(actor.profile.id);
+  await db.update(Posts).set({ repostSourceId: source.id }).where(eq(Posts.id, quote.id));
+  const repost = await repostPost({
+    actorProfileId: actor.profile.id,
+    sourcePostId: source.id,
+  });
+
+  await deletePost({ actorProfileId: actor.profile.id, postId: quote.id });
+
+  const [deletedQuote, activeRepost] = await Promise.all([
+    db.select().from(Posts).where(eq(Posts.id, quote.id)).then(firstOrThrow),
+    db.select().from(Posts).where(eq(Posts.id, repost.id)).then(firstOrThrow),
+  ]);
+  assert.equal(deletedQuote.state, PostState.DELETED);
+  assert.equal(deletedQuote.currentContentId, quote.currentContentId);
+  assert.equal(activeRepost.state, PostState.ACTIVE);
+});
+
+test('deletePost는 caller transaction rollback에 합류한다', async () => {
+  const actor = await createProfile();
+  const post = await createContentPost(actor.profile.id);
+
+  await assert.rejects(
+    db.transaction(async (tx) => {
+      await deletePost({ actorProfileId: actor.profile.id, postId: post.id }, tx);
+      throw new Error('rollback');
+    }),
+    /rollback/,
+  );
+
+  const stored = await db
+    .select({ deletedAt: Posts.deletedAt, state: Posts.state })
+    .from(Posts)
+    .where(eq(Posts.id, post.id))
+    .then(firstOrThrow);
+  assert.equal(stored.state, PostState.ACTIVE);
+  assert.equal(stored.deletedAt, null);
 });

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -195,7 +195,7 @@ export const repostPost = async (
       })
       .onConflictDoNothing()
       .returning()
-    .then(first);
+      .then(first);
     if (inserted) {
       return inserted;
     }

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNotNull, isNull, ne, or } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, ne, or, sql } from 'drizzle-orm';
 import {
   ActivityPubPosts,
   first,
@@ -96,6 +96,44 @@ const findVisiblePost = async (
     .limit(1)
     .then(first);
 
+export const deletePost = async (
+  {
+    actorProfileId,
+    postId,
+  }: {
+    readonly actorProfileId: string;
+    readonly postId: string;
+  },
+  tx?: Transaction,
+): Promise<{ readonly postId: string }> =>
+  getDatabaseConnection(tx).transaction(async (tx) => {
+    const post = await tx
+      .select({ profileId: Posts.profileId })
+      .from(Posts)
+      .where(eq(Posts.id, postId))
+      .limit(1)
+      .then(first);
+    if (!post) {
+      throw new NotFoundError('Post not found');
+    }
+    if (post.profileId !== actorProfileId) {
+      throw new PermissionDeniedError('Post author permission is required');
+    }
+
+    await tx
+      .update(Posts)
+      .set({ deletedAt: sql`now()`, state: PostState.DELETED })
+      .where(
+        and(
+          eq(Posts.id, postId),
+          eq(Posts.profileId, actorProfileId),
+          eq(Posts.state, PostState.ACTIVE),
+        ),
+      );
+
+    return { postId };
+  });
+
 export const repostPost = async (
   {
     actorProfileId,
@@ -157,7 +195,7 @@ export const repostPost = async (
       })
       .onConflictDoNothing()
       .returning()
-      .then(first);
+    .then(first);
     if (inserted) {
       return inserted;
     }
@@ -181,7 +219,6 @@ export const repostPost = async (
 
     return existing;
   });
-
 export function createPost(input: LocalPostInput, tx?: Transaction): Promise<CreatedPost>;
 export function createPost(
   input: ActivityPubPostInput,


### PR DESCRIPTION
## 무엇을 변경했는지
- Repost를 포함한 Post를 Author가 삭제할 수 있는 공통 `deletePost` core action을 추가했습니다.
- Active Post만 조건부로 Tombstone 전이해 반복·동시 삭제에서도 최초 삭제 시각과 Repost Source 관계를 보존합니다.
- GraphQL `deletePost(input: { id })`와 `DeletePostPayload.postId`를 concrete Post global ID 계약으로 추가했습니다.
- Author 권한, Tombstone 전이, count 감소, active uniqueness 해제, 재Repost, transaction rollback을 core 서비스 테스트로 검증했습니다.
- API 테스트는 인증·권한·concrete global ID·payload wiring에 집중하고 core 테스트와 중복되던 DB lifecycle 검증을 제거했습니다.
- OpenSpec `add-post-reposts`의 PROD-411 task 6.1~6.3을 완료 처리했습니다.

## 왜 변경했는지

PROD-411은 Repost를 별도 관계 삭제나 hard delete가 아니라, 기존 Post 삭제 행동을 통한 Tombstone 전이로 취소하도록 요구합니다. 이 방식은 삭제된 Repost의 identity와 Source 관계를 보존하면서 active Repost count와 유일성에서 제외하고, 같은 Source를 다시 Repost할 수 있게 합니다.

계약 근거:
- Linear: [PROD-411 Repost를 취소한다](https://linear.app/byulmaru/issue/PROD-411/repost를-취소한다)
- Canonical domain: `docs/domain/objects/post.md`
- Canonical decision: `docs/domain/decisions/0010-post-interaction-contracts.md`
- OpenSpec: `openspec/changes/add-post-reposts`의 task 6 및 Repost 삭제 requirement

## 이번 PR의 주요 결정

- 새로운 durable decision은 없습니다. 최신 canonical 문서·Linear와 대조한 OpenSpec 결정을 변경 없이 적용했습니다.
- Repost 취소 전용 mutation을 추가하지 않고 일반 Post 삭제 계약인 `deletePost`를 사용합니다.
- 삭제된 Tombstone Node를 payload로 반환하지 않고, 클라이언트가 제거할 concrete Post global ID인 `postId`만 반환합니다.
- Notification 정리는 PROD-416이 소유하므로 이번 transaction과 PR 범위에 포함하지 않습니다.

## 어떻게 확인할 수 있는지

- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm --filter @kosmo/api test:unit` — 25개 통과
- `pnpm --filter @kosmo/core test:services:database` — 97개 통과
- 전용 테스트 DB에서 `apps/api/tests/integration/graphql/post-repost.test.ts` — 10개 통과
- GitHub Actions의 Lint, Test, Semgrep check

## 아직 어떤 문제가 남았는지

- 이 PR 범위에 남은 문제는 없습니다.
- Repost Notification 정리는 PROD-416, client Repost action 연결은 PROD-414가 소유합니다.
- 공유 OpenSpec `add-post-reposts`는 다른 구현 task가 남아 있으므로 이 PR에서 archive하지 않습니다.
