### PR TITLE
[PROD-595] Web 액션 hover target을 시각화한다

### DIFF
--- a/apps/app/src/components/post/PostActionBar.tsx
+++ b/apps/app/src/components/post/PostActionBar.tsx
@@ -1,6 +1,7 @@
 import { Bookmark, Heart, MessageCircle, MoreHorizontal } from 'lucide-react-native';
 import { StyleSheet, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
+import { useTheme } from '@/theme/ThemeProvider';
 import { PostActionControl } from './PostActionControl';
 import { usePostBookmarkAction } from './PostBookmarkAction';
 import { PostDeletionAction } from './PostDeletionAction';
@@ -69,6 +70,7 @@ export function PostActionBar({
   reply,
   repostExecution = execution,
 }: PostActionBarProps) {
+  const theme = useTheme();
   const data = useFragment(postActionBarPostFragment, post ?? null);
   const bookmarkAction = usePostBookmarkAction(
     data?.bookmark ?? null,
@@ -86,6 +88,7 @@ export function PostActionBar({
           count={reply.count}
           controlRef={reply.controlRef}
           expanded={reply.expanded}
+          hoverDisabled={execution.kind === 'resolution-required'}
           icon={MessageCircle}
           onPress={reply.onPress}
           processing={reply.processing}
@@ -109,8 +112,11 @@ export function PostActionBar({
             <PostActionControl
               accessibilityLabel="반응"
               active={hasReacted}
+              activeColor={theme.like}
               controlRef={ref}
               fillActive
+              hoverColor={theme.like}
+              hoverDisabled={execution.kind === 'resolution-required'}
               icon={Heart}
               menuExpanded={expanded}
               onPress={onPress}
@@ -126,6 +132,7 @@ export function PostActionBar({
           accessibilityLabel={resolvedBookmark.accessibilityLabel}
           active={resolvedBookmark.hasBookmarked}
           fillActive
+          hoverDisabled={execution.kind === 'resolution-required'}
           icon={Bookmark}
           onPress={resolvedBookmark.onPress}
           processing={resolvedBookmark.processing}

--- a/apps/app/src/components/post/PostActionBar.tsx
+++ b/apps/app/src/components/post/PostActionBar.tsx
@@ -117,6 +117,8 @@ export function PostActionBar({
               fillActive
               hoverColor={theme.like}
               hoverDisabled={execution.kind === 'resolution-required'}
+              hoverForegroundColor={theme.like}
+              hoverOpacity={0.3}
               icon={Heart}
               menuExpanded={expanded}
               onPress={onPress}

--- a/apps/app/src/components/post/PostActionControl.tsx
+++ b/apps/app/src/components/post/PostActionControl.tsx
@@ -17,6 +17,7 @@ type Icon = ComponentType<{
 
 type Props = {
   accessibilityLabel: string;
+  activeColor?: string;
   active?: boolean;
   alignToEnd?: boolean;
   count?: number;
@@ -29,12 +30,15 @@ type Props = {
   onPress: () => void;
   popupRole?: 'dialog' | 'menu';
   processing?: PostActionProcessingState;
+  hoverColor?: string;
+  hoverDisabled?: boolean;
   stateful?: boolean;
   testID: string;
 };
 
 export function PostActionControl({
   accessibilityLabel,
+  activeColor,
   active = false,
   alignToEnd = false,
   count,
@@ -47,6 +51,8 @@ export function PostActionControl({
   onPress,
   popupRole,
   processing = 'default',
+  hoverColor,
+  hoverDisabled = false,
   stateful = true,
   testID,
 }: Props) {
@@ -57,9 +63,11 @@ export function PostActionControl({
   const blocked = isPending || isDisabled;
   const color = blocked
     ? theme.textSecondary
-    : active || expanded
-      ? theme.primary
-      : theme.textSecondary;
+    : active
+      ? (activeColor ?? theme.primary)
+      : expanded
+        ? theme.primary
+        : theme.textSecondary;
   const accessibilityState: AccessibilityState = {
     busy: isPending,
     disabled: blocked,
@@ -89,7 +97,6 @@ export function PostActionControl({
       style={({ pressed }) => [
         styles.action,
         alignToEnd ? styles.alignToEnd : undefined,
-        hovered && !blocked ? [styles.hovered, { backgroundColor: theme.surface }] : undefined,
         blocked ? styles.blocked : pressed ? styles.pressed : undefined,
       ]}
     >
@@ -109,6 +116,13 @@ export function PostActionControl({
           style={styles.icon}
           testID={`post-action-${testID}-icon`}
         >
+          {hovered && !blocked && !hoverDisabled ? (
+            <View
+              aria-hidden
+              style={[styles.hover, { backgroundColor: hoverColor ?? theme.surface }]}
+              testID={`post-action-${testID}-hover`}
+            />
+          ) : null}
           <Icon
             color={color}
             fill={fillActive && active ? color : 'none'}
@@ -146,7 +160,21 @@ const styles = StyleSheet.create({
     fontSize: typography.md.fontSize,
     lineHeight: typography.md.fontSize,
   },
-  hovered: { borderRadius: radii.full },
-  icon: { alignItems: 'center', height: 16, justifyContent: 'center', width: 16 },
+  hover: {
+    borderRadius: radii.full,
+    height: 28,
+    left: -6,
+    pointerEvents: 'none',
+    position: 'absolute',
+    top: -6,
+    width: 28,
+  },
+  icon: {
+    alignItems: 'center',
+    height: 16,
+    justifyContent: 'center',
+    position: 'relative',
+    width: 16,
+  },
   pressed: { opacity: 0.72 },
 });

--- a/apps/app/src/components/post/PostActionControl.tsx
+++ b/apps/app/src/components/post/PostActionControl.tsx
@@ -65,15 +65,17 @@ export function PostActionControl({
   const isPending = processing === 'pending';
   const isDisabled = processing === 'disabled';
   const blocked = isPending || isDisabled;
-  const color = blocked
+  const countColor = blocked
     ? theme.textSecondary
     : active
       ? (activeColor ?? theme.primary)
-      : hovered && !hoverDisabled
-        ? (hoverForegroundColor ?? theme.primary)
-        : expanded
-          ? theme.primary
-          : theme.textSecondary;
+      : expanded
+        ? theme.primary
+        : theme.textSecondary;
+  const iconColor =
+    hovered && !blocked && !active && !hoverDisabled
+      ? (hoverForegroundColor ?? theme.primary)
+      : countColor;
   const accessibilityState: AccessibilityState = {
     busy: isPending,
     disabled: blocked,
@@ -110,7 +112,7 @@ export function PostActionControl({
         <ActivityIndicator
           accessible={false}
           aria-hidden
-          color={color}
+          color={iconColor}
           size={14}
           style={styles.icon}
           testID={`post-action-${testID}-spinner`}
@@ -139,8 +141,8 @@ export function PostActionControl({
             testID={`post-action-${testID}-glyph`}
           >
             <Icon
-              color={color}
-              fill={fillActive && active ? color : 'none'}
+              color={iconColor}
+              fill={fillActive && active ? iconColor : 'none'}
               size={16}
               strokeWidth={iconStrokeWidth}
             />
@@ -148,7 +150,7 @@ export function PostActionControl({
         </View>
       )}
       {formattedCount ? (
-        <Text numberOfLines={1} style={[styles.count, { color }]}>
+        <Text numberOfLines={1} style={[styles.count, { color: countColor }]}>
           {formattedCount}
         </Text>
       ) : null}

--- a/apps/app/src/components/post/PostActionControl.tsx
+++ b/apps/app/src/components/post/PostActionControl.tsx
@@ -1,6 +1,7 @@
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
+import { ActivityIndicator, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
-import { spacing, typography } from '@/theme/tokens';
+import { radii, spacing, typography } from '@/theme/tokens';
 import { formatPostActionCount } from './postActionCount';
 import type { ComponentType, Ref } from 'react';
 import type { AccessibilityState } from 'react-native';
@@ -50,6 +51,7 @@ export function PostActionControl({
   testID,
 }: Props) {
   const theme = useTheme();
+  const [hovered, setHovered] = useState(false);
   const isPending = processing === 'pending';
   const isDisabled = processing === 'disabled';
   const blocked = isPending || isDisabled;
@@ -79,12 +81,15 @@ export function PostActionControl({
       accessibilityRole="button"
       accessibilityState={stateful ? accessibilityState : undefined}
       disabled={blocked}
+      onHoverIn={Platform.OS === 'web' ? () => setHovered(true) : undefined}
+      onHoverOut={Platform.OS === 'web' ? () => setHovered(false) : undefined}
       onPress={onPress}
       ref={controlRef}
       testID={`post-action-${testID}`}
       style={({ pressed }) => [
         styles.action,
         alignToEnd ? styles.alignToEnd : undefined,
+        hovered && !blocked ? [styles.hovered, { backgroundColor: theme.surface }] : undefined,
         blocked ? styles.blocked : pressed ? styles.pressed : undefined,
       ]}
     >
@@ -141,6 +146,7 @@ const styles = StyleSheet.create({
     fontSize: typography.md.fontSize,
     lineHeight: typography.md.fontSize,
   },
+  hovered: { borderRadius: radii.full },
   icon: { alignItems: 'center', height: 16, justifyContent: 'center', width: 16 },
   pressed: { opacity: 0.72 },
 });

--- a/apps/app/src/components/post/PostActionControl.tsx
+++ b/apps/app/src/components/post/PostActionControl.tsx
@@ -32,6 +32,8 @@ type Props = {
   processing?: PostActionProcessingState;
   hoverColor?: string;
   hoverDisabled?: boolean;
+  hoverForegroundColor?: string;
+  hoverOpacity?: number;
   stateful?: boolean;
   testID: string;
 };
@@ -53,6 +55,8 @@ export function PostActionControl({
   processing = 'default',
   hoverColor,
   hoverDisabled = false,
+  hoverForegroundColor,
+  hoverOpacity = 1,
   stateful = true,
   testID,
 }: Props) {
@@ -65,9 +69,11 @@ export function PostActionControl({
     ? theme.textSecondary
     : active
       ? (activeColor ?? theme.primary)
-      : expanded
-        ? theme.primary
-        : theme.textSecondary;
+      : hovered && !hoverDisabled && hoverForegroundColor
+        ? hoverForegroundColor
+        : expanded
+          ? theme.primary
+          : theme.textSecondary;
   const accessibilityState: AccessibilityState = {
     busy: isPending,
     disabled: blocked,
@@ -119,7 +125,10 @@ export function PostActionControl({
           {hovered && !blocked && !hoverDisabled ? (
             <View
               aria-hidden
-              style={[styles.hover, { backgroundColor: hoverColor ?? theme.surface }]}
+              style={[
+                styles.hover,
+                { backgroundColor: hoverColor ?? theme.surface, opacity: hoverOpacity },
+              ]}
               testID={`post-action-${testID}-hover`}
             />
           ) : null}

--- a/apps/app/src/components/post/PostActionControl.tsx
+++ b/apps/app/src/components/post/PostActionControl.tsx
@@ -56,7 +56,7 @@ export function PostActionControl({
   hoverColor,
   hoverDisabled = false,
   hoverForegroundColor,
-  hoverOpacity = 1,
+  hoverOpacity = 0.3,
   stateful = true,
   testID,
 }: Props) {
@@ -69,8 +69,8 @@ export function PostActionControl({
     ? theme.textSecondary
     : active
       ? (activeColor ?? theme.primary)
-      : hovered && !hoverDisabled && hoverForegroundColor
-        ? hoverForegroundColor
+      : hovered && !hoverDisabled
+        ? (hoverForegroundColor ?? theme.primary)
         : expanded
           ? theme.primary
           : theme.textSecondary;
@@ -127,17 +127,24 @@ export function PostActionControl({
               aria-hidden
               style={[
                 styles.hover,
-                { backgroundColor: hoverColor ?? theme.surface, opacity: hoverOpacity },
+                { backgroundColor: hoverColor ?? theme.primary, opacity: hoverOpacity },
               ]}
               testID={`post-action-${testID}-hover`}
             />
           ) : null}
-          <Icon
-            color={color}
-            fill={fillActive && active ? color : 'none'}
-            size={16}
-            strokeWidth={iconStrokeWidth}
-          />
+          <View
+            accessible={false}
+            aria-hidden
+            style={styles.glyph}
+            testID={`post-action-${testID}-glyph`}
+          >
+            <Icon
+              color={color}
+              fill={fillActive && active ? color : 'none'}
+              size={16}
+              strokeWidth={iconStrokeWidth}
+            />
+          </View>
         </View>
       )}
       {formattedCount ? (
@@ -177,6 +184,15 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: -6,
     width: 28,
+    zIndex: 0,
+  },
+  glyph: {
+    alignItems: 'center',
+    height: 16,
+    justifyContent: 'center',
+    position: 'relative',
+    width: 16,
+    zIndex: 1,
   },
   icon: {
     alignItems: 'center',

--- a/apps/app/src/components/post/RepostAction.tsx
+++ b/apps/app/src/components/post/RepostAction.tsx
@@ -159,6 +159,7 @@ export function RepostAction({
             active={Boolean(data.viewerRepost)}
             controlRef={ref}
             count={data.repostCount}
+            hoverDisabled={execution.kind === 'resolution-required'}
             icon={Repeat2}
             iconStrokeWidth={2.7}
             menuExpanded={execution.kind === 'enabled' ? menuExpanded : false}

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -724,14 +724,22 @@ export const ActionBarCatalog: Story = {
     expect(within(defaultMore).queryByTestId('post-action-more-hover')).toBeNull();
 
     const defaultReaction = defaultToolbarCanvas.getByRole('button', { name: '반응' });
+    const defaultReactionIcon = defaultReaction.querySelector('svg');
+    expect(defaultReactionIcon).toHaveAttribute('stroke', colors.light.textSecondary);
+    expect(defaultReactionIcon).toHaveAttribute('fill', 'none');
     await userEvent.hover(defaultReaction);
     expect(defaultReaction).not.toHaveStyle({ backgroundColor: colors.light.like });
     const reactionHover = within(defaultReaction).getByTestId('post-action-reaction-hover');
     expect(reactionHover).toHaveStyle({ backgroundColor: colors.light.like });
+    expect(getComputedStyle(reactionHover).opacity).toBe('0.3');
     expect(getComputedStyle(reactionHover).borderRadius).toBe('999px');
     expect(getComputedStyle(reactionHover).height).toBe('28px');
     expect(getComputedStyle(reactionHover).width).toBe('28px');
+    expect(defaultReactionIcon).toHaveAttribute('stroke', colors.light.like);
+    expect(defaultReactionIcon).toHaveAttribute('fill', 'none');
     await userEvent.unhover(defaultReaction);
+    expect(defaultReactionIcon).toHaveAttribute('stroke', colors.light.textSecondary);
+    expect(defaultReactionIcon).toHaveAttribute('fill', 'none');
     expect(within(defaultReaction).queryByTestId('post-action-reaction-hover')).toBeNull();
 
     const activeBookmark = within(toolbars[2]!).getByRole('button', { name: /북마크/ });
@@ -754,9 +762,9 @@ export const ActionBarCatalog: Story = {
     await userEvent.hover(activeReaction);
     expect(activeReactionIcon).toHaveAttribute('stroke', colors.light.like);
     expect(activeReactionIcon).toHaveAttribute('fill', colors.light.like);
-    expect(within(activeReaction).getByTestId('post-action-reaction-hover')).toHaveStyle({
-      backgroundColor: colors.light.like,
-    });
+    const activeReactionHover = within(activeReaction).getByTestId('post-action-reaction-hover');
+    expect(activeReactionHover).toHaveStyle({ backgroundColor: colors.light.like });
+    expect(getComputedStyle(activeReactionHover).opacity).toBe('0.3');
     await userEvent.unhover(activeReaction);
     expect(activeReactionIcon).toHaveAttribute('stroke', colors.light.like);
     expect(activeReactionIcon).toHaveAttribute('fill', colors.light.like);

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -11,14 +11,14 @@ import {
   RecordSource,
   Store,
 } from 'relay-runtime';
-import { expect, fn, screen, spyOn, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fireEvent, fn, screen, spyOn, userEvent, waitFor, within } from 'storybook/test';
 import { PostActionBar } from '@/components/post/PostActionBar';
 import { formatPostActionCount } from '@/components/post/postActionCount';
 import { usePostReactionController } from '@/components/post/PostReactionController';
 import { PostReactionSummary } from '@/components/reaction/PostReactionSummary';
 import { RelayActorProvider, useRelayActor } from '@/relay/RelayActorProvider';
 import { SessionProvider } from '@/session/SessionProvider';
-import { spacing, typography } from '@/theme/tokens';
+import { colors, spacing, typography } from '@/theme/tokens';
 import PostActionBarStoryQueryNode from './__generated__/PostActionBarStoryQuery.graphql';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -647,6 +647,48 @@ export const ActionBarCatalog: Story = {
     expect(bookmarkButtons[0]?.querySelector('svg')).toHaveAttribute('fill', 'none');
     expect(reactionButtons[2]?.querySelector('svg')).not.toHaveAttribute('fill', 'none');
     expect(bookmarkButtons[2]?.querySelector('svg')).not.toHaveAttribute('fill', 'none');
+
+    const toolbars = canvas.getAllByRole('toolbar', { name: '액션 바' });
+    const defaultReply = defaultToolbarCanvas.getByRole('button', { name: '답글' });
+    const defaultMore = defaultToolbarCanvas.getByRole('button', { name: '더보기' });
+    const defaultReplyBounds = defaultReply.getBoundingClientRect();
+    const defaultMoreBounds = defaultMore.getBoundingClientRect();
+
+    await userEvent.hover(defaultReply);
+    expect(defaultReply).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(getComputedStyle(defaultReply).borderRadius).toBe('999px');
+    expect(defaultReply.getBoundingClientRect().width).toBe(defaultReplyBounds.width);
+    expect(defaultReply.getBoundingClientRect().height).toBe(defaultReplyBounds.height);
+
+    const pointerUser = userEvent.setup();
+    await pointerUser.pointer({ target: defaultReply, keys: '[MouseLeft>]' });
+    await waitFor(() => expect(getComputedStyle(defaultReply).opacity).toBe('0.72'));
+    expect(defaultReply).toHaveStyle({ backgroundColor: colors.light.surface });
+    await pointerUser.pointer({ target: defaultReply, keys: '[/MouseLeft]' });
+    await userEvent.unhover(defaultReply);
+    expect(getComputedStyle(defaultReply).opacity).toBe('1');
+
+    await userEvent.hover(defaultMore);
+    expect(defaultMore).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(getComputedStyle(defaultMore).borderRadius).toBe('999px');
+    expect(defaultMore.getBoundingClientRect().width).toBe(defaultMoreBounds.width);
+    expect(defaultMore.getBoundingClientRect().height).toBe(defaultMoreBounds.height);
+    await userEvent.unhover(defaultMore);
+    expect(defaultMore).not.toHaveStyle({ backgroundColor: colors.light.surface });
+
+    const activeBookmark = within(toolbars[2]!).getByRole('button', { name: /북마크/ });
+    expect(activeBookmark).toHaveAttribute('aria-pressed', 'true');
+    const activeBookmarkIcon = activeBookmark.querySelector('svg');
+    expect(activeBookmarkIcon).not.toHaveAttribute('fill', 'none');
+    await userEvent.hover(activeBookmark);
+    expect(activeBookmark).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(activeBookmarkIcon).not.toHaveAttribute('fill', 'none');
+    await userEvent.unhover(activeBookmark);
+    expect(activeBookmark).not.toHaveStyle({ backgroundColor: colors.light.surface });
+
+    const blockedReply = within(toolbars[3]!).getByRole('button', { name: '답글' });
+    fireEvent.pointerEnter(blockedReply);
+    expect(blockedReply).not.toHaveStyle({ backgroundColor: colors.light.surface });
   },
 };
 

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -676,15 +676,19 @@ export const ActionBarCatalog: Story = {
     expect(canvas.queryByTestId('post-action-reply-hover')).toBeNull();
 
     await userEvent.hover(defaultReply);
-    expect(defaultReply).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(defaultReply).not.toHaveStyle({ backgroundColor: colors.light.primary });
     const replyHover = within(defaultReply).getByTestId('post-action-reply-hover');
-    expect(replyHover).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(replyHover).toHaveStyle({ backgroundColor: colors.light.primary });
+    expect(getComputedStyle(replyHover).opacity).toBe('0.3');
     expect(getComputedStyle(replyHover).borderRadius).toBe('999px');
     expect(getComputedStyle(replyHover).height).toBe('28px');
     expect(getComputedStyle(replyHover).width).toBe('28px');
     expect(getComputedStyle(replyHover).pointerEvents).toBe('none');
+    const replyGlyph = within(defaultReply).getByTestId('post-action-reply-glyph');
+    expect(getComputedStyle(replyGlyph).zIndex).toBe('1');
     const replyHoverBounds = replyHover.getBoundingClientRect();
     const replyIconBounds = defaultReply.querySelector('svg')!.getBoundingClientRect();
+    expect(defaultReply.querySelector('svg')).toHaveAttribute('stroke', colors.light.primary);
     expect(replyHoverBounds.width).toBe(28);
     expect(replyHoverBounds.height).toBe(28);
     expect(replyHoverBounds.left + replyHoverBounds.width / 2).toBeCloseTo(
@@ -704,24 +708,47 @@ export const ActionBarCatalog: Story = {
     const pointerUser = userEvent.setup();
     await pointerUser.pointer({ target: defaultReply, keys: '[MouseLeft>]' });
     await waitFor(() => expect(getComputedStyle(defaultReply).opacity).toBe('0.72'));
-    expect(defaultReply).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(defaultReply).not.toHaveStyle({ backgroundColor: colors.light.primary });
     expect(within(defaultReply).getByTestId('post-action-reply-hover')).toBeVisible();
     await pointerUser.pointer({ target: defaultReply, keys: '[/MouseLeft]' });
     await userEvent.unhover(defaultReply);
     expect(getComputedStyle(defaultReply).opacity).toBe('1');
+    expect(defaultReply.querySelector('svg')).toHaveAttribute('stroke', colors.light.textSecondary);
     expect(within(defaultReply).queryByTestId('post-action-reply-hover')).toBeNull();
 
     await userEvent.hover(defaultMore);
-    expect(defaultMore).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(defaultMore).not.toHaveStyle({ backgroundColor: colors.light.primary });
     const moreHover = within(defaultMore).getByTestId('post-action-more-hover');
-    expect(moreHover).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(moreHover).toHaveStyle({ backgroundColor: colors.light.primary });
+    expect(getComputedStyle(moreHover).opacity).toBe('0.3');
     expect(getComputedStyle(moreHover).borderRadius).toBe('999px');
     expect(getComputedStyle(moreHover).height).toBe('28px');
     expect(getComputedStyle(moreHover).width).toBe('28px');
+    expect(defaultMore.querySelector('svg')).toHaveAttribute('stroke', colors.light.primary);
     expect(defaultMore.getBoundingClientRect().width).toBe(28);
     expect(defaultMore.getBoundingClientRect().height).toBe(28);
     await userEvent.unhover(defaultMore);
+    expect(defaultMore.querySelector('svg')).toHaveAttribute('stroke', colors.light.textSecondary);
     expect(within(defaultMore).queryByTestId('post-action-more-hover')).toBeNull();
+
+    for (const [label, testID] of [
+      ['재게시', 'repost'],
+      ['북마크', 'bookmark'],
+    ] as const) {
+      const button = defaultToolbarCanvas.getByRole('button', { name: label });
+      const icon = button.querySelector('svg');
+      await userEvent.hover(button);
+      const hover = within(button).getByTestId(`post-action-${testID}-hover`);
+      expect(hover).toHaveStyle({ backgroundColor: colors.light.primary });
+      expect(getComputedStyle(hover).opacity).toBe('0.3');
+      expect(icon).toHaveAttribute('stroke', colors.light.primary);
+      expect(
+        getComputedStyle(within(button).getByTestId(`post-action-${testID}-glyph`)).zIndex,
+      ).toBe('1');
+      await userEvent.unhover(button);
+      expect(icon).toHaveAttribute('stroke', colors.light.textSecondary);
+      expect(within(button).queryByTestId(`post-action-${testID}-hover`)).toBeNull();
+    }
 
     const defaultReaction = defaultToolbarCanvas.getByRole('button', { name: '반응' });
     const defaultReactionIcon = defaultReaction.querySelector('svg');
@@ -747,10 +774,13 @@ export const ActionBarCatalog: Story = {
     const activeBookmarkIcon = activeBookmark.querySelector('svg');
     expect(activeBookmarkIcon).not.toHaveAttribute('fill', 'none');
     await userEvent.hover(activeBookmark);
-    expect(activeBookmark).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(activeBookmark).not.toHaveStyle({ backgroundColor: colors.light.primary });
     expect(within(activeBookmark).getByTestId('post-action-bookmark-hover')).toHaveStyle({
-      backgroundColor: colors.light.surface,
+      backgroundColor: colors.light.primary,
     });
+    expect(
+      getComputedStyle(within(activeBookmark).getByTestId('post-action-bookmark-hover')).opacity,
+    ).toBe('0.3');
     expect(activeBookmarkIcon).not.toHaveAttribute('fill', 'none');
     await userEvent.unhover(activeBookmark);
     expect(within(activeBookmark).queryByTestId('post-action-bookmark-hover')).toBeNull();
@@ -772,7 +802,7 @@ export const ActionBarCatalog: Story = {
 
     const blockedReply = within(toolbars[3]!).getByRole('button', { name: '답글' });
     fireEvent.pointerEnter(blockedReply);
-    expect(blockedReply).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(blockedReply).not.toHaveStyle({ backgroundColor: colors.light.primary });
     expect(within(blockedReply).queryByTestId('post-action-reply-hover')).toBeNull();
 
     const resolutionToolbar = within(toolbars[4]!);

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -684,6 +684,7 @@ export const ActionBarCatalog: Story = {
     expect(getComputedStyle(replyHover).height).toBe('28px');
     expect(getComputedStyle(replyHover).width).toBe('28px');
     expect(getComputedStyle(replyHover).pointerEvents).toBe('none');
+    expect(getComputedStyle(replyHover).zIndex).toBe('0');
     const replyGlyph = within(defaultReply).getByTestId('post-action-reply-glyph');
     expect(getComputedStyle(replyGlyph).zIndex).toBe('1');
     const replyHoverBounds = replyHover.getBoundingClientRect();
@@ -700,6 +701,7 @@ export const ActionBarCatalog: Story = {
       0,
     );
     const replyCount = defaultReply.querySelector('[dir="auto"]') as HTMLElement;
+    expect(replyCount).toHaveStyle({ color: colors.light.textSecondary });
     const replyCountBounds = replyCount.getBoundingClientRect();
     expect(replyCountBounds.left - replyIconBounds.right).toBeCloseTo(spacing.xs, 0);
     expect(defaultReply.getBoundingClientRect().width).toBe(50);
@@ -741,10 +743,16 @@ export const ActionBarCatalog: Story = {
       const hover = within(button).getByTestId(`post-action-${testID}-hover`);
       expect(hover).toHaveStyle({ backgroundColor: colors.light.primary });
       expect(getComputedStyle(hover).opacity).toBe('0.3');
+      expect(getComputedStyle(hover).zIndex).toBe('0');
       expect(icon).toHaveAttribute('stroke', colors.light.primary);
       expect(
         getComputedStyle(within(button).getByTestId(`post-action-${testID}-glyph`)).zIndex,
       ).toBe('1');
+      if (testID === 'repost') {
+        expect(button.querySelector('[dir="auto"]')).toHaveStyle({
+          color: colors.light.textSecondary,
+        });
+      }
       await userEvent.unhover(button);
       expect(icon).toHaveAttribute('stroke', colors.light.textSecondary);
       expect(within(button).queryByTestId(`post-action-${testID}-hover`)).toBeNull();

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -524,6 +524,14 @@ function CatalogStory() {
           repostState="pending"
         />
       </Section>
+      <Section title="Resolution-required · hover blocked">
+        <PostActionBarFixture
+          bookmark={actionBarProps.bookmark}
+          execution={{ kind: 'resolution-required', reason: 'profile' }}
+          reply={actionBarProps.reply}
+          repostExecution={{ kind: 'resolution-required', reason: 'profile' }}
+        />
+      </Section>
       <Section title="Optional actions · More callback only">
         <PostActionBarFixture more={actionBarProps.more} repostState="hidden" />
       </Section>
@@ -651,44 +659,126 @@ export const ActionBarCatalog: Story = {
     const toolbars = canvas.getAllByRole('toolbar', { name: '액션 바' });
     const defaultReply = defaultToolbarCanvas.getByRole('button', { name: '답글' });
     const defaultMore = defaultToolbarCanvas.getByRole('button', { name: '더보기' });
-    const defaultReplyBounds = defaultReply.getBoundingClientRect();
-    const defaultMoreBounds = defaultMore.getBoundingClientRect();
+    const actionTargetSizes = [
+      ['답글', 50],
+      ['재게시', 50],
+      ['반응', 50],
+      ['북마크', 50],
+      ['더보기', 28],
+    ] as const;
+    for (const [label, width] of actionTargetSizes) {
+      const button = defaultToolbarCanvas.getByRole('button', { name: label });
+      const bounds = button.getBoundingClientRect();
+      expect(bounds.width).toBe(width);
+      expect(bounds.height).toBe(28);
+    }
+    expect(defaultToolbar.getBoundingClientRect().height).toBe(28);
+    expect(canvas.queryByTestId('post-action-reply-hover')).toBeNull();
 
     await userEvent.hover(defaultReply);
-    expect(defaultReply).toHaveStyle({ backgroundColor: colors.light.surface });
-    expect(getComputedStyle(defaultReply).borderRadius).toBe('999px');
-    expect(defaultReply.getBoundingClientRect().width).toBe(defaultReplyBounds.width);
-    expect(defaultReply.getBoundingClientRect().height).toBe(defaultReplyBounds.height);
+    expect(defaultReply).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    const replyHover = within(defaultReply).getByTestId('post-action-reply-hover');
+    expect(replyHover).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(getComputedStyle(replyHover).borderRadius).toBe('999px');
+    expect(getComputedStyle(replyHover).height).toBe('28px');
+    expect(getComputedStyle(replyHover).width).toBe('28px');
+    expect(getComputedStyle(replyHover).pointerEvents).toBe('none');
+    const replyHoverBounds = replyHover.getBoundingClientRect();
+    const replyIconBounds = defaultReply.querySelector('svg')!.getBoundingClientRect();
+    expect(replyHoverBounds.width).toBe(28);
+    expect(replyHoverBounds.height).toBe(28);
+    expect(replyHoverBounds.left + replyHoverBounds.width / 2).toBeCloseTo(
+      replyIconBounds.left + replyIconBounds.width / 2,
+      0,
+    );
+    expect(replyHoverBounds.top + replyHoverBounds.height / 2).toBeCloseTo(
+      replyIconBounds.top + replyIconBounds.height / 2,
+      0,
+    );
+    const replyCount = defaultReply.querySelector('[dir="auto"]') as HTMLElement;
+    const replyCountBounds = replyCount.getBoundingClientRect();
+    expect(replyCountBounds.left - replyIconBounds.right).toBeCloseTo(spacing.xs, 0);
+    expect(defaultReply.getBoundingClientRect().width).toBe(50);
+    expect(defaultReply.getBoundingClientRect().height).toBe(28);
 
     const pointerUser = userEvent.setup();
     await pointerUser.pointer({ target: defaultReply, keys: '[MouseLeft>]' });
     await waitFor(() => expect(getComputedStyle(defaultReply).opacity).toBe('0.72'));
-    expect(defaultReply).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(defaultReply).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(within(defaultReply).getByTestId('post-action-reply-hover')).toBeVisible();
     await pointerUser.pointer({ target: defaultReply, keys: '[/MouseLeft]' });
     await userEvent.unhover(defaultReply);
     expect(getComputedStyle(defaultReply).opacity).toBe('1');
+    expect(within(defaultReply).queryByTestId('post-action-reply-hover')).toBeNull();
 
     await userEvent.hover(defaultMore);
-    expect(defaultMore).toHaveStyle({ backgroundColor: colors.light.surface });
-    expect(getComputedStyle(defaultMore).borderRadius).toBe('999px');
-    expect(defaultMore.getBoundingClientRect().width).toBe(defaultMoreBounds.width);
-    expect(defaultMore.getBoundingClientRect().height).toBe(defaultMoreBounds.height);
-    await userEvent.unhover(defaultMore);
     expect(defaultMore).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    const moreHover = within(defaultMore).getByTestId('post-action-more-hover');
+    expect(moreHover).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(getComputedStyle(moreHover).borderRadius).toBe('999px');
+    expect(getComputedStyle(moreHover).height).toBe('28px');
+    expect(getComputedStyle(moreHover).width).toBe('28px');
+    expect(defaultMore.getBoundingClientRect().width).toBe(28);
+    expect(defaultMore.getBoundingClientRect().height).toBe(28);
+    await userEvent.unhover(defaultMore);
+    expect(within(defaultMore).queryByTestId('post-action-more-hover')).toBeNull();
+
+    const defaultReaction = defaultToolbarCanvas.getByRole('button', { name: '반응' });
+    await userEvent.hover(defaultReaction);
+    expect(defaultReaction).not.toHaveStyle({ backgroundColor: colors.light.like });
+    const reactionHover = within(defaultReaction).getByTestId('post-action-reaction-hover');
+    expect(reactionHover).toHaveStyle({ backgroundColor: colors.light.like });
+    expect(getComputedStyle(reactionHover).borderRadius).toBe('999px');
+    expect(getComputedStyle(reactionHover).height).toBe('28px');
+    expect(getComputedStyle(reactionHover).width).toBe('28px');
+    await userEvent.unhover(defaultReaction);
+    expect(within(defaultReaction).queryByTestId('post-action-reaction-hover')).toBeNull();
 
     const activeBookmark = within(toolbars[2]!).getByRole('button', { name: /북마크/ });
     expect(activeBookmark).toHaveAttribute('aria-pressed', 'true');
     const activeBookmarkIcon = activeBookmark.querySelector('svg');
     expect(activeBookmarkIcon).not.toHaveAttribute('fill', 'none');
     await userEvent.hover(activeBookmark);
-    expect(activeBookmark).toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(activeBookmark).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(within(activeBookmark).getByTestId('post-action-bookmark-hover')).toHaveStyle({
+      backgroundColor: colors.light.surface,
+    });
     expect(activeBookmarkIcon).not.toHaveAttribute('fill', 'none');
     await userEvent.unhover(activeBookmark);
-    expect(activeBookmark).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(within(activeBookmark).queryByTestId('post-action-bookmark-hover')).toBeNull();
+
+    const activeReaction = within(toolbars[2]!).getByRole('button', { name: '반응' });
+    const activeReactionIcon = activeReaction.querySelector('svg');
+    expect(activeReactionIcon).toHaveAttribute('stroke', colors.light.like);
+    expect(activeReactionIcon).toHaveAttribute('fill', colors.light.like);
+    await userEvent.hover(activeReaction);
+    expect(activeReactionIcon).toHaveAttribute('stroke', colors.light.like);
+    expect(activeReactionIcon).toHaveAttribute('fill', colors.light.like);
+    expect(within(activeReaction).getByTestId('post-action-reaction-hover')).toHaveStyle({
+      backgroundColor: colors.light.like,
+    });
+    await userEvent.unhover(activeReaction);
+    expect(activeReactionIcon).toHaveAttribute('stroke', colors.light.like);
+    expect(activeReactionIcon).toHaveAttribute('fill', colors.light.like);
+    expect(within(activeReaction).queryByTestId('post-action-reaction-hover')).toBeNull();
 
     const blockedReply = within(toolbars[3]!).getByRole('button', { name: '답글' });
     fireEvent.pointerEnter(blockedReply);
     expect(blockedReply).not.toHaveStyle({ backgroundColor: colors.light.surface });
+    expect(within(blockedReply).queryByTestId('post-action-reply-hover')).toBeNull();
+
+    const resolutionToolbar = within(toolbars[4]!);
+    for (const [label, testID] of [
+      ['답글', 'reply'],
+      ['재게시', 'repost'],
+      ['반응', 'reaction'],
+      ['북마크', 'bookmark'],
+    ] as const) {
+      const button = resolutionToolbar.getByRole('button', { name: label });
+      await userEvent.hover(button);
+      expect(within(button).queryByTestId(`post-action-${testID}-hover`)).toBeNull();
+      await userEvent.unhover(button);
+    }
   },
 };
 

--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -19,15 +19,18 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 
 ## Web hover target
 
-- Web의 비터치 pointer가 action 위에 머무르면 실제 interactive target 전체에 현재 theme의 `surface`
-  background를 표시한다. Reply, Repost, Reaction과 Bookmark의 50×28px target은 pill로, More의 28×28px
-  target은 원형으로 표시한다.
-- hover background는 target의 크기·padding·간격을 바꾸지 않으며 인접 action target과 겹치지 않는다.
-  icon과 count의 default·active 색, selected fill과 pressed opacity는 기존 상태 표현을 유지한다.
+- Web의 비터치 pointer가 action 위에 머무르면 16×16px glyph를 중심으로 한 28×28px 원형 background를
+  표시한다. Reply, Repost, Bookmark와 More는 현재 theme의 중립 `surface`를 사용하고 Reaction은 기존
+  semantic `like`의 옅은 분홍을 사용한다.
+- 원형 hover background는 실제 interactive target의 크기·padding·간격을 바꾸지 않는다. Reply, Repost,
+  Reaction과 Bookmark의 target은 계속 50×28px이고 More는 28×28px이며, background는 count를 감싸거나
+  인접 action target과 겹치지 않는다.
+- Reaction이 selected 상태이면 hover 여부와 관계없이 heart의 stroke와 fill에 `like`를 사용한다. 다른
+  action의 default·active 색, selected fill과 모든 action의 pressed opacity는 기존 상태 표현을 유지한다.
 - pending·disabled·resolution-required처럼 입력이 차단된 action은 hover background를 표시하지 않는다.
   Native와 Web touch 입력에는 hover 전용 background를 표시하지 않는다.
-- light·dark theme 모두 고정 색상 대신 semantic `surface` token을 사용한다. hover가 active·pressed·blocked
-  상태를 가리거나 별도 action 의미 색상을 만들지 않는다.
+- light·dark theme 모두 고정 색상 대신 semantic `surface`와 `like` token을 사용한다. Reply, Repost,
+  Bookmark와 More의 action별 tint는 후속 범위이며 이 변경에서는 추가하지 않는다.
 
 ## 플랫폼 rollout과 release gate
 
@@ -162,9 +165,9 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 - 모든 플랫폼 구현에서 Bar와 control 높이 28, Reply·More target의 content column 양끝 정렬, social action 너비 50, More target 너비 최소
   28, glyph 16, icon-count gap 4와 고정 순서를 검증한다. Web runtime에서는 각 target이 24×24 CSS px 자체를
   포함하고 서로 겹치지 않는지도 확인한다.
-- Web pointer hover에서는 전체 target의 `surface` background, 50×28 pill·28×28 원형 geometry와
-  active·pressed 상태 보존을 검증한다. blocked action, Web touch 입력과 Native에는 hover background가
-  나타나지 않는지 확인한다.
+- Web pointer hover에서는 glyph 중심 28×28 원형 background, social action의 50×28 click target과 More의
+  28×28 click target 보존, Reaction의 `like` hover·selected 표현과 기존 pressed 상태 보존을 검증한다.
+  blocked action, Web touch 입력과 Native에는 hover background가 나타나지 않는지 확인한다.
 - Web menu가 scroll container 밖에서 잘리지 않고 첫 item이 trigger pointer 지점을 덮는지, 같은 위치의
   두 번째 pointer 활성화로 item이 선택되는지 검증한다. More menu는 card 오른쪽이 trigger 오른쪽보다 5px
   바깥에 있고 첫 item 오른쪽은 trigger 오른쪽과 맞아 왼쪽으로 펼쳐지는지, Repost menu는 기존 시작

--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -20,9 +20,9 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 ## Web hover target
 
 - Web의 비터치 pointer가 action 위에 머무르면 16×16px glyph를 중심으로 한 28×28px 원형 background를
-  표시한다. Reply, Repost, Bookmark와 More는 현재 theme의 중립 `surface`를 사용하고 Reaction은 기존
-  semantic `like`를 30% opacity로 사용한다. Reaction의 heart foreground는 hover 동안 불투명 `like`를
-  사용해 옅은 원형 위에서도 glyph가 선명하게 보이게 한다.
+  표시한다. Reply, Repost, Bookmark와 More는 현재 theme의 semantic `primary`를 30% opacity로 사용하고
+  hover foreground에는 불투명 `primary`를 사용한다. Reaction은 기존 semantic `like`를 30% opacity로
+  사용하고 heart foreground에는 불투명 `like`를 사용해 옅은 원형 위에서도 glyph가 선명하게 보이게 한다.
 - 원형 hover background는 실제 interactive target의 크기·padding·간격을 바꾸지 않는다. Reply, Repost,
   Reaction과 Bookmark의 target은 계속 50×28px이고 More는 28×28px이며, background는 count를 감싸거나
   인접 action target과 겹치지 않는다.
@@ -31,8 +31,8 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
   hover가 끝나면 원형 background는 사라지고 미선택 Reaction의 foreground는 기존 default 색으로 돌아간다.
 - pending·disabled·resolution-required처럼 입력이 차단된 action은 hover background를 표시하지 않는다.
   Native와 Web touch 입력에는 hover 전용 background를 표시하지 않는다.
-- light·dark theme 모두 고정 색상 대신 semantic `surface`와 `like` token을 사용한다. Reply, Repost,
-  Bookmark와 More의 action별 tint는 후속 범위이며 이 변경에서는 추가하지 않는다.
+- light·dark theme 모두 고정 색상 대신 semantic `primary`와 `like` token을 사용한다. Reply, Repost,
+  Bookmark와 More를 서로 다른 tint로 분리하는 확장은 후속 범위이며 이 변경에서는 공통 `primary`를 사용한다.
 
 ## 플랫폼 rollout과 release gate
 
@@ -168,8 +168,9 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
   28, glyph 16, icon-count gap 4와 고정 순서를 검증한다. Web runtime에서는 각 target이 24×24 CSS px 자체를
   포함하고 서로 겹치지 않는지도 확인한다.
 - Web pointer hover에서는 glyph 중심 28×28 원형 background, social action의 50×28 click target과 More의
-  28×28 click target 보존, Reaction의 30% `like` background·불투명 `like` foreground·selected 표현과
-  기존 pressed 상태 보존을 검증한다.
+  28×28 click target 보존, 일반 action의 30% `primary` background·불투명 `primary` foreground,
+  Reaction의 30% `like` background·불투명 `like` foreground·selected 표현과 기존 pressed 상태 보존을
+  검증한다.
   blocked action, Web touch 입력과 Native에는 hover background가 나타나지 않는지 확인한다.
 - Web menu가 scroll container 밖에서 잘리지 않고 첫 item이 trigger pointer 지점을 덮는지, 같은 위치의
   두 번째 pointer 활성화로 item이 선택되는지 검증한다. More menu는 card 오른쪽이 trigger 오른쪽보다 5px

--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -21,12 +21,14 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 
 - Web의 비터치 pointer가 action 위에 머무르면 16×16px glyph를 중심으로 한 28×28px 원형 background를
   표시한다. Reply, Repost, Bookmark와 More는 현재 theme의 중립 `surface`를 사용하고 Reaction은 기존
-  semantic `like`의 옅은 분홍을 사용한다.
+  semantic `like`를 30% opacity로 사용한다. Reaction의 heart foreground는 hover 동안 불투명 `like`를
+  사용해 옅은 원형 위에서도 glyph가 선명하게 보이게 한다.
 - 원형 hover background는 실제 interactive target의 크기·padding·간격을 바꾸지 않는다. Reply, Repost,
   Reaction과 Bookmark의 target은 계속 50×28px이고 More는 28×28px이며, background는 count를 감싸거나
   인접 action target과 겹치지 않는다.
 - Reaction이 selected 상태이면 hover 여부와 관계없이 heart의 stroke와 fill에 `like`를 사용한다. 다른
   action의 default·active 색, selected fill과 모든 action의 pressed opacity는 기존 상태 표현을 유지한다.
+  hover가 끝나면 원형 background는 사라지고 미선택 Reaction의 foreground는 기존 default 색으로 돌아간다.
 - pending·disabled·resolution-required처럼 입력이 차단된 action은 hover background를 표시하지 않는다.
   Native와 Web touch 입력에는 hover 전용 background를 표시하지 않는다.
 - light·dark theme 모두 고정 색상 대신 semantic `surface`와 `like` token을 사용한다. Reply, Repost,
@@ -166,7 +168,8 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
   28, glyph 16, icon-count gap 4와 고정 순서를 검증한다. Web runtime에서는 각 target이 24×24 CSS px 자체를
   포함하고 서로 겹치지 않는지도 확인한다.
 - Web pointer hover에서는 glyph 중심 28×28 원형 background, social action의 50×28 click target과 More의
-  28×28 click target 보존, Reaction의 `like` hover·selected 표현과 기존 pressed 상태 보존을 검증한다.
+  28×28 click target 보존, Reaction의 30% `like` background·불투명 `like` foreground·selected 표현과
+  기존 pressed 상태 보존을 검증한다.
   blocked action, Web touch 입력과 Native에는 hover background가 나타나지 않는지 확인한다.
 - Web menu가 scroll container 밖에서 잘리지 않고 첫 item이 trigger pointer 지점을 덮는지, 같은 위치의
   두 번째 pointer 활성화로 item이 선택되는지 검증한다. More menu는 card 오른쪽이 trigger 오른쪽보다 5px

--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -23,6 +23,7 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
   표시한다. Reply, Repost, Bookmark와 More는 현재 theme의 semantic `primary`를 30% opacity로 사용하고
   hover foreground에는 불투명 `primary`를 사용한다. Reaction은 기존 semantic `like`를 30% opacity로
   사용하고 heart foreground에는 불투명 `like`를 사용해 옅은 원형 위에서도 glyph가 선명하게 보이게 한다.
+  Reply와 Repost의 count 색은 hover tint에 포함하지 않고 기존 default 또는 active 색을 유지한다.
 - 원형 hover background는 실제 interactive target의 크기·padding·간격을 바꾸지 않는다. Reply, Repost,
   Reaction과 Bookmark의 target은 계속 50×28px이고 More는 28×28px이며, background는 count를 감싸거나
   인접 action target과 겹치지 않는다.
@@ -169,8 +170,8 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
   포함하고 서로 겹치지 않는지도 확인한다.
 - Web pointer hover에서는 glyph 중심 28×28 원형 background, social action의 50×28 click target과 More의
   28×28 click target 보존, 일반 action의 30% `primary` background·불투명 `primary` foreground,
-  Reaction의 30% `like` background·불투명 `like` foreground·selected 표현과 기존 pressed 상태 보존을
-  검증한다.
+  Reply·Repost count 색 유지, Reaction의 30% `like` background·불투명 `like` foreground·selected 표현과
+  기존 pressed 상태 보존을 검증한다.
   blocked action, Web touch 입력과 Native에는 hover background가 나타나지 않는지 확인한다.
 - Web menu가 scroll container 밖에서 잘리지 않고 첫 item이 trigger pointer 지점을 덮는지, 같은 위치의
   두 번째 pointer 활성화로 item이 선택되는지 검증한다. More menu는 card 오른쪽이 trigger 오른쪽보다 5px

--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -17,6 +17,18 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 - Figma Action은 내부 상하 padding 4px을 포함한다. 목록 surface는 28px Action Bar 자체 geometry를 바꾸지
   않고 전용 slot의 상단 padding은 0, 하단 padding은 4px로 두어 아래 카드 구분선과 4px 간격을 만든다.
 
+## Web hover target
+
+- Web의 비터치 pointer가 action 위에 머무르면 실제 interactive target 전체에 현재 theme의 `surface`
+  background를 표시한다. Reply, Repost, Reaction과 Bookmark의 50×28px target은 pill로, More의 28×28px
+  target은 원형으로 표시한다.
+- hover background는 target의 크기·padding·간격을 바꾸지 않으며 인접 action target과 겹치지 않는다.
+  icon과 count의 default·active 색, selected fill과 pressed opacity는 기존 상태 표현을 유지한다.
+- pending·disabled·resolution-required처럼 입력이 차단된 action은 hover background를 표시하지 않는다.
+  Native와 Web touch 입력에는 hover 전용 background를 표시하지 않는다.
+- light·dark theme 모두 고정 색상 대신 semantic `surface` token을 사용한다. hover가 active·pressed·blocked
+  상태를 가리거나 별도 action 의미 색상을 만들지 않는다.
+
 ## 플랫폼 rollout과 release gate
 
 - 현재 출시 범위는 Web이며, 구현 drift를 막기 위해 Native platform file도 우선 같은 28px geometry를 사용한다.
@@ -150,6 +162,9 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 - 모든 플랫폼 구현에서 Bar와 control 높이 28, Reply·More target의 content column 양끝 정렬, social action 너비 50, More target 너비 최소
   28, glyph 16, icon-count gap 4와 고정 순서를 검증한다. Web runtime에서는 각 target이 24×24 CSS px 자체를
   포함하고 서로 겹치지 않는지도 확인한다.
+- Web pointer hover에서는 전체 target의 `surface` background, 50×28 pill·28×28 원형 geometry와
+  active·pressed 상태 보존을 검증한다. blocked action, Web touch 입력과 Native에는 hover background가
+  나타나지 않는지 확인한다.
 - Web menu가 scroll container 밖에서 잘리지 않고 첫 item이 trigger pointer 지점을 덮는지, 같은 위치의
   두 번째 pointer 활성화로 item이 선택되는지 검증한다. More menu는 card 오른쪽이 trigger 오른쪽보다 5px
   바깥에 있고 첫 item 오른쪽은 trigger 오른쪽과 맞아 왼쪽으로 펼쳐지는지, Repost menu는 기존 시작

--- a/openspec/changes/visualize-post-action-hover-target/.openspec.yaml
+++ b/openspec/changes/visualize-post-action-hover-target/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-30

--- a/openspec/changes/visualize-post-action-hover-target/decisions.md
+++ b/openspec/changes/visualize-post-action-hover-target/decisions.md
@@ -15,14 +15,15 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
   넓게 보였다. 시각 검토에서 Twitter-inspired action bar처럼 icon 중심 반응과 더 가벼운 selected Reaction
   색이 필요하다고 결정했다.
 - Decision Outcome: 모든 hover visual은 16×16 glyph 중심의 28×28 원형을 사용한다. Reply, Repost,
-  Bookmark와 More는 `surface`, Reaction은 `like`를 사용한다. selected Reaction heart의 stroke와 fill도
-  hover 여부와 관계없이 `like`를 사용한다. click target geometry는 유지한다.
+  Bookmark와 More는 `surface`를 사용한다. Reaction은 30% opacity의 `like` background 위에 불투명 `like`
+  heart foreground를 사용하고, selected Reaction heart의 stroke와 fill도 hover 여부와 관계없이 불투명
+  `like`를 사용한다. click target geometry는 유지한다.
 - Alternatives Considered: 모든 action별 tint는 장기 방향이지만 이 PR에서는 semantic token과 action mapping
   범위가 커져 제외했다. Reaction의 기존 `primary` 노랑 유지안은 heart 의미가 덜 분명해 선택하지 않았다.
-- Consequences: 공통 control에는 icon visual layer와 optional color override만 추가하고 action 기능이나 layout은
-  바꾸지 않는다.
-- Confirmation / Follow-up: light Web Storybook에서 원형 geometry, Reaction `like`, pressed·blocked와 click
-  target 불변을 검증한다. 다른 action tint는 후속 계약으로 다룬다.
+- Consequences: 공통 control에는 icon visual layer와 optional background color·opacity 및 foreground color
+  override만 추가하고 action 기능이나 layout은 바꾸지 않는다.
+- Confirmation / Follow-up: light Web Storybook에서 원형 geometry, Reaction 30% `like` background와 불투명
+  foreground, pressed·blocked와 click target 불변을 검증한다. 다른 action tint는 후속 계약으로 다룬다.
 
 ### Hover는 중립 surface와 기존 전체 target geometry를 사용한다 (Superseded)
 

--- a/openspec/changes/visualize-post-action-hover-target/decisions.md
+++ b/openspec/changes/visualize-post-action-hover-target/decisions.md
@@ -5,20 +5,38 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
 
 ## Decision Records
 
-### Hover는 중립 surface와 기존 전체 target geometry를 사용한다
+### Hover는 glyph 중심 원형과 Reaction like tint를 사용한다
 
 - Decision Date: 2026-07-31
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/post-action-bar.md`, PROD-595
 - Status: Active
+- Context / Problem: 전체 50×28 target 배경은 click 영역 표시가 강하고 compact social action의 icon 반응보다
+  넓게 보였다. 시각 검토에서 Twitter-inspired action bar처럼 icon 중심 반응과 더 가벼운 selected Reaction
+  색이 필요하다고 결정했다.
+- Decision Outcome: 모든 hover visual은 16×16 glyph 중심의 28×28 원형을 사용한다. Reply, Repost,
+  Bookmark와 More는 `surface`, Reaction은 `like`를 사용한다. selected Reaction heart의 stroke와 fill도
+  hover 여부와 관계없이 `like`를 사용한다. click target geometry는 유지한다.
+- Alternatives Considered: 모든 action별 tint는 장기 방향이지만 이 PR에서는 semantic token과 action mapping
+  범위가 커져 제외했다. Reaction의 기존 `primary` 노랑 유지안은 heart 의미가 덜 분명해 선택하지 않았다.
+- Consequences: 공통 control에는 icon visual layer와 optional color override만 추가하고 action 기능이나 layout은
+  바꾸지 않는다.
+- Confirmation / Follow-up: light Web Storybook에서 원형 geometry, Reaction `like`, pressed·blocked와 click
+  target 불변을 검증한다. 다른 action tint는 후속 계약으로 다룬다.
+
+### Hover는 중립 surface와 기존 전체 target geometry를 사용한다 (Superseded)
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-action-bar.md`, PROD-595
+- Status: Superseded
 - Context / Problem: 아이콘만 보이는 Web Action Bar에서 실제 클릭 가능한 target 범위를 hover 시 드러내야 한다.
 - Decision Outcome: 현재 theme의 `surface` background를 사용하고 50×28 social action은 pill, 28×28 More는
   원형으로 표시한다. 기존 active·pressed·blocked 표현과 target geometry를 보존한다.
 - Alternatives Considered: action별 semantic 색상은 새 token과 action별 prop을 요구하고 현재 승인 범위를
   넓히므로 선택하지 않았다. `primaryHover`는 selected·pressed 의미와 충돌해 사용하지 않는다.
-- Consequences: 공통 control 하나에서 모든 action에 동일 규칙을 적용하며 action 기능과 layout은 변경하지 않는다.
-- Confirmation / Follow-up: light Web Storybook에서 hover, active·pressed 보존, blocked 미표시와 geometry를
-  검증한다.
+- Consequences: 최초 구현과 검증 기록은 이력으로 유지하지만 현재 완료 계약으로 사용하지 않는다.
+- Confirmation / Follow-up: 위 glyph 중심 원형 결정이 이 결정을 대체한다.
 
 ### PROD-595는 theme provider를 확장하지 않는다
 
@@ -26,15 +44,15 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/design/colors.md`, `docs/design/post-action-bar.md`, PROD-595
 - Status: Active
-- Context / Problem: light·dark `surface` token은 존재하지만 현재 `ThemeProvider`가 light만 공급해 dark runtime
-  상태는 도달할 수 없다.
-- Decision Outcome: hover 구현은 `useTheme()`의 semantic `surface`를 소비하지만 `ThemeProvider`, production
-  dark 전환과 Storybook theme 선택 기반은 변경하지 않는다.
+- Context / Problem: light·dark `surface`와 `like` token은 존재하지만 현재 `ThemeProvider`가 light만 공급해
+  dark runtime 상태는 도달할 수 없다.
+- Decision Outcome: hover 구현은 `useTheme()`의 semantic `surface`와 `like`를 소비하지만 `ThemeProvider`,
+  production dark 전환과 Storybook theme 선택 기반은 변경하지 않는다.
 - Alternatives Considered: `ThemeProvider`에 optional theme 선택을 추가해 dark Storybook을 렌더링하는 안은
   사용자가 제외했다. 고정 light 색상 사용은 dual-mode token 정책을 위반하므로 허용하지 않는다.
 - Consequences: 현재 light Web만 자동·수동 검증하며 dark runtime은 완료 증거 없이 미검증으로 남는다.
-- Confirmation / Follow-up: 코드가 고정 색상 대신 semantic `surface`를 사용함을 확인하고 최종 보고와 PR에
-  dark runtime 미검증을 명시한다.
+- Confirmation / Follow-up: 코드가 고정 색상 대신 semantic `surface`와 `like`를 사용함을 확인하고 최종
+  보고와 PR에 dark runtime 미검증을 명시한다.
 
 ### 기존 Action Bar change와 archive 생명주기를 분리한다
 
@@ -58,4 +76,5 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
 
 ## Superseded Decisions
 
-- 없음.
+- `Hover는 중립 surface와 기존 전체 target geometry를 사용한다`는 2026-07-31 시각 검토와 승인된
+  `Hover는 glyph 중심 원형과 Reaction like tint를 사용한다` 결정으로 대체됐다.

--- a/openspec/changes/visualize-post-action-hover-target/decisions.md
+++ b/openspec/changes/visualize-post-action-hover-target/decisions.md
@@ -5,12 +5,32 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
 
 ## Decision Records
 
-### Hover는 glyph 중심 원형과 Reaction like tint를 사용한다
+### Hover는 glyph 중심 원형과 primary 또는 like tint를 사용한다
 
 - Decision Date: 2026-07-31
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/post-action-bar.md`, PROD-595
 - Status: Active
+- Context / Problem: glyph 중심 원형으로 보정한 뒤에도 일반 action의 불투명 `surface` background가 Web
+  페인팅 순서에서 glyph 위에 그려져 Reply, Repost, Bookmark와 More icon이 사라져 보였다. Reaction은 30%
+  `like` tint와 같은 색 foreground를 사용해 선명하게 보였다.
+- Decision Outcome: 모든 hover visual은 16×16 glyph 중심의 28×28 원형과 30% semantic tint background,
+  불투명 foreground를 사용한다. Reply, Repost, Bookmark와 More는 `primary`, Reaction은 `like`를 사용한다.
+  glyph를 background보다 명시적인 상위 layer에 두고 click target geometry를 유지한다.
+- Alternatives Considered: 일반 action을 계속 불투명 `surface`로 두는 안은 icon을 덮는 실제 시각 결과 때문에
+  제외했다. 액션마다 서로 다른 tint를 배정하는 안은 후속 방향으로 남기고 현재는 KOSMO 공통 `primary`로
+  통일했다.
+- Consequences: 공통 control의 기본 hover background·foreground가 `primary`로 바뀌고 Reaction만 `like`
+  override를 유지한다. action 기능이나 layout은 바뀌지 않는다.
+- Confirmation / Follow-up: light Web Storybook과 dev에서 일반 action의 30% `primary` background·불투명
+  foreground, Reaction의 기존 `like` 표현, layer 순서와 click target 불변을 검증한다.
+
+### Hover는 glyph 중심 원형과 Reaction like tint를 사용한다 (Superseded)
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-action-bar.md`, PROD-595
+- Status: Superseded
 - Context / Problem: 전체 50×28 target 배경은 click 영역 표시가 강하고 compact social action의 icon 반응보다
   넓게 보였다. 시각 검토에서 Twitter-inspired action bar처럼 icon 중심 반응과 더 가벼운 selected Reaction
   색이 필요하다고 결정했다.
@@ -22,8 +42,7 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
   범위가 커져 제외했다. Reaction의 기존 `primary` 노랑 유지안은 heart 의미가 덜 분명해 선택하지 않았다.
 - Consequences: 공통 control에는 icon visual layer와 optional background color·opacity 및 foreground color
   override만 추가하고 action 기능이나 layout은 바꾸지 않는다.
-- Confirmation / Follow-up: light Web Storybook에서 원형 geometry, Reaction 30% `like` background와 불투명
-  foreground, pressed·blocked와 click target 불변을 검증한다. 다른 action tint는 후속 계약으로 다룬다.
+- Confirmation / Follow-up: 위 `primary` 또는 `like` tint 결정이 이 결정을 대체한다.
 
 ### Hover는 중립 surface와 기존 전체 target geometry를 사용한다 (Superseded)
 
@@ -45,14 +64,14 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/design/colors.md`, `docs/design/post-action-bar.md`, PROD-595
 - Status: Active
-- Context / Problem: light·dark `surface`와 `like` token은 존재하지만 현재 `ThemeProvider`가 light만 공급해
+- Context / Problem: light·dark `primary`와 `like` token은 존재하지만 현재 `ThemeProvider`가 light만 공급해
   dark runtime 상태는 도달할 수 없다.
-- Decision Outcome: hover 구현은 `useTheme()`의 semantic `surface`와 `like`를 소비하지만 `ThemeProvider`,
+- Decision Outcome: hover 구현은 `useTheme()`의 semantic `primary`와 `like`를 소비하지만 `ThemeProvider`,
   production dark 전환과 Storybook theme 선택 기반은 변경하지 않는다.
 - Alternatives Considered: `ThemeProvider`에 optional theme 선택을 추가해 dark Storybook을 렌더링하는 안은
   사용자가 제외했다. 고정 light 색상 사용은 dual-mode token 정책을 위반하므로 허용하지 않는다.
 - Consequences: 현재 light Web만 자동·수동 검증하며 dark runtime은 완료 증거 없이 미검증으로 남는다.
-- Confirmation / Follow-up: 코드가 고정 색상 대신 semantic `surface`와 `like`를 사용함을 확인하고 최종
+- Confirmation / Follow-up: 코드가 고정 색상 대신 semantic `primary`와 `like`를 사용함을 확인하고 최종
   보고와 PR에 dark runtime 미검증을 명시한다.
 
 ### 기존 Action Bar change와 archive 생명주기를 분리한다
@@ -77,5 +96,8 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
 
 ## Superseded Decisions
 
+- `Hover는 glyph 중심 원형과 Reaction like tint를 사용한다`는 일반 action icon이 불투명 `surface`에 덮이는
+  2026-07-31 시각 검토 결과와 승인된 `Hover는 glyph 중심 원형과 primary 또는 like tint를 사용한다` 결정으로
+  대체됐다.
 - `Hover는 중립 surface와 기존 전체 target geometry를 사용한다`는 2026-07-31 시각 검토와 승인된
   `Hover는 glyph 중심 원형과 Reaction like tint를 사용한다` 결정으로 대체됐다.

--- a/openspec/changes/visualize-post-action-hover-target/decisions.md
+++ b/openspec/changes/visualize-post-action-hover-target/decisions.md
@@ -16,12 +16,12 @@ PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표�
   `like` tint와 같은 색 foreground를 사용해 선명하게 보였다.
 - Decision Outcome: 모든 hover visual은 16×16 glyph 중심의 28×28 원형과 30% semantic tint background,
   불투명 foreground를 사용한다. Reply, Repost, Bookmark와 More는 `primary`, Reaction은 `like`를 사용한다.
-  glyph를 background보다 명시적인 상위 layer에 두고 click target geometry를 유지한다.
+  glyph를 background보다 명시적인 상위 layer에 두고 Reply·Repost count 색과 click target geometry를 유지한다.
 - Alternatives Considered: 일반 action을 계속 불투명 `surface`로 두는 안은 icon을 덮는 실제 시각 결과 때문에
   제외했다. 액션마다 서로 다른 tint를 배정하는 안은 후속 방향으로 남기고 현재는 KOSMO 공통 `primary`로
   통일했다.
-- Consequences: 공통 control의 기본 hover background·foreground가 `primary`로 바뀌고 Reaction만 `like`
-  override를 유지한다. action 기능이나 layout은 바뀌지 않는다.
+- Consequences: 공통 control의 기본 hover background·glyph foreground가 `primary`로 바뀌고 Reaction만
+  `like` override를 유지한다. count 색, action 기능과 layout은 바뀌지 않는다.
 - Confirmation / Follow-up: light Web Storybook과 dev에서 일반 action의 30% `primary` background·불투명
   foreground, Reaction의 기존 `like` 표현, layer 순서와 click target 불변을 검증한다.
 

--- a/openspec/changes/visualize-post-action-hover-target/decisions.md
+++ b/openspec/changes/visualize-post-action-hover-target/decisions.md
@@ -1,0 +1,61 @@
+## Context
+
+PROD-595와 `docs/design/post-action-bar.md`가 확정한 Web hover target 표현, 현재 공통
+`PostActionControl`·theme 경계, PROD-432 위 stack과 사용자가 선택한 dark runtime 제외 범위를 기록한다.
+
+## Decision Records
+
+### Hover는 중립 surface와 기존 전체 target geometry를 사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-action-bar.md`, PROD-595
+- Status: Active
+- Context / Problem: 아이콘만 보이는 Web Action Bar에서 실제 클릭 가능한 target 범위를 hover 시 드러내야 한다.
+- Decision Outcome: 현재 theme의 `surface` background를 사용하고 50×28 social action은 pill, 28×28 More는
+  원형으로 표시한다. 기존 active·pressed·blocked 표현과 target geometry를 보존한다.
+- Alternatives Considered: action별 semantic 색상은 새 token과 action별 prop을 요구하고 현재 승인 범위를
+  넓히므로 선택하지 않았다. `primaryHover`는 selected·pressed 의미와 충돌해 사용하지 않는다.
+- Consequences: 공통 control 하나에서 모든 action에 동일 규칙을 적용하며 action 기능과 layout은 변경하지 않는다.
+- Confirmation / Follow-up: light Web Storybook에서 hover, active·pressed 보존, blocked 미표시와 geometry를
+  검증한다.
+
+### PROD-595는 theme provider를 확장하지 않는다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/colors.md`, `docs/design/post-action-bar.md`, PROD-595
+- Status: Active
+- Context / Problem: light·dark `surface` token은 존재하지만 현재 `ThemeProvider`가 light만 공급해 dark runtime
+  상태는 도달할 수 없다.
+- Decision Outcome: hover 구현은 `useTheme()`의 semantic `surface`를 소비하지만 `ThemeProvider`, production
+  dark 전환과 Storybook theme 선택 기반은 변경하지 않는다.
+- Alternatives Considered: `ThemeProvider`에 optional theme 선택을 추가해 dark Storybook을 렌더링하는 안은
+  사용자가 제외했다. 고정 light 색상 사용은 dual-mode token 정책을 위반하므로 허용하지 않는다.
+- Consequences: 현재 light Web만 자동·수동 검증하며 dark runtime은 완료 증거 없이 미검증으로 남는다.
+- Confirmation / Follow-up: 코드가 고정 색상 대신 semantic `surface`를 사용함을 확인하고 최종 보고와 PR에
+  dark runtime 미검증을 명시한다.
+
+### 기존 Action Bar change와 archive 생명주기를 분리한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/post-action-bar.md`, PROD-595, PROD-432
+- Status: Active
+- Context / Problem: `add-post-action-bar`는 PROD-432가 선행 action 통합 뒤 archive하는 active change이고,
+  PROD-595는 PROD-432 뒤에 merge되는 별도 구현 slice다.
+- Decision Outcome: PROD-595는 `visualize-post-action-hover-target` change를 소유하고 `add-post-action-bar`의
+  task 또는 archive gate를 변경하지 않는다.
+- Alternatives Considered: 기존 change에 PROD-595를 추가하면 PROD-432 archive와 PROD-595의 blocked stack
+  사이에 순환 생명주기가 생기므로 선택하지 않았다. OpenSpec을 생략하면 새 hover 상태 계약과 검증 경계가
+  durable spec에 남지 않아 선택하지 않았다.
+- Consequences: PROD-595 PR은 PROD-432 위에 stack하되 자체 spec·tasks·검증과 이후 archive 책임을 가진다.
+- Confirmation / Follow-up: PR base를 `prod-432`로 유지하고 이 change만 strict validation한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/visualize-post-action-hover-target/design.md
+++ b/openspec/changes/visualize-post-action-hover-target/design.md
@@ -1,9 +1,9 @@
 ## Context
 
 `PostActionControl`은 Reply, Repost, Reaction, Bookmark와 More가 공유하는 `Pressable` leaf이며 28px 높이,
-50px 또는 28px 너비, active·pressed·blocked 표현을 소유한다. 현재 style callback은 `pressed`만 처리하고
-Web hover 상태는 없다. React Native Web은 `Pressable`의 `onHoverIn`·`onHoverOut`을 제공하지만 React Native
-공통 style callback type은 `pressed`만 노출한다.
+50px 또는 28px 너비, active·pressed·blocked 표현을 소유한다. 최초 PROD-595 구현은 Web hover 시 Pressable
+전체에 `surface`와 full radius를 적용했다. 시각 검토 뒤 click target 표시는 유지할 필요가 없고 glyph
+중심의 28×28 원형 affordance가 더 적합하다는 제품 결정으로 계약이 수정됐다.
 
 Theme에는 light·dark `surface` token이 있지만 현재 `ThemeProvider`는 production과 Storybook 모두 light
 theme만 공급한다. PROD-595에서는 theme provider나 app-wide dark 전환을 추가하지 않고 현재 도달 가능한
@@ -13,24 +13,24 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 
 **Goals:**
 
-- 공통 Post Action control 전체 target에 Web 비터치 hover background를 표시한다.
+- 공통 Post Action control의 glyph 중심에 28×28 Web 비터치 hover background를 표시한다.
 - 기존 active·pressed·blocked 상태와 28px geometry를 보존한다.
-- 현재 theme의 `surface` token을 사용하고 새 색상 token을 만들지 않는다.
+- 일반 action은 `surface`, Reaction hover와 selected heart는 기존 `like` token을 사용한다.
 - 가장 가까운 Storybook interaction에서 hover와 핵심 회귀 위험을 직접 검증한다.
 
 **Non-Goals:**
 
 - action 기능, count, mutation, 실행 eligibility와 Relay cache 변경
 - target 크기, Action Bar 배치와 Native touch target 정책 변경
-- action별 semantic hover 색상 또는 새 색상 token 추가
+- Reply·Repost·Bookmark·More의 action별 semantic tint 또는 새 색상 token 추가
 - production·Storybook dark theme 선택 기반 추가와 dark runtime 완료 주장
 
 ## Implementation Guidance
 
 ### Current Constraints
 
-- 모든 action에 동일 규칙을 적용하려면 각 private action child가 아니라 공통 `PostActionControl` 경계에서
-  처리해야 한다.
+- hover 상태와 28×28 visual layer는 공통 `PostActionControl` 경계에서 처리하되 Reaction만 기존 `like`
+  color를 주입한다.
 - `Pressable` style callback의 React Native TypeScript 계약은 `pressed`만 제공하므로 React Native Web의
   추가 `hovered` field에 의존하면 공통 type을 우회하게 된다.
 - raw pointer enter는 touch pointer도 포함할 수 있다. React Native Web의 hover abstraction을 사용해 touch
@@ -40,13 +40,14 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 
 ### Recommended Approach
 
-공통 control에서 Web일 때만 `onHoverIn`·`onHoverOut`으로 local hover state를 갱신한다. Style 계산은
-`hovered && !blocked`일 때만 현재 theme의 `surface` background와 full radius를 추가한다. 기존
-`blocked > pressed` opacity 우선순위와 width·height·spacing은 그대로 유지한다.
+공통 control에서 Web일 때만 `onHoverIn`·`onHoverOut`으로 local hover state를 갱신한다. `hovered &&
+!blocked`일 때 16×16 icon layout box 뒤에 absolute 28×28 원형 visual layer를 렌더링한다. 일반 action은
+기본 `surface`를 사용하고 Reaction은 `like`를 전달한다. active color도 기본 `primary`를 유지하되 Reaction만
+`like`를 전달한다. 기존 `blocked > pressed` opacity 우선순위와 Pressable width·height·spacing은 유지한다.
 
-기존 Post Action Bar Storybook에 focused Web hover interaction을 추가해 일반 50×28 action과 28×28 More,
-active 상태 보존, blocked 미표시와 geometry 불변을 검증한다. Theme provider는 변경하지 않고 light Web에서만
-실행한다. 구현이 semantic `surface`를 읽는다는 코드 근거를 남기되 dark runtime을 실행한 것으로 보고하지 않는다.
+기존 Post Action Bar Storybook의 Web hover interaction을 수정해 50×28 click target 안의 28×28 icon circle,
+28×28 More, Reaction `like` hover·selected 표현, pressed 보존, blocked 미표시와 geometry 불변을 검증한다.
+Theme provider는 변경하지 않고 light Web에서만 실행한다.
 
 ### Allowed Alternatives
 
@@ -55,9 +56,9 @@ React Native Web이 제공하는 hover abstraction보다 입력 분기 책임이
 
 ### Known Traps
 
-- `primaryHover`는 Reaction selector에서 selected·pressed 의미로 사용되므로 중립 hover background로 재사용하지 않는다.
-- hover를 icon wrapper에만 적용해 실제 50×28 target보다 작은 영역을 표시하지 않는다.
-- background를 위해 padding·width·height를 늘리거나 absolute hit area를 추가하지 않는다.
+- `primaryHover`는 Reaction selector에서 selected·pressed 의미로 사용하므로 Action Bar Reaction에 재사용하지 않는다.
+- 28×28 visual layer를 새 hit target으로 만들거나 pointer event를 받게 하지 않는다.
+- background를 위해 icon layout box, padding·width·height를 늘려 icon-count 간격을 바꾸지 않는다.
 - blocked action의 pointer 이동, Web touch 입력 또는 Native render를 hover 완료 증거로 오판하지 않는다.
 
 ## Risks / Trade-offs
@@ -65,7 +66,7 @@ React Native Web이 제공하는 hover abstraction보다 입력 분기 책임이
 - [local hover state가 blocked 전환 뒤 남을 수 있음] → style 단계에서 `!blocked`를 함께 검사한다.
 - [Storybook browser event가 실제 touch suppression을 모두 증명하지 못함] → light Web pointer 동작만 자동화
   증거로 삼고 Web touch·Native와 dark runtime은 별도 미검증 항목으로 보고한다.
-- [dark theme 요구사항을 runtime에서 확인하지 못함] → 고정 색상 없이 semantic `surface`만 사용하고 완료
+- [dark theme 요구사항을 runtime에서 확인하지 못함] → 고정 색상 없이 semantic `surface`와 `like`만 사용하고 완료
   보고에서 dark runtime 검증을 주장하지 않는다.
 
 ## Migration Plan

--- a/openspec/changes/visualize-post-action-hover-target/design.md
+++ b/openspec/changes/visualize-post-action-hover-target/design.md
@@ -20,6 +20,7 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 - 일반 action은 30% `primary` background와 불투명 `primary` foreground를 사용한다. Reaction hover는
   30% `like` background와 불투명 `like` heart foreground를 함께 사용하고 selected heart는 기존 불투명
   `like`를 유지한다.
+- Reply와 Repost의 count는 hover foreground tint와 분리해 기존 default 또는 active 색을 유지한다.
 - 가장 가까운 Storybook interaction에서 hover와 핵심 회귀 위험을 직접 검증한다.
 
 **Non-Goals:**
@@ -48,12 +49,14 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 !blocked`일 때 16×16 icon layout box 뒤에 absolute 28×28 원형 visual layer를 렌더링한다. 일반 action은
 30% opacity의 `primary` background와 불투명 `primary` hover foreground를 기본으로 사용하고 Reaction은
 같은 표현에 `like`를 전달한다. foreground glyph는 명시적인 상위 layer에 두어 불투명 background가 icon을
-덮지 않게 한다. active color도 기본 `primary`를 유지하되 Reaction만 불투명 `like`를 전달한다. 기존
+덮지 않게 한다. count 색은 hover foreground와 분리한다. active color도 기본 `primary`를 유지하되 Reaction만
+불투명 `like`를 전달한다. 기존
 `blocked > pressed` opacity 우선순위와 Pressable width·height·spacing은 유지한다.
 
 기존 Post Action Bar Storybook의 Web hover interaction을 수정해 50×28 click target 안의 28×28 icon circle,
 28×28 More, 일반 action의 30% `primary` background·불투명 `primary` foreground, Reaction의 30% `like`
-background·불투명 `like` foreground·selected 표현, pressed 보존, blocked 미표시와 geometry 불변을 검증한다.
+background·불투명 `like` foreground·selected 표현, Reply·Repost count 색 유지, pressed 보존, blocked
+미표시와 geometry 불변을 검증한다.
 Theme provider는 변경하지 않고 light Web에서만 실행한다.
 
 ### Allowed Alternatives

--- a/openspec/changes/visualize-post-action-hover-target/design.md
+++ b/openspec/changes/visualize-post-action-hover-target/design.md
@@ -1,0 +1,78 @@
+## Context
+
+`PostActionControl`은 Reply, Repost, Reaction, Bookmark와 More가 공유하는 `Pressable` leaf이며 28px 높이,
+50px 또는 28px 너비, active·pressed·blocked 표현을 소유한다. 현재 style callback은 `pressed`만 처리하고
+Web hover 상태는 없다. React Native Web은 `Pressable`의 `onHoverIn`·`onHoverOut`을 제공하지만 React Native
+공통 style callback type은 `pressed`만 노출한다.
+
+Theme에는 light·dark `surface` token이 있지만 현재 `ThemeProvider`는 production과 Storybook 모두 light
+theme만 공급한다. PROD-595에서는 theme provider나 app-wide dark 전환을 추가하지 않고 현재 도달 가능한
+light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 공통 Post Action control 전체 target에 Web 비터치 hover background를 표시한다.
+- 기존 active·pressed·blocked 상태와 28px geometry를 보존한다.
+- 현재 theme의 `surface` token을 사용하고 새 색상 token을 만들지 않는다.
+- 가장 가까운 Storybook interaction에서 hover와 핵심 회귀 위험을 직접 검증한다.
+
+**Non-Goals:**
+
+- action 기능, count, mutation, 실행 eligibility와 Relay cache 변경
+- target 크기, Action Bar 배치와 Native touch target 정책 변경
+- action별 semantic hover 색상 또는 새 색상 token 추가
+- production·Storybook dark theme 선택 기반 추가와 dark runtime 완료 주장
+
+## Implementation Guidance
+
+### Current Constraints
+
+- 모든 action에 동일 규칙을 적용하려면 각 private action child가 아니라 공통 `PostActionControl` 경계에서
+  처리해야 한다.
+- `Pressable` style callback의 React Native TypeScript 계약은 `pressed`만 제공하므로 React Native Web의
+  추가 `hovered` field에 의존하면 공통 type을 우회하게 된다.
+- raw pointer enter는 touch pointer도 포함할 수 있다. React Native Web의 hover abstraction을 사용해 touch
+  입력이 hover로 분류되지 않게 해야 한다.
+- disabled control은 새 hover 상태가 기존 blocked 표현을 덮지 않아야 하며, hover 중 blocked로 바뀌어도
+  background가 남지 않아야 한다.
+
+### Recommended Approach
+
+공통 control에서 Web일 때만 `onHoverIn`·`onHoverOut`으로 local hover state를 갱신한다. Style 계산은
+`hovered && !blocked`일 때만 현재 theme의 `surface` background와 full radius를 추가한다. 기존
+`blocked > pressed` opacity 우선순위와 width·height·spacing은 그대로 유지한다.
+
+기존 Post Action Bar Storybook에 focused Web hover interaction을 추가해 일반 50×28 action과 28×28 More,
+active 상태 보존, blocked 미표시와 geometry 불변을 검증한다. Theme provider는 변경하지 않고 light Web에서만
+실행한다. 구현이 semantic `surface`를 읽는다는 코드 근거를 남기되 dark runtime을 실행한 것으로 보고하지 않는다.
+
+### Allowed Alternatives
+
+`pointerType`에서 touch를 명시적으로 제외하는 Web pointer handler도 specs를 만족하면 허용한다. 다만 현재
+React Native Web이 제공하는 hover abstraction보다 입력 분기 책임이 늘어나므로 기본 경로로 사용하지 않는다.
+
+### Known Traps
+
+- `primaryHover`는 Reaction selector에서 selected·pressed 의미로 사용되므로 중립 hover background로 재사용하지 않는다.
+- hover를 icon wrapper에만 적용해 실제 50×28 target보다 작은 영역을 표시하지 않는다.
+- background를 위해 padding·width·height를 늘리거나 absolute hit area를 추가하지 않는다.
+- blocked action의 pointer 이동, Web touch 입력 또는 Native render를 hover 완료 증거로 오판하지 않는다.
+
+## Risks / Trade-offs
+
+- [local hover state가 blocked 전환 뒤 남을 수 있음] → style 단계에서 `!blocked`를 함께 검사한다.
+- [Storybook browser event가 실제 touch suppression을 모두 증명하지 못함] → light Web pointer 동작만 자동화
+  증거로 삼고 Web touch·Native와 dark runtime은 별도 미검증 항목으로 보고한다.
+- [dark theme 요구사항을 runtime에서 확인하지 못함] → 고정 색상 없이 semantic `surface`만 사용하고 완료
+  보고에서 dark runtime 검증을 주장하지 않는다.
+
+## Migration Plan
+
+DB·API migration은 없다. hover style과 Storybook 검증을 같은 PR에 배포하며 문제가 있으면 해당 UI 변경만
+되돌린다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/visualize-post-action-hover-target/design.md
+++ b/openspec/changes/visualize-post-action-hover-target/design.md
@@ -2,10 +2,12 @@
 
 `PostActionControl`은 Reply, Repost, Reaction, Bookmark와 More가 공유하는 `Pressable` leaf이며 28px 높이,
 50px 또는 28px 너비, active·pressed·blocked 표현을 소유한다. 최초 PROD-595 구현은 Web hover 시 Pressable
-전체에 `surface`와 full radius를 적용했다. 시각 검토 뒤 click target 표시는 유지할 필요가 없고 glyph
-중심의 28×28 원형 affordance가 더 적합하다는 제품 결정으로 계약이 수정됐다.
+전체에 `surface`와 full radius를 적용했다. 첫 시각 검토 뒤 glyph 중심의 28×28 원형으로 보정했지만,
+불투명 `surface`가 Web 페인팅 순서에서 glyph를 덮어 Reaction 외 아이콘이 사라져 보였다. 최종 시각 검토에서
+Reaction과 같은 30% tint background와 불투명 foreground를 모든 action에 적용하되 일반 action은
+`primary`, Reaction은 `like`를 사용하기로 계약을 수정했다.
 
-Theme에는 light·dark `surface` token이 있지만 현재 `ThemeProvider`는 production과 Storybook 모두 light
+Theme에는 light·dark `primary`·`like` token이 있지만 현재 `ThemeProvider`는 production과 Storybook 모두 light
 theme만 공급한다. PROD-595에서는 theme provider나 app-wide dark 전환을 추가하지 않고 현재 도달 가능한
 light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴다.
 
@@ -15,23 +17,24 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 
 - 공통 Post Action control의 glyph 중심에 28×28 Web 비터치 hover background를 표시한다.
 - 기존 active·pressed·blocked 상태와 28px geometry를 보존한다.
-- 일반 action은 `surface`를 사용한다. Reaction hover는 30% `like` background와 불투명 `like` heart
-  foreground를 함께 사용하고 selected heart는 기존 불투명 `like`를 유지한다.
+- 일반 action은 30% `primary` background와 불투명 `primary` foreground를 사용한다. Reaction hover는
+  30% `like` background와 불투명 `like` heart foreground를 함께 사용하고 selected heart는 기존 불투명
+  `like`를 유지한다.
 - 가장 가까운 Storybook interaction에서 hover와 핵심 회귀 위험을 직접 검증한다.
 
 **Non-Goals:**
 
 - action 기능, count, mutation, 실행 eligibility와 Relay cache 변경
 - target 크기, Action Bar 배치와 Native touch target 정책 변경
-- Reply·Repost·Bookmark·More의 action별 semantic tint 또는 새 색상 token 추가
+- Reply·Repost·Bookmark·More를 서로 다른 semantic tint로 분리하거나 새 색상 token 추가
 - production·Storybook dark theme 선택 기반 추가와 dark runtime 완료 주장
 
 ## Implementation Guidance
 
 ### Current Constraints
 
-- hover 상태와 28×28 visual layer는 공통 `PostActionControl` 경계에서 처리하되 Reaction만 기존 `like`
-  background color·opacity와 hover foreground color를 주입한다.
+- hover 상태와 28×28 visual layer는 공통 `PostActionControl` 경계에서 처리한다. 기본은 `primary`
+  background color·opacity와 foreground color를 사용하고 Reaction만 기존 `like`를 주입한다.
 - `Pressable` style callback의 React Native TypeScript 계약은 `pressed`만 제공하므로 React Native Web의
   추가 `hovered` field에 의존하면 공통 type을 우회하게 된다.
 - raw pointer enter는 touch pointer도 포함할 수 있다. React Native Web의 hover abstraction을 사용해 touch
@@ -43,13 +46,14 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 
 공통 control에서 Web일 때만 `onHoverIn`·`onHoverOut`으로 local hover state를 갱신한다. `hovered &&
 !blocked`일 때 16×16 icon layout box 뒤에 absolute 28×28 원형 visual layer를 렌더링한다. 일반 action은
-기본 `surface`를 사용하고 Reaction은 30% opacity의 `like` background와 불투명 `like` hover foreground를
-전달한다. active color도 기본 `primary`를 유지하되 Reaction만 불투명 `like`를 전달한다. 기존
+30% opacity의 `primary` background와 불투명 `primary` hover foreground를 기본으로 사용하고 Reaction은
+같은 표현에 `like`를 전달한다. foreground glyph는 명시적인 상위 layer에 두어 불투명 background가 icon을
+덮지 않게 한다. active color도 기본 `primary`를 유지하되 Reaction만 불투명 `like`를 전달한다. 기존
 `blocked > pressed` opacity 우선순위와 Pressable width·height·spacing은 유지한다.
 
 기존 Post Action Bar Storybook의 Web hover interaction을 수정해 50×28 click target 안의 28×28 icon circle,
-28×28 More, Reaction 30% `like` background·불투명 `like` foreground·selected 표현, pressed 보존, blocked
-미표시와 geometry 불변을 검증한다.
+28×28 More, 일반 action의 30% `primary` background·불투명 `primary` foreground, Reaction의 30% `like`
+background·불투명 `like` foreground·selected 표현, pressed 보존, blocked 미표시와 geometry 불변을 검증한다.
 Theme provider는 변경하지 않고 light Web에서만 실행한다.
 
 ### Allowed Alternatives
@@ -69,7 +73,7 @@ React Native Web이 제공하는 hover abstraction보다 입력 분기 책임이
 - [local hover state가 blocked 전환 뒤 남을 수 있음] → style 단계에서 `!blocked`를 함께 검사한다.
 - [Storybook browser event가 실제 touch suppression을 모두 증명하지 못함] → light Web pointer 동작만 자동화
   증거로 삼고 Web touch·Native와 dark runtime은 별도 미검증 항목으로 보고한다.
-- [dark theme 요구사항을 runtime에서 확인하지 못함] → 고정 색상 없이 semantic `surface`와 `like`만 사용하고 완료
+- [dark theme 요구사항을 runtime에서 확인하지 못함] → 고정 색상 없이 semantic `primary`와 `like`만 사용하고 완료
   보고에서 dark runtime 검증을 주장하지 않는다.
 
 ## Migration Plan

--- a/openspec/changes/visualize-post-action-hover-target/design.md
+++ b/openspec/changes/visualize-post-action-hover-target/design.md
@@ -15,7 +15,8 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 
 - 공통 Post Action control의 glyph 중심에 28×28 Web 비터치 hover background를 표시한다.
 - 기존 active·pressed·blocked 상태와 28px geometry를 보존한다.
-- 일반 action은 `surface`, Reaction hover와 selected heart는 기존 `like` token을 사용한다.
+- 일반 action은 `surface`를 사용한다. Reaction hover는 30% `like` background와 불투명 `like` heart
+  foreground를 함께 사용하고 selected heart는 기존 불투명 `like`를 유지한다.
 - 가장 가까운 Storybook interaction에서 hover와 핵심 회귀 위험을 직접 검증한다.
 
 **Non-Goals:**
@@ -30,7 +31,7 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 ### Current Constraints
 
 - hover 상태와 28×28 visual layer는 공통 `PostActionControl` 경계에서 처리하되 Reaction만 기존 `like`
-  color를 주입한다.
+  background color·opacity와 hover foreground color를 주입한다.
 - `Pressable` style callback의 React Native TypeScript 계약은 `pressed`만 제공하므로 React Native Web의
   추가 `hovered` field에 의존하면 공통 type을 우회하게 된다.
 - raw pointer enter는 touch pointer도 포함할 수 있다. React Native Web의 hover abstraction을 사용해 touch
@@ -42,11 +43,13 @@ light Web 동작을 검증한다. dark runtime 관찰은 미검증으로 남긴�
 
 공통 control에서 Web일 때만 `onHoverIn`·`onHoverOut`으로 local hover state를 갱신한다. `hovered &&
 !blocked`일 때 16×16 icon layout box 뒤에 absolute 28×28 원형 visual layer를 렌더링한다. 일반 action은
-기본 `surface`를 사용하고 Reaction은 `like`를 전달한다. active color도 기본 `primary`를 유지하되 Reaction만
-`like`를 전달한다. 기존 `blocked > pressed` opacity 우선순위와 Pressable width·height·spacing은 유지한다.
+기본 `surface`를 사용하고 Reaction은 30% opacity의 `like` background와 불투명 `like` hover foreground를
+전달한다. active color도 기본 `primary`를 유지하되 Reaction만 불투명 `like`를 전달한다. 기존
+`blocked > pressed` opacity 우선순위와 Pressable width·height·spacing은 유지한다.
 
 기존 Post Action Bar Storybook의 Web hover interaction을 수정해 50×28 click target 안의 28×28 icon circle,
-28×28 More, Reaction `like` hover·selected 표현, pressed 보존, blocked 미표시와 geometry 불변을 검증한다.
+28×28 More, Reaction 30% `like` background·불투명 `like` foreground·selected 표현, pressed 보존, blocked
+미표시와 geometry 불변을 검증한다.
 Theme provider는 변경하지 않고 light Web에서만 실행한다.
 
 ### Allowed Alternatives

--- a/openspec/changes/visualize-post-action-hover-target/proposal.md
+++ b/openspec/changes/visualize-post-action-hover-target/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Web 게시글 Action Bar는 아이콘만 보여 포인터 사용자가 실제 클릭 가능한 target 범위를 파악하기 어렵다.
+PROD-595는 기존 action 기능과 28px geometry를 유지하면서 hover 시 전체 target을 은은하게 드러내는 공통
+시각 affordance를 추가한다.
+
+## What Changes
+
+- Web의 비터치 pointer hover 시 각 Post Action control 전체 target에 semantic `surface` background를 표시한다.
+- Reply·Repost·Reaction·Bookmark의 50×28 target은 pill, More의 28×28 target은 원형으로 표시한다.
+- active·pressed 표현을 유지하고 pending·disabled·resolution-required에는 hover background를 표시하지 않는다.
+- Web touch와 Native에는 hover 전용 background를 노출하지 않는다.
+- action 기능·count·mutation·target 크기와 Action Bar 배치는 변경하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/design/post-action-bar.md`
+- Linear Contract: [PROD-595](https://linear.app/byulmaru/issue/PROD-595/web-%EA%B2%8C%EC%8B%9C%EA%B8%80-%EC%95%A1%EC%85%98-%EB%B2%84%ED%8A%BC%EC%9D%98-hover-%ED%81%B4%EB%A6%AD-%EC%98%81%EC%97%AD%EC%9D%84-%EC%8B%9C%EA%B0%81%ED%99%94%ED%95%9C%EB%8B%A4)
+- Linear Implementations: PROD-595
+
+## Capabilities
+
+### New Capabilities
+
+- `post-action-hover-target`: Web Post Action control의 실제 target hover 표현과 기존 상태·플랫폼 경계를 정의한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- Universal client: 공통 `PostActionControl`의 Web pointer 상태와 theme style
+- State catalog: Post Action Bar Storybook의 hover·blocked·geometry 검증
+- Canonical design: `docs/design/post-action-bar.md`의 Web hover target 규칙
+- Dependency: PROD-595는 최신 공통 Action Bar 통합을 소유한 PROD-432 위에 stack하며 PROD-432 merge 뒤 전달한다.
+- API·GraphQL·mutation·새 runtime dependency 영향 없음

--- a/openspec/changes/visualize-post-action-hover-target/proposal.md
+++ b/openspec/changes/visualize-post-action-hover-target/proposal.md
@@ -1,16 +1,17 @@
 ## Why
 
-Web 게시글 Action Bar는 아이콘만 보여 포인터 사용자가 실제 클릭 가능한 target 범위를 파악하기 어렵다.
-PROD-595는 기존 action 기능과 28px geometry를 유지하면서 hover 시 전체 target을 은은하게 드러내는 공통
-시각 affordance를 추가한다.
+Web 게시글 Action Bar는 아이콘만 보여 포인터 사용자가 상호작용 가능 여부를 파악하기 어렵다. PROD-595는
+기존 action 기능과 click target geometry를 유지하면서 hover 시 glyph 중심의 원형 affordance를 추가한다.
 
 ## What Changes
 
-- Web의 비터치 pointer hover 시 각 Post Action control 전체 target에 semantic `surface` background를 표시한다.
-- Reply·Repost·Reaction·Bookmark의 50×28 target은 pill, More의 28×28 target은 원형으로 표시한다.
+- Web의 비터치 pointer hover 시 각 Post Action control의 16×16 glyph 중심에 28×28 원형 background를 표시한다.
+- Reply·Repost·Bookmark·More는 semantic `surface`, Reaction은 semantic `like`를 사용한다.
+- selected Reaction heart의 stroke와 fill은 hover 여부와 관계없이 `like`를 사용한다.
 - active·pressed 표현을 유지하고 pending·disabled·resolution-required에는 hover background를 표시하지 않는다.
 - Web touch와 Native에는 hover 전용 background를 노출하지 않는다.
 - action 기능·count·mutation·target 크기와 Action Bar 배치는 변경하지 않는다.
+- 다른 action의 semantic tint 확장은 후속 범위로 남긴다.
 
 ## Authority / Provenance
 
@@ -30,7 +31,7 @@ PROD-595는 기존 action 기능과 28px geometry를 유지하면서 hover 시 �
 
 ## Impact
 
-- Universal client: 공통 `PostActionControl`의 Web pointer 상태와 theme style
+- Universal client: 공통 `PostActionControl`의 Web pointer 상태, icon visual layer와 Reaction theme style
 - State catalog: Post Action Bar Storybook의 hover·blocked·geometry 검증
 - Canonical design: `docs/design/post-action-bar.md`의 Web hover target 규칙
 - Dependency: PROD-595는 최신 공통 Action Bar 통합을 소유한 PROD-432 위에 stack하며 PROD-432 merge 뒤 전달한다.

--- a/openspec/changes/visualize-post-action-hover-target/proposal.md
+++ b/openspec/changes/visualize-post-action-hover-target/proposal.md
@@ -8,6 +8,7 @@ Web 게시글 Action Bar는 아이콘만 보여 포인터 사용자가 상호작
 - Web의 비터치 pointer hover 시 각 Post Action control의 16×16 glyph 중심에 28×28 원형 background를 표시한다.
 - Reply·Repost·Bookmark·More는 semantic `primary`를 30% opacity의 background로 사용하고 hover
   foreground에는 불투명 `primary`를 사용한다. Reaction은 같은 표현에 semantic `like`를 사용한다.
+- Reply와 Repost의 count는 hover tint에 포함하지 않고 기존 색을 유지한다.
 - selected Reaction heart의 stroke와 fill은 hover 여부와 관계없이 `like`를 사용한다.
 - active·pressed 표현을 유지하고 pending·disabled·resolution-required에는 hover background를 표시하지 않는다.
 - Web touch와 Native에는 hover 전용 background를 노출하지 않는다.

--- a/openspec/changes/visualize-post-action-hover-target/proposal.md
+++ b/openspec/changes/visualize-post-action-hover-target/proposal.md
@@ -6,7 +6,8 @@ Web 게시글 Action Bar는 아이콘만 보여 포인터 사용자가 상호작
 ## What Changes
 
 - Web의 비터치 pointer hover 시 각 Post Action control의 16×16 glyph 중심에 28×28 원형 background를 표시한다.
-- Reply·Repost·Bookmark·More는 semantic `surface`, Reaction은 semantic `like`를 사용한다.
+- Reply·Repost·Bookmark·More는 semantic `surface`를 사용한다. Reaction은 semantic `like`를 30% opacity의
+  background로 사용하고 hover foreground에는 불투명 `like`를 사용한다.
 - selected Reaction heart의 stroke와 fill은 hover 여부와 관계없이 `like`를 사용한다.
 - active·pressed 표현을 유지하고 pending·disabled·resolution-required에는 hover background를 표시하지 않는다.
 - Web touch와 Native에는 hover 전용 background를 노출하지 않는다.

--- a/openspec/changes/visualize-post-action-hover-target/proposal.md
+++ b/openspec/changes/visualize-post-action-hover-target/proposal.md
@@ -6,13 +6,13 @@ Web 게시글 Action Bar는 아이콘만 보여 포인터 사용자가 상호작
 ## What Changes
 
 - Web의 비터치 pointer hover 시 각 Post Action control의 16×16 glyph 중심에 28×28 원형 background를 표시한다.
-- Reply·Repost·Bookmark·More는 semantic `surface`를 사용한다. Reaction은 semantic `like`를 30% opacity의
-  background로 사용하고 hover foreground에는 불투명 `like`를 사용한다.
+- Reply·Repost·Bookmark·More는 semantic `primary`를 30% opacity의 background로 사용하고 hover
+  foreground에는 불투명 `primary`를 사용한다. Reaction은 같은 표현에 semantic `like`를 사용한다.
 - selected Reaction heart의 stroke와 fill은 hover 여부와 관계없이 `like`를 사용한다.
 - active·pressed 표현을 유지하고 pending·disabled·resolution-required에는 hover background를 표시하지 않는다.
 - Web touch와 Native에는 hover 전용 background를 노출하지 않는다.
 - action 기능·count·mutation·target 크기와 Action Bar 배치는 변경하지 않는다.
-- 다른 action의 semantic tint 확장은 후속 범위로 남긴다.
+- Reply·Repost·Bookmark·More를 서로 다른 semantic tint로 분리하는 확장은 후속 범위로 남긴다.
 
 ## Authority / Provenance
 

--- a/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
+++ b/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
@@ -8,12 +8,13 @@ approved glyph-centered hover affordance. Universal client는 비터치 Web poin
 한다(MUST). Reply, Repost, Bookmark와 More는 현재 theme의 semantic `primary`를 30% opacity의
 background로 사용하고 hover foreground에는 불투명 `primary`를 사용해야 한다(MUST). Reaction은 semantic
 `like`를 30% opacity의 background로 사용하고 heart foreground에는 불투명 `like`를 사용해야 한다(MUST).
+Reply와 Repost의 count는 hover tint에 포함하지 않고 기존 색을 유지해야 한다(MUST).
 
 #### Scenario: Social action target에 hover한다
 
 - **WHEN** 비터치 Web pointer가 활성 Reply, Repost 또는 Bookmark control에 hover하면
 - **THEN** 50×28 click target은 유지되고 glyph 중심의 28×28 `primary` 원형 background가 30% opacity로
-  표시되며 glyph foreground는 불투명 `primary`로 표시된다
+  표시되며 glyph foreground는 불투명 `primary`로 표시되고 count는 기존 색을 유지한다
 
 #### Scenario: Reaction target에 hover한다
 

--- a/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
+++ b/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Web pointer hover는 전체 action target을 표시한다
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595 — Universal client는 비터치 Web pointer가 활성 Post Action control에 hover하는 동안 전체 interactive target에 현재 theme의 semantic `surface` background를 표시해야 한다(MUST). Reply, Repost, Reaction과 Bookmark는
+기존 50×28 target을 pill로 사용하고 More는 기존 28×28 target을 원형으로 사용해야 한다(MUST).
+
+#### Scenario: Social action target에 hover한다
+
+- **WHEN** 비터치 Web pointer가 활성 Reply, Repost, Reaction 또는 Bookmark control에 hover하면
+- **THEN** 전체 50×28 target은 현재 theme의 `surface` background를 pill로 표시한다
+
+#### Scenario: More target에 hover한다
+
+- **WHEN** 비터치 Web pointer가 활성 More control에 hover하면
+- **THEN** 전체 28×28 target은 현재 theme의 `surface` background를 원형으로 표시한다
+
+#### Scenario: 현재 theme의 surface를 사용한다
+
+- **WHEN** light 또는 dark theme에서 활성 action에 hover하면
+- **THEN** hover background는 고정 색상 대신 해당 theme의 semantic `surface` 값을 사용한다
+
+### Requirement: Hover는 기존 action 상태와 geometry를 보존한다
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595 — Universal client는 hover를 표시하는 동안 기존 default, active, pressed와 selected icon, count, fill과 opacity 의미를 보존해야 한다(MUST). Pending, disabled와 resolution-required control은 hover background를 표시하지
+않아야 한다(MUST NOT). Hover는 target 크기, Action Bar 높이, 간격이나 target 비중첩을 변경하지 않아야
+한다(MUST NOT).
+
+#### Scenario: Active action에 hover한다
+
+- **WHEN** 비터치 Web pointer가 활성 active 또는 selected action에 hover하면
+- **THEN** action은 `surface` background만 추가하고 기존 active icon, count 또는 fill 표현을 유지한다
+
+#### Scenario: Hover 중인 action을 누른다
+
+- **WHEN** hover 중인 활성 action이 pressed 상태로 전환되면
+- **THEN** hover target geometry를 변경하지 않고 기존 pressed opacity를 계속 표시한다
+
+#### Scenario: Blocked action에 pointer가 이동한다
+
+- **WHEN** pointer가 pending, disabled 또는 resolution-required action target에 도달하면
+- **THEN** action은 기존 blocked 표현을 유지하고 hover background를 표시하지 않는다
+
+#### Scenario: Hover는 layout을 변경하지 않는다
+
+- **WHEN** 활성 Post Action control이 hover에 진입하거나 빠져나오면
+- **THEN** control 크기, 28px Action Bar 높이, 간격과 인접 target 비중첩은 변경되지 않는다
+
+### Requirement: Hover 표현은 Web 비터치 pointer로 제한한다
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595 — Universal client는 hover background를 touch 없이 hover할 수 있는 Web 입력으로 제한해야 한다(MUST). Web
+touch 입력과 Native platform은 hover 전용 background를 노출하지 않아야 한다(MUST NOT).
+
+#### Scenario: Web touch 입력이 action에 도달한다
+
+- **WHEN** Web touch pointer가 Post Action control과 상호작용하면
+- **THEN** hover 전용 background를 표시하지 않는다
+
+#### Scenario: Native action을 렌더링하거나 누른다
+
+- **WHEN** Android 또는 iOS에서 Post Action control을 사용하면
+- **THEN** hover 전용 background를 렌더링하지 않고 기존 Native action 표현을 유지한다

--- a/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
+++ b/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
@@ -5,14 +5,15 @@
 **Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595. The Universal client MUST render the
 approved glyph-centered hover affordance. Universal client는 비터치 Web pointer가
 활성 Post Action control에 hover하는 동안 16×16 glyph를 중심으로 28×28 원형 background를 표시해야
-한다(MUST). Reply, Repost, Bookmark와 More는 현재 theme의 semantic `surface`를 사용하고 Reaction은
-semantic `like`를 30% opacity의 background로 사용해야 한다(MUST). Reaction의 heart foreground는
-hover 동안 불투명 semantic `like`를 사용해야 한다(MUST).
+한다(MUST). Reply, Repost, Bookmark와 More는 현재 theme의 semantic `primary`를 30% opacity의
+background로 사용하고 hover foreground에는 불투명 `primary`를 사용해야 한다(MUST). Reaction은 semantic
+`like`를 30% opacity의 background로 사용하고 heart foreground에는 불투명 `like`를 사용해야 한다(MUST).
 
 #### Scenario: Social action target에 hover한다
 
 - **WHEN** 비터치 Web pointer가 활성 Reply, Repost 또는 Bookmark control에 hover하면
-- **THEN** 50×28 click target은 유지되고 glyph 중심의 28×28 `surface` 원형 background만 표시된다
+- **THEN** 50×28 click target은 유지되고 glyph 중심의 28×28 `primary` 원형 background가 30% opacity로
+  표시되며 glyph foreground는 불투명 `primary`로 표시된다
 
 #### Scenario: Reaction target에 hover한다
 
@@ -23,12 +24,14 @@ hover 동안 불투명 semantic `like`를 사용해야 한다(MUST).
 #### Scenario: More target에 hover한다
 
 - **WHEN** 비터치 Web pointer가 활성 More control에 hover하면
-- **THEN** 기존 28×28 target과 일치하는 glyph 중심의 `surface` 원형 background가 표시된다
+- **THEN** 기존 28×28 target과 일치하는 glyph 중심의 `primary` 원형 background가 30% opacity로 표시되며
+  glyph foreground는 불투명 `primary`로 표시된다
 
-#### Scenario: 현재 theme의 surface를 사용한다
+#### Scenario: 현재 theme의 semantic tint를 사용한다
 
 - **WHEN** light 또는 dark theme에서 활성 action에 hover하면
-- **THEN** hover background는 고정 색상 대신 해당 theme의 semantic `surface` 또는 `like` 값을 사용한다
+- **THEN** hover background와 foreground는 고정 색상 대신 해당 theme의 semantic `primary` 또는 `like` 값을
+  사용한다
 
 #### Scenario: 미선택 Reaction에서 pointer가 벗어난다
 

--- a/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
+++ b/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
@@ -6,7 +6,8 @@
 approved glyph-centered hover affordance. Universal client는 비터치 Web pointer가
 활성 Post Action control에 hover하는 동안 16×16 glyph를 중심으로 28×28 원형 background를 표시해야
 한다(MUST). Reply, Repost, Bookmark와 More는 현재 theme의 semantic `surface`를 사용하고 Reaction은
-semantic `like`를 사용해야 한다(MUST).
+semantic `like`를 30% opacity의 background로 사용해야 한다(MUST). Reaction의 heart foreground는
+hover 동안 불투명 semantic `like`를 사용해야 한다(MUST).
 
 #### Scenario: Social action target에 hover한다
 
@@ -16,7 +17,8 @@ semantic `like`를 사용해야 한다(MUST).
 #### Scenario: Reaction target에 hover한다
 
 - **WHEN** 비터치 Web pointer가 활성 Reaction control에 hover하면
-- **THEN** 50×28 click target은 유지되고 glyph 중심의 28×28 `like` 원형 background가 표시된다
+- **THEN** 50×28 click target은 유지되고 glyph 중심의 28×28 `like` 원형 background가 30% opacity로
+  표시되며 heart foreground는 불투명 `like`로 표시된다
 
 #### Scenario: More target에 hover한다
 
@@ -27,6 +29,11 @@ semantic `like`를 사용해야 한다(MUST).
 
 - **WHEN** light 또는 dark theme에서 활성 action에 hover하면
 - **THEN** hover background는 고정 색상 대신 해당 theme의 semantic `surface` 또는 `like` 값을 사용한다
+
+#### Scenario: 미선택 Reaction에서 pointer가 벗어난다
+
+- **WHEN** 미선택 Reaction control의 hover가 끝나면
+- **THEN** 원형 background는 사라지고 heart foreground는 기존 default 색으로 돌아간다
 
 ### Requirement: Selected Reaction은 옅은 분홍 상태를 표시한다
 

--- a/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
+++ b/openspec/changes/visualize-post-action-hover-target/specs/post-action-hover-target/spec.md
@@ -1,40 +1,68 @@
 ## ADDED Requirements
 
-### Requirement: Web pointer hover는 전체 action target을 표시한다
+### Requirement: Web pointer hover는 glyph 중심 원형 affordance를 표시한다
 
-**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595 — Universal client는 비터치 Web pointer가 활성 Post Action control에 hover하는 동안 전체 interactive target에 현재 theme의 semantic `surface` background를 표시해야 한다(MUST). Reply, Repost, Reaction과 Bookmark는
-기존 50×28 target을 pill로 사용하고 More는 기존 28×28 target을 원형으로 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595. The Universal client MUST render the
+approved glyph-centered hover affordance. Universal client는 비터치 Web pointer가
+활성 Post Action control에 hover하는 동안 16×16 glyph를 중심으로 28×28 원형 background를 표시해야
+한다(MUST). Reply, Repost, Bookmark와 More는 현재 theme의 semantic `surface`를 사용하고 Reaction은
+semantic `like`를 사용해야 한다(MUST).
 
 #### Scenario: Social action target에 hover한다
 
-- **WHEN** 비터치 Web pointer가 활성 Reply, Repost, Reaction 또는 Bookmark control에 hover하면
-- **THEN** 전체 50×28 target은 현재 theme의 `surface` background를 pill로 표시한다
+- **WHEN** 비터치 Web pointer가 활성 Reply, Repost 또는 Bookmark control에 hover하면
+- **THEN** 50×28 click target은 유지되고 glyph 중심의 28×28 `surface` 원형 background만 표시된다
+
+#### Scenario: Reaction target에 hover한다
+
+- **WHEN** 비터치 Web pointer가 활성 Reaction control에 hover하면
+- **THEN** 50×28 click target은 유지되고 glyph 중심의 28×28 `like` 원형 background가 표시된다
 
 #### Scenario: More target에 hover한다
 
 - **WHEN** 비터치 Web pointer가 활성 More control에 hover하면
-- **THEN** 전체 28×28 target은 현재 theme의 `surface` background를 원형으로 표시한다
+- **THEN** 기존 28×28 target과 일치하는 glyph 중심의 `surface` 원형 background가 표시된다
 
 #### Scenario: 현재 theme의 surface를 사용한다
 
 - **WHEN** light 또는 dark theme에서 활성 action에 hover하면
-- **THEN** hover background는 고정 색상 대신 해당 theme의 semantic `surface` 값을 사용한다
+- **THEN** hover background는 고정 색상 대신 해당 theme의 semantic `surface` 또는 `like` 값을 사용한다
+
+### Requirement: Selected Reaction은 옅은 분홍 상태를 표시한다
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595. The Universal client MUST render the
+approved selected Reaction tint. Universal client는 Reaction이 selected
+상태이면 hover 여부와 관계없이 heart의 stroke와 fill에 현재 theme의 semantic `like`를 사용해야 한다(MUST).
+다른 action의 active 색은 기존 표현을 유지해야 한다(MUST).
+
+#### Scenario: Reaction이 selected 상태다
+
+- **WHEN** 현재 Profile이 Post에 하나 이상의 Reaction을 남겼으면
+- **THEN** Action Bar의 heart stroke와 fill은 현재 theme의 `like` 값을 사용한다
+
+#### Scenario: Selected Reaction에서 pointer가 벗어난다
+
+- **WHEN** selected Reaction control의 hover가 끝나면
+- **THEN** 원형 background는 사라지지만 heart의 `like` stroke와 fill은 유지된다
 
 ### Requirement: Hover는 기존 action 상태와 geometry를 보존한다
 
-**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595 — Universal client는 hover를 표시하는 동안 기존 default, active, pressed와 selected icon, count, fill과 opacity 의미를 보존해야 한다(MUST). Pending, disabled와 resolution-required control은 hover background를 표시하지
-않아야 한다(MUST NOT). Hover는 target 크기, Action Bar 높이, 간격이나 target 비중첩을 변경하지 않아야
+**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-595. The Universal client MUST preserve the
+approved action state and geometry. Universal client는 hover를 표시하는 동안
+기존 default, pressed, blocked 상태와 Reaction 외 action의 active·selected icon, count, fill과 opacity 의미를
+보존해야 한다(MUST). Pending, disabled와 resolution-required control은 hover background를 표시하지 않아야
+한다(MUST NOT). Hover는 target 크기, Action Bar 높이, icon-count 간격이나 target 비중첩을 변경하지 않아야
 한다(MUST NOT).
 
 #### Scenario: Active action에 hover한다
 
 - **WHEN** 비터치 Web pointer가 활성 active 또는 selected action에 hover하면
-- **THEN** action은 `surface` background만 추가하고 기존 active icon, count 또는 fill 표현을 유지한다
+- **THEN** action은 glyph 중심 원형 background만 추가하고 승인된 active icon, count 또는 fill 표현을 유지한다
 
 #### Scenario: Hover 중인 action을 누른다
 
 - **WHEN** hover 중인 활성 action이 pressed 상태로 전환되면
-- **THEN** hover target geometry를 변경하지 않고 기존 pressed opacity를 계속 표시한다
+- **THEN** 원형 background와 click target geometry를 변경하지 않고 기존 pressed opacity를 계속 표시한다
 
 #### Scenario: Blocked action에 pointer가 이동한다
 
@@ -44,7 +72,7 @@
 #### Scenario: Hover는 layout을 변경하지 않는다
 
 - **WHEN** 활성 Post Action control이 hover에 진입하거나 빠져나오면
-- **THEN** control 크기, 28px Action Bar 높이, 간격과 인접 target 비중첩은 변경되지 않는다
+- **THEN** control 크기, 28px Action Bar 높이, icon-count 간격과 인접 target 비중첩은 변경되지 않는다
 
 ### Requirement: Hover 표현은 Web 비터치 pointer로 제한한다
 

--- a/openspec/changes/visualize-post-action-hover-target/tasks.md
+++ b/openspec/changes/visualize-post-action-hover-target/tasks.md
@@ -32,9 +32,21 @@ Web의 비터치 pointer가 Post Action control에 hover하면 기존 target 전
 - light Web runtime에서 pointer hover와 인접 target 비중첩을 관찰한다. dark·Web touch·Native runtime은
   미실행으로 보고한다.
 
-- [ ] 1.1 공통 Post Action control에 승인된 Web 비터치 hover target 표현을 구현한다.
-- [ ] 1.2 가장 가까운 기존 Storybook interaction에 hover와 핵심 상태·geometry 회귀 검증을 추가한다.
-- [ ] 1.3 App check, targeted Storybook interaction, static Storybook build와 light Web 수동 관찰을 수행하고
+**Verification Record (2026-07-31)**
+
+- `@kosmo/app check`는 Watchman의 FSEvents 시작 실패를 피하도록 Watchman을 PATH에서 제외한 동일 script로
+  실행해 Relay compiler(87 reader, 53 normalization, 94 operation text)와 TypeScript를 통과했다.
+- `PostActionBar.stories.tsx` targeted Storybook interaction 14/14와 static Storybook build, OpenSpec strict
+  validation을 통과했다.
+- light Web Storybook에서 Reply의 `surface` hover가 50×28 pill로 표시되고 More 28×28, active Bookmark
+  50×28, blocked control 미표시와 모든 toolbar의 target 비중첩을 관찰했다.
+- dark runtime, Web touch, Android와 iOS runtime은 실행하지 않았다. 이 gap 때문에 change를 active로 유지한다.
+- 구현과 검증은 canonical design, 이 change의 spec·decision, 작업 시작 시 확인한 live PROD-595 범위와
+  일치한다. Linear connector가 검증 중 unavailable 상태가 되어 status·본문 writeback은 완료하지 못했다.
+
+- [x] 1.1 공통 Post Action control에 승인된 Web 비터치 hover target 표현을 구현한다.
+- [x] 1.2 가장 가까운 기존 Storybook interaction에 hover와 핵심 상태·geometry 회귀 검증을 추가한다.
+- [x] 1.3 App check, targeted Storybook interaction, static Storybook build와 light Web 수동 관찰을 수행하고
       미실행 platform 검증을 구분해 기록한다.
-- [ ] 1.4 구현과 검증 결과를 canonical 문서·Linear·OpenSpec에 대조하고 dark runtime 미검증 때문에 change를
+- [x] 1.4 구현과 검증 결과를 canonical 문서·Linear·OpenSpec에 대조하고 dark runtime 미검증 때문에 change를
       active로 유지한다.

--- a/openspec/changes/visualize-post-action-hover-target/tasks.md
+++ b/openspec/changes/visualize-post-action-hover-target/tasks.md
@@ -21,7 +21,8 @@ background로 드러나고, active·pressed·blocked 상태와 Action Bar geomet
 - Web touch와 Native에 hover 전용 표현을 추가하지 않는다.
 - action 기능·count·mutation·execution eligibility·Relay cache와 ThemeProvider를 변경하지 않는다.
 - 새 색상 token이나 runtime dependency를 추가하지 않는다.
-- dark runtime은 현재 검증 범위가 아니므로 실행 완료를 주장하지 않고 이 change를 archive하지 않는다.
+- dark runtime은 현재 검증 범위가 아니므로 실행 완료를 주장하지 않는다. 이 문장은 초기 구현 당시의
+  역사적 검증 경계이며 현재 archive gate로 사용하지 않는다.
 
 **Verification**
 
@@ -43,7 +44,8 @@ background로 드러나고, active·pressed·blocked 상태와 Action Bar geomet
   validation을 통과했다.
 - light Web Storybook에서 Reply의 `surface` hover가 50×28 pill로 표시되고 More 28×28, active Bookmark
   50×28, blocked control 미표시와 모든 toolbar의 target 비중첩을 관찰했다.
-- dark runtime, Web touch, Android와 iOS runtime은 실행하지 않았다. 이 gap 때문에 change를 active로 유지한다.
+- dark runtime, Web touch, Android와 iOS runtime은 실행하지 않았다. 이 미실행 범위는 현재 계약에서
+  명시적으로 제외됐으므로 이후 archive 자체를 막는 사유로 사용하지 않는다.
 - 구현과 검증은 canonical design, 이 change의 spec·decision, 작업 시작 시 확인한 live PROD-595 범위와
   일치한다. Linear connector가 검증 중 unavailable 상태가 되어 status·본문 writeback은 완료하지 못했다.
 
@@ -51,8 +53,8 @@ background로 드러나고, active·pressed·blocked 상태와 Action Bar geomet
 - [x] 1.2 가장 가까운 기존 Storybook interaction에 hover와 핵심 상태·geometry 회귀 검증을 추가한다.
 - [x] 1.3 App check, targeted Storybook interaction, static Storybook build와 light Web 수동 관찰을 수행하고
       미실행 platform 검증을 구분해 기록한다.
-- [x] 1.4 구현과 검증 결과를 canonical 문서·Linear·OpenSpec에 대조하고 dark runtime 미검증 때문에 change를
-      active로 유지한다.
+- [x] 1.4 구현과 검증 결과를 canonical 문서·Linear·OpenSpec에 대조한다. 이 초기 판단은 superseded됐으며
+      제외된 runtime 검증은 현재 archive gate가 아니다.
 
 ## 2. 시각 검토 보정 — glyph 중심 원형과 Reaction like tint
 
@@ -65,8 +67,8 @@ background로 드러나고, active·pressed·blocked 상태와 Action Bar geomet
 **Deliverable**
 
 Web의 비터치 pointer가 Post Action control에 hover하면 click target은 유지된 채 glyph 중심 28×28 원형만
-표시된다. 일반 action은 중립 `surface`, Reaction은 `like`를 사용하며 selected Reaction heart도 `like`를
-유지한다.
+표시된다. 일반 action은 중립 `surface`를 사용한다. Reaction은 30% opacity의 `like` background와 불투명
+`like` heart foreground를 함께 사용하며 selected Reaction heart도 불투명 `like`를 유지한다.
 
 **Guardrails**
 
@@ -78,24 +80,44 @@ Web의 비터치 pointer가 Post Action control에 hover하면 click target은 �
 - Web touch와 Native에 hover 전용 표현을 추가하지 않는다.
 - action 기능·count·mutation·execution eligibility·Relay cache와 ThemeProvider를 변경하지 않는다.
 - Reply·Repost·Bookmark·More의 action별 tint, 새 색상 token과 runtime dependency를 추가하지 않는다.
-- dark runtime은 현재 검증 범위가 아니므로 실행 완료를 주장하지 않고 이 change를 archive하지 않는다.
+- dark runtime, Web touch, Android와 iOS runtime은 현재 검증 범위가 아니므로 실행 완료를 주장하지 않는다.
+  이 제외 범위는 현재 deliverable 완료 뒤 archive를 막는 별도 gate가 아니다.
 
 **Verification**
 
 - 테스트 코드 범위: 기존 `PostActionBar.stories.tsx`의 `ActionBarCatalog` interaction에서 glyph 중심 28×28
-  원형, `surface`·`like`, click target과 icon-count geometry, selected·pressed 보존과 blocked 미표시를 검증한다.
+  원형, `surface`, Reaction의 30% `like` background와 불투명 `like` foreground, click target과 icon-count
+  geometry, selected·pressed 보존과 blocked 미표시를 검증한다.
 - 테스트 필요성: 사용자에게 보이는 보정 동작과 click target·layout 회귀 위험을 관찰 가능한 DOM style과
   geometry로 증명한다.
 - 테스트 제외 범위: 새 fixture·helper·harness, 중복 action 조합, snapshot, ThemeProvider·dark mode 테스트,
   Web touch·Android·iOS runtime test와 action 기능·mutation test.
 - App check, targeted Storybook interaction, static Storybook build와 OpenSpec strict validation을 통과시킨다.
-- light Web runtime에서 hover 원형과 인접 target 비중첩을 관찰한다. dark·Web touch·Native runtime은
-  미실행으로 보고한다.
+- light Web browser interaction에서 hover 원형과 인접 target 비중첩을 검증하고 API·BFF를 포함한 app dev
+  endpoint를 시각 검토 가능 상태로 유지한다. dark·Web touch·Native runtime은 미실행으로 보고한다.
 
-- [x] 2.1 canonical과 Linear에 승인된 glyph 중심 원형 및 Reaction `like` 계약을 반영한다.
-- [x] 2.2 기존 Storybook interaction을 새 hover·selected Reaction 계약으로 수정하고 RED 실패를 확인한다.
-- [x] 2.3 공통 Post Action control과 Reaction 연결에 최소 구현을 적용하고 targeted interaction을 GREEN으로 만든다.
-- [ ] 2.4 App check, targeted Storybook interaction, static Storybook build, OpenSpec strict와 light Web 수동 관찰을
-      수행하고 미실행 platform 검증을 구분해 기록한다.
-- [ ] 2.5 구현과 검증 결과를 canonical·Linear·OpenSpec에 대조하고 dark runtime 미검증 때문에 change를
-      active로 유지한다.
+**Verification Record (2026-07-31, X-style 보정)**
+
+- `@kosmo/app test`를 게시 직전 트리에서 실행해 Relay compiler와 TypeScript, unit 103/103, static Storybook
+  build, Storybook browser interaction 237/237를 통과했다. Expo dev server가 만든 ignored router type은
+  원본을 임시 경로에 보존한 채 clean check에서 제외하고 즉시 복원했다.
+- `ActionBarCatalog`는 미선택 Reaction hover에서 background `like` opacity `0.3`, heart의 불투명 `like`
+  stroke와 hover 종료 뒤 default 색 복귀를 검증한다. selected Reaction은 hover 전·중·후 불투명 `like`
+  stroke·fill을 유지하며, 원형 background만 hover 동안 opacity `0.3`으로 표시된다.
+- 변경 TypeScript 파일의 ESLint, 변경 전체의 Prettier, `git diff --check`, OpenSpec strict validation을
+  통과했다.
+- API `3300`, Web BFF `5474`, App `5473`의 health와 App `/home`이 모두 HTTP 200인 상태로 시각 검토용 dev를
+  재기동했다.
+- dark runtime, Web touch, Android와 iOS runtime은 실행하지 않았다. 승인된 제외 범위이며 완료 증거로
+  주장하지 않는다.
+
+- [x] 2.1 canonical과 Linear에 승인된 glyph 중심 원형 및 Reaction 30% `like` background·불투명 foreground
+      계약을 반영한다.
+- [x] 2.2 기존 Storybook interaction을 새 hover·selected Reaction 계약으로 수정하고 opacity `1` 실패를
+      RED로 확인한다.
+- [x] 2.3 공통 Post Action control과 Reaction 연결에 background opacity와 hover foreground를 분리하는 최소
+      구현을 적용하고 targeted interaction을 GREEN으로 만든다.
+- [x] 2.4 App 전체 test, Storybook browser interaction, static Storybook build, OpenSpec strict와 light Web dev
+      가동을 검증하고 미실행 platform 검증을 구분해 기록한다.
+- [x] 2.5 구현과 검증 결과를 canonical·Linear·OpenSpec에 대조하고 미실행 runtime 범위와 archive 판단을
+      분리해 기록한다.

--- a/openspec/changes/visualize-post-action-hover-target/tasks.md
+++ b/openspec/changes/visualize-post-action-hover-target/tasks.md
@@ -56,7 +56,7 @@ background로 드러나고, active·pressed·blocked 상태와 Action Bar geomet
 - [x] 1.4 구현과 검증 결과를 canonical 문서·Linear·OpenSpec에 대조한다. 이 초기 판단은 superseded됐으며
       제외된 runtime 검증은 현재 archive gate가 아니다.
 
-## 2. 시각 검토 보정 — glyph 중심 원형과 Reaction like tint
+## 2. 시각 검토 보정 — glyph 중심 원형과 Reaction like tint (Superseded)
 
 **Authority / Provenance**
 
@@ -122,3 +122,54 @@ Web의 비터치 pointer가 Post Action control에 hover하면 click target은 �
       가동을 검증하고 미실행 platform 검증을 구분해 기록한다.
 - [x] 2.5 구현과 검증 결과를 canonical·Linear·OpenSpec에 대조하고 미실행 runtime 범위와 archive 판단을
       분리해 기록한다.
+
+## 3. 최종 시각 검토 보정 — 일반 action primary tint와 foreground layer
+
+**Authority / Provenance**
+
+- `docs/design/colors.md`
+- `docs/design/post-action-bar.md`
+- PROD-595의 2026-07-31 최종 시각 검토
+
+**Deliverable**
+
+Web의 비터치 pointer가 Reply, Repost, Bookmark 또는 More에 hover하면 glyph 중심 28×28 원형은 30% opacity의
+semantic `primary` background로 표시되고 glyph는 불투명 `primary` foreground로 그 위에 표시된다. Reaction은
+같은 표현에 기존 `like`를 사용한다.
+
+**Guardrails**
+
+- Reply·Repost·Reaction·Bookmark의 기존 50×28 target과 More의 기존 28×28 target을 변경하지 않는다.
+- 28×28 background는 count와 glyph를 덮거나 pointer event를 받지 않으며 glyph는 명시적인 상위 layer에 둔다.
+- pending·disabled·resolution-required, Web touch와 Native의 기존 제외 경계를 유지한다.
+- action 기능·count·mutation·execution eligibility·Relay cache·ThemeProvider·dependency를 변경하지 않는다.
+- Reply·Repost·Bookmark·More를 서로 다른 tint로 분리하는 후속 범위는 포함하지 않는다.
+
+**Verification**
+
+- 기존 `ActionBarCatalog` interaction에서 Reply·Repost·Bookmark·More의 30% `primary` background와 불투명
+  `primary` foreground, glyph layer 순서와 hover 종료 시 default foreground 복귀를 검증한다.
+- Reaction의 30% `like` background·불투명 `like` foreground와 selected 표현을 그대로 검증한다.
+- App 전체 test, 변경 파일 lint·format, OpenSpec strict, light Web dev 시각 관찰을 수행한다.
+- dark·Web touch·Android·iOS runtime은 미실행으로 구분한다.
+
+- [x] 3.1 새 `primary` hover와 glyph foreground layer 계약을 Storybook에 추가하고 기존 `surface` 구현에서
+      RED를 확인한다.
+- [x] 3.2 공통 control의 기본 hover tint를 `primary` 30%로 바꾸고 glyph를 background 상위 layer에 두어
+      targeted Storybook interaction을 GREEN으로 만든다.
+- [x] 3.3 canonical과 OpenSpec proposal·design·decision·spec을 최종 시각 결정에 맞춘다.
+- [x] 3.4 App 전체 test, lint·format, OpenSpec strict와 light Web dev 검증을 완료한다.
+- [x] 3.5 Linear와 PR 본문을 최종 계약·검증 결과에 맞춰 동기화한다.
+
+**Verification Record (2026-07-31, primary tint 보정)**
+
+- `@kosmo/app test`에서 Relay compiler(92 reader, 58 normalization, 99 operation text), TypeScript, unit,
+  static Storybook build와 Storybook browser interaction 19 files·256/256을 통과했다. Storybook의 기존 Relay
+  fixture warning·error boundary log·React act warning은 남지만 실패는 없다.
+- 새 hover 계약을 먼저 실행해 기존 `surface` 구현에서 `primary` background 기대가 실패하는 RED를 확인했고,
+  기본 `primary` 30% background·불투명 foreground와 glyph `z-index: 1` 구현 뒤 GREEN을 확인했다.
+- 변경 TypeScript의 ESLint, 변경 전체의 Prettier, `git diff --check`와 OpenSpec strict validation을 통과했다.
+- API `3300`, Web BFF `5474`를 유지한 채 App `5473`을 현재 worktree 소스로 재기동했고, 사용자 브라우저의
+  `/home`에서 최신 glyph foreground layer가 로드됨을 확인했다.
+- dark runtime, Web touch, Android와 iOS runtime은 실행하지 않았다. 승인된 제외 범위이며 완료 증거로
+  주장하지 않는다.

--- a/openspec/changes/visualize-post-action-hover-target/tasks.md
+++ b/openspec/changes/visualize-post-action-hover-target/tasks.md
@@ -1,0 +1,40 @@
+## 1. PROD-595 Web Post Action hover target
+
+**Authority / Provenance**
+
+- `docs/design/colors.md`
+- `docs/design/post-action-bar.md`
+- PROD-595
+
+**Deliverable**
+
+Web의 비터치 pointer가 Post Action control에 hover하면 기존 target 전체가 중립 `surface` background로
+드러나고, active·pressed·blocked 상태와 Action Bar geometry는 유지된다.
+
+**Guardrails**
+
+- Reply·Repost·Reaction·Bookmark는 기존 50×28 target, More는 기존 28×28 target을 변경하지 않는다.
+- pending·disabled·resolution-required에는 hover background를 표시하지 않는다.
+- Web touch와 Native에 hover 전용 표현을 추가하지 않는다.
+- action 기능·count·mutation·execution eligibility·Relay cache와 ThemeProvider를 변경하지 않는다.
+- 새 색상 token이나 runtime dependency를 추가하지 않는다.
+- dark runtime은 현재 검증 범위가 아니므로 실행 완료를 주장하지 않고 이 change를 archive하지 않는다.
+
+**Verification**
+
+- 테스트 코드 범위: 기존 `PostActionBar` Storybook interaction 한 파일에서 hover background, target shape,
+  active·pressed 보존, blocked 미표시와 geometry 불변을 직접 검증한다.
+- 테스트 필요성: 사용자에게 보이는 Web hover 동작과 기존 state·layout 회귀 위험을 관찰 가능한 DOM style과
+  geometry로 증명한다.
+- 테스트 제외 범위: 새 fixture·helper·harness, 중복 action 조합, snapshot, ThemeProvider·dark mode 테스트,
+  Web touch·Android·iOS runtime test와 action 기능·mutation test.
+- App typecheck, targeted Storybook interaction과 static Storybook build를 통과시킨다.
+- light Web runtime에서 pointer hover와 인접 target 비중첩을 관찰한다. dark·Web touch·Native runtime은
+  미실행으로 보고한다.
+
+- [ ] 1.1 공통 Post Action control에 승인된 Web 비터치 hover target 표현을 구현한다.
+- [ ] 1.2 가장 가까운 기존 Storybook interaction에 hover와 핵심 상태·geometry 회귀 검증을 추가한다.
+- [ ] 1.3 App check, targeted Storybook interaction, static Storybook build와 light Web 수동 관찰을 수행하고
+      미실행 platform 검증을 구분해 기록한다.
+- [ ] 1.4 구현과 검증 결과를 canonical 문서·Linear·OpenSpec에 대조하고 dark runtime 미검증 때문에 change를
+      active로 유지한다.

--- a/openspec/changes/visualize-post-action-hover-target/tasks.md
+++ b/openspec/changes/visualize-post-action-hover-target/tasks.md
@@ -58,6 +58,9 @@ background로 드러나고, active·pressed·blocked 상태와 Action Bar geomet
 
 ## 2. 시각 검토 보정 — glyph 중심 원형과 Reaction like tint (Superseded)
 
+이 section은 2026-07-31 중간 시각 결정을 완료했던 역사 기록이다. 아래 `surface` deliverable과 verification은
+section 3의 최종 `primary` 또는 `like` tint 계약으로 대체됐으며 현재 deliverable로 해석하지 않는다.
+
 **Authority / Provenance**
 
 - `docs/design/colors.md`
@@ -135,12 +138,13 @@ Web의 비터치 pointer가 Post Action control에 hover하면 click target은 �
 
 Web의 비터치 pointer가 Reply, Repost, Bookmark 또는 More에 hover하면 glyph 중심 28×28 원형은 30% opacity의
 semantic `primary` background로 표시되고 glyph는 불투명 `primary` foreground로 그 위에 표시된다. Reaction은
-같은 표현에 기존 `like`를 사용한다.
+같은 표현에 기존 `like`를 사용한다. Reply와 Repost의 count는 hover tint에 포함하지 않고 기존 색을 유지한다.
 
 **Guardrails**
 
 - Reply·Repost·Reaction·Bookmark의 기존 50×28 target과 More의 기존 28×28 target을 변경하지 않는다.
 - 28×28 background는 count와 glyph를 덮거나 pointer event를 받지 않으며 glyph는 명시적인 상위 layer에 둔다.
+  Reply·Repost count 색은 hover 전후에 바뀌지 않는다.
 - pending·disabled·resolution-required, Web touch와 Native의 기존 제외 경계를 유지한다.
 - action 기능·count·mutation·execution eligibility·Relay cache·ThemeProvider·dependency를 변경하지 않는다.
 - Reply·Repost·Bookmark·More를 서로 다른 tint로 분리하는 후속 범위는 포함하지 않는다.
@@ -148,7 +152,8 @@ semantic `primary` background로 표시되고 glyph는 불투명 `primary` foreg
 **Verification**
 
 - 기존 `ActionBarCatalog` interaction에서 Reply·Repost·Bookmark·More의 30% `primary` background와 불투명
-  `primary` foreground, glyph layer 순서와 hover 종료 시 default foreground 복귀를 검증한다.
+  `primary` foreground, background `z-index: 0`과 glyph `z-index: 1`, Reply·Repost count 색 유지 및 hover 종료
+  시 default foreground 복귀를 검증한다.
 - Reaction의 30% `like` background·불투명 `like` foreground와 selected 표현을 그대로 검증한다.
 - App 전체 test, 변경 파일 lint·format, OpenSpec strict, light Web dev 시각 관찰을 수행한다.
 - dark·Web touch·Android·iOS runtime은 미실행으로 구분한다.
@@ -160,6 +165,8 @@ semantic `primary` background로 표시되고 glyph는 불투명 `primary` foreg
 - [x] 3.3 canonical과 OpenSpec proposal·design·decision·spec을 최종 시각 결정에 맞춘다.
 - [x] 3.4 App 전체 test, lint·format, OpenSpec strict와 light Web dev 검증을 완료한다.
 - [x] 3.5 Linear와 PR 본문을 최종 계약·검증 결과에 맞춰 동기화한다.
+- [x] 3.6 리뷰에서 확인한 count hover tint 회귀를 Storybook RED로 재현하고 glyph와 count 색을 분리하며
+      background·glyph layer 순서 assertion을 보강한다.
 
 **Verification Record (2026-07-31, primary tint 보정)**
 
@@ -168,6 +175,8 @@ semantic `primary` background로 표시되고 glyph는 불투명 `primary` foreg
   fixture warning·error boundary log·React act warning은 남지만 실패는 없다.
 - 새 hover 계약을 먼저 실행해 기존 `surface` 구현에서 `primary` background 기대가 실패하는 RED를 확인했고,
   기본 `primary` 30% background·불투명 foreground와 glyph `z-index: 1` 구현 뒤 GREEN을 확인했다.
+- 리뷰에서 발견한 Reply·Repost count hover tint 회귀를 Storybook RED로 재현하고 glyph와 count 색을 분리한 뒤
+  256/256 GREEN을 확인했다. background `z-index: 0`과 glyph `z-index: 1`도 함께 고정했다.
 - 변경 TypeScript의 ESLint, 변경 전체의 Prettier, `git diff --check`와 OpenSpec strict validation을 통과했다.
 - API `3300`, Web BFF `5474`를 유지한 채 App `5473`을 현재 worktree 소스로 재기동했고, 사용자 브라우저의
   `/home`에서 최신 glyph foreground layer가 로드됨을 확인했다.

--- a/openspec/changes/visualize-post-action-hover-target/tasks.md
+++ b/openspec/changes/visualize-post-action-hover-target/tasks.md
@@ -98,9 +98,10 @@ Web의 비터치 pointer가 Post Action control에 hover하면 click target은 �
 
 **Verification Record (2026-07-31, X-style 보정)**
 
-- `@kosmo/app test`를 게시 직전 트리에서 실행해 Relay compiler와 TypeScript, unit 103/103, static Storybook
-  build, Storybook browser interaction 237/237를 통과했다. Expo dev server가 만든 ignored router type은
-  원본을 임시 경로에 보존한 채 clean check에서 제외하고 즉시 복원했다.
+- `@kosmo/app test`를 최신 부모 위 게시 직전 트리에서 실행해 Relay compiler(92 reader, 58 normalization,
+  99 operation text)와 TypeScript, unit 137/137, static Storybook build, Storybook browser interaction
+  256/256을 통과했다. Expo dev server가 만든 ignored router type은 원본을 임시 경로에 보존한 채 clean
+  check에서 제외하고 즉시 복원했다.
 - `ActionBarCatalog`는 미선택 Reaction hover에서 background `like` opacity `0.3`, heart의 불투명 `like`
   stroke와 hover 종료 뒤 default 색 복귀를 검증한다. selected Reaction은 hover 전·중·후 불투명 `like`
   stroke·fill을 유지하며, 원형 background만 hover 동안 opacity `0.3`으로 표시된다.

--- a/openspec/changes/visualize-post-action-hover-target/tasks.md
+++ b/openspec/changes/visualize-post-action-hover-target/tasks.md
@@ -1,4 +1,7 @@
-## 1. PROD-595 Web Post Action hover target
+## 1. 초기 전체-target 구현 기록 (Superseded)
+
+이 section은 2026-07-31 시각 검토 전에 완료한 구현과 검증의 역사적 기록이다. 현재 deliverable과 완료
+계약은 아래 `2. 시각 검토 보정` section이 대체한다.
 
 **Authority / Provenance**
 
@@ -8,8 +11,8 @@
 
 **Deliverable**
 
-Web의 비터치 pointer가 Post Action control에 hover하면 기존 target 전체가 중립 `surface` background로
-드러나고, active·pressed·blocked 상태와 Action Bar geometry는 유지된다.
+최초 구현에서는 Web의 비터치 pointer가 Post Action control에 hover하면 기존 target 전체가 중립 `surface`
+background로 드러나고, active·pressed·blocked 상태와 Action Bar geometry가 유지됐다.
 
 **Guardrails**
 
@@ -49,4 +52,50 @@ Web의 비터치 pointer가 Post Action control에 hover하면 기존 target 전
 - [x] 1.3 App check, targeted Storybook interaction, static Storybook build와 light Web 수동 관찰을 수행하고
       미실행 platform 검증을 구분해 기록한다.
 - [x] 1.4 구현과 검증 결과를 canonical 문서·Linear·OpenSpec에 대조하고 dark runtime 미검증 때문에 change를
+      active로 유지한다.
+
+## 2. 시각 검토 보정 — glyph 중심 원형과 Reaction like tint
+
+**Authority / Provenance**
+
+- `docs/design/colors.md`
+- `docs/design/post-action-bar.md`
+- PROD-595의 2026-07-31 승인된 본문
+
+**Deliverable**
+
+Web의 비터치 pointer가 Post Action control에 hover하면 click target은 유지된 채 glyph 중심 28×28 원형만
+표시된다. 일반 action은 중립 `surface`, Reaction은 `like`를 사용하며 selected Reaction heart도 `like`를
+유지한다.
+
+**Guardrails**
+
+- Reply·Repost·Reaction·Bookmark의 기존 50×28 target과 More의 기존 28×28 target을 변경하지 않는다.
+- 28×28 hover visual은 count와 icon의 layout 간격을 바꾸지 않고 pointer event를 받지 않는다.
+- hover visual은 count를 포함해 늘어나는 pill이 아니다. 고정 28×28 원형과 기존 16px glyph·4px count gap을
+  함께 유지한다.
+- pending·disabled·resolution-required에는 hover background를 표시하지 않는다.
+- Web touch와 Native에 hover 전용 표현을 추가하지 않는다.
+- action 기능·count·mutation·execution eligibility·Relay cache와 ThemeProvider를 변경하지 않는다.
+- Reply·Repost·Bookmark·More의 action별 tint, 새 색상 token과 runtime dependency를 추가하지 않는다.
+- dark runtime은 현재 검증 범위가 아니므로 실행 완료를 주장하지 않고 이 change를 archive하지 않는다.
+
+**Verification**
+
+- 테스트 코드 범위: 기존 `PostActionBar.stories.tsx`의 `ActionBarCatalog` interaction에서 glyph 중심 28×28
+  원형, `surface`·`like`, click target과 icon-count geometry, selected·pressed 보존과 blocked 미표시를 검증한다.
+- 테스트 필요성: 사용자에게 보이는 보정 동작과 click target·layout 회귀 위험을 관찰 가능한 DOM style과
+  geometry로 증명한다.
+- 테스트 제외 범위: 새 fixture·helper·harness, 중복 action 조합, snapshot, ThemeProvider·dark mode 테스트,
+  Web touch·Android·iOS runtime test와 action 기능·mutation test.
+- App check, targeted Storybook interaction, static Storybook build와 OpenSpec strict validation을 통과시킨다.
+- light Web runtime에서 hover 원형과 인접 target 비중첩을 관찰한다. dark·Web touch·Native runtime은
+  미실행으로 보고한다.
+
+- [x] 2.1 canonical과 Linear에 승인된 glyph 중심 원형 및 Reaction `like` 계약을 반영한다.
+- [x] 2.2 기존 Storybook interaction을 새 hover·selected Reaction 계약으로 수정하고 RED 실패를 확인한다.
+- [x] 2.3 공통 Post Action control과 Reaction 연결에 최소 구현을 적용하고 targeted interaction을 GREEN으로 만든다.
+- [ ] 2.4 App check, targeted Storybook interaction, static Storybook build, OpenSpec strict와 light Web 수동 관찰을
+      수행하고 미실행 platform 검증을 구분해 기록한다.
+- [ ] 2.5 구현과 검증 결과를 canonical·Linear·OpenSpec에 대조하고 dark runtime 미검증 때문에 change를
       active로 유지한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- 공통 `PostActionControl`의 Web hover를 glyph 중심 28×28 원형 visual로 표시
  - Reply·Repost·Bookmark·More는 30% opacity의 semantic `primary` background와 불투명 `primary` foreground 사용
  - Reaction은 30% opacity의 semantic `like` background와 불투명 `like` heart foreground 사용
  - Reply·Repost count는 hover tint와 분리해 기존 default 또는 active 색 유지
  - foreground glyph를 background보다 높은 layer에 두어 원형이 icon을 덮지 않게 함
- Reply·Repost·Reaction·Bookmark의 기존 50×28 click target과 More의 28×28 target, 16px glyph와 4px icon-count gap 유지
- pending·disabled·resolution-required control에는 hover background를 표시하지 않고 기존 active·selected·pressed 표현 유지
- 기존 `PostActionBar` Storybook interaction에서 모든 action의 tint, foreground layer, Reply·Repost count 색,
  geometry와 상태 회귀를 검증
- PROD-595 Linear, canonical 디자인 문서와 `visualize-post-action-hover-target` OpenSpec을 최종 시각 결정에 맞게 동기화

Stack: `main -> prod-425 -> prod-432 (#437) -> prod-595`

## 왜 변경했는지

초기 glyph 중심 구현에서 Reply·Repost·Bookmark·More의 불투명 `surface` background가 Web 페인팅 순서상 SVG 위에 그려져 icon이 사라진 원처럼 보였습니다. X(Twitter) Action Bar처럼 넓은 click target은 유지하되, 옅은 semantic 원형과 그 위의 같은 tint foreground를 분리해 compact하면서도 선명한 hover 반응을 제공합니다.

## 이번 PR의 주요 결정

### click target과 hover visual을 분리한다

- 결정자: 이예은
- 선택: 기존 50×28/28×28 click target은 유지하고 16×16 glyph 중심에 28×28 원형 visual layer만 표시
- 고려한 대안: click target 전체를 50×28 pill 또는 28×28 원형으로 표시
- 이유: 넓은 클릭 영역은 보존하면서 Action Bar의 시각적 무게를 낮추기 위함
- 감수한 결과: 원형은 count를 감싸지 않으며 기존 4px icon-count layout gap을 그대로 유지함
- 관련 근거: `docs/design/post-action-bar.md`, PROD-595, `openspec/changes/visualize-post-action-hover-target/decisions.md`

### 일반 action은 primary, Reaction은 like tint를 사용한다

- 결정자: 이예은
- 선택: Reply·Repost·Bookmark·More는 30% `primary` background와 불투명 `primary` glyph foreground,
  Reaction은 같은 표현에 `like`를 사용하고 Reply·Repost count는 기존 색을 유지
- 고려한 대안: 일반 action에 불투명 중립 `surface`를 유지하거나, 이번 PR에서 action별 tint를 모두 분리
- 이유: Reaction에서 검증된 옅은 원형과 선명한 foreground 표현을 모든 action에 적용하면서 KOSMO 공통 색을 사용하기 위함
- 감수한 결과: Reply·Repost·Bookmark·More를 서로 다른 tint로 분리하는 확장은 후속 범위로 남김
- 관련 근거: `docs/design/post-action-bar.md`, PROD-595, `openspec/changes/visualize-post-action-hover-target/decisions.md`

### foreground layer를 명시한다

- 결정자: 이예은
- 선택: 16×16 glyph wrapper를 `z-index: 1`, 원형 background를 `z-index: 0`으로 고정
- 고려한 대안: 30% opacity만으로 icon이 비쳐 보이게 유지
- 이유: opacity 합성에 우연히 의존하지 않고 foreground가 실제로 background 위에 그려지게 하기 위함
- 감수한 결과: icon layout box 안에 시각 전용 wrapper 한 겹이 추가되지만 target과 간격은 변하지 않음
- 관련 근거: `docs/design/post-action-bar.md`, PROD-595, `openspec/changes/visualize-post-action-hover-target/decisions.md`

### 기존 Action Bar change와 생명주기를 분리한다

- 결정자: 이예은
- 선택: PROD-595가 별도 OpenSpec change를 소유하고 PROD-432 위에 stack
- 고려한 대안: 기존 `add-post-action-bar` change에 hover task를 추가
- 이유: PROD-432 archive와 후행 PROD-595 사이의 순환 생명주기를 피함
- 감수한 결과: PR readiness와 OpenSpec archive를 분리하며, PR 통합만으로 change를 자동 archive하지 않음
- 관련 근거: PROD-432, PROD-595, `openspec/changes/visualize-post-action-hover-target/decisions.md`

## 어떻게 확인했는지

- `pnpm --filter @kosmo/app test`
  - Relay compiler(92 reader, 58 normalization, 99 operation text)와 TypeScript 통과
  - unit 통과
  - static Storybook build 성공
  - Storybook browser interaction 19 files·256/256 통과
- TDD 회귀 확인
  - 기존 `surface` 구현에서 `primary` background 기대가 실패하는 RED 확인
  - `primary` 30% background·불투명 foreground와 glyph layer 구현 뒤 GREEN 확인
  - 리뷰에서 발견한 Reply·Repost count hover tint 회귀를 RED로 재현하고 glyph/count 색 분리 뒤 GREEN 확인
  - background `z-index: 0`과 glyph `z-index: 1`의 상대 layer 계약을 assertion으로 고정
- `pnpm exec openspec validate visualize-post-action-hover-target --strict`
  - strict validation 통과
- 변경 TypeScript ESLint, 변경 전체 Prettier, `git diff --check`
  - 통과
- 로컬 API(3300), Web BFF(5474), Expo Web(5473)
  - 모두 HTTP 200
  - `http://localhost:5473/home`에서 현재 worktree 번들과 foreground layer 로드를 확인
- 최신 부모 `prod-432` `957be36a`가 현재 브랜치의 ancestor이고 기존 child commit을 `range-diff`로 대조함

## 아직 어떤 문제가 남았는지

- 실제 사용자 pointer의 최종 시각 확인은 `http://localhost:5473/home`에서 가능
- dark theme, Web touch, Android와 iOS runtime은 승인된 제외 범위로 미검증
- API·GraphQL·Relay mutation/cache, ThemeProvider, dependency와 Native target은 변경하지 않음
- OpenSpec change는 PR readiness와 별도 생명주기로 PROD-595 owner가 이후 archive 책임을 유지
- 부모 PR #437 merge 전에는 이 PR을 병합할 수 없음
- 최종 HEAD `b7327634`의 hosted Lint·Test와 독립 3중 리뷰를 모두 통과했으며 finding 없음
