### PR TITLE
Repost 취소 뒤 알림을 안전하게 정리한다

### DIFF
--- a/apps/api/src/graphql/resolvers/post/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/delete.ts
@@ -1,4 +1,5 @@
-import { deletePost } from '@kosmo/core/services';
+import { NotificationKind } from '@kosmo/core/enums';
+import { deleteNotificationBySource, deletePost } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
@@ -17,10 +18,20 @@ builder.mutationField('deletePost', (t) =>
     input: {
       id: t.input.globalID({ for: Post }),
     },
-    resolve: (_, { input }, ctx) =>
-      deletePost({
+    resolve: async (_, { input }, ctx) => {
+      const result = await deletePost({
         actorProfileId: ctx.session.profileId,
         postId: input.id.id,
-      }),
+      });
+
+      await deleteNotificationBySource(NotificationKind.REPOST, result.postId).catch((error) => {
+        console.error('Post-commit Repost notification cleanup failed', {
+          error,
+          postId: result.postId,
+        });
+      });
+
+      return result;
+    },
   }),
 );

--- a/apps/api/tests/integration/graphql/post-repost.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost.test.ts
@@ -1,7 +1,7 @@
 import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
-import { after, before, beforeEach, describe, test } from 'node:test';
+import { after, before, beforeEach, describe, mock, test } from 'node:test';
 import {
   AccountProfileRole,
   AccountState,
@@ -312,17 +312,25 @@ describe('GraphQL Repost', () => {
 
   test('deletePost는 GraphQL 경로에서 Repost를 Tombstone 처리하고 상태를 갱신한다', async () => {
     const auth = await createAuthenticatedSession();
-    const source = await createContentPost(auth.profile.id);
+    const recipient = await createProfile('delete-notification-recipient');
+    const source = await createContentPost(recipient.id);
     await requestRepost(source.id, auth.token);
     const repost = await db
       .select()
       .from(Posts)
       .where(and(eq(Posts.profileId, auth.profile.id), eq(Posts.repostSourceId, source.id)))
       .then(firstOrThrow);
+    assert.equal(await db.$count(Notifications), 1);
 
     const first = await requestDelete(repost.id, auth.token);
     assertNoGraphQLErrors(first);
     assert.deepEqual(first.data?.deletePost, { postId: globalId('Post', repost.id) });
+    assert.equal(await db.$count(Notifications), 0);
+
+    const repeated = await requestDelete(repost.id, auth.token);
+    assertNoGraphQLErrors(repeated);
+    assert.deepEqual(repeated.data?.deletePost, { postId: globalId('Post', repost.id) });
+    assert.equal(await db.$count(Notifications), 0);
 
     const deleted = await db
       .select({ deletedAt: Posts.deletedAt, state: Posts.state })
@@ -357,6 +365,56 @@ describe('GraphQL Repost', () => {
       repostCount: 0,
       viewerRepost: null,
     });
+  });
+
+  test('Notification 정리 실패는 Tombstone 결과를 유지하고 오류를 기록한다', async () => {
+    const auth = await createAuthenticatedSession();
+    const recipient = await createProfile('failed-delete-notification-recipient');
+    const source = await createContentPost(recipient.id);
+    await requestRepost(source.id, auth.token);
+    const repost = await db
+      .select()
+      .from(Posts)
+      .where(and(eq(Posts.profileId, auth.profile.id), eq(Posts.repostSourceId, source.id)))
+      .then(firstOrThrow);
+    const errorLog = mock.method(console, 'error', () => undefined);
+
+    await pg.unsafe(`
+      CREATE FUNCTION fail_repost_notification_delete() RETURNS trigger
+      LANGUAGE plpgsql AS $$ BEGIN
+        IF OLD.kind = 'REPOST' THEN RAISE EXCEPTION 'forced notification cleanup failure'; END IF;
+        RETURN OLD;
+      END $$;
+      CREATE TRIGGER fail_repost_notification_delete
+      BEFORE DELETE ON notification
+      FOR EACH ROW EXECUTE FUNCTION fail_repost_notification_delete();
+    `);
+
+    try {
+      const result = await requestDelete(repost.id, auth.token);
+      assertNoGraphQLErrors(result);
+      assert.deepEqual(result.data?.deletePost, { postId: globalId('Post', repost.id) });
+
+      const deleted = await db
+        .select({ state: Posts.state })
+        .from(Posts)
+        .where(eq(Posts.id, repost.id))
+        .then(firstOrThrow);
+      assert.equal(deleted.state, PostState.DELETED);
+      assert.equal(await db.$count(Notifications), 1);
+      assert.equal(errorLog.mock.callCount(), 1);
+      assert.equal(
+        errorLog.mock.calls[0]?.arguments[0],
+        'Post-commit Repost notification cleanup failed',
+      );
+      assert.equal((errorLog.mock.calls[0]?.arguments[1] as { postId: string }).postId, repost.id);
+    } finally {
+      await pg.unsafe(`
+        DROP TRIGGER IF EXISTS fail_repost_notification_delete ON notification;
+        DROP FUNCTION IF EXISTS fail_repost_notification_delete();
+      `);
+      errorLog.mock.restore();
+    }
   });
 
   test('deletePost는 비Author와 비로그인 요청을 거부한다', async () => {

--- a/openspec/changes/add-post-reposts/tasks.md
+++ b/openspec/changes/add-post-reposts/tasks.md
@@ -325,9 +325,9 @@ Repost Tombstone 뒤 대응 Notification cleanup을 Best Effort로 시도하고,
 
 - 정상·반복·누락 cleanup, 실패 격리와 stale row의 list/count/Node/Read 숨김을 core/API integration test로 검증한다.
 
-- [ ] 11.1 Repost Tombstone 결과에 연결되는 idempotent Notification cleanup을 구현한다.
-- [ ] 11.2 kind-aware visible predicate가 stale Repost Notification을 모든 API surface에서 숨기게 한다.
-- [ ] 11.3 cleanup 성공·반복·실패와 stale visibility 검증을 추가하고 core/API check를 통과시킨다.
+- [x] 11.1 Repost Tombstone 결과에 연결되는 idempotent Notification cleanup을 구현한다.
+- [x] 11.2 kind-aware visible predicate가 stale Repost Notification을 모든 API surface에서 숨기게 한다.
+- [x] 11.3 cleanup 성공·반복·실패와 stale visibility 검증을 추가하고 core/API check를 통과시킨다.
 
 ## 12. PROD-389 Repost 통합 검증·정합성 확인·archive
 

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -338,6 +338,23 @@ test('Repost 알림은 존재하지 않거나 pure Repost가 아닌 source를 �
   await assert.rejects(createRepostNotification(contentPost.id), NotFoundError);
 });
 
+test('Repost 알림 정리는 정상·반복·없는 source에 idempotent하다', async () => {
+  const author = await createProfile();
+  const recipient = await createProfile();
+  const source = await createContentPost(recipient.id);
+  const { repost } = await repostPost({
+    actorProfileId: author.id,
+    sourcePostId: source.id,
+  });
+
+  await createRepostNotification(repost.id);
+  await deleteNotificationBySource(NotificationKind.REPOST, repost.id);
+  await deleteNotificationBySource(NotificationKind.REPOST, repost.id);
+  assert.deepEqual(await readNotifications(repost.id), []);
+
+  await deleteNotificationBySource(NotificationKind.REPOST, crypto.randomUUID());
+});
+
 test('Reaction 알림 정리는 정상·반복·없는 source에 idempotent하다', async () => {
   const author = await createProfile();
   const recipient = await createProfile();


### PR DESCRIPTION
## 무엇을 변경했는지

- `deletePost`가 core Tombstone transaction을 완료한 뒤 Repost Notification cleanup을 같은 요청에서 await합니다.
- cleanup 실패는 Post 삭제 결과를 바꾸지 않고 `postId`와 오류를 기록합니다.
- 정상·반복·누락 cleanup과 실패 격리를 core/API integration test로 검증했습니다.
- 기존 shared visible predicate가 Tombstone Repost Notification을 list, count, Node, Read에서 숨기는 것을 재검증하고 OpenSpec task 11.1~11.3을 완료했습니다.

## 왜 변경했는지

Repost가 Tombstone으로 전이한 뒤 대응 Notification은 Best Effort로 제거하되, cleanup 시점이나 성공 여부가 이미 commit된 Repost 취소 결과를 바꾸면 안 됩니다. 물리 삭제가 실패해 stale row가 남더라도 기존 visible predicate가 모든 Notification API surface에서 이를 숨깁니다.

계약 근거:

- [PROD-416](https://linear.app/byulmaru/issue/PROD-416/repost-notification을-정리한다)
- [Notification canonical](https://github.com/byulmaru/kosmo/blob/main/docs/domain/objects/notification.md)
- [Post interaction contract](https://github.com/byulmaru/kosmo/blob/main/docs/domain/decisions/0010-post-interaction-contracts.md)
- [OpenSpec decision](https://github.com/byulmaru/kosmo/blob/PROD-416/openspec/changes/add-post-reposts/decisions.md)

## 이번 PR의 주요 결정

### GraphQL delete orchestration에서 post-commit cleanup을 소유한다

- 결정자: @HJSmiley
- 선택: 현재 production 삭제 진입점인 GraphQL `deletePost` mutation이 core 삭제 결과를 받은 뒤 source-only Notification cleanup을 await/catch합니다.
- 고려한 대안: optional transaction을 받는 core `deletePost` 내부 통합, 별도 Repost 삭제 wrapper 추가
- 이유: GraphQL 경계에서는 core transaction의 실제 commit 이후를 보장할 수 있고, PROD-412의 Repost Notification 생성 경계와 일관됩니다. core의 caller transaction 합류 계약을 바꾸거나 새 service abstraction을 추가하지 않습니다.
- 감수한 결과: 향후 GraphQL 외 production 삭제 entry가 생기면 같은 post-commit cleanup orchestration을 명시적으로 연결하거나 core action 경계를 다시 정리해야 합니다.
- 관련 근거: 위 canonical·Linear 계약과 `add-post-reposts`의 기존 Notification lifecycle 결정

## 어떻게 확인할 수 있는지

- core service test: 104 passed
- Notification/Repost GraphQL integration: 31 passed
- 오류 로그 assertion 보강 후 Repost GraphQL integration: 14 passed
- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm lint:eslint`
- 변경 파일 `prettier --check`
- `openspec validate add-post-reposts --strict`
- OpenSpec 진행률: 27/38, PROD-416 task 11.1~11.3 완료

## 아직 어떤 문제가 남았는지

- retry, queue, cron, backfill과 bulk cleanup은 PROD-416 범위에 포함하지 않습니다.
- 전체 `pnpm lint:prettier`는 이 PR에서 변경하지 않은 `apps/app/expo-env.d.ts`의 기존 형식 문제로 실패합니다. 이 PR의 변경 파일은 Prettier check를 통과했습니다.
- 부모 `PROD-389`의 다른 구현과 통합 검증이 남아 있어 `add-post-reposts` change는 archive하지 않습니다.
- 전체 검증과 리뷰를 완료해 Ready for review로 전환했습니다.
