### PR TITLE
현재 Session 폐기 mutation과 Web logout BFF를 제공한다

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -216,6 +216,7 @@ type Mutation {
   markNotificationRead(input: MarkNotificationReadInput!): MarkNotificationReadPayload!
   rejectProfileFollowRequest(input: RejectProfileFollowRequestInput!): RejectProfileFollowRequestPayload!
   repostPost(input: RepostPostInput!): RepostPostPayload!
+  revokeCurrentSession: RevokeCurrentSessionPayload!
   selectProfile(input: SelectProfileInput!): SelectProfilePayload!
   unfollowProfile(input: UnfollowProfileInput!): UnfollowProfilePayload!
   updateProfile(input: UpdateProfileInput!): UpdateProfilePayload!
@@ -470,6 +471,10 @@ input RepostPostInput {
 
 type RepostPostPayload {
   repost: Post!
+}
+
+type RevokeCurrentSessionPayload {
+  completed: Boolean!
 }
 
 input SelectProfileInput {

--- a/apps/api/src/graphql/resolvers/session/mutation/index.ts
+++ b/apps/api/src/graphql/resolvers/session/mutation/index.ts
@@ -1,1 +1,2 @@
 import './exchange-native-oidc-session';
+import './revoke-current-session';

--- a/apps/api/src/graphql/resolvers/session/mutation/revoke-current-session.ts
+++ b/apps/api/src/graphql/resolvers/session/mutation/revoke-current-session.ts
@@ -1,0 +1,38 @@
+import { PermissionDeniedError } from '@kosmo/core/error';
+import { revokeCurrentSession } from '@kosmo/core/services';
+import { builder } from '@/graphql/builder';
+
+const getBearerToken = (authorization: string | undefined) => {
+  if (authorization === undefined) {
+    return undefined;
+  }
+
+  const token = authorization.match(/^Bearer\s+(\S+)$/i)?.[1];
+  if (!token) {
+    throw new PermissionDeniedError('Authorization header must use Bearer');
+  }
+
+  return token;
+};
+
+builder.mutationField('revokeCurrentSession', (t) =>
+  t.field({
+    type: builder.simpleObject('RevokeCurrentSessionPayload', {
+      fields: (field) => ({
+        completed: field.boolean(),
+      }),
+    }),
+    resolve: async (_, __, ctx) => {
+      ctx.c.header('Cache-Control', 'no-store');
+      ctx.c.header('Pragma', 'no-cache');
+
+      const result = await revokeCurrentSession({
+        token: getBearerToken(ctx.c.req.header('Authorization')),
+      });
+
+      return {
+        completed: result.status === 'REVOKED' || result.status === 'ALREADY_UNAUTHENTICATED',
+      };
+    },
+  }),
+);

--- a/apps/api/src/graphql/schema.test.ts
+++ b/apps/api/src/graphql/schema.test.ts
@@ -463,6 +463,18 @@ test('exposes the typed Notification Read mutation payload', () => {
   assert.equal(String(payload.getFields().recipientProfile.type), 'Profile!');
 });
 
+test('exposes current-session revoke without a target input', () => {
+  const mutation = schema.getMutationType();
+  const payload = schema.getType('RevokeCurrentSessionPayload');
+  const field = mutation?.getFields().revokeCurrentSession;
+
+  assert.equal(String(field?.type), 'RevokeCurrentSessionPayload!');
+  assert.deepEqual(field?.args, []);
+  assert.ok(isObjectType(payload));
+  assert.deepEqual(Object.keys(payload.getFields()), ['completed']);
+  assert.equal(String(payload.getFields().completed.type), 'Boolean!');
+});
+
 test('exposes the private Bookmark Node and Profile connection contract', () => {
   const bookmark = schema.getType('Bookmark');
   const profile = schema.getType('Profile');

--- a/apps/api/tests/integration/graphql/session.test.ts
+++ b/apps/api/tests/integration/graphql/session.test.ts
@@ -3,7 +3,7 @@ import '@kosmo/core/polyfill';
 import assert from 'node:assert/strict';
 import { after, before, test } from 'node:test';
 import { AccountState, SessionState } from '@kosmo/core/enums';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { Hono } from 'hono';
 import type * as CoreDb from '@kosmo/core/db';
 import type { deriveContext as DeriveContext, Env } from '../../../src/context';
@@ -66,14 +66,8 @@ const createSession = async ({
 };
 
 const cleanup = async (accountIds: string[]) => {
-  await db.delete(Sessions).where(eq(Sessions.accountId, accountIds[0]!));
-  for (const accountId of accountIds.slice(1)) {
-    await db.delete(Sessions).where(eq(Sessions.accountId, accountId));
-  }
-  await db.delete(Accounts).where(eq(Accounts.id, accountIds[0]!));
-  for (const accountId of accountIds.slice(1)) {
-    await db.delete(Accounts).where(eq(Accounts.id, accountId));
-  }
+  await db.delete(Sessions).where(inArray(Sessions.accountId, accountIds));
+  await db.delete(Accounts).where(inArray(Accounts.id, accountIds));
 };
 
 const request = async <T>(query: string, token?: string): Promise<GraphQLResult<T>> => {
@@ -163,6 +157,17 @@ test('GraphQL mutation에는 Session ID 입력이 없고 malformed Authorization
   assert.equal(result.data, null);
   assert.equal(result.errors?.[0]?.extensions?.code, 'PERMISSION_DENIED');
   assert.match(result.errors?.[0]?.message ?? '', /Bearer/);
+});
+
+test('database 결과를 확정할 수 없으면 완료 payload 대신 internal error를 반환한다', async (t) => {
+  t.mock.method(db, 'transaction', async () => {
+    throw new Error('database unavailable');
+  });
+
+  const result = await revoke('unreachable-token');
+
+  assert.equal(result.data, null);
+  assert.equal(result.errors?.[0]?.extensions?.code, 'INTERNAL_SERVER_ERROR');
 });
 
 test('동시 GraphQL 폐기는 한 Session만 Revoked로 수렴한다', async () => {

--- a/apps/api/tests/integration/graphql/session.test.ts
+++ b/apps/api/tests/integration/graphql/session.test.ts
@@ -1,0 +1,194 @@
+import '@kosmo/core/polyfill';
+
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { AccountState, SessionState } from '@kosmo/core/enums';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import type * as CoreDb from '@kosmo/core/db';
+import type { deriveContext as DeriveContext, Env } from '../../../src/context';
+import type { yoga as YogaRouter } from '../../../src/graphql';
+
+const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+process.env.DATABASE_URL = databaseUrl;
+
+let Accounts: typeof CoreDb.Accounts;
+let db: typeof CoreDb.db;
+let firstOrThrow: typeof CoreDb.firstOrThrow;
+let pg: typeof CoreDb.pg;
+let Sessions: typeof CoreDb.Sessions;
+let deriveContext: typeof DeriveContext;
+let yoga: typeof YogaRouter;
+let app: Hono<Env>;
+
+type GraphQLResult<T> = {
+  data?: T;
+  errors?: Array<{ extensions?: { code?: string }; message: string }>;
+};
+
+before(async () => {
+  process.env.NODE_ENV = 'production';
+  ({ Accounts, db, firstOrThrow, pg, Sessions } = await import('@kosmo/core/db'));
+  ({ deriveContext } = await import('../../../src/context'));
+  ({ yoga } = await import('../../../src/graphql'));
+
+  app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    c.set('context', await deriveContext(c));
+    return next();
+  });
+  app.route('/graphql', yoga);
+});
+
+after(async () => {
+  await pg.end();
+});
+
+const createSession = async ({
+  accountState = AccountState.ACTIVE,
+  sessionState = SessionState.ACTIVE,
+}: {
+  accountState?: AccountState;
+  sessionState?: SessionState;
+} = {}) => {
+  const suffix = crypto.randomUUID();
+  const account = await db
+    .insert(Accounts)
+    .values({ displayName: suffix, oidcSubject: suffix, state: accountState })
+    .returning()
+    .then(firstOrThrow);
+  const session = await db
+    .insert(Sessions)
+    .values({ accountId: account.id, state: sessionState, token: `token-${suffix}` })
+    .returning()
+    .then(firstOrThrow);
+  return { account, session };
+};
+
+const cleanup = async (accountIds: string[]) => {
+  await db.delete(Sessions).where(eq(Sessions.accountId, accountIds[0]!));
+  for (const accountId of accountIds.slice(1)) {
+    await db.delete(Sessions).where(eq(Sessions.accountId, accountId));
+  }
+  await db.delete(Accounts).where(eq(Accounts.id, accountIds[0]!));
+  for (const accountId of accountIds.slice(1)) {
+    await db.delete(Accounts).where(eq(Accounts.id, accountId));
+  }
+};
+
+const request = async <T>(query: string, token?: string): Promise<GraphQLResult<T>> => {
+  const response = await app.request('/graphql', {
+    body: JSON.stringify({ query }),
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    method: 'POST',
+  });
+  return response.json() as Promise<GraphQLResult<T>>;
+};
+
+const revoke = (token?: string) =>
+  request<{ revokeCurrentSession: { completed: boolean } }>(
+    'mutation { revokeCurrentSession { completed } }',
+    token,
+  );
+
+test('Active·Suspended current Session을 폐기하고 재사용 인증을 거부한다', async () => {
+  const active = await createSession();
+  const suspended = await createSession({ accountState: AccountState.SUSPENDED });
+
+  try {
+    assert.deepEqual(await revoke(active.session.token), {
+      data: { revokeCurrentSession: { completed: true } },
+    });
+    assert.deepEqual(await revoke(suspended.session.token), {
+      data: { revokeCurrentSession: { completed: true } },
+    });
+
+    const [activeState, suspendedState] = await Promise.all([
+      db.select({ state: Sessions.state }).from(Sessions).where(eq(Sessions.id, active.session.id)),
+      db
+        .select({ state: Sessions.state })
+        .from(Sessions)
+        .where(eq(Sessions.id, suspended.session.id)),
+    ]);
+    assert.equal(activeState[0]?.state, SessionState.REVOKED);
+    assert.equal(suspendedState[0]?.state, SessionState.REVOKED);
+
+    const current = await request<{ currentSession: null }>(
+      'query { currentSession { id } }',
+      active.session.token,
+    );
+    assert.deepEqual(current.data, { currentSession: null });
+  } finally {
+    await cleanup([active.account.id, suspended.account.id]);
+  }
+});
+
+test('Disabled·Revoked·Expired credential은 완료로 처리하되 상태를 재활성화하지 않는다', async () => {
+  const disabled = await createSession({ accountState: AccountState.DISABLED });
+  const revoked = await createSession({ sessionState: SessionState.REVOKED });
+  const expired = await createSession({ sessionState: SessionState.EXPIRED });
+
+  try {
+    const results = await Promise.all([
+      revoke(disabled.session.token),
+      revoke(revoked.session.token),
+      revoke(expired.session.token),
+      revoke(),
+    ]);
+    results.forEach((result) => {
+      assert.deepEqual(result, { data: { revokeCurrentSession: { completed: true } } });
+    });
+
+    const states = await db
+      .select({ id: Sessions.id, state: Sessions.state })
+      .from(Sessions)
+      .where(eq(Sessions.accountId, disabled.account.id));
+    assert.equal(states[0]?.state, SessionState.ACTIVE);
+  } finally {
+    await cleanup([disabled.account.id, revoked.account.id, expired.account.id]);
+  }
+});
+
+test('GraphQL mutation에는 Session ID 입력이 없고 malformed Authorization은 거부한다', async () => {
+  const malformed = await app.request('/graphql', {
+    body: JSON.stringify({ query: 'mutation { revokeCurrentSession { completed } }' }),
+    headers: { authorization: 'Basic invalid', 'content-type': 'application/json' },
+    method: 'POST',
+  });
+  const result = (await malformed.json()) as GraphQLResult<unknown>;
+
+  assert.equal(result.data, null);
+  assert.equal(result.errors?.[0]?.extensions?.code, 'PERMISSION_DENIED');
+  assert.match(result.errors?.[0]?.message ?? '', /Bearer/);
+});
+
+test('동시 GraphQL 폐기는 한 Session만 Revoked로 수렴한다', async () => {
+  const { account, session } = await createSession();
+  const other = await db
+    .insert(Sessions)
+    .values({
+      accountId: account.id,
+      state: SessionState.ACTIVE,
+      token: `other-${crypto.randomUUID()}`,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+  try {
+    const results = await Promise.all(Array.from({ length: 6 }, () => revoke(session.token)));
+    results.forEach((result) => {
+      assert.deepEqual(result, { data: { revokeCurrentSession: { completed: true } } });
+    });
+    const states = await db
+      .select({ id: Sessions.id, state: Sessions.state })
+      .from(Sessions)
+      .where(eq(Sessions.accountId, account.id));
+    assert.equal(states.find(({ id }) => id === session.id)?.state, SessionState.REVOKED);
+    assert.equal(states.find(({ id }) => id === other.id)?.state, SessionState.ACTIVE);
+  } finally {
+    await cleanup([account.id]);
+  }
+});

--- a/apps/web/src/server/app.test.ts
+++ b/apps/web/src/server/app.test.ts
@@ -13,13 +13,18 @@ import type {
   discovery as oidcDiscovery,
 } from 'openid-client';
 
-const { authorizationCodeGrant, createSession, discovery, federationFetch } = vi.hoisted(() => ({
-  authorizationCodeGrant: vi.fn<typeof oidcAuthorizationCodeGrant>(),
-  createSession:
-    vi.fn<(identity: { displayName: string; oidcSubject: string }) => Promise<string>>(),
-  discovery: vi.fn<typeof oidcDiscovery>(),
-  federationFetch: vi.fn<typeof federation.fetch>(),
-}));
+const { authorizationCodeGrant, createSession, discovery, federationFetch, revokeSession } =
+  vi.hoisted(() => ({
+    authorizationCodeGrant: vi.fn<typeof oidcAuthorizationCodeGrant>(),
+    createSession:
+      vi.fn<(identity: { displayName: string; oidcSubject: string }) => Promise<string>>(),
+    discovery: vi.fn<typeof oidcDiscovery>(),
+    federationFetch: vi.fn<typeof federation.fetch>(),
+    revokeSession:
+      vi.fn<
+        (input: { token?: string }) => Promise<{ status: 'REVOKED' | 'ALREADY_UNAUTHENTICATED' }>
+      >(),
+  }));
 
 vi.mock('openid-client', async (importOriginal) => ({
   ...((await importOriginal()) as object),
@@ -29,6 +34,7 @@ vi.mock('openid-client', async (importOriginal) => ({
 
 vi.mock('@kosmo/core/services', () => ({
   createOidcSession: createSession,
+  revokeCurrentSession: revokeSession,
 }));
 
 vi.mock('@kosmo/fedify', () => ({
@@ -83,6 +89,7 @@ beforeEach(() => {
       }) as unknown as Awaited<ReturnType<typeof oidcAuthorizationCodeGrant>>,
   );
   createSession.mockResolvedValue('kosmo-session-token');
+  revokeSession.mockResolvedValue({ status: 'REVOKED' });
   federationFetch.mockImplementation(async (request, options) => {
     if (!options.onNotFound) {
       throw new Error('Missing federation fallback');
@@ -220,6 +227,86 @@ describe('browser login', () => {
     expect(await response.text()).toBe('OIDC callback redirect_uri is invalid');
     expect(authorizationCodeGrant).not.toHaveBeenCalled();
     expect(createSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('Web logout BFF', () => {
+  test('revoke가 확정되면 same-origin response에서 session cookie를 제거한다', async () => {
+    const response = await app.request('https://kos.moe/logout', {
+      headers: {
+        cookie: 'kosmo_session=cookie-token',
+        origin: 'https://kos.moe',
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('pragma')).toBe('no-cache');
+    expect(response.headers.get('set-cookie')).toContain('kosmo_session=');
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+    expect(response.headers.get('set-cookie')).toContain('Path=/');
+    expect(response.headers.get('set-cookie')).toContain('HttpOnly');
+    expect(response.headers.get('set-cookie')).toContain('SameSite=Lax');
+    expect(response.headers.get('set-cookie')).toContain('Secure');
+    expect(revokeSession).toHaveBeenCalledWith({ token: 'cookie-token' });
+  });
+
+  test('cookie가 없어도 이미 인증 불가한 성공으로 처리한다', async () => {
+    const response = await app.request('https://kos.moe/logout', {
+      headers: { origin: 'https://kos.moe' },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(204);
+    expect(revokeSession).toHaveBeenCalledWith({ token: undefined });
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+  });
+
+  test.each([
+    {
+      name: 'Origin 누락',
+      headers: { cookie: 'kosmo_session=cookie-token' } as Record<string, string>,
+    },
+    {
+      name: '다른 Origin',
+      headers: { cookie: 'kosmo_session=cookie-token', origin: 'https://evil.example' },
+    },
+  ])('$name 요청은 revoke와 cookie 제거를 실행하지 않는다', async ({ headers }) => {
+    const response = await app.request('https://kos.moe/logout', {
+      headers,
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('set-cookie')).toBeNull();
+    expect(revokeSession).not.toHaveBeenCalled();
+  });
+
+  test('POST 이외 method는 허용하지 않는다', async () => {
+    const response = await app.request('https://kos.moe/logout', {
+      headers: { origin: 'https://kos.moe' },
+      method: 'GET',
+    });
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('allow')).toBe('POST');
+    expect(revokeSession).not.toHaveBeenCalled();
+  });
+
+  test('revoke 결과가 불명확하면 cookie를 제거하지 않고 500을 반환한다', async () => {
+    revokeSession.mockRejectedValueOnce(new Error('database unavailable'));
+
+    const response = await app.request('https://kos.moe/logout', {
+      headers: {
+        cookie: 'kosmo_session=cookie-token',
+        origin: 'https://kos.moe',
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('set-cookie')).toBeNull();
   });
 });
 

--- a/apps/web/src/server/app.ts
+++ b/apps/web/src/server/app.ts
@@ -4,6 +4,7 @@ import { routePath } from 'hono/route';
 import { OidcAuthError } from './auth';
 import graphqlRoutes from './routes/graphql';
 import loginRoutes from './routes/login';
+import logoutRoutes from './routes/logout';
 import staticRoutes from './routes/static';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
@@ -53,6 +54,7 @@ app.get('/health', (c) => c.text('ok'));
 app.all('/health', (c) => c.text('Method Not Allowed', 405, { Allow: 'GET' }));
 
 app.route('/', loginRoutes);
+app.route('/', logoutRoutes);
 app.route('/', graphqlRoutes);
 app.route('/', staticRoutes);
 

--- a/apps/web/src/server/routes/logout.ts
+++ b/apps/web/src/server/routes/logout.ts
@@ -1,0 +1,32 @@
+import { sessionName } from '@kosmo/core';
+import { revokeCurrentSession } from '@kosmo/core/services';
+import { Hono } from 'hono';
+import { deleteCookie, getCookie } from 'hono/cookie';
+
+const logoutRoutes = new Hono();
+
+logoutRoutes.post('/logout', async (c) => {
+  const requestUrl = new URL(c.req.url);
+  const publicOrigin = new URL(process.env.PUBLIC_ORIGIN ?? requestUrl.origin);
+  if (c.req.header('origin') !== publicOrigin.origin) {
+    return c.text('Forbidden', 403);
+  }
+
+  c.header('Cache-Control', 'no-store');
+  c.header('Pragma', 'no-cache');
+
+  await revokeCurrentSession({ token: getCookie(c, sessionName) });
+
+  deleteCookie(c, sessionName, {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'Lax',
+    secure: publicOrigin.protocol === 'https:',
+  });
+
+  return c.body(null, 204);
+});
+
+logoutRoutes.all('/logout', (c) => c.text('Method Not Allowed', 405, { Allow: 'POST' }));
+
+export default logoutRoutes;

--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -35,6 +35,12 @@ Account session이나 ActivityPub signature처럼 actor identity를 신뢰하기
 Post.Author, Source visibility와 lifecycle처럼 검증된 actor와 domain object 사이의 공통 권한은 core가
 검증한다.
 
+current-session logout은 이 규칙의 의도적인 예외다. missing 또는 terminal Session credential은 검증된
+Session identity를 만들 수 없지만, 로그아웃은 이 상태를 DB·네트워크 오류처럼 결과를 확정하지 못한 실패와
+구분해야 한다. GraphQL과 Web BFF가 같은 판정을 공유하도록 transport-neutral logout action이 raw Kosmo
+Session credential 확인과 조건부 revoke를 함께 소유한다. 이 예외는 다른 인증 action의 caller·actor 검증
+책임을 core로 옮기는 근거가 아니다.
+
 ## Actor와 caller별 조건
 
 기본 소셜 actor는 `Profile`이다. `Account`는 GraphQL caller의 인증 identity이며 selected Profile은

--- a/openspec/changes/add-current-session-logout/.openspec.yaml
+++ b/openspec/changes/add-current-session-logout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-27

--- a/openspec/changes/add-current-session-logout/decisions.md
+++ b/openspec/changes/add-current-session-logout/decisions.md
@@ -1,0 +1,85 @@
+## Context
+
+이 기록은 PROD-344에서 승인된 Session canonical 계약, PROD-473 Issue Gate와 구현 자식 PROD-474/475의 범위, 그리고 current-session logout delta specs와 구현 제약을 반영한다. OpenSpec 작성 중 새로운 제품 행동이나 upstream 변경 필요 사항은 발견되지 않았다.
+
+## Decision Records
+
+### 현재 Session만 폐기하고 terminal 상태와 다른 Session을 보존한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-344`, `PROD-473`, `PROD-474`
+- Status: Active
+- Context / Problem: 로그아웃 요청이 임의 Session을 대상으로 확장되거나 경쟁 요청이 terminal 상태를 되돌리면 current-session 계약과 다른 기기 격리가 깨진다.
+- Decision Outcome: 인증 경계가 `Session.Self`로 식별한 현재 Active Session만 Revoked로 전이한다. 클라이언트 Session ID 입력은 허용하지 않고, Revoked/Expired terminal winner와 같은 Account의 다른 Session을 보존한다.
+- Alternatives Considered: Session ID를 받아 원격 Session까지 폐기하는 방식은 Session 목록·원격 로그아웃이라는 제외 범위를 추가하므로 채택하지 않았다. 모든 Account Session을 폐기하는 방식은 다른 Session 격리 계약을 위반한다.
+- Consequences: core와 transport test는 대상 Session, terminal 경쟁, 동일 Account의 다른 Session과 폐기 뒤 credential 거부를 함께 검증해야 한다.
+- Confirmation / Follow-up: PROD-474의 core/API/BFF 검증에서 조건부 전이와 Session 격리를 증명한다.
+
+### Suspended Account의 현재 Active Session 폐기를 전용 예외로 처리한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-344`, `PROD-473`, `PROD-474`
+- Status: Active
+- Context / Problem: 일반 API context는 Active Account만 인정하지만 Suspended Account는 재활성화될 수 있어 Active Session을 남기면 사용자가 로그아웃한 credential이 나중에 재사용될 수 있다.
+- Decision Outcome: current-session revoke 인증 경계에서만 Suspended Account의 Active Session을 식별하고 Revoked로 전이한다. 일반 `Account.Active` 보호 행동은 계속 거부한다. Deleted Account 또는 Revoked/Expired Session은 core에 진입하지 않고 이미 인증 불가능한 확정 결과로 처리한다.
+- Alternatives Considered: Suspended Account credential을 폐기하지 않고 local credential만 제거하는 방식은 재활성화 뒤 재사용 위험 때문에 채택하지 않았다. 일반 login context를 Suspended까지 확장하는 방식은 다른 보호 행동의 권한을 넓히므로 채택하지 않았다.
+- Consequences: GraphQL과 BFF에는 일반 login context와 분리된 credential boundary가 필요하고, 기존 보호 query/mutation의 Active Account 회귀 검증이 필요하다.
+- Confirmation / Follow-up: Active/Suspended/Deleted Account와 Active/Revoked/Expired Session 조합을 entry integration test로 검증한다.
+
+### GraphQL mutation은 대상 입력 없이 완료 여부만 반환한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-474`
+- Status: Active
+- Context / Problem: Native client에는 current-session revoke 진입점이 필요하지만, revoked Session Node를 payload로 반환하면 Node auth scope와 충돌하고 임의 대상 input은 금지되어 있다.
+- Decision Outcome: 공개 GraphQL field는 `revokeCurrentSession`으로 하고 Session ID input을 정의하지 않는다. `RevokeCurrentSessionPayload`는 확정된 logout 결과를 나타내는 non-null `completed` Boolean만 반환하며, 폐기와 이미 인증 불가능한 결과는 `true`, 결과 불명 실패는 GraphQL error로 표현한다.
+- Alternatives Considered: revoked Session Node 또는 Session ID를 반환하는 방식은 client cache에 필요하지 않고 폐기된 Node 조회 권한과 충돌한다. `REVOKED | ALREADY_UNAUTHENTICATED` enum은 caller가 구분할 필요가 없는 내부 상태를 공개하므로 채택하지 않았다. payload 없는 scalar mutation은 repository의 mutation payload 규칙과 어긋나므로 채택하지 않았다.
+- Consequences: schema와 Relay artifact가 additive하게 바뀌며, client는 success payload와 GraphQL/network failure만 구분한다.
+- Confirmation / Follow-up: schema snapshot, API integration test와 Relay compile로 input 부재와 payload shape를 확인한다.
+
+### Web logout은 전용 same-origin POST route로 처리한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-474`
+- Status: Active
+- Context / Problem: HttpOnly cookie는 browser code가 제거할 수 없고, 범용 `/graphql` streaming proxy가 특정 mutation 결과를 해석하면 proxy와 logout 정책이 결합된다. cookie credential을 사용하는 state-changing endpoint에는 CSRF 경계도 필요하다.
+- Decision Outcome: Web BFF에 `POST /logout`을 추가하고 Origin이 구성된 public origin과 정확히 일치할 때만 처리한다. 확정 결과는 cache 불가 `204 No Content`와 동일 scope의 expired `kosmo_session` cookie로 반환한다. Origin 누락/불일치는 forbidden, 다른 method는 `Allow: POST`의 405, 결과 불명 실패는 cookie를 유지하는 non-2xx로 처리한다.
+- Alternatives Considered: `/graphql` proxy에서 mutation response를 해석하는 방식은 범용 proxy를 결합시키므로 채택하지 않았다. GET logout은 state-changing cookie action과 CSRF 위험 때문에 채택하지 않았다. browser code가 cookie를 지우는 방식은 HttpOnly 계약상 불가능하다.
+- Consequences: login/logout cookie 옵션을 일치시켜야 하고 reverse proxy 환경의 public origin 및 local HTTP를 검증해야 한다.
+- Confirmation / Follow-up: BFF test에서 POST, Origin, 204, no-store, cookie scope, 403/405와 failure cookie 보존을 확인한다.
+
+### 서버 결과 확정 뒤 credential과 Relay Environment를 정리한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-475`
+- Status: Active
+- Context / Problem: local credential이나 일부 Relay record를 먼저 제거하면 결과 불명 실패를 재시도할 수 없고 이전 viewer cache가 guest 또는 다음 Session에 노출될 수 있다.
+- Decision Outcome: Web BFF 또는 Native mutation이 폐기/이미 인증 불가능함을 확정한 뒤에만 runtime credential을 정리한다. Native는 기존 SecureStore 경계를 사용하고 Web은 BFF response에 의존한다. 모든 runtime은 viewer 종속 Relay Environment/Store를 새 guest 환경으로 교체한 뒤 `/`로 replace 이동한다.
+- Alternatives Considered: server 요청 전 local-only logout은 결과 확정 계약을 위반한다. 기존 Relay Store에서 알려진 record만 삭제하는 방식은 누락 record와 in-flight response를 격리하지 못하므로 채택하지 않았다.
+- Consequences: logout action은 server call, credential cleanup, Environment reset과 navigation의 순서를 소유해야 한다. 실패 시 현재 token, Environment와 route를 유지한다.
+- Confirmation / Follow-up: PROD-475의 Web/Native test에서 성공 순서, failure retention, 다른 Session 로그인 뒤 cache 격리와 replace navigation을 확인한다.
+
+### 기존 logout control은 별도 확인 dialog 없이 직접 실행한다
+
+- Decision Date: 2026-07-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear: `PROD-473`, `PROD-475`
+- Status: Active
+- Context / Problem: full/compact/drawer에 이미 logout control이 존재하며, 이번 변경은 메뉴 구조를 바꾸지 않고 실제 action·진행·실패 의미를 연결해야 한다.
+- Decision Outcome: 기존 control을 활성화하면 추가 confirmation step 없이 공용 logout action을 실행한다. 진행 중에는 모든 surface의 중복 실행을 막고 busy/disabled 상태를 보조 기술에 전달한다. 결과 불명 실패에서는 generic 안내와 같은 control의 재시도를 제공한다.
+- Alternatives Considered: confirmation dialog는 실수 방지를 돕지만, 재로그인이 가능한 current-session action에 추가 modal 상태와 접근성 경계를 만들고 현재 승인 범위에서 요구되지 않아 기본 경로로 채택하지 않았다. 각 surface가 독립 pending 상태를 가지는 방식은 중복 요청을 허용하므로 채택하지 않았다.
+- Consequences: 공용 action 상태가 shell surface들보다 상위에서 공유되어야 하고, 오류 원문이나 credential material을 UI에 노출하지 않아야 한다.
+- Confirmation / Follow-up: full/compact/drawer interaction 및 pending/error accessibility test로 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-current-session-logout/decisions.md
+++ b/openspec/changes/add-current-session-logout/decisions.md
@@ -11,7 +11,7 @@
 - Authority / Provenance: `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-344`, `PROD-473`, `PROD-474`
 - Status: Active
 - Context / Problem: 로그아웃 요청이 임의 Session을 대상으로 확장되거나 경쟁 요청이 terminal 상태를 되돌리면 current-session 계약과 다른 기기 격리가 깨진다.
-- Decision Outcome: 인증 경계가 `Session.Self`로 식별한 현재 Active Session만 Revoked로 전이한다. 클라이언트 Session ID 입력은 허용하지 않고, Revoked/Expired terminal winner와 같은 Account의 다른 Session을 보존한다.
+- Decision Outcome: Active 또는 Suspended Account에서 인증 경계가 `Session.Self`로 식별한 현재 Active Session만 Revoked로 전이한다. 클라이언트 Session ID 입력은 허용하지 않고, Revoked/Expired terminal winner와 같은 Account의 다른 Session을 보존한다. Suspended Account의 다른 보호 행동은 계속 거부한다.
 - Alternatives Considered: Session ID를 받아 원격 Session까지 폐기하는 방식은 Session 목록·원격 로그아웃이라는 제외 범위를 추가하므로 채택하지 않았다. 모든 Account Session을 폐기하는 방식은 다른 Session 격리 계약을 위반한다.
 - Consequences: core와 transport test는 대상 Session, terminal 경쟁, 동일 Account의 다른 Session과 폐기 뒤 credential 거부를 함께 검증해야 한다.
 - Confirmation / Follow-up: PROD-474의 core/API/BFF 검증에서 조건부 전이와 Session 격리를 증명한다.
@@ -19,8 +19,8 @@
 ### current-session logout action이 폐기 인증 경계와 조건부 revoke를 함께 소유한다
 
 - Decision Date: 2026-07-27
-- Decision Class: Derived Contract
-- Authority / Provenance: `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-344`, `PROD-473`, `PROD-474`
+- Decision Class: Implementation Choice
+- Authority / Provenance: 이 OpenSpec의 implementation design; informed by `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-344`, `PROD-473`, `PROD-474`
 - Status: Active
 - Context / Problem: 일반 API context는 Active Account만 인정하지만 Suspended Account는 재활성화될 수 있어 Active Session을 남기면 사용자가 로그아웃한 credential이 나중에 재사용될 수 있다. 반대로 일반 인증 경계를 먼저 적용하면 terminal/missing credential에서는 검증된 Session identity를 만들 수 없어, 이미 인증 불가능한 확정 결과를 DB·네트워크 오류 같은 결과 불명 실패와 구분할 수 없다. 이 판정을 GraphQL과 BFF에 복제하면 두 transport의 logout 결과가 달라질 수 있다.
 - Decision Outcome: transport-neutral current-session logout action이 raw Session credential 조회, 결과 분류와 조건부 revoke를 함께 소유한다. 이 action에서만 Suspended Account의 Active Session을 식별해 Revoked로 전이하고, 일반 `Account.Active` 보호 행동은 계속 거부한다. Deleted Account 또는 Revoked/Expired Session은 공유 action에서 이미 인증 불가능한 확정 결과로 분류하되 조건부 Session revoke 단계에는 진입하지 않는다.
@@ -82,4 +82,4 @@
 
 ## Superseded Decisions
 
-- 없음.
+- 이 change의 초기 design에서 GraphQL과 BFF가 각각 raw credential을 조회·분류한 뒤 검증된 Session identity만 core에 전달하도록 한 transport/core 분리 결정은 위의 transport-neutral current-session logout action 소유 결정으로 대체했다. terminal/missing credential에서는 identity를 만들 수 없고, 결과 분류가 transport마다 중복되어 동작이 달라질 수 있기 때문이다.

--- a/openspec/changes/add-current-session-logout/decisions.md
+++ b/openspec/changes/add-current-session-logout/decisions.md
@@ -16,16 +16,16 @@
 - Consequences: core와 transport test는 대상 Session, terminal 경쟁, 동일 Account의 다른 Session과 폐기 뒤 credential 거부를 함께 검증해야 한다.
 - Confirmation / Follow-up: PROD-474의 core/API/BFF 검증에서 조건부 전이와 Session 격리를 증명한다.
 
-### Suspended Account의 현재 Active Session 폐기를 전용 예외로 처리한다
+### current-session logout action이 폐기 인증 경계와 조건부 revoke를 함께 소유한다
 
 - Decision Date: 2026-07-27
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-344`, `PROD-473`, `PROD-474`
 - Status: Active
-- Context / Problem: 일반 API context는 Active Account만 인정하지만 Suspended Account는 재활성화될 수 있어 Active Session을 남기면 사용자가 로그아웃한 credential이 나중에 재사용될 수 있다.
-- Decision Outcome: current-session revoke 인증 경계에서만 Suspended Account의 Active Session을 식별하고 Revoked로 전이한다. 일반 `Account.Active` 보호 행동은 계속 거부한다. Deleted Account 또는 Revoked/Expired Session은 core에 진입하지 않고 이미 인증 불가능한 확정 결과로 처리한다.
-- Alternatives Considered: Suspended Account credential을 폐기하지 않고 local credential만 제거하는 방식은 재활성화 뒤 재사용 위험 때문에 채택하지 않았다. 일반 login context를 Suspended까지 확장하는 방식은 다른 보호 행동의 권한을 넓히므로 채택하지 않았다.
-- Consequences: GraphQL과 BFF에는 일반 login context와 분리된 credential boundary가 필요하고, 기존 보호 query/mutation의 Active Account 회귀 검증이 필요하다.
+- Context / Problem: 일반 API context는 Active Account만 인정하지만 Suspended Account는 재활성화될 수 있어 Active Session을 남기면 사용자가 로그아웃한 credential이 나중에 재사용될 수 있다. 반대로 일반 인증 경계를 먼저 적용하면 terminal/missing credential에서는 검증된 Session identity를 만들 수 없어, 이미 인증 불가능한 확정 결과를 DB·네트워크 오류 같은 결과 불명 실패와 구분할 수 없다. 이 판정을 GraphQL과 BFF에 복제하면 두 transport의 logout 결과가 달라질 수 있다.
+- Decision Outcome: transport-neutral current-session logout action이 raw Session credential 조회, 결과 분류와 조건부 revoke를 함께 소유한다. 이 action에서만 Suspended Account의 Active Session을 식별해 Revoked로 전이하고, 일반 `Account.Active` 보호 행동은 계속 거부한다. Deleted Account 또는 Revoked/Expired Session은 공유 action에서 이미 인증 불가능한 확정 결과로 분류하되 조건부 Session revoke 단계에는 진입하지 않는다.
+- Alternatives Considered: GraphQL과 BFF가 각각 credential을 조회·분류한 뒤 검증된 Session identity만 core에 전달하는 방식은 terminal/missing credential에서 identity를 만들 수 없고 판정이 중복되므로 채택하지 않았다. Suspended Account credential을 폐기하지 않고 local credential만 제거하는 방식은 재활성화 뒤 재사용 위험 때문에 채택하지 않았다. 일반 login context를 Suspended까지 확장하는 방식은 다른 보호 행동의 권한을 넓히므로 채택하지 않았다.
+- Consequences: GraphQL과 BFF는 transport별 credential 추출만 소유하고 같은 application action을 호출해야 한다. 이 예외는 current-session logout에만 적용하며, 기존 보호 query/mutation의 Active Account 회귀 검증이 필요하다.
 - Confirmation / Follow-up: Active/Suspended/Deleted Account와 Active/Revoked/Expired Session 조합을 entry integration test로 검증한다.
 
 ### GraphQL mutation은 대상 입력 없이 완료 여부만 반환한다

--- a/openspec/changes/add-current-session-logout/design.md
+++ b/openspec/changes/add-current-session-logout/design.md
@@ -34,8 +34,8 @@ Web은 Hono BFF가 발급한 HttpOnly `kosmo_session` cookie를 `/graphql`에서
 
 ### Recommended Approach
 
-1. **폐기 인증과 core action을 분리한다.** GraphQL resolver와 BFF route는 각 transport에서 받은 bearer/cookie credential을 server-side로 조회해 `revokeable current Session`, `already unauthenticated`, `unknown failure`를 구분한다. 일반 `ctx.session`의 Active Account 정책은 유지한다.
-2. **core는 검증된 current Session identity로 원자적 상태 전이를 수행한다.** Active Session만 조건부로 Revoked로 갱신하고, 갱신 실패 시 현재 Session/Account 상태를 다시 확인해 terminal winner 또는 삭제된 Account를 이미 인증 불가능한 결과로 분류한다. 명시적 비관적 lock 없이 PostgreSQL의 조건부 update와 짧은 transaction을 사용한다.
+1. **transport-neutral logout action이 폐기 인증과 조건부 revoke를 함께 소유한다.** GraphQL resolver와 BFF route는 bearer/cookie에서 얻은 raw Session credential을 같은 application action에 전달한다. 이 action이 `revokeable current Session`, `already unauthenticated`, `unknown failure`를 일관되게 구분하고, 일반 `ctx.session`의 Active Account 정책은 유지한다.
+2. **공유 action은 식별한 current Session을 원자적으로 전이한다.** Active Session만 조건부로 Revoked로 갱신하고, 갱신 실패 시 현재 Session/Account 상태를 다시 확인해 terminal winner 또는 삭제된 Account를 이미 인증 불가능한 결과로 분류한다. terminal/missing credential은 조건부 revoke 단계에 진입하지 않는다. 명시적 비관적 lock 없이 PostgreSQL의 조건부 update와 짧은 transaction을 사용한다.
 3. **GraphQL은 전용 mutation을 둔다.** `revokeCurrentSession`은 Session ID input 없이 special credential boundary를 사용하고, 확정 결과를 `RevokeCurrentSessionPayload { completed: Boolean! }`로 mapping한다. 예상 밖 DB/server 실패는 기존 `INTERNAL_SERVER_ERROR` 경로를 사용한다.
 4. **Web은 전용 `POST /logout` route를 둔다.** 구성된 public origin과 Origin header를 정확히 비교한 뒤 cookie credential을 처리한다. 확정 결과는 cache 불가 `204 No Content`와 동일 scope의 expired `kosmo_session` cookie로 응답하고, 불명 실패는 cookie를 유지한 채 non-2xx를 반환한다. `/graphql` proxy는 변경하지 않는다.
 5. **client logout action이 cleanup 순서를 소유한다.** Web은 credential 포함 `POST /logout`, Native는 Relay mutation을 호출한다. 성공 뒤 Native SecureStore token 삭제를 완료하고, 모든 runtime에서 actor revision을 바꿔 새 guest Environment/Store를 만든 다음 router replace로 `/`에 이동한다.
@@ -43,7 +43,7 @@ Web은 Hono BFF가 발급한 HttpOnly `kosmo_session` cookie를 `/graphql`에서
 
 ### Allowed Alternatives
 
-- GraphQL/BFF가 credential lookup 코드를 각각 소유해도 되고, transport 타입에 의존하지 않는 실제 공통 경계가 확인되면 server-side helper로 공유해도 된다. 어느 방식이든 일반 API `ctx.session` 정책을 넓히거나 core에 GraphQL/HTTP 타입을 전달해서는 안 된다.
+- GraphQL/BFF는 각 transport에서 raw Session credential을 추출하는 방식만 각각 소유할 수 있다. credential 조회·결과 분류·조건부 revoke는 transport-neutral logout action 안에서 직접 수행하거나 그 action만 사용하는 server-side helper로 분리할 수 있다. 어느 방식이든 일반 API `ctx.session` 정책을 넓히거나 공유 action에 GraphQL/HTTP 타입을 전달해서는 안 된다.
 - core의 조건부 전이는 단일 update 후 outcome 조회 또는 짧은 transaction 안의 동등한 방식으로 구현할 수 있다. specs의 terminal winner, 다른 Session 격리와 결과 분류를 만족해야 한다.
 - shell 실패 표현은 inline status 또는 기존 접근 가능한 공통 오류 surface를 사용할 수 있다. raw backend message나 credential material을 노출하지 않고 재시도를 제공해야 한다.
 

--- a/openspec/changes/add-current-session-logout/design.md
+++ b/openspec/changes/add-current-session-logout/design.md
@@ -1,0 +1,81 @@
+## Context
+
+현재 `session` table과 core enum에는 `ACTIVE`, `REVOKED`, `EXPIRED`가 이미 존재하지만, `packages/core/services`에는 Session 생성만 있고 현재 Session 폐기 action이 없다. API의 일반 request context는 Active Account와 Active Session만 `ctx.session`으로 도출하므로, 이 경계를 그대로 사용하면 Suspended Account의 Active Session을 폐기할 수 없고 terminal credential의 이미 인증 불가능한 결과도 결과 불명 실패와 구분할 수 없다.
+
+Web은 Hono BFF가 발급한 HttpOnly `kosmo_session` cookie를 `/graphql`에서 bearer header로 변환하고, Native는 SecureStore token으로 API GraphQL을 직접 호출한다. Expo client는 Relay actor revision으로 Environment/Store를 교체할 수 있지만, 기존 shell의 logout control에는 handler가 없다. PROD-474가 core/API/BFF를 먼저 전달하고 PROD-475가 그 경계에 공용 UI를 연결하며, PROD-473이 두 결과의 종단 간 검증과 archive를 소유한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Active 또는 Suspended Account의 현재 Active Session을 같은 transport-neutral core action으로 안전하게 폐기한다.
+- Web BFF와 Native GraphQL이 폐기, 이미 인증 불가능함과 결과 불명 실패를 일관되게 구분한다.
+- 결과가 확정된 뒤에만 runtime credential과 viewer 종속 Relay 상태를 정리한다.
+- 중복·경쟁 요청, 다른 Session 격리, Origin 보호와 cookie scope를 검증 가능한 경계로 만든다.
+- backend와 Expo client가 독립 PR로 전달될 수 있도록 task ownership을 분리한다.
+
+**Non-Goals:**
+
+- Session expiration/cleanup, Session 목록, 전체·원격 로그아웃, OIDC global logout
+- Session 폐기 시각·감사 이력 저장 또는 database schema 변경
+- 로그인 시 기존 Session 재사용 정책과 authorization model 변경
+- 메뉴 배치·스타일 개편과 Android·iOS production 배포
+
+## Implementation Guidance
+
+### Current Constraints
+
+- 일반 API context의 Active Account filter를 완화하면 Suspended Account가 다른 인증 행동까지 수행할 수 있으므로 logout 예외를 기존 `ctx.session`에 섞을 수 없다.
+- terminal Session과 Deleted Account credential은 일반 인증 context에서 사라지지만, logout transport는 이를 결과 불명 실패와 구분해야 한다.
+- revoked Session은 기존 `Session` GraphQL Node auth scope를 만족하지 않으므로 mutation payload에서 Session Node를 반환하면 불필요한 재조회·권한 충돌이 생긴다.
+- Web `/graphql` proxy는 upstream body를 그대로 전달하는 범용 경계다. logout cookie 제거를 이 proxy의 특정 GraphQL operation 해석에 결합하면 streaming proxy가 product action을 알아야 한다.
+- `kosmo_session`은 로그인 route가 public origin에 따라 Secure 속성을 결정하고 `Path=/`, `SameSite=Lax`, HttpOnly로 설정한다. 삭제 response가 이 scope와 어긋나면 browser에 stale cookie가 남는다.
+- Relay actor reset은 Environment/Store를 교체할 수 있지만, Web cookie는 client code가 직접 지울 수 없고 Native token 삭제는 비동기 SecureStore 경계를 거친다.
+
+### Recommended Approach
+
+1. **폐기 인증과 core action을 분리한다.** GraphQL resolver와 BFF route는 각 transport에서 받은 bearer/cookie credential을 server-side로 조회해 `revokeable current Session`, `already unauthenticated`, `unknown failure`를 구분한다. 일반 `ctx.session`의 Active Account 정책은 유지한다.
+2. **core는 검증된 current Session identity로 원자적 상태 전이를 수행한다.** Active Session만 조건부로 Revoked로 갱신하고, 갱신 실패 시 현재 Session/Account 상태를 다시 확인해 terminal winner 또는 삭제된 Account를 이미 인증 불가능한 결과로 분류한다. 명시적 비관적 lock 없이 PostgreSQL의 조건부 update와 짧은 transaction을 사용한다.
+3. **GraphQL은 전용 mutation을 둔다.** `revokeCurrentSession`은 Session ID input 없이 special credential boundary를 사용하고, 확정 결과를 `RevokeCurrentSessionPayload { completed: Boolean! }`로 mapping한다. 예상 밖 DB/server 실패는 기존 `INTERNAL_SERVER_ERROR` 경로를 사용한다.
+4. **Web은 전용 `POST /logout` route를 둔다.** 구성된 public origin과 Origin header를 정확히 비교한 뒤 cookie credential을 처리한다. 확정 결과는 cache 불가 `204 No Content`와 동일 scope의 expired `kosmo_session` cookie로 응답하고, 불명 실패는 cookie를 유지한 채 non-2xx를 반환한다. `/graphql` proxy는 변경하지 않는다.
+5. **client logout action이 cleanup 순서를 소유한다.** Web은 credential 포함 `POST /logout`, Native는 Relay mutation을 호출한다. 성공 뒤 Native SecureStore token 삭제를 완료하고, 모든 runtime에서 actor revision을 바꿔 새 guest Environment/Store를 만든 다음 router replace로 `/`에 이동한다.
+6. **shell control은 같은 action 상태를 공유한다.** full/compact/drawer control은 하나의 pending/error 상태를 사용해 중복 요청을 막고, 실패 시 credential과 Environment를 유지한 채 접근 가능한 오류와 재시도를 제공한다. 별도 확인 dialog 없이 기존 logout control을 직접 실행하는 방식을 기본으로 한다.
+
+### Allowed Alternatives
+
+- GraphQL/BFF가 credential lookup 코드를 각각 소유해도 되고, transport 타입에 의존하지 않는 실제 공통 경계가 확인되면 server-side helper로 공유해도 된다. 어느 방식이든 일반 API `ctx.session` 정책을 넓히거나 core에 GraphQL/HTTP 타입을 전달해서는 안 된다.
+- core의 조건부 전이는 단일 update 후 outcome 조회 또는 짧은 transaction 안의 동등한 방식으로 구현할 수 있다. specs의 terminal winner, 다른 Session 격리와 결과 분류를 만족해야 한다.
+- shell 실패 표현은 inline status 또는 기존 접근 가능한 공통 오류 surface를 사용할 수 있다. raw backend message나 credential material을 노출하지 않고 재시도를 제공해야 한다.
+
+### Known Traps
+
+- Suspended Account logout을 위해 일반 login scope에서 `Account.ACTIVE` filter를 제거하면 다른 보호 mutation의 권한이 확장된다.
+- mutation에 Session ID를 받거나 cookie를 browser script에서 읽는 방식은 current-session 및 HttpOnly 계약을 위반한다.
+- GraphQL proxy가 특정 operation response를 파싱해 cookie를 제거하게 만들면 범용 streaming proxy와 logout 정책이 결합된다.
+- server 요청 전에 SecureStore token 또는 Relay store를 지우면 결과 불명 실패를 복구할 수 없다.
+- `finally`에서 cookie/token을 제거하면 network 오류와 응답 유실도 성공으로 바뀐다.
+- 기존 Environment의 record만 일부 삭제하면 viewer-relative record와 in-flight response가 다음 actor 상태에 섞일 수 있다.
+- 명시적 row lock으로 모든 경쟁을 직렬화하면 현재 benign terminal-state race에 비해 복잡성과 deadlock 위험이 커진다.
+
+## Risks / Trade-offs
+
+- [응답 유실 뒤 server에서는 이미 revoke됐지만 client에는 credential이 남음] → retry가 terminal credential을 이미 인증 불가능한 확정 결과로 처리하고 그때 credential을 제거한다.
+- [Origin header 검증이 reverse proxy public origin과 어긋남] → login과 동일하게 `PUBLIC_ORIGIN`을 우선하고, local HTTP와 TLS termination case를 BFF test에 포함한다.
+- [cookie 삭제 scope 불일치] → 로그인/로그아웃이 같은 Session cookie 옵션 계산을 사용하고 `Set-Cookie` 속성을 회귀 검증한다.
+- [Suspended Account 예외가 일반 인증으로 전파됨] → revoke 전용 credential boundary를 두고 기존 `currentSession`과 보호 mutation의 Active Account 회귀 테스트를 유지한다.
+- [Relay cleanup 전에 이전 viewer UI가 잠깐 남음] → 성공 handler가 Environment 교체를 완료한 뒤 route replace를 수행하고, old Environment를 다음 session에 재사용하지 않는다.
+- [backend보다 client가 먼저 배포됨] → 요청 실패 시 credential과 authenticated UI를 유지하므로 데이터 손실은 없지만 logout이 동작하지 않는다. backend를 선배포해 이 창을 피한다.
+
+## Migration Plan
+
+1. PROD-474에서 core revoke, API schema/mutation과 Web BFF route를 기존 Session state에 additive하게 배포한다. database migration은 없다.
+2. 폐기·terminal credential·Suspended Account·결과 불명·경쟁·다른 Session 격리와 Origin/cookie response를 검증한다.
+3. PROD-475에서 generated Relay artifact와 공용 logout action/shell handler를 배포하고 Web·Native client 검증을 수행한다.
+4. PROD-473에서 Web cookie와 Native bearer 종단 간 흐름, 기존 login/session exchange 회귀와 Web production smoke를 확인한다.
+5. 모든 구현 slice와 통합 검증이 끝난 뒤에만 change를 archive한다.
+
+Rollback은 client를 먼저 이전 동작으로 되돌리고 backend endpoint를 후속으로 제거하는 순서를 사용한다. backend만 남는 것은 additive하고 안전하다. client가 남은 채 backend를 되돌리면 logout은 실패하되 credential을 유지하므로, backend rollback 전 client rollout 상태를 확인한다.
+
+## Open Questions
+
+제품 계약을 바꾸는 남은 질문은 없다. GraphQL payload, `POST /logout` response, direct-action UI와 cleanup 순서의 Implementation Choice는 `decisions.md`에서 OpenSpec Gate 승인 대상으로 제시한다.

--- a/openspec/changes/add-current-session-logout/proposal.md
+++ b/openspec/changes/add-current-session-logout/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Kosmo는 Web과 Native에서 현재 Session을 서버에서 폐기하고 runtime credential과 viewer 종속 상태를 안전하게 정리하는 종단 간 로그아웃 경로가 없다. 현재 Expo 로그아웃 버튼을 실제 동작에 연결하기 전에, 두 runtime이 같은 current-session revoke 계약과 결과 확정 규칙을 사용하도록 API·BFF·client 요구사항을 함께 정의해야 한다.
+
+## What Changes
+
+- 인증 경계가 식별한 현재 Active Session만 상태 수준에서 멱등하게 Revoked로 전이하는 transport-neutral core 동작을 추가한다.
+- Native bearer client용 current-session revoke GraphQL mutation을 추가한다.
+- Web HttpOnly session cookie를 사용하는 same-origin logout BFF를 추가하고, 폐기 또는 이미 인증 불가능한 상태가 확정된 응답에서만 cookie를 제거한다.
+- 공용 Expo 로그아웃 버튼을 Web BFF와 Native GraphQL 경계에 연결하고, 성공이 확정된 뒤 credential과 viewer 종속 Relay 상태를 정리해 비인증 화면으로 전환한다.
+- 결과 불명 실패에서는 credential과 기존 viewer 상태를 유지해 재시도할 수 있게 하고, 중복 실행을 방지하며 실패 상태를 접근 가능하게 표시한다.
+- PROD-474와 PROD-475가 각자 구현·테스트를 소유하고 PROD-473이 두 결과의 종단 간 통합 검증과 OpenSpec archive를 소유하도록 작업 경계를 분리한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/session.md`, `docs/domain/objects/account.md`
+- Linear Contract: `PROD-473`
+- Linear Implementations: `PROD-474`, `PROD-475`
+- Domain Gate: `PROD-344`
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `session-auth`: 현재 Session 폐기, GraphQL 진입점, terminal 상태·경쟁·다른 Session 격리와 인증 실패 의미를 추가한다.
+- `web-api-bridge`: Web logout BFF의 method·same-origin 보호·API 호출·HttpOnly cookie 제거 계약을 추가한다.
+- `universal-expo-client`: Web과 Native의 runtime별 로그아웃 호출, credential·Relay 상태 정리, 실패·재시도와 비인증 전환 계약을 추가한다.
+- `web-app-shell`: 기존 full/compact/drawer 로그아웃 control의 실행·진행·실패·접근성 동작을 추가한다.
+
+## Impact
+
+- `packages/core/services`의 Session application action과 기존 `session` state 저장 경계
+- API request authentication context와 Session GraphQL mutation/schema·integration tests
+- Web Hono BFF의 logout route, Origin 검증, upstream API 호출과 `kosmo_session` cookie response
+- Expo React Relay network/actor environment, Native SecureStore token 경계, Session provider와 공용 shell logout control
+- API schema와 Relay generated artifacts, core/API/BFF/client 단위·통합·Web smoke 검증
+- 새 dependency나 database schema migration은 요구하지 않는다.

--- a/openspec/changes/add-current-session-logout/specs/session-auth/spec.md
+++ b/openspec/changes/add-current-session-logout/specs/session-auth/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: 현재 Session 폐기 인증 경계
 
-**Authority / Provenance:** `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-473`, `PROD-474` 시스템은 current-session revoke 요청의 credential을 일반 인증 행동과 분리된 폐기 인증 경계에서 확인해야 한다(MUST). 이 경계는 credential이 가리키는 현재 Active Session과 연결 Account State를 확인하고, 클라이언트가 Session ID를 입력하지 않은 상태에서만 `Session.Self` 대상 identity를 도출해야 한다(MUST). 정상 폐기 가능 상태, 이미 인증 불가능한 확정 상태와 결과 불명 실패를 구분해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-473`, `PROD-474` 시스템은 current-session revoke 요청의 credential을 일반 인증 행동과 분리된 폐기 인증 경계에서 확인해야 한다(MUST). GraphQL과 Web transport가 같은 terminal-state 판정을 공유하도록 transport-neutral current-session logout action이 이 경계와 조건부 revoke를 함께 소유해야 한다(MUST). 이 경계는 credential이 가리키는 현재 Active Session과 연결 Account State를 확인하고, 클라이언트가 Session ID를 입력하지 않은 상태에서만 `Session.Self` 대상 identity를 도출해야 한다(MUST). 정상 폐기 가능 상태, 이미 인증 불가능한 확정 상태와 결과 불명 실패를 구분해야 한다(MUST).
 
 #### Scenario: Active Account의 현재 Active Session 식별
 
@@ -19,7 +19,7 @@
 #### Scenario: 이미 인증 불가능한 credential 확정
 
 - **WHEN** credential이 Deleted Account 또는 Revoked/Expired Session을 가리킨다
-- **THEN** 시스템은 revoke core에 진입하지 않는다
+- **THEN** 시스템은 조건부 Session revoke 단계에 진입하지 않는다
 - **AND** transport가 로그아웃 완료로 처리할 수 있는 이미 인증 불가능한 확정 결과를 반환한다
 
 #### Scenario: credential 확인 결과가 불명확함
@@ -30,11 +30,11 @@
 
 ### Requirement: 현재 Session의 멱등 폐기
 
-**Authority / Provenance:** `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-473`, `PROD-474` transport-neutral revoke core는 폐기 인증 경계가 식별한 현재 Session만 Active에서 Revoked로 전이해야 한다(MUST). Revoked와 Expired는 terminal 상태로 유지해야 하고(MUST), 같은 Account의 다른 Session을 변경해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-473`, `PROD-474` transport-neutral current-session logout action은 폐기 인증 경계가 식별한 현재 Session만 Active에서 Revoked로 전이해야 한다(MUST). Revoked와 Expired는 terminal 상태로 유지해야 하고(MUST), 같은 Account의 다른 Session을 변경해서는 안 된다(MUST NOT).
 
 #### Scenario: 현재 Active Session 폐기
 
-- **WHEN** revoke core가 검증된 현재 Active Session identity를 받는다
+- **WHEN** current-session logout action이 credential에서 현재 Active Session을 식별한다
 - **THEN** 시스템은 그 Session을 Revoked로 전이한다
 - **AND** 같은 Account의 다른 Session은 기존 상태를 유지한다
 
@@ -63,13 +63,13 @@
 #### Scenario: Native bearer Session 폐기 성공
 
 - **WHEN** Native client가 Active 또는 Suspended Account의 현재 Active Session bearer credential로 `revokeCurrentSession`을 호출한다
-- **THEN** API는 같은 transport-neutral revoke core를 사용해 현재 Session 폐기를 확정한다
+- **THEN** API는 같은 transport-neutral current-session logout action을 사용해 현재 Session 폐기를 확정한다
 - **AND** `completed: true`인 payload를 반환한다
 
 #### Scenario: 이미 인증 불가능한 bearer credential
 
 - **WHEN** mutation의 bearer credential이 Deleted Account 또는 Revoked/Expired Session을 가리킨다
-- **THEN** API는 revoke core에 진입하지 않는다
+- **THEN** 공유 action의 조건부 Session revoke 단계에 진입하지 않는다
 - **AND** 이미 인증 불가능함이 확정됐으므로 `completed: true`인 payload를 반환한다
 
 #### Scenario: 결과 불명 실패

--- a/openspec/changes/add-current-session-logout/specs/session-auth/spec.md
+++ b/openspec/changes/add-current-session-logout/specs/session-auth/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: 현재 Session 폐기 인증 경계
+
+**Authority / Provenance:** `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-473`, `PROD-474` 시스템은 current-session revoke 요청의 credential을 일반 인증 행동과 분리된 폐기 인증 경계에서 확인해야 한다(MUST). 이 경계는 credential이 가리키는 현재 Active Session과 연결 Account State를 확인하고, 클라이언트가 Session ID를 입력하지 않은 상태에서만 `Session.Self` 대상 identity를 도출해야 한다(MUST). 정상 폐기 가능 상태, 이미 인증 불가능한 확정 상태와 결과 불명 실패를 구분해야 한다(MUST).
+
+#### Scenario: Active Account의 현재 Active Session 식별
+
+- **WHEN** credential이 Active Account에 연결된 Active Session과 일치한다
+- **THEN** 시스템은 그 Session을 `Session.Self` current-session revoke 대상으로 식별한다
+- **AND** 클라이언트가 Session ID를 제출하지 않아도 된다
+
+#### Scenario: Suspended Account의 현재 Active Session 식별
+
+- **WHEN** credential이 Suspended Account에 연결된 Active Session과 일치한다
+- **THEN** 시스템은 `Account.Active`의 명시적 예외로 그 Session을 current-session revoke 대상으로 식별한다
+- **AND** 일반 인증 행동을 위한 Active Account session context로는 취급하지 않는다
+
+#### Scenario: 이미 인증 불가능한 credential 확정
+
+- **WHEN** credential이 Deleted Account 또는 Revoked/Expired Session을 가리킨다
+- **THEN** 시스템은 revoke core에 진입하지 않는다
+- **AND** transport가 로그아웃 완료로 처리할 수 있는 이미 인증 불가능한 확정 결과를 반환한다
+
+#### Scenario: credential 확인 결과가 불명확함
+
+- **WHEN** database 오류처럼 credential과 Session의 최종 상태를 확정할 수 없는 실패가 발생한다
+- **THEN** 시스템은 revoke 성공이나 이미 인증 불가능한 결과를 반환하지 않는다
+- **AND** caller가 credential을 유지하고 재시도할 수 있는 실패를 반환한다
+
+### Requirement: 현재 Session의 멱등 폐기
+
+**Authority / Provenance:** `docs/domain/objects/session.md`, `docs/domain/objects/account.md`; Linear: `PROD-473`, `PROD-474` transport-neutral revoke core는 폐기 인증 경계가 식별한 현재 Session만 Active에서 Revoked로 전이해야 한다(MUST). Revoked와 Expired는 terminal 상태로 유지해야 하고(MUST), 같은 Account의 다른 Session을 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: 현재 Active Session 폐기
+
+- **WHEN** revoke core가 검증된 현재 Active Session identity를 받는다
+- **THEN** 시스템은 그 Session을 Revoked로 전이한다
+- **AND** 같은 Account의 다른 Session은 기존 상태를 유지한다
+
+#### Scenario: 중복 폐기 요청
+
+- **WHEN** 같은 현재 Session에 대한 폐기 요청이 중복으로 처리된다
+- **THEN** 첫 확정 요청은 Session을 Revoked로 전이한다
+- **AND** 후속 요청은 terminal 상태를 Active로 되돌리지 않는다
+
+#### Scenario: 만료와 폐기가 경쟁함
+
+- **WHEN** 인증을 마친 폐기 요청과 Session 만료가 경쟁한다
+- **THEN** 먼저 확정된 Revoked 또는 Expired terminal 상태를 유지한다
+- **AND** 다른 terminal 상태로 덮어쓰거나 Active로 재활성화하지 않는다
+
+#### Scenario: 폐기된 credential 재사용
+
+- **WHEN** 폐기 완료 뒤 같은 credential로 새 인증 요청을 보낸다
+- **THEN** 일반 API 인증 경계는 현재 Session을 도출하지 않는다
+- **AND** 인증이 필요한 행동을 거부한다
+
+### Requirement: GraphQL current-session revoke mutation
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-474` Kosmo API는 bearer credential의 현재 Session을 폐기하는 `revokeCurrentSession` GraphQL mutation을 제공해야 한다(MUST). mutation은 Session ID 입력을 정의해서는 안 되며(MUST NOT), 폐기 또는 이미 인증 불가능한 상태가 확정된 경우에만 완료 payload를 반환해야 한다(MUST).
+
+#### Scenario: Native bearer Session 폐기 성공
+
+- **WHEN** Native client가 Active 또는 Suspended Account의 현재 Active Session bearer credential로 `revokeCurrentSession`을 호출한다
+- **THEN** API는 같은 transport-neutral revoke core를 사용해 현재 Session 폐기를 확정한다
+- **AND** `completed: true`인 payload를 반환한다
+
+#### Scenario: 이미 인증 불가능한 bearer credential
+
+- **WHEN** mutation의 bearer credential이 Deleted Account 또는 Revoked/Expired Session을 가리킨다
+- **THEN** API는 revoke core에 진입하지 않는다
+- **AND** 이미 인증 불가능함이 확정됐으므로 `completed: true`인 payload를 반환한다
+
+#### Scenario: 결과 불명 실패
+
+- **WHEN** mutation 처리 중 Session의 최종 상태를 확정할 수 없는 database 또는 server 실패가 발생한다
+- **THEN** API는 완료 payload를 반환하지 않는다
+- **AND** 기존 GraphQL internal error 계약으로 실패를 반환한다
+
+#### Scenario: 임의 Session 대상 입력 거부
+
+- **WHEN** client가 다른 Session ID를 mutation 입력으로 제출하려 한다
+- **THEN** GraphQL schema에는 해당 입력 필드가 존재하지 않는다
+- **AND** 요청 credential이 식별한 현재 Session 외의 Session을 폐기할 수 없다

--- a/openspec/changes/add-current-session-logout/specs/universal-expo-client/spec.md
+++ b/openspec/changes/add-current-session-logout/specs/universal-expo-client/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Runtime별 current-session logout 호출
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-475` 공용 Expo client는 사용자가 로그아웃을 요청하면 Web에서는 same-origin logout BFF를, Android/iOS에서는 `revokeCurrentSession` GraphQL mutation을 호출해야 한다(MUST). 두 runtime 모두 서버가 폐기 또는 이미 인증 불가능한 상태를 확정하기 전에는 local logout 완료로 전환해서는 안 된다(MUST NOT).
+
+#### Scenario: Web runtime 로그아웃 호출
+
+- **WHEN** Web 사용자가 공용 logout action을 실행한다
+- **THEN** client는 현재 origin의 `POST /logout`을 credential을 포함해 호출한다
+- **AND** browser script는 HttpOnly cookie 값을 읽거나 조작하지 않는다
+
+#### Scenario: Native runtime 로그아웃 호출
+
+- **WHEN** Android 또는 iOS 사용자가 공용 logout action을 실행한다
+- **THEN** client는 SecureStore에서 복원한 bearer credential로 공개 API의 `revokeCurrentSession` mutation을 호출한다
+- **AND** 임의 Session ID를 mutation input으로 전달하지 않는다
+
+#### Scenario: 이미 인증 불가능한 결과
+
+- **WHEN** runtime별 server 경계가 credential이 이미 인증 불가능한 확정 결과를 반환한다
+- **THEN** client는 정상 폐기와 같은 로그아웃 완료 경로를 실행한다
+
+### Requirement: 확정된 로그아웃의 credential과 Relay 상태 정리
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-475` client는 server 결과가 확정된 뒤에만 caller-owned credential과 viewer 종속 Relay Environment/Store를 제거해야 한다(MUST). 로그아웃한 viewer의 normalized cache를 다음 인증 또는 guest 상태에 재사용해서는 안 되며(MUST NOT), 정리 뒤 root onboarding route로 replace 이동해야 한다(MUST).
+
+#### Scenario: Web 로그아웃 정리
+
+- **WHEN** Web logout BFF가 성공 response를 반환하고 HttpOnly cookie 제거를 확정한다
+- **THEN** client는 viewer 종속 Relay Environment/Store를 새 guest 환경으로 교체한다
+- **AND** route history를 쌓지 않고 `/`로 replace 이동한다
+
+#### Scenario: Native 로그아웃 정리
+
+- **WHEN** Native GraphQL mutation이 로그아웃 완료 payload를 반환한다
+- **THEN** client는 기존 SecureStore 경계로 session token을 제거한다
+- **AND** viewer 종속 Relay Environment/Store를 새 guest 환경으로 교체한다
+- **AND** `/`로 replace 이동한다
+
+#### Scenario: 다음 인증에서 이전 viewer cache 격리
+
+- **WHEN** 사용자가 로그아웃 뒤 guest 상태를 사용하거나 다른 Session으로 로그인한다
+- **THEN** 이전 Session의 viewer-relative Relay record를 표시하지 않는다
+- **AND** 새 actor 상태의 query는 새 Environment/Store에서 실행한다
+
+### Requirement: 로그아웃 실패와 중복 실행 처리
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-475` client는 결과 불명 실패를 로그아웃 성공으로 표시해서는 안 되며(MUST NOT), credential과 기존 viewer 상태를 유지한 채 재시도를 제공해야 한다(MUST). 로그아웃 요청이 진행되는 동안 같은 action의 중복 실행을 방지해야 한다(MUST).
+
+#### Scenario: 결과 불명 실패 유지
+
+- **WHEN** runtime별 logout 요청이 network 오류, 응답 유실 또는 server error로 실패한다
+- **THEN** client는 local credential과 기존 Relay actor 상태를 유지한다
+- **AND** 비인증 화면으로 이동하지 않는다
+- **AND** 사용자가 로그아웃을 재시도할 수 있다
+
+#### Scenario: 진행 중 중복 실행
+
+- **WHEN** logout 요청이 진행되는 동안 사용자가 logout control을 다시 활성화한다
+- **THEN** client는 두 번째 server 요청을 시작하지 않는다
+- **AND** 하나의 진행 상태만 유지한다
+
+#### Scenario: 재시도 성공
+
+- **WHEN** 결과 불명 실패 뒤 사용자가 로그아웃을 다시 요청하고 server 결과가 확정된다
+- **THEN** client는 credential과 Relay 상태 정리를 한 번 완료한다
+- **AND** `/`로 replace 이동한다

--- a/openspec/changes/add-current-session-logout/specs/web-api-bridge/spec.md
+++ b/openspec/changes/add-current-session-logout/specs/web-api-bridge/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Same-origin Web logout BFF
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-474` Web BFF는 HttpOnly `kosmo_session` cookie의 현재 Session 로그아웃을 처리하는 `POST /logout` endpoint를 제공해야 한다(MUST). endpoint는 요청 Origin이 구성된 public origin과 정확히 일치할 때만 cookie credential을 사용해야 하고(MUST), GraphQL mutation과 같은 transport-neutral revoke core 계약을 사용해야 한다(MUST).
+
+#### Scenario: Same-origin Web 로그아웃
+
+- **WHEN** 구성된 public origin의 browser가 `kosmo_session` cookie와 같은 Origin header로 `POST /logout`을 요청한다
+- **THEN** BFF는 cookie credential이 식별한 current-session revoke 결과를 확정한다
+- **AND** 폐기 또는 이미 인증 불가능한 상태가 확정되면 `204 No Content`를 반환한다
+- **AND** response를 cache할 수 없게 한다
+
+#### Scenario: 다른 Origin의 요청 거부
+
+- **WHEN** `POST /logout`의 Origin header가 없거나 구성된 public origin과 다르다
+- **THEN** BFF는 current-session revoke를 실행하지 않는다
+- **AND** Session cookie를 제거하지 않고 forbidden response를 반환한다
+
+#### Scenario: 지원하지 않는 method 거부
+
+- **WHEN** client가 `/logout`에 POST 이외의 method를 사용한다
+- **THEN** BFF는 current-session revoke를 실행하지 않는다
+- **AND** `Allow: POST`를 포함한 method not allowed response를 반환한다
+
+#### Scenario: 결과 불명 실패
+
+- **WHEN** BFF가 Session의 최종 상태를 확정할 수 없는 database 또는 server 실패를 만난다
+- **THEN** BFF는 성공 response를 반환하지 않는다
+- **AND** 기존 Session cookie를 제거하지 않는다
+
+### Requirement: Web Session cookie 제거
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-474` Web BFF는 current-session revoke 또는 이미 인증 불가능한 상태가 확정된 response에서만 HttpOnly `kosmo_session` cookie를 제거해야 한다(MUST). 제거 response는 로그인 시 사용한 `Path=/`, SameSite와 HTTPS Secure 정책에 맞는 cookie scope를 사용해야 한다(MUST).
+
+#### Scenario: 폐기 확정 뒤 cookie 제거
+
+- **WHEN** BFF가 cookie credential의 현재 Session을 Revoked로 전이했음을 확정한다
+- **THEN** response는 `kosmo_session`을 즉시 만료한다
+- **AND** browser script가 cookie 값을 읽거나 직접 제거하지 않는다
+
+#### Scenario: 이미 인증 불가능한 cookie 제거
+
+- **WHEN** cookie가 없거나 credential이 Deleted Account 또는 Revoked/Expired Session을 가리켜 이미 인증 불가능함이 확정된다
+- **THEN** BFF는 로그아웃 완료 response와 함께 `kosmo_session` cookie를 즉시 만료한다
+
+#### Scenario: 불명확한 실패에서 cookie 유지
+
+- **WHEN** BFF가 revoke 결과를 확정하지 못한다
+- **THEN** response는 `kosmo_session` cookie를 만료하지 않는다
+- **AND** browser는 같은 credential로 로그아웃을 재시도할 수 있다

--- a/openspec/changes/add-current-session-logout/specs/web-app-shell/spec.md
+++ b/openspec/changes/add-current-session-logout/specs/web-app-shell/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: 공용 shell 로그아웃 control 실행
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-475` full sidebar, compact rail과 mobile drawer의 기존 로그아웃 control은 같은 공용 Expo logout action을 실행해야 한다(MUST). control의 표면과 관계없이 runtime별 server 경계, credential 정리와 비인증 전환 의미가 같아야 한다(MUST).
+
+#### Scenario: Full sidebar에서 로그아웃
+
+- **WHEN** 사용자가 full sidebar의 `로그아웃` control을 활성화한다
+- **THEN** 시스템은 현재 runtime의 공용 logout action을 실행한다
+
+#### Scenario: Compact rail에서 로그아웃
+
+- **WHEN** 사용자가 compact rail의 로그아웃 icon control을 활성화한다
+- **THEN** 시스템은 full sidebar와 같은 공용 logout action을 실행한다
+
+#### Scenario: Mobile drawer에서 로그아웃
+
+- **WHEN** 사용자가 mobile drawer의 `로그아웃` control을 활성화한다
+- **THEN** 시스템은 같은 공용 logout action을 실행한다
+- **AND** server 결과가 확정되기 전에는 drawer navigation만으로 guest 상태를 표시하지 않는다
+
+### Requirement: 로그아웃 control 진행·실패 접근성
+
+**Authority / Provenance:** `docs/domain/objects/session.md`; Linear: `PROD-473`, `PROD-475` 로그아웃 control은 요청 진행 중 중복 입력을 비활성화하고 진행 상태를 보조 기술에 전달해야 한다(MUST). 결과 불명 실패에서는 control을 다시 활성화하고, credential을 유지한 채 실패 안내와 재시도 동작을 제공해야 한다(MUST).
+
+#### Scenario: 진행 상태 표시
+
+- **WHEN** logout 요청이 진행 중이다
+- **THEN** 모든 shell 표면의 logout control은 추가 요청을 시작할 수 없는 상태가 된다
+- **AND** 보조 기술은 control이 busy 또는 disabled 상태임을 확인할 수 있다
+
+#### Scenario: 실패 상태와 재시도
+
+- **WHEN** logout 요청이 결과 불명 실패로 끝난다
+- **THEN** 사용자는 shell 안에서 로그아웃 실패 안내를 인지할 수 있다
+- **AND** logout control은 다시 활성화되어 같은 동작을 재시도할 수 있다
+
+#### Scenario: 성공 뒤 shell 이탈
+
+- **WHEN** logout 결과가 확정되고 credential과 Relay 상태 정리가 끝난다
+- **THEN** 시스템은 root onboarding route로 replace 이동한다
+- **AND** 이전 authenticated shell을 history back으로 다시 표시하지 않는다

--- a/openspec/changes/add-current-session-logout/tasks.md
+++ b/openspec/changes/add-current-session-logout/tasks.md
@@ -28,11 +28,11 @@ Native bearer client의 GraphQL mutation과 Web HttpOnly cookie client의 same-o
 - BFF에서 Origin, POST/405, 204/no-store, cookie scope·제거, cookie 없음/terminal 상태와 failure cookie 보존을 검증한다.
 - API schema 생성, 관련 typecheck·lint와 database 격리 test를 통과시킨다.
 
-- [ ] 1.1 current-session credential 결과와 Active→Revoked core 계약을 구현한다.
-- [ ] 1.2 중복·경쟁·terminal 상태·다른 Session 격리와 폐기 뒤 인증 거부를 core 검증으로 증명한다.
-- [ ] 1.3 input 없는 `revokeCurrentSession` GraphQL mutation과 완료/error 계약을 구현하고 API schema·integration 검증을 통과시킨다.
-- [ ] 1.4 same-origin `POST /logout` BFF와 확정 결과의 HttpOnly cookie 제거 계약을 구현하고 BFF 검증을 통과시킨다.
-- [ ] 1.5 PROD-474 범위의 typecheck·lint·관련 test 결과와 공개 계약 변경 사항을 PROD-473에 전달한다.
+- [x] 1.1 current-session credential 결과와 Active→Revoked core 계약을 구현한다.
+- [x] 1.2 중복·경쟁·terminal 상태·다른 Session 격리와 폐기 뒤 인증 거부를 core 검증으로 증명한다.
+- [x] 1.3 input 없는 `revokeCurrentSession` GraphQL mutation과 완료/error 계약을 구현하고 API schema·integration 검증을 통과시킨다.
+- [x] 1.4 same-origin `POST /logout` BFF와 확정 결과의 HttpOnly cookie 제거 계약을 구현하고 BFF 검증을 통과시킨다.
+- [x] 1.5 PROD-474 범위의 typecheck·lint·관련 test 결과와 공개 계약 변경 사항을 PROD-473에 전달한다.
 
 ## 2. PROD-475 공용 Expo logout 연결
 

--- a/openspec/changes/add-current-session-logout/tasks.md
+++ b/openspec/changes/add-current-session-logout/tasks.md
@@ -1,0 +1,106 @@
+## 1. PROD-474 현재 Session 폐기 server 경계
+
+**Authority / Provenance**
+
+- `docs/domain/objects/session.md`
+- `docs/domain/objects/account.md`
+- `PROD-344`
+- `PROD-473`
+- `PROD-474`
+
+**Deliverable**
+
+Native bearer client의 GraphQL mutation과 Web HttpOnly cookie client의 same-origin logout BFF가 같은 current-session revoke 계약을 사용해, 폐기 또는 이미 인증 불가능한 결과를 확정하고 결과 불명 실패와 구분한다.
+
+**Guardrails**
+
+- 인증 경계가 `Session.Self`로 식별한 현재 Active Session만 폐기하며 client Session ID 입력을 받지 않는다.
+- Suspended Account의 현재 Active Session 폐기만 `Account.Active`의 예외로 허용하고 일반 보호 행동의 Active Account 정책은 유지한다.
+- Revoked/Expired terminal 상태를 재활성화하거나 같은 Account의 다른 Session을 변경하지 않는다.
+- GraphQL과 BFF는 같은 transport-neutral revoke core 계약을 사용한다.
+- Web은 exact same-origin POST에서만 cookie credential을 처리하고, 결과가 확정된 response에서만 기존 scope의 HttpOnly cookie를 제거한다.
+- database schema, Session 폐기 시각·감사 이력과 원격/전체 로그아웃을 추가하지 않는다.
+
+**Verification**
+
+- core에서 Active→Revoked, 중복·만료 경쟁, terminal 보존, 다른 Session 격리와 폐기 credential 거부를 검증한다.
+- API에서 Active/Suspended/Deleted Account와 Active/Revoked/Expired Session 조합, input 없는 payload와 결과 불명 error를 검증한다.
+- BFF에서 Origin, POST/405, 204/no-store, cookie scope·제거, cookie 없음/terminal 상태와 failure cookie 보존을 검증한다.
+- API schema 생성, 관련 typecheck·lint와 database 격리 test를 통과시킨다.
+
+- [ ] 1.1 current-session credential 결과와 Active→Revoked core 계약을 구현한다.
+- [ ] 1.2 중복·경쟁·terminal 상태·다른 Session 격리와 폐기 뒤 인증 거부를 core 검증으로 증명한다.
+- [ ] 1.3 input 없는 `revokeCurrentSession` GraphQL mutation과 완료/error 계약을 구현하고 API schema·integration 검증을 통과시킨다.
+- [ ] 1.4 same-origin `POST /logout` BFF와 확정 결과의 HttpOnly cookie 제거 계약을 구현하고 BFF 검증을 통과시킨다.
+- [ ] 1.5 PROD-474 범위의 typecheck·lint·관련 test 결과와 공개 계약 변경 사항을 PROD-473에 전달한다.
+
+## 2. PROD-475 공용 Expo logout 연결
+
+**Authority / Provenance**
+
+- `docs/domain/objects/session.md`
+- `PROD-473`
+- `PROD-474`
+- `PROD-475`
+
+**Deliverable**
+
+full/compact/drawer의 공용 로그아웃 control이 Web에서는 logout BFF를, Android/iOS에서는 GraphQL mutation을 사용하고, 결과가 확정된 뒤 credential과 viewer 종속 Relay 상태를 정리해 비인증 화면으로 전환한다.
+
+**Guardrails**
+
+- Web UI는 HttpOnly cookie를 읽거나 직접 조작하지 않고 Native token은 기존 SecureStore 경계로만 제거한다.
+- server 결과가 확정되기 전에 local credential, Relay Environment/Store 또는 authenticated route를 제거하지 않는다.
+- 결과 불명 실패에서는 credential과 현재 viewer 상태를 유지하고 재시도를 제공한다.
+- 이전 viewer Relay cache를 guest 또는 다음 Session에 재사용하지 않는다.
+- 모든 shell surface는 하나의 pending/error 상태를 공유해 중복 server 요청을 막고 접근 가능한 상태를 제공한다.
+- 메뉴 스타일·배치 개편과 Android·iOS production 배포를 포함하지 않는다.
+
+**Verification**
+
+- Web과 Native가 각 runtime server 경계를 호출하고 이미 인증 불가능한 결과를 성공으로 정리하는지 검증한다.
+- 성공 시 credential cleanup→새 guest Relay Environment/Store→`/` replace 순서와 다음 Session cache 격리를 검증한다.
+- network/server failure에서 credential·Environment·route 유지, 오류 안내, 재시도와 중복 실행 방지를 검증한다.
+- full/compact/drawer control의 press, busy/disabled, 실패 안내와 접근성 상태를 검증한다.
+- Relay compile, client typecheck·lint, Web export/E2E와 2026-07-29 Web production smoke 결과를 남긴다.
+
+- [ ] 2.1 Web BFF와 Native GraphQL을 선택하는 공용 runtime logout action을 구현한다.
+- [ ] 2.2 확정된 성공 뒤 credential과 Relay Environment/Store를 정리하고 `/`로 replace 이동하는 흐름을 구현한다.
+- [ ] 2.3 full/compact/drawer logout control에 공용 action, 중복 방지와 접근 가능한 진행·실패·재시도 상태를 연결한다.
+- [ ] 2.4 Web·Native 성공/이미 비인증/결과 불명/중복 실행/cache 격리 검증과 Relay compile·client check를 통과시킨다.
+- [ ] 2.5 2026-07-29 Web production 배포 뒤 logout smoke 결과를 PROD-473에 전달한다.
+
+## 3. PROD-473 종단 간 통합 검증과 archive 준비
+
+**Authority / Provenance**
+
+- `docs/domain/objects/session.md`
+- `docs/domain/objects/account.md`
+- `PROD-344`
+- `PROD-473`
+- `PROD-474`
+- `PROD-475`
+
+**Deliverable**
+
+PROD-474와 PROD-475의 독립 구현 결과가 Web cookie와 Native bearer runtime에서 하나의 current-session logout 사용자 결과를 완성하며, 기존 로그인·Session 교환을 회귀시키지 않고 OpenSpec archive 준비 상태에 도달한다.
+
+**Guardrails**
+
+- 두 구현 자식은 각자 구현·테스트·PR을 완료하고, 부모는 자식 test를 단순 반복하지 않고 연결된 사용자·시스템 흐름을 검증한다.
+- 폐기된 credential은 거부되고 같은 Account의 다른 Session은 유지되어야 한다.
+- 결과 불명 실패를 성공으로 표시하거나 credential을 제거해서는 안 된다.
+- Android·iOS production 배포는 완료 조건이 아니며 Web production smoke만 소비한다.
+- 모든 current change task, 구현 PR, 통합 검증과 authority 정합성이 완료되기 전에는 archive하지 않는다.
+
+**Verification**
+
+- Web에서 cookie Session 폐기, cookie 제거, Relay guest 전환, 재시도와 보호 route 비인증 전환을 종단 간 확인한다.
+- Native에서 bearer Session 폐기, SecureStore 정리, Relay guest 전환과 같은 Account의 다른 Session 보존을 통합 확인한다.
+- browser login callback, Native OIDC exchange, currentSession 조회와 기존 보호 GraphQL 경로의 회귀 검증을 통과시킨다.
+- 최신 canonical·Linear·delta specs·decisions·tasks 정합성과 strict validation을 archive 직전 다시 확인한다.
+
+- [ ] 3.1 PROD-474와 PROD-475가 각자 소유한 구현·테스트·PR 및 전달 증거가 완료됐는지 확인한다.
+- [ ] 3.2 Web cookie와 Native bearer의 current-session logout 종단 간 흐름 및 다른 Session 격리를 통합 검증한다.
+- [ ] 3.3 기존 browser login, Native Session exchange, currentSession과 보호 API 회귀 검증을 통과시킨다.
+- [ ] 3.4 최신 canonical·Linear와 OpenSpec 정합성, 남은 Blocked decision 부재와 strict validation을 확인해 Completion Gate archive 검토 자료를 준비한다.

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -18,4 +18,5 @@ export {
   rejectProfileFollowRequest,
 } from './profile-follow-request';
 export { addReaction, deleteReaction } from './reaction';
-export { createOidcSession } from './session';
+export type { RevokeCurrentSessionResult } from './session';
+export { createOidcSession, revokeCurrentSession } from './session';

--- a/packages/core/services/session.test.ts
+++ b/packages/core/services/session.test.ts
@@ -1,10 +1,12 @@
+import '@kosmo/core/polyfill';
+
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
-import { eq } from 'drizzle-orm';
-import { Accounts, db, firstOrThrow, pg, Sessions } from '../db';
+import { eq, inArray } from 'drizzle-orm';
+import { AccountProfiles, Accounts, db, firstOrThrow, pg, Sessions } from '../db';
 import { AccountState, SessionState } from '../enums';
 import { PermissionDeniedError } from '../error';
-import { createOidcSession } from './session';
+import { createOidcSession, revokeCurrentSession } from './session';
 
 after(async () => {
   await pg.end();
@@ -81,3 +83,154 @@ for (const state of [AccountState.SUSPENDED, AccountState.DISABLED]) {
     assert.deepEqual(await loadSessions(account.id), []);
   });
 }
+
+const createFixture = async ({
+  accountState = AccountState.ACTIVE,
+  sessionState = SessionState.ACTIVE,
+}: {
+  accountState?: AccountState;
+  sessionState?: SessionState;
+} = {}) => {
+  const suffix = crypto.randomUUID();
+  const account = await db
+    .insert(Accounts)
+    .values({ displayName: suffix, oidcSubject: suffix, state: accountState })
+    .returning()
+    .then(firstOrThrow);
+  const session = await db
+    .insert(Sessions)
+    .values({ accountId: account.id, state: sessionState, token: `token-${suffix}` })
+    .returning()
+    .then(firstOrThrow);
+
+  return { account, session };
+};
+
+const cleanup = async (accountIds: string[]) => {
+  await db.delete(Sessions).where(inArray(Sessions.accountId, accountIds));
+  await db.delete(AccountProfiles).where(inArray(AccountProfiles.accountId, accountIds));
+  await db.delete(Accounts).where(inArray(Accounts.id, accountIds));
+};
+
+test('현재 Active Session만 폐기하고 같은 Account의 다른 Session을 보존한다', async () => {
+  const { account, session } = await createFixture();
+  const other = await db
+    .insert(Sessions)
+    .values({
+      accountId: account.id,
+      state: SessionState.ACTIVE,
+      token: `other-${crypto.randomUUID()}`,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+  try {
+    assert.deepEqual(await revokeCurrentSession({ token: session.token }), { status: 'REVOKED' });
+    assert.equal(
+      (
+        await db.select({ state: Sessions.state }).from(Sessions).where(eq(Sessions.id, session.id))
+      )[0]?.state,
+      SessionState.REVOKED,
+    );
+    assert.equal(
+      (
+        await db.select({ state: Sessions.state }).from(Sessions).where(eq(Sessions.id, other.id))
+      )[0]?.state,
+      SessionState.ACTIVE,
+    );
+  } finally {
+    await cleanup([account.id]);
+  }
+});
+
+test('Suspended Account의 현재 Session은 폐기하고 Disabled Account는 이미 인증 불가로 처리한다', async () => {
+  const suspended = await createFixture({ accountState: AccountState.SUSPENDED });
+  const disabled = await createFixture({ accountState: AccountState.DISABLED });
+
+  try {
+    assert.deepEqual(await revokeCurrentSession({ token: suspended.session.token }), {
+      status: 'REVOKED',
+    });
+    assert.deepEqual(await revokeCurrentSession({ token: disabled.session.token }), {
+      status: 'ALREADY_UNAUTHENTICATED',
+    });
+    assert.equal(
+      (
+        await db
+          .select({ state: Sessions.state })
+          .from(Sessions)
+          .where(eq(Sessions.id, disabled.session.id))
+      )[0]?.state,
+      SessionState.ACTIVE,
+    );
+  } finally {
+    await cleanup([suspended.account.id, disabled.account.id]);
+  }
+});
+
+test('Revoked·Expired·missing credential은 terminal 결과를 유지한다', async () => {
+  const revoked = await createFixture({ sessionState: SessionState.REVOKED });
+  const expired = await createFixture({ sessionState: SessionState.EXPIRED });
+
+  try {
+    const results = await Promise.all([
+      revokeCurrentSession({ token: revoked.session.token }),
+      revokeCurrentSession({ token: expired.session.token }),
+      revokeCurrentSession({ token: 'missing-token' }),
+      revokeCurrentSession({}),
+    ]);
+    assert.deepEqual(results, [
+      { status: 'ALREADY_UNAUTHENTICATED' },
+      { status: 'ALREADY_UNAUTHENTICATED' },
+      { status: 'ALREADY_UNAUTHENTICATED' },
+      { status: 'ALREADY_UNAUTHENTICATED' },
+    ]);
+  } finally {
+    await cleanup([revoked.account.id, expired.account.id]);
+  }
+});
+
+test('동시 폐기 요청은 하나의 Revoked terminal 결과로 수렴한다', async () => {
+  const { account, session } = await createFixture();
+
+  try {
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => revokeCurrentSession({ token: session.token })),
+    );
+    assert.ok(
+      results.every(({ status }) => status === 'REVOKED' || status === 'ALREADY_UNAUTHENTICATED'),
+    );
+    assert.equal(
+      (
+        await db.select({ state: Sessions.state }).from(Sessions).where(eq(Sessions.id, session.id))
+      )[0]?.state,
+      SessionState.REVOKED,
+    );
+  } finally {
+    await cleanup([account.id]);
+  }
+});
+
+test('호출 transaction이 rollback되면 Session 폐기도 rollback된다', async () => {
+  const { account, session } = await createFixture();
+
+  try {
+    await assert.rejects(
+      db.transaction(async (tx) => {
+        assert.deepEqual(await revokeCurrentSession({ token: session.token }, tx), {
+          status: 'REVOKED',
+        });
+        throw new Error('rollback');
+      }),
+      /rollback/,
+    );
+    assert.equal(
+      (
+        await db.select({ state: Sessions.state }).from(Sessions).where(eq(Sessions.id, session.id))
+      )[0]?.state,
+      SessionState.ACTIVE,
+    );
+  } finally {
+    await cleanup([account.id]);
+  }
+});

--- a/packages/core/services/session.test.ts
+++ b/packages/core/services/session.test.ts
@@ -2,7 +2,7 @@ import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { AccountProfiles, Accounts, db, firstOrThrow, pg, Sessions } from '../db';
 import { AccountState, SessionState } from '../enums';
 import { PermissionDeniedError } from '../error';
@@ -206,6 +206,36 @@ test('동시 폐기 요청은 하나의 Revoked terminal 결과로 수렴한다'
       )[0]?.state,
       SessionState.REVOKED,
     );
+  } finally {
+    await cleanup([account.id]);
+  }
+});
+
+test('만료와 폐기가 경쟁하면 먼저 확정된 terminal 상태를 보존한다', async () => {
+  const { account, session } = await createFixture();
+
+  try {
+    const [revokeResult, expired] = await Promise.all([
+      revokeCurrentSession({ token: session.token }),
+      db
+        .update(Sessions)
+        .set({ state: SessionState.EXPIRED })
+        .where(and(eq(Sessions.id, session.id), eq(Sessions.state, SessionState.ACTIVE)))
+        .returning({ id: Sessions.id }),
+    ]);
+    const finalState = await db
+      .select({ state: Sessions.state })
+      .from(Sessions)
+      .where(eq(Sessions.id, session.id))
+      .then((rows) => rows[0]?.state);
+
+    if (expired.length === 1) {
+      assert.deepEqual(revokeResult, { status: 'ALREADY_UNAUTHENTICATED' });
+      assert.equal(finalState, SessionState.EXPIRED);
+    } else {
+      assert.deepEqual(revokeResult, { status: 'REVOKED' });
+      assert.equal(finalState, SessionState.REVOKED);
+    }
   } finally {
     await cleanup([account.id]);
   }

--- a/packages/core/services/session.test.ts
+++ b/packages/core/services/session.test.ts
@@ -2,7 +2,8 @@ import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
-import { and, eq, inArray } from 'drizzle-orm';
+import { setTimeout as delay } from 'node:timers/promises';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { AccountProfiles, Accounts, db, firstOrThrow, pg, Sessions } from '../db';
 import { AccountState, SessionState } from '../enums';
 import { PermissionDeniedError } from '../error';
@@ -112,6 +113,26 @@ const cleanup = async (accountIds: string[]) => {
   await db.delete(Accounts).where(inArray(Accounts.id, accountIds));
 };
 
+const waitUntilBlockedBy = async (blockingPid: number) => {
+  for (let attempt = 0; attempt < 250; attempt += 1) {
+    const [activity] = await db.execute<{ blocked: boolean }>(sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE ${blockingPid} = ANY(pg_blocking_pids(pid))
+      ) AS blocked
+    `);
+
+    if (activity?.blocked) {
+      return;
+    }
+
+    await delay(20);
+  }
+
+  assert.fail('Session revoke did not wait for the expiration transaction');
+};
+
 test('현재 Active Session만 폐기하고 같은 Account의 다른 Session을 보존한다', async () => {
   const { account, session } = await createFixture();
   const other = await db
@@ -211,32 +232,53 @@ test('동시 폐기 요청은 하나의 Revoked terminal 결과로 수렴한다'
   }
 });
 
-test('만료와 폐기가 경쟁하면 먼저 확정된 terminal 상태를 보존한다', async () => {
+test('폐기가 Active를 조회한 뒤 만료가 확정돼도 Expired terminal 상태를 보존한다', async () => {
   const { account, session } = await createFixture();
+  const expirationLocked = Promise.withResolvers<number>();
+  const allowExpiration = Promise.withResolvers<void>();
+  const expirationTransaction = db.transaction(async (tx) => {
+    const [connection] = await tx.execute<{ pid: number }>(
+      sql`SELECT pg_backend_pid()::int AS pid`,
+    );
+    assert.ok(connection);
+    await tx
+      .select({ id: Sessions.id })
+      .from(Sessions)
+      .where(eq(Sessions.id, session.id))
+      .for('update');
+    expirationLocked.resolve(connection.pid);
+    await allowExpiration.promise;
+
+    return tx
+      .update(Sessions)
+      .set({ state: SessionState.EXPIRED })
+      .where(and(eq(Sessions.id, session.id), eq(Sessions.state, SessionState.ACTIVE)))
+      .returning({ id: Sessions.id });
+  });
+  let revokeResult: ReturnType<typeof revokeCurrentSession> | undefined;
 
   try {
-    const [revokeResult, expired] = await Promise.all([
-      revokeCurrentSession({ token: session.token }),
-      db
-        .update(Sessions)
-        .set({ state: SessionState.EXPIRED })
-        .where(and(eq(Sessions.id, session.id), eq(Sessions.state, SessionState.ACTIVE)))
-        .returning({ id: Sessions.id }),
+    const blockingPid = await Promise.race([
+      expirationLocked.promise,
+      expirationTransaction.then(() => assert.fail('Expiration transaction ended before locking')),
     ]);
+    revokeResult = revokeCurrentSession({ token: session.token });
+    await waitUntilBlockedBy(blockingPid);
+    allowExpiration.resolve();
+
+    const [revoked, expired] = await Promise.all([revokeResult, expirationTransaction]);
     const finalState = await db
       .select({ state: Sessions.state })
       .from(Sessions)
       .where(eq(Sessions.id, session.id))
       .then((rows) => rows[0]?.state);
 
-    if (expired.length === 1) {
-      assert.deepEqual(revokeResult, { status: 'ALREADY_UNAUTHENTICATED' });
-      assert.equal(finalState, SessionState.EXPIRED);
-    } else {
-      assert.deepEqual(revokeResult, { status: 'REVOKED' });
-      assert.equal(finalState, SessionState.REVOKED);
-    }
+    assert.equal(expired.length, 1);
+    assert.deepEqual(revoked, { status: 'ALREADY_UNAUTHENTICATED' });
+    assert.equal(finalState, SessionState.EXPIRED);
   } finally {
+    allowExpiration.resolve();
+    await Promise.allSettled([expirationTransaction, ...(revokeResult ? [revokeResult] : [])]);
     await cleanup([account.id]);
   }
 });

--- a/packages/core/services/session.ts
+++ b/packages/core/services/session.ts
@@ -43,6 +43,12 @@ const loadCurrentSession = async (token: string, tx: Transaction) =>
 /**
  * Revokes the Session identified by a caller-owned credential.
  *
+ * Unlike ordinary authenticated actions, logout must classify missing and
+ * terminal credentials as settled outcomes without first producing a verified
+ * Session identity. Keeping that lookup in this shared action also prevents
+ * GraphQL and Web transports from implementing different terminal-state rules,
+ * so this action intentionally accepts a raw Kosmo Session credential.
+ *
  * Missing, disabled-account, revoked, and expired credentials are already
  * unauthenticated outcomes. Active Sessions on active or suspended Accounts
  * are revoked with a conditional update so a terminal concurrent winner is

--- a/packages/core/services/session.ts
+++ b/packages/core/services/session.ts
@@ -17,6 +17,79 @@ type VerifiedOidcIdentity = {
   oidcSubject: string;
 };
 
+export type RevokeCurrentSessionResult =
+  | { readonly status: 'REVOKED' }
+  | { readonly status: 'ALREADY_UNAUTHENTICATED' };
+
+type CurrentSessionState = {
+  readonly accountState: AccountState;
+  readonly id: string;
+  readonly state: SessionState;
+};
+
+const loadCurrentSession = async (token: string, tx: Transaction) =>
+  tx
+    .select({
+      accountState: Accounts.state,
+      id: Sessions.id,
+      state: Sessions.state,
+    })
+    .from(Sessions)
+    .innerJoin(Accounts, eq(Accounts.id, Sessions.accountId))
+    .where(eq(Sessions.token, token))
+    .limit(1)
+    .then((rows) => rows[0] as CurrentSessionState | undefined);
+
+/**
+ * Revokes the Session identified by a caller-owned credential.
+ *
+ * Missing, disabled-account, revoked, and expired credentials are already
+ * unauthenticated outcomes. Active Sessions on active or suspended Accounts
+ * are revoked with a conditional update so a terminal concurrent winner is
+ * never changed back to Active.
+ */
+export const revokeCurrentSession = async (
+  { token }: { readonly token?: string },
+  tx?: Transaction,
+): Promise<RevokeCurrentSessionResult> => {
+  if (!token) {
+    return { status: 'ALREADY_UNAUTHENTICATED' };
+  }
+
+  return getDatabaseConnection(tx).transaction(async (transaction) => {
+    const current = await loadCurrentSession(token, transaction);
+    if (
+      !current ||
+      current.accountState === AccountState.DISABLED ||
+      current.state !== SessionState.ACTIVE
+    ) {
+      return { status: 'ALREADY_UNAUTHENTICATED' } as const;
+    }
+
+    const revoked = await transaction
+      .update(Sessions)
+      .set({ state: SessionState.REVOKED })
+      .where(and(eq(Sessions.id, current.id), eq(Sessions.state, SessionState.ACTIVE)))
+      .returning({ id: Sessions.id })
+      .then((rows) => rows[0]);
+
+    if (revoked) {
+      return { status: 'REVOKED' } as const;
+    }
+
+    const settled = await loadCurrentSession(token, transaction);
+    if (
+      !settled ||
+      settled.accountState === AccountState.DISABLED ||
+      settled.state !== SessionState.ACTIVE
+    ) {
+      return { status: 'ALREADY_UNAUTHENTICATED' } as const;
+    }
+
+    throw new Error('Current Session revoke did not settle');
+  });
+};
+
 /**
  * Creates a Kosmo session for an OIDC identity that has already been verified
  * by the caller. Upstream OIDC tokens must not be persisted with the session.


### PR DESCRIPTION
## 무엇을 변경했는지

- current-session revoke core service를 추가해 Active Session을 Revoked로 전이합니다.
- Active/Suspended Account의 현재 Session, 이미 인증 불가능한 credential, 결과 불명 실패를 구분합니다.
- Session ID 입력 없이 동작하는 `revokeCurrentSession` GraphQL mutation을 추가했습니다.
- same-origin `POST /logout` Web BFF를 추가하고, 확정 결과에서만 HttpOnly `kosmo_session` cookie를 제거합니다.
- 만료와 폐기가 경쟁할 때 먼저 확정된 terminal 상태를 보존하는 회귀 테스트를 추가했습니다.
- database 결과를 확정할 수 없을 때 완료 payload 대신 GraphQL internal error를 반환하는 통합 테스트를 추가했습니다.

## 왜 변경했는지

- Native bearer client가 현재 Session을 폐기할 GraphQL 경계가 필요합니다.
- Web의 HttpOnly cookie는 browser UI에서 직접 제거할 수 없으므로 BFF server response에서 로그아웃을 완료해야 합니다.
- GraphQL과 Web이 같은 transport-neutral revoke 계약을 사용하도록 PROD-474 범위를 전달합니다.
- review에서 terminal 상태 경쟁과 결과 불명 실패 경계의 증거가 부족한 점을 확인해 명시적인 회귀 테스트로 보완했습니다.

## 이번 PR의 주요 결정

없음. 최신 canonical 문서와 Linear `PROD-344`·`PROD-473`·`PROD-474`, OpenSpec 결정을 대조해 기존 계약을 적용했습니다.

## 어떻게 확인할 수 있는지

- core session DB 격리 테스트: 10 passed
- GraphQL session DB 격리 통합 테스트: 5 passed
- Web BFF unit test: 29 passed
- API unit/schema test: 31 passed
- API/Web typecheck: passed
- API test 및 Web build: passed
- ESLint: passed
- Prettier: passed
- Syncpack: passed
- OpenSpec strict validation: passed
- latest `main` rebase 후 API/Web unit·typecheck와 OpenSpec strict validation 재검증: passed

DB 검증은 PROD-474 전용 Docker PostgreSQL과 격리 DB를 사용했습니다. 최신 `main`의 프로필 검색 변경까지 반영해 충돌 없이 다시 rebase했으며, 최종 PR head에서 관련 비-DB 검증을 재실행했습니다.

## 아직 어떤 문제가 남았는지

- PROD-475의 Expo logout UI 연결과 PROD-473의 종단 간 통합 검증은 후속 범위입니다.
- Web production smoke와 Native SecureStore/Relay cleanup은 PROD-475·PROD-473에서 수행합니다.
- 이 PR의 범위는 완료됐지만, 위 후속 범위가 남아 있으므로 OpenSpec change는 archive하지 않습니다.

Linear: PROD-474
Parent: PROD-473