### PR TITLE
Mastodon Undo(Like) 호환 경로를 회귀 검증한다

### DIFF
--- a/packages/fedify/src/inbound-reaction.test.ts
+++ b/packages/fedify/src/inbound-reaction.test.ts
@@ -9,6 +9,7 @@ import {
   db,
   firstOrThrow,
   Instances,
+  Notifications,
   pg,
   Profiles,
   Reactions,
@@ -17,6 +18,7 @@ import {
   ActivityPubActorType,
   InstanceKind,
   InstanceState,
+  NotificationKind,
   PostVisibility,
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
@@ -285,6 +287,73 @@ test('Undo URI와 embedded activity는 mapping만 사용하고 actor mismatch를
         .from(ActivityPubReactions)
         .where(eq(ActivityPubReactions.uri, second.id!.href))
     ).length,
+    0,
+  );
+});
+
+test('Mastodon embedded Undo(Like)가 fragment activity mapping과 Notification을 제거한다', async () => {
+  const actor = await createProfile(InstanceKind.ACTIVITYPUB);
+  const target = await createLocalTarget();
+  const activityUri = `${actor.actorUri}#likes/${crypto.randomUUID()}`;
+  const like = await Like.fromJsonLd({
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    actor: actor.actorUri,
+    id: activityUri,
+    object: target.objectUri.href,
+    type: 'Like',
+  });
+
+  await handleInboundReaction(createContext(null), like);
+  const reaction = await readReaction(actor.profile.id, target.post.id);
+  assert.ok(reaction);
+  assert.equal(
+    await db
+      .select()
+      .from(Notifications)
+      .where(
+        and(
+          eq(Notifications.kind, NotificationKind.REACTION),
+          eq(Notifications.sourceId, reaction.id),
+        ),
+      )
+      .then((rows) => rows.length),
+    1,
+  );
+
+  const undo = await Undo.fromJsonLd({
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    actor: actor.actorUri,
+    id: `${activityUri}/undo`,
+    object: {
+      actor: actor.actorUri,
+      id: activityUri,
+      object: target.objectUri.href,
+      type: 'Like',
+    },
+    type: 'Undo',
+  });
+  await handleInboundUndo(createContext(null), undo);
+
+  assert.equal(await readReaction(actor.profile.id, target.post.id), undefined);
+  assert.equal(
+    await db
+      .select()
+      .from(ActivityPubReactions)
+      .where(eq(ActivityPubReactions.uri, activityUri))
+      .then((rows) => rows.length),
+    0,
+  );
+  assert.equal(
+    await db
+      .select()
+      .from(Notifications)
+      .where(
+        and(
+          eq(Notifications.kind, NotificationKind.REACTION),
+          eq(Notifications.sourceId, reaction.id),
+        ),
+      )
+      .then((rows) => rows.length),
     0,
   );
 });


### PR DESCRIPTION
## 무엇을 변경했는지

- Mastodon 4.1 계열이 사용하는 `actor#likes/{id}` activity URI와 embedded `Like` 형태의 compact JSON-LD fixture를 추가했습니다.
- 수신 `Undo(Like)` 뒤 Reaction, ActivityPub mapping, Reaction Notification이 함께 제거되는지 검증합니다.
- 기존 URI/embedded Undo, actor mismatch, missing/repeated Undo, no-network lookup과 core transaction 회귀 검증은 그대로 유지합니다.

## 왜 변경했는지

[PROD-577](https://linear.app/byulmaru/issue/PROD-577/mastodon-undolike를-inbound-reaction에-반영한다)은 ActivityPub Academy에서 Like 취소 뒤 Kosmo 상태가 남는다고 보고했습니다.

조사 결과 최초 QA에서는 Academy의 Like 전송 기록만 있었고 Undo 전송 기록이 없었습니다. 남아 있던 QA 게시물에서 실제 좋아요 취소를 다시 실행하자 현재 `origin/main` 구현이 Reaction 수와 Notification을 정상 정리했습니다. 따라서 기존 계약과 runtime 코드는 변경하지 않고, 실 payload 호환 경로만 회귀 테스트로 고정합니다.

## 이번 PR의 주요 결정

없음. 최신 canonical 문서, PROD-498/577, `activitypub-inbound-reaction` 계약을 변경 없이 적용했습니다. 새 허용 payload나 보안 경계가 필요하지 않아 OpenSpec을 추가하지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm test:fedify` — 150개 통과
- `pnpm --filter @kosmo/core test:services:database` — 145개 통과 (저장소 지정 Node 26.3.0)
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm exec prettier --check packages/fedify/src/inbound-reaction.test.ts`
- 실연합 재검증: Academy에서 남아 있던 QA 게시물의 좋아요를 실제 취소한 뒤 Kosmo Reaction 수 1→0 및 알림 제거 확인

## 아직 어떤 문제가 남았는지

없음. 최초 실연합 재현은 Undo가 실제 발송되지 않은 QA 오탐으로 확인됐습니다.
