### PR TITLE
현재 Session 로그아웃 계약을 확정한다

### DIFF
--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -65,6 +65,7 @@ Membership/Owner 같은 관계 사실과 Account 활성 상태를 하나의 권�
 | 객체                                                                  | 책임                                       | 주요 관계                                                                                                |
 | --------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
 | [Account](./objects/account.md)                                       | 로그인과 운영자 행동의 기준                | [Profile](./objects/profile.md), [Account-Profile Membership](./objects/account-profile-membership.md)   |
+| [Session](./objects/session.md)                                       | Account credential의 서버 인증 생명주기    | [Account](./objects/account.md)                                                                          |
 | [Profile](./objects/profile.md)                                       | 공개 소셜 정체성과 기본 행동 주체          | [Account-Profile Membership](./objects/account-profile-membership.md), [Instance](./objects/instance.md) |
 | [Account-Profile Membership](./objects/account-profile-membership.md) | Account와 Local Profile의 역할 관계        | [Account](./objects/account.md), [Profile](./objects/profile.md)                                         |
 | [Post](./objects/post.md)                                             | Content, 관계 구조, 공개 범위, 후보성 정책 | [Profile](./objects/profile.md), [Media](./objects/media.md)                                             |

--- a/docs/domain/objects/account.md
+++ b/docs/domain/objects/account.md
@@ -26,6 +26,7 @@ Account가 아니라 Profile이다.
 | 관계               | 대상                                                          | 방향                  | cardinality | 존재 조건 | 조회 조건                | 조회 권한                              |
 | ------------------ | ------------------------------------------------------------- | --------------------- | ----------- | --------- | ------------------------ | -------------------------------------- |
 | Profile membership | [Account-Profile Membership](./account-profile-membership.md) | Account -> Membership | 1 -> 0..N   | 항상      | 대상 Account의 운영 관계 | `Account.Self` 또는 `Account.Operator` |
+| Session            | [Session](./session.md)                                       | Account <- Session    | 1 <- 0..N   | 항상      | 현재 Session 내부 조회   | `Session.Self`                         |
 
 ## 행동
 

--- a/docs/domain/objects/account.md
+++ b/docs/domain/objects/account.md
@@ -37,8 +37,8 @@ Account가 아니라 Profile이다.
 | Account 정지 해제 | 운영자 Account | Account   | 사유   | `Account.Active`, `Account.Operator` | 대상 Account State가 Suspended다                                                       | Account State가 Active가 된다                             |
 
 Deleted Account에는 다른 상태 전이를 적용하지 않는다.
-Suspended Account는 `Account.Active`가 필요한 행동을 수행할 수 없지만 Account 삭제와 Account 대상 Operational
-Notification 읽음 처리는 요청할 수 있다.
+Suspended Account는 `Account.Active`가 필요한 행동을 수행할 수 없지만 Account 삭제, 현재 Session 폐기와
+Account 대상 Operational Notification 읽음 처리는 요청할 수 있다.
 
 ## 권한
 

--- a/docs/domain/objects/session.md
+++ b/docs/domain/objects/session.md
@@ -1,0 +1,86 @@
+# Session 객체
+
+## 정의
+
+Session은 Account가 Kosmo에 인증된 상태를 유지하기 위해 발급받은 credential의 서버 생명주기를 소유하는
+durable 객체다. Session은 credential을 사용하는 한 클라이언트 환경의 인증 단위이며, 같은 Account에는 서로
+독립적인 Session이 여러 개 존재할 수 있다.
+
+Session 폐기는 OIDC provider의 전역 로그인 상태나 다른 Session을 함께 종료하지 않는다.
+
+## 상태
+
+### Session State
+
+| 값      | 의미                                                          |
+| ------- | ------------------------------------------------------------- |
+| Active  | Session credential로 인증을 시도할 수 있는 상태               |
+| Revoked | 명시적인 Session 폐기로 인증 자격을 잃은 terminal 상태        |
+| Expired | 적용되는 유효 기간 정책이 끝나 인증 자격을 잃은 terminal 상태 |
+
+Revoked와 Expired Session은 Active로 돌아가지 않는다. 인증 경계는 Active Session만 현재 Session으로 인정하며,
+Revoked 또는 Expired Session의 credential로 인증이 필요한 요청을 수행할 수 없다.
+
+## 속성
+
+| 속성      | 타입/nullability | 검증 정책                            | 존재 조건 | 조회 조건              | 조회 권한      |
+| --------- | ---------------- | ------------------------------------ | --------- | ---------------------- | -------------- |
+| 생성 시각 | 시각, 필수       | 생성 결과로 기록하며 변경하지 않는다 | 항상      | 현재 Session 내부 조회 | `Session.Self` |
+
+Session credential의 원문은 Session의 조회 가능한 속성이 아니다.
+
+## 관계
+
+| 관계    | 대상                    | 방향               | cardinality | 존재 조건 | 조회 조건              | 조회 권한      |
+| ------- | ----------------------- | ------------------ | ----------- | --------- | ---------------------- | -------------- |
+| Account | [Account](./account.md) | Session -> Account | N -> 1      | 항상      | 현재 Session 내부 조회 | `Session.Self` |
+
+## 행동
+
+| 행동              | 행동 주체 | 대상 객체 | 입력값             | 권한                             | 조건                                                                                                                  | 결과                                                                                                                                                                  |
+| ----------------- | --------- | --------- | ------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Session 생성      | Account   | Session   | 검증된 로그인 결과 | `Account.Active`                 | 검증된 로그인 결과가 Account와 연결된다                                                                               | Account에 속한 새 Active Session이 생성된다                                                                                                                           |
+| 현재 Session 폐기 | Account   | Session   | 없음               | `Account.Active`, `Session.Self` | 요청 credential을 검증한 서버 인증 경계가 대상 Session을 식별하며, 클라이언트가 다른 Session 식별자를 지정하지 않는다 | Active Session은 Revoked가 된다. 인증 뒤 경쟁 요청으로 이미 Revoked 또는 Expired가 된 Session은 terminal 상태를 유지한다. 같은 Account의 다른 Session은 바뀌지 않는다 |
+| Session 만료      | 시스템    | Session   | 없음               | 없음                             | Active Session이 적용되는 유효 기간 정책을 더 이상 만족하지 않는다                                                    | Session State가 Expired가 된다                                                                                                                                        |
+
+현재 Session 폐기는 상태 수준에서 멱등이다. 폐기 완료 뒤 같은 credential로 시작한 새 요청은 인증 경계에서 거부되며,
+폐기 전에 인증을 마친 경쟁 요청은 Session을 다른 terminal 상태로 덮어쓰지 않는다.
+
+`Account.Active`와 `Session.Self`는 현재 Session 폐기 행동의 진입 권한이며 클라이언트 로그아웃의 완료 조건이
+아니다. credential이 Suspended/Deleted Account 또는 Revoked/Expired Session을 가리키면 인증 경계는 이 권한을
+성립시키지 않고 폐기 행동에 진입하지 않지만, 서버는 해당 credential이 이미 인증에 사용될 수 없음을 확정할 수
+있다.
+
+클라이언트는 서버가 현재 Session의 폐기를 확정하거나 credential이 이미 인증 불가능한 상태임을 확정한 뒤에만
+caller-owned credential과 해당 Session에 종속된 상태를 제거하고 로그아웃 성공으로 전환한다. DB timeout,
+네트워크 오류, 응답 유실처럼 최종 상태를 확정할 수 없는 실패에서는 성공으로 전환하지 않고 credential을 유지한
+채 같은 Session 폐기를 재시도할 수 있어야 한다.
+
+## 권한
+
+| 권한           | 종류      | 성립 조건                                                                  |
+| -------------- | --------- | -------------------------------------------------------------------------- |
+| `Session.Self` | 객체 종속 | 요청 credential을 검증한 서버 인증 경계가 요청의 현재 Session으로 식별한다 |
+
+## 조회 정책
+
+- 현재 Session 조회는 요청 credential로 식별된 Active Session만 반환한다.
+- credential이 Revoked 또는 Expired Session을 가리키면 현재 Session을 반환하지 않는다.
+- 현재 계약은 다른 Session의 목록과 조회를 제공하지 않는다.
+
+## 확정 용어
+
+- 세션: Session
+- 현재 세션: Current Session
+- 세션 상태: Session State
+- 세션 폐기: Session Revoke
+
+## 제외/보류
+
+- absolute expiration과 idle expiration의 채택 여부, 기간 및 사용 시각 갱신 정책
+- 동일한 로그인 결과에서 기존 Active Session을 재사용할지 새 Session을 생성할지에 관한 정책
+- Session 목록, 전체 로그아웃과 분실 기기의 원격 Session 폐기
+- Session 폐기 시각과 감사 이력의 저장·노출
+- Revoked/Expired Session의 보존 기간과 cleanup, 기존 Session migration·rollout·rollback
+- OIDC provider logout 또는 global SSO logout
+- 공개 API의 mutation 이름, payload와 transport별 error 표현

--- a/docs/domain/objects/session.md
+++ b/docs/domain/objects/session.md
@@ -37,19 +37,20 @@ Session credential의 원문은 Session의 조회 가능한 속성이 아니다.
 
 ## 행동
 
-| 행동              | 행동 주체 | 대상 객체 | 입력값             | 권한                             | 조건                                                                                                                  | 결과                                                                                                                                                                  |
-| ----------------- | --------- | --------- | ------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Session 생성      | Account   | Session   | 검증된 로그인 결과 | `Account.Active`                 | 검증된 로그인 결과가 Account와 연결된다                                                                               | Account에 속한 새 Active Session이 생성된다                                                                                                                           |
-| 현재 Session 폐기 | Account   | Session   | 없음               | `Account.Active`, `Session.Self` | 요청 credential을 검증한 서버 인증 경계가 대상 Session을 식별하며, 클라이언트가 다른 Session 식별자를 지정하지 않는다 | Active Session은 Revoked가 된다. 인증 뒤 경쟁 요청으로 이미 Revoked 또는 Expired가 된 Session은 terminal 상태를 유지한다. 같은 Account의 다른 Session은 바뀌지 않는다 |
-| Session 만료      | 시스템    | Session   | 없음               | 없음                             | Active Session이 적용되는 유효 기간 정책을 더 이상 만족하지 않는다                                                    | Session State가 Expired가 된다                                                                                                                                        |
+| 행동              | 행동 주체 | 대상 객체 | 입력값             | 권한             | 조건                                                                                                                                                                      | 결과                                                                                                                                                                  |
+| ----------------- | --------- | --------- | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Session 생성      | Account   | Session   | 검증된 로그인 결과 | `Account.Active` | 검증된 로그인 결과가 Account와 연결된다                                                                                                                                   | Account에 속한 새 Active Session이 생성된다                                                                                                                           |
+| 현재 Session 폐기 | Account   | Session   | 없음               | `Session.Self`   | 요청 credential을 검증한 서버 인증 경계가 Active Session을 식별하고, 연결된 Account State가 Active 또는 Suspended이며, 클라이언트가 다른 Session 식별자를 지정하지 않는다 | Active Session은 Revoked가 된다. 인증 뒤 경쟁 요청으로 이미 Revoked 또는 Expired가 된 Session은 terminal 상태를 유지한다. 같은 Account의 다른 Session은 바뀌지 않는다 |
+| Session 만료      | 시스템    | Session   | 없음               | 없음             | Active Session이 적용되는 유효 기간 정책을 더 이상 만족하지 않는다                                                                                                        | Session State가 Expired가 된다                                                                                                                                        |
 
 현재 Session 폐기는 상태 수준에서 멱등이다. 폐기 완료 뒤 같은 credential로 시작한 새 요청은 인증 경계에서 거부되며,
 폐기 전에 인증을 마친 경쟁 요청은 Session을 다른 terminal 상태로 덮어쓰지 않는다.
 
-`Account.Active`와 `Session.Self`는 현재 Session 폐기 행동의 진입 권한이며 클라이언트 로그아웃의 완료 조건이
-아니다. credential이 Suspended/Deleted Account 또는 Revoked/Expired Session을 가리키면 인증 경계는 이 권한을
-성립시키지 않고 폐기 행동에 진입하지 않지만, 서버는 해당 credential이 이미 인증에 사용될 수 없음을 확정할 수
-있다.
+`Session.Self`는 현재 Session 폐기 행동의 진입 권한이며 클라이언트 로그아웃의 완료 조건이 아니다. 현재
+Session 폐기는 Suspended Account도 요청할 수 있는 `Account.Active`의 명시적 예외다. 따라서 credential이
+Suspended Account의 Active Session을 가리키면 Session을 Revoked로 전이한 뒤 로그아웃을 완료한다. credential이
+Deleted Account 또는 Revoked/Expired Session을 가리키면 폐기 행동에 진입하지 않지만, 서버는 해당 credential이
+이미 인증에 사용될 수 없음을 확정할 수 있다.
 
 클라이언트는 서버가 현재 Session의 폐기를 확정하거나 credential이 이미 인증 불가능한 상태임을 확정한 뒤에만
 caller-owned credential과 해당 Session에 종속된 상태를 제거하고 로그아웃 성공으로 전환한다. DB timeout,


### PR DESCRIPTION
## 무엇을 변경했는지

- Session을 Account credential의 서버 인증 생명주기를 소유하는 durable 객체로 canonical 문서에 추가했습니다.
- Session State의 Active/Revoked/Expired terminal 계약과 현재 Session 폐기의 대상·멱등성·다른 Session 격리를 정의했습니다.
- Account 관계와 도메인 객체 인덱스에 Session을 연결했습니다.
- revoke core 진입 조건과 클라이언트 logout 완료 조건을 분리했습니다.

## 왜 변경했는지

현재 Session 로그아웃의 대상 식별, 상태 전이, credential 제거 시점이 downstream 구현 전에 canonical로 확정되어야 합니다. 이 PR은 [PROD-344 Domain Gate](https://linear.app/byulmaru/issue/PROD-344/현재-session-로그아웃-canonical-계약과-downstream-이슈를-정렬한다)에서 승인된 계약만 전달합니다.

Stack: `main -> PROD-344`

## 이번 PR의 주요 결정

### Suspended Account에서도 현재 Session을 폐기한다

- 결정자: @HJSmiley
- 선택: `Session.Self`를 revoke core 진입 권한으로 사용하고, Suspended Account의 현재 Active Session 폐기를 `Account.Active`의 명시적 예외로 둡니다. Deleted Account나 Revoked/Expired Session은 credential의 기존 인증 불가를 확정해 logout을 완료합니다.
- 고려한 대안: Suspended Account의 credential도 이미 인증 불가능하다는 이유로 Active Session을 남긴 채 logout을 완료하는 방식
- 이유: Suspended Account는 다시 Active로 전이될 수 있어 Session을 남기면 로그아웃 뒤 credential이 재사용될 수 있기 때문입니다.
- 감수한 결과: 인증 경계는 Account State와 Session State를 분리해 Suspended Account의 Active Session을 식별·폐기하고, downstream transport는 확정된 비인증 결과와 DB timeout·네트워크 오류·응답 유실 같은 결과 불명 실패를 구분해야 합니다.
- 관련 근거: PR #371 리뷰 스레드, PROD-344와 `docs/domain/objects/session.md`

### Session 생성·감사 정책은 로그아웃 계약에서 제외한다

- 결정자: @HJSmiley
- 선택: 동일 로그인 결과의 Session 재사용/신규 생성 정책과 Session 폐기 시각·감사 이력 저장을 제외합니다.
- 고려한 대안: 이번 변경에 Session 생성 deduplication과 `revokedAt` 저장까지 포함하는 방식
- 이유: 현재 Session 로그아웃의 관찰 가능한 결과에 필요하지 않고 별도 migration·보존 정책을 요구하기 때문입니다.
- 감수한 결과: 해당 정책이 필요해지면 별도 Domain Gate와 계약으로 다뤄야 합니다.
- 관련 근거: PROD-344와 `docs/domain/objects/session.md`

## 어떻게 확인할 수 있는지

- 변경된 canonical 3개 파일 Prettier 검사
- docs/domain Markdown link 검사: 50개 링크 통과
- 객체 권한 참조 검사 통과
- 객체 문서 구조 검사 통과
- fact-named 권한 검사 통과
- 변경 canonical 용어 충돌 검사 통과
- `git diff --cached --check` 통과

## 아직 어떤 문제가 남았는지

- 구현, 테스트와 OpenSpec은 포함하지 않습니다. PROD-473 Issue Gate 승인 뒤 공유 OpenSpec과 downstream PROD-474/475 구현으로 진행합니다.
- 전체 canonical 용어 검사에 존재하던 Reaction 관련 기존 finding은 이 PR 범위에서 다루지 않습니다.
- 격리 worktree의 `pnpm lint:prettier`는 dependency 재설치 제약으로 실행하지 못했고, 동일 설치의 Prettier binary로 변경 파일을 직접 검사했습니다.