### PR TITLE
OpenSpec 책임을 이슈 계층이 아니라 행동 계약에 맞춘다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,15 @@
 - When a pull request's own scoped implementation and required verification are complete, mark it Ready for review unless the user explicitly requests that it remain a Draft.
 - Do not archive an OpenSpec change merely because an individual pull request in a split or stacked implementation is complete or merged.
 - Archive an OpenSpec change only after the proposal's entire declared scope and all tasks across every implementation slice are complete, required validation passes, and delta specs are synchronized as appropriate.
+- Assign integration verification and archive ownership explicitly from the remaining work and completion evidence; do not infer either responsibility from parent/child issue status or PR order alone.
 
 ## OpenSpec Workflow
 
 - Before planning or updating an OpenSpec change, read `memory/issue-openspec-workflow.md` and
-  follow the Issue -> OpenSpec -> Implementation order.
+  follow the Issue -> OpenSpec -> Implementation order when an OpenSpec is needed. Do not require
+  an OpenSpec for every issue.
+- Treat Linear issue and OpenSpec change ownership as many-to-many. Split or share changes by
+  behavioral contract and lifecycle, not mechanically by issue hierarchy or PR count.
 - Define the Linear issue scope and dependency structure before creating the OpenSpec change. If
   the spec reveals an independently deliverable scope, update or split the Linear issues first.
 - When creating or updating OpenSpec specs before implementation, explain the resulting spec to the user in Korean.

--- a/memory/issue-openspec-workflow.md
+++ b/memory/issue-openspec-workflow.md
@@ -7,17 +7,19 @@ Kosmo 기능 개발은 다음 순서를 기본으로 한다.
 ```text
 Canonical 도메인·디자인 요구사항 확정
   -> Linear 이슈 구조
-  -> OpenSpec
+  -> 필요한 행동 계약에 OpenSpec
   -> 구현
-  -> 통합 검증과 archive
+  -> 담당 이슈의 검증
+  -> 해당 change가 완료되면 명시된 담당자가 archive
 ```
 
 - `docs/domain`과 `docs/design`은 이슈를 만들기 전에 제품 요구사항과 durable decision을 확정하는 canonical
   source다.
 - Linear는 작업이 필요한 이유, 전달 결과, 우선순위, 범위, 소유권과 의존성을 정의한다.
-- OpenSpec은 승인된 이슈를 요구사항, 설계, 결정과 검증 가능한 구현 작업으로 구체화한다.
-- 구현은 이슈와 OpenSpec을 실행하고, 구현에서 확인한 계약 문제를 canonical 문서부터 정식 순서로 다시
-  반영한다. OpenSpec을 backlog 작업이나 제품 요구사항이 처음 발견되는 장소로 사용하지 않는다.
+- OpenSpec은 명세가 필요한 행동 계약을 요구사항, 설계, 결정과 검증 가능한 구현 작업으로 구체화한다. 모든
+  이슈에 OpenSpec을 요구하지 않는다.
+- 구현은 이슈와 적용되는 OpenSpec을 실행하고, 구현에서 확인한 계약 문제를 canonical 문서부터 정식 순서로
+  다시 반영한다. OpenSpec을 backlog 작업이나 제품 요구사항이 처음 발견되는 장소로 사용하지 않는다.
 
 적용되는 `docs/domain`과 `docs/design` 문서는 해당 영역의 canonical source다. Linear와 OpenSpec은 이를
 재정의하지 않고 참조한다.
@@ -51,19 +53,52 @@ canonical 문서, Linear 이슈, OpenSpec과 PR 본문을 즉시 갱신하고 �
 
 ## 책임 경계
 
-| 단위             | 소유하는 것                                                                     | 소유하지 않는 것                   |
-| ---------------- | ------------------------------------------------------------------------------- | ---------------------------------- |
-| Project          | 장기 제품 영역, 우선순위, milestone                                             | 하나의 영구적인 OpenSpec change    |
-| Milestone        | 독립적으로 전달할 수 있는 제품 단계                                             | 세부 행동 계약과 구현 설계         |
-| 도메인 결정 이슈 | 회의·조사가 필요한 제품 결정, canonical 문서 반영, downstream 이슈 계약 정렬    | OpenSpec, 구현 코드와 최종 archive |
-| 계약 이슈        | 하나의 닫힌 결과, 범위, 제약, OpenSpec 생명주기, 최종 통합 검증과 archive       | 모든 구현을 한 PR에 담는 책임      |
-| 구현 이슈        | 리뷰 가능한 구현 결과 하나, 브랜치, PR, 해당 구현을 증명하는 테스트와 검증 증거 | 공유 계약을 복제한 별도 OpenSpec   |
-| OpenSpec change  | 계약 이슈를 구체화한 요구사항, 설계, durable decision, 구현 체크리스트          | Linear 우선순위와 이슈 계층        |
-| PR               | 해당 이슈가 소유한 OpenSpec, 구현, 검증 또는 archive 결과                       | Project 전체 backlog               |
+| 단위             | 소유하는 것                                                                                  | 소유하지 않는 것                       |
+| ---------------- | -------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Project          | 장기 제품 영역, 우선순위, milestone                                                          | 하나의 영구적인 OpenSpec change        |
+| Milestone        | 독립적으로 전달할 수 있는 제품 단계                                                          | 세부 행동 계약과 구현 설계             |
+| 도메인 결정 이슈 | 회의·조사가 필요한 제품 결정, canonical 문서 반영, downstream 이슈 계약 정렬                 | OpenSpec, 구현 코드와 최종 archive     |
+| 계약 이슈        | 하나의 닫힌 결과, 범위, 제약과 명시적으로 배정된 검증·OpenSpec 책임                          | 모든 구현이나 모든 archive 책임        |
+| 구현 이슈        | 리뷰 가능한 구현 결과 하나, 브랜치, PR, 해당 구현을 증명하는 테스트와 적용되는 OpenSpec 변경 | 계층만으로 추론한 OpenSpec 경계        |
+| OpenSpec change  | 함께 결정·검증·완료할 행동 계약, durable decision, 구현 체크리스트                           | Linear 우선순위와 고정된 1:1 이슈 관계 |
+| PR               | 해당 이슈가 소유한 OpenSpec, 구현, 검증 또는 archive 결과                                    | Project 전체 backlog                   |
 
-OpenSpec 작성 자체만을 전달 결과로 삼는 Linear 이슈는 만들지 않는다. 작은 변경은 하나의 계약 이슈가
-OpenSpec, 구현, 테스트, 통합 검증과 archive를 모두 소유한다. 여러 구현 PR이 필요한 변경은 계약 부모와 구현
-자식 이슈들로 나누며, 계약 부모는 추적용 컨테이너가 아니라 최종 통합 검증과 archive를 직접 수행한다.
+`계약 이슈`와 `구현 이슈`는 책임 역할을 설명하는 이름이지 항상 별도 이슈 두 개를 만들라는 유형 제약이 아니다.
+하나의 이슈가 닫힌 결과의 계약과 구현을 함께 소유할 수 있고, 여러 이슈가 계약·구현 책임을 나눌 수도 있다.
+
+OpenSpec 작성 자체만을 전달 결과로 삼는 Linear 이슈는 만들지 않는다. OpenSpec 필요 여부, change 경계와
+archive 담당자는 이슈 유형이나 부모·자식 계층에서 자동으로 정하지 않고 실제 행동 계약과 완료 증거를 기준으로
+명시한다.
+
+### Issue와 OpenSpec은 many-to-many다
+
+Linear issue는 `0..N`개의 OpenSpec change에 연결될 수 있고, OpenSpec change는 `1..N`개의 Linear issue에
+연결된다. 모든 이슈에 OpenSpec이 필요한 것은 아니지만, issue-first 원칙상 적용 이슈가 하나도 없는 orphan
+change는 만들지 않는다.
+
+- OpenSpec이 필요 없는 이슈가 있을 수 있다. 기존 계약을 그대로 적용하는 구현, 행동 변화가 없는 정리와
+  조사에 명세 파일을 의무적으로 만들지 않는다.
+- 하나의 change를 여러 이슈가 함께 구현할 수 있다. 이때 proposal과 tasks는 적용되는 이슈와 각자의 구현·검증
+  책임을 식별한다.
+- 하나의 이슈가 여러 change를 변경할 수 있다. 서로 독립적으로 승인·연기·완료·archive할 행동 계약은 파일
+  수를 줄이기 위해 하나로 합치지 않는다.
+- 하나의 PR이 여러 change를 수정할 수 있고, 여러 PR이 하나의 change를 순차적으로 수정할 수도 있다. PR은
+  자신이 담당하는 diff와 검증 결과만 소유한다.
+
+“모든 이슈에 OpenSpec을 만들지 않는다”는 원칙을 “구현 이슈는 OpenSpec을 소유할 수 없다” 또는 “여러 구현
+이슈는 반드시 부모가 소유한 change 하나를 공유한다”로 해석하지 않는다. 전자는 불필요한 spec-only 작업을
+막기 위한 규칙이고, 후자는 서로 다른 책임과 생명주기를 이슈 계층에 맞춰 강제로 합치는 별개의 규칙이다.
+
+마찬가지로 부모 이슈, 마지막 구현 이슈 또는 마지막 PR이라는 사실만으로 통합 검증이나 archive 책임을
+추론하지 않는다. 이 책임은 실제로 남은 cross-slice 검증, delta spec 동기화와 전체 완료 증거를 소유한
+이슈·PR에 배정한다. 이미 완료 증거를 소유한 구현 PR이 archive할 수 있고, 별도 통합 작업이 실제로 존재하면
+그 작업을 소유한 이슈와 PR이 archive할 수 있다. 파일 이동만 남았다는 이유로 archive-only 이슈나 PR을 만들지
+않는다.
+
+이 원칙을 추가했다는 사실만으로 기존 active change, Linear 이슈 또는 열린 PR을 자동으로 분리·병합·reparent
+하지 않는다. 현재 mapping에서 실제 책임이 불명확하거나 서로 독립된 생명주기가 결합된 경우에만 적용되는
+이슈·change·PR을 함께 재평가하고, 구조 변경은 별도의 명시적 결정으로 수행한다. `many-to-many`는 가능한
+관계를 설명하는 모델이지 파일이나 이슈 수를 늘리라는 목표가 아니다.
 
 ## Project와 Milestone 선택
 
@@ -78,8 +113,9 @@ OpenSpec, 구현, 테스트, 통합 검증과 archive를 모두 소유한다. �
 
 ## OpenSpec 경계 선택
 
-OpenSpec은 이슈, PR, 담당자, package 또는 디렉터리 수가 아니라 **함께 결정하고 검증하고 전달해야 하는
-행동 계약 묶음**을 기준으로 나눈다.
+OpenSpec은 이슈, PR, 담당자, package 또는 디렉터리 수가 아니라 **함께 결정하고 검증하고 완료해야 하는 행동
+계약 묶음**을 기준으로 나눈다. 이 원칙은 이슈와 OpenSpec을 1:1로 만들라는 뜻도, 한 부모 아래 이슈를 모두
+하나의 change로 합치라는 뜻도 아니다.
 
 다음 조건이면 하나의 OpenSpec으로 묶는다.
 
@@ -95,36 +131,38 @@ OpenSpec은 이슈, PR, 담당자, package 또는 디렉터리 수가 아니라 
 - 서로 다른 행동 계약과 결정을 소유한다.
 - 관련 없는 선행 작업을 기다리느라 하나의 change가 장기간 active로 남는다.
 
-DB, API, client, test가 서로 다른 PR이라는 이유만으로 OpenSpec을 나누지 않는다. 반대로 Project나
-Milestone 전체를 하나의 무기한 active change에 넣지 않는다.
+DB, API, client, test가 서로 다른 PR이라는 이유만으로 OpenSpec을 나누지 않는다. 그러나 서로 다른 구현
+이슈가 독립된 행동 계약, 위험, rollout 또는 완료 조건을 가진다면 같은 제품 결과에 기여한다는 이유만으로
+합치지 않는다. 반대로 Project나 Milestone 전체를 하나의 무기한 active change에 넣지 않는다.
 
 ```text
 작은 변경
-계약 이슈
-  -> OpenSpec
+이슈
+  -> 필요한 경우 OpenSpec
   -> 구현 + 해당 구현의 테스트
-  -> 통합 검증 + archive
+  -> change 전체가 완료됐고 이 PR이 완료 증거를 소유하면 archive
 
-여러 PR이 필요한 변경
-계약 부모
-  -> OpenSpec
-  -> 구현 이슈 A: 구현 + 해당 구현의 테스트
-  -> 구현 이슈 B: 구현 + 해당 구현의 테스트
-  -> 부모: 완성된 결과의 통합 테스트 + 정합성 확인 + archive
+여러 이슈가 하나의 change를 공유
+OpenSpec X
+  -> 구현 이슈 A: 담당 tasks + 구현 + 테스트
+  -> 구현 이슈 B: 담당 tasks + 구현 + 테스트
+  -> 명시된 완료 담당자: 필요한 경우 남은 통합 검증 + 정합성 확인 + archive
 
-부분 통합 계층이 반드시 필요한 예외
-전체 계약 부모
-  -> 부분 계약 부모
-     -> 구현 이슈 A
-     -> 구현 이슈 B
-     -> 부분 부모: 부분 통합 테스트
-  -> 구현 이슈 C
-  -> 전체 부모: 전체 통합 테스트 + archive
+하나의 이슈가 여러 change를 변경
+구현 이슈 A
+  -> OpenSpec X의 담당 계약 + 구현 + 테스트
+  -> OpenSpec Y의 담당 계약 + 구현 + 테스트
+  -> X와 Y의 독립 완료 조건에 따라 각각 archive
+
+OpenSpec이 필요 없는 이슈
+구현 이슈 B
+  -> 기존 계약을 변경 없이 적용하는 구현 + 테스트
 
 장기 제품 영역
 Project / Milestone
-  -> 계약 이슈 A -> OpenSpec A -> 구현
-  -> 계약 이슈 B -> OpenSpec B -> 구현
+  -> 이슈 A -> OpenSpec X
+  -> 이슈 B -> OpenSpec X와 OpenSpec Y
+  -> 이슈 C -> 기존 계약을 적용하는 구현, 새 OpenSpec 없음
 ```
 
 ## 1. Domain Gate
@@ -170,7 +208,7 @@ Domain Gate 승인 요청은 변경한 요구사항, 닫힌 결정, 남은 미�
 
 ## 2. Issue Gate
 
-OpenSpec change를 만들기 전에 Linear 이슈 구조가 먼저 존재해야 한다.
+OpenSpec change가 필요한 경우 이를 만들기 전에 적용되는 Linear 이슈와 책임 구조가 먼저 존재해야 한다.
 
 계약 이슈에는 다음 내용을 기록한다.
 
@@ -187,13 +225,14 @@ OpenSpec change를 만들기 전에 Linear 이슈 구조가 먼저 존재해야 
 테이블 shape, GraphQL payload, 함수, 컴포넌트, migration 방식과 파일별 작업은 기존 공개 계약이 이미
 고정한 경우가 아니라면 이 단계에서 확정하지 않는다.
 
-여러 PR이 필요한 변경은 OpenSpec 착수 전에 구현 자식 경계를 생성하거나 최소한 초안으로 정리한다.
-계약 부모는 OpenSpec과 모든 구현 자식의 완료 뒤에 수행할 통합 테스트, 정합성 확인과 archive 결과를 완료
-조건으로 가진다. 구현과 분리된 테스트 전용 자식 이슈는 기본적으로 만들지 않는다.
+여러 PR이 필요한 변경은 OpenSpec 착수 전에 구현 경계를 생성하거나 최소한 초안으로 정리한다. 각 이슈가
+어떤 change와 task를 구현하고 어떤 검증을 소유하는지, change별 남은 통합 검증·정합성 확인·archive를 누가
+담당하는지 명시한다. 부모가 이 책임을 소유할 수 있지만 계층만으로 자동 배정하지 않는다. 구현과 분리된
+테스트 전용 자식 이슈는 실제로 독립된 cross-slice 검증 결과가 있을 때만 둔다.
 
-Issue Gate 승인 요청은 생성·수정한 계약 부모와 구현 자식을 제목, 전달 결과, 포함·제외 범위, 부모·자식
-관계, blocker, 각자의 테스트·통합·archive 책임으로 나열한다. 이슈를 미리 생성했더라도 명시적 승인 전에는
-OpenSpec Gate로 넘어가지 않는다.
+Issue Gate 승인 요청은 생성·수정한 이슈를 제목, 전달 결과, 포함·제외 범위, 관계, blocker, 적용되는
+OpenSpec과 각자의 구현·테스트·통합·archive 책임으로 나열한다. 이슈를 미리 생성했더라도 명시적 승인 전에는
+OpenSpec이 필요한 작업의 OpenSpec Gate로 넘어가지 않는다.
 
 ## 3. OpenSpec Gate
 
@@ -227,7 +266,9 @@ OpenSpec끼리의 참조, strict validation 통과, 테스트와 PR 구현은 �
 OpenSpec Gate와 구현·리뷰에서는 applicable canonical 문서와 최신 Linear 본문·계약 변경 댓글을 OpenSpec과
 독립적으로 읽고 불일치를 사람이 검토한다.
 
-proposal은 계약 이슈를 링크한다. 공유 change의 task heading은 이미 존재하는 구현 이슈를 식별한다.
+proposal은 change에 authority와 scope를 제공하는 모든 적용 이슈를 링크한다. 공유 change의 task heading은
+이미 존재하는 구현 이슈와 각 이슈의 Deliverable·Verification을 식별한다. 하나의 이슈가 여러 change를
+수정하면 각 proposal과 tasks에서 그 이슈가 맡은 서로 다른 결과를 구분한다.
 
 ```md
 ## 1. PROD-123 Data export API
@@ -287,7 +328,9 @@ OpenSpec은 구현 전에 계약을 검증할 수 있을 만큼 완전해야 하
 현재 계약의 누락, 모순 또는 현실과 맞지 않는 가정을 발견하면 변경 종류에 따라 canonical 문서, Linear,
 OpenSpec 순서로 갱신한 뒤 구현을 계속한다.
 
-다음 조건을 모두 만족한 뒤 구현을 시작한다.
+OpenSpec이 필요한 작업은 다음 조건을 모두 만족한 뒤 구현을 시작한다. OpenSpec이 필요 없는 이슈는 적용할
+기존 canonical·Linear 계약에 따라 Implementation Gate로 진행한다. 필요 여부가 불명확하면 새 change가 없는
+이유를 기록한다.
 
 - Linear와 OpenSpec의 목표와 범위가 일치한다.
 - 필요한 specs, design, decisions, tasks가 존재한다.
@@ -296,7 +339,8 @@ OpenSpec 순서로 갱신한 뒤 구현을 계속한다.
 - `openspec validate <change> --strict`가 통과한다.
 
 OpenSpec만을 만들기 위한 Linear 이슈는 두지 않는다. 여러 PR이 공유하는 change에서 구현 전 OpenSpec
-검토·merge가 필요하더라도 이는 계약 부모가 소유한 생명주기의 일부이지 독립적인 전달 결과가 아니다.
+검토·merge가 필요하더라도 별도 spec-only 이슈를 만들지 않고 실제 구현·검증 결과를 소유한 이슈들에 책임을
+배정한다. 특정 부모가 존재한다는 이유만으로 change 전체를 그 부모의 소유로 간주하지 않는다.
 
 OpenSpec Gate 승인 요청은 requirement와 scenario, Active/Blocked/Superseded decision, 구현 이슈별 task
 ownership, 권장 접근과 허용 대안, 검증 계획, canonical 문서·Linear와 달라진 점을 나열한다. 각 규범 단위,
@@ -306,7 +350,8 @@ validation 확인 전에는 Implementation Gate로 넘어가지 않는다.
 ## 4. Implementation Gate
 
 - 하나의 구현 브랜치와 PR은 하나의 Linear 구현 이슈에 대응한다.
-- 구현 이슈는 계약 부모와 OpenSpec change를 링크한다.
+- 구현 이슈는 적용되는 canonical·Linear와 `0..N`개의 OpenSpec change를 링크한다. OpenSpec 필요 여부가
+  불명확하거나 기존 계약만 적용한다는 사실이 리뷰 범위에 중요할 때는 새 change가 없는 이유를 기록한다.
 - PR은 담당 이슈의 구현 결과와 그 결과를 증명하는 단위·통합·회귀 테스트를 함께 소유한다.
 - 구현은 최신 canonical·Linear와 독립 대조한 specs, design과 decisions를 함께 만족해야 한다.
 - 구현자는 design의 Current Constraints와 Known Traps를 확인하고 Recommended Approach를 기본 경로로 검토한다.
@@ -328,22 +373,24 @@ validation 확인 전에는 Implementation Gate로 넘어가지 않는다.
 
 새로 발견한 작업은 다음처럼 처리한다.
 
-- 현재 결과에 필수인 제품 계약: canonical 문서, 계약 이슈, OpenSpec, 구현 이슈와 tasks 순서로 갱신한다.
-- 독립적으로 전달 가능한 제품 결과: Domain Gate를 다시 통과한 뒤 새 계약 이슈와 새 OpenSpec으로 분리한다.
+- 현재 결과에 필수인 제품 계약: canonical 문서와 적용되는 Linear 이슈를 먼저 갱신한다. OpenSpec이 필요하면
+  행동 계약의 생명주기에 따라 기존 change를 갱신하거나 새 change를 만들고 담당 tasks와 구현을 정렬한다.
+- 독립적으로 전달 가능한 제품 결과: Domain Gate를 다시 통과한 뒤 별도 Linear 이슈로 분리한다. 새 행동
+  계약이 필요하면 기존 change와 함께 완료할지 별도 change로 나눌지 OpenSpec 경계 기준으로 결정한다.
 - 현재 필요 없음: 후속 이슈를 만들고 제외 범위 또는 deferred decision에 연결한다.
 
 ### 테스트와 부분 통합 이슈
 
 - 각 구현 이슈는 자신의 결과를 증명하는 테스트를 구현과 함께 만든다.
 - 테스트 종류나 package가 다르다는 이유만으로 테스트 전용 이슈를 분리하지 않는다.
-- 계약 부모의 통합 테스트는 자식 테스트를 반복하지 않고, 여러 구현 결과를 연결해야만 확인할 수 있는 최종
-  사용자·시스템 흐름을 검증한다.
-- 일부 구현 조각만 결합했을 때 별도의 통합 위험과 완료 결과가 생기는 경우에만 부분 계약 부모를 둘 수 있다.
+- 별도 통합 이슈의 테스트는 구현 이슈 테스트를 반복하지 않고, 여러 구현 결과를 연결해야만 확인할 수 있는
+  사용자·시스템 흐름을 검증한다. 부모가 이 역할을 맡을 수 있지만 필수는 아니다.
+- 일부 구현 조각만 결합했을 때 별도의 통합 위험과 완료 결과가 생기는 경우에만 부분 통합 이슈를 둘 수 있다.
 - 부분 계약 부모 아래 구현 이슈들은 각자 테스트를 소유하고, 부분 부모는 그 조각들을 연결하는 통합 테스트를
   소유한다.
-- 부분 부모가 별도 OpenSpec을 archive하려면 그 부분이 독립적으로 승인, 전달, 검증과 연기할 수 있는 별도
-  계약이어야 한다. 같은 OpenSpec의 task 일부가 끝났다는 이유로 부분 archive하지 않는다.
-- 부분 통합 계층 없이 구현 이슈의 테스트와 최상위 통합 검증으로 충분하면 중간 부모를 만들지 않는다.
+- 부분 통합 이슈가 별도 OpenSpec을 archive하려면 그 부분이 독립적으로 승인, 전달, 검증과 연기할 수 있는
+  별도 계약이어야 한다. 같은 OpenSpec의 task 일부가 끝났다는 이유로 부분 archive하지 않는다.
+- 부분 통합 계층 없이 구현 이슈의 테스트와 명시된 완료 검증으로 충분하면 중간 부모를 만들지 않는다.
 
 각 구현 이슈의 완료 승인 요청은 실제 구현 결과, 중요한 구현 결정, 담당 테스트와 검증 증거, canonical
 문서·Linear·OpenSpec 변경 여부, 남은 위험을 나열한다. 수정 요청이 있으면 PR과 관련 artifact를 갱신해 다시
@@ -351,25 +398,28 @@ validation 확인 전에는 Implementation Gate로 넘어가지 않는다.
 
 ## 5. Completion Gate
 
-다음 조건을 모두 만족한 뒤 계약 이슈를 닫는다.
+다음 조건을 모두 만족한 뒤 이슈를 닫는다.
 
-- 구현 이슈와 PR이 완료됐다.
-- 계약 부모가 requirement scenario와 여러 구현 결과를 연결하는 통합 사용자·시스템 흐름을 검증했다.
-- 현재 OpenSpec tasks가 완료됐다.
-- `Blocked` 또는 아직 supersede되지 않은 `Upstream Change Required` decision이 남아 있지 않다.
-- archive 직전에 최신 canonical·Linear를 독립 대조했고 구현과 OpenSpec 사이에 불일치가 없다.
-- OpenSpec change를 active specs에 archive했다.
-- archive 후 validation이 통과한다.
+- 이슈가 소유한 구현·문서·검증 결과가 완료됐다.
+- 명시된 cross-slice 통합 책임이 있다면 여러 구현 결과를 연결하는 사용자·시스템 흐름을 검증했다.
+- 이슈가 완료 책임을 가진 OpenSpec tasks가 완료됐다.
+- 이슈가 archive를 담당하는 change에 `Blocked` 또는 아직 supersede되지 않은 `Upstream Change Required`
+  decision이 남아 있지 않다.
+- archive 담당 PR은 직전에 최신 canonical·Linear를 독립 대조했고 구현과 OpenSpec 사이에 불일치가 없다.
+- archive 담당 change를 active specs에 동기화했고 archive 후 validation이 통과한다.
 
-여러 구현 PR이 하나의 OpenSpec을 공유하면 계약 부모가 통합 테스트, 정합성 확인, archive와 archive 후
-validation을 직접 소유한다. 부모를 단순 추적 컨테이너로 닫지 않는다.
+이슈에 적용되는 OpenSpec이 없거나 해당 change의 전체 완료·archive 책임을 소유하지 않으면 다른 이슈의
+archive를 기다릴 필요 없이 자신의 Deliverable과 Verification이 끝났을 때 닫을 수 있다. 반대로 하나의
+change를 여러 PR이 공유하면 task 일부가 끝났다는 이유만으로 archive하지 않는다. 전체 완료 증거를 실제로
+소유한 이슈와 PR이 배정된 경우 필요한 통합 테스트를 수행하고, 정합성 확인, archive와 archive 후 validation을
+완료한다.
 
-Completion Gate 승인 요청은 완료된 구현 이슈와 PR, 최종 통합 테스트 결과, requirement scenario 충족,
-canonical 문서·OpenSpec 정합성, archive diff와 validation 결과를 나열한다. OpenSpec archive artifact를 미리
-준비할 수 있지만 명시적 승인 전에는 계약 이슈를 완료하지 않는다.
+Completion Gate 승인 요청은 완료된 구현 이슈와 PR, 배정된 통합 테스트 결과, requirement scenario 충족,
+canonical 문서·OpenSpec 정합성, archive diff와 validation 결과 중 해당하는 항목을 나열한다. OpenSpec archive
+artifact를 미리 준비할 수 있지만 명시적 승인 전에는 archive 담당 이슈를 완료하지 않는다.
 
 Completion Gate의 archive, 커밋, push와 Ready PR 생성은 승인 요청을 준비하고 제출하는 작업이므로 별도
-사전 승인을 요구하지 않는다. 해당 Ready PR의 merge를 Completion Gate의 명시적 승인으로 본다. 계약 이슈는
+사전 승인을 요구하지 않는다. 해당 Ready PR의 merge를 Completion Gate의 명시적 승인으로 본다. 담당 이슈는
 PR이 merge된 뒤에만 완료한다.
 
 ## 예외
@@ -378,11 +428,13 @@ PR이 merge된 뒤에만 완료한다.
   Issue -> Implementation으로 진행하고 회귀 테스트를 추가한다.
 - **행동 변화 없음:** 기계적 refactor, test-only 보강, 오탈자 수정, dependency와 tooling 정리는 관찰 가능한
   행동을 유지할 때 새 OpenSpec이 필요하지 않다.
-- **작은 변경:** 단일 PR 행동 변경은 하나의 계약 이슈가 OpenSpec, 구현, 테스트, 통합 검증과 archive를
-  소유한다. Domain Gate와 Issue Gate를 통과하고 코드가 확장되기 전에 OpenSpec Gate를 통과해야 한다.
+- **작은 변경:** 단일 PR이라는 이유만으로 OpenSpec을 만들거나 생략하지 않는다. 새 행동 계약이나 durable
+  decision이 필요하면 Domain·Issue·OpenSpec Gate를 거치고, 기존 계약 적용이나 행동 변화 없는 작업이면 그
+  근거를 남기고 Implementation Gate로 진행한다.
 - **긴급 장애:** 이슈는 생성한다. 기존 계약을 복구하거나 계약 변경이 불가피하면 최소한의 완전한 OpenSpec을
   포함한다.
-- **조사:** spike는 OpenSpec 없이 진행할 수 있다. 구현하기로 결정하면 계약 이슈를 먼저 만든다.
+- **조사:** spike는 OpenSpec 없이 진행할 수 있다. 구현하기로 결정하면 적용되는 Linear 이슈와 책임을 먼저
+  만들거나 갱신한다.
 - **owner 없는 active change:** 추가 구현 전에 계약 이슈를 지정하고 proposal과 tasks를 이슈 구조에 연결한다.
 
 ## 금지 패턴
@@ -392,11 +444,14 @@ PR이 merge된 뒤에만 완료한다.
 - artifact를 미리 생성했다는 이유로 승인된 것으로 간주하는 것
 - canonical 도메인 요구사항의 미결정을 구현 이슈나 OpenSpec에 넘기는 것
 - OpenSpec 작성만을 전달 결과로 가진 Linear 이슈를 만드는 것
-- 계약 부모를 범위 추적만 하는 빈 컨테이너로 두는 것
+- 실제 Deliverable이나 검증 책임 없이 부모·통합·archive 이슈 또는 PR을 만드는 것
 - 구현이 소유해야 할 테스트를 별도 테스트 전용 이슈로 분리하는 것
 - 독립적인 부분 통합 결과가 없는데 중간 부모와 추가 archive 계층을 만드는 것
 - Project 전체를 하나의 영구 미완료 OpenSpec backlog로 사용하는 것
-- DB, API, UI, test마다 동일한 공유 계약을 복제하는 것
+- 이슈나 PR 수만 보고 동일한 계약을 기계적으로 복제하는 것
+- 부모·자식 관계만 보고 서로 다른 계약을 하나의 OpenSpec으로 합치는 것
+- 부모, 자식 또는 마지막 PR이라는 이유만으로 통합 검증과 archive 책임을 자동 추론하는 것
+- 실제 통합·정합성 작업 없이 파일 이동만을 위한 archive-only 이슈나 PR을 만드는 것
 - 독립 범위를 Linear 없이 `tasks.md`에만 추가하는 것
 - 행동 변경을 Linear와 OpenSpec 갱신 없이 코드에만 반영하는 것
 - 완료된 change를 archive하지 않고 active 상태로 방치하는 것


### PR DESCRIPTION
## 무엇을 변경했는지

- Linear issue와 OpenSpec change의 관계를 이슈당 `0..N`, change당 `1..N`의 many-to-many로 명시했습니다.
- 모든 이슈에 OpenSpec을 요구하지 않으면서도 owner 없는 OpenSpec change는 만들지 않도록 경계를 구분했습니다.
- 하나의 change를 여러 이슈가 공유하거나 하나의 이슈가 여러 change를 수정할 수 있는 예시를 추가했습니다.
- 통합 검증과 archive 책임을 부모·자식 관계나 PR 순서에서 추론하지 않고 실제 남은 작업과 완료 증거에 따라 명시적으로 배정하도록 모든 gate를 정렬했습니다.
- 기존 active change와 열린 PR을 이 규칙만으로 자동 분리·병합·reparent하지 않도록 migration 경계를 추가했습니다.
- `AGENTS.md`의 요약 규칙도 같은 책임 모델로 동기화했습니다.

## 왜 변경했는지

기존 문서는 “모든 이슈에 OpenSpec이 필요하지 않다”는 원칙을 구현 이슈의 별도 OpenSpec 소유 금지, 계약 부모의 공유 change·통합 검증·archive 의무로 확대했습니다.

이를 글자 그대로 적용하면 행동 계약의 경계 대신 Linear 계층으로 OpenSpec을 합치거나 나누고, 실제 통합 작업이 없어도 부모 archive PR을 만들며, 반대로 완료 증거를 가진 구현 PR이 archive하지 못한다고 오해할 수 있습니다.

PROD-568은 이러한 과잉 해석을 막고 OpenSpec 필요 여부, change 경계, 구현·검증·archive 책임을 실제 Deliverable과 생명주기로 판단하도록 문서화합니다.

## 이번 PR의 주요 결정

### Issue와 OpenSpec을 many-to-many로 취급

- 결정자: @robin-maki
- 선택: 이슈는 OpenSpec 없이도 존재할 수 있고, 하나의 change는 하나 이상의 이슈가 공유할 수 있으며, 하나의 이슈도 여러 change를 수정할 수 있습니다.
- 고려한 대안: 모든 구현 이슈에 별도 OpenSpec을 두는 1:1 모델, 계약 부모가 공유 OpenSpec 하나를 항상 소유하는 모델
- 이유: 두 대안 모두 이슈 계층이나 PR 수를 행동 계약의 생명주기보다 우선해 책임과 리뷰 범위를 왜곡할 수 있습니다.
- 감수한 결과: Issue Gate에서 적용 change와 구현·검증 책임을 명시적으로 기록해야 합니다.
- 관련 근거: [PROD-568](https://linear.app/byulmaru/issue/PROD-568/openspec과-이슈의-책임-관계를-명시적-many-to-many로-바로잡는다)

### Archive 담당자를 계층에서 자동 추론하지 않음

- 결정자: @robin-maki
- 선택: 전체 완료 증거와 실제 남은 정합성·통합 작업을 소유한 이슈/PR에 archive 책임을 배정합니다.
- 고려한 대안: 계약 부모가 항상 archive, 마지막 구현 PR이 항상 archive
- 이유: 부모나 순서만으로 책임을 정하면 archive-only PR을 만들거나 필요한 cross-slice 검증을 놓칠 수 있습니다.
- 감수한 결과: 공유 change는 tasks와 이슈 본문에서 완료·archive 담당자를 분명히 해야 합니다.
- 관련 근거: [PROD-568](https://linear.app/byulmaru/issue/PROD-568/openspec과-이슈의-책임-관계를-명시적-many-to-many로-바로잡는다)

## 어떻게 확인할 수 있는지

- `pnpm exec prettier --check AGENTS.md memory/issue-openspec-workflow.md`
- `git diff --check`
- 독립 correctness self-review: orphan change, 강제 1:1 issue 생성, 무조건적 통합 테스트·archive, OpenSpec 없는 이슈의 Completion Gate 충돌 재검토
- ponytail review: 제거 가능한 중복 없음

## 아직 어떤 문제가 남았는지

- 기존 active OpenSpec과 열린 PR의 mapping은 이 PR에서 일괄 재구성하지 않습니다.
- 각 작업은 현재 책임과 생명주기가 실제로 불명확할 때만 별도로 재평가합니다.