### PR TITLE
디자인 영역의 리뷰 책임자를 명확히 한다

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 * @robin-maki
+
+# Design decisions and app presentation
+/docs/design/ @yeeun-uwu
+/apps/app/src/app/ @yeeun-uwu
+/apps/app/src/components/ @yeeun-uwu
+/apps/app/src/stories/ @yeeun-uwu
+/apps/app/src/theme/ @yeeun-uwu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
 * @robin-maki
 
 # Design decisions and app presentation
-/docs/design/ @yeeun-uwu
-/apps/app/src/app/ @yeeun-uwu
-/apps/app/src/components/ @yeeun-uwu
-/apps/app/src/stories/ @yeeun-uwu
-/apps/app/src/theme/ @yeeun-uwu
+/docs/design/ @robin-maki @yeeun-uwu
+/apps/app/.storybook/ @robin-maki @yeeun-uwu
+/apps/app/src/app/ @robin-maki @yeeun-uwu
+/apps/app/src/components/ @robin-maki @yeeun-uwu
+/apps/app/src/stories/ @robin-maki @yeeun-uwu
+/apps/app/src/theme/ @robin-maki @yeeun-uwu


### PR DESCRIPTION
## 무엇을 변경했는지

- 기존 전체 기본 CODEOWNER인 `@robin-maki`를 유지했습니다.
- 디자인 결정 문서와 앱의 화면, 컴포넌트, Storybook, 테마 영역에 `@yeeun-uwu`를 CODEOWNER로 지정했습니다.

## 왜 변경했는지

디자인 관련 변경에서 담당자인 `@yeeun-uwu`의 리뷰가 자동으로 요청되도록 해 리뷰 책임을 명확히 하기 위함입니다.

## 이번 PR의 주요 결정

### 디자인 관련 경로에만 소유권 지정

- 결정자: @robin-maki
- 선택: `docs/design`과 앱의 presentation 경로에만 `@yeeun-uwu` 소유권을 지정
- 고려한 대안: `apps/app` 전체를 디자인 소유 범위로 지정
- 이유: 인증, Relay 세션, 빌드·배포 설정 등 디자인 외 영역까지 소유 범위를 넓히지 않기 위해 경로를 한정
- 감수한 결과: 디자인 변경이 다른 경로에서 이루어지면 이후 CODEOWNERS 범위를 추가로 조정해야 함
- 관련 근거: 이 PR은 요청에 따라 별도 Linear 이슈 없이 진행

## 어떻게 확인할 수 있는지

- `git diff --check`
- 커밋 훅의 ESLint 및 Prettier 검사
- `@yeeun-uwu`의 저장소 `write` 권한 확인

## 아직 어떤 문제가 남았는지

없음.