### PR TITLE
새 Local Post의 이미지를 ActivityPub attachment로 전달한다

### DIFF
--- a/docs/domain/decisions/0017-activitypub-local-post-note.md
+++ b/docs/domain/decisions/0017-activitypub-local-post-note.md
@@ -88,7 +88,7 @@ Note 역참조 권한이 독립적으로 제한하므로, Reply를 조회한 req
 - Parent의 Tombstone 전이는 `inReplyTo`를 제거하지 않는다. 현재 physical delete 행동을 추가하지 않고 Reply
   Parent FK만 향후 실제 row 삭제에 대비해 `SET NULL`로 정의하며 Reply Post에는 cascade delete를 적용하지 않는다.
 - Mentioned Profiles, custom emoji, Quote 전용 federation 표현과 실제 Activity delivery는 독립 후속 계약으로
-  남는다. Media federation 표현은 ADR 0020이 정의한다.
+  남는다. Media federation 표현은 [ADR 0022](./0022-post-content-revision-media-nodes.md)가 정의한다.
 
 ## 문서 반영
 

--- a/docs/domain/decisions/0017-activitypub-local-post-note.md
+++ b/docs/domain/decisions/0017-activitypub-local-post-note.md
@@ -8,6 +8,12 @@ Accepted
 
 2026-07-27
 
+## 후속 결정
+
+Post Content Media node의 `Note.attachment` Image, Alt Text와 sensitive 투영은
+[ADR 0022](./0022-post-content-revision-media-nodes.md)가 정의한다. 나머지 Local Note identity, HTML content,
+summary, audience와 역참조 결정은 유지한다.
+
 ## 결정
 
 - Content가 있는 Local Post의 ActivityPub identity는 Author Profile이 연결된 Local Instance의 canonical
@@ -81,8 +87,8 @@ Note 역참조 권한이 독립적으로 제한하므로, Reply를 조회한 req
   유지된다.
 - Parent의 Tombstone 전이는 `inReplyTo`를 제거하지 않는다. 현재 physical delete 행동을 추가하지 않고 Reply
   Parent FK만 향후 실제 row 삭제에 대비해 `SET NULL`로 정의하며 Reply Post에는 cascade delete를 적용하지 않는다.
-- Mentioned Profiles, Media, custom emoji, Quote 전용 federation 표현과 실제 Activity delivery는 독립 후속
-  계약으로 남는다.
+- Mentioned Profiles, custom emoji, Quote 전용 federation 표현과 실제 Activity delivery는 독립 후속 계약으로
+  남는다. Media federation 표현은 ADR 0020이 정의한다.
 
 ## 문서 반영
 

--- a/openspec/changes/add-activitypub-local-post-note/decisions.md
+++ b/openspec/changes/add-activitypub-local-post-note/decisions.md
@@ -75,8 +75,9 @@ Linear 계약을 독립적으로 다시 확인해야 한다.
   Public/followers, Unlisted는 followers/Public, Followers Only는 followers만 audience로 사용하고 Mentioned
   Profiles는 제공하지 않는다.
 - Alternatives Considered: PROD-494에서 V1 node/mark 재정의, canonical JSON 직접 문자열화, 모든 visibility를
-  anonymous로 반환, 현재 범위에 Media/Mention/Quote 속성 포함. 기존 content 계약을 중복하거나 권한·범위를
-  위반하므로 사용하지 않는다.
+  anonymous로 반환, 당시 범위에 Media/Mention/Quote 속성 포함. 기존 content 계약을 중복하거나 권한·범위를
+  위반하므로 사용하지 않았다. Media는 후속 ADR 0022와 `attach-local-media-to-post` change가 독립 계약으로
+  확장하며 Mention/Quote는 계속 이 change 범위 밖이다.
 - Consequences: PROD-494는 ActivityPub HTML export 연결만 소유한다. PostContent schema 확장은 해당 canonical
   capability가 먼저 결정하고 Note export는 새 schema 의미를 참조해 후속 정렬한다.
 - Confirmation / Follow-up: node별 HTML, escaping, Content Warning과 visibility별 exact audience test로 확인한다.

--- a/openspec/changes/add-activitypub-local-post-note/design.md
+++ b/openspec/changes/add-activitypub-local-post-note/design.md
@@ -27,7 +27,8 @@ export는 아직 완성되지 않았다. 현재 `post.reply_parent_id` self-FK�
 - Reply `Create`/`Delete`, Repost `Announce`/`Undo`, Reaction `Like`/`EmojiReact`/`Undo` delivery
 - ActivityPub Tombstone/Delete, outbox collection, delivery queue, retry와 backfill
 - followers/following collection endpoint 또는 actor document의 followers/following 속성
-- Mentioned Profiles recipient, Media, Mention, custom emoji와 Quote 전용 federation 표현
+- Mentioned Profiles recipient, Mention, custom emoji와 Quote 전용 federation 표현
+- Media 표현은 이 change의 원래 구현 범위가 아니며 후속 ADR 0022와 `attach-local-media-to-post` change가 확장한다.
 - remote Post ingestion과 기존 GraphQL Post read 계약 변경
 - PostContent node·mark·canonicalization·validation 계약 변경
 - Parent Post physical delete service/API

--- a/openspec/changes/add-activitypub-local-post-note/specs/activitypub-local-post-note/spec.md
+++ b/openspec/changes/add-activitypub-local-post-note/specs/activitypub-local-post-note/spec.md
@@ -51,9 +51,11 @@
 
 #### Scenario: Deferred Note properties
 
-- **WHEN** Local Post가 Media, Mention, custom emoji 또는 Quote Source 관계를 가진다
+- **WHEN** Local Post가 Mention, custom emoji 또는 Quote Source 관계를 가진다
 - **THEN** 시스템은 이번 Local Note 표현에 해당 속성이나 Quote 전용 federation 속성을 추가하지 않는다
 - **AND** 지원되는 core Note identity, content, summary와 audience는 계속 제공한다
+
+Media attachment와 sensitive 표현은 후속 ADR 0022와 `attach-local-media-to-post` change가 확장한다.
 
 ### Requirement: Local Note audience and dereference authorization
 

--- a/openspec/changes/add-activitypub-local-post-note/tasks.md
+++ b/openspec/changes/add-activitypub-local-post-note/tasks.md
@@ -76,6 +76,8 @@ Local/Remote Post가 `packages/fedify`의 하나의 안정적인 ActivityPub ide
 **Guardrails**
 
 - URI resolver, Post load, authorization과 FK 작업은 PROD-502 완료 전에도 독립적으로 진행할 수 있다.
+- 이 section의 완료 상태는 PROD-494의 원래 core Note 범위만 나타낸다. 후속 Media attachment·sensitive 확장은
+  ADR 0022와 `attach-local-media-to-post` change가 소유하며 이 task를 다시 열거나 해당 change 완료를 대신하지 않는다.
 - Local Post URI origin은 Author Profile이 속한 `Instances.canonicalOrigin`에서 읽고 resolver caller가 origin이나
   Local Instance ID를 다시 전달하지 않는다.
 - Note `content` 연결과 PROD-494 최종 완료만 PROD-502 serializer 결과에 의존한다.

--- a/openspec/changes/attach-local-media-to-post/tasks.md
+++ b/openspec/changes/attach-local-media-to-post/tasks.md
@@ -131,7 +131,7 @@ Create delivery에서 동일하게 제공된다.
 **Verification**
 
 - paragraph/link와 Media 혼합 document의 safe HTML과 attachment 순서를 확인한다.
-- public WebP URL, media type, nullable Alt Text와 sensitive true/false를 확인한다.
+- 저장된 공개 URL·Media Type, nullable Alt Text와 sensitive true/false를 확인한다.
 - missing/non-Ready/누락·잘못된 저장 표현의 미제공 결과와 내부 identity 비노출을 확인한다.
 - Media 없는 Local Note와 최초 Create delivery가 회귀하지 않는지 확인한다.
 

--- a/openspec/changes/attach-local-media-to-post/tasks.md
+++ b/openspec/changes/attach-local-media-to-post/tasks.md
@@ -135,9 +135,9 @@ Create delivery에서 동일하게 제공된다.
 - missing/non-Ready/unsafe reference의 미제공 결과와 내부 identity 비노출을 확인한다.
 - Media 없는 Local Note와 최초 Create delivery가 회귀하지 않는지 확인한다.
 
-- [ ] 4.1 current PostContent Media를 검증해 ActivityPub Image에 필요한 저장된 공개 표현으로 projection한다.
-- [ ] 4.2 Media node를 제외한 HTML과 ordered attachment/sensitive를 Local Note 역참조 및 최초 delivery에 연결한다.
-- [ ] 4.3 federation projection·권한·회귀 검증과 관련 Fedify check를 통과시킨다.
+- [x] 4.1 current PostContent Media를 검증해 ActivityPub Image에 필요한 저장된 공개 표현으로 projection한다.
+- [x] 4.2 Media node를 제외한 HTML과 ordered attachment/sensitive를 Local Note 역참조 및 최초 delivery에 연결한다.
+- [x] 4.3 federation projection·권한·회귀 검증과 관련 Fedify check를 통과시킨다.
 
 ## 5. PROD-461 통합 검증과 archive
 

--- a/openspec/changes/attach-local-media-to-post/tasks.md
+++ b/openspec/changes/attach-local-media-to-post/tasks.md
@@ -132,7 +132,7 @@ Create delivery에서 동일하게 제공된다.
 
 - paragraph/link와 Media 혼합 document의 safe HTML과 attachment 순서를 확인한다.
 - public WebP URL, media type, nullable Alt Text와 sensitive true/false를 확인한다.
-- missing/non-Ready/unsafe reference의 미제공 결과와 내부 identity 비노출을 확인한다.
+- missing/non-Ready/누락·잘못된 저장 표현의 미제공 결과와 내부 identity 비노출을 확인한다.
 - Media 없는 Local Note와 최초 Create delivery가 회귀하지 않는지 확인한다.
 
 - [x] 4.1 current PostContent Media를 검증해 ActivityPub Image에 필요한 저장된 공개 표현으로 projection한다.

--- a/packages/fedify/src/local-post-delivery.test.ts
+++ b/packages/fedify/src/local-post-delivery.test.ts
@@ -2,11 +2,14 @@ import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
 import { after, afterEach, before, beforeEach, describe, mock, test } from 'node:test';
-import { Create, Delete, Note } from '@fedify/vocab';
+import { Create, Delete, Image, Note } from '@fedify/vocab';
 import {
+  AccountState,
   ActivityPubActorType,
   InstanceKind,
   InstanceState,
+  MediaSource,
+  MediaState,
   PostState,
   PostVisibility,
   ProfileFollowPolicy,
@@ -25,11 +28,13 @@ const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhos
 
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
+let Accounts: typeof CoreDb.Accounts;
 let db: typeof CoreDb.db;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
 let localInstanceId: string;
 let localOutboundFederation: typeof LocalOutboundFederation;
+let Media: typeof CoreDb.Media;
 let pg: typeof CoreDb.pg;
 let PostContents: typeof CoreDb.PostContents;
 let Posts: typeof CoreDb.Posts;
@@ -37,19 +42,24 @@ let ProfileFollows: typeof CoreDb.ProfileFollows;
 let Profiles: typeof CoreDb.Profiles;
 let sendLocalPostCreate: typeof LocalPostDelivery.sendLocalPostCreate;
 let sendLocalPostDelete: typeof LocalPostDelivery.sendLocalPostDelete;
+let testAccountIds: string[] = [];
 let testInstanceIds: string[] = [];
 let testProfileIds: string[] = [];
 
 describe('ActivityPub Local Post delivery', () => {
   before(async () => {
     process.env.DATABASE_URL = databaseUrl;
+    process.env.MEDIA_STORAGE_SERVICE_API_KEY = 'media-secret';
+    process.env.MEDIA_STORAGE_SERVICE_ORIGIN = 'https://media-api.example';
     process.env.PUBLIC_ORIGIN = publicOrigin;
     ({
+      Accounts,
       ActivityPubActors,
       ActivityPubPosts,
       db,
       firstOrThrow,
       Instances,
+      Media,
       pg,
       PostContents,
       Posts,
@@ -129,6 +139,71 @@ describe('ActivityPub Local Post delivery', () => {
       );
       assert.equal(call.recipients[0]?.endpoints?.sharedInbox?.href, parentAuthor.sharedInboxUri);
     }
+  });
+
+  test('최초 Create(Note)가 조회 시점의 ordered Media 표현과 sensitive를 그대로 전달한다', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const parentAuthor = await createRemoteActor({ handle: 'media-parent' });
+    const parent = await createPost(parentAuthor.profile.id);
+    await db.insert(ActivityPubPosts).values({
+      postId: parent.id,
+      receivedAt: Temporal.Instant.from('2026-07-30T00:00:00Z'),
+      uri: 'https://remote.example/notes/media-parent',
+    });
+    const firstMedia = await createMedia(author.id, 'opaque-first');
+    const secondMedia = await createMedia(author.id, 'opaque/second');
+    const reply = await createPost(author.id, {
+      media: [
+        { altText: '', mediaId: secondMedia.id },
+        { altText: '대체 텍스트', mediaId: firstMedia.id },
+      ],
+      replyParentId: parent.id,
+      sensitiveMedia: true,
+    });
+    const mediaRepresentations = new Map([
+      [firstMedia.storageReference, { mediaType: 'image/avif', url: 'https://cdn.example/first' }],
+      [
+        secondMedia.storageReference,
+        { mediaType: 'image/webp', url: 'https://cdn.example/second' },
+      ],
+    ]);
+    mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      assert.equal(new Headers(init?.headers).get('Authorization'), 'Bearer media-secret');
+      const storageReference = decodeURIComponent(url.pathname.split('/').at(-1) ?? '');
+      const representation = mediaRepresentations.get(storageReference);
+      return representation ? Response.json(representation) : new Response(null, { status: 404 });
+    });
+    const fixture = createContextFixture();
+    mock.method(localOutboundFederation, 'createContext', () => fixture.context);
+
+    await sendLocalPostCreate(reply.id);
+
+    assert.equal(fixture.calls.length, 1);
+    assert.ok(fixture.calls[0]?.activity instanceof Create);
+    const object = await fixture.calls[0].activity.getObject();
+    assert.ok(object instanceof Note);
+    assert.equal(object.content?.toString(), '<p>body</p>');
+    assert.equal(object.sensitive, true);
+    const attachments: Image[] = [];
+    for await (const attachment of object.getAttachments()) {
+      assert.ok(attachment instanceof Image);
+      attachments.push(attachment);
+    }
+    assert.deepEqual(
+      attachments.map((attachment) => ({
+        mediaType: attachment.mediaType,
+        name: attachment.name?.toString(),
+        url: attachment.url?.toString(),
+      })),
+      [
+        { mediaType: 'image/webp', name: '', url: 'https://cdn.example/second' },
+        { mediaType: 'image/avif', name: '대체 텍스트', url: 'https://cdn.example/first' },
+      ],
+    );
+    const json = JSON.stringify(await object.toJsonLd());
+    assert.equal(json.includes(firstMedia.id), false);
+    assert.equal(json.includes(secondMedia.id), false);
   });
 
   test('Public/Unlisted만 Parent Author에게 보내고 Followers·Direct·일반 Post는 no-op이다', async () => {
@@ -512,9 +587,16 @@ const createRemoteActor = async ({
 const createPost = async (
   profileId: string,
   {
+    media = [],
     replyParentId = null,
+    sensitiveMedia = false,
     visibility = PostVisibility.PUBLIC,
-  }: { replyParentId?: string | null; visibility?: PostVisibility } = {},
+  }: {
+    media?: readonly { readonly altText: string | null; readonly mediaId: string }[];
+    replyParentId?: string | null;
+    sensitiveMedia?: boolean;
+    visibility?: PostVisibility;
+  } = {},
 ) => {
   const post = await db
     .insert(Posts)
@@ -526,7 +608,14 @@ const createPost = async (
     .values({
       document: {
         body: {
-          content: [{ content: [{ text: 'body', type: 'text' }], type: 'paragraph' }],
+          ...(sensitiveMedia ? { attrs: { sensitiveMedia: true } } : {}),
+          content: [
+            { content: [{ text: 'body', type: 'text' }], type: 'paragraph' },
+            ...media.map(({ altText, mediaId }) => ({
+              attrs: { altText, mediaId },
+              type: 'media' as const,
+            })),
+          ],
           type: 'doc',
         },
         summary: null,
@@ -540,6 +629,32 @@ const createPost = async (
     .update(Posts)
     .set({ currentContentId: content.id })
     .where(eq(Posts.id, post.id))
+    .returning()
+    .then(firstOrThrow);
+};
+
+const createMedia = async (profileId: string, storageReference: string) => {
+  const account = await db
+    .insert(Accounts)
+    .values({
+      displayName: `media-${crypto.randomUUID()}`,
+      oidcSubject: `media-${crypto.randomUUID()}`,
+      state: AccountState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  testAccountIds.push(account.id);
+  return db
+    .insert(Media)
+    .values({
+      accountId: account.id,
+      profileId,
+      readyAt: Temporal.Now.instant(),
+      source: MediaSource.LOCAL,
+      state: MediaState.READY,
+      storageReference,
+      uploadExpiresAt: Temporal.Now.instant().add({ minutes: 5 }),
+    })
     .returning()
     .then(firstOrThrow);
 };
@@ -558,10 +673,15 @@ const cleanTestRows = async () => {
     await db.delete(PostContents).where(inArray(PostContents.postId, postIds));
     await db.delete(Posts).where(inArray(Posts.id, postIds));
   }
+  await db.delete(Media).where(inArray(Media.profileId, testProfileIds));
   await db.delete(Profiles).where(inArray(Profiles.id, testProfileIds));
+  if (testAccountIds.length > 0) {
+    await db.delete(Accounts).where(inArray(Accounts.id, testAccountIds));
+  }
   if (testInstanceIds.length > 0) {
     await db.delete(Instances).where(inArray(Instances.id, testInstanceIds));
   }
   testInstanceIds = [];
+  testAccountIds = [];
   testProfileIds = [];
 };

--- a/packages/fedify/src/local-post-delivery.test.ts
+++ b/packages/fedify/src/local-post-delivery.test.ts
@@ -634,8 +634,8 @@ const createPost = async (
 const createMedia = async (
   profileId: string,
   storageReference: string,
-  originalUrl: string,
-  originalMediaType: string,
+  url: string,
+  mediaType: string,
 ) => {
   const account = await db
     .insert(Accounts)
@@ -651,8 +651,8 @@ const createMedia = async (
     .insert(Media)
     .values({
       accountId: account.id,
-      originalMediaType,
-      originalUrl,
+      mediaType,
+      url,
       profileId,
       readyAt: Temporal.Now.instant(),
       source: MediaSource.LOCAL,

--- a/packages/fedify/src/local-post-delivery.test.ts
+++ b/packages/fedify/src/local-post-delivery.test.ts
@@ -49,8 +49,6 @@ let testProfileIds: string[] = [];
 describe('ActivityPub Local Post delivery', () => {
   before(async () => {
     process.env.DATABASE_URL = databaseUrl;
-    process.env.MEDIA_STORAGE_SERVICE_API_KEY = 'media-secret';
-    process.env.MEDIA_STORAGE_SERVICE_ORIGIN = 'https://media-api.example';
     process.env.PUBLIC_ORIGIN = publicOrigin;
     ({
       Accounts,
@@ -150,8 +148,18 @@ describe('ActivityPub Local Post delivery', () => {
       receivedAt: Temporal.Instant.from('2026-07-30T00:00:00Z'),
       uri: 'https://remote.example/notes/media-parent',
     });
-    const firstMedia = await createMedia(author.id, 'opaque-first');
-    const secondMedia = await createMedia(author.id, 'opaque/second');
+    const firstMedia = await createMedia(
+      author.id,
+      'opaque-first',
+      'https://cdn.example/first',
+      'image/avif',
+    );
+    const secondMedia = await createMedia(
+      author.id,
+      'opaque/second',
+      'https://cdn.example/second',
+      'image/webp',
+    );
     const reply = await createPost(author.id, {
       media: [
         { altText: '', mediaId: secondMedia.id },
@@ -160,19 +168,8 @@ describe('ActivityPub Local Post delivery', () => {
       replyParentId: parent.id,
       sensitiveMedia: true,
     });
-    const mediaRepresentations = new Map([
-      [firstMedia.storageReference, { mediaType: 'image/avif', url: 'https://cdn.example/first' }],
-      [
-        secondMedia.storageReference,
-        { mediaType: 'image/webp', url: 'https://cdn.example/second' },
-      ],
-    ]);
-    mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
-      const url = new URL(input instanceof Request ? input.url : input.toString());
-      assert.equal(new Headers(init?.headers).get('Authorization'), 'Bearer media-secret');
-      const storageReference = decodeURIComponent(url.pathname.split('/').at(-1) ?? '');
-      const representation = mediaRepresentations.get(storageReference);
-      return representation ? Response.json(representation) : new Response(null, { status: 404 });
+    const networkRead = mock.method(globalThis, 'fetch', async () => {
+      throw new Error('Create delivery must use stored representation metadata');
     });
     const fixture = createContextFixture();
     mock.method(localOutboundFederation, 'createContext', () => fixture.context);
@@ -204,6 +201,7 @@ describe('ActivityPub Local Post delivery', () => {
     const json = JSON.stringify(await object.toJsonLd());
     assert.equal(json.includes(firstMedia.id), false);
     assert.equal(json.includes(secondMedia.id), false);
+    assert.equal(networkRead.mock.callCount(), 0);
   });
 
   test('Public/Unlisted만 Parent Author에게 보내고 Followers·Direct·일반 Post는 no-op이다', async () => {
@@ -633,7 +631,12 @@ const createPost = async (
     .then(firstOrThrow);
 };
 
-const createMedia = async (profileId: string, storageReference: string) => {
+const createMedia = async (
+  profileId: string,
+  storageReference: string,
+  originalUrl: string,
+  originalMediaType: string,
+) => {
   const account = await db
     .insert(Accounts)
     .values({
@@ -648,6 +651,8 @@ const createMedia = async (profileId: string, storageReference: string) => {
     .insert(Media)
     .values({
       accountId: account.id,
+      originalMediaType,
+      originalUrl,
       profileId,
       readyAt: Temporal.Now.instant(),
       source: MediaSource.LOCAL,

--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -1,7 +1,7 @@
 import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
-import { after, before, beforeEach, describe, test } from 'node:test';
+import { after, afterEach, before, beforeEach, describe, mock, test } from 'node:test';
 import {
   createFederation,
   generateCryptoKeyPair,
@@ -59,6 +59,8 @@ let testProfileIds: string[] = [];
 describe('ActivityPub Local Post Note', () => {
   before(async () => {
     process.env.DATABASE_URL = databaseUrl;
+    process.env.MEDIA_STORAGE_SERVICE_API_KEY = 'media-secret';
+    process.env.MEDIA_STORAGE_SERVICE_ORIGIN = 'https://media-api.example';
     process.env.PUBLIC_ORIGIN = publicOrigin;
     ({
       ActivityPubActors,
@@ -84,6 +86,10 @@ describe('ActivityPub Local Post Note', () => {
 
   beforeEach(async () => {
     await cleanTestRows();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
   });
 
   after(async () => {
@@ -201,11 +207,28 @@ describe('ActivityPub Local Post Note', () => {
 
   test('projects ordered Ready Local Media as Image attachments without HTML duplication', async () => {
     const author = await createProfile({ handle: 'media-author', kind: InstanceKind.LOCAL });
-    const firstMedia = await createMedia(author.id);
-    const secondMedia = await createMedia(author.id);
+    const firstMedia = await createMedia(author.id, {
+      storageReference: 'provider-opaque-reference-1',
+    });
+    const secondMedia = await createMedia(author.id, {
+      storageReference: 'provider/opaque?reference=2',
+    });
+    const requests: { authorization: string | null; path: string }[] = [];
+    mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      requests.push({
+        authorization: new Headers(init?.headers).get('Authorization'),
+        path: url.pathname,
+      });
+      const storageReference = decodeURIComponent(url.pathname.split('/').at(-1) ?? '');
+      return Response.json({
+        mediaType: storageReference === firstMedia.storageReference ? 'image/avif' : 'image/webp',
+        url: `https://cdn.example/media/${encodeURIComponent(storageReference)}`,
+      });
+    });
     const post = await createPost(author.id, {
       media: [
-        { altText: null, mediaId: secondMedia.id },
+        { altText: '', mediaId: secondMedia.id },
         { altText: '첫 번째 설명', mediaId: firstMedia.id },
       ],
       sensitiveMedia: true,
@@ -225,15 +248,29 @@ describe('ActivityPub Local Post Note', () => {
     assert.equal(attachments.length, 2);
     assert.equal(
       attachments[0]?.url?.toString(),
-      `https://media.byulma.run/original/${secondMedia.storageReference}.webp`,
+      `https://cdn.example/media/${encodeURIComponent(secondMedia.storageReference)}`,
     );
     assert.equal(attachments[0]?.mediaType, 'image/webp');
-    assert.equal(attachments[0]?.name, null);
+    assert.equal(attachments[0]?.name?.toString(), '');
     assert.equal(
       attachments[1]?.url?.toString(),
-      `https://media.byulma.run/original/${firstMedia.storageReference}.webp`,
+      `https://cdn.example/media/${encodeURIComponent(firstMedia.storageReference)}`,
     );
+    assert.equal(attachments[1]?.mediaType, 'image/avif');
     assert.equal(attachments[1]?.name?.toString(), '첫 번째 설명');
+    assert.deepEqual(
+      requests.toSorted((left, right) => left.path.localeCompare(right.path)),
+      [
+        {
+          authorization: 'Bearer media-secret',
+          path: '/v1/uploads/provider-opaque-reference-1',
+        },
+        {
+          authorization: 'Bearer media-secret',
+          path: '/v1/uploads/provider%2Fopaque%3Freference%3D2',
+        },
+      ].toSorted((left, right) => left.path.localeCompare(right.path)),
+    );
 
     const json = JSON.stringify(await note.toJsonLd());
     assert.equal(json.includes(firstMedia.id), false);
@@ -244,13 +281,21 @@ describe('ActivityPub Local Post Note', () => {
     const author = await createProfile({ handle: 'unavailable-media', kind: InstanceKind.LOCAL });
     const uploading = await createMedia(author.id, { state: MediaState.UPLOADING });
     const remote = await createMedia(author.id, { source: MediaSource.REMOTE });
-    const unsafe = await createMedia(author.id, { storageReference: 'unsafe/reference' });
+    const unavailable = await createMedia(author.id, {
+      storageReference: 'provider-opaque-reference',
+    });
     const missingId = crypto.randomUUID();
+    const mediaLookup = mock.method(
+      globalThis,
+      'fetch',
+      async () => new Response(null, { status: 404 }),
+    );
 
-    for (const mediaId of [uploading.id, remote.id, unsafe.id, missingId]) {
+    for (const mediaId of [uploading.id, remote.id, unavailable.id, missingId]) {
       const post = await createPost(author.id, { media: [{ altText: null, mediaId }] });
       assert.equal(await dispatchLocalPostNote(createContext(), { id: post.id }), null);
     }
+    assert.equal(mediaLookup.mock.callCount(), 1);
   });
 
   test('returns the same unavailable boundary for unsupported or ineligible Posts', async () => {

--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -206,12 +206,12 @@ describe('ActivityPub Local Post Note', () => {
   test('projects stored ordered Ready Local Media as Image attachments without HTML duplication or network reads', async () => {
     const author = await createProfile({ handle: 'media-author', kind: InstanceKind.LOCAL });
     const firstMedia = await createMedia(author.id, {
-      originalMediaType: 'image/avif',
-      originalUrl: 'https://cdn.example/media/first',
+      mediaType: 'image/avif',
+      url: 'https://cdn.example/media/first',
       storageReference: 'provider-opaque-reference-1',
     });
     const secondMedia = await createMedia(author.id, {
-      originalUrl: 'https://cdn.example/media/second',
+      url: 'https://cdn.example/media/second',
       storageReference: 'provider/opaque?reference=2',
     });
     const networkRead = mock.method(globalThis, 'fetch', async () => {
@@ -255,12 +255,12 @@ describe('ActivityPub Local Post Note', () => {
     const uploading = await createMedia(author.id, { state: MediaState.UPLOADING });
     const remote = await createMedia(author.id, { source: MediaSource.REMOTE });
     const unavailable = await createMedia(author.id, {
-      originalMediaType: null,
-      originalUrl: null,
+      mediaType: null,
+      url: null,
       storageReference: 'provider-opaque-reference',
     });
-    const malformed = await createMedia(author.id, { originalUrl: 'not-a-url' });
-    const nonHttp = await createMedia(author.id, { originalUrl: 'data:image/png;base64,AA==' });
+    const malformed = await createMedia(author.id, { url: 'not-a-url' });
+    const nonHttp = await createMedia(author.id, { url: 'data:image/png;base64,AA==' });
     const missingId = crypto.randomUUID();
     const networkRead = mock.method(globalThis, 'fetch', async () => {
       throw new Error('Unavailable stored metadata must not trigger a network read');
@@ -588,15 +588,13 @@ const createMedia = async (
     source = MediaSource.LOCAL,
     state = MediaState.READY,
     storageReference = `u_${crypto.randomUUID()}`,
-    originalMediaType = source === MediaSource.LOCAL && state === MediaState.READY
-      ? 'image/webp'
-      : null,
-    originalUrl = source === MediaSource.LOCAL && state === MediaState.READY
+    mediaType = source === MediaSource.LOCAL && state === MediaState.READY ? 'image/webp' : null,
+    url = source === MediaSource.LOCAL && state === MediaState.READY
       ? `https://cdn.example/media/${encodeURIComponent(storageReference)}`
       : null,
   }: {
-    originalMediaType?: string | null;
-    originalUrl?: string | null;
+    mediaType?: string | null;
+    url?: string | null;
     source?: (typeof MediaSource)[keyof typeof MediaSource];
     state?: (typeof MediaState)[keyof typeof MediaState];
     storageReference?: string;
@@ -616,8 +614,8 @@ const createMedia = async (
     .insert(Media)
     .values({
       accountId: account.id,
-      originalMediaType,
-      originalUrl,
+      mediaType,
+      url,
       profileId,
       readyAt: state === MediaState.READY ? Temporal.Now.instant() : null,
       source,

--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -424,6 +424,21 @@ describe('ActivityPub Local Post Note', () => {
 
     assert.equal(await authorizeLocalPostNote(context, { id: followersPost.id }), true);
   });
+
+  test('authorizes Followers Only access before resolving Media representations', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const media = await createMedia(author.id, { storageReference: 'opaque-media' });
+    const followersPost = await createPost(author.id, {
+      media: [{ altText: null, mediaId: media.id }],
+      visibility: PostVisibility.FOLLOWERS,
+    });
+    const mediaLookup = mock.method(globalThis, 'fetch', async () => {
+      throw new Error('Media representation must not be resolved during authorization');
+    });
+
+    assert.equal(await authorizeLocalPostNote(createContext(), { id: followersPost.id }), false);
+    assert.equal(mediaLookup.mock.callCount(), 0);
+  });
 });
 
 const createContext = (): RequestContext<void> => {

--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -8,12 +8,15 @@ import {
   MemoryKvStore,
   signRequest,
 } from '@fedify/fedify';
-import { CryptographicKey, Note, Person, PUBLIC_COLLECTION } from '@fedify/vocab';
+import { CryptographicKey, Image, Note, Person, PUBLIC_COLLECTION } from '@fedify/vocab';
 import { getDocumentLoader } from '@fedify/vocab-runtime';
 import {
+  AccountState,
   ActivityPubActorType,
   InstanceKind,
   InstanceState,
+  MediaSource,
+  MediaState,
   PostState,
   PostVisibility,
   ProfileFollowPolicy,
@@ -32,6 +35,7 @@ const remoteActorUri = new URL('https://prod-494.remote.example/users/follower')
 const remoteKeyUri = new URL('#main-key', remoteActorUri);
 
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
+let Accounts: typeof CoreDb.Accounts;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
 let authorizeLocalPostNote: typeof LocalPostNoteModule.authorizeLocalPostNote;
 let db: typeof CoreDb.db;
@@ -40,6 +44,7 @@ let firstOrThrow: typeof CoreDb.firstOrThrow;
 let isCanonicalPostId: typeof PostUriModule.isCanonicalPostId;
 let Instances: typeof CoreDb.Instances;
 let localInstanceId: string;
+let Media: typeof CoreDb.Media;
 let pg: typeof CoreDb.pg;
 let PostContents: typeof CoreDb.PostContents;
 let Posts: typeof CoreDb.Posts;
@@ -48,6 +53,7 @@ let ProfileFollows: typeof CoreDb.ProfileFollows;
 let Profiles: typeof CoreDb.Profiles;
 let resolveActivityPubPostUri: typeof PostUriModule.resolveActivityPubPostUri;
 let testInstanceIds: string[] = [];
+let testAccountIds: string[] = [];
 let testProfileIds: string[] = [];
 
 describe('ActivityPub Local Post Note', () => {
@@ -56,10 +62,12 @@ describe('ActivityPub Local Post Note', () => {
     process.env.PUBLIC_ORIGIN = publicOrigin;
     ({
       ActivityPubActors,
+      Accounts,
       ActivityPubPosts,
       db,
       firstOrThrow,
       Instances,
+      Media,
       pg,
       PostContents,
       Posts,
@@ -189,6 +197,60 @@ describe('ActivityPub Local Post Note', () => {
       tombstoneParentNote?.replyTargetId?.href,
       `${publicOrigin}/ap/note/${localParent.id}`,
     );
+  });
+
+  test('projects ordered Ready Local Media as Image attachments without HTML duplication', async () => {
+    const author = await createProfile({ handle: 'media-author', kind: InstanceKind.LOCAL });
+    const firstMedia = await createMedia(author.id);
+    const secondMedia = await createMedia(author.id);
+    const post = await createPost(author.id, {
+      media: [
+        { altText: null, mediaId: secondMedia.id },
+        { altText: '첫 번째 설명', mediaId: firstMedia.id },
+      ],
+      sensitiveMedia: true,
+    });
+
+    const note = await dispatchLocalPostNote(createContext(), { id: post.id });
+    assert.ok(note);
+    assert.equal(note.content?.toString(), '<p>body</p>');
+    assert.equal(note.content?.toString().includes('<img'), false);
+    assert.equal(note.sensitive, true);
+
+    const attachments: Image[] = [];
+    for await (const attachment of note.getAttachments()) {
+      assert.ok(attachment instanceof Image);
+      attachments.push(attachment);
+    }
+    assert.equal(attachments.length, 2);
+    assert.equal(
+      attachments[0]?.url?.toString(),
+      `https://media.byulma.run/original/${secondMedia.storageReference}.webp`,
+    );
+    assert.equal(attachments[0]?.mediaType, 'image/webp');
+    assert.equal(attachments[0]?.name, null);
+    assert.equal(
+      attachments[1]?.url?.toString(),
+      `https://media.byulma.run/original/${firstMedia.storageReference}.webp`,
+    );
+    assert.equal(attachments[1]?.name?.toString(), '첫 번째 설명');
+
+    const json = JSON.stringify(await note.toJsonLd());
+    assert.equal(json.includes(firstMedia.id), false);
+    assert.equal(json.includes(secondMedia.id), false);
+  });
+
+  test('does not project a partial Note when required Media is unavailable', async () => {
+    const author = await createProfile({ handle: 'unavailable-media', kind: InstanceKind.LOCAL });
+    const uploading = await createMedia(author.id, { state: MediaState.UPLOADING });
+    const remote = await createMedia(author.id, { source: MediaSource.REMOTE });
+    const unsafe = await createMedia(author.id, { storageReference: 'unsafe/reference' });
+    const missingId = crypto.randomUUID();
+
+    for (const mediaId of [uploading.id, remote.id, unsafe.id, missingId]) {
+      const post = await createPost(author.id, { media: [{ altText: null, mediaId }] });
+      assert.equal(await dispatchLocalPostNote(createContext(), { id: post.id }), null);
+    }
   });
 
   test('returns the same unavailable boundary for unsupported or ineligible Posts', async () => {
@@ -429,11 +491,15 @@ const createPost = async (
   profileId: string,
   {
     replyParentId = null,
+    media = [],
+    sensitiveMedia = false,
     state = PostState.ACTIVE,
     summary = null,
     visibility = PostVisibility.PUBLIC,
   }: {
     replyParentId?: string | null;
+    media?: readonly { readonly altText: string | null; readonly mediaId: string }[];
+    sensitiveMedia?: boolean;
     state?: (typeof PostState)[keyof typeof PostState];
     summary?: string | null;
     visibility?: (typeof PostVisibility)[keyof typeof PostVisibility];
@@ -449,7 +515,14 @@ const createPost = async (
     .values({
       document: {
         body: {
-          content: [{ content: [{ text: 'body', type: 'text' }], type: 'paragraph' }],
+          ...(sensitiveMedia ? { attrs: { sensitiveMedia: true } } : {}),
+          content: [
+            { content: [{ text: 'body', type: 'text' }], type: 'paragraph' },
+            ...media.map(({ altText, mediaId }) => ({
+              attrs: { altText, mediaId },
+              type: 'media' as const,
+            })),
+          ],
           type: 'doc',
         },
         summary,
@@ -463,6 +536,43 @@ const createPost = async (
     .update(Posts)
     .set({ currentContentId: content.id })
     .where(eq(Posts.id, post.id))
+    .returning()
+    .then(firstOrThrow);
+};
+
+const createMedia = async (
+  profileId: string,
+  {
+    source = MediaSource.LOCAL,
+    state = MediaState.READY,
+    storageReference = `u_${crypto.randomUUID()}`,
+  }: {
+    source?: (typeof MediaSource)[keyof typeof MediaSource];
+    state?: (typeof MediaState)[keyof typeof MediaState];
+    storageReference?: string;
+  } = {},
+) => {
+  const account = await db
+    .insert(Accounts)
+    .values({
+      displayName: `media-${crypto.randomUUID()}`,
+      oidcSubject: `media-${crypto.randomUUID()}`,
+      state: AccountState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  testAccountIds.push(account.id);
+  return db
+    .insert(Media)
+    .values({
+      accountId: account.id,
+      profileId,
+      readyAt: state === MediaState.READY ? Temporal.Now.instant() : null,
+      source,
+      state,
+      storageReference,
+      uploadExpiresAt: Temporal.Now.instant().add({ minutes: 5 }),
+    })
     .returning()
     .then(firstOrThrow);
 };
@@ -482,10 +592,15 @@ const cleanTestRows = async () => {
     await db.delete(PostContents).where(inArray(PostContents.postId, postIds));
     await db.delete(Posts).where(inArray(Posts.id, postIds));
   }
+  await db.delete(Media).where(inArray(Media.profileId, testProfileIds));
   await db.delete(Profiles).where(inArray(Profiles.id, testProfileIds));
+  if (testAccountIds.length > 0) {
+    await db.delete(Accounts).where(inArray(Accounts.id, testAccountIds));
+  }
   if (testInstanceIds.length > 0) {
     await db.delete(Instances).where(inArray(Instances.id, testInstanceIds));
   }
   testInstanceIds = [];
+  testAccountIds = [];
   testProfileIds = [];
 };

--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -59,8 +59,6 @@ let testProfileIds: string[] = [];
 describe('ActivityPub Local Post Note', () => {
   before(async () => {
     process.env.DATABASE_URL = databaseUrl;
-    process.env.MEDIA_STORAGE_SERVICE_API_KEY = 'media-secret';
-    process.env.MEDIA_STORAGE_SERVICE_ORIGIN = 'https://media-api.example';
     process.env.PUBLIC_ORIGIN = publicOrigin;
     ({
       ActivityPubActors,
@@ -205,26 +203,19 @@ describe('ActivityPub Local Post Note', () => {
     );
   });
 
-  test('projects ordered Ready Local Media as Image attachments without HTML duplication', async () => {
+  test('projects stored ordered Ready Local Media as Image attachments without HTML duplication or network reads', async () => {
     const author = await createProfile({ handle: 'media-author', kind: InstanceKind.LOCAL });
     const firstMedia = await createMedia(author.id, {
+      originalMediaType: 'image/avif',
+      originalUrl: 'https://cdn.example/media/first',
       storageReference: 'provider-opaque-reference-1',
     });
     const secondMedia = await createMedia(author.id, {
+      originalUrl: 'https://cdn.example/media/second',
       storageReference: 'provider/opaque?reference=2',
     });
-    const requests: { authorization: string | null; path: string }[] = [];
-    mock.method(globalThis, 'fetch', async (input: string | URL | Request, init?: RequestInit) => {
-      const url = new URL(input instanceof Request ? input.url : input.toString());
-      requests.push({
-        authorization: new Headers(init?.headers).get('Authorization'),
-        path: url.pathname,
-      });
-      const storageReference = decodeURIComponent(url.pathname.split('/').at(-1) ?? '');
-      return Response.json({
-        mediaType: storageReference === firstMedia.storageReference ? 'image/avif' : 'image/webp',
-        url: `https://cdn.example/media/${encodeURIComponent(storageReference)}`,
-      });
+    const networkRead = mock.method(globalThis, 'fetch', async () => {
+      throw new Error('Media projection must use stored representation metadata');
     });
     const post = await createPost(author.id, {
       media: [
@@ -246,31 +237,13 @@ describe('ActivityPub Local Post Note', () => {
       attachments.push(attachment);
     }
     assert.equal(attachments.length, 2);
-    assert.equal(
-      attachments[0]?.url?.toString(),
-      `https://cdn.example/media/${encodeURIComponent(secondMedia.storageReference)}`,
-    );
+    assert.equal(attachments[0]?.url?.toString(), 'https://cdn.example/media/second');
     assert.equal(attachments[0]?.mediaType, 'image/webp');
     assert.equal(attachments[0]?.name?.toString(), '');
-    assert.equal(
-      attachments[1]?.url?.toString(),
-      `https://cdn.example/media/${encodeURIComponent(firstMedia.storageReference)}`,
-    );
+    assert.equal(attachments[1]?.url?.toString(), 'https://cdn.example/media/first');
     assert.equal(attachments[1]?.mediaType, 'image/avif');
     assert.equal(attachments[1]?.name?.toString(), '첫 번째 설명');
-    assert.deepEqual(
-      requests.toSorted((left, right) => left.path.localeCompare(right.path)),
-      [
-        {
-          authorization: 'Bearer media-secret',
-          path: '/v1/uploads/provider-opaque-reference-1',
-        },
-        {
-          authorization: 'Bearer media-secret',
-          path: '/v1/uploads/provider%2Fopaque%3Freference%3D2',
-        },
-      ].toSorted((left, right) => left.path.localeCompare(right.path)),
-    );
+    assert.equal(networkRead.mock.callCount(), 0);
 
     const json = JSON.stringify(await note.toJsonLd());
     assert.equal(json.includes(firstMedia.id), false);
@@ -282,20 +255,29 @@ describe('ActivityPub Local Post Note', () => {
     const uploading = await createMedia(author.id, { state: MediaState.UPLOADING });
     const remote = await createMedia(author.id, { source: MediaSource.REMOTE });
     const unavailable = await createMedia(author.id, {
+      originalMediaType: null,
+      originalUrl: null,
       storageReference: 'provider-opaque-reference',
     });
+    const malformed = await createMedia(author.id, { originalUrl: 'not-a-url' });
+    const nonHttp = await createMedia(author.id, { originalUrl: 'data:image/png;base64,AA==' });
     const missingId = crypto.randomUUID();
-    const mediaLookup = mock.method(
-      globalThis,
-      'fetch',
-      async () => new Response(null, { status: 404 }),
-    );
+    const networkRead = mock.method(globalThis, 'fetch', async () => {
+      throw new Error('Unavailable stored metadata must not trigger a network read');
+    });
 
-    for (const mediaId of [uploading.id, remote.id, unavailable.id, missingId]) {
+    for (const mediaId of [
+      uploading.id,
+      remote.id,
+      unavailable.id,
+      malformed.id,
+      nonHttp.id,
+      missingId,
+    ]) {
       const post = await createPost(author.id, { media: [{ altText: null, mediaId }] });
       assert.equal(await dispatchLocalPostNote(createContext(), { id: post.id }), null);
     }
-    assert.equal(mediaLookup.mock.callCount(), 1);
+    assert.equal(networkRead.mock.callCount(), 0);
   });
 
   test('returns the same unavailable boundary for unsupported or ineligible Posts', async () => {
@@ -606,7 +588,15 @@ const createMedia = async (
     source = MediaSource.LOCAL,
     state = MediaState.READY,
     storageReference = `u_${crypto.randomUUID()}`,
+    originalMediaType = source === MediaSource.LOCAL && state === MediaState.READY
+      ? 'image/webp'
+      : null,
+    originalUrl = source === MediaSource.LOCAL && state === MediaState.READY
+      ? `https://cdn.example/media/${encodeURIComponent(storageReference)}`
+      : null,
   }: {
+    originalMediaType?: string | null;
+    originalUrl?: string | null;
     source?: (typeof MediaSource)[keyof typeof MediaSource];
     state?: (typeof MediaState)[keyof typeof MediaState];
     storageReference?: string;
@@ -626,6 +616,8 @@ const createMedia = async (
     .insert(Media)
     .values({
       accountId: account.id,
+      originalMediaType,
+      originalUrl,
       profileId,
       readyAt: state === MediaState.READY ? Temporal.Now.instant() : null,
       source,

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -132,8 +132,8 @@ const projectLocalMediaAttachments = async (
   const rows = await db
     .select({
       id: Media.id,
-      originalMediaType: Media.originalMediaType,
-      originalUrl: Media.originalUrl,
+      mediaType: Media.mediaType,
+      url: Media.url,
     })
     .from(Media)
     .where(
@@ -151,12 +151,12 @@ const projectLocalMediaAttachments = async (
   const attachments: Image[] = [];
   for (const node of mediaNodes) {
     const media = mediaById.get(node.attrs.mediaId);
-    if (!media?.originalUrl || !media.originalMediaType) {
+    if (!media?.url || !media.mediaType) {
       return null;
     }
     let url: URL;
     try {
-      url = new URL(media.originalUrl);
+      url = new URL(media.url);
     } catch {
       return null;
     }
@@ -165,7 +165,7 @@ const projectLocalMediaAttachments = async (
     }
     attachments.push(
       new Image({
-        mediaType: media.originalMediaType,
+        mediaType: media.mediaType,
         ...(node.attrs.altText !== null ? { name: node.attrs.altText } : {}),
         url,
       }),

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -58,10 +58,7 @@ const mediaRepresentationSchema = z.object({
 
 const MEDIA_STORAGE_REQUEST_TIMEOUT_MS = 10_000;
 
-const loadLocalPostNote = async (
-  context: LocalPostNoteContext,
-  postId: string,
-): Promise<LocalPostNote | null> => {
+const loadLocalPostNoteRow = async (context: LocalPostNoteContext, postId: string) => {
   if (!isCanonicalPostId(postId)) {
     return null;
   }
@@ -91,6 +88,18 @@ const loadLocalPostNote = async (
     .then(first);
 
   if (!row?.instanceCanonicalOrigin || row.post.visibility === PostVisibility.DIRECT) {
+    return null;
+  }
+
+  return { ...row, instanceCanonicalOrigin: row.instanceCanonicalOrigin };
+};
+
+const loadLocalPostNote = async (
+  context: LocalPostNoteContext,
+  postId: string,
+): Promise<LocalPostNote | null> => {
+  const row = await loadLocalPostNoteRow(context, postId);
+  if (!row) {
     return null;
   }
 
@@ -227,11 +236,11 @@ export const authorizeLocalPostNote = async (
   context: RequestContext<void>,
   { id }: { id: string },
 ): Promise<boolean> => {
-  const note = await loadLocalPostNote(context, id);
-  if (!note) {
+  const row = await loadLocalPostNoteRow(context, id);
+  if (!row) {
     return false;
   }
-  if (note.visibility !== PostVisibility.FOLLOWERS) {
+  if (row.post.visibility !== PostVisibility.FOLLOWERS) {
     return true;
   }
 
@@ -241,8 +250,8 @@ export const authorizeLocalPostNote = async (
   }
 
   return (
-    signedActor.id.href === context.getActorUri(note.authorProfileId).href ||
-    (await isEstablishedFollower(signedActor.id, note.authorProfileId))
+    signedActor.id.href === context.getActorUri(row.profile.id).href ||
+    (await isEstablishedFollower(signedActor.id, row.profile.id))
   );
 };
 

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -26,7 +26,6 @@ import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { postContentDocumentToHtml } from '@kosmo/core/post-content/server';
 import { and, eq, inArray, ne } from 'drizzle-orm';
 import { escapeText } from 'entities/escape';
-import { z } from 'zod';
 import { isCanonicalPostId, resolveActivityPubPostUri } from './activitypub-post-uri';
 import type { Context, RequestContext } from '@fedify/fedify';
 import type { PostContentDocumentV1 } from '@kosmo/core/post-content';
@@ -50,13 +49,6 @@ type LocalPostNoteProjection = LocalPostNote & {
 };
 
 type LocalPostNoteContext = Pick<Context<void>, 'canonicalOrigin' | 'getActorUri'>;
-
-const mediaRepresentationSchema = z.object({
-  mediaType: z.string().trim().min(1),
-  url: z.httpUrl(),
-});
-
-const MEDIA_STORAGE_REQUEST_TIMEOUT_MS = 10_000;
 
 const loadLocalPostNoteRow = async (context: LocalPostNoteContext, postId: string) => {
   if (!isCanonicalPostId(postId)) {
@@ -124,37 +116,6 @@ const loadLocalPostNote = async (
   };
 };
 
-const resolvePublicMediaRepresentation = async (
-  storageReference: string,
-): Promise<{ readonly mediaType: string; readonly url: URL } | null> => {
-  const mediaStorageOrigin = process.env.MEDIA_STORAGE_SERVICE_ORIGIN;
-  const mediaStorageApiKey = process.env.MEDIA_STORAGE_SERVICE_API_KEY;
-  if (!mediaStorageOrigin || !mediaStorageApiKey) {
-    return null;
-  }
-
-  const representationPath = `/v1/uploads/${encodeURIComponent(storageReference)}`;
-  try {
-    const representationUrl = new URL(representationPath, mediaStorageOrigin);
-    if (representationUrl.pathname !== representationPath) {
-      return null;
-    }
-    const response = await globalThis.fetch(representationUrl, {
-      headers: { Authorization: `Bearer ${mediaStorageApiKey}` },
-      signal: AbortSignal.timeout(MEDIA_STORAGE_REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      return null;
-    }
-    const representation = mediaRepresentationSchema.safeParse(await response.json());
-    return representation.success
-      ? { mediaType: representation.data.mediaType, url: new URL(representation.data.url) }
-      : null;
-  } catch {
-    return null;
-  }
-};
-
 const projectLocalMediaAttachments = async (
   mediaNodes: readonly Extract<
     PostContentDocumentV1['body']['content'][number],
@@ -169,7 +130,11 @@ const projectLocalMediaAttachments = async (
     return null;
   }
   const rows = await db
-    .select({ id: Media.id, storageReference: Media.storageReference })
+    .select({
+      id: Media.id,
+      originalMediaType: Media.originalMediaType,
+      originalUrl: Media.originalUrl,
+    })
     .from(Media)
     .where(
       and(
@@ -182,26 +147,27 @@ const projectLocalMediaAttachments = async (
     return null;
   }
 
-  const resolvedRows = await Promise.all(
-    rows.map(async (media) => ({
-      id: media.id,
-      representation: await resolvePublicMediaRepresentation(media.storageReference),
-    })),
-  );
-  const representationsById = new Map(
-    resolvedRows.map(({ id, representation }) => [id, representation]),
-  );
+  const mediaById = new Map(rows.map((media) => [media.id, media]));
   const attachments: Image[] = [];
   for (const node of mediaNodes) {
-    const representation = representationsById.get(node.attrs.mediaId);
-    if (!representation) {
+    const media = mediaById.get(node.attrs.mediaId);
+    if (!media?.originalUrl || !media.originalMediaType) {
+      return null;
+    }
+    let url: URL;
+    try {
+      url = new URL(media.originalUrl);
+    } catch {
+      return null;
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       return null;
     }
     attachments.push(
       new Image({
-        mediaType: representation.mediaType,
+        mediaType: media.originalMediaType,
         ...(node.attrs.altText !== null ? { name: node.attrs.altText } : {}),
-        url: representation.url,
+        url,
       }),
     );
   }

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -1,11 +1,12 @@
 import '@kosmo/core/polyfill';
 
-import { Note, PUBLIC_COLLECTION } from '@fedify/vocab';
+import { Image, Note, PUBLIC_COLLECTION } from '@fedify/vocab';
 import {
   ActivityPubActors,
   db,
   first,
   Instances,
+  Media,
   PostContents,
   Posts,
   ProfileFollows,
@@ -14,6 +15,8 @@ import {
 import {
   InstanceKind,
   InstanceState,
+  MediaSource,
+  MediaState,
   PostState,
   PostVisibility,
   ProfileState,
@@ -21,7 +24,7 @@ import {
 import { encodeGlobalId } from '@kosmo/core/global-id';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { postContentDocumentToHtml } from '@kosmo/core/post-content/server';
-import { and, eq, ne } from 'drizzle-orm';
+import { and, eq, inArray, ne } from 'drizzle-orm';
 import { escapeText } from 'entities/escape';
 import { isCanonicalPostId, resolveActivityPubPostUri } from './activitypub-post-uri';
 import type { Context, RequestContext } from '@fedify/fedify';
@@ -34,8 +37,10 @@ type LocalPostNote = {
   readonly contentDocument: PostContentDocumentV1;
   readonly createdAt: Temporal.Instant;
   readonly id: string;
+  readonly mediaAttachments: readonly Image[];
   readonly replyParentId: string | null;
   readonly summary: string | null;
+  readonly sensitiveMedia: boolean;
   readonly visibility: (typeof PostVisibility)[keyof typeof PostVisibility];
 };
 
@@ -77,19 +82,86 @@ const loadLocalPostNote = async (
     .limit(1)
     .then(first);
 
-  return row && row.instanceCanonicalOrigin && row.post.visibility !== PostVisibility.DIRECT
-    ? {
-        authorHandle: row.profile.handle,
-        authorProfileId: row.profile.id,
-        canonicalOrigin: row.instanceCanonicalOrigin,
-        contentDocument: row.contentDocument,
-        createdAt: row.post.createdAt,
-        id: row.post.id,
-        replyParentId: row.post.replyParentId,
-        summary: row.contentDocument.summary,
-        visibility: row.post.visibility,
-      }
-    : null;
+  if (!row?.instanceCanonicalOrigin || row.post.visibility === PostVisibility.DIRECT) {
+    return null;
+  }
+
+  const mediaNodes = row.contentDocument.body.content.filter((node) => node.type === 'media');
+  const mediaAttachments = await projectLocalMediaAttachments(mediaNodes);
+  if (!mediaAttachments) {
+    return null;
+  }
+
+  return {
+    authorHandle: row.profile.handle,
+    authorProfileId: row.profile.id,
+    canonicalOrigin: row.instanceCanonicalOrigin,
+    contentDocument: row.contentDocument,
+    createdAt: row.post.createdAt,
+    id: row.post.id,
+    mediaAttachments,
+    replyParentId: row.post.replyParentId,
+    sensitiveMedia: row.contentDocument.body.attrs?.sensitiveMedia ?? false,
+    summary: row.contentDocument.summary,
+    visibility: row.post.visibility,
+  };
+};
+
+const publicMediaUrl = (storageReference: string): URL | null => {
+  if (
+    !/^u_[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+      storageReference,
+    )
+  ) {
+    return null;
+  }
+  return new URL(`/original/${storageReference}.webp`, 'https://media.byulma.run');
+};
+
+const projectLocalMediaAttachments = async (
+  mediaNodes: readonly Extract<
+    PostContentDocumentV1['body']['content'][number],
+    { type: 'media' }
+  >[],
+): Promise<readonly Image[] | null> => {
+  if (mediaNodes.length === 0) {
+    return [];
+  }
+  const mediaIds = mediaNodes.map((node) => node.attrs.mediaId);
+  if (new Set(mediaIds).size !== mediaIds.length) {
+    return null;
+  }
+  const rows = await db
+    .select({ id: Media.id, storageReference: Media.storageReference })
+    .from(Media)
+    .where(
+      and(
+        inArray(Media.id, mediaIds),
+        eq(Media.source, MediaSource.LOCAL),
+        eq(Media.state, MediaState.READY),
+      ),
+    );
+  if (rows.length !== mediaIds.length) {
+    return null;
+  }
+
+  const rowsById = new Map(rows.map((media) => [media.id, media]));
+  const attachments: Image[] = [];
+  for (const node of mediaNodes) {
+    const media = rowsById.get(node.attrs.mediaId);
+    const url = media ? publicMediaUrl(media.storageReference) : null;
+    if (!url) {
+      return null;
+    }
+    attachments.push(
+      new Image({
+        mediaType: 'image/webp',
+        ...(node.attrs.altText ? { name: node.attrs.altText } : {}),
+        url,
+      }),
+    );
+  }
+  return attachments;
 };
 
 const getFollowersUri = (context: LocalPostNoteContext, profileId: string): URL => {
@@ -170,6 +242,7 @@ export const projectLocalPostNote = async (
   const configuredLocalInstance = await resolveConfiguredLocalInstance();
 
   const object = new Note({
+    attachments: [...note.mediaAttachments],
     attribution: authorUri,
     ...(cc ? { cc } : {}),
     content: postContentDocumentToHtml(note.contentDocument),
@@ -178,6 +251,7 @@ export const projectLocalPostNote = async (
     published: note.createdAt,
     ...(replyTarget ? { replyTarget } : {}),
     ...(note.summary ? { summary: escapeText(note.summary) } : {}),
+    sensitive: note.sensitiveMedia,
     to,
     url: new URL(
       `/@${encodeURIComponent(note.authorHandle)}/${encodeGlobalId('Post', note.id)}`,

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -26,6 +26,7 @@ import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { postContentDocumentToHtml } from '@kosmo/core/post-content/server';
 import { and, eq, inArray, ne } from 'drizzle-orm';
 import { escapeText } from 'entities/escape';
+import { z } from 'zod';
 import { isCanonicalPostId, resolveActivityPubPostUri } from './activitypub-post-uri';
 import type { Context, RequestContext } from '@fedify/fedify';
 import type { PostContentDocumentV1 } from '@kosmo/core/post-content';
@@ -49,6 +50,13 @@ type LocalPostNoteProjection = LocalPostNote & {
 };
 
 type LocalPostNoteContext = Pick<Context<void>, 'canonicalOrigin' | 'getActorUri'>;
+
+const mediaRepresentationSchema = z.object({
+  mediaType: z.string().trim().min(1),
+  url: z.httpUrl(),
+});
+
+const MEDIA_STORAGE_REQUEST_TIMEOUT_MS = 10_000;
 
 const loadLocalPostNote = async (
   context: LocalPostNoteContext,
@@ -107,15 +115,35 @@ const loadLocalPostNote = async (
   };
 };
 
-const publicMediaUrl = (storageReference: string): URL | null => {
-  if (
-    !/^u_[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
-      storageReference,
-    )
-  ) {
+const resolvePublicMediaRepresentation = async (
+  storageReference: string,
+): Promise<{ readonly mediaType: string; readonly url: URL } | null> => {
+  const mediaStorageOrigin = process.env.MEDIA_STORAGE_SERVICE_ORIGIN;
+  const mediaStorageApiKey = process.env.MEDIA_STORAGE_SERVICE_API_KEY;
+  if (!mediaStorageOrigin || !mediaStorageApiKey) {
     return null;
   }
-  return new URL(`/original/${storageReference}.webp`, 'https://media.byulma.run');
+
+  const representationPath = `/v1/uploads/${encodeURIComponent(storageReference)}`;
+  try {
+    const representationUrl = new URL(representationPath, mediaStorageOrigin);
+    if (representationUrl.pathname !== representationPath) {
+      return null;
+    }
+    const response = await globalThis.fetch(representationUrl, {
+      headers: { Authorization: `Bearer ${mediaStorageApiKey}` },
+      signal: AbortSignal.timeout(MEDIA_STORAGE_REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const representation = mediaRepresentationSchema.safeParse(await response.json());
+    return representation.success
+      ? { mediaType: representation.data.mediaType, url: new URL(representation.data.url) }
+      : null;
+  } catch {
+    return null;
+  }
 };
 
 const projectLocalMediaAttachments = async (
@@ -145,19 +173,26 @@ const projectLocalMediaAttachments = async (
     return null;
   }
 
-  const rowsById = new Map(rows.map((media) => [media.id, media]));
+  const resolvedRows = await Promise.all(
+    rows.map(async (media) => ({
+      id: media.id,
+      representation: await resolvePublicMediaRepresentation(media.storageReference),
+    })),
+  );
+  const representationsById = new Map(
+    resolvedRows.map(({ id, representation }) => [id, representation]),
+  );
   const attachments: Image[] = [];
   for (const node of mediaNodes) {
-    const media = rowsById.get(node.attrs.mediaId);
-    const url = media ? publicMediaUrl(media.storageReference) : null;
-    if (!url) {
+    const representation = representationsById.get(node.attrs.mediaId);
+    if (!representation) {
       return null;
     }
     attachments.push(
       new Image({
-        mediaType: 'image/webp',
-        ...(node.attrs.altText ? { name: node.attrs.altText } : {}),
-        url,
+        mediaType: representation.mediaType,
+        ...(node.attrs.altText !== null ? { name: node.attrs.altText } : {}),
+        url: representation.url,
       }),
     );
   }


### PR DESCRIPTION
## 무엇을 변경했는지

- Local Post의 ordered Ready Media를 ActivityPub Note의 Image attachment로 투영합니다.
- `media.url`, `media.media_type`에 저장된 공개 표현만 읽으며 projection과 authorization 중 Media Storage Service를 호출하지 않습니다.
- 빈 문자열을 포함한 nullable Alt Text와 sensitive 정보를 역참조 및 최초 `Create(Note)`에 동일하게 반영합니다.
- 본문 HTML에는 `<img>`를 중복 삽입하지 않고 attachment와 분리합니다.
- 기존 active Local Note OpenSpec과 shared `attach-local-media-to-post` OpenSpec을 현재 Media 계약에 맞췄습니다.

## 왜 변경했는지

PostContent document가 소유한 Media를 ActivityPub 수신 서버가 표준 attachment로 해석할 수 있어야 합니다. 공개 URL과 media type은 업로드 완료 시 확정되는 저장 결과이므로, 이를 매 Note 조회마다 Media Storage Service에서 다시 해석하면 read latency·가용성과 목록 요청 수가 외부 서비스에 결합됩니다.

## 이번 PR의 주요 결정

### 공개 표현은 완료 시 저장하고 읽기 경로는 DB만 사용한다

- 결정자: @jiyu
- 선택: 선행 #428이 저장한 URL과 Media Type을 ActivityPub Image에 사용합니다.
- 고려한 대안: Note projection마다 Media Storage Service representation API를 호출하는 방식
- 이유: 요청 증폭, timeout과 장애 전파 없이 저장된 Post를 독립적으로 표현하기 위해서입니다.
- 감수한 결과: 필요한 저장 표현이 누락되거나 HTTP(S) URL이 아니면 불완전한 Note를 제공하지 않습니다.
- 관련 근거: PROD-581, PROD-559, ADR 0013, ADR 0022

### HTML과 Media attachment를 분리한다

- 결정자: @jiyu
- 선택: HTML은 text/rich body만 표현하고 Media는 document 순서의 Note attachment로 제공합니다.
- 고려한 대안: Media node를 HTML `<img>`와 attachment에 함께 표현하는 방식
- 이유: 같은 이미지를 중복 제공하지 않고 ActivityPub의 attachment 의미를 사용하기 위해서입니다.
- 감수한 결과: 본문 내부 위치는 federation에서 attachment 순서로 축약됩니다.
- 관련 근거: PROD-559, ADR 0022, `attach-local-media-to-post` decision

## 어떻게 확인할 수 있는지

- `pnpm test:fedify` — 격리 DB에서 154 passed
- `pnpm --filter @kosmo/fedify lint:tsc`
- 변경 Fedify 파일 ESLint 및 Prettier 검사
- `pnpm exec openspec validate attach-local-media-to-post --strict`

테스트는 attachment projection과 최초 Create delivery에서 `fetch`가 0회인지 직접 검증합니다.

## 의존성과 후속

- 이 PR은 Local Media 완료 결과 저장 PR #428 위에 쌓였습니다.
- 전체 direct upload 통합 검증, canonical spec 동기화와 archive는 PROD-461/#410에서 마무리합니다.

Linear: PROD-559
