### PR TITLE
프로덕션 런타임 준비와 workload 배포를 분리한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -214,6 +214,7 @@ jobs:
           argocd --server "${ARGOCD_SERVER}" --grpc-web app set kosmo-prod \
             -p "version=${version}" \
             -p "imageDigest=${IMAGE_DIGEST}" \
+            -p "workloads.enabled=true" \
             -p "migration.enabled=true" \
             --validate
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -82,7 +82,6 @@ jobs:
             type=sha
             type=ref,event=branch,prefix=branch-,enable=${{ github.ref != 'refs/heads/main' }}
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=tag
             type=raw,value=stable,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push Docker image

--- a/apps/helm/templates/api/httproute.yaml
+++ b/apps/helm/templates/api/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.apiDomain -}}
+{{- if and .Values.workloads.enabled .Values.apiDomain -}}
 {{- $hostname := trimSuffix "." .Values.apiDomain -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/apps/helm/templates/api/preview-service.yaml
+++ b/apps/helm/templates/api/preview-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workloads.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
   selector:
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/templates/api/rollout.yaml
+++ b/apps/helm/templates/api/rollout.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workloads.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
@@ -76,3 +77,4 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+{{- end }}

--- a/apps/helm/templates/api/service.yaml
+++ b/apps/helm/templates/api/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workloads.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
   selector:
     app.kubernetes.io/name: api
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/templates/vaultstaticsecret.yaml
+++ b/apps/helm/templates/vaultstaticsecret.yaml
@@ -45,8 +45,10 @@ spec:
     create: true
     overwrite: true
     type: "Opaque"
+  {{- if .Values.workloads.enabled }}
   rolloutRestartTargets:
     - kind: "argo.Rollout"
       name: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
     - kind: "argo.Rollout"
       name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
+  {{- end }}

--- a/apps/helm/templates/web/httproute.yaml
+++ b/apps/helm/templates/web/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webDomain -}}
+{{- if and .Values.workloads.enabled .Values.webDomain -}}
 {{- $hostname := trimSuffix "." .Values.webDomain -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/apps/helm/templates/web/preview-service.yaml
+++ b/apps/helm/templates/web/preview-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workloads.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
   selector:
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/templates/web/rollout.yaml
+++ b/apps/helm/templates/web/rollout.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workloads.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
@@ -76,3 +77,4 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+{{- end }}

--- a/apps/helm/templates/web/service.yaml
+++ b/apps/helm/templates/web/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.workloads.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
   selector:
     app.kubernetes.io/name: web
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -25,6 +25,24 @@ if helm template kosmo . --namespace kosmo-prod --set env=prod --set-string imag
   exit 1
 fi
 
+helm template kosmo . \
+  --namespace kosmo-prod \
+  --set env=prod \
+  --set workloads.enabled=false \
+  >"${render_dir}/prod-runtime.yaml"
+
+if grep -Eq '^kind: (Rollout|Service|HTTPRoute)$' "${render_dir}/prod-runtime.yaml"; then
+  echo "prod runtime bootstrap unexpectedly rendered application workloads" >&2
+  exit 1
+fi
+
+for runtime_kind in Cluster ObjectStore ScheduledBackup VaultStaticSecret; do
+  if ! grep -Fq "kind: ${runtime_kind}" "${render_dir}/prod-runtime.yaml"; then
+    echo "prod runtime bootstrap is missing ${runtime_kind}" >&2
+    exit 1
+  fi
+done
+
 if [[ "$(grep -Fc 'image: "ghcr.io/byulmaru/kosmo:main"' "${render_dir}/dev.yaml")" -ne 3 ]]; then
   echo "dev migration, API, and Web must keep the mutable main image" >&2
   exit 1

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -36,6 +36,11 @@ if grep -Eq '^kind: (Rollout|Service|HTTPRoute)$' "${render_dir}/prod-runtime.ya
   exit 1
 fi
 
+if grep -Fq 'kind: "argo.Rollout"' "${render_dir}/prod-runtime.yaml"; then
+  echo "prod runtime bootstrap unexpectedly references workload restart targets" >&2
+  exit 1
+fi
+
 for runtime_kind in Cluster ObjectStore ScheduledBackup VaultStaticSecret; do
   if ! grep -Fq "kind: ${runtime_kind}" "${render_dir}/prod-runtime.yaml"; then
     echo "prod runtime bootstrap is missing ${runtime_kind}" >&2

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -2,5 +2,7 @@ env:
 image: ghcr.io/byulmaru/kosmo
 imageDigest: ''
 version: main
+workloads:
+  enabled: true
 migration:
   enabled: false

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -44,7 +44,7 @@ GCP 리소스를 적용한 뒤 관리 권한이 있는 로컬 `gh` 인증으로 
 ./scripts/ensure-github.sh
 ```
 
-main 브랜치를 push하면 Docker Build는 `main` 이미지 태그를 갱신한다. 다른 브랜치에서 수동 실행하면 dev 환경의 Vault build role로 shared 설정을 읽고 `branch-<브랜치명>`과 `sha-*` 태그로 ECR에도 이미지를 push한다. 이름과 관계없이 Git tag를 push하면 prod 환경의 Vault build role로 image를 build하고 tag ref, `sha-*`, `stable` metadata를 발행한 뒤, `prod` Environment 승인 job이 같은 build digest를 Argo CD에 배포한다. Production workload identity는 tag가 아니라 build digest이며 `stable`은 현재 production 후보 image가 lifecycle로 삭제되지 않게 보존하는 표식일 뿐이다. ECR에서는 `main`, `stable`, `branch-*`, `sha-*`를 갱신할 수 있고 Git tag 이름은 immutable하다. Lifecycle policy는 현재 `main`과 `stable` image를 보호하고, untagged image는 하루 뒤, 그 외 image는 7일 뒤 만료한다.
+main 브랜치를 push하면 Docker Build는 `main` 이미지 태그를 갱신한다. 다른 브랜치에서 수동 실행하면 dev 환경의 Vault build role로 shared 설정을 읽고 `branch-<브랜치명>`과 `sha-*` 태그로 ECR에도 이미지를 push한다. 이름과 관계없이 Git tag를 push하면 prod 환경의 Vault build role로 image를 build하고 `sha-*`, `stable` metadata를 발행한 뒤, `prod` Environment 승인 job이 같은 build digest를 Argo CD에 배포한다. Git tag 이름은 workflow 실행과 audit만 식별하며 container tag로 발행하지 않으므로 `main` 같은 운영 tag가 dev용 image tag를 덮어쓰지 않는다. Production workload identity는 tag가 아니라 build digest이며 `stable`은 현재 production 후보 image가 lifecycle로 삭제되지 않게 보존하는 표식일 뿐이다. ECR에서는 `main`, `stable`, `branch-*`, `sha-*`를 갱신할 수 있다. Lifecycle policy는 현재 `main`과 `stable` image를 보호하고, untagged image는 하루 뒤, 그 외 image는 7일 뒤 만료한다.
 
 ECR repository URL과 push role ARN은 공개된 고정 식별자이므로 Docker Build workflow에 직접 선언한다. ECR 리소스가 생성된 뒤에는 별도 GitHub repository variable bootstrap 없이 GHCR과 ECR에 같은 태그를 함께 push한다.
 

--- a/docs/operations/production-migrations.md
+++ b/docs/operations/production-migrations.md
@@ -4,11 +4,11 @@
 
 Production migration은 API/Web과 같은 immutable release image를 사용하지만 database 권한은 분리한다.
 
-- PROD-562는 production migration 전용 database identity와 Kubernetes Secret을 준비한다.
+- PROD-562 구현은 production migration 전용 database identity와 Kubernetes Secret을 준비한다.
 - PROD-564의 Helm Job은 그 Secret의 `username`과 `password`만 읽고 기존 `migrate` command를 실행한다.
 - API/Web의 runtime Secret을 migration에 복제하거나 migration 장애 시 fallback으로 사용하지 않는다.
-- PROD-563은 모든 Git tag build의 migration/API/Web 전체를 production 배포로 한 번 승인하고, 같은 build digest의 migration Job 성공 뒤에만 API/Web을 활성화한다.
-- PROD-565는 실제 첫 production release와 public smoke를 검증한다.
+- PROD-563 구현은 모든 Git tag build의 migration/API/Web 전체를 production 배포로 한 번 승인하고, 같은 build digest의 migration Job 성공 뒤에만 API/Web을 활성화한다.
+- PROD-545는 runtime 준비, restore rehearsal, 첫 production release와 public smoke의 최종 통합을 검증한다.
 
 Migration database identity에는 schema migration에 필요한 권한만 부여한다. API/Web database identity에는 DDL 권한을 부여하지 않는다.
 
@@ -18,9 +18,12 @@ Production migration Job은 다음 값만 사용한다.
 
 - `env=prod`
 - `imageDigest=sha256:<64 lowercase hex>`
+- `workloads.enabled=true`
 - `migration.enabled=true`
 
 Job, API와 Web은 모두 `image@sha256:...` 형태의 같은 image reference를 렌더한다. Production migration에서 mutable tag나 유효하지 않은 digest를 사용하면 Helm render가 실패한다.
+
+첫 release 전 runtime bootstrap은 `workloads.enabled=false`로 API/Web Service·Rollout·HTTPRoute를 렌더하지 않고 PostgreSQL, backup과 Secret 기반만 준비한다. Git tag build의 `prod` Environment 승인을 받은 배포가 digest와 함께 workload와 migration을 활성화한다.
 
 Migration 대상은 Helm release의 PostgreSQL read-write Service, `5432` port와 `kosmo` database로 고정한다. Job은 `<release>-postgres-migration` Secret의 `username`과 `password`만 읽으며 database URL, host, database 또는 Secret 이름/key를 release 입력으로 받지 않는다. Secret이 없거나 key가 누락되면 Kubernetes가 container를 시작할 수 없고 runtime credential로 재시도하지 않는다.
 
@@ -40,7 +43,7 @@ Phase, schema authority, restore point, target LSN, workload compatibility 또�
 4. Job이 성공한 경우에만 같은 digest의 API/Web workload를 활성화한다.
 5. Job이 실패하면 배포를 중단하고 기존 workload를 그대로 유지한다.
 
-Migration Job과 workload 사이의 success barrier 및 실제 pipeline 구현은 PROD-563이 소유한다.
+Migration Job과 workload 사이의 success barrier는 PROD-563 구현을 사용하며 전체 release 완료 판단은 PROD-545가 소유한다.
 
 ## Destructive migration
 

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/decisions.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/decisions.md
@@ -11,10 +11,10 @@
 - Authority / Provenance: 사용자 결정, PROD-563
 - Status: Active
 - Context / Problem: SemVer와 GitHub Release 규칙이 tag push 자체보다 별도의 release lifecycle을 만들었다.
-- Decision Outcome: 이름 형식과 관계없이 모든 Git tag push가 production image를 build한다. Tag ref는 audit 식별자이며 container identity는 build digest다.
+- Decision Outcome: 이름 형식과 관계없이 모든 Git tag push가 production image를 build한다. Tag ref는 workflow audit 식별자이며 container tag로 발행하지 않는다. Container identity는 build digest다.
 - Alternatives Considered: SemVer-only tag와 prefix-based tag는 현재 요구되지 않는 naming policy를 추가하므로 제외했다.
 - Consequences: 임의 tag 문자열을 Kubernetes label로 사용할 수 없으므로 manifest version에는 commit short SHA를 사용한다.
-- Confirmation / Follow-up: Workflow tag glob과 ref validation에 이름 제한이 없고 branch build에는 production deploy가 없는지 확인한다.
+- Confirmation / Follow-up: Workflow tag glob에 이름 제한이 없고 branch build에는 production deploy가 없으며 Docker metadata에 일반 tag ref가 없는지 확인한다. 일반 tag ref metadata를 발행하던 초기 구현은 PR #431에서 교정했다.
 
 ### Build digest를 같은 workflow의 승인 job에 직접 전달한다
 
@@ -106,6 +106,7 @@
 
 ## Superseded Decisions
 
+- Docker metadata에 Git tag 이름의 일반 tag ref를 발행한다. Git tag는 workflow audit에만 사용하고 container metadata에는 SHA와 보존용 `stable`만 사용한다.
 - Immutable GitHub Release tag와 asset을 production selector로 사용한다.
 - Release 해석과 별도 production deploy workflow를 사용한다.
 - API·Web preview를 함께 대기해 직접 promotion하고 ReplicaSet을 자동 복구한다.

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/design.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/design.md
@@ -34,9 +34,9 @@ PROD-563은 tag build에서 production sync까지의 release 경계만 소유한
 
 ### Recommended Approach
 
-Docker Build의 tag trigger를 모든 tag에 적용하고 별도 SemVer validation을 제거한다. Docker metadata에는 tag ref, SHA tag와 ECR 보존용 `stable` tag를 남기되 production container identity는 build output의 `sha256:` digest다. `stable`은 배포 입력으로 읽지 않는다.
+Docker Build의 tag trigger를 모든 tag에 적용하고 별도 SemVer validation을 제거한다. Docker metadata에는 SHA tag와 ECR 보존용 `stable` tag만 남기고 Git tag 이름은 workflow audit ref로만 사용하며 container metadata로 발행하지 않는다. Production container identity는 build output의 `sha256:` digest고 `stable`은 배포 입력으로 읽지 않는다. 일반 tag ref metadata를 발행하던 초기 구현은 PR #431에서 dev용 `main` image tag 충돌 가능성 때문에 교정됐다.
 
-같은 workflow에 `deploy_production` job을 두고 tag ref에서만 실행한다. 이 job은 `docker_build` 성공 뒤 GitHub `prod` Environment 승인을 기다린다. 승인 뒤 Argo CD token을 얻고 `version`, `imageDigest`, `migration.enabled=true`를 `kosmo-prod`에 설정한다. `version`은 Kubernetes label에 안전한 commit short SHA를 사용하고 원래 tag 이름은 GitHub run의 ref에 남긴다.
+같은 workflow에 `deploy_production` job을 두고 tag ref에서만 실행한다. 이 job은 `docker_build` 성공 뒤 GitHub `prod` Environment 승인을 기다린다. 승인 뒤 Argo CD token을 얻고 `version`, `imageDigest`, `workloads.enabled=true`, `migration.enabled=true`를 `kosmo-prod`에 설정한다. `version`은 Kubernetes label에 안전한 commit short SHA를 사용하고 원래 tag 이름은 GitHub run의 ref에 남긴다.
 
 `prod` Environment는 별도 ref policy 없이 사용자 승인을 담당한다. 배포 대상을 tag로 제한하는 권위는 workflow의 tag trigger와 deploy job 조건 하나다.
 
@@ -64,7 +64,7 @@ GitHub Release publish/resolve job과 script, 별도 deploy workflow는 삭제�
 
 ## Migration Plan
 
-1. Tag trigger와 build metadata에서 SemVer 제한을 제거한다.
+1. Tag trigger에서 SemVer 제한을 제거하고 Git tag 이름은 container metadata가 아닌 workflow audit ref로만 유지한다.
 2. 기존 production deploy 단계를 Docker Build workflow의 tag-only 승인 job으로 옮긴다.
 3. GitHub Release publish/resolve job·script와 별도 deploy workflow를 삭제한다.
 4. Workflow, Helm render와 OpenSpec strict validation을 통과시킨다.

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/tasks.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/tasks.md
@@ -16,10 +16,10 @@
 
 **Verification**
 
-- 임의 tag trigger, branch 제외, build digest output과 tag metadata를 정적으로 검증한다.
+- 임의 tag trigger, branch 제외, build digest output, 일반 Git tag container metadata 부재와 workflow audit ref를 정적으로 검증한다.
 
 - [x] 1.1 Docker Build의 tag trigger와 ref validation에서 SemVer 제한을 제거한다.
-- [x] 1.2 Tag image metadata를 일반 tag ref로 만들고 build digest output을 보존한다.
+- [x] 1.2 Git tag 이름을 container metadata로 발행하지 않고 SHA metadata와 build digest output을 보존한다. 초기 일반 tag ref 구현은 PR #431에서 교정했다.
 - [x] 1.3 `stable`을 ECR lifecycle 보존 표식으로 유지하되 deploy identity에는 사용하지 않는다.
 
 ## 2. PROD-563 Production approval and sync


### PR DESCRIPTION
## 무엇을 변경했는지

- Git tag 이름을 container tag로 발행하지 않고 `sha-*`와 ECR 보존용 `stable`만 발행합니다.
- Helm에 `workloads.enabled` 하나를 추가해 production runtime bootstrap에서는 API/Web Service·Rollout·HTTPRoute를 렌더하지 않습니다.
- GitHub `prod` Environment 승인 job이 build digest, migration과 함께 workload를 활성화합니다.
- 운영 문서를 PROD-545 단일 통합 책임과 runtime → restore rehearsal → 첫 release 순서에 맞췄습니다.

## 왜 변경했는지

PR #417 merge 뒤 두 경계가 남았습니다.

- `main`이라는 Git tag가 dev용 `:main` container image를 덮어쓸 수 있었습니다.
- `kosmo-prod` Application이 생성 즉시 API/Web까지 자동 sync하면 production DB를 먼저 준비해 PROD-546 restore rehearsal을 수행하기 전에 workload가 배포됩니다.

Runtime bootstrap은 DB·backup·Secret만 준비하고, application workload는 기존 `prod` 승인 뒤 처음 활성화해야 합니다.

## 이번 PR의 주요 결정

### Git tag 이름을 container registry tag로 사용하지 않는다

- 결정자: @robin-maki
- 선택: Git tag build는 `sha-*`, 보존용 `stable`, build digest만 발행·사용합니다.
- 고려한 대안: Git tag 이름에 prefix를 붙여 container tag로 발행
- 이유: Git tag는 workflow audit에만 필요하고 실제 workload identity는 digest입니다.
- 감수한 결과: Registry에서 Git tag 이름으로 image를 직접 찾지 않고 workflow run의 tag·commit·digest 기록을 사용합니다.
- 관련 근거: PROD-545, PR #417의 digest 기반 production 배포 계약

### Runtime bootstrap과 application workload를 한 flag로 분리한다

- 결정자: @robin-maki
- 선택: `workloads.enabled=false`에서는 PostgreSQL·backup·Secret만 sync하고, tag deploy job이 승인 뒤 `workloads.enabled=true`와 digest를 함께 설정합니다.
- 고려한 대안: runtime/workload를 별도 Argo CD Application으로 분리하거나 production Application 전체를 수동 sync로 전환
- 이유: 기존 chart와 Application 경계를 유지하면서 restore rehearsal 전에 DB를 준비하고 승인 전 workload 배포를 막는 가장 작은 변경입니다.
- 감수한 결과: 최초 runtime 선언은 workload를 의도적으로 포함하지 않으며 첫 승인 배포가 Service·Rollout·HTTPRoute를 생성합니다.
- 관련 근거: PROD-545 실행 순서, PROD-546 live restore rehearsal, PROD-564 PreSync migration

## 어떻게 확인할 수 있는지

- `bash apps/helm/test-render.sh`
- `pnpm lint:prettier`
- `git diff --check`
- Runtime bootstrap render에 Cluster/ObjectStore/ScheduledBackup/VaultStaticSecret이 있고 Rollout/Service/HTTPRoute가 없는지 확인
- Tag deploy가 digest, `workloads.enabled=true`, `migration.enabled=true`를 같은 Argo CD update에 전달하는지 확인

## 아직 어떤 문제가 남았는지

- PR #419가 이 flag를 사용해 `kosmo-prod` runtime bootstrap을 선언해야 합니다.
- Runtime 적용 뒤 PROD-546 live restore rehearsal과 첫 실제 tag 배포는 PROD-545에서 계속 수행합니다.
