### PR TITLE
Kosmo 워크플로 규칙을 저장소 문서로 통합한다

### DIFF
--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -59,6 +59,9 @@ Remote actor 검증 뒤 같은 action을 재사용할 수 있지만, ingress와 
   계층을 맞추기 위한 pass-through core service를 만들지 않는다.
 - 여러 DB 변경이 원자적이어야 하면 core action이 transaction 경계를 소유한다. 실제 caller
   transaction과 합류해야 할 때만 optional transaction을 받는다.
+- 외부 delivery나 notification처럼 DB transaction에 포함되지 않는 side effect는 domain write가 commit된
+  뒤 실행한다. side effect 실패가 이미 commit된 domain 결과를 되돌려서는 안 되는 계약이면 실패를 호출
+  경계에서 격리하고 commit된 상태를 유지한다.
 - core는 공통 domain error를 반환하고 각 진입점이 외부 오류 표현으로 mapping한다.
 - 실제 caller 없이 evaluator, callback, generic port나 대체 implementation을 미리 추가하지 않는다.
 

--- a/memory/git-pr-workflow.md
+++ b/memory/git-pr-workflow.md
@@ -71,3 +71,10 @@
 - 열린 PR의 제목, 본문, base, Draft/Ready 상태 변경은 `gh` 명령을 사용한다.
 - PR 본문 형식은 `memory/pr-writing.md`를 따른다.
 - Ready for review로 전환하기 전에는 현재 HEAD가 정상 동작하고 PR 범위가 리뷰 가능한 단위인지 다시 확인한다.
+
+## Merge And Closeout
+
+- merge 직전에 PR head SHA, base, checks, merge state와 unresolved review thread를 새로 조회한다.
+- merge queue 또는 auto-merge 등록은 merge 완료가 아니다. squash merge를 요청할 때는 가능하면 확인한 head
+  SHA를 `--match-head-commit <sha>`로 고정하고, 등록 뒤 `state: MERGED`, `mergedAt`, `mergeCommit.oid`를
+  다시 확인한다.

--- a/memory/graphql-style.md
+++ b/memory/graphql-style.md
@@ -199,6 +199,9 @@ GraphQL enum은 `apps/api/src/graphql/enums.ts`에서 전역 등록한다.
 
 ## Client And Spec Sync
 
+- Pothos resolver/object/input/payload 변경으로 런타임 GraphQL schema가 바뀌면 같은 변경에서
+  `apps/api/schema.graphql`도 갱신한다. `apps/app/relay.config.json`은 이 파일을 Relay schema source로
+  사용하므로 런타임 등록만으로 client contract가 동기화됐다고 보지 않는다.
 - GraphQL operation은 실제 사용하는 React Native `.tsx` 파일에 Relay `graphql` tag로 colocate한다. 프론트 fragment, connection, actor environment 세부 규칙은 `memory/frontend-react-native.md`를 따른다.
 - GraphQL mutation error UI 분기가 여러 컴포넌트에서 반복되면 공통 helper나 error handling boundary로 모을 후보로 본다.
 - API 구현과 OpenSpec은 root field, object field, payload, error type, connection 단위가 서로 맞아야 한다.

--- a/memory/review-thread.md
+++ b/memory/review-thread.md
@@ -8,7 +8,9 @@
 ## Review Thread Policy
 
 - merge 전에는 unresolved review thread가 남아 있지 않아야 한다.
-- 리뷰 코멘트는 코드를 수정했을 때뿐 아니라 확인만으로 충분한 경우에도 resolve한다.
+- 리뷰 코멘트는 요청한 변경이 반영됐거나, 코드 변경 없이도 충족됨을 확인했거나, 사용자가 명시적으로
+  수용·보류했을 때 resolve한다. 아직 유효한 actionable finding은 단순 응답이나 merge 일정만으로 resolve하지
+  않는다.
 - 같은 문제가 다른 PR에서 이미 논의됐으면 해당 PR/comment를 링크해 같은 기준을 반복 적용한다.
 - 자동화나 AI가 남긴 리뷰라도 의미 있는 지적이면 실제 코드 기준으로 판단하고, 틀린 지적은 왜 틀렸는지 남긴 뒤 무시한다.
 

--- a/memory/script.md
+++ b/memory/script.md
@@ -23,10 +23,6 @@
 - test database의 schema 불일치를 구현 결함으로 판단하기 전에 위 초기화 또는 격리 절차로 재현 여부를 확인한다.
 - workspace package의 기본 `test`는 CI에서 해당 package의 전체 테스트를 실행한다. API integration처럼 DB가 필요한 suite는 package 단위 aggregate script 하나가 격리 DB를 준비해 전체 suite를 실행하며, 개별 테스트 파일 선택용 root script를 추가하지 않는다.
 - 특정 API integration 파일만 디버깅할 때는 package manifest에 파일별 alias를 늘리지 말고 준비된 test DB에서 Node test runner에 파일 경로를 직접 전달한다.
-- PostgreSQL 대체 test backend를 검토할 때는 CRUD와 schema push 성공만으로 채택하지 않는다. 최소한
-  constraint/error propagation, 실제 migration 실행, 독립 connection/session, transaction과 advisory lock
-  semantics를 현재 test suite와 같은 driver 경로에서 검증한다. 하나라도 호환되지 않으면 기존 PostgreSQL
-  test 경로를 제거하지 않는다.
 
 ## Script And Tooling Review
 
@@ -37,9 +33,6 @@
 - CI runner를 바꾸는 PR은 실제 target runner에서 workflow가 실행되는지 확인한다.
 - security scanner나 CI step에 `continue-on-error`를 쓰는 경우, 후속 step에서 실패 여부를 명시적으로 판정해 workflow가 조용히 성공하지 않게 한다.
 - dependency, tooling, CI 명령이 바뀌면 변경 이유와 platform 제약을 리뷰에서 확인한다.
-- Docker layer/cache 동작을 바꾸는 PR은 GitHub check만으로 결론내리지 않는다. 실제 target Docker/BuildKit
-  환경에서 동일 build를 최소 두 번 실행해 최초 build와 cache reuse를 모두 확인한다. `main`이 진전했다면
-  `/private/tmp`의 임시 worktree에서 현재 PR head와 최신 `origin/main`의 merge 결과도 같은 방식으로 검증한다.
 
 ## Expo, Relay, Web BFF
 

--- a/memory/script.md
+++ b/memory/script.md
@@ -23,6 +23,10 @@
 - test database의 schema 불일치를 구현 결함으로 판단하기 전에 위 초기화 또는 격리 절차로 재현 여부를 확인한다.
 - workspace package의 기본 `test`는 CI에서 해당 package의 전체 테스트를 실행한다. API integration처럼 DB가 필요한 suite는 package 단위 aggregate script 하나가 격리 DB를 준비해 전체 suite를 실행하며, 개별 테스트 파일 선택용 root script를 추가하지 않는다.
 - 특정 API integration 파일만 디버깅할 때는 package manifest에 파일별 alias를 늘리지 말고 준비된 test DB에서 Node test runner에 파일 경로를 직접 전달한다.
+- PostgreSQL 대체 test backend를 검토할 때는 CRUD와 schema push 성공만으로 채택하지 않는다. 최소한
+  constraint/error propagation, 실제 migration 실행, 독립 connection/session, transaction과 advisory lock
+  semantics를 현재 test suite와 같은 driver 경로에서 검증한다. 하나라도 호환되지 않으면 기존 PostgreSQL
+  test 경로를 제거하지 않는다.
 
 ## Script And Tooling Review
 
@@ -33,6 +37,9 @@
 - CI runner를 바꾸는 PR은 실제 target runner에서 workflow가 실행되는지 확인한다.
 - security scanner나 CI step에 `continue-on-error`를 쓰는 경우, 후속 step에서 실패 여부를 명시적으로 판정해 workflow가 조용히 성공하지 않게 한다.
 - dependency, tooling, CI 명령이 바뀌면 변경 이유와 platform 제약을 리뷰에서 확인한다.
+- Docker layer/cache 동작을 바꾸는 PR은 GitHub check만으로 결론내리지 않는다. 실제 target Docker/BuildKit
+  환경에서 동일 build를 최소 두 번 실행해 최초 build와 cache reuse를 모두 확인한다. `main`이 진전했다면
+  `/private/tmp`의 임시 worktree에서 현재 PR head와 최신 `origin/main`의 merge 결과도 같은 방식으로 검증한다.
 
 ## Expo, Relay, Web BFF
 


### PR DESCRIPTION
## 무엇을 변경했는지

- 외부 delivery와 notification side effect를 DB commit 이후 실행하고 실패를 호출 경계에서 격리하는 core service 경계를 문서화했습니다.
- GraphQL 런타임 schema 변경 시 Relay가 사용하는 `apps/api/schema.graphql`도 함께 갱신하도록 규칙을 추가했습니다.
- merge queue 완료 확인과 review thread resolve 조건을 구체화했습니다.

PostgreSQL 대체 backend 실험과 Docker cache PR 검증 사례는 저장소 전체에 적용할 범용 규칙이 아니므로 이 PR에 포함하지 않습니다.

## 왜 변경했는지

Kosmo에 재사용되는 작업 규칙이 사용자 장기 메모리와 저장소 문서에 중복되어 새 세션의 기본 컨텍스트를 불필요하게 차지하고 있었습니다. 저장소 전체에 실제로 적용되는 규칙만 저장소가 소유하도록 옮겨, 필요한 작업에서만 `AGENTS.md`와 관련 `memory/*.md`를 읽을 수 있게 합니다.

사용자 요청에 따라 이 문서 정리를 위한 별도 Linear 이슈는 만들지 않았습니다.

## 이번 PR의 주요 결정

### 범용적인 Kosmo 규칙만 저장소 문서가 소유한다

- 결정자: @robin-maki
- 선택: 프로젝트 전체에 반복 적용되는 규칙만 적용 영역별 저장소 문서에 기록하고, 사례별 검증 경험은 장기 메모리의 해당 작업 맥락에 남깁니다.
- 고려한 대안: 사례별로 유용했던 검증법까지 저장소 공통 규칙으로 승격합니다.
- 이유: 저장소 규칙이 특정 실험이나 PR의 조건을 모든 작업에 강제하지 않게 하면서, 새 세션에 항상 주입되는 중복 규칙은 줄일 수 있습니다.
- 감수한 결과: 사례별 검증 경험은 저장소 문서만 읽어서는 나타나지 않으며, 관련 작업 맥락이 있을 때만 장기 메모리에서 조회합니다.
- 관련 근거: `AGENTS.md`의 Memory 라우팅과 이번 PR의 변경 문서

## 어떻게 확인할 수 있는지

- 변경된 각 규칙을 현재 production caller, Relay 설정, GitHub merge queue/ruleset과 대조
- `pnpm lint:prettier`
- commit hook의 `eslint --fix --no-warn-ignored`
- commit hook의 `prettier --write --ignore-unknown`
- `git diff --check`

## 아직 어떤 문제가 남았는지

사용자 장기 메모리 원본과 시작 시 주입되는 요약의 중복 제거는 저장소 밖의 ad-hoc 메모리 업데이트 요청으로 별도 처리됩니다. 이 PR은 범용 규칙의 저장소 측 canonical 위치만 제공합니다.
