### PR TITLE
Composer에서 DIRECT 공개 범위를 임시로 숨긴다

### DIFF
--- a/apps/app/src/components/post/PostComposer.tsx
+++ b/apps/app/src/components/post/PostComposer.tsx
@@ -1,7 +1,7 @@
 import { PostVisibility } from '@kosmo/core/enums';
 import { normalizePostContentPlainText } from '@kosmo/core/post-content';
 import { postBodyMaxLength } from '@kosmo/core/validation/post-policy';
-import { AtSignIcon, GlobeIcon, LockIcon, MoonIcon } from 'lucide-react-native';
+import { GlobeIcon, LockIcon, MoonIcon } from 'lucide-react-native';
 import { useEffect, useRef, useState } from 'react';
 import { Modal, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment, useMutation } from 'react-relay';
@@ -40,12 +40,14 @@ const visibilityOptions = [
     label: '팔로워만',
     value: PostVisibility.FOLLOWERS,
   },
-  {
-    description: '이 글에서 언급한 계정만 볼 수 있어요.',
-    icon: AtSignIcon,
-    label: '언급한 계정만',
-    value: PostVisibility.DIRECT,
-  },
+  // TODO(PROD-462): Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한이 구현되면 복원한다.
+  // Local Post는 현재 이 공개 범위를 선택해도 해당 계약을 보장할 수 없어 임시로 숨긴다.
+  // {
+  //   description: '이 글에서 언급한 계정만 볼 수 있어요.',
+  //   icon: AtSignIcon,
+  //   label: '언급한 계정만',
+  //   value: PostVisibility.DIRECT,
+  // },
 ] as const;
 type Visibility = (typeof visibilityOptions)[number]['value'];
 

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -2697,6 +2697,9 @@ export const ComposerVisibilityAndSubmitInteraction: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: '조용한 공개' }));
     menu = await canvas.findByRole('menu', { name: '게시글 공개 설정' });
+    expect(
+      within(menu).queryByRole('menuitemradio', { name: /^언급한 계정만/ }),
+    ).not.toBeInTheDocument();
     await userEvent.click(within(menu).getByRole('menuitemradio', { name: /^공개/ }));
     await waitFor(() => {
       expect(canvas.queryByRole('menu', { name: '게시글 공개 설정' })).not.toBeInTheDocument();

--- a/apps/web/e2e/compose.e2e.ts
+++ b/apps/web/e2e/compose.e2e.ts
@@ -50,7 +50,7 @@ test('compose에서 공개 범위와 500자 제한을 적용해 createPost를 �
 
   await visibilityTrigger.click();
   await page.keyboard.press('End');
-  await expect(visibilityMenu.getByRole('menuitemradio', { name: /^언급한 계정만/ })).toBeFocused();
+  await expect(visibilityMenu.getByRole('menuitemradio', { name: /^팔로워만/ })).toBeFocused();
   await page.keyboard.press('Tab');
   await expect(visibilityMenu).toHaveCount(0);
 

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/decisions.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/decisions.md
@@ -16,17 +16,17 @@
 - Consequences: Composer의 선택 surface와 client 선택 union은 임시로 세 값에 한정된다. 기존 서버 enum, 저장된 DIRECT Post와 후속 recipient 구현의 호환성은 유지된다.
 - Confirmation / Follow-up: Posts Storybook 37/37, Storybook build, Composer E2E 1/1과 targeted Web checks가 이 계약을 확인한다. PROD-462 완료·검증 승인 뒤 별도 복원 변경을 만든다.
 
-### DIRECT client option은 주석 처리하고 복원 TODO를 남긴다
+### DIRECT client option은 주석으로 보존하고 unused icon import는 제거한다
 
 - Decision Date: 2026-07-30
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/domain/objects/post.md`, [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4)
 - Status: Active
 - Context / Problem: 임시 UI 제한 뒤에도 enum·서버·기존 DIRECT 데이터와 후속 복원 경계를 보존해야 한다.
-- Decision Outcome: Composer option 목록의 DIRECT 객체와 전용 icon import는 삭제하지 않고 주석 처리하며, 주석에 `TODO(PROD-462)`와 recipient 입력·저장·DIRECT 조회 권한 완료 시 복원 기준을 기록한다.
+- Decision Outcome: Composer option 목록의 DIRECT 객체만 주석으로 보존하고 사용하지 않는 `AtSignIcon` import는 제거하며, 주석에 `TODO(PROD-462)`와 recipient 입력·저장·DIRECT 조회 권한 완료 시 복원 기준을 기록한다.
 - Alternatives Considered: enum/server까지 삭제하는 방식은 기존 데이터와 후속 구현을 깨뜨린다. 별도 feature flag를 추가하는 방식은 이 단일 임시 표면 제한에 불필요한 상태·배포 경계를 늘린다.
-- Consequences: 현재 client 메뉴에는 DIRECT가 없지만 복원 시 원래 label·description·icon 정의를 재사용할 수 있다. 주석은 장기 보류가 되지 않도록 후속 issue를 가리킨다.
-- Confirmation / Follow-up: snapshot `bb3bc7e1f893891505559f7fb1ea119bec21a974`에서 주석과 TODO를 확인한다. PROD-462의 완료 증거가 생기면 별도 변경에서 option·recipient 제출 경계를 재검토한다.
+- Consequences: 현재 client 메뉴에는 DIRECT가 없지만 복원 시 주석에 남은 원래 label·description·icon 식별자를 재사용하고 `AtSignIcon` import를 함께 복원할 수 있다. 주석은 장기 보류가 되지 않도록 후속 issue를 가리킨다.
+- Confirmation / Follow-up: archived 최종 상태에서 DIRECT 객체 주석과 TODO, `AtSignIcon` import 제거를 확인한다. PROD-462의 완료 증거가 생기면 별도 변경에서 option·import·recipient 제출 경계를 함께 재검토한다.
 
 ### 사람 승인된 최소 OpenSpec으로 active post capability를 delta 동기화한다
 
@@ -34,11 +34,11 @@
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/domain/objects/post.md`, [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4), 2026-07-30 사용자 승인(최소 OpenSpec 생성 및 active `post` sync)
 - Status: Active
-- Context / Problem: 현재 active `post` spec은 네 옵션을 MUST로 적고 있어 구현된 임시 세 옵션 Composer와 충돌하지만, 이 slice는 기존 active spec 파일이나 도메인 문서를 직접 수정할 권한이 없다.
-- Decision Outcome: 새 change 디렉터리 안에 `post` capability의 MODIFIED delta를 만들고, 기존 requirement 전체를 보존하면서 PROD-462 완료 전 세 옵션·신규 DIRECT 제출 불가·복원 기준을 검증 가능하게 기록한다. 기존 active spec과 canonical 문서는 이 slice에서 수정하지 않는다.
-- Alternatives Considered: active spec 또는 canonical 문서를 직접 편집하는 방식은 승인된 파일 범위를 벗어난다. implementation snapshot만 남기고 명세를 동기화하지 않는 방식은 현재 active contract와 구현의 drift를 남긴다.
-- Consequences: apply/archive 시 delta가 active `post` requirement와 병합될 수 있으며, 이 change는 Composer visibility 외 도메인 enum·server·Mention 계약을 소유하지 않는다.
-- Confirmation / Follow-up: strict OpenSpec validation과 status가 delta·decision·tasks를 apply-ready로 확인한다. archive 전에는 PROD-580의 구현·검증 책임자와 active spec 동기화 및 전체 change 완료 여부를 재확인한다.
+- Context / Problem: 기존 active `post` spec은 네 옵션을 MUST로 적고 있어 구현된 임시 세 옵션 Composer와 충돌했으므로, 승인된 delta를 active spec에 반영해 런타임과 규범 문서를 동기화해야 했다.
+- Decision Outcome: `post` capability의 MODIFIED delta에 기존 requirement 전체를 보존하면서 PROD-462 완료 전 세 옵션·신규 DIRECT 제출 불가·복원 기준을 기록했다. 구현과 검증 완료 뒤 delta를 `openspec/specs/post/spec.md`에 반영하고 change를 archive했다. canonical 도메인 문서는 변경하지 않았다.
+- Alternatives Considered: active spec을 OpenSpec lifecycle 밖에서 직접 편집하는 방식은 delta와 완료 근거를 남기지 않으므로 선택하지 않았다. implementation snapshot만 남기고 명세를 동기화하지 않는 방식도 active contract와 구현의 drift를 남기므로 선택하지 않았다.
+- Consequences: active `post` requirement와 Composer의 임시 세 옵션 계약이 일치하며, archived change가 적용한 delta·결정·완료 증거를 보존한다. 이 change는 Composer visibility 외 도메인 enum·server·Mention 계약을 소유하지 않는다.
+- Confirmation / Follow-up: strict OpenSpec validation 통과와 `openspec/specs/post/spec.md`의 세 옵션 계약 반영을 확인한 뒤 change archive를 완료했다. PROD-462 완료 전까지 active spec과 Composer에서 이 임시 계약을 유지한다.
 
 ## Remaining Decisions
 

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/decisions.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/decisions.md
@@ -14,7 +14,7 @@
 - Decision Outcome: PROD-462가 해당 recipient·권한 계약을 완료하기 전까지 Web·Native Composer는 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 표시하고 새 `DIRECT` 선택·제출을 허용하지 않는다. `UNLISTED` 기본값과 세 옵션의 기존 동작은 유지한다.
 - Alternatives Considered: recipient 계약이 없는 상태에서 DIRECT를 계속 노출하는 방식은 사용자가 보장되지 않는 조회 범위를 기대하게 하므로 선택하지 않는다. 도메인의 Post Visibility enum/기존 data를 제거하는 방식은 PROD-580 제외 범위를 침범하므로 선택하지 않는다.
 - Consequences: Composer의 선택 surface와 client 선택 union은 임시로 세 값에 한정된다. 기존 서버 enum, 저장된 DIRECT Post와 후속 recipient 구현의 호환성은 유지된다.
-- Confirmation / Follow-up: Posts Storybook 34/34, Storybook build, Composer E2E 1/1과 targeted Web checks가 이 계약을 확인한다. PROD-462 완료·검증 승인 뒤 별도 복원 변경을 만든다.
+- Confirmation / Follow-up: Posts Storybook 37/37, Storybook build, Composer E2E 1/1과 targeted Web checks가 이 계약을 확인한다. PROD-462 완료·검증 승인 뒤 별도 복원 변경을 만든다.
 
 ### DIRECT client option은 주석 처리하고 복원 TODO를 남긴다
 
@@ -26,7 +26,7 @@
 - Decision Outcome: Composer option 목록의 DIRECT 객체와 전용 icon import는 삭제하지 않고 주석 처리하며, 주석에 `TODO(PROD-462)`와 recipient 입력·저장·DIRECT 조회 권한 완료 시 복원 기준을 기록한다.
 - Alternatives Considered: enum/server까지 삭제하는 방식은 기존 데이터와 후속 구현을 깨뜨린다. 별도 feature flag를 추가하는 방식은 이 단일 임시 표면 제한에 불필요한 상태·배포 경계를 늘린다.
 - Consequences: 현재 client 메뉴에는 DIRECT가 없지만 복원 시 원래 label·description·icon 정의를 재사용할 수 있다. 주석은 장기 보류가 되지 않도록 후속 issue를 가리킨다.
-- Confirmation / Follow-up: snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a`에서 주석과 TODO를 확인한다. PROD-462의 완료 증거가 생기면 별도 변경에서 option·recipient 제출 경계를 재검토한다.
+- Confirmation / Follow-up: snapshot `bb3bc7e1f893891505559f7fb1ea119bec21a974`에서 주석과 TODO를 확인한다. PROD-462의 완료 증거가 생기면 별도 변경에서 option·recipient 제출 경계를 재검토한다.
 
 ### 사람 승인된 최소 OpenSpec으로 active post capability를 delta 동기화한다
 

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/decisions.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/decisions.md
@@ -1,0 +1,49 @@
+## Context
+
+이 결정 기록은 PROD-580의 Composer 임시 공개 범위 계약, `docs/domain/objects/post.md`의 Post Visibility·작성 경계, 그리고 해당 계약을 구현한 snapshot의 설계·검증 결과를 반영한다. 2026-07-30 사람 승인은 최소 OpenSpec change를 생성하고 active `post` capability를 delta로 동기화하는 범위까지 확정했다.
+
+## Decision Records
+
+### PROD-462 완료 전 Composer는 세 공개 범위만 노출한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4)
+- Status: Active
+- Context / Problem: Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한이 없는데 Composer가 DIRECT를 선택·제출할 수 있었다.
+- Decision Outcome: PROD-462가 해당 recipient·권한 계약을 완료하기 전까지 Web·Native Composer는 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 표시하고 새 `DIRECT` 선택·제출을 허용하지 않는다. `UNLISTED` 기본값과 세 옵션의 기존 동작은 유지한다.
+- Alternatives Considered: recipient 계약이 없는 상태에서 DIRECT를 계속 노출하는 방식은 사용자가 보장되지 않는 조회 범위를 기대하게 하므로 선택하지 않는다. 도메인의 Post Visibility enum/기존 data를 제거하는 방식은 PROD-580 제외 범위를 침범하므로 선택하지 않는다.
+- Consequences: Composer의 선택 surface와 client 선택 union은 임시로 세 값에 한정된다. 기존 서버 enum, 저장된 DIRECT Post와 후속 recipient 구현의 호환성은 유지된다.
+- Confirmation / Follow-up: Posts Storybook 34/34, Storybook build, Composer E2E 1/1과 targeted Web checks가 이 계약을 확인한다. PROD-462 완료·검증 승인 뒤 별도 복원 변경을 만든다.
+
+### DIRECT client option은 주석 처리하고 복원 TODO를 남긴다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`, [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4)
+- Status: Active
+- Context / Problem: 임시 UI 제한 뒤에도 enum·서버·기존 DIRECT 데이터와 후속 복원 경계를 보존해야 한다.
+- Decision Outcome: Composer option 목록의 DIRECT 객체와 전용 icon import는 삭제하지 않고 주석 처리하며, 주석에 `TODO(PROD-462)`와 recipient 입력·저장·DIRECT 조회 권한 완료 시 복원 기준을 기록한다.
+- Alternatives Considered: enum/server까지 삭제하는 방식은 기존 데이터와 후속 구현을 깨뜨린다. 별도 feature flag를 추가하는 방식은 이 단일 임시 표면 제한에 불필요한 상태·배포 경계를 늘린다.
+- Consequences: 현재 client 메뉴에는 DIRECT가 없지만 복원 시 원래 label·description·icon 정의를 재사용할 수 있다. 주석은 장기 보류가 되지 않도록 후속 issue를 가리킨다.
+- Confirmation / Follow-up: snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a`에서 주석과 TODO를 확인한다. PROD-462의 완료 증거가 생기면 별도 변경에서 option·recipient 제출 경계를 재검토한다.
+
+### 사람 승인된 최소 OpenSpec으로 active post capability를 delta 동기화한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`, [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4), 2026-07-30 사용자 승인(최소 OpenSpec 생성 및 active `post` sync)
+- Status: Active
+- Context / Problem: 현재 active `post` spec은 네 옵션을 MUST로 적고 있어 구현된 임시 세 옵션 Composer와 충돌하지만, 이 slice는 기존 active spec 파일이나 도메인 문서를 직접 수정할 권한이 없다.
+- Decision Outcome: 새 change 디렉터리 안에 `post` capability의 MODIFIED delta를 만들고, 기존 requirement 전체를 보존하면서 PROD-462 완료 전 세 옵션·신규 DIRECT 제출 불가·복원 기준을 검증 가능하게 기록한다. 기존 active spec과 canonical 문서는 이 slice에서 수정하지 않는다.
+- Alternatives Considered: active spec 또는 canonical 문서를 직접 편집하는 방식은 승인된 파일 범위를 벗어난다. implementation snapshot만 남기고 명세를 동기화하지 않는 방식은 현재 active contract와 구현의 drift를 남긴다.
+- Consequences: apply/archive 시 delta가 active `post` requirement와 병합될 수 있으며, 이 change는 Composer visibility 외 도메인 enum·server·Mention 계약을 소유하지 않는다.
+- Confirmation / Follow-up: strict OpenSpec validation과 status가 delta·decision·tasks를 apply-ready로 확인한다. archive 전에는 PROD-580의 구현·검증 책임자와 active spec 동기화 및 전체 change 완료 여부를 재확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/design.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/design.md
@@ -28,7 +28,7 @@
 
 ### Recommended Approach
 
-`DIRECT` option 객체와 전용 icon import를 삭제하지 않고 주석 처리하고, 주석에 PROD-462의 recipient 입력·저장·조회 권한 완료 시 복원한다는 이유를 명시한다. Composer Storybook에는 메뉴에 `언급한 계정만`이 없음을 추가하고, Web E2E는 키보드 끝 이동과 공개 제출 payload가 세 옵션 계약과 함께 유지되는지 확인한다. 세 옵션의 labels, descriptions, icons, default와 submit reset은 기존 동작을 그대로 둔다.
+`DIRECT` option 객체만 주석으로 보존하고 사용하지 않는 `AtSignIcon` import는 제거하며, 주석에 PROD-462의 recipient 입력·저장·조회 권한 완료 시 option과 import를 함께 복원한다는 이유를 명시한다. Composer Storybook에는 메뉴에 `언급한 계정만`이 없음을 추가하고, Web E2E는 키보드 끝 이동과 공개 제출 payload가 세 옵션 계약과 함께 유지되는지 확인한다. 세 옵션의 labels, descriptions, icons, default와 submit reset은 기존 동작을 그대로 둔다.
 
 ### Allowed Alternatives
 

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/design.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-현재 Universal Post Composer는 Web과 Native가 공유하는 공개 범위 option 목록에서 `DIRECT`를 선택해 `createPost`에 전달할 수 있다. 그러나 Mentioned Profile recipient 입력·저장과 recipient 기반 조회 권한은 아직 제공되지 않으며, PROD-580은 PROD-462 완료 전까지 이 선택 표면을 임시로 제한하도록 승인했다. 구현 snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a`는 이 제한과 Storybook·E2E 회귀 검증을 이미 반영한다.
+현재 Universal Post Composer는 Web과 Native가 공유하는 공개 범위 option 목록에서 `DIRECT`를 선택해 `createPost`에 전달할 수 있다. 그러나 Mentioned Profile recipient 입력·저장과 recipient 기반 조회 권한은 아직 제공되지 않으며, PROD-580은 PROD-462 완료 전까지 이 선택 표면을 임시로 제한하도록 승인했다. 구현 snapshot `bb3bc7e1f893891505559f7fb1ea119bec21a974`는 이 제한과 Storybook·E2E 회귀 검증을 이미 반영한다.
 
 ## Goals / Non-Goals
 

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/design.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/design.md
@@ -1,0 +1,56 @@
+## Context
+
+현재 Universal Post Composer는 Web과 Native가 공유하는 공개 범위 option 목록에서 `DIRECT`를 선택해 `createPost`에 전달할 수 있다. 그러나 Mentioned Profile recipient 입력·저장과 recipient 기반 조회 권한은 아직 제공되지 않으며, PROD-580은 PROD-462 완료 전까지 이 선택 표면을 임시로 제한하도록 승인했다. 구현 snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a`는 이 제한과 Storybook·E2E 회귀 검증을 이미 반영한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Composer의 Web·Native 공개 범위 메뉴에서 실제로 보장되는 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 선택 가능하게 유지한다.
+- 기본 `UNLISTED`, 세 옵션의 설명·아이콘·선택·제출 동작과 접근 가능한 메뉴/모달 흐름을 보존한다.
+- `DIRECT`를 새로 선택·제출할 수 없음을 Storybook과 Composer E2E에서 확인하고, PROD-462 복원 기준을 코드 주석과 문서에 남긴다.
+
+**Non-Goals:**
+
+- Mentioned Profile recipient 모델, GraphQL 입력, 저장과 조회 권한 구현
+- 본문 Mention 입력 UI와 notification
+- 기존 DIRECT 게시글의 조회·표시 정책 변경
+- `PostVisibility.DIRECT` enum, API/server visibility 코드 또는 기존 데이터 삭제
+- 범용 Composer/visibility control 재설계 또는 접근성 debt 일괄 수정
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `PostComposer`의 `visibilityOptions`가 Web·Native 메뉴/모달의 공통 source이므로 여기서 DIRECT entry를 숨기면 두 platform surface가 함께 정렬된다.
+- option union이 목록에서 추론되므로 DIRECT entry와 전용 icon import를 제거하면 새 Composer 선택값과 mutation 변수가 세 옵션에 한정된다. 서버 enum과 기존 데이터는 이 client union과 별개로 유지된다.
+- 기본값 fallback은 `UNLISTED`를 가리키고, 목록 끝까지 이동하는 keyboard E2E는 마지막으로 남은 `FOLLOWERS`를 기준으로 검증해야 한다.
+
+### Recommended Approach
+
+`DIRECT` option 객체와 전용 icon import를 삭제하지 않고 주석 처리하고, 주석에 PROD-462의 recipient 입력·저장·조회 권한 완료 시 복원한다는 이유를 명시한다. Composer Storybook에는 메뉴에 `언급한 계정만`이 없음을 추가하고, Web E2E는 키보드 끝 이동과 공개 제출 payload가 세 옵션 계약과 함께 유지되는지 확인한다. 세 옵션의 labels, descriptions, icons, default와 submit reset은 기존 동작을 그대로 둔다.
+
+### Allowed Alternatives
+
+없음. 이 change의 temporary hide와 enum/server 보존 경계를 만족하는 최소 구현이 이미 적용되어 있다.
+
+### Known Traps
+
+- enum이나 server resolver를 삭제하면 기존 DIRECT 게시글과 후속 PROD-462 구현의 호환성을 깨뜨린다.
+- DIRECT를 목록에서만 숨기고 client가 임의로 `visibility: DIRECT`를 제출하도록 두면 “신규 제출 불가” 계약을 위반한다.
+- `UNLISTED` 기본값 또는 `FOLLOWERS` keyboard focus를 바꾸면 기존 Composer 계약을 회귀시킨다.
+- 전체 app check와 전체 Storybook의 변경 외 실패를 이 change의 수정 task로 확장하지 않는다.
+
+## Risks / Trade-offs
+
+- [Risk] active `post` spec의 영구적인 Mentioned Profiles 도메인 계약과 Composer 임시 surface가 한동안 다르다 → delta spec과 PROD-462 복원 기준을 함께 유지하고, recipient 권한 계약 완료 뒤 별도 복원 변경에서 다시 동기화한다.
+- [Risk] 주석 처리된 option이 장기간 복원되지 않을 수 있다 → TODO에 PROD-462를 명시하고, 후속 이슈가 해당 완료·검증 증거를 소유하게 한다.
+- [Risk] 변경 외 aggregate check 실패가 전체 결과를 흐릴 수 있다 → targeted Posts story, Storybook build, Composer E2E와 Web check를 별도 증거로 기록한다.
+
+## Migration Plan
+
+DB/API migration은 없다. 이미 배포된 client는 세 옵션만 노출하며, rollback이 필요하면 PROD-580 변경을 되돌려 기존 Composer option을 복구할 수 있다. 정식 복원은 PROD-462의 recipient 입력·저장·조회 권한 검증이 완료된 뒤 별도 변경으로 수행한다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/proposal.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+현재 Post Composer는 `DIRECT`(`언급한 계정만`)을 선택해 `createPost`에 제출할 수 있지만, Mentioned Profile recipient 입력·저장과 recipient 기반 조회 권한 계약이 아직 없어 사용자가 기대하는 접근 범위를 보장하지 못한다. PROD-462가 해당 계약을 완료하기 전까지 Composer의 선택 표면을 실제로 보장할 수 있는 공개 범위로 제한한다.
+
+## What Changes
+
+- Web·Native Post Composer의 공개 범위 메뉴에서 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 노출한다.
+- `DIRECT` 옵션은 삭제하지 않고 주석 처리하며, `PROD-462`에서 Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한이 구현되면 복원한다는 TODO를 남긴다.
+- 기본 공개 범위 `UNLISTED`와 나머지 세 옵션의 선택·제출 동작은 유지한다.
+- `PostVisibility.DIRECT` enum, 서버 visibility 코드, 기존 DIRECT 게시글의 저장·조회·표시 정책은 변경하지 않는다.
+- Composer Storybook과 Web E2E에서 DIRECT 미노출 및 기존 공개 범위 선택을 검증한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md` (Post Visibility와 Post 작성 입력·조회 계약)
+- Linear Contract: [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4) (2026-07-30 최신 계약; 복원 기준으로 PROD-462를 명시)
+- Linear Implementations: `PROD-580` 구현 snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a` 및 연결 PR #429
+
+## Capabilities
+
+### New Capabilities
+
+- 없음.
+
+### Modified Capabilities
+
+- `post`: 기존 `Post visibility dropdown selection` requirement의 옵션 표시를 PROD-462 완료 전 임시 세 옵션 계약으로 수정한다.
+
+## Impact
+
+- Universal Composer의 Web·Native visibility option presentation과 해당 Storybook/E2E 검증만 영향을 받는다.
+- `PostVisibility` enum, GraphQL input/schema, API/core 저장·조회 권한, 기존 DIRECT 데이터와 Mention/notification은 변경하지 않는다.
+- 현재 구현 외 aggregate 검증에서 발견된 변경 범위 밖 실패(다른 route 타입 오류, PostActionBar `aria-modal` a11y 오류)는 이 change의 작업 대상이 아니다.

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/proposal.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/proposal.md
@@ -14,7 +14,7 @@
 
 - Canonical: `docs/domain/objects/post.md` (Post Visibility와 Post 작성 입력·조회 계약)
 - Linear Contract: [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4) (2026-07-30 최신 계약; 복원 기준으로 PROD-462를 명시)
-- Linear Implementations: `PROD-580` 구현 snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a` 및 연결 PR #429
+- Linear Implementations: `PROD-580` 구현 snapshot `bb3bc7e1f893891505559f7fb1ea119bec21a974` 및 연결 PR #429
 
 ## Capabilities
 

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/specs/post/spec.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/specs/post/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Post visibility dropdown selection
+
+**Authority / Provenance:** `docs/domain/objects/post.md` (Post Visibility와 Post 작성 입력 계약), [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4) (PROD-462 완료 전 Composer 임시 계약; 이 authority에 따라 이 requirement는 MUST로 적용한다.)
+
+유니버설 앱은 새 글 작성 컴포넌트에서 게시글 공개 범위를 platform에 맞는 menu 또는 modal control로 선택할 수 있게 해야 한다(MUST). PROD-462가 Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한을 완료하기 전까지 새 글 작성 컴포넌트는 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 선택·제출할 수 있게 해야 하며(MUST), `DIRECT`는 기존 enum과 서버 계약을 유지한 채 Composer 표면에서 숨겨야 한다(MUST).
+
+#### Scenario: 공개 범위 옵션 표시
+
+- **WHEN** PROD-462가 완료되기 전에 사용자가 작성 컴포넌트의 공개 설정 control을 연다
+- **THEN** 시스템은 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 공개 범위 옵션만 표시한다
+- **AND** 시스템은 `DIRECT` 공개 범위 옵션, “언급한 계정만” 라벨, 설명 또는 아이콘을 표시하지 않는다
+- **AND** `PUBLIC` 옵션은 “공개”와 “모두가 볼 수 있어요.” 설명을 표시한다
+- **AND** `UNLISTED` 옵션은 “조용한 공개”와 “모두가 볼 수 있지만 검색되지 않아요.” 설명을 표시한다
+- **AND** `FOLLOWERS` 옵션은 “팔로워만”과 “팔로워만 볼 수 있어요.” 설명을 표시한다
+- **AND** `PUBLIC` 옵션은 Lucide `GlobeIcon` 아이콘을 표시한다
+- **AND** `UNLISTED` 옵션은 Lucide `MoonIcon` 아이콘을 표시한다
+- **AND** `FOLLOWERS` 옵션은 Lucide `LockIcon` 아이콘을 표시한다
+
+#### Scenario: 기본 공개 범위
+
+- **WHEN** 작성 컴포넌트가 처음 표시되고 프로필 기본 공개 범위 값이 제공되지 않는다
+- **THEN** 시스템은 `UNLISTED`를 기본 공개 범위로 선택한다
+- **AND** 공개 설정 control은 현재 선택된 `UNLISTED` 라벨을 표시한다
+- **AND** 공개 설정 control은 현재 선택된 `UNLISTED`의 Lucide `MoonIcon` 아이콘을 표시한다
+- **AND** 공개 설정 control은 작성자 프로필 헤더가 아니라 본문 입력 영역 아래에 표시된다
+- **AND** 공개 설정 control은 제출 버튼과 같은 줄에 표시된다
+
+#### Scenario: 공개 범위 변경
+
+- **WHEN** 사용자가 공개 설정 surface에서 다른 공개 범위 옵션을 선택한다
+- **THEN** 시스템은 작성 컴포넌트의 선택 공개 범위를 사용자가 선택한 값으로 갱신한다
+- **AND** 시스템은 현재 선택된 공개 범위를 제출 전 컴포넌트에서 확인할 수 있게 표시한다
+- **AND** 시스템은 공개 설정 surface를 닫는다
+
+#### Scenario: DIRECT 신규 선택·제출 불가
+
+- **WHEN** 사용자가 Composer의 공개 설정 surface 또는 키보드 탐색을 통해 새 공개 범위로 `DIRECT`를 선택하거나 제출하려 한다
+- **THEN** 시스템은 `DIRECT` 선택지를 노출하지 않는다
+- **AND** 시스템은 새 `createPost` mutation에 `visibility: DIRECT`를 전달하지 않는다
+- **AND** 사용자는 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 중 하나를 선택해 기존 게시 동작을 계속 사용할 수 있다
+
+#### Scenario: PROD-462 복원 기준
+
+- **WHEN** PROD-462가 Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한을 완료하고 그 계약의 검증 증거가 승인된다
+- **THEN** Composer의 DIRECT 옵션 복원은 해당 완료를 근거로 한 별도 변경에서만 수행한다
+- **AND** 그 완료 전에는 이 임시 세 옵션 계약을 유지한다

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/tasks.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/tasks.md
@@ -1,0 +1,31 @@
+## 1. PROD-580 Composer 공개 범위 임시 제한
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4)
+
+**Deliverable**
+
+Web·Native Post Composer에서 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 선택·제출할 수 있고, 기본 `UNLISTED`와 기존 세 옵션 동작이 유지된다. `DIRECT`는 Composer에서 보이지 않으며 새 게시에 사용되지 않는다.
+
+**Guardrails**
+
+- `PostVisibility.DIRECT` enum, GraphQL/server visibility 코드와 기존 DIRECT 게시글의 저장·조회·표시 정책을 삭제하거나 변경하지 않는다.
+- DIRECT option은 주석 처리하고 `TODO(PROD-462)` 복원 기준을 남긴다.
+- Mentioned Profile recipient 모델·입력·저장·조회 권한, 본문 Mention UI와 notification은 포함하지 않는다.
+- 기존 `UNLISTED` 기본값, 세 옵션의 label·description·icon, 선택 surface 종료와 제출 reset 동작을 유지한다.
+
+**Verification**
+
+- 구현 snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a`에서 shared Composer option의 DIRECT 주석/TODO와 enum·server 미변경을 확인한다.
+- Posts Storybook interaction 34/34 통과로 DIRECT 미노출 및 기존 공개 범위 선택을 확인한다.
+- Storybook build 통과로 Composer presentation artifact를 확인한다.
+- Composer Web E2E 1/1 통과로 키보드 끝 이동이 `FOLLOWERS`에 도달하고 공개 게시 payload가 유지됨을 확인한다.
+- Web check, ESLint, Prettier 통과를 확인한다.
+- 전체 app check의 변경 외 route 타입 오류와 전체 Storybook의 변경 외 PostActionBar `aria-modal` a11y 오류는 알려진 범위 밖 aggregate failure로 기록하며 이 change의 수정 작업으로 확장하지 않는다.
+
+- [x] 1.1 Composer의 Web·Native 공개 범위 surface에서 DIRECT option을 주석 처리하고 PROD-462 복원 TODO를 남긴다.
+- [x] 1.2 Composer Storybook interaction에서 `언급한 계정만` 메뉴 항목이 없고 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 선택·기본값 동작이 유지되는지 검증한다.
+- [x] 1.3 Composer Web E2E에서 공개 범위 메뉴 keyboard 경계가 마지막 `FOLLOWERS` option을 가리키고 DIRECT visibility를 새로 제출하지 않는지 검증한다.
+- [x] 1.4 Posts Storybook 34/34, Storybook build, Composer E2E 1/1, Web check·ESLint·Prettier를 통과시키고 변경 외 aggregate failure를 알려진 제한으로 분리 기록한다.

--- a/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/tasks.md
+++ b/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/tasks.md
@@ -18,8 +18,8 @@ Web·Native Post Composer에서 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 선택·제
 
 **Verification**
 
-- 구현 snapshot `4fe6578d707cffff05f3fc7175304b4c96b1002a`에서 shared Composer option의 DIRECT 주석/TODO와 enum·server 미변경을 확인한다.
-- Posts Storybook interaction 34/34 통과로 DIRECT 미노출 및 기존 공개 범위 선택을 확인한다.
+- 구현 snapshot `bb3bc7e1f893891505559f7fb1ea119bec21a974`에서 shared Composer option의 DIRECT 주석/TODO와 enum·server 미변경을 확인한다.
+- Posts Storybook interaction 37/37 통과로 DIRECT 미노출 및 기존 공개 범위 선택을 확인한다.
 - Storybook build 통과로 Composer presentation artifact를 확인한다.
 - Composer Web E2E 1/1 통과로 키보드 끝 이동이 `FOLLOWERS`에 도달하고 공개 게시 payload가 유지됨을 확인한다.
 - Web check, ESLint, Prettier 통과를 확인한다.
@@ -28,4 +28,4 @@ Web·Native Post Composer에서 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 선택·제
 - [x] 1.1 Composer의 Web·Native 공개 범위 surface에서 DIRECT option을 주석 처리하고 PROD-462 복원 TODO를 남긴다.
 - [x] 1.2 Composer Storybook interaction에서 `언급한 계정만` 메뉴 항목이 없고 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 선택·기본값 동작이 유지되는지 검증한다.
 - [x] 1.3 Composer Web E2E에서 공개 범위 메뉴 keyboard 경계가 마지막 `FOLLOWERS` option을 가리키고 DIRECT visibility를 새로 제출하지 않는지 검증한다.
-- [x] 1.4 Posts Storybook 34/34, Storybook build, Composer E2E 1/1, Web check·ESLint·Prettier를 통과시키고 변경 외 aggregate failure를 알려진 제한으로 분리 기록한다.
+- [x] 1.4 Posts Storybook 37/37, Storybook build, Composer E2E 1/1, Web check·ESLint·Prettier를 통과시키고 변경 외 aggregate failure를 알려진 제한으로 분리 기록한다.

--- a/openspec/specs/post/spec.md
+++ b/openspec/specs/post/spec.md
@@ -257,20 +257,21 @@ API는 게시글의 현재 콘텐츠를 GraphQL `PostContent` Node로 노출하�
 
 ### Requirement: Post visibility dropdown selection
 
-유니버설 앱은 새 글 작성 컴포넌트에서 게시글 공개 범위를 platform에 맞는 menu 또는 modal control로 선택할 수 있게 해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/post.md` (Post Visibility와 Post 작성 입력 계약), [PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-%EA%B5%AC%ED%98%84-%EC%A0%84-composer%EC%9D%98-%EC%96%B8%EA%B8%89%ED%95%9C-%EA%B3%84%EC%A0%95%EB%A7%8C-%EC%98%B5%EC%85%98%EC%9D%84-%EC%9E%84%EC%8B%9C%EB%A1%9C-%EC%88%A8%EA%B8%B4%EB%8B%A4) (PROD-462 완료 전 Composer 임시 계약; 이 authority에 따라 이 requirement는 MUST로 적용한다.)
+
+유니버설 앱은 새 글 작성 컴포넌트에서 게시글 공개 범위를 platform에 맞는 menu 또는 modal control로 선택할 수 있게 해야 한다(MUST). PROD-462가 Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한을 완료하기 전까지 새 글 작성 컴포넌트는 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 선택·제출할 수 있게 해야 하며(MUST), `DIRECT`는 기존 enum과 서버 계약을 유지한 채 Composer 표면에서 숨겨야 한다(MUST).
 
 #### Scenario: 공개 범위 옵션 표시
 
-- **WHEN** 사용자가 작성 컴포넌트의 공개 설정 control을 연다
-- **THEN** 시스템은 `PUBLIC`, `UNLISTED`, `FOLLOWERS`, `DIRECT` 공개 범위 옵션을 표시한다
+- **WHEN** PROD-462가 완료되기 전에 사용자가 작성 컴포넌트의 공개 설정 control을 연다
+- **THEN** 시스템은 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 공개 범위 옵션만 표시한다
+- **AND** 시스템은 `DIRECT` 공개 범위 옵션, “언급한 계정만” 라벨, 설명 또는 아이콘을 표시하지 않는다
 - **AND** `PUBLIC` 옵션은 “공개”와 “모두가 볼 수 있어요.” 설명을 표시한다
 - **AND** `UNLISTED` 옵션은 “조용한 공개”와 “모두가 볼 수 있지만 검색되지 않아요.” 설명을 표시한다
 - **AND** `FOLLOWERS` 옵션은 “팔로워만”과 “팔로워만 볼 수 있어요.” 설명을 표시한다
-- **AND** `DIRECT` 옵션은 “언급한 계정만”과 “이 글에서 언급한 계정만 볼 수 있어요.” 설명을 표시한다
 - **AND** `PUBLIC` 옵션은 Lucide `GlobeIcon` 아이콘을 표시한다
 - **AND** `UNLISTED` 옵션은 Lucide `MoonIcon` 아이콘을 표시한다
 - **AND** `FOLLOWERS` 옵션은 Lucide `LockIcon` 아이콘을 표시한다
-- **AND** `DIRECT` 옵션은 Lucide `AtSignIcon` 아이콘을 표시한다
 
 #### Scenario: 기본 공개 범위
 
@@ -287,6 +288,19 @@ API는 게시글의 현재 콘텐츠를 GraphQL `PostContent` Node로 노출하�
 - **THEN** 시스템은 작성 컴포넌트의 선택 공개 범위를 사용자가 선택한 값으로 갱신한다
 - **AND** 시스템은 현재 선택된 공개 범위를 제출 전 컴포넌트에서 확인할 수 있게 표시한다
 - **AND** 시스템은 공개 설정 surface를 닫는다
+
+#### Scenario: DIRECT 신규 선택·제출 불가
+
+- **WHEN** 사용자가 Composer의 공개 설정 surface 또는 키보드 탐색을 통해 새 공개 범위로 `DIRECT`를 선택하거나 제출하려 한다
+- **THEN** 시스템은 `DIRECT` 선택지를 노출하지 않는다
+- **AND** 시스템은 새 `createPost` mutation에 `visibility: DIRECT`를 전달하지 않는다
+- **AND** 사용자는 `PUBLIC`, `UNLISTED`, `FOLLOWERS` 중 하나를 선택해 기존 게시 동작을 계속 사용할 수 있다
+
+#### Scenario: PROD-462 복원 기준
+
+- **WHEN** PROD-462가 Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한을 완료하고 그 계약의 검증 증거가 승인된다
+- **THEN** Composer의 DIRECT 옵션 복원은 해당 완료를 근거로 한 별도 변경에서만 수행한다
+- **AND** 그 완료 전에는 이 임시 세 옵션 계약을 유지한다
 
 ### Requirement: Character count indicator
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Post Composer 공개 범위 메뉴에서 `DIRECT`(“언급한 계정만”) 옵션을 임시로 숨겼습니다.
- PROD-462에서 Mentioned Profile recipient 입력·저장과 DIRECT 조회 권한이 구현되면 복원하도록 TODO를 남겼습니다.
- Storybook interaction test와 Web Composer E2E에서 DIRECT 미노출 및 나머지 공개 범위 동작을 검증했습니다.
- PROD-580의 임시 세 옵션 계약을 OpenSpec으로 기록하고 active `post` spec에 동기화한 뒤 change를 archive했습니다.

## 왜 변경했는지

현재 Local Post 작성에는 Mentioned Profile recipient 계약이 없고 DIRECT 조회 권한도 보장되지 않아, Composer에서 선택 가능한 상태로 두면 사용자 기대와 실제 동작이 어긋납니다. PROD-462 구현 전까지 새 DIRECT 게시글 작성을 막고, 런타임·테스트·active spec이 같은 현재 계약을 설명하게 합니다.

## 이번 PR의 주요 결정

### DIRECT는 Composer에서만 임시로 숨긴다

- 결정자: @HJSmiley
- 선택: `PostVisibility.DIRECT` enum과 서버 동작은 유지하고 Web·Native 공용 Composer 선택지에서만 주석 처리합니다.
- 고려한 대안: DIRECT를 계속 노출하거나 enum·서버 계약까지 삭제하는 방식
- 이유: recipient·권한이 없는 상태의 잘못된 사용자 기대를 막으면서 기존 DIRECT 데이터와 후속 PROD-462 호환성을 보존합니다.
- 감수한 결과: PROD-462 완료 전까지 Composer는 `PUBLIC`, `UNLISTED`, `FOLLOWERS`만 새 게시에 사용할 수 있습니다.
- 관련 근거: [Linear PROD-580](https://linear.app/byulmaru/issue/PROD-580/direct-구현-전-composer의-언급한-계정만-옵션을-임시로-숨긴다), [OpenSpec decisions](https://github.com/byulmaru/kosmo/blob/PROD-580/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility/decisions.md)

### 최소 OpenSpec으로 현재 행동 계약을 동기화한다

- 결정자: @HJSmiley
- 선택: PROD-462 완료 전 세 옵션·DIRECT 신규 제출 불가·복원 기준을 최소 delta로 기록하고 active `post` spec에 동기화합니다.
- 고려한 대안: 구현과 Linear만 남기고 active spec의 기존 네 옵션 MUST 계약을 유지하는 방식
- 이유: 후속 구현과 리뷰가 DIRECT 표시를 현재 필수 계약으로 오해하지 않도록 런타임과 규범 문서를 맞춥니다.
- 감수한 결과: PROD-462 완료 뒤에는 별도 복원 변경으로 Composer와 active spec을 다시 동기화해야 합니다.
- 관련 근거: [active post spec](https://github.com/byulmaru/kosmo/blob/PROD-580/openspec/specs/post/spec.md), [archived change](https://github.com/byulmaru/kosmo/tree/PROD-580/openspec/changes/archive/2026-07-30-temporarily-hide-direct-composer-visibility)

## 어떻게 확인할 수 있는지

- `openspec validate --all --strict` — 55 passed, 0 failed
- `pnpm --filter @kosmo/app exec vitest run --project=storybook src/stories/Posts.stories.tsx` — 37 passed
- `pnpm --filter @kosmo/app build-storybook` — passed
- `pnpm --filter @kosmo/web exec playwright test e2e/compose.e2e.ts` — 1 passed
- `pnpm --filter @kosmo/web check` — passed
- 변경 파일 Prettier, ESLint, `git diff --check` — passed
- `pnpm --filter @kosmo/app check` — 변경 범위 밖 기존 route 타입 오류 1건으로 실패: `apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx:122`
- 전체 Storybook — 변경 범위 밖 `PostActionBar.stories.tsx`의 `aria-modal` a11y 오류 1건으로 실패(관련 `Posts.stories.tsx`는 37/37 통과)

## 아직 어떤 문제가 남았는지

- App aggregate check와 전체 Storybook의 위 기존 오류는 PROD-580 범위 밖입니다.
- PROD-462에서 recipient 입력·저장과 DIRECT 조회 권한이 완성되면 Composer DIRECT 옵션과 active spec을 별도 변경으로 복원해야 합니다.
- Native 실기기·시뮬레이터 수동 검증은 실행하지 않았으며, Web·Storybook과 Web/Native가 공유하는 단일 option 배열로 계약을 검증했습니다.

Linear: https://linear.app/byulmaru/issue/PROD-580/direct-구현-전-composer의-언급한-계정만-옵션을-임시로-숨긴다