### PR TITLE
비활성 Account가 다시 로그인해 Session을 만들지 못하게 한다

### DIFF
--- a/apps/web/e2e/auth-routes.e2e.ts
+++ b/apps/web/e2e/auth-routes.e2e.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { db, Sessions } from '@kosmo/core/db';
+import { Accounts, db, Sessions } from '@kosmo/core/db';
 import { AccountState, SessionState } from '@kosmo/core/enums';
 import { eq } from 'drizzle-orm';
 import { createE2ESession, resetE2EDatabase, setE2ESessionCookie } from './db-fixtures';
@@ -158,6 +158,25 @@ test('mock OIDC로 로그인하면 보호 홈으로 이동하고 세션이 유�
   await expect(page).toHaveURL(/\/home$/);
 });
 
+test('Deleted Account의 Web OIDC callback은 Session 없이 일반 오류로 거부된다', async ({
+  context,
+  page,
+}) => {
+  await db.insert(Accounts).values({
+    displayName: 'Deleted E2E User',
+    oidcSubject: 'oidc-mock-e2e-user',
+    state: AccountState.DISABLED,
+  });
+
+  const response = await page.goto('/login');
+
+  expect(response?.status()).toBe(500);
+  expect(await response?.text()).toBe('Internal Server Error');
+  expect(await db.select().from(Sessions)).toEqual([]);
+  expect((await context.cookies()).some(({ name }) => name === 'kosmo_session')).toBe(false);
+  expect(await page.textContent('body')).not.toContain('oidc-mock-e2e-user');
+});
+
 test('API는 public native PKCE code를 cookie 없이 Kosmo 세션으로 교환한다', async ({ request }) => {
   const codeVerifier = 'v'.repeat(43);
   const callbackUrl = await authorizeNativeCode(request, codeVerifier);
@@ -189,6 +208,33 @@ test('API는 public native PKCE code를 cookie 없이 Kosmo 세션으로 교환�
   expect(session?.oidcSessionKey).toBeNull();
   expect(response.headers()['cache-control']).toContain('no-store');
   expect(response.headers().pragma).toBe('no-cache');
+  expect(response.headers()['set-cookie']).toBeUndefined();
+});
+
+test('Suspended Account의 Native exchange는 Session 없이 일반 권한 오류로 거부된다', async ({
+  request,
+}) => {
+  await db.insert(Accounts).values({
+    displayName: 'Suspended E2E User',
+    oidcSubject: 'oidc-mock-e2e-user',
+    state: AccountState.SUSPENDED,
+  });
+  const codeVerifier = 'v'.repeat(43);
+  const callbackUrl = await authorizeNativeCode(request, codeVerifier);
+  const response = await exchangeNativeOidcSession(request, {
+    code: callbackUrl.searchParams.get('code'),
+    codeVerifier,
+    redirectUri: 'kosmo://login/callback',
+  });
+  const body = (await response.json()) as NativeSessionGraphQLResponse;
+
+  expect(response.status()).toBe(200);
+  expect(body.data).toBeNull();
+  expect(body.errors?.[0]?.extensions?.code).toBe('PERMISSION_DENIED');
+  expect(body.errors?.[0]?.message).toBe('Permission denied');
+  expect(JSON.stringify(body)).not.toContain('oidc-mock-e2e-user');
+  expect(JSON.stringify(body)).not.toContain(codeVerifier);
+  expect(await db.select().from(Sessions)).toEqual([]);
   expect(response.headers()['set-cookie']).toBeUndefined();
 });
 

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -23,7 +23,7 @@
 - **WHEN** `/login/callback` GET 요청에 `code`와 쿠키 state와 일치하는 `state`가 포함된다
 - **THEN** 시스템은 OIDC token endpoint에 authorization code, PKCE code verifier, client id, client secret, grant type, 현재 origin의 `/login/callback` redirect URI를 제출한다
 - **AND** token 응답에는 access token과 id token이 포함되어야 한다
-- **AND** 시스템은 ID token signature, issuer, audience와 시간 claims가 유효하고 연결된 Account가 `ACTIVE`일 때만 Kosmo session을 생성한다
+- **AND** 시스템은 ID token signature, issuer, audience와 시간 claims가 유효하고 연결된 Account가 없거나 `ACTIVE`일 때만 Kosmo session을 생성한다
 
 #### Scenario: 검증되지 않은 ID token 거부
 

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -23,7 +23,7 @@
 - **WHEN** `/login/callback` GET 요청에 `code`와 쿠키 state와 일치하는 `state`가 포함된다
 - **THEN** 시스템은 OIDC token endpoint에 authorization code, PKCE code verifier, client id, client secret, grant type, 현재 origin의 `/login/callback` redirect URI를 제출한다
 - **AND** token 응답에는 access token과 id token이 포함되어야 한다
-- **AND** 시스템은 ID token signature, issuer, audience와 시간 claims가 유효할 때만 Kosmo session을 생성한다
+- **AND** 시스템은 ID token signature, issuer, audience와 시간 claims가 유효하고 연결된 Account가 `ACTIVE`일 때만 Kosmo session을 생성한다
 
 #### Scenario: 검증되지 않은 ID token 거부
 
@@ -49,17 +49,23 @@
 
 ### Requirement: OIDC 계정 upsert와 세션 쿠키
 
-웹 애플리케이션은 OIDC id token의 subject를 기준으로 계정을 upsert하고 kosmo 세션 쿠키를 발급해야 한다(MUST).
+웹 애플리케이션은 OIDC id token의 subject를 기준으로 계정을 upsert하고 신규 또는 기존 `ACTIVE` Account에만 kosmo 세션 쿠키를 발급해야 한다(MUST).
 
 #### Scenario: 로그인 성공
 
-- **WHEN** OIDC token 응답의 id token payload가 문자열 `sub`와 `name`을 포함한다
+- **WHEN** OIDC token 응답의 id token payload가 문자열 `sub`와 `name`을 포함하고 연결된 Account가 없거나 `ACTIVE`이다
 - **THEN** 시스템은 `sub`를 `account.oidc_subject`로 사용하여 계정을 생성하거나 기존 계정의 표시 이름을 갱신한다
 - **AND** 계정 상태는 신규 생성 시 `ACTIVE`이다
 - **AND** 시스템은 무작위 session token을 가진 `ACTIVE` 세션을 생성한다
 - **AND** 시스템은 `kosmo_oidc_state`와 `kosmo_oidc_code_verifier` 쿠키를 삭제한다
 - **AND** 시스템은 1년 동안 유효한 HTTP-only `kosmo_session` 쿠키를 `/` 경로에 설정한다
 - **AND** 시스템은 `/`로 리다이렉트한다
+
+#### Scenario: 비활성 Account의 browser 로그인 거부
+
+- **WHEN** 유효한 OIDC token의 `sub`가 기존 `SUSPENDED` 또는 Deleted Account와 연결된다
+- **THEN** 시스템은 Account 상태나 upstream OIDC 세부 정보를 노출하지 않는 일반 서버 오류를 반환한다
+- **AND** Account를 갱신하거나 Kosmo session과 `kosmo_session` 쿠키를 생성하지 않는다
 
 #### Scenario: id token payload invalid
 
@@ -94,13 +100,20 @@ Kosmo API는 네이티브 공개 OIDC client가 client secret을 보유하지 �
 
 #### Scenario: Exchange a valid native code
 
-- **WHEN** 공개 API origin의 `/graphql`이 code, PKCE verifier, `kosmo://login/callback` redirect URI를 포함한 `exchangeNativeOidcSession` mutation을 받는다
+- **WHEN** 공개 API origin의 `/graphql`이 code, PKCE verifier, `kosmo://login/callback` redirect URI를 포함한 `exchangeNativeOidcSession` mutation을 받고 연결된 Account가 없거나 `ACTIVE`이다
 - **THEN** API는 구성된 공개 native client ID와 client secret 없이 OIDC token endpoint에 authorization code, PKCE verifier, exact redirect URI를 제출한다
 - **AND** API는 discovery metadata와 JWKS를 사용해 ID token signature, issuer, native client audience, expiration, issued-at claims를 검증한다
 - **AND** Kosmo는 단일 configured issuer의 `sub`를 account identity로 사용하고, 해당 issuer가 보장하는 문자열 `name` claim을 display name으로 사용한다
 - **AND** API는 OIDC 계정을 upsert하고 upstream OIDC token을 저장하지 않은 ACTIVE Kosmo session을 생성한다
 - **AND** mutation payload로 Kosmo session token을 반환하고 session cookie를 설정하지 않는다
 - **AND** 응답에 `Cache-Control: no-store`를 설정한다
+
+#### Scenario: Reject a native exchange for an inactive Account
+
+- **WHEN** 검증된 native ID token의 `sub`가 기존 `SUSPENDED` 또는 Deleted Account와 연결된다
+- **THEN** API는 Account 상태나 upstream OIDC 세부 정보를 노출하지 않는 generic GraphQL permission error를 반환한다
+- **AND** Account를 갱신하거나 Kosmo session을 생성하지 않는다
+- **AND** mutation payload와 cookie로 Kosmo session token을 반환하지 않는다
 
 #### Scenario: Reject an invalid native redirect URI
 

--- a/packages/core/services/session.test.ts
+++ b/packages/core/services/session.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { after, test } from 'node:test';
+import { eq } from 'drizzle-orm';
+import { Accounts, db, firstOrThrow, pg, Sessions } from '../db';
+import { AccountState, SessionState } from '../enums';
+import { PermissionDeniedError } from '../error';
+import { createOidcSession } from './session';
+
+after(async () => {
+  await pg.end();
+});
+
+const createIdentity = () => {
+  const suffix = crypto.randomUUID();
+
+  return {
+    displayName: `display-${suffix}`,
+    oidcSubject: `subject-${suffix}`,
+  };
+};
+
+const loadAccount = (oidcSubject: string) =>
+  db
+    .select()
+    .from(Accounts)
+    .where(eq(Accounts.oidcSubject, oidcSubject))
+    .limit(1)
+    .then(firstOrThrow);
+
+const loadSessions = (accountId: string) =>
+  db.select().from(Sessions).where(eq(Sessions.accountId, accountId));
+
+test('신규 OIDC Account와 ACTIVE Session을 생성한다', async () => {
+  const identity = createIdentity();
+
+  const token = await createOidcSession(identity);
+
+  const account = await loadAccount(identity.oidcSubject);
+  const sessions = await loadSessions(account.id);
+  assert.equal(account.displayName, identity.displayName);
+  assert.equal(account.state, AccountState.ACTIVE);
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0]?.state, SessionState.ACTIVE);
+  assert.equal(sessions[0]?.token, token);
+});
+
+test('기존 Active Account는 표시 이름을 갱신하고 새 Session을 생성한다', async () => {
+  const identity = createIdentity();
+  const account = await db
+    .insert(Accounts)
+    .values({ ...identity, displayName: 'old display name', state: AccountState.ACTIVE })
+    .returning()
+    .then(firstOrThrow);
+
+  const token = await createOidcSession(identity);
+
+  assert.equal((await loadAccount(identity.oidcSubject)).displayName, identity.displayName);
+  assert.deepEqual(
+    (await loadSessions(account.id)).map((session) => ({
+      state: session.state,
+      token: session.token,
+    })),
+    [{ state: SessionState.ACTIVE, token }],
+  );
+});
+
+for (const state of [AccountState.SUSPENDED, AccountState.DISABLED]) {
+  test(`${state} Account는 Session을 생성하지 않는다`, async () => {
+    const identity = createIdentity();
+    const account = await db
+      .insert(Accounts)
+      .values({ ...identity, displayName: 'preserved display name', state })
+      .returning()
+      .then(firstOrThrow);
+
+    await assert.rejects(createOidcSession(identity), PermissionDeniedError);
+
+    const persistedAccount = await loadAccount(identity.oidcSubject);
+    assert.equal(persistedAccount.displayName, 'preserved display name');
+    assert.equal(persistedAccount.state, state);
+    assert.deepEqual(await loadSessions(account.id), []);
+  });
+}

--- a/packages/core/services/session.ts
+++ b/packages/core/services/session.ts
@@ -9,6 +9,7 @@ import {
   Sessions,
 } from '../db';
 import { AccountState, ProfileState, SessionState } from '../enums';
+import { PermissionDeniedError } from '../error';
 import type { Transaction } from '../db';
 
 type VerifiedOidcIdentity = {
@@ -36,8 +37,12 @@ export const createOidcSession = async (
         target: [Accounts.oidcSubject],
         set: { displayName },
       })
-      .returning({ id: Accounts.id })
+      .returning({ id: Accounts.id, state: Accounts.state })
       .then(firstOrThrow);
+
+    if (account.state !== AccountState.ACTIVE) {
+      throw new PermissionDeniedError();
+    }
 
     const activeProfile = await tx
       .select({ id: Profiles.id })


### PR DESCRIPTION
## 무엇을 변경했는지

- OIDC identity를 Account에 upsert한 뒤 현재 Account State를 함께 조회합니다.
- Active Account에만 Active Session을 발급하고 Suspended/Deleted Account는 일반 권한 오류로 거부합니다.
- 신규 Account, 기존 Active Account, Suspended/Deleted Account의 Session 생성 결과와 transaction rollback을 집중 검증합니다.
- Web OIDC callback과 Native session exchange가 비활성 Account에서 Session이나 credential을 만들지 않고 내부 세부를 노출하지 않는지 E2E로 검증합니다.

## 왜 변경했는지

Web OIDC callback과 Native exchange가 공유하는 `createOidcSession`은 기존 Account를 upsert한 뒤 Account State를 확인하지 않았습니다. 그 결과 Suspended/Deleted Account가 다시 로그인하면 인증 경계에서 사용할 수 없는 Active Session row가 DB에 남았습니다.

이 변경은 Session 생성에 `Account.Active`를 요구하는 canonical 계약(#371)을 실제 공유 로그인 경로에 적용합니다.

## 이번 PR의 주요 결정

### Account State 검증을 공유 Session service에서 수행

- 결정자: @robin-maki
- 선택: Account upsert 결과에서 State를 확인하고 비활성 Account면 같은 transaction 안에서 거부합니다.
- 고려한 대안: Web callback과 Native mutation에서 각각 Account State를 검사합니다.
- 이유: 두 진입점이 같은 Session 생성 action을 사용하므로 domain policy와 Session 미생성 원자성을 한 곳에서 보장합니다.
- 감수한 결과: Web은 기존 BFF 오류 경계에 따라 일반 500 응답을 반환하고 Native는 일반 `PERMISSION_DENIED`를 반환합니다. transport별 공개 오류 계약은 이번 변경에서 새로 정의하지 않습니다.
- 관련 근거: #371의 `Session 생성 / Account.Active` 계약

별도 Linear 이슈는 만들지 않고 기존 로그인 버그 수정으로 진행합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/core test:services:database` — 113개 통과
- `node scripts/test-db.mjs run -- pnpm test:e2e:database -- e2e/auth-routes.e2e.ts` — 24개 통과
- `pnpm --filter @kosmo/api lint:tsc`
- `pnpm --filter @kosmo/web check`
- 변경 파일 ESLint, Prettier, `git diff --check`

## 아직 어떤 문제가 남았는지

없음.