### PR TITLE
Semgrep 실행 버전을 고정해 스캔 재현성을 보장한다

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,6 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Update only after validating the new version in a Semgrep run.
+  SEMGREP_VERSION: '1.171.0'
   SEMGREP_CONFIGS: >-
     --config=p/default
     --config=p/javascript
@@ -42,7 +44,9 @@ jobs:
             python = "3.12"
 
       - name: Install Semgrep
-        run: python -m pip install --upgrade semgrep
+        run: |
+          python -m pip install "semgrep==${SEMGREP_VERSION}"
+          semgrep --version
 
       - name: Run Semgrep
         id: semgrep


### PR DESCRIPTION
## 무엇을 변경했는지

- Semgrep 설치 버전을 `1.171.0`으로 고정했습니다.
- 설치 후 `semgrep --version`을 출력해 실제 실행 버전을 확인할 수 있게 했습니다.
- 기존 config, artifact, annotation, Job Summary, Slack 알림과 실행 실패 처리는 유지했습니다.

## 왜 변경했는지

실행 시점의 최신 버전을 설치하면 같은 revision도 Semgrep 변경에 따라 결과가 달라질 수 있습니다. 최근 성공한 실행에서 검증된 버전을 명시해 스캔 재현성과 upstream 변경 통제를 개선합니다.

Linear: [PROD-476](https://linear.app/byulmaru/issue/PROD-476/semgrep-실행-버전을-고정해-보안-스캔-재현성을-보장한다)

## 이번 PR의 주요 결정

### 최근 성공한 Semgrep 버전을 고정한다

- 결정자: 사용자
- 선택: 최근 성공 실행에서 사용한 `1.171.0`
- 고려한 대안: 실행 시점의 최신 버전 설치 유지
- 이유: 탐지 동작을 함께 변경하지 않고 재현성만 확보하기 위해서입니다.
- 감수한 결과: Semgrep 갱신은 명시적인 workflow 변경과 검증이 필요합니다.
- 관련 근거: [Semgrep 실행 #30240822733](https://github.com/byulmaru/kosmo/actions/runs/30240822733)

## 어떻게 확인할 수 있는지

- [x] `pnpm exec prettier --check .github/workflows/semgrep.yml`
- [x] `git diff --check`
- [ ] Draft PR Semgrep check에서 설치 버전과 스캔 결과 확인

## 아직 어떤 문제가 남았는지

- Draft PR CI 실행 전까지 원격 runner에서 고정 버전 설치 여부는 미확인입니다.

Stack: `main` → `prod-476`
