### PR TITLE
PROD-470 API·Worker PostgreSQL 인증서 연결을 준비한다

### DIFF
--- a/apps/helm/templates/_helpers.tpl
+++ b/apps/helm/templates/_helpers.tpl
@@ -22,17 +22,47 @@
 {{- printf "postgres://kosmo:$(DATABASE_PASSWORD)@%s-rw:5432/kosmo" (include "kosmo.postgresName" .) -}}
 {{- end -}}
 
+{{- define "kosmo.postgresCredentialClientCertificateIsConfigured" -}}
+{{- $root := index . 0 -}}
+{{- $role := index . 1 -}}
+{{- $credentials := $root.Values.postgres.credentials | default dict -}}
+{{- $config := get $credentials $role | default dict -}}
+{{- $clientCertificate := get $config "clientCertificate" | default dict -}}
+{{- if get $clientCertificate "enabled" | default false }}true{{- else }}false{{- end -}}
+{{- end -}}
+
 {{- define "kosmo.validatePostgresCredentials" -}}
+{{- $root := . -}}
 {{- $credentials := .Values.postgres.credentials | default dict -}}
-{{- range $role := list "api" "fedify" -}}
+{{- range $role := list "api" "fedify" "worker" -}}
 {{- $config := get $credentials $role | default dict -}}
 {{- $databaseUrl := get $config "databaseUrl" | default "" -}}
 {{- $passwordSecret := get $config "passwordSecret" | default dict -}}
 {{- $name := get $passwordSecret "name" | default "" | toString -}}
 {{- $key := get $passwordSecret "key" | default "" | toString -}}
+{{- $clientCertificate := get $config "clientCertificate" | default dict -}}
+{{- $clientCertificateEnabled := get $clientCertificate "enabled" | default false -}}
 {{- $configured := or (ne $databaseUrl "") (ne $name "") (ne $key "") -}}
 {{- $complete := and (ne $databaseUrl "") (ne $name "") (ne $key "") -}}
-{{- if and $configured (not $complete) -}}
+{{- if $clientCertificateEnabled -}}
+{{- if not (ne $databaseUrl "") -}}
+{{- fail (printf "postgres.credentials.%s.clientCertificate requires databaseUrl" $role) -}}
+{{- end -}}
+{{- if or (ne $name "") (ne $key "") -}}
+{{- fail (printf "postgres.credentials.%s.clientCertificate is mutually exclusive with passwordSecret" $role) -}}
+{{- end -}}
+{{- $certificatePrincipal := get (dict "api" "kosmo_api" "worker" "kosmo_worker") $role | default "" -}}
+{{- if eq $certificatePrincipal "" -}}
+{{- fail (printf "postgres.credentials.%s.clientCertificate is only supported for api or worker" $role) -}}
+{{- end -}}
+{{- $clusterService := printf "%s-rw" (include "kosmo.postgresName" $root) -}}
+{{- $directClusterUrlPattern := printf "^postgres(?:ql)?://%s@%s(?:\\.[^/:@]+)*(?::[0-9]+)?/[^?]+(?:\\?.*)?$" $certificatePrincipal $clusterService -}}
+{{- if not (regexMatch $directClusterUrlPattern $databaseUrl) -}}
+{{- fail (printf "postgres.credentials.%s.clientCertificate.databaseUrl must be a direct cluster-rw PostgreSQL URL" $role) -}}
+{{- end -}}
+{{- else if and (eq $role "worker") $configured -}}
+{{- fail "postgres.credentials.worker password selection is owned by PROD-715; use the existing fedify password selector until that cutover" -}}
+{{- else if and $configured (not $complete) -}}
 {{- fail (printf "postgres.credentials.%s requires databaseUrl, passwordSecret.name, and passwordSecret.key together" $role) -}}
 {{- end -}}
 {{- end -}}
@@ -51,11 +81,33 @@
 {{- end -}}
 
 {{- define "kosmo.apiDatabaseUrl" -}}
-{{- if eq (include "kosmo.postgresCredentialIsConfigured" (list . "api") | trim) "true" -}}
+{{- if eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "api") | trim) "true" -}}
+{{- dig "api" "databaseUrl" "" (.Values.postgres.credentials | default dict) -}}
+{{- else if eq (include "kosmo.postgresCredentialIsConfigured" (list . "api") | trim) "true" -}}
 {{- dig "api" "databaseUrl" "" (.Values.postgres.credentials | default dict) -}}
 {{- else -}}
 {{- include "kosmo.databaseUrl" . -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "kosmo.workerDatabaseUrl" -}}
+{{- dig "worker" "databaseUrl" "" (.Values.postgres.credentials | default dict) -}}
+{{- end -}}
+
+{{- define "kosmo.postgresRuntimeRoleName" -}}
+{{- $root := index . 0 -}}
+{{- $role := index . 1 -}}
+{{- printf "%s-postgres-%s" ($root.Release.Name | trunc 47 | trimSuffix "-") $role -}}
+{{- end -}}
+
+{{- define "kosmo.postgresRuntimeClientCertificateSecretName" -}}
+{{- $root := index . 0 -}}
+{{- $role := index . 1 -}}
+{{- printf "%s-client-cert" (include "kosmo.postgresRuntimeRoleName" (list $root $role)) -}}
+{{- end -}}
+
+{{- define "kosmo.postgresClusterCaSecretName" -}}
+{{- printf "%s-ca" (include "kosmo.postgresName" .) -}}
 {{- end -}}
 
 {{- define "kosmo.apiDatabasePasswordSecretName" -}}

--- a/apps/helm/templates/api/rollout.yaml
+++ b/apps/helm/templates/api/rollout.yaml
@@ -1,3 +1,4 @@
+{{- $apiCertificateEnabled := eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "api") | trim) "true" -}}
 {{- include "kosmo.validatePostgresCredentials" . -}}
 {{- if .Values.workloads.enabled }}
 apiVersion: argoproj.io/v1alpha1
@@ -51,16 +52,35 @@ spec:
           env:
             - name: ENVIRONMENT
               value: {{ .Values.env | quote }}
+            {{- if not $apiCertificateEnabled }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kosmo.apiDatabasePasswordSecretName" . | quote }}
                   key: {{ include "kosmo.apiDatabasePasswordSecretKey" . }}
+            {{- end }}
             - name: DATABASE_URL
               value: {{ include "kosmo.apiDatabaseUrl" . | quote }}
+            {{- if $apiCertificateEnabled }}
+            - name: PGSSLCERT
+              value: /var/run/secrets/postgres/api/tls.crt
+            - name: PGSSLKEY
+              value: /var/run/secrets/postgres/api/tls.key
+            - name: PGSSLROOTCERT
+              value: /var/run/secrets/postgres/ca/ca.crt
+            {{- end }}
           envFrom:
             - secretRef:
                 name: env
+          {{- if $apiCertificateEnabled }}
+          volumeMounts:
+            - name: postgres-api-client-cert
+              mountPath: /var/run/secrets/postgres/api
+              readOnly: true
+            - name: postgres-cluster-ca
+              mountPath: /var/run/secrets/postgres/ca
+              readOnly: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -80,4 +100,16 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+      {{- if $apiCertificateEnabled }}
+      volumes:
+        - name: postgres-api-client-cert
+          secret:
+            secretName: {{ include "kosmo.postgresRuntimeClientCertificateSecretName" (list . "api") | quote }}
+        - name: postgres-cluster-ca
+          secret:
+            secretName: {{ include "kosmo.postgresClusterCaSecretName" . | quote }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+      {{- end }}
 {{- end }}

--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -18,9 +18,27 @@ spec:
 {{- end }}
   resources:
 {{ toYaml .Values.postgres.resources | indent 4 }}
+{{- $apiCertificateEnabled := eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "api") | trim) "true" -}}
+{{- $workerCertificateEnabled := eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "worker") | trim) "true" -}}
 {{- if eq .Values.env "prod" }}
   serviceAccountName: kosmo-postgres-backup
+{{- end }}
+{{- if or $apiCertificateEnabled $workerCertificateEnabled (eq .Values.env "prod") }}
   postgresql:
+{{- if $apiCertificateEnabled }}
+    pg_hba:
+      - "hostssl kosmo kosmo_api all cert"
+      - "hostnossl kosmo kosmo_api all reject"
+{{- if $workerCertificateEnabled }}
+      - "hostssl kosmo kosmo_worker all cert"
+      - "hostnossl kosmo kosmo_worker all reject"
+{{- end }}
+{{- else if $workerCertificateEnabled }}
+    pg_hba:
+      - "hostssl kosmo kosmo_worker all cert"
+      - "hostnossl kosmo kosmo_worker all reject"
+{{- end }}
+{{- if eq .Values.env "prod" }}
     parameters:
       archive_timeout: 4min
   plugins:
@@ -28,6 +46,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: kosmo-postgres-backup
+{{- end }}
 {{- end }}
   bootstrap:
     initdb:

--- a/apps/helm/templates/web/rollout.yaml
+++ b/apps/helm/templates/web/rollout.yaml
@@ -1,3 +1,5 @@
+{{- $apiCertificateEnabled := eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "api") | trim) "true" -}}
+{{- $workerCertificateEnabled := eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "worker") | trim) "true" -}}
 {{- include "kosmo.validatePostgresCredentials" . -}}
 {{- if .Values.workloads.enabled }}
 apiVersion: argoproj.io/v1alpha1
@@ -51,13 +53,23 @@ spec:
           env:
             - name: ENVIRONMENT
               value: {{ .Values.env | quote }}
+            {{- if not $apiCertificateEnabled }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kosmo.apiDatabasePasswordSecretName" . | quote }}
                   key: {{ include "kosmo.apiDatabasePasswordSecretKey" . }}
+            {{- end }}
             - name: DATABASE_URL
               value: {{ include "kosmo.apiDatabaseUrl" . | quote }}
+            {{- if $apiCertificateEnabled }}
+            - name: PGSSLCERT
+              value: /var/run/secrets/postgres/api/tls.crt
+            - name: PGSSLKEY
+              value: /var/run/secrets/postgres/api/tls.key
+            - name: PGSSLROOTCERT
+              value: /var/run/secrets/postgres/ca/ca.crt
+            {{- end }}
             {{- if eq (include "kosmo.postgresCredentialIsConfigured" (list . "fedify") | trim) "true" }}
             - name: FEDIFY_DATABASE_PASSWORD
               valueFrom:
@@ -67,9 +79,35 @@ spec:
             - name: FEDIFY_DATABASE_URL
               value: {{ dig "fedify" "databaseUrl" "" (.Values.postgres.credentials | default dict) | quote }}
             {{- end }}
+            {{- if $workerCertificateEnabled }}
+            - name: WORKER_DATABASE_URL
+              value: {{ include "kosmo.workerDatabaseUrl" . | quote }}
+            - name: WORKER_PGSSLCERT
+              value: /var/run/secrets/postgres/worker/tls.crt
+            - name: WORKER_PGSSLKEY
+              value: /var/run/secrets/postgres/worker/tls.key
+            - name: WORKER_PGSSLROOTCERT
+              value: /var/run/secrets/postgres/ca/ca.crt
+            {{- end }}
           envFrom:
             - secretRef:
                 name: env
+          {{- if or $apiCertificateEnabled $workerCertificateEnabled }}
+          volumeMounts:
+            {{- if $apiCertificateEnabled }}
+            - name: postgres-api-client-cert
+              mountPath: /var/run/secrets/postgres/api
+              readOnly: true
+            {{- end }}
+            {{- if $workerCertificateEnabled }}
+            - name: postgres-worker-client-cert
+              mountPath: /var/run/secrets/postgres/worker
+              readOnly: true
+            {{- end }}
+            - name: postgres-cluster-ca
+              mountPath: /var/run/secrets/postgres/ca
+              readOnly: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -89,4 +127,23 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+      {{- if or $apiCertificateEnabled $workerCertificateEnabled }}
+      volumes:
+        {{- if $apiCertificateEnabled }}
+        - name: postgres-api-client-cert
+          secret:
+            secretName: {{ include "kosmo.postgresRuntimeClientCertificateSecretName" (list . "api") | quote }}
+        {{- end }}
+        {{- if $workerCertificateEnabled }}
+        - name: postgres-worker-client-cert
+          secret:
+            secretName: {{ include "kosmo.postgresRuntimeClientCertificateSecretName" (list . "worker") | quote }}
+        {{- end }}
+        - name: postgres-cluster-ca
+          secret:
+            secretName: {{ include "kosmo.postgresClusterCaSecretName" . | quote }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+      {{- end }}
 {{- end }}

--- a/apps/helm/templates/worker.yaml
+++ b/apps/helm/templates/worker.yaml
@@ -1,3 +1,5 @@
+{{- $apiCertificateEnabled := eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "api") | trim) "true" -}}
+{{- $workerCertificateEnabled := eq (include "kosmo.postgresCredentialClientCertificateIsConfigured" (list . "worker") | trim) "true" -}}
 {{- include "kosmo.validatePostgresCredentials" . -}}
 {{- if and .Values.workloads.enabled .Values.worker.enabled }}
 apiVersion: v1
@@ -64,6 +66,15 @@ spec:
               value: {{ .Values.temporal.frontendAddress | quote }}
             - name: TEMPORAL_NAMESPACE
               value: {{ include "kosmo.temporalNamespaceName" . | quote }}
+            {{- if $apiCertificateEnabled }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-app" (include "kosmo.postgresName" .) | quote }}
+                  key: password
+            - name: DATABASE_URL
+              value: {{ include "kosmo.databaseUrl" . | quote }}
+            {{- else }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -71,6 +82,7 @@ spec:
                   key: {{ include "kosmo.apiDatabasePasswordSecretKey" . }}
             - name: DATABASE_URL
               value: {{ include "kosmo.apiDatabaseUrl" . | quote }}
+            {{- end }}
             {{- if eq (include "kosmo.postgresCredentialIsConfigured" (list . "fedify") | trim) "true" }}
             - name: FEDIFY_DATABASE_PASSWORD
               valueFrom:
@@ -80,9 +92,28 @@ spec:
             - name: FEDIFY_DATABASE_URL
               value: {{ dig "fedify" "databaseUrl" "" (.Values.postgres.credentials | default dict) | quote }}
             {{- end }}
+            {{- if $workerCertificateEnabled }}
+            - name: WORKER_DATABASE_URL
+              value: {{ include "kosmo.workerDatabaseUrl" . | quote }}
+            - name: WORKER_PGSSLCERT
+              value: /var/run/secrets/postgres/worker/tls.crt
+            - name: WORKER_PGSSLKEY
+              value: /var/run/secrets/postgres/worker/tls.key
+            - name: WORKER_PGSSLROOTCERT
+              value: /var/run/secrets/postgres/ca/ca.crt
+            {{- end }}
           envFrom:
             - secretRef:
                 name: env
+          {{- if $workerCertificateEnabled }}
+          volumeMounts:
+            - name: postgres-worker-client-cert
+              mountPath: /var/run/secrets/postgres/worker
+              readOnly: true
+            - name: postgres-cluster-ca
+              mountPath: /var/run/secrets/postgres/ca
+              readOnly: true
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -97,4 +128,16 @@ spec:
             periodSeconds: 5
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
+      {{- if $workerCertificateEnabled }}
+      volumes:
+        - name: postgres-worker-client-cert
+          secret:
+            secretName: {{ include "kosmo.postgresRuntimeClientCertificateSecretName" (list . "worker") | quote }}
+        - name: postgres-cluster-ca
+          secret:
+            secretName: {{ include "kosmo.postgresClusterCaSecretName" . | quote }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+      {{- end }}
 {{- end }}

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -44,11 +44,17 @@ postgres:
       passwordSecret:
         name: ''
         key: ''
+      clientCertificate:
+        enabled: false
     fedify:
       databaseUrl: ''
       passwordSecret:
         name: ''
         key: ''
+    worker:
+      databaseUrl: ''
+      clientCertificate:
+        enabled: false
   resources:
     requests:
       cpu: 250m

--- a/docs/operations/postgres-runtime-client-certificates.md
+++ b/docs/operations/postgres-runtime-client-certificates.md
@@ -1,0 +1,102 @@
+# PostgreSQL runtime client certificate 운영
+
+## 범위
+
+이 문서는 CloudNativePG가 `kosmo_api`, `kosmo_worker` DatabaseRole에 발급하는 client certificate의 선택적 소비·회전·rollback 경계를 정의한다.
+
+- API와 Worker certificate 소비는 각각 opt-in이다. 비활성 경로는 기존 owner password·SCRAM과 direct `<cluster>-rw` endpoint를 유지한다.
+- `kosmo_api` certificate는 API와 Web BFF 기본 connection만 사용한다. API에는 Worker certificate를 주입하지 않는다.
+- `kosmo_worker` certificate는 Web trusted federation connection과 Temporal Worker DB Activity만 사용한다. 실제 client 전환은 PROD-715가 소유한다.
+- Workload에는 Cluster CA Secret의 공개 `ca.crt` key만 projection한다. 자동 서명용 `ca.key`는 어떤 application Pod에도 mount하지 않는다.
+- Production migration의 `kosmo_migration` LOGIN → `SET ROLE kosmo`, CNPG replication과 기존 Pooler는 변경하지 않는다.
+- Application hot reload와 Secret restart controller는 사용하지 않는다. CNPG 갱신 뒤 해당 consumer만 계획 재시작한다.
+- Secret 값, private key, certificate 원문과 connection string은 출력하거나 PR·Linear 근거에 첨부하지 않는다.
+
+## 적용 전 확인
+
+대상 namespace와 release를 명시하고 operator/CRD, Cluster CA signing key, 동명 role과 generated Secret 상태를 비민감 정보로 확인한다. Production에서는 아래 명령도 별도 명시적 apply 승인 전에는 read-only로만 실행한다.
+
+```sh
+NAMESPACE=kosmo-dev
+RELEASE=kosmo
+CLUSTER="${RELEASE}-postgres"
+
+kubectl get deployment -n cnpg-system cnpg-controller-manager \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+kubectl get crd databaseroles.postgresql.cnpg.io
+kubectl get cluster "$CLUSTER" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.certificates.clientCASecret}{"\n"}'
+kubectl get secret "${CLUSTER}-ca" -n "$NAMESPACE" \
+  -o json | jq -r '.data | keys | sort | join(",")'
+kubectl get databaserole -n "$NAMESPACE" \
+  "${RELEASE}-postgres-api" "${RELEASE}-postgres-worker"
+```
+
+Cluster CA Secret에는 자동 발급에 필요한 `ca.key`가 있어야 한다. key 이름만 확인하고 값을 decode하거나 출력하지 않는다. 기존 동명 PostgreSQL role이 있으면 attribute, membership, password 존재 여부와 object ownership을 먼저 확인한다. 선언과 다른 live role을 자동 adopt해도 된다는 근거가 없으면 sync하지 않는다.
+
+## Render와 인증 규칙 확인
+
+기본 render에서는 workload certificate volume/env가 없어야 하며 기존 password Secret과 direct endpoint가 유지돼야 한다. Certificate opt-in render에서는 선택한 역할의 URL, certificate Secret과 Cluster CA의 `ca.crt` projection만 해당 workload에 나타나야 한다. Cluster CA volume에 `ca.key` 또는 Secret 전체가 projection되면 적용하지 않는다.
+
+API와 Worker는 각각 다음 값으로만 opt-in한다. URL은 password를 포함하지 않고 certificate CN과 같은 역할명 및 direct `<cluster>-rw` Service를 사용해야 한다. Certificate mode와 `passwordSecret`은 함께 설정할 수 없다.
+
+```yaml
+postgres:
+  credentials:
+    api:
+      databaseUrl: postgres://kosmo_api@<release>-postgres-rw:5432/kosmo
+      clientCertificate:
+        enabled: true
+    worker:
+      databaseUrl: postgres://kosmo_worker@<release>-postgres-rw:5432/kosmo
+      clientCertificate:
+        enabled: true
+```
+
+한 역할만 준비할 때는 해당 block만 활성화한다. 이 값의 실제 환경 활성화와 non-owner principal cutover는 PROD-715/716이 소유하며, PROD-470은 어떤 environment values도 활성화하지 않는다.
+
+`pg_hba`는 role별 `hostssl ... cert` 다음 `hostnossl ... reject` 순서여야 한다. CNPG 고정 replication/Pooler 규칙은 그대로 두고 user rule 뒤의 broad SCRAM fallback보다 먼저 적용한다. 인증 실패는 다음 HBA 줄로 fall through하지 않는다.
+
+```sh
+helm template "$RELEASE" apps/helm --namespace "$NAMESPACE" --set env=dev \
+  | rg -n 'pg_hba|hostssl|hostnossl|DATABASE_URL|PGSSL|volumeMounts|secretName'
+```
+
+## 비운영 연결 검증
+
+Git에 반영된 manifest를 GitOps로 적용한 뒤 다음 상태만 기록한다.
+
+```sh
+kubectl get databaserole -n "$NAMESPACE" \
+  "${RELEASE}-postgres-api" "${RELEASE}-postgres-worker" \
+  -o custom-columns=NAME:.metadata.name,APPLIED:.status.applied,EXPIRES:.status.clientCertificate.expiration
+kubectl get secret -n "$NAMESPACE" \
+  "${RELEASE}-postgres-api-client-cert" \
+  "${RELEASE}-postgres-worker-client-cert" \
+  -o json | jq -r '.items[] | [.metadata.name, (.data | keys | sort | join(","))] | @tsv'
+```
+
+`pg_hba_file_rules`에 두 역할의 `hostssl cert`와 `hostnossl reject`가 올바른 순서로 나타나는지 확인한다. 선택한 workload 안에서 새 connection의 `current_user`가 certificate CN 역할과 일치해야 한다. 다른 역할 certificate, certificate 없는 TLS, non-TLS와 일부만 설정된 certificate 입력은 성공해서는 안 된다. 검증용 SQL 결과는 역할명과 성공/실패만 기록한다.
+
+## Certificate 갱신과 계획 재시작
+
+CNPG는 DatabaseRole status의 expiration 전에 certificate Secret을 갱신한다. 기존 Postgres.js process와 pool은 파일을 자동으로 다시 읽지 않으므로 expiration과 Secret resource version을 관측하고 만료 전에 해당 consumer를 계획 재시작한다.
+
+1. DatabaseRole의 새 expiration과 generated Secret 갱신을 확인한다.
+2. API certificate 갱신이면 API Rollout과 Web BFF만, Worker certificate 갱신이면 Worker connection을 실제 소비하는 Web/Worker workload만 선택한다.
+3. GitOps가 관리하는 workload의 restart annotation을 승인된 Git 변경으로 갱신하거나 승인된 Rollouts restart 절차를 사용한다. Secret data나 hash를 annotation에 복사하지 않는다.
+4. 새 Pod readiness 뒤 새 connection의 CN과 `current_user`를 확인한다.
+5. 기존 Pod가 모두 종료되기 전까지 generated Secret이나 DatabaseRole을 제거하지 않는다.
+
+Production restart는 certificate apply와 별개 승인이다. 한 역할의 갱신을 이유로 migration, replication, Pooler 또는 인증서를 소비하지 않는 workload를 재시작하지 않는다.
+
+## 독립 rollback
+
+소비 뒤 DatabaseRole을 먼저 제거하면 generated Secret이 삭제되므로 workload rollback이 먼저다.
+
+1. 해당 API 또는 Worker certificate selector를 이전 password/SCRAM 설정으로 되돌리는 Git commit을 배포한다.
+2. 대상 workload가 Ready이고 새 connection이 기존 password 경계로 동작하는지 확인한다.
+3. 다른 역할 consumer, migration, replication과 Pooler가 변하지 않았는지 확인한다.
+4. 역할 provisioning 자체를 되돌려야 할 때만 별도 승인으로 DatabaseRole manifest를 revert/prune한다. `databaseRoleReclaimPolicy: retain`은 PostgreSQL role만 남기며 generated Secret은 CNPG owner-reference lifecycle에 따라 제거된다.
+
+Argo CD/Helm 소유 리소스를 `kubectl delete`로 수동 제거하지 않는다. Production rollback sync/apply도 사용자의 별도 명시적 승인 뒤에만 수행한다.

--- a/openspec/changes/add-runtime-postgres-client-certificate-authentication/decisions.md
+++ b/openspec/changes/add-runtime-postgres-client-certificate-authentication/decisions.md
@@ -76,6 +76,18 @@
 - Consequences: DatabaseRole 삭제 시 role은 남고 certificate Secret은 삭제된다. 소비 뒤 rollback은 workload를 먼저 이전 인증으로 되돌려야 한다.
 - Confirmation / Follow-up: Render lifecycle과 live deletion 절차를 검증한다.
 
+### Certificate 갱신은 대상 workload의 계획 재시작으로 소비한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-470`; 2026-08-10 사용자 승인
+- Status: Active
+- Context / Problem: CNPG는 역할별 certificate Secret을 자동 갱신하지만 기존 Postgres.js process와 connection pool을 재시작하거나 key를 다시 읽게 하지 않는다. 현재 cluster에는 Secret 갱신 전용 restart controller도 없다.
+- Decision Outcome: DatabaseRole status expiration과 generated Secret 갱신을 관측하고 만료 전에 해당 certificate를 소비하는 API/Web/Worker workload만 계획 재시작한다. Application hot reload, pool hot swap과 새 restart controller는 구현하지 않는다.
+- Alternatives Considered: Application hot reload는 pool drain과 동시성 실패 계약을 크게 만들고, restart controller는 별도 cluster-wide 운영·권한 범위를 추가하므로 선택하지 않았다.
+- Consequences: 인증서 발급·갱신은 CNPG가, 갱신된 key의 process 반영은 운영 runbook이 소유한다. API와 Worker selector는 독립적이므로 한 역할의 재시작이 다른 workload로 불필요하게 확장되지 않아야 한다.
+- Confirmation / Follow-up: 비운영에서 Secret 갱신 뒤 대상 workload만 재시작해 새 connection의 CN과 `current_user`를 재검증한다.
+
 ### PR merge와 production apply 승인을 분리한다
 
 - Decision Date: 2026-08-10

--- a/openspec/changes/add-runtime-postgres-client-certificate-authentication/design.md
+++ b/openspec/changes/add-runtime-postgres-client-certificate-authentication/design.md
@@ -42,21 +42,25 @@ PROD-369과 PROD-470은 역할별 certificate identity와 lifecycle을 함께 �
 2. PROD-369에서 runtime용 VaultStaticSecret 두 개를 제거하되 기존 공용 env와 production migration VaultStaticSecret은 그대로 둔다.
 3. Helm lint/render에서 모든 environment에 두 DatabaseRole만 추가되고 Vault password source, `pg_hba`, workload mount/restart와 selector가 추가되지 않는지 확인한다.
 4. 비운영 적용 뒤 DatabaseRole `status.applied`, generated Secret의 `tls.crt`/`tls.key`, certificate expiration, role attribute·membership·password 부재와 object ownership 부재를 민감 정보 없이 검증한다.
-5. PROD-470은 별도 PR에서 두 역할 전용 `hostssl ... cert`/non-SSL reject 순서, certificate/Cluster CA mount, atomic selector와 rotation restart를 구현한다. Owner/migration/replication/local 연결은 기존 방식으로 남긴다.
+5. PROD-470은 별도 PR에서 두 역할 전용 `hostssl ... cert`/non-SSL reject 순서, certificate/Cluster CA mount와 atomic selector를 구현한다. CNPG 갱신 뒤에는 status expiration과 Secret 갱신을 관측해 해당 consumer만 계획 재시작하며, application hot reload나 restart controller를 추가하지 않는다. Owner/migration/replication/local 연결은 기존 방식으로 남긴다.
 6. shared integration verification이 끝난 뒤에만 change를 archive한다.
 
 ### Allowed Alternatives
 
-없음. 사용자 결정으로 Vault password credential과 전체 연결의 일괄 TLS 전환은 선택하지 않았다.
+- Application hot reload는 기존 singleton pool을 무중단으로 교체하는 동시성·drain 계약이 필요해 선택하지 않았다.
+- Secret restart controller는 새 cluster-wide 운영 구성요소와 권한을 추가하므로 선택하지 않았다.
+- 사용자 결정으로 Vault password credential과 전체 연결의 일괄 TLS 전환도 선택하지 않았다.
 
 ### Known Traps
 
 - PROD-369에서 `pg_hba`, certificate volume/env, rollout restart target 또는 workload selector를 추가하지 않는다.
 - generated Secret 이름을 `kosmo_api-client-cert`처럼 PostgreSQL role name에서 추론하지 않는다.
 - generated Secret에 `ca.crt`가 있다고 가정하지 않는다.
+- Cluster CA Secret 전체를 workload에 mount하지 않는다. Application에는 공개 `ca.crt` key만 projection하고 자동 서명용 `ca.key`는 노출하지 않는다.
 - `passwordSecret`을 남긴 채 `disablePassword`를 추가하지 않는다.
 - `databaseRoleReclaimPolicy: retain`이 generated Secret까지 retain한다고 설명하지 않는다.
 - API Rollout에 Worker certificate를 주입하지 않는다.
+- CNPG가 Secret을 갱신한다는 사실을 application pool의 자동 reload로 해석하지 않는다.
 - migration SQL, GRANT/default privilege 또는 domain RLS policy를 이 change의 provisioning PR에 넣지 않는다.
 
 ## Risks / Trade-offs
@@ -65,6 +69,7 @@ PROD-369과 PROD-470은 역할별 certificate identity와 lifecycle을 함께 �
 - [Cluster client CA에 signing key가 없을 수 있다] → apply 전 CA Secret metadata/keys를 민감 정보 없이 확인하고, 비운영 status에서 issuance를 검증한다.
 - [기존 동명 role이 adopt되며 attribute/password/membership이 바뀐다] → 환경별 preflight로 기존 role과 소비자를 확인한다. 자동으로 덮어써도 된다는 근거가 없으면 적용하지 않는다.
 - [Certificate가 발급돼도 접속할 수 없다] → 의도된 Expand 경계다. PROD-470이 `pg_hba`와 workload 소비를 별도 배포한다.
+- [갱신된 key를 기존 process가 계속 사용하지 못한다] → DatabaseRole status expiration과 Secret resource version을 관측하고 인증서 만료 전에 해당 API/Web/Worker workload만 계획 재시작한다. 자동 controller와 pool hot swap은 이 change에 넣지 않는다.
 
 ## Migration Plan
 

--- a/openspec/changes/add-runtime-postgres-client-certificate-authentication/proposal.md
+++ b/openspec/changes/add-runtime-postgres-client-certificate-authentication/proposal.md
@@ -9,7 +9,7 @@ CloudNativePG 1.30은 standalone `DatabaseRole`마다 client certificate를 자�
 - PROD-369은 모든 Helm 배포 환경에 `kosmo_api`와 `kosmo_worker` DatabaseRole을 추가한다. 두 역할은 password를 비활성화하고 CNPG 역할별 client certificate 발급을 사용한다.
 - CNPG는 `<DatabaseRole metadata.name>-client-cert` Secret의 `tls.crt`/`tls.key`와 `status.clientCertificate.expiration`을 관리한다. VaultStaticSecret, Vault password source와 `passwordSecret`은 만들지 않는다.
 - API는 `BYPASSRLS=false`, Worker는 `BYPASSRLS=true`이며 두 역할 모두 owner/migration/상대 역할 membership과 상승 권한을 갖지 않는다.
-- PROD-470은 같은 change 안에서 역할별 `pg_hba` 규칙, generated Secret과 Cluster CA mount, connection parameter와 회전 restart를 선택적으로 연결한다. 이 작업은 PROD-369 PR에서 구현하지 않는다.
+- PROD-470은 같은 change 안에서 역할별 `pg_hba` 규칙, generated Secret과 Cluster CA mount, connection parameter와 계획 restart 경계를 선택적으로 연결한다. 이 작업은 PROD-369 PR에서 구현하지 않는다.
 - 기존 owner `kosmo`, `kosmo_migration` LOGIN→`SET ROLE kosmo`, CNPG replication, local/legacy password·SCRAM, 객체 ACL/RLS와 workload selector는 변경하지 않는다.
 - PR merge와 CI 성공은 production apply 승인이 아니다. Production sync/apply는 사용자의 별도 명시적 승인 전에는 수행하지 않는다.
 
@@ -38,3 +38,4 @@ CloudNativePG 1.30은 standalone `DatabaseRole`마다 client certificate를 자�
 - PostgreSQL authorization: `kosmo_api`, `kosmo_worker` role attribute와 password 부재. 객체 GRANT/RLS는 포함하지 않는다.
 - Kubernetes Secret: CNPG가 역할별 client certificate Secret을 생성·갱신·삭제한다. Helm이나 VSO가 해당 Secret data를 소유하지 않는다.
 - Rollout: PROD-369은 기존 workload를 재시작하거나 인증 방식을 바꾸지 않는다. PROD-470까지 완료돼야 generated certificate가 실제 연결에 사용된다.
+- Rotation: CNPG가 certificate를 갱신해도 application pool은 자동 hot reload하지 않는다. 운영자는 expiration과 Secret 갱신을 관측하고 만료 전에 해당 consumer만 계획 재시작한다.

--- a/openspec/changes/add-runtime-postgres-client-certificate-authentication/specs/runtime-postgres-client-certificate-authentication/spec.md
+++ b/openspec/changes/add-runtime-postgres-client-certificate-authentication/specs/runtime-postgres-client-certificate-authentication/spec.md
@@ -38,7 +38,7 @@
 
 ### Requirement: 선택된 API와 Worker 연결만 certificate 인증을 사용한다
 
-**Authority / Provenance:** Linear `PROD-470`. 시스템은 `kosmo_api`와 `kosmo_worker`를 선택한 연결에만 역할별 `hostssl ... cert` 규칙과 해당 generated certificate/Cluster CA를 연결해야 한다(MUST). Owner `kosmo`, `kosmo_migration`, replication, local/test와 certificate selector를 사용하지 않는 연결의 password·SCRAM 경계를 변경해서는 안 된다(MUST NOT).
+**Authority / Provenance:** Linear `PROD-470`. 시스템은 `kosmo_api`와 `kosmo_worker`를 선택한 연결에만 역할별 `hostssl ... cert` 규칙과 해당 generated certificate/Cluster CA의 공개 `ca.crt`를 연결해야 한다(MUST). Cluster CA signing key를 workload에 projection해서는 안 된다(MUST NOT). Owner `kosmo`, `kosmo_migration`, replication, local/test와 certificate selector를 사용하지 않는 연결의 password·SCRAM 경계를 변경해서는 안 된다(MUST NOT).
 
 #### Scenario: API certificate 연결을 준비함
 
@@ -84,6 +84,23 @@
 - **THEN** 인증서 CN과 `current_user`가 선택한 역할과 일치한다
 - **AND** `pg_hba` first-match와 non-SSL 거부가 적용된다
 - **AND** 다른 역할의 certificate나 일부 certificate 입력은 연결 전에 거부된다
+
+### Requirement: 갱신된 certificate는 대상 workload의 계획 재시작으로 반영한다
+
+**Authority / Provenance:** Linear `PROD-470`; 2026-08-10 사용자 결정. CNPG가 generated certificate Secret을 갱신한 뒤 시스템은 expiration과 Secret 갱신을 관측하고 만료 전에 해당 certificate를 소비하는 workload만 계획 재시작해야 한다(MUST). 이 change는 application pool hot reload나 새 restart controller를 추가해서는 안 된다(MUST NOT).
+
+#### Scenario: API certificate만 갱신됨
+
+- **WHEN** CNPG가 `kosmo_api` certificate를 갱신한다
+- **THEN** 운영자는 expiration과 Secret 갱신을 확인한 뒤 API certificate를 소비하는 API Rollout과 Web BFF만 계획 재시작한다
+- **AND** Worker 전용 workload와 migration은 재시작하지 않는다
+
+#### Scenario: 계획 재시작 뒤 새 certificate를 확인함
+
+- **WHEN** 대상 workload가 계획 재시작되어 새 process와 pool을 생성한다
+- **THEN** 새 connection은 갱신된 key와 CA를 읽는다
+- **AND** certificate CN과 `current_user`가 선택한 역할과 일치한다
+- **AND** 검증 로그에는 certificate나 private key 원문이 포함되지 않는다
 
 ### Requirement: Production apply는 별도 수동 승인을 요구한다
 

--- a/openspec/changes/add-runtime-postgres-client-certificate-authentication/tasks.md
+++ b/openspec/changes/add-runtime-postgres-client-certificate-authentication/tasks.md
@@ -22,7 +22,7 @@
 - [x] 1.3 기존 공용 env와 production migration VaultStaticSecret, owner workload, migration identity, replication, selector, `pg_hba`, ACL/RLS manifest가 변경되지 않았음을 검증한다.
 - [x] 1.4 Generated Secret 이름이 `<DatabaseRole metadata.name>-client-cert`로 파생되고 `tls.crt`/`tls.key`, status expiration을 CNPG가 소유한다는 계약과 rollback 절차를 문서·검증 assertion에 반영한다.
 - [x] 1.5 Helm lint/render, formatting, strict shared OpenSpec validation, diff-check와 self-review를 통과시킨다.
-- [ ] 1.6 비운영 환경의 operator/CRD, client CA signing key와 동명 role을 확인한 뒤 적용하고 DatabaseRole applied, generated Secret shape/expiration, 실제 role attribute·password·membership·ownership 경계를 검증한다.
+- [x] 1.6 비운영 환경의 operator/CRD, client CA signing key와 동명 role을 확인한 뒤 적용하고 DatabaseRole applied, generated Secret shape/expiration, 실제 role attribute·password·membership·ownership 경계를 검증한다.
 - [ ] 1.7 사용자의 별도 명시적 production apply 승인 뒤에만 같은 preflight·sync·live 검증을 수행한다.
 
 ## 2. PROD-470 선택적 client certificate authentication 소비
@@ -37,10 +37,10 @@
 
 `kosmo_api`와 `kosmo_worker`를 선택한 연결만 CNPG generated client certificate를 사용할 준비가 되고, 기존 owner/migration/replication/local/password 연결은 유지된다.
 
-- [ ] 2.1 `kosmo_api`, `kosmo_worker` 전용 `hostssl ... cert`와 non-SSL reject 규칙을 broad SCRAM보다 먼저 선언하고 순서를 검증한다. (Owner: PROD-470)
-- [ ] 2.2 Generated role certificate와 Cluster CA를 역할·connection별 read-only mount하고 API에 Worker certificate가 주입되지 않도록 한다. (Owner: PROD-470)
-- [ ] 2.3 Password와 certificate selector 입력을 atomic하게 검증하고 Postgres.js에 cert/key/CA와 hostname verification을 연결한다. (Owner: PROD-470)
-- [ ] 2.4 Certificate rotation 뒤 새 process/pool이 key를 읽는 declarative restart 경계를 구현한다. (Owner: PROD-470)
-- [ ] 2.5 Owner, migration, replication, local/test, Pooler와 certificate selector 비활성 경로가 기존 password·SCRAM/direct endpoint 계약을 유지하는지 검증한다. (Owner: PROD-470)
+- [x] 2.1 `kosmo_api`, `kosmo_worker` 전용 `hostssl ... cert`와 non-SSL reject 규칙을 broad SCRAM보다 먼저 선언하고 순서를 검증한다. (Owner: PROD-470)
+- [x] 2.2 Generated role certificate와 Cluster CA의 공개 `ca.crt`만 역할·connection별 read-only mount하고 API에 Worker certificate나 CA signing key가 주입되지 않도록 한다. (Owner: PROD-470)
+- [x] 2.3 Password와 certificate selector 입력을 atomic하게 검증하고 Postgres.js에 cert/key/CA와 hostname verification을 연결한다. Worker prefix helper의 실제 connection seam 소비와 principal cutover는 PROD-715가 소유한다. (Owner: PROD-470)
+- [x] 2.4 Certificate rotation 뒤 expiration/Secret 갱신을 관측하고 해당 consumer만 계획 재시작해 새 process/pool이 key를 읽는 운영 경계를 구현한다. Application hot reload와 restart controller는 추가하지 않는다. (Owner: PROD-470)
+- [x] 2.5 Owner, migration, replication, local/test, Pooler와 certificate selector 비활성 경로가 기존 password·SCRAM/direct endpoint 계약을 유지하는지 검증한다. (Owner: PROD-470)
 - [ ] 2.6 비운영 환경에서 `pg_hba_file_rules`, CN-role 일치, 선택적 certificate connection과 독립 rollback을 검증한다. Production은 별도 사용자 승인 전 적용하지 않는다. (Owner: PROD-470)
 - [ ] 2.7 PROD-369/470 전체 requirement와 integration evidence를 최신 Linear/canonical에 대조하고 모든 task 완료 뒤 shared change를 archive한다. (Owner: PROD-470)

--- a/packages/core/db/index.ts
+++ b/packages/core/db/index.ts
@@ -1,12 +1,14 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as enums from './enums';
+import { getPostgresTlsOptions } from './postgres-tls';
 import * as tables from './tables';
 
 export * from './tables';
 export * from './utils';
 
 export const pg = postgres(process.env.DATABASE_URL!, {
+  ...getPostgresTlsOptions(),
   max: 20,
   max_lifetime: 3600,
   connection: {

--- a/packages/core/db/postgres-tls.test.ts
+++ b/packages/core/db/postgres-tls.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { getPostgresTlsOptions } from './postgres-tls';
+
+test('returns no ssl option when client certificate paths are disabled', () => {
+  assert.deepEqual(getPostgresTlsOptions('PGSSL', {}), {});
+});
+
+test('reads a complete client certificate configuration before returning ssl options', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'kosmo-postgres-tls-'));
+
+  try {
+    const paths = {
+      cert: join(root, 'client.crt'),
+      key: join(root, 'client.key'),
+      ca: join(root, 'ca.crt'),
+    };
+    await Promise.all([
+      writeFile(paths.cert, 'certificate contents'),
+      writeFile(paths.key, 'private key contents'),
+      writeFile(paths.ca, 'root certificate contents'),
+    ]);
+
+    assert.deepEqual(
+      getPostgresTlsOptions('PGSSL', {
+        PGSSLCERT: paths.cert,
+        PGSSLKEY: paths.key,
+        PGSSLROOTCERT: paths.ca,
+      }),
+      {
+        ssl: {
+          cert: 'certificate contents',
+          key: 'private key contents',
+          ca: 'root certificate contents',
+          rejectUnauthorized: true,
+        },
+      },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects partial client certificate configuration before reading files', () => {
+  assert.throws(
+    () =>
+      getPostgresTlsOptions('PGSSL', {
+        PGSSLCERT: '/path/that/is/not/read',
+      }),
+    (error: unknown) => {
+      assert.match(
+        error instanceof Error ? error.message : '',
+        /PGSSLCERT, PGSSLKEY, PGSSLROOTCERT.*configured together/,
+      );
+      assert.doesNotMatch(error instanceof Error ? error.message : '', /not read/);
+      return true;
+    },
+  );
+});
+
+test('rejects unreadable files without exposing their contents', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'kosmo-postgres-tls-'));
+
+  try {
+    const cert = join(root, 'client.crt');
+    const key = join(root, 'client.key');
+    const ca = join(root, 'ca.crt');
+    await Promise.all([
+      writeFile(cert, 'certificate contents'),
+      writeFile(key, 'private key contents'),
+      mkdir(ca),
+    ]);
+
+    assert.throws(
+      () =>
+        getPostgresTlsOptions('PGSSL', {
+          PGSSLCERT: cert,
+          PGSSLKEY: key,
+          PGSSLROOTCERT: ca,
+        }),
+      (error: unknown) => {
+        assert.match(error instanceof Error ? error.message : '', /Unable to read PGSSLROOTCERT/);
+        assert.doesNotMatch(
+          error instanceof Error ? error.message : '',
+          /certificate contents|private key contents/,
+        );
+        return true;
+      },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('supports a separate environment prefix without mixing credentials', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'kosmo-postgres-tls-'));
+
+  try {
+    const paths = {
+      cert: join(root, 'worker.crt'),
+      key: join(root, 'worker.key'),
+      ca: join(root, 'worker-ca.crt'),
+    };
+    await Promise.all([
+      writeFile(paths.cert, 'worker certificate'),
+      writeFile(paths.key, 'worker key'),
+      writeFile(paths.ca, 'worker ca'),
+    ]);
+
+    assert.deepEqual(
+      getPostgresTlsOptions('WORKER_PGSSL', {
+        WORKER_PGSSLCERT: paths.cert,
+        WORKER_PGSSLKEY: paths.key,
+        WORKER_PGSSLROOTCERT: paths.ca,
+        PGSSLCERT: '/different/api/certificate',
+        PGSSLKEY: '/different/api/key',
+        PGSSLROOTCERT: '/different/api/ca',
+      }),
+      {
+        ssl: {
+          cert: 'worker certificate',
+          key: 'worker key',
+          ca: 'worker ca',
+          rejectUnauthorized: true,
+        },
+      },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/core/db/postgres-tls.ts
+++ b/packages/core/db/postgres-tls.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+
+export interface PostgresTlsClientOptions {
+  ssl?: {
+    ca: string;
+    cert: string;
+    key: string;
+    rejectUnauthorized: true;
+  };
+}
+
+/**
+ * Read the optional Postgres.js client-certificate configuration.
+ *
+ * The environment prefix is the part before `CERT`, `KEY`, and `ROOTCERT`.
+ * For example, `WORKER_PGSSL` reads `WORKER_PGSSLCERT`, `WORKER_PGSSLKEY`,
+ * and `WORKER_PGSSLROOTCERT`.
+ */
+export function getPostgresTlsOptions(
+  prefix = 'PGSSL',
+  environment: NodeJS.ProcessEnv = process.env,
+): PostgresTlsClientOptions {
+  const variables = {
+    cert: `${prefix}CERT`,
+    key: `${prefix}KEY`,
+    ca: `${prefix}ROOTCERT`,
+  } as const;
+
+  const paths = {
+    cert: environment[variables.cert],
+    key: environment[variables.key],
+    ca: environment[variables.ca],
+  };
+  const configured = Object.values(paths).filter(Boolean).length;
+
+  if (configured === 0) {
+    return {};
+  }
+
+  if (configured !== Object.keys(paths).length) {
+    throw new Error(
+      `${Object.values(variables).join(', ')} must be configured together for PostgreSQL TLS client authentication.`,
+    );
+  }
+
+  const contents = {
+    cert: readTlsFile(paths.cert!, variables.cert),
+    key: readTlsFile(paths.key!, variables.key),
+    ca: readTlsFile(paths.ca!, variables.ca),
+  };
+
+  return {
+    ssl: {
+      ...contents,
+      rejectUnauthorized: true,
+    },
+  };
+}
+
+function readTlsFile(path: string, variable: string): string {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    // Do not include the filesystem error: it may be supplied by a wrapper and
+    // must never expose certificate or private-key contents.
+    throw new Error(`Unable to read ${variable} for PostgreSQL TLS client authentication.`);
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "test:services": "node --import tsx --test --test-concurrency=1 'services/*.test.ts'",
     "test:services:database": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/core test:services:isolated",
     "test:services:isolated": "cd ../.. && pnpm db:test:push && pnpm --filter @kosmo/core test:services",
-    "test:unit": "node --import tsx --test activitypub-note-content.test.ts 'post-content/**/*.test.ts' validation/profile-tag.test.ts"
+    "test:unit": "node --import tsx --test activitypub-note-content.test.ts db/postgres-tls.test.ts 'post-content/**/*.test.ts' validation/profile-tag.test.ts"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",


### PR DESCRIPTION
## 요약

PROD-470을 최신 결정에 맞춰 과거 Vault PKI 전체 전환에서 `kosmo_api`·`kosmo_worker` 선택적 client-certificate connection capability로 재구축합니다.

PR #548 / PROD-369가 `b6994939`로 merge되어 두 DatabaseRole과 CNPG 자동 client certificate 발급을 소유합니다. 이 PR은 해당 provisioning을 재구현하지 않고 소비 경계만 추가합니다.

## 변경

- API/Worker별 기본 비활성 `clientCertificate.enabled` selector와 password/certificate atomic validation
- certificate CN과 같은 DB username 및 direct `<cluster>-rw` URL만 허용
- 역할별 ordered `hostssl ... cert` / `hostnossl ... reject` HBA 규칙
- CNPG generated role certificate와 Cluster CA 공개 `ca.crt`의 역할별 read-only mount (`ca.key` 비주입)
- API/Web 기본 connection의 `PGSSL*`, Worker 후속 seam의 `WORKER_PGSSL*` 준비
- Postgres.js pool 생성 시 cert/key/CA를 함께 읽고 `rejectUnauthorized: true`로 server identity 검증
- expiration/Secret 갱신 관측 후 해당 consumer만 계획 재시작하는 운영 runbook
- 공유 OpenSpec `add-runtime-postgres-client-certificate-authentication`의 PROD-470 task 2.1–2.5 완료

## 보존한 경계

- `kosmo_api`/`kosmo_worker` DatabaseRole, role attributes, `disablePassword`, client certificate issuance는 PROD-369 소유 그대로 유지
- 실제 non-owner principal cutover와 Worker DB client seam은 PROD-716/715 소유
- owner `kosmo`, `kosmo_migration` → `SET ROLE kosmo`, CNPG replication, local/test, 기존 password·SCRAM과 Pooler 변경 없음
- API Rollout에 Worker certificate를 주입하지 않음
- Vault PKI issuer/role/ACL, VaultPKISecret, server/replication/migration/local certificate 전환 없음
- 어떤 environment value도 certificate mode로 활성화하지 않음

## 검증

- Helm lint: dev/prod 통과
- default dev/prod render: 기존 password 경계 유지
- API-only / Worker-only render: HBA 순서, direct endpoint, Secret/env/mount 격리 확인
- invalid render: missing URL, partial/conflicting password, Pooler URL, 잘못된 CN-role URL 거부
- security review: Cluster CA Secret 전체가 아니라 `ca.crt`만 projection하는지 API/Web/Worker render 확인
- Core unit: 56 passed
- ESLint 전체 및 Prettier 통과
- OpenSpec strict validation 통과
- self-review: merge-blocking finding 없음

PROD-369 dev live evidence도 shared task 1.6에 반영했습니다: 두 DatabaseRole applied, generated TLS Secrets/status expiration, password NULL, attribute/membership/ownership 경계와 기존 owner/migration/replication/Pooler/workload 경계가 확인됐습니다.

## 남은 gate

- shared task 1.7 production provisioning은 별도 사용자 승인 전 미완료
- PROD-470 task 2.6 비운영 HBA/CN/current_user/rotation/rollback integration은 실제 cutover 선행 조건과 함께 미완료
- task 2.7 shared integration/archive는 전체 change 완료 뒤 PROD-470이 소유하며, 이 PR에서 OpenSpec을 archive하지 않음
- production sync/apply는 수행하지 않았고 별도 명시적 승인 전 금지

## PR 이력

기존 PR #353 번호와 `PROD-470` 브랜치는 재사용하되, 과거 `add-vault-pki-postgres-auth` 구현은 최신 계약과 충돌해 main에 합치지 않았습니다. 이전 원격 head `d0444627`은 복구용 로컬 backup ref로 보존하고, 이 PR head는 최신 main `44fab9b4` 기반 `b2374b8e`로 교체했습니다.
