### PR TITLE
GraphQL 스키마 정렬 누락을 머지 전에 차단한다

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "db:bootstrap-local-instance": "tsx scripts/bootstrap-local-instance.ts",
     "dev": "tsx watch src/index.ts",
+    "lint:schema": "NODE_ENV=production node --import tsx scripts/check-schema.ts",
     "lint:tsc": "tsc --noEmit",
     "start": "node --import tsx src/index.ts",
     "test": "pnpm lint:tsc && pnpm test:unit && pnpm test:integration",

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -428,14 +428,6 @@ type ReactionNotification implements Node & Notification {
   type: String!
 }
 
-type ReplyNotification implements Node & Notification {
-  createdAt: DateTime!
-  id: ID!
-  post: Post!
-  profile: Profile!
-  readAt: DateTime
-}
-
 input RejectProfileFollowRequestInput {
   id: ID!
 }
@@ -443,6 +435,14 @@ input RejectProfileFollowRequestInput {
 type RejectProfileFollowRequestPayload {
   followeeProfile: Profile!
   profileFollowRequestId: ID!
+}
+
+type ReplyNotification implements Node & Notification {
+  createdAt: DateTime!
+  id: ID!
+  post: Post!
+  profile: Profile!
+  readAt: DateTime
 }
 
 type RepostNotification implements Node & Notification {

--- a/apps/api/scripts/check-schema.ts
+++ b/apps/api/scripts/check-schema.ts
@@ -1,0 +1,14 @@
+import { readFile } from 'node:fs/promises';
+import { lexicographicSortSchema, printSchema } from 'graphql';
+import { schema } from '../src/graphql/schema';
+
+const schemaPath = new URL('../schema.graphql', import.meta.url);
+const committedSchema = await readFile(schemaPath, 'utf8');
+const generatedSchema = `${printSchema(lexicographicSortSchema(schema))}\n`;
+
+if (committedSchema !== generatedSchema) {
+  console.error(
+    'apps/api/schema.graphql does not match the lexicographically sorted runtime schema.',
+  );
+  process.exitCode = 1;
+}

--- a/memory/script.md
+++ b/memory/script.md
@@ -36,6 +36,9 @@
 
 ## Expo, Relay, Web BFF
 
+- `apps/api`의 `lint:schema`는 runtime GraphQL schema를 사전식으로 정렬한 결과와 committed
+  `schema.graphql`이 완전히 같은지 검사한다. root CI의 workspace `lint:*` 실행에 포함되므로 schema를
+  변경하면 generated SDL도 같은 변경에서 정렬한다.
 - `apps/app`의 `prepare`, `dev`, `check`, `build`는 필요한 Relay generated artifact보다 먼저 `relay-compiler`를 실행한다. `__generated__`는 commit하지 않으므로 clean checkout과 CI에서도 compiler 선행을 생략하지 않는다.
 - universal client 검증은 `pnpm --filter @kosmo/app relay`, `check`, `export:web`을 분리해 실패 경계를 확인한다. `export:web`은 이전 환경의 `EXPO_PUBLIC_*` inline 값을 Metro cache에서 재사용하지 않도록 `expo export --clear`를 사용한다. Expo web export 산출물은 `apps/app/dist`이며 UI source를 소유하지 않는 `apps/web` Hono BFF가 이를 제공한다.
 - BFF 검증은 federation-first 전역 전달과 공식 미처리 callback, federation 표현의 404 보존, `/health`, browser 로그인/callback, cookie/Bearer GraphQL proxy, WebFinger/ActivityPub 응답, SPA deep-link fallback을 포함한다. Native session exchange는 API GraphQL mutation의 별도 API E2E로 검증한다. Expo export 성공만으로 server origin 계약이 검증됐다고 보지 않는다.


### PR DESCRIPTION
## 무엇을 변경했는지

- `schema.graphql`에서 `RejectProfileFollowRequest*`와 `ReplyNotification`의 깨진 사전식 순서를 바로잡았습니다.
- API 런타임 스키마를 `lexicographicSortSchema`로 출력한 결과와 committed `schema.graphql` 전체가 일치하는지 검사하는 `lint:schema`를 추가했습니다.
- 새 검사가 기존 workspace `lint:*` CI 경로에서 실행된다는 규칙을 저장소 메모리에 기록했습니다.

## 왜 변경했는지

main에 머지된 committed GraphQL schema의 타입 순서가 런타임에서 생성되는 사전식 정렬 결과와 달랐습니다. 파일만 한 번 보정하면 같은 문제가 다시 머지될 수 있으므로, PR과 merge queue의 기존 lint에서 schema snapshot 불일치를 실패로 처리합니다. 이 검사는 정렬 오류뿐 아니라 런타임 스키마 변경의 committed SDL 누락도 함께 잡습니다.

## 이번 PR의 주요 결정

### 런타임 스키마와 committed SDL의 완전 일치를 lint에서 검사

- 결정자: @robin-maki
- 선택: 런타임 스키마의 사전식 출력과 committed `schema.graphql`을 전체 문자열로 비교합니다.
- 고려한 대안: 현재 정렬만 수동으로 수정합니다.
- 이유: 별도 workflow나 새로운 의존성 없이 기존 workspace lint merge gate에서 재발과 schema 동기화 누락을 함께 차단할 수 있습니다.
- 감수한 결과: GraphQL schema를 변경하는 PR은 generated SDL도 같은 변경에서 정렬해 커밋해야 합니다.
- 관련 근거: 별도 이슈 없이 이 PR에서 보정합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api run "/^lint:.*/"`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `git diff --check`

## 아직 어떤 문제가 남았는지

없음.