### PR TITLE
Remote actor handle 탐색을 Fedify에 맡긴다

### DIFF
--- a/packages/fedify/src/inbound-follow.test.ts
+++ b/packages/fedify/src/inbound-follow.test.ts
@@ -419,31 +419,38 @@ describe('inbound Follow and Undo', () => {
     assert.equal((await db.select().from(ProfileFollows)).length, 0);
   });
 
-  test('ignores expected actor validation failures but propagates lookup outages', async () => {
+  test('uses Fedify actor discovery failures and propagates object lookup outages', async () => {
     await createFixture();
     const unknownActorUri = new URL('https://unknown.example/users/mallory');
     const follow = new Follow({ actor: unknownActorUri, object: localActorUri });
-
-    await handleInboundFollow(
-      createContext({
-        lookupWebFinger: mock.fn(async () => null),
-        recipient: localProfileId,
-      }),
-      follow,
+    const fetch = mock.method(globalThis, 'fetch', async () =>
+      Response.json({}, { status: 404, headers: { 'Content-Type': 'application/jrd+json' } }),
     );
 
-    await assert.rejects(
-      handleInboundFollow(
-        createContext({
-          lookupWebFinger: mock.fn(async () => {
-            throw new Error('WebFinger unavailable');
+    try {
+      await handleInboundFollow(createContext({ recipient: localProfileId }), follow);
+
+      fetch.mock.mockImplementation(async () =>
+        Response.json(
+          { subject: 'acct:mallory@unknown.example' },
+          { headers: { 'Content-Type': 'application/jrd+json' } },
+        ),
+      );
+      await assert.rejects(
+        handleInboundFollow(
+          createContext({
+            lookupObject: mock.fn(async () => {
+              throw new Error('Actor lookup unavailable');
+            }),
+            recipient: localProfileId,
           }),
-          recipient: localProfileId,
-        }),
-        follow,
-      ),
-      /WebFinger unavailable/,
-    );
+          follow,
+        ),
+        /Actor lookup unavailable/,
+      );
+    } finally {
+      fetch.mock.restore();
+    }
     assert.equal((await db.select().from(ProfileFollows)).length, 0);
   });
 

--- a/packages/fedify/src/remote-actor-materialization.test.ts
+++ b/packages/fedify/src/remote-actor-materialization.test.ts
@@ -1,7 +1,7 @@
 import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
-import { after, before, beforeEach, describe, mock, test } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, mock, test } from 'node:test';
 import { Endpoints, LanguageString, Note, Person } from '@fedify/vocab';
 import {
   ActivityPubActorType,
@@ -62,6 +62,8 @@ describe('remote actor materialization', () => {
     await db.delete(Instances).where(ne(Instances.id, localInstanceId));
   });
 
+  afterEach(() => mock.restoreAll());
+
   after(async () => {
     await pg.end();
   });
@@ -109,44 +111,33 @@ describe('remote actor materialization', () => {
     assert.equal(stored.actor.lastFetchedAt?.toString(), now.toString());
   });
 
-  for (const mediaType of [
-    'application/activity+json',
-    'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-  ]) {
-    test(`materializes an inbound actor URI from WebFinger self type ${mediaType}`, async () => {
-      const actor = createActor();
-      const lookupObject = mock.fn(async () => actor);
-      const lookupWebFinger = mock.fn(async () => ({
-        links: [{ href: actor.id?.href, rel: 'self', type: mediaType }],
-        subject: `acct:alice@${remoteDomain}`,
-      }));
+  test('materializes an inbound actor URI through Fedify actor handle discovery', async () => {
+    const actor = createActor();
+    const lookupObject = mock.fn(async () => actor);
+    const fetch = mockWebFinger({ subject: `acct:alice@${remoteDomain}` });
 
-      const result = await findOrMaterializeRemoteProfileActorByUri({
-        actorUri: actor.id!,
-        context: { lookupObject, lookupWebFinger } as unknown as Context<void>,
-      });
-
-      assert.equal(result.actor.uri, actor.id?.href);
-      assert.equal(lookupWebFinger.mock.calls.length, 1);
-      assert.equal(
-        (lookupObject.mock.calls as unknown as Array<{ arguments: unknown[] }>)[0]?.arguments[0],
-        `acct:alice@${remoteDomain}`,
-      );
+    const result = await findOrMaterializeRemoteProfileActorByUri({
+      actorUri: actor.id!,
+      context: { lookupObject },
     });
-  }
+
+    assert.equal(result.actor.uri, actor.id?.href);
+    assert.equal(fetch.mock.calls.length, 1);
+    assert.equal(
+      (lookupObject.mock.calls as unknown as Array<{ arguments: unknown[] }>)[0]?.arguments[0],
+      `acct:alice@${remoteDomain}`,
+    );
+  });
 
   test('reactivates an unknown actor instance only after materialization succeeds', async () => {
     const instance = await createRemoteInstance({ state: InstanceState.UNRESPONSIVE });
     const actor = createActor();
     const lookupObject = mock.fn(async () => actor);
-    const lookupWebFinger = mock.fn(async () => ({
-      links: [{ href: actor.id?.href, rel: 'self', type: 'application/activity+json' }],
-      subject: `acct:alice@${remoteDomain}`,
-    }));
+    mockWebFinger({ subject: `acct:alice@${remoteDomain}` });
 
     await findOrMaterializeRemoteProfileActorByUri({
       actorUri: actor.id!,
-      context: { lookupObject, lookupWebFinger } as unknown as Context<void>,
+      context: { lookupObject },
     });
 
     const reactivated = await db
@@ -162,15 +153,12 @@ describe('remote actor materialization', () => {
     const instance = await createRemoteInstance({ state: InstanceState.UNRESPONSIVE });
     const actor = createActor();
     const lookupObject = mock.fn(async () => null);
-    const lookupWebFinger = mock.fn(async () => ({
-      links: [{ href: actor.id?.href, rel: 'self', type: 'application/activity+json' }],
-      subject: `acct:alice@${remoteDomain}`,
-    }));
+    mockWebFinger({ subject: `acct:alice@${remoteDomain}` });
 
     await assert.rejects(
       findOrMaterializeRemoteProfileActorByUri({
         actorUri: actor.id!,
-        context: { lookupObject, lookupWebFinger } as unknown as Context<void>,
+        context: { lookupObject },
       }),
       RemoteActorMaterializationError,
     );
@@ -187,33 +175,29 @@ describe('remote actor materialization', () => {
   test('reuses a stored inbound actor and reactivates UNRESPONSIVE with compare-and-set', async () => {
     const stored = await createStoredRemoteActor({ instanceState: InstanceState.UNRESPONSIVE });
     const lookupObject = mock.fn(async () => createActor());
-    const lookupWebFinger = mock.fn(async () => null);
 
     const result = await findOrMaterializeRemoteProfileActorByUri({
       actorUri: new URL(stored.actor.uri),
-      context: { lookupObject, lookupWebFinger } as unknown as Context<void>,
+      context: { lookupObject },
     });
 
     assert.equal(result.profile.id, stored.profile.id);
     assert.equal(result.instance.state, InstanceState.ACTIVE);
     assert.equal(lookupObject.mock.calls.length, 0);
-    assert.equal(lookupWebFinger.mock.calls.length, 0);
   });
 
   test('ignores a stored SUSPENDED inbound actor without network access', async () => {
     const stored = await createStoredRemoteActor({ instanceState: InstanceState.SUSPENDED });
     const lookupObject = mock.fn(async () => createActor());
-    const lookupWebFinger = mock.fn(async () => null);
 
     await assert.rejects(
       findOrMaterializeRemoteProfileActorByUri({
         actorUri: new URL(stored.actor.uri),
-        context: { lookupObject, lookupWebFinger } as unknown as Context<void>,
+        context: { lookupObject },
       }),
       /Profile not found/,
     );
     assert.equal(lookupObject.mock.calls.length, 0);
-    assert.equal(lookupWebFinger.mock.calls.length, 0);
   });
 
   test('preserves the original handle casing during lookup', async () => {
@@ -867,6 +851,19 @@ const createActor = (overrides: Partial<PersonOptions> = {}) =>
     published: Temporal.Instant.from('2024-01-02T03:04:05Z'),
     summary: 'Remote bio',
     ...overrides,
+  });
+
+const mockWebFinger = (descriptor: { subject: string }) =>
+  mock.method(globalThis, 'fetch', async (input: string | URL | Request) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+
+    assert.equal(url.origin, `https://${remoteDomain}`);
+    assert.equal(url.pathname, '/.well-known/webfinger');
+    assert.equal(url.searchParams.get('resource'), `https://${remoteDomain}/users/alice`);
+
+    return Response.json(descriptor, {
+      headers: { 'Content-Type': 'application/jrd+json' },
+    });
   });
 
 const createLookupContext = (

--- a/packages/fedify/src/remote-actor-materialization.ts
+++ b/packages/fedify/src/remote-actor-materialization.ts
@@ -305,14 +305,6 @@ export const findUsableStoredRemoteProfileActorByUri = async (actorUri: URL | st
   return stored ? requireUsableStoredRemoteActor(stored) : undefined;
 };
 
-const resolveActorHandleByUri = async (actorUri: URL): Promise<string> => {
-  try {
-    return await getActorHandle(actorUri, { trimLeadingAt: true });
-  } catch {
-    throw new RemoteActorMaterializationError('WebFinger actor identity does not match.');
-  }
-};
-
 export const findOrMaterializeRemoteProfileActorByUri = async ({
   actorUri,
   context,
@@ -328,7 +320,12 @@ export const findOrMaterializeRemoteProfileActorByUri = async ({
     return stored;
   }
 
-  const handle = await resolveActorHandleByUri(actorUri);
+  let handle: string;
+  try {
+    handle = await getActorHandle(actorUri, { trimLeadingAt: true });
+  } catch {
+    throw new RemoteActorMaterializationError('WebFinger actor identity does not match.');
+  }
   await materializeRemoteProfileActor({ context, handle, now, reactivateUnresponsive: true });
 
   const materialized = await findStoredRemoteProfileActorByUri(actorUri);

--- a/packages/fedify/src/remote-actor-materialization.ts
+++ b/packages/fedify/src/remote-actor-materialization.ts
@@ -1,6 +1,6 @@
 import '@kosmo/core/polyfill';
 
-import { getActorTypeName, isActor } from '@fedify/vocab';
+import { getActorHandle, getActorTypeName, isActor } from '@fedify/vocab';
 import {
   ActivityPubActors,
   db,
@@ -40,7 +40,6 @@ export class RemoteActorMaterializationError extends Error {
 }
 
 type RemoteActorLookupContext = Pick<Context<void>, 'lookupObject'>;
-type RemoteActorUriLookupContext = Pick<Context<void>, 'lookupObject' | 'lookupWebFinger'>;
 
 type RemoteActorMaterializationOptions = {
   context: RemoteActorLookupContext;
@@ -306,26 +305,12 @@ export const findUsableStoredRemoteProfileActorByUri = async (actorUri: URL | st
   return stored ? requireUsableStoredRemoteActor(stored) : undefined;
 };
 
-const resolveActorHandleByUri = async (
-  context: RemoteActorUriLookupContext,
-  actorUri: URL,
-): Promise<string> => {
-  const descriptor = await context.lookupWebFinger(actorUri);
-  const subject = descriptor?.subject;
-  const self = descriptor?.links?.find(
-    ({ href, rel, type }) =>
-      rel === 'self' &&
-      href === actorUri.href &&
-      ['application/activity+json', 'application/ld+json'].includes(
-        type?.split(';', 1)[0]?.trim().toLowerCase() ?? '',
-      ),
-  );
-
-  if (!subject?.startsWith('acct:') || !self) {
+const resolveActorHandleByUri = async (actorUri: URL): Promise<string> => {
+  try {
+    return await getActorHandle(actorUri, { trimLeadingAt: true });
+  } catch {
     throw new RemoteActorMaterializationError('WebFinger actor identity does not match.');
   }
-
-  return subject.slice('acct:'.length);
 };
 
 export const findOrMaterializeRemoteProfileActorByUri = async ({
@@ -334,7 +319,7 @@ export const findOrMaterializeRemoteProfileActorByUri = async ({
   now = getNow(),
 }: {
   actorUri: URL;
-  context: RemoteActorUriLookupContext;
+  context: RemoteActorLookupContext;
   now?: Temporal.Instant;
 }) => {
   const stored = await findUsableStoredRemoteProfileActorByUri(actorUri);
@@ -343,7 +328,7 @@ export const findOrMaterializeRemoteProfileActorByUri = async ({
     return stored;
   }
 
-  const handle = await resolveActorHandleByUri(context, actorUri);
+  const handle = await resolveActorHandleByUri(actorUri);
   await materializeRemoteProfileActor({ context, handle, now, reactivateUnresponsive: true });
 
   const materialized = await findStoredRemoteProfileActorByUri(actorUri);


### PR DESCRIPTION
## 무엇을 변경했는지

- remote actor URI를 handle로 변환할 때 `@fedify/vocab`의 `getActorHandle()`을 사용합니다.
- Kosmo가 직접 수행하던 WebFinger `subject`, `self`, media type 해석을 제거했습니다.
- 저장된 remote actor의 무네트워크 재사용 경로와 actor 객체 조회 장애 전파를 계속 검증합니다.

## 왜 변경했는지

Fedify가 이미 actor URI의 WebFinger handle 탐색과 alias·cross-origin 검증을 제공하고 있는데 Kosmo가 같은 프로토콜 해석을 별도로 구현하고 있었습니다. 라이브러리의 검증 규칙을 그대로 사용해 중복 구현과 향후 동작 차이를 줄입니다.

관련 이슈는 별도로 만들지 않았습니다.

## 이번 PR의 주요 결정

### Fedify의 actor handle 탐색 규칙을 그대로 사용한다

- 결정자: @robin-maki
- 선택: 수동 WebFinger 응답 해석 대신 `getActorHandle(actorUri, { trimLeadingAt: true })`을 사용합니다.
- 고려한 대안: 현재의 `subject`·`self`·media type 검증을 Kosmo 코드로 계속 유지합니다.
- 이유: 해당 검증은 도메인 정책이 아니라 Fedify가 소유하는 federation protocol 동작이며, Fedify는 alias와 cross-origin 검증도 함께 제공합니다.
- 감수한 결과: WebFinger에서 handle을 찾지 못한 경우 Fedify의 실패 분류를 따릅니다. handle 탐색 뒤 실제 actor 객체 조회 장애는 계속 전파합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm exec eslint packages/fedify/src/remote-actor-materialization.ts packages/fedify/src/remote-actor-materialization.test.ts packages/fedify/src/inbound-follow.test.ts`
- `pnpm exec prettier --check packages/fedify/src/remote-actor-materialization.ts packages/fedify/src/remote-actor-materialization.test.ts packages/fedify/src/inbound-follow.test.ts`
- `pnpm test:fedify` — 104개 테스트 통과

## 아직 어떤 문제가 남았는지

없음
