### PR TITLE
오류 화면에서 Sentry 추적 ID를 제공한다

### DIFF
--- a/apps/app/.storybook/main.ts
+++ b/apps/app/.storybook/main.ts
@@ -35,6 +35,10 @@ const config: StorybookConfig = {
           replacement: fileURLToPath(new URL('./mocks/expo-image-picker.ts', import.meta.url)),
         },
         {
+          find: /^expo-clipboard$/,
+          replacement: fileURLToPath(new URL('./mocks/expo-clipboard.ts', import.meta.url)),
+        },
+        {
           find: /^react-native-safe-area-context$/,
           replacement: fileURLToPath(new URL('./mocks/safe-area-context.tsx', import.meta.url)),
         },

--- a/apps/app/.storybook/mocks/expo-clipboard.ts
+++ b/apps/app/.storybook/mocks/expo-clipboard.ts
@@ -1,0 +1,3 @@
+export async function setStringAsync(): Promise<void> {
+  return;
+}

--- a/apps/app/.storybook/mocks/expo-router.tsx
+++ b/apps/app/.storybook/mocks/expo-router.tsx
@@ -15,6 +15,8 @@ export type Href = string | { params?: Record<string, string | undefined>; pathn
 type RouterContextValue = {
   params: Record<string, string | undefined>;
   pathname: string;
+  push: (href: Href) => void;
+  replace: (href: Href) => void;
   setPathname: (href: Href) => void;
   slotLabel: string;
 };
@@ -22,6 +24,8 @@ type RouterContextValue = {
 const RouterContext = createContext<RouterContextValue>({
   params: {},
   pathname: '/home',
+  push: () => undefined,
+  replace: () => undefined,
   setPathname: () => undefined,
   slotLabel: '현재 라우트 콘텐츠',
 });
@@ -30,18 +34,28 @@ export function RouterMockProvider({
   children,
   params = {},
   pathname: initialPathname = '/home',
+  onNavigate,
   slotLabel = '현재 라우트 콘텐츠',
 }: PropsWithChildren<{
   params?: Record<string, string | undefined>;
   pathname?: string;
+  onNavigate?: (action: 'push' | 'replace', href: Href) => void;
   slotLabel?: string;
 }>) {
   const [pathname, setCurrentPathname] = useState(initialPathname);
   const setPathname = (href: Href) =>
     setCurrentPathname(typeof href === 'string' ? href : href.pathname);
+  const push = (href: Href) => {
+    onNavigate?.('push', href);
+    setPathname(href);
+  };
+  const replace = (href: Href) => {
+    onNavigate?.('replace', href);
+    setPathname(href);
+  };
   const value = useMemo(
-    () => ({ params, pathname, setPathname, slotLabel }),
-    [params, pathname, slotLabel],
+    () => ({ params, pathname, push, replace, setPathname, slotLabel }),
+    [params, pathname, push, replace, setPathname, slotLabel],
   );
 
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;
@@ -60,14 +74,14 @@ export function useGlobalSearchParams<T extends Record<string, string | undefine
 }
 
 export function useRouter() {
-  const { setPathname } = useContext(RouterContext);
+  const { push, replace } = useContext(RouterContext);
   return useMemo(
     () => ({
       back: () => undefined,
-      push: setPathname,
-      replace: setPathname,
+      push,
+      replace,
     }),
-    [setPathname],
+    [push, replace],
   );
 }
 
@@ -76,7 +90,7 @@ export function Link({
   children,
   href,
 }: PropsWithChildren<{ asChild?: boolean; href: Href }>) {
-  const { setPathname } = useContext(RouterContext);
+  const { push } = useContext(RouterContext);
   if (
     !asChild ||
     !isValidElement<{
@@ -92,7 +106,7 @@ export function Link({
     onPress: (event: { preventDefault?: () => void }) => {
       event.preventDefault?.();
       children.props.onPress?.(event);
-      setPathname(href);
+      push(href);
     },
   });
 }

--- a/apps/app/.storybook/mocks/react-relay.tsx
+++ b/apps/app/.storybook/mocks/react-relay.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { Environment, Network, RecordSource, Store } from 'relay-runtime';
+import { StructuredClientError } from '@/observability/client-error';
 import { RelayActorProvider } from '@/relay/RelayActorProvider';
 import type { PropsWithChildren } from 'react';
 import type { GraphQLResponse, RequestParameters } from 'relay-runtime';
@@ -133,7 +134,7 @@ async function executeStoryOperation(
     }
 
     if (operationResponse.error) {
-      return Promise.reject(new Error(operationResponse.error));
+      return Promise.reject(createStoryExpectedError(operationResponse.error));
     }
 
     return { data: (operationResponse.data ?? {}) as GraphQLResponse['data'] };
@@ -145,7 +146,7 @@ async function executeStoryOperation(
       return resolveOperationResponse(operationResponse);
     }
     if (mock.mutationError) {
-      return Promise.reject(new Error(mock.mutationError));
+      return Promise.reject(createStoryExpectedError(mock.mutationError));
     }
     if (mock.mutationLoading) {
       return new Promise(() => undefined);
@@ -163,14 +164,14 @@ async function executeStoryOperation(
         Math.min(nextPaginationResponseIndex(), mock.paginationResponses.length - 1)
       ];
     if (configuredResponse?.error) {
-      return Promise.reject(new Error(configuredResponse.error));
+      return Promise.reject(createStoryExpectedError(configuredResponse.error));
     }
     if (configuredResponse) {
       return Promise.resolve({ data: (configuredResponse.data ?? {}) as GraphQLResponse['data'] });
     }
     if (mock.paginationError) {
       return Promise.reject(
-        new Error(
+        createStoryExpectedError(
           typeof mock.paginationError === 'string'
             ? mock.paginationError
             : '다음 페이지를 불러오지 못했습니다.',
@@ -190,4 +191,13 @@ async function executeStoryOperation(
   }
 
   return Promise.resolve({ data: (mock.queryData ?? {}) as GraphQLResponse['data'] });
+}
+
+function createStoryExpectedError(message: string): StructuredClientError {
+  return new StructuredClientError({
+    code: 'NETWORK_REQUEST_FAILED',
+    message,
+    origin: 'transport',
+    type: 'network',
+  });
 }

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -30,6 +30,7 @@
     "@sun-typeface/suit": "^2.0.5",
     "expo": "~56.0.14",
     "expo-auth-session": "~56.0.15",
+    "expo-clipboard": "~56.0.4",
     "expo-constants": "~56.0.20",
     "expo-crypto": "~56.0.4",
     "expo-font": "~56.0.7",

--- a/apps/app/src/components/AppProviders.tsx
+++ b/apps/app/src/components/AppProviders.tsx
@@ -1,4 +1,5 @@
-import { Suspense, useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { Suspense, useCallback, useEffect } from 'react';
 import { AnalyticsSessionBridge } from '@/analytics/AnalyticsSessionBridge';
 import { initializeAnalytics } from '@/analytics/client';
 import { RelayActorProvider, useRelayActor } from '@/relay/RelayActorProvider';
@@ -14,10 +15,12 @@ import { ToastProvider } from './ui/ToastProvider';
 import type { PropsWithChildren } from 'react';
 
 function RelaySessionBoundary({ children }: PropsWithChildren) {
+  const router = useRouter();
   const { retry, revision } = useRelayActor();
+  const navigateToSafeScreen = useCallback(() => router.replace('/'), [router]);
 
   return (
-    <GraphQLErrorBoundary onRetry={retry}>
+    <GraphQLErrorBoundary onRetry={retry} onSafeNavigate={navigateToSafeScreen}>
       <SessionFailOpenBoundary
         fallback={
           <SessionErrorProvider>

--- a/apps/app/src/components/ClientErrorBoundary.tsx
+++ b/apps/app/src/components/ClientErrorBoundary.tsx
@@ -8,6 +8,8 @@ import type { UnexpectedErrorReporter } from '@/observability/UnexpectedErrorCon
 
 export type ClientErrorFallbackProps = FallbackProps & {
   eventId?: string;
+  occurrenceKey?: number;
+  resetForSafeNavigation: () => void;
 };
 
 type ClientErrorBoundaryProps = PropsWithChildren<{
@@ -24,24 +26,12 @@ export function ClientErrorBoundary({
 }: ClientErrorBoundaryProps) {
   const inheritedReporter = useUnexpectedErrorReporter();
   const reporter = onError ?? inheritedReporter;
-
-  return (
-    <ReportedErrorBoundary onError={reporter} onReset={onReset} renderFallback={renderFallback}>
-      {children}
-    </ReportedErrorBoundary>
-  );
-}
-
-function ReportedErrorBoundary({
-  children,
-  onError,
-  onReset,
-  renderFallback,
-}: ClientErrorBoundaryProps) {
   const reportedErrorRef = useRef<unknown>(null);
+  const occurrenceCounterRef = useRef(0);
   const [reported, setReported] = useState<{
     error: unknown;
     eventId?: string;
+    occurrenceKey: number;
   } | null>(null);
 
   return (
@@ -50,6 +40,9 @@ function ReportedErrorBoundary({
         renderFallback({
           ...props,
           eventId: reported && reported.error === props.error ? reported.eventId : undefined,
+          occurrenceKey:
+            reported && reported.error === props.error ? reported.occurrenceKey : undefined,
+          resetForSafeNavigation: () => props.resetErrorBoundary(safeNavigationReset),
         })
       }
       onError={(error, info) => {
@@ -60,23 +53,27 @@ function ReportedErrorBoundary({
         reportedErrorRef.current = error;
         let eventId: string | undefined;
         try {
-          eventId = onError?.(error, info);
+          eventId = reporter?.(error, info);
         } catch {
           eventId = undefined;
         }
-        setReported({ error, eventId });
+        setReported({ error, eventId, occurrenceKey: ++occurrenceCounterRef.current });
         logBoundaryError(error, info);
       }}
-      onReset={() => {
+      onReset={(details) => {
         reportedErrorRef.current = null;
         setReported(null);
-        onReset();
+        if (details.reason !== 'imperative-api' || details.args[0] !== safeNavigationReset) {
+          onReset();
+        }
       }}
     >
       {children}
     </ErrorBoundary>
   );
 }
+
+const safeNavigationReset = Symbol('safe-navigation-reset');
 
 function logBoundaryError(error: unknown, info: ErrorInfo): void {
   console.error('Client render error', error, info.componentStack);

--- a/apps/app/src/components/ClientErrorBoundary.tsx
+++ b/apps/app/src/components/ClientErrorBoundary.tsx
@@ -26,23 +26,42 @@ export function ClientErrorBoundary({
 }: ClientErrorBoundaryProps) {
   const inheritedReporter = useUnexpectedErrorReporter();
   const reporter = onError ?? inheritedReporter;
-  const reportedErrorRef = useRef<unknown>(null);
+  const reportedErrorRef = useRef<unknown>(unreportedError);
   const occurrenceCounterRef = useRef(0);
+  const [boundaryKey, setBoundaryKey] = useState(0);
   const [reported, setReported] = useState<{
     error: unknown;
     eventId?: string;
     occurrenceKey: number;
   } | null>(null);
+  const clearReportedError = () => {
+    reportedErrorRef.current = unreportedError;
+    setReported(null);
+  };
+  const resetBoundary = (props: FallbackProps, ...args: unknown[]) => {
+    if (props.error === null || props.error === undefined) {
+      clearReportedError();
+      setBoundaryKey((key) => key + 1);
+      if (args[0] !== safeNavigationReset) {
+        onReset();
+      }
+      return;
+    }
+
+    props.resetErrorBoundary(...args);
+  };
 
   return (
     <ErrorBoundary
+      key={boundaryKey}
       fallbackRender={(props) =>
         renderFallback({
           ...props,
+          resetErrorBoundary: (...args) => resetBoundary(props, ...args),
           eventId: reported && reported.error === props.error ? reported.eventId : undefined,
           occurrenceKey:
             reported && reported.error === props.error ? reported.occurrenceKey : undefined,
-          resetForSafeNavigation: () => props.resetErrorBoundary(safeNavigationReset),
+          resetForSafeNavigation: () => resetBoundary(props, safeNavigationReset),
         })
       }
       onError={(error, info) => {
@@ -61,8 +80,7 @@ export function ClientErrorBoundary({
         logBoundaryError(error, info);
       }}
       onReset={(details) => {
-        reportedErrorRef.current = null;
-        setReported(null);
+        clearReportedError();
         if (details.reason !== 'imperative-api' || details.args[0] !== safeNavigationReset) {
           onReset();
         }
@@ -73,6 +91,7 @@ export function ClientErrorBoundary({
   );
 }
 
+const unreportedError = Symbol('unreported-client-error');
 const safeNavigationReset = Symbol('safe-navigation-reset');
 
 function logBoundaryError(error: unknown, info: ErrorInfo): void {

--- a/apps/app/src/components/ClientErrorBoundary.tsx
+++ b/apps/app/src/components/ClientErrorBoundary.tsx
@@ -1,0 +1,83 @@
+import { useRef, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { isExpectedClientError } from '@/observability/client-error';
+import { useUnexpectedErrorReporter } from '@/observability/UnexpectedErrorContext';
+import type { ErrorInfo, PropsWithChildren, ReactNode } from 'react';
+import type { FallbackProps } from 'react-error-boundary';
+import type { UnexpectedErrorReporter } from '@/observability/UnexpectedErrorContext';
+
+export type ClientErrorFallbackProps = FallbackProps & {
+  eventId?: string;
+};
+
+type ClientErrorBoundaryProps = PropsWithChildren<{
+  onError?: UnexpectedErrorReporter;
+  onReset: () => void;
+  renderFallback: (props: ClientErrorFallbackProps) => ReactNode;
+}>;
+
+export function ClientErrorBoundary({
+  children,
+  onError,
+  onReset,
+  renderFallback,
+}: ClientErrorBoundaryProps) {
+  const inheritedReporter = useUnexpectedErrorReporter();
+  const reporter = onError ?? inheritedReporter;
+
+  return (
+    <ReportedErrorBoundary onError={reporter} onReset={onReset} renderFallback={renderFallback}>
+      {children}
+    </ReportedErrorBoundary>
+  );
+}
+
+function ReportedErrorBoundary({
+  children,
+  onError,
+  onReset,
+  renderFallback,
+}: ClientErrorBoundaryProps) {
+  const reportedErrorRef = useRef<unknown>(null);
+  const [reported, setReported] = useState<{
+    error: unknown;
+    eventId?: string;
+  } | null>(null);
+
+  return (
+    <ErrorBoundary
+      fallbackRender={(props) =>
+        renderFallback({
+          ...props,
+          eventId: reported && reported.error === props.error ? reported.eventId : undefined,
+        })
+      }
+      onError={(error, info) => {
+        if (isExpectedClientError(error) || reportedErrorRef.current === error) {
+          return;
+        }
+
+        reportedErrorRef.current = error;
+        let eventId: string | undefined;
+        try {
+          eventId = onError?.(error, info);
+        } catch {
+          eventId = undefined;
+        }
+        setReported({ error, eventId });
+        logBoundaryError(error, info);
+      }}
+      onReset={() => {
+        reportedErrorRef.current = null;
+        setReported(null);
+        onReset();
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+function logBoundaryError(error: unknown, info: ErrorInfo): void {
+  console.error('Client render error', error, info.componentStack);
+}

--- a/apps/app/src/components/GraphQLErrorBoundary.tsx
+++ b/apps/app/src/components/GraphQLErrorBoundary.tsx
@@ -35,7 +35,13 @@ export function GraphQLErrorBoundary({
         <ClientErrorBoundary
           onError={reportError}
           onReset={onRetry}
-          renderFallback={({ error, eventId, resetErrorBoundary }) =>
+          renderFallback={({
+            error,
+            eventId,
+            occurrenceKey,
+            resetErrorBoundary,
+            resetForSafeNavigation,
+          }) =>
             isExpectedClientError(error) ? (
               <StateView
                 actionLabel="다시 시도"
@@ -48,7 +54,11 @@ export function GraphQLErrorBoundary({
               <UnexpectedErrorScreen
                 eventId={eventId}
                 onRetry={resetErrorBoundary}
-                onSafeNavigate={safeNavigation}
+                onSafeNavigate={() => {
+                  resetForSafeNavigation();
+                  safeNavigation();
+                }}
+                occurrenceKey={occurrenceKey}
               />
             )
           }

--- a/apps/app/src/components/GraphQLErrorBoundary.tsx
+++ b/apps/app/src/components/GraphQLErrorBoundary.tsx
@@ -1,7 +1,11 @@
-import { ErrorBoundary } from 'react-error-boundary';
+import { ClientErrorBoundary } from '@/components/ClientErrorBoundary';
 import { StateView } from '@/components/ui/StateView';
+import { UnexpectedErrorScreen } from '@/components/UnexpectedErrorScreen';
+import { isExpectedClientError } from '@/observability/client-error';
 import {
+  SafeErrorNavigationContext,
   UnexpectedErrorContext,
+  useSafeErrorNavigation,
   useUnexpectedErrorReporter,
 } from '@/observability/UnexpectedErrorContext';
 import { formatGraphQLError } from '@/relay/network';
@@ -11,32 +15,47 @@ import type { UnexpectedErrorReporter } from '@/observability/UnexpectedErrorCon
 export type GraphQLErrorBoundaryProps = PropsWithChildren<{
   onError?: UnexpectedErrorReporter;
   onRetry: () => void;
+  onSafeNavigate?: () => void;
 }>;
 
-export function GraphQLErrorBoundary({ children, onError, onRetry }: GraphQLErrorBoundaryProps) {
+export function GraphQLErrorBoundary({
+  children,
+  onError,
+  onRetry,
+  onSafeNavigate,
+}: GraphQLErrorBoundaryProps) {
   const inheritedErrorReporter = useUnexpectedErrorReporter();
+  const inheritedSafeNavigation = useSafeErrorNavigation();
   const reportError = onError ?? inheritedErrorReporter;
+  const safeNavigation = onSafeNavigate ?? inheritedSafeNavigation ?? (() => undefined);
 
   return (
     <UnexpectedErrorContext.Provider value={reportError}>
-      <ErrorBoundary
-        fallbackRender={({ error, resetErrorBoundary }) => (
-          <StateView
-            actionLabel="다시 시도"
-            alert
-            description={formatGraphQLError(error)}
-            onAction={resetErrorBoundary}
-            title="화면을 불러오지 못했어요"
-          />
-        )}
-        onError={(error, info) => {
-          reportError?.(error, info);
-          console.error('Relay render error', error, info.componentStack);
-        }}
-        onReset={onRetry}
-      >
-        {children}
-      </ErrorBoundary>
+      <SafeErrorNavigationContext.Provider value={safeNavigation}>
+        <ClientErrorBoundary
+          onError={reportError}
+          onReset={onRetry}
+          renderFallback={({ error, eventId, resetErrorBoundary }) =>
+            isExpectedClientError(error) ? (
+              <StateView
+                actionLabel="다시 시도"
+                alert
+                description={formatGraphQLError(error)}
+                onAction={resetErrorBoundary}
+                title="화면을 불러오지 못했어요"
+              />
+            ) : (
+              <UnexpectedErrorScreen
+                eventId={eventId}
+                onRetry={resetErrorBoundary}
+                onSafeNavigate={safeNavigation}
+              />
+            )
+          }
+        >
+          {children}
+        </ClientErrorBoundary>
+      </SafeErrorNavigationContext.Provider>
     </UnexpectedErrorContext.Provider>
   );
 }

--- a/apps/app/src/components/RouteBoundary.tsx
+++ b/apps/app/src/components/RouteBoundary.tsx
@@ -33,7 +33,13 @@ export function RouteBoundary({
     <ClientErrorBoundary
       onError={reportUnexpectedError}
       onReset={onRetry}
-      renderFallback={({ error, eventId, resetErrorBoundary }) =>
+      renderFallback={({
+        error,
+        eventId,
+        occurrenceKey,
+        resetErrorBoundary,
+        resetForSafeNavigation,
+      }) =>
         isExpectedClientError(error) ? (
           renderError ? (
             renderError(resetErrorBoundary)
@@ -50,7 +56,11 @@ export function RouteBoundary({
           <UnexpectedErrorScreen
             eventId={eventId}
             onRetry={resetErrorBoundary}
-            onSafeNavigate={safeNavigation}
+            onSafeNavigate={() => {
+              resetForSafeNavigation();
+              safeNavigation();
+            }}
+            occurrenceKey={occurrenceKey}
           />
         )
       }

--- a/apps/app/src/components/RouteBoundary.tsx
+++ b/apps/app/src/components/RouteBoundary.tsx
@@ -1,7 +1,12 @@
 import { Suspense } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
+import { ClientErrorBoundary } from '@/components/ClientErrorBoundary';
 import { StateView } from '@/components/ui/StateView';
-import { useUnexpectedErrorReporter } from '@/observability/UnexpectedErrorContext';
+import { UnexpectedErrorScreen } from '@/components/UnexpectedErrorScreen';
+import { isExpectedClientError } from '@/observability/client-error';
+import {
+  useSafeErrorNavigation,
+  useUnexpectedErrorReporter,
+} from '@/observability/UnexpectedErrorContext';
 import type { ReactNode } from 'react';
 
 type RouteBoundaryProps = {
@@ -22,29 +27,35 @@ export function RouteBoundary({
   title,
 }: RouteBoundaryProps) {
   const reportUnexpectedError = useUnexpectedErrorReporter();
+  const safeNavigation = useSafeErrorNavigation() ?? (() => undefined);
 
   return (
-    <ErrorBoundary
-      fallbackRender={({ resetErrorBoundary }) =>
-        renderError ? (
-          renderError(resetErrorBoundary)
+    <ClientErrorBoundary
+      onError={reportUnexpectedError}
+      onReset={onRetry}
+      renderFallback={({ error, eventId, resetErrorBoundary }) =>
+        isExpectedClientError(error) ? (
+          renderError ? (
+            renderError(resetErrorBoundary)
+          ) : (
+            <StateView
+              actionLabel="다시 시도"
+              alert
+              description={description ?? '잠시 후 다시 시도해주세요.'}
+              onAction={resetErrorBoundary}
+              title={title}
+            />
+          )
         ) : (
-          <StateView
-            actionLabel="다시 시도"
-            alert
-            description={description ?? '잠시 후 다시 시도해주세요.'}
-            onAction={resetErrorBoundary}
-            title={title}
+          <UnexpectedErrorScreen
+            eventId={eventId}
+            onRetry={resetErrorBoundary}
+            onSafeNavigate={safeNavigation}
           />
         )
       }
-      onError={(error, info) => {
-        reportUnexpectedError?.(error, info);
-        console.error('Route error', error, info.componentStack);
-      }}
-      onReset={onRetry}
     >
       <Suspense fallback={loading}>{children}</Suspense>
-    </ErrorBoundary>
+    </ClientErrorBoundary>
   );
 }

--- a/apps/app/src/components/UnexpectedErrorScreen.tsx
+++ b/apps/app/src/components/UnexpectedErrorScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { useToast } from '@/components/ui/ToastProvider';
 import { copyToClipboard } from '@/observability/clipboard';
@@ -7,12 +7,11 @@ import { breakpoints, radii, spacing, typography } from '@/theme/tokens';
 import { Button } from './ui/Button';
 import type { ClipboardWriter } from '@/observability/clipboard';
 
-type CopyStatus = 'idle' | 'success' | 'failure';
-
 export type UnexpectedErrorScreenProps = {
   eventId?: string;
   onRetry: () => void;
   onSafeNavigate: () => void;
+  occurrenceKey?: number;
   writeClipboard?: ClipboardWriter;
 };
 
@@ -20,20 +19,45 @@ export function UnexpectedErrorScreen({
   eventId,
   onRetry,
   onSafeNavigate,
+  occurrenceKey,
   writeClipboard = copyToClipboard,
 }: UnexpectedErrorScreenProps) {
   const theme = useTheme();
-  const { showToast } = useToast();
+  const { dismissToast, showToast } = useToast();
   const { width } = useWindowDimensions();
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
   const [copying, setCopying] = useState(false);
+  const mountedRef = useRef(true);
+  const copyRequestRef = useRef(0);
   const compact = width < breakpoints.compact;
+
+  useEffect(() => {
+    copyRequestRef.current += 1;
+    setCopying(false);
+    dismissToast();
+  }, [dismissToast, eventId, occurrenceKey]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+      copyRequestRef.current += 1;
+      dismissToast();
+    };
+  }, [dismissToast]);
+
+  const clearTransientFeedback = () => {
+    copyRequestRef.current += 1;
+    setCopying(false);
+    dismissToast();
+  };
 
   const copyEventId = async () => {
     if (!eventId || copying) {
       return;
     }
 
+    const requestId = ++copyRequestRef.current;
     setCopying(true);
     let copied = false;
     try {
@@ -41,7 +65,9 @@ export function UnexpectedErrorScreen({
     } catch {
       copied = false;
     }
-    setCopyStatus(copied ? 'success' : 'failure');
+    if (!mountedRef.current || requestId !== copyRequestRef.current) {
+      return;
+    }
     setCopying(false);
     showToast(copied ? '오류 추적 ID를 복사했어요.' : '오류 추적 ID를 복사하지 못했어요.');
   };
@@ -88,22 +114,24 @@ export function UnexpectedErrorScreen({
           </Text>
         )}
 
-        {copyStatus !== 'idle' ? (
-          <Text
-            accessibilityLiveRegion="polite"
-            style={[styles.status, { color: copyStatus === 'success' ? theme.text : theme.danger }]}
-          >
-            {copyStatus === 'success'
-              ? '오류 추적 ID를 복사했습니다.'
-              : '오류 추적 ID를 복사하지 못했습니다.'}
-          </Text>
-        ) : null}
-
         <View style={styles.actions}>
-          <Button onPress={onRetry} style={styles.actionButton}>
+          <Button
+            onPress={() => {
+              clearTransientFeedback();
+              onRetry();
+            }}
+            style={styles.actionButton}
+          >
             다시 시도
           </Button>
-          <Button onPress={onSafeNavigate} style={styles.actionButton} tone="secondary">
+          <Button
+            onPress={() => {
+              clearTransientFeedback();
+              onSafeNavigate();
+            }}
+            style={styles.actionButton}
+            tone="secondary"
+          >
             안전한 화면으로 이동
           </Button>
         </View>
@@ -129,7 +157,6 @@ const styles = StyleSheet.create({
   eventLabel: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
   eventId: { fontFamily: 'SUIT', ...typography.md },
   copyButton: { alignSelf: 'flex-start', minHeight: 48 },
-  status: { fontFamily: 'SUIT', ...typography.sm },
   actions: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md },
   actionButton: { minHeight: 48 },
 });

--- a/apps/app/src/components/UnexpectedErrorScreen.tsx
+++ b/apps/app/src/components/UnexpectedErrorScreen.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import { useToast } from '@/components/ui/ToastProvider';
+import { copyToClipboard } from '@/observability/clipboard';
+import { useTheme } from '@/theme/ThemeProvider';
+import { breakpoints, radii, spacing, typography } from '@/theme/tokens';
+import { Button } from './ui/Button';
+import type { ClipboardWriter } from '@/observability/clipboard';
+
+type CopyStatus = 'idle' | 'success' | 'failure';
+
+export type UnexpectedErrorScreenProps = {
+  eventId?: string;
+  onRetry: () => void;
+  onSafeNavigate: () => void;
+  writeClipboard?: ClipboardWriter;
+};
+
+export function UnexpectedErrorScreen({
+  eventId,
+  onRetry,
+  onSafeNavigate,
+  writeClipboard = copyToClipboard,
+}: UnexpectedErrorScreenProps) {
+  const theme = useTheme();
+  const { showToast } = useToast();
+  const { width } = useWindowDimensions();
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+  const [copying, setCopying] = useState(false);
+  const compact = width < breakpoints.compact;
+
+  const copyEventId = async () => {
+    if (!eventId || copying) {
+      return;
+    }
+
+    setCopying(true);
+    let copied = false;
+    try {
+      copied = await writeClipboard(eventId);
+    } catch {
+      copied = false;
+    }
+    setCopyStatus(copied ? 'success' : 'failure');
+    setCopying(false);
+    showToast(copied ? '오류 추적 ID를 복사했어요.' : '오류 추적 ID를 복사하지 못했어요.');
+  };
+
+  return (
+    <ScrollView
+      contentContainerStyle={[
+        styles.root,
+        { paddingHorizontal: compact ? spacing.lg : spacing.xl },
+      ]}
+      style={{ backgroundColor: theme.background }}
+    >
+      <View
+        accessibilityRole="alert"
+        style={[styles.card, { backgroundColor: theme.card, borderColor: theme.border }]}
+      >
+        <Text accessibilityRole="header" style={[styles.title, { color: theme.text }]}>
+          문제가 발생했어요
+        </Text>
+        <Text style={[styles.description, { color: theme.textSecondary }]}>
+          화면을 불러오는 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.
+        </Text>
+
+        {eventId ? (
+          <View style={[styles.eventCard, { backgroundColor: theme.surface }]}>
+            <Text style={[styles.eventLabel, { color: theme.textSecondary }]}>오류 추적 ID</Text>
+            <Text selectable style={[styles.eventId, { color: theme.text }]}>
+              {eventId}
+            </Text>
+            <Button
+              accessibilityLabel="오류 추적 ID 복사"
+              disabled={copying}
+              loading={copying}
+              onPress={copyEventId}
+              style={styles.copyButton}
+              tone="secondary"
+            >
+              오류 추적 ID 복사
+            </Button>
+          </View>
+        ) : (
+          <Text style={[styles.description, { color: theme.textSecondary }]}>
+            오류 추적 ID를 확인하지 못했지만, 아래 복구 동작은 계속 사용할 수 있습니다.
+          </Text>
+        )}
+
+        {copyStatus !== 'idle' ? (
+          <Text
+            accessibilityLiveRegion="polite"
+            style={[styles.status, { color: copyStatus === 'success' ? theme.text : theme.danger }]}
+          >
+            {copyStatus === 'success'
+              ? '오류 추적 ID를 복사했습니다.'
+              : '오류 추적 ID를 복사하지 못했습니다.'}
+          </Text>
+        ) : null}
+
+        <View style={styles.actions}>
+          <Button onPress={onRetry} style={styles.actionButton}>
+            다시 시도
+          </Button>
+          <Button onPress={onSafeNavigate} style={styles.actionButton} tone="secondary">
+            안전한 화면으로 이동
+          </Button>
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flexGrow: 1, justifyContent: 'center', paddingVertical: spacing.xxxl },
+  card: {
+    alignSelf: 'center',
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    gap: spacing.lg,
+    maxWidth: 560,
+    padding: spacing.xl,
+    width: '100%',
+  },
+  title: { fontFamily: 'SUIT', fontWeight: '800', ...typography.xl },
+  description: { fontFamily: 'SUIT', ...typography.md },
+  eventCard: { borderRadius: radii.md, gap: spacing.sm, padding: spacing.lg },
+  eventLabel: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
+  eventId: { fontFamily: 'SUIT', ...typography.md },
+  copyButton: { alignSelf: 'flex-start', minHeight: 48 },
+  status: { fontFamily: 'SUIT', ...typography.sm },
+  actions: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.md },
+  actionButton: { minHeight: 48 },
+});

--- a/apps/app/src/components/profile/ProfileRoute.test.ts
+++ b/apps/app/src/components/profile/ProfileRoute.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, before, describe, it, mock } from 'node:test';
 import { createContext, createElement, useContext } from 'react';
 import { act, create } from 'react-test-renderer';
+import { StructuredClientError } from '../../observability/client-error';
 import type { ComponentType } from 'react';
 import type { ReactTestRenderer } from 'react-test-renderer';
 
@@ -36,6 +37,9 @@ const mockModule = (specifier: string | URL, exports: object) =>
     exports,
   } as unknown as Parameters<typeof mock.module>[1]);
 
+mockModule(new URL('../UnexpectedErrorScreen.tsx', import.meta.url), {
+  UnexpectedErrorScreen: () => null,
+});
 mockModule('expo-router', {
   Slot: () =>
     SlotContent
@@ -71,7 +75,12 @@ mockModule('react-relay', {
       throw pending;
     }
     if (mode === 'error') {
-      throw new Error(`${query}:${variables.handle}`);
+      throw new StructuredClientError({
+        code: 'NETWORK_REQUEST_FAILED',
+        message: `${query}:${variables.handle}`,
+        origin: 'transport',
+        type: 'network',
+      });
     }
 
     return {
@@ -118,6 +127,7 @@ mockModule(new URL('../ui/StateView.tsx', import.meta.url), {
   StateView: (props: object) => createElement('StateView', props),
 });
 mockModule(new URL('../../observability/UnexpectedErrorContext.ts', import.meta.url), {
+  useSafeErrorNavigation: () => undefined,
   useUnexpectedErrorReporter: () => undefined,
 });
 mockModule(new URL('../../relay/RelayActorProvider.tsx', import.meta.url), {

--- a/apps/app/src/components/ui/ToastProvider.tsx
+++ b/apps/app/src/components/ui/ToastProvider.tsx
@@ -9,6 +9,7 @@ import type { ViewStyle } from 'react-native';
 const toastDurationMs = 3000;
 
 type ToastContextValue = Readonly<{
+  dismissToast: () => void;
   showToast: (message: string) => void;
 }>;
 
@@ -28,6 +29,14 @@ export function ToastProvider({ children }: PropsWithChildren): ReactNode {
   const { width } = useWindowDimensions();
   const hasBottomTabBar = Platform.OS !== 'web' || width < breakpoints.compact;
   const bottom = insets.bottom + (hasBottomTabBar ? 56 : 0) + spacing.sm;
+
+  const dismissToast = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    setToast(null);
+  }, []);
 
   const showToast = useCallback((nextMessage: string) => {
     if (timer.current) {
@@ -50,7 +59,7 @@ export function ToastProvider({ children }: PropsWithChildren): ReactNode {
   );
 
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext.Provider value={{ dismissToast, showToast }}>
       {children}
       {toast ? (
         <View

--- a/apps/app/src/observability/UnexpectedErrorContext.ts
+++ b/apps/app/src/observability/UnexpectedErrorContext.ts
@@ -1,10 +1,15 @@
 import { createContext, useContext } from 'react';
 import type { ErrorInfo } from 'react';
 
-export type UnexpectedErrorReporter = (error: unknown, info: ErrorInfo) => void;
+export type UnexpectedErrorReporter = (error: unknown, info: ErrorInfo) => string | undefined;
 
 export const UnexpectedErrorContext = createContext<UnexpectedErrorReporter | undefined>(undefined);
+export const SafeErrorNavigationContext = createContext<(() => void) | undefined>(undefined);
 
 export function useUnexpectedErrorReporter(): UnexpectedErrorReporter | undefined {
   return useContext(UnexpectedErrorContext);
+}
+
+export function useSafeErrorNavigation(): (() => void) | undefined {
+  return useContext(SafeErrorNavigationContext);
 }

--- a/apps/app/src/observability/client-error.test.ts
+++ b/apps/app/src/observability/client-error.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { classifyClientError, isExpectedClientError, StructuredClientError } from './client-error';
+
+describe('클라이언트 오류 분류', () => {
+  it('구조화된 transport 오류를 예상 오류로 분류한다', () => {
+    const error = new StructuredClientError({
+      code: 'NETWORK_REQUEST_FAILED',
+      message: 'network down',
+      origin: 'transport',
+      type: 'network',
+    });
+
+    assert.deepEqual(classifyClientError(error), {
+      code: 'NETWORK_REQUEST_FAILED',
+      origin: 'transport',
+      type: 'network',
+    });
+    assert.equal(isExpectedClientError(error), true);
+  });
+
+  it('Relay source의 GraphQL 오류를 message와 무관하게 예상 오류로 분류한다', () => {
+    const error = Object.assign(new Error('민감한 서버 오류 원문'), {
+      name: 'RelayNetwork',
+      source: {
+        errors: [{ extensions: { code: 'INTERNAL_SERVER_ERROR' }, message: '원문' }],
+        operation: {},
+      },
+    });
+
+    assert.deepEqual(classifyClientError(error), {
+      code: 'INTERNAL_SERVER_ERROR',
+      origin: 'graphql-response',
+      type: 'graphql',
+    });
+    assert.equal(isExpectedClientError(error), true);
+  });
+
+  it('구조화되지 않은 local render 오류만 예상하지 못한 오류로 분류한다', () => {
+    const error = new Error('private stack and path');
+
+    assert.deepEqual(classifyClientError(error), {
+      code: 'UNEXPECTED_RENDER_ERROR',
+      origin: 'local-render',
+      type: 'render',
+    });
+    assert.equal(isExpectedClientError(error), false);
+  });
+});

--- a/apps/app/src/observability/client-error.ts
+++ b/apps/app/src/observability/client-error.ts
@@ -1,0 +1,66 @@
+export type ClientErrorOrigin = 'graphql-response' | 'transport' | 'local-render';
+export type ClientErrorType = 'graphql' | 'network' | 'render';
+
+export type ClientErrorClassification = Readonly<{
+  code: string;
+  origin: ClientErrorOrigin;
+  type: ClientErrorType;
+}>;
+
+export class StructuredClientError extends Error {
+  readonly code: string;
+  readonly origin: ClientErrorOrigin;
+  readonly type: ClientErrorType;
+  readonly cause: unknown;
+
+  constructor({
+    cause,
+    code,
+    message,
+    origin,
+    type,
+  }: ClientErrorClassification & { cause?: unknown; message: string }) {
+    super(message);
+    this.name = 'StructuredClientError';
+    this.cause = cause;
+    this.code = code;
+    this.origin = origin;
+    this.type = type;
+  }
+}
+
+export function classifyClientError(error: unknown): ClientErrorClassification {
+  if (error instanceof StructuredClientError) {
+    return { code: error.code, origin: error.origin, type: error.type };
+  }
+
+  const source = getRecord(getRecord(error)?.source);
+  if (source && 'operation' in source) {
+    const errors = Array.isArray(source.errors) ? source.errors : [];
+    const code = errors
+      .map(getGraphQLErrorCode)
+      .find((value: string | null): value is string => value !== null);
+
+    return {
+      code: code ?? 'GRAPHQL_RESPONSE_ERROR',
+      origin: 'graphql-response',
+      type: 'graphql',
+    };
+  }
+
+  return { code: 'UNEXPECTED_RENDER_ERROR', origin: 'local-render', type: 'render' };
+}
+
+export function isExpectedClientError(error: unknown): boolean {
+  return classifyClientError(error).origin !== 'local-render';
+}
+
+export function getGraphQLErrorCode(error: unknown): string | null {
+  const extensions = getRecord(error)?.extensions;
+  const code = getRecord(extensions)?.code;
+  return typeof code === 'string' ? code : null;
+}
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
+}

--- a/apps/app/src/observability/clipboard.test.ts
+++ b/apps/app/src/observability/clipboard.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+const clipboardModule = new URL('./clipboard.ts', import.meta.url).href;
+
+afterEach(() => mock.restoreAll());
+
+describe('기본 clipboard adapter', () => {
+  it('expo-clipboard에 화면의 ID를 그대로 전달한다', async () => {
+    const setStringAsync = mock.fn(async () => undefined);
+    mock.module('expo-clipboard', {
+      namedExports: { setStringAsync },
+    } as unknown as Parameters<typeof mock.module>[1]);
+
+    const { copyToClipboard } = await import(`${clipboardModule}?success`);
+
+    assert.equal(await copyToClipboard('event-default'), true);
+    assert.equal(setStringAsync.mock.callCount(), 1);
+    assert.deepEqual(setStringAsync.mock.calls[0].arguments, ['event-default']);
+  });
+
+  it('clipboard 오류를 실패 결과로 안전하게 변환한다', async () => {
+    const setStringAsync = mock.fn(async () => {
+      throw new Error('clipboard unavailable');
+    });
+    mock.module('expo-clipboard', {
+      namedExports: { setStringAsync },
+    } as unknown as Parameters<typeof mock.module>[1]);
+
+    const { copyToClipboard } = await import(`${clipboardModule}?failure`);
+
+    assert.equal(await copyToClipboard('event-failure'), false);
+  });
+});

--- a/apps/app/src/observability/clipboard.ts
+++ b/apps/app/src/observability/clipboard.ts
@@ -1,0 +1,12 @@
+import * as Clipboard from 'expo-clipboard';
+
+export type ClipboardWriter = (value: string) => Promise<boolean>;
+
+export const copyToClipboard: ClipboardWriter = async (value) => {
+  try {
+    await Clipboard.setStringAsync(value);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/apps/app/src/observability/sentry-browser.ts
+++ b/apps/app/src/observability/sentry-browser.ts
@@ -19,10 +19,16 @@ if (enabled) {
   });
 }
 
-export const captureReactError = (cause: unknown, info: ErrorInfo): void => {
-  if (enabled) {
-    Sentry.captureReactException(cause, info, {
+export const captureReactError = (cause: unknown, info: ErrorInfo): string | undefined => {
+  if (!enabled) {
+    return undefined;
+  }
+
+  try {
+    return Sentry.captureReactException(cause, info, {
       mechanism: { handled: true, type: 'auto.function.react.error_boundary' },
     });
+  } catch {
+    return undefined;
   }
 };

--- a/apps/app/src/relay/network.test.ts
+++ b/apps/app/src/relay/network.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { classifyClientError, StructuredClientError } from '@/observability/client-error';
 import {
   executeGraphQLRequest,
   formatGraphQLError,
@@ -74,6 +75,48 @@ describe('Relay 네트워크', () => {
   it('Error와 알 수 없는 실패를 공통 boundary 형식으로 변환한다', () => {
     assert.equal(formatGraphQLError(new Error('network down')), 'network down');
     assert.equal(formatGraphQLError(null), '요청을 처리하지 못했습니다.');
+  });
+
+  it('transport 실패의 origin과 code를 보존한다', async () => {
+    await assert.rejects(
+      executeGraphQLRequest(request, {}, null, async () => {
+        throw new Error('offline');
+      }),
+      (error: unknown) => {
+        assert.equal(error instanceof StructuredClientError, true);
+        assert.deepEqual(classifyClientError(error), {
+          code: 'NETWORK_REQUEST_FAILED',
+          origin: 'transport',
+          type: 'network',
+        });
+        return true;
+      },
+    );
+  });
+
+  it('HTTP GraphQL 오류의 response origin과 server code를 보존한다', async () => {
+    await assert.rejects(
+      executeGraphQLRequest(
+        request,
+        {},
+        null,
+        async () =>
+          new Response(
+            JSON.stringify({
+              errors: [{ extensions: { code: 'PERMISSION_DENIED' }, message: 'private message' }],
+            }),
+            { status: 403 },
+          ),
+      ),
+      (error: unknown) => {
+        assert.deepEqual(classifyClientError(error), {
+          code: 'PERMISSION_DENIED',
+          origin: 'graphql-response',
+          type: 'graphql',
+        });
+        return true;
+      },
+    );
   });
 });
 

--- a/apps/app/src/relay/network.ts
+++ b/apps/app/src/relay/network.ts
@@ -1,3 +1,4 @@
+import { getGraphQLErrorCode, StructuredClientError } from '@/observability/client-error';
 import type { GraphQLResponse, RequestParameters, Variables } from 'relay-runtime';
 
 const loopbackHosts = new Set(['127.0.0.1', '[::1]', 'localhost']);
@@ -80,35 +81,59 @@ export async function executeGraphQLRequest(
 
   const native = isNativeRuntime();
   const origin = native ? getApiOrigin() : getWebOrigin();
-  const response = await fetchImplementation(`${origin}/graphql`, {
-    method: 'POST',
-    credentials: native ? 'omit' : 'include',
-    headers: {
-      accept: 'application/json',
-      'content-type': 'application/json',
-      ...(native && token ? { authorization: `Bearer ${token}` } : {}),
-    },
-    body: JSON.stringify({
-      operationName: request.name,
-      query: request.text,
-      variables,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetchImplementation(`${origin}/graphql`, {
+      method: 'POST',
+      credentials: native ? 'omit' : 'include',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...(native && token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({
+        operationName: request.name,
+        query: request.text,
+        variables,
+      }),
+    });
+  } catch (cause) {
+    throw new StructuredClientError({
+      cause,
+      code: 'NETWORK_REQUEST_FAILED',
+      message: cause instanceof Error ? cause.message : 'GraphQL request failed.',
+      origin: 'transport',
+      type: 'network',
+    });
+  }
   const body = (await response.json().catch(() => null)) as GraphQLResponse | null;
 
   if (!response.ok) {
-    const message =
-      body && 'errors' in body
-        ? body.errors
-            ?.map((error) => error.message)
-            .filter(Boolean)
-            .join('\n')
-        : undefined;
-    throw new Error(message || `GraphQL request failed with HTTP ${response.status}.`);
+    const responseError = getResponseError(body);
+    if (responseError) {
+      throw new StructuredClientError({
+        code: getGraphQLErrorCode(responseError) ?? 'GRAPHQL_RESPONSE_ERROR',
+        message: getResponseErrorMessage(body),
+        origin: 'graphql-response',
+        type: 'graphql',
+      });
+    }
+
+    throw new StructuredClientError({
+      code: `HTTP_${response.status}`,
+      message: `GraphQL request failed with HTTP ${response.status}.`,
+      origin: 'transport',
+      type: 'network',
+    });
   }
 
   if (!body) {
-    throw new Error('GraphQL response was not JSON.');
+    throw new StructuredClientError({
+      code: 'INVALID_GRAPHQL_RESPONSE',
+      message: 'GraphQL response was not JSON.',
+      origin: 'transport',
+      type: 'network',
+    });
   }
 
   return body;
@@ -116,4 +141,25 @@ export async function executeGraphQLRequest(
 
 export function formatGraphQLError(error: unknown): string {
   return error instanceof Error ? error.message : '요청을 처리하지 못했습니다.';
+}
+
+function getResponseError(body: GraphQLResponse | null): unknown {
+  if (!body || Array.isArray(body) || !('errors' in body)) {
+    return null;
+  }
+
+  return body.errors?.[0] ?? null;
+}
+
+function getResponseErrorMessage(body: GraphQLResponse | null): string {
+  if (!body || Array.isArray(body) || !('errors' in body)) {
+    return 'GraphQL request failed.';
+  }
+
+  return (
+    body.errors
+      ?.map((error) => error.message)
+      .filter(Boolean)
+      .join('\n') || 'GraphQL request failed.'
+  );
 }

--- a/apps/app/src/session/SessionProvider.tsx
+++ b/apps/app/src/session/SessionProvider.tsx
@@ -3,7 +3,6 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { Platform } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { isExpectedClientError } from '@/observability/client-error';
-import { useUnexpectedErrorReporter } from '@/observability/UnexpectedErrorContext';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import type { PropsWithChildren, ReactNode } from 'react';
 import type { SessionProviderQuery as SessionProviderQueryType } from './__generated__/SessionProviderQuery.graphql';
@@ -94,15 +93,13 @@ export function SessionFailOpenBoundary({
   fallback,
   resetKey,
 }: PropsWithChildren<{ fallback: ReactNode; resetKey: number }>) {
-  const reportUnexpectedError = useUnexpectedErrorReporter();
-
   return (
     <ErrorBoundary
-      fallback={fallback}
-      onError={(error, info) => {
+      fallbackRender={({ error }) => {
         if (!isExpectedClientError(error)) {
-          reportUnexpectedError?.(error, info);
+          throw error;
         }
+        return fallback;
       }}
       resetKeys={[resetKey]}
     >

--- a/apps/app/src/session/SessionProvider.tsx
+++ b/apps/app/src/session/SessionProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Platform } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { isExpectedClientError } from '@/observability/client-error';
 import { useUnexpectedErrorReporter } from '@/observability/UnexpectedErrorContext';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import type { PropsWithChildren, ReactNode } from 'react';
@@ -96,7 +97,15 @@ export function SessionFailOpenBoundary({
   const reportUnexpectedError = useUnexpectedErrorReporter();
 
   return (
-    <ErrorBoundary fallback={fallback} onError={reportUnexpectedError} resetKeys={[resetKey]}>
+    <ErrorBoundary
+      fallback={fallback}
+      onError={(error, info) => {
+        if (!isExpectedClientError(error)) {
+          reportUnexpectedError?.(error, info);
+        }
+      }}
+      resetKeys={[resetKey]}
+    >
       {children}
     </ErrorBoundary>
   );

--- a/apps/app/src/stories/ErrorBoundaries.stories.tsx
+++ b/apps/app/src/stories/ErrorBoundaries.stories.tsx
@@ -8,8 +8,10 @@ import { RouteBoundary } from '@/components/RouteBoundary';
 import { UnexpectedErrorScreen } from '@/components/UnexpectedErrorScreen';
 import { StructuredClientError } from '@/observability/client-error';
 import { SessionFailOpenBoundary } from '@/session/SessionProvider';
+import { RouterMockProvider } from '../../.storybook/mocks/expo-router';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ErrorInfo } from 'react';
+import type { Href } from '../../.storybook/mocks/expo-router';
 
 const storyGlobal = globalThis as unknown as {
   process?: { env: Record<string, string | undefined> };
@@ -168,11 +170,17 @@ function ProductionRouteFailure() {
   );
 }
 
-function ProductionAppProvidersHarness() {
+function ProductionAppProvidersHarness({
+  onNavigate,
+}: {
+  onNavigate: (action: 'push' | 'replace', href: Href) => void;
+}) {
   return (
-    <AppProviders>
-      <ProductionRouteFailure />
-    </AppProviders>
+    <RouterMockProvider onNavigate={onNavigate} pathname="/settings">
+      <AppProviders>
+        <ProductionRouteFailure />
+      </AppProviders>
+    </RouterMockProvider>
   );
 }
 
@@ -332,10 +340,11 @@ export const SessionFailOpenAndResetKey: Story = {
   },
 };
 
+const productionNavigation = fn();
+
 export const ProductionAppProvidersSafeNavigation: Story = {
   globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
-  parameters: { router: { pathname: '/settings' } },
-  render: () => <ProductionAppProvidersHarness />,
+  render: () => <ProductionAppProvidersHarness onNavigate={productionNavigation} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.findByText('문제가 발생했어요')).resolves.toBeVisible();
@@ -343,6 +352,8 @@ export const ProductionAppProvidersSafeNavigation: Story = {
 
     await expect(canvas.findByText('/')).resolves.toBeVisible();
     expect(canvas.queryByText('문제가 발생했어요')).not.toBeInTheDocument();
+    expect(productionNavigation).toHaveBeenCalledTimes(1);
+    expect(productionNavigation).toHaveBeenCalledWith('replace', '/');
   },
 };
 

--- a/apps/app/src/stories/ErrorBoundaries.stories.tsx
+++ b/apps/app/src/stories/ErrorBoundaries.stories.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react';
+import { usePathname } from 'expo-router';
+import { useCallback, useRef, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { expect, fn, userEvent, within } from 'storybook/test';
+import { AppProviders } from '@/components/AppProviders';
 import { GraphQLErrorBoundary } from '@/components/GraphQLErrorBoundary';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { UnexpectedErrorScreen } from '@/components/UnexpectedErrorScreen';
@@ -8,6 +10,11 @@ import { StructuredClientError } from '@/observability/client-error';
 import { SessionFailOpenBoundary } from '@/session/SessionProvider';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ErrorInfo } from 'react';
+
+const storyGlobal = globalThis as unknown as {
+  process?: { env: Record<string, string | undefined> };
+};
+storyGlobal.process ??= { env: {} };
 
 const unexpectedRenderError = new Error('production boundary fixture with a private path');
 const expectedNetworkError = new StructuredClientError({
@@ -150,6 +157,63 @@ function SessionBoundaryHarness() {
   );
 }
 
+function ProductionRouteFailure() {
+  const pathname = usePathname();
+
+  return (
+    <View>
+      <Text>{pathname}</Text>
+      <ThrowOnRender active={pathname !== '/'} />
+    </View>
+  );
+}
+
+function ProductionAppProvidersHarness() {
+  return (
+    <AppProviders>
+      <ProductionRouteFailure />
+    </AppProviders>
+  );
+}
+
+function DeferredClipboardHarness() {
+  const [visible, setVisible] = useState(true);
+  const resolverRef = useRef<((copied: boolean) => void) | null>(null);
+  const writeClipboard = useCallback(
+    () =>
+      new Promise<boolean>((resolve) => {
+        resolverRef.current = resolve;
+      }),
+    [],
+  );
+  const resolveClipboard = () => {
+    resolverRef.current?.(true);
+    resolverRef.current = null;
+  };
+
+  return (
+    <View>
+      {visible ? (
+        <UnexpectedErrorScreen
+          eventId="event-deferred"
+          onRetry={() => setVisible(false)}
+          onSafeNavigate={() => setVisible(false)}
+          writeClipboard={writeClipboard}
+        />
+      ) : (
+        <Text>복구됐습니다.</Text>
+      )}
+      <Pressable
+        accessibilityLabel="지연 복사 완료"
+        accessibilityRole="button"
+        onPress={resolveClipboard}
+      >
+        <Text>지연 복사 완료</Text>
+      </Pressable>
+    </View>
+  );
+}
+
 const meta = {
   title: 'Foundation/Error Boundaries',
 } satisfies Meta;
@@ -183,6 +247,7 @@ export const RouteFallbackAndRetry: Story = {
 
     await expect(canvas.findByText('콘텐츠가 복구됐습니다.')).resolves.toBeVisible();
     expect(routeRetry).toHaveBeenCalledTimes(1);
+    expect(expectedRouteReporter).not.toHaveBeenCalled();
   },
 };
 
@@ -267,6 +332,50 @@ export const SessionFailOpenAndResetKey: Story = {
   },
 };
 
+export const ProductionAppProvidersSafeNavigation: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  parameters: { router: { pathname: '/settings' } },
+  render: () => <ProductionAppProvidersHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByText('문제가 발생했어요')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '안전한 화면으로 이동' }));
+
+    await expect(canvas.findByText('/')).resolves.toBeVisible();
+    expect(canvas.queryByText('문제가 발생했어요')).not.toBeInTheDocument();
+  },
+};
+
+export const DeferredClipboardAfterRetry: Story = {
+  render: () => <DeferredClipboardHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
+    expect(canvas.queryByText('오류 추적 ID를 복사했어요.')).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
+    await expect(canvas.findByText('복구됐습니다.')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '지연 복사 완료' }));
+
+    expect(canvas.queryByText('오류 추적 ID를 복사했어요.')).not.toBeInTheDocument();
+  },
+};
+
+export const DeferredClipboardAfterSafeNavigation: Story = {
+  render: () => <DeferredClipboardHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
+    expect(canvas.queryByText('오류 추적 ID를 복사했어요.')).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: '안전한 화면으로 이동' }));
+    await expect(canvas.findByText('복구됐습니다.')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '지연 복사 완료' }));
+
+    expect(canvas.queryByText('오류 추적 ID를 복사했어요.')).not.toBeInTheDocument();
+  },
+};
+
 const copySuccess = fn(async (value: string) => value === 'event-123');
 const copyFailure = fn(async () => false);
 
@@ -314,5 +423,50 @@ export const UnexpectedErrorCopyFailure: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
 
     await expect(canvas.findByText('오류 추적 ID를 복사하지 못했어요.')).resolves.toBeVisible();
+  },
+};
+
+const longEventId = `sentry-event-${'0123456789abcdef'.repeat(10)}`;
+const longEventCopy = fn(async (value: string) => value === longEventId);
+const longEventRetry = fn();
+const longEventSafeNavigate = fn();
+
+export const LongEventIdMobileKeyboardActions: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  render: () => (
+    <UnexpectedErrorScreen
+      eventId={longEventId}
+      onRetry={longEventRetry}
+      onSafeNavigate={longEventSafeNavigate}
+      writeClipboard={longEventCopy}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const eventId = canvas.getByText(longEventId);
+    const copyButton = canvas.getByRole('button', { name: '오류 추적 ID 복사' });
+    const retryButton = canvas.getByRole('button', { name: '다시 시도' });
+    const safeNavigateButton = canvas.getByRole('button', { name: '안전한 화면으로 이동' });
+
+    expect(eventId).toBeVisible();
+    expect(eventId.getBoundingClientRect().height).toBeGreaterThan(24);
+    expect(canvasElement.scrollWidth).toBeLessThanOrEqual(canvasElement.clientWidth + 1);
+
+    await userEvent.tab();
+    expect(copyButton).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    await expect(canvas.findByText('오류 추적 ID를 복사했어요.')).resolves.toBeVisible();
+    expect(longEventCopy).toHaveBeenCalledWith(longEventId);
+
+    copyButton.focus();
+    await userEvent.tab();
+    expect(retryButton).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    expect(longEventRetry).toHaveBeenCalledTimes(1);
+
+    await userEvent.tab();
+    expect(safeNavigateButton).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    expect(longEventSafeNavigate).toHaveBeenCalledTimes(1);
   },
 };

--- a/apps/app/src/stories/ErrorBoundaries.stories.tsx
+++ b/apps/app/src/stories/ErrorBoundaries.stories.tsx
@@ -7,6 +7,7 @@ import { GraphQLErrorBoundary } from '@/components/GraphQLErrorBoundary';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { UnexpectedErrorScreen } from '@/components/UnexpectedErrorScreen';
 import { StructuredClientError } from '@/observability/client-error';
+import { UnexpectedErrorContext } from '@/observability/UnexpectedErrorContext';
 import { SessionFailOpenBoundary } from '@/session/SessionProvider';
 import { RouterMockProvider } from '../../.storybook/mocks/expo-router';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -31,7 +32,7 @@ function ThrowOnRender({
   error = unexpectedRenderError,
 }: {
   active: boolean;
-  error?: Error;
+  error?: unknown;
 }) {
   if (active) {
     throw error;
@@ -117,6 +118,28 @@ function ReporterFallbackHarness({
   );
 }
 
+function NullThrownValueHarness({
+  onReport,
+  onRetry,
+}: {
+  onReport: (error: unknown, info: ErrorInfo) => string | undefined;
+  onRetry: () => void;
+}) {
+  const [failed, setFailed] = useState(true);
+
+  return (
+    <GraphQLErrorBoundary
+      onError={onReport}
+      onRetry={() => {
+        setFailed(false);
+        onRetry();
+      }}
+    >
+      <ThrowOnRender active={failed} error={null} />
+    </GraphQLErrorBoundary>
+  );
+}
+
 function RetryReFailureHarness({ onReport }: { onReport: (eventId: string) => void }) {
   const [attempt, setAttempt] = useState(0);
 
@@ -152,7 +175,7 @@ function SessionBoundaryHarness() {
           <Text>세션 갱신</Text>
         </Pressable>
         <SessionFailOpenBoundary fallback={<Text>세션 오류 상태</Text>} resetKey={resetKey}>
-          <ThrowOnRender active={failed} />
+          <ThrowOnRender active={failed} error={expectedNetworkError} />
         </SessionFailOpenBoundary>
       </View>
     </GraphQLErrorBoundary>
@@ -172,14 +195,18 @@ function ProductionRouteFailure() {
 
 function ProductionAppProvidersHarness({
   onNavigate,
+  onReport,
 }: {
   onNavigate: (action: 'push' | 'replace', href: Href) => void;
+  onReport: (error: unknown, info: ErrorInfo) => string | undefined;
 }) {
   return (
     <RouterMockProvider onNavigate={onNavigate} pathname="/settings">
-      <AppProviders>
-        <ProductionRouteFailure />
-      </AppProviders>
+      <UnexpectedErrorContext.Provider value={onReport}>
+        <AppProviders>
+          <ProductionRouteFailure />
+        </AppProviders>
+      </UnexpectedErrorContext.Provider>
     </RouterMockProvider>
   );
 }
@@ -309,6 +336,23 @@ export const ReporterWithoutEventIdFallsBackSafely: Story = {
   },
 };
 
+const nullThrownValueReporter = fn(() => 'null-event');
+const nullThrownValueRetry = fn();
+
+export const NullThrownValueReportsWithEventId: Story = {
+  render: () => (
+    <NullThrownValueHarness onReport={nullThrownValueReporter} onRetry={nullThrownValueRetry} />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByText('null-event')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
+    await expect(canvas.findByText('콘텐츠가 복구됐습니다.')).resolves.toBeVisible();
+    expect(nullThrownValueReporter).toHaveBeenCalledTimes(1);
+    expect(nullThrownValueRetry).toHaveBeenCalledTimes(1);
+  },
+};
+
 const retryReFailureReports = fn();
 
 export const RetryReFailureUsesNewIdAndClearsOldToast: Story = {
@@ -341,17 +385,26 @@ export const SessionFailOpenAndResetKey: Story = {
 };
 
 const productionNavigation = fn();
+const productionReporter = fn(() => 'production-event');
 
 export const ProductionAppProvidersSafeNavigation: Story = {
   globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
-  render: () => <ProductionAppProvidersHarness onNavigate={productionNavigation} />,
+  render: () => (
+    <ProductionAppProvidersHarness
+      onNavigate={productionNavigation}
+      onReport={productionReporter}
+    />
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.findByText('문제가 발생했어요')).resolves.toBeVisible();
+    await expect(canvas.findByText('production-event')).resolves.toBeVisible();
+    expect(productionReporter).toHaveBeenCalledTimes(1);
     await userEvent.click(canvas.getByRole('button', { name: '안전한 화면으로 이동' }));
 
     await expect(canvas.findByText('/')).resolves.toBeVisible();
     expect(canvas.queryByText('문제가 발생했어요')).not.toBeInTheDocument();
+    expect(productionReporter).toHaveBeenCalledTimes(1);
     expect(productionNavigation).toHaveBeenCalledTimes(1);
     expect(productionNavigation).toHaveBeenCalledWith('replace', '/');
   },

--- a/apps/app/src/stories/ErrorBoundaries.stories.tsx
+++ b/apps/app/src/stories/ErrorBoundaries.stories.tsx
@@ -3,14 +3,28 @@ import { Pressable, Text, View } from 'react-native';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import { GraphQLErrorBoundary } from '@/components/GraphQLErrorBoundary';
 import { RouteBoundary } from '@/components/RouteBoundary';
+import { UnexpectedErrorScreen } from '@/components/UnexpectedErrorScreen';
+import { StructuredClientError } from '@/observability/client-error';
 import { SessionFailOpenBoundary } from '@/session/SessionProvider';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-const renderError = new Error('production boundary fixture');
+const unexpectedRenderError = new Error('production boundary fixture with a private path');
+const expectedNetworkError = new StructuredClientError({
+  code: 'NETWORK_REQUEST_FAILED',
+  message: 'network down',
+  origin: 'transport',
+  type: 'network',
+});
 
-function ThrowOnRender({ active }: { active: boolean }) {
+function ThrowOnRender({
+  active,
+  error = unexpectedRenderError,
+}: {
+  active: boolean;
+  error?: Error;
+}) {
   if (active) {
-    throw renderError;
+    throw error;
   }
 
   return <Text>콘텐츠가 복구됐습니다.</Text>;
@@ -44,7 +58,7 @@ function RouteBoundaryHarness({ onRetry }: { onRetry: () => void }) {
         }}
         title="경로를 불러오지 못했어요"
       >
-        <ThrowOnRender active={failed} />
+        <ThrowOnRender active={failed} error={expectedNetworkError} />
       </RouteBoundary>
     </GraphQLErrorBoundary>
   );
@@ -88,7 +102,7 @@ export const GraphQLFallbackAndRetry: Story = {
   render: () => <GraphQLBoundaryHarness onRetry={graphQLRetry} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent('화면을 불러오지 못했어요');
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent('문제가 발생했어요');
     await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
 
     await expect(canvas.findByText('콘텐츠가 복구됐습니다.')).resolves.toBeVisible();
@@ -118,5 +132,57 @@ export const SessionFailOpenAndResetKey: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '세션 갱신' }));
 
     await expect(canvas.findByText('콘텐츠가 복구됐습니다.')).resolves.toBeVisible();
+  },
+};
+
+const copySuccess = fn(async (value: string) => value === 'event-123');
+const copyFailure = fn(async () => false);
+
+export const UnexpectedErrorWithEventIdAndCopy: Story = {
+  render: () => (
+    <UnexpectedErrorScreen
+      eventId="event-123"
+      onRetry={() => undefined}
+      onSafeNavigate={() => undefined}
+      writeClipboard={copySuccess}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText('event-123')).toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
+
+    expect(copySuccess).toHaveBeenCalledWith('event-123');
+    await expect(canvas.findByText('오류 추적 ID를 복사했습니다.')).resolves.toBeVisible();
+    await expect(canvas.findByText('오류 추적 ID를 복사했어요.')).resolves.toBeVisible();
+  },
+};
+
+export const UnexpectedErrorWithoutEventIdFallback: Story = {
+  render: () => (
+    <UnexpectedErrorScreen onRetry={() => undefined} onSafeNavigate={() => undefined} />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByRole('button', { name: '오류 추적 ID 복사' })).not.toBeInTheDocument();
+    expect(canvas.getByText(/오류 추적 ID를 확인하지 못했지만/)).toBeVisible();
+  },
+};
+
+export const UnexpectedErrorCopyFailure: Story = {
+  render: () => (
+    <UnexpectedErrorScreen
+      eventId="event-123"
+      onRetry={() => undefined}
+      onSafeNavigate={() => undefined}
+      writeClipboard={copyFailure}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
+
+    await expect(canvas.findByText('오류 추적 ID를 복사하지 못했습니다.')).resolves.toBeVisible();
+    await expect(canvas.findByText('오류 추적 ID를 복사하지 못했어요.')).resolves.toBeVisible();
   },
 };

--- a/apps/app/src/stories/ErrorBoundaries.stories.tsx
+++ b/apps/app/src/stories/ErrorBoundaries.stories.tsx
@@ -7,6 +7,7 @@ import { UnexpectedErrorScreen } from '@/components/UnexpectedErrorScreen';
 import { StructuredClientError } from '@/observability/client-error';
 import { SessionFailOpenBoundary } from '@/session/SessionProvider';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ErrorInfo } from 'react';
 
 const unexpectedRenderError = new Error('production boundary fixture with a private path');
 const expectedNetworkError = new StructuredClientError({
@@ -45,11 +46,17 @@ function GraphQLBoundaryHarness({ onRetry }: { onRetry: () => void }) {
   );
 }
 
-function RouteBoundaryHarness({ onRetry }: { onRetry: () => void }) {
+function RouteBoundaryHarness({
+  onReport,
+  onRetry,
+}: {
+  onReport: () => string;
+  onRetry: () => void;
+}) {
   const [failed, setFailed] = useState(true);
 
   return (
-    <GraphQLErrorBoundary onRetry={() => undefined}>
+    <GraphQLErrorBoundary onError={onReport} onRetry={() => undefined}>
       <RouteBoundary
         loading={<Text>route loading</Text>}
         onRetry={() => {
@@ -60,6 +67,60 @@ function RouteBoundaryHarness({ onRetry }: { onRetry: () => void }) {
       >
         <ThrowOnRender active={failed} error={expectedNetworkError} />
       </RouteBoundary>
+    </GraphQLErrorBoundary>
+  );
+}
+
+function SafeNavigationHarness({
+  onNavigate,
+  onReport,
+  onRetry,
+}: {
+  onNavigate: () => void;
+  onReport: () => string;
+  onRetry: () => void;
+}) {
+  const [failed, setFailed] = useState(true);
+
+  return (
+    <GraphQLErrorBoundary
+      onError={onReport}
+      onRetry={onRetry}
+      onSafeNavigate={() => {
+        setFailed(false);
+        onNavigate();
+      }}
+    >
+      <ThrowOnRender active={failed} />
+    </GraphQLErrorBoundary>
+  );
+}
+
+function ReporterFallbackHarness({
+  onReport,
+}: {
+  onReport: (error: unknown, info: ErrorInfo) => string | undefined;
+}) {
+  return (
+    <GraphQLErrorBoundary onError={onReport} onRetry={() => undefined}>
+      <ThrowOnRender active />
+    </GraphQLErrorBoundary>
+  );
+}
+
+function RetryReFailureHarness({ onReport }: { onReport: (eventId: string) => void }) {
+  const [attempt, setAttempt] = useState(0);
+
+  return (
+    <GraphQLErrorBoundary
+      onError={() => {
+        const eventId = `event-${attempt + 1}`;
+        onReport(eventId);
+        return eventId;
+      }}
+      onRetry={() => setAttempt((current) => current + 1)}
+    >
+      <ThrowOnRender active error={new Error(`retry failure ${attempt}`)} />
     </GraphQLErrorBoundary>
   );
 }
@@ -102,7 +163,7 @@ export const GraphQLFallbackAndRetry: Story = {
   render: () => <GraphQLBoundaryHarness onRetry={graphQLRetry} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent('문제가 발생했어요');
+    await expect(canvas.findByText('문제가 발생했어요')).resolves.toBeVisible();
     await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
 
     await expect(canvas.findByText('콘텐츠가 복구됐습니다.')).resolves.toBeVisible();
@@ -111,9 +172,10 @@ export const GraphQLFallbackAndRetry: Story = {
 };
 
 const routeRetry = fn();
+const expectedRouteReporter = fn(() => 'unexpected-id');
 
 export const RouteFallbackAndRetry: Story = {
-  render: () => <RouteBoundaryHarness onRetry={routeRetry} />,
+  render: () => <RouteBoundaryHarness onReport={expectedRouteReporter} onRetry={routeRetry} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.findByRole('alert')).resolves.toHaveTextContent('경로를 불러오지 못했어요');
@@ -121,6 +183,76 @@ export const RouteFallbackAndRetry: Story = {
 
     await expect(canvas.findByText('콘텐츠가 복구됐습니다.')).resolves.toBeVisible();
     expect(routeRetry).toHaveBeenCalledTimes(1);
+  },
+};
+
+const safeNavigationReporter = fn(() => 'event-current');
+const safeNavigationOwnerRetry = fn();
+const safeNavigation = fn();
+
+export const SafeNavigationResetsWithoutOwnerRetry: Story = {
+  render: () => (
+    <SafeNavigationHarness
+      onNavigate={safeNavigation}
+      onReport={safeNavigationReporter}
+      onRetry={safeNavigationOwnerRetry}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByText('event-current')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '안전한 화면으로 이동' }));
+
+    await expect(canvas.findByText('콘텐츠가 복구됐습니다.')).resolves.toBeVisible();
+    expect(safeNavigationReporter).toHaveBeenCalledTimes(1);
+    expect(safeNavigationOwnerRetry).not.toHaveBeenCalled();
+    expect(safeNavigation).toHaveBeenCalledTimes(1);
+  },
+};
+
+const throwingReporter = fn(() => {
+  throw new Error('reporter unavailable');
+});
+
+export const ReporterThrowFallsBackWithoutEventId: Story = {
+  render: () => <ReporterFallbackHarness onReport={throwingReporter} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByText(/오류 추적 ID를 확인하지 못했지만/)).resolves.toBeVisible();
+    expect(canvas.queryByRole('button', { name: '오류 추적 ID 복사' })).not.toBeInTheDocument();
+    expect(throwingReporter).toHaveBeenCalledTimes(1);
+  },
+};
+
+const noIdReporter = fn(() => undefined);
+
+export const ReporterWithoutEventIdFallsBackSafely: Story = {
+  render: () => <ReporterFallbackHarness onReport={noIdReporter} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByText(/오류 추적 ID를 확인하지 못했지만/)).resolves.toBeVisible();
+    expect(canvas.queryByRole('button', { name: '오류 추적 ID 복사' })).not.toBeInTheDocument();
+    expect(noIdReporter).toHaveBeenCalledTimes(1);
+  },
+};
+
+const retryReFailureReports = fn();
+
+export const RetryReFailureUsesNewIdAndClearsOldToast: Story = {
+  render: () => <RetryReFailureHarness onReport={retryReFailureReports} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.findByText('event-1')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
+    await expect(canvas.findByText('오류 추적 ID를 복사했어요.')).resolves.toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
+
+    await expect(canvas.findByText('event-2')).resolves.toBeVisible();
+    expect(canvas.queryByText('오류 추적 ID를 복사했어요.')).not.toBeInTheDocument();
+    expect(retryReFailureReports).toHaveBeenCalledTimes(2);
+    expect(retryReFailureReports).toHaveBeenNthCalledWith(1, 'event-1');
+    expect(retryReFailureReports).toHaveBeenNthCalledWith(2, 'event-2');
   },
 };
 
@@ -153,7 +285,6 @@ export const UnexpectedErrorWithEventIdAndCopy: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
 
     expect(copySuccess).toHaveBeenCalledWith('event-123');
-    await expect(canvas.findByText('오류 추적 ID를 복사했습니다.')).resolves.toBeVisible();
     await expect(canvas.findByText('오류 추적 ID를 복사했어요.')).resolves.toBeVisible();
   },
 };
@@ -182,7 +313,6 @@ export const UnexpectedErrorCopyFailure: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: '오류 추적 ID 복사' }));
 
-    await expect(canvas.findByText('오류 추적 ID를 복사하지 못했습니다.')).resolves.toBeVisible();
     await expect(canvas.findByText('오류 추적 ID를 복사하지 못했어요.')).resolves.toBeVisible();
   },
 };

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
               replacement: join(currentDirectory, '.storybook/mocks/expo-secure-store.ts'),
             },
             {
+              find: /^expo-clipboard$/,
+              replacement: join(currentDirectory, '.storybook/mocks/expo-clipboard.ts'),
+            },
+            {
               find: /^react-native-safe-area-context$/,
               replacement: join(currentDirectory, '.storybook/mocks/safe-area-context.tsx'),
             },

--- a/openspec/changes/add-sentry-event-id-error-screen/.openspec.yaml
+++ b/openspec/changes/add-sentry-event-id-error-screen/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-30

--- a/openspec/changes/add-sentry-event-id-error-screen/decisions.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/decisions.md
@@ -1,0 +1,109 @@
+## Context
+
+이 기록은 PROD-480의 universal 오류 화면 계약, 구현 자식 PROD-485·PROD-486의 platform 책임, PROD-477·483·493의 Sentry 수집 경계와 canonical 디자인 제약을 현재 Expo Router·Relay·`react-error-boundary` 조합에 적용한 선택을 정리한다.
+
+## Decision Records
+
+### 예상 오류와 화면을 사용할 수 없는 예상하지 못한 오류를 분리한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/accessibility.md`, PROD-477, PROD-480
+- Status: Active
+- Context / Problem: 현재 GraphQL·route 경계는 예상된 GraphQL·network 오류와 local render 오류를 같은 fallback과 Web reporter로 전달할 수 있다. 모든 오류를 추적 ID가 있는 전용 화면으로 바꾸면 PROD-480의 inline 예상 오류 보존과 PROD-477의 expected 오류 수집 제외를 위반한다.
+- Decision Outcome: validation·권한·의도된 GraphQL/domain 오류와 현재 화면에서 재시도 가능한 network·transport 오류는 가장 가까운 기존 inline 또는 route-local 상태에 남긴다. 현재 화면을 계속 렌더링할 수 없게 만드는 local unexpected render/runtime 오류만 전용 오류 화면과 client Sentry report 대상이다. Server GraphQL response는 server capture 여부와 무관하게 별도 client render event로 중복 보고하지 않는다.
+- Alternatives Considered: boundary에 도달한 모든 오류를 전용 화면과 client Sentry에 보내는 방식은 예상 오류·server 오류를 중복 수집한다. 모든 query 오류를 무조건 inline으로 간주하는 방식은 실제 local render 결함을 누락할 수 있다.
+- Consequences: 기존 mutation inline UX는 유지한다. Query·transport 경계는 origin을 보존해야 하며 분류 회귀 테스트가 필요하다.
+- Confirmation / Follow-up: expected mutation·GraphQL response·network fixture는 전용 화면과 client reporter를 사용하지 않고, unexpected render fixture만 reporter 한 번과 전용 화면으로 이어지는지 검증한다.
+
+### 오류 종류는 구조화된 origin과 code로 구분한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `memory/coding-style.md`, `memory/frontend-react-native.md`, PROD-477, PROD-480
+- Status: Active
+- Context / Problem: 현재 network 경계는 HTTP·GraphQL 오류를 plain `Error.message`로 평탄화하고 fallback formatter도 message를 그대로 노출한다. Message는 번역·서버 문구·네트워크 환경에 따라 달라져 정확한 분류나 보안 경계가 될 수 없다.
+- Decision Outcome: Transport failure, GraphQL response와 local render error의 origin을 app-owned metadata/type으로 보존하고 Relay가 제공하는 structured error source·extensions를 함께 사용한다. Expected/unexpected 분류는 이 구조화된 정보로 수행하며 사용자-facing message 문자열이나 정규식을 분류 근거로 사용하지 않는다.
+- Alternatives Considered: message prefix·한국어 문구·HTTP status 문자열 parsing은 불안정하고 오류 원문 노출을 고착시킨다. 모든 plain `Error`를 unexpected로 처리하면 network 실패를 수집하고, 모두 expected로 처리하면 render 결함을 놓친다.
+- Consequences: Network와 boundary 사이의 내부 오류 표현은 바뀔 수 있지만 GraphQL schema·server payload 계약은 바뀌지 않는다. 전용 화면은 기존 raw formatter를 사용하지 않는다.
+- Confirmation / Follow-up: 같은 사용자 message라도 origin/code가 다른 fixture를 구분하고, raw message가 전용 화면·accessibility output에 포함되지 않는지 검증한다.
+
+### 전용 오류 화면은 새 route가 아니라 포착 경계 안에서 렌더링한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `memory/frontend-react-native.md`, PROD-480, PROD-513
+- Status: Active
+- Context / Problem: 별도 `/error` route로 navigation하면 오류가 난 route tree를 다시 사용하고 React error occurrence·component stack·`resetErrorBoundary` 소유권을 navigation state로 옮겨야 한다.
+- Decision Outcome: GraphQL·route·session을 구성하는 기존 함수형 `react-error-boundary` 조합이 공용 전용 오류 화면을 fallback으로 직접 렌더링한다. 화면은 Expo Router singleton이나 오류 route parameter에서 error를 읽지 않고 boundary가 제공한 ID 상태와 retry·safe navigation callback만 받는다.
+- Alternatives Considered: 전용 route navigation은 URL 공유·refresh가 가능하지만 오류 원문/ID를 navigation state에 넣을 위험과 route 자체 실패 가능성이 있다. 새 class boundary는 PROD-513의 함수형 조합·lint 계약을 위반한다.
+- Consequences: 현재 route context 안에서 화면을 표시하므로 reset과 원래 owner callback을 보존한다. 공용 화면은 route·Sentry SDK를 직접 소유하지 않는다.
+- Confirmation / Follow-up: GraphQL·route·session story에서 class component 없이 fallback, reset과 재렌더가 동작하고 오류 route가 생성되지 않았는지 확인한다.
+
+### Platform reporter는 현재 capture의 optional event ID를 반환한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: PROD-477, PROD-480, PROD-483, PROD-493
+- Status: Active
+- Context / Problem: 현재 Web reporter는 Sentry SDK가 반환하는 event ID를 버린다. 앱이 별도 UUID를 만들거나 전역 `lastEventId`를 읽으면 현재 오류와 다른 event를 연결할 수 있다. 반대로 client SDK는 capture 시 ID를 만들고 전송을 비동기로 처리하므로 개별 원격 수락을 화면 render 전에 증명하지 못한다.
+- Decision Outcome: 공용 reporter contract는 현재 오류와 component stack을 받아 해당 capture에서 SDK가 반환한 opaque event ID 또는 `없음`을 반환한다. 화면은 이 값만 표시하고, 앱 생성 ID·이전 ID·message hash를 사용하지 않는다. Adapter 미구성·capture 예외·ID 부재는 `없음`으로 처리하며 오류 화면을 block하지 않는다. Client에 Sentry read token을 두거나 매 오류마다 원격 조회하지 않고, platform 배포 smoke에서 표시 ID와 실제 event를 대조한다.
+- Alternatives Considered: App-generated UUID는 실제 Sentry event와 연결되지 않는다. `lastEventId`는 동시·이전 event를 잘못 연결할 수 있다. Capture 뒤 원격 API 확인은 public client에 read credential을 노출하고 offline fallback을 실패시킨다. 전송 queue flush는 특정 event의 원격 저장을 증명하지 못한다.
+- Consequences: 표시 ID는 current SDK capture와 정확히 같은 식별자지만 transport 장애나 backend drop을 UI가 동기적으로 판별하지는 못한다. 실제 조회 가능성은 Web·native runtime gate가 검증한다.
+- Confirmation / Follow-up: Reporter 단위 테스트에서 returned ID passthrough, disabled/throw/no-ID fallback과 한 occurrence 한 capture를 확인하고, PROD-485·486 smoke에서 화면 ID로 같은 Sentry event를 조회한다.
+
+### 복사에는 Expo universal clipboard와 기존 접근성 feedback을 사용한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/accessibility.md`, `docs/design/colors.md`, `memory/frontend-react-native.md`, PROD-480
+- Status: Active
+- Context / Problem: 현재 workspace에는 clipboard API나 dependency가 없다. Web `navigator.clipboard`만 직접 호출하면 native 구현이 갈라지고, 별도 native menu는 공용 화면 계약을 중복한다.
+- Decision Outcome: `apps/app`은 pnpm으로 Expo SDK 호환 `expo-clipboard`를 dependency로 추가하고, 공용 화면은 ID string 쓰기의 성공·실패만 노출하는 작은 universal adapter를 사용한다. Copy 성공·실패는 기존 `ToastProvider`의 안전한 한국어 alert로 알리며 오류 원문은 전달하지 않는다.
+- Alternatives Considered: Web DOM API와 native package를 별도로 호출하는 방식은 platform UI·test를 중복한다. ID를 선택 가능한 Text로만 제공하면 명시적인 복사 완료·실패와 native 접근성을 보장하지 못한다. 새 toast system은 기존 theme·announcement surface를 중복한다.
+- Consequences: App runtime dependency 하나가 추가되고 clipboard 실패를 async UI 상태로 처리해야 한다. Toast는 copy 결과만 알리고 retry·navigation 상태는 바꾸지 않는다.
+- Confirmation / Follow-up: Dependency는 구현 slice에서 `pnpm` CLI로 추가하고 Web·Android·iOS에서 정확한 ID copy, success/failure announcement와 action 유지 여부를 검증한다.
+
+### 오류 화면의 안전한 이동은 public root를 replace한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `memory/frontend-react-native.md`, PROD-480
+- Status: Active
+- Context / Problem: PROD-480은 복구되지 않을 때 홈 등 안전한 화면으로 이동하도록 요구하지만 `/home`은 보호 route라 guest에게 다시 redirect될 수 있고, push는 back action으로 실패한 route를 즉시 다시 열 수 있다.
+- Decision Outcome: 안전한 이동 action은 인증 상태와 무관하게 열리는 canonical public root `/`로 `replace`한다. 전용 화면은 navigation singleton을 직접 읽지 않고 boundary owner가 전달한 callback을 실행한다.
+- Alternatives Considered: `/home` push/replace는 인증 상태에 따라 보호 route redirect와 상호작용한다. `router.back()`은 이전 entry가 없거나 같은 실패 route일 수 있다. 강제 reload는 native parity와 boundary reset 의미를 잃는다.
+- Consequences: Guest는 landing에 남고 인증된 사용자는 root의 기존 session 분기에 따라 `/home`으로 전환될 수 있다. 실패 route는 현재 back stack entry에서 제거된다.
+- Confirmation / Follow-up: Guest·authenticated fixture와 not-found/logout의 기존 `/` semantics를 회귀 검증하고 안전 이동 뒤 실패 화면으로 즉시 돌아가지 않는지 확인한다.
+
+### 오류 ID는 피드백에 자동 연결하지 않는다
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: PROD-479, PROD-480, PROD-487
+- Status: Active
+- Context / Problem: PROD-480은 사용자가 ID를 복사해 지원 요청에 전달할 수 있게 하지만, 최신 feedback 계약은 Sentry event·trace ID의 자동 연결과 Slack payload field를 명시적으로 제외한다.
+- Decision Outcome: 오류 화면은 복사까지만 소유한다. 사용자는 기존 feedback 본문이나 외부 지원 채널에 수동으로 붙여 넣을 수 있지만 `/feedback` GraphQL input, URL, prefill, client state와 Slack payload에 Sentry ID field를 추가하지 않는다.
+- Alternatives Considered: Feedback form 자동 prefill·구조화 field·Slack metadata는 PROD-479·487의 제외 범위를 다시 열어야 하므로 선택하지 않는다. 복사 자체를 제외하면 PROD-480 완료 조건을 충족하지 못한다.
+- Consequences: 운영자는 사용자가 제공한 본문에서 ID를 수동으로 찾아야 한다. 자동 상관관계가 필요하면 feedback upstream 계약을 먼저 변경해야 한다.
+- Confirmation / Follow-up: Feedback schema·form·Slack payload diff가 없고 copy 뒤 navigation해도 ID가 자동 주입되지 않는지 확인한다.
+
+### 공용 기반과 platform 검증 책임을 세 이슈로 분리한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: PROD-480 본문과 2026-07-27 플랫폼 구현 자식 댓글, PROD-483, PROD-485, PROD-486, PROD-493
+- Status: Active
+- Context / Problem: 공용 UI와 분류·reporter contract는 세 platform이 공유하지만 Web과 native의 Sentry 선행 이슈, 배포 시점과 runtime 검증은 다르다.
+- Decision Outcome: PROD-480은 공용 분류·오류 화면·reporter/clipboard contract, cross-platform 정합성과 최종 integration/archive를 소유한다. PROD-486은 PROD-493 이후 Web event ID·copy·retry·safe navigation과 production smoke를 소유한다. PROD-485는 PROD-483 이후 Android·iOS adapter·clipboard·접근성·event ID runtime 검증을 소유한다. Web 완료만으로 native task나 전체 change를 완료·archive하지 않는다.
+- Alternatives Considered: 한 platform 이슈가 공용·다른 platform 구현까지 소유하면 branch/PR 검증 책임이 섞인다. Platform별 OpenSpec에 공용 계약을 복제하면 분류·UI·reset 결정이 갈라진다. Parent 계층만으로 archive owner를 추론하는 대신 PROD-480 본문이 명시한 통합·archive 책임을 사용한다.
+- Consequences: Web 배포 뒤에도 native blocker가 남으면 change는 active 상태를 유지한다. 각 구현 PR은 자신의 platform 증거만 소유하며 parent owner가 마지막 정합성과 archive를 수행한다.
+- Confirmation / Follow-up: Tasks heading, implementation handoff와 PR 본문에 이슈별 Deliverable·Verification을 유지하고 archive 전 두 platform runtime evidence를 대조한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-sentry-event-id-error-screen/decisions.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/decisions.md
@@ -4,6 +4,18 @@
 
 ## Decision Records
 
+### 안전한 이동 reset과 copy feedback은 오류 발생 건 단위로 분리한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: PROD-480 review repair, `react-error-boundary` reset contract, ErrorBoundaries Storybook verification
+- Status: Active
+- Context / Problem: 전용 화면의 안전한 이동이 일반 retry callback을 호출하면 소유자 재조회가 불필요하게 실행되고, copy 결과를 화면의 별도 live region과 Toast에 함께 표시하면 중복 announcement가 생긴다. reset·즉시 재실패 뒤에는 이전 Toast와 진행 중 clipboard 결과가 다음 오류 발생 건에 남을 수 있다.
+- Decision Outcome: ClientErrorBoundary는 안전한 이동만을 위한 private reset marker로 occurrence/report 상태를 비우고 owner retry callback은 건너뛴다. Boundary owner가 전달한 public safe callback은 한 번만 실행하고, 일반 retry는 기존 owner callback을 한 번 실행한다. UnexpectedErrorScreen은 occurrence key와 ToastProvider의 좁은 dismiss API를 사용해 reset·unmount·새 오류 발생 건에서 pending clipboard와 이전 Toast를 취소하고, copy 결과는 기존 assertive Toast 하나로만 알린다.
+- Alternatives Considered: 안전한 이동에서 일반 reset callback을 재사용하면 실패한 route의 재조회가 다시 시작된다. 화면 안에 polite copy status를 추가하면 기존 Toast와 중복되며, 전역 이전 Toast를 그대로 두면 새 occurrence에 잘못된 feedback이 남는다. 별도 오류 feedback 시스템은 현재 Toast 소유권과 범위를 불필요하게 늘린다.
+- Consequences: fallback render props에 occurrence key와 안전한 reset callback이 추가되고 Toast context에 dismiss API가 추가된다. Clipboard promise가 늦게 완료되어도 reset된 화면에 feedback을 재표시하지 않는다. 기존 public ClientErrorBoundary props와 owner retry 동작은 유지한다.
+- Confirmation / Follow-up: ErrorBoundaries Storybook에서 reporter return ID·throw/no-ID, safe navigation callback 1회·owner retry 0회, retry 후 새 ID와 이전 Toast 제거를 검증하고 기본 clipboard adapter 단위 테스트에서 ID 전달을 확인한다.
+
 ### 예상 오류와 화면을 사용할 수 없는 예상하지 못한 오류를 분리한다
 
 - Decision Date: 2026-07-30

--- a/openspec/changes/add-sentry-event-id-error-screen/design.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/design.md
@@ -1,0 +1,98 @@
+## Context
+
+`apps/app`은 Android·iOS·Web이 Expo Router route tree와 React Native UI를 공유한다. 현재 `GraphQLErrorBoundary`와 `RouteBoundary`는 `react-error-boundary`로 오류를 포착해 `StateView` fallback을 렌더링하고, reset 뒤 Relay actor revision 또는 route-local fetch key를 바꿔 재조회한다. Web entry는 `UnexpectedErrorContext`에 Sentry reporter를 주입하지만 reporter 반환형이 `void`라 SDK가 생성한 event ID를 버린다. Native entry에는 PROD-483 범위를 선행하지 않도록 Sentry adapter가 없다.
+
+현재 Relay network는 HTTP 실패를 message만 가진 `Error`로 평탄화하고, Relay는 `data: null`인 GraphQL 오류를 `RelayNetwork` 오류로 경계에 던질 수 있다. GraphQL·route 경계와 Web reporter는 오류 종류를 검사하지 않아 예상된 query·network 오류도 client Sentry에 보고될 가능성이 있다. Mutation의 validation·권한 오류는 다수 화면이 callback에서 inline 상태로 처리한다.
+
+Sentry JavaScript SDK의 capture API는 전송 완료를 기다리지 않고 생성한 event ID를 동기적으로 반환한다. 따라서 UI는 SDK adapter가 현재 오류에 반환한 ID만 사용할 수 있지만, client만으로 개별 event의 원격 수락을 동기적으로 증명할 수는 없다. 배포 gate에서 화면 ID와 실제 Sentry event를 대조해야 한다.
+
+기존 `ToastProvider`는 universal하고 접근 가능한 상태 알림을 제공한다. 반면 workspace에는 clipboard dependency나 공용 clipboard adapter가 없고, `/`는 guest redirect, logout과 not-found 복귀에 이미 사용하는 인증 독립 public root다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 예상 오류와 화면을 사용할 수 없게 만드는 예상하지 못한 client 오류를 구조적으로 구분한다.
+- 예상하지 못한 오류를 platform reporter에 한 번 보고하고 반환된 event ID를 전용 오류 화면에 연결한다.
+- ID 발급·전송·clipboard 실패와 무관하게 다시 시도와 public 안전 화면 이동을 유지한다.
+- 공용 React Native 화면을 공유하면서 Sentry·clipboard platform API만 adapter 경계에 둔다.
+- Web과 Android·iOS의 서로 다른 선행 이슈와 runtime 검증 책임을 OpenSpec task에서 분리한다.
+
+**Non-Goals:**
+
+- Sentry SDK·project·DSN·source map/debug symbol·secret 경계를 새로 구축하거나 PROD-477·483·493 계약을 변경하는 작업
+- API·Web BFF 오류 응답, server event ID 전달 또는 server symbolication 구현
+- 예상 오류, validation·권한 실패와 모든 network 오류를 client Sentry에 수집하는 작업
+- 오류 원문·stack·내부 경로·credential·사용자 콘텐츠를 사용자에게 노출하는 작업
+- Sentry ID를 `/feedback` input, URL, navigation state 또는 Slack payload에 자동 연결하는 작업
+- tracing, Session Replay, analytics 또는 Sentry 자체 User Feedback UI 도입
+
+## Implementation Guidance
+
+### Current Constraints
+
+- 하나의 `UnexpectedErrorReporter`가 nested GraphQL·route·session 경계에 상속된다. 현재 모든 경계가 동일 reporter를 호출하므로 분류와 occurrence 단위 중복 방지를 공용 경계에서 일관되게 적용해야 한다.
+- `GraphQLErrorBoundary`는 backend·network message를 사용자 설명에 그대로 전달한다. 전용 오류 화면에서 이 formatter를 재사용하면 Linear의 민감 정보 비노출 제약을 위반할 수 있다.
+- HTTP 실패를 plain `Error`로 바꾸면 render 오류와 transport 오류를 message 이외의 근거로 구분할 수 없다. Relay의 `source.errors`에는 GraphQL extensions가 남을 수 있지만 partial data와 `data: null` 경로가 다르다.
+- `react-error-boundary`의 `onError` 반환값은 fallback에 전달되지 않는다. reporter 결과를 오류 발생 건의 UI 상태로 연결하고 reset에서 제거하는 얇은 함수형 조합이 필요하다.
+- Sentry capture API가 반환한 ID는 해당 SDK event에 사용한 식별자지만 네트워크 수락 확인은 아니다. UI render를 전송 대기나 Sentry API 조회에 묶으면 offline·전송 장애에서 fallback 자체가 불안정해진다.
+- Web Sentry는 platform entry에서만 import한다. 공용 source가 `@sentry/react` 또는 향후 native SDK를 직접 import하면 PROD-483 이전 native bundle 경계를 깨뜨린다.
+- `StateView`는 action 하나만 제공한다. 전용 화면은 copy·retry·safe navigation과 상태 알림을 함께 다뤄야 하므로 기존 단일 action API를 억지로 확장하면 일반 loading/empty/error state와 치명적 오류 책임이 섞일 수 있다.
+- Android·iOS runtime event ID 검증은 PROD-483이 완료되기 전에는 수행할 수 없다. Web 완료 증거를 native 완료로 일반화할 수 없다.
+
+### Recommended Approach
+
+공용 오류 경계 앞에 구조화된 분류 단계를 두고, GraphQL response·Relay query·HTTP/network에서 온 예상 오류와 local render/runtime 오류를 message가 아니라 보존된 origin·type·code로 구분한다. Network 경계는 transport 실패와 GraphQL response metadata를 잃지 않는 app-owned 오류 표현을 사용하고, mutation의 기존 inline 처리에는 손대지 않는다. Server가 반환한 GraphQL 오류와 transport 실패는 가장 가까운 기존 route-local 상태에서 복구하고 client reporter로 보내지 않는다. 분류할 수 없는 render 예외는 예상하지 못한 오류로 취급하되 원문은 사용자 화면에 전달하지 않는다.
+
+Platform-neutral reporter는 현재 오류와 React component stack을 받아 `event ID | 없음` 결과를 반환하게 한다. Web adapter는 기존 Sentry capture 호출의 반환값을 전달하고, adapter가 없거나 capture가 예외를 던지면 `없음`으로 안전하게 종료한다. Android·iOS는 PROD-483이 정의한 native adapter를 같은 contract에 맞춘다. 공용 경계 조합이 최초 처리한 오류 발생 건의 report 결과를 소유하고, nested 경계·재렌더가 같은 발생 건을 다시 보고하지 않게 한다. Reset에서는 오류·ID·copy 상태를 함께 지우고, reset 뒤 재발한 오류는 새 발생 건으로 처리한다.
+
+예상하지 못한 오류 fallback은 별도 route로 navigation하지 않고 포착한 경계 안에서 공용 전용 오류 화면을 렌더링하는 것을 기본으로 한다. 그래야 `resetErrorBoundary`와 소유자 retry callback을 그대로 유지하고, route 자체가 실패한 상황에서도 오류 route를 추가로 해석하지 않는다. 안전한 이동은 현재 인증 상태와 무관한 public root `/`로 replace하여 실패한 route가 back stack에서 즉시 다시 열리지 않게 한다.
+
+전용 화면은 theme·typography·spacing token을 사용하는 공용 React Native component로 두고 다음 상태를 표현한다.
+
+- 고정된 안전한 한국어 title·description
+- adapter가 반환한 경우에만 opaque event ID와 copy action
+- 다시 시도와 public 안전 화면 이동
+- 기존 universal toast를 재사용한 copy 성공·실패 announcement
+
+Clipboard는 Expo runtime을 지원하는 단일 dependency를 app package에 pnpm으로 추가하고, 공용 화면은 작은 platform-neutral async adapter만 호출하는 방식을 권장한다. Adapter는 성공·실패만 반환하고 ID 외의 오류 세부를 UI로 전달하지 않는다. Web의 `navigator.clipboard` 직접 호출과 native 별도 UI를 만들지 않는다.
+
+Component/Storybook 검증은 no-ID, ID, 긴 ID, copy success/failure, retry success/re-failure, guest-safe navigation, 좁은 Web viewport, keyboard와 text scaling 상태를 포함한다. Reporter 단위 검증은 structured expected 오류 제외, unexpected capture 한 번, returned ID 연결, adapter throw fallback과 reset dedupe를 확인한다. 실제 runtime gate는 Web(PROD-486)과 Android·iOS(PROD-485)가 각 platform의 화면 ID와 Sentry event를 독립적으로 대조한다.
+
+### Allowed Alternatives
+
+- 별도 전용 component 대신 기존 상태 primitive를 합성해도 specs의 action·민감 정보·접근성·occurrence 상태 경계를 모두 지키고 일반 state API에 Sentry 책임을 노출하지 않으면 허용한다.
+- Expo 호환 clipboard package 대신 현재 지원 Expo SDK에서 Android·iOS·Web을 모두 제공하는 다른 유지보수되는 adapter를 사용할 수 있다. Web-only DOM API와 native UI 중복은 허용하지 않는다.
+- Reporter 결과를 동기 optional ID가 아닌 비동기 result로 모델링할 수 있다. 이 경우 오류 화면은 ID pending 자체를 blocking loading으로 만들지 않고, 늦게 도착한 결과가 reset된 occurrence에 붙지 않도록 해야 한다.
+
+### Known Traps
+
+- `error.message`, GraphQL 한국어 문구 또는 문자열 정규식으로 expected/unexpected를 분류하지 않는다.
+- 모든 `RelayNetwork` 이름을 곧바로 사용자 잘못으로 취급하지 않는다. `source.errors`, transport origin과 server 변환 계약을 보존해 client 중복 capture만 막는다.
+- fallback render 안에서 Sentry side effect를 직접 실행하지 않는다. React 재렌더·Strict Mode·Storybook play 재실행이 같은 오류를 중복 보고할 수 있다.
+- SDK event ID처럼 보이는 random UUID를 app에서 만들거나 이전 `lastEventId`를 읽어 현재 오류에 붙이지 않는다.
+- Sentry 전송 완료를 기다리느라 오류 화면·retry를 block하거나 public client에서 Sentry read API token을 사용하지 않는다.
+- raw 오류를 ID copy 실패 toast, accessibility label, console-derived description 또는 navigation parameter에 포함하지 않는다.
+- `/home`을 무조건 안전 목적지로 쓰지 않는다. guest는 protected route redirect와 상호작용하므로 기존 public root를 사용한다.
+- Web Storybook a11y 통과를 color contrast·Web runtime·VoiceOver·TalkBack 전체 검증으로 해석하지 않는다.
+
+## Risks / Trade-offs
+
+- [Sentry SDK ID 반환과 원격 event 수락 사이에 비동기 간극이 있다] → 앱은 SDK가 현재 capture에 반환한 ID만 표시하고 가짜 ID를 만들지 않으며, platform 배포 smoke에서 표시 ID로 실제 event를 조회한다. 전송 장애는 no-ID 또는 미전달 가능성으로 운영 검증에 기록하되 fallback을 실패시키지 않는다.
+- [예상 query 오류의 기존 plain `Error` 평탄화가 구조적 분류를 어렵게 한다] → transport와 GraphQL response origin을 app-owned type/metadata로 보존하고 message는 표시용 fallback 외 분류 근거로 사용하지 않는다.
+- [분류를 너무 넓게 expected로 두면 실제 client 결함을 누락할 수 있다] → server response·transport로 출처가 확인되는 오류만 client capture에서 제외하고 local render/runtime 예외는 기본적으로 unexpected로 둔다. 분류 회귀 fixture를 유지한다.
+- [분류를 너무 좁게 두면 server/client 중복 event가 생긴다] → `INTERNAL_SERVER_ERROR`를 포함한 server GraphQL response는 client render event로 다시 capture하지 않고 platform integration에서 event 수를 확인한다.
+- [Native blocker 때문에 change가 Web 배포 뒤에도 active로 남는다] → task ownership과 완료 evidence를 PROD-480·485·486으로 분리하고 parent archive는 두 platform slice와 통합 검증이 모두 끝난 뒤에만 수행한다.
+- [clipboard dependency가 bundle과 권한 경계를 늘린다] → Expo 호환 최소 package를 pnpm으로 추가하고 ID string 쓰기만 감싼다. clipboard 실패는 local UI 상태로만 처리한다.
+
+## Migration Plan
+
+1. PROD-480 공용 slice에서 오류 origin 분류, optional event ID reporter contract, 전용 오류 화면과 clipboard adapter·component 검증을 추가한다. 기존 예상 오류 inline/route-local fixture를 먼저 고정한다.
+2. PROD-486 Web slice에서 기존 PROD-493 Sentry adapter의 capture 반환 ID를 공용 contract에 연결하고 Web copy·retry·safe navigation, 중복 보고와 실제 event ID 대조를 검증한다.
+3. PROD-483이 native Sentry 수집 경계를 제공한 뒤 PROD-485가 Android·iOS adapter와 device clipboard·접근성·event ID 대조를 검증한다.
+4. PROD-480 통합 owner가 strict OpenSpec, 공용 Storybook/unit 회귀, Web·Android·iOS runtime evidence와 upstream 정합성을 확인하고 전체 change를 archive한다.
+5. Rollback이 필요하면 platform reporter가 ID를 반환하지 않게 해 추적 ID·copy를 숨기고 기존 안전 안내·retry를 유지한다. DB·GraphQL schema·서버 migration은 없으며, dependency 제거는 모든 platform caller가 제거된 뒤 pnpm으로 수행한다.
+
+## Open Questions
+
+제품 또는 구현 선택으로 남은 질문은 없음. PROD-483 native 수집 완료와 PROD-477의 실제 배포 event 검증은 이 change 밖 선행 evidence이며, 각 task gate에서 최신 상태를 다시 확인한다.

--- a/openspec/changes/add-sentry-event-id-error-screen/proposal.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+현재 공용 오류 경계는 화면을 계속 사용할 수 없는 예상하지 못한 오류에도 일반 오류 문구와 재시도만 제공해, 사용자가 운영자에게 실제 Sentry event를 식별할 정보를 전달할 수 없다. Web 오류 수집 기반이 마련된 지금 공용 오류 UX와 Sentry event ID를 연결하고, Android·iOS는 native 수집 선행 작업 이후 같은 사용자 계약을 적용해야 한다.
+
+## What Changes
+
+- 화면 사용을 계속할 수 없는 예상하지 못한 오류에 Android·iOS·Web 공용 전용 오류 화면을 표시한다.
+- 실제 Sentry event가 생성된 경우에만 해당 event ID를 opaque 사용자용 오류 추적 ID로 표시하고 복사할 수 있게 한다.
+- Sentry 전송 실패나 ID 미발급 시에도 안전한 한국어 안내, 오류 경계 reset을 통한 다시 시도, 인증 상태와 무관한 공용 루트로 이동하는 복구 동작을 유지한다.
+- validation·권한·예상된 GraphQL/domain 오류와 사용자가 현재 화면에서 복구할 수 있는 일시적 네트워크 오류는 전용 화면이나 새 Sentry event로 승격하지 않고 기존 좁은 inline 흐름을 유지한다.
+- 한 오류를 nested React 경계와 platform Sentry 경계에서 중복 보고하지 않고, 오류 원문·stack trace·인증 정보·사용자 작성 콘텐츠를 화면에 노출하지 않는다.
+- Web은 PROD-493의 수집 경계를 재사용하고 Android·iOS는 PROD-483이 제공할 native 수집 경계 뒤에 연결한다. 오류 화면의 ID 복사는 피드백 본문이나 Slack payload에 자동 연결하지 않으며 사용자가 필요할 때 수동으로 전달한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain` 적용 없음(새 durable 도메인 객체·상태·행동 없음); `docs/design/accessibility.md`; `docs/design/colors.md`; `docs/design/typography.md`; `docs/design/breakpoints.md`
+- Linear Contract: PROD-480
+- Linear Implementations: PROD-485, PROD-486
+
+## Capabilities
+
+### New Capabilities
+
+- `sentry-event-id-error-screen`: 예상하지 못한 화면 오류의 전용 universal 화면, 실제 Sentry event ID 표시·복사, 안전한 복구와 플랫폼별 검증 계약
+
+### Modified Capabilities
+
+- `react-error-boundary-composition`: 기존 일반 fallback 보존 요구를 전용 오류 화면, event ID 상태, 중복 없는 보고와 안전한 이동을 포함하는 복구 계약으로 확장한다.
+
+## Impact
+
+- `apps/app`의 GraphQL·route·session 오류 경계, 공용 오류 reporter context, 상태 화면과 Expo Router 복구 navigation
+- Web Sentry wrapper의 event ID 반환 계약과 PROD-483 이후의 Android·iOS Sentry adapter
+- Android·iOS·Web clipboard platform boundary 및 필요 시 Expo 호환 clipboard dependency
+- 오류 경계 unit/Storybook 검증, Web·native runtime 검증, 실제 Sentry event ID 대응 운영 확인
+- GraphQL schema, API·Web BFF 오류 응답, 구조화된 피드백 input과 Slack payload에는 변경 없음

--- a/openspec/changes/add-sentry-event-id-error-screen/specs/react-error-boundary-composition/spec.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/specs/react-error-boundary-composition/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: 기존 fallback과 reset 동작 보존
+
+**Authority / Provenance:** `memory/frontend-react-native.md`, PROD-477, PROD-480, PROD-513 — GraphQL 경계와 route 경계는 validation·권한·의도된 GraphQL/domain 오류와 재시도 가능한 network·transport 오류의 기존 한국어 inline 또는 route-local 복구 동작을 보존해야 한다(MUST). 현재 화면을 계속 렌더링할 수 없게 만드는 예상하지 못한 client 오류에는 공용 전용 오류 화면을 렌더링하고 현재 platform reporter의 event ID 결과를 연결해야 한다(MUST). retry는 경계 오류 상태와 해당 오류의 event ID·복사 상태를 reset한 뒤 소유자의 재조회 callback을 정확히 한 번 호출해야 한다(MUST). Session fail-open 경계는 오류 시 지정된 fallback을 표시하고 reset key가 바뀌면 자식 렌더링을 다시 시도해야 한다(MUST).
+
+#### Scenario: 예상된 GraphQL 또는 network 오류
+
+- **WHEN** GraphQL·route 흐름이 validation·권한·의도된 GraphQL/domain 오류 또는 재시도 가능한 network·transport 오류를 받는다
+- **THEN** 가장 가까운 기존 inline 또는 route-local fallback과 재시도 동작을 유지한다
+- **AND** 전용 오류 화면과 사용자용 Sentry event ID로 승격하지 않는다
+
+#### Scenario: 예상하지 못한 GraphQL 또는 route render 오류
+
+- **WHEN** GraphQL 또는 route 경계 아래의 예상하지 못한 client render 오류가 현재 화면 렌더링을 중단한다
+- **THEN** 경계는 공용 전용 오류 화면을 렌더링한다
+- **AND** 현재 platform reporter가 반환한 event ID가 있을 때만 같은 오류 발생 건의 추적 ID로 연결한다
+
+#### Scenario: GraphQL 또는 route 재시도
+
+- **WHEN** 오류 fallback에서 사용자가 다시 시도 action을 실행한다
+- **THEN** 경계는 포착한 오류와 해당 오류의 event ID·복사 상태를 reset하고 제공된 retry callback을 정확히 한 번 호출한다
+
+#### Scenario: Session reset key 변경
+
+- **WHEN** session 자식의 오류로 fail-open fallback이 표시된 뒤 reset key가 변경된다
+- **THEN** 경계는 오류 상태를 reset하고 session 자식 렌더링을 다시 시도한다
+
+#### Scenario: reset 뒤 오류 재발
+
+- **WHEN** reset 뒤 자식 렌더링에서 예상하지 못한 오류가 다시 발생한다
+- **THEN** 경계는 이전 event ID를 재사용하지 않고 새 오류 발생 건으로 처리한다

--- a/openspec/changes/add-sentry-event-id-error-screen/specs/sentry-event-id-error-screen/spec.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/specs/sentry-event-id-error-screen/spec.md
@@ -1,0 +1,122 @@
+## ADDED Requirements
+
+### Requirement: 전용 오류 화면 대상과 예상 오류 경계
+
+**Authority / Provenance:** `docs/design/accessibility.md`, PROD-477, PROD-480 — Android·iOS·Web 앱은 현재 화면 렌더링을 계속할 수 없게 만드는 예상하지 못한 client 오류에 공용 전용 오류 화면을 표시해야 한다(MUST). validation·권한·의도된 GraphQL/domain 오류와 사용자가 현재 화면에서 수정하거나 재시도할 수 있는 네트워크·transport 오류는 새 client Sentry event나 전용 오류 화면으로 승격하지 않고 가장 가까운 기존 inline 또는 route-local 복구 흐름을 유지해야 한다(MUST). 사용자에게 보이는 message 문자열을 파싱해 두 종류를 구분해서는 안 된다(MUST NOT).
+
+#### Scenario: 예상하지 못한 render 오류
+
+- **WHEN** 공용 React 또는 route 경계 아래의 예상하지 못한 render 오류 때문에 현재 화면을 계속 렌더링할 수 없다
+- **THEN** 앱은 해당 경계에서 공용 전용 오류 화면을 표시한다
+- **AND** 오류를 현재 platform의 client Sentry adapter에 한 번 보고한다
+
+#### Scenario: 예상된 mutation 오류
+
+- **WHEN** validation·권한·의도된 GraphQL/domain 오류가 기존 mutation 결과로 반환된다
+- **THEN** 앱은 현재 form·control의 inline 오류와 재시도 흐름을 유지한다
+- **AND** 해당 오류 때문에 전용 오류 화면이나 새 client Sentry event를 만들지 않는다
+
+#### Scenario: 재시도 가능한 query 또는 network 오류
+
+- **WHEN** 구조화된 GraphQL 응답 오류나 일시적 network·transport 실패를 현재 화면의 가장 가까운 오류 상태에서 재시도할 수 있다
+- **THEN** 앱은 해당 inline 또는 route-local 복구 상태를 유지한다
+- **AND** 오류 원문을 새 client Sentry event로 다시 보고하거나 사용자용 오류 추적 ID를 표시하지 않는다
+
+#### Scenario: 서버에서 이미 처리한 오류
+
+- **WHEN** API가 예상된 GraphQL 오류를 반환하거나 unexpected server 오류를 기존 서버 Sentry 경계에서 처리해 `INTERNAL_SERVER_ERROR`로 반환한다
+- **THEN** client는 그 응답을 별도의 client render 오류로 중복 보고하지 않는다
+
+### Requirement: 실제 Sentry event ID 연결과 중복 방지
+
+**Authority / Provenance:** PROD-477, PROD-480, PROD-483, PROD-493 — 전용 오류 화면은 현재 오류 발생 건을 Sentry에 보고한 adapter가 반환한 opaque event ID만 사용자용 오류 추적 ID로 표시해야 한다(MUST). 앱은 ID를 생성·변환·추측하거나 이전 오류의 ID를 재사용해서는 안 되며(MUST NOT), 하나의 오류 발생 건을 nested React 경계와 platform runtime 경계에서 중복 보고해서는 안 된다(MUST NOT). Web은 PROD-493의 browser reporter를 재사용하고 Android·iOS는 PROD-483의 native reporter가 제공된 뒤 같은 반환 계약을 사용해야 한다(MUST).
+
+#### Scenario: event ID가 발급된 오류
+
+- **WHEN** 현재 platform의 Sentry adapter가 예상하지 못한 오류 한 건을 보고하고 event ID를 반환한다
+- **THEN** 전용 오류 화면은 반환된 값을 변경하지 않은 오류 추적 ID로 표시한다
+- **AND** 운영 검증에서 같은 ID의 Sentry event 한 건을 조회할 수 있어야 한다
+
+#### Scenario: nested 경계가 같은 오류를 관찰함
+
+- **WHEN** 내부 route·session 경계가 외부 공용 경계보다 먼저 같은 render 오류를 처리한다
+- **THEN** 가장 먼저 오류를 처리한 경계의 공용 reporter만 해당 오류를 한 번 보고한다
+- **AND** 외부 경계와 browser 전역 수집은 같은 오류의 두 번째 event ID를 만들지 않는다
+
+#### Scenario: ID를 제공할 수 없음
+
+- **WHEN** Sentry adapter가 구성되지 않았거나 보고 과정이 실패하거나 event ID를 반환하지 않는다
+- **THEN** 전용 오류 화면은 추적 ID와 복사 action을 표시하지 않는다
+- **AND** 안전한 안내와 모든 복구 action은 계속 동작한다
+
+#### Scenario: native 수집 선행 작업이 완료되지 않음
+
+- **WHEN** Android 또는 iOS에서 PROD-483의 native Sentry adapter가 아직 제공되지 않았다
+- **THEN** 앱은 Web event ID나 임의 ID를 대신 표시하지 않는다
+- **AND** PROD-485의 event ID 대응 검증은 blocker가 해소될 때까지 완료 처리하지 않는다
+
+### Requirement: 오류 추적 ID 복사와 피드백 경계
+
+**Authority / Provenance:** `docs/design/accessibility.md`, PROD-479, PROD-480, PROD-487 — 오류 추적 ID가 있는 전용 오류 화면은 사용자가 그 값을 system clipboard에 복사할 수 있는 action을 제공해야 한다(MUST). 복사 성공과 실패는 안전한 한국어 상태로 시각적·보조 기술 사용자에게 전달되어야 하고(MUST), clipboard 실패가 오류 화면이나 복구 action을 실패시켜서는 안 된다(MUST NOT). 오류 추적 ID를 `/feedback`의 구조화된 input이나 Slack payload에 자동으로 추가해서는 안 된다(MUST NOT).
+
+#### Scenario: 추적 ID 복사 성공
+
+- **WHEN** 사용자가 오류 추적 ID 복사 action을 실행하고 clipboard 쓰기가 성공한다
+- **THEN** system clipboard에는 화면에 표시된 ID와 정확히 같은 값이 저장된다
+- **AND** 앱은 중복되지 않는 접근 가능한 복사 완료 상태를 알린다
+
+#### Scenario: 추적 ID 복사 실패
+
+- **WHEN** clipboard 권한·platform API 또는 일시적 runtime 문제로 복사가 실패한다
+- **THEN** 앱은 내부 오류나 ID를 추가로 노출하지 않는 안전한 실패 상태를 알린다
+- **AND** ID 표시, 다시 시도와 안전한 이동 action을 유지한다
+
+#### Scenario: 피드백으로 수동 전달
+
+- **WHEN** 사용자가 복사한 오류 추적 ID를 지원 요청이나 피드백 본문에 직접 붙여 넣는다
+- **THEN** 기존 피드백 본문 계약 안에서 일반 사용자 입력으로 전달할 수 있다
+- **AND** 앱은 별도 Sentry ID field, 자동 prefill 또는 Slack payload field를 만들지 않는다
+
+### Requirement: 오류 경계 복구와 안전한 이동
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/breakpoints.md`, PROD-480 — 전용 오류 화면은 오류 경계를 reset한 뒤 원래 소유자의 재조회·재렌더 callback을 정확히 한 번 실행하는 다시 시도 action과, 현재 인증 상태와 관계없이 열 수 있는 canonical public 안전 화면으로 이동하는 action을 제공해야 한다(MUST). reset은 이전 오류의 event ID와 복사 상태를 제거해야 하며(MUST), 복구되지 않고 다시 발생한 오류는 이전 ID를 재사용하지 않는 새 오류 발생 건으로 처리해야 한다(MUST).
+
+#### Scenario: 다시 시도 후 복구
+
+- **WHEN** 사용자가 다시 시도를 실행하고 원래 화면이 정상 렌더링된다
+- **THEN** 경계는 기존 오류와 event ID·복사 상태를 reset하고 소유자 callback을 정확히 한 번 실행한다
+- **AND** 사용자는 원래 흐름을 계속 사용할 수 있다
+
+#### Scenario: 다시 시도 후 동일 경로가 다시 실패함
+
+- **WHEN** reset 뒤의 재조회·재렌더가 예상하지 못한 오류로 다시 실패한다
+- **THEN** 앱은 이를 새 오류 발생 건으로 한 번 보고한다
+- **AND** 이전 event ID나 복사 완료 상태를 새 오류 화면에 재사용하지 않는다
+
+#### Scenario: 안전한 화면으로 이동
+
+- **WHEN** 사용자가 전용 오류 화면에서 안전한 이동 action을 실행한다
+- **THEN** 앱은 실패한 route를 복귀 대상으로 남기지 않고 canonical public 안전 화면으로 이동한다
+- **AND** guest와 인증된 사용자 모두 보호 route redirect loop 없이 목적지를 열 수 있다
+
+### Requirement: 안전하고 접근 가능한 universal 오류 화면
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/colors.md`, `docs/design/typography.md`, `docs/design/breakpoints.md`, PROD-480 — 전용 오류 화면은 Android·iOS·Web이 공유하는 React Native UI로 구현해야 하며(MUST), platform별 차이는 Sentry와 clipboard adapter 같은 platform API 경계로 제한해야 한다(MUST). 화면은 안전한 한국어 안내와 opaque 오류 추적 ID만 표시하고 원래 오류 message, stack trace, 내부 경로, 인증 정보 또는 사용자 작성 콘텐츠를 노출해서는 안 된다(MUST NOT). 색상·typography·spacing·breakpoint와 접근성 target은 적용되는 canonical design token과 platform 기준을 따라야 한다(MUST).
+
+#### Scenario: 민감한 오류가 전용 화면에 도달함
+
+- **WHEN** 포착된 오류의 message나 stack에 내부 경로, credential 또는 사용자 작성 콘텐츠가 포함되어 있다
+- **THEN** 화면은 그 값을 렌더링하거나 접근성 label·announcement에 포함하지 않는다
+- **AND** 사용자에게는 고정된 안전한 한국어 안내와 발급된 opaque event ID만 제공한다
+
+#### Scenario: Web keyboard와 좁은 viewport
+
+- **WHEN** 사용자가 폭 768px 미만 Web viewport에서 keyboard로 오류 화면을 조작한다
+- **THEN** 복사·다시 시도·안전한 이동 action은 논리적인 focus 순서와 보이는 focus 상태로 모두 실행 가능하다
+- **AND** 각 독립 target은 적용 가능한 Web 최소 크기와 zoom·reflow를 유지한다
+
+#### Scenario: Native 접근성과 text scaling
+
+- **WHEN** Android 또는 iOS 사용자가 큰 글자와 TalkBack 또는 VoiceOver로 오류 화면을 조작한다
+- **THEN** 안내·ID·상태가 잘리지 않고 읽히며 action은 고유한 accessible name을 가진다
+- **AND** iOS hit region은 최소 44×44pt, Android touch target은 최소 48×48dp를 유지한다

--- a/openspec/changes/add-sentry-event-id-error-screen/tasks.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/tasks.md
@@ -39,6 +39,7 @@ Android·iOS·Web 공용 앱이 예상 오류의 기존 inline·route-local 복�
 - [x] 1.3 안전한 한국어 안내, optional ID, copy·retry·public root 이동을 제공하는 universal 전용 오류 화면을 구현한다.
 - [x] 1.4 `expo-clipboard`를 pnpm으로 앱 dependency에 추가하고 정확한 ID copy와 기존 toast 기반 성공·실패 feedback을 연결한다.
 - [x] 1.5 기존 Error Boundary·feedback 회귀와 전용 화면의 component·Storybook 상태, 접근성·responsive 검증을 완료한다.
+- [x] 1.6 리뷰 정정으로 안전한 이동 reset의 owner retry 분리, occurrence별 report·copy feedback cleanup, 단일 Toast announcement와 reporter/clipboard 회귀 검증을 보강한다.
 
 ## 2. PROD-486 Web 오류 화면과 실제 event ID
 

--- a/openspec/changes/add-sentry-event-id-error-screen/tasks.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/tasks.md
@@ -31,7 +31,7 @@ Android·iOS·Web 공용 앱이 예상 오류의 기존 inline·route-local 복�
 
 - Expected mutation·GraphQL response·network fixture가 기존 inline 또는 route-local 상태를 유지하고 reporter를 호출하지 않는지 검증한다.
 - Unexpected render fixture가 report 한 번, returned ID/no-ID, retry reset·재발과 public root 이동으로 이어지는지 단위·Storybook interaction으로 검증한다.
-- ID·no-ID·긴 ID, copy success/failure, 좁은 Web viewport, keyboard, text scaling과 platform target 상태를 Storybook catalog와 접근성 검사에서 확인한다.
+- ID·no-ID·긴 ID, copy success/failure, 좁은 Web viewport와 keyboard focus/action 순서는 Storybook catalog와 접근성 검사에서 확인한다. Native text scaling·touch target은 이 browser harness의 증거로 대체하지 않는다.
 - `pnpm --filter @kosmo/app test`, `pnpm lint:eslint`, `pnpm lint:prettier`를 통과시킨다.
 
 - [x] 1.1 GraphQL response·network·local render 오류의 구조화된 origin을 보존하고 expected/unexpected 분류 및 client 중복 보고 회귀 검증을 추가한다.

--- a/openspec/changes/add-sentry-event-id-error-screen/tasks.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/tasks.md
@@ -34,11 +34,11 @@ Android·iOS·Web 공용 앱이 예상 오류의 기존 inline·route-local 복�
 - ID·no-ID·긴 ID, copy success/failure, 좁은 Web viewport, keyboard, text scaling과 platform target 상태를 Storybook catalog와 접근성 검사에서 확인한다.
 - `pnpm --filter @kosmo/app test`, `pnpm lint:eslint`, `pnpm lint:prettier`를 통과시킨다.
 
-- [ ] 1.1 GraphQL response·network·local render 오류의 구조화된 origin을 보존하고 expected/unexpected 분류 및 client 중복 보고 회귀 검증을 추가한다.
-- [ ] 1.2 공용 platform reporter가 현재 오류 발생 건의 optional event ID를 반환하고 occurrence 단위 중복 방지·reset 상태를 유지하도록 연결한다.
-- [ ] 1.3 안전한 한국어 안내, optional ID, copy·retry·public root 이동을 제공하는 universal 전용 오류 화면을 구현한다.
-- [ ] 1.4 `expo-clipboard`를 pnpm으로 앱 dependency에 추가하고 정확한 ID copy와 기존 toast 기반 성공·실패 feedback을 연결한다.
-- [ ] 1.5 기존 Error Boundary·feedback 회귀와 전용 화면의 component·Storybook 상태, 접근성·responsive 검증을 완료한다.
+- [x] 1.1 GraphQL response·network·local render 오류의 구조화된 origin을 보존하고 expected/unexpected 분류 및 client 중복 보고 회귀 검증을 추가한다.
+- [x] 1.2 공용 platform reporter가 현재 오류 발생 건의 optional event ID를 반환하고 occurrence 단위 중복 방지·reset 상태를 유지하도록 연결한다.
+- [x] 1.3 안전한 한국어 안내, optional ID, copy·retry·public root 이동을 제공하는 universal 전용 오류 화면을 구현한다.
+- [x] 1.4 `expo-clipboard`를 pnpm으로 앱 dependency에 추가하고 정확한 ID copy와 기존 toast 기반 성공·실패 feedback을 연결한다.
+- [x] 1.5 기존 Error Boundary·feedback 회귀와 전용 화면의 component·Storybook 상태, 접근성·responsive 검증을 완료한다.
 
 ## 2. PROD-486 Web 오류 화면과 실제 event ID
 

--- a/openspec/changes/add-sentry-event-id-error-screen/tasks.md
+++ b/openspec/changes/add-sentry-event-id-error-screen/tasks.md
@@ -1,0 +1,155 @@
+## 1. PROD-480 공용 오류 분류와 universal 오류 화면
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/colors.md`
+- `docs/design/typography.md`
+- `docs/design/breakpoints.md`
+- `memory/coding-style.md`
+- `memory/frontend-react-native.md`
+- PROD-477
+- PROD-480
+- PROD-513
+
+**Deliverable**
+
+Android·iOS·Web 공용 앱이 예상 오류의 기존 inline·route-local 복구를 유지하면서, 화면을 사용할 수 없게 만드는 예상하지 못한 client 오류에는 민감한 원문을 노출하지 않는 전용 화면, optional Sentry event ID, 복사·다시 시도·public 안전 이동을 제공한다.
+
+**Guardrails**
+
+- 오류 종류는 구조화된 origin·type·code로 구분하고 사용자-facing message를 parsing하지 않는다.
+- Server GraphQL response와 재시도 가능한 network·transport 오류는 새 client Sentry event로 중복 보고하지 않는다.
+- 전용 화면에는 SDK adapter가 현재 capture에서 반환한 ID만 표시하고 앱 생성·이전 ID를 사용하지 않는다.
+- 같은 오류 발생 건은 한 번만 보고하고 reset 뒤 재발은 새 발생 건으로 처리한다.
+- 전용 화면은 함수형 error boundary 안에서 공용 React Native UI로 렌더링하고 Sentry SDK와 navigation singleton을 직접 소유하지 않는다.
+- 오류 message, stack, 내부 경로, credential과 사용자 작성 콘텐츠를 UI·clipboard feedback·accessibility output에 포함하지 않는다.
+- Clipboard dependency는 pnpm CLI로 추가하고 `expo-clipboard`와 기존 `ToastProvider`를 사용한다.
+- 안전한 이동은 public root `/`로 replace하며 `/feedback` input·prefill·Slack payload는 변경하지 않는다.
+
+**Verification**
+
+- Expected mutation·GraphQL response·network fixture가 기존 inline 또는 route-local 상태를 유지하고 reporter를 호출하지 않는지 검증한다.
+- Unexpected render fixture가 report 한 번, returned ID/no-ID, retry reset·재발과 public root 이동으로 이어지는지 단위·Storybook interaction으로 검증한다.
+- ID·no-ID·긴 ID, copy success/failure, 좁은 Web viewport, keyboard, text scaling과 platform target 상태를 Storybook catalog와 접근성 검사에서 확인한다.
+- `pnpm --filter @kosmo/app test`, `pnpm lint:eslint`, `pnpm lint:prettier`를 통과시킨다.
+
+- [ ] 1.1 GraphQL response·network·local render 오류의 구조화된 origin을 보존하고 expected/unexpected 분류 및 client 중복 보고 회귀 검증을 추가한다.
+- [ ] 1.2 공용 platform reporter가 현재 오류 발생 건의 optional event ID를 반환하고 occurrence 단위 중복 방지·reset 상태를 유지하도록 연결한다.
+- [ ] 1.3 안전한 한국어 안내, optional ID, copy·retry·public root 이동을 제공하는 universal 전용 오류 화면을 구현한다.
+- [ ] 1.4 `expo-clipboard`를 pnpm으로 앱 dependency에 추가하고 정확한 ID copy와 기존 toast 기반 성공·실패 feedback을 연결한다.
+- [ ] 1.5 기존 Error Boundary·feedback 회귀와 전용 화면의 component·Storybook 상태, 접근성·responsive 검증을 완료한다.
+
+## 2. PROD-486 Web 오류 화면과 실제 event ID
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/colors.md`
+- `docs/design/typography.md`
+- `docs/design/breakpoints.md`
+- PROD-477
+- PROD-480
+- PROD-486
+- PROD-493
+
+**Deliverable**
+
+Web에서 화면을 사용할 수 없게 만드는 예상하지 못한 client 오류 한 건이 PROD-493의 기존 Sentry 수집 경계를 통해 한 번 보고되고, 전용 화면의 동일 event ID·복사·재시도·public 안전 이동과 no-ID fallback이 실제 browser runtime에서 동작한다.
+
+**Guardrails**
+
+- 기존 DSN·environment·release 활성화 조건, `runtime=web`, component stack과 event 전달 정책을 유지한다.
+- `beforeSend`, breadcrumb, BrowserSession, default PII, Web source map과 secret 경계를 이 이슈에서 다시 정의하지 않는다.
+- Android·iOS entry나 native Sentry SDK를 Web slice에서 변경하지 않는다.
+- Expected GraphQL response·network 오류와 server event를 별도 Web render event로 수집하지 않는다.
+- 표시 ID는 현재 Web Sentry capture 반환값이어야 하며 전송·ID 실패가 화면과 복구 action을 실패시키지 않는다.
+- 피드백 route와 Slack payload에 ID를 자동 연결하지 않는다.
+
+**Verification**
+
+- Web reporter 설정·return ID·disabled/throw/no-ID와 React boundary capture 한 번을 단위 테스트로 검증한다.
+- Browser Storybook/runtime에서 ID copy, keyboard focus, retry reset, `/` replace와 no-ID fallback을 확인한다.
+- 배포 metadata가 있는 검증 환경에서 의도한 client 오류 한 건을 발생시키고 화면 ID와 조회한 Sentry event ID, release·runtime·원본 위치가 일치하며 중복 event가 없는지 확인한다.
+- `pnpm --filter @kosmo/app test`, Expo Web export와 관련 Sentry artifact 검증을 통과시킨다.
+
+- [ ] 2.1 PROD-493 Web reporter의 현재 capture 반환 ID를 공용 optional event ID contract에 연결하고 설정·중복·expected 오류 회귀 테스트를 추가한다.
+- [ ] 2.2 Web에서 추적 ID copy, retry, public root replace, keyboard·responsive 상태와 Sentry 실패 fallback을 통합 검증한다.
+- [ ] 2.3 배포 검증용 unexpected Web 오류의 화면 ID와 실제 Sentry event·release·runtime·source 위치를 대조하고 증거를 PROD-486 handoff에 기록한다.
+
+## 3. PROD-485 Android·iOS 오류 화면과 실제 event ID
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/colors.md`
+- `docs/design/typography.md`
+- `memory/frontend-react-native.md`
+- PROD-480
+- PROD-483
+- PROD-485
+
+**Deliverable**
+
+PROD-483의 native Sentry 수집 경계가 제공된 뒤 Android·iOS에서 화면을 사용할 수 없게 만드는 예상하지 못한 오류 한 건이 한 번 보고되고, 공용 전용 화면의 동일 event ID·native clipboard·재시도·public 안전 이동과 no-ID fallback이 두 platform에서 동작한다.
+
+**Guardrails**
+
+- PROD-483이 native SDK·release·debug symbol·수집 경계를 제공하기 전에는 이 task group을 완료하지 않는다.
+- Web Sentry module·browser SDK를 native bundle에 import하거나 native SDK 설정을 이 오류 UX slice에서 중복 구축하지 않는다.
+- 공용 오류 화면·분류·reporter contract를 재사용하고 Android·iOS 전용 화면을 만들지 않는다.
+- 표시 ID는 현재 native capture 반환값이어야 하고 fake/Web/이전 ID로 대체하지 않는다.
+- iOS는 44×44pt, Android는 48×48dp target과 VoiceOver·TalkBack, font scaling을 실제 runtime에서 검증한다.
+- Native 완료 증거를 Web Storybook이나 Web event로 대체하지 않는다.
+
+**Verification**
+
+- Native adapter의 return ID·disabled/throw/no-ID, expected 오류 제외와 occurrence 한 번 capture를 단위 또는 platform integration test로 검증한다.
+- Android·iOS 각각에서 ID copy, clipboard 실패, retry reset·재발, `/` replace, text scaling과 assistive technology focus/announcement를 관찰한다.
+- 검증용 오류의 화면 ID와 실제 Sentry event ID, environment·release와 native 원본 위치를 각 platform에서 대조한다.
+- `pnpm --filter @kosmo/app test`, Android·iOS build/config 검증과 PROD-483이 요구하는 native artifact 검증을 통과시킨다.
+
+- [ ] 3.1 PROD-483의 최신 완료 evidence와 native reporter contract를 독립 확인한 뒤 공용 optional event ID contract에 연결하고 expected·중복 회귀 검증을 추가한다.
+- [ ] 3.2 Android·iOS에서 추적 ID copy·실패 feedback, retry·public root 이동, platform target·text scaling·VoiceOver·TalkBack을 검증한다.
+- [ ] 3.3 각 platform 검증용 unexpected 오류의 화면 ID와 실제 Sentry event·release·원본 위치를 대조하고 증거를 PROD-485 handoff에 기록한다.
+
+## 4. PROD-480 cross-platform 통합 검증과 archive
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/colors.md`
+- `docs/design/typography.md`
+- `docs/design/breakpoints.md`
+- PROD-477
+- PROD-479
+- PROD-480
+- PROD-483
+- PROD-485
+- PROD-486
+- PROD-487
+- PROD-493
+
+**Deliverable**
+
+공용 오류 분류·화면과 Web·Android·iOS adapter가 같은 보안·event ID·복구 계약을 만족한다는 통합 evidence를 확보하고, 최신 canonical·Linear와 delta spec을 동기화한 뒤 change 전체를 archive할 수 있다.
+
+**Guardrails**
+
+- PROD-485·486의 platform별 actual event ID, copy·retry·fallback evidence가 모두 완료되기 전에는 전체 change를 archive하지 않는다.
+- Web 완료를 native 완료로, Storybook을 실제 browser·VoiceOver·TalkBack·Sentry event 대조로 대체하지 않는다.
+- 오류 원문·stack·credential·사용자 콘텐츠 비노출과 expected 오류 client 비수집을 cross-platform으로 유지한다.
+- Feedback input·Slack payload의 Sentry ID 자동 연결 제외 계약을 유지한다.
+- Pull request readiness와 OpenSpec 전체 completion/archive를 별도로 판단한다.
+
+**Verification**
+
+- 최신 Linear 본문·relations·contract-changing comments와 canonical design 문서를 OpenSpec과 독립 대조한다.
+- Requirement별 scenario와 PROD-480·485·486 task ownership을 Web·Android·iOS evidence에 매핑한다.
+- `openspec validate add-sentry-event-id-error-screen --strict`, `pnpm --filter @kosmo/app test`, `pnpm lint:eslint`, `pnpm lint:prettier`와 필요한 platform build를 통과시킨다.
+- Archive 직전 Blocked decision 없음, 모든 checkbox 완료, active spec sync와 archive 후 validation을 확인한다.
+
+- [ ] 4.1 최신 canonical·Linear·선행 Sentry 계약을 독립 재확인하고 구현에서 드러난 requirement·decision·task 정합성 차이를 권위 순서대로 동기화한다.
+- [ ] 4.2 Web·Android·iOS의 실제 event ID, 중복 보고, ID/copy 실패, retry·safe navigation과 접근성 evidence를 requirement scenario별로 통합 검토한다.
+- [ ] 4.3 App test·lint·format·platform build와 strict OpenSpec validation을 실행하고 미실행·외부 검증 공백을 명시한다.
+- [ ] 4.4 전체 scope와 승인 snapshot이 일치할 때 delta spec을 active specs에 동기화해 change를 archive하고 archive 후 validation을 통과시킨다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       expo-auth-session:
         specifier: ~56.0.15
         version: 56.0.15(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)
+      expo-clipboard:
+        specifier: ~56.0.4
+        version: 56.0.4(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)
       expo-constants:
         specifier: ~56.0.20
         version: 56.0.20(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))
@@ -4169,6 +4172,13 @@ packages:
   expo-auth-session@56.0.15:
     resolution: {integrity: sha512-vviFyzIkMBkDMuWzU4SnbRq6EIHBOhUdBQIQffPl/DFLOo5k4tUpxj4YmU1viRYZH9XNP6d3R4MU2pW0GCYNWA==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-clipboard@56.0.4:
+    resolution: {integrity: sha512-qb4DYlkiowHYHaUYVT2FN9nk/nI1xShXOUYsI7J9dVpQCOHcGFjCBPX1VAvEW4Ye4/Aagd6IuhOVAq/+scBOiA==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -10937,6 +10947,12 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-clipboard@56.0.4(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      expo: 56.0.14(@babel/core@7.29.7)(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.16)(expo-router@56.2.13)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3)
 
   expo-constants@56.0.20(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3)):
     dependencies:


### PR DESCRIPTION
## 무엇을 변경했는지

- 예상하지 못한 client render 오류를 공용 오류 경계에서 분류하고 전용 universal 오류 화면으로 전환합니다.
- Sentry reporter가 현재 capture에서 반환한 optional event ID를 화면에 표시하고 복사할 수 있게 합니다.
- 다시 시도하면 boundary와 오류 발생 건의 상태를 reset하고, 안전한 이동은 실패한 route의 재시도 없이 public root(`/`)로 이동합니다.
- 예상 가능한 GraphQL response·transport 오류는 기존 inline/route-local 흐름을 유지하고 중복 보고하지 않습니다.
- 복사 성공·실패는 단일 Toast announcement로 전달하고, reset·unmount 뒤 이전 Toast나 pending clipboard 결과가 남지 않게 합니다.
- 오류 원문·stack·내부 경로·credential·사용자 작성 콘텐츠는 화면과 clipboard feedback에 노출하지 않습니다.
- 관련 OpenSpec change `add-sentry-event-id-error-screen`과 Storybook 오류 경계 상태를 함께 반영했습니다.

## 왜 변경했는지

화면을 계속 사용할 수 없는 오류를 지원 요청과 운영 Sentry event에 연결할 수 있는 opaque 추적 ID가 필요합니다. 기존 예상 오류 복구 UX는 유지하면서, 오류 화면에서 복사·재시도·안전한 이동이 실제로 복구 가능한 상태를 만들어야 합니다.

## 이번 PR의 주요 결정

- 공용 오류 화면은 Sentry SDK와 navigation singleton을 직접 소유하지 않고 reporter/context와 public navigation callback을 주입받습니다.
- event ID는 reporter가 현재 capture에서 반환한 값만 표시하며, 전송 실패·ID 미발급은 no-ID fallback으로 안전하게 처리합니다.
- 안전한 이동 reset은 owner retry와 분리하고, 복사 결과는 기존 Toast 한 곳에서만 알립니다.
- 오류 발생 건이 바뀌면 이전 report ID·clipboard 진행 상태·Toast를 제거합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app test`: 89 unit tests, 17 Storybook files의 222 tests 통과
- Storybook static build: 통과
- `pnpm lint:eslint`: 통과
- `pnpm lint:prettier`: 통과
- `pnpm exec openspec validate add-sentry-event-id-error-screen --strict`: 통과
- `git diff --check`: 통과

## 아직 어떤 문제가 남아 있는지

없음.

Stack: main -> PROD-480