### PR TITLE
Local Reply 생성과 삭제를 ActivityPub으로 전달한다

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.10",
     "@kosmo/core": "workspace:*",
+    "@kosmo/fedify": "workspace:*",
     "@pothos/core": "^4.12.0",
     "@pothos/plugin-dataloader": "^4.4.3",
     "@pothos/plugin-relay": "^4.7.0",

--- a/apps/api/src/graphql/resolvers/post/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.ts
@@ -1,13 +1,8 @@
-import { db, first, Instances, Posts, Profiles } from '@kosmo/core/db';
 import { PostVisibility } from '@kosmo/core/enums';
-import { NotFoundError } from '@kosmo/core/error';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
-import { createPost, createReplyNotificationBestEffort } from '@kosmo/core/services';
+import { createLocalPost } from '@kosmo/core/services';
 import { postBodyTextSchema } from '@kosmo/core/validation';
-import { sendLocalReplyCreate } from '@kosmo/fedify';
-import { and, eq } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
-import { postVisibilityAccessWhere } from '../access/visibility';
 import { Post } from '../ref';
 
 builder.mutationField('createPost', (t) =>
@@ -23,46 +18,14 @@ builder.mutationField('createPost', (t) =>
       visibility: t.input.field({ type: PostVisibility }),
     },
     resolve: async (_, { input }, ctx) => {
-      const result = await db.transaction(async (tx) => {
-        const replyParentId = input.replyParentId?.id;
-        if (replyParentId) {
-          const parent = await tx
-            .select({ id: Posts.id })
-            .from(Posts)
-            .innerJoin(Profiles, eq(Posts.profileId, Profiles.id))
-            .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-            .where(and(eq(Posts.id, replyParentId), postVisibilityAccessWhere({ ctx })))
-            .limit(1)
-            .then(first);
-          if (!parent) {
-            throw new NotFoundError('Post not found');
-          }
-        }
-
-        const { post } = await createPost(
-          {
-            document: postContentDocumentFromText(input.bodyText),
-            origin: 'LOCAL',
-            profileId: ctx.session.profileId,
-            replyParentId,
-            visibility: input.visibility,
-          },
-          tx,
-        );
-
-        return { post };
+      const { post } = await createLocalPost({
+        document: postContentDocumentFromText(input.bodyText),
+        profileId: ctx.session.profileId,
+        replyParentId: input.replyParentId?.id,
+        visibility: input.visibility,
       });
 
-      if (input.replyParentId) {
-        await createReplyNotificationBestEffort(result.post.id);
-        await sendLocalReplyCreate(result.post.id).catch((error) => {
-          console.error('Post-commit ActivityPub Reply Create delivery failed', {
-            error,
-            postId: result.post.id,
-          });
-        });
-      }
-      return result;
+      return { post };
     },
   }),
 );

--- a/apps/api/src/graphql/resolvers/post/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.ts
@@ -1,6 +1,6 @@
 import { PostVisibility } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
-import { createLocalPost } from '@kosmo/core/services';
+import { createPost } from '@kosmo/core/services';
 import { postBodyTextSchema } from '@kosmo/core/validation';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
@@ -18,8 +18,9 @@ builder.mutationField('createPost', (t) =>
       visibility: t.input.field({ type: PostVisibility }),
     },
     resolve: async (_, { input }, ctx) => {
-      const { post } = await createLocalPost({
+      const { post } = await createPost({
         document: postContentDocumentFromText(input.bodyText),
+        origin: 'LOCAL',
         profileId: ctx.session.profileId,
         replyParentId: input.replyParentId?.id,
         visibility: input.visibility,

--- a/apps/api/src/graphql/resolvers/post/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.ts
@@ -4,6 +4,7 @@ import { NotFoundError } from '@kosmo/core/error';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { createPost, createReplyNotificationBestEffort } from '@kosmo/core/services';
 import { postBodyTextSchema } from '@kosmo/core/validation';
+import { sendLocalReplyCreate } from '@kosmo/fedify';
 import { and, eq } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
 import { postVisibilityAccessWhere } from '../access/visibility';
@@ -54,6 +55,12 @@ builder.mutationField('createPost', (t) =>
 
       if (input.replyParentId) {
         await createReplyNotificationBestEffort(result.post.id);
+        await sendLocalReplyCreate(result.post.id).catch((error) => {
+          console.error('Post-commit ActivityPub Reply Create delivery failed', {
+            error,
+            postId: result.post.id,
+          });
+        });
       }
       return result;
     },

--- a/apps/api/src/graphql/resolvers/post/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/delete.ts
@@ -1,4 +1,5 @@
 import { deletePost } from '@kosmo/core/services';
+import { sendLocalReplyDelete } from '@kosmo/fedify';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
@@ -23,6 +24,12 @@ builder.mutationField('deletePost', (t) =>
         postId: input.id.id,
       });
 
+      await sendLocalReplyDelete(result.postId).catch((error) => {
+        console.error('Post-commit ActivityPub Reply Delete delivery failed', {
+          error,
+          postId: result.postId,
+        });
+      });
       return result;
     },
   }),

--- a/apps/api/src/graphql/resolvers/post/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/delete.ts
@@ -1,5 +1,4 @@
 import { deletePost } from '@kosmo/core/services';
-import { sendLocalReplyDelete } from '@kosmo/fedify';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
@@ -24,12 +23,6 @@ builder.mutationField('deletePost', (t) =>
         postId: input.id.id,
       });
 
-      await sendLocalReplyDelete(result.postId).catch((error) => {
-        console.error('Post-commit ActivityPub Reply Delete delivery failed', {
-          error,
-          postId: result.postId,
-        });
-      });
       return result;
     },
   }),

--- a/apps/api/tests/integration/graphql/post.test.ts
+++ b/apps/api/tests/integration/graphql/post.test.ts
@@ -22,7 +22,7 @@ import { Hono } from 'hono';
 import type { Activity, Recipient } from '@fedify/vocab';
 import type * as CoreDb from '@kosmo/core/db';
 import type { encodeGlobalId as EncodeGlobalId } from '@kosmo/core/global-id';
-import type { federation as Federation } from '@kosmo/fedify';
+import type { localReplyFederation as LocalReplyFederation } from '../../../../../packages/fedify/src/local-reply-federation';
 import type { deriveContext as DeriveContext, Env } from '../../../src/context';
 import type { yoga as YogaRouter } from '../../../src/graphql';
 
@@ -44,11 +44,11 @@ let Sessions: typeof CoreDb.Sessions;
 let deriveContext: typeof DeriveContext;
 let yoga: typeof YogaRouter;
 let encodeGlobalId: typeof EncodeGlobalId;
-let federation: typeof Federation;
+let localReplyFederation: typeof LocalReplyFederation;
 let app: Hono<Env>;
 let localInstanceId: string;
 
-type FederationContext = ReturnType<(typeof Federation)['createContext']>;
+type FederationContext = ReturnType<(typeof LocalReplyFederation)['createContext']>;
 
 describe('Post Reply GraphQL 경계', () => {
   before(async () => {
@@ -78,7 +78,8 @@ describe('Post Reply GraphQL 경계', () => {
     ({ deriveContext } = await import('../../../src/context'));
     ({ yoga } = await import('../../../src/graphql'));
     ({ encodeGlobalId } = await import('@kosmo/core/global-id'));
-    ({ federation } = await import('@kosmo/fedify'));
+    ({ localReplyFederation } =
+      await import('../../../../../packages/fedify/src/local-reply-federation'));
 
     app = new Hono<Env>();
     app.use('*', async (c, next) => {
@@ -172,7 +173,7 @@ describe('Post Reply GraphQL 경계', () => {
     const hidden = await createContentPost(author.id, { visibility: PostVisibility.DIRECT });
     const deleted = await createContentPost(author.id, { state: PostState.DELETED });
     const before = await db.$count(Posts);
-    const createContext = t.mock.method(federation, 'createContext');
+    const createContext = t.mock.method(localReplyFederation, 'createContext');
 
     for (const parentId of [hidden.id, deleted.id, crypto.randomUUID()]) {
       const result = await requestCreatePost(
@@ -195,7 +196,7 @@ describe('Post Reply GraphQL 경계', () => {
     const parentAuthor = await createRemoteActorProfile('delivery-create-parent');
     const parent = await createContentPost(parentAuthor.id);
     const deliveredPostIds: string[] = [];
-    t.mock.method(federation, 'createContext', () =>
+    t.mock.method(localReplyFederation, 'createContext', () =>
       createFailingDeliveryContext(async (activity) => {
         assert.ok(activity instanceof Create);
         const postId = activity.objectId?.pathname.split('/').at(-1);
@@ -235,7 +236,7 @@ describe('Post Reply GraphQL 경계', () => {
     const parentAuthor = await createRemoteActorProfile('delivery-delete-parent');
     const parent = await createContentPost(parentAuthor.id);
     const reply = await createContentPost(auth.profile.id, { replyParentId: parent.id });
-    t.mock.method(federation, 'createContext', () =>
+    t.mock.method(localReplyFederation, 'createContext', () =>
       createFailingDeliveryContext(async (activity) => {
         assert.ok(activity instanceof Delete);
         const committed = await db
@@ -265,7 +266,7 @@ describe('Post Reply GraphQL 경계', () => {
     const otherAuthor = await createProfile('delete-rollback-author');
     const parent = await createContentPost(otherAuthor.id);
     const reply = await createContentPost(otherAuthor.id, { replyParentId: parent.id });
-    const createContext = t.mock.method(federation, 'createContext');
+    const createContext = t.mock.method(localReplyFederation, 'createContext');
 
     const forbidden = await requestDeletePost(reply.id, auth.token);
     const missing = await requestDeletePost(crypto.randomUUID(), auth.token);
@@ -289,7 +290,7 @@ describe('Post Reply GraphQL 경계', () => {
     const reply = await createContentPost(auth.profile.id, { replyParentId: parent.id });
     const rootPost = await createContentPost(auth.profile.id);
     const activityIds: string[] = [];
-    t.mock.method(federation, 'createContext', () =>
+    t.mock.method(localReplyFederation, 'createContext', () =>
       createDeliveryContext(async (activity) => {
         assert.ok(activity instanceof Delete);
         assert.ok(activity.id);

--- a/apps/api/tests/integration/graphql/post.test.ts
+++ b/apps/api/tests/integration/graphql/post.test.ts
@@ -2,9 +2,11 @@ import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
 import { after, before, beforeEach, describe, test } from 'node:test';
+import { Create, Delete } from '@fedify/vocab';
 import {
   AccountProfileRole,
   AccountState,
+  ActivityPubActorType,
   InstanceKind,
   InstanceState,
   PostState,
@@ -17,8 +19,10 @@ import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { normalizeHandle } from '@kosmo/core/utils';
 import { and, eq, ne } from 'drizzle-orm';
 import { Hono } from 'hono';
+import type { Activity, Recipient } from '@fedify/vocab';
 import type * as CoreDb from '@kosmo/core/db';
 import type { encodeGlobalId as EncodeGlobalId } from '@kosmo/core/global-id';
+import type { federation as Federation } from '@kosmo/fedify';
 import type { deriveContext as DeriveContext, Env } from '../../../src/context';
 import type { yoga as YogaRouter } from '../../../src/graphql';
 
@@ -26,6 +30,7 @@ const publicOrigin = 'http://127.0.0.1:4173';
 process.env.DATABASE_URL ??= 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
 
 let db: typeof CoreDb.db;
+let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let AccountProfiles: typeof CoreDb.AccountProfiles;
 let Accounts: typeof CoreDb.Accounts;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
@@ -39,8 +44,11 @@ let Sessions: typeof CoreDb.Sessions;
 let deriveContext: typeof DeriveContext;
 let yoga: typeof YogaRouter;
 let encodeGlobalId: typeof EncodeGlobalId;
+let federation: typeof Federation;
 let app: Hono<Env>;
 let localInstanceId: string;
+
+type FederationContext = ReturnType<(typeof Federation)['createContext']>;
 
 describe('Post Reply GraphQL 경계', () => {
   before(async () => {
@@ -50,6 +58,7 @@ describe('Post Reply GraphQL 경계', () => {
     ({
       AccountProfiles,
       Accounts,
+      ActivityPubActors,
       db,
       firstOrThrow,
       Instances,
@@ -69,6 +78,7 @@ describe('Post Reply GraphQL 경계', () => {
     ({ deriveContext } = await import('../../../src/context'));
     ({ yoga } = await import('../../../src/graphql'));
     ({ encodeGlobalId } = await import('@kosmo/core/global-id'));
+    ({ federation } = await import('@kosmo/fedify'));
 
     app = new Hono<Env>();
     app.use('*', async (c, next) => {
@@ -156,12 +166,13 @@ describe('Post Reply GraphQL 경계', () => {
     }
   });
 
-  test('없거나 조회할 수 없거나 삭제된 Parent는 같은 NOT_FOUND로 숨기고 rollback한다', async () => {
+  test('없거나 조회할 수 없거나 삭제된 Parent는 같은 NOT_FOUND로 숨기고 rollback한다', async (t) => {
     const auth = await createAuthenticatedSession();
     const author = await createProfile('hidden-parent-author');
     const hidden = await createContentPost(author.id, { visibility: PostVisibility.DIRECT });
     const deleted = await createContentPost(author.id, { state: PostState.DELETED });
     const before = await db.$count(Posts);
+    const createContext = t.mock.method(federation, 'createContext');
 
     for (const parentId of [hidden.id, deleted.id, crypto.randomUUID()]) {
       const result = await requestCreatePost(
@@ -176,6 +187,125 @@ describe('Post Reply GraphQL 경계', () => {
     }
 
     assert.equal(await db.$count(Posts), before);
+    assert.equal(createContext.mock.callCount(), 0);
+  });
+
+  test('Reply Create delivery 실패는 commit된 Post와 GraphQL 성공을 바꾸지 않는다', async (t) => {
+    const auth = await createAuthenticatedSession();
+    const parentAuthor = await createRemoteActorProfile('delivery-create-parent');
+    const parent = await createContentPost(parentAuthor.id);
+    const deliveredPostIds: string[] = [];
+    t.mock.method(federation, 'createContext', () =>
+      createFailingDeliveryContext(async (activity) => {
+        assert.ok(activity instanceof Create);
+        const postId = activity.objectId?.pathname.split('/').at(-1);
+        assert.ok(postId);
+        const committed = await db
+          .select({ currentContentId: Posts.currentContentId, state: Posts.state })
+          .from(Posts)
+          .where(eq(Posts.id, postId))
+          .then(firstOrThrow);
+        assert.equal(committed.state, PostState.ACTIVE);
+        assert.ok(committed.currentContentId);
+        deliveredPostIds.push(postId);
+      }),
+    );
+    const errorLog = t.mock.method(console, 'error', () => undefined);
+
+    const result = await requestCreatePost(
+      {
+        bodyText: 'committed reply',
+        replyParentId: encodeGlobalId('Post', parent.id),
+        visibility: PostVisibility.PUBLIC,
+      },
+      auth.token,
+    );
+
+    assertNoGraphQLErrors(result);
+    assert.equal(deliveredPostIds.length, 1);
+    assert.equal(errorLog.mock.callCount(), 1);
+    assert.equal(
+      errorLog.mock.calls[0]?.arguments[0],
+      'Post-commit ActivityPub Reply Create delivery failed',
+    );
+  });
+
+  test('Reply Delete delivery 실패는 commit된 Tombstone과 GraphQL 성공을 바꾸지 않는다', async (t) => {
+    const auth = await createAuthenticatedSession();
+    const parentAuthor = await createRemoteActorProfile('delivery-delete-parent');
+    const parent = await createContentPost(parentAuthor.id);
+    const reply = await createContentPost(auth.profile.id, { replyParentId: parent.id });
+    t.mock.method(federation, 'createContext', () =>
+      createFailingDeliveryContext(async (activity) => {
+        assert.ok(activity instanceof Delete);
+        const committed = await db
+          .select({ deletedAt: Posts.deletedAt, state: Posts.state })
+          .from(Posts)
+          .where(eq(Posts.id, reply.id))
+          .then(firstOrThrow);
+        assert.equal(committed.state, PostState.DELETED);
+        assert.ok(committed.deletedAt);
+      }),
+    );
+    const errorLog = t.mock.method(console, 'error', () => undefined);
+
+    const result = await requestDeletePost(reply.id, auth.token);
+
+    assertNoGraphQLErrors(result);
+    assert.equal(result.data?.deletePost.postId, encodeGlobalId('Post', reply.id));
+    assert.equal(errorLog.mock.callCount(), 1);
+    assert.equal(
+      errorLog.mock.calls[0]?.arguments[0],
+      'Post-commit ActivityPub Reply Delete delivery failed',
+    );
+  });
+
+  test('Reply 삭제 transaction 실패는 ActivityPub delivery를 호출하지 않는다', async (t) => {
+    const auth = await createAuthenticatedSession();
+    const otherAuthor = await createProfile('delete-rollback-author');
+    const parent = await createContentPost(otherAuthor.id);
+    const reply = await createContentPost(otherAuthor.id, { replyParentId: parent.id });
+    const createContext = t.mock.method(federation, 'createContext');
+
+    const forbidden = await requestDeletePost(reply.id, auth.token);
+    const missing = await requestDeletePost(crypto.randomUUID(), auth.token);
+
+    assert.equal(forbidden.errors?.[0]?.extensions?.code, 'PERMISSION_DENIED');
+    assert.equal(missing.errors?.[0]?.extensions?.code, 'NOT_FOUND');
+    assert.equal(createContext.mock.callCount(), 0);
+    const stored = await db
+      .select({ deletedAt: Posts.deletedAt, state: Posts.state })
+      .from(Posts)
+      .where(eq(Posts.id, reply.id))
+      .then(firstOrThrow);
+    assert.equal(stored.state, PostState.ACTIVE);
+    assert.equal(stored.deletedAt, null);
+  });
+
+  test('반복 Reply 삭제는 같은 Delete identity로 전달하고 일반 Post 삭제는 전달하지 않는다', async (t) => {
+    const auth = await createAuthenticatedSession();
+    const parentAuthor = await createRemoteActorProfile('delivery-repeat-parent');
+    const parent = await createContentPost(parentAuthor.id);
+    const reply = await createContentPost(auth.profile.id, { replyParentId: parent.id });
+    const rootPost = await createContentPost(auth.profile.id);
+    const activityIds: string[] = [];
+    t.mock.method(federation, 'createContext', () =>
+      createDeliveryContext(async (activity) => {
+        assert.ok(activity instanceof Delete);
+        assert.ok(activity.id);
+        activityIds.push(activity.id.href);
+      }),
+    );
+
+    for (const post of [reply, reply, rootPost]) {
+      const result = await requestDeletePost(post.id, auth.token);
+      assertNoGraphQLErrors(result);
+    }
+
+    assert.deepEqual(activityIds, [
+      `${publicOrigin}/ap/note/${reply.id}#delete`,
+      `${publicOrigin}/ap/note/${reply.id}#delete`,
+    ]);
   });
 
   test('Content 없는 Repost Parent는 replyParentId VALIDATION으로 거부하고 rollback한다', async () => {
@@ -645,6 +775,10 @@ type CreatePostNode = {
   visibility: PostVisibility;
 };
 
+type DeletePostNode = {
+  postId: string;
+};
+
 type PostAncestorsNode = {
   id: string;
   replyAncestors: Array<{ id: string }>;
@@ -770,6 +904,15 @@ const requestCreatePost = (
     token,
   );
 
+const requestDeletePost = (postId: string, token?: string) =>
+  requestGraphQL<{ deletePost: DeletePostNode }>(
+    `mutation DeletePost($input: DeletePostInput!) {
+      deletePost(input: $input) { postId }
+    }`,
+    { input: { id: encodeGlobalId('Post', postId) } },
+    token,
+  );
+
 const assertNoGraphQLErrors = (result: GraphQLResult<unknown>) => {
   assert.equal(result.errors, undefined, JSON.stringify(result.errors));
 };
@@ -793,6 +936,42 @@ const createInstance = (kind: InstanceKind, state: InstanceState) => {
     .returning()
     .then(firstOrThrow);
 };
+
+const createRemoteActorProfile = async (handle: string) => {
+  const instance = await createInstance(InstanceKind.ACTIVITYPUB, InstanceState.ACTIVE);
+  const profile = await createProfile(handle, { instanceId: instance.id });
+  const actorUri = `https://${instance.domain}/users/${handle}`;
+  await db.insert(ActivityPubActors).values({
+    inboxUri: `${actorUri}/inbox`,
+    profileId: profile.id,
+    type: ActivityPubActorType.PERSON,
+    uri: actorUri,
+  });
+  return profile;
+};
+
+const createFailingDeliveryContext = (
+  beforeFailure: (activity: Activity) => Promise<void>,
+): FederationContext =>
+  createDeliveryContext(async (activity) => {
+    await beforeFailure(activity);
+    throw new Error('remote delivery unavailable');
+  });
+
+const createDeliveryContext = (
+  sendActivity: (activity: Activity) => Promise<void>,
+): FederationContext =>
+  ({
+    canonicalOrigin: publicOrigin,
+    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
+    sendActivity: async (
+      _sender: { identifier: string },
+      _recipients: Recipient[],
+      activity: Activity,
+    ) => {
+      await sendActivity(activity);
+    },
+  }) as unknown as FederationContext;
 
 const createProfile = (
   handle: string,

--- a/docs/domain/decisions/0017-activitypub-local-post-note.md
+++ b/docs/domain/decisions/0017-activitypub-local-post-note.md
@@ -10,8 +10,9 @@ Accepted
 
 ## 결정
 
-- Content가 있는 Local Post의 ActivityPub identity는 configured Local Instance의 canonical origin과
-  `/ap/note/{postId}`를 결합한 URI다. `postId`는 immutable DB UUID다.
+- Content가 있는 Local Post의 ActivityPub identity는 Author Profile이 연결된 Local Instance의 canonical
+  origin과 `/ap/note/{postId}`를 결합한 URI다. `postId`는 immutable DB UUID다. Activity를 실행하는
+  deployment의 configured Local Instance가 다르더라도 Author Instance identity를 대체하지 않는다.
 - Author handle이나 GraphQL global ID는 ActivityPub identity에 포함하지 않는다. Post의 canonical Web 공유
   참조는 ActivityPub identity와 구분해 Note의 `url`로 제공한다.
 - PROD-255와 archived 원격 Post 수신 계약에 따라 ActivityPub Post mapping은 remote object URI와
@@ -41,6 +42,10 @@ Post UUID에 기반한 별도 ActivityPub URI는 mutable handle과 API 전용 gl
 분리한다. Web 공유 URL은 사람이 탐색하는 canonical 참조이고 ActivityPub object URI는 protocol이 안정적으로
 역참조하는 identity이므로 역할을 하나의 URL에 합치지 않는다.
 
+Local Post의 federation identity를 Author Profile의 Local Instance에 결속하면 여러 Local Instance가 같은
+저장 모델에 존재하더라도 Activity를 실행한 deployment에 따라 Author Profile과 object origin이 바뀌지 않는다.
+해당 Local Instance를 운영하는 HTTP 경계는 그 origin에서 Author Profile과 Note를 역참조할 수 있어야 한다.
+
 기존 remote mapping은 remote ingestion의 received/published metadata를 포함하며 Local Post를 저장 대상으로
 정의하지 않는다. Local identity는 이 상위 계약을 변경하지 않고 파생 규칙만 추가한다. Visibility에서
 audience를 직접 투영하면 후속 Reply, Repost와 Reaction delivery가 별도 규칙을 만들지 않고 같은 Post 계약을
@@ -54,6 +59,8 @@ Note 역참조 권한이 독립적으로 제한하므로, Reply를 조회한 req
 
 - canonical Web 공유 URL을 Note `id`로 사용하는 방안은 handle과 GraphQL URL shape 변화가 federation identity에
   영향을 주므로 채택하지 않았다.
+- Activity를 실행하는 deployment의 configured Local Instance origin을 사용하는 방안은 Author가 속한 Local
+  Instance와 다른 Author Profile과 object identity를 만들 수 있으므로 채택하지 않았다.
 - Author와 Post ID를 모두 path에 넣는 방안은 globally unique Post UUID에 중복 identity를 추가하고 Author
   경로 정합성을 별도로 검증해야 하므로 채택하지 않았다.
 - 모든 Visibility를 anonymous dispatcher에서 반환하는 방안은 Followers Only와 Mentioned Profiles 조회 정책을
@@ -65,6 +72,8 @@ Note 역참조 권한이 독립적으로 제한하므로, Reply를 조회한 req
 
 - `packages/fedify`의 Local Note dispatcher와 후속 activity delivery는 하나의 Post URI resolver와 Note
   projection을 공유한다.
+- Local Post의 Author Profile, Note와 후속 activity identity는 Author Profile이 연결된 Local Instance의
+  canonical origin을 공유하며, 해당 Instance의 HTTP 경계에서 역참조할 수 있어야 한다.
 - Followers Only 역참조는 서명으로 검증된 요청 Profile과 stored Follow 관계를 연결해야 한다.
 - remote Parent와 대상 Post는 기존 ActivityPub Post mapping URI를 사용하고 local Parent와 대상 Post는 파생 URI를
   사용한다.

--- a/docs/domain/objects/post.md
+++ b/docs/domain/objects/post.md
@@ -140,9 +140,10 @@ Profile과 달라도 같은 Upload Account를 가지면 연결할 수 있다. St
 
 ### ActivityPub Local Note 표현
 
-- Content가 있는 Local Post의 ActivityPub identity는 현재 deployment가 사용하는 configured Local Instance의
-  canonical origin과 `/ap/note/{postId}` 경로를 결합한 절대 URI다. `postId`는 Post의 immutable DB UUID이며
-  Author Profile의 handle이나 GraphQL global ID를 사용하지 않는다.
+- Content가 있는 Local Post의 ActivityPub identity는 Author Profile이 연결된 Local Instance의 canonical
+  origin과 `/ap/note/{postId}` 경로를 결합한 절대 URI다. `postId`는 Post의 immutable DB UUID이며 Author
+  Profile의 handle이나 GraphQL global ID를 사용하지 않는다. Activity를 실행하는 deployment의 configured
+  Local Instance가 다르더라도 이 identity를 대체하지 않는다.
 - 같은 Local Post는 프로세스 재시작, 역참조 요청 경로와 후속 Activity 종류에 관계없이 같은 Note URI를
   가진다. Local Post를 위해 remote ActivityPub Post mapping을 만들지 않는다.
 - ActivityPub `Note`는 위 URI를 `id`, Author Profile의 canonical ActivityPub URI를 `attributedTo`, Post
@@ -171,8 +172,10 @@ ActivityPub audience는 Post Visibility에서 다음과 같이 투영한다.
 - Followers Only signed fetch는 서명으로 검증된 요청 Profile이 Author이거나 저장된 established Follow 관계의
   Follower일 때만 허용한다. 인증되지 않았거나 식별되지 않은 요청 주체와 Follower가 아닌 Profile에게는 Post가
   없는 것처럼 응답한다.
-- Post가 Tombstone이거나 Content가 없거나, Author Profile 또는 configured Local Instance가 unavailable이거나,
-  지원하지 않는 Visibility이면 Note를 제공하지 않는다. 이 unavailable 응답은 Post의 존재를 노출하지 않는다.
+- Post가 Tombstone이거나 Content가 없거나, Author Profile 또는 Author Profile이 연결된 Local Instance가
+  unavailable이거나, 지원하지 않는 Visibility이면 Note를 제공하지 않는다. Author Local Instance의 HTTP
+  경계는 그 Instance origin의 Author Profile과 Note를 역참조할 수 있어야 한다. 이 unavailable 응답은 Post의
+  존재를 노출하지 않는다.
 - Local Note의 ActivityPub Tombstone, `Delete`, `Create`, `Announce`, `Like`, `EmojiReact`, `Undo` delivery는 각
   lifecycle과 delivery 계약이 소유한다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-28

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -1,0 +1,123 @@
+## Context
+
+이 기록은 canonical Post·Instance·core service 계약, 완료된 Local Note identity 기반, 최신 PROD-497·447·448과
+현재 Local Reply 생성·삭제 및 Fedify delivery 경계를 독립 확인한 결과를 반영한다. 구현자는 OpenSpec 자체를
+상위 권위로 사용하지 않고 구현 전에 최신 canonical 문서와 Linear 계약을 다시 대조해야 한다.
+
+## Decision Records
+
+### Reply Create와 Delete는 기존 Local Note identity를 공유한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-494, PROD-497
+- Status: Active
+- Context / Problem: Reply delivery가 별도 object identity나 Tombstone 표현을 만들면 object dispatcher의
+  `/ap/note/{postId}`와 remote server가 받은 Create/Delete 대상이 달라질 수 있다.
+- Decision Outcome: Create는 PROD-494의 full Local Note projection을 object로 사용하고 Delete는 같은 canonical
+  Note URI를 object IRI로 가리킨다. Delete를 위해 새 Tombstone object endpoint나 local Post mapping row를 만들지
+  않는다.
+- Alternatives Considered: delivery 전용 Note URI, Local Post mapping row, embedded Tombstone, Delete 이후
+  Active-only Note dispatcher 허용.
+- Consequences: Create의 content·summary·audience·`inReplyTo`는 object dispatcher와 같고, Tombstone Reply는
+  직접 역참조할 수 없어도 Delete object identity가 유지된다.
+- Confirmation / Follow-up: Local/Remote Parent Create와 Tombstone Delete가 같은 Note identity를 사용하는지
+  Fedify integration test로 확인한다.
+
+### Activity identity는 Note URI fragment에서 파생한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497
+- Status: Active
+- Context / Problem: Fedify의 자동 activity ID를 사용하면 같은 committed Reply의 delivery 재호출마다 새 logical
+  activity가 생기고, 별도 activity row를 추가하면 현재 범위를 넘어선다.
+- Decision Outcome: Create activity ID는 `{noteUri}#create`, Delete activity ID는 `{noteUri}#delete`로 파생하고
+  fragment 없는 canonical Note URI를 두 activity의 ordering key로 사용한다.
+- Alternatives Considered: 자동 생성 URN UUID, 별도 `/ap/activity/{id}` row·route, Post UUID와 activity kind를
+  포함한 별도 path.
+- Consequences: DB schema나 activity dispatcher 없이 반복 호출 identity와 Create/Delete ordering domain이
+  안정된다. 같은 Post에는 lifecycle별 logical Create와 Delete 하나만 표현한다.
+- Confirmation / Follow-up: 반복 Create·Delete 호출의 ID와 ordering key를 검증한다.
+
+### Recipient는 action 시점의 현재 저장 관계에서 계산한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497
+- Status: Active
+- Context / Problem: remote follower와 Parent Author가 겹칠 수 있고 Followers Only Reply가 follower가 아닌 Parent
+  Author에게 전달되면 visibility를 우회한다. 반대로 과거 recipient를 보존하려면 명시적으로 제외된 delivery
+  history가 필요하다.
+- Decision Outcome: Public/Unlisted는 현재 established remote follower와 remote Parent Author를, Followers
+  Only는 현재 established remote follower만 선택한다. Parent Author도 Followers Only에서는 established
+  follower여야 한다. Active ActivityPub Instance와 usable actor endpoint만 허용하고 actor identity로 중복을
+  제거한다. Create 당시 recipient snapshot은 저장하지 않는다.
+- Alternatives Considered: visibility와 무관하게 Parent Author에게 항상 전달, Parent Author 제외, Create recipient
+  snapshot 저장, Instance 상태와 무관한 delivery.
+- Consequences: 삭제 시점 전에 unfollow한 과거 recipient는 Delete를 받지 못할 수 있다. 이 한계는 history가 없는
+  현재 직접 delivery 범위에 남고, visibility와 Instance 정책은 현재 저장 상태에 일치한다.
+- Confirmation / Follow-up: visibility·follower·Parent Author·Instance state·중복 actor matrix를 검증한다.
+
+### 저장된 Recipient 배열을 Fedify에 직접 전달한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, PROD-497
+- Status: Active
+- Context / Problem: Fedify의 special `"followers"` recipient는 followers collection dispatcher가 필요하지만
+  현재 actor contract는 collection GET을 제공하지 않으며 remote Parent Author도 별도로 합쳐야 한다.
+- Decision Outcome: 현재 DB 관계에서 usable remote actor를 조회해 Fedify `Recipient[]`로 전달하고 shared inbox를
+  선호한다. 이번 change에서 followers collection dispatcher나 collection endpoint를 열지 않는다.
+- Alternatives Considered: `"followers"` special recipient와 새 collection dispatcher, recipient별 개별
+  `sendActivity()`, ActivityPub followers collection mirror.
+- Consequences: 기존 저장 ProfileFollow와 ActivityPub Actor가 recipient source of truth로 유지된다. 동일 server
+  delivery는 Fedify shared inbox 경계에서 묶을 수 있고 새 공개 collection API가 생기지 않는다.
+- Confirmation / Follow-up: recipient 배열, actor 중복 제거, shared inbox option과 no-recipient no-op을 검증한다.
+
+### 실제 outer commit 뒤 application entry에서 delivery를 orchestration한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, PROD-447, PROD-497
+- Status: Active
+- Context / Problem: `createPost()`는 caller transaction에 합류할 수 있어 그 함수 반환만으로 실제 domain
+  transaction commit을 알 수 없다. 그 안에서 delivery하면 rollback될 Reply를 remote inbox로 먼저 보낼 수 있다.
+- Decision Outcome: 현재 production Local Reply entry인 GraphQL resolver가 가장 바깥 생성 transaction 또는
+  `deletePost()` transaction의 성공 반환 뒤 Fedify delivery를 `await`하고 catch/log한다. Core Post public contract에
+  protocol object, callback이나 delivery port를 추가하지 않는다.
+- Alternatives Considered: `createPost(..., tx)` 내부 delivery, transaction callback 주입, fire-and-forget Promise,
+  Parent access를 포함한 새 core orchestration action.
+- Consequences: 현재 transaction ownership과 transport-neutral core contract를 유지하면서 실제 commit 이후에만
+  전달한다. 향후 다른 Local Reply production entry가 생기면 같은 post-commit orchestration을 연결하거나 core가
+  outer transaction 전체를 소유하도록 별도 정렬해야 한다.
+- Confirmation / Follow-up: rollback에서 delivery zero-call, commit 뒤 delivery와 failure isolation을 API integration
+  test로 확인한다.
+
+### Direct delivery 실패는 committed Reply 결과와 분리한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/architecture/core-services.md`, PROD-447, PROD-497, PROD-448
+- Status: Active
+- Context / Problem: 현재 Fedify federation에는 queue가 없어 remote HTTP 실패가 `sendActivity()`에서 throw된다.
+  이 오류를 application 밖으로 전파하면 DB state는 commit됐지만 GraphQL은 실패하는 모순이 생긴다.
+- Decision Outcome: Create/Delete delivery를 commit 뒤 직접 await하고 실패를 Reply identity와 함께 기록하되,
+  create/delete application action은 committed payload를 성공으로 반환한다. `UNRESPONSIVE`에서는 delivery와
+  pending retry를 만들지 않는다.
+- Alternatives Considered: delivery 실패 시 domain rollback, GraphQL 실패 유지와 client refetch, fire-and-forget,
+  이번 change에서 outbox·queue를 선행 구현.
+- Consequences: remote HTTP 지연은 API 응답 경로에 남고 commit과 delivery 사이 process 종료 시 유실될 수 있다.
+  Durable intent와 queue handoff로 이 임시 경계를 대체하는 migration은 PROD-448이 별도로 소유한다.
+- Confirmation / Follow-up: Create/Delete delivery rejection에서 로그, GraphQL 성공 payload와 committed DB state를
+  함께 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -147,3 +147,24 @@
 
 - "Recipient는 action 시점의 현재 저장 관계에서 계산한다"
 - "저장된 Recipient 배열을 Fedify에 직접 전달한다"
+
+## Additional Active Decisions
+
+### Fedify Context는 Reply Author의 Local Instance origin을 사용한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/instance.md`, `docs/domain/objects/profile.md`,
+  `docs/domain/objects/post.md`, PROD-497
+- Status: Active
+- Context / Problem: configured Local Instance origin으로 Context를 고정하면 다른 Local Instance에 연결된 Profile의
+  Reply actor와 Note identity가 잘못된 origin으로 전달된다.
+- Decision Outcome: Create는 Active Reply의 Author Profile에서 Local Instance `canonicalOrigin`을 조회해 Context를
+  만들고, Delete는 Tombstone source와 함께 같은 origin을 복원한다. actor URI, Note URI, Create/Delete activity와
+  ordering domain은 모두 이 Context와 origin에서 파생한다.
+- Alternatives Considered: deployment configured origin 고정, caller가 origin을 인자로 전달, Post UUID만으로 origin을
+  추론.
+- Consequences: Create/Delete가 각각 Author Instance origin을 조회하지만 caller가 identity를 지정하거나 configured
+  deployment가 다른 Local Profile의 identity를 덮을 수 없다.
+- Confirmation / Follow-up: configured origin과 다른 Local Instance의 Author로 Create/Delete를 실행해 Context,
+  actor, Note, activity와 ordering key origin을 검증한다.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -105,8 +105,8 @@
 - Context / Problem: 현재 Fedify federation에는 queue가 없어 remote HTTP 실패가 `sendActivity()`에서 throw된다.
   이 오류를 application 밖으로 전파하면 DB state는 commit됐지만 GraphQL은 실패하는 모순이 생긴다.
 - Decision Outcome: Create/Delete delivery를 commit 뒤 직접 await하고 실패를 Reply identity와 함께 기록하되,
-  create/delete application action은 committed payload를 성공으로 반환한다. `UNRESPONSIVE`에도 direct delivery를
-  시도하되 pending retry는 만들지 않는다.
+  create/delete application action은 committed payload를 성공으로 반환한다. `UNRESPONSIVE`에는 direct delivery나
+  pending retry를 만들지 않는다.
 - Alternatives Considered: delivery 실패 시 domain rollback, GraphQL 실패 유지와 client refetch, fire-and-forget,
   이번 change에서 outbox·queue를 선행 구현.
 - Consequences: remote HTTP 지연은 API 응답 경로에 남고 commit과 delivery 사이 process 종료 시 유실될 수 있다.
@@ -131,15 +131,15 @@
   구현하도록 해 공통 recipient expansion의 소유권을 중복했다. 또한 Reply의 `inReplyTo` object IRI는 thread
   relation일 뿐 delivery endpoint가 아니다.
 - Decision Outcome: PROD-497은 Public/Unlisted Reply의 원격 직접 Parent 작성자만 direct recipient로 선택한다.
-  Parent는 Active remote Profile, ACTIVE 또는 UNRESPONSIVE ActivityPub Instance와 유효한 HTTP(S) actor/personal
+  Parent는 Active remote Profile, ACTIVE ActivityPub Instance와 유효한 HTTP(S) actor/personal
   inbox를 가져야 한다. 유효한 shared inbox는 보존하고 사용할 수 없으면 personal inbox로 fallback한다. Followers
   Only·Direct는 이 capability에서 전달하지 않으며 `ProfileFollows`를 조회하지 않는다. 공통 followers fanout과
   Repost migration은 PROD-512가 소유한다.
 - Alternatives Considered: interaction마다 follower query 유지, `inReplyTo` IRI로 delivery, PROD-497에서 Fedify
   followers dispatcher까지 구현, 모든 visibility의 Parent Author에게 무조건 direct delivery.
-- Consequences: PROD-512 전에는 Followers Only Reply와 일반 follower 배포가 없지만 Parent Author 직접 전달과
-  activity identity·post-commit failure isolation은 독립적으로 완료된다. Queue/outbox는 계속 PROD-314·448의
-  후속 범위다.
+- Consequences: PROD-512 전에는 Followers Only Reply와 일반 follower 배포가 없고, UNRESPONSIVE Parent에는
+  direct delivery를 시도하지 않는다. Parent Author 직접 전달과 activity identity·post-commit failure isolation은
+  독립적으로 완료된다. Queue/outbox는 계속 PROD-314·448의 후속 범위다.
 - Confirmation / Follow-up: Parent endpoint·visibility·Instance state matrix와 follower query 부재를 PROD-497에서
   검증하고, `.authorize(() => false)`로 공개 collection을 막는 공통 dispatcher는 PROD-512에서 검증한다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -156,10 +156,10 @@
   Reply Delete lifecycle을 소유한다. transaction 인자의 존재 여부는 origin이나 lifecycle 실행 여부를 결정하는
   신호로 사용하지 않는다.
 - Alternatives Considered: 별도 `createLocalPost`, GraphQL resolver orchestration, callback 또는 delivery port.
-- Consequences: 모든 Post 생성 진입점이 `createPost`로 통일되고 public action 수가 늘지 않는다. 현재
-  `createPost`는 자신의 transaction을 소유한다. 향후 caller transaction 합류가 실제로 필요해지면 `tx` 유무로
-  lifecycle을 생략하지 않고 명시적인 post-commit coordination 경계를 먼저 설계한다. Remote Reply Notification과
-  durable delivery는 현재 범위에 추가하지 않는다.
+- Consequences: 모든 Post 생성 진입점이 `createPost`로 통일되고 public action 수가 늘지 않는다. 기존 optional
+  caller transaction 계약을 보존하되 `tx` 유무로 lifecycle을 생략하지 않는다. caller transaction에서 실제
+  outer commit 이후 전달까지 보장해야 하는 production 요구가 생기면 명시적인 post-commit coordination 경계를
+  먼저 설계한다. Remote Reply Notification과 durable delivery는 현재 범위에 추가하지 않는다.
 - Confirmation / Follow-up: production GraphQL과 ActivityPub ingress가 모두 `createPost`를 사용하고, Local
   origin만 commit 뒤 Notification/Create를 실행하며 resolver에는 lifecycle 호출과 transaction 유무에 따른
   lifecycle 분기가 없는지 검증한다.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -82,7 +82,7 @@
 - Decision Date: 2026-07-28
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/architecture/core-services.md`, PROD-447, PROD-497
-- Status: Active
+- Status: Superseded by "core Local Post application action이 post-commit lifecycle을 소유한다"
 - Context / Problem: `createPost()`는 caller transaction에 합류할 수 있어 그 함수 반환만으로 실제 domain
   transaction commit을 알 수 없다. 그 안에서 delivery하면 rollback될 Reply를 remote inbox로 먼저 보낼 수 있다.
 - Decision Outcome: 현재 production Local Reply entry인 GraphQL resolver가 가장 바깥 생성 transaction 또는
@@ -120,6 +120,28 @@
 
 ## Decision Amendments
 
+### core Local Post application action이 post-commit lifecycle을 소유한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, PROD-447, PROD-497
+- Status: Active
+- Context / Problem: commit 이후 실행해야 한다는 시점 제약을 이유로 GraphQL resolver가 Reply Notification과
+  Fedify delivery를 직접 조립하면 Local Reply lifecycle이 transport entry에 누출되고 다른 production entry가
+  같은 side effect를 빠뜨릴 수 있다.
+- Decision Outcome: core `createLocalPost` application action이 Parent 정책과 outer transaction을 소유하고,
+  commit 뒤 Reply Notification과 Create delivery를 best effort로 실행한다. `deletePost`는 삭제 commit 결과에서
+  Reply를 판별해 Delete delivery를 best effort로 실행한다. GraphQL resolver는 인증된 Profile과 입력을 전달하고
+  payload만 구성한다. ActivityPub ingress가 사용하는 low-level `createPost`에는 Local Reply lifecycle을 추가하지
+  않는다.
+- Alternatives Considered: GraphQL resolver의 개별 side effect 호출 유지, transaction callback 또는 delivery
+  port 주입, low-level `createPost`의 모든 Local/Remote caller에 lifecycle 적용.
+- Consequences: 실제 outer commit 뒤 실패 격리는 유지하면서 Notification과 protocol delivery의 필수 lifecycle을
+  production core action이 소유한다. Remote Reply Notification은 이번 정정으로 추가되지 않으며 outbox·queue는
+  PROD-448 범위로 남는다.
+- Confirmation / Follow-up: GraphQL resolver에 Notification/Fedify 호출이 없고 core production 기본 경로가
+  commit 뒤 Create/Delete와 실패 격리를 실행하는지 검증한다.
+
 ### PROD-497은 원격 직접 Parent 작성자만 전달한다
 
 - Decision Date: 2026-07-28
@@ -147,6 +169,7 @@
 
 - "Recipient는 action 시점의 현재 저장 관계에서 계산한다"
 - "저장된 Recipient 배열을 Fedify에 직접 전달한다"
+- "실제 outer commit 뒤 application entry에서 delivery를 orchestration한다"
 
 ## Additional Active Decisions
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -150,16 +150,19 @@
 - Status: Active
 - Context / Problem: 별도 `createLocalPost` action은 Local GraphQL 전용 진입점을 추가해 GraphQL과 ActivityPub이
   같은 Post application action을 사용하도록 통일하는 core service 목적을 깨뜨린다.
-- Decision Outcome: 단일 `createPost`가 Local/ActivityPub origin별 입력 정책과 transaction을 소유한다. caller
-  transaction이 없는 Local Reply production 호출은 실제 commit 뒤 Reply Notification과 Create delivery를 best
-  effort로 실행한다. ActivityPub origin에는 outbound Local Reply delivery를 실행하지 않는다. `deletePost`는 기존
-  통합 action에서 Reply Delete lifecycle을 소유한다.
+- Decision Outcome: 단일 `createPost`가 Local/ActivityPub origin별 입력 정책과 transaction을 소유한다. Local
+  Reply production 호출은 실제 commit 뒤 Reply Notification과 Create delivery를 best effort로 실행한다.
+  ActivityPub origin에는 outbound Local Reply delivery를 실행하지 않는다. `deletePost`는 기존 통합 action에서
+  Reply Delete lifecycle을 소유한다. transaction 인자의 존재 여부는 origin이나 lifecycle 실행 여부를 결정하는
+  신호로 사용하지 않는다.
 - Alternatives Considered: 별도 `createLocalPost`, GraphQL resolver orchestration, callback 또는 delivery port.
-- Consequences: 모든 Post 생성 진입점이 `createPost`로 통일되고 public action 수가 늘지 않는다. optional caller
-  transaction을 사용하는 내부 호출은 outer commit을 알 수 없으므로 post-commit side effect를 실행하지 않는다.
-  Remote Reply Notification과 durable delivery는 현재 범위에 추가하지 않는다.
-- Confirmation / Follow-up: production GraphQL과 ActivityPub ingress가 모두 `createPost`를 사용하고, Local 기본
-  호출만 commit 뒤 Notification/Create를 실행하며 resolver에는 lifecycle 호출이 없는지 검증한다.
+- Consequences: 모든 Post 생성 진입점이 `createPost`로 통일되고 public action 수가 늘지 않는다. 현재
+  `createPost`는 자신의 transaction을 소유한다. 향후 caller transaction 합류가 실제로 필요해지면 `tx` 유무로
+  lifecycle을 생략하지 않고 명시적인 post-commit coordination 경계를 먼저 설계한다. Remote Reply Notification과
+  durable delivery는 현재 범위에 추가하지 않는다.
+- Confirmation / Follow-up: production GraphQL과 ActivityPub ingress가 모두 `createPost`를 사용하고, Local
+  origin만 commit 뒤 Notification/Create를 실행하며 resolver에는 lifecycle 호출과 transaction 유무에 따른
+  lifecycle 분기가 없는지 검증한다.
 
 ### PROD-497은 원격 직접 Parent 작성자만 전달한다
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -125,7 +125,7 @@
 - Decision Date: 2026-07-28
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/architecture/core-services.md`, PROD-447, PROD-497
-- Status: Active
+- Status: Superseded by "통합 createPost action이 origin별 lifecycle을 소유한다"
 - Context / Problem: commit 이후 실행해야 한다는 시점 제약을 이유로 GraphQL resolver가 Reply Notification과
   Fedify delivery를 직접 조립하면 Local Reply lifecycle이 transport entry에 누출되고 다른 production entry가
   같은 side effect를 빠뜨릴 수 있다.
@@ -141,6 +141,25 @@
   PROD-448 범위로 남는다.
 - Confirmation / Follow-up: GraphQL resolver에 Notification/Fedify 호출이 없고 core production 기본 경로가
   commit 뒤 Create/Delete와 실패 격리를 실행하는지 검증한다.
+
+### 통합 createPost action이 origin별 lifecycle을 소유한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, PROD-447, PROD-497
+- Status: Active
+- Context / Problem: 별도 `createLocalPost` action은 Local GraphQL 전용 진입점을 추가해 GraphQL과 ActivityPub이
+  같은 Post application action을 사용하도록 통일하는 core service 목적을 깨뜨린다.
+- Decision Outcome: 단일 `createPost`가 Local/ActivityPub origin별 입력 정책과 transaction을 소유한다. caller
+  transaction이 없는 Local Reply production 호출은 실제 commit 뒤 Reply Notification과 Create delivery를 best
+  effort로 실행한다. ActivityPub origin에는 outbound Local Reply delivery를 실행하지 않는다. `deletePost`는 기존
+  통합 action에서 Reply Delete lifecycle을 소유한다.
+- Alternatives Considered: 별도 `createLocalPost`, GraphQL resolver orchestration, callback 또는 delivery port.
+- Consequences: 모든 Post 생성 진입점이 `createPost`로 통일되고 public action 수가 늘지 않는다. optional caller
+  transaction을 사용하는 내부 호출은 outer commit을 알 수 없으므로 post-commit side effect를 실행하지 않는다.
+  Remote Reply Notification과 durable delivery는 현재 범위에 추가하지 않는다.
+- Confirmation / Follow-up: production GraphQL과 ActivityPub ingress가 모두 `createPost`를 사용하고, Local 기본
+  호출만 commit 뒤 Notification/Create를 실행하며 resolver에는 lifecycle 호출이 없는지 검증한다.
 
 ### PROD-497은 원격 직접 Parent 작성자만 전달한다
 
@@ -170,6 +189,7 @@
 - "Recipient는 action 시점의 현재 저장 관계에서 계산한다"
 - "저장된 Recipient 배열을 Fedify에 직접 전달한다"
 - "실제 outer commit 뒤 application entry에서 delivery를 orchestration한다"
+- "core Local Post application action이 post-commit lifecycle을 소유한다"
 
 ## Additional Active Decisions
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -47,7 +47,7 @@
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`,
   `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497
-- Status: Active
+- Status: Superseded by "PROD-497은 원격 직접 Parent 작성자만 전달한다"
 - Context / Problem: remote follower와 Parent Author가 겹칠 수 있고 Followers Only Reply가 follower가 아닌 Parent
   Author에게 전달되면 visibility를 우회한다. 반대로 과거 recipient를 보존하려면 명시적으로 제외된 delivery
   history가 필요하다.
@@ -66,7 +66,7 @@
 - Decision Date: 2026-07-28
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, PROD-497
-- Status: Active
+- Status: Superseded by "PROD-497은 원격 직접 Parent 작성자만 전달한다"
 - Context / Problem: Fedify의 special `"followers"` recipient는 followers collection dispatcher가 필요하지만
   현재 actor contract는 collection GET을 제공하지 않으며 remote Parent Author도 별도로 합쳐야 한다.
 - Decision Outcome: 현재 DB 관계에서 usable remote actor를 조회해 Fedify `Recipient[]`로 전달하고 shared inbox를
@@ -105,8 +105,8 @@
 - Context / Problem: 현재 Fedify federation에는 queue가 없어 remote HTTP 실패가 `sendActivity()`에서 throw된다.
   이 오류를 application 밖으로 전파하면 DB state는 commit됐지만 GraphQL은 실패하는 모순이 생긴다.
 - Decision Outcome: Create/Delete delivery를 commit 뒤 직접 await하고 실패를 Reply identity와 함께 기록하되,
-  create/delete application action은 committed payload를 성공으로 반환한다. `UNRESPONSIVE`에서는 delivery와
-  pending retry를 만들지 않는다.
+  create/delete application action은 committed payload를 성공으로 반환한다. `UNRESPONSIVE`에도 direct delivery를
+  시도하되 pending retry는 만들지 않는다.
 - Alternatives Considered: delivery 실패 시 domain rollback, GraphQL 실패 유지와 client refetch, fire-and-forget,
   이번 change에서 outbox·queue를 선행 구현.
 - Consequences: remote HTTP 지연은 API 응답 경로에 남고 commit과 delivery 사이 process 종료 시 유실될 수 있다.
@@ -118,6 +118,32 @@
 
 - 없음.
 
+## Decision Amendments
+
+### PROD-497은 원격 직접 Parent 작성자만 전달한다
+
+- Decision Date: 2026-07-28
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, PROD-497,
+  PROD-512
+- Status: Active
+- Context / Problem: 기존 결정은 각 interaction delivery가 `ProfileFollows`를 직접 조회해 follower fanout을
+  구현하도록 해 공통 recipient expansion의 소유권을 중복했다. 또한 Reply의 `inReplyTo` object IRI는 thread
+  relation일 뿐 delivery endpoint가 아니다.
+- Decision Outcome: PROD-497은 Public/Unlisted Reply의 원격 직접 Parent 작성자만 direct recipient로 선택한다.
+  Parent는 Active remote Profile, ACTIVE 또는 UNRESPONSIVE ActivityPub Instance와 유효한 HTTP(S) actor/personal
+  inbox를 가져야 한다. 유효한 shared inbox는 보존하고 사용할 수 없으면 personal inbox로 fallback한다. Followers
+  Only·Direct는 이 capability에서 전달하지 않으며 `ProfileFollows`를 조회하지 않는다. 공통 followers fanout과
+  Repost migration은 PROD-512가 소유한다.
+- Alternatives Considered: interaction마다 follower query 유지, `inReplyTo` IRI로 delivery, PROD-497에서 Fedify
+  followers dispatcher까지 구현, 모든 visibility의 Parent Author에게 무조건 direct delivery.
+- Consequences: PROD-512 전에는 Followers Only Reply와 일반 follower 배포가 없지만 Parent Author 직접 전달과
+  activity identity·post-commit failure isolation은 독립적으로 완료된다. Queue/outbox는 계속 PROD-314·448의
+  후속 범위다.
+- Confirmation / Follow-up: Parent endpoint·visibility·Instance state matrix와 follower query 부재를 PROD-497에서
+  검증하고, `.authorize(() => false)`로 공개 collection을 막는 공통 dispatcher는 PROD-512에서 검증한다.
+
 ## Superseded Decisions
 
-- 없음.
+- "Recipient는 action 시점의 현재 저장 관계에서 계산한다"
+- "저장된 Recipient 배열을 Fedify에 직접 전달한다"

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md
@@ -151,15 +151,16 @@
 - Context / Problem: 별도 `createLocalPost` action은 Local GraphQL 전용 진입점을 추가해 GraphQL과 ActivityPub이
   같은 Post application action을 사용하도록 통일하는 core service 목적을 깨뜨린다.
 - Decision Outcome: 단일 `createPost`가 Local/ActivityPub origin별 입력 정책과 transaction을 소유한다. Local
-  Reply production 호출은 실제 commit 뒤 Reply Notification과 Create delivery를 best effort로 실행한다.
-  ActivityPub origin에는 outbound Local Reply delivery를 실행하지 않는다. `deletePost`는 기존 통합 action에서
-  Reply Delete lifecycle을 소유한다. transaction 인자의 존재 여부는 origin이나 lifecycle 실행 여부를 결정하는
-  신호로 사용하지 않는다.
+  Reply Notification은 같은 transaction에 참여시키고 Create delivery는 best effort로 실행한다. ActivityPub
+  origin에는 outbound Local Reply delivery를 실행하지 않는다. `deletePost`는 기존 통합 action에서 Reply Delete
+  lifecycle을 소유한다. transaction 인자의 존재 여부는 origin이나 lifecycle 실행 여부를 결정하는 신호로
+  사용하지 않는다.
 - Alternatives Considered: 별도 `createLocalPost`, GraphQL resolver orchestration, callback 또는 delivery port.
 - Consequences: 모든 Post 생성 진입점이 `createPost`로 통일되고 public action 수가 늘지 않는다. 기존 optional
-  caller transaction 계약을 보존하되 `tx` 유무로 lifecycle을 생략하지 않는다. caller transaction에서 실제
-  outer commit 이후 전달까지 보장해야 하는 production 요구가 생기면 명시적인 post-commit coordination 경계를
-  먼저 설계한다. Remote Reply Notification과 durable delivery는 현재 범위에 추가하지 않는다.
+  caller transaction 계약을 보존하되 `tx` 유무로 lifecycle을 생략하지 않는다. caller transaction의 uncommitted
+  Reply는 별도 delivery 조회에서 보이지 않으므로 rollback될 Activity를 전달하지 않지만, outer commit 뒤 delivery를
+  재실행하지 않아 Activity가 누락될 수 있다. 존재하지 않는 Activity 전달은 허용하지 않고 commit 뒤 delivery 실패와
+  누락은 PROD-448 전까지 수용한다. Remote Reply Notification과 durable delivery는 현재 범위에 추가하지 않는다.
 - Confirmation / Follow-up: production GraphQL과 ActivityPub ingress가 모두 `createPost`를 사용하고, Local
   origin만 commit 뒤 Notification/Create를 실행하며 resolver에는 lifecycle 호출과 transaction 유무에 따른
   lifecycle 분기가 없는지 검증한다.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -40,6 +40,8 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
   계약이 쉽게 달라진다.
 - Fedify의 special `"followers"` recipient는 followers collection dispatcher가 필요하지만 현재 actor 계약은
   collection GET을 열지 않는다.
+- deployment configured Local Instance를 항상 사용하면 다른 Local Instance에 속한 Author의 actor와 Note가 잘못된
+  origin으로 전달된다.
 
 ### Recommended Approach
 
@@ -52,6 +54,10 @@ Fedify package에서는 기존 Local Note 조회와 projection을 내부적으�
 commit된 Active Reply에서 object dispatcher와 동일한 Note를 만들고, Delete는 Tombstone row에 남아 있는 Author,
 Visibility와 Reply Parent 관계에서 actor, canonical Note URI, audience와 recipient를 복원한다. Delete에는 Active
 Note representation이나 새 Tombstone endpoint가 필요하지 않다.
+
+Create는 Reply Post에서 Author Profile의 Local Instance `canonicalOrigin`을 먼저 조회하고 그 origin으로 Fedify
+Context를 만든 뒤 Local Note를 projection한다. Delete는 Tombstone source 조회 결과에 같은 origin을 포함하고 그
+origin으로 Context, actor URI와 Note identity를 재구성한다. configured deployment origin은 사용하지 않는다.
 
 Recipient는 delivery 시점의 저장 상태에서 직접 Parent Author만 조회한다. Public/Unlisted Reply이며 Parent가
 Active remote Profile, ACTIVE ActivityPub Instance, 유효한 HTTP(S) actor URI와 personal inbox를

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -32,9 +32,9 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 
 ### Current Constraints
 
-- low-level `createPost()`는 optional caller transaction에 합류하므로 그 안에서 delivery를 호출하면 가장 바깥
-  transaction이 아직 rollback될 수 있다. Local production entry는 caller transaction 없이 통합 `createPost`를
-  호출해 action이 outer transaction과 post-commit lifecycle을 함께 소유하게 해야 한다.
+- `createPost()`는 현재 자신의 transaction과 post-commit lifecycle을 함께 소유한다. transaction 인자의 존재
+  여부로 lifecycle을 켜거나 끄지 않는다. 향후 caller transaction 합류가 실제로 필요해지면 commit 이후 전달을
+  보장하는 명시적인 post-commit coordination 경계를 먼저 설계해야 한다.
 - 현재 Local Note loader는 Active Post만 제공한다. Reply가 Tombstone이 된 뒤에는 dispatcher를 그대로 호출해
   Delete projection을 만들 수 없다.
 - Create의 embedded Note를 별도로 다시 직렬화하면 object dispatcher의 content, summary, audience와 `inReplyTo`

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -1,0 +1,109 @@
+## Context
+
+PROD-494는 `packages/fedify`에 Local Post의 `/ap/note/{postId}` identity, Local Note projection, visibility audience,
+signed fetch authorization과 Local/Remote Post URI resolver를 제공한다. Local Reply도 이 dispatcher에서 기존
+`inReplyTo`를 포함한 Note로 역참조할 수 있지만, 현재 Local Post 생성·삭제 application flow는 activity를 remote
+inbox로 전달하지 않는다.
+
+Local Reply 생성의 가장 바깥 transaction은 GraphQL resolver가 Parent 접근을 검증하고 `createPost(..., tx)`를
+호출하는 경계에 있다. 반면 `deletePost()`는 core action이 transaction을 직접 연다. 기존 Remote Follow은 domain
+transaction이 끝난 뒤 Fedify delivery를 `await`하고, 실패를 catch/log해 committed result와 분리한다. 현재
+federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP 요청을 직접 수행한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Local Reply 생성과 삭제를 기존 Fedify delivery 경계에 연결한다.
+- Local Note projection과 Post identity를 복제하지 않고 Create와 Delete에서 재사용한다.
+- visibility, established Follow, remote Parent Author와 Instance 상태에서 recipient를 결정한다.
+- 실제 outer transaction commit 뒤 delivery하고 실패와 committed application 결과를 격리한다.
+- 반복 호출에 안정적인 activity identity와 Create/Delete ordering domain을 제공한다.
+
+**Non-Goals:**
+
+- transactional outbox, NATS, Fedify MessageQueue, worker, retry/history와 delivery status
+- 과거 Create recipient snapshot 또는 이미 unfollow한 recipient에 대한 Delete 보정
+- inbound Reply, Repost, Reaction, Mention, Media, Direct와 Tombstone object endpoint
+- followers collection dispatcher 또는 ActivityPub outbox collection
+- Post·Profile·Follow·ActivityPub Actor schema와 GraphQL payload 변경
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `createPost()`는 optional caller transaction에 합류한다. 이 함수 안에서 delivery를 호출하면 가장 바깥
+  transaction이 아직 rollback될 수 있으므로 post-commit 계약을 보장하지 못한다.
+- 현재 Local Note loader는 Active Post만 제공한다. Reply가 Tombstone이 된 뒤에는 dispatcher를 그대로 호출해
+  Delete projection을 만들 수 없다.
+- Create의 embedded Note를 별도로 다시 직렬화하면 object dispatcher의 content, summary, audience와 `inReplyTo`
+  계약이 쉽게 달라진다.
+- Fedify의 special `"followers"` recipient는 followers collection dispatcher가 필요하지만 현재 actor 계약은
+  collection GET을 열지 않는다.
+- Remote actor row에는 inbox가 nullable이고 같은 shared inbox를 여러 Profile이 공유할 수 있다. 전달 후보와
+  실제 `Recipient` 구성, actor 중복과 shared inbox 묶음을 구분해야 한다.
+
+### Recommended Approach
+
+가장 바깥 application transaction을 소유하는 GraphQL resolver가 commit된 Post ID를 받은 뒤 Fedify package의
+좁은 Reply delivery API를 호출하는 방식을 기본으로 한다. Create resolver는 기존 outer transaction이 끝난 뒤,
+Delete resolver는 `deletePost()`가 반환된 뒤 호출한다. 두 호출은 각각 `await`하되 오류를 구조화해 기록하고 기존
+payload를 반환한다.
+
+Fedify package에서는 기존 Local Note 조회와 projection을 내부적으로 재사용 가능한 경계로 정리한다. Create는
+commit된 Active Reply에서 object dispatcher와 동일한 Note를 만들고, Delete는 Tombstone row에 남아 있는 Author,
+Visibility와 Reply Parent 관계에서 actor, canonical Note URI, audience와 recipient를 복원한다. Delete에는 Active
+Note representation이나 새 Tombstone endpoint가 필요하지 않다.
+
+Recipient는 delivery 시점의 저장 상태에서 한 번 조회한다. Author의 established remote follower와 필요하면 remote
+Parent Author를 모으고, Active ActivityPub Instance, Active Profile, actor URI와 inbox가 있는 후보만 `Recipient`
+배열로 만든다. actor URI로 중복을 제거하고 Fedify의 shared inbox 선호 옵션을 사용한다. 후보가 없으면
+`sendActivity()`를 호출하지 않는다.
+
+Activity ID는 canonical Note URI에서 Create와 Delete를 구분하는 안정적인 fragment로 파생하고 ordering key는
+fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 공개 activity dispatcher 없이 같은 Post의
+반복 delivery identity와 Create/Delete ordering domain을 유지한다.
+
+### Allowed Alternatives
+
+- core application action이 실제 outer transaction 전체를 직접 소유하도록 구조를 정리한 뒤 그 action의
+  post-commit 구간에서 delivery를 orchestration할 수 있다. 다만 현재 Parent 접근 검증을 callback이나 protocol
+  타입으로 core public contract에 주입해서는 안 되며, optional caller transaction 안에서 delivery해서도 안 된다.
+- recipient를 한 번에 전달하거나 server별로 나누어 전달할 수 있다. 어느 방식이든 actor 중복 제거, shared inbox
+  사용, 안정적인 activity identity, recipient별 Create/Delete ordering과 전체 failure isolation을 보존해야 한다.
+
+### Known Traps
+
+- `createPost(..., tx)` 또는 transaction callback 안에서 Fedify를 호출해 rollback될 state를 먼저 전달하지 않는다.
+- delivery Promise를 await하지 않는 fire-and-forget으로 바꾸지 않는다. 실패 관측과 process 종료 동작이 더
+  불명확해진다.
+- Fedify의 자동 생성 activity ID를 사용하지 않는다. 같은 Reply 재호출이 다른 activity가 된다.
+- Create 전용 Note serialization을 새로 만들거나 Delete를 위해 Active-only dispatcher 조건을 완화하지 않는다.
+- followers collection dispatcher 없이 special `"followers"` recipient를 사용하지 않는다.
+- Followers Only Reply를 follower가 아닌 remote Parent Author에게 전달하지 않는다.
+- `UNRESPONSIVE` recipient를 durable pending delivery로 저장하거나 회복 뒤 자동 재전송하지 않는다.
+- 한 remote actor의 inbox 누락 때문에 유효한 다른 recipient 전체를 projection 단계에서 실패시키지 않는다.
+- PROD-448의 outbox·queue 구조를 현재 작업의 abstraction이나 test seam으로 미리 추가하지 않는다.
+
+## Risks / Trade-offs
+
+- [Remote HTTP가 느리면 mutation 응답이 지연됨] → 현재 직접 delivery 계약에 따라 await하되 transaction은 이미
+  commit된 상태로 유지한다. 응답 경로 분리는 PROD-448이 소유한다.
+- [Commit 뒤 process 종료 시 activity 유실] → 현재 제한을 문서와 테스트 경계에 남기고 outbox를 부분 구현하지
+  않는다.
+- [다중 recipient delivery가 일부 성공한 뒤 실패할 수 있음] → activity identity와 ordering key를 안정적으로
+  유지해 재호출이 새 logical activity가 되지 않게 하고 committed 결과에는 영향을 주지 않는다.
+- [삭제 시점 recipient가 생성 시점과 달라 과거 recipient에 Delete가 도달하지 않을 수 있음] → history가 없는
+  현재 범위에서는 action 시점의 recipient만 사용하며 delivery history migration과 분리한다.
+- [Tombstone Post에서 Note projection을 잘못 재사용할 수 있음] → Create의 full Note projection과 Delete의 identity·
+  audience projection을 구분하고 각각 lifecycle matrix를 검증한다.
+
+## Migration Plan
+
+DB schema와 저장 데이터 migration은 없다. OpenSpec Gate 승인 뒤 Fedify projection/delivery와 API post-commit
+wiring을 추가하고 package·API integration test를 먼저 통과시킨다. Rollback은 새 resolver wiring과 Fedify Reply
+delivery 경계를 제거하면 기존 Local Reply 저장·조회·삭제 동작으로 돌아가며 저장 데이터 변환은 필요 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -5,7 +5,7 @@ signed fetch authorization과 Local/Remote Post URI resolver를 제공한다. Lo
 `inReplyTo`를 포함한 Note로 역참조할 수 있지만, 현재 Local Post 생성·삭제 application flow는 activity를 remote
 inbox로 전달하지 않는다.
 
-Local Reply 생성은 core application action이 Parent 접근 검증과 가장 바깥 transaction을 함께 소유한다.
+Local Reply 생성은 통합 core `createPost` action이 Parent 접근 검증과 가장 바깥 transaction을 함께 소유한다.
 `deletePost()`도 core action이 transaction을 직접 연다. 기존 Remote Follow은 domain
 transaction이 끝난 뒤 Fedify delivery를 `await`하고, 실패를 catch/log해 committed result와 분리한다. 현재
 federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP 요청을 직접 수행한다.
@@ -33,8 +33,8 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 ### Current Constraints
 
 - low-level `createPost()`는 optional caller transaction에 합류하므로 그 안에서 delivery를 호출하면 가장 바깥
-  transaction이 아직 rollback될 수 있다. Local production entry는 outer transaction을 소유하는 별도 core
-  application action을 사용해야 한다.
+  transaction이 아직 rollback될 수 있다. Local production entry는 caller transaction 없이 통합 `createPost`를
+  호출해 action이 outer transaction과 post-commit lifecycle을 함께 소유하게 해야 한다.
 - 현재 Local Note loader는 Active Post만 제공한다. Reply가 Tombstone이 된 뒤에는 dispatcher를 그대로 호출해
   Delete projection을 만들 수 없다.
 - Create의 embedded Note를 별도로 다시 직렬화하면 object dispatcher의 content, summary, audience와 `inReplyTo`
@@ -46,7 +46,7 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 
 ### Recommended Approach
 
-core `createLocalPost` application action이 Parent 접근 정책과 가장 바깥 transaction을 소유하고, commit된 Reply
+통합 core `createPost` action이 origin별 Parent 정책과 가장 바깥 transaction을 소유하고, Local Reply의 commit된
 ID를 받은 뒤 Notification과 Fedify package의 좁은 Reply Create delivery API를 호출한다. `deletePost()`는 commit
 결과에서 Reply를 판별해 Reply Delete delivery를 호출한다. 두 delivery는 각각 `await`하되 오류를 구조화해 기록하고
 committed domain 결과를 반환한다. GraphQL resolver는 인증된 Profile과 business input만 전달하고 payload를 구성한다.
@@ -72,9 +72,8 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
 
 ### Allowed Alternatives
 
-- 별도 API-local orchestration module이 outer transaction과 post-commit lifecycle을 소유할 수 있다. 다만 이
-  lifecycle은 GraphQL에 고유하지 않고 현재 Repost와 같은 core ownership을 공유하므로 core application action을
-  사용한다.
+- 별도 Local Post action이나 API-local orchestration module이 outer transaction과 post-commit lifecycle을 소유할
+  수 있다. 하지만 진입점 통일을 깨뜨리므로 통합 `createPost` action의 origin별 정책으로 유지한다.
 
 ### Known Traps
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -5,8 +5,8 @@ signed fetch authorization과 Local/Remote Post URI resolver를 제공한다. Lo
 `inReplyTo`를 포함한 Note로 역참조할 수 있지만, 현재 Local Post 생성·삭제 application flow는 activity를 remote
 inbox로 전달하지 않는다.
 
-Local Reply 생성은 통합 core `createPost` action이 Parent 접근 검증과 가장 바깥 transaction을 함께 소유한다.
-`deletePost()`도 core action이 transaction을 직접 연다. 기존 Remote Follow은 domain
+Local Reply 생성은 통합 core `createPost` action이 Parent 접근 검증을 소유하고 optional caller transaction에
+합류할 수 있다. `deletePost()`도 같은 optional transaction 계약을 유지한다. 기존 Remote Follow은 domain
 transaction이 끝난 뒤 Fedify delivery를 `await`하고, 실패를 catch/log해 committed result와 분리한다. 현재
 federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP 요청을 직접 수행한다.
 
@@ -17,7 +17,8 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 - Local Reply 생성과 삭제를 기존 Fedify delivery 경계에 연결한다.
 - Local Note projection과 Post identity를 복제하지 않고 Create와 Delete에서 재사용한다.
 - visibility, remote Parent Author와 Instance 상태에서 direct recipient를 결정한다.
-- 실제 outer transaction commit 뒤 delivery하고 실패와 committed application 결과를 격리한다.
+- top-level transaction commit 뒤 delivery하고 실패와 committed application 결과를 격리한다. caller transaction은
+  rollback될 Activity를 전달하지 않으며 commit 뒤 누락을 허용한다.
 - 반복 호출에 안정적인 activity identity와 Create/Delete ordering domain을 제공한다.
 
 **Non-Goals:**
@@ -33,8 +34,9 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 ### Current Constraints
 
 - `createPost()`는 optional caller transaction 계약을 유지하지만 transaction 인자의 존재 여부로 lifecycle을
-  켜거나 끄지 않는다. caller transaction에서 실제 outer commit 이후 전달까지 보장해야 하는 production 요구가
-  생기면 명시적인 post-commit coordination 경계를 먼저 설계해야 한다.
+  켜거나 끄지 않는다. Reply Notification은 caller transaction에 참여한다. Fedify delivery는 별도 committed-read
+  조회를 사용하므로 uncommitted Reply에서는 no-op이며 rollback될 Activity를 전달하지 않는다. outer commit 뒤
+  재실행하지 않아 생기는 Activity 누락과 commit 뒤 delivery 실패는 PROD-448 전까지 수용한다.
 - 현재 Local Note loader는 Active Post만 제공한다. Reply가 Tombstone이 된 뒤에는 dispatcher를 그대로 호출해
   Delete projection을 만들 수 없다.
 - Create의 embedded Note를 별도로 다시 직렬화하면 object dispatcher의 content, summary, audience와 `inReplyTo`
@@ -46,10 +48,12 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 
 ### Recommended Approach
 
-통합 core `createPost` action이 origin별 Parent 정책과 가장 바깥 transaction을 소유하고, Local Reply의 commit된
-ID를 받은 뒤 Notification과 Fedify package의 좁은 Reply Create delivery API를 호출한다. `deletePost()`는 commit
-결과에서 Reply를 판별해 Reply Delete delivery를 호출한다. 두 delivery는 각각 `await`하되 오류를 구조화해 기록하고
-committed domain 결과를 반환한다. GraphQL resolver는 인증된 Profile과 business input만 전달하고 payload를 구성한다.
+통합 core `createPost` action이 origin별 Parent 정책을 소유하고 Reply Notification을 생성 transaction의 nested
+savepoint에 참여시킨다. transaction 단계가 반환된 뒤 Fedify package의 좁은 Reply Create delivery API를 호출한다.
+top-level 호출은 실제 commit 뒤 전달하고 caller transaction은 uncommitted source에서 no-op될 수 있다.
+`deletePost()`는 commit 결과에서 Reply를 판별해 Reply Delete delivery를 호출한다. 두 Fedify delivery는 각각
+`await`하되 오류를 구조화해 기록하고 committed domain 결과를 반환한다. GraphQL resolver는 인증된 Profile과
+business input만 전달하고 payload를 구성한다.
 
 Fedify package에서는 기존 Local Note 조회와 projection을 내부적으로 재사용 가능한 경계로 정리한다. Create는
 commit된 Active Reply에서 object dispatcher와 동일한 Note를 만들고, Delete는 Tombstone row에 남아 있는 Author,
@@ -77,7 +81,8 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
 
 ### Known Traps
 
-- `createPost(..., tx)` 또는 transaction callback 안에서 Fedify를 호출해 rollback될 state를 먼저 전달하지 않는다.
+- caller transaction의 uncommitted Reply는 별도 committed-read delivery 조회에서 no-op으로 처리해 rollback될
+  state를 먼저 전달하지 않는다. outer commit 뒤 delivery가 재실행되지 않는 누락은 허용한다.
 - delivery Promise를 await하지 않는 fire-and-forget으로 바꾸지 않는다. 실패 관측과 process 종료 동작이 더
   불명확해진다.
 - Fedify의 자동 생성 activity ID를 사용하지 않는다. 같은 Reply 재호출이 다른 activity가 된다.
@@ -103,7 +108,7 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
 
 ## Migration Plan
 
-DB schema와 저장 데이터 migration은 없다. OpenSpec Gate 승인 뒤 Fedify projection/delivery와 core post-commit
+DB schema와 저장 데이터 migration은 없다. OpenSpec Gate 승인 뒤 Fedify projection/delivery와 core lifecycle
 wiring을 추가하고 package·core·API integration test를 먼저 통과시킨다. Rollback은 새 core lifecycle wiring과
 Fedify Reply delivery 경계를 제거하면 기존 Local Reply 저장·조회·삭제 동작으로 돌아가며 저장 데이터 변환은
 필요 없다.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -16,16 +16,16 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 
 - Local Reply 생성과 삭제를 기존 Fedify delivery 경계에 연결한다.
 - Local Note projection과 Post identity를 복제하지 않고 Create와 Delete에서 재사용한다.
-- visibility, established Follow, remote Parent Author와 Instance 상태에서 recipient를 결정한다.
+- visibility, remote Parent Author와 Instance 상태에서 direct recipient를 결정한다.
 - 실제 outer transaction commit 뒤 delivery하고 실패와 committed application 결과를 격리한다.
 - 반복 호출에 안정적인 activity identity와 Create/Delete ordering domain을 제공한다.
 
 **Non-Goals:**
 
 - transactional outbox, NATS, Fedify MessageQueue, worker, retry/history와 delivery status
-- 과거 Create recipient snapshot 또는 이미 unfollow한 recipient에 대한 Delete 보정
+- 과거 Create Parent endpoint snapshot에 대한 Delete 보정
 - inbound Reply, Repost, Reaction, Mention, Media, Direct와 Tombstone object endpoint
-- followers collection dispatcher 또는 ActivityPub outbox collection
+- followers fanout/collection dispatcher(PROD-512) 또는 ActivityPub outbox collection
 - Post·Profile·Follow·ActivityPub Actor schema와 GraphQL payload 변경
 
 ## Implementation Guidance
@@ -40,8 +40,6 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
   계약이 쉽게 달라진다.
 - Fedify의 special `"followers"` recipient는 followers collection dispatcher가 필요하지만 현재 actor 계약은
   collection GET을 열지 않는다.
-- Remote actor row에는 inbox가 nullable이고 같은 shared inbox를 여러 Profile이 공유할 수 있다. 전달 후보와
-  실제 `Recipient` 구성, actor 중복과 shared inbox 묶음을 구분해야 한다.
 
 ### Recommended Approach
 
@@ -55,10 +53,11 @@ commit된 Active Reply에서 object dispatcher와 동일한 Note를 만들고, D
 Visibility와 Reply Parent 관계에서 actor, canonical Note URI, audience와 recipient를 복원한다. Delete에는 Active
 Note representation이나 새 Tombstone endpoint가 필요하지 않다.
 
-Recipient는 delivery 시점의 저장 상태에서 한 번 조회한다. Author의 established remote follower와 필요하면 remote
-Parent Author를 모으고, Active ActivityPub Instance, Active Profile, actor URI와 inbox가 있는 후보만 `Recipient`
-배열로 만든다. actor URI로 중복을 제거하고 Fedify의 shared inbox 선호 옵션을 사용한다. 후보가 없으면
-`sendActivity()`를 호출하지 않는다.
+Recipient는 delivery 시점의 저장 상태에서 직접 Parent Author만 조회한다. Public/Unlisted Reply이며 Parent가
+Active remote Profile, ACTIVE 또는 UNRESPONSIVE ActivityPub Instance, 유효한 HTTP(S) actor URI와 personal inbox를
+가질 때만 `Recipient`로 만든다. 유효한 shared inbox는 Fedify의 선호 옵션에 맡기고 사용할 수 없으면 personal
+inbox로 fallback한다. Followers Only·Direct, Local Parent 또는 usable Parent recipient가 없으면 `sendActivity()`를
+호출하지 않는다. follower expansion은 PROD-512가 별도 공통 dispatcher에서 소유한다.
 
 Activity ID는 canonical Note URI에서 Create와 Delete를 구분하는 안정적인 fragment로 파생하고 ordering key는
 fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 공개 activity dispatcher 없이 같은 Post의
@@ -69,8 +68,6 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
 - core application action이 실제 outer transaction 전체를 직접 소유하도록 구조를 정리한 뒤 그 action의
   post-commit 구간에서 delivery를 orchestration할 수 있다. 다만 현재 Parent 접근 검증을 callback이나 protocol
   타입으로 core public contract에 주입해서는 안 되며, optional caller transaction 안에서 delivery해서도 안 된다.
-- recipient를 한 번에 전달하거나 server별로 나누어 전달할 수 있다. 어느 방식이든 actor 중복 제거, shared inbox
-  사용, 안정적인 activity identity, recipient별 Create/Delete ordering과 전체 failure isolation을 보존해야 한다.
 
 ### Known Traps
 
@@ -79,10 +76,10 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
   불명확해진다.
 - Fedify의 자동 생성 activity ID를 사용하지 않는다. 같은 Reply 재호출이 다른 activity가 된다.
 - Create 전용 Note serialization을 새로 만들거나 Delete를 위해 Active-only dispatcher 조건을 완화하지 않는다.
-- followers collection dispatcher 없이 special `"followers"` recipient를 사용하지 않는다.
-- Followers Only Reply를 follower가 아닌 remote Parent Author에게 전달하지 않는다.
-- `UNRESPONSIVE` recipient를 durable pending delivery로 저장하거나 회복 뒤 자동 재전송하지 않는다.
-- 한 remote actor의 inbox 누락 때문에 유효한 다른 recipient 전체를 projection 단계에서 실패시키지 않는다.
+- follower 집합을 `ProfileFollows`에서 직접 조회하거나 special `"followers"` recipient를 이 capability에 추가하지 않는다.
+- Followers Only Reply를 remote Parent Author에게 direct delivery하지 않는다.
+- `UNRESPONSIVE` recipient를 durable pending delivery로 저장하거나 별도 자동 재전송하지 않는다.
+- usable Parent actor/inbox가 없으면 invalid URL을 Fedify에 전달하지 않고 no-op한다.
 - PROD-448의 outbox·queue 구조를 현재 작업의 abstraction이나 test seam으로 미리 추가하지 않는다.
 
 ## Risks / Trade-offs
@@ -91,10 +88,10 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
   commit된 상태로 유지한다. 응답 경로 분리는 PROD-448이 소유한다.
 - [Commit 뒤 process 종료 시 activity 유실] → 현재 제한을 문서와 테스트 경계에 남기고 outbox를 부분 구현하지
   않는다.
-- [다중 recipient delivery가 일부 성공한 뒤 실패할 수 있음] → activity identity와 ordering key를 안정적으로
-  유지해 재호출이 새 logical activity가 되지 않게 하고 committed 결과에는 영향을 주지 않는다.
-- [삭제 시점 recipient가 생성 시점과 달라 과거 recipient에 Delete가 도달하지 않을 수 있음] → history가 없는
-  현재 범위에서는 action 시점의 recipient만 사용하며 delivery history migration과 분리한다.
+- [Parent delivery가 실패한 뒤 재호출될 수 있음] → activity identity와 ordering key를 안정적으로 유지해 재호출이
+  새 logical activity가 되지 않게 하고 committed 결과에는 영향을 주지 않는다.
+- [Parent actor endpoint가 Create 뒤 바뀌면 Delete가 과거 inbox에 도달하지 않을 수 있음] → history가 없는
+  현재 범위에서는 action 시점의 Parent recipient만 사용하며 delivery history migration과 분리한다.
 - [Tombstone Post에서 Note projection을 잘못 재사용할 수 있음] → Create의 full Note projection과 Delete의 identity·
   audience projection을 구분하고 각각 lifecycle matrix를 검증한다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -5,8 +5,8 @@ signed fetch authorization과 Local/Remote Post URI resolver를 제공한다. Lo
 `inReplyTo`를 포함한 Note로 역참조할 수 있지만, 현재 Local Post 생성·삭제 application flow는 activity를 remote
 inbox로 전달하지 않는다.
 
-Local Reply 생성의 가장 바깥 transaction은 GraphQL resolver가 Parent 접근을 검증하고 `createPost(..., tx)`를
-호출하는 경계에 있다. 반면 `deletePost()`는 core action이 transaction을 직접 연다. 기존 Remote Follow은 domain
+Local Reply 생성은 core application action이 Parent 접근 검증과 가장 바깥 transaction을 함께 소유한다.
+`deletePost()`도 core action이 transaction을 직접 연다. 기존 Remote Follow은 domain
 transaction이 끝난 뒤 Fedify delivery를 `await`하고, 실패를 catch/log해 committed result와 분리한다. 현재
 federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP 요청을 직접 수행한다.
 
@@ -32,8 +32,9 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 
 ### Current Constraints
 
-- `createPost()`는 optional caller transaction에 합류한다. 이 함수 안에서 delivery를 호출하면 가장 바깥
-  transaction이 아직 rollback될 수 있으므로 post-commit 계약을 보장하지 못한다.
+- low-level `createPost()`는 optional caller transaction에 합류하므로 그 안에서 delivery를 호출하면 가장 바깥
+  transaction이 아직 rollback될 수 있다. Local production entry는 outer transaction을 소유하는 별도 core
+  application action을 사용해야 한다.
 - 현재 Local Note loader는 Active Post만 제공한다. Reply가 Tombstone이 된 뒤에는 dispatcher를 그대로 호출해
   Delete projection을 만들 수 없다.
 - Create의 embedded Note를 별도로 다시 직렬화하면 object dispatcher의 content, summary, audience와 `inReplyTo`
@@ -45,10 +46,10 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 
 ### Recommended Approach
 
-가장 바깥 application transaction을 소유하는 GraphQL resolver가 commit된 Post ID를 받은 뒤 Fedify package의
-좁은 Reply delivery API를 호출하는 방식을 기본으로 한다. Create resolver는 기존 outer transaction이 끝난 뒤,
-Delete resolver는 `deletePost()`가 반환된 뒤 호출한다. 두 호출은 각각 `await`하되 오류를 구조화해 기록하고 기존
-payload를 반환한다.
+core `createLocalPost` application action이 Parent 접근 정책과 가장 바깥 transaction을 소유하고, commit된 Reply
+ID를 받은 뒤 Notification과 Fedify package의 좁은 Reply Create delivery API를 호출한다. `deletePost()`는 commit
+결과에서 Reply를 판별해 Reply Delete delivery를 호출한다. 두 delivery는 각각 `await`하되 오류를 구조화해 기록하고
+committed domain 결과를 반환한다. GraphQL resolver는 인증된 Profile과 business input만 전달하고 payload를 구성한다.
 
 Fedify package에서는 기존 Local Note 조회와 projection을 내부적으로 재사용 가능한 경계로 정리한다. Create는
 commit된 Active Reply에서 object dispatcher와 동일한 Note를 만들고, Delete는 Tombstone row에 남아 있는 Author,
@@ -71,9 +72,9 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
 
 ### Allowed Alternatives
 
-- core application action이 실제 outer transaction 전체를 직접 소유하도록 구조를 정리한 뒤 그 action의
-  post-commit 구간에서 delivery를 orchestration할 수 있다. 다만 현재 Parent 접근 검증을 callback이나 protocol
-  타입으로 core public contract에 주입해서는 안 되며, optional caller transaction 안에서 delivery해서도 안 된다.
+- 별도 API-local orchestration module이 outer transaction과 post-commit lifecycle을 소유할 수 있다. 다만 이
+  lifecycle은 GraphQL에 고유하지 않고 현재 Repost와 같은 core ownership을 공유하므로 core application action을
+  사용한다.
 
 ### Known Traps
 
@@ -103,9 +104,10 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
 
 ## Migration Plan
 
-DB schema와 저장 데이터 migration은 없다. OpenSpec Gate 승인 뒤 Fedify projection/delivery와 API post-commit
-wiring을 추가하고 package·API integration test를 먼저 통과시킨다. Rollback은 새 resolver wiring과 Fedify Reply
-delivery 경계를 제거하면 기존 Local Reply 저장·조회·삭제 동작으로 돌아가며 저장 데이터 변환은 필요 없다.
+DB schema와 저장 데이터 migration은 없다. OpenSpec Gate 승인 뒤 Fedify projection/delivery와 core post-commit
+wiring을 추가하고 package·core·API integration test를 먼저 통과시킨다. Rollback은 새 core lifecycle wiring과
+Fedify Reply delivery 경계를 제거하면 기존 Local Reply 저장·조회·삭제 동작으로 돌아가며 저장 데이터 변환은
+필요 없다.
 
 ## Open Questions
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -54,7 +54,7 @@ Visibility와 Reply Parent 관계에서 actor, canonical Note URI, audience와 r
 Note representation이나 새 Tombstone endpoint가 필요하지 않다.
 
 Recipient는 delivery 시점의 저장 상태에서 직접 Parent Author만 조회한다. Public/Unlisted Reply이며 Parent가
-Active remote Profile, ACTIVE 또는 UNRESPONSIVE ActivityPub Instance, 유효한 HTTP(S) actor URI와 personal inbox를
+Active remote Profile, ACTIVE ActivityPub Instance, 유효한 HTTP(S) actor URI와 personal inbox를
 가질 때만 `Recipient`로 만든다. 유효한 shared inbox는 Fedify의 선호 옵션에 맡기고 사용할 수 없으면 personal
 inbox로 fallback한다. Followers Only·Direct, Local Parent 또는 usable Parent recipient가 없으면 `sendActivity()`를
 호출하지 않는다. follower expansion은 PROD-512가 별도 공통 dispatcher에서 소유한다.
@@ -78,7 +78,7 @@ fragment 없는 Note URI를 사용한다. 이 방법은 별도 activity row나 �
 - Create 전용 Note serialization을 새로 만들거나 Delete를 위해 Active-only dispatcher 조건을 완화하지 않는다.
 - follower 집합을 `ProfileFollows`에서 직접 조회하거나 special `"followers"` recipient를 이 capability에 추가하지 않는다.
 - Followers Only Reply를 remote Parent Author에게 direct delivery하지 않는다.
-- `UNRESPONSIVE` recipient를 durable pending delivery로 저장하거나 별도 자동 재전송하지 않는다.
+- `UNRESPONSIVE` recipient에게 direct delivery하거나 durable pending delivery를 저장하지 않는다.
 - usable Parent actor/inbox가 없으면 invalid URL을 Fedify에 전달하지 않고 no-op한다.
 - PROD-448의 outbox·queue 구조를 현재 작업의 abstraction이나 test seam으로 미리 추가하지 않는다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/design.md
@@ -32,9 +32,9 @@ federation에는 MessageQueue가 없으므로 `sendActivity()`는 remote HTTP �
 
 ### Current Constraints
 
-- `createPost()`는 현재 자신의 transaction과 post-commit lifecycle을 함께 소유한다. transaction 인자의 존재
-  여부로 lifecycle을 켜거나 끄지 않는다. 향후 caller transaction 합류가 실제로 필요해지면 commit 이후 전달을
-  보장하는 명시적인 post-commit coordination 경계를 먼저 설계해야 한다.
+- `createPost()`는 optional caller transaction 계약을 유지하지만 transaction 인자의 존재 여부로 lifecycle을
+  켜거나 끄지 않는다. caller transaction에서 실제 outer commit 이후 전달까지 보장해야 하는 production 요구가
+  생기면 명시적인 post-commit coordination 경계를 먼저 설계해야 한다.
 - 현재 Local Note loader는 Active Post만 제공한다. Reply가 Tombstone이 된 뒤에는 dispatcher를 그대로 호출해
   Delete projection을 만들 수 없다.
 - Create의 embedded Note를 별도로 다시 직렬화하면 object dispatcher의 content, summary, audience와 `inReplyTo`

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
@@ -1,14 +1,15 @@
 ## Why
 
 Local Reply는 Kosmo 안에서 생성·삭제되고 안정적인 ActivityPub Note identity와 표현도 제공되지만, 그 lifecycle이
-remote follower와 원격 Parent 작성자의 inbox로 전달되지 않는다. PROD-494의 공통 Local Note 경계와 PROD-447의
+원격 Parent 작성자의 inbox로 전달되지 않는다. PROD-494의 공통 Local Note 경계와 PROD-447의
 post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭제를 기존 Fedify delivery 경계에 연결한다.
 
 ## What Changes
 
 - 처음 생성된 Local Reply를 기존 Local Note 표현을 포함한 `Create(Note)`로 전달한다.
 - Reply 삭제를 같은 canonical Note identity를 가리키는 `Delete`로 전달한다.
-- Reply visibility에 맞는 remote follower와 원격 Parent 작성자를 현재 저장 상태에서 recipient로 선택한다.
+- Public/Unlisted Reply의 원격 직접 Parent 작성자를 현재 저장 상태에서 direct recipient로 선택한다.
+- outbound followers fanout은 공통 Fedify dispatcher를 소유하는 PROD-512로 분리한다.
 - domain transaction commit 뒤 Fedify로 직접 전달하고, delivery 실패를 관측하되 committed application 결과는
   성공으로 유지한다.
 - duplicate application action 또는 delivery 재호출에서도 같은 Post에 대해 안정적인 activity identity와
@@ -38,10 +39,10 @@ post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭
 
 ## Impact
 
-- `packages/fedify`: 기존 Local Note projection을 재사용하는 Reply Create/Delete activity 구성, recipient 조회와
+- `packages/fedify`: 기존 Local Note projection을 재사용하는 Reply Create/Delete activity 구성, Parent recipient 조회와
   직접 delivery
 - `apps/api`: Local Reply 생성·삭제 transaction commit 이후 delivery 호출과 오류 격리
-- `packages/core`: 기존 Post·Reply Parent·ProfileFollow·ActivityPub Actor 저장 계약을 조회에 재사용하며 새 schema나
+- `packages/core`: 기존 Post·Reply Parent·ActivityPub Actor 저장 계약을 조회에 재사용하며 새 schema나
   migration은 추가하지 않음
 - 운영 제약: API process가 remote HTTP delivery를 직접 기다리고 commit과 delivery 사이 process 종료 시 activity가
   유실될 수 있는 현재 제한을 유지함

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
@@ -11,8 +11,9 @@ post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭
 - Fedify Context와 local actor/Note identity를 Reply Author Profile의 Local Instance `canonicalOrigin`에서 파생한다.
 - Public/Unlisted Reply의 원격 직접 Parent 작성자를 현재 저장 상태에서 direct recipient로 선택한다.
 - outbound followers fanout은 공통 Fedify dispatcher를 소유하는 PROD-512로 분리한다.
-- domain transaction commit 뒤 Fedify로 직접 전달하고, delivery 실패를 관측하되 committed application 결과는
-  성공으로 유지한다.
+- top-level domain transaction commit 뒤 Fedify로 직접 전달하고, delivery 실패를 관측하되 committed application
+  결과는 성공으로 유지한다. caller transaction에서는 rollback될 Activity를 전달하지 않는 대신 commit 뒤 전달
+  누락을 PROD-448 전까지 수용한다.
 - duplicate application action 또는 delivery 재호출에서도 같은 Post에 대해 안정적인 activity identity와
   Create/Delete ordering domain을 사용한다.
 - transactional outbox, NATS, Fedify MessageQueue, durable retry와 delivery history는 구현하지 않고 PROD-448의
@@ -43,7 +44,7 @@ post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭
 - `packages/fedify`: 기존 Local Note projection을 재사용하는 Reply Create/Delete activity 구성, Parent recipient 조회와
   직접 delivery
 - `apps/api`: 인증된 Profile과 입력을 core application action에 전달하고 기존 GraphQL payload를 유지
-- `packages/core`: 통합 `createPost`·`deletePost`가 Local Reply 생성·삭제 outer transaction과 post-commit
-  Notification/Fedify lifecycle을 소유하며 새 schema나 migration은 추가하지 않음
+- `packages/core`: 통합 `createPost`·`deletePost`가 Local Reply lifecycle을 소유하고 Reply Notification을 생성
+  transaction에 참여시키며 새 schema나 migration은 추가하지 않음
 - 운영 제약: API process가 remote HTTP delivery를 직접 기다리고 commit과 delivery 사이 process 종료 시 activity가
   유실될 수 있는 현재 제한을 유지함

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
@@ -43,7 +43,7 @@ post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭
 - `packages/fedify`: 기존 Local Note projection을 재사용하는 Reply Create/Delete activity 구성, Parent recipient 조회와
   직접 delivery
 - `apps/api`: 인증된 Profile과 입력을 core application action에 전달하고 기존 GraphQL payload를 유지
-- `packages/core`: Local Reply 생성·삭제 outer transaction과 post-commit Notification/Fedify lifecycle을 소유하며
-  새 schema나 migration은 추가하지 않음
+- `packages/core`: 통합 `createPost`·`deletePost`가 Local Reply 생성·삭제 outer transaction과 post-commit
+  Notification/Fedify lifecycle을 소유하며 새 schema나 migration은 추가하지 않음
 - 운영 제약: API process가 remote HTTP delivery를 직접 기다리고 commit과 delivery 사이 process 종료 시 activity가
   유실될 수 있는 현재 제한을 유지함

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
@@ -8,6 +8,7 @@ post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭
 
 - 처음 생성된 Local Reply를 기존 Local Note 표현을 포함한 `Create(Note)`로 전달한다.
 - Reply 삭제를 같은 canonical Note identity를 가리키는 `Delete`로 전달한다.
+- Fedify Context와 local actor/Note identity를 Reply Author Profile의 Local Instance `canonicalOrigin`에서 파생한다.
 - Public/Unlisted Reply의 원격 직접 Parent 작성자를 현재 저장 상태에서 direct recipient로 선택한다.
 - outbound followers fanout은 공통 Fedify dispatcher를 소유하는 PROD-512로 분리한다.
 - domain transaction commit 뒤 Fedify로 직접 전달하고, delivery 실패를 관측하되 committed application 결과는

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
@@ -42,8 +42,8 @@ post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭
 
 - `packages/fedify`: 기존 Local Note projection을 재사용하는 Reply Create/Delete activity 구성, Parent recipient 조회와
   직접 delivery
-- `apps/api`: Local Reply 생성·삭제 transaction commit 이후 delivery 호출과 오류 격리
-- `packages/core`: 기존 Post·Reply Parent·ActivityPub Actor 저장 계약을 조회에 재사용하며 새 schema나
-  migration은 추가하지 않음
+- `apps/api`: 인증된 Profile과 입력을 core application action에 전달하고 기존 GraphQL payload를 유지
+- `packages/core`: Local Reply 생성·삭제 outer transaction과 post-commit Notification/Fedify lifecycle을 소유하며
+  새 schema나 migration은 추가하지 않음
 - 운영 제약: API process가 remote HTTP delivery를 직접 기다리고 commit과 delivery 사이 process 종료 시 activity가
   유실될 수 있는 현재 제한을 유지함

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Local Reply는 Kosmo 안에서 생성·삭제되고 안정적인 ActivityPub Note identity와 표현도 제공되지만, 그 lifecycle이
+remote follower와 원격 Parent 작성자의 inbox로 전달되지 않는다. PROD-494의 공통 Local Note 경계와 PROD-447의
+post-commit failure isolation이 준비되었으므로, 이제 Reply 생성·삭제를 기존 Fedify delivery 경계에 연결한다.
+
+## What Changes
+
+- 처음 생성된 Local Reply를 기존 Local Note 표현을 포함한 `Create(Note)`로 전달한다.
+- Reply 삭제를 같은 canonical Note identity를 가리키는 `Delete`로 전달한다.
+- Reply visibility에 맞는 remote follower와 원격 Parent 작성자를 현재 저장 상태에서 recipient로 선택한다.
+- domain transaction commit 뒤 Fedify로 직접 전달하고, delivery 실패를 관측하되 committed application 결과는
+  성공으로 유지한다.
+- duplicate application action 또는 delivery 재호출에서도 같은 Post에 대해 안정적인 activity identity와
+  Create/Delete ordering domain을 사용한다.
+- transactional outbox, NATS, Fedify MessageQueue, durable retry와 delivery history는 구현하지 않고 PROD-448의
+  후속 migration으로 유지한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`,
+  `docs/domain/decisions/0010-post-interaction-contracts.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, `docs/architecture/core-services.md`
+- Linear Contract: PROD-497
+- Linear Implementations: PROD-497. PROD-494는 Local Note identity·표현 기반, PROD-447은 현재 post-commit failure
+  isolation 계약, PROD-448은 별도 후속 migration을 소유한다.
+
+## Capabilities
+
+### New Capabilities
+
+- `activitypub-local-reply-delivery`: Local Reply의 `Create(Note)`·`Delete` activity, recipient, identity,
+  post-commit delivery와 failure isolation을 정의한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `packages/fedify`: 기존 Local Note projection을 재사용하는 Reply Create/Delete activity 구성, recipient 조회와
+  직접 delivery
+- `apps/api`: Local Reply 생성·삭제 transaction commit 이후 delivery 호출과 오류 격리
+- `packages/core`: 기존 Post·Reply Parent·ProfileFollow·ActivityPub Actor 저장 계약을 조회에 재사용하며 새 schema나
+  migration은 추가하지 않음
+- 운영 제약: API process가 remote HTTP delivery를 직접 기다리고 commit과 delivery 사이 process 종료 시 activity가
+  유실될 수 있는 현재 제한을 유지함

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -88,13 +88,12 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 ### Requirement: Post-commit delivery failure isolation
 
-**Authority / Provenance:** `docs/architecture/core-services.md`, PROD-447, PROD-497. 시스템은 Reply domain transaction이 commit된 뒤 기존 Fedify 경계로 activity를 직접 전달해야 한다(MUST).
+**Authority / Provenance:** `docs/architecture/core-services.md`, PROD-447, PROD-497. 시스템은 top-level Reply domain transaction이 commit된 뒤 기존 Fedify 경계로 activity를 직접 전달해야 한다(MUST).
 Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
 바꾸거나 rollback해서는 안 된다(MUST NOT).
 
-통합 core `createPost`·`deletePost` action은 outer transaction과 origin별 post-commit Reply lifecycle을 소유해야
-하며(MUST), 별도 Local Post action이나 GraphQL resolver가 Reply Notification 또는 Fedify delivery를 직접
-조립해서는 안 된다(MUST NOT).
+통합 core `createPost`·`deletePost` action은 origin별 Reply lifecycle을 소유해야 하며(MUST), 별도 Local Post
+action이나 GraphQL resolver가 Reply Notification 또는 Fedify delivery를 직접 조립해서는 안 된다(MUST NOT).
 
 #### Scenario: Create delivery 실패
 
@@ -115,18 +114,25 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 - **WHEN** Local Reply 생성 또는 삭제 transaction이 rollback된다
 - **THEN** 시스템은 해당 state transition의 Create 또는 Delete activity를 전달하지 않는다
 
+#### Scenario: caller transaction commit 뒤 Activity 누락
+
+- **WHEN** Local Reply action이 caller transaction에 합류하고 outer commit 전에 direct delivery 조회가 uncommitted Reply를 찾지 못한다
+- **THEN** 시스템은 rollback될 수 있는 Reply의 Activity를 전달하지 않는다
+- **AND** outer transaction이 commit된 뒤 Activity를 재실행하지 않아 발생하는 전달 누락은 PROD-448 전까지 수용한다
+- **AND** Reply Notification은 caller transaction에 참여해 commit과 rollback을 함께 따른다
+
 #### Scenario: GraphQL entry의 책임
 
 - **WHEN** GraphQL mutation이 Local Reply를 생성하거나 삭제한다
 - **THEN** resolver는 인증된 Profile과 business input을 통합 `createPost` 또는 `deletePost`에 전달한다
-- **AND** 통합 core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
+- **AND** 통합 core production 기본 경로가 Reply Notification을 transaction에 참여시키고 top-level commit 뒤 Create 또는 Delete delivery를 실행한다
 - **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
 #### Scenario: Transaction 구성은 lifecycle 의미를 바꾸지 않는다
 
 - **WHEN** Post 생성 action의 transaction 구성 방식이 달라진다
 - **THEN** transaction 인자의 존재 여부로 Reply lifecycle 실행 여부를 결정하지 않는다
-- **AND** caller transaction 합류가 필요하면 commit 이후 전달을 보장하는 명시적 coordination 경계를 먼저 정의한다
+- **AND** caller transaction에서는 rollback될 Activity를 전달하지 않고 commit 뒤 전달 누락을 현재 제한으로 수용한다
 
 ### Requirement: 현재 직접 delivery 제한
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -54,6 +54,16 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 - **WHEN** visibility와 instance 정책을 통과한 remote recipient가 없다
 - **THEN** 시스템은 remote delivery 없이 committed application 결과를 성공으로 유지한다
 
+### Requirement: Reply Author Local Instance origin
+
+**Authority / Provenance:** `docs/domain/objects/instance.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/post.md`, PROD-497. 시스템은 Reply Create/Delete의 Fedify Context, actor URI, Note URI와 activity identity를 Reply Author Profile이 연결된 Local Instance의 `canonicalOrigin`에서 파생해야 한다(MUST). 별도의 deployment configured origin으로 Author Instance identity를 대체해서는 안 된다(MUST NOT).
+
+#### Scenario: 여러 Local Instance가 저장된 상태의 Reply delivery
+
+- **WHEN** configured Local Instance와 다른 Local Instance에 속한 Profile의 Reply Create 또는 Delete를 전달한다
+- **THEN** Fedify Context와 actor URI는 Reply Author의 Local Instance `canonicalOrigin`을 사용한다
+- **AND** Create/Delete는 그 origin에서 파생한 동일한 canonical Note URI와 ordering domain을 사용한다
+
 ### Requirement: Local Reply Delete delivery
 
 **Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply가 Tombstone으로 commit된 뒤 생성 때 사용한 canonical Note identity를 object로 가리키는 ActivityPub `Delete`를 전달해야 한다(MUST). 같은 Reply의 Create와 Delete는 recipient별 순서를 보존할 수 있는

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -8,8 +8,8 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 #### Scenario: Local Parent에 대한 Reply 생성
 
 - **WHEN** Local Profile이 Content가 있는 Local Post를 직접 Parent로 참조하는 Reply를 생성하고 transaction이 commit된다
-- **THEN** 시스템은 Reply의 canonical Local Note를 포함한 `Create(Note)`를 전달한다
-- **AND** Note의 `inReplyTo`는 Parent의 `/ap/note/{postId}` identity를 가리킨다
+- **THEN** Reply의 canonical Local Note에서 `inReplyTo`는 Parent의 `/ap/note/{postId}` identity를 가리킨다
+- **AND** 이번 capability는 remote direct recipient가 없으므로 activity를 전달하지 않는다
 
 #### Scenario: Remote Parent에 대한 Reply 생성
 
@@ -24,21 +24,19 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 ### Requirement: Reply delivery recipient와 audience
 
-**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, 현재 저장된 established remote follower와 원격 직접 Parent 작성자 중 해당 visibility가 허용하는 Profile을 recipient로 선택해야 한다(MUST). 새 원격 요청이
-허용되는 `ACTIVE` ActivityPub Instance의 저장된 actor endpoint에만 전달해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, Public 또는 Unlisted Reply의 원격 직접 Parent 작성자를 direct recipient로 선택해야 한다(MUST). `inReplyTo` object IRI를 delivery endpoint로 취급해서는 안 된다(MUST NOT). 새 원격 요청이 허용되는 `ACTIVE` 또는 `UNRESPONSIVE` ActivityPub Instance의 저장된 HTTP(S) actor와 personal inbox만 전달에 사용해야 한다(MUST).
 
 #### Scenario: Public 또는 Unlisted Reply recipient
 
 - **WHEN** Public 또는 Unlisted Local Reply의 Create나 Delete를 전달한다
-- **THEN** 시스템은 Author의 현재 established remote follower를 recipient로 선택한다
-- **AND** 직접 Parent의 Author가 remote Profile이면 follower 관계와 무관하게 recipient에 포함한다
-- **AND** 같은 remote actor가 follower이면서 Parent Author이면 한 recipient로 취급한다
+- **THEN** 직접 Parent의 Author가 remote Profile이면 follower 관계와 무관하게 direct recipient로 선택한다
+- **AND** 저장된 유효한 HTTP(S) shared inbox가 있으면 Fedify가 우선할 수 있게 보존하고, 사용할 수 없으면 personal inbox를 사용한다
 
 #### Scenario: Followers Only Reply recipient
 
 - **WHEN** Followers Only Local Reply의 Create나 Delete를 전달한다
-- **THEN** 시스템은 Author의 현재 established remote follower만 recipient로 선택한다
-- **AND** remote Parent Author도 Author를 follow하는 established remote follower일 때만 포함한다
+- **THEN** 시스템은 이번 capability에서 remote recipient를 선택하지 않는다
+- **AND** follower 집합을 직접 조회하거나 fanout하지 않는다
 
 #### Scenario: 지원하지 않는 Direct Reply
 
@@ -47,7 +45,7 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 #### Scenario: unavailable remote instance
 
-- **WHEN** 후보 recipient의 ActivityPub Instance가 `UNRESPONSIVE` 또는 `SUSPENDED`이다
+- **WHEN** 후보 recipient의 ActivityPub Instance가 `SUSPENDED`이다
 - **THEN** 시스템은 해당 recipient에게 activity를 전달하지 않는다
 - **AND** 이번 capability를 위한 pending delivery, durable retry 또는 delivery history를 만들지 않는다
 
@@ -105,7 +103,7 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 
 ### Requirement: 현재 직접 delivery 제한
 
-**Authority / Provenance:** PROD-448, PROD-497. 시스템은 이번 capability에서 transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될
+**Authority / Provenance:** PROD-448, PROD-497, PROD-512. 시스템은 이번 capability에서 followers fanout, transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될
 수 있는 현재 제한은 PROD-448 migration 전까지 수용해야 한다(MUST).
 
 #### Scenario: commit 직후 process 종료

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -92,8 +92,9 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
 바꾸거나 rollback해서는 안 된다(MUST NOT).
 
-Local Reply 생성·삭제의 core application action은 outer transaction과 post-commit Reply lifecycle을 소유해야
-하며(MUST), GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립해서는 안 된다(MUST NOT).
+통합 core `createPost`·`deletePost` action은 outer transaction과 origin별 post-commit Reply lifecycle을 소유해야
+하며(MUST), 별도 Local Post action이나 GraphQL resolver가 Reply Notification 또는 Fedify delivery를 직접
+조립해서는 안 된다(MUST NOT).
 
 #### Scenario: Create delivery 실패
 
@@ -117,8 +118,8 @@ Local Reply 생성·삭제의 core application action은 outer transaction과 po
 #### Scenario: GraphQL entry의 책임
 
 - **WHEN** GraphQL mutation이 Local Reply를 생성하거나 삭제한다
-- **THEN** resolver는 인증된 Profile과 business input을 core application action에 전달한다
-- **AND** core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
+- **THEN** resolver는 인증된 Profile과 business input을 통합 `createPost` 또는 `deletePost`에 전달한다
+- **AND** 통합 core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
 - **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
 ### Requirement: 현재 직접 delivery 제한

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Local Reply Create delivery
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 처음 commit된 Local Reply를 PROD-494의 canonical Local Note identity와 표현을 사용하는 ActivityPub `Create(Note)`로 remote recipient에게 전달해야 한다(MUST). `Create`의 Note는 Reply가 직접 참조하는 Local 또는
+Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다(MUST).
+
+#### Scenario: Local Parent에 대한 Reply 생성
+
+- **WHEN** Local Profile이 Content가 있는 Local Post를 직접 Parent로 참조하는 Reply를 생성하고 transaction이 commit된다
+- **THEN** 시스템은 Reply의 canonical Local Note를 포함한 `Create(Note)`를 전달한다
+- **AND** Note의 `inReplyTo`는 Parent의 `/ap/note/{postId}` identity를 가리킨다
+
+#### Scenario: Remote Parent에 대한 Reply 생성
+
+- **WHEN** Local Profile이 저장된 Remote Post를 직접 Parent로 참조하는 Reply를 생성하고 transaction이 commit된다
+- **THEN** 시스템은 Reply의 canonical Local Note를 포함한 `Create(Note)`를 전달한다
+- **AND** Note의 `inReplyTo`는 Parent의 기존 ActivityPub Post mapping URI를 가리킨다
+
+#### Scenario: 동일 Reply의 Create 재호출
+
+- **WHEN** 같은 committed Reply에 대한 Create delivery가 둘 이상 호출된다
+- **THEN** 각 호출은 같은 Reply Note identity와 같은 안정적인 Create activity identity를 사용한다
+
+### Requirement: Reply delivery recipient와 audience
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, 현재 저장된 established remote follower와 원격 직접 Parent 작성자 중 해당 visibility가 허용하는 Profile을 recipient로 선택해야 한다(MUST). 새 원격 요청이
+허용되는 `ACTIVE` ActivityPub Instance의 저장된 actor endpoint에만 전달해야 한다(MUST).
+
+#### Scenario: Public 또는 Unlisted Reply recipient
+
+- **WHEN** Public 또는 Unlisted Local Reply의 Create나 Delete를 전달한다
+- **THEN** 시스템은 Author의 현재 established remote follower를 recipient로 선택한다
+- **AND** 직접 Parent의 Author가 remote Profile이면 follower 관계와 무관하게 recipient에 포함한다
+- **AND** 같은 remote actor가 follower이면서 Parent Author이면 한 recipient로 취급한다
+
+#### Scenario: Followers Only Reply recipient
+
+- **WHEN** Followers Only Local Reply의 Create나 Delete를 전달한다
+- **THEN** 시스템은 Author의 현재 established remote follower만 recipient로 선택한다
+- **AND** remote Parent Author도 Author를 follow하는 established remote follower일 때만 포함한다
+
+#### Scenario: 지원하지 않는 Direct Reply
+
+- **WHEN** Reply의 Visibility가 Direct이다
+- **THEN** 시스템은 Reply Create 또는 Delete activity를 전달하지 않는다
+
+#### Scenario: unavailable remote instance
+
+- **WHEN** 후보 recipient의 ActivityPub Instance가 `UNRESPONSIVE` 또는 `SUSPENDED`이다
+- **THEN** 시스템은 해당 recipient에게 activity를 전달하지 않는다
+- **AND** 이번 capability를 위한 pending delivery, durable retry 또는 delivery history를 만들지 않는다
+
+#### Scenario: 전달할 remote recipient가 없음
+
+- **WHEN** visibility와 instance 정책을 통과한 remote recipient가 없다
+- **THEN** 시스템은 remote delivery 없이 committed application 결과를 성공으로 유지한다
+
+### Requirement: Local Reply Delete delivery
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply가 Tombstone으로 commit된 뒤 생성 때 사용한 canonical Note identity를 object로 가리키는 ActivityPub `Delete`를 전달해야 한다(MUST). 같은 Reply의 Create와 Delete는 recipient별 순서를 보존할 수 있는
+동일한 안정적 ordering domain을 사용해야 한다(MUST).
+
+#### Scenario: Local Reply 삭제
+
+- **WHEN** Author가 Active Local Reply를 삭제하고 Tombstone transaction이 commit된다
+- **THEN** 시스템은 Reply 생성 때 사용한 canonical Note URI를 object로 가리키는 `Delete`를 전달한다
+- **AND** Delete는 같은 Reply의 Create와 동일한 ordering domain을 사용한다
+
+#### Scenario: 동일 Reply의 반복 삭제 또는 Delete 재호출
+
+- **WHEN** 같은 Reply 삭제 action 또는 Delete delivery가 반복된다
+- **THEN** 각 delivery는 같은 Note object identity와 같은 안정적인 Delete activity identity를 사용한다
+- **AND** duplicate 억제를 위한 별도 delivery 상태를 저장하지 않는다
+
+#### Scenario: Reply가 아닌 Post 삭제
+
+- **WHEN** Reply Parent 관계가 없는 Local Post 또는 Content 없는 Repost가 삭제된다
+- **THEN** 시스템은 이번 capability의 Reply Delete activity를 전달하지 않는다
+
+### Requirement: Post-commit delivery failure isolation
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, PROD-447, PROD-497. 시스템은 Reply domain transaction이 commit된 뒤 기존 Fedify 경계로 activity를 직접 전달해야 한다(MUST).
+Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
+바꾸거나 rollback해서는 안 된다(MUST NOT).
+
+#### Scenario: Create delivery 실패
+
+- **WHEN** Local Reply 생성 transaction이 commit된 뒤 remote HTTP Create delivery가 실패한다
+- **THEN** 시스템은 실패와 Reply identity를 관측 가능하게 기록한다
+- **AND** 생성된 Reply와 Content를 유지한다
+- **AND** application action은 committed Reply를 나타내는 성공 결과를 반환한다
+
+#### Scenario: Delete delivery 실패
+
+- **WHEN** Local Reply 삭제 transaction이 commit된 뒤 remote HTTP Delete delivery가 실패한다
+- **THEN** 시스템은 실패와 Reply identity를 관측 가능하게 기록한다
+- **AND** Reply Tombstone과 삭제 시각을 유지한다
+- **AND** application action은 committed 삭제를 나타내는 성공 결과를 반환한다
+
+#### Scenario: transaction rollback
+
+- **WHEN** Local Reply 생성 또는 삭제 transaction이 rollback된다
+- **THEN** 시스템은 해당 state transition의 Create 또는 Delete activity를 전달하지 않는다
+
+### Requirement: 현재 직접 delivery 제한
+
+**Authority / Provenance:** PROD-448, PROD-497. 시스템은 이번 capability에서 transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될
+수 있는 현재 제한은 PROD-448 migration 전까지 수용해야 한다(MUST).
+
+#### Scenario: commit 직후 process 종료
+
+- **WHEN** Reply state가 commit된 뒤 Fedify direct delivery가 시작되기 전에 API process가 종료된다
+- **THEN** committed Reply state는 유지된다
+- **AND** 이번 capability는 유실된 activity를 복원할 durable intent나 retry record를 제공하지 않는다

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -122,6 +122,12 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 - **AND** 통합 core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
 - **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
+#### Scenario: Transaction 구성은 lifecycle 의미를 바꾸지 않는다
+
+- **WHEN** Post 생성 action의 transaction 구성 방식이 달라진다
+- **THEN** transaction 인자의 존재 여부로 Reply lifecycle 실행 여부를 결정하지 않는다
+- **AND** caller transaction 합류가 필요하면 commit 이후 전달을 보장하는 명시적 coordination 경계를 먼저 정의한다
+
 ### Requirement: 현재 직접 delivery 제한
 
 **Authority / Provenance:** PROD-448, PROD-497, PROD-512. 시스템은 이번 capability에서 followers fanout, transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -24,7 +24,7 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 ### Requirement: Reply delivery recipient와 audience
 
-**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, Public 또는 Unlisted Reply의 원격 직접 Parent 작성자를 direct recipient로 선택해야 한다(MUST). `inReplyTo` object IRI를 delivery endpoint로 취급해서는 안 된다(MUST NOT). 새 원격 요청이 허용되는 `ACTIVE` 또는 `UNRESPONSIVE` ActivityPub Instance의 저장된 HTTP(S) actor와 personal inbox만 전달에 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, Public 또는 Unlisted Reply의 원격 직접 Parent 작성자를 direct recipient로 선택해야 한다(MUST). `inReplyTo` object IRI를 delivery endpoint로 취급해서는 안 된다(MUST NOT). 새 원격 요청이 허용되는 `ACTIVE` ActivityPub Instance의 저장된 HTTP(S) actor와 personal inbox만 전달에 사용해야 한다(MUST).
 
 #### Scenario: Public 또는 Unlisted Reply recipient
 
@@ -45,7 +45,7 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 #### Scenario: unavailable remote instance
 
-- **WHEN** 후보 recipient의 ActivityPub Instance가 `SUSPENDED`이다
+- **WHEN** 후보 recipient의 ActivityPub Instance가 `UNRESPONSIVE` 또는 `SUSPENDED`이다
 - **THEN** 시스템은 해당 recipient에게 activity를 전달하지 않는다
 - **AND** 이번 capability를 위한 pending delivery, durable retry 또는 delivery history를 만들지 않는다
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/specs/activitypub-local-reply-delivery/spec.md
@@ -92,6 +92,9 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
 바꾸거나 rollback해서는 안 된다(MUST NOT).
 
+Local Reply 생성·삭제의 core application action은 outer transaction과 post-commit Reply lifecycle을 소유해야
+하며(MUST), GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립해서는 안 된다(MUST NOT).
+
 #### Scenario: Create delivery 실패
 
 - **WHEN** Local Reply 생성 transaction이 commit된 뒤 remote HTTP Create delivery가 실패한다
@@ -110,6 +113,13 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 
 - **WHEN** Local Reply 생성 또는 삭제 transaction이 rollback된다
 - **THEN** 시스템은 해당 state transition의 Create 또는 Delete activity를 전달하지 않는다
+
+#### Scenario: GraphQL entry의 책임
+
+- **WHEN** GraphQL mutation이 Local Reply를 생성하거나 삭제한다
+- **THEN** resolver는 인증된 Profile과 business input을 core application action에 전달한다
+- **AND** core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
+- **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
 ### Requirement: 현재 직접 delivery 제한
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -44,28 +44,29 @@ Local Reply가 기존 canonical Note 표현과 identity를 사용하는 안정�
 
 **Deliverable**
 
-Local Reply domain transaction이 commit된 뒤에만 Create/Delete delivery가 실행되고, remote delivery 실패에도
-GraphQL application 결과와 committed Reply state가 성공으로 유지된다.
+rollback된 Local Reply의 Create/Delete는 전달되지 않고, top-level commit 뒤 remote delivery 실패에도 GraphQL
+application 결과와 committed Reply state가 성공으로 유지된다. caller transaction의 commit 뒤 Activity 누락은
+현재 직접 delivery 제한으로 수용한다.
 
 **Guardrails**
 
 - transaction 인자의 존재 여부로 origin이나 lifecycle 실행 여부를 분기하지 않는다.
-- caller transaction 합류가 필요해지면 delivery를 생략하거나 commit 전에 실행하지 않고 명시적인 post-commit
-  coordination 경계를 먼저 설계한다.
+- caller transaction의 uncommitted Reply는 별도 delivery 조회에서 no-op으로 처리하며 commit 뒤 재실행 누락을
+  수용한다.
 - core Post public contract에 GraphQL·Fedify 타입, callback이나 speculative delivery port를 추가하지 않는다.
 - GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립하지 않는다.
-- 통합 `createPost`와 `deletePost`가 outer commit과 origin별 post-commit lifecycle을 소유한다.
+- 통합 `createPost`와 `deletePost`가 origin별 lifecycle을 소유한다.
 - delivery Promise를 fire-and-forget하지 않고 await한 뒤 실패를 Reply identity와 함께 관측한다.
 - 기존 Reply Notification과 Post 삭제 Notification cleanup의 best-effort lifecycle을 재정의하지 않는다.
 - Reply가 아닌 Post의 생성·삭제에는 이 capability의 activity를 전달하지 않는다.
 
 **Verification**
 
-- transaction rollback에서 delivery가 호출되지 않고 commit 뒤에만 호출되는지 검증한다.
+- transaction rollback에서 Activity가 전달되지 않고 top-level commit 뒤 delivery되는지 검증한다.
 - Create/Delete remote failure에서 GraphQL 성공 payload와 committed DB state가 일치하는지 검증한다.
 - 일반 Post, Repost와 remote-origin Post lifecycle이 Reply delivery를 만들지 않는지 회귀 검증한다.
 
-- [x] 2.1 통합 `createPost`의 Local Reply outer transaction commit 뒤 Notification과 Create delivery를 연결하고 실패를 application 결과와 격리한다.
+- [x] 2.1 통합 `createPost`의 Local Reply Notification을 transaction에 참여시키고 top-level commit 뒤 Create delivery 실패를 application 결과와 격리한다.
 - [x] 2.2 `deletePost`의 Local Reply Tombstone commit 뒤 Delete delivery를 연결하고 실패를 application 결과와 격리한다.
 - [x] 2.3 create/delete rollback, delivery rejection, 반복 삭제와 non-Reply 경계의 API integration 검증을 추가한다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -51,6 +51,8 @@ GraphQL application 결과와 committed Reply state가 성공으로 유지된다
 
 - transaction callback 또는 optional caller transaction 내부에서 delivery하지 않는다.
 - core Post public contract에 GraphQL·Fedify 타입, callback이나 speculative delivery port를 추가하지 않는다.
+- GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립하지 않는다.
+- core Local Post application action과 `deletePost`가 outer commit과 post-commit lifecycle을 소유한다.
 - delivery Promise를 fire-and-forget하지 않고 await한 뒤 실패를 Reply identity와 함께 관측한다.
 - 기존 Reply Notification과 Post 삭제 Notification cleanup의 best-effort lifecycle을 재정의하지 않는다.
 - Reply가 아닌 Post의 생성·삭제에는 이 capability의 activity를 전달하지 않는다.
@@ -61,8 +63,8 @@ GraphQL application 결과와 committed Reply state가 성공으로 유지된다
 - Create/Delete remote failure에서 GraphQL 성공 payload와 committed DB state가 일치하는지 검증한다.
 - 일반 Post, Repost와 remote-origin Post lifecycle이 Reply delivery를 만들지 않는지 회귀 검증한다.
 
-- [x] 2.1 Local Reply 생성의 outer transaction commit 뒤 Create delivery를 연결하고 실패를 application 결과와 격리한다.
-- [x] 2.2 Local Reply Tombstone commit 뒤 Delete delivery를 연결하고 실패를 application 결과와 격리한다.
+- [x] 2.1 core Local Post application action의 outer transaction commit 뒤 Notification과 Create delivery를 연결하고 실패를 application 결과와 격리한다.
+- [x] 2.2 `deletePost`의 Local Reply Tombstone commit 뒤 Delete delivery를 연결하고 실패를 application 결과와 격리한다.
 - [x] 2.3 create/delete rollback, delivery rejection, 반복 삭제와 non-Reply 경계의 API integration 검증을 추가한다.
 
 ## 3. PROD-497 통합 검증과 OpenSpec 완료

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -17,7 +17,7 @@ Local Reply가 기존 canonical Note 표현과 identity를 사용하는 안정�
 - Create는 PROD-494의 Local Note content, summary, audience와 Local/Remote Parent `inReplyTo`를 재사용한다.
 - Delete는 생성 때 사용한 canonical Note URI를 가리키며 별도 Tombstone endpoint나 mapping row를 만들지 않는다.
 - Public/Unlisted는 remote Parent Author만 direct recipient로 허용하고 Followers Only·Direct는 전달하지 않는다.
-- ACTIVE 또는 UNRESPONSIVE ActivityPub Instance의 usable HTTP(S) actor endpoint만 사용한다.
+- ACTIVE ActivityPub Instance의 usable HTTP(S) actor endpoint만 사용하고 UNRESPONSIVE/SUSPENDED는 제외한다.
 - Create는 `{noteUri}#create`, Delete는 `{noteUri}#delete`, ordering domain은 canonical Note URI를 사용한다.
 - follower 직접 조회·fanout, followers/outbox collection, queue, retry/history와 새 DB schema를 추가하지 않는다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -52,7 +52,7 @@ GraphQL application 결과와 committed Reply state가 성공으로 유지된다
 - transaction callback 또는 optional caller transaction 내부에서 delivery하지 않는다.
 - core Post public contract에 GraphQL·Fedify 타입, callback이나 speculative delivery port를 추가하지 않는다.
 - GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립하지 않는다.
-- core Local Post application action과 `deletePost`가 outer commit과 post-commit lifecycle을 소유한다.
+- 통합 `createPost`와 `deletePost`가 outer commit과 origin별 post-commit lifecycle을 소유한다.
 - delivery Promise를 fire-and-forget하지 않고 await한 뒤 실패를 Reply identity와 함께 관측한다.
 - 기존 Reply Notification과 Post 삭제 Notification cleanup의 best-effort lifecycle을 재정의하지 않는다.
 - Reply가 아닌 Post의 생성·삭제에는 이 capability의 activity를 전달하지 않는다.
@@ -63,7 +63,7 @@ GraphQL application 결과와 committed Reply state가 성공으로 유지된다
 - Create/Delete remote failure에서 GraphQL 성공 payload와 committed DB state가 일치하는지 검증한다.
 - 일반 Post, Repost와 remote-origin Post lifecycle이 Reply delivery를 만들지 않는지 회귀 검증한다.
 
-- [x] 2.1 core Local Post application action의 outer transaction commit 뒤 Notification과 Create delivery를 연결하고 실패를 application 결과와 격리한다.
+- [x] 2.1 통합 `createPost`의 Local Reply outer transaction commit 뒤 Notification과 Create delivery를 연결하고 실패를 application 결과와 격리한다.
 - [x] 2.2 `deletePost`의 Local Reply Tombstone commit 뒤 Delete delivery를 연결하고 실패를 application 결과와 격리한다.
 - [x] 2.3 create/delete rollback, delivery rejection, 반복 삭제와 non-Reply 경계의 API integration 검증을 추가한다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -49,7 +49,9 @@ GraphQL application 결과와 committed Reply state가 성공으로 유지된다
 
 **Guardrails**
 
-- transaction callback 또는 optional caller transaction 내부에서 delivery하지 않는다.
+- transaction 인자의 존재 여부로 origin이나 lifecycle 실행 여부를 분기하지 않는다.
+- caller transaction 합류가 필요해지면 delivery를 생략하거나 commit 전에 실행하지 않고 명시적인 post-commit
+  coordination 경계를 먼저 설계한다.
 - core Post public contract에 GraphQL·Fedify 타입, callback이나 speculative delivery port를 추가하지 않는다.
 - GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립하지 않는다.
 - 통합 `createPost`와 `deletePost`가 outer commit과 origin별 post-commit lifecycle을 소유한다.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -18,12 +18,14 @@ Local Reply가 기존 canonical Note 표현과 identity를 사용하는 안정�
 - Delete는 생성 때 사용한 canonical Note URI를 가리키며 별도 Tombstone endpoint나 mapping row를 만들지 않는다.
 - Public/Unlisted는 remote Parent Author만 direct recipient로 허용하고 Followers Only·Direct는 전달하지 않는다.
 - ACTIVE ActivityPub Instance의 usable HTTP(S) actor endpoint만 사용하고 UNRESPONSIVE/SUSPENDED는 제외한다.
+- Fedify Context, actor URI와 Note identity는 Reply Author Profile의 Local Instance `canonicalOrigin`에서 파생한다.
 - Create는 `{noteUri}#create`, Delete는 `{noteUri}#delete`, ordering domain은 canonical Note URI를 사용한다.
 - follower 직접 조회·fanout, followers/outbox collection, queue, retry/history와 새 DB schema를 추가하지 않는다.
 
 **Verification**
 
 - Local/Remote Parent의 Create Note projection과 Delete object identity를 검증한다.
+- configured origin과 다른 Local Instance Author의 Create/Delete identity와 Context origin을 검증한다.
 - visibility, Parent Author, endpoint와 Instance state recipient matrix를 검증한다.
 - 반복 delivery ID, Create/Delete ordering key, shared inbox와 no-recipient no-op을 검증한다.
 

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -10,27 +10,26 @@
 **Deliverable**
 
 Local Reply가 기존 canonical Note 표현과 identity를 사용하는 안정적인 `Create(Note)`·`Delete` activity로 현재
-허용된 remote follower와 Parent Author에게 전달된다.
+허용된 remote Parent Author에게 전달된다.
 
 **Guardrails**
 
 - Create는 PROD-494의 Local Note content, summary, audience와 Local/Remote Parent `inReplyTo`를 재사용한다.
 - Delete는 생성 때 사용한 canonical Note URI를 가리키며 별도 Tombstone endpoint나 mapping row를 만들지 않는다.
-- Public/Unlisted는 established remote follower와 remote Parent Author를, Followers Only는 established remote
-  follower만 허용한다.
-- Active ActivityPub Instance의 usable actor endpoint만 사용하고 actor identity 중복을 제거한다.
+- Public/Unlisted는 remote Parent Author만 direct recipient로 허용하고 Followers Only·Direct는 전달하지 않는다.
+- ACTIVE 또는 UNRESPONSIVE ActivityPub Instance의 usable HTTP(S) actor endpoint만 사용한다.
 - Create는 `{noteUri}#create`, Delete는 `{noteUri}#delete`, ordering domain은 canonical Note URI를 사용한다.
-- followers collection, outbox collection, queue, retry/history와 새 DB schema를 추가하지 않는다.
+- follower 직접 조회·fanout, followers/outbox collection, queue, retry/history와 새 DB schema를 추가하지 않는다.
 
 **Verification**
 
 - Local/Remote Parent의 Create Note projection과 Delete object identity를 검증한다.
-- visibility, follower, Parent Author, actor 중복, endpoint와 Instance state recipient matrix를 검증한다.
+- visibility, Parent Author, endpoint와 Instance state recipient matrix를 검증한다.
 - 반복 delivery ID, Create/Delete ordering key, shared inbox와 no-recipient no-op을 검증한다.
 
 - [x] 1.1 기존 Local Note projection을 Create delivery에서도 동일하게 사용할 수 있도록 Fedify 내부 경계를 정렬한다.
 - [x] 1.2 stable activity identity와 ordering domain을 사용하는 Reply Create/Delete delivery를 구현한다.
-- [x] 1.3 현재 visibility·Follow·Parent Author·Instance·actor endpoint 계약에 맞는 recipient selection과 중복 제거를 구현한다.
+- [x] 1.3 현재 visibility·Parent Author·Instance·actor endpoint 계약에 맞는 direct recipient selection을 구현한다.
 - [x] 1.4 Create/Delete projection, recipient matrix, 반복 호출과 delivery option의 Fedify 검증을 추가한다.
 
 ## 2. PROD-497 Post-commit application integration
@@ -81,7 +80,7 @@ PROD-497의 Reply Create/Delete delivery 범위가 기존 Local Note, Reply 작�
 
 **Guardrails**
 
-- PROD-448의 transactional outbox, NATS, Fedify MessageQueue와 worker를 선행 구현하지 않는다.
+- PROD-512의 followers fanout이나 PROD-448의 transactional outbox, NATS, Fedify MessageQueue와 worker를 선행 구현하지 않는다.
 - inbound Reply, Repost, Reaction, Mention, Media, Direct와 사용자용 delivery status를 포함하지 않는다.
 - PROD-494의 미완료 archive task를 이 change가 흡수하거나 대신 완료하지 않는다.
 - 이 change의 모든 requirement와 task가 완료되기 전에는 archive하지 않는다.

--- a/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
+++ b/openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/tasks.md
@@ -1,0 +1,97 @@
+## 1. PROD-497 Reply Create/Delete Fedify delivery
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/instance.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- PROD-497
+
+**Deliverable**
+
+Local Reply가 기존 canonical Note 표현과 identity를 사용하는 안정적인 `Create(Note)`·`Delete` activity로 현재
+허용된 remote follower와 Parent Author에게 전달된다.
+
+**Guardrails**
+
+- Create는 PROD-494의 Local Note content, summary, audience와 Local/Remote Parent `inReplyTo`를 재사용한다.
+- Delete는 생성 때 사용한 canonical Note URI를 가리키며 별도 Tombstone endpoint나 mapping row를 만들지 않는다.
+- Public/Unlisted는 established remote follower와 remote Parent Author를, Followers Only는 established remote
+  follower만 허용한다.
+- Active ActivityPub Instance의 usable actor endpoint만 사용하고 actor identity 중복을 제거한다.
+- Create는 `{noteUri}#create`, Delete는 `{noteUri}#delete`, ordering domain은 canonical Note URI를 사용한다.
+- followers collection, outbox collection, queue, retry/history와 새 DB schema를 추가하지 않는다.
+
+**Verification**
+
+- Local/Remote Parent의 Create Note projection과 Delete object identity를 검증한다.
+- visibility, follower, Parent Author, actor 중복, endpoint와 Instance state recipient matrix를 검증한다.
+- 반복 delivery ID, Create/Delete ordering key, shared inbox와 no-recipient no-op을 검증한다.
+
+- [x] 1.1 기존 Local Note projection을 Create delivery에서도 동일하게 사용할 수 있도록 Fedify 내부 경계를 정렬한다.
+- [x] 1.2 stable activity identity와 ordering domain을 사용하는 Reply Create/Delete delivery를 구현한다.
+- [x] 1.3 현재 visibility·Follow·Parent Author·Instance·actor endpoint 계약에 맞는 recipient selection과 중복 제거를 구현한다.
+- [x] 1.4 Create/Delete projection, recipient matrix, 반복 호출과 delivery option의 Fedify 검증을 추가한다.
+
+## 2. PROD-497 Post-commit application integration
+
+**Authority / Provenance**
+
+- `docs/architecture/core-services.md`
+- PROD-447
+- PROD-497
+
+**Deliverable**
+
+Local Reply domain transaction이 commit된 뒤에만 Create/Delete delivery가 실행되고, remote delivery 실패에도
+GraphQL application 결과와 committed Reply state가 성공으로 유지된다.
+
+**Guardrails**
+
+- transaction callback 또는 optional caller transaction 내부에서 delivery하지 않는다.
+- core Post public contract에 GraphQL·Fedify 타입, callback이나 speculative delivery port를 추가하지 않는다.
+- delivery Promise를 fire-and-forget하지 않고 await한 뒤 실패를 Reply identity와 함께 관측한다.
+- 기존 Reply Notification과 Post 삭제 Notification cleanup의 best-effort lifecycle을 재정의하지 않는다.
+- Reply가 아닌 Post의 생성·삭제에는 이 capability의 activity를 전달하지 않는다.
+
+**Verification**
+
+- transaction rollback에서 delivery가 호출되지 않고 commit 뒤에만 호출되는지 검증한다.
+- Create/Delete remote failure에서 GraphQL 성공 payload와 committed DB state가 일치하는지 검증한다.
+- 일반 Post, Repost와 remote-origin Post lifecycle이 Reply delivery를 만들지 않는지 회귀 검증한다.
+
+- [x] 2.1 Local Reply 생성의 outer transaction commit 뒤 Create delivery를 연결하고 실패를 application 결과와 격리한다.
+- [x] 2.2 Local Reply Tombstone commit 뒤 Delete delivery를 연결하고 실패를 application 결과와 격리한다.
+- [x] 2.3 create/delete rollback, delivery rejection, 반복 삭제와 non-Reply 경계의 API integration 검증을 추가한다.
+
+## 3. PROD-497 통합 검증과 OpenSpec 완료
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/instance.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- `docs/architecture/core-services.md`
+- PROD-497
+
+**Deliverable**
+
+PROD-497의 Reply Create/Delete delivery 범위가 기존 Local Note, Reply 작성·삭제, Notification과 federation routing을
+회귀시키지 않고 검증되며 OpenSpec lifecycle이 완료된다.
+
+**Guardrails**
+
+- PROD-448의 transactional outbox, NATS, Fedify MessageQueue와 worker를 선행 구현하지 않는다.
+- inbound Reply, Repost, Reaction, Mention, Media, Direct와 사용자용 delivery status를 포함하지 않는다.
+- PROD-494의 미완료 archive task를 이 change가 흡수하거나 대신 완료하지 않는다.
+- 이 change의 모든 requirement와 task가 완료되기 전에는 archive하지 않는다.
+
+**Verification**
+
+- Fedify package test/typecheck, core Post test와 API Post GraphQL integration을 통과한다.
+- workspace ESLint, Prettier, Syncpack과 관련 회귀 검증을 통과한다.
+- change strict validation과 전체 OpenSpec strict validation을 통과한다.
+
+- [x] 3.1 관련 package·core·API test와 workspace lint·format 검증을 통과시킨다.
+- [x] 3.2 canonical·Linear·구현·OpenSpec 정합성과 명시적 제외 범위를 최종 대조한다.
+- [x] 3.3 모든 구현·검증 완료 뒤 delta spec을 active capability에 동기화하고 change를 archive한 뒤 전체 strict validation을 통과시킨다.

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 Local Reply의 생성과 삭제를 기존 canonical Note identity, visibility와 post-commit failure isolation 계약에 맞는
-ActivityPub `Create(Note)`와 `Delete`로 remote recipient에게 전달하는 행동을 정의한다.
+ActivityPub `Create(Note)`와 `Delete`로 원격 직접 Parent 작성자에게 전달하는 행동을 정의한다.
 
 ## Requirements
 
@@ -15,8 +15,8 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 #### Scenario: Local Parent에 대한 Reply 생성
 
 - **WHEN** Local Profile이 Content가 있는 Local Post를 직접 Parent로 참조하는 Reply를 생성하고 transaction이 commit된다
-- **THEN** 시스템은 Reply의 canonical Local Note를 포함한 `Create(Note)`를 전달한다
-- **AND** Note의 `inReplyTo`는 Parent의 `/ap/note/{postId}` identity를 가리킨다
+- **THEN** Reply의 canonical Local Note에서 `inReplyTo`는 Parent의 `/ap/note/{postId}` identity를 가리킨다
+- **AND** 이번 capability는 remote direct recipient가 없으므로 activity를 전달하지 않는다
 
 #### Scenario: Remote Parent에 대한 Reply 생성
 
@@ -31,21 +31,19 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 ### Requirement: Reply delivery recipient와 audience
 
-**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, 현재 저장된 established remote follower와 원격 직접 Parent 작성자 중 해당 visibility가 허용하는 Profile을 recipient로 선택해야 한다(MUST). 새 원격 요청이
-허용되는 `ACTIVE` ActivityPub Instance의 저장된 actor endpoint에만 전달해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, Public 또는 Unlisted Reply의 원격 직접 Parent 작성자를 direct recipient로 선택해야 한다(MUST). `inReplyTo` object IRI를 delivery endpoint로 취급해서는 안 된다(MUST NOT). 새 원격 요청이 허용되는 `ACTIVE` 또는 `UNRESPONSIVE` ActivityPub Instance의 저장된 HTTP(S) actor와 personal inbox만 전달에 사용해야 한다(MUST).
 
 #### Scenario: Public 또는 Unlisted Reply recipient
 
 - **WHEN** Public 또는 Unlisted Local Reply의 Create나 Delete를 전달한다
-- **THEN** 시스템은 Author의 현재 established remote follower를 recipient로 선택한다
-- **AND** 직접 Parent의 Author가 remote Profile이면 follower 관계와 무관하게 recipient에 포함한다
-- **AND** 같은 remote actor가 follower이면서 Parent Author이면 한 recipient로 취급한다
+- **THEN** 직접 Parent의 Author가 remote Profile이면 follower 관계와 무관하게 direct recipient로 선택한다
+- **AND** 저장된 유효한 HTTP(S) shared inbox가 있으면 Fedify가 우선할 수 있게 보존하고, 사용할 수 없으면 personal inbox를 사용한다
 
 #### Scenario: Followers Only Reply recipient
 
 - **WHEN** Followers Only Local Reply의 Create나 Delete를 전달한다
-- **THEN** 시스템은 Author의 현재 established remote follower만 recipient로 선택한다
-- **AND** remote Parent Author도 Author를 follow하는 established remote follower일 때만 포함한다
+- **THEN** 시스템은 이번 capability에서 remote recipient를 선택하지 않는다
+- **AND** follower 집합을 직접 조회하거나 fanout하지 않는다
 
 #### Scenario: 지원하지 않는 Direct Reply
 
@@ -54,7 +52,7 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 #### Scenario: unavailable remote instance
 
-- **WHEN** 후보 recipient의 ActivityPub Instance가 `UNRESPONSIVE` 또는 `SUSPENDED`이다
+- **WHEN** 후보 recipient의 ActivityPub Instance가 `SUSPENDED`이다
 - **THEN** 시스템은 해당 recipient에게 activity를 전달하지 않는다
 - **AND** 이번 capability를 위한 pending delivery, durable retry 또는 delivery history를 만들지 않는다
 
@@ -112,7 +110,7 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 
 ### Requirement: 현재 직접 delivery 제한
 
-**Authority / Provenance:** PROD-448, PROD-497. 시스템은 이번 capability에서 transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될
+**Authority / Provenance:** PROD-448, PROD-497, PROD-512. 시스템은 이번 capability에서 followers fanout, transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될
 수 있는 현재 제한은 PROD-448 migration 전까지 수용해야 한다(MUST).
 
 #### Scenario: commit 직후 process 종료

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -95,13 +95,12 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 ### Requirement: Post-commit delivery failure isolation
 
-**Authority / Provenance:** `docs/architecture/core-services.md`, PROD-447, PROD-497. 시스템은 Reply domain transaction이 commit된 뒤 기존 Fedify 경계로 activity를 직접 전달해야 한다(MUST).
+**Authority / Provenance:** `docs/architecture/core-services.md`, PROD-447, PROD-497. 시스템은 top-level Reply domain transaction이 commit된 뒤 기존 Fedify 경계로 activity를 직접 전달해야 한다(MUST).
 Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
 바꾸거나 rollback해서는 안 된다(MUST NOT).
 
-통합 core `createPost`·`deletePost` action은 outer transaction과 origin별 post-commit Reply lifecycle을 소유해야
-하며(MUST), 별도 Local Post action이나 GraphQL resolver가 Reply Notification 또는 Fedify delivery를 직접
-조립해서는 안 된다(MUST NOT).
+통합 core `createPost`·`deletePost` action은 origin별 Reply lifecycle을 소유해야 하며(MUST), 별도 Local Post
+action이나 GraphQL resolver가 Reply Notification 또는 Fedify delivery를 직접 조립해서는 안 된다(MUST NOT).
 
 #### Scenario: Create delivery 실패
 
@@ -122,18 +121,25 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 - **WHEN** Local Reply 생성 또는 삭제 transaction이 rollback된다
 - **THEN** 시스템은 해당 state transition의 Create 또는 Delete activity를 전달하지 않는다
 
+#### Scenario: caller transaction commit 뒤 Activity 누락
+
+- **WHEN** Local Reply action이 caller transaction에 합류하고 outer commit 전에 direct delivery 조회가 uncommitted Reply를 찾지 못한다
+- **THEN** 시스템은 rollback될 수 있는 Reply의 Activity를 전달하지 않는다
+- **AND** outer transaction이 commit된 뒤 Activity를 재실행하지 않아 발생하는 전달 누락은 PROD-448 전까지 수용한다
+- **AND** Reply Notification은 caller transaction에 참여해 commit과 rollback을 함께 따른다
+
 #### Scenario: GraphQL entry의 책임
 
 - **WHEN** GraphQL mutation이 Local Reply를 생성하거나 삭제한다
 - **THEN** resolver는 인증된 Profile과 business input을 통합 `createPost` 또는 `deletePost`에 전달한다
-- **AND** 통합 core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
+- **AND** 통합 core production 기본 경로가 Reply Notification을 transaction에 참여시키고 top-level commit 뒤 Create 또는 Delete delivery를 실행한다
 - **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
 #### Scenario: Transaction 구성은 lifecycle 의미를 바꾸지 않는다
 
 - **WHEN** Post 생성 action의 transaction 구성 방식이 달라진다
 - **THEN** transaction 인자의 존재 여부로 Reply lifecycle 실행 여부를 결정하지 않는다
-- **AND** caller transaction 합류가 필요하면 commit 이후 전달을 보장하는 명시적 coordination 경계를 먼저 정의한다
+- **AND** caller transaction에서는 rollback될 Activity를 전달하지 않고 commit 뒤 전달 누락을 현재 제한으로 수용한다
 
 ### Requirement: 현재 직접 delivery 제한
 

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -31,7 +31,7 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 ### Requirement: Reply delivery recipient와 audience
 
-**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, Public 또는 Unlisted Reply의 원격 직접 Parent 작성자를 direct recipient로 선택해야 한다(MUST). `inReplyTo` object IRI를 delivery endpoint로 취급해서는 안 된다(MUST NOT). 새 원격 요청이 허용되는 `ACTIVE` 또는 `UNRESPONSIVE` ActivityPub Instance의 저장된 HTTP(S) actor와 personal inbox만 전달에 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, Public 또는 Unlisted Reply의 원격 직접 Parent 작성자를 direct recipient로 선택해야 한다(MUST). `inReplyTo` object IRI를 delivery endpoint로 취급해서는 안 된다(MUST NOT). 새 원격 요청이 허용되는 `ACTIVE` ActivityPub Instance의 저장된 HTTP(S) actor와 personal inbox만 전달에 사용해야 한다(MUST).
 
 #### Scenario: Public 또는 Unlisted Reply recipient
 
@@ -52,7 +52,7 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 
 #### Scenario: unavailable remote instance
 
-- **WHEN** 후보 recipient의 ActivityPub Instance가 `SUSPENDED`이다
+- **WHEN** 후보 recipient의 ActivityPub Instance가 `UNRESPONSIVE` 또는 `SUSPENDED`이다
 - **THEN** 시스템은 해당 recipient에게 activity를 전달하지 않는다
 - **AND** 이번 capability를 위한 pending delivery, durable retry 또는 delivery history를 만들지 않는다
 

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -99,8 +99,9 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
 바꾸거나 rollback해서는 안 된다(MUST NOT).
 
-Local Reply 생성·삭제의 core application action은 outer transaction과 post-commit Reply lifecycle을 소유해야
-하며(MUST), GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립해서는 안 된다(MUST NOT).
+통합 core `createPost`·`deletePost` action은 outer transaction과 origin별 post-commit Reply lifecycle을 소유해야
+하며(MUST), 별도 Local Post action이나 GraphQL resolver가 Reply Notification 또는 Fedify delivery를 직접
+조립해서는 안 된다(MUST NOT).
 
 #### Scenario: Create delivery 실패
 
@@ -124,8 +125,8 @@ Local Reply 생성·삭제의 core application action은 outer transaction과 po
 #### Scenario: GraphQL entry의 책임
 
 - **WHEN** GraphQL mutation이 Local Reply를 생성하거나 삭제한다
-- **THEN** resolver는 인증된 Profile과 business input을 core application action에 전달한다
-- **AND** core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
+- **THEN** resolver는 인증된 Profile과 business input을 통합 `createPost` 또는 `deletePost`에 전달한다
+- **AND** 통합 core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
 - **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
 ### Requirement: 현재 직접 delivery 제한

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -1,0 +1,122 @@
+# activitypub-local-reply-delivery Specification
+
+## Purpose
+
+Local Reply의 생성과 삭제를 기존 canonical Note identity, visibility와 post-commit failure isolation 계약에 맞는
+ActivityPub `Create(Note)`와 `Delete`로 remote recipient에게 전달하는 행동을 정의한다.
+
+## Requirements
+
+### Requirement: Local Reply Create delivery
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 처음 commit된 Local Reply를 PROD-494의 canonical Local Note identity와 표현을 사용하는 ActivityPub `Create(Note)`로 remote recipient에게 전달해야 한다(MUST). `Create`의 Note는 Reply가 직접 참조하는 Local 또는
+Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다(MUST).
+
+#### Scenario: Local Parent에 대한 Reply 생성
+
+- **WHEN** Local Profile이 Content가 있는 Local Post를 직접 Parent로 참조하는 Reply를 생성하고 transaction이 commit된다
+- **THEN** 시스템은 Reply의 canonical Local Note를 포함한 `Create(Note)`를 전달한다
+- **AND** Note의 `inReplyTo`는 Parent의 `/ap/note/{postId}` identity를 가리킨다
+
+#### Scenario: Remote Parent에 대한 Reply 생성
+
+- **WHEN** Local Profile이 저장된 Remote Post를 직접 Parent로 참조하는 Reply를 생성하고 transaction이 commit된다
+- **THEN** 시스템은 Reply의 canonical Local Note를 포함한 `Create(Note)`를 전달한다
+- **AND** Note의 `inReplyTo`는 Parent의 기존 ActivityPub Post mapping URI를 가리킨다
+
+#### Scenario: 동일 Reply의 Create 재호출
+
+- **WHEN** 같은 committed Reply에 대한 Create delivery가 둘 이상 호출된다
+- **THEN** 각 호출은 같은 Reply Note identity와 같은 안정적인 Create activity identity를 사용한다
+
+### Requirement: Reply delivery recipient와 audience
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/instance.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply의 기존 Post Visibility audience를 유지하고, 현재 저장된 established remote follower와 원격 직접 Parent 작성자 중 해당 visibility가 허용하는 Profile을 recipient로 선택해야 한다(MUST). 새 원격 요청이
+허용되는 `ACTIVE` ActivityPub Instance의 저장된 actor endpoint에만 전달해야 한다(MUST).
+
+#### Scenario: Public 또는 Unlisted Reply recipient
+
+- **WHEN** Public 또는 Unlisted Local Reply의 Create나 Delete를 전달한다
+- **THEN** 시스템은 Author의 현재 established remote follower를 recipient로 선택한다
+- **AND** 직접 Parent의 Author가 remote Profile이면 follower 관계와 무관하게 recipient에 포함한다
+- **AND** 같은 remote actor가 follower이면서 Parent Author이면 한 recipient로 취급한다
+
+#### Scenario: Followers Only Reply recipient
+
+- **WHEN** Followers Only Local Reply의 Create나 Delete를 전달한다
+- **THEN** 시스템은 Author의 현재 established remote follower만 recipient로 선택한다
+- **AND** remote Parent Author도 Author를 follow하는 established remote follower일 때만 포함한다
+
+#### Scenario: 지원하지 않는 Direct Reply
+
+- **WHEN** Reply의 Visibility가 Direct이다
+- **THEN** 시스템은 Reply Create 또는 Delete activity를 전달하지 않는다
+
+#### Scenario: unavailable remote instance
+
+- **WHEN** 후보 recipient의 ActivityPub Instance가 `UNRESPONSIVE` 또는 `SUSPENDED`이다
+- **THEN** 시스템은 해당 recipient에게 activity를 전달하지 않는다
+- **AND** 이번 capability를 위한 pending delivery, durable retry 또는 delivery history를 만들지 않는다
+
+#### Scenario: 전달할 remote recipient가 없음
+
+- **WHEN** visibility와 instance 정책을 통과한 remote recipient가 없다
+- **THEN** 시스템은 remote delivery 없이 committed application 결과를 성공으로 유지한다
+
+### Requirement: Local Reply Delete delivery
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply가 Tombstone으로 commit된 뒤 생성 때 사용한 canonical Note identity를 object로 가리키는 ActivityPub `Delete`를 전달해야 한다(MUST). 같은 Reply의 Create와 Delete는 recipient별 순서를 보존할 수 있는
+동일한 안정적 ordering domain을 사용해야 한다(MUST).
+
+#### Scenario: Local Reply 삭제
+
+- **WHEN** Author가 Active Local Reply를 삭제하고 Tombstone transaction이 commit된다
+- **THEN** 시스템은 Reply 생성 때 사용한 canonical Note URI를 object로 가리키는 `Delete`를 전달한다
+- **AND** Delete는 같은 Reply의 Create와 동일한 ordering domain을 사용한다
+
+#### Scenario: 동일 Reply의 반복 삭제 또는 Delete 재호출
+
+- **WHEN** 같은 Reply 삭제 action 또는 Delete delivery가 반복된다
+- **THEN** 각 delivery는 같은 Note object identity와 같은 안정적인 Delete activity identity를 사용한다
+- **AND** duplicate 억제를 위한 별도 delivery 상태를 저장하지 않는다
+
+#### Scenario: Reply가 아닌 Post 삭제
+
+- **WHEN** Reply Parent 관계가 없는 Local Post 또는 Content 없는 Repost가 삭제된다
+- **THEN** 시스템은 이번 capability의 Reply Delete activity를 전달하지 않는다
+
+### Requirement: Post-commit delivery failure isolation
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, PROD-447, PROD-497. 시스템은 Reply domain transaction이 commit된 뒤 기존 Fedify 경계로 activity를 직접 전달해야 한다(MUST).
+Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
+바꾸거나 rollback해서는 안 된다(MUST NOT).
+
+#### Scenario: Create delivery 실패
+
+- **WHEN** Local Reply 생성 transaction이 commit된 뒤 remote HTTP Create delivery가 실패한다
+- **THEN** 시스템은 실패와 Reply identity를 관측 가능하게 기록한다
+- **AND** 생성된 Reply와 Content를 유지한다
+- **AND** application action은 committed Reply를 나타내는 성공 결과를 반환한다
+
+#### Scenario: Delete delivery 실패
+
+- **WHEN** Local Reply 삭제 transaction이 commit된 뒤 remote HTTP Delete delivery가 실패한다
+- **THEN** 시스템은 실패와 Reply identity를 관측 가능하게 기록한다
+- **AND** Reply Tombstone과 삭제 시각을 유지한다
+- **AND** application action은 committed 삭제를 나타내는 성공 결과를 반환한다
+
+#### Scenario: transaction rollback
+
+- **WHEN** Local Reply 생성 또는 삭제 transaction이 rollback된다
+- **THEN** 시스템은 해당 state transition의 Create 또는 Delete activity를 전달하지 않는다
+
+### Requirement: 현재 직접 delivery 제한
+
+**Authority / Provenance:** PROD-448, PROD-497. 시스템은 이번 capability에서 transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될
+수 있는 현재 제한은 PROD-448 migration 전까지 수용해야 한다(MUST).
+
+#### Scenario: commit 직후 process 종료
+
+- **WHEN** Reply state가 commit된 뒤 Fedify direct delivery가 시작되기 전에 API process가 종료된다
+- **THEN** committed Reply state는 유지된다
+- **AND** 이번 capability는 유실된 activity를 복원할 durable intent나 retry record를 제공하지 않는다

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -61,6 +61,16 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 - **WHEN** visibility와 instance 정책을 통과한 remote recipient가 없다
 - **THEN** 시스템은 remote delivery 없이 committed application 결과를 성공으로 유지한다
 
+### Requirement: Reply Author Local Instance origin
+
+**Authority / Provenance:** `docs/domain/objects/instance.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/post.md`, PROD-497. 시스템은 Reply Create/Delete의 Fedify Context, actor URI, Note URI와 activity identity를 Reply Author Profile이 연결된 Local Instance의 `canonicalOrigin`에서 파생해야 한다(MUST). 별도의 deployment configured origin으로 Author Instance identity를 대체해서는 안 된다(MUST NOT).
+
+#### Scenario: 여러 Local Instance가 저장된 상태의 Reply delivery
+
+- **WHEN** configured Local Instance와 다른 Local Instance에 속한 Profile의 Reply Create 또는 Delete를 전달한다
+- **THEN** Fedify Context와 actor URI는 Reply Author의 Local Instance `canonicalOrigin`을 사용한다
+- **AND** Create/Delete는 그 origin에서 파생한 동일한 canonical Note URI와 ordering domain을 사용한다
+
 ### Requirement: Local Reply Delete delivery
 
 **Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, PROD-497. 시스템은 Local Reply가 Tombstone으로 commit된 뒤 생성 때 사용한 canonical Note identity를 object로 가리키는 ActivityPub `Delete`를 전달해야 한다(MUST). 같은 Reply의 Create와 Delete는 recipient별 순서를 보존할 수 있는

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -129,6 +129,12 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 - **AND** 통합 core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
 - **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
+#### Scenario: Transaction 구성은 lifecycle 의미를 바꾸지 않는다
+
+- **WHEN** Post 생성 action의 transaction 구성 방식이 달라진다
+- **THEN** transaction 인자의 존재 여부로 Reply lifecycle 실행 여부를 결정하지 않는다
+- **AND** caller transaction 합류가 필요하면 commit 이후 전달을 보장하는 명시적 coordination 경계를 먼저 정의한다
+
 ### Requirement: 현재 직접 delivery 제한
 
 **Authority / Provenance:** PROD-448, PROD-497, PROD-512. 시스템은 이번 capability에서 followers fanout, transactional outbox, broker handoff, Fedify MessageQueue, durable retry 또는 사용자용 delivery status를 추가해서는 안 된다(MUST NOT). Commit과 직접 delivery 사이 process 종료로 activity가 유실될

--- a/openspec/specs/activitypub-local-reply-delivery/spec.md
+++ b/openspec/specs/activitypub-local-reply-delivery/spec.md
@@ -99,6 +99,9 @@ Remote Parent의 ActivityPub Post identity를 `inReplyTo`로 제공해야 한다
 Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생성·삭제 또는 application 성공 결과를 실패로
 바꾸거나 rollback해서는 안 된다(MUST NOT).
 
+Local Reply 생성·삭제의 core application action은 outer transaction과 post-commit Reply lifecycle을 소유해야
+하며(MUST), GraphQL resolver가 Reply Notification이나 Fedify delivery를 직접 조립해서는 안 된다(MUST NOT).
+
 #### Scenario: Create delivery 실패
 
 - **WHEN** Local Reply 생성 transaction이 commit된 뒤 remote HTTP Create delivery가 실패한다
@@ -117,6 +120,13 @@ Delivery 실패는 관측 가능하게 기록하되 이미 commit된 Reply 생�
 
 - **WHEN** Local Reply 생성 또는 삭제 transaction이 rollback된다
 - **THEN** 시스템은 해당 state transition의 Create 또는 Delete activity를 전달하지 않는다
+
+#### Scenario: GraphQL entry의 책임
+
+- **WHEN** GraphQL mutation이 Local Reply를 생성하거나 삭제한다
+- **THEN** resolver는 인증된 Profile과 business input을 core application action에 전달한다
+- **AND** core production 기본 경로가 commit 뒤 Reply Notification과 Create 또는 Delete delivery를 실행한다
+- **AND** resolver는 Notification 또는 Fedify lifecycle 함수를 직접 호출하지 않는다
 
 ### Requirement: 현재 직접 delivery 제한
 

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -8,7 +8,7 @@ export {
   createRepostNotification,
   deleteNotificationBySource,
 } from './notification';
-export { createPost, deletePost, repostPost } from './post';
+export { createLocalPost, createPost, deletePost, repostPost } from './post';
 export { disableProfile } from './profile';
 export { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
 export {

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -3,8 +3,6 @@ export { createBookmark, deleteBookmark } from './bookmark';
 export {
   createFollowNotification,
   createReactionNotification,
-  createReplyNotification,
-  createReplyNotificationBestEffort,
   createRepostNotification,
   deleteNotificationBySource,
 } from './notification';

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -8,7 +8,7 @@ export {
   createRepostNotification,
   deleteNotificationBySource,
 } from './notification';
-export { createLocalPost, createPost, deletePost, repostPost } from './post';
+export { createPost, deletePost, repostPost } from './post';
 export { disableProfile } from './profile';
 export { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
 export {

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -87,17 +87,12 @@ const createReaction = async (authorProfileId: string, recipientProfileId: strin
 };
 
 const createContentPost = (profileId: string) =>
-  db.transaction((tx) =>
-    createPost(
-      {
-        document: postContentDocumentFromText(crypto.randomUUID()),
-        origin: 'LOCAL',
-        profileId,
-        visibility: PostVisibility.PUBLIC,
-      },
-      tx,
-    ).then(({ post }) => post),
-  );
+  createPost({
+    document: postContentDocumentFromText(crypto.randomUUID()),
+    origin: 'LOCAL',
+    profileId,
+    visibility: PostVisibility.PUBLIC,
+  }).then(({ post }) => post);
 
 const createReply = async (
   authorProfileId: string,
@@ -105,18 +100,14 @@ const createReply = async (
   visibility: PostVisibility = PostVisibility.PUBLIC,
 ) => {
   const parent = await createContentPost(recipientProfileId);
-  const reply = await db.transaction((tx) =>
-    createPost(
-      {
-        document: postContentDocumentFromText(crypto.randomUUID()),
-        origin: 'LOCAL',
-        profileId: authorProfileId,
-        replyParentId: parent.id,
-        visibility,
-      },
-      tx,
-    ).then(({ post }) => post),
-  );
+  const reply = await createPost({
+    document: postContentDocumentFromText(crypto.randomUUID()),
+    origin: 'LOCAL',
+    profileId: authorProfileId,
+    replyParentId: parent.id,
+    visibility,
+  }).then(({ post }) => post);
+  await db.delete(Notifications).where(eq(Notifications.sourceId, reply.id));
   return { parent, reply };
 };
 

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -87,12 +87,17 @@ const createReaction = async (authorProfileId: string, recipientProfileId: strin
 };
 
 const createContentPost = (profileId: string) =>
-  createPost({
-    document: postContentDocumentFromText(crypto.randomUUID()),
-    origin: 'LOCAL',
-    profileId,
-    visibility: PostVisibility.PUBLIC,
-  }).then(({ post }) => post);
+  db.transaction((tx) =>
+    createPost(
+      {
+        document: postContentDocumentFromText(crypto.randomUUID()),
+        origin: 'LOCAL',
+        profileId,
+        visibility: PostVisibility.PUBLIC,
+      },
+      tx,
+    ).then(({ post }) => post),
+  );
 
 const createReply = async (
   authorProfileId: string,
@@ -100,13 +105,18 @@ const createReply = async (
   visibility: PostVisibility = PostVisibility.PUBLIC,
 ) => {
   const parent = await createContentPost(recipientProfileId);
-  const reply = await createPost({
-    document: postContentDocumentFromText(crypto.randomUUID()),
-    origin: 'LOCAL',
-    profileId: authorProfileId,
-    replyParentId: parent.id,
-    visibility,
-  }).then(({ post }) => post);
+  const reply = await db.transaction((tx) =>
+    createPost(
+      {
+        document: postContentDocumentFromText(crypto.randomUUID()),
+        origin: 'LOCAL',
+        profileId: authorProfileId,
+        replyParentId: parent.id,
+        visibility,
+      },
+      tx,
+    ).then(({ post }) => post),
+  );
   return { parent, reply };
 };
 

--- a/packages/core/services/notification.ts
+++ b/packages/core/services/notification.ts
@@ -3,6 +3,7 @@ import { alias } from 'drizzle-orm/pg-core';
 import {
   db,
   firstOrThrowWith,
+  getDatabaseConnection,
   Instances,
   Notifications,
   Posts,
@@ -19,6 +20,7 @@ import {
   ProfileState,
 } from '../enums';
 import { NotFoundError } from '../error';
+import type { Transaction } from '../db';
 
 const NotificationRepostAuthors = alias(Profiles, 'notification_repost_author');
 const NotificationRepostAuthorInstances = alias(Instances, 'notification_repost_author_instance');
@@ -91,14 +93,17 @@ export const createReactionNotification = async (sourceId: string): Promise<void
     });
 };
 
-const selectReplyVisibleToProfile = async ({
-  profileId,
-  sourceId,
-}: {
-  profileId: string;
-  sourceId: string;
-}) =>
-  db
+const selectReplyVisibleToProfile = async (
+  tx: Transaction,
+  {
+    profileId,
+    sourceId,
+  }: {
+    profileId: string;
+    sourceId: string;
+  },
+) =>
+  tx
     .select({ id: Posts.id })
     .from(Posts)
     .innerJoin(ReplyParents, eq(ReplyParents.id, Posts.replyParentId))
@@ -133,53 +138,46 @@ const selectReplyVisibleToProfile = async ({
     .limit(1)
     .then((rows) => rows.length > 0);
 
-export const createReplyNotification = async (sourceId: string): Promise<void> => {
-  const source = await db
-    .select({
-      actorProfileId: Posts.profileId,
-      id: Posts.id,
-      recipientInstanceKind: Instances.kind,
-      recipientProfileId: ReplyParents.profileId,
-    })
-    .from(Posts)
-    .innerJoin(ReplyParents, eq(ReplyParents.id, Posts.replyParentId))
-    .innerJoin(Profiles, eq(Profiles.id, ReplyParents.profileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .where(eq(Posts.id, sourceId))
-    .limit(1)
-    .then(firstOrThrowWith(() => new NotFoundError('Reply not found')));
+export const createReplyNotification = async (sourceId: string, tx?: Transaction): Promise<void> =>
+  getDatabaseConnection(tx).transaction(async (tx) => {
+    const source = await tx
+      .select({
+        actorProfileId: Posts.profileId,
+        id: Posts.id,
+        recipientInstanceKind: Instances.kind,
+        recipientProfileId: ReplyParents.profileId,
+      })
+      .from(Posts)
+      .innerJoin(ReplyParents, eq(ReplyParents.id, Posts.replyParentId))
+      .innerJoin(Profiles, eq(Profiles.id, ReplyParents.profileId))
+      .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+      .where(eq(Posts.id, sourceId))
+      .limit(1)
+      .then(firstOrThrowWith(() => new NotFoundError('Reply not found')));
 
-  if (
-    source.actorProfileId === source.recipientProfileId ||
-    source.recipientInstanceKind !== InstanceKind.LOCAL ||
-    !(await selectReplyVisibleToProfile({
-      profileId: source.recipientProfileId,
-      sourceId: source.id,
-    }))
-  ) {
-    return;
-  }
+    if (
+      source.actorProfileId === source.recipientProfileId ||
+      source.recipientInstanceKind !== InstanceKind.LOCAL ||
+      !(await selectReplyVisibleToProfile(tx, {
+        profileId: source.recipientProfileId,
+        sourceId: source.id,
+      }))
+    ) {
+      return;
+    }
 
-  await db
-    .insert(Notifications)
-    .values({
-      data: {},
-      kind: NotificationKind.REPLY,
-      recipientProfileId: source.recipientProfileId,
-      sourceId: source.id,
-    })
-    .onConflictDoNothing({
-      target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
-    });
-};
-
-export const createReplyNotificationBestEffort = async (sourceId: string): Promise<void> => {
-  try {
-    await createReplyNotification(sourceId);
-  } catch {
-    // Notification은 Reply source 성공을 바꾸지 않는다.
-  }
-};
+    await tx
+      .insert(Notifications)
+      .values({
+        data: {},
+        kind: NotificationKind.REPLY,
+        recipientProfileId: source.recipientProfileId,
+        sourceId: source.id,
+      })
+      .onConflictDoNothing({
+        target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
+      });
+  });
 
 export const createRepostNotification = async (sourceId: string): Promise<void> => {
   const source = await db

--- a/packages/core/services/post.test.ts
+++ b/packages/core/services/post.test.ts
@@ -152,6 +152,30 @@ test('createPost는 Local과 ActivityPub Reply Parent를 직접 저장한다', a
   assert.equal(activityPubReply.post.replyParentId, parent.post.id);
 });
 
+test('createPost는 caller transaction rollback에 Post와 Content를 남기지 않는다', async () => {
+  const profile = await createProfile();
+  const contentCount = await db.$count(PostContents);
+
+  await assert.rejects(
+    db.transaction(async (tx) => {
+      await createPost(
+        {
+          document: postContentDocumentFromText('rollback'),
+          origin: 'LOCAL',
+          profileId: profile.id,
+          visibility: PostVisibility.PUBLIC,
+        },
+        tx,
+      );
+      throw new Error('rollback caller transaction');
+    }),
+    /rollback caller transaction/,
+  );
+
+  assert.equal(await db.$count(Posts, eq(Posts.profileId, profile.id)), 0);
+  assert.equal(await db.$count(PostContents), contentCount);
+});
+
 test('createPost는 존재하지 않는 Reply Parent에서 ActivityPub transaction을 rollback한다', async () => {
   const profile = await createProfile();
   const objectUri = `https://remote.example/notes/orphan-${profile.id}`;

--- a/packages/core/services/post.test.ts
+++ b/packages/core/services/post.test.ts
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import {
   ActivityPubPosts,
   db,
   firstOrThrow,
   Instances,
+  Notifications,
   pg,
   PostContents,
   Posts,
@@ -14,6 +15,7 @@ import {
 import {
   InstanceKind,
   InstanceState,
+  NotificationKind,
   PostState,
   PostVisibility,
   ProfileFollowPolicy,
@@ -174,6 +176,50 @@ test('createPost는 caller transaction rollback에 Post와 Content를 남기지 
 
   assert.equal(await db.$count(Posts, eq(Posts.profileId, profile.id)), 0);
   assert.equal(await db.$count(PostContents), contentCount);
+});
+
+test('caller transaction의 Reply Notification은 rollback에 참여한다', async () => {
+  const author = await createProfile();
+  const recipient = await createProfile();
+  const parent = await createPost({
+    document: postContentDocumentFromText('parent'),
+    origin: 'LOCAL',
+    profileId: recipient.id,
+    visibility: PostVisibility.PUBLIC,
+  });
+  let replyId: string | undefined;
+
+  await assert.rejects(
+    db.transaction(async (tx) => {
+      const reply = await createPost(
+        {
+          document: postContentDocumentFromText('reply'),
+          origin: 'LOCAL',
+          profileId: author.id,
+          replyParentId: parent.post.id,
+          visibility: PostVisibility.PUBLIC,
+        },
+        tx,
+      );
+      replyId = reply.post.id;
+      assert.equal(
+        await tx.$count(
+          Notifications,
+          and(
+            eq(Notifications.kind, NotificationKind.REPLY),
+            eq(Notifications.sourceId, reply.post.id),
+          ),
+        ),
+        1,
+      );
+      throw new Error('rollback caller transaction');
+    }),
+    /rollback caller transaction/,
+  );
+
+  assert.ok(replyId);
+  assert.equal(await db.$count(Posts, eq(Posts.id, replyId)), 0);
+  assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, replyId)), 0);
 });
 
 test('createPost는 존재하지 않는 Reply Parent에서 ActivityPub transaction을 rollback한다', async () => {

--- a/packages/core/services/post.test.ts
+++ b/packages/core/services/post.test.ts
@@ -152,30 +152,6 @@ test('createPost는 Local과 ActivityPub Reply Parent를 직접 저장한다', a
   assert.equal(activityPubReply.post.replyParentId, parent.post.id);
 });
 
-test('createPost는 caller transaction rollback에 Post와 Content를 남기지 않는다', async () => {
-  const profile = await createProfile();
-  const contentCount = await db.$count(PostContents);
-
-  await assert.rejects(
-    db.transaction(async (tx) => {
-      await createPost(
-        {
-          document: postContentDocumentFromText('rollback'),
-          origin: 'LOCAL',
-          profileId: profile.id,
-          visibility: PostVisibility.PUBLIC,
-        },
-        tx,
-      );
-      throw new Error('rollback caller transaction');
-    }),
-    /rollback caller transaction/,
-  );
-
-  assert.equal(await db.$count(Posts, eq(Posts.profileId, profile.id)), 0);
-  assert.equal(await db.$count(PostContents), contentCount);
-});
-
 test('createPost는 존재하지 않는 Reply Parent에서 ActivityPub transaction을 rollback한다', async () => {
   const profile = await createProfile();
   const objectUri = `https://remote.example/notes/orphan-${profile.id}`;

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -15,7 +15,7 @@ import {
 import { InstanceState, NotificationKind, PostState, PostVisibility, ProfileState } from '../enums';
 import { NotFoundError, PermissionDeniedError, ValidationError } from '../error';
 import {
-  createReplyNotificationBestEffort,
+  createReplyNotification,
   createRepostNotification,
   deleteNotificationBySource,
 } from './notification';
@@ -387,6 +387,10 @@ export async function createPost(
         .returning()
         .then(firstOrThrow);
 
+      if (input.origin === 'LOCAL' && input.replyParentId !== undefined) {
+        await createReplyNotification(linkedPost.id, tx).catch(() => undefined);
+      }
+
       return { content, created: true, post: linkedPost };
     });
   } catch (error) {
@@ -398,8 +402,6 @@ export async function createPost(
   }
 
   if (input.origin === 'LOCAL' && input.replyParentId !== undefined) {
-    await createReplyNotificationBestEffort(result.post.id);
-
     try {
       const { sendLocalReplyCreate } = await import('@kosmo/fedify');
       await sendLocalReplyCreate(result.post.id);

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -304,8 +304,24 @@ export async function createPost(
   input: LocalPostInput | ActivityPubPostInput,
   tx?: Transaction,
 ): Promise<CreatedPost | DuplicatePost> {
+  let result: CreatedPost;
   try {
-    return await getDatabaseConnection(tx).transaction(async (tx) => {
+    result = await getDatabaseConnection(tx).transaction(async (tx) => {
+      if (input.origin === 'LOCAL' && input.replyParentId !== undefined) {
+        const parent = await findVisiblePost(tx, {
+          actorProfileId: input.profileId,
+          postId: input.replyParentId,
+        });
+        if (!parent) {
+          throw new NotFoundError('Post not found');
+        }
+        if (parent.currentContentId === null) {
+          throw new ValidationError('Reply Parent must have content', {
+            field: 'replyParentId',
+          });
+        }
+      }
+
       const createdAt =
         input.origin === 'ACTIVITYPUB' &&
         input.publishedAt &&
@@ -351,7 +367,7 @@ export async function createPost(
         repostSourceId: post.repostSourceId,
       });
 
-      if (input.replyParentId !== undefined) {
+      if (input.origin === 'ACTIVITYPUB' && input.replyParentId !== undefined) {
         const replyParent = await tx
           .select({ currentContentId: Posts.currentContentId })
           .from(Posts)
@@ -380,31 +396,8 @@ export async function createPost(
 
     return { created: false };
   }
-}
 
-export const createLocalPost = async (
-  input: Omit<LocalPostInput, 'origin'>,
-): Promise<CreatedPost> => {
-  const result = await getDatabaseConnection().transaction(async (tx) => {
-    if (input.replyParentId !== undefined) {
-      const parent = await findVisiblePost(tx, {
-        actorProfileId: input.profileId,
-        postId: input.replyParentId,
-      });
-      if (!parent) {
-        throw new NotFoundError('Post not found');
-      }
-      if (parent.currentContentId === null) {
-        throw new ValidationError('Reply Parent must have content', {
-          field: 'replyParentId',
-        });
-      }
-    }
-
-    return createPost({ ...input, origin: 'LOCAL' }, tx);
-  });
-
-  if (input.replyParentId !== undefined) {
+  if (!tx && input.origin === 'LOCAL' && input.replyParentId !== undefined) {
     await createReplyNotificationBestEffort(result.post.id);
 
     try {
@@ -419,4 +412,4 @@ export const createLocalPost = async (
   }
 
   return result;
-};
+}

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -1,7 +1,6 @@
 import { and, eq, inArray, isNotNull, isNull, ne, or, sql } from 'drizzle-orm';
 import {
   ActivityPubPosts,
-  db,
   first,
   firstOrThrow,
   firstOrThrowWith,
@@ -296,14 +295,18 @@ export const repostPost = async (
 
   return result;
 };
-export function createPost(input: LocalPostInput): Promise<CreatedPost>;
-export function createPost(input: ActivityPubPostInput): Promise<CreatedPost | DuplicatePost>;
+export function createPost(input: LocalPostInput, tx?: Transaction): Promise<CreatedPost>;
+export function createPost(
+  input: ActivityPubPostInput,
+  tx?: Transaction,
+): Promise<CreatedPost | DuplicatePost>;
 export async function createPost(
   input: LocalPostInput | ActivityPubPostInput,
+  tx?: Transaction,
 ): Promise<CreatedPost | DuplicatePost> {
   let result: CreatedPost;
   try {
-    result = await db.transaction(async (tx) => {
+    result = await getDatabaseConnection(tx).transaction(async (tx) => {
       if (input.origin === 'LOCAL' && input.replyParentId !== undefined) {
         const parent = await findVisiblePost(tx, {
           actorProfileId: input.profileId,

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, isNotNull, isNull, ne, or, sql } from 'drizzle-orm';
 import {
   ActivityPubPosts,
+  db,
   first,
   firstOrThrow,
   firstOrThrowWith,
@@ -295,18 +296,14 @@ export const repostPost = async (
 
   return result;
 };
-export function createPost(input: LocalPostInput, tx?: Transaction): Promise<CreatedPost>;
-export function createPost(
-  input: ActivityPubPostInput,
-  tx?: Transaction,
-): Promise<CreatedPost | DuplicatePost>;
+export function createPost(input: LocalPostInput): Promise<CreatedPost>;
+export function createPost(input: ActivityPubPostInput): Promise<CreatedPost | DuplicatePost>;
 export async function createPost(
   input: LocalPostInput | ActivityPubPostInput,
-  tx?: Transaction,
 ): Promise<CreatedPost | DuplicatePost> {
   let result: CreatedPost;
   try {
-    result = await getDatabaseConnection(tx).transaction(async (tx) => {
+    result = await db.transaction(async (tx) => {
       if (input.origin === 'LOCAL' && input.replyParentId !== undefined) {
         const parent = await findVisiblePost(tx, {
           actorProfileId: input.profileId,
@@ -397,7 +394,7 @@ export async function createPost(
     return { created: false };
   }
 
-  if (!tx && input.origin === 'LOCAL' && input.replyParentId !== undefined) {
+  if (input.origin === 'LOCAL' && input.replyParentId !== undefined) {
     await createReplyNotificationBestEffort(result.post.id);
 
     try {

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -14,7 +14,11 @@ import {
 } from '../db';
 import { InstanceState, NotificationKind, PostState, PostVisibility, ProfileState } from '../enums';
 import { NotFoundError, PermissionDeniedError, ValidationError } from '../error';
-import { createRepostNotification, deleteNotificationBySource } from './notification';
+import {
+  createReplyNotificationBestEffort,
+  createRepostNotification,
+  deleteNotificationBySource,
+} from './notification';
 import { validatePostStructure } from './post-structure';
 import type { Transaction } from '../db';
 import type { PostContentDocumentV1 } from '../post-content';
@@ -107,9 +111,14 @@ export const deletePost = async (
   },
   tx?: Transaction,
 ): Promise<{ readonly postId: string }> => {
-  const { repostId, result } = await getDatabaseConnection(tx).transaction(async (tx) => {
+  const { replyId, repostId, result } = await getDatabaseConnection(tx).transaction(async (tx) => {
     const post = await tx
-      .select({ profileId: Posts.profileId })
+      .select({
+        currentContentId: Posts.currentContentId,
+        profileId: Posts.profileId,
+        replyParentId: Posts.replyParentId,
+        state: Posts.state,
+      })
       .from(Posts)
       .where(eq(Posts.id, postId))
       .limit(1)
@@ -139,7 +148,14 @@ export const deletePost = async (
       })
       .then(first);
 
+    const replySource = deleted ?? post;
+    const isDeletedReply =
+      replySource.currentContentId !== null &&
+      replySource.replyParentId !== null &&
+      (deleted !== undefined || post.state === PostState.DELETED);
+
     return {
+      replyId: isDeletedReply ? postId : undefined,
       repostId:
         deleted &&
         deleted.currentContentId === null &&
@@ -170,6 +186,18 @@ export const deletePost = async (
       console.error('Post-commit ActivityPub Repost Undo delivery failed', {
         error,
         repostId,
+      });
+    }
+  }
+
+  if (!tx && replyId) {
+    try {
+      const { sendLocalReplyDelete } = await import('@kosmo/fedify');
+      await sendLocalReplyDelete(replyId);
+    } catch (error) {
+      console.error('Post-commit ActivityPub Reply Delete delivery failed', {
+        error,
+        postId: replyId,
       });
     }
   }
@@ -353,3 +381,42 @@ export async function createPost(
     return { created: false };
   }
 }
+
+export const createLocalPost = async (
+  input: Omit<LocalPostInput, 'origin'>,
+): Promise<CreatedPost> => {
+  const result = await getDatabaseConnection().transaction(async (tx) => {
+    if (input.replyParentId !== undefined) {
+      const parent = await findVisiblePost(tx, {
+        actorProfileId: input.profileId,
+        postId: input.replyParentId,
+      });
+      if (!parent) {
+        throw new NotFoundError('Post not found');
+      }
+      if (parent.currentContentId === null) {
+        throw new ValidationError('Reply Parent must have content', {
+          field: 'replyParentId',
+        });
+      }
+    }
+
+    return createPost({ ...input, origin: 'LOCAL' }, tx);
+  });
+
+  if (input.replyParentId !== undefined) {
+    await createReplyNotificationBestEffort(result.post.id);
+
+    try {
+      const { sendLocalReplyCreate } = await import('@kosmo/fedify');
+      await sendLocalReplyCreate(result.post.id);
+    } catch (error) {
+      console.error('Post-commit ActivityPub Reply Create delivery failed', {
+        error,
+        postId: result.post.id,
+      });
+    }
+  }
+
+  return result;
+};

--- a/packages/fedify/index.ts
+++ b/packages/fedify/index.ts
@@ -1,6 +1,7 @@
 export { resolveActivityPubPostUri } from './src/activitypub-post-uri';
 export { federation } from './src/federation';
 export { sendAcceptFollowActivity } from './src/follow-delivery';
+export { sendLocalReplyCreate, sendLocalReplyDelete } from './src/local-reply-delivery';
 export { sendProfileFollow, sendProfileUnfollow } from './src/profile-follow-delivery';
 export {
   findOrMaterializeRemoteProfileActor,

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -23,7 +23,7 @@ import { postContentDocumentToHtml } from '@kosmo/core/post-content/server';
 import { and, eq, ne } from 'drizzle-orm';
 import { escapeText } from 'entities/escape';
 import { isCanonicalPostId, resolveActivityPubPostUri } from './activitypub-post-uri';
-import type { RequestContext } from '@fedify/fedify';
+import type { Context, RequestContext } from '@fedify/fedify';
 import type { PostContentDocumentV1 } from '@kosmo/core/post-content';
 
 type LocalPostNote = {
@@ -38,8 +38,14 @@ type LocalPostNote = {
   readonly visibility: (typeof PostVisibility)[keyof typeof PostVisibility];
 };
 
+type LocalPostNoteProjection = LocalPostNote & {
+  readonly object: Note;
+};
+
+type LocalPostNoteContext = Pick<Context<void>, 'canonicalOrigin' | 'getActorUri'>;
+
 const loadLocalPostNote = async (
-  context: RequestContext<void>,
+  context: LocalPostNoteContext,
   postId: string,
 ): Promise<LocalPostNote | null> => {
   if (!isCanonicalPostId(postId)) {
@@ -85,7 +91,7 @@ const loadLocalPostNote = async (
     : null;
 };
 
-const getFollowersUri = (context: RequestContext<void>, profileId: string): URL => {
+const getFollowersUri = (context: LocalPostNoteContext, profileId: string): URL => {
   const actorUri = context.getActorUri(profileId);
   return new URL(`${actorUri.pathname.replace(/\/$/, '')}/followers`, actorUri);
 };
@@ -136,7 +142,14 @@ export const dispatchLocalPostNote = async (
   context: RequestContext<void>,
   { id }: { id: string },
 ): Promise<Note | null> => {
-  const note = await loadLocalPostNote(context, id);
+  return (await projectLocalPostNote(context, id))?.object ?? null;
+};
+
+export const projectLocalPostNote = async (
+  context: LocalPostNoteContext,
+  postId: string,
+): Promise<LocalPostNoteProjection | null> => {
+  const note = await loadLocalPostNote(context, postId);
   if (!note) {
     return null;
   }
@@ -154,7 +167,7 @@ export const dispatchLocalPostNote = async (
         ? PUBLIC_COLLECTION
         : undefined;
 
-  return new Note({
+  const object = new Note({
     attribution: authorUri,
     ...(cc ? { cc } : {}),
     content: postContentDocumentToHtml(note.contentDocument),
@@ -169,4 +182,6 @@ export const dispatchLocalPostNote = async (
       note.canonicalOrigin,
     ),
   });
+
+  return { ...note, object };
 };

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -19,6 +19,7 @@ import {
   ProfileState,
 } from '@kosmo/core/enums';
 import { encodeGlobalId } from '@kosmo/core/global-id';
+import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { postContentDocumentToHtml } from '@kosmo/core/post-content/server';
 import { and, eq, ne } from 'drizzle-orm';
 import { escapeText } from 'entities/escape';
@@ -166,6 +167,7 @@ export const projectLocalPostNote = async (
       : note.visibility === PostVisibility.UNLISTED
         ? PUBLIC_COLLECTION
         : undefined;
+  const configuredLocalInstance = await resolveConfiguredLocalInstance();
 
   const object = new Note({
     attribution: authorUri,
@@ -179,7 +181,7 @@ export const projectLocalPostNote = async (
     to,
     url: new URL(
       `/@${encodeURIComponent(note.authorHandle)}/${encodeGlobalId('Post', note.id)}`,
-      note.canonicalOrigin,
+      configuredLocalInstance.canonicalOrigin,
     ),
   });
 

--- a/packages/fedify/src/local-reply-delivery.test.ts
+++ b/packages/fedify/src/local-reply-delivery.test.ts
@@ -17,8 +17,8 @@ import type { Context } from '@fedify/fedify';
 import type { Activity, Recipient } from '@fedify/vocab';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
-import type { federation as Federation } from './federation';
 import type * as LocalReplyDelivery from './local-reply-delivery';
+import type { localReplyFederation as LocalReplyFederation } from './local-reply-federation';
 
 const publicOrigin = 'http://127.0.0.1:4173';
 const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
@@ -26,10 +26,10 @@ const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhos
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
 let db: typeof CoreDb.db;
-let federation: typeof Federation;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
 let localInstanceId: string;
+let localReplyFederation: typeof LocalReplyFederation;
 let pg: typeof CoreDb.pg;
 let PostContents: typeof CoreDb.PostContents;
 let Posts: typeof CoreDb.Posts;
@@ -55,7 +55,7 @@ describe('ActivityPub Local Reply delivery', () => {
       Profiles,
     } = await import('@kosmo/core/db'));
     const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
-    ({ federation } = await import('./federation'));
+    ({ localReplyFederation } = await import('./local-reply-federation'));
     ({ sendLocalReplyCreate, sendLocalReplyDelete } = await import('./local-reply-delivery'));
     const { localInstance } = await seedDatabase({ publicOrigin });
     localInstanceId = localInstance.id;
@@ -75,7 +75,8 @@ describe('ActivityPub Local Reply delivery', () => {
   });
 
   test('Create(Note)가 기존 projection과 stable identity를 쓰고 remote Parent Author에게 전달된다', async () => {
-    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const { canonicalOrigin: authorOrigin, id: authorInstanceId } = await createLocalInstance();
+    const author = await createProfile({ instanceId: authorInstanceId });
     const parentAuthor = await createRemoteActor({ handle: 'parent', sharedInbox: true });
     const parent = await createPost(parentAuthor.profile.id);
     const parentUri = new URL('https://remote.example/notes/parent');
@@ -85,24 +86,41 @@ describe('ActivityPub Local Reply delivery', () => {
       uri: parentUri.href,
     });
     const reply = await createPost(author.id, { replyParentId: parent.id });
-    const fixture = createContextFixture();
-    mock.method(federation, 'createContext', () => fixture.context);
+    const actualContext = localReplyFederation.createContext(new URL(authorOrigin), {
+      localInstanceId: authorInstanceId,
+    });
+    assert.equal(actualContext.canonicalOrigin, authorOrigin);
+    assert.equal(actualContext.getActorUri(author.id).origin, authorOrigin);
+    const keyPairs = await actualContext.getActorKeyPairs(author.id);
+    assert.equal(keyPairs.length, 2);
+    assert.ok(keyPairs.every((keyPair) => keyPair.keyId.origin === authorOrigin));
+    const fixture = createContextFixture(authorOrigin);
+    const createContext = mock.method(
+      localReplyFederation,
+      'createContext',
+      (origin: URL, data: { readonly localInstanceId: string }) => {
+        assert.equal(origin.href, `${authorOrigin}/`);
+        assert.equal(data.localInstanceId, authorInstanceId);
+        return fixture.context;
+      },
+    );
 
     await sendLocalReplyCreate(reply.id);
     await sendLocalReplyCreate(reply.id);
 
+    assert.equal(createContext.mock.callCount(), 2);
     assert.equal(fixture.calls.length, 2);
     for (const call of fixture.calls) {
       assert.ok(call.activity instanceof Create);
-      assert.equal(call.activity.id?.href, `${publicOrigin}/ap/note/${reply.id}#create`);
-      assert.equal(call.activity.actorId?.href, `${publicOrigin}/ap/actor/${author.id}`);
+      assert.equal(call.activity.id?.href, `${authorOrigin}/ap/note/${reply.id}#create`);
+      assert.equal(call.activity.actorId?.href, `${authorOrigin}/ap/actor/${author.id}`);
       const object = await call.activity.getObject();
       assert.ok(object instanceof Note);
-      assert.equal(object.id?.href, `${publicOrigin}/ap/note/${reply.id}`);
+      assert.equal(object.id?.href, `${authorOrigin}/ap/note/${reply.id}`);
       assert.equal(object.replyTargetId?.href, parentUri.href);
       assert.deepEqual(call.sender, { identifier: author.id });
       assert.deepEqual(call.options, {
-        orderingKey: `${publicOrigin}/ap/note/${reply.id}`,
+        orderingKey: `${authorOrigin}/ap/note/${reply.id}`,
         preferSharedInbox: true,
       });
       assert.deepEqual(
@@ -132,7 +150,7 @@ describe('ActivityPub Local Reply delivery', () => {
     });
     const rootPost = await createPost(author.id);
     const fixture = createContextFixture();
-    mock.method(federation, 'createContext', () => fixture.context);
+    mock.method(localReplyFederation, 'createContext', () => fixture.context);
 
     await sendLocalReplyCreate(publicReply.id);
     await sendLocalReplyCreate(unlistedReply.id);
@@ -156,7 +174,7 @@ describe('ActivityPub Local Reply delivery', () => {
     const parent = await createPost(parentAuthor.profile.id);
     const reply = await createPost(author.id, { replyParentId: parent.id });
     const fixture = createContextFixture();
-    mock.method(federation, 'createContext', () => fixture.context);
+    mock.method(localReplyFederation, 'createContext', () => fixture.context);
 
     await sendLocalReplyCreate(reply.id);
 
@@ -196,7 +214,7 @@ describe('ActivityPub Local Reply delivery', () => {
       replyParentId: (await createPost(suspended.profile.id)).id,
     });
     const fixture = createContextFixture();
-    mock.method(federation, 'createContext', () => fixture.context);
+    mock.method(localReplyFederation, 'createContext', () => fixture.context);
 
     await sendLocalReplyCreate(unresponsiveReply.id);
     await sendLocalReplyCreate(suspendedReply.id);
@@ -205,7 +223,8 @@ describe('ActivityPub Local Reply delivery', () => {
   });
 
   test('Delete가 tombstone 뒤 같은 Note·activity identity와 Create ordering domain을 반복 사용한다', async () => {
-    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const { canonicalOrigin: authorOrigin, id: authorInstanceId } = await createLocalInstance();
+    const author = await createProfile({ instanceId: authorInstanceId });
     const parentAuthor = await createRemoteActor({ handle: 'parent' });
     const parent = await createPost(parentAuthor.profile.id);
     const reply = await createPost(author.id, { replyParentId: parent.id });
@@ -214,19 +233,33 @@ describe('ActivityPub Local Reply delivery', () => {
       .update(Posts)
       .set({ deletedAt, state: PostState.DELETED })
       .where(eq(Posts.id, reply.id));
-    const fixture = createContextFixture();
-    mock.method(federation, 'createContext', () => fixture.context);
+    const actualContext = localReplyFederation.createContext(new URL(authorOrigin), {
+      localInstanceId: authorInstanceId,
+    });
+    assert.equal(actualContext.canonicalOrigin, authorOrigin);
+    assert.equal(actualContext.getActorUri(author.id).origin, authorOrigin);
+    const fixture = createContextFixture(authorOrigin);
+    const createContext = mock.method(
+      localReplyFederation,
+      'createContext',
+      (origin: URL, data: { readonly localInstanceId: string }) => {
+        assert.equal(origin.href, `${authorOrigin}/`);
+        assert.equal(data.localInstanceId, authorInstanceId);
+        return fixture.context;
+      },
+    );
 
     await sendLocalReplyDelete(reply.id);
     await sendLocalReplyDelete(reply.id);
 
+    assert.equal(createContext.mock.callCount(), 2);
     assert.equal(fixture.calls.length, 2);
     for (const call of fixture.calls) {
       assert.ok(call.activity instanceof Delete);
-      assert.equal(call.activity.id?.href, `${publicOrigin}/ap/note/${reply.id}#delete`);
-      assert.equal(call.activity.objectId?.href, `${publicOrigin}/ap/note/${reply.id}`);
+      assert.equal(call.activity.id?.href, `${authorOrigin}/ap/note/${reply.id}#delete`);
+      assert.equal(call.activity.objectId?.href, `${authorOrigin}/ap/note/${reply.id}`);
       assert.equal(call.activity.published?.toString(), deletedAt.toString());
-      assert.equal(call.options.orderingKey, `${publicOrigin}/ap/note/${reply.id}`);
+      assert.equal(call.options.orderingKey, `${authorOrigin}/ap/note/${reply.id}`);
       assert.deepEqual(
         call.recipients.map((recipient) => recipient.id?.href),
         [parentAuthor.actorUri],
@@ -242,11 +275,11 @@ interface SendActivityCall {
   readonly sender: { readonly identifier: string };
 }
 
-const createContextFixture = () => {
+const createContextFixture = (canonicalOrigin = publicOrigin) => {
   const calls: SendActivityCall[] = [];
   const context = {
-    canonicalOrigin: publicOrigin,
-    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
+    canonicalOrigin,
+    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, canonicalOrigin),
     sendActivity: async (
       sender: { identifier: string },
       recipients: Recipient | Recipient[],
@@ -262,6 +295,18 @@ const createContextFixture = () => {
     },
   } as Context<void>;
   return { calls, context };
+};
+
+const createLocalInstance = async () => {
+  const domain = `${crypto.randomUUID()}.local.example`;
+  const canonicalOrigin = `https://${domain}`;
+  const instance = await db
+    .insert(Instances)
+    .values({ canonicalOrigin, domain, kind: InstanceKind.LOCAL, state: InstanceState.ACTIVE })
+    .returning()
+    .then(firstOrThrow);
+  testInstanceIds.push(instance.id);
+  return { canonicalOrigin, id: instance.id };
 };
 
 const createProfile = async ({

--- a/packages/fedify/src/local-reply-delivery.test.ts
+++ b/packages/fedify/src/local-reply-delivery.test.ts
@@ -33,7 +33,6 @@ let localInstanceId: string;
 let pg: typeof CoreDb.pg;
 let PostContents: typeof CoreDb.PostContents;
 let Posts: typeof CoreDb.Posts;
-let ProfileFollows: typeof CoreDb.ProfileFollows;
 let Profiles: typeof CoreDb.Profiles;
 let sendLocalReplyCreate: typeof LocalReplyDelivery.sendLocalReplyCreate;
 let sendLocalReplyDelete: typeof LocalReplyDelivery.sendLocalReplyDelete;
@@ -53,7 +52,6 @@ describe('ActivityPub Local Reply delivery', () => {
       pg,
       PostContents,
       Posts,
-      ProfileFollows,
       Profiles,
     } = await import('@kosmo/core/db'));
     const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
@@ -76,23 +74,9 @@ describe('ActivityPub Local Reply delivery', () => {
     await pg.end();
   });
 
-  test('Create(Note)가 기존 projection과 stable identity를 쓰고 recipient를 actor URI로 중복 제거한다', async () => {
+  test('Create(Note)가 기존 projection과 stable identity를 쓰고 remote Parent Author에게 전달된다', async () => {
     const author = await createProfile({ kind: InstanceKind.LOCAL });
-    const parentAuthor = await createRemoteActor({ handle: 'parent' });
-    const follower = await createRemoteActor({ handle: 'follower', sharedInbox: true });
-    const unavailable = await createRemoteActor({
-      handle: 'unavailable',
-      instanceState: InstanceState.UNRESPONSIVE,
-    });
-    await follow(parentAuthor.profile.id, author.id);
-    await follow(follower.profile.id, author.id);
-    await follow(unavailable.profile.id, author.id);
-    const malformed = await createRemoteActor({ handle: 'malformed' });
-    await follow(malformed.profile.id, author.id);
-    await db
-      .update(ActivityPubActors)
-      .set({ inboxUri: 'not-an-inbox-uri' })
-      .where(eq(ActivityPubActors.profileId, malformed.profile.id));
+    const parentAuthor = await createRemoteActor({ handle: 'parent', sharedInbox: true });
     const parent = await createPost(parentAuthor.profile.id);
     const parentUri = new URL('https://remote.example/notes/parent');
     await db.insert(ActivityPubPosts).values({
@@ -122,23 +106,22 @@ describe('ActivityPub Local Reply delivery', () => {
         preferSharedInbox: true,
       });
       assert.deepEqual(
-        call.recipients.map((recipient) => recipient.id?.href).sort(),
-        [follower.actorUri, parentAuthor.actorUri].sort(),
+        call.recipients.map((recipient) => recipient.id?.href),
+        [parentAuthor.actorUri],
       );
-      assert.equal(
-        call.recipients.find((recipient) => recipient.id?.href === follower.actorUri)?.endpoints
-          ?.sharedInbox?.href,
-        follower.sharedInboxUri,
-      );
+      assert.equal(call.recipients[0]?.endpoints?.sharedInbox?.href, parentAuthor.sharedInboxUri);
     }
   });
 
-  test('Followers Reply는 established follower만 보내고 Direct·일반 Post는 no-op이다', async () => {
+  test('Public/Unlisted만 Parent Author에게 보내고 Followers·Direct·일반 Post는 no-op이다', async () => {
     const author = await createProfile({ kind: InstanceKind.LOCAL });
     const parentAuthor = await createRemoteActor({ handle: 'parent' });
-    const follower = await createRemoteActor({ handle: 'follower' });
-    await follow(follower.profile.id, author.id);
     const parent = await createPost(parentAuthor.profile.id);
+    const publicReply = await createPost(author.id, { replyParentId: parent.id });
+    const unlistedReply = await createPost(author.id, {
+      replyParentId: parent.id,
+      visibility: PostVisibility.UNLISTED,
+    });
     const followersReply = await createPost(author.id, {
       replyParentId: parent.id,
       visibility: PostVisibility.FOLLOWERS,
@@ -151,15 +134,75 @@ describe('ActivityPub Local Reply delivery', () => {
     const fixture = createContextFixture();
     mock.method(federation, 'createContext', () => fixture.context);
 
+    await sendLocalReplyCreate(publicReply.id);
+    await sendLocalReplyCreate(unlistedReply.id);
     await sendLocalReplyCreate(followersReply.id);
     await sendLocalReplyCreate(directReply.id);
     await sendLocalReplyCreate(rootPost.id);
 
-    assert.equal(fixture.calls.length, 1);
-    assert.deepEqual(
-      fixture.calls[0]?.recipients.map((recipient) => recipient.id?.href),
-      [follower.actorUri],
+    assert.equal(fixture.calls.length, 2);
+    assert.ok(
+      fixture.calls.every((call) => call.recipients[0]?.id?.href === parentAuthor.actorUri),
     );
+  });
+
+  test('Parent endpoint는 HTTP(S)만 허용하고 invalid shared inbox는 personal inbox로 fallback한다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const parentAuthor = await createRemoteActor({ handle: 'parent', sharedInbox: true });
+    await db
+      .update(ActivityPubActors)
+      .set({ sharedInboxUri: 'ftp://remote.example/inbox' })
+      .where(eq(ActivityPubActors.profileId, parentAuthor.profile.id));
+    const parent = await createPost(parentAuthor.profile.id);
+    const reply = await createPost(author.id, { replyParentId: parent.id });
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendLocalReplyCreate(reply.id);
+
+    assert.equal(fixture.calls.length, 1);
+    assert.equal(fixture.calls[0]?.recipients[0]?.inboxId?.href, `${parentAuthor.actorUri}/inbox`);
+    assert.equal(fixture.calls[0]?.recipients[0]?.endpoints, null);
+
+    await db
+      .update(ActivityPubActors)
+      .set({ inboxUri: 'ftp://remote.example/inbox' })
+      .where(eq(ActivityPubActors.profileId, parentAuthor.profile.id));
+    await sendLocalReplyCreate(reply.id);
+    assert.equal(fixture.calls.length, 1);
+
+    await db
+      .update(ActivityPubActors)
+      .set({ inboxUri: `${parentAuthor.actorUri}/inbox`, uri: 'ftp://remote.example/actor' })
+      .where(eq(ActivityPubActors.profileId, parentAuthor.profile.id));
+    await sendLocalReplyCreate(reply.id);
+    assert.equal(fixture.calls.length, 1);
+  });
+
+  test('UNRESPONSIVE Parent는 전달하고 SUSPENDED Parent는 제외한다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const unresponsive = await createRemoteActor({
+      handle: 'unresponsive-parent',
+      instanceState: InstanceState.UNRESPONSIVE,
+    });
+    const suspended = await createRemoteActor({
+      handle: 'suspended-parent',
+      instanceState: InstanceState.SUSPENDED,
+    });
+    const unresponsiveReply = await createPost(author.id, {
+      replyParentId: (await createPost(unresponsive.profile.id)).id,
+    });
+    const suspendedReply = await createPost(author.id, {
+      replyParentId: (await createPost(suspended.profile.id)).id,
+    });
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendLocalReplyCreate(unresponsiveReply.id);
+    await sendLocalReplyCreate(suspendedReply.id);
+
+    assert.equal(fixture.calls.length, 1);
+    assert.equal(fixture.calls[0]?.recipients[0]?.id?.href, unresponsive.actorUri);
   });
 
   test('Delete가 tombstone 뒤 같은 Note·activity identity와 Create ordering domain을 반복 사용한다', async () => {
@@ -207,11 +250,16 @@ const createContextFixture = () => {
     getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
     sendActivity: async (
       sender: { identifier: string },
-      recipients: Recipient[],
+      recipients: Recipient | Recipient[],
       activity: Activity,
       options: { orderingKey: string; preferSharedInbox: boolean },
     ) => {
-      calls.push({ activity, options, recipients, sender });
+      calls.push({
+        activity,
+        options,
+        recipients: Array.isArray(recipients) ? recipients : [recipients],
+        sender,
+      });
     },
   } as Context<void>;
   return { calls, context };
@@ -291,9 +339,6 @@ const createRemoteActor = async ({
   });
   return { actorUri, profile, sharedInboxUri };
 };
-
-const follow = (followerProfileId: string, followeeProfileId: string) =>
-  db.insert(ProfileFollows).values({ followeeProfileId, followerProfileId });
 
 const createPost = async (
   profileId: string,

--- a/packages/fedify/src/local-reply-delivery.test.ts
+++ b/packages/fedify/src/local-reply-delivery.test.ts
@@ -179,7 +179,7 @@ describe('ActivityPub Local Reply delivery', () => {
     assert.equal(fixture.calls.length, 1);
   });
 
-  test('UNRESPONSIVE Parent는 전달하고 SUSPENDED Parent는 제외한다', async () => {
+  test('UNRESPONSIVE와 SUSPENDED Parent는 모두 제외한다', async () => {
     const author = await createProfile({ kind: InstanceKind.LOCAL });
     const unresponsive = await createRemoteActor({
       handle: 'unresponsive-parent',
@@ -201,8 +201,7 @@ describe('ActivityPub Local Reply delivery', () => {
     await sendLocalReplyCreate(unresponsiveReply.id);
     await sendLocalReplyCreate(suspendedReply.id);
 
-    assert.equal(fixture.calls.length, 1);
-    assert.equal(fixture.calls[0]?.recipients[0]?.id?.href, unresponsive.actorUri);
+    assert.equal(fixture.calls.length, 0);
   });
 
   test('Delete가 tombstone 뒤 같은 Note·activity identity와 Create ordering domain을 반복 사용한다', async () => {

--- a/packages/fedify/src/local-reply-delivery.test.ts
+++ b/packages/fedify/src/local-reply-delivery.test.ts
@@ -117,6 +117,7 @@ describe('ActivityPub Local Reply delivery', () => {
       const object = await call.activity.getObject();
       assert.ok(object instanceof Note);
       assert.equal(object.id?.href, `${authorOrigin}/ap/note/${reply.id}`);
+      assert.equal(object.url && new URL(object.url.toString()).origin, publicOrigin);
       assert.equal(object.replyTargetId?.href, parentUri.href);
       assert.deepEqual(call.sender, { identifier: author.id });
       assert.deepEqual(call.options, {

--- a/packages/fedify/src/local-reply-delivery.test.ts
+++ b/packages/fedify/src/local-reply-delivery.test.ts
@@ -1,0 +1,353 @@
+import '@kosmo/core/polyfill';
+
+import assert from 'node:assert/strict';
+import { after, afterEach, before, beforeEach, describe, mock, test } from 'node:test';
+import { Create, Delete, Note } from '@fedify/vocab';
+import {
+  ActivityPubActorType,
+  InstanceKind,
+  InstanceState,
+  PostState,
+  PostVisibility,
+  ProfileFollowPolicy,
+  ProfileState,
+} from '@kosmo/core/enums';
+import { eq, inArray } from 'drizzle-orm';
+import type { Context } from '@fedify/fedify';
+import type { Activity, Recipient } from '@fedify/vocab';
+import type * as CoreDb from '@kosmo/core/db';
+import type * as CoreSeed from '@kosmo/core/db/seed';
+import type { federation as Federation } from './federation';
+import type * as LocalReplyDelivery from './local-reply-delivery';
+
+const publicOrigin = 'http://127.0.0.1:4173';
+const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+
+let ActivityPubActors: typeof CoreDb.ActivityPubActors;
+let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
+let db: typeof CoreDb.db;
+let federation: typeof Federation;
+let firstOrThrow: typeof CoreDb.firstOrThrow;
+let Instances: typeof CoreDb.Instances;
+let localInstanceId: string;
+let pg: typeof CoreDb.pg;
+let PostContents: typeof CoreDb.PostContents;
+let Posts: typeof CoreDb.Posts;
+let ProfileFollows: typeof CoreDb.ProfileFollows;
+let Profiles: typeof CoreDb.Profiles;
+let sendLocalReplyCreate: typeof LocalReplyDelivery.sendLocalReplyCreate;
+let sendLocalReplyDelete: typeof LocalReplyDelivery.sendLocalReplyDelete;
+let testInstanceIds: string[] = [];
+let testProfileIds: string[] = [];
+
+describe('ActivityPub Local Reply delivery', () => {
+  before(async () => {
+    process.env.DATABASE_URL = databaseUrl;
+    process.env.PUBLIC_ORIGIN = publicOrigin;
+    ({
+      ActivityPubActors,
+      ActivityPubPosts,
+      db,
+      firstOrThrow,
+      Instances,
+      pg,
+      PostContents,
+      Posts,
+      ProfileFollows,
+      Profiles,
+    } = await import('@kosmo/core/db'));
+    const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
+    ({ federation } = await import('./federation'));
+    ({ sendLocalReplyCreate, sendLocalReplyDelete } = await import('./local-reply-delivery'));
+    const { localInstance } = await seedDatabase({ publicOrigin });
+    localInstanceId = localInstance.id;
+  });
+
+  beforeEach(async () => {
+    await cleanTestRows();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  after(async () => {
+    await cleanTestRows();
+    await pg.end();
+  });
+
+  test('Create(Note)가 기존 projection과 stable identity를 쓰고 recipient를 actor URI로 중복 제거한다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const parentAuthor = await createRemoteActor({ handle: 'parent' });
+    const follower = await createRemoteActor({ handle: 'follower', sharedInbox: true });
+    const unavailable = await createRemoteActor({
+      handle: 'unavailable',
+      instanceState: InstanceState.UNRESPONSIVE,
+    });
+    await follow(parentAuthor.profile.id, author.id);
+    await follow(follower.profile.id, author.id);
+    await follow(unavailable.profile.id, author.id);
+    const malformed = await createRemoteActor({ handle: 'malformed' });
+    await follow(malformed.profile.id, author.id);
+    await db
+      .update(ActivityPubActors)
+      .set({ inboxUri: 'not-an-inbox-uri' })
+      .where(eq(ActivityPubActors.profileId, malformed.profile.id));
+    const parent = await createPost(parentAuthor.profile.id);
+    const parentUri = new URL('https://remote.example/notes/parent');
+    await db.insert(ActivityPubPosts).values({
+      postId: parent.id,
+      receivedAt: Temporal.Instant.from('2026-07-28T00:00:00Z'),
+      uri: parentUri.href,
+    });
+    const reply = await createPost(author.id, { replyParentId: parent.id });
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendLocalReplyCreate(reply.id);
+    await sendLocalReplyCreate(reply.id);
+
+    assert.equal(fixture.calls.length, 2);
+    for (const call of fixture.calls) {
+      assert.ok(call.activity instanceof Create);
+      assert.equal(call.activity.id?.href, `${publicOrigin}/ap/note/${reply.id}#create`);
+      assert.equal(call.activity.actorId?.href, `${publicOrigin}/ap/actor/${author.id}`);
+      const object = await call.activity.getObject();
+      assert.ok(object instanceof Note);
+      assert.equal(object.id?.href, `${publicOrigin}/ap/note/${reply.id}`);
+      assert.equal(object.replyTargetId?.href, parentUri.href);
+      assert.deepEqual(call.sender, { identifier: author.id });
+      assert.deepEqual(call.options, {
+        orderingKey: `${publicOrigin}/ap/note/${reply.id}`,
+        preferSharedInbox: true,
+      });
+      assert.deepEqual(
+        call.recipients.map((recipient) => recipient.id?.href).sort(),
+        [follower.actorUri, parentAuthor.actorUri].sort(),
+      );
+      assert.equal(
+        call.recipients.find((recipient) => recipient.id?.href === follower.actorUri)?.endpoints
+          ?.sharedInbox?.href,
+        follower.sharedInboxUri,
+      );
+    }
+  });
+
+  test('Followers Reply는 established follower만 보내고 Direct·일반 Post는 no-op이다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const parentAuthor = await createRemoteActor({ handle: 'parent' });
+    const follower = await createRemoteActor({ handle: 'follower' });
+    await follow(follower.profile.id, author.id);
+    const parent = await createPost(parentAuthor.profile.id);
+    const followersReply = await createPost(author.id, {
+      replyParentId: parent.id,
+      visibility: PostVisibility.FOLLOWERS,
+    });
+    const directReply = await createPost(author.id, {
+      replyParentId: parent.id,
+      visibility: PostVisibility.DIRECT,
+    });
+    const rootPost = await createPost(author.id);
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendLocalReplyCreate(followersReply.id);
+    await sendLocalReplyCreate(directReply.id);
+    await sendLocalReplyCreate(rootPost.id);
+
+    assert.equal(fixture.calls.length, 1);
+    assert.deepEqual(
+      fixture.calls[0]?.recipients.map((recipient) => recipient.id?.href),
+      [follower.actorUri],
+    );
+  });
+
+  test('Delete가 tombstone 뒤 같은 Note·activity identity와 Create ordering domain을 반복 사용한다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const parentAuthor = await createRemoteActor({ handle: 'parent' });
+    const parent = await createPost(parentAuthor.profile.id);
+    const reply = await createPost(author.id, { replyParentId: parent.id });
+    const deletedAt = Temporal.Instant.from('2026-07-28T01:00:00Z');
+    await db
+      .update(Posts)
+      .set({ deletedAt, state: PostState.DELETED })
+      .where(eq(Posts.id, reply.id));
+    const fixture = createContextFixture();
+    mock.method(federation, 'createContext', () => fixture.context);
+
+    await sendLocalReplyDelete(reply.id);
+    await sendLocalReplyDelete(reply.id);
+
+    assert.equal(fixture.calls.length, 2);
+    for (const call of fixture.calls) {
+      assert.ok(call.activity instanceof Delete);
+      assert.equal(call.activity.id?.href, `${publicOrigin}/ap/note/${reply.id}#delete`);
+      assert.equal(call.activity.objectId?.href, `${publicOrigin}/ap/note/${reply.id}`);
+      assert.equal(call.activity.published?.toString(), deletedAt.toString());
+      assert.equal(call.options.orderingKey, `${publicOrigin}/ap/note/${reply.id}`);
+      assert.deepEqual(
+        call.recipients.map((recipient) => recipient.id?.href),
+        [parentAuthor.actorUri],
+      );
+    }
+  });
+});
+
+interface SendActivityCall {
+  readonly activity: Activity;
+  readonly options: { readonly orderingKey: string; readonly preferSharedInbox: boolean };
+  readonly recipients: Recipient[];
+  readonly sender: { readonly identifier: string };
+}
+
+const createContextFixture = () => {
+  const calls: SendActivityCall[] = [];
+  const context = {
+    canonicalOrigin: publicOrigin,
+    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
+    sendActivity: async (
+      sender: { identifier: string },
+      recipients: Recipient[],
+      activity: Activity,
+      options: { orderingKey: string; preferSharedInbox: boolean },
+    ) => {
+      calls.push({ activity, options, recipients, sender });
+    },
+  } as Context<void>;
+  return { calls, context };
+};
+
+const createProfile = async ({
+  handle = `profile-${crypto.randomUUID()}`,
+  instanceId,
+  kind = InstanceKind.ACTIVITYPUB,
+}: {
+  handle?: string;
+  instanceId?: string;
+  kind?: InstanceKind;
+}) => {
+  const resolvedInstanceId =
+    instanceId ??
+    (kind === InstanceKind.LOCAL
+      ? localInstanceId
+      : await db
+          .insert(Instances)
+          .values({
+            domain: `${crypto.randomUUID()}.example`,
+            kind,
+            state: InstanceState.ACTIVE,
+          })
+          .returning({ id: Instances.id })
+          .then(firstOrThrow)
+          .then(({ id }) => {
+            testInstanceIds.push(id);
+            return id;
+          }));
+  assert.ok(resolvedInstanceId);
+  const profile = await db
+    .insert(Profiles)
+    .values({
+      displayName: handle,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle,
+      instanceId: resolvedInstanceId,
+      normalizedHandle: handle,
+      state: ProfileState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  testProfileIds.push(profile.id);
+  return profile;
+};
+
+const createRemoteActor = async ({
+  handle,
+  instanceState = InstanceState.ACTIVE,
+  sharedInbox = false,
+}: {
+  handle: string;
+  instanceState?: InstanceState;
+  sharedInbox?: boolean;
+}) => {
+  const instance = await db
+    .insert(Instances)
+    .values({
+      domain: `${crypto.randomUUID()}.remote.example`,
+      kind: InstanceKind.ACTIVITYPUB,
+      state: instanceState,
+    })
+    .returning()
+    .then(firstOrThrow);
+  testInstanceIds.push(instance.id);
+  const profile = await createProfile({ handle, instanceId: instance.id });
+  const actorUri = `https://${instance.domain}/users/${handle}`;
+  const sharedInboxUri = sharedInbox ? `https://${instance.domain}/inbox` : null;
+  await db.insert(ActivityPubActors).values({
+    inboxUri: `${actorUri}/inbox`,
+    profileId: profile.id,
+    sharedInboxUri,
+    type: ActivityPubActorType.PERSON,
+    uri: actorUri,
+  });
+  return { actorUri, profile, sharedInboxUri };
+};
+
+const follow = (followerProfileId: string, followeeProfileId: string) =>
+  db.insert(ProfileFollows).values({ followeeProfileId, followerProfileId });
+
+const createPost = async (
+  profileId: string,
+  {
+    replyParentId = null,
+    visibility = PostVisibility.PUBLIC,
+  }: { replyParentId?: string | null; visibility?: PostVisibility } = {},
+) => {
+  const post = await db
+    .insert(Posts)
+    .values({ profileId, replyParentId, state: PostState.ACTIVE, visibility })
+    .returning()
+    .then(firstOrThrow);
+  const content = await db
+    .insert(PostContents)
+    .values({
+      document: {
+        body: {
+          content: [{ content: [{ text: 'body', type: 'text' }], type: 'paragraph' }],
+          type: 'doc',
+        },
+        summary: null,
+        version: 1,
+      },
+      postId: post.id,
+    })
+    .returning()
+    .then(firstOrThrow);
+  return db
+    .update(Posts)
+    .set({ currentContentId: content.id })
+    .where(eq(Posts.id, post.id))
+    .returning()
+    .then(firstOrThrow);
+};
+
+const cleanTestRows = async () => {
+  if (testProfileIds.length === 0) {
+    return;
+  }
+  const postIds = await db
+    .select({ id: Posts.id })
+    .from(Posts)
+    .where(inArray(Posts.profileId, testProfileIds))
+    .then((rows) => rows.map(({ id }) => id));
+  if (postIds.length > 0) {
+    await db.update(Posts).set({ currentContentId: null }).where(inArray(Posts.id, postIds));
+    await db.delete(PostContents).where(inArray(PostContents.postId, postIds));
+    await db.delete(Posts).where(inArray(Posts.id, postIds));
+  }
+  await db.delete(Profiles).where(inArray(Profiles.id, testProfileIds));
+  if (testInstanceIds.length > 0) {
+    await db.delete(Instances).where(inArray(Instances.id, testInstanceIds));
+  }
+  testInstanceIds = [];
+  testProfileIds = [];
+};

--- a/packages/fedify/src/local-reply-delivery.ts
+++ b/packages/fedify/src/local-reply-delivery.ts
@@ -7,17 +7,17 @@ import {
   PostVisibility,
   ProfileState,
 } from '@kosmo/core/enums';
-import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { and, eq, isNotNull } from 'drizzle-orm';
 import { isHttpUri } from './activitypub-uri';
-import { federation } from './federation';
 import { projectLocalPostNote } from './local-post-note';
-import type { Context } from '@fedify/fedify';
+import { localReplyFederation } from './local-reply-federation';
 import type { Recipient } from '@fedify/vocab';
 
 type DeliverySource = {
   readonly authorProfileId: string;
+  readonly canonicalOrigin: string;
   readonly deletedAt: Temporal.Instant | null;
+  readonly localInstanceId: string;
   readonly replyParentId: string;
   readonly visibility: (typeof PostVisibility)[keyof typeof PostVisibility];
 };
@@ -28,19 +28,46 @@ type StoredRecipient = {
   readonly uri: string;
 };
 
-const createFederationContext = async (): Promise<Context<void>> => {
-  const localInstance = await resolveConfiguredLocalInstance();
-  return federation.createContext(new URL(localInstance.canonicalOrigin), undefined);
+const createFederationContext = (
+  source: Pick<DeliverySource, 'canonicalOrigin' | 'localInstanceId'>,
+) =>
+  localReplyFederation.createContext(new URL(source.canonicalOrigin), {
+    localInstanceId: source.localInstanceId,
+  });
+
+const loadLocalPostSource = async (
+  postId: string,
+): Promise<Pick<DeliverySource, 'canonicalOrigin' | 'localInstanceId'> | null> => {
+  const row = await db
+    .select({ canonicalOrigin: Instances.canonicalOrigin, localInstanceId: Instances.id })
+    .from(Posts)
+    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(
+      and(
+        eq(Posts.id, postId),
+        eq(Posts.state, PostState.ACTIVE),
+        eq(Instances.kind, InstanceKind.LOCAL),
+        eq(Instances.state, InstanceState.ACTIVE),
+        isNotNull(Instances.canonicalOrigin),
+        eq(Profiles.state, ProfileState.ACTIVE),
+      ),
+    )
+    .limit(1)
+    .then(first);
+
+  return row?.canonicalOrigin
+    ? { canonicalOrigin: row.canonicalOrigin, localInstanceId: row.localInstanceId }
+    : null;
 };
 
-const loadDeletedReplySource = async (
-  context: Context<void>,
-  postId: string,
-): Promise<DeliverySource | null> => {
+const loadDeletedReplySource = async (postId: string): Promise<DeliverySource | null> => {
   const row = await db
     .select({
       authorProfileId: Profiles.id,
+      canonicalOrigin: Instances.canonicalOrigin,
       deletedAt: Posts.deletedAt,
+      localInstanceId: Instances.id,
       replyParentId: Posts.replyParentId,
       visibility: Posts.visibility,
     })
@@ -53,18 +80,20 @@ const loadDeletedReplySource = async (
         eq(Posts.state, PostState.DELETED),
         isNotNull(Posts.replyParentId),
         eq(Instances.kind, InstanceKind.LOCAL),
-        eq(Instances.canonicalOrigin, context.canonicalOrigin),
         eq(Instances.state, InstanceState.ACTIVE),
+        isNotNull(Instances.canonicalOrigin),
         eq(Profiles.state, ProfileState.ACTIVE),
       ),
     )
     .limit(1)
     .then(first);
 
-  return row?.replyParentId
+  return row?.replyParentId && row.canonicalOrigin
     ? {
         authorProfileId: row.authorProfileId,
+        canonicalOrigin: row.canonicalOrigin,
         deletedAt: row.deletedAt,
+        localInstanceId: row.localInstanceId,
         replyParentId: row.replyParentId,
         visibility: row.visibility,
       }
@@ -145,7 +174,12 @@ const noteUri = (canonicalOrigin: string | URL, postId: string): URL =>
   new URL(`/ap/note/${postId}`, canonicalOrigin);
 
 export const sendLocalReplyCreate = async (postId: string): Promise<void> => {
-  const context = await createFederationContext();
+  const source = await loadLocalPostSource(postId);
+  if (!source) {
+    return;
+  }
+
+  const context = createFederationContext(source);
   const projection = await projectLocalPostNote(context, postId);
   if (!projection?.replyParentId) {
     return;
@@ -172,21 +206,21 @@ export const sendLocalReplyCreate = async (postId: string): Promise<void> => {
 };
 
 export const sendLocalReplyDelete = async (postId: string): Promise<void> => {
-  const context = await createFederationContext();
-  const source = await loadDeletedReplySource(context, postId);
+  const source = await loadDeletedReplySource(postId);
   if (!source) {
     return;
   }
 
+  const context = createFederationContext(source);
   const recipient = await selectRecipient(source);
   if (!recipient) {
     return;
   }
 
-  const objectUri = noteUri(context.canonicalOrigin, postId);
+  const objectUri = noteUri(source.canonicalOrigin, postId);
   const followersUri = new URL(
     `${context.getActorUri(source.authorProfileId).pathname.replace(/\/$/, '')}/followers`,
-    context.canonicalOrigin,
+    source.canonicalOrigin,
   );
   const activity = new Delete({
     actor: context.getActorUri(source.authorProfileId),

--- a/packages/fedify/src/local-reply-delivery.ts
+++ b/packages/fedify/src/local-reply-delivery.ts
@@ -1,13 +1,5 @@
 import { Create, Delete, PUBLIC_COLLECTION } from '@fedify/vocab';
-import {
-  ActivityPubActors,
-  db,
-  first,
-  Instances,
-  Posts,
-  ProfileFollows,
-  Profiles,
-} from '@kosmo/core/db';
+import { ActivityPubActors, db, first, Instances, Posts, Profiles } from '@kosmo/core/db';
 import {
   InstanceKind,
   InstanceState,
@@ -16,17 +8,12 @@ import {
   ProfileState,
 } from '@kosmo/core/enums';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
-import { and, eq, isNotNull } from 'drizzle-orm';
-import { alias } from 'drizzle-orm/pg-core';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import { isHttpUri } from './activitypub-uri';
 import { federation } from './federation';
 import { projectLocalPostNote } from './local-post-note';
 import type { Context } from '@fedify/fedify';
 import type { Recipient } from '@fedify/vocab';
-
-const ParentPosts = alias(Posts, 'local_reply_delivery_parent_post');
-const ParentProfiles = alias(Profiles, 'local_reply_delivery_parent_profile');
-const ParentInstances = alias(Instances, 'local_reply_delivery_parent_instance');
-const ParentActors = alias(ActivityPubActors, 'local_reply_delivery_parent_actor');
 
 type DeliverySource = {
   readonly authorProfileId: string;
@@ -84,54 +71,26 @@ const loadDeletedReplySource = async (
     : null;
 };
 
-const loadFollowerRecipients = async (authorProfileId: string): Promise<StoredRecipient[]> =>
-  db
-    .select({
-      inboxUri: ActivityPubActors.inboxUri,
-      sharedInboxUri: ActivityPubActors.sharedInboxUri,
-      uri: ActivityPubActors.uri,
-    })
-    .from(ProfileFollows)
-    .innerJoin(Profiles, eq(Profiles.id, ProfileFollows.followerProfileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .innerJoin(ActivityPubActors, eq(ActivityPubActors.profileId, Profiles.id))
-    .where(
-      and(
-        eq(ProfileFollows.followeeProfileId, authorProfileId),
-        eq(Profiles.state, ProfileState.ACTIVE),
-        eq(Instances.kind, InstanceKind.ACTIVITYPUB),
-        eq(Instances.state, InstanceState.ACTIVE),
-        isNotNull(ActivityPubActors.inboxUri),
-      ),
-    )
-    .then((rows) =>
-      rows.flatMap((row) =>
-        row.inboxUri
-          ? [{ inboxUri: row.inboxUri, sharedInboxUri: row.sharedInboxUri, uri: row.uri }]
-          : [],
-      ),
-    );
-
 const loadRemoteParentRecipient = async (
   replyParentId: string,
 ): Promise<StoredRecipient | null> => {
   const row = await db
     .select({
-      inboxUri: ParentActors.inboxUri,
-      sharedInboxUri: ParentActors.sharedInboxUri,
-      uri: ParentActors.uri,
+      inboxUri: ActivityPubActors.inboxUri,
+      sharedInboxUri: ActivityPubActors.sharedInboxUri,
+      uri: ActivityPubActors.uri,
     })
-    .from(ParentPosts)
-    .innerJoin(ParentProfiles, eq(ParentProfiles.id, ParentPosts.profileId))
-    .innerJoin(ParentInstances, eq(ParentInstances.id, ParentProfiles.instanceId))
-    .innerJoin(ParentActors, eq(ParentActors.profileId, ParentProfiles.id))
+    .from(Posts)
+    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .innerJoin(ActivityPubActors, eq(ActivityPubActors.profileId, Profiles.id))
     .where(
       and(
-        eq(ParentPosts.id, replyParentId),
-        eq(ParentProfiles.state, ProfileState.ACTIVE),
-        eq(ParentInstances.kind, InstanceKind.ACTIVITYPUB),
-        eq(ParentInstances.state, InstanceState.ACTIVE),
-        isNotNull(ParentActors.inboxUri),
+        eq(Posts.id, replyParentId),
+        eq(Profiles.state, ProfileState.ACTIVE),
+        eq(Instances.kind, InstanceKind.ACTIVITYPUB),
+        inArray(Instances.state, [InstanceState.ACTIVE, InstanceState.UNRESPONSIVE]),
+        isNotNull(ActivityPubActors.inboxUri),
       ),
     )
     .limit(1)
@@ -142,50 +101,44 @@ const loadRemoteParentRecipient = async (
     : null;
 };
 
-const toRecipient = (actor: StoredRecipient): Recipient | null => {
+const parseHttpUri = (value: string): URL | null => {
   try {
-    let sharedInbox: URL | undefined;
-    if (actor.sharedInboxUri) {
-      try {
-        sharedInbox = new URL(actor.sharedInboxUri);
-      } catch {
-        // 잘못 저장된 optional shared inbox는 usable personal inbox를 막지 않는다.
-      }
-    }
-    return {
-      endpoints: sharedInbox ? { sharedInbox } : null,
-      id: new URL(actor.uri),
-      inboxId: new URL(actor.inboxUri),
-    };
+    const uri = new URL(value);
+    return isHttpUri(uri) ? uri : null;
   } catch {
     return null;
   }
 };
 
-const selectRecipients = async (
-  source: Pick<DeliverySource, 'authorProfileId' | 'visibility'> & {
+const toRecipient = (actor: StoredRecipient): Recipient | null => {
+  const id = parseHttpUri(actor.uri);
+  const inboxId = parseHttpUri(actor.inboxUri);
+  if (!id || !inboxId) {
+    return null;
+  }
+
+  const sharedInbox = actor.sharedInboxUri ? parseHttpUri(actor.sharedInboxUri) : null;
+  return {
+    endpoints: sharedInbox ? { sharedInbox } : null,
+    id,
+    inboxId,
+  };
+};
+
+const selectRecipient = async (
+  source: Pick<DeliverySource, 'visibility'> & {
     readonly replyParentId: string | null;
   },
-): Promise<Recipient[]> => {
-  if (!source.replyParentId || source.visibility === PostVisibility.DIRECT) {
-    return [];
-  }
-
-  const actors = await loadFollowerRecipients(source.authorProfileId);
+): Promise<Recipient | null> => {
   if (
-    source.visibility === PostVisibility.PUBLIC ||
-    source.visibility === PostVisibility.UNLISTED
+    !source.replyParentId ||
+    (source.visibility !== PostVisibility.PUBLIC && source.visibility !== PostVisibility.UNLISTED)
   ) {
-    const parentActor = await loadRemoteParentRecipient(source.replyParentId);
-    if (parentActor) {
-      actors.push(parentActor);
-    }
+    return null;
   }
 
-  return [...new Map(actors.map((actor) => [actor.uri, actor])).values()].flatMap((actor) => {
-    const recipient = toRecipient(actor);
-    return recipient ? [recipient] : [];
-  });
+  const parentActor = await loadRemoteParentRecipient(source.replyParentId);
+  return parentActor ? toRecipient(parentActor) : null;
 };
 
 const noteUri = (canonicalOrigin: string | URL, postId: string): URL =>
@@ -198,8 +151,8 @@ export const sendLocalReplyCreate = async (postId: string): Promise<void> => {
     return;
   }
 
-  const recipients = await selectRecipients(projection);
-  if (recipients.length === 0) {
+  const recipient = await selectRecipient(projection);
+  if (!recipient) {
     return;
   }
 
@@ -212,7 +165,7 @@ export const sendLocalReplyCreate = async (postId: string): Promise<void> => {
     published: projection.createdAt,
     tos: projection.object.toIds,
   });
-  await context.sendActivity({ identifier: projection.authorProfileId }, recipients, activity, {
+  await context.sendActivity({ identifier: projection.authorProfileId }, recipient, activity, {
     orderingKey: objectUri.href,
     preferSharedInbox: true,
   });
@@ -225,8 +178,8 @@ export const sendLocalReplyDelete = async (postId: string): Promise<void> => {
     return;
   }
 
-  const recipients = await selectRecipients(source);
-  if (recipients.length === 0) {
+  const recipient = await selectRecipient(source);
+  if (!recipient) {
     return;
   }
 
@@ -248,7 +201,7 @@ export const sendLocalReplyDelete = async (postId: string): Promise<void> => {
     published: source.deletedAt,
     tos: source.visibility === PostVisibility.PUBLIC ? [PUBLIC_COLLECTION] : [followersUri],
   });
-  await context.sendActivity({ identifier: source.authorProfileId }, recipients, activity, {
+  await context.sendActivity({ identifier: source.authorProfileId }, recipient, activity, {
     orderingKey: objectUri.href,
     preferSharedInbox: true,
   });

--- a/packages/fedify/src/local-reply-delivery.ts
+++ b/packages/fedify/src/local-reply-delivery.ts
@@ -8,7 +8,7 @@ import {
   ProfileState,
 } from '@kosmo/core/enums';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
-import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import { and, eq, isNotNull } from 'drizzle-orm';
 import { isHttpUri } from './activitypub-uri';
 import { federation } from './federation';
 import { projectLocalPostNote } from './local-post-note';
@@ -89,7 +89,7 @@ const loadRemoteParentRecipient = async (
         eq(Posts.id, replyParentId),
         eq(Profiles.state, ProfileState.ACTIVE),
         eq(Instances.kind, InstanceKind.ACTIVITYPUB),
-        inArray(Instances.state, [InstanceState.ACTIVE, InstanceState.UNRESPONSIVE]),
+        eq(Instances.state, InstanceState.ACTIVE),
         isNotNull(ActivityPubActors.inboxUri),
       ),
     )

--- a/packages/fedify/src/local-reply-delivery.ts
+++ b/packages/fedify/src/local-reply-delivery.ts
@@ -1,0 +1,255 @@
+import { Create, Delete, PUBLIC_COLLECTION } from '@fedify/vocab';
+import {
+  ActivityPubActors,
+  db,
+  first,
+  Instances,
+  Posts,
+  ProfileFollows,
+  Profiles,
+} from '@kosmo/core/db';
+import {
+  InstanceKind,
+  InstanceState,
+  PostState,
+  PostVisibility,
+  ProfileState,
+} from '@kosmo/core/enums';
+import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
+import { and, eq, isNotNull } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { federation } from './federation';
+import { projectLocalPostNote } from './local-post-note';
+import type { Context } from '@fedify/fedify';
+import type { Recipient } from '@fedify/vocab';
+
+const ParentPosts = alias(Posts, 'local_reply_delivery_parent_post');
+const ParentProfiles = alias(Profiles, 'local_reply_delivery_parent_profile');
+const ParentInstances = alias(Instances, 'local_reply_delivery_parent_instance');
+const ParentActors = alias(ActivityPubActors, 'local_reply_delivery_parent_actor');
+
+type DeliverySource = {
+  readonly authorProfileId: string;
+  readonly deletedAt: Temporal.Instant | null;
+  readonly replyParentId: string;
+  readonly visibility: (typeof PostVisibility)[keyof typeof PostVisibility];
+};
+
+type StoredRecipient = {
+  readonly inboxUri: string;
+  readonly sharedInboxUri: string | null;
+  readonly uri: string;
+};
+
+const createFederationContext = async (): Promise<Context<void>> => {
+  const localInstance = await resolveConfiguredLocalInstance();
+  return federation.createContext(new URL(localInstance.canonicalOrigin), undefined);
+};
+
+const loadDeletedReplySource = async (
+  context: Context<void>,
+  postId: string,
+): Promise<DeliverySource | null> => {
+  const row = await db
+    .select({
+      authorProfileId: Profiles.id,
+      deletedAt: Posts.deletedAt,
+      replyParentId: Posts.replyParentId,
+      visibility: Posts.visibility,
+    })
+    .from(Posts)
+    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(
+      and(
+        eq(Posts.id, postId),
+        eq(Posts.state, PostState.DELETED),
+        isNotNull(Posts.replyParentId),
+        eq(Instances.kind, InstanceKind.LOCAL),
+        eq(Instances.canonicalOrigin, context.canonicalOrigin),
+        eq(Instances.state, InstanceState.ACTIVE),
+        eq(Profiles.state, ProfileState.ACTIVE),
+      ),
+    )
+    .limit(1)
+    .then(first);
+
+  return row?.replyParentId
+    ? {
+        authorProfileId: row.authorProfileId,
+        deletedAt: row.deletedAt,
+        replyParentId: row.replyParentId,
+        visibility: row.visibility,
+      }
+    : null;
+};
+
+const loadFollowerRecipients = async (authorProfileId: string): Promise<StoredRecipient[]> =>
+  db
+    .select({
+      inboxUri: ActivityPubActors.inboxUri,
+      sharedInboxUri: ActivityPubActors.sharedInboxUri,
+      uri: ActivityPubActors.uri,
+    })
+    .from(ProfileFollows)
+    .innerJoin(Profiles, eq(Profiles.id, ProfileFollows.followerProfileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .innerJoin(ActivityPubActors, eq(ActivityPubActors.profileId, Profiles.id))
+    .where(
+      and(
+        eq(ProfileFollows.followeeProfileId, authorProfileId),
+        eq(Profiles.state, ProfileState.ACTIVE),
+        eq(Instances.kind, InstanceKind.ACTIVITYPUB),
+        eq(Instances.state, InstanceState.ACTIVE),
+        isNotNull(ActivityPubActors.inboxUri),
+      ),
+    )
+    .then((rows) =>
+      rows.flatMap((row) =>
+        row.inboxUri
+          ? [{ inboxUri: row.inboxUri, sharedInboxUri: row.sharedInboxUri, uri: row.uri }]
+          : [],
+      ),
+    );
+
+const loadRemoteParentRecipient = async (
+  replyParentId: string,
+): Promise<StoredRecipient | null> => {
+  const row = await db
+    .select({
+      inboxUri: ParentActors.inboxUri,
+      sharedInboxUri: ParentActors.sharedInboxUri,
+      uri: ParentActors.uri,
+    })
+    .from(ParentPosts)
+    .innerJoin(ParentProfiles, eq(ParentProfiles.id, ParentPosts.profileId))
+    .innerJoin(ParentInstances, eq(ParentInstances.id, ParentProfiles.instanceId))
+    .innerJoin(ParentActors, eq(ParentActors.profileId, ParentProfiles.id))
+    .where(
+      and(
+        eq(ParentPosts.id, replyParentId),
+        eq(ParentProfiles.state, ProfileState.ACTIVE),
+        eq(ParentInstances.kind, InstanceKind.ACTIVITYPUB),
+        eq(ParentInstances.state, InstanceState.ACTIVE),
+        isNotNull(ParentActors.inboxUri),
+      ),
+    )
+    .limit(1)
+    .then(first);
+
+  return row?.inboxUri
+    ? { inboxUri: row.inboxUri, sharedInboxUri: row.sharedInboxUri, uri: row.uri }
+    : null;
+};
+
+const toRecipient = (actor: StoredRecipient): Recipient | null => {
+  try {
+    let sharedInbox: URL | undefined;
+    if (actor.sharedInboxUri) {
+      try {
+        sharedInbox = new URL(actor.sharedInboxUri);
+      } catch {
+        // 잘못 저장된 optional shared inbox는 usable personal inbox를 막지 않는다.
+      }
+    }
+    return {
+      endpoints: sharedInbox ? { sharedInbox } : null,
+      id: new URL(actor.uri),
+      inboxId: new URL(actor.inboxUri),
+    };
+  } catch {
+    return null;
+  }
+};
+
+const selectRecipients = async (
+  source: Pick<DeliverySource, 'authorProfileId' | 'visibility'> & {
+    readonly replyParentId: string | null;
+  },
+): Promise<Recipient[]> => {
+  if (!source.replyParentId || source.visibility === PostVisibility.DIRECT) {
+    return [];
+  }
+
+  const actors = await loadFollowerRecipients(source.authorProfileId);
+  if (
+    source.visibility === PostVisibility.PUBLIC ||
+    source.visibility === PostVisibility.UNLISTED
+  ) {
+    const parentActor = await loadRemoteParentRecipient(source.replyParentId);
+    if (parentActor) {
+      actors.push(parentActor);
+    }
+  }
+
+  return [...new Map(actors.map((actor) => [actor.uri, actor])).values()].flatMap((actor) => {
+    const recipient = toRecipient(actor);
+    return recipient ? [recipient] : [];
+  });
+};
+
+const noteUri = (canonicalOrigin: string | URL, postId: string): URL =>
+  new URL(`/ap/note/${postId}`, canonicalOrigin);
+
+export const sendLocalReplyCreate = async (postId: string): Promise<void> => {
+  const context = await createFederationContext();
+  const projection = await projectLocalPostNote(context, postId);
+  if (!projection?.replyParentId) {
+    return;
+  }
+
+  const recipients = await selectRecipients(projection);
+  if (recipients.length === 0) {
+    return;
+  }
+
+  const objectUri = noteUri(projection.canonicalOrigin, postId);
+  const activity = new Create({
+    actor: context.getActorUri(projection.authorProfileId),
+    ccs: projection.object.ccIds,
+    id: new URL('#create', objectUri),
+    object: projection.object,
+    published: projection.createdAt,
+    tos: projection.object.toIds,
+  });
+  await context.sendActivity({ identifier: projection.authorProfileId }, recipients, activity, {
+    orderingKey: objectUri.href,
+    preferSharedInbox: true,
+  });
+};
+
+export const sendLocalReplyDelete = async (postId: string): Promise<void> => {
+  const context = await createFederationContext();
+  const source = await loadDeletedReplySource(context, postId);
+  if (!source) {
+    return;
+  }
+
+  const recipients = await selectRecipients(source);
+  if (recipients.length === 0) {
+    return;
+  }
+
+  const objectUri = noteUri(context.canonicalOrigin, postId);
+  const followersUri = new URL(
+    `${context.getActorUri(source.authorProfileId).pathname.replace(/\/$/, '')}/followers`,
+    context.canonicalOrigin,
+  );
+  const activity = new Delete({
+    actor: context.getActorUri(source.authorProfileId),
+    ccs:
+      source.visibility === PostVisibility.PUBLIC
+        ? [followersUri]
+        : source.visibility === PostVisibility.UNLISTED
+          ? [PUBLIC_COLLECTION]
+          : [],
+    id: new URL('#delete', objectUri),
+    object: objectUri,
+    published: source.deletedAt,
+    tos: source.visibility === PostVisibility.PUBLIC ? [PUBLIC_COLLECTION] : [followersUri],
+  });
+  await context.sendActivity({ identifier: source.authorProfileId }, recipients, activity, {
+    orderingKey: objectUri.href,
+    preferSharedInbox: true,
+  });
+};

--- a/packages/fedify/src/local-reply-delivery.ts
+++ b/packages/fedify/src/local-reply-delivery.ts
@@ -23,7 +23,7 @@ type DeliverySource = {
 };
 
 type StoredRecipient = {
-  readonly inboxUri: string;
+  readonly inboxUri: string | null;
   readonly sharedInboxUri: string | null;
   readonly uri: string;
 };
@@ -35,101 +35,6 @@ const createFederationContext = (
     localInstanceId: source.localInstanceId,
   });
 
-const loadLocalPostSource = async (
-  postId: string,
-): Promise<Pick<DeliverySource, 'canonicalOrigin' | 'localInstanceId'> | null> => {
-  const row = await db
-    .select({ canonicalOrigin: Instances.canonicalOrigin, localInstanceId: Instances.id })
-    .from(Posts)
-    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .where(
-      and(
-        eq(Posts.id, postId),
-        eq(Posts.state, PostState.ACTIVE),
-        eq(Instances.kind, InstanceKind.LOCAL),
-        eq(Instances.state, InstanceState.ACTIVE),
-        isNotNull(Instances.canonicalOrigin),
-        eq(Profiles.state, ProfileState.ACTIVE),
-      ),
-    )
-    .limit(1)
-    .then(first);
-
-  return row?.canonicalOrigin
-    ? { canonicalOrigin: row.canonicalOrigin, localInstanceId: row.localInstanceId }
-    : null;
-};
-
-const loadDeletedReplySource = async (postId: string): Promise<DeliverySource | null> => {
-  const row = await db
-    .select({
-      authorProfileId: Profiles.id,
-      canonicalOrigin: Instances.canonicalOrigin,
-      deletedAt: Posts.deletedAt,
-      localInstanceId: Instances.id,
-      replyParentId: Posts.replyParentId,
-      visibility: Posts.visibility,
-    })
-    .from(Posts)
-    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .where(
-      and(
-        eq(Posts.id, postId),
-        eq(Posts.state, PostState.DELETED),
-        isNotNull(Posts.replyParentId),
-        eq(Instances.kind, InstanceKind.LOCAL),
-        eq(Instances.state, InstanceState.ACTIVE),
-        isNotNull(Instances.canonicalOrigin),
-        eq(Profiles.state, ProfileState.ACTIVE),
-      ),
-    )
-    .limit(1)
-    .then(first);
-
-  return row?.replyParentId && row.canonicalOrigin
-    ? {
-        authorProfileId: row.authorProfileId,
-        canonicalOrigin: row.canonicalOrigin,
-        deletedAt: row.deletedAt,
-        localInstanceId: row.localInstanceId,
-        replyParentId: row.replyParentId,
-        visibility: row.visibility,
-      }
-    : null;
-};
-
-const loadRemoteParentRecipient = async (
-  replyParentId: string,
-): Promise<StoredRecipient | null> => {
-  const row = await db
-    .select({
-      inboxUri: ActivityPubActors.inboxUri,
-      sharedInboxUri: ActivityPubActors.sharedInboxUri,
-      uri: ActivityPubActors.uri,
-    })
-    .from(Posts)
-    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .innerJoin(ActivityPubActors, eq(ActivityPubActors.profileId, Profiles.id))
-    .where(
-      and(
-        eq(Posts.id, replyParentId),
-        eq(Profiles.state, ProfileState.ACTIVE),
-        eq(Instances.kind, InstanceKind.ACTIVITYPUB),
-        eq(Instances.state, InstanceState.ACTIVE),
-        isNotNull(ActivityPubActors.inboxUri),
-      ),
-    )
-    .limit(1)
-    .then(first);
-
-  return row?.inboxUri
-    ? { inboxUri: row.inboxUri, sharedInboxUri: row.sharedInboxUri, uri: row.uri }
-    : null;
-};
-
 const parseHttpUri = (value: string): URL | null => {
   try {
     const uri = new URL(value);
@@ -140,6 +45,10 @@ const parseHttpUri = (value: string): URL | null => {
 };
 
 const toRecipient = (actor: StoredRecipient): Recipient | null => {
+  if (!actor.inboxUri) {
+    return null;
+  }
+
   const id = parseHttpUri(actor.uri);
   const inboxId = parseHttpUri(actor.inboxUri);
   if (!id || !inboxId) {
@@ -166,7 +75,28 @@ const selectRecipient = async (
     return null;
   }
 
-  const parentActor = await loadRemoteParentRecipient(source.replyParentId);
+  const parentActor = await db
+    .select({
+      inboxUri: ActivityPubActors.inboxUri,
+      sharedInboxUri: ActivityPubActors.sharedInboxUri,
+      uri: ActivityPubActors.uri,
+    })
+    .from(Posts)
+    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .innerJoin(ActivityPubActors, eq(ActivityPubActors.profileId, Profiles.id))
+    .where(
+      and(
+        eq(Posts.id, source.replyParentId),
+        eq(Profiles.state, ProfileState.ACTIVE),
+        eq(Instances.kind, InstanceKind.ACTIVITYPUB),
+        eq(Instances.state, InstanceState.ACTIVE),
+        isNotNull(ActivityPubActors.inboxUri),
+      ),
+    )
+    .limit(1)
+    .then(first);
+
   return parentActor ? toRecipient(parentActor) : null;
 };
 
@@ -174,12 +104,31 @@ const noteUri = (canonicalOrigin: string | URL, postId: string): URL =>
   new URL(`/ap/note/${postId}`, canonicalOrigin);
 
 export const sendLocalReplyCreate = async (postId: string): Promise<void> => {
-  const source = await loadLocalPostSource(postId);
-  if (!source) {
+  const source = await db
+    .select({ canonicalOrigin: Instances.canonicalOrigin, localInstanceId: Instances.id })
+    .from(Posts)
+    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(
+      and(
+        eq(Posts.id, postId),
+        eq(Posts.state, PostState.ACTIVE),
+        eq(Instances.kind, InstanceKind.LOCAL),
+        eq(Instances.state, InstanceState.ACTIVE),
+        isNotNull(Instances.canonicalOrigin),
+        eq(Profiles.state, ProfileState.ACTIVE),
+      ),
+    )
+    .limit(1)
+    .then(first);
+  if (!source?.canonicalOrigin) {
     return;
   }
 
-  const context = createFederationContext(source);
+  const context = createFederationContext({
+    canonicalOrigin: source.canonicalOrigin,
+    localInstanceId: source.localInstanceId,
+  });
   const projection = await projectLocalPostNote(context, postId);
   if (!projection?.replyParentId) {
     return;
@@ -206,12 +155,39 @@ export const sendLocalReplyCreate = async (postId: string): Promise<void> => {
 };
 
 export const sendLocalReplyDelete = async (postId: string): Promise<void> => {
-  const source = await loadDeletedReplySource(postId);
-  if (!source) {
+  const source = await db
+    .select({
+      authorProfileId: Profiles.id,
+      canonicalOrigin: Instances.canonicalOrigin,
+      deletedAt: Posts.deletedAt,
+      localInstanceId: Instances.id,
+      replyParentId: Posts.replyParentId,
+      visibility: Posts.visibility,
+    })
+    .from(Posts)
+    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(
+      and(
+        eq(Posts.id, postId),
+        eq(Posts.state, PostState.DELETED),
+        isNotNull(Posts.replyParentId),
+        eq(Instances.kind, InstanceKind.LOCAL),
+        eq(Instances.state, InstanceState.ACTIVE),
+        isNotNull(Instances.canonicalOrigin),
+        eq(Profiles.state, ProfileState.ACTIVE),
+      ),
+    )
+    .limit(1)
+    .then(first);
+  if (!source?.replyParentId || !source.canonicalOrigin) {
     return;
   }
 
-  const context = createFederationContext(source);
+  const context = createFederationContext({
+    canonicalOrigin: source.canonicalOrigin,
+    localInstanceId: source.localInstanceId,
+  });
   const recipient = await selectRecipient(source);
   if (!recipient) {
     return;

--- a/packages/fedify/src/local-reply-federation.ts
+++ b/packages/fedify/src/local-reply-federation.ts
@@ -1,0 +1,23 @@
+import { createFederation, MemoryKvStore } from '@fedify/fedify';
+import { ensureDrizzleLocalProfileActor } from './local-actor-store';
+
+type LocalReplyContextData = {
+  readonly localInstanceId: string;
+};
+
+export const localReplyFederation = createFederation<LocalReplyContextData>({
+  allowPrivateAddress: false,
+  kv: new MemoryKvStore(),
+});
+
+localReplyFederation
+  .setActorDispatcher('/ap/actor/{identifier}', () => null)
+  .setKeyPairsDispatcher(async (context, identifier) => {
+    const result = await ensureDrizzleLocalProfileActor({
+      actorUri: context.getActorUri(identifier),
+      localInstanceId: context.data.localInstanceId,
+      profileId: identifier,
+    });
+
+    return result ? [...result.keyPairs] : [];
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@kosmo/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@kosmo/fedify':
+        specifier: workspace:*
+        version: link:../../packages/fedify
       '@pothos/core':
         specifier: ^4.12.0
         version: 4.12.0(graphql@16.14.0)


### PR DESCRIPTION
## 무엇을 변경했는지

- Local Reply 생성 후 기존 canonical Local Note를 포함한 ActivityPub `Create(Note)`를 전달합니다.
- Local Reply 삭제 후 같은 Note identity를 가리키는 `Delete`를 전달합니다.
- Reply Author Profile에 연결된 Local Instance의 `canonicalOrigin`으로 Fedify Context, actor URI, Note URI, activity identity와 서명 키를 구성합니다.
- Public·Unlisted Reply의 원격 직접 Parent 작성자만 direct recipient로 선택하고 Followers Only·Direct는 이 PR에서 전달하지 않습니다.
- Parent의 ActivityPub Instance가 `ACTIVE`일 때만 전달하며 `UNRESPONSIVE`·`SUSPENDED`에는 새 원격 요청을 보내지 않습니다.
- `inReplyTo`는 thread 관계를 나타내는 Parent object IRI로 유지하고, 실제 delivery는 저장된 Parent actor의 HTTP(S) inbox로 수행합니다.
- invalid actor/personal/shared inbox를 걸러내고 invalid shared inbox는 personal inbox로 fallback합니다.
- Create/Delete의 activity ID와 Note ordering domain을 안정적으로 유지합니다.
- 통합 core `createPost`가 optional caller transaction 계약을 유지하고 Local Reply Notification을 같은 transaction에 참여시킵니다. Fedify Create delivery는 action의 transaction 단계가 끝난 뒤 best-effort로 실행하며 GraphQL resolver는 인증된 입력과 payload mapping만 담당합니다.
- PROD-497 OpenSpec과 active capability를 최신 Linear 범위에 맞춰 동기화했습니다.

## 왜 변경했는지

Kosmo에서 생성·삭제된 Local Reply가 원격 Parent 작성자에게 전달되지 않아 ActivityPub thread lifecycle이 이어지지 않았습니다. PROD-494의 Local Note identity와 PROD-447의 post-commit failure isolation 계약을 재사용해 Parent-author direct delivery를 연결합니다.

기존 구현 초안은 각 interaction이 `ProfileFollows`를 직접 조회해 follower fanout까지 소유했지만, 이는 Reply activity 생성과 recipient expansion의 책임을 섞고 Repost 구현과도 중복됩니다. 공통 outbound followers fanout은 [PROD-512](https://linear.app/byulmaru/issue/PROD-512/activitypub-outbound-followers-fanout-dispatcher를-구현한다)로 분리했습니다.

## 이번 PR의 주요 결정

### 발신 identity는 Reply Author의 Local Instance를 따른다

- 결정자: @robin-maki
- 선택: 배포 기본 Local Instance가 아니라 Reply Author Profile에 연결된 Local Instance의 `canonicalOrigin`과 ID로 outbound Fedify Context와 actor key를 구성합니다.
- 고려한 대안: request-facing singleton federation의 `PUBLIC_ORIGIN`을 그대로 사용하거나 전역 federation의 fixed-origin 보호를 제거
- 이유: 여러 Local Instance가 저장된 경우에도 actor, Note, activity와 HTTP signature key ID가 모두 실제 Author Instance origin에 속해야 합니다. request-facing federation의 Host/canonical-origin 보호 계약은 유지해야 합니다.
- 감수한 결과: fixed-origin request federation과 별도로 origin-free outbound Reply federation 경계를 둡니다.
- 관련 근거: PROD-497, `docs/domain/objects/instance.md`, `openspec/specs/activitypub-local-reply-delivery/spec.md`

### Reply는 ACTIVE 원격 직접 Parent 작성자만 전달한다

- 결정자: @robin-maki
- 선택: Public·Unlisted Reply는 `ACTIVE` Instance의 원격 직접 Parent 작성자에게 direct delivery하고, follower fanout은 PROD-512로 분리합니다.
- 고려한 대안: PROD-497에서 `ProfileFollows`를 직접 조회하거나 `UNRESPONSIVE` Parent에도 delivery를 시도하고 Fedify followers dispatcher까지 함께 구현
- 이유: Parent-author direct delivery는 Reply interaction의 고유 책임이고 follower recipient expansion은 여러 outbound activity가 공유하는 별도 경계입니다. 또한 canonical Instance 정책은 Unreachable 상태에서 새 원격 요청을 중단합니다.
- 감수한 결과: PROD-512 전에는 Followers Only Reply와 일반 follower 배포가 수행되지 않으며, `UNRESPONSIVE` Parent delivery도 복구 대기 상태로 저장하지 않습니다.
- 관련 근거: PROD-497, PROD-512, `docs/domain/objects/instance.md`, `openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md`

### `inReplyTo`와 delivery endpoint를 분리한다

- 결정자: @robin-maki
- 선택: `inReplyTo`에는 Parent Post의 canonical object IRI를 넣고, delivery는 Parent actor의 저장된 inbox recipient로 수행합니다.
- 고려한 대안: Parent object IRI 자체를 delivery endpoint로 사용
- 이유: `inReplyTo`는 ActivityStreams object relation이고 inbox는 ActivityPub delivery endpoint이므로 역할이 다릅니다.
- 감수한 결과: 저장된 remote Parent actor/inbox를 안전하게 해석할 수 없으면 delivery는 no-op입니다.
- 관련 근거: PROD-497, `openspec/specs/activitypub-local-reply-delivery/spec.md`

### Post 생성 lifecycle은 통합 core `createPost`가 소유한다

- 결정자: @robin-maki
- 선택: GraphQL Local Post와 ActivityPub ingress가 하나의 core `createPost` application action을 사용합니다. 이 action은 optional caller transaction 계약을 유지하고 origin별 Parent 정책을 소유합니다. Local Reply Notification은 같은 transaction에 참여하고, Create delivery는 transaction 단계가 끝난 뒤 best-effort로 실행합니다. transaction 인자의 존재 여부는 origin이나 lifecycle 실행 여부를 결정하지 않습니다. `deletePost`는 Reply Delete delivery를 소유합니다.
- 고려한 대안: GraphQL resolver가 lifecycle을 직접 조립하거나, Local 전용 `createLocalPost` action을 별도로 만들거나, callback/delivery port를 추가
- 이유: core는 production 진입점을 통일해야 합니다. 별도 Local action은 GraphQL과 ActivityPub의 Post 생성 경계를 다시 나누고, GraphQL orchestration은 다른 production entry가 lifecycle을 빠뜨리게 만듭니다.
- 감수한 결과: top-level 호출에서는 실제 commit 뒤 Create delivery를 시도합니다. caller-owned transaction에서는 committed-read delivery 조회가 uncommitted Reply를 보지 못해 no-op되고 outer commit 뒤 재실행되지 않을 수 있으며, 이 누락은 PROD-448의 durable delivery 전환 전까지 수용합니다. rollback된 Reply의 Activity를 먼저 전달하지는 않습니다.
- 관련 근거: PROD-497, `docs/architecture/core-services.md`, `openspec/changes/archive/2026-07-28-deliver-activitypub-local-replies/decisions.md`

### 현재 Fedify 직접 전달 경계를 유지한다

- 결정자: @robin-maki
- 선택: 기존 Fedify 직접 전달 경계를 유지합니다. top-level transaction은 commit 뒤 전달하고, caller-owned transaction에서는 uncommitted source의 committed-read no-op과 outer commit 뒤 전달 누락을 수용합니다. 어떤 경우에도 delivery 실패가 committed application 결과를 뒤집지 않습니다.
- 고려한 대안: transactional outbox, NATS 또는 Fedify MessageQueue를 이번 PR에서 선행 구현
- 이유: PROD-497은 Reply Create/Delete 전달만 소유하며 durable delivery migration은 PROD-448이 별도로 소유합니다.
- 감수한 결과: commit과 delivery 사이 process 종료 시 activity가 유실될 수 있고 durable retry는 아직 제공하지 않습니다.
- 관련 근거: PROD-497, PROD-447, PROD-448, [PROD-533](https://linear.app/byulmaru/issue/PROD-533/core-transaction과-activity-delivery-보장-수준을-문서화한다), [정책 PR #399](https://github.com/byulmaru/kosmo/pull/399)

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/core test` — 128/128 통과
- `pnpm --filter @kosmo/fedify test` — 134/134 통과
- 실제 origin-free Fedify Context에서 secondary Local Instance의 canonical origin, actor URI와 key ID 2개를 검증
- `pnpm --filter @kosmo/api test:integration` — 159 통과, 기존 1개 skip
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm exec openspec validate --all --strict` — 43/43 통과
- correctness 및 Ponytail 서브에이전트 재리뷰 후 확정 finding 없음

## 아직 어떤 문제가 남았는지

- 여러 Local Instance origin의 Actor·Note·Activity HTTP 역참조와 Host별 dispatcher routing은 Backlog PROD-376 범위입니다.
- 공통 outbound followers dispatcher와 기존 Repost 수동 follower 조회 migration은 PROD-512 범위입니다.
- NATS/Fedify MessageQueue transport는 PROD-314, transactional outbox와 durable delivery intent는 PROD-448 범위입니다.
- commit과 direct delivery 사이 process 종료 시 activity가 유실될 수 있습니다. caller-owned transaction에서는 committed-read no-op 뒤 outer commit이 성공해도 Create activity가 누락될 수 있으며, durable retry는 PROD-448 전까지 제공하지 않습니다.
- 이미 머지된 Repost의 `UNRESPONSIVE` fanout 정책은 PROD-497 범위에서 변경하지 않았습니다.
