### PR TITLE
App과 Web 접근성 기준을 AA 목표로 분리한다

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -5,6 +5,7 @@ KOSMO의 UI/프로덕트 디자인 결정을 기록하고 공유하는 문서 �
 ## 문서 목록
 
 - [figma.md](./figma.md) — Figma 파일 구조와 작업 규칙
+- [accessibility.md](./accessibility.md) — Web·Android·iOS 접근성 목표, target과 검증 기준
 - [colors.md](./colors.md) — 컬러 토큰 정책
 - [typography.md](./typography.md) — 폰트 사용 규칙
 - [breakpoints.md](./breakpoints.md) — 레이아웃 브레이크포인트 단계와 컨벤션

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -1,0 +1,89 @@
+# 접근성 기준
+
+## 목표와 적용 범위
+
+KOSMO의 Web 디자인과 구현은 적용 가능한 [WCAG 2.2](https://www.w3.org/TR/WCAG22/) Level A·AA 성공 기준을 기본 목표로 한다. Level AAA는 저장소 전체의 완료 조건이 아니며, 사용자 위험이나 컴포넌트 맥락상 필요한 기준만 별도 계약으로 강화한다.
+
+이 목표는 현재 제품 전체가 이미 WCAG 2.2 AA를 준수한다는 선언이나 접근성 인증·법률 자문을 뜻하지 않는다. 기능이나 PR에서 AA 준수를 표현하려면 평가 범위, 적용한 성공 기준, 자동화와 수동 관찰 결과, 확인하지 못한 항목을 함께 기록한다.
+
+Android·iOS 같은 Native App에는 WCAG를 Web과 같은 방식으로 직접 적용했다고 표현하지 않는다. [WCAG2ICT](https://www.w3.org/WAI/standards-guidelines/wcag/non-web-ict/)의 A·AA 매핑을 해석 지침으로 사용하고 각 플랫폼의 접근성 지침과 runtime 관찰을 함께 적용한다. WCAG2ICT는 비규범적 W3C Group Note이므로 Native App의 접근성을 전부 보장하거나 별도의 플랫폼 요구사항을 대체하지 않는다.
+
+## 플랫폼별 기준
+
+| Surface    | 기본 기준                                | 단위와 target 계약                                                                                                                                       |
+| ---------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Web        | WCAG 2.2 Level A·AA                      | pointer target은 원칙적으로 24×24 CSS px 이상이다. 조밀한 icon action은 컴포넌트 계약에 따라 32×32 또는 36×36 CSS px를 사용할 수 있다.                   |
+| iOS·iPadOS | WCAG2ICT A·AA 매핑과 Apple HIG           | 보이는 glyph와 무관하게 기본 hit region은 44×44 pt를 사용한다. 더 작은 control은 Apple 지침과 컴포넌트별 근거·간격·runtime 검증이 있을 때만 예외로 둔다. |
+| Android    | WCAG2ICT A·AA 매핑과 Android 접근성 지침 | 보이는 glyph와 무관하게 touch target은 48×48 dp 이상을 기본으로 한다.                                                                                    |
+
+CSS px, pt, dp는 서로 다른 플랫폼 단위다. 저장소의 공통 목표가 A·AA라는 이유로 Web과 Native App의 target 숫자를 하나로 통일하지 않는다. React Native Web으로 렌더되는 surface는 Web 기준을 적용하고 실제 Android·iOS binary는 각 Native 기준을 적용한다.
+
+## Web target과 밀도
+
+[WCAG 2.2 SC 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)은 Level AA에서 pointer target이 최소 24×24 CSS px이거나 공식 예외를 만족하도록 요구한다. 공식 예외는 spacing, equivalent control, inline target, user-agent control, essential presentation이다.
+
+- KOSMO가 직접 만든 독립 control은 가능한 한 24×24 CSS px 자체를 확보한다. 24px보다 작은 target을 spacing 예외로 처리해야 한다면 인접 target과의 24 CSS px 평가 원이 겹치지 않는지 검증하고 예외 근거를 남긴다.
+- 조밀한 Action Bar·toolbar의 icon action은 32×32 또는 36×36 CSS px처럼 44px보다 작은 target을 선택할 수 있다. exact size와 간격은 해당 컴포넌트 계약이 소유하며, 전역 convention만을 이유로 보이지 않는 상하 padding을 44px까지 추가하지 않는다.
+- [SC 2.5.5 Target Size (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html)의 44×44 CSS px는 Level AAA 강화 기준이다. 중요한 control, 오류 비용이 큰 control, touch 중심 Web surface에서는 선택적으로 적용할 수 있지만 모든 Web control의 전역 최소값은 아니다.
+- target이 둥글거나 clipping된 경우 bounding box 숫자만으로 통과를 판단하지 않는다. target 내부에 24×24 CSS px 사각형을 포함할 수 있는지 또는 공식 spacing 예외를 만족하는지 확인한다.
+
+## Visual geometry와 interactive target
+
+보이는 icon·glyph·label 크기, control이 layout에서 차지하는 크기, 실제 pointer/touch를 받는 target은 같은 값일 필요가 없다.
+
+- 16·20·24 크기의 glyph를 더 큰 target 안에 배치할 수 있다. target을 키운다는 이유로 glyph나 배경을 같은 크기로 확대하지 않는다.
+- hit slop이나 별도 interaction layer로 target을 확장할 때 인접한 서로 다른 action target과 겹치지 않게 한다. 서로 다른 target이 겹치면 겹친 영역은 각 target의 유효 크기로 계산하지 않는다.
+- 시각적으로 조밀한 row를 만들 때도 focus indicator, pressed·selected·disabled·busy 상태와 accessible name을 보존한다.
+- Native에서 visual control을 작게 유지하더라도 iOS·Android의 실제 hit/touch target과 assistive technology focus 경계는 플랫폼 기준을 충족해야 한다.
+
+## 의미와 입력 방식
+
+- 모든 interactive element는 실제 동작에 맞는 role, accessible name, state를 제공한다. selected, expanded, pressed, disabled, busy와 오류 상태를 색이나 모양만으로 전달하지 않는다.
+- Web의 모든 기능은 keyboard로 도달하고 실행할 수 있어야 한다. focus-visible을 숨기지 않고 modal·menu·popover는 open, 이동, dismiss, focus restore를 검증한다.
+- 상태 변화와 오류는 필요한 경우 `aria-live` 또는 플랫폼 equivalent로 보조 기술에 전달한다. 같은 내용을 중복 announcement하지 않는다.
+- pointer, touch, keyboard와 screen reader 경로가 서로 다른 제품 결과를 만들지 않게 한다. 복잡한 gesture가 필요하면 같은 결과를 제공하는 단순 control을 둔다.
+- text scaling, zoom, reflow와 reduced-motion처럼 target 크기만으로 확인할 수 없는 A·AA 기준도 해당 surface 범위에서 함께 검토한다.
+
+## 가독성과 색상
+
+텍스트·아이콘·상태 표현은 적용 가능한 WCAG 2.2 A·AA 대비와 비색상 정보 전달 기준을 목표로 한다. 디자인 token이나 Figma 값이 존재한다는 사실만으로 대비를 통과한 것으로 보지 않는다.
+
+현재 `apps/app/.storybook/preview.tsx`는 Storybook a11y를 `error` 모드로 실행하지만 `color-contrast` 규칙을 명시적으로 제외한다. 따라서 Storybook a11y 통과는 semantic·검출 가능한 일부 규칙의 증거이며 색상 대비를 포함한 전체 AA 준수 증거가 아니다. 이 문서는 해당 debt를 수정하지 않고 검증 공백으로 기록한다.
+
+## 검증과 보고
+
+자동화는 수동 runtime 관찰을 대체하지 않는다. 변경 범위에 맞춰 다음 증거를 구분해 기록한다.
+
+| 증거                | 확인하는 범위                                                            | 대체하지 못하는 것                                                                 |
+| ------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| 정적·Storybook a11y | role, name, 일부 state와 axe가 검출하는 규칙                             | 실제 keyboard 흐름, screen reader announcement, 제외된 color contrast, Native 동작 |
+| Web runtime         | keyboard, focus, pointer·touch, zoom·reflow, browser screen reader 동작  | Android·iOS assistive technology와 플랫폼 target                                   |
+| Android·iOS runtime | TalkBack·VoiceOver, font scaling, platform target, modal·sheet와 gesture | Web browser의 WCAG 적합성                                                          |
+| 시각 검토           | density, focus indicator, 상태 식별, token 대비                          | programmatic semantics와 announcement                                              |
+
+PR과 이슈에는 실행한 자동화, 실제 관찰한 platform·viewport·입력 방식, 실행하지 못한 검증을 나눠 적는다. 특정 surface만 확인했다면 제품 또는 저장소 전체가 AA를 만족한다고 일반화하지 않는다.
+
+## 기존 44×44 계약의 우선순위
+
+이 문서는 전역의 무조건적인 44×44 규칙을 제거하지만, 이미 승인된 더 강한 컴포넌트 계약을 자동으로 낮추지 않는다.
+
+- Reaction Quick Picker는 [reactions.md](./reactions.md)의 44×44 option과 pending overlay를 유지한다. `apps/app/src/stories/Reactions.stories.tsx`의 exact 44×44 assertion도 그대로 유지한다.
+- Post Action Bar는 현재 `openspec/changes/add-post-action-bar`와 `apps/app/src/stories/PostActionBar.stories.tsx`에서 최소 44×44와 single-row geometry를 요구한다. 이 PR에서는 변경하지 않는다.
+- Post Action Bar의 조밀한 Web target 결정은 PROD-414가 소유한다. PROD-414의 Linear 계약과 적용되는 canonical 디자인 결정을 exact target·간격으로 먼저 정렬하고, 그 결정에 맞춰 OpenSpec과 Storybook assertion을 수정한 뒤 구현한다. 전역 Web AA 최소값만으로 기존 component-specific 44×44 계약을 우회하지 않는다.
+- 새 컴포넌트는 이 문서의 플랫폼 baseline을 사용한다. 더 큰 target이나 엄격한 검증이 필요하면 컴포넌트 디자인 문서·Linear·OpenSpec에 이유와 exact contract를 기록한다.
+
+## 이 문서가 변경하지 않는 것
+
+- 기존 UI의 접근성 결함을 일괄 수정하지 않는다.
+- 기존 44×44 컴포넌트와 테스트를 일괄 축소하지 않는다.
+- Storybook의 `color-contrast` 제외를 해소하지 않는다.
+- 접근성 인증이나 법적 준수를 선언하지 않는다.
+
+## 참고 자료
+
+- [Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/TR/WCAG22/)
+- [Understanding SC 2.5.8: Target Size (Minimum), Level AA](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
+- [Understanding SC 2.5.5: Target Size (Enhanced), Level AAA](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html)
+- [WCAG2ICT Overview](https://www.w3.org/WAI/standards-guidelines/wcag/non-web-ict/)
+- [Apple Human Interface Guidelines: Accessibility](https://developer.apple.com/design/human-interface-guidelines/accessibility)
+- [Android Developers: Make apps more accessible](https://developer.android.com/guide/topics/ui/accessibility/views/apps-views)

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -27,7 +27,7 @@ CSS px, pt, dp는 서로 다른 플랫폼 단위다. 저장소의 공통 목표�
 - KOSMO가 직접 만든 독립 control은 가능한 한 24×24 CSS px 자체를 확보한다. 24px보다 작은 target을 spacing 예외로 처리해야 한다면 인접 target과의 24 CSS px 평가 원이 겹치지 않는지 검증하고 예외 근거를 남긴다.
 - 조밀한 Action Bar·toolbar의 icon action은 32×32 또는 36×36 CSS px처럼 44px보다 작은 target을 선택할 수 있다. exact size와 간격은 해당 컴포넌트 계약이 소유하며, 전역 convention만을 이유로 보이지 않는 상하 padding을 44px까지 추가하지 않는다.
 - [SC 2.5.5 Target Size (Enhanced)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html)의 44×44 CSS px는 Level AAA 강화 기준이다. 중요한 control, 오류 비용이 큰 control, touch 중심 Web surface에서는 선택적으로 적용할 수 있지만 모든 Web control의 전역 최소값은 아니다.
-- target이 둥글거나 clipping된 경우 bounding box 숫자만으로 통과를 판단하지 않는다. target 내부에 24×24 CSS px 사각형을 포함할 수 있는지 또는 공식 spacing 예외를 만족하는지 확인한다.
+- target이 둥글거나 clipping된 경우 bounding box 숫자만으로 크기 요구사항 통과를 판단하지 않는다. 크기 요구사항은 target 내부에 축 정렬된 24×24 CSS px 사각형을 포함할 수 있는지 확인한다. 이를 충족하지 못한 target의 spacing 예외를 평가할 때만 bounding box 중심에 24 CSS px 지름의 원을 배치한다.
 
 ## Visual geometry와 interactive target
 
@@ -44,7 +44,8 @@ CSS px, pt, dp는 서로 다른 플랫폼 단위다. 저장소의 공통 목표�
 - Web의 모든 기능은 keyboard로 도달하고 실행할 수 있어야 한다. focus-visible을 숨기지 않고 modal·menu·popover는 open, 이동, dismiss, focus restore를 검증한다.
 - 상태 변화와 오류는 필요한 경우 `aria-live` 또는 플랫폼 equivalent로 보조 기술에 전달한다. 같은 내용을 중복 announcement하지 않는다.
 - pointer, touch, keyboard와 screen reader 경로가 서로 다른 제품 결과를 만들지 않게 한다. 복잡한 gesture가 필요하면 같은 결과를 제공하는 단순 control을 둔다.
-- text scaling, zoom, reflow와 reduced-motion처럼 target 크기만으로 확인할 수 없는 A·AA 기준도 해당 surface 범위에서 함께 검토한다.
+- text scaling, zoom, reflow처럼 target 크기만으로 확인할 수 없는 A·AA 기준도 해당 surface 범위에서 함께 검토한다.
+- 사용자 상호작용으로 시작된 비필수 motion animation을 끌 수 있게 하는 [SC 2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html)은 Level AAA다. `prefers-reduced-motion` 대응은 저장소 전체의 A·AA 완료 조건이 아니며, 사용자 위험이나 컴포넌트 맥락상 필요할 때 별도 강화 계약으로 적용한다. 자동으로 시작되어 5초를 넘는 moving·blinking·scrolling content의 일시정지·중지는 Level A인 SC 2.2.2로 별도 평가한다.
 
 ## 가독성과 색상
 
@@ -71,7 +72,7 @@ PR과 이슈에는 실행한 자동화, 실제 관찰한 platform·viewport·입
 
 - Reaction Quick Picker는 [reactions.md](./reactions.md)의 44×44 option과 pending overlay를 유지한다. `apps/app/src/stories/Reactions.stories.tsx`의 exact 44×44 assertion도 그대로 유지한다.
 - Post Action Bar는 현재 `openspec/changes/add-post-action-bar`와 `apps/app/src/stories/PostActionBar.stories.tsx`에서 최소 44×44와 single-row geometry를 요구한다. 이 PR에서는 변경하지 않는다.
-- Post Action Bar의 조밀한 Web target 결정은 PROD-414가 소유한다. PROD-414의 Linear 계약과 적용되는 canonical 디자인 결정을 exact target·간격으로 먼저 정렬하고, 그 결정에 맞춰 OpenSpec과 Storybook assertion을 수정한 뒤 구현한다. 전역 Web AA 최소값만으로 기존 component-specific 44×44 계약을 우회하지 않는다.
+- Post Action Bar의 현재 44×44 interactive target 계약은 PROD-433이 소유한다. 이 PR은 더 작은 exact Web target이나 그 변경의 구현 이슈를 확정하지 않는다. 후속 변경은 해당 Linear 이슈의 범위와 canonical 디자인 결정을 exact target·간격으로 먼저 정렬하고, 그 결정에 맞춰 OpenSpec과 Storybook assertion을 수정한 뒤 구현한다. 전역 Web AA 최소값만으로 기존 component-specific 44×44 계약을 우회하지 않는다.
 - 새 컴포넌트는 이 문서의 플랫폼 baseline을 사용한다. 더 큰 target이나 엄격한 검증이 필요하면 컴포넌트 디자인 문서·Linear·OpenSpec에 이유와 exact contract를 기록한다.
 
 ## 이 문서가 변경하지 않는 것

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -4,7 +4,9 @@
 
 KOSMO의 Web 디자인과 구현은 적용 가능한 [WCAG 2.2](https://www.w3.org/TR/WCAG22/) Level A·AA 성공 기준을 기본 목표로 한다. Level AAA는 저장소 전체의 완료 조건이 아니며, 사용자 위험이나 컴포넌트 맥락상 필요한 기준만 별도 계약으로 강화한다.
 
-이 목표는 현재 제품 전체가 이미 WCAG 2.2 AA를 준수한다는 선언이나 접근성 인증·법률 자문을 뜻하지 않는다. 기능이나 PR에서 AA 준수를 표현하려면 평가 범위, 적용한 성공 기준, 자동화와 수동 관찰 결과, 확인하지 못한 항목을 함께 기록한다.
+이 목표는 현재 제품 전체가 이미 WCAG 2.2 AA를 준수한다는 선언이나 접근성 인증·법률 자문을 뜻하지 않는다. 기능이나 PR의 접근성 결과는 "적용 가능한 A·AA 성공 기준에 대응했다" 또는 "부분 평가 증거를 확보했다"고 표현하고, 평가 범위, 적용한 성공 기준, 자동화와 수동 관찰 결과, 확인하지 못한 항목을 함께 기록한다.
+
+[WCAG 2.2의 정식 Level AA 적합성](https://www.w3.org/TR/WCAG22/#conformance-reqs) 주장은 기능이나 PR 일부가 아니라 완전한 Web page와 전체 process를 대상으로 한다. 이 표현을 사용하려면 적용 가능한 Level A·AA 성공 기준 전체뿐 아니라 accessibility-supported 방식, non-interference 등 모든 적합성 요구사항을 충족해야 한다. 선택적으로 적합성 주장을 공개할 때는 날짜, WCAG 제목·버전·URI, 충족 수준, 대상 page 설명, 의존한 Web 기술 목록 등 [필수 claim 항목](https://www.w3.org/TR/WCAG22/#conformance-claims)을 함께 기록한다.
 
 Android·iOS 같은 Native App에는 WCAG를 Web과 같은 방식으로 직접 적용했다고 표현하지 않는다. [WCAG2ICT](https://www.w3.org/WAI/standards-guidelines/wcag/non-web-ict/)의 A·AA 매핑을 해석 지침으로 사용하고 각 플랫폼의 접근성 지침과 runtime 관찰을 함께 적용한다. WCAG2ICT는 비규범적 W3C Group Note이므로 Native App의 접근성을 전부 보장하거나 별도의 플랫폼 요구사항을 대체하지 않는다.
 

--- a/memory/frontend-react-native.md
+++ b/memory/frontend-react-native.md
@@ -46,7 +46,7 @@
 - `View`, `Text`, `TextInput`, `Pressable`, `Modal`, `ScrollView` 등 React Native primitive를 기본으로 사용한다. browser-only element나 DOM API는 platform 경계 밖의 공용 컴포넌트에 넣지 않는다.
 - 색상, spacing, radius, typography, breakpoint는 `apps/app/src/theme` token을 사용한다. 일회성 raw hex/숫자로 Foundation 값을 복제하지 않는다.
 - UI 텍스트는 `SUIT`, 포스트 본문과 긴 입력은 `Pretendard`를 사용한다. React Native에는 CSS 상속이 없으므로 공용 primitive 또는 각 `Text`/`TextInput` style에서 family를 명시한다.
-- touch target은 최소 44×44를 확보하고 `accessibilityRole`, `accessibilityLabel`, `accessibilityState`를 실제 동작과 맞춘다. 선택 tab, disabled/loading button, modal/drawer 상태는 시각 표현만으로 전달하지 않는다.
+- 접근성 목표와 target은 [`docs/design/accessibility.md`](../docs/design/accessibility.md)를 따른다. Web은 적용 가능한 WCAG 2.2 A·AA와 24×24 CSS px 최소 target·공식 예외를 사용하고, iOS는 기본 44×44 pt hit region, Android는 48×48 dp touch target을 사용한다. 기존 component-specific 강화 계약은 전역 기준보다 우선한다. `accessibilityRole`, `accessibilityLabel`, `accessibilityState`를 실제 동작과 맞추고 선택 tab, disabled/loading button, modal/drawer 상태를 시각 표현만으로 전달하지 않는다.
 - `useWindowDimensions`로 layout 단계를 고르되 product breakpoint 값은 token에서 읽는다. render 중 플랫폼 전역 `window`를 직접 읽지 않는다.
 - 게시글 canonical read 계약은 schema version이 식별된 ProseMirror document JSON이다. composer는 trim된 Plain Text를 `CreatePostInput.bodyText`로 계속 제출하고 서버 공통 경계가 document로 변환한다. 앱은 native-safe JSON 타입과 제한된 paragraph/text/hard-break/link renderer만 사용하며, 파생 `bodyText`는 미지원 document fallback으로 표시한다. `prosemirror-model` 검증/canonicalization은 server-only subpath에 두고 앱 bundle에는 TipTap, ProseMirror runtime/editor/view 또는 WebView editor를 포함하지 않는다.
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `docs/design/accessibility.md`에 Web·iOS·Android별 접근성 기준과 target 단위를 정의했습니다.
- Web은 WCAG 2.2 Level A·AA와 24×24 CSS px 최소 target·공식 예외를 적용하고, 조밀한 icon action은 component 계약에 따라 32×32 또는 36×36 CSS px를 사용할 수 있게 했습니다.
- 기능·PR의 부분 평가 증거와 완전한 Web page·process를 대상으로 하는 정식 WCAG Level AA 적합성 주장을 구분했습니다.
- iOS는 기본 44×44 pt hit region, Android는 48×48 dp touch target을 사용하며 visual geometry와 interactive target을 분리했습니다.
- `memory/frontend-react-native.md`의 무조건적인 44×44 convention을 canonical 디자인 문서 참조로 교체했습니다.
- 기존 Reaction·Post Action Bar의 component-specific 44×44 계약과 Storybook assertion은 변경하지 않았습니다.

## 왜 변경했는지

Web의 WCAG AA 최소 기준, WCAG AAA의 44×44 CSS px 강화 기준, Native 플랫폼 권장 target이 하나의 44×44 규칙으로 섞여 있었습니다. 이 때문에 Figma가 의도한 조밀한 Web Action Bar에도 불필요한 상하 padding이 전역 의무처럼 적용될 수 있었습니다.

저장소의 공통 목표는 A·AA로 유지하되 Web과 Native의 단위·입력 방식·플랫폼 지침을 분리해 접근성과 시각적 밀도를 함께 판단할 수 있게 했습니다.

## 이번 PR의 주요 결정

### AA 목표는 통일하고 target 숫자는 플랫폼별로 분리한다

- 결정자: 이예은
- 선택: Web은 WCAG 2.2 A·AA, Native는 WCAG2ICT A·AA 매핑과 Apple·Android 플랫폼 지침을 적용합니다.
- 고려한 대안: 저장소 전체에서 44×44를 강제하거나 Web의 24×24 CSS px를 Native에도 동일하게 적용하는 방식.
- 이유: AAA를 전역 완료 조건으로 두지 않으면서 각 플랫폼의 실제 입력 방식과 접근성 권장값을 지키기 위해서입니다.
- 감수한 결과: component별 exact target 계약과 Web·Native runtime 검증을 별도로 관리해야 합니다.
- 관련 근거: [DSN-25](https://linear.app/byulmaru/issue/DSN-25/kosmo-appweb-접근성-기준을-wcag-22-aa-기반으로-분리-정리한다)

### 기존의 더 강한 component 계약은 자동 완화하지 않는다

- 결정자: 이예은
- 선택: Reaction과 Post Action Bar의 현재 44×44 계약은 유지합니다.
- 고려한 대안: 새 전역 기준만으로 기존 44×44 assertion을 즉시 낮추는 방식.
- 이유: 전역 baseline 변경이 이미 승인된 component geometry와 검증을 우회하지 않게 하기 위해서입니다.
- 감수한 결과: Post Action Bar의 exact Web target과 후속 구현 이슈는 이 PR에서 확정하지 않습니다. PROD-414 재개 전에 Linear 이슈 범위와 canonical 결정을 먼저 정렬하고, 이후 OpenSpec·Storybook → 구현 순서로 갱신해야 합니다.

## 어떻게 확인할 수 있는지

- `pnpm exec prettier --check docs/design/accessibility.md docs/design/README.md memory/frontend-react-native.md`
- `pnpm exec openspec validate --all --strict` — 42 passed, 0 failed
- `pnpm test` — 전체 통과
- `git diff --check`
- 독립 implementation review 1회 — P2 1건을 `a43b3a60`에서 반영했으며 사용자 요청에 따라 추가 리뷰는 수행하지 않았습니다.
- Codex 자동 리뷰 — `reduced-motion`의 AAA 분류와 Action Bar 계약 소유권을 정정하고, target 크기 요구사항과 spacing 예외의 서로 다른 bounding box 사용을 명확히 했습니다.
- 공식 W3C·Apple·Android 문서와 target 수치·적용 범위를 대조했습니다.
- GitHub Actions — Lint, Semgrep scan, Test 통과 (head `173d72ca`)

## 아직 어떤 문제가 남았는지

- Storybook의 `color-contrast` 규칙 제외는 이번 PR에서 수정하지 않았습니다.
- 제품 코드와 Storybook assertion은 변경하지 않았으므로 Web·Android·iOS runtime 관찰은 수행하지 않았습니다.
- PROD-414는 이 PR이 병합된 뒤 Repost action과 menu 개선을 계속합니다. Action Bar의 component-wide exact target 변경은 먼저 Linear 이슈 범위와 canonical 결정을 정렬해야 합니다.

Stack: `main → codex/dsn-25-accessibility-guidance`
