### PR TITLE
PostContent를 ActivityPub HTML로 직렬화한다

### DIFF
--- a/docs/domain/decisions/0017-activitypub-local-post-note.md
+++ b/docs/domain/decisions/0017-activitypub-local-post-note.md
@@ -1,0 +1,80 @@
+# ADR 0017: ActivityPub Local Post Identity and Note Representation
+
+## 상태
+
+Accepted
+
+## 날짜
+
+2026-07-27
+
+## 결정
+
+- Content가 있는 Local Post의 ActivityPub identity는 configured Local Instance의 canonical origin과
+  `/ap/note/{postId}`를 결합한 URI다. `postId`는 immutable DB UUID다.
+- Author handle이나 GraphQL global ID는 ActivityPub identity에 포함하지 않는다. Post의 canonical Web 공유
+  참조는 ActivityPub identity와 구분해 Note의 `url`로 제공한다.
+- PROD-255와 archived remote-post ingestion 계약에 따라 ActivityPub Post mapping은 remote object URI와
+  materialized Post의 관계만 소유한다. Local Post identity는 이 기존 경계를 유지하며 DB row를 추가하지 않고
+  Post ID에서 파생한다.
+- Note content는 기존 canonical PostContent Document 계약을 재정의하지 않고 그 의미를 안전한 HTML로 투영하며
+  Content Warning은 `summary`로 제공한다. Author actor, immutable 생성 시각과 canonical Web 공유 참조를 함께
+  제공한다.
+- Public은 ActivityStreams Public을 `to`, followers collection을 `cc`로 사용한다. Unlisted는 followers
+  collection을 `to`, ActivityStreams Public을 `cc`로 사용한다. Followers Only는 followers collection만
+  `to`로 사용하고 Author 또는 established Follower의 signed fetch에서만 역참조할 수 있다.
+- Mentioned Profiles audience는 recipient identity가 canonical 관계로 구현되기 전까지 Local Note로 제공하지
+  않는다.
+- Reply Parent 관계가 있으면 requester의 Parent 조회 가능성과 무관하게 Parent의 ActivityPub Post identity를
+  `inReplyTo`로 제공한다. Parent의 실제 표현은 Parent 자체의 역참조 권한으로 보호하며, Reply Parent 관계가
+  없을 때만 `inReplyTo`를 생략한다. Parent의 Tombstone 전이는 저장 관계를 변경하지 않는다. 현재 physical
+  delete 행동은 없지만 Reply Parent FK는 향후 실제 Parent row 제거 시 Reply를 유지한 채 관계만 `null`로
+  만들도록 정의한다.
+- Content가 없는 Repost는 Note로 표현하지 않는다. 후속 Announce와 Reaction delivery는 대상 Post의 같은
+  ActivityPub Post identity를 재사용한다.
+- unavailable Local Post는 존재를 노출하지 않는 응답을 사용한다. ActivityPub Tombstone과 Delete delivery는
+  후속 lifecycle 계약이 소유한다.
+
+## 이유
+
+Post UUID에 기반한 별도 ActivityPub URI는 mutable handle과 API 전용 global ID에서 federation identity를
+분리한다. Web 공유 URL은 사람이 탐색하는 canonical 참조이고 ActivityPub object URI는 protocol이 안정적으로
+역참조하는 identity이므로 역할을 하나의 URL에 합치지 않는다.
+
+기존 remote mapping은 remote ingestion의 received/published metadata를 포함하며 Local Post를 저장 대상으로
+정의하지 않는다. Local identity는 이 상위 계약을 변경하지 않고 파생 규칙만 추가한다. Visibility에서
+audience를 직접 투영하면 후속 Reply, Repost와 Reaction delivery가 별도 규칙을 만들지 않고 같은 Post 계약을
+재사용할 수 있다.
+
+`inReplyTo`는 Reply가 참조하는 객체의 identity이지 그 객체의 Content가 아니다. Parent의 Content 접근은 Parent
+Note 역참조 권한이 독립적으로 제한하므로, Reply를 조회한 requester에 따라 `inReplyTo`를 제거해 같은 Note의
+표현을 가변적으로 만들 필요가 없다.
+
+## 대안
+
+- canonical Web 공유 URL을 Note `id`로 사용하는 방안은 handle과 GraphQL URL shape 변화가 federation identity에
+  영향을 주므로 채택하지 않았다.
+- Author와 Post ID를 모두 path에 넣는 방안은 globally unique Post UUID에 중복 identity를 추가하고 Author
+  경로 정합성을 별도로 검증해야 하므로 채택하지 않았다.
+- 모든 Visibility를 anonymous dispatcher에서 반환하는 방안은 Followers Only와 Mentioned Profiles 조회 정책을
+  우회하므로 채택하지 않았다.
+- requester가 Parent를 조회할 수 있을 때만 `inReplyTo`를 제공하는 방안은 같은 Reply Note의 표현을 requester별로
+  바꾸고 Parent identity와 Content 권한을 결합하므로 채택하지 않았다.
+
+## 결과
+
+- `packages/fedify`의 Local Note dispatcher와 후속 activity delivery는 하나의 Post URI resolver와 Note
+  projection을 공유한다.
+- Followers Only 역참조는 verified signed actor와 stored Follow 관계를 연결해야 한다.
+- remote Parent와 대상 Post는 기존 ActivityPub Post mapping URI를 사용하고 local Parent와 대상 Post는 파생 URI를
+  사용한다.
+- Parent의 실제 표현이 requester에게 unavailable이어도 Reply Parent 관계가 유지되는 동안 `inReplyTo` identity는
+  유지된다.
+- Parent의 Tombstone 전이는 `inReplyTo`를 제거하지 않는다. 현재 physical delete 행동을 추가하지 않고 Reply
+  Parent FK만 향후 실제 row 삭제에 대비해 `SET NULL`로 정의하며 Reply Post에는 cascade delete를 적용하지 않는다.
+- Mentioned Profiles, Media, custom emoji, Quote 전용 federation 표현과 실제 Activity delivery는 독립 후속
+  계약으로 남는다.
+
+## 문서 반영
+
+- [Post](../objects/post.md)는 local Note identity, serialization, audience와 unavailable lifecycle을 정의한다.

--- a/docs/domain/objects/post.md
+++ b/docs/domain/objects/post.md
@@ -45,6 +45,10 @@ Source 관계, Content Warning, Sensitive Media, Tombstone, Post Eligibility 정
 | Reaction          | [Reaction](./reaction.md) | Post <- Reaction | 1 -> 0..N   | Reaction이 존재할 때                                  | Post 조회 정책 통과                                   | 없음             |
 | Bookmark          | [Bookmark](./bookmark.md) | Post <- Bookmark | 1 -> 0..N   | Bookmark가 존재할 때                                  | 저장한 Profile의 개인 조회                            | `Bookmark.Owner` |
 
+Reply Parent가 Tombstone으로 전이되어도 저장된 직접 관계를 유지한다. 현재 Parent Post row를 물리적으로
+제거하는 행동은 제공하지 않지만, Reply Parent FK는 향후 실제 row 제거 시 Reply Post를 cascade 삭제하지 않고
+관계만 `null`로 만드는 참조 동작을 가진다.
+
 Post의 게시 구조는 다음 관계 조합으로 정의한다.
 
 | Content | Reply Parent | Repost Source | 구조              |
@@ -126,6 +130,43 @@ Media 또는 Attached Media로 취급하지 않는다. Tombstone Post에는 다�
 - 인증하지 않은 guest도 조회할 수 있는 Post의 공유 참조를 복사할 수 있다.
 - 공유 참조는 Post Visibility와 Post Eligibility가 허용하지 않은 viewer에게 조회 범위를 넓히지 않는다.
 
+### ActivityPub Local Note 표현
+
+- Content가 있는 Local Post의 ActivityPub identity는 현재 deployment가 사용하는 configured Local Instance의
+  canonical origin과 `/ap/note/{postId}` 경로를 결합한 절대 URI다. `postId`는 Post의 immutable DB UUID이며
+  Author Profile의 handle이나 GraphQL global ID를 사용하지 않는다.
+- 같은 Local Post는 프로세스 재시작, 역참조 요청 경로와 후속 Activity 종류에 관계없이 같은 Note URI를
+  가진다. Local Post를 위해 remote ActivityPub Post mapping을 만들지 않는다.
+- ActivityPub `Note`는 위 URI를 `id`, Author Profile의 canonical ActivityPub actor URI를 `attributedTo`, Post
+  생성 시각을 `published`, Post 공유 참조를 `url`로 제공한다.
+- canonical PostContent 계약이 정의한 document 의미와 안전한 link 제약을 ActivityPub HTML `content`에
+  투영한다. Content Warning은 있으면 안전한 `summary`로 투영한다. 이 Local Note 계약은 PostContent node,
+  mark, canonicalization 또는 validation을 다시 정의하지 않는다. Media, Mention, custom emoji와 Quote 전용
+  federation 속성은 이 표현에 포함하지 않는다.
+- Reply Parent 관계가 있으면 Parent의 ActivityPub Post identity를 `inReplyTo`로 제공한다. Local Parent는
+  같은 local Note URI 규칙을 사용하고 remote Parent는 저장된 ActivityPub Post URI를 사용한다. `inReplyTo`는
+  requester별 Parent 조회 가능성에 따라 달라지지 않으며, Parent의 실제 표현은 Parent 자체의 역참조 권한으로
+  보호한다. Tombstone Parent도 저장 관계가 유지되는 동안 같은 identity를 제공하며, Parent row의 물리적
+  제거로 Reply Parent 관계가 `null`이 된 뒤에는 `inReplyTo`를 제공하지 않는다.
+- Content와 Reply Parent 없이 Repost Source만 있는 Repost는 Note로 표현하지 않는다. 후속 Announce와
+  Reaction Activity는 대상 Post의 같은 ActivityPub Post identity를 `object`로 재사용한다.
+
+ActivityPub audience는 Post Visibility에서 다음과 같이 투영한다.
+
+| Post Visibility    | `to`                        | `cc`                        | Note 역참조 조건                                       |
+| ------------------ | --------------------------- | --------------------------- | ------------------------------------------------------ |
+| Public             | ActivityStreams Public      | Author followers collection | 인증 없이 허용                                         |
+| Unlisted           | Author followers collection | ActivityStreams Public      | 인증 없이 허용                                         |
+| Followers Only     | Author followers collection | 없음                        | Author 또는 established Follower의 signed fetch만 허용 |
+| Mentioned Profiles | 지원하지 않음               | 지원하지 않음               | 제공하지 않음                                          |
+
+- Followers Only signed fetch는 검증된 ActivityPub actor가 Author이거나 저장된 established Follow 관계의
+  Follower일 때만 허용한다. anonymous, unknown actor와 non-follower에게는 Post가 없는 것처럼 응답한다.
+- Post가 Tombstone이거나 Content가 없거나, Author Profile 또는 configured Local Instance가 unavailable이거나,
+  지원하지 않는 Visibility이면 Note를 제공하지 않는다. 이 unavailable 응답은 Post의 존재를 노출하지 않는다.
+- Local Note의 ActivityPub Tombstone, `Delete`, `Create`, `Announce`, `Like`, `EmojiReact`, `Undo` delivery는 각
+  lifecycle과 delivery 계약이 소유한다.
+
 ### 검색
 
 - 검색 후보는 Post Visibility가 Public이고 Post Eligibility를 통과한 Post다.
@@ -149,6 +190,8 @@ Media 또는 Attached Media로 취급하지 않는다. Tombstone Post에는 다�
 - 민감한 미디어: Sensitive Media
 - Tombstone: Tombstone
 - 게시 공유 참조: Post Share Reference
+- ActivityPub 게시 정체성: ActivityPub Post Identity
+- 로컬 Note 표현: Local Note Representation
 
 ## 제외/보류
 
@@ -157,3 +200,4 @@ Media 또는 Attached Media로 취급하지 않는다. Tombstone Post에는 다�
 - 게시 후 Media 연결/해제와 Post Visibility 변경은 지원하지 않는다.
 - 본문의 canonical 표현은 schema version이 식별된 document다. Plain Text는 작성 입력과 읽기·검색·접근성 projection이며 별도 canonical 저장값이 아니다.
 - 현재 document V1은 paragraph, text, hard break와 안전한 HTTP(S) link만 지원한다. `pre`와 rich-text editor는 지원하지 않는다.
+- Mentioned Profiles audience, ActivityPub Media·Mention·custom emoji·Quote 전용 속성은 후속 계약에서 정의한다.

--- a/openspec/changes/add-activitypub-local-post-note/.openspec.yaml
+++ b/openspec/changes/add-activitypub-local-post-note/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-27

--- a/openspec/changes/add-activitypub-local-post-note/decisions.md
+++ b/openspec/changes/add-activitypub-local-post-note/decisions.md
@@ -1,0 +1,202 @@
+## Context
+
+이 기록은 PROD-494, canonical Post·Instance·Post 공유 참조와 ADR 0017, 기존 actor discovery와 remote Post mapping
+계약, 현재 Fedify·Post·Follow·PostContent·DB 구현을 반영한다. 구현자는 OpenSpec이 아니라 최신 canonical 문서와
+Linear 계약을 독립적으로 다시 확인해야 한다.
+
+## Decision Records
+
+### Local Note identity는 canonical origin과 immutable Post UUID에서 파생한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494
+- Status: Active
+- Context / Problem: handle, request host 또는 API URL 변화와 무관한 Local Post federation identity가 필요하다.
+- Decision Outcome: Content가 있는 Local Post identity는 configured Local Instance canonical origin의
+  `/ap/note/{postId}`이며 `postId`는 immutable DB UUID다. Web 공유 참조는 별도 `url` 속성으로 유지한다.
+- Alternatives Considered: Web 공유 URL을 Note ID로 사용, Author handle을 path에 포함, GraphQL global ID 사용.
+  mutable presentation identity 또는 API encoding을 federation identity와 결합하므로 사용하지 않는다.
+- Consequences: 같은 Post는 재시작과 요청 host에 무관하게 같은 URI를 가지며 Local Note dispatcher는 exact path를
+  공용 공개 계약으로 유지해야 한다.
+- Confirmation / Follow-up: canonical origin 변경 입력, process restart와 alternate request host에서도 같은 ID를
+  반환하는 unit/integration test로 확인한다.
+
+### Local Post에는 remote ActivityPub Post mapping을 만들지 않는다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494, PROD-255
+- Status: Active
+- Context / Problem: 기존 ActivityPub Post mapping은 received/published metadata를 가진 remote object ingestion
+  경계이며 Local identity까지 저장하면 같은 table의 의미와 lifecycle이 섞인다.
+- Decision Outcome: Local Post URI는 Post ID에서 파생하고 mapping row를 만들지 않는다. Remote Post는 기존 unique
+  mapping URI를 사용하며 local/remote 공통 identity resolver가 이 구분을 캡슐화한다.
+- Alternatives Considered: 모든 Local Post mapping backfill, 최초 역참조 시 lazy mapping 생성. remote-only 저장
+  계약을 바꾸고 불필요한 중복 identity를 만들므로 사용하지 않는다.
+- Consequences: mapping 부재만으로 Local 여부를 판정할 수 없고 configured Local Instance 소속 Author를 확인해야
+  한다. 후속 activity는 별도 URI 규칙을 만들지 않고 같은 resolver를 사용한다.
+- Confirmation / Follow-up: Local 역참조 전후 mapping row가 늘지 않고 Remote Parent는 저장 URI를 사용하는 DB
+  integration test로 확인한다.
+
+### Post URI resolver는 packages/fedify가 소유한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494
+- Status: Active
+- Context / Problem: Local/Remote Post URI 해석은 outbound Note와 후속 federation activity가 공유하지만 GraphQL과
+  일반 core Post action에는 필요하지 않은 ActivityPub protocol projection이다.
+- Decision Outcome: 공통 Post URI resolver와 Local Note URI projection은 `packages/fedify`가 소유한다.
+  `packages/core`는 Post, Instance와 mapping 저장 조회 계약만 제공한다.
+- Alternatives Considered: `packages/core` 공개 service, `apps/web` route helper, activity별 URI 조립. core domain에
+  protocol URL을 노출하거나 BFF와 후속 activity에서 규칙을 중복하므로 사용하지 않는다.
+- Consequences: Fedify dispatcher와 후속 activity delivery는 같은 package 경계를 재사용하고 GraphQL/API는 이
+  resolver에 의존하지 않는다. 내부 helper와 query 분리는 구현 중 달라질 수 있다.
+- Confirmation / Follow-up: package dependency와 후속 재사용 가능한 export, Local/Remote URI test로 확인한다.
+
+### Note serialization은 기존 PostContent 계약을 재정의하지 않는다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0015-post-share-reference.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-341, PROD-494
+- Status: Active
+- Context / Problem: Local Note가 GraphQL 표현이나 remote ingestion parser와 별도 의미를 만들지 않으면서 안전한
+  protocol 표현을 제공해야 한다.
+- Decision Outcome: id, attributedTo, published, Web url, canonical document의 safe HTML content와 선택적 summary를
+  제공하되 node, mark, canonicalization, validation과 safe link 정책은 PROD-341을 그대로 사용한다. Public은
+  Public/followers, Unlisted는 followers/Public, Followers Only는 followers만 audience로 사용하고 Mentioned
+  Profiles는 제공하지 않는다.
+- Alternatives Considered: PROD-494에서 V1 node/mark 재정의, canonical JSON 직접 문자열화, 모든 visibility를
+  anonymous로 반환, 현재 범위에 Media/Mention/Quote 속성 포함. 기존 content 계약을 중복하거나 권한·범위를
+  위반하므로 사용하지 않는다.
+- Consequences: PROD-494는 ActivityPub HTML export 연결만 소유한다. PostContent schema 확장은 해당 canonical
+  capability가 먼저 결정하고 Note export는 새 schema 의미를 참조해 후속 정렬한다.
+- Confirmation / Follow-up: node별 HTML, escaping, Content Warning과 visibility별 exact audience test로 확인한다.
+
+### ActivityPub HTML export는 ProseMirror DOMSerializer를 사용한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-341, PROD-494, PROD-502
+- Status: Active
+- Context / Problem: 기존 server-only ProseMirror schema는 validation과 `parseDOM`을 제공하지만 node/mark spec에
+  `toDOM`이 없어 outbound HTML serialization은 아직 완성되지 않았다. 별도 수동 renderer는 schema 의미를 중복한다.
+- Decision Outcome: existing PostContent ProseMirror node/mark spec에 현재 canonical 의미와 일치하는 `toDOM`을
+  보완하고, validated canonical body를 `Schema.nodeFromJSON()`과 `DOMSerializer.fromSchema()`로 HTML export한다.
+  앱의 React Native renderer나 inbound HTML parser를 재사용하지 않는다.
+- Alternatives Considered: 수동 JSON 순회 renderer, React Native renderer의 server adaptation, inbound parser
+  역사용. ProseMirror schema를 단일 serialization source로 활용하지 못하고 node·mark 책임을 중복하므로 사용하지
+  않는다.
+- Consequences: `prosemirror-model`은 기존대로 server-only에 남으며 `toDOM`은 저장 schema나 앱 bundle을 바꾸지
+  않는다. DOM document 제공과 wrapper adapter의 내부 형태는 고정하지 않는다.
+- Confirmation / Follow-up: canonical document를 nodeFromJSON/check 후 DOMSerializer로 직렬화하고 PROD-341
+  paragraph·hard break·link fixture와 unsafe input 거부를 재사용해 검증한다.
+
+### Followers collection identity는 canonical actor URI의 followers suffix다
+
+- Decision Date: 2026-07-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494, PROD-175
+- Status: Active
+- Context / Problem: audience에 사용할 Author followers collection의 안정적인 절대 URI가 필요하지만 이번 범위는
+  collection endpoint와 actor `followers` 속성을 제공하지 않는다.
+- Decision Outcome: followers audience identity는 canonical actor URI
+  `/ap/actor/{authorProfileId}`에 `/followers`를 붙인 `/ap/actor/{authorProfileId}/followers`다. 이 URI는 이번
+  변경에서 address로만 사용하며 GET collection이나 actor document 속성을 열지 않는다.
+- Alternatives Considered: Web `/{relativeHandle}/followers`, handle 기반 ActivityPub path, 새 top-level
+  `/ap/followers/{id}`, collection endpoint까지 함께 구현. Web UI와 protocol identity를 섞거나 기존 actor path와
+  불필요하게 갈라지고 PROD-494 범위를 넓히므로 사용하지 않는다.
+- Consequences: Note audience는 안정적 URI를 가지지만 현재 해당 URI의 직접 GET은 계속 unsupported다. collection을
+  공개하는 후속 계약은 같은 identity를 재사용해야 한다.
+- Confirmation / Follow-up: visibility별 Note audience와 기존 followers path 404 회귀 test를 함께 확인한다.
+
+### Followers Only signed fetch 성공 응답은 shared cache에 저장하지 않는다
+
+- Decision Date: 2026-07-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494
+- Status: Active
+- Context / Problem: Note body 자체가 requester별로 달라지지 않아도 Followers Only의 200 여부는 signed actor와
+  stored Follow 관계에 의존한다. Fedify 기본 success response만 사용하면 shared cache 격리를 명시적으로 보장할
+  수 없다.
+- Decision Outcome: Followers Only 성공 응답에는 `Cache-Control: private, no-store`를 적용한다. 권한 실패는
+  Post가 없는 것처럼 처리하고 cache를 통해 성공 representation이 anonymous 또는 다른 actor에게 재사용되지 않게
+  한다.
+- Alternatives Considered: `Vary: Signature`만 사용, CDN별 authenticated cache key, Fedify 기본 header에 의존.
+  HTTP Signature 전체를 cache key로 삼는 복잡도와 배포별 암묵 설정을 피하고 가장 좁고 검증 가능한 정책을 택한다.
+- Consequences: Followers Only Note는 shared cache 성능 이점을 사용하지 않지만 authorization 경계를 deployment
+  cache 설정과 독립적으로 보존한다. Public/Unlisted는 이 decision으로 `no-store`를 강제하지 않는다.
+- Confirmation / Follow-up: authorized success의 exact Cache-Control과 같은 URI의 anonymous/non-follower 요청이
+  representation을 받지 않는 web integration test로 확인한다.
+
+### inReplyTo는 requester와 무관한 저장 Parent identity다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494
+- Status: Active
+- Context / Problem: Reply Note 자체와 Parent Note의 visibility가 다를 수 있으며 Parent visibility로
+  `inReplyTo`를 필터링하면 같은 Reply URI의 표현이 requester별로 달라진다.
+- Decision Outcome: Reply Parent 관계가 있으면 Local Parent는 파생 Note URI, Remote Parent는 저장 mapping URI를
+  `inReplyTo`로 제공한다. Parent visibility, block 또는 Tombstone으로 다시 필터링하지 않고 Parent Content 접근은
+  Parent dispatcher가 독립적으로 판정한다.
+- Alternatives Considered: requester가 Parent를 볼 때만 포함, Parent Content snapshot embed, unavailable Parent에서
+  Reply 전체 숨김. identity와 Content 권한을 결합하거나 canonical Reply eligibility를 위반하므로 사용하지 않는다.
+- Consequences: requester가 Parent Content를 볼 수 없어도 Parent IRI는 알 수 있다. Tombstone Parent IRI도 관계가
+  유지되는 동안 남고 relation이 null일 때만 생략한다.
+- Confirmation / Follow-up: public Reply/private Parent, Tombstone Parent, Local/Remote Parent와 null relation test로
+  확인한다.
+
+### Parent Tombstone은 관계를 보존하고 FK만 future physical delete에 대비한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494
+- Status: Active
+- Context / Problem: canonical Post 삭제는 Tombstone 전이며 현재 Parent row physical delete application flow는
+  없다. 다만 FK 기본 동작을 그대로 두면 향후 actual cleanup이 Reply 보존 정책과 충돌한다.
+- Decision Outcome: Tombstone update는 `replyParentId`를 유지한다. physical delete action/service/API는 추가하지
+  않고 Reply Parent self-FK delete action만 `ON DELETE SET NULL`로 바꾼다.
+- Alternatives Considered: Tombstone 시 nullify, 현재 FK 유지, Reply cascade delete. thread identity를 조기에
+  잃거나 future cleanup이 surviving Reply를 막거나 제거하므로 사용하지 않는다.
+- Consequences: forward migration은 FK metadata만 바꾸고 기존 data를 rewrite하지 않는다. 현재 production 행동은
+  Tombstone이므로 새로운 physical delete runtime case가 생기지 않는다.
+- Confirmation / Follow-up: migration catalog, existing relation/Tombstone 보존과 직접 DB fixture delete의 FK
+  동작만 PostgreSQL test로 확인하며 application physical-delete flow는 만들지 않는다.
+
+### Activity delivery는 Local Note object 경계와 분리한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494
+- Status: Active
+- Context / Problem: 후속 Reply·Repost·Reaction federation이 같은 identity를 필요로 하지만 PROD-494가 delivery
+  lifecycle까지 소유하면 독립 이슈의 검증과 rollout 경계가 합쳐진다.
+- Decision Outcome: 이 변경은 object identity, Note projection과 dereference만 제공한다. Create/Delete, Announce,
+  Like/EmojiReact/Undo, outbox/queue/retry와 ActivityPub Tombstone/Delete는 구현하지 않는다.
+- Alternatives Considered: Local Reply/Repost/Reaction delivery 동시 구현, 범용 activity framework 선행 구축. 현재
+  계약보다 넓고 독립 deliverable을 묶으므로 사용하지 않는다.
+- Consequences: 후속 activity 이슈는 공통 identity/projection을 재사용하지만 각 delivery audience, ordering,
+  retry와 lifecycle을 독립적으로 결정하고 검증한다.
+- Confirmation / Follow-up: dispatcher 구현 diff와 회귀 test에서 새 outbound/inbox activity handler가 없음을
+  확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-activitypub-local-post-note/design.md
+++ b/openspec/changes/add-activitypub-local-post-note/design.md
@@ -1,0 +1,134 @@
+## Context
+
+현재 `packages/fedify`는 Fedify federation instance, `/ap/actor/{identifier}` actor dispatcher,
+actor-scoped/shared inbox와 Follow 계열 delivery를 소유한다. `apps/web`은 모든 요청을 Fedify에 먼저 전달하고,
+Fedify가 처리하지 않은 요청만 기존 BFF와 SPA로 넘긴다. configured Local Instance의 canonical origin은
+`PUBLIC_ORIGIN`과 일치하는 Local/Active Instance row에서 해석되며 actor와 Follow URI에 이미 사용된다.
+
+Post, current PostContent, Author Profile/Instance, established ProfileFollow와 remote ActivityPub Post mapping은
+PostgreSQL에 존재하지만 Local Note object dispatcher는 없다. PROD-341의 server-only ProseMirror schema와
+validation은 이미 존재하지만 node/mark spec에 `toDOM`이 없어 `DOMSerializer.fromSchema()`를 사용한 HTML
+export는 아직 완성되지 않았다. 현재 `post.reply_parent_id` self-FK는 delete action을 명시하지 않으며, Post
+삭제 행동은 row 삭제가 아니라 `DELETED` state의 canonical Tombstone 전이다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Local Post의 안정적인 `/ap/note/{postId}` identity와 Fedify Note 역참조를 제공한다.
+- PROD-341의 canonical PostContent schema를 재정의하지 않고 ProseMirror serialization으로 HTML을 export하며
+  audience와 authorized fetch를 Post Visibility에 맞춘다.
+- Local/Remote Parent identity를 같은 경계에서 해석하고 requester와 무관한 `inReplyTo`를 제공한다.
+- physical delete application 흐름은 추가하지 않고 Reply Parent FK만 미래 row 삭제에 대비해 `SET NULL`로 바꾼다.
+- 기존 federation-first routing, actor/inbox 동작과 remote Post mapping 경계를 회귀시키지 않는다.
+
+**Non-Goals:**
+
+- Reply `Create`/`Delete`, Repost `Announce`/`Undo`, Reaction `Like`/`EmojiReact`/`Undo` delivery
+- ActivityPub Tombstone/Delete, outbox collection, delivery queue, retry와 backfill
+- followers/following collection endpoint 또는 actor document의 followers/following 속성
+- Mentioned Profiles recipient, Media, Mention, custom emoji와 Quote 전용 federation 표현
+- remote Post ingestion과 기존 GraphQL Post read 계약 변경
+- PostContent node·mark·canonicalization·validation 계약 변경
+- Parent Post physical delete service/API
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Fedify `Context.canonicalOrigin`과 core configured Local Instance가 같은 canonical origin을 가리켜야 한다. 요청
+  `Host`, API origin이나 Web client runtime origin에서 Note URI를 조립하면 actor identity와 갈라질 수 있다.
+- Local/Remote Post는 같은 `post` table을 사용한다. Local 여부는 mapping 부재만으로 판정하면 안 되고 Author가
+  configured Local Instance에 속하는지 확인해야 한다. Local Post에는 remote mapping을 만들지 않는 것이 계약이다.
+- GraphQL의 viewer visibility predicate는 session Profile을 전제로 한다. signed HTTP request의 key owner URI를
+  Profile로 해석하는 federation authorization에는 그대로 재사용할 수 없다.
+- `ProfileFollow` 방향은 remote requester Profile이 follower, Local Author Profile이 followee다. pending
+  `ProfileFollowRequest`는 established follow가 아니므로 Followers Only 접근을 허용하지 않는다.
+- `activitypub-note-content`는 inbound remote HTML을 canonical document로 변환한다. outbound Local Note는 반대
+  방향이지만 PROD-341의 ProseMirror schema를 다시 손으로 순회하면 canonical node·mark 책임을 중복한다. 현재
+  schema spec에는 `parseDOM`만 있고 `toDOM`이 없어 DOMSerializer를 사용하려면 그 serialization metadata를
+  보완해야 한다.
+- Parent visibility를 Note 조회 query에 결합하면 같은 Reply 표현이 requester별로 달라지고, Tombstone Parent
+  identity도 잃는다. Reply 자체의 authorization과 Parent identity projection을 분리해야 한다.
+- 현재 Reply Parent FK에는 `ON DELETE SET NULL`이 없다. Drizzle 선언과 forward migration의 실제 constraint가
+  함께 바뀌어야 schema push와 migration DB가 일치한다.
+
+### Recommended Approach
+
+1. `packages/fedify`에 configured Local Instance와 Post DB UUID를 받는 Local Note URI projection과, Post ID에서
+   Local identity 또는 existing remote mapping URI를 반환하는 공통 Post identity 경계를 둔다. 후속 federation
+   activity는 이 경계를 재사용한다.
+2. Fedify에 `Note` object dispatcher `/ap/note/{id}`를 등록한다. dispatcher load는 Post, current Content, Author
+   Profile/Instance와 direct Parent identity에 필요한 최소 열을 한 경계에서 읽고 Local/Active/contentful 조건을
+   먼저 확인한다.
+3. 별도의 signed-fetch authorization 경계에서 key owner URI를 저장된 ActivityPub actor/Profile로 해석한다.
+   Public/Unlisted는 anonymous를 허용하고 Followers Only는 Author 또는 established Follower만 허용한다.
+   Mentioned Profiles와 unavailable Post는 원인을 구분하지 않는 미제공 결과로 수렴시킨다.
+4. Author followers collection identity는 canonical actor URI에 `/followers`를 붙인
+   `/ap/actor/{authorProfileId}/followers`로 사용한다. 이는 audience address이며 이 변경에서 collection GET이나
+   actor `followers` 속성을 열지 않는다.
+5. PROD-341 ProseMirror node/mark spec에 기존 schema 의미와 일치하는 `toDOM`을 보완하고, canonical document를
+   `Schema.nodeFromJSON()`으로 검증한 뒤 `DOMSerializer.fromSchema()`로 Note HTML을 만든다. 별도 수동 node
+   renderer나 앱의 React Native renderer를 재사용하지 않는다. summary는 Plain Text 의미를 유지한 안전한 HTML
+   text로 export하고 빈 Content Warning을 만들지 않는다.
+6. `inReplyTo`는 load된 direct relation의 identity만 사용한다. Parent visibility와 lifecycle로 다시 필터링하지
+   않으며 Parent Content를 함께 load하거나 embed하지 않는다. relation이 `null`일 때만 생략한다.
+7. Followers Only 성공 응답은 requester authorization 결과가 shared cache에서 재사용되지 않도록 명시적으로
+   보호한다. 기본 권고는 `Cache-Control: private, no-store`이며, 동등한 격리를 증명하는 federation/web 경계도
+   허용한다. Public/Unlisted 응답에는 requester별 body 변형을 만들지 않는다.
+8. Reply Parent self-FK를 drop/recreate하는 forward migration으로 delete action을 `SET NULL`로 바꾸되 기존 row를
+   update하지 않는다. physical delete application 경로는 추가하지 않고 catalog와 직접 DB fixture로 constraint만
+   검증한다.
+
+### Allowed Alternatives
+
+- Post identity resolver의 public 결과와 `packages/fedify` 소유권은 고정한다. 내부 query/helper 분리는 달라질 수
+  있다.
+- ProseMirror DOMSerializer를 감싸는 adapter와 DOM document 제공 방식은 달라질 수 있지만 별도 수동 node
+  renderer로 schema 의미를 복제하지 않는다.
+- Followers Only cache 격리는 `private, no-store` 외에도 서명 identity별 격리가 실제 web/federation 응답에서
+  검증되는 방식이면 허용된다. 단순 `Vary: Accept`는 허용되지 않는다.
+
+### Known Traps
+
+- request URL이나 `Host` header로 Note `id`를 만들면 reverse proxy와 alternate host에서 identity가 달라진다.
+- mapping row가 없다는 이유만으로 Local Post로 판정하면 mapping이 아직 없는 Remote Post 또는 잘못된 row를
+  Local URI로 노출할 수 있다.
+- Followers Only authorization에서 actor URI 문자열만 비교하거나 pending FollowRequest를 허용하면 저장된
+  established relationship 계약을 우회한다.
+- Parent visibility를 확인해 `inReplyTo`를 생략하면 requester별 표현과 cache key 문제가 생긴다.
+- inbound HTML parser, 앱 React Native renderer 또는 수동 JSON 순회를 outbound serializer로 사용하면
+  ProseMirror schema 의미와 책임을 중복한다.
+- Tombstone update에서 `reply_parent_id`를 직접 nullify하거나 Parent row에 cascade delete를 사용하면 승인된
+  Reply lifecycle을 위반한다.
+- object dispatcher를 BFF 뒤에 연결하면 ActivityPub 요청이 GraphQL proxy 또는 SPA fallback으로 잘못 처리될 수
+  있다.
+
+## Risks / Trade-offs
+
+- [Risk] Tombstone Parent URI는 `inReplyTo`에 남지만 직접 역참조할 수 없다. → identity와 Content 권한을 분리한
+  canonical 계약으로 유지하고 Parent Content를 Reply에 embed하지 않는다.
+- [Risk] Followers collection URI는 audience에 사용되지만 collection endpoint는 404다. → 이번 scope에서는
+  address identity로만 사용하고 endpoint 공개는 별도 계약 전까지 열지 않는다.
+- [Risk] Fedify 기본 success 응답의 cache header가 signed-fetch 격리를 보장하지 않을 수 있다. → Followers Only
+  응답에 명시적 cache 격리를 적용하고 web-level response test로 확인한다.
+- [Risk] FK를 `SET NULL`로 바꾼 뒤 실제 physical delete가 발생하면 Parent identity는 복구할 수 없다. → 현재
+  사용자 삭제는 Tombstone이라 영향을 받지 않으며 migration과 rollback 문서에서 비가역 가능성을 명시한다.
+- [Risk] `toDOM` metadata가 existing parse/canonical schema와 어긋날 수 있다. → 같은 ProseMirror schema의
+  nodeFromJSON/check/DOMSerializer 경계와 PROD-341 fixtures로 round-trip 의미를 검증한다.
+
+## Migration Plan
+
+1. 기존 schema의 Reply Parent FK 이름과 delete action, 기존 Reply/Tombstone row를 검증한다.
+2. forward migration으로 기존 FK를 `ON DELETE SET NULL` self-FK로 교체한다. column nullability, self-reference
+   check와 index는 유지하고 data update/backfill을 수행하지 않는다.
+3. migration DB에서 기존 관계·Tombstone 보존과 직접 DB fixture 삭제의 FK nullification을 검증하되 physical
+   delete application path는 만들지 않는다.
+4. Local Note identity/projection과 dispatcher를 배포하고 Public/Unlisted/Follower signed fetch 및 web routing
+   회귀를 검증한다.
+5. rollback이 필요하면 dispatcher 노출을 제거하고 FK를 기존 delete action으로 되돌릴 수 있다. 이미 물리 삭제로
+   null이 된 관계는 자동 복구할 수 없지만 현재 canonical Post 삭제 경로는 physical delete를 수행하지 않는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-activitypub-local-post-note/proposal.md
+++ b/openspec/changes/add-activitypub-local-post-note/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Kosmo의 Local Post는 GraphQL과 Web 공유 참조는 있지만 외부 ActivityPub 서버가 안정적으로 식별하고 역참조할
+수 있는 object identity와 Note 표현이 없다. 후속 Reply·Repost·Reaction delivery가 각자 URI와 audience 규칙을
+만들기 전에 PROD-494에서 공통 Local Note 경계를 먼저 제공한다.
+
+## What Changes
+
+- Content가 있는 Local Post의 ActivityPub identity를 configured Local Instance의 canonical origin과
+  `/ap/note/{postId}`에서 파생한다.
+- Local Post를 별도 remote ActivityPub Post mapping 없이 Fedify `Note`로 직렬화하고 같은 URI에서 역참조한다.
+- PROD-341이 정의한 canonical PostContent schema·validation을 재정의하지 않고 기존 ProseMirror document를
+  ActivityPub HTML `content`와 Content Warning `summary`로 export한다.
+- Public·Unlisted audience와 익명 역참조, Followers Only audience와 verified signed fetch 권한을 제공한다.
+- Reply Parent identity를 requester별 Parent 가시성과 무관한 `inReplyTo`로 제공하고 Parent 객체의 내용은 Parent
+  자체의 역참조 권한으로 보호한다.
+- Parent Tombstone에는 Reply Parent 관계를 유지하고, 현재 존재하지 않는 physical delete 흐름을 새로 만들지
+  않으면서 Reply Parent FK만 향후 실제 row 삭제에 대비해 `SET NULL`로 변경한다.
+- Tombstone·contentless Repost·unavailable Author/Instance·Mentioned Profiles와 권한 없는 Followers Only Post는
+  존재를 노출하지 않는 unavailable 결과로 처리한다.
+- Reply·Repost·Reaction activity delivery와 ActivityPub Tombstone/Delete delivery는 이 변경에서 구현하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`,
+  `docs/domain/decisions/0015-post-share-reference.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- Linear Contract: PROD-494
+- Existing Content Contract: PROD-341
+- Linear Implementations: PROD-502가 PostContent ProseMirror HTML serialization을 소유한다. PROD-494는 Fedify
+  Local Note, FK 변경, 통합 검증과 OpenSpec archive를 소유한다. 두 구현은 병행할 수 있지만 Note `content` 연결과
+  PROD-494 완료는 PROD-502 serializer 결과가 필요하다.
+
+## Capabilities
+
+### New Capabilities
+
+- `activitypub-local-post-note`: Local Post의 ActivityPub identity, Note 직렬화, audience, authorized fetch,
+  `inReplyTo`와 unavailable 경계를 정의한다.
+
+### Modified Capabilities
+
+- `data-model`: 현재 physical delete 행동을 추가하지 않고 Reply Parent FK의 delete action만 향후 row 삭제 시
+  nullable 관계를 제거하도록 정렬한다.
+
+## Impact
+
+- `packages/fedify`: Local Note object dispatcher, signed fetch authorization, local/remote Post URI resolver와
+  PROD-502가 제공하는 Note HTML export의 사용
+- `packages/core`: Local Post·Content·Author·Follow 저장 조회와 Reply Parent FK 선언
+- PostgreSQL/Drizzle: `post.reply_parent_id` FK delete action을 additive forward migration으로 정렬
+- `apps/web`: 기존 federation-first 요청 routing에서 `/ap/note/{postId}` 응답과 미처리 BFF 회귀 검증
+- 후속 PROD-358·495·496·497·498·499는 이 변경의 Post URI resolver와 Note identity를 재사용하지만 실제 activity
+  delivery는 각 이슈가 소유한다.

--- a/openspec/changes/add-activitypub-local-post-note/specs/activitypub-local-post-note/spec.md
+++ b/openspec/changes/add-activitypub-local-post-note/specs/activitypub-local-post-note/spec.md
@@ -1,0 +1,157 @@
+## ADDED Requirements
+
+### Requirement: Local Post ActivityPub identity
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494. 시스템은 Content가 있는 Local Post의 ActivityPub identity를 configured Local Instance의 canonical origin과 immutable Post DB UUID에서 파생한 `/ap/note/{postId}` 절대 URI로 제공해야 한다(MUST). Local Post identity를 위해 remote ActivityPub Post mapping row를 만들지 않아야 한다(MUST).
+
+#### Scenario: Local Note identity 파생
+
+- **WHEN** configured Local Instance에 속한 Author의 Content가 있는 Local Post를 ActivityPub object로 식별한다
+- **THEN** 시스템은 `{canonicalOrigin}/ap/note/{postId}`를 Note identity로 사용한다
+- **AND** `postId`에는 immutable Post DB UUID를 사용한다
+- **AND** Author handle, GraphQL global ID, request origin과 API origin을 identity에 포함하지 않는다
+
+#### Scenario: Local identity 안정성
+
+- **WHEN** 같은 Local Post를 프로세스 재시작 뒤 또는 서로 다른 federation 요청 경로에서 다시 식별한다
+- **THEN** 시스템은 항상 같은 Note URI를 반환한다
+- **AND** identity를 만들기 위해 ActivityPub Post mapping row를 생성하거나 조회하지 않는다
+
+#### Scenario: Remote Post identity 재사용
+
+- **WHEN** Reply Parent 또는 후속 activity 대상이 materialized Remote Post다
+- **THEN** 시스템은 기존 ActivityPub Post mapping에 저장된 remote object URI를 ActivityPub Post identity로 사용한다
+- **AND** remote Post에 Local Note URI를 새로 부여하지 않는다
+
+### Requirement: Local Note core serialization
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0015-post-share-reference.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-341, PROD-494. 시스템은 제공 가능한 Local Post를 기존 canonical PostContent 계약을 재정의하지 않는 안전한 ActivityPub `Note`로 직렬화해야 한다(MUST).
+
+#### Scenario: Local Note 기본 속성
+
+- **WHEN** 제공 가능한 Content가 있는 Local Post를 Note로 직렬화한다
+- **THEN** Note `id`는 Local Post의 ActivityPub identity다
+- **AND** `attributedTo`는 Author Profile의 canonical ActivityPub actor URI다
+- **AND** `published`는 immutable Post 생성 시각이다
+- **AND** `url`은 configured Local Instance canonical origin에서 파생한 canonical Web Post 공유 참조다
+
+#### Scenario: Existing canonical document HTML export
+
+- **WHEN** PROD-341 validator가 수락한 canonical PostContent Document를 Note `content`로 직렬화한다
+- **THEN** 시스템은 PROD-341 ProseMirror schema가 정의한 document 의미와 link 제약을 HTML로 export한다
+- **AND** 이 capability는 node, mark, canonicalization, validation 또는 URL 허용 정책을 다시 정의하지 않는다
+- **AND** canonical document 밖의 raw HTML을 export 입력으로 사용하지 않는다
+
+#### Scenario: Content Warning projection
+
+- **WHEN** canonical PostContent Document에 Content Warning summary가 있다
+- **THEN** 시스템은 안전하게 escape한 summary를 Note `summary`로 제공한다
+- **WHEN** Content Warning이 없다
+- **THEN** 시스템은 의미 없는 빈 summary를 생성하지 않는다
+
+#### Scenario: Deferred Note properties
+
+- **WHEN** Local Post가 Media, Mention, custom emoji 또는 Quote Source 관계를 가진다
+- **THEN** 시스템은 이번 Local Note 표현에 해당 속성이나 Quote 전용 federation 속성을 추가하지 않는다
+- **AND** 지원되는 core Note identity, content, summary와 audience는 계속 제공한다
+
+### Requirement: Local Note audience and dereference authorization
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494. 시스템은 Post Visibility를 ActivityPub audience와 Note 역참조 권한으로 일관되게 투영해야 하며(MUST), 권한 있는 Followers Only 응답이 다른 requester에게 재사용되어 Post 존재나 내용을 노출하지 않게 해야 한다(MUST).
+
+#### Scenario: Public Note audience
+
+- **WHEN** Public Local Post를 Note로 직렬화한다
+- **THEN** `to`는 ActivityStreams Public을 포함한다
+- **AND** `cc`는 `/ap/actor/{authorProfileId}/followers` Author followers collection을 포함한다
+- **AND** anonymous ActivityPub 역참조를 허용한다
+
+#### Scenario: Unlisted Note audience
+
+- **WHEN** Unlisted Local Post를 Note로 직렬화한다
+- **THEN** `to`는 `/ap/actor/{authorProfileId}/followers` Author followers collection을 포함한다
+- **AND** `cc`는 ActivityStreams Public을 포함한다
+- **AND** anonymous ActivityPub 역참조를 허용한다
+
+#### Scenario: Followers Only Note authorized fetch
+
+- **WHEN** Followers Only Local Post의 Author 또는 Author와 established Follow 관계인 remote actor가 검증된 signed fetch를 수행한다
+- **THEN** 시스템은 `to`에 `/ap/actor/{authorProfileId}/followers` Author followers collection만 포함한 Note를 반환한다
+- **AND** `cc`에 ActivityStreams Public을 포함하지 않는다
+
+#### Scenario: Followers Only Note unauthorized fetch
+
+- **WHEN** anonymous, unknown actor 또는 Author의 established Follower가 아닌 actor가 Followers Only Local Post를 역참조한다
+- **THEN** 시스템은 Post가 없는 것처럼 응답한다
+- **AND** 응답 또는 shared cache를 통해 Post 존재, audience와 Content를 다른 requester에게 노출하지 않는다
+
+#### Scenario: Mentioned Profiles Note 제외
+
+- **WHEN** Mentioned Profiles Visibility의 Local Post를 역참조한다
+- **THEN** 시스템은 Local Note를 제공하지 않는다
+- **AND** recipient identity나 임의의 ActivityPub audience를 추정하지 않는다
+
+### Requirement: Stable Reply inReplyTo identity
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494. 시스템은 Reply Parent 관계가 있는 Local Note에 Parent의 ActivityPub Post identity를 requester별 Parent 조회 가능성과 무관한 `inReplyTo`로 제공해야 한다(MUST). Parent의 실제 표현은 Parent 자체의 역참조 권한으로 보호해야 한다(MUST).
+
+#### Scenario: Local Reply Parent identity
+
+- **WHEN** Local Post를 직접 Parent로 참조하는 Reply Note를 직렬화한다
+- **THEN** `inReplyTo`는 같은 `/ap/note/{parentPostId}` identity 규칙을 사용한다
+
+#### Scenario: Remote Reply Parent identity
+
+- **WHEN** materialized Remote Post를 직접 Parent로 참조하는 Reply Note를 직렬화한다
+- **THEN** `inReplyTo`는 기존 ActivityPub Post mapping에 저장된 remote object URI를 사용한다
+
+#### Scenario: Parent 접근 권한과 독립적인 identity
+
+- **WHEN** requester가 Reply Note는 역참조할 수 있지만 Reply Parent의 실제 Note 표현은 역참조할 수 없다
+- **THEN** Reply Note는 저장된 Parent identity를 `inReplyTo`로 계속 제공한다
+- **AND** 시스템은 Parent Content 또는 audience를 Reply Note에 포함하지 않는다
+
+#### Scenario: Tombstone Parent identity 유지
+
+- **WHEN** Reply Parent가 Tombstone으로 전이됐지만 Reply Parent 관계가 저장되어 있다
+- **THEN** Reply Note는 저장된 Parent identity를 `inReplyTo`로 계속 제공한다
+- **AND** Parent URI의 실제 역참조 결과는 Parent lifecycle 계약에 따라 unavailable하다
+
+#### Scenario: Reply Parent 관계 없음
+
+- **WHEN** Reply Parent 관계가 없거나 Parent row의 물리 삭제로 관계가 `null`이다
+- **THEN** Note는 `inReplyTo`를 제공하지 않는다
+- **AND** Reply Note 자체의 제공 가능성은 Reply의 Visibility와 lifecycle로 독립 판정한다
+
+### Requirement: Local Note unavailable lifecycle
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494. 시스템은 Local Note 계약이 지원하지 않거나 unavailable한 Post를 존재를 노출하지 않는 결과로 처리해야 한다(MUST).
+
+#### Scenario: Missing or non-local Post
+
+- **WHEN** `/ap/note/{postId}`가 missing Post 또는 configured Local Instance에 속하지 않은 Author의 Post를 가리킨다
+- **THEN** 시스템은 Note를 제공하지 않는다
+- **AND** remote object를 이 Local Note URI로 대신 반환하지 않는다
+
+#### Scenario: Lifecycle or structure unavailable Post
+
+- **WHEN** 대상 Post가 Tombstone이거나 current Content가 없는 contentless Repost다
+- **THEN** 시스템은 Note를 제공하지 않는다
+- **AND** Post 존재나 내부 구조를 구분해 노출하지 않는다
+
+#### Scenario: Author or Instance unavailable Post
+
+- **WHEN** Author Profile 또는 configured Local Instance가 canonical Post Eligibility를 충족하지 않는다
+- **THEN** 시스템은 Note를 제공하지 않는다
+- **AND** unavailable 원인을 federation 응답으로 구분해 노출하지 않는다
+
+### Requirement: Local Note scope boundary
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494. Local Note capability는 Post object identity와 역참조 표현만 제공하고 activity delivery lifecycle을 새로 열지 않아야 한다(MUST).
+
+#### Scenario: Object dereference without activity delivery
+
+- **WHEN** Local Note dispatcher와 공통 Post identity resolver가 제공된다
+- **THEN** 시스템은 Reply `Create`/`Delete`, Repost `Announce`/`Undo`, Reaction `Like`/`EmojiReact`/`Undo` delivery를 이 변경에서 추가하지 않는다
+- **AND** ActivityPub Tombstone과 Delete delivery를 이 변경에서 추가하지 않는다
+- **AND** 후속 capability가 같은 Local/Remote Post identity를 재사용할 수 있게 한다

--- a/openspec/changes/add-activitypub-local-post-note/specs/data-model/spec.md
+++ b/openspec/changes/add-activitypub-local-post-note/specs/data-model/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Reply Parent FK future physical-delete action
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494. 시스템은 현재 physical delete 행동을 추가하지 않으면서 Reply Parent의 Tombstone 보존 계약과 향후 실제 Post row 삭제에 대한 FK 참조 동작을 서로 다르게 정의해야 한다(MUST).
+
+#### Scenario: Parent Tombstone 뒤 관계 보존
+
+- **WHEN** Reply Parent가 저장된 뒤 Parent Post가 Tombstone으로 전이된다
+- **THEN** 시스템은 Reply에 저장된 직접 Reply Parent 식별자를 유지한다
+- **AND** Parent Tombstone을 이유로 Reply row를 삭제하거나 관계를 `null`로 바꾸지 않는다
+
+#### Scenario: Future Parent row physical delete constraint
+
+- **WHEN** 향후 또는 관리 작업에서 Reply Parent로 참조되는 Post row가 실제로 삭제된다
+- **THEN** 데이터베이스는 살아 있는 Reply Post의 Reply Parent 관계만 `null`로 만든다
+- **AND** Reply Post 자체와 그 Content를 cascade 삭제하지 않는다
+
+#### Scenario: No physical delete application flow
+
+- **WHEN** 이번 capability를 구현한다
+- **THEN** 시스템은 Parent Post row를 물리 삭제하는 application action, service 또는 API를 추가하지 않는다
+- **AND** 기존 Post 삭제는 Tombstone 전이를 계속 사용한다
+
+#### Scenario: FK delete action migration
+
+- **WHEN** 기존 Reply Parent 관계와 Tombstone Parent가 있는 데이터베이스에 변경 migration을 적용한다
+- **THEN** 시스템은 기존 Reply Parent ID와 Post lifecycle state를 변경하지 않는다
+- **AND** 기존 FK를 실제 Parent row 삭제 시 `SET NULL`하는 참조 동작으로 정렬한다

--- a/openspec/changes/add-activitypub-local-post-note/tasks.md
+++ b/openspec/changes/add-activitypub-local-post-note/tasks.md
@@ -1,0 +1,138 @@
+## 1. PROD-494 Reply Parent FK future-proofing
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- PROD-494
+
+**Deliverable**
+
+현재 physical delete flow를 추가하지 않으면서 Parent Tombstone에는 Reply Parent 관계가 유지되고 Reply Parent
+FK는 향후 actual row 삭제 시 관계만 `null`로 만들도록 정렬된다.
+
+**Guardrails**
+
+- Tombstone은 canonical Post 삭제 행동이며 physical row deletion으로 취급하지 않는다.
+- Parent Post를 물리 삭제하는 application action, service 또는 API를 추가하지 않는다.
+- migration은 기존 Reply Parent 값, Post state와 Content를 backfill하거나 rewrite하지 않는다.
+- Reply Parent 직접 self-reference check, nullable column과 하위 조회 index를 유지한다.
+
+**Verification**
+
+- 기존 row가 있는 실제 PostgreSQL migration에서 FK delete action과 schema catalog를 확인한다.
+- Parent Tombstone 뒤 관계 보존과 직접 DB fixture delete의 null FK를 검증한다.
+
+- [ ] 1.1 Reply Parent FK의 physical delete 동작을 `SET NULL`로 정렬하는 additive forward migration과 schema 선언을 추가한다.
+- [ ] 1.2 기존 관계·Tombstone 보존, FK catalog와 직접 DB fixture 삭제의 nullification을 실제 PostgreSQL에서 검증한다.
+
+## 2. PROD-502 PostContent ProseMirror HTML serialization
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- PROD-341
+- PROD-494
+- PROD-502
+
+**Deliverable**
+
+PROD-341 canonical PostContent document를 기존 server-only ProseMirror schema로 결정적인 HTML로 직렬화할 수
+있다.
+
+**Guardrails**
+
+- PROD-341의 node·mark·canonicalization·validation을 다시 정의하지 않는다.
+- 기존 server-only ProseMirror schema의 `toDOM`과 `DOMSerializer.fromSchema()`로 HTML을 export하고 별도 수동
+  node renderer를 만들지 않는다.
+- Fedify Note, ActivityPub URI, audience, signed fetch와 `inReplyTo`를 구현하지 않는다.
+- React Native/Web 앱 bundle에 `prosemirror-model` runtime을 추가하지 않는다.
+
+**Verification**
+
+- PROD-341 canonical fixture의 ProseMirror HTML export와 결정성을 검증한다.
+- malformed·unsupported document 거부와 server-only runtime boundary를 검증한다.
+
+- [x] 2.1 기존 ProseMirror schema의 DOM serialization metadata와 server-only HTML serializer를 구현한다.
+- [x] 2.2 PROD-341 canonical fixture, invalid input과 bundle boundary 검증을 추가한다.
+
+## 3. PROD-494 Local Post identity, Note dispatcher와 authorized fetch
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/instance.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- PROD-494
+- PROD-502
+
+**Deliverable**
+
+Local/Remote Post가 `packages/fedify`의 하나의 안정적인 ActivityPub identity 경계를 사용한다. 외부 requester는
+`/ap/note/{postId}`에서 PROD-502 HTML을 포함한 Public·Unlisted Note를 익명으로, Followers Only Note를 Author
+또는 established Follower의 verified signed fetch로 역참조하며 안정적인 Parent identity를 받을 수 있다.
+
+**Guardrails**
+
+- URI resolver, Post load, authorization과 FK 작업은 PROD-502 완료 전에도 독립적으로 진행할 수 있다.
+- Note `content` 연결과 PROD-494 최종 완료만 PROD-502 serializer 결과에 의존한다.
+- Followers Only는 signed actor URI가 Author이거나 stored established Follow의 follower일 때만 허용한다.
+- pending FollowRequest, anonymous, unknown actor와 non-follower는 권한을 부여하지 않는다.
+- followers audience identity는 `/ap/actor/{authorProfileId}/followers`이며 collection GET과 actor `followers`
+  속성은 열지 않는다.
+- Followers Only 성공 응답은 `Cache-Control: private, no-store`로 shared cache 재사용을 막는다.
+- `inReplyTo`는 Parent visibility와 requester에 따라 필터링하지 않고 relation이 있을 때 Local/Remote identity를
+  사용한다. Tombstone Parent 관계와 identity는 유지한다.
+- unavailable 원인을 구분해 노출하지 않고 Reply·Repost·Reaction 또는 Tombstone/Delete activity delivery를
+  추가하지 않는다.
+
+**Verification**
+
+- Public/Unlisted/Follower audience와 anonymous/Author/follower/non-follower/unknown signed fetch를 검증한다.
+- process restart·alternate request host에서 Local URI 안정성, Local mapping 미생성과 Remote mapping URI 재사용을 검증한다.
+- signed success cache header와 동일 URI의 후속 unauthorized request가 representation을 받지 않음을 검증한다.
+- Local/Remote/private/Tombstone/null Parent의 `inReplyTo`와 requester-independent body를 검증한다.
+- missing/non-local/Tombstone/contentless/unsupported visibility/unavailable Author·Instance를 같은 미제공 경계로
+  검증한다.
+
+- [ ] 3.1 `packages/fedify`에 Local/Remote Post ActivityPub URI resolver를 구현한다.
+- [ ] 3.2 PROD-502 HTML을 사용하는 Local Note object dispatcher와 제공 가능 Post load 경계를 구현한다.
+- [ ] 3.3 Post Visibility audience와 signed actor 기반 Followers Only authorization 및 cache 격리를 구현한다.
+- [ ] 3.4 requester-independent Local/Remote Parent `inReplyTo` projection을 연결한다.
+- [ ] 3.5 identity, mapping, audience, authorization, cache, Parent와 unavailable matrix의 federation integration test를 추가한다.
+
+## 4. PROD-494 Federation routing 회귀와 OpenSpec 완료
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- PROD-494
+
+**Deliverable**
+
+Local Note 역참조가 기존 federation-first BFF 경계에서 제공되고 actor, inbox, WebFinger, GraphQL, health와 SPA
+요청을 회귀시키지 않으며 전체 PROD-494 계약이 검증된다.
+
+**Guardrails**
+
+- ActivityPub 요청은 BFF/SPA보다 먼저 Fedify에서 처리하고 처리된 Note 요청을 GraphQL proxy로 넘기지 않는다.
+- non-federation 요청과 기존 actor/inbox/WebFinger 계약을 변경하지 않는다.
+- PROD-494 외 activity delivery handler, queue, retry, backfill과 GraphQL schema를 추가하지 않는다.
+- OpenSpec archive는 모든 task와 통합 검증이 완료된 뒤에만 수행한다.
+
+**Verification**
+
+- ActivityPub Accept header의 Note 200/미제공, HTML navigation fallback과 기존 actor/inbox/WebFinger/BFF test를
+  통과시킨다.
+- package typecheck/lint/test, migration 검증, `openspec validate add-activitypub-local-post-note --strict`와 전체
+  strict validation 결과를 기록한다.
+
+- [ ] 4.1 federation-first web routing에서 Note 응답과 기존 BFF/SPA fallback 회귀를 검증한다.
+- [ ] 4.2 관련 workspace checks와 PROD-494 전체 계약 통합 검증을 통과시킨다.
+- [ ] 4.3 구현·검증 완료 뒤 delta spec 정합성을 확인하고 `add-activitypub-local-post-note` change를 archive한다.
+- Local identity는 configured Local Instance canonical origin과 immutable Post DB UUID의 `/ap/note/{postId}`다.
+- Local Post에 remote ActivityPub Post mapping row를 만들지 않으며 Remote Post는 기존 mapping URI를 사용한다.
+- Post URI resolver는 `packages/fedify`가 소유하고 Web 공유 참조는 Note `url`로 별도 제공한다.
+- Note content는 PROD-502 serializer 결과를 사용하고 serializer를 이 이슈에서 복제하지 않는다.

--- a/packages/core/post-content/post-content-html.test.ts
+++ b/packages/core/post-content/post-content-html.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import { postContentDocumentToHtml } from './server';
+import type { PostContentDocumentV1 } from './index';
 
 const canonicalFixture = {
   version: 1,
@@ -94,7 +95,7 @@ for (const [name, document] of [
   ],
 ] as const) {
   test(`rejects ${name} before producing HTML`, () => {
-    assert.throws(() => postContentDocumentToHtml(document));
+    assert.throws(() => postContentDocumentToHtml(document as unknown as PostContentDocumentV1));
   });
 }
 

--- a/packages/core/post-content/post-content-html.test.ts
+++ b/packages/core/post-content/post-content-html.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { postContentDocumentToHtml } from './server';
+
+const canonicalFixture = {
+  version: 1,
+  summary: null,
+  body: {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'First <line> & ' },
+          { type: 'hard_break' },
+          {
+            type: 'text',
+            text: 'linked text',
+            marks: [
+              {
+                type: 'link',
+                attrs: { href: 'HTTPS://EXAMPLE.COM:443/a/../path?one=1&two=2' },
+              },
+            ],
+          },
+        ],
+      },
+      { type: 'paragraph', content: [{ type: 'text', text: 'Second paragraph' }] },
+    ],
+  },
+} as const;
+
+test('serializes the PROD-341 canonical fixture to deterministic safe HTML', () => {
+  const expected =
+    '<p>First &lt;line&gt; &amp; <br><a href="https://example.com/path?one=1&amp;two=2">linked text</a></p>' +
+    '<p>Second paragraph</p>';
+
+  assert.equal(postContentDocumentToHtml(canonicalFixture), expected);
+  assert.equal(postContentDocumentToHtml(canonicalFixture), expected);
+});
+
+for (const [name, document] of [
+  ['unsupported version', { ...canonicalFixture, version: 2 }],
+  [
+    'unsupported node',
+    {
+      ...canonicalFixture,
+      body: { type: 'doc', content: [{ type: 'pre', content: [] }] },
+    },
+  ],
+  [
+    'unsupported mark',
+    {
+      ...canonicalFixture,
+      body: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'bold', marks: [{ type: 'bold' }] }],
+          },
+        ],
+      },
+    },
+  ],
+  [
+    'unknown attribute',
+    {
+      ...canonicalFixture,
+      body: { type: 'doc', content: [{ type: 'paragraph', attrs: { class: 'unsafe' } }] },
+    },
+  ],
+  [
+    'unsafe link',
+    {
+      ...canonicalFixture,
+      body: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'unsafe',
+                marks: [{ type: 'link', attrs: { href: 'javascript:alert(1)' } }],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+] as const) {
+  test(`rejects ${name} before producing HTML`, () => {
+    assert.throws(() => postContentDocumentToHtml(document));
+  });
+}
+
+test('keeps the ProseMirror runtime behind the server-only package export', async () => {
+  const corePackage = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+  );
+  const appPackage = JSON.parse(
+    await readFile(new URL('../../../apps/app/package.json', import.meta.url), 'utf8'),
+  );
+  const clientEntry = await readFile(new URL('./index.ts', import.meta.url), 'utf8');
+
+  assert.equal(corePackage.exports['./post-content'], './post-content/index.ts');
+  assert.equal(corePackage.exports['./post-content/server'], './post-content/server.ts');
+  assert.doesNotMatch(clientEntry, /\.\/server/u);
+  assert.doesNotMatch(clientEntry, /prosemirror-model/u);
+  assert.equal(appPackage.dependencies['prosemirror-model'], undefined);
+});

--- a/packages/core/post-content/schema/marks/link.ts
+++ b/packages/core/post-content/schema/marks/link.ts
@@ -16,6 +16,7 @@ export const linkMarkSpec = {
       },
     },
   ],
+  toDOM: (mark) => ['a', { href: normalizeLinkHref(mark.attrs.href) }, 0],
 } satisfies MarkSpec;
 
 export function normalizeLinkHref(value: unknown): string {

--- a/packages/core/post-content/schema/nodes/hard-break.ts
+++ b/packages/core/post-content/schema/nodes/hard-break.ts
@@ -6,4 +6,5 @@ export const hardBreakNodeSpec = {
   marks: '',
   parseDOM: [{ tag: 'br' }],
   selectable: false,
+  toDOM: () => ['br'],
 } satisfies NodeSpec;

--- a/packages/core/post-content/schema/nodes/paragraph.ts
+++ b/packages/core/post-content/schema/nodes/paragraph.ts
@@ -5,4 +5,5 @@ export const paragraphNodeSpec = {
   group: 'block',
   marks: 'link',
   parseDOM: [{ tag: 'p' }],
+  toDOM: () => ['p', 0],
 } satisfies NodeSpec;

--- a/packages/core/post-content/server.ts
+++ b/packages/core/post-content/server.ts
@@ -100,7 +100,6 @@ export function postContentDocumentToText(value: unknown): string {
 export function postContentDocumentToHtml(value: unknown): string {
   const { body } = canonicalizePostContentDocument(value);
   const node = postContentSchema.nodeFromJSON(body);
-  node.check();
 
   const document = new JSDOM().window.document;
   const container = document.createElement('div');

--- a/packages/core/post-content/server.ts
+++ b/packages/core/post-content/server.ts
@@ -97,14 +97,16 @@ export function postContentDocumentToText(value: unknown): string {
   return postContentBodyToText(canonicalizePostContentDocument(value).body);
 }
 
-export function postContentDocumentToHtml(value: unknown): string {
-  const { body } = canonicalizePostContentDocument(value);
+export function postContentDocumentToHtml(document: PostContentDocumentV1): string {
+  const { body } = canonicalizePostContentDocument(document);
   const node = postContentSchema.nodeFromJSON(body);
 
-  const document = new JSDOM().window.document;
-  const container = document.createElement('div');
+  const domDocument = new JSDOM().window.document;
+  const container = domDocument.createElement('div');
   container.append(
-    DOMSerializer.fromSchema(postContentSchema).serializeFragment(node.content, { document }),
+    DOMSerializer.fromSchema(postContentSchema).serializeFragment(node.content, {
+      document: domDocument,
+    }),
   );
   return container.innerHTML;
 }

--- a/packages/core/post-content/server.ts
+++ b/packages/core/post-content/server.ts
@@ -1,4 +1,6 @@
 import { isDeepStrictEqual } from 'node:util';
+import { JSDOM } from 'jsdom';
+import { DOMSerializer } from 'prosemirror-model';
 import { postBodyMaxLength } from '../validation/post-policy';
 import { normalizePostContentPlainText, postContentSchemaVersion } from './index';
 import { postContentSchema } from './schema';
@@ -93,6 +95,19 @@ export function postContentDocumentFromText(
 
 export function postContentDocumentToText(value: unknown): string {
   return postContentBodyToText(canonicalizePostContentDocument(value).body);
+}
+
+export function postContentDocumentToHtml(value: unknown): string {
+  const { body } = canonicalizePostContentDocument(value);
+  const node = postContentSchema.nodeFromJSON(body);
+  node.check();
+
+  const document = new JSDOM().window.document;
+  const container = document.createElement('div');
+  container.append(
+    DOMSerializer.fromSchema(postContentSchema).serializeFragment(node.content, { document }),
+  );
+  return container.innerHTML;
 }
 
 export function validateLocalPostContentDocument(value: unknown): PostContentDocumentV1 {


### PR DESCRIPTION
## 무엇을 변경했는지

- ActivityPub Local Note identity와 표현의 canonical 문서, ADR 0017, 공유 `add-activitypub-local-post-note` OpenSpec을 추가했습니다.
- 기존 server-only PostContent ProseMirror schema의 paragraph, hard break, link에 canonical 의미와 일치하는 `toDOM`을 추가했습니다.
- `@kosmo/core/post-content/server`에 `postContentDocumentToHtml(document: PostContentDocumentV1): string`을 추가했습니다.
  - 기존 canonicalizer로 PostContent envelope를 런타임에 다시 검증합니다.
  - canonicalizer의 `Schema.nodeFromJSON()`과 `Node.check()`를 통과한 body를 `DOMSerializer.fromSchema()`로 직렬화합니다.
- canonical fixture의 exact HTML과 결정성, escaping, invalid version/node/mark/attr/link, server-only bundle 경계를 검증하는 테스트를 추가했습니다.
- 공유 OpenSpec에서 PROD-502 소유 task 2.1과 2.2만 완료 처리했습니다.

## 왜 변경했는지

PROD-494의 Local Note dispatcher가 canonical PostContent를 안전한 ActivityPub HTML `content`로 사용할 공통 export 경계가 필요합니다. 수동 JSON renderer나 inbound parser를 재사용하지 않고 PROD-341의 schema와 validation을 그대로 serialization source로 사용해 node·mark 의미와 safe HTTP(S) link 정책이 갈라지지 않게 합니다.

## 이번 PR의 주요 결정

새로운 주요 결정은 없습니다. 최신 canonical 문서와 Linear PROD-341, PROD-494, PROD-502를 대조한 [OpenSpec decision](openspec/changes/add-activitypub-local-post-note/decisions.md)의 `DOMSerializer.fromSchema()` 선택을 변경 없이 적용했습니다.

## 어떻게 확인할 수 있는지

- Core PostContent 및 inbound projection unit test: 36개 통과
- Targeted TypeScript, ESLint, Prettier 통과
- Expo Web export 성공
- 생성된 Expo Web bundle에서 ProseMirror runtime signature 미검출
- `openspec validate add-activitypub-local-post-note --strict` 통과
- 전체 OpenSpec strict validation: 34개 통과, 실패 0개
- correctness와 Ponytail 병렬 self-review 완료
  - boundary test의 client `./server` 재-export false negative를 보강한 뒤 correctness finding 없음
  - Ponytail: `Lean already. Ship.`

## 아직 어떤 문제가 남았는지

- 공유 OpenSpec 진행률은 2/12입니다.
- Local/Remote Post URI, Fedify Note dispatcher, audience, signed fetch/cache, `inReplyTo`, FK와 routing 통합 검증은 PROD-494가 소유합니다.
- 전체 task와 통합 검증이 끝나기 전에는 OpenSpec을 archive하지 않습니다.

Linear: [PROD-502](https://linear.app/byulmaru/issue/PROD-502/postcontent-prosemirror-document를-activitypub-html로-직렬화한다)