### PR TITLE
PROD-588 앱의 프로필 아바타와 헤더 이미지를 실제 이미지로 표시한다

### DIFF
--- a/apps/app/src/components/notification/NotificationListItem.tsx
+++ b/apps/app/src/components/notification/NotificationListItem.tsx
@@ -20,6 +20,7 @@ type NotificationListItemProps = {
 
 type NotificationRowProps = {
   action: string;
+  avatarUrl: string | null | undefined;
   destination: string;
   href: Href;
   id: string;
@@ -38,6 +39,10 @@ const notificationFragment = graphql`
       displayName
       handle
       relativeHandle
+      avatar {
+        id
+        url
+      }
     }
   }
 `;
@@ -64,6 +69,7 @@ export function NotificationListItem({ notification }: NotificationListItemProps
   return (
     <NotificationRow
       action="팔로우했습니다"
+      avatarUrl={data.profile.avatar?.url}
       destination="프로필"
       href={`/${data.profile.relativeHandle}` as Href}
       id={data.id}
@@ -84,6 +90,10 @@ const reactionNotificationFragment = graphql`
     profile {
       displayName
       handle
+      avatar {
+        id
+        url
+      }
     }
     post {
       id
@@ -105,6 +115,7 @@ export function ReactionNotificationListItem({
   return (
     <NotificationRow
       action={`${data.type} 반응을 남겼습니다`}
+      avatarUrl={data.profile.avatar?.url}
       destination="게시글"
       href={`/${data.post.profile.relativeHandle}/${data.post.id}` as Href}
       id={data.id}
@@ -124,6 +135,10 @@ const replyNotificationFragment = graphql`
     profile {
       displayName
       handle
+      avatar {
+        id
+        url
+      }
     }
     post {
       id
@@ -144,6 +159,7 @@ export function ReplyNotificationListItem({
   return (
     <NotificationRow
       action="답글을 남겼습니다"
+      avatarUrl={data.profile.avatar?.url}
       destination="게시글"
       href={`/${data.post.profile.relativeHandle}/${data.post.id}` as Href}
       id={data.id}
@@ -163,6 +179,10 @@ const repostNotificationFragment = graphql`
     profile {
       displayName
       handle
+      avatar {
+        id
+        url
+      }
     }
     post {
       id
@@ -184,6 +204,7 @@ export function RepostNotificationListItem({
   return (
     <NotificationRow
       action="게시물을 재게시했습니다"
+      avatarUrl={data.profile.avatar?.url}
       destination="게시글"
       href={`/${data.post.profile.relativeHandle}/${data.post.id}` as Href}
       id={data.id}
@@ -197,6 +218,7 @@ export function RepostNotificationListItem({
 
 function NotificationRow({
   action,
+  avatarUrl,
   destination,
   href,
   id,
@@ -255,7 +277,7 @@ function NotificationRow({
               onPress={markRead}
               style={styles.avatarLink}
             >
-              <Avatar label={name} size={28} />
+              <Avatar imageUri={avatarUrl} label={name} size={28} />
             </Pressable>
           </Link>
           <Text style={[styles.time, { color: theme.textSecondary }]}>{timestamp}</Text>

--- a/apps/app/src/components/post/PostComposer.tsx
+++ b/apps/app/src/components/post/PostComposer.tsx
@@ -68,6 +68,10 @@ const PostComposerFragment = graphql`
     id
     displayName
     handle
+    avatar {
+      id
+      url
+    }
     ...ProfileNameBlock_profile
   }
 `;
@@ -460,7 +464,7 @@ function PostComposerContents({
     <>
       {beforeEditor}
       <View style={styles.author}>
-        <Avatar label={profile.displayName} size={40} />
+        <Avatar imageUri={profile.avatar?.url} label={profile.displayName} size={40} />
         <ProfileNameBlock profile={profile} />
       </View>
       <View

--- a/apps/app/src/components/post/PostLayout.tsx
+++ b/apps/app/src/components/post/PostLayout.tsx
@@ -28,6 +28,10 @@ const PostLayoutFragment = graphql`
       bodyText
     }
     profile {
+      avatar {
+        id
+        url
+      }
       id
       handle
       relativeHandle
@@ -48,6 +52,10 @@ const PostLayoutFragment = graphql`
         document
       }
       profile {
+        avatar {
+          id
+          url
+        }
         displayName
         handle
         relativeHandle
@@ -90,6 +98,7 @@ export function PostLayout({ post: postKey }: { post: PostLayout_post$key }) {
           displayName: source.profile.displayName,
           handle: source.profile.handle,
           relativeHandle: source.profile.relativeHandle,
+          avatar: source.profile.avatar,
         },
       }
     : null;
@@ -106,7 +115,11 @@ export function PostLayout({ post: postKey }: { post: PostLayout_post$key }) {
           style={styles.avatar}
           tabIndex={-1}
         >
-          <Avatar label={post.profile.displayName || post.profile.handle} size={40} />
+          <Avatar
+            imageUri={post.profile.avatar?.url}
+            label={post.profile.displayName || post.profile.handle}
+            size={40}
+          />
         </Pressable>
       </Link>
       <View style={styles.content}>

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -31,6 +31,10 @@ const PostListRowFragment = graphql`
       bodyText
     }
     profile {
+      avatar {
+        id
+        url
+      }
       handle
       relativeHandle
       displayName
@@ -51,6 +55,10 @@ const PostListItemFragment = graphql`
       document
     }
     profile {
+      avatar {
+        id
+        url
+      }
       id
       handle
       relativeHandle
@@ -70,6 +78,10 @@ const PostListItemFragment = graphql`
         document
       }
       profile {
+        avatar {
+          id
+          url
+        }
         displayName
         handle
         relativeHandle
@@ -178,6 +190,7 @@ export function PostListItem({
       displayName: post.profile.displayName,
       handle: post.profile.handle,
       relativeHandle: post.profile.relativeHandle,
+      avatar: post.profile.avatar,
     },
     replyParent: post.replyParent ? { id: post.replyParent.id } : null,
     repostSource: {
@@ -190,6 +203,7 @@ export function PostListItem({
         displayName: source.profile.displayName,
         handle: source.profile.handle,
         relativeHandle: source.profile.relativeHandle,
+        avatar: source.profile.avatar,
       },
     },
   };
@@ -207,7 +221,11 @@ export function PostListItem({
             style={styles.avatar}
             tabIndex={-1}
           >
-            <Avatar label={post.profile.displayName || post.profile.handle} size={48} />
+            <Avatar
+              imageUri={post.profile.avatar?.url}
+              label={post.profile.displayName || post.profile.handle}
+              size={48}
+            />
           </Pressable>
         </Link>
         <View style={styles.sourcePresentation}>
@@ -257,7 +275,11 @@ function PostListRow({
           style={styles.avatar}
           tabIndex={-1}
         >
-          <Avatar label={post.profile.displayName || post.profile.handle} size={48} />
+          <Avatar
+            imageUri={post.profile.avatar?.url}
+            label={post.profile.displayName || post.profile.handle}
+            size={48}
+          />
         </Pressable>
       </Link>
       <View style={styles.content}>

--- a/apps/app/src/components/post/PostSourcePresentationView.tsx
+++ b/apps/app/src/components/post/PostSourcePresentationView.tsx
@@ -10,6 +10,13 @@ import type { ReactNode } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 
 export type PresentationProfile = {
+  readonly avatar:
+    | {
+        readonly id: string;
+        readonly url: string | null | undefined;
+      }
+    | null
+    | undefined;
   readonly displayName: string;
   readonly handle: string;
   readonly relativeHandle: string;
@@ -234,7 +241,13 @@ function Author({ profile, showAvatar }: { profile: PresentationProfile; showAva
 
   return (
     <View style={styles.author}>
-      {showAvatar ? <Avatar label={profile.displayName || profile.handle} size={40} /> : null}
+      {showAvatar ? (
+        <Avatar
+          imageUri={profile.avatar?.url}
+          label={profile.displayName || profile.handle}
+          size={40}
+        />
+      ) : null}
       <View style={styles.authorText}>
         <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
           {profile.displayName}

--- a/apps/app/src/components/post/ReplyComposerSurface.tsx
+++ b/apps/app/src/components/post/ReplyComposerSurface.tsx
@@ -45,6 +45,10 @@ const ReplyComposerSurfaceParentFragment = graphql`
     profile {
       displayName
       handle
+      avatar {
+        id
+        url
+      }
       ...ProfileNameBlock_profile
     }
     repostSource {
@@ -58,6 +62,10 @@ const ReplyComposerSurfaceParentFragment = graphql`
         displayName
         handle
         relativeHandle
+        avatar {
+          id
+          url
+        }
       }
     }
     ...PostBody_post
@@ -447,6 +455,7 @@ function ReplyComposerSurfaceContents({
                     <View style={styles.parent} testID="reply-parent">
                       <View style={styles.parentAvatarColumn}>
                         <Avatar
+                          imageUri={parent.profile.avatar?.url}
                           label={parent.profile.displayName || parent.profile.handle}
                           size={40}
                         />

--- a/apps/app/src/components/profile/ProfileListItem.tsx
+++ b/apps/app/src/components/profile/ProfileListItem.tsx
@@ -18,6 +18,10 @@ type ProfileListItemProps = {
 
 const profileListItemFragment = graphql`
   fragment ProfileListItem_profile on Profile {
+    avatar {
+      id
+      url
+    }
     displayName
     handle
     relativeHandle
@@ -32,7 +36,7 @@ export function ProfileListItem({ linked = false, onPress, profile, style }: Pro
   const profileHref = `/${data.relativeHandle}` as Href;
   const content = (
     <>
-      <Avatar label={data.displayName || data.handle} size={40} />
+      <Avatar imageUri={data.avatar?.url} label={data.displayName || data.handle} size={40} />
       <View style={styles.copy}>
         <Text numberOfLines={1} style={[styles.name, { color: theme.text }]}>
           {data.displayName}

--- a/apps/app/src/components/shell/BottomTabBar.tsx
+++ b/apps/app/src/components/shell/BottomTabBar.tsx
@@ -18,6 +18,10 @@ const BottomTabBarFragment = graphql`
   fragment BottomTabBar_profile on Profile {
     relativeHandle
     displayName
+    avatar {
+      id
+      url
+    }
   }
 `;
 
@@ -86,6 +90,7 @@ export function BottomTabBar({
               <>
                 {tab.label === '프로필' ? (
                   <Avatar
+                    imageUri={profile?.avatar?.url}
                     label={profile?.displayName ?? '프로필'}
                     size={24}
                     style={pressed && styles.pressedContent}

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -2,6 +2,7 @@ import { profileHandleSchema } from '@kosmo/core/validation/profile';
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon, PlusIcon } from 'lucide-react-native';
 import { useEffect, useRef, useState } from 'react';
 import {
+  Image,
   Modal,
   Platform,
   Pressable,
@@ -35,6 +36,14 @@ const ProfileSwitcherFragment = graphql`
         displayName
         followingCount
         followersCount
+        avatar {
+          id
+          url
+        }
+        header {
+          id
+          url
+        }
       }
     }
     me {
@@ -44,6 +53,10 @@ const ProfileSwitcherFragment = graphql`
         handle
         relativeHandle
         displayName
+        avatar {
+          id
+          url
+        }
       }
     }
   }
@@ -305,7 +318,11 @@ export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, sur
           },
         ]}
       >
-        <Avatar label={profile.displayName} size={selected ? 48 : 32} />
+        <Avatar
+          imageUri={profile.avatar?.url}
+          label={profile.displayName}
+          size={selected ? 48 : 32}
+        />
         <View style={styles.profileLabel}>
           <Text numberOfLines={1} style={[styles.profileName, { color: theme.text }]}>
             {profile.displayName}
@@ -461,7 +478,9 @@ export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, sur
         { opacity: pressed ? 0.65 : 1 },
       ]}
     >
-      {compact ? <Avatar label={active?.displayName ?? '?'} size={40} /> : null}
+      {compact ? (
+        <Avatar imageUri={active?.avatar?.url} label={active?.displayName ?? '?'} size={40} />
+      ) : null}
       {fullWeb || mobileWebDrawer ? (
         <View style={styles.webTriggerContent}>{triggerCopy}</View>
       ) : (
@@ -528,9 +547,19 @@ export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, sur
           { backgroundColor: theme.surface },
           Platform.OS === 'web' && webCover,
         ]}
-      />
+      >
+        {active?.header?.url ? (
+          <Image
+            accessible={false}
+            resizeMode="cover"
+            source={{ uri: active.header.url }}
+            style={styles.coverImage}
+          />
+        ) : null}
+      </View>
       <View style={styles.largeAvatar}>
         <Avatar
+          imageUri={active?.avatar?.url}
           label={active?.displayName || active?.handle || '?'}
           size={96}
           style={avatarShadow}
@@ -617,7 +646,8 @@ const styles = StyleSheet.create({
   drawerMenuPosition: { left: 0, top: 190 },
   fullOverlayPosition: { left: -10, top: 50 },
   profileHeader: { height: 260, position: 'relative', width: 320, zIndex: 20 },
-  cover: { height: 104, left: 0, position: 'absolute', right: 0, top: 0 },
+  cover: { height: 104, left: 0, overflow: 'hidden', position: 'absolute', right: 0, top: 0 },
+  coverImage: { height: '100%', width: '100%' },
   largeAvatar: { left: 20, position: 'absolute', top: 54 },
   profileCopy: {
     left: 10,

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -545,7 +545,7 @@ export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, sur
         style={[
           styles.cover,
           { backgroundColor: theme.surface },
-          Platform.OS === 'web' && webCover,
+          Platform.OS === 'web' && !active?.header?.url && webCover,
         ]}
       >
         {active?.header?.url ? (

--- a/apps/app/src/stories/Notifications.stories.tsx
+++ b/apps/app/src/stories/Notifications.stories.tsx
@@ -23,7 +23,10 @@ import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { NotificationsStoriesQuery as NotificationsStoriesQueryType } from './__generated__/NotificationsStoriesQuery.graphql';
 
+const unreadFollowerAvatarUrl =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="56" height="56"%3E%3Crect width="56" height="56" fill="%237c3aed"/%3E%3C/svg%3E';
 const unreadFollower = profile({
+  avatar: { id: 'media-notification-follower-avatar', url: unreadFollowerAvatarUrl },
   displayName: '별빛 여행자',
   handle: 'starlight',
   id: 'notification-follower-unread',
@@ -245,6 +248,13 @@ type Story = StoryObj<typeof meta>;
 export const StatesAndFollowItems: Story = {
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    for (const avatar of canvas.getAllByLabelText('별빛 여행자 프로필 이미지')) {
+      expect(avatar.querySelector('img')).toHaveAttribute('src', unreadFollowerAvatarUrl);
+    }
+    for (const avatar of canvas.getAllByLabelText('은하 기록자 프로필 이미지')) {
+      expect(avatar.querySelector('img')).not.toBeInTheDocument();
+      expect(avatar).toHaveTextContent('은');
+    }
     expect(canvas.getByText('아직 알림이 없어요')).toBeVisible();
     expect(
       canvas.getByRole('link', {

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -171,13 +171,17 @@ const mediaOnlyPost = post({
   bodyText: '',
   id: 'media-only',
 });
+const sourceAuthorAvatarUrl = 'https://images.example.test/source-avatar.png';
+const repostAuthorAvatarUrl = 'https://images.example.test/repost-avatar.png';
 const sourceAuthor = profile({
+  avatar: { id: 'media-source-avatar', url: sourceAuthorAvatarUrl },
   displayName: '아주 긴 Source 작성자 표시 이름',
   handle: 'source@remote.example',
   id: 'profile-repost-source',
   relativeHandle: '@source@remote.example',
 });
 const repostAuthor = profile({
+  avatar: { id: 'media-repost-avatar', url: repostAuthorAvatarUrl },
   displayName: '재게시한 코스모 사용자',
   handle: 'reposter',
   id: 'profile-repost-author',
@@ -2008,6 +2012,7 @@ export const PureRepost: Story = {
     expect(article.querySelector('[data-testid="post-source-presentation"]')).toBeNull();
     expect(article.querySelector('[data-testid="source-post-preview"]')).toBeNull();
     expect(getComputedStyle(article).borderBottomWidth).toBe('1px');
+    expect(sourceAvatar.querySelector('img')).toHaveAttribute('src', sourceAuthorAvatarUrl);
     expect(sourceAvatar.getBoundingClientRect().width).toBe(48);
     expect(sourceAvatar.getBoundingClientRect().height).toBe(48);
     expect(article.querySelector('a a')).toBeNull();
@@ -2076,11 +2081,17 @@ export const Quote: Story = {
   play: async ({ canvasElement }) => {
     const root = within(canvasElement).getByTestId('post-source-presentation');
     const canvas = within(root);
+    const outerAvatar = canvas.getByLabelText(`${repostAuthor.displayName} 프로필 이미지`);
     expect(canvas.getByText('이 원문에 덧붙이는 인용자의 본문입니다.')).toBeVisible();
     expect(canvas.getByTestId('post-timestamp')).toHaveTextContent(
       formatTimelineTimestamp(quotePost.createdAt),
     );
     const preview = canvas.getByTestId('source-post-preview');
+    const sourceAvatar = within(preview).getByLabelText(
+      `${sourceAuthor.displayName} 프로필 이미지`,
+    );
+    expect(outerAvatar.querySelector('img')).toHaveAttribute('src', repostAuthorAvatarUrl);
+    expect(sourceAvatar.querySelector('img')).toHaveAttribute('src', sourceAuthorAvatarUrl);
     expect(preview.textContent).toContain('원문 작성자의 긴 본문과 줄바꿈을 표시합니다.');
     expect(canvas.getAllByRole('link')).toHaveLength(4);
     expect(within(preview).getAllByRole('link')).toHaveLength(2);
@@ -2103,6 +2114,24 @@ export const Quote: Story = {
     );
   },
   render: () => <RepostQuotePresentationStory postId="post-quote" />,
+};
+
+export const QuoteListItemAvatars: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const outerAvatar = canvas.getByLabelText(`${repostAuthor.displayName} 프로필 이미지`);
+    const sourceAvatar = within(canvas.getByTestId('source-post-preview')).getByLabelText(
+      `${sourceAuthor.displayName} 프로필 이미지`,
+    );
+
+    expect(outerAvatar.querySelector('img')).toHaveAttribute('src', repostAuthorAvatarUrl);
+    expect(sourceAvatar.querySelector('img')).toHaveAttribute('src', sourceAuthorAvatarUrl);
+    expect(outerAvatar.getBoundingClientRect().width).toBe(48);
+    expect(outerAvatar.getBoundingClientRect().height).toBe(48);
+    expect(sourceAvatar.getBoundingClientRect().width).toBe(40);
+    expect(sourceAvatar.getBoundingClientRect().height).toBe(40);
+  },
+  render: () => <ProductionPostListItemStory postId="post-quote" />,
 };
 
 export const QuoteOfQuote: Story = {
@@ -2160,7 +2189,10 @@ export const OrdinaryPost: Story = {
     const article = canvas.getByRole('article');
     const standardRow = within(article).getByTestId('post-list-standard-row');
     const bodyShortcut = within(standardRow).getByTestId('post-list-row-body');
+    const avatar = within(standardRow).getByLabelText('코스모 작가 프로필 이미지');
     expect(canvas.getByText('짧은 본문 한 줄.')).toBeVisible();
+    expect(avatar.querySelector('img')).not.toBeInTheDocument();
+    expect(avatar).toHaveTextContent('코');
     expect(canvas.queryByTestId('source-post-preview')).not.toBeInTheDocument();
     expect(article.querySelectorAll('[data-testid="post-list-standard-row"]')).toHaveLength(1);
     expect(bodyShortcut).not.toHaveAttribute('role', 'link');
@@ -2569,9 +2601,15 @@ export const PostDetailCurrentQuoteSourceNavigation: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const currentQuote = within(await canvas.findByTestId('post-thread-current-post-quote'));
+    const outerAvatar = currentQuote.getByLabelText(`${repostAuthor.displayName} 프로필 이미지`);
+    const sourceAvatar = within(currentQuote.getByTestId('source-post-preview')).getByLabelText(
+      `${sourceAuthor.displayName} 프로필 이미지`,
+    );
 
     expect(canvas.queryAllByTestId(/^post-thread-divider-/)).toHaveLength(0);
     expect(currentQuote.getAllByTestId('source-post-preview')).toHaveLength(1);
+    expect(outerAvatar.querySelector('img')).toHaveAttribute('src', repostAuthorAvatarUrl);
+    expect(sourceAvatar.querySelector('img')).toHaveAttribute('src', sourceAuthorAvatarUrl);
     expect(
       currentQuote.queryByRole('link', { name: `${repostAuthor.displayName}의 게시글 보기` }),
     ).not.toBeInTheDocument();

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -3177,7 +3177,7 @@ export const PostDetailThreadReplyOwnerIntegration: Story = {
     await userEvent.click(continueButton);
     expect(screen.queryByRole('alertdialog', { name: '답글 작성을 취소할까요?' })).toBeNull();
     expect(body).toHaveValue('첫 Parent draft');
-    expect(body).toHaveFocus();
+    await waitFor(() => expect(body).toHaveFocus());
 
     await userEvent.click(replyButtons[1]!);
     await userEvent.click(
@@ -3642,7 +3642,7 @@ export const ReplyModalPresentation: Story = {
     await userEvent.click(continueButton);
     expect(screen.queryByRole('alertdialog', { name: '답글 작성을 취소할까요?' })).toBeNull();
     expect(body).toHaveValue('작성 중인 답글');
-    expect(body).toHaveFocus();
+    await waitFor(() => expect(body).toHaveFocus());
 
     await userEvent.click(within(reopenedDialog).getByRole('button', { name: '닫기' }));
     await userEvent.click(

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -523,7 +523,12 @@ const storyPosts = [
   mediaTextPost,
   mediaOnlyPost,
 ];
-const composerProfile = profile({ id: 'profile-composer' });
+const composerAvatarUrl =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="96" height="96"%3E%3Crect width="96" height="96" fill="%232563eb"/%3E%3C/svg%3E';
+const composerProfile = profile({
+  avatar: { id: 'media-composer-avatar', url: composerAvatarUrl },
+  id: 'profile-composer',
+});
 const alternateComposerProfile = profile({ id: 'profile-composer-alternate' });
 const emptyPostsProfile = profileWithPosts([], { id: 'profile-posts-empty' });
 const contentPostsProfile = profileWithPosts(
@@ -3196,7 +3201,9 @@ export const PostDetailThreadReplyOwnerIntegration: Story = {
 export const ComposerDefault: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const avatar = canvas.getByLabelText('코스모 작가 프로필 이미지');
     const body = canvas.getByRole('textbox', { name: '게시글 본문' });
+    expect(avatar.querySelector('img')).toHaveAttribute('src', composerAvatarUrl);
     expect(body).not.toHaveAttribute('maxlength');
     await userEvent.click(body);
     expect(body).toHaveFocus();

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -171,8 +171,8 @@ const mediaOnlyPost = post({
   bodyText: '',
   id: 'media-only',
 });
-const sourceAuthorAvatarUrl = 'https://images.example.test/source-avatar.png';
-const repostAuthorAvatarUrl = 'https://images.example.test/repost-avatar.png';
+const sourceAuthorAvatarUrl = '/apple-touch-icon.png';
+const repostAuthorAvatarUrl = '/icon-192.png';
 const sourceAuthor = profile({
   avatar: { id: 'media-source-avatar', url: sourceAuthorAvatarUrl },
   displayName: '아주 긴 Source 작성자 표시 이름',
@@ -298,7 +298,7 @@ const linkedSourceQuote = {
   ...linkedPost,
   id: 'post-quote-linked-source',
   profile: repostAuthor,
-  repostSource: linkedPost,
+  repostSource: { ...linkedPost, id: 'post-linked-source', profile: sourceAuthor },
 };
 const threadRootPost = post({ bodyText: '대화의 시작입니다.', id: 'thread-root' });
 const threadParentPost = post({ bodyText: '직접 Parent Reply입니다.', id: 'thread-parent' });
@@ -3881,6 +3881,12 @@ export const ReplyQuoteParentPresentation: Story = {
   globals: { viewport: { isRotated: false, value: 'kosmoCompact' } },
   play: async () => {
     const dialog = await screen.findByRole('dialog', { name: '답글 쓰기' });
+    const parentAvatar = within(dialog).getByLabelText(`${repostAuthor.displayName} 프로필 이미지`);
+    const sourceAvatar = within(dialog).getByLabelText(`${sourceAuthor.displayName} 프로필 이미지`);
+    await waitFor(() => {
+      expect(parentAvatar.querySelector('img')).toHaveAttribute('src', repostAuthorAvatarUrl);
+      expect(sourceAvatar.querySelector('img')).toHaveAttribute('src', sourceAuthorAvatarUrl);
+    });
     expect(within(dialog).getByTestId('reply-parent')).toHaveTextContent('안전한 외부 링크');
     expect(within(dialog).queryByRole('link')).toBeNull();
     const source = within(dialog).getByTestId('source-post-preview');

--- a/apps/app/src/stories/Profiles.stories.tsx
+++ b/apps/app/src/stories/Profiles.stories.tsx
@@ -15,9 +15,13 @@ import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ProfilesStoriesQuery as ProfilesStoriesQueryType } from './__generated__/ProfilesStoriesQuery.graphql';
 
-const followable = profile({ id: 'profile-followable' });
+const followable = profile({
+  avatar: { id: 'media-profile-followable-avatar', url: '/profile-followable-avatar.png' },
+  id: 'profile-followable',
+});
 const followingOwnerId = 'profile-following-content';
 const followed = profile({
+  avatar: { id: 'media-profile-followed-avatar', url: '/profile-followed-avatar.png' },
   id: 'profile-followed',
   viewerState: {
     follow: {
@@ -57,7 +61,13 @@ const remoteApprovalRequired = profile({
   relativeHandle: '@approval-required@remote.example',
 });
 const noBio = profile({ bio: null, id: 'profile-no-bio' });
-const noViewer = profile({ id: 'profile-no-viewer', viewerState: null });
+const noViewer = profile({
+  displayName: '이니셜 폴백 프로필',
+  handle: 'initial-fallback',
+  id: 'profile-no-viewer',
+  relativeHandle: '@initial-fallback',
+  viewerState: null,
+});
 const withImages = profile({
   avatar: { id: 'media-profile-avatar', url: '/apple-touch-icon.png' },
   header: { id: 'media-profile-header', url: '/og-default.png' },
@@ -344,10 +354,26 @@ export const HeroNameAndLoadingStates: Story = {
 
 export const ListAndFollowStates: Story = {
   play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const followableSection = within(canvas.getByText('Followable').parentElement!);
+    const followingSection = within(canvas.getByText('Following').parentElement!);
     expect(
       canvasElement.querySelector('a[href="/@remote-user@very-long-instance.example"]'),
     ).toBeInTheDocument();
-    expect(within(canvasElement).getAllByRole('button', { name: '팔로우' })).toHaveLength(2);
+    expect(canvas.getAllByRole('button', { name: '팔로우' })).toHaveLength(2);
+    const followableAvatar = followableSection.getByLabelText('코스모 작가 프로필 이미지');
+    const followingAvatar = followingSection.getByLabelText('코스모 작가 프로필 이미지');
+    expect(followableAvatar.querySelector('img')).toHaveAttribute(
+      'src',
+      '/profile-followable-avatar.png',
+    );
+    expect(followingAvatar.querySelector('img')).toHaveAttribute(
+      'src',
+      '/profile-followed-avatar.png',
+    );
+    const fallbackAvatar = canvas.getByLabelText('이니셜 폴백 프로필 프로필 이미지');
+    expect(fallbackAvatar.querySelector('img')).not.toBeInTheDocument();
+    expect(fallbackAvatar).toHaveTextContent('이');
   },
   render: () => <ProfileListCatalog />,
 };

--- a/apps/app/src/stories/Reactions.stories.tsx
+++ b/apps/app/src/stories/Reactions.stories.tsx
@@ -55,6 +55,10 @@ const quickReactionOptions = [
 
 const storyProfiles = [
   profile({
+    avatar: {
+      id: 'reaction-profile-starlight-avatar',
+      url: '/reaction-profile-starlight-avatar.png',
+    },
     displayName: '별빛 반응 프로필',
     id: 'reaction-profile-starlight',
     relativeHandle: '@starlight',
@@ -554,6 +558,14 @@ export const ProfileListStates: Story = {
     expect(canvas.getAllByText(profileCopy.emptyTitle)).toHaveLength(2);
     expect(canvasElement.querySelector('a[href="/@starlight"]')).toBeInTheDocument();
     expect(canvasElement.querySelector('a[href="/@milky-way"]')).toBeInTheDocument();
+    const imageAvatar = populatedSection.getByLabelText('별빛 반응 프로필 프로필 이미지');
+    const fallbackAvatar = populatedSection.getByLabelText('은하수 반응 프로필 프로필 이미지');
+    expect(imageAvatar.querySelector('img')).toHaveAttribute(
+      'src',
+      '/reaction-profile-starlight-avatar.png',
+    );
+    expect(fallbackAvatar.querySelector('img')).not.toBeInTheDocument();
+    expect(fallbackAvatar).toHaveTextContent('은');
     expect(canvas.getAllByText('❤️')).toHaveLength(9);
     const populatedRows = populatedSection
       .getAllByLabelText('❤️ 반응')

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -24,7 +24,11 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { GuardedNavigationAction } from '@/components/shell/NavigationGuardContext';
 import type { ShellStoriesQuery as ShellStoriesQueryType } from './__generated__/ShellStoriesQuery.graphql';
 
+const selectedAvatarUrl = '/apple-touch-icon.png';
+const selectedHeaderUrl = '/og-default.png';
+const secondAvatarUrl = '/icon-192.png';
 const secondProfile = profile({
+  avatar: { id: 'media-shell-second-avatar', url: secondAvatarUrl },
   displayName: '먼 우주의 사용자',
   handle: 'remote',
   id: 'profile-remote',
@@ -32,6 +36,8 @@ const secondProfile = profile({
   viewerState: { follow: null, followRequest: null, isSelf: true },
 });
 const selectedProfile = profile({
+  avatar: { id: 'media-shell-selected-avatar', url: selectedAvatarUrl },
+  header: { id: 'media-shell-selected-header', url: selectedHeaderUrl },
   handle: 'selected',
   id: 'profile-selected',
   relativeHandle: '@selected',
@@ -68,6 +74,23 @@ const additionalProfiles = Array.from({ length: 11 }, (_, index) =>
 const longProfileQuery = {
   ...query,
   ...shellQuery({ profiles: [selectedProfile, ...additionalProfiles], selectedProfile }),
+};
+const imagePresentationQuery = {
+  ...query,
+  ...shellQuery({
+    profiles: [
+      selectedProfile,
+      secondProfile,
+      profile({
+        displayName: '이미지 없는 프로필',
+        handle: 'fallback',
+        id: 'profile-fallback',
+        relativeHandle: '@fallback',
+        viewerState: { follow: null, followRequest: null, isSelf: true },
+      }),
+    ],
+    selectedProfile,
+  }),
 };
 
 const ShellStoriesQuery = graphql`
@@ -258,10 +281,10 @@ export const SharedNavigation: Story = {
 
 export const BottomNavigation: Story = {
   play: ({ canvasElement }) => {
-    expect(within(canvasElement).getByRole('link', { name: '글쓰기' })).toHaveAttribute(
-      'href',
-      '/compose',
-    );
+    const canvas = within(canvasElement);
+    const avatar = canvas.getByLabelText(`${selectedProfile.displayName} 프로필 이미지`);
+    expect(canvas.getByRole('link', { name: '글쓰기' })).toHaveAttribute('href', '/compose');
+    expect(avatar.querySelector('img')).toHaveAttribute('src', selectedAvatarUrl);
   },
   render: () => <BottomNavigationStory />,
 };
@@ -764,6 +787,37 @@ export const ProfileSwitcherInteraction: Story = {
     const reopenedPicker = await canvas.findByLabelText('프로필 전환');
     expect(within(reopenedPicker).queryByRole('form', { name: '새 프로필 만들기' })).toBeNull();
     expect(canvas.getByRole('button', { name: '새 프로필 추가' })).toBeVisible();
+  },
+  render: () => <ProfileSwitcherStory />,
+};
+
+export const ProfileSwitcherImagePresentation: Story = {
+  parameters: { relay: { data: imagePresentationQuery } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const activeAvatar = canvas.getByLabelText(`${selectedProfile.displayName} 프로필 이미지`);
+    await waitFor(() =>
+      expect(activeAvatar.querySelector('img')).toHaveAttribute('src', selectedAvatarUrl),
+    );
+    await waitFor(() =>
+      expect(canvasElement.querySelector(`img[src="${selectedHeaderUrl}"]`)).toBeInTheDocument(),
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: '프로필 목록' }));
+    const list = await canvas.findByLabelText('전환할 프로필 목록');
+    const options = within(list).getAllByRole('button');
+    expect(options).toHaveLength(3);
+
+    const secondAvatar = within(options[1]!).getByLabelText(
+      `${secondProfile.displayName} 프로필 이미지`,
+    );
+    await waitFor(() =>
+      expect(secondAvatar.querySelector('img')).toHaveAttribute('src', secondAvatarUrl),
+    );
+
+    const fallbackAvatar = within(options[2]!).getByLabelText('이미지 없는 프로필 프로필 이미지');
+    expect(fallbackAvatar.querySelector('img')).not.toBeInTheDocument();
+    expect(fallbackAvatar).toHaveTextContent('이');
   },
   render: () => <ProfileSwitcherStory />,
 };

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -92,6 +92,14 @@ const imagePresentationQuery = {
     selectedProfile,
   }),
 };
+const selectedProfileWithoutHeader = { ...selectedProfile, header: null };
+const headerFallbackQuery = {
+  ...query,
+  ...shellQuery({
+    profiles: [selectedProfileWithoutHeader, secondProfile],
+    selectedProfile: selectedProfileWithoutHeader,
+  }),
+};
 
 const ShellStoriesQuery = graphql`
   query ShellStoriesQuery {
@@ -799,9 +807,17 @@ export const ProfileSwitcherImagePresentation: Story = {
     await waitFor(() =>
       expect(activeAvatar.querySelector('img')).toHaveAttribute('src', selectedAvatarUrl),
     );
-    await waitFor(() =>
-      expect(canvasElement.querySelector(`img[src="${selectedHeaderUrl}"]`)).toBeInTheDocument(),
-    );
+    const headerImage = await waitFor(() => {
+      const image = canvasElement.querySelector<HTMLImageElement>(
+        `img[src="${selectedHeaderUrl}"]`,
+      );
+      expect(image).toBeInTheDocument();
+      return image!;
+    });
+    const activeSurface = canvas.getByLabelText('활성 프로필');
+    const cover = activeSurface.firstElementChild as HTMLElement;
+    expect(cover.contains(headerImage)).toBe(true);
+    expect(getComputedStyle(cover).filter).toBe('none');
 
     await userEvent.click(canvas.getByRole('button', { name: '프로필 목록' }));
     const list = await canvas.findByLabelText('전환할 프로필 목록');
@@ -818,6 +834,20 @@ export const ProfileSwitcherImagePresentation: Story = {
     const fallbackAvatar = within(options[2]!).getByLabelText('이미지 없는 프로필 프로필 이미지');
     expect(fallbackAvatar.querySelector('img')).not.toBeInTheDocument();
     expect(fallbackAvatar).toHaveTextContent('이');
+  },
+  render: () => <ProfileSwitcherStory />,
+};
+
+export const ProfileSwitcherHeaderFallbackPresentation: Story = {
+  parameters: { relay: { data: headerFallbackQuery } },
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const activeSurface = canvas.getByLabelText('활성 프로필');
+    const cover = activeSurface.firstElementChild as HTMLElement;
+
+    expect(canvasElement.querySelector(`img[src="${selectedHeaderUrl}"]`)).not.toBeInTheDocument();
+    expect(getComputedStyle(cover).backgroundImage).toContain('linear-gradient');
+    expect(getComputedStyle(cover).filter).toBe('blur(1px)');
   },
   render: () => <ProfileSwitcherStory />,
 };

--- a/openspec/changes/show-post-author-avatar-images/.openspec.yaml
+++ b/openspec/changes/show-post-author-avatar-images/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-30

--- a/openspec/changes/show-post-author-avatar-images/decisions.md
+++ b/openspec/changes/show-post-author-avatar-images/decisions.md
@@ -37,8 +37,8 @@
 - Context / Problem: PROD-588이 필요한 Profile avatar/header URL과 image-capable Avatar는 PROD-492가 제공하며 현재 production consumer fragment만 이 필드를 완전히 소비하지 않는다.
 - Decision Outcome: PROD-492 결과를 선행 입력으로 사용하고 실제 Profile 이미지를 렌더링하는 leaf Relay fragment가 `avatar { id url }`과 필요한 경우에만 `header { id url }`을 조회한다. PROD-588에서 같은 API·schema·Media projection을 복제하지 않는다.
 - Alternatives Considered: 상위 route query가 image scalar를 따로 조립하는 방식, PROD-588이 API·Avatar 구현을 복제하는 방식. 각각 fragment colocation을 약화하거나 ownership 중복과 stack 충돌을 만든다.
-- Consequences: Relay compiler 산출물은 생성해 검증하되 commit하지 않고, PROD-588 PR은 PROD-492 결과가 포함되는 stack 순서를 유지한다.
-- Confirmation / Follow-up: parent ancestry와 PR base를 확인하고 Relay compile·typecheck에서 leaf fragment와 schema 정합성을 검증한다.
+- Consequences: Relay compiler 산출물은 생성해 검증하되 commit하지 않는다. PROD-492가 `main`에 통합된 뒤 PROD-588 PR은 최신 `main`을 base로 이 change의 고유 commit만 유지한다.
+- Confirmation / Follow-up: PR base와 unique commit 범위를 확인하고 Relay compile·typecheck에서 leaf fragment와 schema 정합성을 검증한다.
 
 ### 공용 Avatar는 재사용하고 header는 기존 cover에서 직접 표시한다
 

--- a/openspec/changes/show-post-author-avatar-images/decisions.md
+++ b/openspec/changes/show-post-author-avatar-images/decisions.md
@@ -1,0 +1,49 @@
+## Context
+
+이 기록은 PROD-588의 작성자 avatar 표시 계약, Profile이 소유하는 avatar Media 관계, 기존 게시글 presentation의 작성자·direct Source 소유 경계와 PR #435가 제공하는 공개 Profile avatar projection을 구현 입력으로 사용한다. 제품 동작은 delta specs에 두고 여기에는 구현 전 계속 지켜야 할 파생 계약과 dependency 선택만 기록한다.
+
+## Decision Records
+
+### 표시 위치가 소유한 Profile avatar를 우선 사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
+- Status: Active
+- Context / Problem: 일반 Post, Repost와 Quote는 직접 작성자와 direct Source 작성자가 서로 다를 수 있어 하나의 avatar 값을 presentation 전체에 재사용하면 잘못된 Profile 이미지를 표시한다.
+- Decision Outcome: 각 작성자 표시 위치는 그 위치가 나타내는 Profile의 공개 Ready avatar URL을 우선 사용하고, 관계 또는 URL이 없을 때만 같은 Profile의 표시 이름·핸들 기반 이니셜 fallback을 사용한다.
+- Alternatives Considered: 바깥 Post 작성자의 avatar를 Source에도 재사용하는 방식, 모든 위치에 이니셜만 유지하는 방식. 전자는 Profile 소유 관계를 위반하고 후자는 PROD-588의 전달 결과를 충족하지 않는다.
+- Consequences: fragment와 presentation mapping은 outer 작성자와 direct Source 작성자의 avatar를 독립적으로 운반해야 한다.
+- Confirmation / Follow-up: 일반 Post, 순수 Repost direct Source, Quote 직접 작성자와 direct Source, null avatar 상태를 서로 구분되는 fixture와 runtime으로 확인한다.
+
+### 이미지 연결은 기존 presentation 계약을 바꾸지 않는다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
+- Status: Active
+- Context / Problem: avatar 이미지 연결이 크기, 레이아웃, Profile 이동과 접근성 이름 변경으로 확장되면 기존 게시글 UI 계약과 별도 디자인 범위를 침범한다.
+- Decision Outcome: 실제 이미지와 이니셜 fallback 모두 기존 목록 48px, 상세·Source preview 40px 크기, Profile Link, 접근성 label과 layout을 유지한다. 업로드·저장·Media 공개 정책, 공용 Avatar 재설계, 기본 asset과 네트워크 이미지 로드 실패 정책은 이 change에서 변경하지 않는다.
+- Alternatives Considered: 이미지 상태에 맞춰 크기·layout을 재설계하거나 네트워크 오류 fallback까지 함께 추가하는 방식. 두 선택 모두 PROD-588의 제외 범위를 넓힌다.
+- Consequences: 이번 change는 기존 Avatar props를 소비하는 leaf presentation과 그 검증만 수정한다.
+- Confirmation / Follow-up: Storybook에서 이미지와 fallback의 크기·Profile 이동·접근성 이름이 동일하게 유지되는지 확인한다.
+
+### PROD-492의 공개 projection을 leaf Relay fragment에서 소비한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/profile.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588), [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
+- Status: Active
+- Context / Problem: PROD-588이 필요한 `Profile.avatar { id url }`와 image-capable Avatar는 PROD-492가 제공하며 현재 게시글 fragment만 이 필드를 소비하지 않는다.
+- Decision Outcome: PROD-492 결과를 선행 입력으로 사용하고 게시글을 실제 렌더링하는 leaf Relay fragment가 `avatar { id url }`을 조회해 기존 Avatar의 nullable image URI에 전달한다. PROD-588에서 같은 API·schema·Media projection이나 별도 primitive를 복제하지 않는다.
+- Alternatives Considered: 상위 route query가 avatar scalar를 따로 조립하는 방식, PROD-588이 API·Avatar 구현을 복제하는 방식, PROD-492와 무관하게 main에서 독립 구현하는 방식. 각각 fragment colocation을 약화하거나 ownership 중복과 stack 충돌을 만든다.
+- Consequences: PROD-588 PR은 PROD-492 결과가 먼저 포함되는 stack 순서를 유지하며 Relay compiler 산출물은 생성해 검증하되 commit하지 않는다.
+- Confirmation / Follow-up: parent ancestry와 PR base를 확인하고 Relay compile·typecheck에서 leaf fragment와 schema 정합성을 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/show-post-author-avatar-images/decisions.md
+++ b/openspec/changes/show-post-author-avatar-images/decisions.md
@@ -1,44 +1,56 @@
 ## Context
 
-이 기록은 PROD-588의 작성자 avatar 표시 계약, Profile이 소유하는 avatar Media 관계, 기존 게시글 presentation의 작성자·direct Source 소유 경계와 PR #435가 제공하는 공개 Profile avatar projection을 구현 입력으로 사용한다. 제품 동작은 delta specs에 두고 여기에는 구현 전 계속 지켜야 할 파생 계약과 dependency 선택만 기록한다.
+이 기록은 PROD-588의 앱 공용 Profile avatar/header 표시 계약과 PROD-492가 제공하는 공개 Profile image projection을 구현 입력으로 사용한다. 제품 동작은 delta specs에 두고 여기에는 구현 전 계속 지켜야 할 파생 계약과 dependency 선택만 기록한다.
 
 ## Decision Records
 
-### 표시 위치가 소유한 Profile avatar를 우선 사용한다
+### 각 표시 위치는 자신이 나타내는 Profile 이미지를 소유한다
 
 - Decision Date: 2026-07-31
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
 - Status: Active
-- Context / Problem: 일반 Post, Repost와 Quote는 직접 작성자와 direct Source 작성자가 서로 다를 수 있어 하나의 avatar 값을 presentation 전체에 재사용하면 잘못된 Profile 이미지를 표시한다.
-- Decision Outcome: 각 작성자 표시 위치는 그 위치가 나타내는 Profile의 공개 Ready avatar URL을 우선 사용하고, 관계 또는 URL이 없을 때만 같은 Profile의 표시 이름·핸들 기반 이니셜 fallback을 사용한다.
-- Alternatives Considered: 바깥 Post 작성자의 avatar를 Source에도 재사용하는 방식, 모든 위치에 이니셜만 유지하는 방식. 전자는 Profile 소유 관계를 위반하고 후자는 PROD-588의 전달 결과를 충족하지 않는다.
-- Consequences: fragment와 presentation mapping은 outer 작성자와 direct Source 작성자의 avatar를 독립적으로 운반해야 한다.
-- Confirmation / Follow-up: 일반 Post, 순수 Repost direct Source, Quote 직접 작성자와 direct Source, null avatar 상태를 서로 구분되는 fixture와 runtime으로 확인한다.
+- Context / Problem: Repost·Quote의 작성자와 Source, Profile 목록의 여러 행, selected Profile과 Notification Related Profile은 서로 다를 수 있어 하나의 image URL을 presentation 전체에 재사용하면 잘못된 Profile 이미지를 표시한다.
+- Decision Outcome: 각 avatar/header 표시 위치는 그 위치가 나타내는 Profile의 공개 Ready URL을 우선 사용하고, 관계 또는 URL이 없을 때만 같은 Profile의 기존 이니셜 또는 gradient fallback을 사용한다.
+- Alternatives Considered: 상위 화면이 하나의 URL을 모든 하위 표면에 전달하는 방식, 모든 위치에 이니셜·gradient만 유지하는 방식. 전자는 Profile 소유 관계를 위반하고 후자는 PROD-588의 전달 결과를 충족하지 않는다.
+- Consequences: leaf fragment와 presentation mapping은 각 Profile의 image 관계를 독립적으로 운반해야 한다.
+- Confirmation / Follow-up: 게시글 작성자·Source, ProfileSwitcher 활성·목록 Profile, 공용 ProfileListItem, 하단 탭·작성기, Notification Related Profile과 null 상태를 서로 구분되는 fixture와 runtime으로 확인한다.
 
-### 이미지 연결은 기존 presentation 계약을 바꾸지 않는다
+### 이미지 연결은 기존 presentation과 actor 전환 계약을 바꾸지 않는다
 
 - Decision Date: 2026-07-31
 - Decision Class: Derived Contract
 - Authority / Provenance: [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
 - Status: Active
-- Context / Problem: avatar 이미지 연결이 크기, 레이아웃, Profile 이동과 접근성 이름 변경으로 확장되면 기존 게시글 UI 계약과 별도 디자인 범위를 침범한다.
-- Decision Outcome: 실제 이미지와 이니셜 fallback 모두 기존 목록 48px, 상세·Source preview 40px 크기, Profile Link, 접근성 label과 layout을 유지한다. 업로드·저장·Media 공개 정책, 공용 Avatar 재설계, 기본 asset과 네트워크 이미지 로드 실패 정책은 이 change에서 변경하지 않는다.
-- Alternatives Considered: 이미지 상태에 맞춰 크기·layout을 재설계하거나 네트워크 오류 fallback까지 함께 추가하는 방식. 두 선택 모두 PROD-588의 제외 범위를 넓힌다.
-- Consequences: 이번 change는 기존 Avatar props를 소비하는 leaf presentation과 그 검증만 수정한다.
-- Confirmation / Follow-up: Storybook에서 이미지와 fallback의 크기·Profile 이동·접근성 이름이 동일하게 유지되는지 확인한다.
+- Context / Problem: 이미지 연결이 크기, 레이아웃, Profile 이동, 접근성 이름이나 selected Profile 전환 변경으로 확장되면 기존 UI·상태 계약과 별도 디자인 범위를 침범한다.
+- Decision Outcome: 실제 이미지와 fallback 모두 각 소비자의 기존 크기, Profile Link, 접근성 label과 layout을 유지한다. ProfileSwitcher의 mutation, Relay store 갱신과 actor별 Environment 재생성도 유지한다. 업로드·저장·Media 공개 정책, 기본 asset과 네트워크 이미지 로드 실패 정책은 변경하지 않는다.
+- Alternatives Considered: 이미지 상태에 맞춰 layout을 재설계하거나 ProfileSwitcher의 상태 흐름을 함께 재구성하는 방식. 두 선택 모두 PROD-588의 제외 범위를 넓힌다.
+- Consequences: 이번 change는 기존 image props를 소비하는 leaf presentation과 그 검증만 수정한다.
+- Confirmation / Follow-up: 기존 Storybook interaction을 유지하며 이미지와 fallback의 크기·이동·접근성·Profile 전환 동작을 확인한다.
 
-### PROD-492의 공개 projection을 leaf Relay fragment에서 소비한다
+### PROD-492 projection을 leaf Relay fragment에서 소비한다
 
 - Decision Date: 2026-07-31
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/domain/objects/profile.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588), [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
 - Status: Active
-- Context / Problem: PROD-588이 필요한 `Profile.avatar { id url }`와 image-capable Avatar는 PROD-492가 제공하며 현재 게시글 fragment만 이 필드를 소비하지 않는다.
-- Decision Outcome: PROD-492 결과를 선행 입력으로 사용하고 게시글을 실제 렌더링하는 leaf Relay fragment가 `avatar { id url }`을 조회해 기존 Avatar의 nullable image URI에 전달한다. PROD-588에서 같은 API·schema·Media projection이나 별도 primitive를 복제하지 않는다.
-- Alternatives Considered: 상위 route query가 avatar scalar를 따로 조립하는 방식, PROD-588이 API·Avatar 구현을 복제하는 방식, PROD-492와 무관하게 main에서 독립 구현하는 방식. 각각 fragment colocation을 약화하거나 ownership 중복과 stack 충돌을 만든다.
-- Consequences: PROD-588 PR은 PROD-492 결과가 먼저 포함되는 stack 순서를 유지하며 Relay compiler 산출물은 생성해 검증하되 commit하지 않는다.
+- Context / Problem: PROD-588이 필요한 Profile avatar/header URL과 image-capable Avatar는 PROD-492가 제공하며 현재 production consumer fragment만 이 필드를 완전히 소비하지 않는다.
+- Decision Outcome: PROD-492 결과를 선행 입력으로 사용하고 실제 Profile 이미지를 렌더링하는 leaf Relay fragment가 `avatar { id url }`과 필요한 경우에만 `header { id url }`을 조회한다. PROD-588에서 같은 API·schema·Media projection을 복제하지 않는다.
+- Alternatives Considered: 상위 route query가 image scalar를 따로 조립하는 방식, PROD-588이 API·Avatar 구현을 복제하는 방식. 각각 fragment colocation을 약화하거나 ownership 중복과 stack 충돌을 만든다.
+- Consequences: Relay compiler 산출물은 생성해 검증하되 commit하지 않고, PROD-588 PR은 PROD-492 결과가 포함되는 stack 순서를 유지한다.
 - Confirmation / Follow-up: parent ancestry와 PR base를 확인하고 Relay compile·typecheck에서 leaf fragment와 schema 정합성을 검증한다.
+
+### 공용 Avatar는 재사용하고 header는 기존 cover에서 직접 표시한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: [PROD-588](https://linear.app/byulmaru/issue/PROD-588), [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
+- Status: Active
+- Context / Problem: avatar는 이미 nullable `imageUri`와 이니셜 fallback을 지원하지만 header는 원형 avatar primitive의 역할이 아니며 기존 ProfileSwitcher cover geometry와 gradient fallback을 가진다.
+- Decision Outcome: avatar 소비자는 기존 `Avatar.imageUri`만 사용한다. ProfileSwitcher header는 기존 cover 영역에 조건부 React Native `Image`를 표시하고 URL이 없으면 현재 gradient를 유지한다. data-aware Avatar나 새 header primitive를 만들지 않는다.
+- Alternatives Considered: Avatar가 Relay fragment를 직접 소유하게 하는 방식, header까지 Avatar로 표현하는 방식, 새 공용 header primitive를 만드는 방식. 모두 현재 변경에 불필요한 추상화 또는 역할 혼합을 만든다.
+- Consequences: image data ownership은 leaf consumer에 남고 primitive API와 header layout은 변하지 않는다.
+- Confirmation / Follow-up: Shell Storybook에서 full·drawer·compact avatar와 실제 header·gradient fallback을 함께 확인한다.
 
 ## Remaining Decisions
 

--- a/openspec/changes/show-post-author-avatar-images/design.md
+++ b/openspec/changes/show-post-author-avatar-images/design.md
@@ -1,0 +1,64 @@
+## Context
+
+현재 `PostListItem`, `PostLayout`과 `PostSourcePresentationView`는 작성자 표시 이름·핸들만 조회하고 공용 `Avatar`에 label만 전달한다. PR #435는 `Profile.avatar { id url }` 공개 projection과 `Avatar.imageUri`를 제공하지만 게시글 leaf fragment와 presentation mapping은 이를 소비하지 않는다. 이 change는 PR #435 exact head 위에 쌓이며 게시글 공용 React Native 경로만 변경한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 일반 Post, 순수 Repost direct Source, Quote의 직접 작성자와 direct Source가 각자의 Ready avatar 이미지를 표시하게 한다.
+- 홈·프로필·북마크 목록과 상세 thread가 공유하는 leaf fragment 소유권을 유지한다.
+- URL이 없을 때 현재 이니셜 fallback을 유지하고 기존 크기·레이아웃·이동·접근성 계약을 보존한다.
+- 기존 Storybook과 Relay/typecheck 표면에서 변경 동작을 검증한다.
+
+**Non-Goals:**
+
+- Profile avatar 업로드·저장·공개 권한 또는 Media lifecycle 변경
+- 공용 Avatar primitive, 기본 avatar asset, 이미지 로드 실패 fallback 정책 변경
+- 비게시글 Avatar 소비자, Post 첨부 이미지 또는 새로운 디자인 변경
+- 새 dependency, GraphQL schema, API resolver와 DB migration 추가
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `PostListRow_post`는 일반 목록 Post와 순수 Repost direct Source의 비재귀 표준 행을 함께 소유한다.
+- Quote와 상세은 outer Profile과 direct Source Profile을 별도로 조회한 뒤 `PostSourcePresentationData` 또는 `SourcePostPresentationData`로 수동 mapping한다. 한쪽 Profile 값을 재사용하면 작성자 이미지가 뒤바뀐다.
+- GraphQL 문서는 실제 소비 컴포넌트에 colocate하고 부모는 leaf fragment를 spread해야 한다. generated Relay artifact는 compiler 산출물이며 저장소에 commit하지 않는다.
+- PR #435가 제공하는 `Avatar`는 URL 존재 여부만으로 이미지와 이니셜을 선택한다. 네트워크 이미지 로드 실패 시 별도 fallback으로 전환하는 계약은 없다.
+- 기존 Posts Storybook은 production fragment shape와 Router decorator를 사용해 Repost·Quote의 작성자·Source 이동, avatar 크기와 presentation 구조를 검증한다.
+
+### Recommended Approach
+
+- 게시글을 실제로 렌더링하는 leaf fragment의 각 Profile selection에 `avatar { id url }`을 추가한다.
+- outer 작성자와 direct Source 작성자의 avatar 값을 각자의 presentation data에 독립적으로 mapping한다.
+- 기존 Avatar 호출에 해당 Profile의 nullable URL을 `imageUri`로 전달하고 label, size와 wrapper의 이동·접근성 속성은 유지한다.
+- 기존 Storybook fixture에 서로 구분되는 작성자별 avatar URL과 null 상태를 추가하고, 일반 목록·Repost Source·Quote·상세에서 이미지 선택과 이니셜 fallback을 관찰 가능한 결과로 검증한다.
+- Relay compiler, app typecheck와 Storybook 검증 뒤 실제 Web 공용 경로에서 목록·상세와 Source presentation을 확인한다.
+
+### Allowed Alternatives
+
+- 내부 presentation 타입은 nullable `avatar` 객체를 유지하거나 nullable `avatarUrl`로 평탄화할 수 있다. 어느 쪽이든 leaf fragment는 `id`와 `url`을 조회하고 작성자별 값을 섞지 않으며 공개 props를 불필요하게 확장하지 않아야 한다.
+- 변경 동작을 직접 증명할 수 있는 기존 근접 unit test가 발견되면 Storybook assertion 일부를 그 테스트에 둘 수 있다. 새 fixture·helper·test harness는 추가하지 않는다.
+
+### Known Traps
+
+- `main`에는 필요한 Profile field와 image-capable Avatar가 없으므로 PR #435 의존성을 복제하거나 우회하지 않는다.
+- route 또는 상위 query에 avatar scalar props를 수동으로 추가해 Relay fragment colocation을 우회하지 않는다.
+- Quote outer 작성자, Repost 작성자와 direct Source 작성자의 avatar를 하나의 값으로 합치지 않는다.
+- 이미지 표시를 이유로 48px·40px 크기, Profile Link, 접근성 label이나 layout spacing을 바꾸지 않는다.
+- URL 부재 fallback을 네트워크 오류 fallback이나 PROD-596의 기본 asset 범위로 확대하지 않는다.
+
+## Risks / Trade-offs
+
+- [부모 PR #435 head가 rewrite되거나 먼저 병합됨] → exact parent SHA와 stack base를 확인하고, 변경 전 backup ref와 range-diff를 사용하는 stack 유지 절차로 새 부모에 정렬한다.
+- [공개 또는 비로그인 Profile 조회에서 avatar projection이 예상과 다름] → 제품 코드 완료 주장 전 API/Web runtime에서 Ready avatar와 null avatar를 각각 관찰하고, 문제가 PR #435 계약에 있으면 PROD-588에 우회 구현하지 않는다.
+- [Relay fixture가 실제 fragment shape와 어긋남] → compiler와 production fragment 기반 Storybook을 함께 실행해 schema·fixture 불일치를 검출한다.
+
+## Migration Plan
+
+DB 또는 데이터 migration은 없다. PR #435가 먼저 merge되도록 stacked PR base를 유지하고, 부모 merge 뒤 PROD-588 branch를 최신 `main` ancestry에 정렬한다. 배포는 앱 fragment와 presentation 변경만 포함하며 문제가 생기면 PROD-588 commit을 되돌려 기존 이니셜-only 표시로 복구할 수 있다.
+
+## Open Questions
+
+없음. 비로그인 공개 조회와 실제 이미지 로드 결과는 구현 선택이 아니라 완료 전 runtime 검증 항목으로 남긴다.

--- a/openspec/changes/show-post-author-avatar-images/design.md
+++ b/openspec/changes/show-post-author-avatar-images/design.md
@@ -8,7 +8,7 @@ PROD-492는 `Profile.avatar { id url }`, `Profile.header { id url }` 공개 proj
 
 **Goals:**
 
-- 게시글의 직접 작성자와 direct Source, Profile 전환 표면, 공용 Profile 목록 행, 하단 탭, 작성기와 알림 행이 각자 나타내는 Profile의 Ready avatar 이미지를 표시하게 한다.
+- 게시글의 직접 작성자와 direct Source, Reply Composer의 parent·direct Source, Profile 전환 표면, 공용 Profile 목록 행, 하단 탭, 작성기와 알림 행이 각자 나타내는 Profile의 Ready avatar 이미지를 표시하게 한다.
 - `ProfileSwitcher`의 활성 Profile cover가 Ready header 이미지를 표시하고 URL이 없으면 기존 gradient를 유지하게 한다.
 - URL이 없을 때 현재 이니셜 fallback을 유지하고 기존 크기·레이아웃·이동·접근성 계약을 보존한다.
 - Profile 전환 후 actor별 Relay Environment와 Store 재생성 계약을 바꾸지 않는다.
@@ -38,7 +38,7 @@ PROD-492는 `Profile.avatar { id url }`, `Profile.header { id url }` 공개 proj
 
 - 각 production leaf fragment의 표시 Profile selection에 `avatar { id url }`을 추가하고 기존 Avatar 호출에 nullable URL을 `imageUri`로 전달한다.
 - 활성 Profile cover를 소유하는 `ProfileSwitcher` fragment에만 `header { id url }`을 추가하고, URL이 있으면 cover 안에 이미지를 채우며 없으면 기존 gradient를 렌더링한다.
-- `PostListItem`, `PostLayout`, `PostSourcePresentationView`는 outer 작성자와 direct Source의 avatar를 독립적으로 mapping한다.
+- `PostListItem`, `PostLayout`, `PostSourcePresentationView`, `ReplyComposerSurface`는 outer 또는 parent 작성자와 direct Source의 avatar를 독립적으로 mapping한다.
 - `ProfileListItem` 한 곳에 avatar 연결을 추가해 검색·팔로워·팔로잉·Reaction 목록이 동일한 계약을 재사용하게 한다.
 - `BottomTabBar`, `PostComposer`, 각 `NotificationListItem` subtype fragment는 자신이 직접 표시하는 Profile의 avatar만 조회한다.
 - label, size, wrapper의 Profile 이동·접근성 속성, ProfileSwitcher mutation과 actor environment 재생성은 그대로 유지한다.
@@ -68,7 +68,7 @@ PROD-492는 `Profile.avatar { id url }`, `Profile.header { id url }` 공개 proj
 
 ## Migration Plan
 
-DB 또는 데이터 migration은 없다. PROD-492가 먼저 포함되는 stacked PR base를 유지한다. 배포는 앱 fragment와 presentation 변경만 포함하며 문제가 생기면 PROD-588 commit을 되돌려 기존 이니셜·gradient 표시로 복구할 수 있다. archive는 이 change의 전체 소비자 구현·검증이 끝난 뒤 최신 active capability 계약과 동기화해 수행한다.
+DB 또는 데이터 migration은 없다. PROD-492는 `main`에 통합됐고 PROD-588 PR #438은 최신 `main`을 base로 이 change의 고유 commit만 유지한다. 배포는 앱 fragment와 presentation 변경만 포함하며 문제가 생기면 PROD-588 commit을 되돌려 기존 이니셜·gradient 표시로 복구할 수 있다. archive는 이 change의 전체 소비자 구현·검증이 끝난 뒤 최신 active capability 계약과 동기화해 수행한다.
 
 ## Open Questions
 

--- a/openspec/changes/show-post-author-avatar-images/design.md
+++ b/openspec/changes/show-post-author-avatar-images/design.md
@@ -1,64 +1,75 @@
 ## Context
 
-현재 `PostListItem`, `PostLayout`과 `PostSourcePresentationView`는 작성자 표시 이름·핸들만 조회하고 공용 `Avatar`에 label만 전달한다. PR #435는 `Profile.avatar { id url }` 공개 projection과 `Avatar.imageUri`를 제공하지만 게시글 leaf fragment와 presentation mapping은 이를 소비하지 않는다. 이 change는 PR #435 exact head 위에 쌓이며 게시글 공용 React Native 경로만 변경한다.
+PROD-492는 `Profile.avatar { id url }`, `Profile.header { id url }` 공개 projection과 URL이 있으면 이미지를 표시하는 공용 `Avatar.imageUri`를 제공한다. 현재 게시글 presentation 일부는 이 입력을 연결했지만 `ProfileSwitcher`, 공용 `ProfileListItem`, `BottomTabBar`, `PostComposer`, `NotificationListItem`은 여전히 Profile 이미지 필드를 조회하거나 전달하지 않는다. `ProfileSwitcher`의 cover도 header URL 대신 gradient만 표시한다.
+
+이 change는 Profile projection이나 primitive를 다시 만들지 않고, 각 production leaf consumer가 자신이 표시하는 Profile의 공개 URL을 직접 소유하도록 연결한다. 알림 capability의 기존 initials-only 문구는 확장된 PROD-588과 충돌하므로 같은 change에서 명시적으로 갱신한다.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- 일반 Post, 순수 Repost direct Source, Quote의 직접 작성자와 direct Source가 각자의 Ready avatar 이미지를 표시하게 한다.
-- 홈·프로필·북마크 목록과 상세 thread가 공유하는 leaf fragment 소유권을 유지한다.
+- 게시글의 직접 작성자와 direct Source, Profile 전환 표면, 공용 Profile 목록 행, 하단 탭, 작성기와 알림 행이 각자 나타내는 Profile의 Ready avatar 이미지를 표시하게 한다.
+- `ProfileSwitcher`의 활성 Profile cover가 Ready header 이미지를 표시하고 URL이 없으면 기존 gradient를 유지하게 한다.
 - URL이 없을 때 현재 이니셜 fallback을 유지하고 기존 크기·레이아웃·이동·접근성 계약을 보존한다.
-- 기존 Storybook과 Relay/typecheck 표면에서 변경 동작을 검증한다.
+- Profile 전환 후 actor별 Relay Environment와 Store 재생성 계약을 바꾸지 않는다.
+- 기존 production fragment 기반 Storybook과 Relay/typecheck 표면에서 이미지·fallback 동작을 검증한다.
 
 **Non-Goals:**
 
-- Profile avatar 업로드·저장·공개 권한 또는 Media lifecycle 변경
+- Profile avatar/header 업로드·저장·공개 권한, crop·thumbnail 또는 Media lifecycle 변경
 - 공용 Avatar primitive, 기본 avatar asset, 이미지 로드 실패 fallback 정책 변경
-- 비게시글 Avatar 소비자, Post 첨부 이미지 또는 새로운 디자인 변경
+- Post 첨부 이미지, 기존 크기·레이아웃·내비게이션 재설계
 - 새 dependency, GraphQL schema, API resolver와 DB migration 추가
+- iOS·Android 실제 기기 QA
 
 ## Implementation Guidance
 
 ### Current Constraints
 
-- `PostListRow_post`는 일반 목록 Post와 순수 Repost direct Source의 비재귀 표준 행을 함께 소유한다.
-- Quote와 상세은 outer Profile과 direct Source Profile을 별도로 조회한 뒤 `PostSourcePresentationData` 또는 `SourcePostPresentationData`로 수동 mapping한다. 한쪽 Profile 값을 재사용하면 작성자 이미지가 뒤바뀐다.
 - GraphQL 문서는 실제 소비 컴포넌트에 colocate하고 부모는 leaf fragment를 spread해야 한다. generated Relay artifact는 compiler 산출물이며 저장소에 commit하지 않는다.
-- PR #435가 제공하는 `Avatar`는 URL 존재 여부만으로 이미지와 이니셜을 선택한다. 네트워크 이미지 로드 실패 시 별도 fallback으로 전환하는 계약은 없다.
-- 기존 Posts Storybook은 production fragment shape와 Router decorator를 사용해 Repost·Quote의 작성자·Source 이동, avatar 크기와 presentation 구조를 검증한다.
+- 게시글의 outer 작성자와 direct Source 작성자, Profile 목록의 각 행, Notification의 Related Profile은 서로 다른 Profile일 수 있다. 한 위치의 URL을 다른 위치에 재사용하면 잘못된 이미지를 표시한다.
+- `ProfileSwitcher`는 `currentSession.selectedProfile`, 접근 가능한 `me.profiles`, Profile 생성·전환 mutation과 actor environment 재생성을 함께 소유한다. 이미지 연결은 이 상태 전환 경계를 바꾸지 않는다.
+- `ProfileListItem`은 검색·팔로워·팔로잉·Reaction Profile 목록이 공유하므로 해당 leaf fragment 한 곳이 avatar를 소유해야 한다.
+- Follow Notification subtype fragment는 Related Profile을 직접 표시하며 기존 active `notification` spec은 28px initials-only를 요구한다. delta spec에서 공용 Avatar의 이미지 우선·이니셜 fallback으로 대체해야 한다.
+- 기존 Avatar는 URL 존재 여부로 이미지와 이니셜을 선택한다. 네트워크 이미지 로드 실패 뒤 별도 fallback으로 전환하는 계약은 없다.
+- header는 Avatar primitive의 역할이 아니므로 기존 cover 영역에서 React Native `Image`로 표시하고 null일 때 gradient를 유지한다.
 
 ### Recommended Approach
 
-- 게시글을 실제로 렌더링하는 leaf fragment의 각 Profile selection에 `avatar { id url }`을 추가한다.
-- outer 작성자와 direct Source 작성자의 avatar 값을 각자의 presentation data에 독립적으로 mapping한다.
-- 기존 Avatar 호출에 해당 Profile의 nullable URL을 `imageUri`로 전달하고 label, size와 wrapper의 이동·접근성 속성은 유지한다.
-- 기존 Storybook fixture에 서로 구분되는 작성자별 avatar URL과 null 상태를 추가하고, 일반 목록·Repost Source·Quote·상세에서 이미지 선택과 이니셜 fallback을 관찰 가능한 결과로 검증한다.
-- Relay compiler, app typecheck와 Storybook 검증 뒤 실제 Web 공용 경로에서 목록·상세와 Source presentation을 확인한다.
+- 각 production leaf fragment의 표시 Profile selection에 `avatar { id url }`을 추가하고 기존 Avatar 호출에 nullable URL을 `imageUri`로 전달한다.
+- 활성 Profile cover를 소유하는 `ProfileSwitcher` fragment에만 `header { id url }`을 추가하고, URL이 있으면 cover 안에 이미지를 채우며 없으면 기존 gradient를 렌더링한다.
+- `PostListItem`, `PostLayout`, `PostSourcePresentationView`는 outer 작성자와 direct Source의 avatar를 독립적으로 mapping한다.
+- `ProfileListItem` 한 곳에 avatar 연결을 추가해 검색·팔로워·팔로잉·Reaction 목록이 동일한 계약을 재사용하게 한다.
+- `BottomTabBar`, `PostComposer`, 각 `NotificationListItem` subtype fragment는 자신이 직접 표시하는 Profile의 avatar만 조회한다.
+- label, size, wrapper의 Profile 이동·접근성 속성, ProfileSwitcher mutation과 actor environment 재생성은 그대로 유지한다.
+- 기존 Posts·Shell·Profiles·Reactions·Notifications Storybook fixture에 서로 구분되는 이미지 URL과 null 상태를 추가해 production fragment 경로에서 이미지와 fallback을 검증한다.
 
 ### Allowed Alternatives
 
-- 내부 presentation 타입은 nullable `avatar` 객체를 유지하거나 nullable `avatarUrl`로 평탄화할 수 있다. 어느 쪽이든 leaf fragment는 `id`와 `url`을 조회하고 작성자별 값을 섞지 않으며 공개 props를 불필요하게 확장하지 않아야 한다.
+- 내부 presentation 타입은 nullable `avatar` 객체를 유지하거나 nullable `avatarUrl`로 평탄화할 수 있다. 어느 쪽이든 leaf fragment는 `id`와 `url`을 조회하고 Profile별 값을 섞지 않으며 공개 props를 불필요하게 확장하지 않아야 한다.
+- header null 분기는 조건부 `Image` 또는 기존 gradient 위의 조건부 image layer로 구현할 수 있다. 실제 이미지가 있을 때 기존 cover geometry를 채우고 null 상태의 gradient가 변하지 않으면 된다.
 - 변경 동작을 직접 증명할 수 있는 기존 근접 unit test가 발견되면 Storybook assertion 일부를 그 테스트에 둘 수 있다. 새 fixture·helper·test harness는 추가하지 않는다.
 
 ### Known Traps
 
-- `main`에는 필요한 Profile field와 image-capable Avatar가 없으므로 PR #435 의존성을 복제하거나 우회하지 않는다.
-- route 또는 상위 query에 avatar scalar props를 수동으로 추가해 Relay fragment colocation을 우회하지 않는다.
-- Quote outer 작성자, Repost 작성자와 direct Source 작성자의 avatar를 하나의 값으로 합치지 않는다.
-- 이미지 표시를 이유로 48px·40px 크기, Profile Link, 접근성 label이나 layout spacing을 바꾸지 않는다.
+- route 또는 상위 query에 avatar/header scalar props를 수동으로 추가해 Relay fragment colocation을 우회하지 않는다.
+- Quote outer 작성자, Repost 작성자, direct Source 작성자, 목록의 다른 Profile 또는 Notification Related Profile의 URL을 하나로 합치지 않는다.
+- data-aware Avatar나 Profile fragment를 소유하는 새 primitive를 만들어 기존 leaf fragment 소유권을 역전하지 않는다.
+- 이미지 표시를 이유로 기존 크기, Profile Link, 접근성 label, layout spacing 또는 ProfileSwitcher 전환 동작을 바꾸지 않는다.
 - URL 부재 fallback을 네트워크 오류 fallback이나 PROD-596의 기본 asset 범위로 확대하지 않는다.
+- `web-app-shell`과 `notification`을 수정하는 다른 active change가 있으므로 archive 시 최신 active spec과 다른 delta를 다시 대조하지 않으면 오래된 계약을 복원할 수 있다.
 
 ## Risks / Trade-offs
 
-- [부모 PR #435 head가 rewrite되거나 먼저 병합됨] → exact parent SHA와 stack base를 확인하고, 변경 전 backup ref와 range-diff를 사용하는 stack 유지 절차로 새 부모에 정렬한다.
-- [공개 또는 비로그인 Profile 조회에서 avatar projection이 예상과 다름] → 제품 코드 완료 주장 전 API/Web runtime에서 Ready avatar와 null avatar를 각각 관찰하고, 문제가 PR #435 계약에 있으면 PROD-588에 우회 구현하지 않는다.
-- [Relay fixture가 실제 fragment shape와 어긋남] → compiler와 production fragment 기반 Storybook을 함께 실행해 schema·fixture 불일치를 검출한다.
+- [Profile마다 여러 이미지가 함께 표시될 때 URL이 섞임] → leaf fragment별 소유와 서로 다른 fixture URL로 각 위치를 검증한다.
+- [ProfileSwitcher 이미지 연결이 actor 전환을 회귀시킴] → 기존 create/switch interaction과 selected Profile store 갱신 검증을 유지한 채 이미지 assertion만 추가한다.
+- [공개 또는 비로그인 Profile 조회에서 projection이 예상과 다름] → 제품 코드 완료 주장 전 API/Web runtime에서 Ready 이미지와 null 상태를 각각 관찰하고, 문제가 PROD-492 계약에 있으면 PROD-588에 우회 구현하지 않는다.
+- [동시에 active인 capability delta와 archive 충돌] → archive 직전에 `web-app-shell`·`notification` active changes와 base spec을 재대조하고 strict validation을 수행한다.
 
 ## Migration Plan
 
-DB 또는 데이터 migration은 없다. PR #435가 먼저 merge되도록 stacked PR base를 유지하고, 부모 merge 뒤 PROD-588 branch를 최신 `main` ancestry에 정렬한다. 배포는 앱 fragment와 presentation 변경만 포함하며 문제가 생기면 PROD-588 commit을 되돌려 기존 이니셜-only 표시로 복구할 수 있다.
+DB 또는 데이터 migration은 없다. PROD-492가 먼저 포함되는 stacked PR base를 유지한다. 배포는 앱 fragment와 presentation 변경만 포함하며 문제가 생기면 PROD-588 commit을 되돌려 기존 이니셜·gradient 표시로 복구할 수 있다. archive는 이 change의 전체 소비자 구현·검증이 끝난 뒤 최신 active capability 계약과 동기화해 수행한다.
 
 ## Open Questions
 
-없음. 비로그인 공개 조회와 실제 이미지 로드 결과는 구현 선택이 아니라 완료 전 runtime 검증 항목으로 남긴다.
+없음. 비로그인 공개 조회, 실제 이미지 로드 결과와 iOS·Android 실제 기기 QA는 구현 선택이 아니라 완료 전 보고에서 Web·자동화와 구분할 항목이다.

--- a/openspec/changes/show-post-author-avatar-images/proposal.md
+++ b/openspec/changes/show-post-author-avatar-images/proposal.md
@@ -1,21 +1,22 @@
 ## Why
 
-저장된 Profile avatar가 공개 조회에 제공되어도 게시글 목록과 상세의 작성자 영역은 이미지 URL을 조회하지 않아 항상 이니셜 fallback만 표시한다. PROD-492가 제공하는 Profile avatar 공개 표현과 기존 공용 Avatar의 이미지 렌더링을 게시글 presentation에 연결해 실제 작성자 이미지를 일관되게 표시해야 한다.
+PROD-492가 Profile의 Ready avatar/header 공개 URL과 이미지 표시가 가능한 공용 Avatar를 제공하지만, 현재 앱의 여러 production 소비자는 해당 URL을 Relay fragment에서 조회하거나 presentation에 전달하지 않아 이니셜 또는 임시 gradient만 표시한다. 게시글뿐 아니라 현재 Profile을 나타내는 공용 UI 전반에서 실제 Profile 이미지를 일관되게 표시해야 한다.
 
 ## What Changes
 
-- 홈·프로필·북마크 목록과 게시글 상세에서 작성자 Profile의 Ready avatar URL이 있으면 실제 이미지를 표시한다.
-- 일반 Post, 순수 Repost의 direct Source, Quote의 직접 작성자와 direct Source가 각자 자신의 avatar를 표시한다.
-- avatar 관계 또는 공개 URL이 없으면 현재 표시 이름·핸들 기반 이니셜 fallback을 유지한다.
-- 기존 작성자 Profile 이동, 접근성 이름, 목록 48px·상세 및 Source preview 40px 크기와 레이아웃을 유지한다.
-- 삭제된 `PostAuthorProfile` 재사용을 요구하는 오래된 active spec 문구를 PROD-588의 leaf consumer·공용 `Avatar` 계약에 맞춘다.
-- 게시글 leaf Relay fragment와 가장 가까운 Storybook 검증만 확장하며 avatar 업로드·저장·공개 정책, 공용 Avatar 재설계와 비게시글 소비자는 변경하지 않는다.
+- 홈·프로필·북마크 목록과 게시글 상세에서 일반 Post, Repost, Quote와 direct Source 작성자의 실제 Ready avatar 이미지를 표시한다.
+- `ProfileSwitcher`의 full·drawer·compact trigger와 프로필 전환 목록에 각 Profile의 실제 avatar를 표시하고, 활성 Profile의 Ready header URL이 있으면 기존 cover 영역에 실제 이미지를 표시한다.
+- 팔로워·팔로잉·Reaction 목록이 공유하는 `ProfileListItem`, `BottomTabBar`, `PostComposer`, `NotificationListItem`에 해당 Profile의 실제 avatar를 표시한다.
+- 각 leaf Relay fragment가 자신이 표시하는 Profile의 `avatar { id url }`을 조회하고 기존 `Avatar.imageUri`에 전달하며, 활성 Profile header를 표시하는 fragment만 `header { id url }`을 조회한다.
+- avatar 관계 또는 공개 URL이 없으면 기존 이니셜 fallback을 유지하고, header 관계 또는 공개 URL이 없으면 기존 gradient cover를 유지한다.
+- 기존 크기, 레이아웃, Profile 이동, 접근성 이름과 actor별 Relay Environment 전환 계약을 유지한다.
+- 알림 목록의 기존 initials-only 계약을 Ready avatar 이미지 우선·이니셜 fallback 계약으로 갱신한다.
 
 ## Authority / Provenance
 
 - Canonical: `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`; 적용되는 별도 `docs/design` 변경 없음
 - Linear Contract: [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
-- Linear Implementations: PROD-588; Profile avatar 공개 표현 제공 의존성 [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
+- Linear Implementations: PROD-588; Profile avatar/header 공개 표현 제공 의존성 [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
 
 ## Capabilities
 
@@ -26,11 +27,12 @@
 ### Modified Capabilities
 
 - `web-post`: 게시글 목록·상세와 direct Source 작성자가 Ready avatar 이미지를 우선 표시하고 이미지가 없을 때만 이니셜 fallback을 표시한다.
-- `web-app-shell`: 공용 `PostListItem`과 `PostLayout` 소비 화면에서 작성자별 avatar 이미지·fallback·기존 크기와 이동 계약을 일관되게 적용한다.
+- `web-app-shell`: `ProfileSwitcher`, 공용 `ProfileListItem`, `BottomTabBar`, `PostComposer`와 게시글 presentation이 각 Profile의 실제 이미지와 기존 fallback을 일관되게 표시한다.
+- `notification`: Follow·Reaction·Reply·Repost Notification 행이 Related Profile의 Ready avatar 이미지를 28px 공용 Avatar로 표시하고 이미지가 없을 때 이니셜 fallback을 유지한다.
 
 ## Impact
 
-- `apps/app`의 게시글 Relay fragment, `PostListItem`, `PostLayout`, `PostSourcePresentationView`와 기존 Posts Storybook 검증이 영향을 받는다.
-- PR #435의 `Profile.avatar { id url }`와 `Avatar.imageUri`를 선행 입력으로 사용한다.
+- `apps/app`의 게시글 presentation, `ProfileSwitcher`, `ProfileListItem`, `BottomTabBar`, `PostComposer`, `NotificationListItem` Relay fragment와 기존 Posts·Shell·Profiles·Reactions·Notifications Storybook 검증이 영향을 받는다.
+- PROD-492가 제공하는 `Profile.avatar { id url }`, `Profile.header { id url }`와 `Avatar.imageUri`를 선행 입력으로 사용한다.
 - PROD-588 자체에서 GraphQL schema, API resolver, DB migration, Media 공개 정책, 새 dependency는 변경하지 않는다.
-- PROD-596이 소유하는 기본 avatar asset과 네트워크 이미지 로드 실패 정책은 제외한다.
+- 공용 Avatar primitive 재설계, 업로드·저장·crop·thumbnail, Post 첨부 이미지, PROD-596의 기본 avatar asset, 네트워크 이미지 로드 실패 fallback과 iOS·Android 실제 기기 QA는 제외한다.

--- a/openspec/changes/show-post-author-avatar-images/proposal.md
+++ b/openspec/changes/show-post-author-avatar-images/proposal.md
@@ -4,7 +4,7 @@ PROD-492가 Profile의 Ready avatar/header 공개 URL과 이미지 표시가 가
 
 ## What Changes
 
-- 홈·프로필·북마크 목록과 게시글 상세에서 일반 Post, Repost, Quote와 direct Source 작성자의 실제 Ready avatar 이미지를 표시한다.
+- 홈·프로필·북마크 목록, 게시글 상세와 Reply Composer에서 일반 Post, Repost, Quote와 direct Source 작성자의 실제 Ready avatar 이미지를 표시한다.
 - `ProfileSwitcher`의 full·drawer·compact trigger와 프로필 전환 목록에 각 Profile의 실제 avatar를 표시하고, 활성 Profile의 Ready header URL이 있으면 기존 cover 영역에 실제 이미지를 표시한다.
 - 팔로워·팔로잉·Reaction 목록이 공유하는 `ProfileListItem`, `BottomTabBar`, `PostComposer`, `NotificationListItem`에 해당 Profile의 실제 avatar를 표시한다.
 - 각 leaf Relay fragment가 자신이 표시하는 Profile의 `avatar { id url }`을 조회하고 기존 `Avatar.imageUri`에 전달하며, 활성 Profile header를 표시하는 fragment만 `header { id url }`을 조회한다.
@@ -32,7 +32,7 @@ PROD-492가 Profile의 Ready avatar/header 공개 URL과 이미지 표시가 가
 
 ## Impact
 
-- `apps/app`의 게시글 presentation, `ProfileSwitcher`, `ProfileListItem`, `BottomTabBar`, `PostComposer`, `NotificationListItem` Relay fragment와 기존 Posts·Shell·Profiles·Reactions·Notifications Storybook 검증이 영향을 받는다.
+- `apps/app`의 게시글 presentation과 `ReplyComposerSurface`, `ProfileSwitcher`, `ProfileListItem`, `BottomTabBar`, `PostComposer`, `NotificationListItem` Relay fragment와 기존 Posts·Shell·Profiles·Reactions·Notifications Storybook 검증이 영향을 받는다.
 - PROD-492가 제공하는 `Profile.avatar { id url }`, `Profile.header { id url }`와 `Avatar.imageUri`를 선행 입력으로 사용한다.
 - PROD-588 자체에서 GraphQL schema, API resolver, DB migration, Media 공개 정책, 새 dependency는 변경하지 않는다.
 - 공용 Avatar primitive 재설계, 업로드·저장·crop·thumbnail, Post 첨부 이미지, PROD-596의 기본 avatar asset, 네트워크 이미지 로드 실패 fallback과 iOS·Android 실제 기기 QA는 제외한다.

--- a/openspec/changes/show-post-author-avatar-images/proposal.md
+++ b/openspec/changes/show-post-author-avatar-images/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+저장된 Profile avatar가 공개 조회에 제공되어도 게시글 목록과 상세의 작성자 영역은 이미지 URL을 조회하지 않아 항상 이니셜 fallback만 표시한다. PROD-492가 제공하는 Profile avatar 공개 표현과 기존 공용 Avatar의 이미지 렌더링을 게시글 presentation에 연결해 실제 작성자 이미지를 일관되게 표시해야 한다.
+
+## What Changes
+
+- 홈·프로필·북마크 목록과 게시글 상세에서 작성자 Profile의 Ready avatar URL이 있으면 실제 이미지를 표시한다.
+- 일반 Post, 순수 Repost의 direct Source, Quote의 직접 작성자와 direct Source가 각자 자신의 avatar를 표시한다.
+- avatar 관계 또는 공개 URL이 없으면 현재 표시 이름·핸들 기반 이니셜 fallback을 유지한다.
+- 기존 작성자 Profile 이동, 접근성 이름, 목록 48px·상세 및 Source preview 40px 크기와 레이아웃을 유지한다.
+- 삭제된 `PostAuthorProfile` 재사용을 요구하는 오래된 active spec 문구를 PROD-588의 leaf consumer·공용 `Avatar` 계약에 맞춘다.
+- 게시글 leaf Relay fragment와 가장 가까운 Storybook 검증만 확장하며 avatar 업로드·저장·공개 정책, 공용 Avatar 재설계와 비게시글 소비자는 변경하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`; 적용되는 별도 `docs/design` 변경 없음
+- Linear Contract: [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
+- Linear Implementations: PROD-588; Profile avatar 공개 표현 제공 의존성 [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `web-post`: 게시글 목록·상세와 direct Source 작성자가 Ready avatar 이미지를 우선 표시하고 이미지가 없을 때만 이니셜 fallback을 표시한다.
+- `web-app-shell`: 공용 `PostListItem`과 `PostLayout` 소비 화면에서 작성자별 avatar 이미지·fallback·기존 크기와 이동 계약을 일관되게 적용한다.
+
+## Impact
+
+- `apps/app`의 게시글 Relay fragment, `PostListItem`, `PostLayout`, `PostSourcePresentationView`와 기존 Posts Storybook 검증이 영향을 받는다.
+- PR #435의 `Profile.avatar { id url }`와 `Avatar.imageUri`를 선행 입력으로 사용한다.
+- PROD-588 자체에서 GraphQL schema, API resolver, DB migration, Media 공개 정책, 새 dependency는 변경하지 않는다.
+- PROD-596이 소유하는 기본 avatar asset과 네트워크 이미지 로드 실패 정책은 제외한다.

--- a/openspec/changes/show-post-author-avatar-images/specs/notification/spec.md
+++ b/openspec/changes/show-post-author-avatar-images/specs/notification/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Selected Profile Follow Notification 목록 UI
 
-**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 클라이언트는 selected Profile의 visible Follow Notification을 모바일과 Web에서 같은 단일 목록으로 제공하고 Relay connection과 actor cache를 Profile별로 격리해야 한다(MUST). 각 item의 Related Profile에 공개 Ready avatar URL이 있으면 28px 공용 Avatar로 실제 이미지를 표시하고 URL이 없으면 기존 이니셜 fallback을 표시해야 한다(MUST).
+**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/breakpoints.md`, `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, `PROD-277`, `PROD-372`, `PROD-541`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 클라이언트는 selected Profile의 visible Follow Notification을 모바일과 Web에서 같은 단일 목록으로 제공하고 Relay connection과 actor cache를 Profile별로 격리해야 한다(MUST). 각 item의 Related Profile에 공개 Ready avatar URL이 있으면 28px 공용 Avatar로 실제 이미지를 표시하고 URL이 없으면 기존 이니셜 fallback을 표시해야 한다(MUST).
 
 #### Scenario: 단일 Follow item 표시와 Profile link
 
@@ -24,8 +24,9 @@
 #### Scenario: 알림 화면 header와 단일 목록
 
 - **WHEN** 사용자가 `/notifications` 화면을 연다
-- **THEN** 화면은 `알림` 제목과 최소 44px의 `알림 설정 (준비 중)` disabled control을 표시한다
-- **AND** 설정 route가 추가되기 전에는 control이 navigation이나 임시 안내 action을 실행하지 않는다
+- **THEN** 화면은 `알림` 제목을 표시하고 설정 진입 control을 시각적으로 표시하지 않는다
+- **AND** `알림 설정 (준비 중)` 또는 같은 의미의 설정 진입 control을 접근성 트리에 button이나 다른 interactive element로 노출하지 않는다
+- **AND** 설정 control 없이도 mobile과 Web에서 제목의 정렬과 header 간격을 유지한다
 - **AND** `모두`·`멘션` 탭, 단독 `모두` section heading과 날짜별 heading을 표시하지 않는다
 
 #### Scenario: Read와 Unread 표시

--- a/openspec/changes/show-post-author-avatar-images/specs/notification/spec.md
+++ b/openspec/changes/show-post-author-avatar-images/specs/notification/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: Selected Profile Follow Notification 목록 UI
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 클라이언트는 selected Profile의 visible Follow Notification을 모바일과 Web에서 같은 단일 목록으로 제공하고 Relay connection과 actor cache를 Profile별로 격리해야 한다(MUST). 각 item의 Related Profile에 공개 Ready avatar URL이 있으면 28px 공용 Avatar로 실제 이미지를 표시하고 URL이 없으면 기존 이니셜 fallback을 표시해야 한다(MUST).
+
+#### Scenario: 단일 Follow item 표시와 Profile link
+
+- **WHEN** selected Profile의 connection이 Related Profile 한 명을 가진 visible Follow Notification을 반환한다
+- **THEN** 목록은 Figma Like 알림 행처럼 왼쪽 28px kind icon과 오른쪽 콘텐츠 column을 같은 상단선에 두고, 콘텐츠 첫 Avatar row에 28px 공용 Avatar와 상대 시각을 배치한 뒤 `OOO님이 팔로우했습니다` 문구를 그 아래에 표시한다
+- **AND** Avatar와 본문은 `Profile.relativeHandle`의 Profile route를 가리키는 link다
+- **AND** inline 맞팔로우, 빈 action 영역, snippet과 복수 사용자 aggregation을 만들지 않는다
+
+#### Scenario: Related Profile avatar image
+
+- **WHEN** Follow Notification의 Related Profile에 공개 URL을 가진 Ready avatar가 있다
+- **THEN** item의 28px 공용 Avatar는 해당 Profile의 실제 이미지를 표시한다
+
+#### Scenario: Related Profile avatar initial fallback
+
+- **WHEN** Follow Notification의 Related Profile에 avatar 관계가 없거나 공개 avatar URL을 제공할 수 없다
+- **THEN** item의 28px 공용 Avatar는 같은 Profile의 표시 이름 또는 핸들 기반 기존 이니셜 fallback을 표시한다
+
+#### Scenario: 알림 화면 header와 단일 목록
+
+- **WHEN** 사용자가 `/notifications` 화면을 연다
+- **THEN** 화면은 `알림` 제목과 최소 44px의 `알림 설정 (준비 중)` disabled control을 표시한다
+- **AND** 설정 route가 추가되기 전에는 control이 navigation이나 임시 안내 action을 실행하지 않는다
+- **AND** `모두`·`멘션` 탭, 단독 `모두` section heading과 날짜별 heading을 표시하지 않는다
+
+#### Scenario: Read와 Unread 표시
+
+- **WHEN** Follow item의 `readAt`이 `null`이다
+- **THEN** item은 `card` 기본 배경과 접근성 Unread 상태를 제공한다
+- **AND** `readAt`이 존재하면 같은 `card` 기본 배경을 사용하고 Unread 상태를 제공하지 않는다
+- **AND** Web에서는 pointer hover 중인 item만 `surface` 배경으로 강조한다
+- **AND** hover가 없는 native 화면은 Read 상태와 관계없이 `card` 기본 배경을 유지한다
+
+#### Scenario: Profile 이동과 Read side effect 분리
+
+- **WHEN** 사용자가 Follow item의 Avatar 또는 본문 link를 활성화한다
+- **THEN** 클라이언트는 Related Profile navigation을 즉시 시작한다
+- **AND** Read mutation의 pending, 실패 또는 재시도는 navigation을 지연, 취소 또는 되돌리지 않는다
+- **AND** client Read mutation과 Unread count cache 갱신은 `PROD-372`가 소유한다
+
+#### Scenario: 성공 payload 기반 item과 Recipient count 동기화
+
+- **WHEN** Avatar 또는 본문 link activation에서 시작한 Read mutation이 `notification`과 `recipientProfile` payload로 성공한다
+- **THEN** 클라이언트는 payload가 반환한 ID를 기준으로 item의 `readAt`과 정확한 Recipient Profile의 `unreadNotificationCount`를 Relay cache에 정규화한다
+- **AND** 현재 selected Profile을 cache target으로 다시 추론하거나 client-side count 산술, optimistic update와 성공 뒤 추가 refetch를 수행하지 않는다
+- **AND** 같은 Unread item에 대한 반복 activation 또는 동시 Read의 성공 payload는 서버가 보존한 동일 `readAt`과 일관된 visible Unread count를 반환하며, 어떤 순서로 적용되어도 같은 item/Recipient record로 수렴하고 다른 Profile cache를 변경하지 않는다
+
+#### Scenario: client Read 실패와 수렴
+
+- **WHEN** navigation과 독립적으로 시작한 Read mutation이 pending이거나 실패한다
+- **THEN** 클라이언트는 navigation을 유지하고 item 또는 count cache를 보정하지 않는다
+- **AND** 앱 수준 자동 retry나 오류 UI를 추가하지 않으며 이후 activation 또는 refetch에서 서버 source of truth로 수렴한다
+
+#### Scenario: Initial loading, error와 empty
+
+- **WHEN** selected Profile 목록의 첫 query가 진행 중이거나 실패하거나 visible edge 없이 성공한다
+- **THEN** 화면은 각 상태에 맞는 loading, 안전한 한국어 error와 retry, empty UI를 구분해 표시한다
+- **AND** backend error 원문이나 unavailable generic fallback을 표시하지 않는다
+
+#### Scenario: Native refresh와 다음 page
+
+- **WHEN** 사용자가 native pull-to-refresh를 실행한다
+- **THEN** 클라이언트는 selected Profile query를 다시 가져온다
+- **AND** Web은 별도 in-app refresh control을 표시하지 않고 browser의 표준 document reload를 사용한다
+- **AND** 다음 page는 20개 단위 Relay connection으로 요청하고 요청 중 중복 호출을 막는다
+- **AND** 다음 page가 실패하면 기존 item을 유지하고 같은 위치에서 재시도할 수 있다
+- **AND** route state가 edge를 수동 병합하거나 client-side filtering하지 않는다
+
+#### Scenario: selected Profile 전환
+
+- **WHEN** 사용자가 Recipient Profile A에서 B로 selected Profile을 전환한다
+- **THEN** actor별 Relay Environment와 Store가 바뀌고 목록은 Profile B를 target으로 다시 조회한다
+- **AND** Profile A의 edge, loading, error 또는 pagination 상태를 Profile B 목록에 재사용하지 않는다
+
+## ADDED Requirements
+
+### Requirement: Reaction·Reply·Repost Notification Related Profile avatar presentation
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 클라이언트는 visible Reaction·Reply·Repost Notification item이 나타내는 Related Profile의 공개 Ready avatar URL이 있으면 기존 28px 공용 Avatar로 실제 이미지를 표시하고, URL이 없으면 같은 Profile의 기존 이니셜 fallback을 표시해야 한다(MUST).
+
+#### Scenario: Related Profile avatar image by Notification subtype
+
+- **WHEN** visible Reaction, Reply 또는 Repost Notification의 Related Profile에 공개 URL을 가진 Ready avatar가 있다
+- **THEN** 각 item의 28px 공용 Avatar는 해당 item이 나타내는 Related Profile의 실제 이미지를 표시한다
+- **AND** 한 Notification의 avatar URL을 다른 item의 Related Profile에 재사용하지 않는다
+
+#### Scenario: Related Profile avatar fallback by Notification subtype
+
+- **WHEN** visible Reaction, Reply 또는 Repost Notification의 Related Profile에 avatar 관계가 없거나 공개 avatar URL을 제공할 수 없다
+- **THEN** 각 item의 28px 공용 Avatar는 같은 Profile의 표시 이름 또는 핸들 기반 기존 이니셜 fallback을 표시한다
+
+#### Scenario: Preserve Notification subtype presentation contracts
+
+- **WHEN** Reaction·Reply·Repost item이 실제 avatar 이미지 또는 이니셜 fallback을 표시한다
+- **THEN** 기존 28px 크기, kind icon, 문구, Related Post 이동, Read mutation과 actor별 Relay cache 격리 계약을 유지한다

--- a/openspec/changes/show-post-author-avatar-images/specs/web-app-shell/spec.md
+++ b/openspec/changes/show-post-author-avatar-images/specs/web-app-shell/spec.md
@@ -59,3 +59,41 @@
 
 - **WHEN** 게시글의 `content`가 비어 있다
 - **THEN** 시스템은 본문 영역 없이 작성자와 작성 시간만 표시하고 레이아웃이 깨지지 않는다
+
+## ADDED Requirements
+
+### Requirement: Production Profile avatar image presentation
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 앱 셸과 공용 Profile presentation의 production avatar 소비자는 자신이 표시하는 Profile의 공개 Ready avatar URL이 있으면 기존 공용 Avatar로 실제 이미지를 표시하고, URL이 없으면 기존 이니셜 fallback을 유지해야 한다(MUST).
+
+#### Scenario: Display ProfileSwitcher active avatar and header images
+
+- **WHEN** `ProfileSwitcher`가 공개 Ready avatar와 header URL을 가진 활성 Profile을 full·drawer 또는 compact surface에 표시한다
+- **THEN** 시스템은 해당 Profile의 실제 avatar를 기존 trigger 크기로 표시한다
+- **AND** full·drawer cover 영역은 해당 Profile의 실제 header 이미지를 기존 geometry 안에 표시한다
+
+#### Scenario: Display ProfileSwitcher profile option avatars
+
+- **WHEN** `ProfileSwitcher`가 접근 가능한 Profile 목록을 표시하고 각 Profile에 공개 Ready avatar URL이 있다
+- **THEN** 각 option은 자신이 나타내는 Profile의 실제 avatar 이미지를 기존 크기로 표시한다
+- **AND** 활성 Profile 표시와 Profile 생성·전환 mutation, Relay store 갱신과 actor별 Environment 재생성 계약을 유지한다
+
+#### Scenario: Keep ProfileSwitcher image fallbacks
+
+- **WHEN** 활성 Profile 또는 option Profile에 avatar 관계·공개 URL이 없거나 활성 Profile에 header 관계·공개 URL이 없다
+- **THEN** avatar 위치는 같은 Profile의 표시 이름·핸들 기반 기존 이니셜 fallback을 표시한다
+- **AND** full·drawer cover는 기존 gradient를 유지한다
+
+#### Scenario: Display shared ProfileListItem avatar image
+
+- **WHEN** 검색·팔로워·팔로잉 또는 Reaction Profile 목록이 공개 Ready avatar URL을 가진 Profile을 공용 `ProfileListItem`으로 표시한다
+- **THEN** 해당 행은 그 Profile의 실제 avatar 이미지를 기존 크기로 표시한다
+- **AND** 이미지가 없으면 같은 Profile의 기존 이니셜 fallback을 표시한다
+- **AND** 기존 Profile 이동, Follow action과 접근성 이름을 유지한다
+
+#### Scenario: Display active Profile avatar in BottomTabBar and PostComposer
+
+- **WHEN** `BottomTabBar` 또는 `PostComposer`가 공개 Ready avatar URL을 가진 활성 Profile을 표시한다
+- **THEN** 각 소비자는 활성 Profile의 실제 avatar 이미지를 기존 크기로 표시한다
+- **AND** 이미지가 없으면 기존 이니셜 fallback을 표시한다
+- **AND** 기존 탭·Profile 이동, composer 동작과 접근성 이름을 유지한다

--- a/openspec/changes/show-post-author-avatar-images/specs/web-app-shell/spec.md
+++ b/openspec/changes/show-post-author-avatar-images/specs/web-app-shell/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Post basic information display
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 게시글 디테일 페이지는 게시글의 기본 정보를 표시해야 한다(MUST). 표시 항목은 Plain Text 본문, 작성자(avatar·표시 이름·핸들), 작성 시각, 공개 범위이며, 색·반경은 시맨틱 디자인 토큰을 사용해 라이트/다크에 대응해야 한다(MUST).
+
+#### Scenario: Display post body and author
+
+- **WHEN** 표시할 활성 게시글이 있다
+- **THEN** 시스템은 Plain Text 본문을 줄바꿈을 보존해 표시하고, 작성자 표시 이름과 `relativeHandle`, 작성 시각, 공개 범위를 표시한다
+- **AND** 작성자 영역은 작성자의 `/${relativeHandle}` 프로필 페이지로 이동할 수 있다
+
+#### Scenario: Display post author avatar image
+
+- **WHEN** 현재 상세 Post 또는 표시되는 direct Source 작성자에게 공개 URL을 가진 Ready Profile avatar가 있다
+- **THEN** 시스템은 해당 작성자의 실제 avatar 이미지를 표시한다
+- **AND** 현재 상세 작성자는 40px avatar 크기를 유지한다
+
+#### Scenario: Author avatar initial fallback
+
+- **WHEN** 작성자에게 avatar 관계가 없거나 공개 avatar URL을 제공할 수 없다
+- **THEN** 시스템은 표시 이름(없으면 핸들)의 첫 글자를 대문자로 한 이니셜 avatar를 표시한다
+
+#### Scenario: Keep detail and source authors distinct
+
+- **WHEN** 게시글 상세가 현재 Post 작성자와 direct Source 작성자를 서로 다른 Profile로 표시한다
+- **THEN** 시스템은 각 위치에서 해당 Profile의 avatar 이미지 또는 fallback을 표시한다
+
+#### Scenario: Missing post content
+
+- **WHEN** 게시글에 표시할 본문 콘텐츠가 없다
+- **THEN** 시스템은 본문 영역을 비워도 레이아웃이 깨지지 않는다
+
+### Requirement: Post list item display
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 게시글 목록 항목 컴포넌트(`PostListItem`)는 게시글 한 건의 작성자 프로필(avatar·표시 이름·핸들), Plain Text 본문, 작성 시간을 표시해야 한다(MUST). 작성자 avatar는 공용 Avatar를 사용해 48px로 표시해야 한다(MUST). 필요한 데이터는 컴포넌트 자신의 fragment(`PostListItem_post`)로 선언하고, 공개 Ready avatar URL이 있으면 실제 이미지를 표시하며 URL이 없으면 이니셜 fallback을 표시해야 한다(MUST).
+
+#### Scenario: Item content display
+
+- **WHEN** 게시글 데이터(fragment ref)가 항목 컴포넌트에 전달된다
+- **THEN** 시스템은 좌측 avatar 거터와 우측 콘텐츠 컬럼 구조로 작성자 표시 이름·핸들, 본문, 작성 시간을 표시한다
+
+#### Scenario: Display list author avatar image
+
+- **WHEN** 목록에서 표시되는 일반 Post, 순수 Repost direct Source 또는 Quote 작성자에게 공개 URL을 가진 Ready Profile avatar가 있다
+- **THEN** 시스템은 해당 표시 위치에 그 작성자의 실제 avatar 이미지를 48px로 표시한다
+
+#### Scenario: Display list author avatar fallback
+
+- **WHEN** 목록에서 표시되는 작성자에게 avatar 관계가 없거나 공개 avatar URL을 제공할 수 없다
+- **THEN** 시스템은 해당 작성자의 표시 이름 또는 핸들 기반 이니셜 avatar를 48px로 표시한다
+
+#### Scenario: Keep list and source authors distinct
+
+- **WHEN** Repost 또는 Quote가 직접 작성자와 direct Source 작성자를 서로 다른 Profile로 표시한다
+- **THEN** 시스템은 각 표시 위치에서 해당 Profile의 avatar 이미지 또는 fallback을 표시한다
+
+#### Scenario: Empty body
+
+- **WHEN** 게시글의 `content`가 비어 있다
+- **THEN** 시스템은 본문 영역 없이 작성자와 작성 시간만 표시하고 레이아웃이 깨지지 않는다

--- a/openspec/changes/show-post-author-avatar-images/specs/web-post/spec.md
+++ b/openspec/changes/show-post-author-avatar-images/specs/web-post/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Post author profile display
 
-**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 웹 앱은 게시글 목록과 게시글 상세 페이지의 leaf GraphQL fragment가 소유하는 작성자 프로필 presentation을 제공하고, 작성자의 공개 Ready avatar URL이 있으면 공용 Avatar로 실제 이미지를 표시하며 URL이 없으면 이니셜 fallback을 표시해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 웹 앱은 게시글 목록, 게시글 상세 페이지와 Reply Composer의 leaf GraphQL fragment가 소유하는 작성자 프로필 presentation을 제공하고, 작성자의 공개 Ready avatar URL이 있으면 공용 Avatar로 실제 이미지를 표시하며 URL이 없으면 이니셜 fallback을 표시해야 한다(MUST).
 
 #### Scenario: Render author identity
 
@@ -21,7 +21,7 @@
 
 #### Scenario: Keep displayed author avatars distinct
 
-- **WHEN** Repost 또는 Quote presentation이 직접 작성자와 direct Source 작성자를 함께 또는 교대로 표시한다
+- **WHEN** Repost, Quote 또는 Reply Composer presentation이 직접 또는 parent 작성자와 direct Source 작성자를 함께 또는 교대로 표시한다
 - **THEN** 시스템은 표시되는 각 위치에서 그 위치가 나타내는 Profile의 avatar 이미지 또는 fallback을 사용한다
 - **AND** 한 작성자의 avatar URL을 다른 작성자에게 재사용하지 않는다
 
@@ -38,7 +38,7 @@
 #### Scenario: Preserve author avatar presentation contract
 
 - **WHEN** 시스템이 실제 avatar 이미지 또는 이니셜 fallback을 렌더링한다
-- **THEN** 목록의 48px avatar와 상세·Source preview의 40px avatar 크기를 유지한다
+- **THEN** 목록의 48px avatar와 상세·Reply Composer parent·Source preview의 40px avatar 크기를 유지한다
 - **AND** 기존 작성자 Profile 이동과 접근성 이름을 유지한다
 
 #### Scenario: Link to author profile when available

--- a/openspec/changes/show-post-author-avatar-images/specs/web-post/spec.md
+++ b/openspec/changes/show-post-author-avatar-images/specs/web-post/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Post author profile display
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, [PROD-588](https://linear.app/byulmaru/issue/PROD-588) — 웹 앱은 게시글 목록과 게시글 상세 페이지의 leaf GraphQL fragment가 소유하는 작성자 프로필 presentation을 제공하고, 작성자의 공개 Ready avatar URL이 있으면 공용 Avatar로 실제 이미지를 표시하며 URL이 없으면 이니셜 fallback을 표시해야 한다(MUST).
+
+#### Scenario: Render author identity
+
+- **WHEN** 게시글 작성자 표시 이름과 핸들이 제공된다
+- **THEN** 시스템은 작성자 표시 이름과 핸들을 함께 렌더링한다
+
+#### Scenario: Render ready author avatar image
+
+- **WHEN** 게시글 presentation이 공개 URL을 가진 Ready Profile avatar를 제공한다
+- **THEN** 시스템은 해당 작성자의 실제 avatar 이미지를 렌더링한다
+
+#### Scenario: Render author fallback avatar
+
+- **WHEN** 게시글 작성자 Profile에 avatar 관계가 없거나 공개 avatar URL을 제공할 수 없다
+- **THEN** 시스템은 표시 이름 또는 핸들 기반 이니셜 fallback avatar를 렌더링한다
+
+#### Scenario: Keep displayed author avatars distinct
+
+- **WHEN** Repost 또는 Quote presentation이 직접 작성자와 direct Source 작성자를 함께 또는 교대로 표시한다
+- **THEN** 시스템은 표시되는 각 위치에서 그 위치가 나타내는 Profile의 avatar 이미지 또는 fallback을 사용한다
+- **AND** 한 작성자의 avatar URL을 다른 작성자에게 재사용하지 않는다
+
+#### Scenario: Declare author profile fields as fragment
+
+- **WHEN** 부모 GraphQL query가 게시글 작성자 프로필을 조회한다
+- **THEN** 시스템은 실제 작성자 presentation을 소비하는 게시글 leaf fragment가 필요한 Profile 필드를 선언하고 부모 query가 해당 fragment를 spread할 수 있어야 한다
+
+#### Scenario: Keep layout with long author text
+
+- **WHEN** 작성자 표시 이름 또는 핸들이 긴 값이다
+- **THEN** 시스템은 게시글 목록 또는 상세 레이아웃을 깨지 않고 텍스트를 줄임 처리한다
+
+#### Scenario: Preserve author avatar presentation contract
+
+- **WHEN** 시스템이 실제 avatar 이미지 또는 이니셜 fallback을 렌더링한다
+- **THEN** 목록의 48px avatar와 상세·Source preview의 40px avatar 크기를 유지한다
+- **AND** 기존 작성자 Profile 이동과 접근성 이름을 유지한다
+
+#### Scenario: Link to author profile when available
+
+- **WHEN** 작성자 프로필 링크가 제공된다
+- **THEN** 시스템은 작성자 프로필 영역을 해당 링크로 이동 가능한 요소로 렌더링한다
+
+#### Scenario: Render without route dependency
+
+- **WHEN** 작성자 프로필 링크가 제공되지 않는다
+- **THEN** 시스템은 특정 라우트 구현에 의존하지 않고 작성자 정보를 non-interactive 요소로 렌더링한다

--- a/openspec/changes/show-post-author-avatar-images/tasks.md
+++ b/openspec/changes/show-post-author-avatar-images/tasks.md
@@ -20,7 +20,7 @@
 **Verification**
 
 - Relay compiler와 TypeScript가 일반 Post, Repost direct Source, Quote 직접 작성자·direct Source, 상세 fragment의 avatar shape를 검증한다.
-- 기존 Posts Storybook surface에서 작성자별 이미지 URL과 null fallback, 크기·이동·접근성 계약을 확인한다.
+- 기존 Posts Storybook surface에서 목록·상세 작성자별 이미지 URL과 null fallback, 크기·이동·접근성 계약을 확인한다.
 
 - [x] 1.1 게시글 leaf fragment가 각 표시 작성자의 `avatar { id url }`을 조회하고 목록·상세·Source presentation에 독립적으로 공급하게 한다.
 - [x] 1.2 실제 이미지와 이니셜 fallback 모두 기존 Avatar 크기·Profile 이동·접근성 이름·layout을 유지하게 한다.
@@ -36,7 +36,7 @@
 
 **Deliverable**
 
-현재 production의 나머지 Profile avatar 소비자와 ProfileSwitcher header가 각 Profile의 실제 Ready 이미지를 표시하고, URL이 없으면 기존 이니셜·gradient fallback을 유지한다.
+현재 production의 나머지 Profile avatar 소비자, Reply Composer의 parent·direct Source와 ProfileSwitcher header가 각 Profile의 실제 Ready 이미지를 표시하고, URL이 없으면 기존 이니셜·gradient fallback을 유지한다.
 
 **Guardrails**
 
@@ -47,11 +47,11 @@
 
 **Verification**
 
-- Relay compiler와 TypeScript가 각 production consumer의 avatar/header fragment shape를 검증한다.
+- Relay compiler와 TypeScript가 각 production consumer와 Reply Composer parent·direct Source의 avatar/header fragment shape를 검증한다.
 - 기존 Shell·Profiles·Reactions·Posts·Notifications Storybook surface에서 서로 다른 이미지와 null fallback을 확인한다.
 
 - [x] 2.1 `ProfileSwitcher`의 full·drawer·compact trigger와 전환 목록에 각 Profile avatar를 연결하고, 활성 Profile header 이미지·gradient fallback을 기존 전환 계약과 함께 유지한다.
-- [x] 2.2 공용 `ProfileListItem`, `BottomTabBar`, `PostComposer`가 자신이 표시하는 Profile avatar를 기존 크기·이동·접근성 계약으로 사용하게 한다.
+- [x] 2.2 공용 `ProfileListItem`, `BottomTabBar`, `PostComposer`와 `ReplyComposerSurface` parent·direct Source가 자신이 표시하는 Profile avatar를 기존 크기·이동·접근성 계약으로 사용하게 한다.
 - [x] 2.3 각 `NotificationListItem` subtype fragment가 Related Profile avatar를 조회해 28px 이미지 또는 기존 이니셜 fallback을 표시하게 한다.
 
 ## 3. PROD-588 최소 자동화 검증
@@ -81,7 +81,7 @@
 - [x] 3.1 Posts production fixture에 서로 구분되는 Ready avatar URL과 null 상태를 추가하고 게시글 변경 동작의 최소 assertion을 작성한다.
 - [x] 3.2 기존 게시글 범위의 Relay, app check, Storybook test와 static build를 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
 - [x] 3.3 Shell·Profiles·Reactions·Posts·Notifications의 확장 소비자 fixture와 최소 assertion을 추가한다.
-- [x] 3.4 확장 구현 뒤 Relay, app check, unit, Storybook test와 static build를 다시 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
+- [ ] 3.4 확장 구현 뒤 Relay, app check, unit, Storybook test와 static build를 다시 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
 
 ## 4. PROD-588 통합 검증과 OpenSpec 완료
 
@@ -95,7 +95,7 @@ PROD-588이 소유한 Web runtime과 공용 코드 경로 검증을 완료하고
 
 **Guardrails**
 
-- PROD-492가 먼저 포함되는 stacked ancestry와 PR base를 유지한다.
+- PROD-492가 통합된 최신 `main`을 PR base로 유지하고 PROD-588 고유 commit만 포함한다.
 - Web runtime 관찰을 Android·iOS 실제 기기 QA 완료 증거로 사용하지 않는다.
 - Android·iOS 공용 React Native 코드와 자동화 결과는 확인하되 실제 기기 QA는 이번 이슈에서 미실행으로 보고한다.
 - 모든 requirement와 task가 완료되기 전에는 change를 archive하지 않는다.
@@ -109,5 +109,5 @@ PROD-588이 소유한 Web runtime과 공용 코드 경로 검증을 완료하고
 - PR ancestry, base, hosted CI와 미실행 runtime QA를 최종 보고에 구분한다.
 
 - [ ] 4.1 Web 공용 경로에서 각 이미지·fallback과 기존 이동·접근성·Profile 전환 동작을 수동 확인한다.
-- [x] 4.2 app 전체 검증과 hosted CI를 통과시키고 Android·iOS 실제 기기 QA 미실행 여부를 기록한다.
+- [ ] 4.2 app 전체 검증과 hosted CI를 통과시키고 Android·iOS 실제 기기 QA 미실행 여부를 기록한다.
 - [ ] 4.3 canonical·Linear·delta specs·구현과 다른 active change를 다시 대조한 뒤 PROD-588 소유로 change를 archive하고 archive 후 strict validation을 통과시킨다.

--- a/openspec/changes/show-post-author-avatar-images/tasks.md
+++ b/openspec/changes/show-post-author-avatar-images/tasks.md
@@ -1,0 +1,81 @@
+## 1. PROD-588 게시글 작성자 avatar 연결
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`
+- [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
+- Profile avatar 공개 표현 의존성 [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
+
+**Deliverable**
+
+홈·프로필·북마크 목록과 게시글 상세에서 일반 Post, Repost, Quote의 각 표시 위치가 해당 작성자의 실제 Ready avatar 이미지를 표시하고, URL이 없으면 기존 이니셜 fallback을 표시한다.
+
+**Guardrails**
+
+- 각 표시 위치는 자신이 나타내는 Profile의 avatar만 사용한다.
+- 목록 48px, 상세·Source preview 40px 크기와 기존 Profile 이동·접근성 이름·layout을 유지한다.
+- PROD-492가 제공하는 Profile avatar 공개 projection과 공용 Avatar를 재사용하며 API·schema·migration·Media 정책이나 별도 primitive를 복제하지 않는다.
+- avatar 업로드·저장, 기본 avatar asset, 네트워크 이미지 로드 실패 정책과 비게시글 소비자는 변경하지 않는다.
+
+**Verification**
+
+- Relay compiler와 TypeScript가 일반 Post, Repost direct Source, Quote 직접 작성자·direct Source, 상세 fragment의 avatar shape를 검증한다.
+- 기존 Storybook surface에서 작성자별 이미지 URL과 null fallback, 크기·이동·접근성 계약을 확인한다.
+
+- [ ] 1.1 게시글 leaf fragment가 각 표시 작성자의 `avatar { id url }`을 조회하고 목록·상세·Source presentation에 독립적으로 공급하게 한다.
+- [ ] 1.2 실제 이미지와 이니셜 fallback 모두 기존 Avatar 크기·Profile 이동·접근성 이름·layout을 유지하게 한다.
+
+## 2. PROD-588 최소 자동화 검증
+
+**Authority / Provenance**
+
+- [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
+
+**Deliverable**
+
+작성자 avatar 이미지 연결과 null fallback, 서로 다른 직접 작성자·Source 작성자 선택이 기존 production-shaped 테스트 표면에서 회귀 가능하게 검증된다.
+
+**Guardrails**
+
+- 테스트 코드 범위: `apps/app/src/stories/Posts.stories.tsx`의 기존 production fragment fixture·interaction 영역 또는 같은 동작을 더 가깝게 직접 검증하는 기존 component/unit test 한 곳.
+- 테스트 필요성: 일반 목록·상세, 순수 Repost direct Source, Quote 직접 작성자·direct Source의 올바른 이미지 선택과 URL 부재 fallback, 기존 크기·Profile 이동·접근성 이름을 관찰 가능한 결과로 검증한다.
+- 테스트 제외 범위: 관련 없는 coverage 확대, 중복 조합, 새 test-only fixture·helper·harness, 광범위한 snapshot, Avatar primitive와 비게시글 소비자 테스트 변경.
+
+**Verification**
+
+- `pnpm --filter @kosmo/app relay`
+- `pnpm --filter @kosmo/app check`
+- `pnpm --filter @kosmo/app test:storybook`
+- `pnpm --filter @kosmo/app build-storybook`
+
+- [ ] 2.1 기존 production fragment fixture에 서로 구분되는 Ready avatar URL과 null avatar 상태를 추가하고 변경 동작의 최소 assertion을 작성한다.
+- [ ] 2.2 Relay, app check, Storybook test와 static build를 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
+
+## 3. PROD-588 통합 검증과 OpenSpec 완료
+
+**Authority / Provenance**
+
+- [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
+
+**Deliverable**
+
+PROD-588이 소유한 Web runtime과 공용 코드 경로 검증을 완료하고, 상위 계약·구현·검증 증거가 일치할 때 이 change를 active specs에 동기화해 archive한다.
+
+**Guardrails**
+
+- PR #435가 먼저 포함되는 stacked ancestry와 PR base를 유지한다.
+- Web runtime 관찰을 Android·iOS 실제 기기 QA 완료 증거로 사용하지 않는다.
+- Android·iOS 공용 React Native 코드와 자동화 결과는 확인하되 실제 기기 QA는 이번 이슈의 별도 승인 범위가 아니면 미실행으로 보고한다.
+- 모든 requirement와 task가 완료되기 전에는 change를 archive하지 않는다.
+
+**Verification**
+
+- root `pnpm dev`로 API·Web BFF·App을 기동하고 서비스 health를 확인한다.
+- Ready avatar와 null avatar를 가진 작성자의 홈·프로필·북마크 목록, 게시글 상세, Repost·Quote presentation을 Web에서 확인한다.
+- 구현 중에는 `pnpm exec openspec validate show-post-author-avatar-images --strict`, archive 뒤에는 `pnpm exec openspec validate --specs --strict`를 통과시킨다.
+- PR ancestry, base, hosted CI와 미실행 runtime QA를 최종 보고에 구분한다.
+
+- [ ] 3.1 Web 공용 경로에서 이미지·fallback·작성자별 Source 선택과 기존 이동·접근성 동작을 수동 확인한다.
+- [ ] 3.2 app 전체 검증과 hosted CI를 통과시키고 Android·iOS 실제 기기 QA 미실행 여부를 기록한다.
+- [ ] 3.3 canonical·Linear·delta specs·구현을 다시 대조한 뒤 PROD-588 소유로 change를 archive하고 archive 후 strict validation을 통과시킨다.

--- a/openspec/changes/show-post-author-avatar-images/tasks.md
+++ b/openspec/changes/show-post-author-avatar-images/tasks.md
@@ -23,8 +23,8 @@
 - Relay compiler와 TypeScript가 일반 Post, Repost direct Source, Quote 직접 작성자·direct Source, 상세 fragment의 avatar shape를 검증한다.
 - 기존 Storybook surface에서 작성자별 이미지 URL과 null fallback, 크기·이동·접근성 계약을 확인한다.
 
-- [ ] 1.1 게시글 leaf fragment가 각 표시 작성자의 `avatar { id url }`을 조회하고 목록·상세·Source presentation에 독립적으로 공급하게 한다.
-- [ ] 1.2 실제 이미지와 이니셜 fallback 모두 기존 Avatar 크기·Profile 이동·접근성 이름·layout을 유지하게 한다.
+- [x] 1.1 게시글 leaf fragment가 각 표시 작성자의 `avatar { id url }`을 조회하고 목록·상세·Source presentation에 독립적으로 공급하게 한다.
+- [x] 1.2 실제 이미지와 이니셜 fallback 모두 기존 Avatar 크기·Profile 이동·접근성 이름·layout을 유지하게 한다.
 
 ## 2. PROD-588 최소 자동화 검증
 
@@ -49,8 +49,8 @@
 - `pnpm --filter @kosmo/app test:storybook`
 - `pnpm --filter @kosmo/app build-storybook`
 
-- [ ] 2.1 기존 production fragment fixture에 서로 구분되는 Ready avatar URL과 null avatar 상태를 추가하고 변경 동작의 최소 assertion을 작성한다.
-- [ ] 2.2 Relay, app check, Storybook test와 static build를 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
+- [x] 2.1 기존 production fragment fixture에 서로 구분되는 Ready avatar URL과 null avatar 상태를 추가하고 변경 동작의 최소 assertion을 작성한다.
+- [x] 2.2 Relay, app check, Storybook test와 static build를 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
 
 ## 3. PROD-588 통합 검증과 OpenSpec 완료
 

--- a/openspec/changes/show-post-author-avatar-images/tasks.md
+++ b/openspec/changes/show-post-author-avatar-images/tasks.md
@@ -81,7 +81,7 @@
 - [x] 3.1 Posts production fixture에 서로 구분되는 Ready avatar URL과 null 상태를 추가하고 게시글 변경 동작의 최소 assertion을 작성한다.
 - [x] 3.2 기존 게시글 범위의 Relay, app check, Storybook test와 static build를 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
 - [x] 3.3 Shell·Profiles·Reactions·Posts·Notifications의 확장 소비자 fixture와 최소 assertion을 추가한다.
-- [ ] 3.4 확장 구현 뒤 Relay, app check, unit, Storybook test와 static build를 다시 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
+- [x] 3.4 확장 구현 뒤 Relay, app check, unit, Storybook test와 static build를 다시 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
 
 ## 4. PROD-588 통합 검증과 OpenSpec 완료
 
@@ -109,5 +109,5 @@ PROD-588이 소유한 Web runtime과 공용 코드 경로 검증을 완료하고
 - PR ancestry, base, hosted CI와 미실행 runtime QA를 최종 보고에 구분한다.
 
 - [ ] 4.1 Web 공용 경로에서 각 이미지·fallback과 기존 이동·접근성·Profile 전환 동작을 수동 확인한다.
-- [ ] 4.2 app 전체 검증과 hosted CI를 통과시키고 Android·iOS 실제 기기 QA 미실행 여부를 기록한다.
+- [x] 4.2 app 전체 검증과 hosted CI를 통과시키고 Android·iOS 실제 기기 QA 미실행 여부를 기록한다.
 - [ ] 4.3 canonical·Linear·delta specs·구현과 다른 active change를 다시 대조한 뒤 PROD-588 소유로 change를 archive하고 archive 후 strict validation을 통과시킨다.

--- a/openspec/changes/show-post-author-avatar-images/tasks.md
+++ b/openspec/changes/show-post-author-avatar-images/tasks.md
@@ -5,7 +5,7 @@
 - `docs/domain/objects/profile.md`
 - `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`
 - [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
-- Profile avatar 공개 표현 의존성 [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
+- Profile avatar/header 공개 표현 의존성 [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
 
 **Deliverable**
 
@@ -16,17 +16,45 @@
 - 각 표시 위치는 자신이 나타내는 Profile의 avatar만 사용한다.
 - 목록 48px, 상세·Source preview 40px 크기와 기존 Profile 이동·접근성 이름·layout을 유지한다.
 - PROD-492가 제공하는 Profile avatar 공개 projection과 공용 Avatar를 재사용하며 API·schema·migration·Media 정책이나 별도 primitive를 복제하지 않는다.
-- avatar 업로드·저장, 기본 avatar asset, 네트워크 이미지 로드 실패 정책과 비게시글 소비자는 변경하지 않는다.
 
 **Verification**
 
 - Relay compiler와 TypeScript가 일반 Post, Repost direct Source, Quote 직접 작성자·direct Source, 상세 fragment의 avatar shape를 검증한다.
-- 기존 Storybook surface에서 작성자별 이미지 URL과 null fallback, 크기·이동·접근성 계약을 확인한다.
+- 기존 Posts Storybook surface에서 작성자별 이미지 URL과 null fallback, 크기·이동·접근성 계약을 확인한다.
 
 - [x] 1.1 게시글 leaf fragment가 각 표시 작성자의 `avatar { id url }`을 조회하고 목록·상세·Source presentation에 독립적으로 공급하게 한다.
 - [x] 1.2 실제 이미지와 이니셜 fallback 모두 기존 Avatar 크기·Profile 이동·접근성 이름·layout을 유지하게 한다.
 
-## 2. PROD-588 최소 자동화 검증
+## 2. PROD-588 공용 Profile 이미지 소비자 연결
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`
+- [PROD-588](https://linear.app/byulmaru/issue/PROD-588)
+- Profile avatar/header 공개 표현 의존성 [PROD-492](https://linear.app/byulmaru/issue/PROD-492)
+
+**Deliverable**
+
+현재 production의 나머지 Profile avatar 소비자와 ProfileSwitcher header가 각 Profile의 실제 Ready 이미지를 표시하고, URL이 없으면 기존 이니셜·gradient fallback을 유지한다.
+
+**Guardrails**
+
+- 각 leaf Relay fragment가 자신이 표시하는 Profile image field를 소유한다.
+- 공용 Avatar primitive, ProfileSwitcher의 Profile 전환·actor Environment 계약, 기존 크기·layout·이동·접근성 이름을 변경하지 않는다.
+- header만 기존 cover 영역에서 별도 Image로 표시하며 null이면 gradient를 유지한다.
+- API·schema·migration·Media 정책, 업로드·저장·crop·thumbnail과 네트워크 이미지 로드 실패 정책을 변경하지 않는다.
+
+**Verification**
+
+- Relay compiler와 TypeScript가 각 production consumer의 avatar/header fragment shape를 검증한다.
+- 기존 Shell·Profiles·Reactions·Posts·Notifications Storybook surface에서 서로 다른 이미지와 null fallback을 확인한다.
+
+- [x] 2.1 `ProfileSwitcher`의 full·drawer·compact trigger와 전환 목록에 각 Profile avatar를 연결하고, 활성 Profile header 이미지·gradient fallback을 기존 전환 계약과 함께 유지한다.
+- [x] 2.2 공용 `ProfileListItem`, `BottomTabBar`, `PostComposer`가 자신이 표시하는 Profile avatar를 기존 크기·이동·접근성 계약으로 사용하게 한다.
+- [x] 2.3 각 `NotificationListItem` subtype fragment가 Related Profile avatar를 조회해 28px 이미지 또는 기존 이니셜 fallback을 표시하게 한다.
+
+## 3. PROD-588 최소 자동화 검증
 
 **Authority / Provenance**
 
@@ -34,25 +62,28 @@
 
 **Deliverable**
 
-작성자 avatar 이미지 연결과 null fallback, 서로 다른 직접 작성자·Source 작성자 선택이 기존 production-shaped 테스트 표면에서 회귀 가능하게 검증된다.
+실제 avatar/header 이미지와 null fallback, 서로 다른 Profile별 이미지 선택이 기존 production-shaped 테스트 표면에서 회귀 가능하게 검증된다.
 
 **Guardrails**
 
-- 테스트 코드 범위: `apps/app/src/stories/Posts.stories.tsx`의 기존 production fragment fixture·interaction 영역 또는 같은 동작을 더 가깝게 직접 검증하는 기존 component/unit test 한 곳.
-- 테스트 필요성: 일반 목록·상세, 순수 Repost direct Source, Quote 직접 작성자·direct Source의 올바른 이미지 선택과 URL 부재 fallback, 기존 크기·Profile 이동·접근성 이름을 관찰 가능한 결과로 검증한다.
-- 테스트 제외 범위: 관련 없는 coverage 확대, 중복 조합, 새 test-only fixture·helper·harness, 광범위한 snapshot, Avatar primitive와 비게시글 소비자 테스트 변경.
+- 테스트 코드 범위: 기존 `Posts.stories.tsx`, `Shell.stories.tsx`, `Profiles.stories.tsx`, `Reactions.stories.tsx`, `Notifications.stories.tsx`의 production fragment fixture·interaction 영역 또는 같은 동작을 더 가깝게 직접 검증하는 기존 component/unit test.
+- 테스트 필요성: 각 production consumer의 올바른 이미지 선택과 URL 부재 fallback, 기존 크기·Profile 이동·접근성 이름·Profile 전환 계약을 관찰 가능한 결과로 검증한다.
+- 테스트 제외 범위: 관련 없는 coverage 확대, 중복 조합, 새 test-only fixture·helper·harness, 광범위한 snapshot과 Avatar primitive 자체 테스트 변경.
 
 **Verification**
 
 - `pnpm --filter @kosmo/app relay`
 - `pnpm --filter @kosmo/app check`
+- `pnpm --filter @kosmo/app test`
 - `pnpm --filter @kosmo/app test:storybook`
 - `pnpm --filter @kosmo/app build-storybook`
 
-- [x] 2.1 기존 production fragment fixture에 서로 구분되는 Ready avatar URL과 null avatar 상태를 추가하고 변경 동작의 최소 assertion을 작성한다.
-- [x] 2.2 Relay, app check, Storybook test와 static build를 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
+- [x] 3.1 Posts production fixture에 서로 구분되는 Ready avatar URL과 null 상태를 추가하고 게시글 변경 동작의 최소 assertion을 작성한다.
+- [x] 3.2 기존 게시글 범위의 Relay, app check, Storybook test와 static build를 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
+- [x] 3.3 Shell·Profiles·Reactions·Posts·Notifications의 확장 소비자 fixture와 최소 assertion을 추가한다.
+- [ ] 3.4 확장 구현 뒤 Relay, app check, unit, Storybook test와 static build를 다시 통과시키고 생성 artifact가 commit 대상이 아닌지 확인한다.
 
-## 3. PROD-588 통합 검증과 OpenSpec 완료
+## 4. PROD-588 통합 검증과 OpenSpec 완료
 
 **Authority / Provenance**
 
@@ -64,18 +95,19 @@ PROD-588이 소유한 Web runtime과 공용 코드 경로 검증을 완료하고
 
 **Guardrails**
 
-- PR #435가 먼저 포함되는 stacked ancestry와 PR base를 유지한다.
+- PROD-492가 먼저 포함되는 stacked ancestry와 PR base를 유지한다.
 - Web runtime 관찰을 Android·iOS 실제 기기 QA 완료 증거로 사용하지 않는다.
-- Android·iOS 공용 React Native 코드와 자동화 결과는 확인하되 실제 기기 QA는 이번 이슈의 별도 승인 범위가 아니면 미실행으로 보고한다.
+- Android·iOS 공용 React Native 코드와 자동화 결과는 확인하되 실제 기기 QA는 이번 이슈에서 미실행으로 보고한다.
 - 모든 requirement와 task가 완료되기 전에는 change를 archive하지 않는다.
+- archive 직전에 같은 capability를 수정하는 다른 active change와 최신 base spec을 다시 대조한다.
 
 **Verification**
 
 - root `pnpm dev`로 API·Web BFF·App을 기동하고 서비스 health를 확인한다.
-- Ready avatar와 null avatar를 가진 작성자의 홈·프로필·북마크 목록, 게시글 상세, Repost·Quote presentation을 Web에서 확인한다.
+- Ready avatar/header와 null 상태를 가진 Profile을 사용해 게시글, ProfileSwitcher, ProfileListItem, BottomTabBar, PostComposer, NotificationListItem을 Web에서 확인한다.
 - 구현 중에는 `pnpm exec openspec validate show-post-author-avatar-images --strict`, archive 뒤에는 `pnpm exec openspec validate --specs --strict`를 통과시킨다.
 - PR ancestry, base, hosted CI와 미실행 runtime QA를 최종 보고에 구분한다.
 
-- [ ] 3.1 Web 공용 경로에서 이미지·fallback·작성자별 Source 선택과 기존 이동·접근성 동작을 수동 확인한다.
-- [ ] 3.2 app 전체 검증과 hosted CI를 통과시키고 Android·iOS 실제 기기 QA 미실행 여부를 기록한다.
-- [ ] 3.3 canonical·Linear·delta specs·구현을 다시 대조한 뒤 PROD-588 소유로 change를 archive하고 archive 후 strict validation을 통과시킨다.
+- [ ] 4.1 Web 공용 경로에서 각 이미지·fallback과 기존 이동·접근성·Profile 전환 동작을 수동 확인한다.
+- [ ] 4.2 app 전체 검증과 hosted CI를 통과시키고 Android·iOS 실제 기기 QA 미실행 여부를 기록한다.
+- [ ] 4.3 canonical·Linear·delta specs·구현과 다른 active change를 다시 대조한 뒤 PROD-588 소유로 change를 archive하고 archive 후 strict validation을 통과시킨다.


### PR DESCRIPTION
## 무엇을 변경했는지

- PROD-588 OpenSpec을 게시글 전용에서 앱 공용 Profile 이미지 소비 범위로 확장했습니다.
- 게시글 작성자와 Source, `ProfileSwitcher`, 공용 `ProfileListItem`, `BottomTabBar`, `PostComposer`, Follow·Reaction·Reply·Repost 알림에 실제 avatar 이미지를 연결했습니다.
- `ProfileSwitcher` 활성 Profile의 실제 header 이미지를 기존 cover 영역에 표시합니다.
- 각 leaf Relay fragment가 자신이 표시하는 Profile의 `avatar { id url }`과 필요한 `header { id url }`을 직접 조회합니다.
- 이미지 URL이 없으면 기존 이니셜 avatar와 gradient header fallback을 유지합니다.
- 기존 Storybook fixture에서 Profile별 URL 격리와 null fallback을 검증하고, Reply modal의 비동기 focus 복원 assertion을 안정화했습니다.

## 왜 변경했는지

PROD-492가 Profile의 공개 avatar/header URL과 image-capable `Avatar`를 제공하지만, 여러 production consumer가 해당 URL을 Relay에서 조회하거나 presentation에 전달하지 않아 실제 이미지가 표시되지 않았습니다. 앱에서 Profile을 나타내는 기존 표면에 실제 이미지를 일관되게 연결합니다.

## 이번 PR의 주요 결정

### 표시 위치별 Profile 이미지 소유

- 결정자: @yeeun-uwu
- 선택: 각 leaf consumer가 자신이 표시하는 Profile의 이미지 필드를 소유합니다.
- 고려한 대안: 상위 화면에서 하나의 URL을 주입하거나 공용 Avatar를 다시 설계하는 방식
- 이유: 게시글 작성자·Source, Profile 목록 행, 활성 Profile과 알림 Related Profile의 URL이 섞이지 않게 하면서 기존 컴포넌트를 재사용할 수 있습니다.
- 감수한 결과: 여러 leaf fragment에 동일한 nullable image field가 추가됩니다.
- 관련 근거: [PROD-588 OpenSpec decisions](openspec/changes/show-post-author-avatar-images/decisions.md)

### 기존 동작과 fallback 유지

- avatar URL이 없으면 기존 이니셜을 표시합니다.
- header URL이 없으면 기존 gradient cover를 표시합니다.
- 기존 크기, 레이아웃, 이동, 접근성 이름과 ProfileSwitcher의 mutation·actor별 Relay Environment 전환은 변경하지 않습니다.

### PROD-492 통합 후 main base

- 부모 PR #435가 squash merge되어 PR #438의 base가 `main`으로 자동 변경되었습니다.
- PROD-588 고유 7개 커밋만 `main` 위에 유지했습니다.
- API·GraphQL schema·DB·Media 공개 정책은 이 PR에서 변경하지 않습니다.

## 어떻게 확인할 수 있는지

- `pnpm exec openspec validate show-post-author-avatar-images --strict`
- Relay compiler: reader 85개, normalization 54개, operation text 92개 생성 검증 통과
- app unit 122/122 통과
- local branch app Storybook 233/233을 연속 2회 통과
- final PR merge ref hosted app Storybook 19파일·249/249 통과
- app Storybook static build 통과
- 최종 HEAD GitHub Lint/Test/Semgrep 통과
- 최종 HEAD 자유 리뷰·저장소 지침 리뷰·문서–코드 정합성 리뷰 모두 PASS
- API·Web BFF·App health 응답 확인

## 아직 어떤 문제가 남았는지

- 자동화 브라우저가 사용자의 로그인 세션을 공유받지 못해 실제 계정 데이터 기반 Web 수동 관찰은 남아 있습니다.
- iOS·Android 실제 기기 QA는 실행하지 않았습니다.
- Web 수동 확인과 다른 active notification delta 대조 후 OpenSpec을 archive해야 합니다.

Linear: PROD-588
