### PR TITLE
프로필 route 전환 시 상단 정보를 함께 갱신한다

### DIFF
--- a/apps/app/.storybook/mocks/expo-router.tsx
+++ b/apps/app/.storybook/mocks/expo-router.tsx
@@ -55,6 +55,10 @@ export function useLocalSearchParams<T extends Record<string, string | undefined
   return useContext(RouterContext).params as T;
 }
 
+export function useGlobalSearchParams<T extends Record<string, string | undefined>>() {
+  return useContext(RouterContext).params as T;
+}
+
 export function useRouter() {
   const { setPathname } = useContext(RouterContext);
   return useMemo(

--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
@@ -1,10 +1,10 @@
-import { Slot } from 'expo-router';
+import { Slot, useGlobalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { FollowButton } from '@/components/profile/FollowButton';
 import { ProfileHero } from '@/components/profile/ProfileHero';
-import { useProfileLayoutHandle } from '@/components/profile/route';
+import { normalizeProfileHandle } from '@/components/profile/route';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { StateView } from '@/components/ui/StateView';
 import { useRelayActor } from '@/relay/RelayActorProvider';
@@ -22,7 +22,10 @@ const ProfileLayoutQuery = graphql`
 `;
 
 export default function ProfileLayout() {
-  const handle = useProfileLayoutHandle();
+  const { profileHandle } = useGlobalSearchParams<{
+    profileHandle?: string | string[];
+  }>();
+  const handle = normalizeProfileHandle(profileHandle);
   const { revision } = useRelayActor();
   const [fetchKey, setFetchKey] = useState(0);
 

--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
@@ -4,7 +4,7 @@ import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { FollowButton } from '@/components/profile/FollowButton';
 import { ProfileHero } from '@/components/profile/ProfileHero';
-import { useProfileHandle } from '@/components/profile/route';
+import { useProfileLayoutHandle } from '@/components/profile/route';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { StateView } from '@/components/ui/StateView';
 import { useRelayActor } from '@/relay/RelayActorProvider';
@@ -22,7 +22,7 @@ const ProfileLayoutQuery = graphql`
 `;
 
 export default function ProfileLayout() {
-  const handle = useProfileHandle();
+  const handle = useProfileLayoutHandle();
   const { revision } = useRelayActor();
   const [fetchKey, setFetchKey] = useState(0);
 

--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/followers.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/followers.tsx
@@ -1,10 +1,11 @@
+import { useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import {
   ProfileConnectionList,
   ProfileConnectionListState,
 } from '@/components/profile/ProfileConnectionList';
-import { useProfileHandle } from '@/components/profile/route';
+import { normalizeProfileHandle } from '@/components/profile/route';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import type { ProfileFollowersPageQuery as ProfileFollowersPageQueryType } from './__generated__/ProfileFollowersPageQuery.graphql';
@@ -19,7 +20,10 @@ const ProfileFollowersPageQuery = graphql`
 `;
 
 export default function ProfileFollowersPage() {
-  const handle = useProfileHandle();
+  const { profileHandle } = useLocalSearchParams<{
+    profileHandle?: string | string[];
+  }>();
+  const handle = normalizeProfileHandle(profileHandle);
   const { revision } = useRelayActor();
   const [fetchKey, setFetchKey] = useState(0);
 

--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/following.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/following.tsx
@@ -1,10 +1,11 @@
+import { useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import {
   ProfileConnectionList,
   ProfileConnectionListState,
 } from '@/components/profile/ProfileConnectionList';
-import { useProfileHandle } from '@/components/profile/route';
+import { normalizeProfileHandle } from '@/components/profile/route';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import type { ProfileFollowingPageQuery as ProfileFollowingPageQueryType } from './__generated__/ProfileFollowingPageQuery.graphql';
@@ -19,7 +20,10 @@ const ProfileFollowingPageQuery = graphql`
 `;
 
 export default function ProfileFollowingPage() {
-  const handle = useProfileHandle();
+  const { profileHandle } = useLocalSearchParams<{
+    profileHandle?: string | string[];
+  }>();
+  const handle = normalizeProfileHandle(profileHandle);
   const { revision } = useRelayActor();
   const [fetchKey, setFetchKey] = useState(0);
 

--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/index.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/index.tsx
@@ -1,7 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { PostList } from '@/components/post/PostList';
-import { useProfileHandle } from '@/components/profile/route';
+import { normalizeProfileHandle } from '@/components/profile/route';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import type { ProfilePostListPageQuery as ProfilePostListPageQueryType } from './__generated__/ProfilePostListPageQuery.graphql';
@@ -16,7 +17,10 @@ const ProfilePostListPageQuery = graphql`
 `;
 
 export default function ProfilePostListPage() {
-  const handle = useProfileHandle();
+  const { profileHandle } = useLocalSearchParams<{
+    profileHandle?: string | string[];
+  }>();
+  const handle = normalizeProfileHandle(profileHandle);
   const { revision } = useRelayActor();
   const [fetchKey, setFetchKey] = useState(0);
 

--- a/apps/app/src/components/profile/ProfileRoute.test.ts
+++ b/apps/app/src/components/profile/ProfileRoute.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { afterEach, before, describe, it, mock } from 'node:test';
-import { createElement } from 'react';
+import { createContext, createElement, useContext } from 'react';
 import { act, create } from 'react-test-renderer';
 import type { ComponentType } from 'react';
 import type { ReactTestRenderer } from 'react-test-renderer';
@@ -21,7 +21,13 @@ const queryHistory: Array<{
 }> = [];
 const pending = new Promise<never>(() => undefined);
 
-let params: { profileHandle?: string | string[] } = {};
+type RouteParams = { profileHandle?: string | string[] };
+
+const LocalParamsContext = createContext<RouteParams>({});
+
+let globalParams: RouteParams = {};
+let layoutLocalParams: RouteParams = {};
+let screenLocalParams: RouteParams = {};
 let renderer: ReactTestRenderer | null = null;
 let SlotContent: ComponentType | null = null;
 
@@ -31,9 +37,16 @@ const mockModule = (specifier: string | URL, exports: object) =>
   } as unknown as Parameters<typeof mock.module>[1]);
 
 mockModule('expo-router', {
-  Slot: () => (SlotContent ? createElement(SlotContent) : null),
-  useGlobalSearchParams: () => params,
-  useLocalSearchParams: () => params,
+  Slot: () =>
+    SlotContent
+      ? createElement(
+          LocalParamsContext.Provider,
+          { value: screenLocalParams },
+          createElement(SlotContent),
+        )
+      : null,
+  useGlobalSearchParams: () => globalParams,
+  useLocalSearchParams: () => useContext(LocalParamsContext),
 });
 mockModule('react-native', {
   Platform: { OS: 'web' },
@@ -126,19 +139,37 @@ afterEach(async () => {
     await act(async () => renderer?.unmount());
     renderer = null;
   }
-  params = {};
+  globalParams = {};
+  layoutLocalParams = {};
+  screenLocalParams = {};
   queryModes.ProfileLayoutQuery = 'success';
   queryModes.ProfilePostListPageQuery = 'success';
   queryHistory.length = 0;
 });
 
 async function renderRoute(profileHandle: string) {
-  params = { profileHandle };
+  globalParams = { profileHandle };
+  screenLocalParams = { profileHandle };
+  if (!renderer) {
+    layoutLocalParams = { profileHandle };
+  }
   await act(async () => {
     if (renderer) {
-      renderer.update(createElement(ProfileLayout));
+      renderer.update(
+        createElement(
+          LocalParamsContext.Provider,
+          { value: layoutLocalParams },
+          createElement(ProfileLayout),
+        ),
+      );
     } else {
-      renderer = create(createElement(ProfileLayout));
+      renderer = create(
+        createElement(
+          LocalParamsContext.Provider,
+          { value: layoutLocalParams },
+          createElement(ProfileLayout),
+        ),
+      );
     }
   });
   assert.ok(renderer);

--- a/apps/app/src/components/profile/ProfileRoute.test.ts
+++ b/apps/app/src/components/profile/ProfileRoute.test.ts
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, describe, it, mock } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ComponentType } from 'react';
+import type { ReactTestRenderer } from 'react-test-renderer';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type QueryMode = 'error' | 'loading' | 'success';
+type QueryName = 'ProfileLayoutQuery' | 'ProfilePostListPageQuery';
+
+const queryModes: Record<QueryName, QueryMode> = {
+  ProfileLayoutQuery: 'success',
+  ProfilePostListPageQuery: 'success',
+};
+const queryHistory: Array<{
+  fetchKey: string;
+  handle: string;
+  query: QueryName;
+}> = [];
+const pending = new Promise<never>(() => undefined);
+
+let params: { profileHandle?: string | string[] } = {};
+let renderer: ReactTestRenderer | null = null;
+let SlotContent: ComponentType | null = null;
+
+const mockModule = (specifier: string | URL, exports: object) =>
+  mock.module(specifier, {
+    exports,
+  } as unknown as Parameters<typeof mock.module>[1]);
+
+mockModule('expo-router', {
+  Slot: () => (SlotContent ? createElement(SlotContent) : null),
+  useGlobalSearchParams: () => params,
+  useLocalSearchParams: () => params,
+});
+mockModule('react-native', {
+  Platform: { OS: 'web' },
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: <T>(styles: T) => styles },
+  View: 'View',
+});
+mockModule('react-relay', {
+  graphql: (parts: TemplateStringsArray) => {
+    const query = parts.join('').match(/query (ProfileLayoutQuery|ProfilePostListPageQuery)/)?.[1];
+    assert.ok(query);
+    return query as QueryName;
+  },
+  useLazyLoadQuery: (
+    query: QueryName,
+    variables: { handle: string },
+    options: { fetchKey: string },
+  ) => {
+    queryHistory.push({ fetchKey: options.fetchKey, handle: variables.handle, query });
+    const mode = queryModes[query];
+    if (mode === 'loading') {
+      throw pending;
+    }
+    if (mode === 'error') {
+      throw new Error(`${query}:${variables.handle}`);
+    }
+
+    return {
+      profileByHandle: {
+        handle: variables.handle,
+        id: `profile:${variables.handle}`,
+      },
+    };
+  },
+});
+mockModule(new URL('./ProfileHero.tsx', import.meta.url), {
+  ProfileHero: ({
+    action,
+    loading,
+    profile,
+  }: {
+    action?: ReturnType<typeof createElement>;
+    loading?: boolean;
+    profile?: { handle: string };
+  }) => createElement('ProfileHero', { identity: loading ? 'loading' : profile?.handle }, action),
+});
+mockModule(new URL('./FollowButton.tsx', import.meta.url), {
+  FollowButton: ({ profile }: { profile: { handle: string } }) =>
+    createElement('FollowButton', { identity: profile.handle }),
+});
+mockModule(new URL('../post/PostList.tsx', import.meta.url), {
+  PostList: ({
+    error,
+    loading,
+    onRetry,
+    profile,
+  }: {
+    error?: boolean;
+    loading?: boolean;
+    onRetry?: () => void;
+    profile?: { handle: string };
+  }) =>
+    createElement('PostList', {
+      identity: error ? 'error' : loading ? 'loading' : profile?.handle,
+      onRetry,
+    }),
+});
+mockModule(new URL('../ui/StateView.tsx', import.meta.url), {
+  StateView: (props: object) => createElement('StateView', props),
+});
+mockModule(new URL('../../observability/UnexpectedErrorContext.ts', import.meta.url), {
+  useUnexpectedErrorReporter: () => undefined,
+});
+mockModule(new URL('../../relay/RelayActorProvider.tsx', import.meta.url), {
+  useRelayActor: () => ({ revision: 4 }),
+});
+
+let ProfileLayout: ComponentType;
+let ProfilePostListPage: ComponentType;
+
+before(async () => {
+  ({ default: ProfileLayout } = await import('../../app/(tabs)/(profile)/[profileHandle]/_layout'));
+  ({ default: ProfilePostListPage } =
+    await import('../../app/(tabs)/(profile)/[profileHandle]/index'));
+  SlotContent = ProfilePostListPage;
+});
+
+afterEach(async () => {
+  if (renderer) {
+    await act(async () => renderer?.unmount());
+    renderer = null;
+  }
+  params = {};
+  queryModes.ProfileLayoutQuery = 'success';
+  queryModes.ProfilePostListPageQuery = 'success';
+  queryHistory.length = 0;
+});
+
+async function renderRoute(profileHandle: string) {
+  params = { profileHandle };
+  await act(async () => {
+    if (renderer) {
+      renderer.update(createElement(ProfileLayout));
+    } else {
+      renderer = create(createElement(ProfileLayout));
+    }
+  });
+  assert.ok(renderer);
+}
+
+function identities(type: string) {
+  return rendered(type).map((node) => node.props.identity as string);
+}
+
+function rendered(type: string) {
+  assert.ok(renderer);
+  return renderer.root.findAll((node) => node.type === type);
+}
+
+function requireRendered(type: string) {
+  const node = rendered(type)[0];
+  assert.ok(node);
+  return node;
+}
+
+describe('profile route parameter lifecycle', () => {
+  it('local → remote → local 뒤로 가기에서 header, action, nested list를 같은 identity로 전환한다', async () => {
+    await renderRoute('@local');
+    assert.deepEqual(identities('ProfileHero'), ['local']);
+    assert.deepEqual(identities('FollowButton'), ['local']);
+    assert.deepEqual(identities('PostList'), ['local']);
+
+    await renderRoute('@remote@activitypub.example');
+    assert.deepEqual(identities('ProfileHero'), ['remote@activitypub.example']);
+    assert.deepEqual(identities('FollowButton'), ['remote@activitypub.example']);
+    assert.deepEqual(identities('PostList'), ['remote@activitypub.example']);
+
+    await renderRoute('@local');
+    assert.deepEqual(identities('ProfileHero'), ['local']);
+    assert.deepEqual(identities('FollowButton'), ['local']);
+    assert.deepEqual(identities('PostList'), ['local']);
+    assert.deepEqual(
+      queryHistory.slice(-2).map(({ handle, query }) => ({ handle, query })),
+      [
+        { handle: 'local', query: 'ProfileLayoutQuery' },
+        { handle: 'local', query: 'ProfilePostListPageQuery' },
+      ],
+    );
+  });
+
+  it('handle 전환 중 layout과 nested query의 기존 loading fallback을 유지한다', async () => {
+    await renderRoute('@local');
+
+    queryModes.ProfileLayoutQuery = 'loading';
+    await renderRoute('@remote@activitypub.example');
+    assert.deepEqual(identities('ProfileHero'), ['loading']);
+    assert.deepEqual(identities('PostList'), []);
+
+    queryModes.ProfileLayoutQuery = 'success';
+    queryModes.ProfilePostListPageQuery = 'loading';
+    await renderRoute('@remote@activitypub.example');
+    assert.deepEqual(identities('ProfileHero'), ['remote@activitypub.example']);
+    assert.deepEqual(identities('PostList'), ['loading']);
+  });
+
+  it('현재 handle의 layout error를 표시하고 retry에서 같은 query를 다시 실행한다', async () => {
+    const originalConsoleError = console.error;
+    console.error = () => undefined;
+    try {
+      queryModes.ProfileLayoutQuery = 'error';
+      await renderRoute('@remote@activitypub.example');
+      assert.equal(requireRendered('StateView').props.title, '프로필을 불러오지 못했어요');
+
+      queryModes.ProfileLayoutQuery = 'success';
+      await act(async () => requireRendered('StateView').props.onAction());
+
+      assert.deepEqual(identities('ProfileHero'), ['remote@activitypub.example']);
+      const latestLayoutQuery = queryHistory.findLast(
+        ({ query }) => query === 'ProfileLayoutQuery',
+      );
+      assert.equal(latestLayoutQuery?.handle, 'remote@activitypub.example');
+      assert.equal(latestLayoutQuery?.fetchKey, '4:1');
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  it('현재 handle의 nested error와 retry 동작을 유지한다', async () => {
+    const originalConsoleError = console.error;
+    console.error = () => undefined;
+    try {
+      queryModes.ProfilePostListPageQuery = 'error';
+      await renderRoute('@local');
+      assert.deepEqual(identities('ProfileHero'), ['local']);
+      assert.deepEqual(identities('PostList'), ['error']);
+
+      queryModes.ProfilePostListPageQuery = 'success';
+      const errorPostList = rendered('PostList').find((node) => node.props.identity === 'error');
+      assert.ok(errorPostList);
+      await act(async () => errorPostList.props.onRetry());
+
+      assert.deepEqual(identities('PostList'), ['local']);
+      const latestPostQuery = queryHistory.findLast(
+        ({ query }) => query === 'ProfilePostListPageQuery',
+      );
+      assert.equal(latestPostQuery?.handle, 'local');
+      assert.equal(latestPostQuery?.fetchKey, '4:1');
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});

--- a/apps/app/src/components/profile/route.ts
+++ b/apps/app/src/components/profile/route.ts
@@ -1,8 +1,19 @@
-import { useLocalSearchParams } from 'expo-router';
+import { useGlobalSearchParams, useLocalSearchParams } from 'expo-router';
 
-export function useProfileHandle(): string {
-  const { profileHandle } = useLocalSearchParams<{ profileHandle?: string | string[] }>();
+function normalizeProfileHandle(profileHandle?: string | string[]): string {
   const value = Array.isArray(profileHandle) ? profileHandle[0] : profileHandle;
 
   return (value ?? '').replace(/^@/, '');
+}
+
+export function useProfileHandle(): string {
+  const { profileHandle } = useLocalSearchParams<{ profileHandle?: string | string[] }>();
+
+  return normalizeProfileHandle(profileHandle);
+}
+
+export function useProfileLayoutHandle(): string {
+  const { profileHandle } = useGlobalSearchParams<{ profileHandle?: string | string[] }>();
+
+  return normalizeProfileHandle(profileHandle);
 }

--- a/apps/app/src/components/profile/route.ts
+++ b/apps/app/src/components/profile/route.ts
@@ -1,19 +1,5 @@
-import { useGlobalSearchParams, useLocalSearchParams } from 'expo-router';
-
-function normalizeProfileHandle(profileHandle?: string | string[]): string {
+export function normalizeProfileHandle(profileHandle?: string | string[]): string {
   const value = Array.isArray(profileHandle) ? profileHandle[0] : profileHandle;
 
   return (value ?? '').replace(/^@/, '');
-}
-
-export function useProfileHandle(): string {
-  const { profileHandle } = useLocalSearchParams<{ profileHandle?: string | string[] }>();
-
-  return normalizeProfileHandle(profileHandle);
-}
-
-export function useProfileLayoutHandle(): string {
-  const { profileHandle } = useGlobalSearchParams<{ profileHandle?: string | string[] }>();
-
-  return normalizeProfileHandle(profileHandle);
 }


### PR DESCRIPTION
## 무엇을 변경했는지

- `[profileHandle]` layout에서 `useGlobalSearchParams`를 직접 사용해 현재 URL의 route parameter를 구독합니다.
- 활성 `index`·`followers`·`following` screen은 `useLocalSearchParams`를 직접 사용합니다.
- 공용 profile route 유틸에는 leading `@` 제거만 담당하는 순수 정규화 함수를 남겼습니다.
- handle이 바뀌면 기존 handle-keyed `RouteBoundary`가 실제로 다시 생성되어 layout query, `ProfileHero`, `FollowButton`이 새 profile identity로 전환됩니다.
- Storybook Expo Router mock에 global search params 계약을 추가했습니다.
- local → remote → local(back), layout/nested loading, layout/nested error와 retry를 검증하는 route-level 회귀 테스트를 추가했습니다.

## 왜 변경했는지

같은 Expo Router `[profileHandle]` route 안에서 client navigation하면 활성 nested screen은 새 local parameter를 받아 PostList를 갱신하지만, 재사용되는 상위 layout은 이전 local parameter를 유지할 수 있었습니다. 그 결과 URL·PostList와 상단 ProfileHero·FollowButton이 서로 다른 profile identity를 표시했습니다.

기존 `useProfileHandle` 래퍼가 local parameter 구독이라는 중요한 lifecycle 선택을 호출부에서 숨기고 있어, layout이 잘못된 구독 방식을 사용한다는 사실을 발견하기 어려웠습니다.

관련 이슈: [PROD-578](https://linear.app/byulmaru/issue/PROD-578/프로필-route-전환-시-상단-profilehero를-갱신한다)

## 이번 PR의 주요 결정

### Route parameter 구독 방식을 호출부에 명시한다

- 결정자: @robin-maki
- 선택: layout은 `useGlobalSearchParams`, 활성 screen은 `useLocalSearchParams`를 각 route에서 직접 호출하고 공용 코드는 handle 문자열 정규화만 담당합니다.
- 고려한 대안: local/global 차이를 각각 `useProfileHandle`·`useProfileLayoutHandle` custom hook으로 감쌉니다.
- 이유: route 수명에 직접 영향을 주는 local/global 선택이 호출부와 코드 리뷰에서 보여야 같은 lifecycle 오류를 조기에 발견할 수 있습니다.
- 감수한 결과: 각 route에 parameter 타입 선언과 정규화 호출이 반복되지만, subscription semantics의 명시성을 우선합니다.
- 관련 근거: PROD-578 재현 및 Expo Router local/global search parameter lifecycle.

그 외에는 최신 PROD-578/PROD-109/PROD-443 및 canonical profile/web-app-shell 계약을 변경 없이 적용했습니다. 새 loading/navigation 행동이나 active profile actor 계약이 없어 새 OpenSpec change를 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:unit` — 81 passed
- `pnpm --filter @kosmo/app build-storybook`
- `pnpm --filter @kosmo/app test:storybook` — 208 passed
- `pnpm --filter @kosmo/app export:web`
- `pnpm lint:prettier`
- 대상 파일 ESLint
- dev.kos.moe 로그인 세션을 사용하는 실제 브라우저 smoke는 현재 작업 환경에 브라우저 제어 도구가 없어 실행하지 못했습니다. 동일 재현 흐름은 route-level 테스트에서 local/remote/back과 loading/error/retry까지 검증했습니다.

## 아직 어떤 문제가 남았는지

- PROD-443의 frontend-wide actor/query retry lifecycle 정리는 이번 PR 범위 밖입니다.
- 배포 후 dev.kos.moe에서 원래 반응자 모달 흐름의 수동 smoke를 한 번 확인할 수 있습니다.

Stack: main -> PROD-578