### PR TITLE
ActivityPub actor에 팔로워·팔로잉 수를 제공한다

### DIFF
--- a/docs/domain/objects/profile.md
+++ b/docs/domain/objects/profile.md
@@ -45,6 +45,8 @@ Local Profile과 Remote Profile은 Profile Origin 상태 차원으로 구분한�
 | qualified handle | 문자열, 필수       | `@handle@host` 형식이며 Host는 연결된 Instance Domain에서 파생한다 | 항상            | Profile 조회 정책 통과 | 없음      |
 | 표시 이름        | 문자열, 필수       | 1-40자                                                             | 항상            | Profile 조회 정책 통과 | 없음      |
 | bio              | 문자열, nullable   | 500자 이하                                                         | 항상            | Profile 조회 정책 통과 | 없음      |
+| 팔로워 수        | 0 이상 정수, 필수  | 저장된 best-effort Follow Relationship 수다                        | 항상            | Profile 조회 정책 통과 | 없음      |
+| 팔로잉 수        | 0 이상 정수, 필수  | 저장된 best-effort Follow Relationship 수다                        | 항상            | Profile 조회 정책 통과 | 없음      |
 | Remote URL       | URL, 필수          | 원격 원본 Profile URL                                              | Origin이 Remote | Profile 조회 정책 통과 | 없음      |
 | Profile Link     | URL 목록, nullable | 각 항목은 유효한 URL이다                                           | Origin이 Local  | Profile 조회 정책 통과 | 없음      |
 
@@ -104,6 +106,8 @@ Hashtag에는 영향을 주지 않는다.
 - Profile Tag는 해당 Profile이 위 공개 조회 조건을 통과할 때만 공개하며 독립적인 공개 범위를 가지지 않는다.
 - Hashtag 관련 Profile 목록 탐색은 [ADR 0021](../decisions/0021-hashtag-related-profile-navigation.md)에 따라
   공개 조회 가능한 Active·Normal Local Profile 중 TagChip이 전달한 Hashtag identity 정확 일치만 후보로 사용한다.
+- Local Profile의 ActivityPub actor는 followers와 following collection 참조를 공개한다. 각 collection은 저장된
+  팔로워 수 또는 팔로잉 수를 `totalItems`로 제공하지만 membership, page 또는 item은 공개하지 않는다.
 
 위 Domain Limit 및 viewer Profile Domain Block 규칙은 공개 Profile 조회·검색의 최종 canonical moderation
 정책이다. 다만 해당 정책을 exact/partial Profile lookup에 함께 적용할 저장 모델과 공통 predicate가 아직 없는
@@ -128,11 +132,14 @@ partial lookup을 함께 전환해야 한다.
 - qualified handle: Qualified Handle
 - 원격 원본 URL: Remote URL
 - 팔로우 승인 정책: Follow Approval Policy
+- 팔로워 수: Followers Count
+- 팔로잉 수: Following Count
 - 프로필 태그: Profile Tag
 
 ## 제외/보류
 
-- 팔로워/팔로잉 목록 공개 범위의 구체 값은 확정 전이므로 canonical 속성에서 제외한다.
+- 팔로워/팔로잉 membership 목록 공개 범위의 구체 값은 확정 전이며 ActivityPub collection도 membership을
+  공개하지 않는다.
 - 다른 Profile의 Media를 avatar/header로 재사용할 수 있는지는 후속 결정 대상으로 둔다.
 - active Profile 선택은 Profile 객체를 바꾸지 않는 세션 동작이므로 도메인 행동에서 제외한다.
 - theme, 계정 이동, 서버 이전은 현재 범위에서 제외한다.

--- a/docs/domain/objects/profile.md
+++ b/docs/domain/objects/profile.md
@@ -106,8 +106,6 @@ Hashtag에는 영향을 주지 않는다.
 - Profile Tag는 해당 Profile이 위 공개 조회 조건을 통과할 때만 공개하며 독립적인 공개 범위를 가지지 않는다.
 - Hashtag 관련 Profile 목록 탐색은 [ADR 0021](../decisions/0021-hashtag-related-profile-navigation.md)에 따라
   공개 조회 가능한 Active·Normal Local Profile 중 TagChip이 전달한 Hashtag identity 정확 일치만 후보로 사용한다.
-- Local Profile의 ActivityPub actor는 followers와 following collection 참조를 공개한다. 각 collection은 저장된
-  팔로워 수 또는 팔로잉 수를 `totalItems`로 제공하지만 membership, page 또는 item은 공개하지 않는다.
 
 위 Domain Limit 및 viewer Profile Domain Block 규칙은 공개 Profile 조회·검색의 최종 canonical moderation
 정책이다. 다만 해당 정책을 exact/partial Profile lookup에 함께 적용할 저장 모델과 공통 predicate가 아직 없는
@@ -138,8 +136,7 @@ partial lookup을 함께 전환해야 한다.
 
 ## 제외/보류
 
-- 팔로워/팔로잉 membership 목록 공개 범위의 구체 값은 확정 전이며 ActivityPub collection도 membership을
-  공개하지 않는다.
+- 팔로워/팔로잉 membership 목록 공개 범위의 구체 값은 확정 전이다.
 - 다른 Profile의 Media를 avatar/header로 재사용할 수 있는지는 후속 결정 대상으로 둔다.
 - active Profile 선택은 Profile 객체를 바꾸지 않는 세션 동작이므로 도메인 행동에서 제외한다.
 - theme, 계정 이동, 서버 이전은 현재 범위에서 제외한다.

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/decisions.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/decisions.md
@@ -1,7 +1,8 @@
 ## Context
 
-PROD-560과 `docs/domain/objects/profile.md`가 승인한 count-only ActivityPub social graph 공개 범위를 Local actor
-discovery 계약과 현재 Fedify 경계에 적용한다.
+`docs/domain/objects/profile.md`가 정의한 공개 가능한 저장 count 정책과 PROD-560이 정의한 ActivityPub wire 표현을
+Local actor discovery 계약과 현재 Fedify 경계에 적용한다. collection URI와 직렬화 형식은 downstream OpenSpec이
+소유하며 canonical 도메인 문서로 승격하지 않는다.
 
 ## Decision Records
 

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/decisions.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/decisions.md
@@ -1,0 +1,78 @@
+## Context
+
+PROD-560과 `docs/domain/objects/profile.md`가 승인한 count-only ActivityPub social graph 공개 범위를 Local actor
+discovery 계약과 현재 Fedify 경계에 적용한다.
+
+## Decision Records
+
+### Social graph collection은 count만 공개한다
+
+- Decision Date: 2026-07-29
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, PROD-560
+- Status: Active
+- Context / Problem: 원격 서버에 팔로워·팔로잉 수는 제공해야 하지만 membership 목록의 공개 범위는 확정되지
+  않았다.
+- Decision Outcome: actor는 followers/following collection URI를 광고하고 각 collection은 저장 count를
+  `totalItems`로 제공한다. membership item과 pagination reference는 제공하지 않는다.
+- Alternatives Considered: actor-level 비표준 count 속성은 ActivityStreams collection 상호운용 계약이 아니므로
+  선택하지 않았다. membership 전체 공개는 승인된 범위를 넘으므로 선택하지 않았다.
+- Consequences: count를 읽는 원격 서버는 표준 collection을 사용할 수 있지만 관계 membership은 알 수 없다.
+- Confirmation / Follow-up: actor와 collection JSON wire 테스트에서 URI, `totalItems`, 빈 membership과 pagination
+  부재를 검증한다.
+
+### 저장 count를 그대로 사용한다
+
+- Decision Date: 2026-07-29
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, PROD-560
+- Status: Active
+- Context / Problem: collection 요청마다 관계를 aggregate하면 GraphQL과 follow lifecycle이 유지하는 저장 count
+  projection과 별도 정확성 계약이 생긴다.
+- Decision Outcome: followers는 `Profiles.followersCount`, following은 `Profiles.followingCount`를
+  `totalItems`로 반환하며 요청 중 관계 aggregate query를 수행하지 않는다.
+- Alternatives Considered: `ProfileFollows` 실시간 aggregate와 count backfill은 이번 계약의 범위를 넓히므로
+  선택하지 않았다.
+- Consequences: 노출 count는 기존 best-effort 의미를 유지하며 visible membership 수와 항상 같다고 보장하지 않는다.
+- Confirmation / Follow-up: 서로 다른 저장 count를 설정한 integration test에서 각 collection이 대응 값을 반환하는지
+  검증한다.
+
+### HTTP count collection과 outbound fan-out을 분리한다
+
+- Decision Date: 2026-07-29
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/profile.md`, PROD-560
+- Status: Active
+- Context / Problem: HTTP collection은 membership을 비워야 하지만 outbound delivery는 실제 established followers를
+  확장해야 한다.
+- Decision Outcome: count-only collection dispatcher는 HTTP root federation에만 등록하고, outbound recipient
+  dispatcher와 `localOutboundFederation`의 membership expansion은 변경하거나 재사용하지 않는다.
+- Alternatives Considered: 하나의 dispatcher를 HTTP membership과 delivery fan-out에 공용하면 membership이
+  노출되거나 delivery recipient가 0명이 되므로 선택하지 않았다.
+- Consequences: read와 delivery가 서로 다른 projection을 명시적으로 유지하며 이번 변경은 PROD-512 delivery 동작에
+  영향을 주지 않는다.
+- Confirmation / Follow-up: 기존 outbound delivery 테스트를 유지하고 새 테스트는 HTTP federation singleton만
+  대상으로 한다.
+
+### Collection 조회는 actor key lifecycle을 실행하지 않는다
+
+- Decision Date: 2026-07-29
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/profile.md`, PROD-560
+- Status: Active
+- Context / Problem: actor document helper는 key가 없으면 생성하지만 count collection은 Profile 공개 여부와 저장
+  count만 필요하다.
+- Decision Outcome: collection callback은 key 생성 없이 Active Local Profile read projection을 조회한다.
+- Alternatives Considered: actor ensure 경계를 재사용하면 read-only collection 요청이 actor metadata와 key를 생성하므로
+  선택하지 않았다.
+- Consequences: collection GET은 DB read만 수행하고 actor key 저장 생명주기를 바꾸지 않는다.
+- Confirmation / Follow-up: collection 구현이 actor ensure helper를 호출하지 않는지 코드 경계와 테스트 fixture로
+  확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/decisions.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/decisions.md
@@ -69,6 +69,23 @@ discovery 계약과 현재 Fedify 경계에 적용한다.
 - Confirmation / Follow-up: collection 구현이 actor ensure helper를 호출하지 않는지 코드 경계와 테스트 fixture로
   확인한다.
 
+### Configured Local Instance 검사는 현재 runtime 안전 경계다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/instance.md`, PROD-560, PROD-376
+- Status: Active
+- Context / Problem: 도메인 계약은 여러 Local Instance를 허용하지만 현재 federation runtime은 `PUBLIC_ORIGIN`에
+  대응하는 configured Local Instance 하나만 해석한다.
+- Decision Outcome: 이번 collection dispatcher는 현재 runtime과 같은 configured Local Instance 및 canonical Host
+  검사를 유지한다. 이를 영구적인 단일 origin 계약으로 해석하지 않는다.
+- Alternatives Considered: 이 이슈에서 request origin별 instance resolver까지 구현하면 PROD-376의 actor, key,
+  inbox/outbox identity 전환과 분리되어 일부 route만 다중 origin을 지원하게 되므로 선택하지 않았다.
+- Consequences: 현재 지원하지 않는 origin이나 다른 Local Instance의 Profile을 교차 노출하지 않으며, 다중 instance
+  지원 전까지 collection endpoint도 configured origin 하나에서만 동작한다.
+- Confirmation / Follow-up: PROD-376은 request origin별 Local Instance resolver를 도입할 때 followers/following
+  collection dispatcher와 count 조회도 함께 전환하고 기존 configured origin의 URI를 유지한다.
+
 ## Remaining Decisions
 
 - 없음.

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/design.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/design.md
@@ -39,10 +39,9 @@ source로 사용하지 않는다.
 
 ### Recommended Approach
 
-Local actor store의 Active Local Profile read projection에 두 저장 count를 포함한다. key 생성 없이 같은 projection을
-조회하는 read helper를 두고, root federation에 followers/following dispatcher를 등록한다. 각 item dispatcher는
-Profile이 없으면 `null`, 있으면 빈 items를 반환하고, counter는 같은 공개 조건을 통과한 Profile의 해당 저장 count를
-반환한다.
+root federation에 followers/following dispatcher를 등록하고, HTTP federation entry에서 canonical Host와 Profile
+식별자를 검증한 뒤 Active Local Profile의 두 저장 count만 DB에서 직접 조회한다. 각 item dispatcher는 Profile이
+없으면 `null`, 있으면 빈 items를 반환하고, counter는 같은 공개 조건을 통과한 Profile의 해당 저장 count를 반환한다.
 
 actor `Person`은 Fedify context가 생성한 두 collection URI를 사용한다. 이를 통해 actor와 collection route가 같은
 canonical URI template을 공유한다. wire 테스트는 actor reference, collection `id`/`type`/`totalItems`, 빈

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/design.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/design.md
@@ -1,9 +1,9 @@
 ## Context
 
 Local actor는 `packages/fedify/src/federation.ts`의 Fedify actor dispatcher와
-`local-profile-person.ts`의 `Person` projection으로 제공된다. 현재 actor 조회용 Profile projection은 표시 속성만
-가지며, Fedify root federation에는 followers/following collection dispatcher가 없다. 저장 count는 이미
-`Profiles.followersCount`와 `Profiles.followingCount`에 있고 GraphQL과 follow lifecycle이 이를 유지한다.
+`local-profile-person.ts`의 `Person` projection으로 제공된다. Fedify root federation에는 followers/following
+collection dispatcher가 없다. 저장 count는 이미 `Profiles.followersCount`와 `Profiles.followingCount`에 있고
+GraphQL과 follow lifecycle이 이를 유지한다.
 
 HTTP federation singleton과 outbound delivery용 `localOutboundFederation`은 분리되어 있다. PROD-512의 outbound
 recipient dispatcher는 `ProfileFollows`를 직접 확장하므로, 이번 read-only collection을 delivery membership
@@ -36,16 +36,23 @@ source로 사용하지 않는다.
 - collection 요청에서 actor key를 생성할 필요가 없으므로 key lifecycle을 포함하는
   `ensureDrizzleLocalProfileActor()`를 재사용하면 불필요한 mutation이 생긴다.
 - root HTTP federation의 count-only dispatcher는 outbound delivery용 `localOutboundFederation`과 다른 경계다.
+- 도메인 계약은 서로 다른 domain을 가진 여러 Local Instance를 허용하지만, 현재 federation runtime은
+  `PUBLIC_ORIGIN`에 대응하는 configured Local Instance 하나만 해석한다. 이 제한은 현재 구현의 안전 경계이며
+  영구적인 단일 origin 계약이 아니다.
 
 ### Recommended Approach
 
-root federation에 followers/following dispatcher를 등록하고, HTTP federation entry에서 canonical Host와 Profile
-식별자를 검증한 뒤 Active Local Profile의 두 저장 count만 DB에서 직접 조회한다. 각 item dispatcher는 Profile이
-없으면 `null`, 있으면 빈 items를 반환하고, counter는 같은 공개 조건을 통과한 Profile의 해당 저장 count를 반환한다.
+root federation에 followers/following dispatcher를 등록하고, 현재 HTTP federation entry에서 canonical Host와
+configured Local Instance의 Profile 식별자를 검증한 뒤 Active Local Profile의 두 저장 count만 DB에서 직접
+조회한다. 각 item dispatcher는 Profile이 없으면 `null`, 있으면 빈 items를 반환하고, counter는 같은 공개 조건을
+통과한 Profile의 해당 저장 count를 반환한다.
 
 actor `Person`은 Fedify context가 생성한 두 collection URI를 사용한다. 이를 통해 actor와 collection route가 같은
 canonical URI template을 공유한다. wire 테스트는 actor reference, collection `id`/`type`/`totalItems`, 빈
 membership과 unavailable Profile의 404를 검증한다.
+
+PROD-376이 request origin별 Local Instance 해석을 구현할 때 이 collection dispatcher와 count 조회도 같은 resolver로
+전환한다. 기존 configured origin의 collection URI와 count 계약은 유지한다.
 
 ### Allowed Alternatives
 

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/design.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Local actor는 `packages/fedify/src/federation.ts`의 Fedify actor dispatcher와
+`local-profile-person.ts`의 `Person` projection으로 제공된다. 현재 actor 조회용 Profile projection은 표시 속성만
+가지며, Fedify root federation에는 followers/following collection dispatcher가 없다. 저장 count는 이미
+`Profiles.followersCount`와 `Profiles.followingCount`에 있고 GraphQL과 follow lifecycle이 이를 유지한다.
+
+HTTP federation singleton과 outbound delivery용 `localOutboundFederation`은 분리되어 있다. PROD-512의 outbound
+recipient dispatcher는 `ProfileFollows`를 직접 확장하므로, 이번 read-only collection을 delivery membership
+source로 사용하지 않는다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- actor에 canonical followers/following URI를 광고한다.
+- 각 URI에서 저장 count를 `totalItems`로 제공한다.
+- actor와 같은 Local Active Profile 조회 조건을 적용한다.
+- membership을 조회하거나 직렬화하지 않는다.
+
+**Non-Goals:**
+
+- membership 또는 pagination 공개
+- count 재계산, backfill이나 DB schema 변경
+- outbound recipient expansion 변경
+- remote collection fetch/mirror, GraphQL 또는 UI 변경
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Fedify는 followers/following dispatcher가 등록되어야 `Context.getFollowersUri()`와
+  `Context.getFollowingUri()`를 actor projection에서 사용할 수 있다.
+- Fedify collection counter와 item dispatcher는 별도 callback이므로 unavailable Profile에서 item dispatcher가
+  무조건 빈 목록을 반환하면 count가 없어도 잘못된 HTTP 200 collection이 만들어진다.
+- collection 요청에서 actor key를 생성할 필요가 없으므로 key lifecycle을 포함하는
+  `ensureDrizzleLocalProfileActor()`를 재사용하면 불필요한 mutation이 생긴다.
+- root HTTP federation의 count-only dispatcher는 outbound delivery용 `localOutboundFederation`과 다른 경계다.
+
+### Recommended Approach
+
+Local actor store의 Active Local Profile read projection에 두 저장 count를 포함한다. key 생성 없이 같은 projection을
+조회하는 read helper를 두고, root federation에 followers/following dispatcher를 등록한다. 각 item dispatcher는
+Profile이 없으면 `null`, 있으면 빈 items를 반환하고, counter는 같은 공개 조건을 통과한 Profile의 해당 저장 count를
+반환한다.
+
+actor `Person`은 Fedify context가 생성한 두 collection URI를 사용한다. 이를 통해 actor와 collection route가 같은
+canonical URI template을 공유한다. wire 테스트는 actor reference, collection `id`/`type`/`totalItems`, 빈
+membership과 unavailable Profile의 404를 검증한다.
+
+### Allowed Alternatives
+
+Fedify의 built-in collection dispatcher와 같은 URI·응답·공개 조건을 보장하고 outbound delivery membership과
+분리된다면 custom object dispatcher를 사용할 수 있다.
+
+### Known Traps
+
+- collection 응답에서 `ProfileFollows`를 조회하거나 저장 count 대신 aggregate하면 기존 count projection 계약을
+  우회한다.
+- root count-only dispatcher를 outbound followers fan-out source로 재사용하면 실제 recipient가 0명이 되므로 delivery
+  경계와 결합하면 안 된다.
+- collection 요청에서 local actor metadata/key를 생성하면 read-only count 조회가 identity mutation을 일으킨다.
+
+## Risks / Trade-offs
+
+- [저장 count가 실제 공개 가능한 관계 수와 일시적으로 다를 수 있음] → 기존 best-effort count 계약을 그대로
+  노출하고 membership 정확성을 주장하지 않는다.
+- [Fedify callback 분리로 같은 Profile을 두 번 조회할 수 있음] → 작은 read-only endpoint의 단순성을 우선하며 DB
+  aggregate나 request cache를 새로 만들지 않는다.
+- [빈 items 속성이 직렬화될 수 있음] → membership identifier가 없고 pagination reference가 없다는 wire 결과를
+  검증한다.
+
+## Migration Plan
+
+DB migration은 없다. actor와 collection wire contract를 함께 배포한다. rollback은 dispatcher 등록과 actor의 두 URI를
+함께 제거하고 이전 OpenSpec 계약으로 되돌린다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/proposal.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/proposal.md
@@ -15,8 +15,8 @@
 
 ## Authority / Provenance
 
-- Canonical: `docs/domain/objects/profile.md`
-- Linear Contract: PROD-560
+- Canonical Domain Policy: `docs/domain/objects/profile.md`의 공개 가능한 저장 count
+- Linear Wire Contract: PROD-560의 ActivityPub collection 표현
 - Linear Implementations: PROD-560
 
 ## Capabilities

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/proposal.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/proposal.md
@@ -9,7 +9,8 @@
 - Local ActivityPub actor document에 canonical `followers`와 `following` collection URI를 추가한다.
 - 두 collection은 저장된 `followersCount` 또는 `followingCount`를 `totalItems`로 반환한다.
 - collection membership, page와 item은 공개하지 않는다.
-- Local Profile 공개 조건과 Local Instance별 actor identity를 collection에도 동일하게 적용한다.
+- Local Profile 공개 조건과 현재 runtime의 configured Local Instance 안전 경계를 collection에도 동일하게 적용한다.
+- 여러 Local Instance를 허용하는 도메인 계약은 유지하며, request origin별 instance 해석은 PROD-376에서 구현한다.
 - outbound followers expansion, GraphQL follow graph와 remote collection materialization은 변경하지 않는다.
 
 ## Authority / Provenance
@@ -31,8 +32,8 @@
 
 ## Impact
 
-- `packages/fedify`: Local actor 조회 projection, `Person` 직렬화, count-only collection dispatcher와 federation
-  테스트가 변경된다.
+- `packages/fedify`: `Person` 직렬화, count-only collection dispatcher의 직접 DB 조회와 federation 테스트가
+  변경된다.
 - `openspec/specs/activitypub-actor-discovery/spec.md`: 기존 social graph collection 제외 계약이 count-only 공개
   계약으로 바뀐다.
 - DB schema, GraphQL schema, 앱 UI와 dependency는 변경하지 않는다.

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/proposal.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+현재 Local ActivityPub actor는 `followers`와 `following`을 광고하지 않아 원격 서버가 이미 저장된 팔로워 수와
+팔로잉 수를 알 수 없다. membership 목록은 비공개로 유지하면서 ActivityStreams collection의 `totalItems`로
+두 수를 제공한다.
+
+## What Changes
+
+- Local ActivityPub actor document에 canonical `followers`와 `following` collection URI를 추가한다.
+- 두 collection은 저장된 `followersCount` 또는 `followingCount`를 `totalItems`로 반환한다.
+- collection membership, page와 item은 공개하지 않는다.
+- Local Profile 공개 조건과 Local Instance별 actor identity를 collection에도 동일하게 적용한다.
+- outbound followers expansion, GraphQL follow graph와 remote collection materialization은 변경하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/profile.md`
+- Linear Contract: PROD-560
+- Linear Implementations: PROD-560
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `activitypub-actor-discovery`: Local actor가 count-only followers/following collection을 광고하고 제공하도록 공개
+  범위를 확장한다.
+
+## Impact
+
+- `packages/fedify`: Local actor 조회 projection, `Person` 직렬화, count-only collection dispatcher와 federation
+  테스트가 변경된다.
+- `openspec/specs/activitypub-actor-discovery/spec.md`: 기존 social graph collection 제외 계약이 count-only 공개
+  계약으로 바뀐다.
+- DB schema, GraphQL schema, 앱 UI와 dependency는 변경하지 않는다.

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/specs/activitypub-actor-discovery/spec.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/specs/activitypub-actor-discovery/spec.md
@@ -1,63 +1,4 @@
-## Purpose
-
-canonical 웹 origin에서 local ActivityPub actor를 발견하고 actor document와 key를 제공하며, 지원되는 inbox delivery를 activity capability handler로 연결하는 계약을 문서화한다.
-
-## Requirements
-
-### Requirement: Federation request routing
-
-웹 애플리케이션은 canonical 웹 origin에서 federation 요청을 일반 BFF 요청보다 먼저 처리하고, 처리되지 않은 요청은 기존 BFF 동작으로 이어야 한다(MUST).
-
-#### Scenario: Handle federation request before BFF routes
-
-- **WHEN** 외부 서버가 웹 origin으로 ActivityPub 또는 WebFinger 요청을 보낸다
-- **THEN** 시스템은 해당 요청을 일반 BFF route보다 먼저 federation protocol 처리 경계로 전달한다
-- **AND** federation 요청 판별, WebFinger parsing과 HTTP 응답 조립은 federation protocol library에 위임한다
-
-#### Scenario: Preserve existing web requests
-
-- **WHEN** 요청이 ActivityPub 또는 WebFinger discovery 요청이 아니다
-- **THEN** 시스템은 요청을 기존 Hono BFF 처리로 이어간다
-- **AND** `/health`, `/graphql`, `/login`, `/@{handle}`와 SPA route 동작을 유지한다
-
-#### Scenario: Do not fall through handled federation requests
-
-- **WHEN** federation protocol 경계가 ActivityPub 또는 WebFinger 요청을 처리한다
-- **THEN** 시스템은 해당 요청을 `/graphql` proxy, API 서버 또는 SPA fallback으로 전달하지 않는다
-
-### Requirement: Local actor WebFinger discovery
-
-시스템은 local active profile을 `acct:{handle}@{localDomain}` WebFinger resource로 발견할 수 있게 해야 한다(MUST).
-
-#### Scenario: Discover local active profile
-
-- **WHEN** 외부 서버가 `GET /.well-known/webfinger?resource=acct:{handle}@{localDomain}`를 요청한다
-- **THEN** 시스템은 configured local instance에 속하고 정규화 handle이 일치하는 `ACTIVE` profile을 찾는다
-- **AND** 시스템은 HTTP 200과 `application/jrd+json` content type으로 응답한다
-- **AND** WebFinger JRD의 `subject`는 canonical `acct:{handle}@{localDomain}`이다
-- **AND** `rel = self` link는 `application/activity+json` type과 `{localOrigin}/ap/actor/{profile.id}` href를 포함한다
-- **AND** profile-page link는 기존 웹 프로필 URL `{localOrigin}/@{handle}`을 가리킨다
-
-#### Scenario: Missing or malformed WebFinger resource
-
-- **WHEN** WebFinger `resource` parameter가 없거나 URL로 해석할 수 없다
-- **THEN** 시스템은 HTTP 400으로 응답한다
-
-#### Scenario: Discover local active profile by canonical actor URI
-
-- **WHEN** 외부 서버가 canonical `{localOrigin}/ap/actor/{profile.id}` URI를 WebFinger resource로 요청한다
-- **THEN** 시스템은 해당 local active profile의 WebFinger JRD를 HTTP 200으로 반환한다
-- **AND** WebFinger JRD의 `subject`는 요청한 canonical actor URI이다
-
-#### Scenario: Unknown or non-local WebFinger resource
-
-- **WHEN** WebFinger resource의 domain이 configured local instance domain과 다르거나 resource가 local actor를 식별하지 않는다
-- **THEN** 시스템은 HTTP 404로 응답한다
-
-#### Scenario: Missing local profile WebFinger
-
-- **WHEN** WebFinger resource의 handle과 일치하는 local active profile이 없다
-- **THEN** 시스템은 HTTP 404로 응답한다
+## MODIFIED Requirements
 
 ### Requirement: Local actor document
 
@@ -95,30 +36,6 @@ ActivityPub inbox delivery는 federation inbox 처리 경계로 연결하는 것
 - **AND** activity의 검증, 저장과 side effect는 해당 activity capability가 정의하며 local actor discovery는
   이를 직접 정의하지 않는다
 - **AND** 시스템은 해당 요청을 `/graphql` proxy 또는 API 서버로 전달하지 않는다
-
-### Requirement: Local actor key dispatch
-
-시스템은 local actor document에 포함할 RSA-PKCS#1-v1.5와 Ed25519 공개 key를 profile별로 제공해야 한다(MUST).
-
-#### Scenario: Lazily create missing local actor keys
-
-- **WHEN** local active profile의 actor key가 필요하지만 저장된 key pair가 없다
-- **THEN** 시스템은 해당 profile의 ActivityPub actor metadata row를 보장한다
-- **AND** 시스템은 해당 ActivityPub actor에 대한 RSA-PKCS#1-v1.5 key pair와 Ed25519 key pair를 생성해 저장한다
-- **AND** 같은 ActivityPub actor와 key kind에 대해 중복 key row를 만들지 않는다
-
-#### Scenario: Reuse existing local actor keys
-
-- **WHEN** local active profile의 actor key pair가 이미 저장되어 있다
-- **THEN** 시스템은 새 key pair를 생성하지 않고 기존 key pair에서 public key를 dispatch한다
-
-#### Scenario: Expose actor keys in actor document
-
-- **WHEN** 시스템이 local actor document를 반환한다
-- **THEN** RSA-PKCS#1-v1.5 public key는 `publicKey`로 노출된다
-- **AND** Ed25519 public key는 `assertionMethod`로 노출된다
-- **AND** 공개 key는 해당 actor가 소유하거나 제어하는 key로 표현된다
-- **AND** key 식별자와 JSON-LD 직렬화 형식은 federation protocol library가 생성한다
 
 ### Requirement: ActivityPub discovery scope boundary
 

--- a/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/tasks.md
+++ b/openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/tasks.md
@@ -1,0 +1,32 @@
+## 1. PROD-560 ActivityPub follow count 공개
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- PROD-560
+
+**Deliverable**
+
+외부 서버가 Local actor에서 followers/following collection을 발견하고 membership 공개 없이 저장된 팔로워 수와
+팔로잉 수를 읽을 수 있다.
+
+**Guardrails**
+
+- collection은 저장 count를 사용하고 관계 aggregate query를 수행하지 않는다.
+- membership item과 pagination reference를 공개하지 않는다.
+- unknown, non-local, inactive 또는 suspended Profile에는 collection을 제공하지 않는다.
+- collection 조회는 actor key lifecycle이나 outbound followers fan-out을 실행하지 않는다.
+- GraphQL, 앱 UI, DB schema와 follow lifecycle을 변경하지 않는다.
+
+**Verification**
+
+- Local actor JSON의 followers/following URI를 검증한다.
+- 두 collection의 canonical ID, type, 서로 다른 `totalItems`, 빈 membership과 pagination 부재를 검증한다.
+- unavailable Profile의 collection 응답과 actor key 비생성을 검증한다.
+- Fedify package test, typecheck, lint, Prettier와 OpenSpec strict validation을 통과시킨다.
+
+- [x] 1.1 Local actor read projection과 actor document에 followers/following count collection 참조를 추가한다.
+- [x] 1.2 두 count-only collection과 Local Profile 공개 조건을 구현하되 delivery membership과 key lifecycle을
+      변경하지 않는다.
+- [x] 1.3 actor·collection 성공 및 unavailable Profile 회귀 테스트를 추가한다.
+- [x] 1.4 관련 package 검증과 OpenSpec strict validation을 통과시킨다.

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -17,7 +17,7 @@ import { handleInboundCreate } from './inbound-create';
 import { handleInboundFollow, handleInboundUndo } from './inbound-follow';
 import { handleInboundReaction } from './inbound-reaction';
 import { handleInboundReject } from './inbound-reject';
-import { ensureDrizzleLocalProfileActor } from './local-actor-store';
+import { ensureDrizzleLocalProfileActor, findDrizzleActiveLocalProfile } from './local-actor-store';
 import { authorizeLocalPostNote, dispatchLocalPostNote } from './local-post-note';
 import { createLocalProfilePerson } from './local-profile-person';
 import { resolveLocalActorIdentifierByHandle } from './webfinger';
@@ -72,6 +72,31 @@ federation
 
     return result ? [...result.keyPairs] : [];
   });
+
+const findActiveLocalProfile = async (profileId: string) => {
+  const localInstance = await resolveConfiguredLocalInstance();
+
+  return findDrizzleActiveLocalProfile({
+    localInstanceId: localInstance.id,
+    profileId,
+  });
+};
+
+federation
+  .setFollowersDispatcher('/ap/actor/{identifier}/followers', async (_, identifier) =>
+    (await findActiveLocalProfile(identifier)) ? { items: [] } : null,
+  )
+  .setCounter(async (_, identifier) =>
+    findActiveLocalProfile(identifier).then((profile) => profile?.followersCount ?? null),
+  );
+
+federation
+  .setFollowingDispatcher('/ap/actor/{identifier}/following', async (_, identifier) =>
+    (await findActiveLocalProfile(identifier)) ? { items: [] } : null,
+  )
+  .setCounter(async (_, identifier) =>
+    findActiveLocalProfile(identifier).then((profile) => profile?.followingCount ?? null),
+  );
 
 federation
   .setObjectDispatcher(Note, '/ap/note/{id}', dispatchLocalPostNote)

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -81,6 +81,8 @@ const findActiveLocalProfile = async (
   context: Pick<Context<void>, 'canonicalOrigin' | 'host'>,
   profileId: string,
 ) => {
+  // Multiple Local Instances are valid domain state. This runtime currently serves only its
+  // configured origin; request-origin instance resolution is tracked by PROD-376.
   if (
     context.host !== new URL(context.canonicalOrigin).host ||
     !isCanonicalLocalProfileId(profileId)

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -21,7 +21,7 @@ import { ensureDrizzleLocalProfileActor, findDrizzleActiveLocalProfile } from '.
 import { authorizeLocalPostNote, dispatchLocalPostNote } from './local-post-note';
 import { createLocalProfilePerson } from './local-profile-person';
 import { resolveLocalActorIdentifierByHandle } from './webfinger';
-import type { Federation } from '@fedify/fedify';
+import type { Context, Federation } from '@fedify/fedify';
 
 const federationOrigin = process.env.PUBLIC_ORIGIN;
 
@@ -73,7 +73,14 @@ federation
     return result ? [...result.keyPairs] : [];
   });
 
-const findActiveLocalProfile = async (profileId: string) => {
+const findActiveLocalProfile = async (
+  context: Pick<Context<void>, 'canonicalOrigin' | 'host'>,
+  profileId: string,
+) => {
+  if (context.host !== new URL(context.canonicalOrigin).host) {
+    return undefined;
+  }
+
   const localInstance = await resolveConfiguredLocalInstance();
 
   return findDrizzleActiveLocalProfile({
@@ -83,19 +90,23 @@ const findActiveLocalProfile = async (profileId: string) => {
 };
 
 federation
-  .setFollowersDispatcher('/ap/actor/{identifier}/followers', async (_, identifier) =>
-    (await findActiveLocalProfile(identifier)) ? { items: [] } : null,
+  .setFollowersDispatcher(
+    '/ap/actor/{identifier}/followers',
+    async (context, identifier, cursor) =>
+      cursor == null && (await findActiveLocalProfile(context, identifier)) ? { items: [] } : null,
   )
-  .setCounter(async (_, identifier) =>
-    findActiveLocalProfile(identifier).then((profile) => profile?.followersCount ?? null),
+  .setCounter(async (context, identifier) =>
+    findActiveLocalProfile(context, identifier).then((profile) => profile?.followersCount ?? null),
   );
 
 federation
-  .setFollowingDispatcher('/ap/actor/{identifier}/following', async (_, identifier) =>
-    (await findActiveLocalProfile(identifier)) ? { items: [] } : null,
+  .setFollowingDispatcher(
+    '/ap/actor/{identifier}/following',
+    async (context, identifier, cursor) =>
+      cursor == null && (await findActiveLocalProfile(context, identifier)) ? { items: [] } : null,
   )
-  .setCounter(async (_, identifier) =>
-    findActiveLocalProfile(identifier).then((profile) => profile?.followingCount ?? null),
+  .setCounter(async (context, identifier) =>
+    findActiveLocalProfile(context, identifier).then((profile) => profile?.followingCount ?? null),
   );
 
 federation

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -10,15 +10,19 @@ import {
   Reject,
   Undo,
 } from '@fedify/vocab';
+import { db, first, Profiles } from '@kosmo/core/db';
+import { ProfileState } from '@kosmo/core/enums';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
+import { and, eq } from 'drizzle-orm';
 import { handleInboundAccept } from './inbound-accept';
 import { handleInboundAnnounce } from './inbound-announce';
 import { handleInboundCreate } from './inbound-create';
 import { handleInboundFollow, handleInboundUndo } from './inbound-follow';
 import { handleInboundReaction } from './inbound-reaction';
 import { handleInboundReject } from './inbound-reject';
-import { ensureDrizzleLocalProfileActor, findDrizzleActiveLocalProfile } from './local-actor-store';
+import { ensureDrizzleLocalProfileActor } from './local-actor-store';
 import { authorizeLocalPostNote, dispatchLocalPostNote } from './local-post-note';
+import { isCanonicalLocalProfileId } from './local-profile-actor';
 import { createLocalProfilePerson } from './local-profile-person';
 import { resolveLocalActorIdentifierByHandle } from './webfinger';
 import type { Context, Federation } from '@fedify/fedify';
@@ -77,16 +81,30 @@ const findActiveLocalProfile = async (
   context: Pick<Context<void>, 'canonicalOrigin' | 'host'>,
   profileId: string,
 ) => {
-  if (context.host !== new URL(context.canonicalOrigin).host) {
+  if (
+    context.host !== new URL(context.canonicalOrigin).host ||
+    !isCanonicalLocalProfileId(profileId)
+  ) {
     return undefined;
   }
 
   const localInstance = await resolveConfiguredLocalInstance();
 
-  return findDrizzleActiveLocalProfile({
-    localInstanceId: localInstance.id,
-    profileId,
-  });
+  return db
+    .select({
+      followersCount: Profiles.followersCount,
+      followingCount: Profiles.followingCount,
+    })
+    .from(Profiles)
+    .where(
+      and(
+        eq(Profiles.id, profileId),
+        eq(Profiles.instanceId, localInstance.id),
+        eq(Profiles.state, ProfileState.ACTIVE),
+      ),
+    )
+    .limit(1)
+    .then(first);
 };
 
 federation

--- a/packages/fedify/src/local-actor-store.ts
+++ b/packages/fedify/src/local-actor-store.ts
@@ -3,7 +3,7 @@ import '@kosmo/core/polyfill';
 import { ActivityPubActorKeys, ActivityPubActors, db, first, Profiles } from '@kosmo/core/db';
 import { ActivityPubActorType, ProfileState } from '@kosmo/core/enums';
 import { and, eq } from 'drizzle-orm';
-import { ensureLocalProfileActor, isCanonicalLocalProfileId } from './local-profile-actor';
+import { ensureLocalProfileActor } from './local-profile-actor';
 import type { Database } from '@kosmo/core/db';
 import type {
   CreateLocalActorKeyInput,
@@ -149,14 +149,6 @@ export const createDrizzleLocalActorStore = (client: LocalActorDbClient = db): L
     return insertedKey ?? requireExistingActorKey(client, input);
   },
 });
-
-export const findDrizzleActiveLocalProfile = (input: {
-  localInstanceId: string;
-  profileId: string;
-}): Promise<LocalProfileActorProfile | undefined> =>
-  isCanonicalLocalProfileId(input.profileId)
-    ? findActiveLocalProfile(db, input)
-    : Promise.resolve(undefined);
 
 export const ensureDrizzleLocalProfileActor = async (
   options: Omit<EnsureLocalProfileActorOptions, 'store'>,

--- a/packages/fedify/src/local-actor-store.ts
+++ b/packages/fedify/src/local-actor-store.ts
@@ -3,7 +3,7 @@ import '@kosmo/core/polyfill';
 import { ActivityPubActorKeys, ActivityPubActors, db, first, Profiles } from '@kosmo/core/db';
 import { ActivityPubActorType, ProfileState } from '@kosmo/core/enums';
 import { and, eq } from 'drizzle-orm';
-import { ensureLocalProfileActor } from './local-profile-actor';
+import { ensureLocalProfileActor, isCanonicalLocalProfileId } from './local-profile-actor';
 import type { Database } from '@kosmo/core/db';
 import type {
   CreateLocalActorKeyInput,
@@ -25,8 +25,30 @@ const toLocalProfileActorProfile = (
   handle: profile.handle,
   name: profile.displayName,
   bio: profile.bio,
+  followersCount: profile.followersCount,
+  followingCount: profile.followingCount,
   createdAt: profile.createdAt,
 });
+
+const findActiveLocalProfile = async (
+  client: LocalActorDbClient,
+  { localInstanceId, profileId }: { localInstanceId: string; profileId: string },
+): Promise<LocalProfileActorProfile | undefined> => {
+  const profile = await client
+    .select()
+    .from(Profiles)
+    .where(
+      and(
+        eq(Profiles.id, profileId),
+        eq(Profiles.instanceId, localInstanceId),
+        eq(Profiles.state, ProfileState.ACTIVE),
+      ),
+    )
+    .limit(1)
+    .then(first);
+
+  return profile ? toLocalProfileActorProfile(profile) : undefined;
+};
 
 const findActorByProfileId = async (
   client: LocalActorDbClient,
@@ -84,21 +106,8 @@ const requireExistingActorKey = async (
 };
 
 export const createDrizzleLocalActorStore = (client: LocalActorDbClient = db): LocalActorStore => ({
-  async findActiveLocalProfile({ localInstanceId, profileId }) {
-    const profile = await client
-      .select()
-      .from(Profiles)
-      .where(
-        and(
-          eq(Profiles.id, profileId),
-          eq(Profiles.instanceId, localInstanceId),
-          eq(Profiles.state, ProfileState.ACTIVE),
-        ),
-      )
-      .limit(1)
-      .then(first);
-
-    return profile ? toLocalProfileActorProfile(profile) : undefined;
+  findActiveLocalProfile(input) {
+    return findActiveLocalProfile(client, input);
   },
 
   findActorByProfileId(profileId) {
@@ -140,6 +149,14 @@ export const createDrizzleLocalActorStore = (client: LocalActorDbClient = db): L
     return insertedKey ?? requireExistingActorKey(client, input);
   },
 });
+
+export const findDrizzleActiveLocalProfile = (input: {
+  localInstanceId: string;
+  profileId: string;
+}): Promise<LocalProfileActorProfile | undefined> =>
+  isCanonicalLocalProfileId(input.profileId)
+    ? findActiveLocalProfile(db, input)
+    : Promise.resolve(undefined);
 
 export const ensureDrizzleLocalProfileActor = async (
   options: Omit<EnsureLocalProfileActorOptions, 'store'>,

--- a/packages/fedify/src/local-actor-store.ts
+++ b/packages/fedify/src/local-actor-store.ts
@@ -25,30 +25,8 @@ const toLocalProfileActorProfile = (
   handle: profile.handle,
   name: profile.displayName,
   bio: profile.bio,
-  followersCount: profile.followersCount,
-  followingCount: profile.followingCount,
   createdAt: profile.createdAt,
 });
-
-const findActiveLocalProfile = async (
-  client: LocalActorDbClient,
-  { localInstanceId, profileId }: { localInstanceId: string; profileId: string },
-): Promise<LocalProfileActorProfile | undefined> => {
-  const profile = await client
-    .select()
-    .from(Profiles)
-    .where(
-      and(
-        eq(Profiles.id, profileId),
-        eq(Profiles.instanceId, localInstanceId),
-        eq(Profiles.state, ProfileState.ACTIVE),
-      ),
-    )
-    .limit(1)
-    .then(first);
-
-  return profile ? toLocalProfileActorProfile(profile) : undefined;
-};
 
 const findActorByProfileId = async (
   client: LocalActorDbClient,
@@ -106,8 +84,21 @@ const requireExistingActorKey = async (
 };
 
 export const createDrizzleLocalActorStore = (client: LocalActorDbClient = db): LocalActorStore => ({
-  findActiveLocalProfile(input) {
-    return findActiveLocalProfile(client, input);
+  async findActiveLocalProfile({ localInstanceId, profileId }) {
+    const profile = await client
+      .select()
+      .from(Profiles)
+      .where(
+        and(
+          eq(Profiles.id, profileId),
+          eq(Profiles.instanceId, localInstanceId),
+          eq(Profiles.state, ProfileState.ACTIVE),
+        ),
+      )
+      .limit(1)
+      .then(first);
+
+    return profile ? toLocalProfileActorProfile(profile) : undefined;
   },
 
   findActorByProfileId(profileId) {

--- a/packages/fedify/src/local-profile-actor.ts
+++ b/packages/fedify/src/local-profile-actor.ts
@@ -10,8 +10,6 @@ export interface LocalProfileActorProfile {
   readonly handle: string;
   readonly name: string;
   readonly bio: string | null;
-  readonly followersCount: number;
-  readonly followingCount: number;
   readonly createdAt: Temporal.Instant;
 }
 

--- a/packages/fedify/src/local-profile-actor.ts
+++ b/packages/fedify/src/local-profile-actor.ts
@@ -10,6 +10,8 @@ export interface LocalProfileActorProfile {
   readonly handle: string;
   readonly name: string;
   readonly bio: string | null;
+  readonly followersCount: number;
+  readonly followingCount: number;
   readonly createdAt: Temporal.Instant;
 }
 
@@ -68,7 +70,8 @@ const keyKinds = Object.values(ActivityPubActorKeyKind);
 
 const profileIdSchema = z.uuid().refine((value) => value === value.toLowerCase());
 
-const isCanonicalUuid = (value: string): boolean => profileIdSchema.safeParse(value).success;
+export const isCanonicalLocalProfileId = (value: string): boolean =>
+  profileIdSchema.safeParse(value).success;
 
 type GenerateCryptoKeyPairAlgorithm = 'RSASSA-PKCS1-v1_5' | 'Ed25519';
 
@@ -146,7 +149,7 @@ export const ensureLocalProfileActor = async ({
   store,
 }: EnsureLocalProfileActorOptions): Promise<LocalProfileActorResult | null> => {
   // Route identifiers are public path input; reject non-canonical UUIDs before they reach uuid columns.
-  if (!isCanonicalUuid(profileId)) {
+  if (!isCanonicalLocalProfileId(profileId)) {
     return null;
   }
 

--- a/packages/fedify/src/local-profile-person.ts
+++ b/packages/fedify/src/local-profile-person.ts
@@ -43,6 +43,8 @@ export const createLocalProfilePerson = ({
     published: profile.createdAt,
     inbox: inboxUri,
     outbox: outboxUri,
+    followers: context.getFollowersUri(profile.id),
+    following: context.getFollowingUri(profile.id),
     publicKey: rsaKeyPair.cryptographicKey,
     assertionMethods: ed25519KeyPairs.map((keyPair) => keyPair.multikey),
     endpoints: new Endpoints({ sharedInbox: sharedInboxUri }),

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -281,6 +281,22 @@ describe('WebFinger local profile handle mapping', () => {
       assert.deepEqual(json.orderedItems ?? [], []);
       assert.equal(json.first, undefined);
       assert.equal(json.last, undefined);
+
+      const pageResponse = await federation.fetch(
+        new Request(`${collectionUri}?cursor=arbitrary`, {
+          headers: { accept: 'application/activity+json' },
+        }),
+        { contextData: undefined },
+      );
+      assert.equal(pageResponse.status, 404);
+
+      const alternateHostResponse = await federation.fetch(
+        new Request(collectionUri.replace(publicOrigin, 'https://alternate.example'), {
+          headers: { accept: 'application/activity+json' },
+        }),
+        { contextData: undefined },
+      );
+      assert.equal(alternateHostResponse.status, 404);
     }
 
     assert.deepEqual(await db.select().from(ActivityPubActors), []);

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -224,6 +224,8 @@ describe('WebFinger local profile handle mapping', () => {
     assert.equal(actor.inbox, `${publicOrigin}/ap/actor/${profile.id}/inbox`);
     assert.equal(actor.endpoints?.sharedInbox, `${publicOrigin}/inbox`);
     assert.equal(actor.outbox, `${publicOrigin}/ap/actor/${profile.id}/outbox`);
+    assert.equal(actor.followers, `${publicOrigin}/ap/actor/${profile.id}/followers`);
+    assert.equal(actor.following, `${publicOrigin}/ap/actor/${profile.id}/following`);
     const actorUri = `${publicOrigin}/ap/actor/${profile.id}`;
     assert.equal(typeof actor.publicKey?.id, 'string');
     assert.equal(actor.publicKey?.owner, actorUri);
@@ -232,9 +234,6 @@ describe('WebFinger local profile handle mapping', () => {
         (method) => typeof method.id === 'string' && method.controller === actorUri,
       ),
     );
-    assert.equal(actor.followers, undefined);
-    assert.equal(actor.following, undefined);
-
     const actorsAfterFirstRequest = await db.select().from(ActivityPubActors);
     const keysAfterFirstRequest = await db.select().from(ActivityPubActorKeys);
     assert.equal(actorsAfterFirstRequest.length, 1);
@@ -246,6 +245,82 @@ describe('WebFinger local profile handle mapping', () => {
     const keysAfterSecondRequest = await db.select().from(ActivityPubActorKeys);
     assert.deepEqual(actorsAfterSecondRequest, actorsAfterFirstRequest);
     assert.deepEqual(keysAfterSecondRequest, keysAfterFirstRequest);
+  });
+
+  test('serves count-only followers and following collections without creating actor keys', async () => {
+    const profile = await createProfile({
+      followersCount: 41,
+      followingCount: 43,
+      handle: 'alice',
+      instanceId: localInstanceId,
+    });
+
+    for (const [collection, totalItems] of [
+      ['followers', 41],
+      ['following', 43],
+    ] as const) {
+      const collectionUri = `${publicOrigin}/ap/actor/${profile.id}/${collection}`;
+      const response = await federation.fetch(
+        new Request(collectionUri, { headers: { accept: 'application/activity+json' } }),
+        { contextData: undefined },
+      );
+      const json = (await response.json()) as {
+        first?: string;
+        id?: string;
+        last?: string;
+        orderedItems?: unknown[];
+        totalItems?: number;
+        type?: string;
+      };
+
+      assert.equal(response.status, 200);
+      assert.match(response.headers.get('content-type') ?? '', /application\/activity\+json/);
+      assert.equal(json.id, collectionUri);
+      assert.equal(json.type, 'OrderedCollection');
+      assert.equal(json.totalItems, totalItems);
+      assert.deepEqual(json.orderedItems ?? [], []);
+      assert.equal(json.first, undefined);
+      assert.equal(json.last, undefined);
+    }
+
+    assert.deepEqual(await db.select().from(ActivityPubActors), []);
+    assert.deepEqual(await db.select().from(ActivityPubActorKeys), []);
+  });
+
+  test('does not serve follow count collections for unavailable profiles', async () => {
+    const remote = await createProfile({ handle: 'remote', instanceId: remoteInstanceId });
+    const disabled = await createProfile({
+      handle: 'disabled',
+      instanceId: localInstanceId,
+      state: ProfileState.DISABLED,
+    });
+    const suspended = await createProfile({
+      handle: 'suspended',
+      instanceId: localInstanceId,
+      state: ProfileState.SUSPENDED,
+    });
+
+    for (const profileId of [
+      '019f6f67-1111-7777-8888-123456789abc',
+      remote.id,
+      disabled.id,
+      suspended.id,
+      'not-a-profile-id',
+    ]) {
+      for (const collection of ['followers', 'following']) {
+        const response = await federation.fetch(
+          new Request(`${publicOrigin}/ap/actor/${profileId}/${collection}`, {
+            headers: { accept: 'application/activity+json' },
+          }),
+          { contextData: undefined },
+        );
+
+        assert.equal(response.status, 404);
+      }
+    }
+
+    assert.deepEqual(await db.select().from(ActivityPubActors), []);
+    assert.deepEqual(await db.select().from(ActivityPubActorKeys), []);
   });
 
   test('returns 404 for a missing local actor document', async () => {
@@ -319,11 +394,15 @@ const createRemoteInstance = async () =>
     .then((instance) => instance.id);
 
 const createProfile = async ({
+  followersCount,
+  followingCount,
   handle,
   id,
   instanceId,
   state = ProfileState.ACTIVE,
 }: {
+  followersCount?: number;
+  followingCount?: number;
   handle: string;
   id?: string;
   instanceId: string;
@@ -334,6 +413,8 @@ const createProfile = async ({
     .values({
       displayName: handle,
       followPolicy: ProfileFollowPolicy.OPEN,
+      ...(followersCount == null ? {} : { followersCount }),
+      ...(followingCount == null ? {} : { followingCount }),
       handle,
       ...(id ? { id } : {}),
       instanceId,


### PR DESCRIPTION
## 무엇을 변경했는지

- Local ActivityPub `Person`에 canonical `followers`와 `following` collection URI를 추가했습니다.
- 각 collection을 `OrderedCollection`으로 제공하고 저장된 `followersCount`/`followingCount`를 `totalItems`로 반환합니다.
- collection entry에서 count를 DB로 직접 조회하며 actor key lifecycle은 실행하지 않습니다.
- unknown, remote, disabled, suspended, malformed Profile 식별자는 collection을 제공하지 않습니다.
- 도메인 문서와 `activitypub-actor-discovery` OpenSpec을 동기화하고 구현 change를 완료 상태로 보관했습니다.

## 왜 변경했는지

현재 actor document에는 social graph collection 참조가 없어 원격 서버가 Kosmo에 이미 저장된 팔로워·팔로잉 수를 발견할 표준 경로가 없습니다. membership 공개 범위를 넓히지 않으면서 ActivityStreams collection의 `totalItems`로 두 수를 제공하기 위한 변경입니다.

- Linear: [PROD-560](https://linear.app/byulmaru/issue/PROD-560/activitypub-actor에-팔로워팔로잉-수를-제공한다)

## 이번 PR의 주요 결정

### Social graph collection은 count만 공개한다

- 선택: actor가 표준 followers/following URI를 광고하고 collection은 `totalItems`만 제공합니다.
- 고려한 대안: actor-level 비표준 count 속성, membership 전체 공개.
- 이유: 표준 collection 상호운용성을 유지하면서 아직 확정되지 않은 membership 공개 범위를 열지 않기 위해서입니다.
- 감수한 결과: 원격 서버는 count를 읽을 수 있지만 관계 membership은 알 수 없습니다.

### 저장된 best-effort count를 그대로 사용한다

- 선택: 요청마다 관계를 aggregate하지 않고 기존 Profile count projection을 반환합니다.
- 이유: GraphQL과 follow lifecycle이 유지하는 기존 count 의미를 보존하고 별도 정확성 계약을 만들지 않기 위해서입니다.
- 감수한 결과: `totalItems`는 visible membership 수와 항상 같다고 보장하지 않습니다.

### HTTP collection과 outbound fan-out을 분리한다

- 선택: count-only dispatcher는 HTTP federation에만 등록하고 PROD-512의 실제 follower recipient 확장은 유지합니다.
- 이유: 빈 membership collection을 delivery source로 사용하면 발신 대상이 사라지기 때문입니다.

### Collection GET은 actor key lifecycle을 실행하지 않는다

- 선택: HTTP federation entry에서 Active Local Profile의 count만 DB로 직접 조회합니다.
- 이유: count 조회가 actor metadata나 signing key를 생성하는 mutation이 되지 않도록 하기 위해서입니다.

### Configured Local Instance 검사는 현재 runtime 안전 경계다

- 선택: 현재는 `PUBLIC_ORIGIN`에 대응하는 configured Local Instance와 canonical Host 검사를 유지합니다.
- 고려한 대안: 이 PR에서 일부 collection route만 request origin별 instance를 해석하도록 확장하는 방식.
- 이유: 도메인 계약은 여러 Local Instance를 허용하지만 현재 federation runtime 전체가 아직 하나의 configured origin만 해석하며, 일부 route만 먼저 확장하면 actor·key·inbox identity와 불일치하기 때문입니다.
- 감수한 결과: 다중 Local Instance federation routing이 구현되기 전까지 collection도 configured origin 하나에서만 제공됩니다. 이 제한은 영구적인 단일 origin 계약이 아닙니다.
- 후속: [PROD-376](https://linear.app/byulmaru/issue/PROD-376/local-instance별-federation-origin과-actor-identity를-지원한다)에서 actor·key·inbox/outbox와 함께 followers/following dispatcher도 request origin별 Local Instance resolver로 전환합니다.

상세 결정 기록: `openspec/changes/archive/2026-07-29-expose-activitypub-follow-counts/decisions.md`

## 어떻게 확인했는지

- `pnpm test:fedify` — 145 passed
- `pnpm --filter @kosmo/fedify lint:tsc`
- 변경된 Fedify 파일 ESLint
- `pnpm lint:prettier`
- `pnpm exec openspec validate --all --strict` — 48 passed
- `git diff --check`

## 아직 남은 문제

- 다중 Local Instance의 request origin별 federation routing은 PROD-376이 소유합니다.
- followers/following membership과 pagination 공개는 이번 범위에서 제외했습니다.
- remote collection fetch/mirror, count backfill, DB schema, GraphQL, 앱 UI는 변경하지 않았습니다.
