### PR TITLE
Barman ObjectStore 조회 권한을 추가한다

### DIFF
--- a/apps/helm/templates/postgres-backup.yaml
+++ b/apps/helm/templates/postgres-backup.yaml
@@ -9,6 +9,43 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kosmo-postgres-backup-objectstore-reader
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: postgres-backup
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - barmancloud.cnpg.io
+    resources:
+      - objectstores
+    resourceNames:
+      - kosmo-postgres-backup
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kosmo-postgres-backup-objectstore-reader
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: postgres-backup
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: kosmo-postgres-backup
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kosmo-postgres-backup-objectstore-reader
+---
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -196,6 +196,7 @@ backup_markers=(
   "apiVersion: barmancloud.cnpg.io/v1"
   "kind: ScheduledBackup"
   "name: kosmo-postgres-backup"
+  "name: kosmo-postgres-backup-objectstore-reader"
   "serviceAccountName: kosmo-postgres-backup"
   "barman-cloud.cloudnative-pg.io"
 )
@@ -210,6 +211,12 @@ done
 required_prod_markers=(
   "kind: ServiceAccount"
   "name: kosmo-postgres-backup"
+  "kind: Role"
+  "kind: RoleBinding"
+  "name: kosmo-postgres-backup-objectstore-reader"
+  "- barmancloud.cnpg.io"
+  "- objectstores"
+  "- get"
   "kind: ObjectStore"
   "destinationPath: s3://byulmaru-kosmo-prod-postgresql-backups-822638974464/kosmo-prod/"
   "inheritFromIAMRole: true"
@@ -227,7 +234,7 @@ required_prod_markers=(
 )
 
 for marker in "${required_prod_markers[@]}"; do
-  if ! grep -Fq "${marker}" "${render_dir}/prod-runtime.yaml"; then
+  if ! grep -Fq -- "${marker}" "${render_dir}/prod-runtime.yaml"; then
     echo "prod manifest is missing backup marker: ${marker}" >&2
     exit 1
   fi

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -196,7 +196,6 @@ backup_markers=(
   "apiVersion: barmancloud.cnpg.io/v1"
   "kind: ScheduledBackup"
   "name: kosmo-postgres-backup"
-  "name: kosmo-postgres-backup-objectstore-reader"
   "serviceAccountName: kosmo-postgres-backup"
   "barman-cloud.cloudnative-pg.io"
 )
@@ -211,12 +210,6 @@ done
 required_prod_markers=(
   "kind: ServiceAccount"
   "name: kosmo-postgres-backup"
-  "kind: Role"
-  "kind: RoleBinding"
-  "name: kosmo-postgres-backup-objectstore-reader"
-  "- barmancloud.cnpg.io"
-  "- objectstores"
-  "- get"
   "kind: ObjectStore"
   "destinationPath: s3://byulmaru-kosmo-prod-postgresql-backups-822638974464/kosmo-prod/"
   "inheritFromIAMRole: true"
@@ -234,7 +227,7 @@ required_prod_markers=(
 )
 
 for marker in "${required_prod_markers[@]}"; do
-  if ! grep -Fq -- "${marker}" "${render_dir}/prod-runtime.yaml"; then
+  if ! grep -Fq "${marker}" "${render_dir}/prod-runtime.yaml"; then
     echo "prod manifest is missing backup marker: ${marker}" >&2
     exit 1
   fi

--- a/docs/operations/postgres-backup.md
+++ b/docs/operations/postgres-backup.md
@@ -31,6 +31,10 @@ kubectl get backup -n kosmo-prod --sort-by=.metadata.creationTimestamp
 ```sh
 kubectl describe objectstore kosmo-postgres-backup -n kosmo-prod
 kubectl get serviceaccount kosmo-postgres-backup -n kosmo-prod -o yaml
+kubectl auth can-i get objectstores.barmancloud.cnpg.io \
+  --resource-name=kosmo-postgres-backup \
+  --namespace=kosmo-prod \
+  --as=system:serviceaccount:kosmo-prod:kosmo-postgres-backup
 aws eks list-pod-identity-associations --cluster-name byulmaru --region ap-northeast-2
 kubectl logs deployment/barman-cloud-plugin-barman-cloud -n cnpg-system --since=30m
 kubectl get pod -n kosmo-prod -l cnpg.io/cluster=kosmo-postgres \

--- a/openspec/changes/add-production-postgres-s3-backups/decisions.md
+++ b/openspec/changes/add-production-postgres-s3-backups/decisions.md
@@ -62,7 +62,7 @@
 - Decision Outcome: `kosmo-postgres-backup` ServiceAccount, ObjectStore, Cluster plugin/WAL 설정과 ScheduledBackup은 prod values에서만 렌더한다. PostgreSQL Pod의 plugin이 ObjectStore를 읽을 수 있도록 같은 ServiceAccount에 동명 ObjectStore 하나의 `get`만 허용하는 namespaced Role/RoleBinding을 함께 렌더한다. Dev manifest는 현재 상태를 유지한다.
 - Alternatives Considered: 모든 환경에 resource를 만들고 dev에서 비활성화하는 방식은 불필요한 CR과 identity 계약을 남겨 제외했다. 별도 chart는 공통 Cluster 선언이 중복되어 제외했다.
 - Consequences: dev/prod 양쪽의 render test가 필요하고 production 값이 활성화되기 전에는 live backup 검증이 불가능하다. ServiceAccount는 다른 ObjectStore나 write verb를 사용할 수 없다.
-- Confirmation / Follow-up: dev에는 관련 resource/field가 없고 prod에는 정확한 ServiceAccount, 최소 Role/RoleBinding, ObjectStore, plugin과 ScheduledBackup이 있는지 render와 `kubectl auth can-i`로 검증한다.
+- Confirmation / Follow-up: Role/RoleBinding은 API server dry-run을 통과해야 하고, 적용 후 exact ObjectStore `get`은 `kubectl auth can-i`로 검증한다. Backup과 WAL archive 성공을 실제 상태로 확인한다.
 
 ### 원본 쓰기 없는 격리 PITR rehearsal
 

--- a/openspec/changes/add-production-postgres-s3-backups/decisions.md
+++ b/openspec/changes/add-production-postgres-s3-backups/decisions.md
@@ -59,10 +59,10 @@
 - Authority / Provenance: Linear `PROD-546`, `PROD-551`
 - Status: Active
 - Context / Problem: 아직 production Application이 없는 동안 선언을 먼저 병합하되 dev database에 backup 자원이나 AWS identity 의존성을 추가하면 안 된다.
-- Decision Outcome: `kosmo-postgres-backup` ServiceAccount, ObjectStore, Cluster plugin/WAL 설정과 ScheduledBackup은 prod values에서만 렌더한다. Dev manifest는 현재 상태를 유지한다.
+- Decision Outcome: `kosmo-postgres-backup` ServiceAccount, ObjectStore, Cluster plugin/WAL 설정과 ScheduledBackup은 prod values에서만 렌더한다. PostgreSQL Pod의 plugin이 ObjectStore를 읽을 수 있도록 같은 ServiceAccount에 동명 ObjectStore 하나의 `get`만 허용하는 namespaced Role/RoleBinding을 함께 렌더한다. Dev manifest는 현재 상태를 유지한다.
 - Alternatives Considered: 모든 환경에 resource를 만들고 dev에서 비활성화하는 방식은 불필요한 CR과 identity 계약을 남겨 제외했다. 별도 chart는 공통 Cluster 선언이 중복되어 제외했다.
-- Consequences: dev/prod 양쪽의 render test가 필요하고 production 값이 활성화되기 전에는 live backup 검증이 불가능하다.
-- Confirmation / Follow-up: dev에는 관련 resource/field가 없고 prod에는 정확한 ServiceAccount, ObjectStore, plugin과 ScheduledBackup이 있는지 snapshot 또는 manifest assertion으로 검증한다.
+- Consequences: dev/prod 양쪽의 render test가 필요하고 production 값이 활성화되기 전에는 live backup 검증이 불가능하다. ServiceAccount는 다른 ObjectStore나 write verb를 사용할 수 없다.
+- Confirmation / Follow-up: dev에는 관련 resource/field가 없고 prod에는 정확한 ServiceAccount, 최소 Role/RoleBinding, ObjectStore, plugin과 ScheduledBackup이 있는지 render와 `kubectl auth can-i`로 검증한다.
 
 ### 원본 쓰기 없는 격리 PITR rehearsal
 

--- a/openspec/changes/add-production-postgres-s3-backups/specs/production-postgres-backup/spec.md
+++ b/openspec/changes/add-production-postgres-s3-backups/specs/production-postgres-backup/spec.md
@@ -18,6 +18,8 @@
 
 **Authority / Provenance:** `PROD-546`. 시스템은 production backup과 별도 restore workload가 EKS Pod Identity로 같은 최소 권한 IAM role의 단기 자격 증명을 받게 해야 한다(MUST). 시스템은 AWS access key, secret key 또는 session token을 repository, Kubernetes Secret이나 workflow 입력으로 저장해서는 안 된다.
 
+Production backup ServiceAccount는 같은 namespace의 `kosmo-postgres-backup` ObjectStore 하나를 읽을 수 있어야 하며(MUST), 다른 ObjectStore나 write verb 권한을 받아서는 안 된다(MUST NOT).
+
 #### Scenario: Production backup Pod의 S3 접근
 
 - **WHEN** `kosmo-prod`의 PostgreSQL Pod가 Barman Cloud sidecar에서 기본 AWS credential chain으로 S3에 접근한다
@@ -27,6 +29,11 @@
 
 - **WHEN** `kosmo-prod-restore`의 복구 Pod가 source backup을 읽는다
 - **THEN** 같은 이름의 restore ServiceAccount에 연결된 Pod Identity role로 source prefix를 읽고 static credential을 사용하지 않는다
+
+#### Scenario: Production plugin의 ObjectStore 조회
+
+- **WHEN** production PostgreSQL Pod의 Barman plugin이 backup 설정을 해석한다
+- **THEN** `kosmo-postgres-backup` ServiceAccount는 같은 namespace의 동명 ObjectStore에 대한 `get`만 허용받고 WAL archive와 base backup을 시작할 수 있다
 
 ### Requirement: 연속 WAL archive와 매일 base backup
 

--- a/openspec/changes/add-production-postgres-s3-backups/tasks.md
+++ b/openspec/changes/add-production-postgres-s3-backups/tasks.md
@@ -89,7 +89,7 @@ Production CNPG Cluster가 5분 WAL archive 목표와 매일 03:00 KST base back
 - [x] 3.4 On-demand backup, 상태 확인과 S3/Pod Identity/plugin 장애 진단 절차를 운영 문서에 기록한다.
 - [x] 3.5 격리 PITR manifest 작성, named restore point와 WAL archive gate, 데이터 검증과 namespace 정리 절차를 운영 문서에 기록한다.
 - [x] 3.6 OpenSpec strict validation과 관련 Helm 검증을 통과시키고 결과를 `PROD-551`에 기록한다.
-- [ ] 3.7 Live activation에서 확인된 ObjectStore 조회 권한 누락을 namespaced 최소 Role/RoleBinding으로 보완하고 dev/prod render, `kubectl auth can-i`와 OpenSpec strict validation을 통과시킨다.
+- [ ] 3.7 Live activation에서 확인된 ObjectStore 조회 권한 누락을 namespaced 최소 Role/RoleBinding으로 보완하고 API server dry-run, `kubectl auth can-i`와 OpenSpec strict validation을 통과시킨다.
 
 ## 4. PROD-546 운영 통합 검증과 archive gate
 

--- a/openspec/changes/add-production-postgres-s3-backups/tasks.md
+++ b/openspec/changes/add-production-postgres-s3-backups/tasks.md
@@ -71,6 +71,7 @@ Production CNPG Cluster가 5분 WAL archive 목표와 매일 03:00 KST base back
 
 - Backup resource와 Cluster 설정은 prod에서만 렌더하며 dev manifest에는 나타나지 않는다.
 - Production Cluster는 `kosmo-postgres-backup` ServiceAccount를 사용하고 ObjectStore는 IAM role 상속으로 고정 bucket의 `kosmo-prod/` prefix에 연결한다.
+- Production ServiceAccount에는 같은 namespace의 동명 ObjectStore 하나를 읽는 `get`만 허용하고 다른 ObjectStore나 write verb 권한을 부여하지 않는다.
 - 공식 plugin을 WAL archiver와 ScheduledBackup method로 사용하며 `archive_timeout=4min`, retention 7일, immediate 실행과 UTC 6-field cron `0 0 18 * * *`을 사용한다.
 - Restore Cluster는 별도 `kosmo-prod-restore` namespace에서 source를 recovery source로만 읽고 같은 destination에 WAL 또는 새 backup을 쓰지 않는다.
 - Restore 검증은 application write pause 중 생성한 named restore point와 직전 불변 snapshot을 기준으로 하며 이후 현재 production count와 비교하지 않는다. RPO 측정에서는 WAL 전환을 강제하지 않고 대상 WAL의 자연 archive 성공을 확인한 뒤 restore를 시작한다.
@@ -88,6 +89,7 @@ Production CNPG Cluster가 5분 WAL archive 목표와 매일 03:00 KST base back
 - [x] 3.4 On-demand backup, 상태 확인과 S3/Pod Identity/plugin 장애 진단 절차를 운영 문서에 기록한다.
 - [x] 3.5 격리 PITR manifest 작성, named restore point와 WAL archive gate, 데이터 검증과 namespace 정리 절차를 운영 문서에 기록한다.
 - [x] 3.6 OpenSpec strict validation과 관련 Helm 검증을 통과시키고 결과를 `PROD-551`에 기록한다.
+- [ ] 3.7 Live activation에서 확인된 ObjectStore 조회 권한 누락을 namespaced 최소 Role/RoleBinding으로 보완하고 dev/prod render, `kubectl auth can-i`와 OpenSpec strict validation을 통과시킨다.
 
 ## 4. PROD-546 운영 통합 검증과 archive gate
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Production backup ServiceAccount가 같은 namespace의 `kosmo-postgres-backup` ObjectStore 하나를 읽을 수 있는 Role과 RoleBinding을 추가합니다.
- PROD-546 OpenSpec과 runbook에 최소 Kubernetes 권한 및 진단 명령을 기록합니다.

## 왜 변경했는지

`kosmo-prod` runtime bootstrap을 실제 동기화한 뒤 CloudNativePG의 immediate backup과 WAL archive가 다음 오류로 실패했습니다.

```text
objectstores.barmancloud.cnpg.io "kosmo-postgres-backup" is forbidden:
system:serviceaccount:kosmo-prod:kosmo-postgres-backup cannot get objectstores
```

Barman plugin sidecar는 Cluster가 참조하는 ObjectStore 설정을 읽어야 하지만 기존 prod manifest에는 해당 Kubernetes RBAC가 없었습니다.

## 이번 PR의 결정

새 제품 결정은 없습니다. PROD-546의 최소 권한 workload identity와 backup/WAL 성공 계약을 그대로 적용합니다.

- 선택: namespaced Role에서 정확히 `objectstores`의 `kosmo-postgres-backup` resourceName에 대한 `get`만 허용합니다.
- 제외: ClusterRole, 모든 ObjectStore 조회, create/update/delete/watch 권한
- 이유: live 오류를 해결하는 데 필요한 최소 Kubernetes 권한만 부여하고 다른 backup 설정의 열람·변경 가능성을 만들지 않기 위해서입니다.
- 결과: production plugin은 자신의 ObjectStore를 읽을 수 있지만 다른 ObjectStore나 write verb는 사용할 수 없습니다.

## 검증

- `pnpm exec openspec validate add-production-postgres-s3-backups --strict`
- `pnpm lint:prettier`
- `git diff --check`
- production workload 비활성 Helm render 전체의 server-side dry-run

RBAC의 의미를 문자열 marker로 검사하지 않습니다. 실제 권한은 merge 후 `kubectl auth can-i`와 backup/WAL 성공 상태로 검증합니다.

## merge 후 확인

- `kubectl auth can-i`로 production ServiceAccount의 exact ObjectStore `get`을 확인합니다.
- Cluster의 `ContinuousArchiving`과 `LastBackupSucceeded`, Backup resource와 S3 object 성공을 확인합니다.
- live 증거가 생기기 전에는 OpenSpec task 3.7과 PROD-546을 완료하지 않습니다.

Linear: PROD-546
