### PR TITLE
Storybook에서도 프로덕션 폰트를 그대로 표시한다

### DIFF
--- a/apps/app/.storybook/fonts.css
+++ b/apps/app/.storybook/fonts.css
@@ -1,0 +1,15 @@
+@font-face {
+  font-family: 'SUIT';
+  font-weight: 100 900;
+  src: url('../node_modules/@sun-typeface/suit/fonts/variable/woff2/SUIT-Variable.woff2')
+    format('woff2-variations');
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  font-weight: 45 920;
+  font-style: normal;
+  font-display: swap;
+  src: url('../node_modules/pretendard/dist/web/variable/woff2/PretendardVariable.woff2')
+    format('woff2-variations');
+}

--- a/apps/app/.storybook/preview.tsx
+++ b/apps/app/.storybook/preview.tsx
@@ -1,5 +1,4 @@
-import '@sun-typeface/suit/fonts/variable/woff2/SUIT-Variable.css';
-import 'pretendard/dist/web/variable/pretendardvariable.css';
+import './fonts.css';
 import './preview.css';
 
 import { Suspense } from 'react';

--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -31,4 +31,6 @@
   - UI, 버튼, 내비게이션, 라벨, heading: `fontFamily: 'SUIT'`
   - 포스트 본문, 긴 글 입력: `fontFamily: 'Pretendard'`
 - font size/line height는 `apps/app/src/theme/tokens.ts`의 `typography` token을 사용한다. 화면에서 같은 Foundation 값을 raw number로 반복하지 않는다.
-- React Native Web Storybook은 app과 같은 font loader/decorator를 사용해 production family name과 asset을 그대로 검증한다.
+- React Native Web Storybook은 전용 `@font-face` 설정으로 같은 npm package의 Variable WOFF2 asset을
+  `SUIT`와 `Pretendard` family로 등록한다. Expo runtime의 `useFonts` loader는 사용하지 않지만,
+  component의 production family name과 asset은 동일하게 유지한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- Storybook 전용 `@font-face` 설정에서 npm package의 SUIT·Pretendard Variable WOFF2를 각각 `SUIT`, `Pretendard` family로 등록했습니다.
- Storybook preview가 package 기본 CSS 대신 이 설정을 불러오게 했습니다.
- `docs/design/typography.md`의 Storybook 설명을 실제 loader 경계와 family·asset 계약에 맞게 정리했습니다.

## 왜 변경했는지

기존 package CSS는 font face를 `SUIT Variable`, `Pretendard Variable`로 등록하지만, 앱 컴포넌트는 production family인 `SUIT`, `Pretendard`를 요청하고 있었습니다. 이 불일치 때문에 Storybook에서는 Variable WOFF2를 번들하고도 시스템 fallback 폰트를 사용했습니다.

## 이번 PR의 주요 결정

없음. 새 durable decision을 추가하지 않고, 기존 `docs/design/typography.md`의 “Storybook도 production family name과 같은 Variable asset을 사용한다”는 계약을 구현에 맞게 바로잡았습니다.

Expo runtime의 `useFonts` loader, 앱 컴포넌트의 `fontFamily`, package dependency는 변경하지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app test`
  - Relay/TypeScript check
  - unit 49/49
  - Storybook static build
  - Storybook 141/141
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `git diff --check`
- 실제 Storybook 브라우저
  - `SUIT`, `Pretendard` `@font-face` 규칙 확인
  - `document.fonts.check(...)` 두 family 모두 `true`
  - Post story 계산 스타일: 작성자 `SUIT` 700, 본문 `Pretendard` 400
  - 두 Variable WOFF2 resource 로드 확인

## 아직 어떤 문제가 남았는지

Storybook Web 이외의 iOS·Android·production app runtime 수동 QA는 수행하지 않았습니다. 해당 runtime loader와 컴포넌트 규칙은 이번 PR에서 변경하지 않았습니다.
