### PR TITLE
PROD-418 Reaction 요약 UI를 실제 데이터에 연결한다

### DIFF
--- a/apps/app/.storybook/mocks/react-relay.tsx
+++ b/apps/app/.storybook/mocks/react-relay.tsx
@@ -13,13 +13,21 @@ type RelayMockValue = {
   paginationLoading?: boolean;
   paginationResponse?: unknown;
   paginationResponses?: StoryOperationResponse[];
-  operationResponses?: Record<string, StoryOperationResponse | StoryOperationResponse[]>;
+  operationResponses?: Record<
+    string,
+    StoryOperationResponse | StoryOperationResponse[] | StoryOperationResponseSequence
+  >;
   queryData?: unknown;
 };
 
 type StoryOperationResponse = {
   data?: unknown;
+  delayMs?: number;
   error?: string;
+};
+
+type StoryOperationResponseSequence = {
+  sequence: [StoryOperationResponse, ...StoryOperationResponse[]];
 };
 
 export function RelayStoryProvider({
@@ -76,19 +84,33 @@ export function RelayStoryProvider({
 
 function createStoryEnvironment(mock: RelayMockValue, environmentIndex: number): Environment {
   let paginationResponseIndex = 0;
+  const operationResponseIndices = new Map<string, number>();
+  const nextOperationResponseIndex = (operationName: string) => {
+    const index = operationResponseIndices.get(operationName) ?? 0;
+    operationResponseIndices.set(operationName, index + 1);
+    return index;
+  };
+
   return new Environment({
     network: Network.create((request) =>
-      executeStoryOperation(request, mock, environmentIndex, () => paginationResponseIndex++),
+      executeStoryOperation(
+        request,
+        mock,
+        environmentIndex,
+        () => paginationResponseIndex++,
+        nextOperationResponseIndex,
+      ),
     ),
     store: new Store(new RecordSource()),
   });
 }
 
-function executeStoryOperation(
+async function executeStoryOperation(
   request: RequestParameters,
   mock: RelayMockValue,
   environmentIndex: number,
   nextPaginationResponseIndex: () => number,
+  nextOperationResponseIndex: (operationName: string) => number,
 ): Promise<GraphQLResponse> {
   if (request.operationKind === 'mutation') {
     if (mock.mutationError) {
@@ -134,7 +156,15 @@ function executeStoryOperation(
   const configuredResponse = mock.operationResponses?.[request.name];
   const operationResponse = Array.isArray(configuredResponse)
     ? configuredResponse[Math.min(environmentIndex, configuredResponse.length - 1)]
-    : configuredResponse;
+    : configuredResponse && 'sequence' in configuredResponse
+      ? configuredResponse.sequence[
+          Math.min(nextOperationResponseIndex(request.name), configuredResponse.sequence.length - 1)
+        ]
+      : configuredResponse;
+
+  if (operationResponse?.delayMs) {
+    await new Promise((resolve) => setTimeout(resolve, operationResponse.delayMs));
+  }
 
   if (operationResponse?.error) {
     return Promise.reject(new Error(operationResponse.error));

--- a/apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx
+++ b/apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { PostLayout } from '@/components/post/PostLayout';
+import { PostReactionSummary } from '@/components/reaction/PostReactionSummary';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { StateView } from '@/components/ui/StateView';
 import { useRelayActor } from '@/relay/RelayActorProvider';
@@ -23,6 +24,7 @@ const PostQuery = graphql`
           relativeHandle
         }
         ...PostLayout_post @alias
+        ...PostReactionSummary_post @alias
       }
     }
   }
@@ -98,7 +100,7 @@ function PostDetailContent({
     />
   ) : post.state === 'DELETED' ? (
     <StateView description="작성자가 이 게시글을 삭제했어요." title="삭제된 게시글이에요" />
-  ) : !post.PostLayout_post ? (
+  ) : !post.PostLayout_post || !post.PostReactionSummary_post ? (
     <StateView
       description="게시글 데이터를 다시 불러와 주세요."
       title="게시글을 표시할 수 없어요"
@@ -106,6 +108,7 @@ function PostDetailContent({
   ) : (
     <View style={styles.post}>
       <PostLayout post={post.PostLayout_post} />
+      <PostReactionSummary post={post.PostReactionSummary_post} />
     </View>
   );
 }
@@ -128,5 +131,5 @@ const styles = StyleSheet.create({
     width: 44,
   },
   heading: { fontFamily: 'SUIT', fontSize: 18, fontWeight: '700', lineHeight: 28 },
-  post: { padding: spacing.lg },
+  post: { gap: spacing.lg, padding: spacing.lg },
 });

--- a/apps/app/src/components/reaction/PostReactionSummary.tsx
+++ b/apps/app/src/components/reaction/PostReactionSummary.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import { ReactionProfilesModal } from './ReactionProfilesModal';
+import { ReactionSummary } from './ReactionSummary';
+import type { PostReactionSummary_post$key } from './__generated__/PostReactionSummary_post.graphql';
+
+const postReactionSummaryFragment = graphql`
+  fragment PostReactionSummary_post on Post {
+    id
+    reactionCounts {
+      type
+      count
+    }
+  }
+`;
+
+export function PostReactionSummary({ post: postKey }: { post: PostReactionSummary_post$key }) {
+  const post = useFragment(postReactionSummaryFragment, postKey);
+  const [selectedType, setSelectedType] = useState<string>();
+
+  if (post.reactionCounts.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <ReactionSummary entries={post.reactionCounts} onSelectType={setSelectedType} />
+      {selectedType ? (
+        <ReactionProfilesModal
+          key={`${post.id}:${selectedType}`}
+          onClose={() => setSelectedType(undefined)}
+          postId={post.id}
+          reactionType={selectedType}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/app/src/components/reaction/ReactionProfileConnection.tsx
+++ b/apps/app/src/components/reaction/ReactionProfileConnection.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from 'react';
+import { graphql, usePaginationFragment } from 'react-relay';
+import { ReactionProfileList } from './ReactionProfileList';
+import type { ReactionProfileConnection_post$key } from './__generated__/ReactionProfileConnection_post.graphql';
+import type { ReactionProfileConnectionNextPageQuery } from './__generated__/ReactionProfileConnectionNextPageQuery.graphql';
+
+const reactionProfileConnectionFragment = graphql`
+  fragment ReactionProfileConnection_post on Post
+  @argumentDefinitions(
+    count: { type: "Int", defaultValue: 20 }
+    cursor: { type: "String" }
+    reactionType: { type: "String!" }
+  )
+  @refetchable(queryName: "ReactionProfileConnectionNextPageQuery") {
+    id
+    reactionProfiles(type: $reactionType, first: $count, after: $cursor)
+      @connection(key: "ReactionProfileConnection_reactionProfiles", filters: ["type"]) {
+      edges {
+        cursor
+        node {
+          id
+          ...ProfileListItem_profile
+        }
+      }
+    }
+  }
+`;
+
+type ReactionProfileConnectionProps = {
+  post: ReactionProfileConnection_post$key;
+  reactionType: string;
+};
+
+export function ReactionProfileConnection({ post, reactionType }: ReactionProfileConnectionProps) {
+  const pagination = usePaginationFragment<
+    ReactionProfileConnectionNextPageQuery,
+    ReactionProfileConnection_post$key
+  >(reactionProfileConnectionFragment, post);
+  const [loadMoreError, setLoadMoreError] = useState(false);
+  const scope = `${pagination.data.id}:${reactionType}`;
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
+
+  useEffect(() => {
+    setLoadMoreError(false);
+  }, [scope]);
+
+  const loadMore = () => {
+    if (pagination.isLoadingNext) {
+      return;
+    }
+
+    setLoadMoreError(false);
+    pagination.loadNext(20, {
+      onComplete: (error) => {
+        if (scopeRef.current === scope) {
+          setLoadMoreError(Boolean(error));
+        }
+      },
+    });
+  };
+
+  const items = pagination.data.reactionProfiles.edges.map(({ cursor, node }) => ({
+    id: cursor,
+    profile: node,
+  }));
+
+  return (
+    <ReactionProfileList
+      hasNext={pagination.hasNext}
+      isLoadingMore={pagination.isLoadingNext}
+      items={items}
+      loadMoreError={loadMoreError}
+      onLoadMore={loadMore}
+      reactionType={reactionType}
+    />
+  );
+}

--- a/apps/app/src/components/reaction/ReactionProfileConnection.tsx
+++ b/apps/app/src/components/reaction/ReactionProfileConnection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { graphql, usePaginationFragment } from 'react-relay';
 import { ReactionProfileList } from './ReactionProfileList';
 import type { ReactionProfileConnection_post$key } from './__generated__/ReactionProfileConnection_post.graphql';
@@ -37,13 +37,6 @@ export function ReactionProfileConnection({ post, reactionType }: ReactionProfil
     ReactionProfileConnection_post$key
   >(reactionProfileConnectionFragment, post);
   const [loadMoreError, setLoadMoreError] = useState(false);
-  const scope = `${pagination.data.id}:${reactionType}`;
-  const scopeRef = useRef(scope);
-  scopeRef.current = scope;
-
-  useEffect(() => {
-    setLoadMoreError(false);
-  }, [scope]);
 
   const loadMore = () => {
     if (pagination.isLoadingNext) {
@@ -52,11 +45,7 @@ export function ReactionProfileConnection({ post, reactionType }: ReactionProfil
 
     setLoadMoreError(false);
     pagination.loadNext(20, {
-      onComplete: (error) => {
-        if (scopeRef.current === scope) {
-          setLoadMoreError(Boolean(error));
-        }
-      },
+      onComplete: (error) => setLoadMoreError(Boolean(error)),
     });
   };
 

--- a/apps/app/src/components/reaction/ReactionProfilesModal.tsx
+++ b/apps/app/src/components/reaction/ReactionProfilesModal.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet } from 'react-native';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import { RouteBoundary } from '@/components/RouteBoundary';
+import { StateView } from '@/components/ui/StateView';
+import { useTheme } from '@/theme/ThemeProvider';
+import { radii, spacing } from '@/theme/tokens';
+import { ReactionProfileConnection } from './ReactionProfileConnection';
+import { ReactionProfileList } from './ReactionProfileList';
+import type { ReactionProfilesModalQuery } from './__generated__/ReactionProfilesModalQuery.graphql';
+
+const reactionProfilesModalQuery = graphql`
+  query ReactionProfilesModalQuery($postId: ID!, $reactionType: String!) {
+    node(id: $postId) {
+      __typename
+      ... on Post {
+        ...ReactionProfileConnection_post
+          @arguments(reactionType: $reactionType)
+          @alias(as: "reactionProfileConnection")
+      }
+    }
+  }
+`;
+
+type ReactionProfilesModalProps = {
+  onClose: () => void;
+  postId: string;
+  reactionType: string;
+};
+
+function ReactionProfilesContent({
+  fetchKey,
+  postId,
+  reactionType,
+}: {
+  fetchKey: number;
+  postId: string;
+  reactionType: string;
+}) {
+  const data = useLazyLoadQuery<ReactionProfilesModalQuery>(
+    reactionProfilesModalQuery,
+    { postId, reactionType },
+    { fetchKey, fetchPolicy: 'store-and-network' },
+  );
+
+  return data.node?.__typename === 'Post' && data.node.reactionProfileConnection ? (
+    <ReactionProfileConnection
+      post={data.node.reactionProfileConnection}
+      reactionType={reactionType}
+    />
+  ) : (
+    <StateView title="게시글을 찾을 수 없어요" />
+  );
+}
+
+export function ReactionProfilesModal({
+  onClose,
+  postId,
+  reactionType,
+}: ReactionProfilesModalProps) {
+  const [fetchKey, setFetchKey] = useState(0);
+  const theme = useTheme();
+  const title = `${reactionType} 반응한 프로필`;
+
+  return (
+    <Modal
+      accessibilityLabel={title}
+      animationType="fade"
+      onRequestClose={onClose}
+      transparent
+      visible
+    >
+      <Pressable accessibilityLabel={`${title} 닫기`} onPress={onClose} style={styles.backdrop}>
+        <Pressable
+          accessibilityLabel={title}
+          accessibilityViewIsModal
+          onPress={(event) => event.stopPropagation()}
+          role="dialog"
+          style={[styles.surface, { backgroundColor: theme.card, borderColor: theme.border }]}
+        >
+          <ScrollView contentContainerStyle={styles.content}>
+            <RouteBoundary
+              loading={<ReactionProfileList loading reactionType={reactionType} />}
+              onRetry={() => setFetchKey((key) => key + 1)}
+              title="반응한 프로필을 불러오지 못했어요"
+            >
+              <ReactionProfilesContent
+                fetchKey={fetchKey}
+                postId={postId}
+                reactionType={reactionType}
+              />
+            </RouteBoundary>
+          </ScrollView>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: spacing.lg,
+  },
+  surface: {
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    maxHeight: '80%',
+    maxWidth: 420,
+    width: '100%',
+  },
+  content: { padding: spacing.lg },
+});

--- a/apps/app/src/stories/Reactions.stories.tsx
+++ b/apps/app/src/stories/Reactions.stories.tsx
@@ -1,16 +1,19 @@
 import { useState } from 'react';
-import { Text } from 'react-native';
+import { Button, Text } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, screen, userEvent, within } from 'storybook/test';
+import { PostReactionSummary } from '@/components/reaction/PostReactionSummary';
 import { ReactionProfileConnection } from '@/components/reaction/ReactionProfileConnection';
 import { ReactionProfileList } from '@/components/reaction/ReactionProfileList';
 import { ReactionSelector } from '@/components/reaction/ReactionSelector';
 import { ReactionSummary } from '@/components/reaction/ReactionSummary';
+import { useRelayActor } from '@/relay/RelayActorProvider';
 import { profile } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactionOption, ReactionToggleIntent } from '@/components/reaction/ReactionSelector';
 import type { ReactionProfileConnectionStoriesQuery } from './__generated__/ReactionProfileConnectionStoriesQuery.graphql';
+import type { ReactionsIntegrationStoriesQuery } from './__generated__/ReactionsIntegrationStoriesQuery.graphql';
 import type { ReactionsStoriesQuery as ReactionsStoriesQueryType } from './__generated__/ReactionsStoriesQuery.graphql';
 
 const tiedEntries = [
@@ -62,6 +65,44 @@ const reactionPostWithProfiles = {
   },
 };
 
+const reactionPostSummary = {
+  __typename: 'Post' as const,
+  id: 'reaction-post',
+  reactionCounts: [
+    { count: 12, type: '❤️' },
+    { count: 7, type: '🎉' },
+  ],
+};
+
+function reactionPostWithProfile(displayName: string, id: string) {
+  return {
+    __typename: 'Post' as const,
+    id: 'reaction-post',
+    reactionProfiles: {
+      edges: [
+        {
+          cursor: `${id}-cursor`,
+          node: profile({ displayName, id, relativeHandle: `@${id}` }),
+        },
+      ],
+      pageInfo: { endCursor: `${id}-cursor`, hasNextPage: false },
+    },
+  };
+}
+
+const reactionPostWithActorAProfiles = reactionPostWithProfile(
+  'Actor A Profile',
+  'reaction-profile-actor-a',
+);
+const reactionPostWithActorBProfiles = reactionPostWithProfile(
+  'Actor B Profile',
+  'reaction-profile-actor-b',
+);
+const reactionPostWithRefreshedProfiles = reactionPostWithProfile(
+  'Refreshed Profile',
+  'reaction-profile-refreshed',
+);
+
 const reactionProfilesNextPage = {
   node: {
     ...reactionPostWithProfiles,
@@ -106,6 +147,17 @@ const ReactionProfileConnectionStoriesQueryNode = graphql`
   }
 `;
 
+const ReactionsIntegrationStoriesQueryNode = graphql`
+  query ReactionsIntegrationStoriesQuery($postId: ID!) {
+    node(id: $postId) {
+      __typename
+      ... on Post {
+        ...PostReactionSummary_post @alias(as: "reactionSummary")
+      }
+    }
+  }
+`;
+
 type ProfileNode = Extract<
   NonNullable<ReactionsStoriesQueryType['response']['nodes'][number]>,
   { readonly __typename: 'Profile' }
@@ -140,6 +192,29 @@ function ReactionProfileConnectionStory() {
     throw new Error('Missing Reaction Profile connection Post fixture.');
   }
   return <ReactionProfileConnection post={data.node.reactionProfileConnection} reactionType="❤️" />;
+}
+
+function PostReactionSummaryStory({ postId = 'reaction-post' }: { postId?: string }) {
+  const data = useLazyLoadQuery<ReactionsIntegrationStoriesQuery>(
+    ReactionsIntegrationStoriesQueryNode,
+    { postId },
+  );
+  if (data.node?.__typename !== 'Post' || !data.node.reactionSummary) {
+    throw new Error('Missing Reaction Summary Post fixture.');
+  }
+
+  return <PostReactionSummary post={data.node.reactionSummary} />;
+}
+
+function ActorSwitchPostReactionSummaryStory() {
+  const { resetActor } = useRelayActor();
+
+  return (
+    <>
+      <Button onPress={() => resetActor('reaction-actor-b')} title="프로필 전환" />
+      <PostReactionSummaryStory />
+    </>
+  );
 }
 
 function ReactionSummaryCatalog() {
@@ -421,6 +496,135 @@ export const ProfilePaginationFailurePreservesRows: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
     await expect(canvas.findAllByRole('link')).resolves.toHaveLength(3);
     expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+
+export const ZeroCountSummaryIsNotRendered: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        ReactionsIntegrationStoriesQuery: {
+          data: { node: { __typename: 'Post', id: 'post-empty', reactionCounts: [] } },
+        },
+      },
+    },
+  },
+  render: () => <PostReactionSummaryStory postId="post-empty" />,
+  play: ({ canvasElement }) => {
+    expect(within(canvasElement).queryByRole('heading', { name: '반응' })).not.toBeInTheDocument();
+  },
+};
+
+export const SummaryOrderAndModalDismiss: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        ReactionsIntegrationStoriesQuery: { data: { node: reactionPostSummary } },
+        ReactionProfilesModalQuery: { data: { node: reactionPostWithProfiles } },
+      },
+    },
+  },
+  render: () => <PostReactionSummaryStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getAllByRole('button').map((button) => button.textContent)).toEqual([
+      '❤️ 12',
+      '🎉 7',
+    ]);
+
+    await userEvent.click(canvas.getByRole('button', { name: '❤️ 반응 12개 보기' }));
+    await expect(
+      screen.findByRole('dialog', { name: '❤️ 반응한 프로필' }),
+    ).resolves.toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
+    expect(screen.queryByRole('dialog', { name: '❤️ 반응한 프로필' })).not.toBeInTheDocument();
+  },
+};
+
+export const InitialProfileQueryFailureIsInline: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        ReactionsIntegrationStoriesQuery: { data: { node: reactionPostSummary } },
+        ReactionProfilesModalQuery: {
+          sequence: [
+            { error: 'Reaction Profile 최초 조회 실패' },
+            { data: { node: reactionPostWithProfiles } },
+          ],
+        },
+      },
+    },
+  },
+  render: () => <PostReactionSummaryStory />,
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: '❤️ 반응 12개 보기' }));
+    await expect(screen.findByRole('alert')).resolves.toHaveTextContent(
+      '반응한 프로필을 불러오지 못했어요',
+    );
+    await userEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+    await expect(screen.findByText('별빛 반응 프로필')).resolves.toBeVisible();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
+  },
+};
+
+export const ReopenShowsCacheBeforeBackgroundRefresh: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        ReactionsIntegrationStoriesQuery: { data: { node: reactionPostSummary } },
+        ReactionProfilesModalQuery: {
+          sequence: [
+            { data: { node: reactionPostWithActorAProfiles } },
+            { data: { node: reactionPostWithRefreshedProfiles }, delayMs: 150 },
+          ],
+        },
+      },
+    },
+  },
+  render: () => <PostReactionSummaryStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const summaryButton = canvas.getByRole('button', { name: '❤️ 반응 12개 보기' });
+
+    await userEvent.click(summaryButton);
+    await expect(screen.findByText('Actor A Profile')).resolves.toBeVisible();
+    await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
+    await userEvent.click(summaryButton);
+    expect(screen.getByText('Actor A Profile')).toBeInTheDocument();
+    await expect(screen.findByText('Refreshed Profile')).resolves.toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
+  },
+};
+
+export const ActorSwitchDoesNotReuseProfileRows: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        ReactionsIntegrationStoriesQuery: [
+          { data: { node: reactionPostSummary } },
+          { data: { node: reactionPostSummary } },
+        ],
+        ReactionProfilesModalQuery: [
+          { data: { node: reactionPostWithActorAProfiles } },
+          { data: { node: reactionPostWithActorBProfiles } },
+        ],
+      },
+    },
+  },
+  render: () => <ActorSwitchPostReactionSummaryStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: '❤️ 반응 12개 보기' }));
+    await expect(screen.findByText('Actor A Profile')).resolves.toBeVisible();
+    await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
+    await userEvent.click(canvas.getByRole('button', { name: '프로필 전환' }));
+    await userEvent.click(await canvas.findByRole('button', { name: '❤️ 반응 12개 보기' }));
+    await expect(screen.findByText('Actor B Profile')).resolves.toBeVisible();
+    expect(screen.queryByText('Actor A Profile')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
   },
 };
 

--- a/apps/app/src/stories/Reactions.stories.tsx
+++ b/apps/app/src/stories/Reactions.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Button, Text } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { expect, screen, userEvent, within } from 'storybook/test';
+import { expect, screen, spyOn, userEvent, within } from 'storybook/test';
 import { PostReactionSummary } from '@/components/reaction/PostReactionSummary';
 import { ReactionProfileConnection } from '@/components/reaction/ReactionProfileConnection';
 import { ReactionProfileList } from '@/components/reaction/ReactionProfileList';
@@ -543,6 +543,22 @@ export const SummaryOrderAndModalDismiss: Story = {
 };
 
 export const InitialProfileQueryFailureIsInline: Story = {
+  beforeEach: () => {
+    const originalError = console.error;
+    const errorSpy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      const isExpectedRouteError = args.some((argument) =>
+        argument instanceof Error
+          ? argument.message === 'Reaction Profile 최초 조회 실패'
+          : typeof argument === 'string' && argument.includes('Reaction Profile 최초 조회 실패'),
+      );
+
+      if (!isExpectedRouteError) {
+        originalError(...args);
+      }
+    });
+
+    return () => errorSpy.mockRestore();
+  },
   parameters: {
     relay: {
       operationResponses: {

--- a/apps/app/src/stories/Reactions.stories.tsx
+++ b/apps/app/src/stories/Reactions.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Text } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { expect, userEvent, within } from 'storybook/test';
+import { ReactionProfileConnection } from '@/components/reaction/ReactionProfileConnection';
 import { ReactionProfileList } from '@/components/reaction/ReactionProfileList';
 import { ReactionSelector } from '@/components/reaction/ReactionSelector';
 import { ReactionSummary } from '@/components/reaction/ReactionSummary';
@@ -9,6 +10,7 @@ import { profile } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactionOption, ReactionToggleIntent } from '@/components/reaction/ReactionSelector';
+import type { ReactionProfileConnectionStoriesQuery } from './__generated__/ReactionProfileConnectionStoriesQuery.graphql';
 import type { ReactionsStoriesQuery as ReactionsStoriesQueryType } from './__generated__/ReactionsStoriesQuery.graphql';
 
 const tiedEntries = [
@@ -48,6 +50,37 @@ const storyProfiles = [
   }),
 ];
 
+const reactionPostWithProfiles = {
+  __typename: 'Post' as const,
+  id: 'reaction-post',
+  reactionProfiles: {
+    edges: storyProfiles.map((node, index) => ({
+      cursor: `reaction-profile-cursor-${index + 1}`,
+      node,
+    })),
+    pageInfo: { endCursor: 'reaction-profile-cursor-2', hasNextPage: true },
+  },
+};
+
+const reactionProfilesNextPage = {
+  node: {
+    ...reactionPostWithProfiles,
+    reactionProfiles: {
+      edges: [
+        {
+          cursor: 'reaction-profile-cursor-3',
+          node: profile({
+            displayName: '혜성 반응 프로필',
+            id: 'reaction-profile-comet',
+            relativeHandle: '@comet',
+          }),
+        },
+      ],
+      pageInfo: { endCursor: 'reaction-profile-cursor-3', hasNextPage: false },
+    },
+  },
+};
+
 const ReactionsStoriesQuery = graphql`
   query ReactionsStoriesQuery($ids: [ID!]!) {
     nodes(ids: $ids) {
@@ -55,6 +88,19 @@ const ReactionsStoriesQuery = graphql`
       ... on Profile {
         id
         ...ProfileListItem_profile @alias(as: "reactionListItem")
+      }
+    }
+  }
+`;
+
+const ReactionProfileConnectionStoriesQueryNode = graphql`
+  query ReactionProfileConnectionStoriesQuery($reactionType: String!) {
+    node(id: "reaction-post") {
+      __typename
+      ... on Post {
+        ...ReactionProfileConnection_post
+          @arguments(reactionType: $reactionType)
+          @alias(as: "reactionProfileConnection")
       }
     }
   }
@@ -83,6 +129,17 @@ function requireFragment<T>(fragment: T | null | undefined, label: string): T {
     throw new Error(`Missing ${label} fragment reference.`);
   }
   return fragment;
+}
+
+function ReactionProfileConnectionStory() {
+  const data = useLazyLoadQuery<ReactionProfileConnectionStoriesQuery>(
+    ReactionProfileConnectionStoriesQueryNode,
+    { reactionType: '❤️' },
+  );
+  if (data.node?.__typename !== 'Post' || !data.node.reactionProfileConnection) {
+    throw new Error('Missing Reaction Profile connection Post fixture.');
+  }
+  return <ReactionProfileConnection post={data.node.reactionProfileConnection} reactionType="❤️" />;
 }
 
 function ReactionSummaryCatalog() {
@@ -340,6 +397,31 @@ export const ProfileListStates: Story = {
     expect(loadingMoreButton).toHaveAttribute('aria-busy', 'true');
   },
   render: () => <ReactionProfileListCatalog />,
+};
+
+export const ProfilePaginationFailurePreservesRows: Story = {
+  parameters: {
+    relay: {
+      data: { node: reactionPostWithProfiles },
+      paginationResponses: [
+        { error: '다음 Reaction Profile page 조회 실패' },
+        { data: reactionProfilesNextPage },
+      ],
+    },
+  },
+  render: () => <ReactionProfileConnectionStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getAllByRole('link')).toHaveLength(2);
+    await userEvent.click(canvas.getByRole('button', { name: '더 불러오기' }));
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
+      '반응한 프로필을 더 불러오지 못했어요',
+    );
+    expect(canvas.getAllByRole('link')).toHaveLength(2);
+    await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
+    await expect(canvas.findAllByRole('link')).resolves.toHaveLength(3);
+    expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
 };
 
 export const QuickPickerInteraction: Story = {

--- a/apps/app/src/stories/Reactions.stories.tsx
+++ b/apps/app/src/stories/Reactions.stories.tsx
@@ -102,6 +102,14 @@ const reactionPostWithRefreshedProfiles = reactionPostWithProfile(
   'Refreshed Profile',
   'reaction-profile-refreshed',
 );
+const reactionPostWithHeartTypeProfiles = reactionPostWithProfile(
+  'Heart Type Profile',
+  'reaction-profile-heart-type',
+);
+const reactionPostWithPartyTypeProfiles = reactionPostWithProfile(
+  'Party Type Profile',
+  'reaction-profile-party-type',
+);
 
 const reactionProfilesNextPage = {
   node: {
@@ -611,6 +619,35 @@ export const ReopenShowsCacheBeforeBackgroundRefresh: Story = {
     expect(screen.getByText('Actor A Profile')).toBeInTheDocument();
     await expect(screen.findByText('Refreshed Profile')).resolves.toBeInTheDocument();
     await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
+  },
+};
+
+export const SwitchingReactionTypeDoesNotReuseProfileRows: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        ReactionsIntegrationStoriesQuery: { data: { node: reactionPostSummary } },
+        ReactionProfilesModalQuery: {
+          sequence: [
+            { data: { node: reactionPostWithHeartTypeProfiles } },
+            { data: { node: reactionPostWithPartyTypeProfiles }, delayMs: 150 },
+          ],
+        },
+      },
+    },
+  },
+  render: () => <PostReactionSummaryStory />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: '❤️ 반응 12개 보기' }));
+    await expect(screen.findByText('Heart Type Profile')).resolves.toBeVisible();
+    await userEvent.click(screen.getByLabelText('❤️ 반응한 프로필 닫기'));
+    await userEvent.click(canvas.getByRole('button', { name: '🎉 반응 7개 보기' }));
+    expect(screen.queryByText('Heart Type Profile')).not.toBeInTheDocument();
+    await expect(screen.findByText('Party Type Profile')).resolves.toBeVisible();
+    expect(screen.queryByText('Heart Type Profile')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('🎉 반응한 프로필 닫기'));
   },
 };
 

--- a/docs/design/reactions.md
+++ b/docs/design/reactions.md
@@ -1,4 +1,6 @@
-# Reaction Quick Picker
+# Reaction UI
+
+## Reaction Quick Picker
 
 Reaction Quick Picker는 현재 제공된 Reaction option을 빠르게 선택하는 펼쳐진 패널이다. option 목록과 상태는 부모가 공급하며, Picker는 시각 표현과 toggle intent만 소유한다.
 
@@ -32,3 +34,14 @@ Reaction Quick Picker는 현재 제공된 Reaction option을 빠르게 선택하
 
 - Storybook interaction에서 border 없는 option, 70% opacity의 selected 배경과 100% opacity의 이모지, 44×44px pending overlay와 24×24px fading arc, 오류 재시도와 disabled 시 미렌더링을 검증한다.
 - 390px와 600px Web viewport에서 여섯 option이 한 줄을 유지하고 각 target이 44×44px인지 확인한다.
+
+## Reaction 요약과 Profile 목록
+
+- Post에 하나 이상의 Reaction이 있을 때만 Type별 count 요약을 표시한다. Reaction이 없으면 별도 빈 요약 영역이나 zero-count Type을 표시하지 않는다.
+- 요약은 server가 제공한 양수 count Type과 순서를 그대로 사용하며, viewer가 볼 수 있는 Profile 수로 count를 다시 계산하지 않는다.
+- 사용자가 한 Type을 선택하면 현재 Post 위에 modal overlay를 열어 그 Type의 Profile 목록을 표시한다. 별도 route나 공개 URL은 만들지 않는다.
+- modal은 외부 영역 클릭·터치와 Android back으로 닫으며 별도 닫기 버튼을 표시하지 않는다.
+- Profile 목록의 최초 조회가 실패하면 modal 내부에 오류와 다시 시도 동작을 표시한다.
+- 추가 page 조회가 실패하면 이미 표시한 Profile을 유지하고 목록 내부에 오류와 다시 시도 동작을 표시한다. 이 조회 오류에 snackbar나 toast를 사용하지 않는다.
+- 같은 Type의 modal을 다시 열 때 cache된 Profile을 먼저 표시하고 background에서 최신 목록을 조회한다. Profile 전환 뒤에는 이전 actor의 cache를 재사용하지 않는다.
+- Reaction 추가·삭제 mutation의 오류 알림 방식은 Reaction 요약·Profile 조회 UI의 계약에 포함하지 않는다.

--- a/openspec/changes/add-post-reactions/decisions.md
+++ b/openspec/changes/add-post-reactions/decisions.md
@@ -110,6 +110,21 @@
 - Consequences: 실제 `Post` count query와 `reactionProfiles` connection, modal/route, selected Profile/viewer cache 통합은 PROD-418에 남는다. supplied order는 server가 제공한 count 내림차순과 동률 무보장 계약을 그대로 보존하며, component는 이를 재해석하지 않는다. 이 선택은 최종 `post-reaction-ui` spec을 축소하거나 대체하지 않으며, 나중에 되돌릴 중간 제품 계약이 아니다.
 - Confirmation / Follow-up: PROD-449는 fixture state, 복수 Type·동률, 기존 Profile row, callback interaction과 Relay mock fragment Storybook을 component 수준에서 검증한다. PROD-418은 같은 seam을 유지한 채 실제 query/connection, zero-count와 modal/route UX, cache 통합 및 최종 spec의 pagination 검증을 수행한다.
 
+### PROD-418은 Reaction이 있는 Post에서 modal 기반 Profile 탐색을 제공한다
+
+- Decision Date: 2026-07-25
+- Decision Class: Implementation Choice
+- Authority / Provenance:
+  - `docs/domain/objects/reaction.md`
+  - `docs/design/reactions.md`
+  - `PROD-418`의 2026-07-25 설계 결정 댓글
+- Status: Active
+- Context / Problem: PROD-418은 이미 제공된 viewer-independent Type별 count와 viewer-filtered Profile connection을 현재 Post 맥락에서 연결해야 한다. Reaction이 없는 Post의 빈 요약, 별도 route, 조회 오류용 전역 알림과 매번 빈 loading부터 시작하는 modal은 이 결과에 불필요한 UI·cache 계약을 추가한다.
+- Decision Outcome: `reactionCounts`가 비어 있으면 `ReactionSummary`를 렌더링하지 않고, 양수 count가 있으면 server 순서를 그대로 표시한다. Type 선택은 현재 Post 위의 modal overlay를 열며 별도 route나 URL을 만들지 않는다. modal은 외부 영역 클릭·터치와 Android back으로 닫고 별도 닫기 버튼을 두지 않는다. 최초 Profile 조회 실패와 추가 page 실패는 각각 modal·목록 내부 오류와 다시 시도로 복구하며 추가 page 실패 전까지의 Profile을 유지한다. Profile 조회 오류에는 snackbar·toast·전역 outlet을 추가하지 않는다. 같은 Type의 modal 재진입은 cache된 목록을 먼저 표시하고 background에서 갱신하며 selected Profile 전환 뒤에는 이전 Relay Environment의 cache를 재사용하지 않는다.
+- Alternatives Considered: Reaction이 없는 Post에 빈 요약을 표시하는 방식은 요약 진입점 없이 중복 empty UI를 남긴다. Profile 목록을 별도 route로 여는 방식은 현재 Post 맥락과 불필요한 URL 계약을 추가한다. 조회 오류를 snackbar로만 알리는 방식은 지속적인 복구 동작을 화면 밖의 일시적 알림에 의존하게 한다. 매번 network-only loading부터 시작하는 방식은 이미 조회한 목록을 불필요하게 숨긴다.
+- Consequences: PROD-418은 기존 backend API와 props-only seam의 Relay·modal·cache 통합 및 기존 Post detail route의 요약 진입점만 추가한다. Reaction 추가·삭제 mutation 오류 UX, snackbar/toast infrastructure, 공통 Post Action Bar와 feed/list surface 조립은 이 결정에 포함하지 않는다.
+- Confirmation / Follow-up: PROD-418 component/integration test는 zero-count 미렌더링, server 순서, modal dismiss, 최초·추가 page 오류 복구, 기존 edge 보존, cache 우선 재진입과 selected Profile 격리를 검증한다.
+
 ### PROD-450은 supplied option 기반 Quick Picker 프레젠테이션을 먼저 전달한다
 
 - Decision Date: 2026-07-23

--- a/openspec/changes/add-post-reactions/decisions.md
+++ b/openspec/changes/add-post-reactions/decisions.md
@@ -277,12 +277,12 @@
 - Context / Problem: canonical과 PROD-406은 viewer-independent Type별 count와 정렬을 고정하지만 GraphQL field와 항목 shape는 구현 전 공개 계약으로 확정되지 않았다.
 - Decision Outcome: GraphQL은 `Post.reactionCounts: [ReactionCount!]!`를 제공하고 `ReactionCount`는 `type: String!`과 `count: Int!`만 제공한다. 목록은 현재 Reaction이 하나 이상 존재하는 Type만 포함하며 Reaction이 없으면 빈 목록이다. Type별 Profile connection은 기존 `Post.reactionProfiles`로 분리한다.
 - Alternatives Considered: Relay connection은 현재 Type 수가 제한되고 pagination 계약이 없어 불필요한 cursor 표면을 만든다. map 또는 JSON scalar는 Type과 count의 정적 schema 계약을 잃는다. `ReactionSummary` 명칭은 client presentation component와 API aggregate를 혼동시킨다.
-- Consequences: API consumer는 서버가 제공한 count 내림차순을 그대로 사용하고 동률 순서에 의존하지 않는다. zero-count Type 공급은 PROD-417/418의 별도 결정이며 이 field가 합성하지 않는다.
+- Consequences: API consumer는 서버가 제공한 count 내림차순을 그대로 사용하고 동률 순서에 의존하지 않는다. summary에는 zero-count Type을 합성하지 않으며 selector의 zero-count option 공급은 PROD-417의 별도 결정이다. 이 field는 어느 쪽도 합성하지 않는다.
 - Confirmation / Follow-up: schema test와 PROD-406 integration test에서 non-null list·항목 shape, 빈 목록, viewer-independent 집계, 정렬, 삭제와 Post visibility를 검증한다.
 
 ## Remaining Decisions
 
-- PROD-417/418: zero-count Type 공급 API, selector·Profile 목록 UX, optimistic update 사용 여부
+- PROD-417: zero-count option 공급, selector 통합 UX와 optimistic update 사용 여부
 
 ## Superseded Decisions
 

--- a/openspec/changes/add-post-reactions/design.md
+++ b/openspec/changes/add-post-reactions/design.md
@@ -2,7 +2,7 @@
 
 현재 `main`에는 PROD-395·404·405·406·407의 Reaction 저장·생성·삭제·Type별 count·Profile connection, PROD-449의 fixture-first 요약·Profile 목록 presentation, PROD-450의 fixture-first Reaction Quick Picker presentation, PROD-277·324·372의 Notification 목록·badge·Read/navigation 기반과 PROD-413의 Reaction Notification 생성·inbox 통합이 있다. 아직 `main`에 없는 범위는 selector·요약 presentation을 실제 data와 연결하는 UI integration과 Reaction Notification 정리 lifecycle이다. PostgreSQL/Drizzle은 UUIDv7 default, 명시적 foreign key와 SQL-like query builder를 사용하며, Post 조회 권한은 API의 기존 Post visibility predicate가 소유한다. Notification Node/list/count/read는 Follow와 Reaction의 kind별 visible projection을 함께 사용하고 source가 없는 Reaction Notification을 숨긴다.
 
-이 change는 PROD-390이 소유한 공유 계약이며 구현은 PROD-395, PROD-404, PROD-405, PROD-406, PROD-407, PROD-413, PROD-450, PROD-417, PROD-418, PROD-419의 독립 PR로 나뉜다. PROD-395 저장 slice, PROD-404 멱등 생성 slice, PROD-405 멱등 삭제 slice, PROD-406 viewer-independent Reaction Type count 조회 slice, PROD-407 Type별 Profile connection slice, PROD-413 Reaction Notification slice, PROD-449 fixture-first 요약·Profile 목록 presentation slice와 PROD-450 fixture-first Reaction Quick Picker presentation slice는 `main`에 병합됐다. 현재 적용 대상은 PROD-419의 Reaction 삭제 뒤 Best Effort Notification 정리 slice이며, 나머지 slice는 자신의 blocker와 미결정을 해소한 뒤 같은 change를 이어서 사용한다.
+이 change는 PROD-390이 소유한 공유 계약이며 구현은 PROD-395, PROD-404, PROD-405, PROD-406, PROD-407, PROD-413, PROD-450, PROD-417, PROD-418, PROD-419의 독립 PR로 나뉜다. PROD-395 저장 slice, PROD-404 멱등 생성 slice, PROD-405 멱등 삭제 slice, PROD-406 viewer-independent Reaction Type count 조회 slice, PROD-407 Type별 Profile connection slice, PROD-413 Reaction Notification slice, PROD-449 fixture-first 요약·Profile 목록 presentation slice와 PROD-450 fixture-first Reaction Quick Picker presentation slice는 `main`에 병합됐다. 현재 적용 대상은 PROD-418의 Reaction 요약·Profile modal 통합과 PROD-419의 Reaction 삭제 뒤 Best Effort Notification 정리 slice이며, 나머지 slice는 자신의 blocker와 미결정을 해소한 뒤 같은 change를 이어서 사용한다.
 
 ## Goals / Non-Goals
 
@@ -47,7 +47,7 @@
 6. PROD-449는 먼저 props-only `ReactionSummary`와 `ReactionProfileList`의 fixture 상태 catalog를 전달한다. supplied count entry는 order·zero-count를 바꾸지 않고 렌더하며, Profile row는 기존 `ProfileListItem` Relay fragment ref를 재사용하고 Storybook은 Relay mock fragment ref로 상태를 구성한다. 이 구현 단계는 최종 `post-reaction-ui` spec을 변경하지 않는다.
 7. PROD-450은 부모가 공급한 option 순서를 그대로 사용하는 props-only `ReactionSelector` Quick Picker panel을 먼저 제공한다. 외부 컨테이너는 16px radius와 border를 유지하고 각 44×44px option은 border 없는 12px 둥근 사각형으로 표시한다. selected는 이모지와 분리된 `primary`/`primaryHover` 배경 layer를 70% opacity로 표시하고 error에는 빨간 border를 추가하지 않는다. pending option은 이모지 위에 `zIndex` 없는 full-size 투명 overlay를 표시하고, 가운데에서 `textSecondary` head가 투명한 tail로 흐려지는 24×24px·3px 두께의 연결된 180° 호를 약 820ms 주기로 시계 방향·linear 회전시킨다. 배경 track, 점과 분리된 spoke는 사용하지 않으며 전체 disabled이면 panel을 렌더링하지 않는다. 선택·pending·error는 표시 문자열과 분리된 opaque option identity별 controlled 상태로 받고, 현재 Storybook fixture는 canonical 여섯 Unicode와 복수 Type 공존을 검증한다. 이 단계는 최종 `post-reaction-ui` spec을 변경하지 않는다.
 8. PROD-417은 같은 presentation seam에 zero-count option 공급, add/delete mutation과 selected Profile Relay cache를 연결하고, Type별 pending/error를 격리해 서버가 확인한 상태를 기준으로 복구한다. optimistic update 여부는 이 통합 slice에서 결정한다.
-9. PROD-418은 실제 Post count query와 `reactionProfiles` Relay connection을 기존 summary/list props seam에 연결하고, zero-count와 modal/route UX 및 cache 통합을 결정·검증한다. seam은 PROD-418 통합에서도 유지하고, summary는 server count와 정렬을 그대로 사용하며 visible Profile 수로 count를 다시 계산하지 않는다.
+9. PROD-418은 실제 Post count query와 `reactionProfiles` Relay connection을 기존 summary/list props seam에 연결한다. `reactionCounts`가 비어 있으면 summary를 렌더링하지 않고, 양수 count가 있으면 server 순서를 그대로 표시한다. Type 선택은 현재 Post 위의 modal overlay를 열며 별도 route나 URL을 만들지 않는다. modal은 backdrop click·touch와 Android back으로 닫고 별도 닫기 버튼을 두지 않는다. 최초·추가 page 조회 오류는 modal·목록 내부 오류와 retry로 복구하고 추가 page 실패 전의 edge를 유지하며 snackbar·toast·전역 outlet을 추가하지 않는다. 재진입은 cache된 목록을 먼저 표시하고 background에서 갱신하되 selected Profile 전환 뒤에는 이전 Relay Environment의 cache를 재사용하지 않는다.
 10. PROD-277·324·372가 전달한 공통 목록 UI·badge·read/navigation 계약 위에 Reaction Notification item을 확장한다. `add-in-app-notifications`의 남은 E2E·archive는 그 부모 범위로 유지하며 PROD-413의 직접 구현 gate로 사용하지 않는다.
 11. PROD-419는 Owner 삭제 transaction이 성공한 뒤 반환된 Reaction ID로 기존 Notification delete 경계를 호출한다. 같은 request에서 cleanup을 await하되 실패는 Reaction 성공 payload와 분리하고, 기존 post-commit 오류 관례에 따라 error와 source Reaction ID를 기록한다. 반복 삭제와 이미 없는 source에도 같은 idempotent cleanup을 시도한다.
 12. PROD-390은 모든 자식 뒤 사용자 흐름과 canonical/OpenSpec 정합성을 검증하고 통합·archive를 소유한다.
@@ -75,6 +75,8 @@
 - Profile/Post/Type 조합을 삭제 input으로 사용해 이전 요청이 같은 조합으로 다시 생성된 새 Reaction을 제거하게 하지 않는다.
 - viewer가 볼 수 없는 Profile의 Reaction을 count에서 제외하지 않는다.
 - `reactionCounts`에 zero-count Type을 합성하거나 Profile connection 길이로 count를 다시 계산하지 않는다.
+- Reaction이 없는 Post에 빈 summary를 렌더링하거나 Profile 목록을 별도 route·URL로 확장하지 않는다.
+- Profile 조회 오류를 snackbar·toast로만 알리거나 추가 page 실패 때 기존 edge를 제거하지 않는다.
 - Profile visibility filtering을 page fetch 뒤 애플리케이션에서 수행하지 않는다.
 - Notification kind와 concrete object만 추가한 채 Follow 전용 list/count/read join을 유지하지 않는다.
 - Notification 저장·cleanup 실패로 Reaction mutation을 rollback하지 않는다.
@@ -101,9 +103,9 @@
 3. rollback이 필요하고 아직 consumer가 배포되지 않았다면 신규 table을 제거할 수 있다. consumer 배포 뒤에는 기존 migration을 수정하지 않고 forward migration으로 고친다.
 4. PROD-404~407에서 mutation과 조회를 추가한다. PROD-407은 `(post_id, type, created_at DESC, id DESC)` pagination ordering index를 별도 forward migration으로 추가한다.
 5. `add-in-app-notifications` archive 뒤 PROD-413/419에서 `REACTION` kind와 multi-kind visibility/API/UI migration을 별도로 추가한다.
-6. PROD-449/450은 props-only presentation과 Storybook 검증을 먼저 전달하고, PROD-417/418은 같은 seam에 실제 Relay data와 mutation/cache integration을 연결한다. 실제 Post surface 조립은 PROD-432로 넘긴다.
+6. PROD-449/450은 props-only presentation과 Storybook 검증을 먼저 전달하고, PROD-417/418은 같은 seam에 실제 Relay data와 mutation/cache integration을 연결한다. PROD-418은 기존 Post detail route에 요약 진입점을 연결하며, 공통 Post Action Bar와 feed/list surface 조립은 PROD-432로 넘긴다.
 7. 모든 자식 완료 뒤 PROD-390이 통합 검증, canonical·delta 정합성, archive와 archive 후 strict validation을 수행한다.
 
 ## Open Questions
 
-- PROD-417/418 전에 zero-count Type 공급 API를 결정해야 한다. PROD-450은 이 API나 optimistic update를 선결정하지 않고 supplied option fixture만 사용한다. PROD-417은 selector optimistic UX를, PROD-418은 Profile 목록 modal/route UX를 각각 결정해야 한다.
+- PROD-417은 zero-count option 공급과 selector optimistic UX를 결정해야 한다. PROD-450은 이 API나 optimistic update를 선결정하지 않고 supplied option fixture만 사용한다. PROD-418의 summary zero-count·Profile 목록 modal·조회 오류·cache UX는 2026-07-25 설계 결정으로 확정됐다.

--- a/openspec/changes/add-post-reactions/specs/post-reaction-ui/spec.md
+++ b/openspec/changes/add-post-reactions/specs/post-reaction-ui/spec.md
@@ -44,17 +44,49 @@
 - **THEN** component는 Type과 count를 count 내림차순으로 표시한다
 - **AND** count 동률 Type의 순서에 의존하지 않는다
 
+#### Scenario: Reaction이 없는 Post
+
+- **WHEN** Post의 `reactionCounts`가 빈 목록이다
+- **THEN** 클라이언트는 Reaction 요약 영역을 렌더링하지 않는다
+- **AND** zero-count Type이나 별도 빈 요약 상태를 합성하지 않는다
+
 #### Scenario: Type별 Profile 목록 진입
 
 - **WHEN** 사용자가 한 Reaction Type 요약을 연다
-- **THEN** component는 그 Type의 Profile connection만 표시한다
+- **THEN** 클라이언트는 현재 Post 위의 modal overlay에서 그 Type의 Profile connection만 표시한다
+- **AND** 별도 route나 공개 URL을 만들지 않는다
 - **AND** server가 viewer 기준으로 숨긴 Profile을 client에서 복구하거나 count에서 빼지 않는다
+
+#### Scenario: Profile 목록 modal 닫기
+
+- **WHEN** 사용자가 modal 외부 영역을 클릭·터치하거나 Android back을 실행한다
+- **THEN** 클라이언트는 Profile 목록 modal을 닫는다
+- **AND** modal 내부에는 별도 닫기 버튼을 표시하지 않는다
+
+#### Scenario: Profile 목록 최초 조회 실패
+
+- **WHEN** 선택한 Type의 Profile 목록 최초 조회가 실패한다
+- **THEN** modal 내부에 오류와 다시 시도 동작을 표시한다
+- **AND** snackbar·toast·전역 outlet을 조회 오류 복구에 요구하지 않는다
 
 #### Scenario: Profile 목록 추가 page
 
 - **WHEN** Type별 Profile 목록에 다음 page가 있다
 - **THEN** component는 Relay cursor로 다음 page를 불러온다
 - **AND** 이미 표시한 Profile을 중복 추가하지 않는다
+
+#### Scenario: Profile 목록 추가 page 실패
+
+- **WHEN** 다음 Profile page 조회가 실패한다
+- **THEN** component는 이미 표시한 Profile을 유지한다
+- **AND** 목록 내부에 오류와 다시 시도 동작을 표시한다
+- **AND** snackbar·toast·전역 outlet을 조회 오류 복구에 요구하지 않는다
+
+#### Scenario: Profile 목록 재진입과 actor 격리
+
+- **WHEN** 같은 selected Profile이 이전에 조회한 Type의 modal을 다시 연다
+- **THEN** 클라이언트는 cache된 Profile을 먼저 표시하고 background에서 최신 목록을 조회한다
+- **AND** selected Profile 전환 뒤에는 이전 Relay Environment의 Profile 목록 cache를 표시하지 않는다
 
 ### Requirement: 독립 Reaction UI 검증 경계
 

--- a/openspec/changes/add-post-reactions/tasks.md
+++ b/openspec/changes/add-post-reactions/tasks.md
@@ -209,9 +209,9 @@ Post를 조회할 수 있는 viewer가 한 Reaction Type에 반응한 조회 가
 - [x] 8.2 PROD-449 props-only `ReactionSummary`와 `ReactionProfileList`를 구현한다.
 - [x] 8.3 PROD-449 Storybook과 component interaction에서 Relay mock fragment ref의 supplied-order·Type selection·상태·retry/pagination callback 조합을 검증한다.
 - [x] 8.4 PROD-418의 zero-count·modal·조회 오류·cache 결정을 specs·decisions·design·tasks에 동기화하고 strict validation을 통과시킨다.
-- [ ] 8.5 실제 Post count query와 Type별 `reactionProfiles` Relay connection을 기존 props seam에 연결하고, zero-count summary 미렌더링과 현재 Post 위 modal dismiss를 구현한다.
-- [ ] 8.6 최초·추가 page 조회 오류를 modal·목록 내부 retry로 연결하고 기존 edge 보존, cache 우선 background 갱신과 selected Profile 격리를 구현한다.
-- [ ] 8.7 실제 Relay data shape의 count·Type 격리·pagination·modal·오류 복구·cache 동작을 최소 component/integration test로 검증하고 app check를 통과시킨다.
+- [x] 8.5 실제 Post count query와 Type별 `reactionProfiles` Relay connection을 기존 props seam에 연결하고, zero-count summary 미렌더링과 현재 Post 위 modal dismiss를 구현한다.
+- [x] 8.6 최초·추가 page 조회 오류를 modal·목록 내부 retry로 연결하고 기존 edge 보존, cache 우선 background 갱신과 selected Profile 격리를 구현한다.
+- [x] 8.7 실제 Relay data shape의 count·Type 격리·pagination·modal·오류 복구·cache 동작을 최소 component/integration test로 검증하고 app check를 통과시킨다.
 
 ## 9. PROD-419 Reaction Notification Best Effort 정리
 

--- a/openspec/changes/add-post-reactions/tasks.md
+++ b/openspec/changes/add-post-reactions/tasks.md
@@ -180,6 +180,13 @@ Post를 조회할 수 있는 viewer가 한 Reaction Type에 반응한 조회 가
 
 ## 8. PROD-449 Reaction 요약 프레젠테이션과 PROD-418 통합
 
+**Authority / Provenance**
+
+- [Reaction canonical 객체](../../../docs/domain/objects/reaction.md)
+- [Reaction UI 디자인](../../../docs/design/reactions.md)
+- `PROD-449`
+- `PROD-418`의 2026-07-25 설계 결정 댓글
+
 **Deliverable**
 
 사용자가 Post의 viewer-independent Type별 count와 viewer가 조회할 수 있는 Type별 Profile 목록을 실제 page 단위로 확인한다. PROD-449는 이를 위한 재사용 presentation seam을 전달하고, PROD-418은 실제 data와 surface 통합을 전달한다.
@@ -189,18 +196,22 @@ Post를 조회할 수 있는 viewer가 한 Reaction Type에 반응한 조회 가
 - PROD-449 seam은 supplied count order를 그대로 사용하고 zero-count Type을 만들거나 제거·정렬·필터링하지 않으며, visible Profile 수로 count를 재계산하지 않는다.
 - PROD-449 row는 기존 `ProfileListItem`의 Relay `Profile` fragment ref를 재사용하고, Storybook은 raw `$key` cast 대신 Relay mock fragment ref를 사용한다.
 - PROD-449는 실제 query/connection, selected Profile/viewer cache, modal/route와 zero-count UX를 소유하지 않는다.
-- 공통 Post Action Bar와 실제 surface 조립을 포함하지 않는다.
+- PROD-418은 기존 Post detail route에 요약 진입점을 연결하되, 공통 Post Action Bar와 feed/list surface 조립은 포함하지 않는다.
 - selector, 사용자 정의 Reaction과 Reaction history를 구현하지 않는다.
+- PROD-418은 Profile 조회 오류용 snackbar·toast·전역 outlet이나 Reaction mutation 오류 UX를 추가하지 않는다.
 
 **Verification**
 
 - PROD-449는 supplied-order count, Type selection callback, loading/empty/error/populated, 복수 Type·동률, 기존 Profile row와 mock retry/pagination callback을 Storybook/component interaction으로 검증한다.
-- PROD-418은 실제 Relay data shape의 count·viewer별 Profile 숨김·Type 격리·다중 page pagination과 modal/route 통합을 component/integration test로 검증한다.
+- PROD-418은 실제 Relay data shape의 count·viewer별 Profile 숨김·Type 격리·다중 page pagination, zero-count 미렌더링, modal dismiss, inline retry, edge 보존, cache 우선 재진입과 selected Profile 격리를 component/integration test로 검증한다.
 
 - [x] 8.1 최종 `post-reaction-ui` spec이 변경되지 않음을 확인하고, PROD-449 fixture-first props 경계와 기존 Profile row 재사용 결정을 decisions·design·tasks에 동기화하고 strict validation을 통과시킨다.
 - [x] 8.2 PROD-449 props-only `ReactionSummary`와 `ReactionProfileList`를 구현한다.
 - [x] 8.3 PROD-449 Storybook과 component interaction에서 Relay mock fragment ref의 supplied-order·Type selection·상태·retry/pagination callback 조합을 검증한다.
-- [ ] 8.4 PROD-418 zero-count/modal-route 결정 뒤 실제 count query·Relay connection·selected Profile/viewer cache 통합과 component/integration 검증을 구현한다.
+- [x] 8.4 PROD-418의 zero-count·modal·조회 오류·cache 결정을 specs·decisions·design·tasks에 동기화하고 strict validation을 통과시킨다.
+- [ ] 8.5 실제 Post count query와 Type별 `reactionProfiles` Relay connection을 기존 props seam에 연결하고, zero-count summary 미렌더링과 현재 Post 위 modal dismiss를 구현한다.
+- [ ] 8.6 최초·추가 page 조회 오류를 modal·목록 내부 retry로 연결하고 기존 edge 보존, cache 우선 background 갱신과 selected Profile 격리를 구현한다.
+- [ ] 8.7 실제 Relay data shape의 count·Type 격리·pagination·modal·오류 복구·cache 동작을 최소 component/integration test로 검증하고 app check를 통과시킨다.
 
 ## 9. PROD-419 Reaction Notification Best Effort 정리
 


### PR DESCRIPTION
## 관련 작업

- [PROD-418](https://linear.app/byulmaru/issue/PROD-418)
- [PROD-449](https://linear.app/byulmaru/issue/PROD-449)
- `add-post-reactions` OpenSpec

## 무엇을 변경했는지

- 기존 `Post.reactionCounts`를 Post 상세의 Reaction 요약에 연결
- 선택한 Type의 `reactionProfiles`를 Relay cursor pagination으로 조회
- 현재 Post 위에 닫기 버튼 없는 Profile modal 표시
- 최초 조회와 추가 page 오류를 modal·목록 내부에서 재시도
- 같은 Type 재진입 시 cache를 먼저 표시하고 background에서 갱신
- selected Profile 전환 시 Relay Environment별 cache 격리
- Storybook Relay mock에 동일 Environment query sequence와 `delayMs`를 최소 확장
- PROD-418 설계 결정과 OpenSpec 8.4–8.7 동기화

## 왜 변경했는지

기존 backend에는 Type별 Reaction count와 Profile connection이 이미 제공되고 있지만, 실제 Post 화면에서 이를 탐색할 UI 연결이 없었습니다. 기존 PROD-449 presentation seam을 유지하면서 현재 Post 맥락 안에서 Reaction 요약과 Profile 목록을 사용할 수 있게 합니다.

## 이번 PR의 주요 결정

없음. 최신 canonical 문서와 Linear에 기록된 PROD-418 결정을 변경 없이 적용했습니다.

- Reaction이 없으면 요약 영역을 렌더링하지 않음
- server가 제공한 count와 순서를 그대로 사용
- Profile 목록은 별도 route가 아닌 현재 Post 위 modal로 표시
- 조회 오류는 snackbar·toast가 아닌 modal·목록 내부에서 복구
- 재진입은 `store-and-network`로 cache 우선 표시
- Reaction mutation 오류 UX와 공통 Post Action Bar/feed/list 조립은 제외

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app relay`
- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:unit` — 32 tests passed
- `pnpm --filter @kosmo/app test:storybook` — 117 tests passed
- `pnpm --filter @kosmo/app build-storybook`
- `node_modules/.bin/openspec validate add-post-reactions --strict`
- `node_modules/.bin/openspec validate --all --strict` — 33/33 passed
- `git diff --check`
- Storybook: `http://localhost:6006/?path=/story/kosmo-reactions-reactionsummary--summary-order-and-modal-dismiss`
- 390px·600px에서 modal 크기, Profile row, pagination, 내부·외부 click을 수동 확인

## 아직 어떤 문제가 남았는지

- 연결된 Android device/emulator가 없어 system-back dismissal은 수동 확인하지 못함
- modal 내부 click의 non-dismiss 동작은 수동 확인했지만 별도 자동 assertion은 없음
- Post detail route E2E는 승인된 테스트 범위에서 제외하고 Relay compiler·typecheck·component Storybook으로 검증
