### PR TITLE
프로덕션 런타임 기반을 선언한다

### DIFF
--- a/apps/helm/templates/postgres-backup.yaml
+++ b/apps/helm/templates/postgres-backup.yaml
@@ -13,6 +13,8 @@ apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
   name: kosmo-postgres-backup
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: postgres-backup

--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -2,13 +2,17 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: {{ include "kosmo.postgresName" . }}
+{{- if eq .Values.env "prod" }}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
+{{- end }}
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: postgres
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  instances: 1
+  instances: {{ ternary 3 1 (eq .Values.env "prod") }}
 {{- if eq .Values.env "dev" }}
   enablePDB: false
 {{- end }}

--- a/apps/helm/templates/postgres-migration-role.yaml
+++ b/apps/helm/templates/postgres-migration-role.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Values.env "prod" }}
+apiVersion: postgresql.cnpg.io/v1
+kind: DatabaseRole
+metadata:
+  name: {{ printf "%s-postgres-migration" .Release.Name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: postgres-migration
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  cluster:
+    name: {{ include "kosmo.postgresName" . }}
+  name: kosmo_migration
+  login: true
+  superuser: false
+  inRoles:
+    - kosmo
+  passwordSecret:
+    name: {{ printf "%s-postgres-migration" .Release.Name | trunc 63 | trimSuffix "-" }}
+  databaseRoleReclaimPolicy: retain
+{{- end }}

--- a/apps/helm/templates/validate.yaml
+++ b/apps/helm/templates/validate.yaml
@@ -1,0 +1,6 @@
+{{- if eq .Values.env "prod" -}}
+{{- $isSemverVersion := regexMatch "^[0-9]+[.][0-9]+[.][0-9]+$" .Values.version -}}
+{{- if not $isSemverVersion -}}
+{{- fail "production version must be an explicit SemVer image version" -}}
+{{- end -}}
+{{- end -}}

--- a/apps/helm/templates/validate.yaml
+++ b/apps/helm/templates/validate.yaml
@@ -1,6 +1,0 @@
-{{- if eq .Values.env "prod" -}}
-{{- $isSemverVersion := regexMatch "^[0-9]+[.][0-9]+[.][0-9]+$" .Values.version -}}
-{{- if not $isSemverVersion -}}
-{{- fail "production version must be an explicit SemVer image version" -}}
-{{- end -}}
-{{- end -}}

--- a/apps/helm/templates/vaultstaticsecret.yaml
+++ b/apps/helm/templates/vaultstaticsecret.yaml
@@ -52,3 +52,34 @@ spec:
     - kind: "argo.Rollout"
       name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
   {{- end }}
+{{- if eq .Values.env "prod" }}
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: "migration-database"
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: migration-database
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  vaultAuthRef: "vso-kubernetes-sync"
+  mount: "secret"
+  type: "kv-v2"
+  path: "kubernetes/kosmo/prod/migration"
+  refreshAfter: "5m"
+  destination:
+    name: {{ printf "%s-postgres-migration" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
+    create: true
+    overwrite: true
+    type: "kubernetes.io/basic-auth"
+    labels:
+      cnpg.io/reload: "true"
+    transformation:
+      includes:
+        - "^username$"
+        - "^password$"
+{{- end }}

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -9,11 +9,25 @@ cd "${chart_dir}"
 release_tag="1.2.3"
 release_digest="sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 release_image="ghcr.io/byulmaru/kosmo@${release_digest}"
+prod_web_domain="kos.moe"
+prod_api_domain="api.kos.moe"
 
 helm lint . --set env=dev
-helm lint . --set env=prod --set-string version="${release_tag}" --set-string imageDigest="${release_digest}"
+helm lint . \
+  --set env=prod \
+  --set-string version="${release_tag}" \
+  --set-string imageDigest="${release_digest}" \
+  --set-string webDomain="${prod_web_domain}" \
+  --set-string apiDomain="${prod_api_domain}"
 helm template kosmo . --namespace kosmo-dev --set env=dev >"${render_dir}/dev.yaml"
-helm template kosmo . --namespace kosmo-prod --set env=prod --set-string version="${release_tag}" --set-string imageDigest="${release_digest}" >"${render_dir}/prod.yaml"
+helm template kosmo . \
+  --namespace kosmo-prod \
+  --set env=prod \
+  --set-string version="${release_tag}" \
+  --set-string imageDigest="${release_digest}" \
+  --set-string webDomain="${prod_web_domain}" \
+  --set-string apiDomain="${prod_api_domain}" \
+  >"${render_dir}/prod.yaml"
 
 if helm template kosmo . --namespace kosmo-prod --set env=prod >"${render_dir}/invalid-prod.yaml" 2>/dev/null; then
   echo "prod manifest rendered without an image digest" >&2
@@ -29,6 +43,9 @@ helm template kosmo . \
   --namespace kosmo-prod \
   --set env=prod \
   --set workloads.enabled=false \
+  --set-string version="${release_tag}" \
+  --set-string webDomain="${prod_web_domain}" \
+  --set-string apiDomain="${prod_api_domain}" \
   >"${render_dir}/prod-runtime.yaml"
 
 if grep -Eq '^kind: (Rollout|Service|HTTPRoute)$' "${render_dir}/prod-runtime.yaml"; then
@@ -48,6 +65,76 @@ for runtime_kind in Cluster ObjectStore ScheduledBackup VaultStaticSecret; do
   fi
 done
 
+prod_runtime_markers=(
+  "instances: 3"
+  "argocd.argoproj.io/sync-options: Prune=confirm"
+  "path: \"kubernetes/kosmo/prod\""
+  "path: \"kubernetes/kosmo/prod/migration\""
+  "type: \"kubernetes.io/basic-auth\""
+  "cnpg.io/reload: \"true\""
+  "kind: DatabaseRole"
+  "name: kosmo_migration"
+  "databaseRoleReclaimPolicy: retain"
+  "- kosmo"
+  "name: \"kosmo-postgres-migration\""
+  "- \"^username$\""
+  "- \"^password$\""
+)
+
+for marker in "${prod_runtime_markers[@]}"; do
+  if ! grep -Fq -- "${marker}" "${render_dir}/prod-runtime.yaml"; then
+    echo "prod runtime bootstrap is missing marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+for protected_kind in Cluster ObjectStore; do
+  if ! awk -v kind="${protected_kind}" '
+    $0 == "kind: " kind { in_resource = 1 }
+    in_resource && /argocd.argoproj.io\/sync-options: Prune=confirm/ { found = 1 }
+    in_resource && /^---$/ { exit }
+    END { exit !found }
+  ' "${render_dir}/prod-runtime.yaml"; then
+    echo "prod ${protected_kind} must require explicit prune confirmation" >&2
+    exit 1
+  fi
+done
+
+for protected_resource in "DatabaseRole kosmo-postgres-migration" "VaultStaticSecret migration-database"; do
+  read -r protected_kind protected_name <<<"${protected_resource}"
+  if ! awk -v kind="${protected_kind}" -v name="${protected_name}" '
+    $0 == "kind: " kind { in_resource = 1 }
+    in_resource && $0 ~ "^  name: [\" ]*" name "[\" ]*$" { named = 1 }
+    in_resource && /argocd.argoproj.io\/sync-options: Prune=confirm/ { protected = 1 }
+    /^---$/ {
+      if (in_resource && named && protected) { found = 1 }
+      in_resource = named = protected = 0
+    }
+    END {
+      if (in_resource && named && protected) { found = 1 }
+      exit !found
+    }
+  ' "${render_dir}/prod-runtime.yaml"; then
+    echo "prod ${protected_kind}/${protected_name} must require explicit prune confirmation" >&2
+    exit 1
+  fi
+done
+
+dev_forbidden_markers=(
+  "instances: 3"
+  "kubernetes/kosmo/prod"
+  "kind: DatabaseRole"
+  "kosmo-postgres-migration"
+  "argocd.argoproj.io/sync-options: Prune=confirm"
+)
+
+for marker in "${dev_forbidden_markers[@]}"; do
+  if grep -Fq "${marker}" "${render_dir}/dev.yaml"; then
+    echo "dev manifest unexpectedly contains production marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
 if [[ "$(grep -Fc 'image: "ghcr.io/byulmaru/kosmo:main"' "${render_dir}/dev.yaml")" -ne 3 ]]; then
   echo "dev migration, API, and Web must keep the mutable main image" >&2
   exit 1
@@ -55,6 +142,16 @@ fi
 
 if [[ "$(grep -Fc "image: \"${release_image}\"" "${render_dir}/prod.yaml")" -ne 2 ]]; then
   echo "prod API and Web must use the selected digest image" >&2
+  exit 1
+fi
+
+if grep -Fq -- "-ro:5432" "${render_dir}/prod.yaml"; then
+  echo "prod API or Web unexpectedly uses the read-only database service" >&2
+  exit 1
+fi
+
+if [[ "$(grep -Fc 'kosmo-postgres-rw:5432' "${render_dir}/prod.yaml")" -ne 2 ]]; then
+  echo "prod API and Web must both use the read-write database service" >&2
   exit 1
 fi
 
@@ -72,6 +169,7 @@ image_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 helm template kosmo . \
   --namespace kosmo-prod \
   --set env=prod \
+  --set-string version="${release_tag}" \
   --set imageDigest="${image_digest}" \
   --set migration.enabled=true \
   >"${render_dir}/prod-migration.yaml"
@@ -79,6 +177,7 @@ helm template kosmo . \
   --namespace kosmo-prod \
   --show-only templates/database-migration-job.yaml \
   --set env=prod \
+  --set-string version="${release_tag}" \
   --set imageDigest="${image_digest}" \
   --set migration.enabled=true \
   >"${render_dir}/prod-migration-job.yaml"
@@ -128,7 +227,7 @@ required_prod_markers=(
 )
 
 for marker in "${required_prod_markers[@]}"; do
-  if ! grep -Fq "${marker}" "${render_dir}/prod.yaml"; then
+  if ! grep -Fq "${marker}" "${render_dir}/prod-runtime.yaml"; then
     echo "prod manifest is missing backup marker: ${marker}" >&2
     exit 1
   fi

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -13,7 +13,7 @@
 - `kosmo` ECR 저장소와 Docker Build 전용 GitHub Actions OIDC push role
 - ECR의 `main`/`stable` 이미지 보호, untagged 1일 만료, 나머지 이미지 7일 만료 정책
 - `byulmaru-kosmo-prod-postgresql-backups-822638974464` PostgreSQL backup bucket과 `byulmaru-kosmo-prod-postgres-backup` EKS Pod Identity role
-- Argo CD `kosmo` ApplicationSet과 여기서 생성하는 `kosmo-dev` Application의 선언
+- Argo CD `kosmo` ApplicationSet이 생성하는 `kosmo-dev` Application과 별도 `kosmo-prod` Application의 선언
 
 Firebase를 Google Cloud 프로젝트에 추가하는 작업은 되돌릴 수 없다. 앱 리소스에는 `PREVENT` 삭제 정책을 적용한다.
 

--- a/apps/terraform/argocd.tf
+++ b/apps/terraform/argocd.tf
@@ -68,6 +68,54 @@ resource "argocd_application_set" "kosmo" {
   }
 }
 
+resource "argocd_application" "kosmo_prod" {
+  cascade = false
+  wait    = false
+
+  metadata {
+    name      = "kosmo-prod"
+    namespace = "argocd"
+  }
+
+  spec {
+    project                = "kosmo"
+    revision_history_limit = 10
+
+    source {
+      repo_url        = "https://github.com/byulmaru/kosmo.git"
+      target_revision = "main"
+      path            = "apps/helm"
+
+      helm {
+        release_name = "kosmo"
+        values       = <<-EOT
+          env: 'prod'
+          webDomain: 'kos.moe'
+          apiDomain: 'api.kos.moe'
+          image: 'ghcr.io/byulmaru/kosmo'
+          version: '0.0.0'
+          workloads:
+            enabled: false
+        EOT
+      }
+    }
+
+    destination {
+      server    = "https://kubernetes.default.svc"
+      namespace = "kosmo-prod"
+    }
+
+    sync_policy {
+      automated {
+        prune     = true
+        self_heal = true
+      }
+
+      sync_options = ["CreateNamespace=true"]
+    }
+  }
+}
+
 import {
   to = argocd_application_set.kosmo
   id = "kosmo:argocd"

--- a/apps/terraform/argocd.tf
+++ b/apps/terraform/argocd.tf
@@ -72,6 +72,12 @@ resource "argocd_application" "kosmo_prod" {
   cascade = false
   wait    = false
 
+  lifecycle {
+    # PROD-545 owns release-time digest, workload, and migration parameters.
+    # Terraform continues to own the bootstrap values and Application structure.
+    ignore_changes = [spec[0].source[0].helm[0].parameter]
+  }
+
   metadata {
     name      = "kosmo-prod"
     namespace = "argocd"

--- a/openspec/changes/add-production-runtime/.openspec.yaml
+++ b/openspec/changes/add-production-runtime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-29

--- a/openspec/changes/add-production-runtime/decisions.md
+++ b/openspec/changes/add-production-runtime/decisions.md
@@ -1,0 +1,121 @@
+## Context
+
+이 결정 기록은 2026-07-30에 정정된 Linear `PROD-562`의 독립 `production-runtime` 계약, 현재 Kosmo ApplicationSet/Helm/Vault/CNPG 구성, Kubernetes platform의 public Gateway/TLS 및 add-on 경계와 `PROD-546`의 기존 production backup 계약을 반영한다.
+
+## Decision Records
+
+### PROD-562 독립 capability와 후속 계약 분리
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-562`
+- Status: Active
+- Context / Problem: Production runtime 기반과 release·migration·첫 출시 통합 계약의 OpenSpec ownership을 명확히 해야 한다.
+- Decision Outcome: `PROD-562`가 `production-runtime` capability의 OpenSpec, 구현, 검증과 archive를 자체 소유한다. 이 change는 `kosmo-prod` Application/namespace, automated sync와 pinned image version, route/TLS 연결, 총 3 instances의 PostgreSQL/storage/backup 연결, production runtime 환경값 projection, 분리된 migration DB identity/credential 기반과 readiness만 포함한다.
+- Alternatives Considered: `PROD-545` 전체를 하나의 공유 change로 묶는 방식은 최신 Linear ownership과 맞지 않아 제외했다. PROD-563/564/565 계약을 이 change에 포함하는 방식도 독립 delivery와 검증 경계를 침범해 제외했다.
+- Consequences: PROD-562는 runtime readiness가 증명되면 독립 archive할 수 있다. Release pipeline, production migration gate와 첫 release 통합 검증은 이 change가 완료되어도 별도로 남는다.
+- Confirmation / Follow-up: Diff와 tasks에 PROD-563/564/565 소유 resource나 검증이 없는지 확인한다.
+
+### Production public hostname
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-562`
+- Status: Active
+- Context / Problem: Production Web/API가 dev와 다른 public hostname으로 기존 `kos.moe` Gateway/TLS 경계를 사용해야 한다.
+- Decision Outcome: Web hostname은 apex `kos.moe`, API hostname은 `api.kos.moe`로 둔다. 두 HTTPRoute는 기존 `gateway/public`을 parent로 사용하고 TLS는 platform이 소유한 `kos.moe`/`*.kos.moe` certificate에서 종료한다.
+- Alternatives Considered: Web을 `www.kos.moe`로 두는 방식은 현재 서비스 canonical origin과 맞지 않아 제외했다. API를 Web origin 아래 path로 합치는 방식은 기존 별도 API route 구조를 바꾸므로 제외했다. Kosmo chart가 Certificate를 직접 소유하는 방식은 platform TLS ownership과 중복되어 제외했다.
+- Consequences: DNS와 wildcard/apex certificate가 먼저 준비되어야 한다. Kosmo repository는 hostname과 Route만 소유하고 Gateway, Certificate, ClusterIssuer와 DNS credential은 소유하지 않는다.
+- Confirmation / Follow-up: Render에서 두 hostname과 parentRef를 확인하고 live HTTPRoute Accepted/ResolvedRefs 및 TLS certificate를 확인한다.
+
+### Production runtime 환경값과 migration DB credential의 분리
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-562`
+- Status: Active
+- Context / Problem: Production runtime 환경값은 dev와 격리해야 하고 migration은 API/Web runtime과 다른 DB credential 경계가 필요하지만, migration용으로 API/Web의 전체 runtime 환경값을 복제해서는 안 된다.
+- Decision Outcome: 기존 환경별 projection 구조를 재사용해 production runtime 환경값은 `kubernetes/kosmo/prod` Vault KV path에서 `env` Kubernetes Secret으로 동기화하고 API/Web과 rollout restart target이 이를 소비한다. 별도 migration projection은 `kubernetes/kosmo/prod/migration`에서 database username/password만 `kubernetes.io/basic-auth` Secret으로 동기화한다. `/prod/runtime` path는 만들지 않으며 API/Web은 migration Secret을 소비하지 않는다.
+- Alternatives Considered: Runtime 환경값을 `kubernetes/kosmo/prod/runtime`으로 옮기는 방식은 기존 환경별 path 계약과 맞지 않아 제외했다. Migration Secret에 API/Web runtime 환경값 전체를 복제하는 방식은 credential 경계를 불필요하게 넓혀 제외했다. Secret value를 Helm/Terraform 입력으로 전달하는 방식은 manifest/state 노출 위험 때문에 제외했다.
+- Consequences: Application sync 전에 두 production Vault path와 각 key가 준비되어야 한다. PROD-562는 migration DB credential을 프로비저닝하지만 실제 migration Job 연결과 소비는 PROD-564가 소유한다.
+- Confirmation / Follow-up: Render와 live VSO 상태에서 runtime/migration path, 각 destination/type, API/Web 참조 격리와 secret value 비노출을 확인한다.
+
+### 별도 migration DB login identity
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-562`
+- Status: Active
+- Context / Problem: Secret만 분리하고 PostgreSQL login을 공유하면 credential rotation과 소비 경계가 실제 database identity에서 분리되지 않는다. 반면 이번 change는 migration privilege 자체를 재설계하지 않는다.
+- Decision Outcome: CloudNativePG `DatabaseRole`로 `kosmo_migration` login role을 선언하고 migration basic-auth Secret을 `passwordSecret`으로 참조한다. Role은 login 가능, superuser 불가로 두고 기존 `kosmo` database owner role membership을 상속해 현재 migration 권한을 유지한다. API/Web은 기존 bootstrap owner의 `-app` Secret과 `-rw` Service를 계속 사용한다. DatabaseRole reclaim은 `retain`으로 두며 DatabaseRole과 migration VaultStaticSecret prune에는 명시적 확인을 요구한다.
+- Alternatives Considered: Runtime과 migration이 같은 login/Secret을 공유하는 방식은 확정된 credential 경계를 충족하지 못해 제외했다. 이 change에서 별도 least-privilege migration grant 체계를 설계하는 방식은 migration 실행·contract 정책까지 범위를 넓혀 제외했다.
+- Consequences: Runtime과 migration은 서로 다른 login과 credential을 갖지만 migration role은 기존 owner 권한을 상속하므로 권한 수준 자체를 축소하는 계약은 아니다. Application/manifest가 제거되어도 schema object를 소유할 수 있는 login은 자동 삭제되지 않으며, 제거 또는 rotation에는 명시적인 운영 확인이 필요하다. Migration Job이 이 identity를 소비하는 연결은 PROD-564까지 존재하지 않는다.
+- Confirmation / Follow-up: Render와 live 상태에서 `DatabaseRole`, basic-auth Secret 참조와 role membership을 확인하고 API/Web이 migration credential을 참조하지 않는지 검사한다.
+
+### 기존 platform add-on과 TLS의 소비
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-562`
+- Status: Active
+- Context / Problem: Production runtime에 필요한 controller와 TLS 기반이 이미 cluster-wide ownership으로 존재하며 Kosmo가 중복 설치하면 lifecycle과 권한이 충돌한다.
+- Decision Outcome: Argo CD/Rollouts, Gateway API `gateway/public`, cert-manager TLS, CloudNativePG, Barman Cloud plugin, Vault Secrets Operator와 EKS Pod Identity를 선행 dependency로 확인해 소비한다. Kosmo change는 add-on 설치나 public Gateway/TLS resource를 만들지 않는다.
+- Alternatives Considered: Kosmo Terraform/Helm에서 add-on을 재설치하거나 Certificate를 생성하는 방식은 중복 ownership과 upgrade 순서 충돌 때문에 제외했다.
+- Consequences: Dependency가 준비되지 않으면 `kosmo-prod` sync/readiness를 완료할 수 없다. 외부 platform 변경이 필요하면 이 change의 숨은 task로 추가하지 않고 해당 owner에서 먼저 처리해야 한다.
+- Confirmation / Follow-up: Sync 전에 CRD/controller, public Gateway listener/certificate, Barman plugin, VSO와 Pod Identity 상태를 확인한다.
+
+### Automated sync와 명시적인 image version
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-562`
+- Status: Active
+- Context / Problem: Production은 GitOps 자동 수렴을 유지해야 하지만 workload image가 mutable tag를 자동 추적해서는 안 된다.
+- Decision Outcome: `kosmo-prod`는 automated sync, prune와 self-heal을 항상 사용한다. Workload image version은 Application 선언에 명시된 non-`main` immutable version으로 고정하고 version 변경은 Git의 명시적인 선언 변경으로만 수행한다. 이 change는 version 선택·승인·rollback workflow를 만들지 않는다.
+- Alternatives Considered: Manual sync는 항상 자동이어야 한다는 production 운영 계약과 맞지 않아 제외했다. `main` 또는 `stable` 자동 추적은 image identity가 선언 밖에서 이동하므로 제외했다.
+- Consequences: Git의 production manifest 변경은 Argo CD가 자동 반영한다. 정식 version을 어떤 절차로 선택·승인·되돌릴지는 별도 release pipeline 계약이 계속 소유한다.
+- Confirmation / Follow-up: Application에 automated/prune/self-heal이 있고 prod render에 `main`/`stable`이 없으며 명시적인 version이 workload image에 사용되는지 확인한다.
+
+### 첫 release 전 bootstrap image version
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: 사용자 정정, Linear `PROD-562`와 `PROD-563` ownership 경계
+- Status: Active
+- Context / Problem: PROD-562의 선언형 runtime 구현 시점에는 production-built image가 아직 없으며, 이를 이유로 PROD-562가 one-off image build나 PROD-563 release workflow를 소유해서는 안 된다.
+- Decision Outcome: `kosmo-prod` Application에는 의도적으로 존재하지 않는 `0.0.0` bootstrap version을 명시한다. Application은 automated sync를 유지하지만 이 version을 workload readiness 증거로 사용하지 않는다. PROD-563이 첫 production-built immutable release version을 선택해 명시적으로 교체한다.
+- Alternatives Considered: `main`, `stable` 또는 현재 dev용 `sha-*` image를 사용하는 방식은 production build 경계와 mutable-tag 금지를 위반해 제외했다. PROD-562가 one-off production image를 만드는 방식은 PROD-563 ownership을 침범해 제외했다.
+- Consequences: 선언과 admission 검증은 production image 없이 완료할 수 있지만 실제 API/Web readiness는 첫 production image와 runtime key가 준비될 때까지 완료되지 않는다. 개별 PR readiness와 OpenSpec 전체 runtime readiness는 별도로 판정한다.
+- Confirmation / Follow-up: Terraform plan에서 `version: '0.0.0'`을 확인하고 Helm이 mutable operational tag를 거부하는지 검증한다. PROD-563은 이 값을 production image version으로 교체한다.
+
+### Production Application lifecycle 분리
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-562`의 production database 보존 계약
+- Status: Active
+- Context / Problem: Shared ApplicationSet의 resource preservation을 켜면 dev Application 삭제 lifecycle도 바뀌고, 켜지 않으면 production Application 제거가 Cluster/PVC 삭제로 이어질 수 있다.
+- Decision Outcome: 기존 dev ApplicationSet은 변경하지 않고 production을 별도 Terraform `argocd_application` resource로 선언한다. Production Application은 `cascade=false`를 사용하며 Cluster, ObjectStore, migration DatabaseRole과 migration VaultStaticSecret의 prune에는 명시적 확인을 요구한다.
+- Alternatives Considered: Shared ApplicationSet에 `preserveResourcesOnDeletion`을 설정하는 방식은 dev scope를 불필요하게 변경해 제외했다. 데이터 resource에 아무 보호도 두지 않는 방식은 자동 prune과 실수 삭제 위험 때문에 제외했다.
+- Consequences: Production Application lifecycle과 dev lifecycle이 분리되고 Application 제거만으로 production resource가 연쇄 삭제되지 않는다. 실제 데이터 resource 제거에는 별도의 명시적 확인 및 운영 절차가 필요하다.
+- Confirmation / Follow-up: Terraform schema/plan에서 `cascade=false`를 확인하고 prod render에서 보호 대상 resource의 `Prune=confirm` annotation을 검사한다.
+
+### Primary 1개와 standby replica 2개
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-562`, `PROD-546`
+- Status: Active
+- Context / Problem: Production PostgreSQL은 두 standby를 갖는 HA 기반을 제공해야 하지만 application read-routing과 별도 replica cluster는 현재 범위가 아니다.
+- Decision Outcome: Production CloudNativePG Cluster는 `instances: 3`으로 primary 1개와 standby replica 2개를 사용한다. 기존 10Gi per-instance storage와 prod-only backup ServiceAccount/ObjectStore/Barman WAL/ScheduledBackup 선언을 같은 Cluster에 연결한다. API/Web은 기존 read-write Service를 유지하고 read-only Service를 사용하지 않는다.
+- Alternatives Considered: 총 2 instances는 standby가 1개뿐이라 확정된 두-replica 계약을 충족하지 못해 제외했다. 단일 instance는 production HA를 제공하지 못해 제외했다. Application read-routing이나 standalone/cross-cluster replica는 독립적인 consistency와 운영 계약이 필요해 제외했다.
+- Consequences: 세 Pod와 PVC의 compute/storage 비용이 발생한다. Standby는 HA와 failover에 사용 가능하지만 API/Web read 부하는 자동 분산되지 않는다.
+- Confirmation / Follow-up: Prod render와 live Cluster에서 총 3 instances/Pods와 persistent storage를 확인하고 API/Web `DATABASE_URL`이 `-rw`를 유지하는지 검증한 뒤 PROD-546 live 검증을 연다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-production-runtime/decisions.md
+++ b/openspec/changes/add-production-runtime/decisions.md
@@ -1,6 +1,6 @@
 ## Context
 
-이 결정 기록은 2026-07-30에 정정된 Linear `PROD-562`의 독립 `production-runtime` 계약, 현재 Kosmo ApplicationSet/Helm/Vault/CNPG 구성, Kubernetes platform의 public Gateway/TLS 및 add-on 경계와 `PROD-546`의 기존 production backup 계약을 반영한다.
+이 결정 기록은 2026-07-30에 작성된 Linear `PROD-562`의 `production-runtime` 계약과 이후 PROD-545로 통합 완료 책임을 옮긴 정정, 현재 Kosmo ApplicationSet/Helm/Vault/CNPG 구성, Kubernetes platform의 public Gateway/TLS 및 add-on 경계와 `PROD-546`의 기존 production backup 계약을 반영한다.
 
 ## Decision Records
 
@@ -9,12 +9,24 @@
 - Decision Date: 2026-07-30
 - Decision Class: Derived Contract
 - Authority / Provenance: Linear `PROD-562`
-- Status: Active
+- Status: Superseded by `PROD-545 통합 완료 책임과 runtime bootstrap 경계`
 - Context / Problem: Production runtime 기반과 release·migration·첫 출시 통합 계약의 OpenSpec ownership을 명확히 해야 한다.
 - Decision Outcome: `PROD-562`가 `production-runtime` capability의 OpenSpec, 구현, 검증과 archive를 자체 소유한다. 이 change는 `kosmo-prod` Application/namespace, automated sync와 pinned image version, route/TLS 연결, 총 3 instances의 PostgreSQL/storage/backup 연결, production runtime 환경값 projection, 분리된 migration DB identity/credential 기반과 readiness만 포함한다.
 - Alternatives Considered: `PROD-545` 전체를 하나의 공유 change로 묶는 방식은 최신 Linear ownership과 맞지 않아 제외했다. PROD-563/564/565 계약을 이 change에 포함하는 방식도 독립 delivery와 검증 경계를 침범해 제외했다.
 - Consequences: PROD-562는 runtime readiness가 증명되면 독립 archive할 수 있다. Release pipeline, production migration gate와 첫 release 통합 검증은 이 change가 완료되어도 별도로 남는다.
 - Confirmation / Follow-up: Diff와 tasks에 PROD-563/564/565 소유 resource나 검증이 없는지 확인한다.
+
+### PROD-545 통합 완료 책임과 runtime bootstrap 경계
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: 사용자 정정, Linear `PROD-545`, `PROD-562`
+- Status: Active
+- Context / Problem: PROD-562/563/564를 서로 독립적인 최종 결과로 완료하면 runtime 적용, restore rehearsal과 첫 release의 통합 완료 책임이 분산된다.
+- Decision Outcome: PROD-562는 이 OpenSpec과 runtime bootstrap 구현 이력을 보존한다. Terraform 적용, database·backup·Secret readiness, PROD-546 restore rehearsal 연계, workload/migration 활성화, public smoke와 첫 release 최종 완료 판단은 PROD-545가 소유한다. PROD-563/564의 완료된 구현 이력은 다시 열거나 삭제하지 않는다.
+- Alternatives Considered: 구현이 시작된 세 change를 뒤늦게 공통 OpenSpec 하나로 재작성하는 방식은 감사 이력을 훼손하므로 제외했다. PROD-565를 별도 최종 통합 owner로 유지하는 방식은 PROD-545와 책임이 중복되어 제외했다.
+- Consequences: 이 change는 workload가 비활성화된 runtime 기반까지만 merge할 수 있다. Live 적용 이후 검증 증거는 PROD-545에 모이며, restore rehearsal이 성공한 뒤에만 첫 release로 진행한다.
+- Confirmation / Follow-up: Terraform plan/apply에서 public workload가 생성되지 않는지 확인하고, readiness와 후속 실행 결과를 PROD-545에 기록한다.
 
 ### Production public hostname
 
@@ -69,7 +81,7 @@
 - Decision Date: 2026-07-30
 - Decision Class: Derived Contract
 - Authority / Provenance: Linear `PROD-562`
-- Status: Active
+- Status: Superseded by `Terraform bootstrap values와 release parameter의 소유권 분리`
 - Context / Problem: Production은 GitOps 자동 수렴을 유지해야 하지만 workload image가 mutable tag를 자동 추적해서는 안 된다.
 - Decision Outcome: `kosmo-prod`는 automated sync, prune와 self-heal을 항상 사용한다. Workload image version은 Application 선언에 명시된 non-`main` immutable version으로 고정하고 version 변경은 Git의 명시적인 선언 변경으로만 수행한다. 이 change는 version 선택·승인·rollback workflow를 만들지 않는다.
 - Alternatives Considered: Manual sync는 항상 자동이어야 한다는 production 운영 계약과 맞지 않아 제외했다. `main` 또는 `stable` 자동 추적은 image identity가 선언 밖에서 이동하므로 제외했다.
@@ -81,12 +93,24 @@
 - Decision Date: 2026-07-30
 - Decision Class: Implementation Choice
 - Authority / Provenance: 사용자 정정, Linear `PROD-562`와 `PROD-563` ownership 경계
-- Status: Active
+- Status: Superseded by `Terraform bootstrap values와 release parameter의 소유권 분리`
 - Context / Problem: PROD-562의 선언형 runtime 구현 시점에는 production-built image가 아직 없으며, 이를 이유로 PROD-562가 one-off image build나 PROD-563 release workflow를 소유해서는 안 된다.
 - Decision Outcome: `kosmo-prod` Application에는 의도적으로 존재하지 않는 `0.0.0` bootstrap version을 명시한다. Application은 automated sync를 유지하지만 이 version을 workload readiness 증거로 사용하지 않는다. PROD-563이 첫 production-built immutable release version을 선택해 명시적으로 교체한다.
 - Alternatives Considered: `main`, `stable` 또는 현재 dev용 `sha-*` image를 사용하는 방식은 production build 경계와 mutable-tag 금지를 위반해 제외했다. PROD-562가 one-off production image를 만드는 방식은 PROD-563 ownership을 침범해 제외했다.
 - Consequences: 선언과 admission 검증은 production image 없이 완료할 수 있지만 실제 API/Web readiness는 첫 production image와 runtime key가 준비될 때까지 완료되지 않는다. 개별 PR readiness와 OpenSpec 전체 runtime readiness는 별도로 판정한다.
 - Confirmation / Follow-up: Terraform declaration과 plan에서 `version: '0.0.0'`이 명시되어 있는지 확인한다. PROD-563은 이 값을 production image version으로 교체한다.
+
+### Terraform bootstrap values와 release parameter의 소유권 분리
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-545`, `PROD-562`; PR review
+- Status: Active
+- Context / Problem: Terraform이 선언한 bootstrap Helm values와 PROD-545 release workflow가 설정하는 digest, workload, migration Helm parameter를 함께 관리하면 이후 Terraform reconciliation이 release parameter를 제거해 배포된 workload를 prune할 수 있다.
+- Decision Outcome: Terraform은 Application 구조와 `workloads.enabled=false`, `version=0.0.0` bootstrap values를 소유한다. PROD-545 release workflow는 Argo CD Helm parameter overlay를 소유한다. Terraform은 `spec.source.helm.parameter` 변경만 무시하고 values와 나머지 Application 구조는 계속 조정한다.
+- Alternatives Considered: Release마다 Terraform 선언을 커밋하는 방식은 승인된 tag deployment를 불필요하게 Git 선언 변경과 결합해 제외했다. Application 전체 변경을 무시하는 방식은 실제 infrastructure drift까지 숨기므로 제외했다.
+- Consequences: 첫 Terraform 적용은 workload 없이 database, backup과 Secret 기반만 준비한다. 이후 release workflow가 설정한 immutable digest와 workload/migration 활성화는 다음 Terraform 적용에도 유지된다.
+- Confirmation / Follow-up: Provider schema와 Terraform plan에서 정확히 Helm `parameter` block만 lifecycle ignore 대상인지 확인하고, release parameter가 values나 다른 Application 구조의 drift를 숨기지 않는지 검토한다.
 
 ### Production Application lifecycle 분리
 

--- a/openspec/changes/add-production-runtime/decisions.md
+++ b/openspec/changes/add-production-runtime/decisions.md
@@ -74,7 +74,7 @@
 - Decision Outcome: `kosmo-prod`는 automated sync, prune와 self-heal을 항상 사용한다. Workload image version은 Application 선언에 명시된 non-`main` immutable version으로 고정하고 version 변경은 Git의 명시적인 선언 변경으로만 수행한다. 이 change는 version 선택·승인·rollback workflow를 만들지 않는다.
 - Alternatives Considered: Manual sync는 항상 자동이어야 한다는 production 운영 계약과 맞지 않아 제외했다. `main` 또는 `stable` 자동 추적은 image identity가 선언 밖에서 이동하므로 제외했다.
 - Consequences: Git의 production manifest 변경은 Argo CD가 자동 반영한다. 정식 version을 어떤 절차로 선택·승인·되돌릴지는 별도 release pipeline 계약이 계속 소유한다.
-- Confirmation / Follow-up: Application에 automated/prune/self-heal이 있고 prod render에 `main`/`stable`이 없으며 명시적인 version이 workload image에 사용되는지 확인한다.
+- Confirmation / Follow-up: Application에 automated/prune/self-heal이 있고 선언에 명시된 version이 workload image에 사용되는지 확인한다. Version 형식과 release 선택 정책은 PROD-563이 소유한다.
 
 ### 첫 release 전 bootstrap image version
 
@@ -86,7 +86,7 @@
 - Decision Outcome: `kosmo-prod` Application에는 의도적으로 존재하지 않는 `0.0.0` bootstrap version을 명시한다. Application은 automated sync를 유지하지만 이 version을 workload readiness 증거로 사용하지 않는다. PROD-563이 첫 production-built immutable release version을 선택해 명시적으로 교체한다.
 - Alternatives Considered: `main`, `stable` 또는 현재 dev용 `sha-*` image를 사용하는 방식은 production build 경계와 mutable-tag 금지를 위반해 제외했다. PROD-562가 one-off production image를 만드는 방식은 PROD-563 ownership을 침범해 제외했다.
 - Consequences: 선언과 admission 검증은 production image 없이 완료할 수 있지만 실제 API/Web readiness는 첫 production image와 runtime key가 준비될 때까지 완료되지 않는다. 개별 PR readiness와 OpenSpec 전체 runtime readiness는 별도로 판정한다.
-- Confirmation / Follow-up: Terraform plan에서 `version: '0.0.0'`을 확인하고 Helm이 mutable operational tag를 거부하는지 검증한다. PROD-563은 이 값을 production image version으로 교체한다.
+- Confirmation / Follow-up: Terraform declaration과 plan에서 `version: '0.0.0'`이 명시되어 있는지 확인한다. PROD-563은 이 값을 production image version으로 교체한다.
 
 ### Production Application lifecycle 분리
 
@@ -98,7 +98,7 @@
 - Decision Outcome: 기존 dev ApplicationSet은 변경하지 않고 production을 별도 Terraform `argocd_application` resource로 선언한다. Production Application은 `cascade=false`를 사용하며 Cluster, ObjectStore, migration DatabaseRole과 migration VaultStaticSecret의 prune에는 명시적 확인을 요구한다.
 - Alternatives Considered: Shared ApplicationSet에 `preserveResourcesOnDeletion`을 설정하는 방식은 dev scope를 불필요하게 변경해 제외했다. 데이터 resource에 아무 보호도 두지 않는 방식은 자동 prune과 실수 삭제 위험 때문에 제외했다.
 - Consequences: Production Application lifecycle과 dev lifecycle이 분리되고 Application 제거만으로 production resource가 연쇄 삭제되지 않는다. 실제 데이터 resource 제거에는 별도의 명시적 확인 및 운영 절차가 필요하다.
-- Confirmation / Follow-up: Terraform schema/plan에서 `cascade=false`를 확인하고 prod render에서 보호 대상 resource의 `Prune=confirm` annotation을 검사한다.
+- Confirmation / Follow-up: Terraform schema/plan에서 `cascade=false`를 확인하고 production manifest 검토에서 보호 대상 resource의 `Prune=confirm` annotation을 확인한다.
 
 ### Primary 1개와 standby replica 2개
 

--- a/openspec/changes/add-production-runtime/design.md
+++ b/openspec/changes/add-production-runtime/design.md
@@ -4,29 +4,29 @@
 
 PROD-546의 선행 구현으로 prod render에는 Barman Cloud ObjectStore, backup ServiceAccount, WAL archiver와 ScheduledBackup이 이미 존재하지만 이를 실행할 `kosmo-prod` Application과 namespace는 없다. Kubernetes platform은 `gateway/public`에서 `kos.moe`와 `*.kos.moe` TLS를 종료하고, Argo Rollouts, Gateway API, cert-manager, CloudNativePG 1.30, Barman Cloud plugin, Vault Secrets Operator와 EKS Pod Identity를 제공한다. 이 change는 해당 cluster-wide 기반을 재구현하지 않고 준비 상태를 확인해 소비한다.
 
-PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 검증과 archive를 직접 소유한다. 정식 release version을 선택·승인·rollback하는 workflow는 PROD-563, production migration 실행과 contract gate는 PROD-564, 실제 public 사용자 journey와 첫 release 통합 검증은 PROD-565가 소유한다.
+PROD-562는 `production-runtime`의 선언형 bootstrap 구현 이력을 소유한다. Runtime 적용과 readiness, PROD-546 restore rehearsal 연계, workload/migration 활성화, public smoke와 첫 release 완료 판단은 통합 이슈 PROD-545가 소유한다. 완료된 PROD-563 release pipeline과 PROD-564 migration gate 이력은 지우거나 다시 열지 않는다.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - dev와 격리된 `kosmo-prod` Application, namespace와 production Helm 입력을 선언한다.
-- Production automated sync, prune와 self-heal을 유지하되 workload image는 선언에 명시된 non-`main` version으로 고정한다.
+- Production automated sync, prune와 self-heal을 유지하되 bootstrap에서는 workload를 비활성화하고 release overlay를 Terraform이 되돌리지 않는다.
 - `kos.moe` Web과 `api.kos.moe` API route를 기존 public Gateway/TLS 경계에 연결한다.
 - Production CloudNativePG를 primary 1개와 standby replica 2개, 총 3 instances로 구성하고 기존 persistent storage와 backup 선언을 연결한다.
 - API/Web database traffic은 기존 read-write Service에 유지한다.
 - Production runtime 환경값은 Vault `kubernetes/kosmo/prod`에서 동기화하고 `/prod/runtime` 하위 path를 만들지 않는다.
 - Runtime DB identity와 다른 migration 전용 DB login identity 및 basic-auth credential Secret을 선언형으로 프로비저닝한다.
 - Migration DB Secret은 database 인증 정보만 포함하고 API/Web에 주입하지 않는다.
-- dev/prod render, admission dry-run, Application automated sync와 runtime readiness를 검증한다.
+- dev/prod render, admission dry-run, Application automated sync와 database·backup·Secret 기반 readiness를 검증한다.
 - PROD-546의 live backup/restore 검증이 사용할 production Cluster를 제공한다.
 
 **Non-Goals:**
 
-- PROD-563의 SemVer release 선택, production 승인, 배포 workflow와 rollback 자동화.
-- PROD-564의 migration DB Secret consumer, production migration Job, 단계별 migration 실행 및 contract gate.
+- PROD-545의 tag release 선택, production 승인, workload/migration 활성화와 첫 release 완료 판단.
+- 완료된 PROD-564 migration Job과 contract gate 구현의 재설계.
 - API/Web query를 CloudNativePG read-only Service로 분기하는 application read-routing.
-- PROD-565의 로그인·피드·게시 등 public 사용자 경로 smoke, Sentry 확인과 첫 release 통합 판정.
+- 로그인·피드·게시 등 public 사용자 경로 smoke와 Sentry 확인.
 - S3/IAM/Barman plugin 재구현, standalone/cross-cluster replica 또는 총 3 instances를 넘는 추가 failover topology와 새로운 cluster-wide add-on 설치.
 
 ## Implementation Guidance
@@ -34,7 +34,7 @@ PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 
 ### Current Constraints
 
 - ApplicationSet의 단일 template은 dev의 automated sync, prune와 self-heal을 모든 element에 동일하게 적용한다. Production도 이 동작을 유지하되 `main` 같은 mutable operational tag가 아니라 명시적으로 고정된 image version을 받아야 한다.
-- 현재 Docker workflow는 branch와 `main` build에 `EXPO_PUBLIC_ENVIRONMENT=dev`와 dev Vault의 browser Sentry DSN을 bake하고, production build는 정식 SemVer Git tag에서만 만든다. 첫 release 전에는 production-built image가 없는 것이 의도된 상태이므로 Application은 `0.0.0` bootstrap version을 명시하고, PROD-563이 정식 image version을 제공하기 전까지 workload readiness를 완료로 기록하지 않는다.
+- 현재 Docker workflow는 branch와 `main` build에 `EXPO_PUBLIC_ENVIRONMENT=dev`와 dev Vault의 browser Sentry DSN을 bake하고, production build는 Git tag에서 만든다. 첫 release 전에는 production-built image가 없는 것이 의도된 상태이므로 Application은 `0.0.0` sentinel과 `workloads.enabled=false`를 bootstrap values로 명시한다. PROD-545가 승인된 build digest와 workload/migration parameter를 설정하기 전까지 public workload를 만들지 않는다.
 - `apps/helm/values.yaml`은 `env`, `image`, `version`만 제공한다. Production의 public hostname과 고정 image version을 명시적으로 검토할 환경별 값 경계가 없다.
 - 기존 Vault manifest는 `kubernetes/kosmo/<env>` 하나를 `env` Secret으로 투영하고 API/Web 모두에 주입한다. Production runtime은 이 구조를 `kubernetes/kosmo/prod`에 그대로 사용해야 하며 `/prod/runtime`으로 옮기지 않는다.
 - 2026-07-30 live key-only 확인에서 `kubernetes/kosmo/prod`에는 Sentry와 Slack key만 존재하고 API에 필요한 public origin, OIDC와 media runtime key가 없었다. 이 change는 해당 path를 소비하는 선언을 구현하되 값을 복제하거나 임의 생성하지 않으며, 필수 key가 준비되기 전까지 workload readiness를 완료로 기록하지 않는다.
@@ -46,8 +46,8 @@ PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 
 
 ### Recommended Approach
 
-1. Review 가능한 production values에 `env=prod`, Web/API hostname과 명시적인 image version을 둔다. 첫 release 전에는 의도적으로 존재하지 않는 `0.0.0` bootstrap version을 사용한다. Version 형식과 release 선택 정책은 PROD-563에 남긴다.
-2. `apps/terraform/argocd.tf`가 별도 `kosmo-prod` Application과 `kosmo-prod` destination namespace를 선언하게 한다. 기존 dev ApplicationSet lifecycle은 바꾸지 않고 production Application은 `cascade=false`로 제거 시 resource를 보존한다. Automated sync, prune와 self-heal을 유지하고 image version 변경은 Git의 명시적인 Application 선언 변경으로만 일어나게 한다.
+1. Review 가능한 production values에 `env=prod`, Web/API hostname, `0.0.0` bootstrap sentinel과 `workloads.enabled=false`를 둔다. Release 선택과 활성화는 PROD-545에 남긴다.
+2. `apps/terraform/argocd.tf`가 별도 `kosmo-prod` Application과 `kosmo-prod` destination namespace를 선언하게 한다. 기존 dev ApplicationSet lifecycle은 바꾸지 않고 production Application은 `cascade=false`로 제거 시 resource를 보존한다. Automated sync, prune와 self-heal을 유지한다. Terraform은 workload가 비활성화된 bootstrap values를 소유하고 PROD-545 release workflow가 설정한 Helm parameter overlay는 이후 Terraform reconciliation에서도 보존한다.
 3. Web은 `kos.moe`, API는 `api.kos.moe`를 사용하고 기존 HTTPRoute가 `gateway/public`을 참조하게 한다. Certificate, ClusterIssuer, Cloudflare credential과 public Gateway는 Kubernetes platform 소유로 유지한다.
 4. 기존 CloudNativePG Cluster template에서 dev는 1 instance, prod는 3 instances를 렌더한다. 기존 10Gi per-instance storage와 prod backup 조건을 재사용하고 API/Web `DATABASE_URL`은 `-rw` Service에 유지한다.
 5. 기존 환경별 Vault projection 구조를 재사용해 production runtime 환경값은 `kubernetes/kosmo/prod`에서 `env` Secret으로 동기화한다. 별도 migration VaultStaticSecret은 `kubernetes/kosmo/prod/migration`에서 database username/password만 `kubernetes.io/basic-auth` Secret으로 투영한다.
@@ -64,6 +64,7 @@ PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 
 ### Known Traps
 
 - Production image에 `main`이나 자동 이동하는 `stable` tag를 넣지 않는다. Automated sync와 mutable image tracking을 혼동하지 않는다. `0.0.0`은 첫 release 전 bootstrap sentinel이며 Ready image로 간주하지 않는다.
+- Release workflow가 설정한 Helm parameter를 Terraform의 빈 선언으로 되돌리지 않는다. Lifecycle ignore 범위는 release overlay인 `helm.parameter`로만 한정하고 bootstrap values나 Application 전체 drift를 숨기지 않는다.
 - `main`에서 만든 `sha-*` image를 tag만 고정됐다는 이유로 production-built artifact로 간주하지 않는다.
 - 필수 runtime key가 없는 production Vault path로 API/Web을 먼저 활성화하지 않는다.
 - Kosmo chart에서 `Certificate`, `ClusterIssuer`, public Gateway 또는 Cloudflare secret을 만들지 않는다.
@@ -76,21 +77,21 @@ PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 
 
 ## Risks / Trade-offs
 
-- [Automated sync가 Git의 production manifest 변경을 즉시 반영한다] → Workload image version은 immutable하고 명시적인 값으로 유지하며 정식 version 선택·승인과 rollback workflow는 PROD-563에서 제공한다.
+- [Automated sync가 승인된 release parameter를 즉시 반영한다] → Workload image digest는 immutable하게 유지하고 정식 release 선택·승인과 rollback workflow는 PROD-545가 제공한다. Terraform은 해당 parameter overlay를 되돌리지 않는다.
 - [Application 생성 즉시 불완전한 secret이나 add-on 때문에 sync가 실패할 수 있다] → Production Vault path와 필수 add-on/Gateway/TLS 상태를 사전 점검하고 server-side dry-run 뒤 Terraform을 적용한다.
 - [Migration DatabaseRole이 runtime owner membership을 상속하므로 privilege 자체는 분리되지 않는다] → 이번 계약을 credential/identity 분리로 한정하고 runtime least-privilege 전환은 별도 database authorization 계약 없이 선제 도입하지 않는다.
 - [Migration password Secret 형식이나 rotation이 잘못되면 role reconciliation이 실패한다] → basic-auth type, reload label, username 일치와 DatabaseRole status를 render/live 검증한다.
 - [세 PostgreSQL instance가 storage와 compute 비용을 늘린다] → Production HA를 위해 primary 1개와 standby 2개를 명시적으로 유지하고 read-routing이나 추가 topology는 포함하지 않는다.
 - [비동기 standby는 primary보다 늦을 수 있다] → 이번 change에서는 application을 `-rw`에 유지해 read-after-write 의미를 바꾸지 않는다.
-- [Route controller 정상 상태가 실제 사용자 journey 성공을 보장하지 않는다] → 이 change는 infra readiness만 증명하고 public origin smoke는 PROD-565에서 수행한다.
+- [Runtime 기반 정상 상태가 실제 사용자 journey 성공을 보장하지 않는다] → 이 change는 database·backup·Secret 기반만 준비하고 public origin smoke는 PROD-545에서 수행한다.
 
 ## Migration Plan
 
 1. Helm dev/prod lint와 render를 통과시키고 기존 dev 동작과 backup 계약이 보존됨을 확인한다.
 2. Platform의 Argo Rollouts, Gateway/TLS, CNPG/Barman, VSO와 Pod Identity 준비 상태 및 runtime/migration production Vault path 존재를 확인한다.
 3. Production manifest를 API server에 server-side dry-run해 CRD, schema와 admission을 검증한다.
-4. `apps/terraform` plan에서 `kosmo-prod` Application 추가 외의 의도하지 않은 변경이 없는지 검토한다. Production-built image와 필수 runtime key가 준비되기 전에는 적용 및 workload readiness를 완료로 기록하지 않는다.
-5. 적용 시 Application automated sync로 `kosmo-prod`가 조정되는지 확인하고 CNPG 3 instances/PVC, Vault runtime projection, migration basic-auth Secret/DatabaseRole, API/Web Rollout·Service와 HTTPRoute 상태를 확인한다.
+4. `apps/terraform` plan에서 `kosmo-prod` Application 추가 외의 의도하지 않은 변경이 없는지 검토한다. `workloads.enabled=false` bootstrap이 public workload를 만들지 않는지 확인한다.
+5. 적용 시 Application automated sync로 `kosmo-prod`가 조정되는지 확인하고 CNPG 3 instances/PVC, Vault runtime projection과 migration basic-auth Secret/DatabaseRole 상태를 확인한다.
 6. API/Web database endpoint와 credential이 기존 runtime `-rw`/`-app` 경계에 유지되고 migration Secret을 참조하지 않는지 확인한 뒤 PROD-546에 production Cluster 준비 사실을 전달한다.
 
 Rollback은 Git의 `kosmo-prod` 선언 변경을 되돌려 automated sync가 이전 선언으로 수렴하게 한다. PVC나 production database를 자동 삭제하지 않으며 backup 연결이 활성화된 뒤에는 backup 연속성과 보존을 확인하지 않고 Cluster/PVC/ObjectStore를 제거하지 않는다.

--- a/openspec/changes/add-production-runtime/design.md
+++ b/openspec/changes/add-production-runtime/design.md
@@ -34,7 +34,7 @@ PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 
 ### Current Constraints
 
 - ApplicationSet의 단일 template은 dev의 automated sync, prune와 self-heal을 모든 element에 동일하게 적용한다. Production도 이 동작을 유지하되 `main` 같은 mutable operational tag가 아니라 명시적으로 고정된 image version을 받아야 한다.
-- 현재 Docker workflow는 branch와 `main` build에 `EXPO_PUBLIC_ENVIRONMENT=dev`와 dev Vault의 browser Sentry DSN을 bake하고, production build는 정식 SemVer Git tag에서만 만든다. 첫 release 전에는 production-built image가 없는 것이 의도된 상태이므로 Application은 `0.0.0` bootstrap version을 명시하고, PROD-563이 정식 image digest를 제공하기 전까지 workload readiness를 완료로 기록하지 않는다.
+- 현재 Docker workflow는 branch와 `main` build에 `EXPO_PUBLIC_ENVIRONMENT=dev`와 dev Vault의 browser Sentry DSN을 bake하고, production build는 정식 SemVer Git tag에서만 만든다. 첫 release 전에는 production-built image가 없는 것이 의도된 상태이므로 Application은 `0.0.0` bootstrap version을 명시하고, PROD-563이 정식 image version을 제공하기 전까지 workload readiness를 완료로 기록하지 않는다.
 - `apps/helm/values.yaml`은 `env`, `image`, `version`만 제공한다. Production의 public hostname과 고정 image version을 명시적으로 검토할 환경별 값 경계가 없다.
 - 기존 Vault manifest는 `kubernetes/kosmo/<env>` 하나를 `env` Secret으로 투영하고 API/Web 모두에 주입한다. Production runtime은 이 구조를 `kubernetes/kosmo/prod`에 그대로 사용해야 하며 `/prod/runtime`으로 옮기지 않는다.
 - 2026-07-30 live key-only 확인에서 `kubernetes/kosmo/prod`에는 Sentry와 Slack key만 존재하고 API에 필요한 public origin, OIDC와 media runtime key가 없었다. 이 change는 해당 path를 소비하는 선언을 구현하되 값을 복제하거나 임의 생성하지 않으며, 필수 key가 준비되기 전까지 workload readiness를 완료로 기록하지 않는다.
@@ -46,13 +46,13 @@ PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 
 
 ### Recommended Approach
 
-1. Review 가능한 production values에 `env=prod`, Web/API hostname과 명시적인 non-`main` image version을 둔다. 첫 release 전에는 의도적으로 존재하지 않는 `0.0.0` bootstrap version을 사용하고 mutable `main`/`stable` 같은 operational tag를 거부하는 render assertion을 추가한다.
+1. Review 가능한 production values에 `env=prod`, Web/API hostname과 명시적인 image version을 둔다. 첫 release 전에는 의도적으로 존재하지 않는 `0.0.0` bootstrap version을 사용한다. Version 형식과 release 선택 정책은 PROD-563에 남긴다.
 2. `apps/terraform/argocd.tf`가 별도 `kosmo-prod` Application과 `kosmo-prod` destination namespace를 선언하게 한다. 기존 dev ApplicationSet lifecycle은 바꾸지 않고 production Application은 `cascade=false`로 제거 시 resource를 보존한다. Automated sync, prune와 self-heal을 유지하고 image version 변경은 Git의 명시적인 Application 선언 변경으로만 일어나게 한다.
 3. Web은 `kos.moe`, API는 `api.kos.moe`를 사용하고 기존 HTTPRoute가 `gateway/public`을 참조하게 한다. Certificate, ClusterIssuer, Cloudflare credential과 public Gateway는 Kubernetes platform 소유로 유지한다.
 4. 기존 CloudNativePG Cluster template에서 dev는 1 instance, prod는 3 instances를 렌더한다. 기존 10Gi per-instance storage와 prod backup 조건을 재사용하고 API/Web `DATABASE_URL`은 `-rw` Service에 유지한다.
 5. 기존 환경별 Vault projection 구조를 재사용해 production runtime 환경값은 `kubernetes/kosmo/prod`에서 `env` Secret으로 동기화한다. 별도 migration VaultStaticSecret은 `kubernetes/kosmo/prod/migration`에서 database username/password만 `kubernetes.io/basic-auth` Secret으로 투영한다.
 6. CloudNativePG `DatabaseRole`로 별도 `kosmo_migration` login identity를 관리하고 migration basic-auth Secret을 `passwordSecret`으로 참조한다. 기존 `kosmo` database owner role membership을 상속해 현재 migration 권한을 유지하되, API/Web은 기존 `-app` runtime DB Secret을 계속 사용한다. Role reclaim은 `retain`으로 두고 DatabaseRole과 migration VaultStaticSecret의 prune에는 명시적 확인을 요구한다. 이 change는 credential/identity만 분리하며 runtime role의 privilege를 축소하지 않는다.
-7. `test-render.sh`를 production runtime 경계까지 확장해 hostname, pinned version, prod 3 instances, runtime path, migration basic-auth/DatabaseRole, API/Web credential 격리, prod backup 연결과 production migration Job/read-routing 비소유를 검사한다. Helm lint/render 다음 실제 cluster의 server-side dry-run으로 CRD/admission 호환성을 확인한다.
+7. 기존 Helm lint/render를 통과시키고 production render를 검토한 다음 실제 cluster의 server-side dry-run으로 CRD/schema/admission 호환성을 확인한다. YAML 텍스트 marker 검사는 추가하지 않는다.
 8. 구현 PR에서는 정적 검증과 Terraform plan까지 완료한다. 실제 적용은 필수 add-on, public Gateway/TLS, 두 production Vault path 및 production-built image가 준비된 시점에 수행하고, Application automated sync로 `kosmo-prod`를 조정한 뒤 CNPG/DatabaseRole/VSO/Rollout/Service/HTTPRoute readiness까지만 증거로 남긴다.
 
 ### Allowed Alternatives
@@ -86,7 +86,7 @@ PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 
 
 ## Migration Plan
 
-1. Helm dev/prod lint와 render assertion을 통과시켜 기존 dev 동작과 backup 계약이 보존됨을 확인한다.
+1. Helm dev/prod lint와 render를 통과시키고 기존 dev 동작과 backup 계약이 보존됨을 확인한다.
 2. Platform의 Argo Rollouts, Gateway/TLS, CNPG/Barman, VSO와 Pod Identity 준비 상태 및 runtime/migration production Vault path 존재를 확인한다.
 3. Production manifest를 API server에 server-side dry-run해 CRD, schema와 admission을 검증한다.
 4. `apps/terraform` plan에서 `kosmo-prod` Application 추가 외의 의도하지 않은 변경이 없는지 검토한다. Production-built image와 필수 runtime key가 준비되기 전에는 적용 및 workload readiness를 완료로 기록하지 않는다.

--- a/openspec/changes/add-production-runtime/design.md
+++ b/openspec/changes/add-production-runtime/design.md
@@ -1,0 +1,100 @@
+## Context
+
+현재 `apps/terraform/argocd.tf`의 `kosmo` ApplicationSet은 `kosmo-dev`만 생성하며 dev namespace, `dev.kos.moe`/`dev-api.kos.moe`와 `main` image version을 inline Helm 값으로 전달하고 automated sync, prune와 self-heal을 사용한다. Helm chart는 API/Web Rollout·Service·HTTPRoute, CloudNativePG Cluster와 하나의 환경별 Vault Secrets Operator projection을 렌더하고, database migration Job만 dev에서 렌더한다. API와 Web 및 dev migration Job의 `DATABASE_URL`은 모두 CloudNativePG가 bootstrap owner용으로 생성한 같은 `-app` Secret과 read-write Service를 사용한다.
+
+PROD-546의 선행 구현으로 prod render에는 Barman Cloud ObjectStore, backup ServiceAccount, WAL archiver와 ScheduledBackup이 이미 존재하지만 이를 실행할 `kosmo-prod` Application과 namespace는 없다. Kubernetes platform은 `gateway/public`에서 `kos.moe`와 `*.kos.moe` TLS를 종료하고, Argo Rollouts, Gateway API, cert-manager, CloudNativePG 1.30, Barman Cloud plugin, Vault Secrets Operator와 EKS Pod Identity를 제공한다. 이 change는 해당 cluster-wide 기반을 재구현하지 않고 준비 상태를 확인해 소비한다.
+
+PROD-562는 작은 독립 계약으로 `production-runtime` capability, 구현, 검증과 archive를 직접 소유한다. 정식 release version을 선택·승인·rollback하는 workflow는 PROD-563, production migration 실행과 contract gate는 PROD-564, 실제 public 사용자 journey와 첫 release 통합 검증은 PROD-565가 소유한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- dev와 격리된 `kosmo-prod` Application, namespace와 production Helm 입력을 선언한다.
+- Production automated sync, prune와 self-heal을 유지하되 workload image는 선언에 명시된 non-`main` version으로 고정한다.
+- `kos.moe` Web과 `api.kos.moe` API route를 기존 public Gateway/TLS 경계에 연결한다.
+- Production CloudNativePG를 primary 1개와 standby replica 2개, 총 3 instances로 구성하고 기존 persistent storage와 backup 선언을 연결한다.
+- API/Web database traffic은 기존 read-write Service에 유지한다.
+- Production runtime 환경값은 Vault `kubernetes/kosmo/prod`에서 동기화하고 `/prod/runtime` 하위 path를 만들지 않는다.
+- Runtime DB identity와 다른 migration 전용 DB login identity 및 basic-auth credential Secret을 선언형으로 프로비저닝한다.
+- Migration DB Secret은 database 인증 정보만 포함하고 API/Web에 주입하지 않는다.
+- dev/prod render, admission dry-run, Application automated sync와 runtime readiness를 검증한다.
+- PROD-546의 live backup/restore 검증이 사용할 production Cluster를 제공한다.
+
+**Non-Goals:**
+
+- PROD-563의 SemVer release 선택, production 승인, 배포 workflow와 rollback 자동화.
+- PROD-564의 migration DB Secret consumer, production migration Job, 단계별 migration 실행 및 contract gate.
+- API/Web query를 CloudNativePG read-only Service로 분기하는 application read-routing.
+- PROD-565의 로그인·피드·게시 등 public 사용자 경로 smoke, Sentry 확인과 첫 release 통합 판정.
+- S3/IAM/Barman plugin 재구현, standalone/cross-cluster replica 또는 총 3 instances를 넘는 추가 failover topology와 새로운 cluster-wide add-on 설치.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- ApplicationSet의 단일 template은 dev의 automated sync, prune와 self-heal을 모든 element에 동일하게 적용한다. Production도 이 동작을 유지하되 `main` 같은 mutable operational tag가 아니라 명시적으로 고정된 image version을 받아야 한다.
+- 현재 Docker workflow는 branch와 `main` build에 `EXPO_PUBLIC_ENVIRONMENT=dev`와 dev Vault의 browser Sentry DSN을 bake하고, production build는 정식 SemVer Git tag에서만 만든다. 첫 release 전에는 production-built image가 없는 것이 의도된 상태이므로 Application은 `0.0.0` bootstrap version을 명시하고, PROD-563이 정식 image digest를 제공하기 전까지 workload readiness를 완료로 기록하지 않는다.
+- `apps/helm/values.yaml`은 `env`, `image`, `version`만 제공한다. Production의 public hostname과 고정 image version을 명시적으로 검토할 환경별 값 경계가 없다.
+- 기존 Vault manifest는 `kubernetes/kosmo/<env>` 하나를 `env` Secret으로 투영하고 API/Web 모두에 주입한다. Production runtime은 이 구조를 `kubernetes/kosmo/prod`에 그대로 사용해야 하며 `/prod/runtime`으로 옮기지 않는다.
+- 2026-07-30 live key-only 확인에서 `kubernetes/kosmo/prod`에는 Sentry와 Slack key만 존재하고 API에 필요한 public origin, OIDC와 media runtime key가 없었다. 이 change는 해당 path를 소비하는 선언을 구현하되 값을 복제하거나 임의 생성하지 않으며, 필수 key가 준비되기 전까지 workload readiness를 완료로 기록하지 않는다.
+- 현재 CloudNativePG bootstrap owner `kosmo`와 `-app` Secret을 API/Web 및 dev migration이 공유한다. Production migration credential 경계를 분리하려면 runtime 환경값을 복제하지 않는 basic-auth Secret과 별도 PostgreSQL login identity가 필요하다.
+- CloudNativePG 1.30은 `DatabaseRole`과 `passwordSecret`으로 별도 login role과 password를 선언형으로 조정할 수 있다. 참조 Secret은 `kubernetes.io/basic-auth` type과 `cnpg.io/reload: "true"` label을 사용해야 password 변경이 즉시 적용된다.
+- `gateway/public`이 이미 `kos.moe`와 `*.kos.moe` 인증서를 소유하므로 Kosmo chart가 Certificate나 DNS provider credential을 다시 만들면 ownership이 겹친다.
+- Prod backup manifest는 `env=prod` 조건에 연결되어 있다. Production Cluster를 추가할 때 이 선언을 우회하거나 별도 Cluster를 중복 생성하면 PROD-546의 검증 대상이 달라진다.
+- CloudNativePG의 `instances`는 primary를 포함한다. `instances: 3`은 primary 1개와 standby replica 2개이며 기본 `-ro` Service가 생기지만 현재 application은 `-rw`만 사용한다.
+
+### Recommended Approach
+
+1. Review 가능한 production values에 `env=prod`, Web/API hostname과 명시적인 non-`main` image version을 둔다. 첫 release 전에는 의도적으로 존재하지 않는 `0.0.0` bootstrap version을 사용하고 mutable `main`/`stable` 같은 operational tag를 거부하는 render assertion을 추가한다.
+2. `apps/terraform/argocd.tf`가 별도 `kosmo-prod` Application과 `kosmo-prod` destination namespace를 선언하게 한다. 기존 dev ApplicationSet lifecycle은 바꾸지 않고 production Application은 `cascade=false`로 제거 시 resource를 보존한다. Automated sync, prune와 self-heal을 유지하고 image version 변경은 Git의 명시적인 Application 선언 변경으로만 일어나게 한다.
+3. Web은 `kos.moe`, API는 `api.kos.moe`를 사용하고 기존 HTTPRoute가 `gateway/public`을 참조하게 한다. Certificate, ClusterIssuer, Cloudflare credential과 public Gateway는 Kubernetes platform 소유로 유지한다.
+4. 기존 CloudNativePG Cluster template에서 dev는 1 instance, prod는 3 instances를 렌더한다. 기존 10Gi per-instance storage와 prod backup 조건을 재사용하고 API/Web `DATABASE_URL`은 `-rw` Service에 유지한다.
+5. 기존 환경별 Vault projection 구조를 재사용해 production runtime 환경값은 `kubernetes/kosmo/prod`에서 `env` Secret으로 동기화한다. 별도 migration VaultStaticSecret은 `kubernetes/kosmo/prod/migration`에서 database username/password만 `kubernetes.io/basic-auth` Secret으로 투영한다.
+6. CloudNativePG `DatabaseRole`로 별도 `kosmo_migration` login identity를 관리하고 migration basic-auth Secret을 `passwordSecret`으로 참조한다. 기존 `kosmo` database owner role membership을 상속해 현재 migration 권한을 유지하되, API/Web은 기존 `-app` runtime DB Secret을 계속 사용한다. Role reclaim은 `retain`으로 두고 DatabaseRole과 migration VaultStaticSecret의 prune에는 명시적 확인을 요구한다. 이 change는 credential/identity만 분리하며 runtime role의 privilege를 축소하지 않는다.
+7. `test-render.sh`를 production runtime 경계까지 확장해 hostname, pinned version, prod 3 instances, runtime path, migration basic-auth/DatabaseRole, API/Web credential 격리, prod backup 연결과 production migration Job/read-routing 비소유를 검사한다. Helm lint/render 다음 실제 cluster의 server-side dry-run으로 CRD/admission 호환성을 확인한다.
+8. 구현 PR에서는 정적 검증과 Terraform plan까지 완료한다. 실제 적용은 필수 add-on, public Gateway/TLS, 두 production Vault path 및 production-built image가 준비된 시점에 수행하고, Application automated sync로 `kosmo-prod`를 조정한 뒤 CNPG/DatabaseRole/VSO/Rollout/Service/HTTPRoute readiness까지만 증거로 남긴다.
+
+### Allowed Alternatives
+
+- Production 값을 별도 values 파일 대신 Application의 구조화된 Helm values로 전달할 수 있다. 다만 dev/prod 차이와 pinned version이 한곳에서 명시적으로 검토 가능하고 render test가 같은 격리를 증명해야 한다.
+- ApplicationSet element 또는 별도 Terraform `argocd_application` resource를 사용할 수 있다. 어느 방식이든 `kosmo-prod`가 automated sync, prune와 self-heal을 유지하고 image version은 명시적인 Git 변경으로만 바뀌어야 한다. 이 구현은 dev 삭제 lifecycle을 바꾸지 않고 production resource 보존 경계를 독립시키기 위해 별도 Application을 사용한다.
+- Admission 검증은 `kubectl apply --server-side --dry-run=server` 또는 동일한 API-server admission 경로를 통과하는 도구를 사용할 수 있다.
+
+### Known Traps
+
+- Production image에 `main`이나 자동 이동하는 `stable` tag를 넣지 않는다. Automated sync와 mutable image tracking을 혼동하지 않는다. `0.0.0`은 첫 release 전 bootstrap sentinel이며 Ready image로 간주하지 않는다.
+- `main`에서 만든 `sha-*` image를 tag만 고정됐다는 이유로 production-built artifact로 간주하지 않는다.
+- 필수 runtime key가 없는 production Vault path로 API/Web을 먼저 활성화하지 않는다.
+- Kosmo chart에서 `Certificate`, `ClusterIssuer`, public Gateway 또는 Cloudflare secret을 만들지 않는다.
+- Migration projection에 API/Web runtime 환경값 전체를 복제하지 않는다. Database username/password만 basic-auth Secret으로 동기화한다.
+- Migration DB Secret을 API/Web에 주입하거나 PROD-562에서 production migration Job에 연결하지 않는다.
+- Production migration Job을 임시로 활성화해 database readiness를 확인하지 않는다. PROD-564 전에는 production render에 migration Job이 없어야 한다.
+- `instances: 3`만으로 API/Web read query가 replica로 분산된다고 가정하지 않는다. Application 연결은 `-rw`에 유지한다.
+- Backup readiness를 manifest 존재만으로 PROD-546의 실제 backup/restore 성공으로 간주하지 않는다.
+- HTTP 200 수준의 public smoke를 PROD-562 완료 증거로 확장하지 않는다. Route/TLS/controller 상태 확인까지만 이 change가 소유한다.
+
+## Risks / Trade-offs
+
+- [Automated sync가 Git의 production manifest 변경을 즉시 반영한다] → Workload image version은 immutable하고 명시적인 값으로 유지하며 정식 version 선택·승인과 rollback workflow는 PROD-563에서 제공한다.
+- [Application 생성 즉시 불완전한 secret이나 add-on 때문에 sync가 실패할 수 있다] → Production Vault path와 필수 add-on/Gateway/TLS 상태를 사전 점검하고 server-side dry-run 뒤 Terraform을 적용한다.
+- [Migration DatabaseRole이 runtime owner membership을 상속하므로 privilege 자체는 분리되지 않는다] → 이번 계약을 credential/identity 분리로 한정하고 runtime least-privilege 전환은 별도 database authorization 계약 없이 선제 도입하지 않는다.
+- [Migration password Secret 형식이나 rotation이 잘못되면 role reconciliation이 실패한다] → basic-auth type, reload label, username 일치와 DatabaseRole status를 render/live 검증한다.
+- [세 PostgreSQL instance가 storage와 compute 비용을 늘린다] → Production HA를 위해 primary 1개와 standby 2개를 명시적으로 유지하고 read-routing이나 추가 topology는 포함하지 않는다.
+- [비동기 standby는 primary보다 늦을 수 있다] → 이번 change에서는 application을 `-rw`에 유지해 read-after-write 의미를 바꾸지 않는다.
+- [Route controller 정상 상태가 실제 사용자 journey 성공을 보장하지 않는다] → 이 change는 infra readiness만 증명하고 public origin smoke는 PROD-565에서 수행한다.
+
+## Migration Plan
+
+1. Helm dev/prod lint와 render assertion을 통과시켜 기존 dev 동작과 backup 계약이 보존됨을 확인한다.
+2. Platform의 Argo Rollouts, Gateway/TLS, CNPG/Barman, VSO와 Pod Identity 준비 상태 및 runtime/migration production Vault path 존재를 확인한다.
+3. Production manifest를 API server에 server-side dry-run해 CRD, schema와 admission을 검증한다.
+4. `apps/terraform` plan에서 `kosmo-prod` Application 추가 외의 의도하지 않은 변경이 없는지 검토한다. Production-built image와 필수 runtime key가 준비되기 전에는 적용 및 workload readiness를 완료로 기록하지 않는다.
+5. 적용 시 Application automated sync로 `kosmo-prod`가 조정되는지 확인하고 CNPG 3 instances/PVC, Vault runtime projection, migration basic-auth Secret/DatabaseRole, API/Web Rollout·Service와 HTTPRoute 상태를 확인한다.
+6. API/Web database endpoint와 credential이 기존 runtime `-rw`/`-app` 경계에 유지되고 migration Secret을 참조하지 않는지 확인한 뒤 PROD-546에 production Cluster 준비 사실을 전달한다.
+
+Rollback은 Git의 `kosmo-prod` 선언 변경을 되돌려 automated sync가 이전 선언으로 수렴하게 한다. PVC나 production database를 자동 삭제하지 않으며 backup 연결이 활성화된 뒤에는 backup 연속성과 보존을 확인하지 않고 Cluster/PVC/ObjectStore를 제거하지 않는다.
+
+## Open Questions
+
+- 없음.

--- a/openspec/changes/add-production-runtime/proposal.md
+++ b/openspec/changes/add-production-runtime/proposal.md
@@ -6,11 +6,11 @@ Kosmo의 ApplicationSet은 dev 환경만 선언하고 있어 API, Web, PostgreSQ
 
 - dev와 독립된 `kosmo-prod` Argo CD Application과 `kosmo-prod` namespace를 선언한다.
 - production 전용 Helm values에서 Web/API hostname, environment, runtime secret reference, 총 3 instances의 PostgreSQL/storage와 backup 연결을 구성한다.
-- API와 Web Service·HTTPRoute를 production public gateway의 `kos.moe` TLS 경계에 연결한다.
+- API와 Web Service·HTTPRoute가 이후 PROD-545 release에서 production public gateway의 `kos.moe` TLS 경계에 연결될 production 입력을 선언한다.
 - production runtime 환경값은 dev와 분리된 Vault `kubernetes/kosmo/prod` path에서 동기화하고 `/prod/runtime` path를 만들지 않는다.
 - Runtime DB identity와 분리된 migration 전용 DB identity 및 credential Secret을 프로비저닝하되 migration Secret에는 database 인증 정보만 담는다.
-- `kosmo-prod`는 automated sync를 항상 유지하되 workload image는 mutable tag를 추적하지 않고 명시적인 non-`main` version으로 고정한다.
-- CloudNativePG, Barman Cloud plugin, Vault Secrets Operator, Argo Rollouts, Gateway API와 public Gateway 등 선행 add-on의 준비 상태를 확인하고 workload readiness까지 검증한다.
+- `kosmo-prod`는 automated sync를 유지하되 bootstrap에서는 workload를 비활성화한다. 이후 PROD-545가 immutable digest와 workload/migration Helm parameter를 설정하며 Terraform은 이 release overlay를 보존한다.
+- CloudNativePG, Barman Cloud plugin과 Vault Secrets Operator 등 bootstrap 선행 add-on의 준비 상태를 확인하고 database·backup·Secret 기반 readiness까지 검증한다.
 - dev render에 production resource, secret path, backup 설정 또는 production image policy가 섞이지 않음을 검증한다.
 - 정식 release workflow, migration/contract gate, public 사용자 경로 smoke와 첫 release 통합 검증은 추가하지 않는다.
 
@@ -36,4 +36,4 @@ Kosmo의 ApplicationSet은 dev 환경만 선언하고 있어 API, Web, PostgreSQ
 - `apps/helm`: prod values, 환경별 render 경계, production runtime 환경값 projection, migration DB identity/credential, route와 workload/database 구성.
 - Helm render/admission 검증: dev/prod 격리와 production runtime manifest 확인.
 - EKS add-on 경계: Argo CD/Rollouts, Gateway API와 `gateway/public`, cert-manager TLS, CloudNativePG/Barman plugin, Vault Secrets Operator, EKS Pod Identity.
-- 후속 관계: production Cluster가 준비되면 `PROD-546`의 live backup/restore 검증이 진행될 수 있다. `PROD-563`, `PROD-564`, `PROD-565`의 계약이나 구현은 변경하지 않는다.
+- 후속 관계: production Cluster가 준비되면 `PROD-546`의 live backup/restore 검증을 진행한다. 이후 workload 활성화, migration 연동, public smoke와 첫 release 완료 판단은 `PROD-545`가 소유한다. 완료된 `PROD-563`/`PROD-564` 구현 이력은 보존한다.

--- a/openspec/changes/add-production-runtime/proposal.md
+++ b/openspec/changes/add-production-runtime/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Kosmo의 ApplicationSet은 dev 환경만 선언하고 있어 API, Web, PostgreSQL을 dev와 분리된 production namespace, domain, secret, storage 경계에서 실행할 수 없다. PROD-562는 release·migration·첫 출시 검증과 분리해 `kosmo-prod`의 선언형 runtime 기반을 먼저 제공하고, PROD-546의 실제 backup/restore 검증이 사용할 production Cluster를 연다.
+
+## What Changes
+
+- dev와 독립된 `kosmo-prod` Argo CD Application과 `kosmo-prod` namespace를 선언한다.
+- production 전용 Helm values에서 Web/API hostname, environment, runtime secret reference, 총 3 instances의 PostgreSQL/storage와 backup 연결을 구성한다.
+- API와 Web Service·HTTPRoute를 production public gateway의 `kos.moe` TLS 경계에 연결한다.
+- production runtime 환경값은 dev와 분리된 Vault `kubernetes/kosmo/prod` path에서 동기화하고 `/prod/runtime` path를 만들지 않는다.
+- Runtime DB identity와 분리된 migration 전용 DB identity 및 credential Secret을 프로비저닝하되 migration Secret에는 database 인증 정보만 담는다.
+- `kosmo-prod`는 automated sync를 항상 유지하되 workload image는 mutable tag를 추적하지 않고 명시적인 non-`main` version으로 고정한다.
+- CloudNativePG, Barman Cloud plugin, Vault Secrets Operator, Argo Rollouts, Gateway API와 public Gateway 등 선행 add-on의 준비 상태를 확인하고 workload readiness까지 검증한다.
+- dev render에 production resource, secret path, backup 설정 또는 production image policy가 섞이지 않음을 검증한다.
+- 정식 release workflow, migration/contract gate, public 사용자 경로 smoke와 첫 release 통합 검증은 추가하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: 적용되는 `docs/domain` 또는 `docs/design` 문서 없음.
+- Linear Contract: `PROD-562`
+- Linear Implementations: 없음. `PROD-562`가 OpenSpec, 구현, 검증과 archive를 함께 소유한다.
+
+## Capabilities
+
+### New Capabilities
+
+- `production-runtime`: dev와 격리된 production Application, namespace, automated sync와 고정 image version, public routing/TLS, 총 3 instances의 PostgreSQL/storage, Vault runtime 환경값, 분리된 migration DB identity/Secret과 readiness 계약.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/terraform/argocd.tf`: dev ApplicationSet과 lifecycle을 분리한 `kosmo-prod` Application 및 production Helm input.
+- `apps/helm`: prod values, 환경별 render 경계, production runtime 환경값 projection, migration DB identity/credential, route와 workload/database 구성.
+- `apps/helm/test-render.sh`: dev/prod 격리와 production runtime manifest assertions.
+- EKS add-on 경계: Argo CD/Rollouts, Gateway API와 `gateway/public`, cert-manager TLS, CloudNativePG/Barman plugin, Vault Secrets Operator, EKS Pod Identity.
+- 후속 관계: production Cluster가 준비되면 `PROD-546`의 live backup/restore 검증이 진행될 수 있다. `PROD-563`, `PROD-564`, `PROD-565`의 계약이나 구현은 변경하지 않는다.

--- a/openspec/changes/add-production-runtime/proposal.md
+++ b/openspec/changes/add-production-runtime/proposal.md
@@ -34,6 +34,6 @@ Kosmo의 ApplicationSet은 dev 환경만 선언하고 있어 API, Web, PostgreSQ
 
 - `apps/terraform/argocd.tf`: dev ApplicationSet과 lifecycle을 분리한 `kosmo-prod` Application 및 production Helm input.
 - `apps/helm`: prod values, 환경별 render 경계, production runtime 환경값 projection, migration DB identity/credential, route와 workload/database 구성.
-- `apps/helm/test-render.sh`: dev/prod 격리와 production runtime manifest assertions.
+- Helm render/admission 검증: dev/prod 격리와 production runtime manifest 확인.
 - EKS add-on 경계: Argo CD/Rollouts, Gateway API와 `gateway/public`, cert-manager TLS, CloudNativePG/Barman plugin, Vault Secrets Operator, EKS Pod Identity.
 - 후속 관계: production Cluster가 준비되면 `PROD-546`의 live backup/restore 검증이 진행될 수 있다. `PROD-563`, `PROD-564`, `PROD-565`의 계약이나 구현은 변경하지 않는다.

--- a/openspec/changes/add-production-runtime/specs/production-runtime/spec.md
+++ b/openspec/changes/add-production-runtime/specs/production-runtime/spec.md
@@ -1,0 +1,149 @@
+## ADDED Requirements
+
+### Requirement: Dev와 격리된 production Application
+
+**Authority / Provenance:** Linear `PROD-562`. 시스템은 Argo CD가 `kosmo-prod` Application을 `kosmo-prod` namespace에 선언형으로 생성하고 항상 automated sync하게 해야 한다(MUST). Production Helm 입력은 dev와 다른 environment, namespace, public hostname, runtime secret path와 database 경계를 사용해야 하며(MUST), workload image는 mutable tag를 자동 추적하지 않는 명시적인 non-`main` version으로 고정해야 한다(MUST). Dev 전용 resource나 `main` image version을 포함해서는 안 된다(MUST NOT).
+
+#### Scenario: Production Application 선언
+
+- **WHEN** Terraform의 production Application을 계획하거나 렌더한다
+- **THEN** `kosmo-prod` Application의 destination은 `kosmo-prod` namespace이고 automated sync와 production 전용 Helm 입력을 사용한다
+
+#### Scenario: Production image version 고정
+
+- **WHEN** production Application이 자동 동기화된다
+- **THEN** workload image는 Application 선언에 명시된 non-`main` version을 사용하고 registry의 mutable operational tag를 자동 추적하지 않는다
+
+#### Scenario: 첫 release 전 bootstrap version
+
+- **WHEN** PROD-563이 production-built image digest를 아직 제공하지 않았다
+- **THEN** Application은 자동 추적 tag 대신 명시적인 `0.0.0` bootstrap version을 유지하고 workload readiness는 완료로 기록하지 않는다
+
+#### Scenario: Dev 정책 격리
+
+- **WHEN** production Helm manifest를 렌더한다
+- **THEN** dev namespace, dev hostname, dev Vault path, dev 전용 database 설정과 `main` image version이 나타나지 않는다
+
+#### Scenario: 기존 dev Application 보존
+
+- **WHEN** 기존 dev ApplicationSet과 공용 Helm chart에서 dev manifest를 렌더한다
+- **THEN** `kosmo-dev`의 현재 namespace, hostname, mutable `main` version과 dev 전용 database 동작은 유지되고 production resource는 나타나지 않는다
+
+### Requirement: Production public route와 TLS 연결
+
+**Authority / Provenance:** Linear `PROD-562`. 시스템은 production Web과 API Service를 서로 다른 production hostname의 HTTPRoute로 노출하고 기존 `gateway/public`의 HTTPS listener와 TLS certificate 경계에 연결해야 한다(MUST). Route는 자신의 namespace에 있는 active Service만 backend로 참조해야 하며(MUST), dev hostname을 공유해서는 안 된다(MUST NOT).
+
+#### Scenario: Production Web route
+
+- **WHEN** production Web HTTPRoute를 Gateway API controller가 조정한다
+- **THEN** production Web hostname은 `gateway/public`의 호환되는 HTTPS listener에 수락되고 `kosmo-prod`의 Web active Service로 전달된다
+
+#### Scenario: Production API route
+
+- **WHEN** production API HTTPRoute를 Gateway API controller가 조정한다
+- **THEN** production API hostname은 `gateway/public`의 호환되는 HTTPS listener에 수락되고 `kosmo-prod`의 API active Service로 전달된다
+
+#### Scenario: TLS 연결 확인
+
+- **WHEN** production hostname의 TLS 연결 상태를 확인한다
+- **THEN** Gateway listener가 `kos.moe` certificate 경계로 유효한 인증서를 제공하고 HTTPRoute는 Accepted와 ResolvedRefs 상태를 가진다
+
+### Requirement: Production PostgreSQL과 persistent storage
+
+**Authority / Provenance:** Linear `PROD-562`, `PROD-546`. 시스템은 `kosmo-prod`에 primary 1개와 standby replica 2개, 총 3 instances의 production CloudNativePG Cluster와 persistent storage를 선언해야 한다(MUST). Cluster는 prod 전용 database identity와 storage를 dev와 공유해서는 안 되며(MUST NOT), 기존 production backup ServiceAccount, ObjectStore, Barman plugin WAL archiver와 ScheduledBackup 선언에 연결되어 PROD-546의 live backup/restore 검증 대상이 되어야 한다(MUST). API와 Web은 기존 read-write Service를 계속 사용해야 하며(MUST), read-only Service로 query를 분기해서는 안 된다(MUST NOT).
+
+#### Scenario: Production database 렌더
+
+- **WHEN** Helm chart를 production 값으로 렌더한다
+- **THEN** `kosmo-prod`에 총 3 instances의 production CloudNativePG Cluster, 각 instance의 persistent storage, backup ServiceAccount, ObjectStore, WAL archiver와 ScheduledBackup 연결이 함께 나타난다
+
+#### Scenario: Standby replica와 application 연결
+
+- **WHEN** production Cluster와 API/Web workload를 렌더한다
+- **THEN** Cluster는 standby replica 2개를 포함하고 API/Web `DATABASE_URL`은 read-write Service를 가리키며 read-only Service를 참조하지 않는다
+
+#### Scenario: Dev database와 격리
+
+- **WHEN** dev와 production manifest를 비교한다
+- **THEN** 각 환경의 Cluster와 PVC는 namespace로 격리되고 dev manifest에는 production backup identity나 object-store 연결이 나타나지 않는다
+
+#### Scenario: Backup 검증 선행 조건 제공
+
+- **WHEN** production Cluster와 backup add-on이 Ready가 된다
+- **THEN** PROD-546은 해당 Cluster에서 immediate backup, WAL archive와 격리 restore 검증을 시작할 수 있다
+
+### Requirement: Production Vault runtime 환경값 경계
+
+**Authority / Provenance:** Linear `PROD-562`. 시스템은 production runtime 환경값을 dev와 다른 Vault `kubernetes/kosmo/prod` path에서 production Kubernetes Secret으로 동기화해야 한다(MUST). API와 Web workload는 이 runtime Secret을 참조해야 하며(MUST), `kubernetes/kosmo/prod/runtime` path를 생성해서는 안 된다(MUST NOT). Repository와 rendered manifest에는 secret value가 포함되어서는 안 된다(MUST NOT).
+
+#### Scenario: Runtime secret 동기화
+
+- **WHEN** Vault Secrets Operator가 `kosmo-prod`의 runtime VaultStaticSecret을 조정한다
+- **THEN** `kubernetes/kosmo/prod`의 값이 runtime Kubernetes Secret에 동기화되고 API와 Web Rollout이 그 Secret을 참조한다
+
+#### Scenario: Runtime 하위 path 비생성
+
+- **WHEN** production runtime VaultStaticSecret manifest를 렌더한다
+- **THEN** path는 `kubernetes/kosmo/prod`이고 `kubernetes/kosmo/prod/runtime`을 참조하지 않는다
+
+#### Scenario: Secret 환경 격리
+
+- **WHEN** dev와 production manifest의 VaultAuth, VaultStaticSecret과 destination을 비교한다
+- **THEN** production은 dev path나 destination을 참조하지 않고 어느 manifest에도 secret value가 포함되지 않는다
+
+### Requirement: Migration DB identity와 credential 경계
+
+**Authority / Provenance:** Linear `PROD-562`. 시스템은 API/Web의 runtime DB identity와 다른 production migration 전용 PostgreSQL login identity 및 credential Secret을 선언형으로 프로비저닝해야 한다(MUST). Migration credential은 database 인증에 필요한 username/password만 포함해야 하며(MUST), API/Web runtime 환경값 전체를 복제하거나 API/Web workload에 주입해서는 안 된다(MUST NOT). 이 change는 migration Secret을 실제 migration Job에 연결해서는 안 된다(MUST NOT).
+
+#### Scenario: Migration DB identity 프로비저닝
+
+- **WHEN** production PostgreSQL과 credential resource를 조정한다
+- **THEN** runtime DB identity와 다른 migration login identity가 별도 basic-auth Secret의 credential로 인증할 수 있다
+
+#### Scenario: Migration credential 최소 projection
+
+- **WHEN** migration DB credential Vault projection을 렌더한다
+- **THEN** `kubernetes/kosmo/prod/migration`에서 database username/password만 별도 basic-auth Secret으로 동기화하고 runtime 환경값을 복제하지 않는다
+
+#### Scenario: API와 Web의 credential 격리
+
+- **WHEN** production API와 Web Rollout을 렌더한다
+- **THEN** 두 workload는 기존 runtime DB credential을 사용하고 migration DB Secret을 secretKeyRef나 envFrom으로 참조하지 않는다
+
+#### Scenario: Migration consumer 비소유
+
+- **WHEN** production manifest를 렌더한다
+- **THEN** migration DB identity와 Secret은 존재하지만 이를 소비하는 production migration Job은 생성되지 않는다
+
+### Requirement: Production runtime dependency와 readiness 검증
+
+**Authority / Provenance:** Linear `PROD-562`. 시스템은 production runtime을 동기화하기 전에 Argo CD, Argo Rollouts, Gateway API의 public Gateway와 TLS, CloudNativePG, Barman Cloud plugin, Vault Secrets Operator 및 필요한 production ServiceAccount가 준비되었음을 확인할 수 있어야 한다(MUST). 선언은 Helm lint/render와 Kubernetes admission dry-run을 통과해야 하며(MUST), 동기화 뒤 PostgreSQL, secret projection, API와 Web workload 및 route 상태를 확인할 수 있어야 한다(MUST).
+
+#### Scenario: 선언형 사전 검증
+
+- **WHEN** production runtime 변경을 cluster에 동기화하기 전에 검증한다
+- **THEN** dev/prod Helm lint와 render 검사가 통과하고 production manifest가 server-side admission dry-run에서 수락된다
+
+#### Scenario: Add-on 준비 실패
+
+- **WHEN** 필수 CRD, controller, public Gateway, TLS certificate, Barman plugin 또는 Vault 인증 경계가 준비되지 않았다
+- **THEN** 운영자는 Application sync 전에 실패한 dependency를 식별하고 production workload readiness를 완료로 기록하지 않는다
+
+#### Scenario: Runtime readiness
+
+- **WHEN** `kosmo-prod` Application sync가 완료된다
+- **THEN** CloudNativePG Cluster, Vault secret projection, API와 Web Rollout, Service와 HTTPRoute의 상태가 Ready 또는 정상 조정 상태임을 확인한다
+
+### Requirement: 후속 release와 migration 계약의 비소유
+
+**Authority / Provenance:** Linear `PROD-562`. 이 capability는 production runtime resource와 migration DB identity/credential 기반만 제공해야 한다(MUST). 시스템은 PROD-563의 정식 release version 선택·승인·배포·rollback workflow, PROD-564의 migration Secret consumer·production migration 순서·실행·contract gate, PROD-565의 public 사용자 경로 smoke·첫 release 통합 검증이나 application read-routing을 이 변경으로 구현해서는 안 된다(MUST NOT).
+
+#### Scenario: Production runtime 변경 범위 검토
+
+- **WHEN** 이 capability의 manifest, workflow와 검증 task를 검토한다
+- **THEN** production Application, runtime 기반과 migration DB identity/Secret만 포함되고 release workflow, migration Secret consumer·Job/gate, application read-routing과 public 사용자 journey smoke는 포함되지 않는다
+
+#### Scenario: Production migration 리소스 렌더
+
+- **WHEN** 이 변경의 production Helm 값을 렌더한다
+- **THEN** PROD-564가 소유할 production migration Job이나 destructive contract 실행 resource는 생성되지 않는다

--- a/openspec/changes/add-production-runtime/specs/production-runtime/spec.md
+++ b/openspec/changes/add-production-runtime/specs/production-runtime/spec.md
@@ -2,22 +2,22 @@
 
 ### Requirement: Dev와 격리된 production Application
 
-**Authority / Provenance:** Linear `PROD-562`. 시스템은 Argo CD가 `kosmo-prod` Application을 `kosmo-prod` namespace에 선언형으로 생성하고 항상 automated sync하게 해야 한다(MUST). Production Helm 입력은 dev와 다른 environment, namespace, public hostname, runtime secret path와 database 경계를 사용해야 하며(MUST), workload image는 mutable tag를 자동 추적하지 않는 명시적인 non-`main` version으로 고정해야 한다(MUST). Dev 전용 resource나 `main` image version을 포함해서는 안 된다(MUST NOT).
+**Authority / Provenance:** Linear `PROD-562`, 통합 완료 책임 `PROD-545`. 시스템은 Argo CD가 `kosmo-prod` Application을 `kosmo-prod` namespace에 선언형으로 생성하고 항상 automated sync하게 해야 한다(MUST). Production Helm 입력은 dev와 다른 environment, namespace, public hostname, runtime secret path와 database 경계를 사용해야 한다(MUST). Bootstrap은 workload를 비활성화해야 하며(MUST), 이후 PROD-545가 설정한 immutable digest와 workload/migration Helm parameter를 Terraform이 제거해서는 안 된다(MUST NOT).
 
 #### Scenario: Production Application 선언
 
 - **WHEN** Terraform의 production Application을 계획하거나 렌더한다
 - **THEN** `kosmo-prod` Application의 destination은 `kosmo-prod` namespace이고 automated sync와 production 전용 Helm 입력을 사용한다
 
-#### Scenario: Production image version 고정
+#### Scenario: Release parameter 소유권 보존
 
-- **WHEN** production Application이 자동 동기화된다
-- **THEN** workload image는 Application 선언에 명시된 non-`main` version을 사용하고 registry의 mutable operational tag를 자동 추적하지 않는다
+- **WHEN** PROD-545 release workflow가 production Application에 digest와 workload/migration Helm parameter를 설정한 뒤 Terraform을 다시 적용한다
+- **THEN** Terraform은 해당 parameter overlay를 보존하면서 bootstrap values와 나머지 Application 구조의 drift는 계속 조정한다
 
 #### Scenario: 첫 release 전 bootstrap version
 
-- **WHEN** PROD-563이 production-built image digest를 아직 제공하지 않았다
-- **THEN** Application은 자동 추적 tag 대신 명시적인 `0.0.0` bootstrap version을 유지하고 workload readiness는 완료로 기록하지 않는다
+- **WHEN** PROD-545가 production release를 아직 배포하지 않았다
+- **THEN** Application은 `0.0.0` bootstrap sentinel과 `workloads.enabled=false`를 유지하고 API/Web Service, Rollout과 HTTPRoute를 생성하지 않는다
 
 #### Scenario: Dev 정책 격리
 
@@ -117,7 +117,7 @@
 
 ### Requirement: Production runtime dependency와 readiness 검증
 
-**Authority / Provenance:** Linear `PROD-562`. 시스템은 production runtime을 동기화하기 전에 Argo CD, Argo Rollouts, Gateway API의 public Gateway와 TLS, CloudNativePG, Barman Cloud plugin, Vault Secrets Operator 및 필요한 production ServiceAccount가 준비되었음을 확인할 수 있어야 한다(MUST). 선언은 Helm lint/render와 Kubernetes admission dry-run을 통과해야 하며(MUST), 동기화 뒤 PostgreSQL, secret projection, API와 Web workload 및 route 상태를 확인할 수 있어야 한다(MUST).
+**Authority / Provenance:** Linear `PROD-562`, 통합 완료 책임 `PROD-545`. 시스템은 production runtime bootstrap을 동기화하기 전에 Argo CD, CloudNativePG, Barman Cloud plugin, Vault Secrets Operator 및 필요한 production ServiceAccount가 준비되었음을 확인할 수 있어야 한다(MUST). 선언은 Helm lint/render와 Kubernetes admission dry-run을 통과해야 하며(MUST), 동기화 뒤 PostgreSQL과 secret projection 상태를 확인할 수 있어야 한다(MUST).
 
 #### Scenario: 선언형 사전 검증
 
@@ -129,14 +129,14 @@
 - **WHEN** 필수 CRD, controller, public Gateway, TLS certificate, Barman plugin 또는 Vault 인증 경계가 준비되지 않았다
 - **THEN** 운영자는 Application sync 전에 실패한 dependency를 식별하고 production workload readiness를 완료로 기록하지 않는다
 
-#### Scenario: Runtime readiness
+#### Scenario: Bootstrap readiness
 
 - **WHEN** `kosmo-prod` Application sync가 완료된다
-- **THEN** CloudNativePG Cluster, Vault secret projection, API와 Web Rollout, Service와 HTTPRoute의 상태가 Ready 또는 정상 조정 상태임을 확인한다
+- **THEN** CloudNativePG Cluster와 Vault secret projection의 상태가 Ready 또는 정상 조정 상태임을 확인하고 API/Web workload와 public route는 존재하지 않는다
 
 ### Requirement: 후속 release와 migration 계약의 비소유
 
-**Authority / Provenance:** Linear `PROD-562`. 이 capability는 production runtime resource와 migration DB identity/credential 기반만 제공해야 한다(MUST). 시스템은 PROD-563의 정식 release version 선택·승인·배포·rollback workflow, PROD-564의 migration Secret consumer·production migration 순서·실행·contract gate, PROD-565의 public 사용자 경로 smoke·첫 release 통합 검증이나 application read-routing을 이 변경으로 구현해서는 안 된다(MUST NOT).
+**Authority / Provenance:** Linear `PROD-562`, 통합 완료 책임 `PROD-545`. 이 capability는 production runtime bootstrap resource와 migration DB identity/credential 기반만 제공해야 한다(MUST). 시스템은 PROD-545의 release 선택·승인, workload/migration 활성화, restore rehearsal 연계, public 사용자 경로 smoke와 첫 release 완료 판단이나 application read-routing을 이 변경으로 구현해서는 안 된다(MUST NOT). 완료된 PROD-563/564 구현 이력은 보존해야 한다(MUST).
 
 #### Scenario: Production runtime 변경 범위 검토
 

--- a/openspec/changes/add-production-runtime/tasks.md
+++ b/openspec/changes/add-production-runtime/tasks.md
@@ -7,14 +7,14 @@
 
 **Deliverable**
 
-Argo CD가 dev와 격리된 `kosmo-prod` Application을 pinned image version으로 항상 자동 동기화하고, API·Web과 총 3 instances의 PostgreSQL이 production namespace, public route/TLS, runtime Vault 환경값, 분리된 migration DB identity/credential과 persistent storage 경계에서 Ready가 되어 PROD-546의 실제 backup/restore 검증을 시작할 수 있다.
+Argo CD가 dev와 격리된 `kosmo-prod` Application을 workload 비활성 bootstrap으로 자동 동기화하고, 총 3 instances의 PostgreSQL, backup, runtime Vault 환경값과 분리된 migration DB identity/credential 기반이 Ready가 되어 PROD-545가 PROD-546 live restore rehearsal을 시작할 수 있다.
 
 **Guardrails**
 
 - Production Web은 `kos.moe`, API는 `api.kos.moe`를 사용하고 기존 `gateway/public` TLS 경계를 소비한다. Kosmo change가 Gateway, Certificate, ClusterIssuer 또는 DNS credential을 만들지 않는다.
 - Production runtime 환경값은 기존 환경별 Vault projection에 따라 `kubernetes/kosmo/prod`에서 동기화하며 `/prod/runtime` path를 만들지 않는다. Migration DB credential은 `kubernetes/kosmo/prod/migration`에서 username/password만 별도 basic-auth Secret으로 동기화하고 API/Web runtime 환경값 전체를 복제하지 않는다. 어떤 secret value도 repository, Terraform input/state 또는 rendered manifest에 넣지 않는다.
 - 별도 `kosmo_migration` DB login identity를 선언하고 migration credential과 연결한다. API/Web은 기존 runtime `-app` Secret만 사용하며 migration Secret을 참조하지 않는다.
-- `kosmo-prod`는 automated sync, prune와 self-heal을 항상 유지한다. Workload image는 명시적인 non-`main` immutable version으로 고정하고 이 change는 release version 선택·승인·rollback workflow를 구현하지 않는다.
+- `kosmo-prod`는 automated sync, prune와 self-heal을 유지하되 bootstrap에서 workload를 만들지 않는다. 이 change는 release 선택·승인·활성화 workflow를 구현하지 않고, PROD-545가 설정한 release parameter를 이후 Terraform 적용에서 보존한다.
 - Production CloudNativePG는 primary 1개와 standby replica 2개, 총 3 instances 및 기존 10Gi per-instance storage를 사용한다. 기존 prod backup ServiceAccount/ObjectStore/Barman WAL/ScheduledBackup을 재사용하고 S3/IAM/plugin과 backup policy를 변경하지 않는다.
 - API/Web은 기존 read-write Service를 유지한다. Application read-routing, standalone/cross-cluster replica와 추가 failover topology를 구현하지 않는다.
 - PROD-562는 migration DB identity/credential 기반까지만 프로비저닝한다. Production migration Job, 이 credential의 consumer wiring, 실행 순서와 contract gate 및 public 사용자 journey smoke를 추가하지 않는다.
@@ -33,7 +33,8 @@ Argo CD가 dev와 격리된 `kosmo-prod` Application을 pinned image version으�
 - [x] 1.5 Dev/prod Helm lint/render와 admission dry-run으로 production runtime 요구사항 및 명시적 제외 범위를 확인한다.
 - [x] 1.6 OpenSpec strict validation, Helm lint/render와 repository 정적 검증을 통과시킨다.
 - [x] 1.7 Cluster-wide add-on, public Gateway/TLS, production runtime/migration Vault path와 Pod Identity의 live 선행 조건을 확인하고 production manifest의 server-side admission dry-run을 통과시킨다.
-- [ ] 1.8 Terraform saved plan을 검토·적용하고 ApplicationSet이 명시적인 non-`main` version으로 `kosmo-prod`를 자동 동기화하는지 확인한다.
-- [ ] 1.9 PostgreSQL 3 Pods/PVC, runtime projection, migration basic-auth Secret/`DatabaseRole`, API/Web workload·Service와 route/TLS controller readiness를 확인하고 민감 정보 없이 PROD-562에 증거를 기록한다.
-- [ ] 1.10 API/Web이 runtime `-rw`/`-app` 경계를 유지하고 migration Secret을 참조하지 않는지 확인한다. Production Cluster 준비 사실을 PROD-546 검증 흐름에 전달하고 PROD-563/564/565 범위가 구현되지 않았음을 최종 대조한다.
-- [ ] 1.11 모든 구현·live 검증과 정합성 확인 뒤 `production-runtime` spec을 archive하고 archive 후 validation을 통과시킨다.
+- [x] 1.8 Terraform이 bootstrap values와 Application 구조를 소유하되 PROD-545 release workflow의 Helm parameter overlay를 이후 reconciliation에서 보존하도록 lifecycle 경계를 선언하고 provider schema 및 정적 검증을 통과시킨다.
+- [ ] 1.9 Terraform saved plan을 검토·적용하고 `kosmo-prod`가 workload 비활성 bootstrap 상태로 자동 동기화하는지 확인한다.
+- [ ] 1.10 PostgreSQL 3 Pods/PVC, runtime projection, migration basic-auth Secret/`DatabaseRole` readiness를 확인하고 민감 정보 없이 PROD-545에 증거를 기록한다.
+- [ ] 1.11 Production Cluster 준비 사실을 PROD-546 restore rehearsal 흐름에 전달하고, workload 활성화·public smoke·첫 release가 PROD-545에 남아 있음을 최종 대조한다.
+- [ ] 1.12 모든 구현·live 검증과 정합성 확인 뒤 `production-runtime` spec을 archive하고 archive 후 validation을 통과시킨다.

--- a/openspec/changes/add-production-runtime/tasks.md
+++ b/openspec/changes/add-production-runtime/tasks.md
@@ -1,0 +1,39 @@
+## 1. PROD-562 Production runtime
+
+**Authority / Provenance**
+
+- `PROD-562`
+- `PROD-546` — 기존 backup 선언의 production Cluster 연결과 후속 live 검증 dependency에 한함
+
+**Deliverable**
+
+Argo CD가 dev와 격리된 `kosmo-prod` Application을 pinned image version으로 항상 자동 동기화하고, API·Web과 총 3 instances의 PostgreSQL이 production namespace, public route/TLS, runtime Vault 환경값, 분리된 migration DB identity/credential과 persistent storage 경계에서 Ready가 되어 PROD-546의 실제 backup/restore 검증을 시작할 수 있다.
+
+**Guardrails**
+
+- Production Web은 `kos.moe`, API는 `api.kos.moe`를 사용하고 기존 `gateway/public` TLS 경계를 소비한다. Kosmo change가 Gateway, Certificate, ClusterIssuer 또는 DNS credential을 만들지 않는다.
+- Production runtime 환경값은 기존 환경별 Vault projection에 따라 `kubernetes/kosmo/prod`에서 동기화하며 `/prod/runtime` path를 만들지 않는다. Migration DB credential은 `kubernetes/kosmo/prod/migration`에서 username/password만 별도 basic-auth Secret으로 동기화하고 API/Web runtime 환경값 전체를 복제하지 않는다. 어떤 secret value도 repository, Terraform input/state 또는 rendered manifest에 넣지 않는다.
+- 별도 `kosmo_migration` DB login identity를 선언하고 migration credential과 연결한다. API/Web은 기존 runtime `-app` Secret만 사용하며 migration Secret을 참조하지 않는다.
+- `kosmo-prod`는 automated sync, prune와 self-heal을 항상 유지한다. Workload image는 명시적인 non-`main` immutable version으로 고정하고 이 change는 release version 선택·승인·rollback workflow를 구현하지 않는다.
+- Production CloudNativePG는 primary 1개와 standby replica 2개, 총 3 instances 및 기존 10Gi per-instance storage를 사용한다. 기존 prod backup ServiceAccount/ObjectStore/Barman WAL/ScheduledBackup을 재사용하고 S3/IAM/plugin과 backup policy를 변경하지 않는다.
+- API/Web은 기존 read-write Service를 유지한다. Application read-routing, standalone/cross-cluster replica와 추가 failover topology를 구현하지 않는다.
+- PROD-562는 migration DB identity/credential 기반까지만 프로비저닝한다. Production migration Job, 이 credential의 consumer wiring, 실행 순서와 contract gate 및 public 사용자 journey smoke를 추가하지 않는다.
+
+**Verification**
+
+- Dev/prod Helm lint와 render assertion으로 environment, hostname, pinned image version, runtime/migration Vault path와 Secret type, `DatabaseRole`, prod 3 instances, backup 연결, API/Web credential 격리와 migration Job/read-routing 비렌더를 검증한다.
+- Production manifest의 server-side admission dry-run과 Terraform saved plan을 검토한다.
+- 필수 add-on, public Gateway/TLS, production runtime/migration Vault path와 Pod Identity 준비 상태를 확인한 뒤 Application automated sync 상태를 확인한다.
+- CloudNativePG 3 Pods/PVC, 두 VSO projection, migration basic-auth Secret과 `DatabaseRole`, API/Web Rollout·Service와 HTTPRoute Accepted/ResolvedRefs/readiness를 확인하고 API/Web database endpoint/credential이 `-rw`/`-app` 경계에 유지됨을 기록한다. Secret value는 읽거나 기록하지 않는다.
+
+- [x] 1.1 Production values와 runtime Vault projection을 추가해 environment, public hostname, pinned image version과 dev secret 격리를 구현한다.
+- [x] 1.2 Migration DB username/password만 투영하는 production basic-auth Secret과 별도 `kosmo_migration` `DatabaseRole`을 선언하고 API/Web runtime credential과 격리한다.
+- [x] 1.3 `kosmo-prod` Application과 namespace를 선언형으로 추가하고 automated sync, prune와 self-heal을 유지하면서 mutable image tag 추적을 차단한다.
+- [x] 1.4 Production CloudNativePG를 총 3 instances로 구성하고 기존 storage/backup 선언에 연결하되 API/Web read-write endpoint를 유지한다.
+- [x] 1.5 Dev/prod Helm 검증을 확장해 production runtime 요구사항과 명시적 제외 범위의 회귀를 검사한다.
+- [x] 1.6 OpenSpec strict validation, Helm lint/render와 repository 정적 검증을 통과시킨다.
+- [x] 1.7 Cluster-wide add-on, public Gateway/TLS, production runtime/migration Vault path와 Pod Identity의 live 선행 조건을 확인하고 production manifest의 server-side admission dry-run을 통과시킨다.
+- [ ] 1.8 Terraform saved plan을 검토·적용하고 ApplicationSet이 명시적인 non-`main` version으로 `kosmo-prod`를 자동 동기화하는지 확인한다.
+- [ ] 1.9 PostgreSQL 3 Pods/PVC, runtime projection, migration basic-auth Secret/`DatabaseRole`, API/Web workload·Service와 route/TLS controller readiness를 확인하고 민감 정보 없이 PROD-562에 증거를 기록한다.
+- [ ] 1.10 API/Web이 runtime `-rw`/`-app` 경계를 유지하고 migration Secret을 참조하지 않는지 확인한다. Production Cluster 준비 사실을 PROD-546 검증 흐름에 전달하고 PROD-563/564/565 범위가 구현되지 않았음을 최종 대조한다.
+- [ ] 1.11 모든 구현·live 검증과 정합성 확인 뒤 `production-runtime` spec을 archive하고 archive 후 validation을 통과시킨다.

--- a/openspec/changes/add-production-runtime/tasks.md
+++ b/openspec/changes/add-production-runtime/tasks.md
@@ -21,7 +21,7 @@ Argo CD가 dev와 격리된 `kosmo-prod` Application을 pinned image version으�
 
 **Verification**
 
-- Dev/prod Helm lint와 render assertion으로 environment, hostname, pinned image version, runtime/migration Vault path와 Secret type, `DatabaseRole`, prod 3 instances, backup 연결, API/Web credential 격리와 migration Job/read-routing 비렌더를 검증한다.
+- Dev/prod Helm lint/render와 admission dry-run으로 environment, hostname, 명시적인 image version, runtime/migration Vault path와 Secret type, `DatabaseRole`, prod 3 instances, backup 연결, API/Web credential 격리와 migration Job/read-routing 비렌더를 검증한다.
 - Production manifest의 server-side admission dry-run과 Terraform saved plan을 검토한다.
 - 필수 add-on, public Gateway/TLS, production runtime/migration Vault path와 Pod Identity 준비 상태를 확인한 뒤 Application automated sync 상태를 확인한다.
 - CloudNativePG 3 Pods/PVC, 두 VSO projection, migration basic-auth Secret과 `DatabaseRole`, API/Web Rollout·Service와 HTTPRoute Accepted/ResolvedRefs/readiness를 확인하고 API/Web database endpoint/credential이 `-rw`/`-app` 경계에 유지됨을 기록한다. Secret value는 읽거나 기록하지 않는다.
@@ -30,7 +30,7 @@ Argo CD가 dev와 격리된 `kosmo-prod` Application을 pinned image version으�
 - [x] 1.2 Migration DB username/password만 투영하는 production basic-auth Secret과 별도 `kosmo_migration` `DatabaseRole`을 선언하고 API/Web runtime credential과 격리한다.
 - [x] 1.3 `kosmo-prod` Application과 namespace를 선언형으로 추가하고 automated sync, prune와 self-heal을 유지하면서 mutable image tag 추적을 차단한다.
 - [x] 1.4 Production CloudNativePG를 총 3 instances로 구성하고 기존 storage/backup 선언에 연결하되 API/Web read-write endpoint를 유지한다.
-- [x] 1.5 Dev/prod Helm 검증을 확장해 production runtime 요구사항과 명시적 제외 범위의 회귀를 검사한다.
+- [x] 1.5 Dev/prod Helm lint/render와 admission dry-run으로 production runtime 요구사항 및 명시적 제외 범위를 확인한다.
 - [x] 1.6 OpenSpec strict validation, Helm lint/render와 repository 정적 검증을 통과시킨다.
 - [x] 1.7 Cluster-wide add-on, public Gateway/TLS, production runtime/migration Vault path와 Pod Identity의 live 선행 조건을 확인하고 production manifest의 server-side admission dry-run을 통과시킨다.
 - [ ] 1.8 Terraform saved plan을 검토·적용하고 ApplicationSet이 명시적인 non-`main` version으로 `kosmo-prod`를 자동 동기화하는지 확인한다.


### PR DESCRIPTION
선행 변경 [#431](https://github.com/byulmaru/kosmo/pull/431)은 merge됐으며, 이 PR은 최신 `main`을 직접 대상으로 합니다.

## 무엇을 변경했는지

- 기존 `production-runtime` OpenSpec과 구현 이력을 보존합니다.
- Dev ApplicationSet과 분리된 `kosmo-prod` Argo CD Application을 선언하고 automated sync, prune, self-heal을 유지합니다.
- 최초 sync에는 `workloads.enabled=false`를 전달해 API/Web Service·Rollout·HTTPRoute 없이 PostgreSQL·backup·runtime/migration Secret 기반만 준비합니다.
- Production CloudNativePG를 primary 1개와 standby 2개, 총 3 instances로 구성하고 Cluster/ObjectStore 삭제에는 명시적 prune 확인을 요구합니다.
- `kubernetes/kosmo/prod` runtime projection과 별도로 `kubernetes/kosmo/prod/migration`의 username/password만 투영하는 basic-auth Secret 및 `kosmo_migration` DatabaseRole을 추가합니다.
- API/Web은 첫 Git tag 배포의 `prod` 승인 뒤 #431 pipeline이 digest와 함께 활성화하며 runtime `-rw`/`-app` credential 경계를 유지합니다.
- Terraform은 bootstrap values와 Application 구조를 소유하되, PROD-545 release workflow가 설정한 Helm parameter overlay는 이후 apply에서도 보존합니다.

## 왜 변경했는지

PROD-546 live restore rehearsal을 첫 workload 배포보다 먼저 수행하려면 production DB·backup·Secret 기반은 미리 자동 sync하되 API/Web은 배포하면 안 됩니다. #431의 단일 bootstrap flag를 사용해 별도 Application이나 수동 resource 목록 없이 이 순서를 만듭니다.

이 PR과 기존 OpenSpec은 PROD-562 구현 이력으로 보존하며, 실제 runtime 적용·restore rehearsal·첫 release·public smoke와 최종 완료 판단은 PROD-545가 소유합니다.

## 이번 PR의 주요 결정

### 최초 Application sync는 runtime 기반만 만든다

- 결정자: @robin-maki
- 선택: `kosmo-prod`는 `workloads.enabled=false`로 시작하고 PostgreSQL·backup·Vault projection·migration identity만 자동 sync합니다.
- 고려한 대안: 존재하지 않는 `0.0.0` image로 API/Web까지 sync하거나 production Application 전체를 수동 sync
- 이유: Runtime은 선언형으로 준비하면서 GitHub `prod` 승인 전 workload 배포와 실패 상태를 만들지 않기 위해서입니다.
- 감수한 결과: `0.0.0`은 workload image가 아니라 bootstrap metadata sentinel로만 남고, Service·Rollout·HTTPRoute readiness는 PROD-545 첫 release에서 확인합니다.
- 관련 근거: PROD-545 실행 순서, PR #431

### Terraform과 release parameter 소유권을 분리한다

- 결정자: @robin-maki
- 선택: Terraform lifecycle은 정확히 `spec.source.helm.parameter`만 무시하고 bootstrap values와 나머지 Application 구조는 계속 관리합니다.
- 고려한 대안: Release마다 Terraform 선언을 커밋하거나 Application 전체 drift를 무시하는 방식
- 이유: 승인된 digest·workload·migration parameter를 다음 Terraform apply가 제거해 workload를 prune하는 장애를 막으면서 infrastructure drift는 계속 조정하기 위해서입니다.
- 감수한 결과: Release parameter를 의도적으로 초기화할 때는 Terraform이 아니라 release 운영 경계에서 명시적으로 수행해야 합니다.
- 관련 근거: PR review, `add-production-runtime` superseding decision

### Production Application lifecycle 분리

- 결정자: @robin-maki
- 선택: Dev ApplicationSet은 유지하고 production을 `cascade=false`인 별도 Application으로 선언합니다. 데이터 및 migration identity resource prune에는 명시적 확인을 요구합니다.
- 고려한 대안: Shared ApplicationSet 전체에 resource preservation 적용
- 이유: Production 데이터 보존 경계를 추가하면서 dev Application 삭제 lifecycle까지 바꾸지 않기 위해서입니다.
- 감수한 결과: Dev/prod Application 선언이 Terraform에서 서로 다른 resource로 관리됩니다.
- 관련 근거: 기존 `add-production-runtime` decision 이력

## 어떻게 확인할 수 있는지

- `pnpm exec openspec validate add-production-runtime --strict`
- `bash apps/helm/test-render.sh`
- `pnpm lint:prettier`
- `terraform fmt -check -recursive apps/terraform`
- Argo CD provider 7.15.3의 최소 configuration에서 lifecycle 경로 `terraform validate`
- `git diff --check`
- GitHub Terraform Plan의 saved plan과 merge tree 일치 여부

## 아직 어떤 문제가 남았는지

- Merge/apply 뒤 PostgreSQL 3 Pods/PVC, 두 Vault projection, migration DatabaseRole과 backup/WAL readiness를 확인해야 합니다.
- PROD-546 live restore rehearsal 뒤 첫 tag release가 API/Web·migration을 활성화합니다.
- 기존 OpenSpec은 당시 구현 결정과 감사 이력을 보존하며 공통 OpenSpec으로 재작성하지 않습니다.

Linear: PROD-562
