### PR TITLE
Local Repost를 ActivityPub Announce와 Undo로 전달한다

### DIFF
--- a/apps/api/src/graphql/resolvers/post/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/delete.ts
@@ -1,5 +1,4 @@
-import { NotificationKind } from '@kosmo/core/enums';
-import { deleteNotificationBySource, deletePost } from '@kosmo/core/services';
+import { deletePost } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
@@ -22,13 +21,6 @@ builder.mutationField('deletePost', (t) =>
       const result = await deletePost({
         actorProfileId: ctx.session.profileId,
         postId: input.id.id,
-      });
-
-      await deleteNotificationBySource(NotificationKind.REPOST, result.postId).catch((error) => {
-        console.error('Post-commit Repost notification cleanup failed', {
-          error,
-          postId: result.postId,
-        });
       });
 
       return result;

--- a/apps/api/src/graphql/resolvers/post/mutation/repost.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/repost.ts
@@ -1,4 +1,4 @@
-import { createRepostNotification, repostPost } from '@kosmo/core/services';
+import { repostPost } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
@@ -17,10 +17,6 @@ builder.mutationField('repostPost', (t) =>
         actorProfileId: ctx.session.profileId,
         sourcePostId: input.sourceId.id,
       });
-
-      if (result.created) {
-        await createRepostNotification(result.repost.id).catch(() => undefined);
-      }
 
       return { repost: result.repost };
     },

--- a/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-28

--- a/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/decisions.md
+++ b/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/decisions.md
@@ -1,0 +1,97 @@
+## Context
+
+이 기록은 canonical Post·Profile·Instance 문서와 ADR 0010·0014·0017, 최신 PROD-496·447·448 계약, 현재 `repostPost`·`deletePost`, PROD-494 Post URI resolver와 remote Follow post-commit delivery 경계를 반영한다. 구현자는 이 기록과 별개로 최신 canonical 문서와 Linear authority를 다시 확인해야 한다.
+
+## Decision Records
+
+### Announce와 Undo identity는 immutable Repost Post UUID에서 파생한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496
+- Status: Active
+- Context / Problem: 중복 application action과 delivery 재호출이 서로 다른 activity를 만들면 원격 수신자가 같은 Repost lifecycle을 중복 객체로 처리하거나 Undo 대상을 식별하지 못한다.
+- Decision Outcome: Announce ID는 configured Local Instance canonical origin의 `/ap/announce/{repostId}`, Undo ID는 같은 lifecycle에서 파생된 `/ap/announce/{repostId}#undo`다. Announce actor는 Repost Author actor, object는 PROD-494 공통 resolver가 반환한 direct Source URI, published는 Repost 생성 시각이다. Undo는 같은 원본 Announce를 가리킨다.
+- Alternatives Considered: delivery 시점 UUID, GraphQL global ID, Author handle 포함 URI, Source URI와 actor pair 기반 identity. 재호출 안정성이 없거나 mutable/API presentation identity를 federation identity와 결합하므로 사용하지 않는다.
+- Consequences: Repost와 Source 관계를 보존하는 동안 process restart와 호출 경로에 관계없이 Announce/Undo를 재구성할 수 있다. 별도 outbound activity mapping row는 만들지 않는다.
+- Confirmation / Follow-up: Local/Remote Source, 반복 projection과 process context가 달라도 ID·actor·object·published가 같은지 검증한다.
+
+### Undo는 Source의 현재 표현이 아니라 보존된 identity를 사용한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496
+- Status: Active
+- Context / Problem: Repost가 취소될 때는 Repost가 Tombstone이고 Source도 먼저 Tombstone으로 전이됐을 수 있다. Active Note 제공 가능성을 요구하면 이미 전달한 Announce를 취소하지 못한다.
+- Decision Outcome: Undo projection은 Tombstone Repost에 보존된 direct Source 관계와 canonical ActivityPub URI로 원본 Announce를 재구성한다. Source Content나 현재 Note representation은 요구하지 않되 relation 또는 URI를 해석할 수 없으면 delivery를 생략한다.
+- Alternatives Considered: Active/Content Source만 Undo 허용, Announce payload를 별도 DB row에 저장, Source URI를 취소 시 network dereference. 첫 방식은 정상 취소를 막고 나머지는 PROD-448 또는 remote network scope를 끌어오므로 사용하지 않는다.
+- Consequences: Source Tombstone 뒤에도 identity가 남으면 정확한 Undo가 가능하다. hard-deleted/missing mapping처럼 identity가 없으면 현재 non-durable 경계에서는 skip한다.
+- Confirmation / Follow-up: Active와 Tombstone Local/Remote Source, missing mapping과 보존 관계 matrix를 검증한다.
+
+### 실제 delivery recipient는 행동 Local Profile의 established remote follower다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496
+- Status: Active
+- Context / Problem: Activity audience URI와 실제 HTTP inbox recipient는 다른 역할이다. 현재 followers dispatcher가 없고 Source Author를 별도 recipient로 추가하는 계약도 없다.
+- Decision Outcome: Announce/Undo audience는 Repost Visibility의 followers/Public 규칙을 사용한다. 실제 recipient는 행동 Profile을 followee로 하는 established remote follower 중 Active Profile, ACTIVE 또는 UNRESPONSIVE ActivityPub Instance와 inbox를 가진 actor다. Local, Suspended, inactive와 missing inbox recipient는 제외하며 Source Author는 follower가 아니면 추가하지 않는다.
+- Alternatives Considered: Source Author 항상 추가, 모든 materialized remote actor에게 broadcast, local follower 포함, ACTIVE Instance만 포함. 승인된 범위를 넓히거나 PROD-496의 ACTIVE/UNRESPONSIVE 계약을 축소하므로 사용하지 않는다.
+- Consequences: shared inbox가 있으면 이를 우선할 수 있고 local state는 federation으로 재전달하지 않는다. UNRESPONSIVE endpoint 실패는 post-commit 경계에서 관측된다.
+- Confirmation / Follow-up: follower 방향, Profile/Instance 상태, local/remote origin, inbox/shared inbox와 Source Author 비포함을 DB/Fedify test로 검증한다.
+
+### 최초 application 상태 전이만 outbound delivery를 시작한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, PROD-496
+- Status: Active
+- Context / Problem: Repost 생성은 duplicate/concurrent 요청을 같은 Active row로 수렴시키고 삭제도 반복·동시 요청에 멱등 성공한다. 모든 성공 응답에서 delivery하면 같은 user action이 여러 번 발송된다.
+- Decision Outcome: `repostPost`의 최초 생성 결과만 Announce를 시작하고, `deletePost` conditional update가 실제 Active→Tombstone 전이를 수행한 결과만 Undo를 시작한다. 반복 delivery helper 자체는 동일 identity를 유지하지만 application retry가 새 helper 호출을 만들지 않는다.
+- Alternatives Considered: 모든 성공 요청에서 재전송, 별도 delivery deduplication table, 클라이언트 request ID. 불필요한 중복을 만들거나 durable transport 범위를 선행하므로 사용하지 않는다.
+- Consequences: 생성은 기존 `created` 결과를 사용하고 삭제는 실제 conditional update 결과를 내부에 보존해야 한다. GraphQL payload는 바뀌지 않는다.
+- Confirmation / Follow-up: 순차·동시 생성과 취소에서 한 결과만 delivery를 시작하고 일반 Post/Reply/Quote 삭제는 Repost Undo를 시작하지 않는지 검증한다.
+
+### Repost core application service가 commit 후 Fedify를 동적 호출한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Implementation Choice
+- Authority / Provenance: PROD-447, PROD-496
+- Status: Active
+- Context / Problem: 현재 API package는 Fedify에 직접 의존하지 않고 core와 Fedify는 remote Follow에서 이미 dynamic import 기반 application→delivery 경계를 사용한다. Repost transaction callback이나 API 전용 분기에 delivery를 두면 검증된 경계와 caller 의미가 갈라진다.
+- Decision Outcome: Repost core application service는 transaction 결과를 먼저 commit한 뒤 Repost Notification lifecycle을 best-effort로 처리하고, 최초 상태 전이에만 `@kosmo/fedify` delivery adapter를 dynamic import한다. 두 side effect는 실패를 공유하지 않는다. adapter는 committed Author origin을 검증해 non-local Repost를 skip한다. API resolver orchestration, static package cycle이나 새 API→Fedify dependency는 추가하지 않는다.
+- Alternatives Considered: GraphQL resolver에서 Fedify 직접 호출, transaction callback 안에서 delivery, static core import, 별도 queue command service. 첫 방식은 application caller를 분산하고 나머지는 rollback 경계, package cycle 또는 제외 범위를 위반하므로 사용하지 않는다.
+- Consequences: core 직접 caller와 GraphQL caller가 같은 post-commit contract를 사용하고 향후 inbound remote Repost caller는 Author origin 검증으로 outbound loop를 만들지 않는다. 기존 core↔Fedify dynamic cycle은 유지된다.
+- Confirmation / Follow-up: transaction rollback에는 send가 없고 local 최초 전이만 send하며 remote-origin action은 skip하는 core service test로 검증한다.
+
+### Direct delivery 실패는 committed Repost 결과와 분리한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: PROD-447, PROD-448, PROD-496
+- Status: Active
+- Context / Problem: DB transaction commit 이후 Fedify projection 또는 remote HTTP가 실패할 수 있다. 오류를 application 밖으로 전파하면 실제 Repost 상태와 GraphQL 실패 응답이 불일치한다.
+- Decision Outcome: Announce/Undo projection과 send 오류는 Repost ID를 포함한 post-commit 관측 경계에서 catch/log하고, committed Active/Tombstone 상태와 기존 GraphQL payload를 반환한다. Notification side effect와도 실패를 공유하지 않는다.
+- Alternatives Considered: delivery를 transaction에 넣어 rollback, GraphQL 실패 유지와 refetch, commit 전 NATS enqueue, 이번 change에서 outbox/queue 도입. domain/응답 불일치 또는 승인된 제외 범위를 위반하므로 사용하지 않는다.
+- Consequences: commit→send 사이 process crash와 취소 시점 recipient 집합으로 인한 유실 구간이 남는다. PROD-448이 추후 same-transaction durable intent와 queue handoff로 이 임시 경계를 대체한다.
+- Confirmation / Follow-up: Announce/Undo query·serialization·HTTP failure를 주입해 DB state와 GraphQL payload가 성공으로 유지되고 각 로그가 남는지 검증한다.
+
+### Followers collection은 공개하지 않고 explicit recipient projection을 사용한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496
+- Status: Active
+- Context / Problem: Note audience에는 followers collection URI가 있지만 collection GET과 actor property는 기존 범위에서 제외됐다. Fedify `sendActivity`의 followers shorthand는 dispatcher가 필요하다.
+- Decision Outcome: 이번 delivery는 stored Follow와 ActivityPub actor endpoint에서 explicit recipient 배열을 만들고 Fedify에 전달한다. followers dispatcher, collection pagination/sync와 actor document 변경을 추가하지 않는다.
+- Alternatives Considered: followers dispatcher를 함께 공개, 첫 page dispatcher만 구현, activity audience URI만 넘기고 실제 recipient를 생략. 제품 공개 범위를 넓히거나 부분 delivery/무전송을 만들므로 사용하지 않는다.
+- Consequences: recipient projection query가 direct delivery 호출마다 실행된다. 대규모 fan-out과 collection sync는 별도 capability 또는 queue migration에서 다룬다.
+- Confirmation / Follow-up: 저장 follower 전체가 explicit recipient로 전달되고 public collection route와 actor document가 바뀌지 않는지 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/design.md
+++ b/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/design.md
@@ -1,0 +1,88 @@
+## Context
+
+현재 `packages/core/services/post.ts`의 `repostPost`는 Source 접근·구조·visibility를 검증하고 내부 transaction에서 Active contentless Repost를 멱등 생성해 `{ created, repost }`를 반환한다. `deletePost`는 Author를 검증한 뒤 Active Post를 Tombstone으로 전이하지만 실제 전이 여부를 반환하지 않는다. GraphQL resolver는 이 결과가 반환된 뒤 Repost Notification 생성·정리를 best-effort로 수행하므로 application side effect 소유권이 API와 core로 나뉘어 있다.
+
+`packages/fedify`에는 configured Local Instance context, local actor/key dispatcher, Follow/Undo delivery helper와 PROD-494의 Local/Remote Post ActivityPub URI resolver가 있다. Remote Follow application service는 transaction 안에서 결과를 확정한 뒤 dynamic import로 Fedify delivery를 호출하고 실패를 catch/log해 committed payload를 유지한다. 이 패턴이 PROD-447에서 검증된 현재 post-commit 경계다.
+
+Post audience에는 followers collection URI가 이미 사용되지만 followers collection dispatcher는 공개되지 않았다. 따라서 Fedify의 `"followers"` shorthand에 의존할 수 없고, 현재 저장된 established Follow와 ActivityPub actor endpoint에서 실제 recipient를 투영해야 한다. 저장소에는 MessageQueue, transactional outbox 또는 outbound delivery history가 연결되어 있지 않다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Local Repost identity에서 deterministic Announce와 Undo를 만든다.
+- Local/Remote Source에 PROD-494 Post URI resolver를 재사용한다.
+- Repost audience와 established remote follower recipient를 일관되게 적용한다.
+- 최초 생성·취소 transaction commit 이후에만 delivery를 시작한다.
+- delivery 실패를 committed domain/GraphQL 결과와 분리하고 관측한다.
+- 기존 Repost Notification과 일반 Post 삭제 동작을 회귀시키지 않는다.
+
+**Non-Goals:**
+
+- inbound Announce/Undo, Reply·Reaction federation, Quote·중첩 Repost federation
+- Source Author를 follower 관계와 무관한 recipient로 추가
+- followers/outbox collection endpoint와 actor document 확장
+- transactional outbox, NATS/Fedify MessageQueue, worker, durable retry/history
+- Repost 저장·visibility·GraphQL/UI 제품 계약 변경
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Repost 생성의 `created` 값은 partial unique index conflict를 정규화한 뒤에만 확정된다. insert 시도 전에 delivery 여부를 결정하면 동시 요청이 중복 Announce를 시작할 수 있다.
+- `deletePost`는 현재 이미 Tombstone인 반복 요청과 최초 update를 구분하지 않는다. post-transaction row 상태만 다시 읽으면 동시 취소 두 건이 모두 Undo를 시작할 수 있으므로 conditional update의 실제 반환 결과가 필요하다.
+- `@kosmo/api`는 `@kosmo/fedify`에 직접 의존하지 않고, `@kosmo/core`와 `@kosmo/fedify`는 기존 remote Follow delivery 때문에 runtime cycle을 dynamic import로 끊고 있다. 새 API→Fedify dependency를 추가하기보다 검증된 core application boundary를 재사용하는 편이 현재 구조와 맞는다.
+- Repost core action은 Local/Remote selected Profile 모두에 재사용될 수 있다. protocol helper가 committed Repost Author의 configured Local Instance 소속을 확인하지 않으면 remote-origin action을 Local Announce로 잘못 보낼 수 있다.
+- Undo 시점에는 Repost가 Tombstone이고 Source도 이후 Tombstone일 수 있다. Active Note projection을 그대로 재사용하면 원본 Announce identity를 복구하지 못한다. Activity identity projection과 현재 object representation availability를 구분해야 한다.
+- Post URI resolver는 Post lifecycle과 무관하게 저장 identity를 해석하지만 remote Post mapping이 없는 remote Source에는 URI를 만들 수 없다.
+- follower audience address만으로 실제 HTTP recipient가 정해지지 않는다. established remote follower의 actor URI, inbox와 선택적 shared inbox를 DB에서 projection해야 한다.
+- 현재 direct Fedify context에는 durable queue가 없으므로 send 실패가 호출자에게 전파된다. 모든 projection/query/serialization/send 오류를 commit 이후 관측 경계에서 함께 격리해야 한다.
+- `repostPost`와 `deletePost`는 caller-owned transaction에도 참여할 수 있지만 현재 transaction abstraction에는 after-commit hook이 없다. 전달 호출을 nested transaction 반환 직후 실행하면 outer transaction commit 전 side effect가 되므로, direct delivery는 `tx`를 받지 않은 top-level application 호출만 소유하고 caller-owned transaction 경로에서는 실행하지 않는다.
+
+### Recommended Approach
+
+1. `packages/fedify`에 committed Repost ID와 activity 종류를 입력받는 Repost delivery adapter를 둔다. adapter는 DB에서 Repost, Author Profile/Instance와 direct Source를 읽고 Local Author, Repost 구조/lifecycle와 Source identity 조건을 검증한다.
+2. Announce projection은 Active contentless Repost와 Content Source를 요구한다. Undo projection은 Tombstone Repost와 보존된 direct Source 관계/identity를 요구하되 Source의 현재 Content나 Active representation은 요구하지 않는다.
+3. activity ID는 configured Local Instance canonical origin과 Repost UUID에서 파생하고, actor는 Fedify context의 Local actor URI, object는 공통 Post URI resolver 결과를 사용한다. Announce와 Undo에는 Repost ID 기반의 같은 ordering key를 사용한다.
+4. Repost Visibility에서 followers/Public audience를 만들고, 행동 Profile을 followee로 가진 established Follow를 remote ActivityPub actor endpoint와 join해 recipient 배열을 만든다. Active Profile, non-Suspended ActivityPub Instance와 inbox를 요구하고 local follower를 제외한다. shared inbox가 있으면 Fedify의 shared inbox 우선 옵션을 사용한다.
+5. `repostPost`는 기존 transaction 결과를 먼저 확정한 뒤 `created: true`인 경우에만 dynamic import로 Announce delivery를 호출한다. helper가 non-local 또는 unavailable projection을 반환하면 조용히 skip하고, 예외는 Repost ID를 포함해 catch/log한 뒤 기존 결과를 반환한다.
+6. `deletePost` conditional update는 실제 전이된 row 또는 boolean을 내부 결과에 포함한다. transaction commit 뒤 실제 전이가 있었을 때만 dynamic import로 Undo delivery를 호출하고, adapter가 Repost가 아닌 구조를 skip하게 한다. GraphQL resolver는 기존 `postId`만 공개한다.
+7. Notification 생성·정리도 Repost application service의 top-level post-commit 경계로 이동한다. Notification과 Fedify delivery는 각각 실패를 격리하고, API resolver는 application 결과를 GraphQL payload로 변환하는 역할만 유지한다.
+8. Fedify adapter test는 activity projection과 send call을 검증하고, core/API test는 최초 상태 전이, post-commit 호출 조건과 failure isolation을 검증한다.
+
+### Allowed Alternatives
+
+- recipient projection을 Fedify adapter 내부 helper 또는 core의 read-only projection으로 둘 수 있다. 다만 protocol `Recipient` 형식과 ActivityPub URI 조립은 `packages/fedify`가 소유하고, application transaction 안에서 HTTP delivery를 수행하지 않아야 한다.
+- Undo `object`는 정확한 Announce identity를 유지하는 한 embedded Announce 또는 IRI 표현을 사용할 수 있다. 현재 Follow Undo와의 일관성을 위해 embedded Announce를 기본으로 한다.
+- transition 여부를 boolean 또는 반환 row로 표현할 수 있다. GraphQL public payload에 새 field를 추가하지 않고 동시 최초 전이를 정확히 구분해야 한다.
+
+### Known Traps
+
+- GraphQL resolver에서 transaction 시작 전에 delivery promise를 만들거나 core transaction callback 안에서 Fedify를 await하면 rollback된 Repost가 외부에 전달될 수 있다.
+- `repostPost`의 반환 row가 존재한다는 사실만으로 Announce를 보내면 duplicate action마다 재전송한다. 반드시 `created`를 사용한다.
+- Tombstone row를 읽었다는 이유만으로 Undo를 보내면 반복·동시 삭제가 중복 delivery를 시작한다. conditional update의 실제 transition 결과를 사용한다.
+- mapping 부재만으로 Source를 Local로 간주하거나 request host에서 activity URI를 만들면 PROD-494 identity와 갈라진다.
+- Undo에서 Active Source/Content를 요구하면 Source가 먼저 Tombstone된 Repost를 원격에서 취소할 수 없다.
+- Source Author를 암묵적으로 recipient에 더하거나 local follower에게 federation delivery를 하면 승인된 recipient 범위를 넓힌다.
+- `sendActivity(..., "followers", ...)`를 사용하면서 followers dispatcher를 구현하지 않거나 첫 page만 반환하면 delivery가 실패하거나 일부 follower만 받는다.
+- delivery 오류를 GraphQL까지 throw하거나 Notification catch와 하나로 묶으면 committed result 또는 독립 side effect 계약을 위반한다.
+
+## Risks / Trade-offs
+
+- [Risk] commit 직후 process 종료 시 Announce/Undo가 유실된다. → 현재 direct-delivery 제한으로 명시하고 PROD-448의 transactional outbox migration 전에는 durable 상태를 추가하지 않는다.
+- [Risk] Undo는 취소 시점의 현재 follower에게만 전달되어 과거 Announce recipient와 정확히 일치하지 않을 수 있다. → recipient history를 이번 범위에 추가하지 않고 stable activity identity로 수신 측 멱등 처리를 가능하게 한다.
+- [Risk] UNRESPONSIVE Instance delivery가 다시 실패할 수 있다. → 저장 endpoint가 있는 non-Suspended recipient에는 시도하되 실패를 post-commit 관측 경계에서 격리한다.
+- [Risk] recipient 수가 많으면 mutation 응답 시간이 길어진다. → 현재 scope에서는 direct delivery 제한을 수용하고 queue/fan-out migration을 PROD-448 이후 범위로 둔다.
+- [Risk] `packages/core`와 `packages/fedify`의 기존 runtime cycle이 유지된다. → static import를 추가하지 않고 PROD-447과 같은 post-commit dynamic import를 사용하며 package-graph 정리는 별도 소유 범위로 둔다.
+
+## Migration Plan
+
+1. storage migration 없이 Fedify Repost projection과 serialization을 추가하고 local/remote Source, recipient와 unavailable matrix를 검증한다.
+2. core Repost 생성·삭제의 최초 transition 판별과 post-commit delivery를 연결한다.
+3. delivery 실패 주입을 포함한 core/API integration과 기존 Notification·일반 삭제 회귀를 검증한다.
+4. OpenSpec strict, package typecheck/test와 workspace lint를 통과한 뒤 기존 API/Fedify process를 함께 배포한다.
+5. rollback은 Repost post-commit 호출과 Fedify adapter export를 제거하는 코드 rollback으로 수행한다. DB schema와 저장 row 변환이 없어 데이터 rollback은 필요하지 않다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/proposal.md
+++ b/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Kosmo의 Local Repost 생성과 취소는 domain transaction과 GraphQL mutation까지 구현되어 있지만 원격 ActivityPub follower에게 전달되지 않는다. PROD-494가 제공한 공통 Post identity를 재사용해 Repost를 안정적인 `Announce`와 정확한 `Undo`로 전달하되, 현재 direct-delivery 구조에서 외부 실패가 committed application 결과를 뒤집지 않게 한다.
+
+## What Changes
+
+- 최초 Local Repost 생성 뒤 Repost Post UUID에서 안정적인 ActivityPub `Announce` identity를 파생하고 Source Post의 canonical ActivityPub URI를 object로 전달한다.
+- 최초 Repost Tombstone 전이 뒤 같은 원본 `Announce`를 가리키는 안정적인 `Undo`를 전달한다.
+- Repost Visibility를 ActivityPub audience로 투영하고 행동 Local Profile의 established remote follower를 실제 recipient로 사용한다.
+- Local/Remote Source identity는 PROD-494의 `packages/fedify` Post URI resolver를 재사용한다.
+- domain transaction commit 뒤 Fedify로 직접 전달하고 delivery 실패는 관측하되 committed Repost 생성·취소와 GraphQL payload를 실패로 바꾸지 않는다.
+- 반복·동시 application action은 새 delivery를 시작하지 않고, 반복 delivery helper 호출은 동일 activity identity와 ordering domain을 사용한다.
+- transactional outbox, NATS/Fedify MessageQueue, durable retry/history와 follower/outbox collection 공개는 PROD-448을 포함한 후속 범위로 유지한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- Linear Contract: PROD-496
+- Linear Implementations: PROD-496. PROD-494가 선행 Local/Remote Post ActivityPub URI resolver를 제공하며 PROD-448은 비차단 후속 migration이다.
+
+## Capabilities
+
+### New Capabilities
+
+- `activitypub-local-repost-delivery`: Local Repost의 stable Announce/Undo identity, audience, remote follower recipient, post-commit direct delivery와 failure isolation을 정의한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `packages/fedify`: Repost projection, Announce/Undo serialization, remote follower recipient projection과 Fedify delivery helper
+- `packages/core`: `repostPost`와 `deletePost` transaction 결과에서 최초 생성·Active→Tombstone 전이를 판별하고, Repost Notification lifecycle과 Fedify delivery를 commit 이후 독립 best-effort side effect로 연결
+- `apps/api`: Repost Notification orchestration을 core에 위임하고 기존 GraphQL payload와 delivery failure integration 회귀 검증
+- GraphQL public schema와 Repost domain model에는 breaking change가 없다.
+- PostgreSQL schema, broker, queue, worker와 durable delivery 상태는 변경하지 않는다.

--- a/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/specs/activitypub-local-repost-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/specs/activitypub-local-repost-delivery/spec.md
@@ -1,0 +1,176 @@
+## ADDED Requirements
+
+### Requirement: Stable Local Repost Announce identity
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496. 시스템은 configured Local Instance에 속한 행동 Profile의 Local Repost를 immutable Repost Post DB UUID에서 파생한 안정적인 ActivityPub `Announce`로 표현하고, Local/Remote Source의 object identity에 PROD-494가 확정한 공통 ActivityPub Post URI 규칙을 재사용해야 한다(MUST).
+
+#### Scenario: Local Source Repost Announce
+
+- **WHEN** Local Profile이 Content가 있는 제공 가능한 Local Post를 처음 Repost하고 transaction이 commit된다
+- **THEN** 시스템은 `{canonicalOrigin}/ap/announce/{repostId}`를 `Announce.id`로 사용한다
+- **AND** `Announce.actor`는 Repost Author Profile의 canonical actor URI다
+- **AND** `Announce.object`는 `{canonicalOrigin}/ap/note/{sourcePostId}`다
+- **AND** `Announce.published`는 immutable Repost 생성 시각이다
+
+#### Scenario: Remote Source Repost Announce
+
+- **WHEN** Local Profile이 Content가 있고 existing ActivityPub Post mapping을 가진 제공 가능한 Remote Post를 처음 Repost하고 transaction이 commit된다
+- **THEN** 시스템은 Local Source와 같은 Repost 기반 `Announce.id`, actor와 published 규칙을 사용한다
+- **AND** `Announce.object`는 existing ActivityPub Post mapping의 remote object URI다
+- **AND** Remote Source에 Local Note identity나 새 ActivityPub Post mapping을 만들지 않는다
+
+#### Scenario: Stable Announce reconstruction
+
+- **WHEN** 같은 committed Repost identity의 Announce projection 또는 delivery가 반복된다
+- **THEN** 시스템은 항상 같은 Announce ID, actor, object와 published 값을 사용한다
+- **AND** request host, GraphQL global ID, Author handle과 delivery 시각을 identity에 포함하지 않는다
+
+### Requirement: Exact Local Repost Undo identity
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, PROD-496. 시스템은 취소된 Local Repost의 immutable identity와 보존된 direct Source 관계를 사용해 정확한 원본 Announce를 가리키는 안정적인 `Undo`를 표현해야 한다(MUST).
+
+#### Scenario: Repost cancellation Undo
+
+- **WHEN** Local Repost가 처음 Active에서 Tombstone으로 전이되고 transaction이 commit된다
+- **THEN** 시스템은 `{canonicalOrigin}/ap/announce/{repostId}#undo`를 `Undo.id`로 사용한다
+- **AND** `Undo.actor`는 원본 Announce actor와 같다
+- **AND** `Undo.object`는 같은 ID, actor, object와 published 값을 가진 원본 Announce를 가리킨다
+- **AND** Repost와 Source 관계를 hard delete하거나 transport mapping을 새로 저장하지 않는다
+
+#### Scenario: Source lifecycle after Announce
+
+- **WHEN** Repost 취소 전에 Source가 Tombstone으로 전이됐지만 direct Source 관계와 canonical ActivityPub identity가 남아 있다
+- **THEN** 시스템은 보존된 identity로 원본 Announce와 Undo를 재구성한다
+- **AND** Source의 현재 Content 표현을 요구하거나 embed하지 않는다
+
+#### Scenario: Stable Undo reconstruction
+
+- **WHEN** 같은 canceled Repost identity의 Undo projection 또는 delivery가 반복된다
+- **THEN** 시스템은 항상 같은 Undo ID와 원본 Announce identity를 사용한다
+- **AND** Announce와 Undo는 같은 Repost ordering domain을 사용한다
+
+### Requirement: Repost audience and remote follower recipients
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496. 시스템은 Repost Visibility를 ActivityPub audience로 투영하고 행동 Local Profile의 established remote follower 중 지원되는 recipient에게 Announce와 Undo를 전달해야 한다(MUST).
+
+#### Scenario: Unlisted Repost audience
+
+- **WHEN** Public 또는 Unlisted Source에서 파생된 Unlisted Repost의 Announce 또는 Undo를 직렬화한다
+- **THEN** activity `to`는 행동 Profile의 followers collection URI를 포함한다
+- **AND** activity `cc`는 ActivityStreams Public을 포함한다
+
+#### Scenario: Followers Only Repost audience
+
+- **WHEN** Author가 자신의 Followers Only Source에서 만든 Followers Only Repost의 Announce 또는 Undo를 직렬화한다
+- **THEN** activity `to`는 행동 Profile의 followers collection URI만 포함한다
+- **AND** activity `cc`는 ActivityStreams Public을 포함하지 않는다
+
+#### Scenario: Established remote follower recipients
+
+- **WHEN** 행동 Local Profile에 established follower인 Active Remote Profile이 있고 그 ActivityPub Instance가 ACTIVE 또는 UNRESPONSIVE이며 actor inbox가 저장되어 있다
+- **THEN** 시스템은 해당 remote actor를 delivery recipient로 포함한다
+- **AND** shared inbox가 저장되어 있으면 Fedify shared inbox delivery를 우선 사용한다
+
+#### Scenario: Unsupported recipients
+
+- **WHEN** follower가 Local Profile이거나 Profile이 inactive이거나 ActivityPub Instance가 Suspended이거나 actor inbox가 없다
+- **THEN** 시스템은 해당 follower를 delivery recipient에서 제외한다
+- **AND** 제외 사실 때문에 committed Repost action을 실패시키지 않는다
+
+#### Scenario: Source Author is not an implicit recipient
+
+- **WHEN** Remote Source Author가 행동 Profile의 established follower가 아니다
+- **THEN** 시스템은 Source Author라는 이유만으로 recipient에 추가하지 않는다
+- **AND** follower recipient와 activity audience 규칙을 확장하지 않는다
+
+### Requirement: First-transition post-commit delivery
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, PROD-447, PROD-496. 시스템은 Repost domain transaction이 성공적으로 commit된 뒤 최초 생성과 최초 취소 상태 전이에만 직접 Fedify delivery를 시작하고, 반복·동시 application action에서는 추가 activity delivery를 시작하지 않아야 한다(MUST).
+
+#### Scenario: First Repost creation delivery
+
+- **WHEN** Repost application action이 새 Active Repost를 생성하고 commit한다
+- **THEN** 시스템은 commit 이후 해당 Repost의 Announce delivery를 한 번 시작한다
+- **AND** commit 전에 Fedify delivery 또는 broker enqueue를 수행하지 않는다
+
+#### Scenario: Duplicate or concurrent Repost creation
+
+- **WHEN** 반복 또는 동시 Repost action이 기존 Active Repost identity로 수렴한다
+- **THEN** 최초 생성 결과만 Announce delivery를 시작한다
+- **AND** 기존 Repost를 반환한 action은 Announce delivery를 추가로 시작하지 않는다
+
+#### Scenario: First Repost cancellation delivery
+
+- **WHEN** deletePost가 Repost를 처음 Active에서 Tombstone으로 전이하고 commit한다
+- **THEN** 시스템은 commit 이후 해당 Repost의 Undo delivery를 한 번 시작한다
+- **AND** GraphQL public payload는 기존 Post global ID 계약을 유지한다
+
+#### Scenario: Duplicate or concurrent Repost cancellation
+
+- **WHEN** 반복 또는 동시 deletePost action이 이미 Tombstone인 같은 Repost를 대상으로 한다
+- **THEN** 최초 Tombstone 전이 결과만 Undo delivery를 시작한다
+- **AND** 이미 Tombstone인 결과는 Undo delivery를 추가로 시작하지 않는다
+
+#### Scenario: Non-Repost Post deletion
+
+- **WHEN** 일반 Post, Reply, Quote 또는 Reply이면서 Quote인 Content Post가 deletePost로 Tombstone 전이된다
+- **THEN** 시스템은 Repost Undo delivery를 시작하지 않는다
+- **AND** 기존 Post 삭제 결과를 유지한다
+
+### Requirement: Post-commit delivery failure isolation
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, PROD-447, PROD-448, PROD-496. 시스템은 direct Fedify Announce/Undo delivery 실패를 committed Repost application 결과와 분리해 관측하며, 외부 delivery 실패를 GraphQL mutation 실패나 domain state rollback으로 바꾸지 않아야 한다(MUST).
+
+#### Scenario: Announce delivery failure after commit
+
+- **WHEN** 새 Repost transaction이 commit된 뒤 Announce projection 또는 remote HTTP delivery가 실패한다
+- **THEN** 시스템은 실패를 Repost ID와 함께 post-commit delivery 관측 경계에 기록한다
+- **AND** committed Active Repost와 `repostPost` 성공 payload를 유지한다
+- **AND** delivery 실패를 이유로 Repost 또는 Notification 결과를 rollback하지 않는다
+
+#### Scenario: Undo delivery failure after commit
+
+- **WHEN** Repost Tombstone transaction이 commit된 뒤 Undo projection 또는 remote HTTP delivery가 실패한다
+- **THEN** 시스템은 실패를 Repost ID와 함께 post-commit delivery 관측 경계에 기록한다
+- **AND** committed Tombstone, count 감소, active uniqueness 해제와 `deletePost` 성공 payload를 유지한다
+- **AND** delivery 실패를 이유로 Repost를 Active로 복원하지 않는다
+
+#### Scenario: Independent post-commit side effects
+
+- **WHEN** Repost Notification 생성·정리와 ActivityPub delivery 중 하나가 실패한다
+- **THEN** 시스템은 각 실패를 독립적으로 격리한다
+- **AND** 한 side effect 실패가 다른 side effect 실행 또는 committed application payload를 실패시키지 않는다
+
+#### Scenario: Accepted direct-delivery loss window
+
+- **WHEN** application process가 domain commit 이후 Fedify delivery 시작 전에 종료된다
+- **THEN** 이번 capability는 durable intent, retry 또는 delivery history를 생성하지 않는다
+- **AND** PROD-448 migration 전까지 activity가 유실될 수 있는 현재 제한을 수용한다
+
+### Requirement: Repost delivery availability and scope boundary
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496. 시스템은 canonical Repost와 Source activity를 안전하게 재구성할 수 있는 경우에만 outbound Repost delivery를 시도하며, sibling interaction과 durable transport 범위를 추가하지 않아야 한다(MUST).
+
+#### Scenario: Unsupported Repost structure
+
+- **WHEN** 대상 Post에 Content가 있거나 Reply Parent가 있거나 direct Repost Source가 없다
+- **THEN** 시스템은 그 Post를 outbound Repost Announce/Undo 대상으로 취급하지 않는다
+- **AND** Quote, Reply이면서 Quote 또는 일반 Post를 Repost activity로 직렬화하지 않는다
+
+#### Scenario: Unavailable Announce projection
+
+- **WHEN** Repost 또는 Author가 unavailable하거나 configured Local Instance에 속하지 않거나 direct Source가 missing·contentless이거나 canonical ActivityPub URI를 해석할 수 없다
+- **THEN** 시스템은 Announce delivery를 시도하지 않는다
+- **AND** unavailable 원인을 GraphQL 결과로 새로 노출하지 않는다
+
+#### Scenario: Unavailable Undo projection
+
+- **WHEN** canceled Repost identity, Local Author identity, 보존된 Source 관계 또는 Source canonical ActivityPub URI를 해석할 수 없다
+- **THEN** 시스템은 Undo delivery를 시도하지 않는다
+- **AND** committed Tombstone 결과를 유지한다
+
+#### Scenario: Excluded transport and sibling capabilities
+
+- **WHEN** Local Repost Announce/Undo capability를 제공한다
+- **THEN** 시스템은 inbound Announce materialization, Reply·Reaction federation, Quote·중첩 Repost federation을 추가하지 않는다
+- **AND** followers/outbox collection, transactional outbox, NATS/Fedify MessageQueue, worker, durable retry/history와 사용자용 delivery status를 추가하지 않는다

--- a/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/tasks.md
+++ b/openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/tasks.md
@@ -1,0 +1,111 @@
+## 1. PROD-496 Announce/Undo identity와 recipient delivery
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/profile.md`
+- `docs/domain/objects/instance.md`
+- `docs/domain/decisions/0010-post-interaction-contracts.md`
+- `docs/domain/decisions/0014-post-structure-relations.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- PROD-496
+
+**Deliverable**
+
+Committed Local Repost identity를 Local/Remote Source에 공통인 안정적인 Announce와 정확한 Undo로 직렬화하고, Repost audience를 가진 activity를 행동 Profile의 지원되는 established remote follower에게 Fedify로 전달할 수 있다.
+
+**Guardrails**
+
+- Announce와 Undo identity는 configured Local Instance canonical origin과 immutable Repost Post UUID에서 파생한다.
+- Local/Remote Source는 PROD-494 Post URI resolver를 재사용하고 별도 mapping이나 URI 규칙을 만들지 않는다.
+- Announce는 Active contentless Repost와 Content Source만 지원하고, Undo는 Tombstone Repost에 보존된 Source identity를 사용한다.
+- Source Author를 follower 관계와 무관한 recipient로 추가하지 않는다.
+- Local, inactive, Suspended와 missing inbox recipient를 제외하고 ACTIVE/UNRESPONSIVE remote follower를 지원한다.
+- followers/outbox collection, queue, retry와 delivery history를 추가하지 않는다.
+
+**Verification**
+
+- Local/Remote Source의 ID·actor·object·published와 Unlisted/Followers Only audience를 검증한다.
+- Source Tombstone 뒤 exact Undo, 반복 projection identity와 같은 ordering domain을 검증한다.
+- follower 방향, Profile/Instance 상태, actor inbox/shared inbox, local follower 제외와 Source Author 비포함을 검증한다.
+- unsupported 구조, missing mapping과 unavailable Author/Instance가 delivery를 만들지 않는지 검증한다.
+
+- [x] 1.1 Local/Remote Source를 공통 identity로 해석하는 Repost Announce와 exact Undo projection을 구현한다.
+- [x] 1.2 Repost Visibility audience와 established remote follower recipient projection을 구현하고 Fedify direct delivery에 연결한다.
+- [x] 1.3 identity, audience, recipient, shared inbox, unavailable와 Source lifecycle matrix의 Fedify 검증을 추가한다.
+
+## 2. PROD-496 최초 상태 전이와 post-commit failure isolation
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/decisions/0010-post-interaction-contracts.md`
+- PROD-447
+- PROD-496
+
+**Deliverable**
+
+최초 Local Repost 생성과 최초 Repost 취소 transaction이 commit된 뒤에만 Announce/Undo delivery가 시작되고, projection 또는 remote delivery 실패에도 committed Repost 상태와 기존 GraphQL payload가 성공으로 유지된다.
+
+**Guardrails**
+
+- transaction callback이나 commit 전에 Fedify delivery와 broker enqueue를 수행하지 않는다.
+- duplicate/concurrent Repost 생성은 기존 `created` 결과에 따라 추가 Announce를 시작하지 않는다.
+- duplicate/concurrent 삭제는 conditional Active→Tombstone 전이 결과에 따라 추가 Undo를 시작하지 않는다.
+- 일반 Post, Reply, Quote와 Reply이면서 Quote 삭제는 Repost Undo를 만들지 않는다.
+- protocol adapter는 non-local Author의 Repost를 Local activity로 보내지 않는다.
+- GraphQL public schema와 `repostPost`·`deletePost` payload를 변경하지 않는다.
+- Notification 생성·정리와 ActivityPub delivery 실패는 독립적으로 격리한다.
+
+**Verification**
+
+- transaction rollback에는 delivery가 없고 최초 commit에만 delivery가 있음을 검증한다.
+- 순차·동시 생성과 취소에서 한 결과만 delivery를 시작함을 검증한다.
+- non-local Author와 non-Repost 삭제가 delivery를 만들지 않는지 검증한다.
+- Announce/Undo projection·HTTP failure를 주입해 DB state, count, uniqueness, 재Repost와 GraphQL payload가 성공으로 유지되는지 검증한다.
+- 기존 Repost Notification 생성·정리 실패 격리와 일반 Post 삭제 회귀를 검증한다.
+
+- [x] 2.1 Repost 생성 결과를 commit한 뒤 최초 생성에만 Local Announce delivery를 시작하고 실패를 관측 경계에서 격리한다.
+- [x] 2.2 Post 삭제의 실제 Active→Tombstone 전이 여부를 내부 결과로 보존하고 최초 Repost 취소에만 Undo delivery를 연결한다.
+- [x] 2.3 duplicate/concurrent action, rollback, non-local/non-Repost 분기와 post-commit delivery 실패의 core/API 검증을 추가한다.
+- [x] 2.4 기존 GraphQL payload와 Repost Notification·count·재Repost lifecycle 회귀 검증을 통과시킨다.
+
+## 3. PROD-496 통합 검증과 OpenSpec 완료
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/decisions/0010-post-interaction-contracts.md`
+- `docs/domain/decisions/0014-post-structure-relations.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- PROD-496
+
+**Deliverable**
+
+PROD-496의 Local Repost Announce/Undo 전체 계약이 package와 GraphQL 경계에서 검증되고, sibling interaction이나 durable transport 범위를 추가하지 않은 채 change를 완료할 수 있다.
+
+**Guardrails**
+
+- inbound Announce, Reply·Reaction federation, Quote·중첩 Repost, collection과 PROD-448 migration을 구현하지 않는다.
+- OpenSpec archive는 PROD-496 구현·검증과 delta spec 정합성이 모두 완료된 뒤에만 수행한다.
+
+**Verification**
+
+- Fedify, core와 API targeted/full test, TypeScript check와 workspace lint를 통과시킨다.
+- `openspec validate add-activitypub-local-repost-delivery --strict`와 전체 strict validation을 통과시킨다.
+- 최종 diff와 테스트 목록에서 제외 범위 침범이 없는지 확인한다.
+
+- [x] 3.1 관련 Fedify/core/API targeted test와 package full test를 통과시킨다.
+- [x] 3.2 workspace ESLint, Prettier, Syncpack과 OpenSpec strict validation을 통과시킨다.
+- [x] 3.3 PROD-496 완료 기준과 제외 범위를 최종 대조하고 구현·검증 증거를 정리한다.
+- [x] 3.4 전체 change 완료 뒤 delta spec을 canonical spec에 동기화하고 OpenSpec을 archive한다.
+
+## Verification Evidence
+
+- `pnpm --filter @kosmo/fedify test`: 119 passed
+- `pnpm --filter @kosmo/core test`: 121 passed
+- `pnpm --filter @kosmo/api test`: 154 passed, 1 skipped
+- `pnpm lint:eslint`, `pnpm lint:prettier`, `pnpm lint:syncpack`: passed
+- `openspec validate add-activitypub-local-repost-delivery --strict`: passed
+- `openspec validate --all --strict`: 39 passed, 0 failed
+- 최종 diff에는 inbound Announce, Reply/Reaction/Quote federation, followers/outbox collection, broker/queue/outbox, durable retry/history, schema migration이 없다.

--- a/openspec/specs/activitypub-local-repost-delivery/spec.md
+++ b/openspec/specs/activitypub-local-repost-delivery/spec.md
@@ -1,0 +1,182 @@
+# activitypub-local-repost-delivery Specification
+
+## Purpose
+
+TBD - created by archiving change add-activitypub-local-repost-delivery. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: Stable Local Repost Announce identity
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496. 시스템은 configured Local Instance에 속한 행동 Profile의 Local Repost를 immutable Repost Post DB UUID에서 파생한 안정적인 ActivityPub `Announce`로 표현하고, Local/Remote Source의 object identity에 PROD-494가 확정한 공통 ActivityPub Post URI 규칙을 재사용해야 한다(MUST).
+
+#### Scenario: Local Source Repost Announce
+
+- **WHEN** Local Profile이 Content가 있는 제공 가능한 Local Post를 처음 Repost하고 transaction이 commit된다
+- **THEN** 시스템은 `{canonicalOrigin}/ap/announce/{repostId}`를 `Announce.id`로 사용한다
+- **AND** `Announce.actor`는 Repost Author Profile의 canonical actor URI다
+- **AND** `Announce.object`는 `{canonicalOrigin}/ap/note/{sourcePostId}`다
+- **AND** `Announce.published`는 immutable Repost 생성 시각이다
+
+#### Scenario: Remote Source Repost Announce
+
+- **WHEN** Local Profile이 Content가 있고 existing ActivityPub Post mapping을 가진 제공 가능한 Remote Post를 처음 Repost하고 transaction이 commit된다
+- **THEN** 시스템은 Local Source와 같은 Repost 기반 `Announce.id`, actor와 published 규칙을 사용한다
+- **AND** `Announce.object`는 existing ActivityPub Post mapping의 remote object URI다
+- **AND** Remote Source에 Local Note identity나 새 ActivityPub Post mapping을 만들지 않는다
+
+#### Scenario: Stable Announce reconstruction
+
+- **WHEN** 같은 committed Repost identity의 Announce projection 또는 delivery가 반복된다
+- **THEN** 시스템은 항상 같은 Announce ID, actor, object와 published 값을 사용한다
+- **AND** request host, GraphQL global ID, Author handle과 delivery 시각을 identity에 포함하지 않는다
+
+### Requirement: Exact Local Repost Undo identity
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, PROD-496. 시스템은 취소된 Local Repost의 immutable identity와 보존된 direct Source 관계를 사용해 정확한 원본 Announce를 가리키는 안정적인 `Undo`를 표현해야 한다(MUST).
+
+#### Scenario: Repost cancellation Undo
+
+- **WHEN** Local Repost가 처음 Active에서 Tombstone으로 전이되고 transaction이 commit된다
+- **THEN** 시스템은 `{canonicalOrigin}/ap/announce/{repostId}#undo`를 `Undo.id`로 사용한다
+- **AND** `Undo.actor`는 원본 Announce actor와 같다
+- **AND** `Undo.object`는 같은 ID, actor, object와 published 값을 가진 원본 Announce를 가리킨다
+- **AND** Repost와 Source 관계를 hard delete하거나 transport mapping을 새로 저장하지 않는다
+
+#### Scenario: Source lifecycle after Announce
+
+- **WHEN** Repost 취소 전에 Source가 Tombstone으로 전이됐지만 direct Source 관계와 canonical ActivityPub identity가 남아 있다
+- **THEN** 시스템은 보존된 identity로 원본 Announce와 Undo를 재구성한다
+- **AND** Source의 현재 Content 표현을 요구하거나 embed하지 않는다
+
+#### Scenario: Stable Undo reconstruction
+
+- **WHEN** 같은 canceled Repost identity의 Undo projection 또는 delivery가 반복된다
+- **THEN** 시스템은 항상 같은 Undo ID와 원본 Announce identity를 사용한다
+- **AND** Announce와 Undo는 같은 Repost ordering domain을 사용한다
+
+### Requirement: Repost audience and remote follower recipients
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496. 시스템은 Repost Visibility를 ActivityPub audience로 투영하고 행동 Local Profile의 established remote follower 중 지원되는 recipient에게 Announce와 Undo를 전달해야 한다(MUST).
+
+#### Scenario: Unlisted Repost audience
+
+- **WHEN** Public 또는 Unlisted Source에서 파생된 Unlisted Repost의 Announce 또는 Undo를 직렬화한다
+- **THEN** activity `to`는 행동 Profile의 followers collection URI를 포함한다
+- **AND** activity `cc`는 ActivityStreams Public을 포함한다
+
+#### Scenario: Followers Only Repost audience
+
+- **WHEN** Author가 자신의 Followers Only Source에서 만든 Followers Only Repost의 Announce 또는 Undo를 직렬화한다
+- **THEN** activity `to`는 행동 Profile의 followers collection URI만 포함한다
+- **AND** activity `cc`는 ActivityStreams Public을 포함하지 않는다
+
+#### Scenario: Established remote follower recipients
+
+- **WHEN** 행동 Local Profile에 established follower인 Active Remote Profile이 있고 그 ActivityPub Instance가 ACTIVE 또는 UNRESPONSIVE이며 actor inbox가 저장되어 있다
+- **THEN** 시스템은 해당 remote actor를 delivery recipient로 포함한다
+- **AND** shared inbox가 저장되어 있으면 Fedify shared inbox delivery를 우선 사용한다
+
+#### Scenario: Unsupported recipients
+
+- **WHEN** follower가 Local Profile이거나 Profile이 inactive이거나 ActivityPub Instance가 Suspended이거나 actor inbox가 없다
+- **THEN** 시스템은 해당 follower를 delivery recipient에서 제외한다
+- **AND** 제외 사실 때문에 committed Repost action을 실패시키지 않는다
+
+#### Scenario: Source Author is not an implicit recipient
+
+- **WHEN** Remote Source Author가 행동 Profile의 established follower가 아니다
+- **THEN** 시스템은 Source Author라는 이유만으로 recipient에 추가하지 않는다
+- **AND** follower recipient와 activity audience 규칙을 확장하지 않는다
+
+### Requirement: First-transition post-commit delivery
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, PROD-447, PROD-496. 시스템은 Repost domain transaction이 성공적으로 commit된 뒤 최초 생성과 최초 취소 상태 전이에만 직접 Fedify delivery를 시작하고, 반복·동시 application action에서는 추가 activity delivery를 시작하지 않아야 한다(MUST).
+
+#### Scenario: First Repost creation delivery
+
+- **WHEN** Repost application action이 새 Active Repost를 생성하고 commit한다
+- **THEN** 시스템은 commit 이후 해당 Repost의 Announce delivery를 한 번 시작한다
+- **AND** commit 전에 Fedify delivery 또는 broker enqueue를 수행하지 않는다
+
+#### Scenario: Duplicate or concurrent Repost creation
+
+- **WHEN** 반복 또는 동시 Repost action이 기존 Active Repost identity로 수렴한다
+- **THEN** 최초 생성 결과만 Announce delivery를 시작한다
+- **AND** 기존 Repost를 반환한 action은 Announce delivery를 추가로 시작하지 않는다
+
+#### Scenario: First Repost cancellation delivery
+
+- **WHEN** deletePost가 Repost를 처음 Active에서 Tombstone으로 전이하고 commit한다
+- **THEN** 시스템은 commit 이후 해당 Repost의 Undo delivery를 한 번 시작한다
+- **AND** GraphQL public payload는 기존 Post global ID 계약을 유지한다
+
+#### Scenario: Duplicate or concurrent Repost cancellation
+
+- **WHEN** 반복 또는 동시 deletePost action이 이미 Tombstone인 같은 Repost를 대상으로 한다
+- **THEN** 최초 Tombstone 전이 결과만 Undo delivery를 시작한다
+- **AND** 이미 Tombstone인 결과는 Undo delivery를 추가로 시작하지 않는다
+
+#### Scenario: Non-Repost Post deletion
+
+- **WHEN** 일반 Post, Reply, Quote 또는 Reply이면서 Quote인 Content Post가 deletePost로 Tombstone 전이된다
+- **THEN** 시스템은 Repost Undo delivery를 시작하지 않는다
+- **AND** 기존 Post 삭제 결과를 유지한다
+
+### Requirement: Post-commit delivery failure isolation
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, PROD-447, PROD-448, PROD-496. 시스템은 direct Fedify Announce/Undo delivery 실패를 committed Repost application 결과와 분리해 관측하며, 외부 delivery 실패를 GraphQL mutation 실패나 domain state rollback으로 바꾸지 않아야 한다(MUST).
+
+#### Scenario: Announce delivery failure after commit
+
+- **WHEN** 새 Repost transaction이 commit된 뒤 Announce projection 또는 remote HTTP delivery가 실패한다
+- **THEN** 시스템은 실패를 Repost ID와 함께 post-commit delivery 관측 경계에 기록한다
+- **AND** committed Active Repost와 `repostPost` 성공 payload를 유지한다
+- **AND** delivery 실패를 이유로 Repost 또는 Notification 결과를 rollback하지 않는다
+
+#### Scenario: Undo delivery failure after commit
+
+- **WHEN** Repost Tombstone transaction이 commit된 뒤 Undo projection 또는 remote HTTP delivery가 실패한다
+- **THEN** 시스템은 실패를 Repost ID와 함께 post-commit delivery 관측 경계에 기록한다
+- **AND** committed Tombstone, count 감소, active uniqueness 해제와 `deletePost` 성공 payload를 유지한다
+- **AND** delivery 실패를 이유로 Repost를 Active로 복원하지 않는다
+
+#### Scenario: Independent post-commit side effects
+
+- **WHEN** Repost Notification 생성·정리와 ActivityPub delivery 중 하나가 실패한다
+- **THEN** 시스템은 각 실패를 독립적으로 격리한다
+- **AND** 한 side effect 실패가 다른 side effect 실행 또는 committed application payload를 실패시키지 않는다
+
+#### Scenario: Accepted direct-delivery loss window
+
+- **WHEN** application process가 domain commit 이후 Fedify delivery 시작 전에 종료된다
+- **THEN** 이번 capability는 durable intent, retry 또는 delivery history를 생성하지 않는다
+- **AND** PROD-448 migration 전까지 activity가 유실될 수 있는 현재 제한을 수용한다
+
+### Requirement: Repost delivery availability and scope boundary
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-496. 시스템은 canonical Repost와 Source activity를 안전하게 재구성할 수 있는 경우에만 outbound Repost delivery를 시도하며, sibling interaction과 durable transport 범위를 추가하지 않아야 한다(MUST).
+
+#### Scenario: Unsupported Repost structure
+
+- **WHEN** 대상 Post에 Content가 있거나 Reply Parent가 있거나 direct Repost Source가 없다
+- **THEN** 시스템은 그 Post를 outbound Repost Announce/Undo 대상으로 취급하지 않는다
+- **AND** Quote, Reply이면서 Quote 또는 일반 Post를 Repost activity로 직렬화하지 않는다
+
+#### Scenario: Unavailable Announce projection
+
+- **WHEN** Repost 또는 Author가 unavailable하거나 configured Local Instance에 속하지 않거나 direct Source가 missing·contentless이거나 canonical ActivityPub URI를 해석할 수 없다
+- **THEN** 시스템은 Announce delivery를 시도하지 않는다
+- **AND** unavailable 원인을 GraphQL 결과로 새로 노출하지 않는다
+
+#### Scenario: Unavailable Undo projection
+
+- **WHEN** canceled Repost identity, Local Author identity, 보존된 Source 관계 또는 Source canonical ActivityPub URI를 해석할 수 없다
+- **THEN** 시스템은 Undo delivery를 시도하지 않는다
+- **AND** committed Tombstone 결과를 유지한다
+
+#### Scenario: Excluded transport and sibling capabilities
+
+- **WHEN** Local Repost Announce/Undo capability를 제공한다
+- **THEN** 시스템은 inbound Announce materialization, Reply·Reaction federation, Quote·중첩 Repost federation을 추가하지 않는다
+- **AND** followers/outbox collection, transactional outbox, NATS/Fedify MessageQueue, worker, durable retry/history와 사용자용 delivery status를 추가하지 않는다

--- a/packages/core/services/post-repost.test.ts
+++ b/packages/core/services/post-repost.test.ts
@@ -1,10 +1,21 @@
 import assert from 'node:assert/strict';
-import { after, test } from 'node:test';
+import { after, afterEach, before, mock, test } from 'node:test';
 import { and, eq, isNull } from 'drizzle-orm';
-import { db, firstOrThrow, Instances, pg, Posts, ProfileFollows, Profiles } from '../db';
+import {
+  ActivityPubActors,
+  db,
+  firstOrThrow,
+  Instances,
+  Notifications,
+  pg,
+  Posts,
+  ProfileFollows,
+  Profiles,
+} from '../db';
 import {
   InstanceKind,
   InstanceState,
+  NotificationKind,
   PostState,
   PostVisibility,
   ProfileFollowPolicy,
@@ -13,6 +24,19 @@ import {
 import { NotFoundError, PermissionDeniedError, ValidationError } from '../error';
 import { postContentDocumentFromText } from '../post-content/server';
 import { createPost, deletePost, repostPost } from './post';
+
+const publicOrigin = 'http://127.0.0.1:4173';
+process.env.PUBLIC_ORIGIN = publicOrigin;
+let configuredLocalInstanceId: string;
+
+before(async () => {
+  const { seedDatabase } = await import('../db/seed');
+  configuredLocalInstanceId = (await seedDatabase({ publicOrigin })).localInstance.id;
+});
+
+afterEach(() => {
+  mock.restoreAll();
+});
 
 after(async () => pg.end());
 
@@ -61,6 +85,37 @@ const createContentPost = async (
     profileId,
     visibility,
   }).then(({ post }) => post);
+
+const createConfiguredLocalProfile = async () => {
+  const suffix = crypto.randomUUID();
+  return db
+    .insert(Profiles)
+    .values({
+      displayName: suffix,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle: suffix,
+      instanceId: configuredLocalInstanceId,
+      normalizedHandle: suffix,
+      state: ProfileState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+};
+
+const createRemoteFollower = async (followeeProfileId: string) => {
+  const remote = await createProfile({ instanceKind: InstanceKind.ACTIVITYPUB });
+  const actorUri = `https://${remote.instance.domain}/users/${remote.profile.id}`;
+  await db.insert(ActivityPubActors).values({
+    inboxUri: `${actorUri}/inbox`,
+    profileId: remote.profile.id,
+    type: 'PERSON',
+    uri: actorUri,
+  });
+  await db.insert(ProfileFollows).values({
+    followeeProfileId,
+    followerProfileId: remote.profile.id,
+  });
+};
 
 test('repostPost는 Public과 Unlisted Source를 direct Unlisted Repost로 생성한다', async () => {
   const actor = await createProfile();
@@ -234,6 +289,120 @@ test('repostPost의 순차·동시 요청은 같은 Active Repost identity로 �
   );
 });
 
+test('최초 top-level Repost 생성과 취소만 commit 뒤 Announce와 Undo를 전달한다', async () => {
+  const actor = await createConfiguredLocalProfile();
+  const recipient = await createConfiguredLocalProfile();
+  const source = await createContentPost(recipient.id);
+  await createRemoteFollower(actor.id);
+  const { federation } = await import('@kosmo/fedify');
+  const fixture = createDeliveryContextFixture();
+  mock.method(federation, 'createContext', () => fixture.context);
+  const input = { actorProfileId: actor.id, sourcePostId: source.id };
+
+  const concurrent = await Promise.all(Array.from({ length: 4 }, () => repostPost(input)));
+  const repost = concurrent.find(({ created }) => created)?.repost;
+  assert.ok(repost);
+  assert.equal(fixture.calls.length, 1);
+  assert.equal(fixture.calls[0]?.constructor.name, 'Announce');
+  assert.equal(
+    await db
+      .select({ id: Notifications.id })
+      .from(Notifications)
+      .where(
+        and(eq(Notifications.kind, NotificationKind.REPOST), eq(Notifications.sourceId, repost.id)),
+      )
+      .then((rows) => rows.length),
+    1,
+  );
+
+  await repostPost(input);
+  assert.equal(fixture.calls.length, 1);
+  assert.equal(
+    await db
+      .select({ id: Notifications.id })
+      .from(Notifications)
+      .where(
+        and(eq(Notifications.kind, NotificationKind.REPOST), eq(Notifications.sourceId, repost.id)),
+      )
+      .then((rows) => rows.length),
+    1,
+  );
+
+  const deleteInput = { actorProfileId: actor.id, postId: repost.id };
+  await Promise.all(Array.from({ length: 4 }, () => deletePost(deleteInput)));
+  assert.equal(fixture.calls.length, 2);
+  assert.equal(fixture.calls[1]?.constructor.name, 'Undo');
+
+  await deletePost(deleteInput);
+  assert.equal(fixture.calls.length, 2);
+
+  const rollbackSource = await createContentPost(actor.id);
+  await assert.rejects(
+    db.transaction(async (tx) => {
+      await repostPost({ actorProfileId: actor.id, sourcePostId: rollbackSource.id }, tx);
+      throw new Error('rollback');
+    }),
+    /rollback/,
+  );
+  assert.equal(fixture.calls.length, 2);
+
+  const remoteActor = await createProfile({ instanceKind: InstanceKind.ACTIVITYPUB });
+  await repostPost({ actorProfileId: remoteActor.profile.id, sourcePostId: source.id });
+  assert.equal(fixture.calls.length, 2);
+
+  const ordinaryPost = await createContentPost(actor.id);
+  await deletePost({ actorProfileId: actor.id, postId: ordinaryPost.id });
+  assert.equal(fixture.calls.length, 2);
+});
+
+test('post-commit Repost delivery 실패는 committed 생성과 취소 결과를 바꾸지 않는다', async () => {
+  const actor = await createConfiguredLocalProfile();
+  const source = await createContentPost(actor.id);
+  await createRemoteFollower(actor.id);
+  const { federation } = await import('@kosmo/fedify');
+  const context = {
+    canonicalOrigin: publicOrigin,
+    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
+    sendActivity: async () => {
+      throw new Error('delivery failed');
+    },
+  } as never;
+  mock.method(federation, 'createContext', () => context);
+  const errorLog = mock.method(console, 'error', () => undefined);
+
+  const result = await repostPost({ actorProfileId: actor.id, sourcePostId: source.id });
+  assert.equal(result.created, true);
+  assert.equal(
+    await db
+      .select({ state: Posts.state })
+      .from(Posts)
+      .where(eq(Posts.id, result.repost.id))
+      .then(firstOrThrow)
+      .then(({ state }) => state),
+    PostState.ACTIVE,
+  );
+
+  assert.deepEqual(await deletePost({ actorProfileId: actor.id, postId: result.repost.id }), {
+    postId: result.repost.id,
+  });
+  assert.equal(
+    await db
+      .select({ state: Posts.state })
+      .from(Posts)
+      .where(eq(Posts.id, result.repost.id))
+      .then(firstOrThrow)
+      .then(({ state }) => state),
+    PostState.DELETED,
+  );
+  assert.deepEqual(
+    errorLog.mock.calls.map(({ arguments: [message] }) => message),
+    [
+      'Post-commit ActivityPub Repost Announce delivery failed',
+      'Post-commit ActivityPub Repost Undo delivery failed',
+    ],
+  );
+});
+
 test('repostPost는 caller transaction rollback에 합류한다', async () => {
   const actor = await createProfile();
   const source = await createContentPost(actor.profile.id);
@@ -397,3 +566,19 @@ test('deletePost는 caller transaction rollback에 합류한다', async () => {
   assert.equal(stored.state, PostState.ACTIVE);
   assert.equal(stored.deletedAt, null);
 });
+
+const createDeliveryContextFixture = () => {
+  const calls: { readonly constructor: { readonly name: string } }[] = [];
+  const context = {
+    canonicalOrigin: publicOrigin,
+    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
+    sendActivity: async (
+      _sender: { identifier: string },
+      _recipients: unknown,
+      activity: { readonly constructor: { readonly name: string } },
+    ) => {
+      calls.push(activity);
+    },
+  } as never;
+  return { calls, context };
+};

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -12,8 +12,9 @@ import {
   ProfileFollows,
   Profiles,
 } from '../db';
-import { InstanceState, PostState, PostVisibility, ProfileState } from '../enums';
+import { InstanceState, NotificationKind, PostState, PostVisibility, ProfileState } from '../enums';
 import { NotFoundError, PermissionDeniedError, ValidationError } from '../error';
+import { createRepostNotification, deleteNotificationBySource } from './notification';
 import { validatePostStructure } from './post-structure';
 import type { Transaction } from '../db';
 import type { PostContentDocumentV1 } from '../post-content';
@@ -105,8 +106,8 @@ export const deletePost = async (
     readonly postId: string;
   },
   tx?: Transaction,
-): Promise<{ readonly postId: string }> =>
-  getDatabaseConnection(tx).transaction(async (tx) => {
+): Promise<{ readonly postId: string }> => {
+  const { repostId, result } = await getDatabaseConnection(tx).transaction(async (tx) => {
     const post = await tx
       .select({ profileId: Posts.profileId })
       .from(Posts)
@@ -120,7 +121,7 @@ export const deletePost = async (
       throw new PermissionDeniedError('Post author permission is required');
     }
 
-    await tx
+    const deleted = await tx
       .update(Posts)
       .set({ deletedAt: sql`now()`, state: PostState.DELETED })
       .where(
@@ -129,10 +130,52 @@ export const deletePost = async (
           eq(Posts.profileId, actorProfileId),
           eq(Posts.state, PostState.ACTIVE),
         ),
-      );
+      )
+      .returning({
+        currentContentId: Posts.currentContentId,
+        id: Posts.id,
+        replyParentId: Posts.replyParentId,
+        repostSourceId: Posts.repostSourceId,
+      })
+      .then(first);
 
-    return { postId };
+    return {
+      repostId:
+        deleted &&
+        deleted.currentContentId === null &&
+        deleted.replyParentId === null &&
+        deleted.repostSourceId !== null
+          ? deleted.id
+          : undefined,
+      result: { postId },
+    };
   });
+
+  // A caller-owned transaction has no after-commit hook. Its caller owns any
+  // post-commit side effect so delivery cannot run before the outer commit.
+  if (!tx) {
+    await deleteNotificationBySource(NotificationKind.REPOST, result.postId).catch((error) => {
+      console.error('Post-commit Repost notification cleanup failed', {
+        error,
+        postId: result.postId,
+      });
+    });
+  }
+
+  if (!tx && repostId) {
+    try {
+      const { sendRepostUndo } = await import('@kosmo/fedify');
+      await sendRepostUndo(repostId);
+    } catch (error) {
+      console.error('Post-commit ActivityPub Repost Undo delivery failed', {
+        error,
+        repostId,
+      });
+    }
+  }
+
+  return result;
+};
 
 export const repostPost = async (
   {
@@ -146,8 +189,8 @@ export const repostPost = async (
 ): Promise<{
   readonly created: boolean;
   readonly repost: typeof Posts.$inferSelect;
-}> =>
-  getDatabaseConnection(tx).transaction(async (tx) => {
+}> => {
+  const result = await getDatabaseConnection(tx).transaction(async (tx) => {
     const source = await findVisiblePost(tx, { actorProfileId, postId: sourcePostId });
     if (!source) {
       throw new NotFoundError('Post not found');
@@ -205,6 +248,25 @@ export const repostPost = async (
 
     return { created: false, repost: existing };
   });
+
+  // See deletePost: caller-owned transactions cannot safely emit before their
+  // outer commit, so only this top-level transaction owns post-commit effects.
+  if (!tx && result.created) {
+    await createRepostNotification(result.repost.id).catch(() => undefined);
+
+    try {
+      const { sendRepostAnnounce } = await import('@kosmo/fedify');
+      await sendRepostAnnounce(result.repost.id);
+    } catch (error) {
+      console.error('Post-commit ActivityPub Repost Announce delivery failed', {
+        error,
+        repostId: result.repost.id,
+      });
+    }
+  }
+
+  return result;
+};
 export function createPost(input: LocalPostInput, tx?: Transaction): Promise<CreatedPost>;
 export function createPost(
   input: ActivityPubPostInput,

--- a/packages/fedify/index.ts
+++ b/packages/fedify/index.ts
@@ -7,3 +7,4 @@ export {
   materializeRemoteProfileActor,
   RemoteActorMaterializationError,
 } from './src/remote-actor-materialization';
+export { sendRepostAnnounce, sendRepostUndo } from './src/repost-delivery';

--- a/packages/fedify/src/repost-delivery.test.ts
+++ b/packages/fedify/src/repost-delivery.test.ts
@@ -1,0 +1,418 @@
+import '@kosmo/core/polyfill';
+
+import assert from 'node:assert/strict';
+import { after, afterEach, before, beforeEach, describe, mock, test } from 'node:test';
+import { Announce, PUBLIC_COLLECTION, Undo } from '@fedify/vocab';
+import {
+  ActivityPubActorType,
+  InstanceKind,
+  InstanceState,
+  PostState,
+  PostVisibility,
+  ProfileFollowPolicy,
+  ProfileState,
+} from '@kosmo/core/enums';
+import { eq, inArray } from 'drizzle-orm';
+import type { Context } from '@fedify/fedify';
+import type { Activity, Recipient } from '@fedify/vocab';
+import type * as CoreDb from '@kosmo/core/db';
+import type * as CoreSeed from '@kosmo/core/db/seed';
+import type { federation as Federation } from './federation';
+import type * as RepostDelivery from './repost-delivery';
+
+const publicOrigin = 'http://127.0.0.1:4173';
+const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+
+let ActivityPubActors: typeof CoreDb.ActivityPubActors;
+let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
+let db: typeof CoreDb.db;
+let federation: typeof Federation;
+let firstOrThrow: typeof CoreDb.firstOrThrow;
+let Instances: typeof CoreDb.Instances;
+let localInstanceId: string;
+let pg: typeof CoreDb.pg;
+let PostContents: typeof CoreDb.PostContents;
+let Posts: typeof CoreDb.Posts;
+let ProfileFollows: typeof CoreDb.ProfileFollows;
+let Profiles: typeof CoreDb.Profiles;
+let sendRepostAnnounce: typeof RepostDelivery.sendRepostAnnounce;
+let sendRepostUndo: typeof RepostDelivery.sendRepostUndo;
+let testInstanceIds: string[] = [];
+let testProfileIds: string[] = [];
+
+describe('ActivityPub Local Repost delivery', () => {
+  before(async () => {
+    process.env.DATABASE_URL = databaseUrl;
+    process.env.PUBLIC_ORIGIN = publicOrigin;
+    ({
+      ActivityPubActors,
+      ActivityPubPosts,
+      db,
+      firstOrThrow,
+      Instances,
+      pg,
+      PostContents,
+      Posts,
+      ProfileFollows,
+      Profiles,
+    } = await import('@kosmo/core/db'));
+    const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
+    ({ federation } = await import('./federation'));
+    ({ sendRepostAnnounce, sendRepostUndo } = await import('./repost-delivery'));
+    const { localInstance } = await seedDatabase({ publicOrigin });
+    localInstanceId = localInstance.id;
+  });
+
+  beforeEach(async () => {
+    await cleanTestRows();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  after(async () => {
+    await cleanTestRows();
+    await pg.end();
+  });
+
+  test('Local Source Announce identity와 Unlisted audience를 remote follower에게 전달한다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const source = await createContentPost(author.id);
+    const repost = await createRepost(author.id, source.id);
+    const activeFollower = await createRemoteActorProfile({ sharedInbox: true });
+    const unresponsiveFollower = await createRemoteActorProfile({
+      instanceState: InstanceState.UNRESPONSIVE,
+    });
+    const suspendedFollower = await createRemoteActorProfile({
+      instanceState: InstanceState.SUSPENDED,
+    });
+    const inactiveFollower = await createRemoteActorProfile({
+      profileState: ProfileState.DISABLED,
+    });
+    const noInboxFollower = await createRemoteActorProfile({ inbox: false });
+    const localFollower = await createProfile({ kind: InstanceKind.LOCAL });
+
+    await db
+      .insert(ProfileFollows)
+      .values(
+        [
+          activeFollower,
+          unresponsiveFollower,
+          suspendedFollower,
+          inactiveFollower,
+          noInboxFollower,
+          localFollower,
+        ].map(({ id }) => ({ followeeProfileId: author.id, followerProfileId: id })),
+      );
+
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendRepostAnnounce(repost.id);
+
+    assert.equal(fixture.calls.length, 1);
+    const call = fixture.calls[0]!;
+    assert.ok(call.activity instanceof Announce);
+    assert.equal(call.activity.id?.href, `${publicOrigin}/ap/announce/${repost.id}`);
+    assert.equal(call.activity.actorId?.href, `${publicOrigin}/ap/actor/${author.id}`);
+    assert.equal(call.activity.objectId?.href, `${publicOrigin}/ap/note/${source.id}`);
+    assert.equal(call.activity.published?.toString(), repost.createdAt.toString());
+    assert.deepEqual(call.activity.toIds.map(String), [
+      `${publicOrigin}/ap/actor/${author.id}/followers`,
+    ]);
+    assert.deepEqual(call.activity.ccIds.map(String), [PUBLIC_COLLECTION.href]);
+    assert.deepEqual(
+      call.recipients.map(({ id }) => id?.href).sort(),
+      [activeFollower.actorUri, unresponsiveFollower.actorUri].sort(),
+    );
+    const activeRecipient = call.recipients.find(({ id }) => id?.href === activeFollower.actorUri);
+    assert.equal(activeRecipient?.endpoints?.sharedInbox?.href, activeFollower.sharedInboxUri);
+    assert.deepEqual(call.options, {
+      orderingKey: `activitypub-repost:${repost.id}`,
+      preferSharedInbox: true,
+    });
+  });
+
+  test('Followers Only Announce는 Public audience를 포함하지 않는다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const source = await createContentPost(author.id, PostVisibility.FOLLOWERS);
+    const repost = await createRepost(author.id, source.id, PostVisibility.FOLLOWERS);
+    const follower = await createRemoteActorProfile();
+    await db.insert(ProfileFollows).values({
+      followeeProfileId: author.id,
+      followerProfileId: follower.id,
+    });
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendRepostAnnounce(repost.id);
+
+    const activity = fixture.calls[0]?.activity;
+    assert.ok(activity instanceof Announce);
+    assert.deepEqual(activity.ccIds, []);
+    assert.deepEqual(activity.toIds.map(String), [
+      `${publicOrigin}/ap/actor/${author.id}/followers`,
+    ]);
+  });
+
+  test('Remote Source identity를 재사용하고 Source Tombstone 뒤 exact Undo를 만든다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const sourceAuthor = await createProfile({ kind: InstanceKind.ACTIVITYPUB });
+    const source = await createContentPost(sourceAuthor.id);
+    const remoteObjectUri = `https://${sourceAuthor.instanceDomain}/objects/${source.id}`;
+    await db.insert(ActivityPubPosts).values({
+      postId: source.id,
+      receivedAt: Temporal.Instant.from('2026-07-28T00:00:00Z'),
+      uri: remoteObjectUri,
+    });
+    const repost = await createRepost(author.id, source.id);
+    const follower = await createRemoteActorProfile();
+    await db.insert(ProfileFollows).values({
+      followeeProfileId: author.id,
+      followerProfileId: follower.id,
+    });
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendRepostAnnounce(repost.id);
+    await db.update(Posts).set({ state: PostState.DELETED }).where(eq(Posts.id, source.id));
+    await db.update(Posts).set({ state: PostState.DELETED }).where(eq(Posts.id, repost.id));
+    await sendRepostUndo(repost.id);
+
+    assert.equal(fixture.calls.length, 2);
+    const original = fixture.calls[0]!.activity;
+    const undo = fixture.calls[1]!.activity;
+    assert.ok(original instanceof Announce);
+    assert.equal(original.objectId?.href, remoteObjectUri);
+    assert.ok(undo instanceof Undo);
+    assert.equal(undo.id?.href, `${publicOrigin}/ap/announce/${repost.id}#undo`);
+    assert.equal(undo.actorId?.href, original.actorId?.href);
+    const embedded = await undo.getObject();
+    assert.ok(embedded instanceof Announce);
+    assert.equal(embedded.id?.href, original.id?.href);
+    assert.equal(embedded.actorId?.href, original.actorId?.href);
+    assert.equal(embedded.objectId?.href, original.objectId?.href);
+    assert.equal(embedded.published?.toString(), original.published?.toString());
+    assert.equal(fixture.calls[1]!.options.orderingKey, fixture.calls[0]!.options.orderingKey);
+  });
+
+  test('unsupported 또는 unavailable projection과 recipient 부재는 전송하지 않는다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const follower = await createRemoteActorProfile();
+    await db.insert(ProfileFollows).values({
+      followeeProfileId: author.id,
+      followerProfileId: follower.id,
+    });
+    const source = await createContentPost(author.id);
+    const quote = await createContentPost(author.id);
+    await db.update(Posts).set({ repostSourceId: source.id }).where(eq(Posts.id, quote.id));
+    const contentlessSource = await createRepost(author.id, source.id);
+    const nested = await createRepost(author.id, contentlessSource.id);
+    const remoteAuthor = await createProfile({ kind: InstanceKind.ACTIVITYPUB });
+    const unmappedRemoteSource = await createContentPost(remoteAuthor.id);
+    const unmapped = await createRepost(author.id, unmappedRemoteSource.id);
+    const inactiveAuthor = await createProfile({
+      kind: InstanceKind.LOCAL,
+      profileState: ProfileState.DISABLED,
+    });
+    const inactiveSource = await createContentPost(inactiveAuthor.id);
+    const inactive = await createRepost(inactiveAuthor.id, inactiveSource.id);
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendRepostAnnounce(quote.id);
+    await sendRepostAnnounce(nested.id);
+    await sendRepostAnnounce(unmapped.id);
+    await sendRepostAnnounce(inactive.id);
+    await sendRepostAnnounce(crypto.randomUUID());
+
+    assert.equal(fixture.calls.length, 0);
+  });
+
+  test('Source Author는 follower가 아니면 recipient로 암묵 추가하지 않는다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const sourceAuthor = await createRemoteActorProfile();
+    const source = await createContentPost(sourceAuthor.id);
+    await db.insert(ActivityPubPosts).values({
+      postId: source.id,
+      receivedAt: Temporal.Instant.from('2026-07-28T00:00:00Z'),
+      uri: `https://${sourceAuthor.instanceDomain}/objects/${source.id}`,
+    });
+    const repost = await createRepost(author.id, source.id);
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendRepostAnnounce(repost.id);
+
+    assert.equal(fixture.calls.length, 0);
+  });
+});
+
+interface SendActivityCall {
+  readonly activity: Activity;
+  readonly options: { readonly orderingKey: string; readonly preferSharedInbox: boolean };
+  readonly recipients: Recipient[];
+  readonly sender: { readonly identifier: string };
+}
+
+const createContextFixture = () => {
+  const calls: SendActivityCall[] = [];
+  const context = {
+    canonicalOrigin: publicOrigin,
+    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
+    sendActivity: async (
+      sender: { identifier: string },
+      recipients: Recipient[],
+      activity: Activity,
+      options: { orderingKey: string; preferSharedInbox: boolean },
+    ) => {
+      calls.push({ activity, options, recipients, sender });
+    },
+  } as unknown as Context<void>;
+  return { calls, context };
+};
+
+const createProfile = async ({
+  kind,
+  profileState = ProfileState.ACTIVE,
+}: {
+  kind: InstanceKind;
+  profileState?: ProfileState;
+}) => {
+  const suffix = crypto.randomUUID();
+  const instance =
+    kind === InstanceKind.LOCAL
+      ? await db
+          .select()
+          .from(Instances)
+          .where(eq(Instances.id, localInstanceId))
+          .then(firstOrThrow)
+      : await db
+          .insert(Instances)
+          .values({
+            domain: `${suffix}.remote.example`,
+            kind,
+            state: InstanceState.ACTIVE,
+          })
+          .returning()
+          .then(firstOrThrow);
+  if (kind !== InstanceKind.LOCAL) {
+    testInstanceIds.push(instance.id);
+  }
+  const profile = await db
+    .insert(Profiles)
+    .values({
+      displayName: suffix,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle: suffix,
+      instanceId: instance.id,
+      normalizedHandle: suffix,
+      state: profileState,
+    })
+    .returning()
+    .then(firstOrThrow);
+  testProfileIds.push(profile.id);
+  return { ...profile, instanceDomain: instance.domain };
+};
+
+const createRemoteActorProfile = async ({
+  inbox = true,
+  instanceState = InstanceState.ACTIVE,
+  profileState = ProfileState.ACTIVE,
+  sharedInbox = false,
+}: {
+  inbox?: boolean;
+  instanceState?: InstanceState;
+  profileState?: ProfileState;
+  sharedInbox?: boolean;
+} = {}) => {
+  const profile = await createProfile({ kind: InstanceKind.ACTIVITYPUB, profileState });
+  await db
+    .update(Instances)
+    .set({ state: instanceState })
+    .where(eq(Instances.id, profile.instanceId));
+  const actorUri = `https://${profile.instanceDomain}/users/${profile.id}`;
+  const sharedInboxUri = sharedInbox ? `https://${profile.instanceDomain}/inbox` : null;
+  await db.insert(ActivityPubActors).values({
+    inboxUri: inbox ? `${actorUri}/inbox` : null,
+    profileId: profile.id,
+    sharedInboxUri,
+    type: ActivityPubActorType.PERSON,
+    uri: actorUri,
+  });
+  return { ...profile, actorUri, sharedInboxUri };
+};
+
+const createContentPost = async (
+  profileId: string,
+  visibility: PostVisibility = PostVisibility.PUBLIC,
+) => {
+  const post = await db
+    .insert(Posts)
+    .values({ profileId, state: PostState.ACTIVE, visibility })
+    .returning()
+    .then(firstOrThrow);
+  const content = await db
+    .insert(PostContents)
+    .values({
+      document: {
+        body: {
+          content: [{ content: [{ text: 'body', type: 'text' }], type: 'paragraph' }],
+          type: 'doc',
+        },
+        summary: null,
+        version: 1,
+      },
+      postId: post.id,
+    })
+    .returning()
+    .then(firstOrThrow);
+  return db
+    .update(Posts)
+    .set({ currentContentId: content.id })
+    .where(eq(Posts.id, post.id))
+    .returning()
+    .then(firstOrThrow);
+};
+
+const createRepost = async (
+  profileId: string,
+  sourceId: string,
+  visibility: PostVisibility = PostVisibility.UNLISTED,
+) =>
+  db
+    .insert(Posts)
+    .values({
+      profileId,
+      repostSourceId: sourceId,
+      state: PostState.ACTIVE,
+      visibility,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+const cleanTestRows = async () => {
+  if (testProfileIds.length === 0) {
+    return;
+  }
+  const postIds = await db
+    .select({ id: Posts.id })
+    .from(Posts)
+    .where(inArray(Posts.profileId, testProfileIds))
+    .then((rows) => rows.map(({ id }) => id));
+  if (postIds.length > 0) {
+    await db
+      .update(Posts)
+      .set({ currentContentId: null, replyParentId: null, repostSourceId: null })
+      .where(inArray(Posts.id, postIds));
+    await db.delete(PostContents).where(inArray(PostContents.postId, postIds));
+    await db.delete(Posts).where(inArray(Posts.id, postIds));
+  }
+  await db.delete(Profiles).where(inArray(Profiles.id, testProfileIds));
+  if (testInstanceIds.length > 0) {
+    await db.delete(Instances).where(inArray(Instances.id, testInstanceIds));
+  }
+  testProfileIds = [];
+  testInstanceIds = [];
+};

--- a/packages/fedify/src/repost-delivery.ts
+++ b/packages/fedify/src/repost-delivery.ts
@@ -1,0 +1,230 @@
+import '@kosmo/core/polyfill';
+
+import { Announce, PUBLIC_COLLECTION, Undo } from '@fedify/vocab';
+import {
+  ActivityPubActors,
+  db,
+  first,
+  Instances,
+  Posts,
+  ProfileFollows,
+  Profiles,
+} from '@kosmo/core/db';
+import {
+  InstanceKind,
+  InstanceState,
+  PostState,
+  PostVisibility,
+  ProfileState,
+} from '@kosmo/core/enums';
+import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
+import { and, eq, isNotNull, ne } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { resolveActivityPubPostUri } from './activitypub-post-uri';
+import { federation } from './federation';
+import type { Context } from '@fedify/fedify';
+import type { Recipient } from '@fedify/vocab';
+
+const FollowerProfiles = alias(Profiles, 'repost_delivery_follower_profile');
+const FollowerInstances = alias(Instances, 'repost_delivery_follower_instance');
+
+type RepostDeliveryKind = 'ANNOUNCE' | 'UNDO';
+
+type RepostProjection = {
+  readonly activityId: URL;
+  readonly actorProfileId: string;
+  readonly actorUri: URL;
+  readonly followersUri: URL;
+  readonly objectUri: URL;
+  readonly orderingKey: string;
+  readonly published: Temporal.Instant;
+  readonly undoId: URL;
+  readonly visibility: PostVisibility;
+};
+
+const parseHttpUri = (value: string): URL | undefined => {
+  try {
+    const uri = new URL(value);
+    return uri.protocol === 'http:' || uri.protocol === 'https:' ? uri : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const getFollowersUri = (actorUri: URL): URL =>
+  new URL(`${actorUri.pathname.replace(/\/$/, '')}/followers`, actorUri);
+
+const loadRepostProjection = async (
+  context: Context<void>,
+  repostId: string,
+  kind: RepostDeliveryKind,
+): Promise<RepostProjection | undefined> => {
+  const localInstance = await resolveConfiguredLocalInstance();
+  const row = await db
+    .select({
+      authorInstanceId: Instances.id,
+      authorInstanceKind: Instances.kind,
+      authorInstanceOrigin: Instances.canonicalOrigin,
+      authorInstanceState: Instances.state,
+      authorProfileId: Profiles.id,
+      authorProfileState: Profiles.state,
+      repost: Posts,
+    })
+    .from(Posts)
+    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(eq(Posts.id, repostId))
+    .limit(1)
+    .then(first);
+
+  const expectedState = kind === 'ANNOUNCE' ? PostState.ACTIVE : PostState.DELETED;
+  if (
+    !row ||
+    row.repost.state !== expectedState ||
+    row.repost.currentContentId !== null ||
+    row.repost.replyParentId !== null ||
+    row.repost.repostSourceId === null ||
+    (row.repost.visibility !== PostVisibility.UNLISTED &&
+      row.repost.visibility !== PostVisibility.FOLLOWERS) ||
+    row.authorProfileState !== ProfileState.ACTIVE ||
+    row.authorInstanceId !== localInstance.id ||
+    row.authorInstanceKind !== InstanceKind.LOCAL ||
+    row.authorInstanceState !== InstanceState.ACTIVE ||
+    row.authorInstanceOrigin !== localInstance.canonicalOrigin ||
+    context.canonicalOrigin !== localInstance.canonicalOrigin
+  ) {
+    return undefined;
+  }
+
+  if (kind === 'ANNOUNCE') {
+    const source = await db
+      .select({
+        currentContentId: Posts.currentContentId,
+        instanceState: Instances.state,
+        profileState: Profiles.state,
+        state: Posts.state,
+      })
+      .from(Posts)
+      .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+      .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+      .where(eq(Posts.id, row.repost.repostSourceId))
+      .limit(1)
+      .then(first);
+    if (
+      !source ||
+      source.currentContentId === null ||
+      source.state !== PostState.ACTIVE ||
+      source.profileState !== ProfileState.ACTIVE ||
+      source.instanceState === InstanceState.SUSPENDED
+    ) {
+      return undefined;
+    }
+  }
+
+  const objectUri = await resolveActivityPubPostUri(row.repost.repostSourceId);
+  if (!objectUri) {
+    return undefined;
+  }
+
+  const actorUri = context.getActorUri(row.authorProfileId);
+  const activityId = new URL(`/ap/announce/${row.repost.id}`, localInstance.canonicalOrigin);
+  return {
+    activityId,
+    actorProfileId: row.authorProfileId,
+    actorUri,
+    followersUri: getFollowersUri(actorUri),
+    objectUri,
+    orderingKey: `activitypub-repost:${row.repost.id}`,
+    published: row.repost.createdAt,
+    undoId: new URL('#undo', activityId),
+    visibility: row.repost.visibility,
+  };
+};
+
+const loadRecipients = async (actorProfileId: string): Promise<Recipient[]> => {
+  const rows = await db
+    .select({
+      inboxUri: ActivityPubActors.inboxUri,
+      sharedInboxUri: ActivityPubActors.sharedInboxUri,
+      uri: ActivityPubActors.uri,
+    })
+    .from(ProfileFollows)
+    .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, ProfileFollows.followerProfileId))
+    .innerJoin(FollowerInstances, eq(FollowerInstances.id, FollowerProfiles.instanceId))
+    .innerJoin(ActivityPubActors, eq(ActivityPubActors.profileId, FollowerProfiles.id))
+    .where(
+      and(
+        eq(ProfileFollows.followeeProfileId, actorProfileId),
+        eq(FollowerProfiles.state, ProfileState.ACTIVE),
+        eq(FollowerInstances.kind, InstanceKind.ACTIVITYPUB),
+        ne(FollowerInstances.state, InstanceState.SUSPENDED),
+        isNotNull(ActivityPubActors.inboxUri),
+      ),
+    );
+
+  return rows.flatMap(({ inboxUri, sharedInboxUri, uri }) => {
+    const id = parseHttpUri(uri);
+    const inboxId = inboxUri ? parseHttpUri(inboxUri) : undefined;
+    if (!id || !inboxId) {
+      return [];
+    }
+
+    const sharedInbox = sharedInboxUri ? parseHttpUri(sharedInboxUri) : undefined;
+    return [
+      {
+        endpoints: sharedInbox ? { sharedInbox } : null,
+        id,
+        inboxId,
+      },
+    ];
+  });
+};
+
+const createAnnounce = (projection: RepostProjection): Announce =>
+  new Announce({
+    actor: projection.actorUri,
+    ...(projection.visibility === PostVisibility.UNLISTED ? { ccs: [PUBLIC_COLLECTION] } : {}),
+    id: projection.activityId,
+    object: projection.objectUri,
+    published: projection.published,
+    tos: [projection.followersUri],
+  });
+
+const sendRepostActivity = async (repostId: string, kind: RepostDeliveryKind): Promise<void> => {
+  const localInstance = await resolveConfiguredLocalInstance();
+  const context = federation.createContext(new URL(localInstance.canonicalOrigin), undefined);
+  const projection = await loadRepostProjection(context, repostId, kind);
+  if (!projection) {
+    return;
+  }
+
+  const recipients = await loadRecipients(projection.actorProfileId);
+  if (recipients.length === 0) {
+    return;
+  }
+
+  const announce = createAnnounce(projection);
+  const activity =
+    kind === 'ANNOUNCE'
+      ? announce
+      : new Undo({
+          actor: projection.actorUri,
+          ...(projection.visibility === PostVisibility.UNLISTED
+            ? { ccs: [PUBLIC_COLLECTION] }
+            : {}),
+          id: projection.undoId,
+          object: announce,
+          tos: [projection.followersUri],
+        });
+
+  await context.sendActivity({ identifier: projection.actorProfileId }, recipients, activity, {
+    orderingKey: projection.orderingKey,
+    preferSharedInbox: true,
+  });
+};
+
+export const sendRepostAnnounce = async (repostId: string): Promise<void> =>
+  sendRepostActivity(repostId, 'ANNOUNCE');
+
+export const sendRepostUndo = async (repostId: string): Promise<void> =>
+  sendRepostActivity(repostId, 'UNDO');


### PR DESCRIPTION
## 무엇을 변경했는지

- 최초 Local Repost 생성 뒤 remote follower에게 ActivityPub `Announce`를 직접 전달합니다.
- 최초 Repost Tombstone 전이 뒤 같은 Announce를 가리키는 `Undo`를 전달합니다.
- Local/Remote Source의 canonical ActivityPub URI와 Repost visibility를 activity object·audience로 투영합니다.
- Repost Notification 생성·정리를 API resolver에서 core post-commit application 경계로 이동했습니다.
- 동시·반복 요청, Source lifecycle, recipient projection과 delivery failure isolation을 core·Fedify·API 테스트로 검증했습니다.
- PROD-496 OpenSpec을 canonical spec에 반영하고 완료 change를 archive했습니다.

## 왜 변경했는지

Local Repost는 domain transaction과 GraphQL mutation까지만 구현되어 원격 ActivityPub follower에게 전달되지 않았습니다. PROD-494의 Post URI resolver와 PROD-447의 post-commit failure isolation 패턴을 재사용해, committed application 결과를 외부 delivery 성공 여부와 분리하면서 Announce/Undo lifecycle을 완성합니다.

## 이번 PR의 주요 결정

### Repost Notification lifecycle은 core가 소유한다

- 결정자: @robin-maki
- 선택: `repostPost`와 `deletePost`의 top-level post-commit 경계에서 Notification 생성·정리와 Fedify delivery를 각각 best-effort로 실행합니다.
- 고려한 대안: GraphQL resolver가 `created`와 삭제 결과를 해석해 Notification을 실행하는 방식
- 이유: 최초 상태 전이와 transaction commit을 확정하는 application service가 필수 side effect lifecycle도 함께 소유해야 GraphQL 외 caller와 계약이 갈라지지 않습니다.
- 감수한 결과: caller-owned transaction에는 after-commit hook이 없어 현재처럼 side effect를 실행하지 않습니다.
- 관련 근거: [OpenSpec decisions](openspec/changes/archive/2026-07-28-add-activitypub-local-repost-delivery/decisions.md)

### Undo는 Announce identity의 `#undo` fragment를 사용한다

- 결정자: @robin-maki
- 선택: Announce는 `/ap/announce/{repostId}`, Undo는 `/ap/announce/{repostId}#undo`를 사용합니다.
- 고려한 대안: 별도 하위 리소스처럼 보이는 `/ap/announce/{repostId}/undo`
- 이유: 이번 범위의 Undo는 독립 HTTP resource가 아니라 같은 Repost/Announce lifecycle에서 파생된 안정적인 ActivityPub identity입니다.
- 감수한 결과: fragment는 HTTP 요청 시 서버로 전달되지 않으므로 향후 activity dereference를 도입할 때 representation 계약을 별도로 정해야 합니다.
- 관련 근거: [canonical capability](openspec/specs/activitypub-local-repost-delivery/spec.md)

### 현재 Fedify direct-delivery 경계를 유지한다

- 선택: domain transaction commit 후 기존 Fedify 경계로 직접 전달하고 실패를 committed 결과와 분리합니다.
- 고려한 대안: NATS, Fedify MessageQueue, transactional outbox를 이번 PR에 추가
- 이유: durable transport는 PROD-448 후속 migration이며 PROD-496의 선행 또는 범위가 아닙니다.
- 감수한 결과: commit 직후 process 종료 시 delivery가 유실될 수 있고 remote 전송 시간이 mutation 응답에 포함됩니다.

## 어떻게 확인할 수 있는지

- `pnpm test:fedify` — 129/129
- `pnpm --filter @kosmo/core test:services:database` — 121/121
- `pnpm --filter @kosmo/api test` — 155 passed, 1 skipped
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm lint:syncpack`
- `pnpm exec openspec validate --all --strict` — 40/40

## 아직 어떤 문제가 남았는지

- durable delivery intent, retry, history와 queue handoff는 PROD-448 후속 범위입니다.
- caller-owned transaction 경로에는 after-commit side effect 자동 실행이 없습니다. 현재 production caller는 top-level GraphQL 경로뿐입니다.
