### PR TITLE
최근 검색어 선택과 삭제가 포커스 해제로 막히지 않게 한다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -157,6 +157,7 @@ export default function SearchScreen() {
   const [input, setInput] = useState(query);
   const [recent, setRecent] = useState<string[]>([]);
   const [focused, setFocused] = useState(false);
+  const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     let current = true;
@@ -177,6 +178,14 @@ export default function SearchScreen() {
       current = false;
     };
   }, [query]);
+  useEffect(
+    () => () => {
+      if (blurTimerRef.current) {
+        clearTimeout(blurTimerRef.current);
+      }
+    },
+    [],
+  );
   useEffect(() => {
     if (!focused) {
       setInput(query);
@@ -188,6 +197,22 @@ export default function SearchScreen() {
       void writeRecentSearches(next);
       return next;
     });
+  };
+  const keepSearchFocused = () => {
+    if (blurTimerRef.current) {
+      clearTimeout(blurTimerRef.current);
+      blurTimerRef.current = null;
+    }
+    setFocused(true);
+  };
+  const leaveSearchFocus = () => {
+    if (blurTimerRef.current) {
+      clearTimeout(blurTimerRef.current);
+    }
+    blurTimerRef.current = setTimeout(() => {
+      blurTimerRef.current = null;
+      setFocused(false);
+    }, 0);
   };
 
   const navigate = (nextQuery: string, tab: SearchTab = activeTab) => {
@@ -201,7 +226,7 @@ export default function SearchScreen() {
 
   const clearSearch = () => {
     setInput('');
-    setFocused(true);
+    keepSearchFocused();
     if (query) {
       router.setParams({ q: undefined });
     }
@@ -212,103 +237,104 @@ export default function SearchScreen() {
 
   return (
     <ScrollView contentContainerStyle={styles.root} keyboardShouldPersistTaps="handled">
-      <View
-        accessibilityLabel="검색"
-        style={[styles.searchBar, { backgroundColor: theme.card, borderColor: theme.border }]}
-      >
-        {phase !== 'before' ? (
-          <Link asChild href={searchHref('', activeTab)}>
-            <Pressable
-              accessibilityLabel="뒤로"
-              accessibilityRole="link"
-              onPress={() => {
-                setInput('');
-                setFocused(false);
-              }}
-              style={styles.iconButton}
-            >
-              <ArrowLeft color={theme.textSecondary} size={20} strokeWidth={2} />
-            </Pressable>
-          </Link>
-        ) : null}
-        <View style={[styles.inputShell, { backgroundColor: theme.surface }]}>
-          <SearchIcon color={theme.textSecondary} size={20} strokeWidth={2} />
-          <TextInput
-            ref={inputRef}
-            accessibilityLabel="검색어"
-            autoCapitalize="none"
-            autoCorrect={false}
-            onBlur={() =>
-              setTimeout(() => {
-                if (!inputRef.current?.isFocused()) {
+      <View onBlur={leaveSearchFocus} onFocus={keepSearchFocused}>
+        <View
+          accessibilityLabel="검색"
+          style={[styles.searchBar, { backgroundColor: theme.card, borderColor: theme.border }]}
+        >
+          {phase !== 'before' ? (
+            <Link asChild href={searchHref('', activeTab)}>
+              <Pressable
+                accessibilityLabel="뒤로"
+                accessibilityRole="link"
+                onPress={() => {
+                  setInput('');
                   setFocused(false);
-                }
-              }, 0)
-            }
-            onChangeText={setInput}
-            onFocus={() => setFocused(true)}
-            onSubmitEditing={() => navigate(input)}
-            placeholder="검색어를 입력하세요"
-            placeholderTextColor={theme.textSecondary}
-            returnKeyType="search"
-            style={[styles.input, { color: theme.text }]}
-            value={input}
-          />
-          {input ? (
-            <Pressable
-              accessibilityLabel="검색 지우기"
-              accessibilityRole="button"
-              onPress={clearSearch}
-              style={styles.clearButton}
-            >
-              <X color={theme.textSecondary} size={18} strokeWidth={2} />
-            </Pressable>
+                }}
+                onPressIn={keepSearchFocused}
+                style={styles.iconButton}
+              >
+                <ArrowLeft color={theme.textSecondary} size={20} strokeWidth={2} />
+              </Pressable>
+            </Link>
           ) : null}
+          <View style={[styles.inputShell, { backgroundColor: theme.surface }]}>
+            <SearchIcon color={theme.textSecondary} size={20} strokeWidth={2} />
+            <TextInput
+              ref={inputRef}
+              accessibilityLabel="검색어"
+              autoCapitalize="none"
+              autoCorrect={false}
+              onChangeText={setInput}
+              onSubmitEditing={() => navigate(input)}
+              placeholder="검색어를 입력하세요"
+              placeholderTextColor={theme.textSecondary}
+              returnKeyType="search"
+              style={[styles.input, { color: theme.text }]}
+              value={input}
+            />
+            {input ? (
+              <Pressable
+                accessibilityLabel="검색 지우기"
+                accessibilityRole="button"
+                onPress={clearSearch}
+                onPressIn={keepSearchFocused}
+                style={styles.clearButton}
+              >
+                <X color={theme.textSecondary} size={18} strokeWidth={2} />
+              </Pressable>
+            ) : null}
+          </View>
         </View>
+
+        {phase === 'input' ? (
+          <View style={styles.recent}>
+            <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>최근 검색</Text>
+            {recent.length ? (
+              recent.map((term) => (
+                <View key={term} style={[styles.recentItem, { borderColor: theme.border }]}>
+                  <Link asChild href={searchHref(term, activeTab)}>
+                    <Pressable
+                      accessibilityRole="link"
+                      onPress={() => {
+                        setFocused(false);
+                        remember(term);
+                      }}
+                      onPressIn={keepSearchFocused}
+                      style={styles.recentTerm}
+                    >
+                      <History color={theme.textSecondary} size={16} strokeWidth={2} />
+                      <Text numberOfLines={1} style={[styles.recentText, { color: theme.text }]}>
+                        {term}
+                      </Text>
+                    </Pressable>
+                  </Link>
+                  <Pressable
+                    accessibilityLabel={`최근 검색 '${term}' 삭제`}
+                    accessibilityRole="button"
+                    onPress={() => {
+                      const next = recent.filter((item) => item !== term);
+                      setRecent(next);
+                      void writeRecentSearches(next);
+                      inputRef.current?.focus();
+                    }}
+                    onPressIn={keepSearchFocused}
+                    style={styles.deleteButton}
+                  >
+                    <X color={theme.textSecondary} size={16} strokeWidth={2} />
+                  </Pressable>
+                </View>
+              ))
+            ) : (
+              <Text style={[styles.help, { color: theme.textSecondary }]}>
+                아직 최근 검색이 없어요.
+              </Text>
+            )}
+          </View>
+        ) : null}
       </View>
 
-      {phase === 'input' ? (
-        <View style={styles.recent}>
-          <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>최근 검색</Text>
-          {recent.length ? (
-            recent.map((term) => (
-              <View key={term} style={[styles.recentItem, { borderColor: theme.border }]}>
-                <Link asChild href={searchHref(term, activeTab)}>
-                  <Pressable
-                    accessibilityRole="link"
-                    onPress={() => {
-                      setFocused(false);
-                      remember(term);
-                    }}
-                    style={styles.recentTerm}
-                  >
-                    <History color={theme.textSecondary} size={16} strokeWidth={2} />
-                    <Text numberOfLines={1} style={[styles.recentText, { color: theme.text }]}>
-                      {term}
-                    </Text>
-                  </Pressable>
-                </Link>
-                <Pressable
-                  accessibilityLabel={`최근 검색 '${term}' 삭제`}
-                  accessibilityRole="button"
-                  onPress={() => {
-                    const next = recent.filter((item) => item !== term);
-                    setRecent(next);
-                    void writeRecentSearches(next);
-                  }}
-                  style={styles.deleteButton}
-                >
-                  <X color={theme.textSecondary} size={16} strokeWidth={2} />
-                </Pressable>
-              </View>
-            ))
-          ) : (
-            <Text style={[styles.help, { color: theme.textSecondary }]}>
-              아직 최근 검색이 없어요.
-            </Text>
-          )}
-        </View>
-      ) : phase === 'results' ? (
+      {phase === 'results' ? (
         <>
           <View
             accessibilityLabel="검색 결과 유형"
@@ -347,12 +373,12 @@ export default function SearchScreen() {
             />
           )}
         </>
-      ) : (
+      ) : phase === 'before' ? (
         <StateView
           description="handle을 입력하면 일치하는 프로필을 찾아드려요."
           title="프로필을 검색해보세요"
         />
-      )}
+      ) : null}
     </ScrollView>
   );
 }

--- a/apps/app/src/stories/Search.stories.tsx
+++ b/apps/app/src/stories/Search.stories.tsx
@@ -132,10 +132,15 @@ export const RecentSearchInteraction: Story = {
   parameters: { router: { params: {}, pathname: '/search' } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('textbox', { name: '검색어' }));
+    const input = canvas.getByRole('textbox', { name: '검색어' });
+    await userEvent.click(input);
     await expect(canvas.findByText('별마루')).resolves.toBeVisible();
+    await userEvent.tab();
+    await expect(canvas.getByRole('link', { name: '별마루' })).toHaveFocus();
     await userEvent.click(canvas.getByRole('button', { name: "최근 검색 '별마루' 삭제" }));
     await expect(canvas.queryByText('별마루')).not.toBeInTheDocument();
+    await expect(canvas.findByText('@remote@space.example')).resolves.toBeVisible();
+    await expect(input).toHaveFocus();
   },
 };
 

--- a/apps/web/e2e/search.e2e.ts
+++ b/apps/web/e2e/search.e2e.ts
@@ -104,6 +104,9 @@ test('저장된 최근 검색을 표시하고 개별 항목을 삭제한다', as
   await page.getByRole('button', { name: "최근 검색 'recent-alpha' 삭제" }).click();
 
   await expect(page.getByText('recent-alpha', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('최근 검색', { exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'recent-beta' })).toBeVisible();
+  await expect(page.getByRole('textbox', { name: '검색어' })).toBeFocused();
   expect(
     await page.evaluate((key) => JSON.parse(localStorage.getItem(key) ?? '[]'), recentSearchesKey),
   ).toEqual(['recent-beta']);

--- a/apps/web/e2e/search.e2e.ts
+++ b/apps/web/e2e/search.e2e.ts
@@ -119,7 +119,7 @@ test('최근 검색 항목을 선택하면 사람 검색 결과를 요청한다'
   await setRecentSearchesBeforeNavigation(page, [handle]);
   await page.goto('/search');
   await page.getByRole('textbox', { name: '검색어' }).focus();
-  await page.getByRole('link', { name: handle }).click();
+  await page.getByRole('link', { name: handle }).click({ delay: 50 });
 
   await expectSearchParams(page, { q: handle, tab: 'people' });
   await expectTabSelected(page, '사람');


### PR DESCRIPTION
## 무엇을 변경했는지

- 검색바와 최근 검색 목록을 하나의 focus-within 상호작용 경계로 복원했습니다.
- 영역 내부 컨트롤로 포커스나 press가 이동하면 대기 중인 blur 처리를 취소합니다.
- 최근 검색어 선택 시 링크가 언마운트되기 전에 URL과 검색 결과로 정상 이동하도록 했습니다.
- 최근 검색어 삭제 후 남은 목록을 유지하고 검색 입력으로 포커스를 복원합니다.
- Storybook과 Web E2E에 키보드 포커스, 남은 항목, localStorage 회귀 검증을 추가했습니다.

## 왜 변경했는지

Expo 전환 커밋 `6bc64560`에서 기존 “검색바 + 최근 검색 목록” 전체의 focus-within 추적이 `TextInput.onBlur` 단독 검사로 축소되었습니다. Web에서는 pointer down으로 입력이 blur된 뒤 0ms 타이머가 최근 검색 목록을 click/onPress 전에 언마운트할 수 있어, 최근 검색어 선택이 결과로 이동하지 않거나 삭제가 실행되지 않고 입력 단계만 닫혔습니다.

- Linear: [PROD-511](https://linear.app/byulmaru/issue/PROD-511/bug-search-최근-검색어-선택-및-삭제가-동작하지-않는다)
- Stack: `main -> PROD-511`

## 이번 PR의 주요 결정

새로운 제품 결정은 없습니다. 기존 `web-app-shell` 검색 계약과 PROD-511의 선택·삭제·접근성 요구사항을 변경 없이 복원했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:storybook`
  - 11 files, 138 tests 통과
- `node scripts/test-db.mjs run -- pnpm test:e2e:database -- search.e2e.ts`
  - 검색 E2E 13 tests 통과
  - 최근 검색 선택 → URL `q` 갱신 및 사람 검색 결과 표시
  - 최근 검색 삭제 → 남은 항목, 입력 포커스, localStorage 유지
- 변경 파일 ESLint·Prettier 검사 통과

## 아직 어떤 문제가 남았는지

- Android/iOS 실기기 수동 확인은 이번 세션에서 수행하지 않았습니다. 변경은 공용 React Native 컴포넌트 경계에 적용했고, 타입 검사와 React Native Web Storybook/E2E로 검증했습니다.