### PR TITLE
Post 목록과 상세에서 첨부 이미지를 표시한다

### DIFF
--- a/apps/app/src/components/post/PostBody.tsx
+++ b/apps/app/src/components/post/PostBody.tsx
@@ -9,6 +9,11 @@ const PostBodyFragment = graphql`
       id
       document
       bodyText
+      media {
+        id
+        altText
+        url
+      }
     }
   }
 `;
@@ -16,10 +21,12 @@ const PostBodyFragment = graphql`
 export function PostBody({
   interactive = true,
   post: postKey,
+  onBodyPress,
   size = 'md',
 }: {
   interactive?: boolean;
   post: PostBody_post$key;
+  onBodyPress?: () => void;
   size?: 'md' | 'lg';
 }) {
   const post = useFragment(PostBodyFragment, postKey);
@@ -34,6 +41,14 @@ export function PostBody({
       bodyText={content.bodyText}
       document={content.document}
       interactive={interactive}
+      media={
+        content.media?.map(({ altText, id, url }) => ({
+          altText: altText ?? null,
+          id,
+          url: url ?? null,
+        })) ?? null
+      }
+      onBodyPress={onBodyPress}
       size={size}
     />
   );

--- a/apps/app/src/components/post/PostContentRenderer.tsx
+++ b/apps/app/src/components/post/PostContentRenderer.tsx
@@ -1,9 +1,10 @@
 import { isPostContentDocumentV1 } from '@kosmo/core/post-content';
 import { Fragment } from 'react';
-import { Linking, StyleSheet, Text } from 'react-native';
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
 import { match } from 'ts-pattern';
 import { useTheme } from '@/theme/ThemeProvider';
-import { typography } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
+import { PostMediaGallery } from './PostMediaGallery';
 import type {
   PostContentBlockNode,
   PostContentBodyDocumentV1,
@@ -12,6 +13,7 @@ import type {
 } from '@kosmo/core/post-content';
 import type { Key, ReactNode } from 'react';
 import type { StyleProp, TextProps, TextStyle } from 'react-native';
+import type { PostMediaItem } from './PostMediaGallery';
 
 type PostContentMark = NonNullable<PostContentTextNode['marks']>[number];
 
@@ -26,11 +28,15 @@ export function PostContentRenderer({
   bodyText,
   document: value,
   interactive = true,
+  media,
+  onBodyPress,
   size = 'md',
 }: {
   bodyText: string;
   document: unknown;
   interactive?: boolean;
+  media: ReadonlyArray<PostMediaItem> | null;
+  onBodyPress?: () => void;
   size?: 'md' | 'lg';
 }) {
   const theme = useTheme();
@@ -41,14 +47,37 @@ export function PostContentRenderer({
     { color: theme.text },
   ];
 
-  if (!document) {
-    return bodyText ? (
-      <Text {...replayBlockProps} style={bodyStyle}>
-        {bodyText}
-      </Text>
-    ) : null;
+  const body = !bodyText ? null : !document ? (
+    <Text {...replayBlockProps} style={bodyStyle}>
+      {bodyText}
+    </Text>
+  ) : (
+    renderNode(document, 'body', { bodyStyle, interactive })
+  );
+  const bodyContent =
+    body && onBodyPress ? (
+      <Pressable
+        accessible={false}
+        focusable={false}
+        onPress={onBodyPress}
+        tabIndex={-1}
+        testID="post-list-row-body"
+      >
+        {body}
+      </Pressable>
+    ) : (
+      body
+    );
+
+  if (!bodyContent && media !== null && media.length === 0) {
+    return null;
   }
-  return renderNode(document, 'body', { bodyStyle, interactive });
+  return (
+    <View style={styles.root} testID="post-content-renderer">
+      {bodyContent}
+      <PostMediaGallery media={media} sensitive={document?.attrs?.sensitiveMedia ?? false} />
+    </View>
+  );
 }
 
 type PostContentNode = PostContentBodyDocumentV1 | PostContentBlockNode | PostContentInlineNode;
@@ -117,6 +146,7 @@ function renderMark(
 }
 
 const styles = StyleSheet.create({
+  root: { gap: spacing.sm, minWidth: 0 },
   body: { fontFamily: 'Pretendard' },
   link: { textDecorationLine: 'underline' },
 });

--- a/apps/app/src/components/post/PostContentRenderer.tsx
+++ b/apps/app/src/components/post/PostContentRenderer.tsx
@@ -75,7 +75,11 @@ export function PostContentRenderer({
   return (
     <View style={styles.root} testID="post-content-renderer">
       {bodyContent}
-      <PostMediaGallery media={media} sensitive={document?.attrs?.sensitiveMedia ?? false} />
+      <PostMediaGallery
+        interactive={interactive}
+        media={media}
+        sensitive={document?.attrs?.sensitiveMedia ?? false}
+      />
     </View>
   );
 }

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -315,17 +315,10 @@ function PostListRow({
             </Pressable>
           </Link>
         </View>
-        {post.content?.bodyText ? (
-          <Pressable
-            accessible={false}
-            focusable={false}
-            onPress={() => router.push(detailHref)}
-            style={styles.bodyLink}
-            tabIndex={-1}
-            testID="post-list-row-body"
-          >
-            <PostBody post={post} />
-          </Pressable>
+        {post.content ? (
+          <View style={styles.bodyLink}>
+            <PostBody onBodyPress={() => router.push(detailHref)} post={post} />
+          </View>
         ) : null}
         <PostReactionActions
           actionBar={post.actionBar!}

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -8,19 +8,18 @@ import type { PostMediaItem } from './PostMediaGallery';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-const ImageMock = Object.assign((props: Record<string, unknown>) => createElement('Image', props), {
-  getSize: (uri: string, success: (width: number, height: number) => void) => {
-    success(uri.endsWith('/2.webp') ? 900 : 1600, uri.endsWith('/2.webp') ? 1600 : 900);
-  },
-});
-
 mock.module('react-native', {
   exports: {
-    Image: ImageMock,
     Pressable: 'Pressable',
     StyleSheet: { create: <T>(styles: T) => styles },
     Text: 'Text',
     View: 'View',
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+
+mock.module('./PostMediaImage', {
+  exports: {
+    PostMediaImage: (props: Record<string, unknown>) => createElement('PostMediaImage', props),
   },
 } as unknown as Parameters<typeof mock.module>[1]);
 
@@ -42,7 +41,7 @@ afterEach(async () => {
 });
 
 describe('PostMediaGallery', () => {
-  it('document 순서의 최대 네 이미지와 nullable Alt Text fallback을 표시한다', async () => {
+  it('document 순서대로 이미지를 최대 네 개 표시한다', async () => {
     await render({
       media: Array.from({ length: 5 }, (_, index) =>
         media(index + 1, index === 1 ? null : `설명 ${index + 1}`),
@@ -51,59 +50,30 @@ describe('PostMediaGallery', () => {
     });
 
     assert.deepEqual(
-      rendered('Image').map((image) => image.props.accessibilityLabel),
-      ['설명 1', '2번째 첨부 이미지', '설명 3', '설명 4'],
+      rendered('PostMediaImage').map(({ props }) => props.item.id),
+      ['media-1', 'media-2', 'media-3', 'media-4'],
     );
-
-    const firstOnLoad = image('media-1').props.onLoad;
-    await act(async () => firstOnLoad());
-    assert.equal(image('media-1').props.onLoad, firstOnLoad);
-    assert.equal(frameAspectRatio('media-1'), 1600 / 900);
-    assert.equal(frameAspectRatio('media-2'), 1);
   });
 
   it('Sensitive Media를 image mount 없이 시작하고 전체 표시와 다시 가리기를 제공한다', async () => {
     await render({ media: [media(1, null), media(2, '두 번째 이미지')], sensitive: true });
 
-    assert.equal(rendered('Image').length, 0);
+    assert.equal(rendered('PostMediaImage').length, 0);
     const reveal = pressable('민감한 이미지 표시');
     assert.deepEqual(reveal.props.accessibilityState, { expanded: false });
 
     await act(async () => reveal.props.onPress());
-    assert.equal(rendered('Image').length, 2);
+    assert.equal(rendered('PostMediaImage').length, 2);
     const hide = pressable('민감한 이미지 다시 가리기');
     assert.deepEqual(hide.props.accessibilityState, { expanded: true });
 
     await act(async () => hide.props.onPress());
-    assert.equal(rendered('Image').length, 0);
+    assert.equal(rendered('PostMediaImage').length, 0);
   });
 
-  it('한 이미지 오류를 격리하고 같은 URL로 해당 Image만 다시 mount한다', async () => {
-    await render({
-      media: [media(1, '첫 번째 이미지'), media(2, '두 번째 이미지')],
-      sensitive: false,
-    });
-    const firstUrl = image('media-1').props.source;
-
-    await act(async () => image('media-1').props.onError());
-    assert.equal(rendered('Image').length, 1);
-    assert.equal(rendered('Image')[0]?.props.accessibilityLabel, '두 번째 이미지');
-
-    await act(async () => pressable('첫 번째 이미지 다시 시도').props.onPress());
-    assert.equal(rendered('Image').length, 2);
-    assert.deepEqual(image('media-1').props.source, firstUrl);
-
-    await act(async () => image('media-1').props.onError());
-    assert.equal(pressable('첫 번째 이미지 다시 시도').props.accessibilityRole, 'button');
-  });
-
-  it('표시 정보 unavailable과 URL 없는 Media를 Post 전체 오류 없이 구분한다', async () => {
+  it('표시 정보 unavailable을 Post 전체 오류 없이 표시한다', async () => {
     await render({ media: null, sensitive: false });
     assert.equal(byTestId('post-media-unavailable').props.accessibilityRole, 'alert');
-
-    await render({ media: [{ ...media(1, null), url: null }], sensitive: false });
-    assert.ok(byTestId('post-media-error-media-1'));
-    assert.equal(rendered('Pressable').length, 0);
   });
 });
 
@@ -133,17 +103,6 @@ function pressable(accessibilityLabel: string): ReactTestInstance {
   );
   assert.ok(result);
   return result;
-}
-
-function image(id: string): ReactTestInstance {
-  return byTestId(`post-media-image-${id}`);
-}
-
-function frameAspectRatio(id: string): number | undefined {
-  const style = byTestId(`post-media-frame-${id}`).props.style as ReadonlyArray<{
-    aspectRatio?: number;
-  }>;
-  return style.find(({ aspectRatio }) => aspectRatio !== undefined)?.aspectRatio;
 }
 
 function byTestId(testID: string): ReactTestInstance {

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -65,10 +65,12 @@ describe('PostMediaGallery', () => {
     await act(async () => reveal.props.onPress());
     assert.equal(rendered('PostMediaImage').length, 2);
     const hide = pressable('민감한 이미지 다시 가리기');
+    assert.equal(hide, reveal);
     assert.deepEqual(hide.props.accessibilityState, { expanded: true });
 
     await act(async () => hide.props.onPress());
     assert.equal(rendered('PostMediaImage').length, 0);
+    assert.equal(pressable('민감한 이미지 표시'), reveal);
   });
 
   it('표시 정보 unavailable을 Post 전체 오류 없이 표시한다', async () => {

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -48,6 +48,10 @@ describe('PostMediaGallery', () => {
       rendered('Image').map((image) => image.props.accessibilityLabel),
       ['설명 1', '2번째 첨부 이미지', '설명 3', '설명 4'],
     );
+
+    const firstOnLoad = image('media-1').props.onLoad;
+    await act(async () => firstOnLoad());
+    assert.equal(image('media-1').props.onLoad, firstOnLoad);
   });
 
   it('Sensitive Media를 image mount 없이 시작하고 전체 표시와 다시 가리기를 제공한다', async () => {

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -8,9 +8,15 @@ import type { PostMediaItem } from './PostMediaGallery';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
+const ImageMock = Object.assign((props: Record<string, unknown>) => createElement('Image', props), {
+  getSize: (uri: string, success: (width: number, height: number) => void) => {
+    success(uri.endsWith('/2.webp') ? 900 : 1600, uri.endsWith('/2.webp') ? 1600 : 900);
+  },
+});
+
 mock.module('react-native', {
   exports: {
-    Image: 'Image',
+    Image: ImageMock,
     Pressable: 'Pressable',
     StyleSheet: { create: <T>(styles: T) => styles },
     Text: 'Text',
@@ -52,6 +58,8 @@ describe('PostMediaGallery', () => {
     const firstOnLoad = image('media-1').props.onLoad;
     await act(async () => firstOnLoad());
     assert.equal(image('media-1').props.onLoad, firstOnLoad);
+    assert.equal(frameAspectRatio('media-1'), 1600 / 900);
+    assert.equal(frameAspectRatio('media-2'), 1);
   });
 
   it('Sensitive Media를 image mount 없이 시작하고 전체 표시와 다시 가리기를 제공한다', async () => {
@@ -129,6 +137,13 @@ function pressable(accessibilityLabel: string): ReactTestInstance {
 
 function image(id: string): ReactTestInstance {
   return byTestId(`post-media-image-${id}`);
+}
+
+function frameAspectRatio(id: string): number | undefined {
+  const style = byTestId(`post-media-frame-${id}`).props.style as ReadonlyArray<{
+    aspectRatio?: number;
+  }>;
+  return style.find(({ aspectRatio }) => aspectRatio !== undefined)?.aspectRatio;
 }
 
 function byTestId(testID: string): ReactTestInstance {

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, describe, it, mock } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ComponentType } from 'react';
+import type { ReactTestInstance, ReactTestRenderer } from 'react-test-renderer';
+import type { PostMediaItem } from './PostMediaGallery';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+mock.module('react-native', {
+  exports: {
+    Image: 'Image',
+    Pressable: 'Pressable',
+    StyleSheet: { create: <T>(styles: T) => styles },
+    Text: 'Text',
+    View: 'View',
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+
+let PostMediaGallery: ComponentType<{
+  media: ReadonlyArray<PostMediaItem> | null;
+  sensitive: boolean;
+}>;
+let renderer: ReactTestRenderer | null = null;
+
+before(async () => {
+  ({ PostMediaGallery } = await import('./PostMediaGallery'));
+});
+
+afterEach(async () => {
+  if (renderer) {
+    await act(async () => renderer?.unmount());
+    renderer = null;
+  }
+});
+
+describe('PostMediaGallery', () => {
+  it('document 순서의 최대 네 이미지와 nullable Alt Text fallback을 표시한다', async () => {
+    await render({
+      media: Array.from({ length: 5 }, (_, index) =>
+        media(index + 1, index === 1 ? null : `설명 ${index + 1}`),
+      ),
+      sensitive: false,
+    });
+
+    assert.deepEqual(
+      rendered('Image').map((image) => image.props.accessibilityLabel),
+      ['설명 1', '2번째 첨부 이미지', '설명 3', '설명 4'],
+    );
+  });
+
+  it('Sensitive Media를 image mount 없이 시작하고 전체 표시와 다시 가리기를 제공한다', async () => {
+    await render({ media: [media(1, null), media(2, '두 번째 이미지')], sensitive: true });
+
+    assert.equal(rendered('Image').length, 0);
+    const reveal = pressable('민감한 이미지 표시');
+    assert.deepEqual(reveal.props.accessibilityState, { expanded: false });
+
+    await act(async () => reveal.props.onPress());
+    assert.equal(rendered('Image').length, 2);
+    const hide = pressable('민감한 이미지 다시 가리기');
+    assert.deepEqual(hide.props.accessibilityState, { expanded: true });
+
+    await act(async () => hide.props.onPress());
+    assert.equal(rendered('Image').length, 0);
+  });
+
+  it('한 이미지 오류를 격리하고 같은 URL로 해당 Image만 다시 mount한다', async () => {
+    await render({
+      media: [media(1, '첫 번째 이미지'), media(2, '두 번째 이미지')],
+      sensitive: false,
+    });
+    const firstUrl = image('media-1').props.source;
+
+    await act(async () => image('media-1').props.onError());
+    assert.equal(rendered('Image').length, 1);
+    assert.equal(rendered('Image')[0]?.props.accessibilityLabel, '두 번째 이미지');
+
+    await act(async () => pressable('첫 번째 이미지 다시 시도').props.onPress());
+    assert.equal(rendered('Image').length, 2);
+    assert.deepEqual(image('media-1').props.source, firstUrl);
+
+    await act(async () => image('media-1').props.onError());
+    assert.equal(pressable('첫 번째 이미지 다시 시도').props.accessibilityRole, 'button');
+  });
+
+  it('표시 정보 unavailable과 URL 없는 Media를 Post 전체 오류 없이 구분한다', async () => {
+    await render({ media: null, sensitive: false });
+    assert.equal(byTestId('post-media-unavailable').props.accessibilityRole, 'alert');
+
+    await render({ media: [{ ...media(1, null), url: null }], sensitive: false });
+    assert.ok(byTestId('post-media-error-media-1'));
+    assert.equal(rendered('Pressable').length, 0);
+  });
+});
+
+function media(index: number, altText: string | null): PostMediaItem {
+  return { altText, id: `media-${index}`, url: `https://media.example/${index}.webp` };
+}
+
+async function render(props: { media: ReadonlyArray<PostMediaItem> | null; sensitive: boolean }) {
+  await act(async () => {
+    if (renderer) {
+      renderer.update(createElement(PostMediaGallery, props));
+    } else {
+      renderer = create(createElement(PostMediaGallery, props));
+    }
+  });
+  assert.ok(renderer);
+}
+
+function rendered(type: string): ReactTestInstance[] {
+  assert.ok(renderer);
+  return renderer.root.findAll((node) => node.type === type);
+}
+
+function pressable(accessibilityLabel: string): ReactTestInstance {
+  const result = rendered('Pressable').find(
+    (node) => node.props.accessibilityLabel === accessibilityLabel,
+  );
+  assert.ok(result);
+  return result;
+}
+
+function image(id: string): ReactTestInstance {
+  return byTestId(`post-media-image-${id}`);
+}
+
+function byTestId(testID: string): ReactTestInstance {
+  assert.ok(renderer);
+  return renderer.root.findByProps({ testID });
+}

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -24,6 +24,7 @@ mock.module('./PostMediaImage', {
 } as unknown as Parameters<typeof mock.module>[1]);
 
 let PostMediaGallery: ComponentType<{
+  interactive?: boolean;
   media: ReadonlyArray<PostMediaItem> | null;
   sensitive: boolean;
 }>;
@@ -77,13 +78,24 @@ describe('PostMediaGallery', () => {
     await render({ media: null, sensitive: false });
     assert.equal(byTestId('post-media-unavailable').props.accessibilityRole, 'alert');
   });
+
+  it('비대화형 Sensitive Media에서는 image와 공개 control을 mount하지 않는다', async () => {
+    await render({ interactive: false, media: [media(1, null)], sensitive: true });
+
+    assert.equal(rendered('PostMediaImage').length, 0);
+    assert.equal(rendered('Pressable').length, 0);
+  });
 });
 
 function media(index: number, altText: string | null): PostMediaItem {
   return { altText, id: `media-${index}`, url: `https://media.example/${index}.webp` };
 }
 
-async function render(props: { media: ReadonlyArray<PostMediaItem> | null; sensitive: boolean }) {
+async function render(props: {
+  interactive?: boolean;
+  media: ReadonlyArray<PostMediaItem> | null;
+  sensitive: boolean;
+}) {
   await act(async () => {
     if (renderer) {
       renderer.update(createElement(PostMediaGallery, props));

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/theme/ThemeProvider';
+import { radii, spacing, typography } from '@/theme/tokens';
+
+export type PostMediaItem = {
+  readonly altText: string | null;
+  readonly id: string;
+  readonly url: string | null;
+};
+
+export function PostMediaGallery({
+  media,
+  sensitive,
+}: {
+  readonly media: ReadonlyArray<PostMediaItem> | null;
+  readonly sensitive: boolean;
+}) {
+  const theme = useTheme();
+  const [revealed, setRevealed] = useState(false);
+
+  if (media === null) {
+    return (
+      <View
+        accessibilityLiveRegion="polite"
+        accessibilityRole="alert"
+        style={[styles.fallback, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        testID="post-media-unavailable"
+      >
+        <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
+          이미지를 불러올 수 없습니다.
+        </Text>
+      </View>
+    );
+  }
+
+  const items = media.slice(0, 4);
+  if (items.length === 0) {
+    return null;
+  }
+
+  if (sensitive && !revealed) {
+    return (
+      <View
+        style={[styles.sensitive, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        testID="post-media-sensitive"
+      >
+        <Text style={[styles.sensitiveTitle, { color: theme.text }]}>민감한 이미지</Text>
+        <Text style={[styles.sensitiveDescription, { color: theme.textSecondary }]}>
+          작성자가 민감한 내용으로 표시했습니다.
+        </Text>
+        <MediaVisibilityButton expanded={false} onPress={() => setRevealed(true)} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.root} testID="post-media-gallery">
+      {sensitive ? <MediaVisibilityButton expanded onPress={() => setRevealed(false)} /> : null}
+      {items.map((item, index) => (
+        <PostMediaImage index={index} item={item} key={item.id} />
+      ))}
+    </View>
+  );
+}
+
+function MediaVisibilityButton({
+  expanded,
+  onPress,
+}: {
+  readonly expanded: boolean;
+  readonly onPress: () => void;
+}) {
+  const theme = useTheme();
+
+  return (
+    <Pressable
+      aria-expanded={expanded}
+      accessibilityLabel={expanded ? '민감한 이미지 다시 가리기' : '민감한 이미지 표시'}
+      accessibilityRole="button"
+      accessibilityState={{ expanded }}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.visibilityButton,
+        { backgroundColor: pressed ? theme.primaryHover : theme.primary },
+      ]}
+    >
+      <Text style={[styles.visibilityButtonText, { color: theme.text }]}>
+        {expanded ? '다시 가리기' : '이미지 표시'}
+      </Text>
+    </Pressable>
+  );
+}
+
+function PostMediaImage({ index, item }: { readonly index: number; readonly item: PostMediaItem }) {
+  const theme = useTheme();
+  const [generation, setGeneration] = useState(0);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
+
+  if (!item.url || status === 'error') {
+    return (
+      <View
+        accessibilityLiveRegion="polite"
+        style={[styles.fallback, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        testID={`post-media-error-${item.id}`}
+      >
+        <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
+          {accessibilityLabel}을 불러오지 못했습니다.
+        </Text>
+        {item.url ? (
+          <Pressable
+            accessibilityLabel={`${accessibilityLabel} 다시 시도`}
+            accessibilityRole="button"
+            onPress={() => {
+              setGeneration((value) => value + 1);
+              setStatus('loading');
+            }}
+            style={({ pressed }) => [
+              styles.retryButton,
+              { borderColor: theme.border, opacity: pressed ? 0.7 : 1 },
+            ]}
+          >
+            <Text style={[styles.retryButtonText, { color: theme.text }]}>다시 시도</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.imageFrame, { backgroundColor: theme.surface }]}
+      testID={`post-media-frame-${item.id}`}
+    >
+      <Image
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={{ busy: status === 'loading' }}
+        key={`${item.id}:${generation}`}
+        onError={() => setStatus('error')}
+        onLoad={() => setStatus('ready')}
+        onLoadStart={() => setStatus('loading')}
+        resizeMode="cover"
+        source={{ uri: item.url }}
+        style={styles.image}
+        testID={`post-media-image-${item.id}`}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { gap: spacing.sm },
+  imageFrame: { aspectRatio: 16 / 9, borderRadius: radii.md, overflow: 'hidden' },
+  image: { height: '100%', width: '100%' },
+  sensitive: {
+    alignItems: 'center',
+    borderRadius: radii.md,
+    borderWidth: 1,
+    gap: spacing.xs,
+    padding: spacing.lg,
+  },
+  sensitiveTitle: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
+  sensitiveDescription: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
+  visibilityButton: {
+    alignItems: 'center',
+    borderRadius: radii.full,
+    justifyContent: 'center',
+    marginTop: spacing.xs,
+    minHeight: 48,
+    minWidth: 120,
+    paddingHorizontal: spacing.lg,
+  },
+  visibilityButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
+  fallback: {
+    alignItems: 'center',
+    borderRadius: radii.md,
+    borderWidth: 1,
+    gap: spacing.sm,
+    justifyContent: 'center',
+    minHeight: 144,
+    padding: spacing.lg,
+  },
+  fallbackText: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
+  retryButton: {
+    alignItems: 'center',
+    borderRadius: radii.full,
+    borderWidth: 1,
+    justifyContent: 'center',
+    minHeight: 48,
+    minWidth: 112,
+    paddingHorizontal: spacing.lg,
+  },
+  retryButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
+});

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -37,24 +37,38 @@ export function PostMediaGallery({
     return null;
   }
 
-  if (sensitive && !revealed) {
+  if (sensitive) {
     return (
       <View
-        style={[styles.sensitive, { backgroundColor: theme.surface, borderColor: theme.border }]}
-        testID="post-media-sensitive"
+        style={
+          revealed
+            ? styles.root
+            : [styles.sensitive, { backgroundColor: theme.surface, borderColor: theme.border }]
+        }
+        testID={revealed ? 'post-media-gallery' : 'post-media-sensitive'}
       >
-        <Text style={[styles.sensitiveTitle, { color: theme.text }]}>민감한 이미지</Text>
-        <Text style={[styles.sensitiveDescription, { color: theme.textSecondary }]}>
-          작성자가 민감한 내용으로 표시했습니다.
-        </Text>
-        <MediaVisibilityButton expanded={false} onPress={() => setRevealed(true)} />
+        {revealed ? null : (
+          <Text style={[styles.sensitiveTitle, { color: theme.text }]}>민감한 이미지</Text>
+        )}
+        {revealed ? null : (
+          <Text style={[styles.sensitiveDescription, { color: theme.textSecondary }]}>
+            작성자가 민감한 내용으로 표시했습니다.
+          </Text>
+        )}
+        <MediaVisibilityButton
+          expanded={revealed}
+          key="media-visibility"
+          onPress={() => setRevealed((current) => !current)}
+        />
+        {revealed
+          ? items.map((item, index) => <PostMediaImage index={index} item={item} key={item.id} />)
+          : null}
       </View>
     );
   }
 
   return (
     <View style={styles.root} testID="post-media-gallery">
-      {sensitive ? <MediaVisibilityButton expanded onPress={() => setRevealed(false)} /> : null}
       {items.map((item, index) => (
         <PostMediaImage index={index} item={item} key={item.id} />
       ))}

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -1,13 +1,11 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
+import { PostMediaImage } from './PostMediaImage';
+import type { PostMediaItem } from './PostMediaImage';
 
-export type PostMediaItem = {
-  readonly altText: string | null;
-  readonly id: string;
-  readonly url: string | null;
-};
+export type { PostMediaItem } from './PostMediaImage';
 
 export function PostMediaGallery({
   media,
@@ -24,10 +22,10 @@ export function PostMediaGallery({
       <View
         accessibilityLiveRegion="polite"
         accessibilityRole="alert"
-        style={[styles.fallback, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        style={[styles.unavailable, { backgroundColor: theme.surface, borderColor: theme.border }]}
         testID="post-media-unavailable"
       >
-        <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
+        <Text style={[styles.unavailableText, { color: theme.textSecondary }]}>
           이미지를 불러올 수 없습니다.
         </Text>
       </View>
@@ -92,92 +90,8 @@ function MediaVisibilityButton({
   );
 }
 
-function PostMediaImage({ index, item }: { readonly index: number; readonly item: PostMediaItem }) {
-  const theme = useTheme();
-  const [generation, setGeneration] = useState(0);
-  const [aspectRatio, setAspectRatio] = useState(1);
-  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
-  const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
-  const handleError = useCallback(() => setStatus('error'), []);
-  const handleLoad = useCallback(() => setStatus('ready'), []);
-  const handleLoadStart = useCallback(() => setStatus('loading'), []);
-
-  useEffect(() => {
-    if (!item.url) {
-      return;
-    }
-
-    let active = true;
-    Image.getSize(
-      item.url,
-      (width, height) => {
-        if (active && height > 0 && width > 0) {
-          setAspectRatio(Math.max(width / height, 1));
-        }
-      },
-      () => undefined,
-    );
-
-    return () => {
-      active = false;
-    };
-  }, [generation, item.url]);
-
-  if (!item.url || status === 'error') {
-    return (
-      <View
-        accessibilityLiveRegion="polite"
-        style={[styles.fallback, { backgroundColor: theme.surface, borderColor: theme.border }]}
-        testID={`post-media-error-${item.id}`}
-      >
-        <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
-          {accessibilityLabel}을 불러오지 못했습니다.
-        </Text>
-        {item.url ? (
-          <Pressable
-            accessibilityLabel={`${accessibilityLabel} 다시 시도`}
-            accessibilityRole="button"
-            onPress={() => {
-              setGeneration((value) => value + 1);
-              setStatus('loading');
-            }}
-            style={({ pressed }) => [
-              styles.retryButton,
-              { borderColor: theme.border, opacity: pressed ? 0.7 : 1 },
-            ]}
-          >
-            <Text style={[styles.retryButtonText, { color: theme.text }]}>다시 시도</Text>
-          </Pressable>
-        ) : null}
-      </View>
-    );
-  }
-
-  return (
-    <View
-      style={[styles.imageFrame, { aspectRatio, backgroundColor: theme.surface }]}
-      testID={`post-media-frame-${item.id}`}
-    >
-      <Image
-        accessibilityLabel={accessibilityLabel}
-        accessibilityState={{ busy: status === 'loading' }}
-        key={`${item.id}:${generation}`}
-        onError={handleError}
-        onLoad={handleLoad}
-        onLoadStart={handleLoadStart}
-        resizeMode="cover"
-        source={{ uri: item.url }}
-        style={styles.image}
-        testID={`post-media-image-${item.id}`}
-      />
-    </View>
-  );
-}
-
 const styles = StyleSheet.create({
   root: { gap: spacing.sm },
-  imageFrame: { borderRadius: radii.md, overflow: 'hidden', width: '100%' },
-  image: { height: '100%', width: '100%' },
   sensitive: {
     alignItems: 'center',
     borderRadius: radii.md,
@@ -197,7 +111,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
   },
   visibilityButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
-  fallback: {
+  unavailable: {
     alignItems: 'center',
     borderRadius: radii.md,
     borderWidth: 1,
@@ -206,15 +120,5 @@ const styles = StyleSheet.create({
     minHeight: 144,
     padding: spacing.lg,
   },
-  fallbackText: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
-  retryButton: {
-    alignItems: 'center',
-    borderRadius: radii.full,
-    borderWidth: 1,
-    justifyContent: 'center',
-    minHeight: 48,
-    minWidth: 112,
-    paddingHorizontal: spacing.lg,
-  },
-  retryButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
+  unavailableText: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
 });

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -8,9 +8,11 @@ import type { PostMediaItem } from './PostMediaImage';
 export type { PostMediaItem } from './PostMediaImage';
 
 export function PostMediaGallery({
+  interactive = true,
   media,
   sensitive,
 }: {
+  readonly interactive?: boolean;
   readonly media: ReadonlyArray<PostMediaItem> | null;
   readonly sensitive: boolean;
 }) {
@@ -55,13 +57,17 @@ export function PostMediaGallery({
             작성자가 민감한 내용으로 표시했습니다.
           </Text>
         )}
-        <MediaVisibilityButton
-          expanded={revealed}
-          key="media-visibility"
-          onPress={() => setRevealed((current) => !current)}
-        />
+        {interactive ? (
+          <MediaVisibilityButton
+            expanded={revealed}
+            key="media-visibility"
+            onPress={() => setRevealed((current) => !current)}
+          />
+        ) : null}
         {revealed
-          ? items.map((item, index) => <PostMediaImage index={index} item={item} key={item.id} />)
+          ? items.map((item, index) => (
+              <PostMediaImage index={index} interactive={interactive} item={item} key={item.id} />
+            ))
           : null}
       </View>
     );
@@ -70,7 +76,7 @@ export function PostMediaGallery({
   return (
     <View style={styles.root} testID="post-media-gallery">
       {items.map((item, index) => (
-        <PostMediaImage index={index} item={item} key={item.id} />
+        <PostMediaImage index={index} interactive={interactive} item={item} key={item.id} />
       ))}
     </View>
   );

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
@@ -95,11 +95,33 @@ function MediaVisibilityButton({
 function PostMediaImage({ index, item }: { readonly index: number; readonly item: PostMediaItem }) {
   const theme = useTheme();
   const [generation, setGeneration] = useState(0);
+  const [aspectRatio, setAspectRatio] = useState(1);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
   const handleError = useCallback(() => setStatus('error'), []);
   const handleLoad = useCallback(() => setStatus('ready'), []);
   const handleLoadStart = useCallback(() => setStatus('loading'), []);
+
+  useEffect(() => {
+    if (!item.url) {
+      return;
+    }
+
+    let active = true;
+    Image.getSize(
+      item.url,
+      (width, height) => {
+        if (active && height > 0 && width > 0) {
+          setAspectRatio(Math.max(width / height, 1));
+        }
+      },
+      () => undefined,
+    );
+
+    return () => {
+      active = false;
+    };
+  }, [generation, item.url]);
 
   if (!item.url || status === 'error') {
     return (
@@ -133,7 +155,7 @@ function PostMediaImage({ index, item }: { readonly index: number; readonly item
 
   return (
     <View
-      style={[styles.imageFrame, { backgroundColor: theme.surface }]}
+      style={[styles.imageFrame, { aspectRatio, backgroundColor: theme.surface }]}
       testID={`post-media-frame-${item.id}`}
     >
       <Image
@@ -154,7 +176,7 @@ function PostMediaImage({ index, item }: { readonly index: number; readonly item
 
 const styles = StyleSheet.create({
   root: { gap: spacing.sm },
-  imageFrame: { aspectRatio: 16 / 9, borderRadius: radii.md, overflow: 'hidden' },
+  imageFrame: { borderRadius: radii.md, overflow: 'hidden', width: '100%' },
   image: { height: '100%', width: '100%' },
   sensitive: {
     alignItems: 'center',

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
@@ -97,6 +97,9 @@ function PostMediaImage({ index, item }: { readonly index: number; readonly item
   const [generation, setGeneration] = useState(0);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
+  const handleError = useCallback(() => setStatus('error'), []);
+  const handleLoad = useCallback(() => setStatus('ready'), []);
+  const handleLoadStart = useCallback(() => setStatus('loading'), []);
 
   if (!item.url || status === 'error') {
     return (
@@ -137,9 +140,9 @@ function PostMediaImage({ index, item }: { readonly index: number; readonly item
         accessibilityLabel={accessibilityLabel}
         accessibilityState={{ busy: status === 'loading' }}
         key={`${item.id}:${generation}`}
-        onError={() => setStatus('error')}
-        onLoad={() => setStatus('ready')}
-        onLoadStart={() => setStatus('loading')}
+        onError={handleError}
+        onLoad={handleLoad}
+        onLoadStart={handleLoadStart}
         resizeMode="cover"
         source={{ uri: item.url }}
         style={styles.image}

--- a/apps/app/src/components/post/PostMediaImage.test.ts
+++ b/apps/app/src/components/post/PostMediaImage.test.ts
@@ -9,13 +9,24 @@ import type { PostMediaItem } from './PostMediaImage';
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 const ImageMock = Object.assign((props: Record<string, unknown>) => createElement('Image', props), {
-  getSize: (uri: string, success: (width: number, height: number) => void) => {
+  getSize: (
+    uri: string,
+    success: (width: number, height: number) => void,
+    failure?: () => void,
+  ) => {
+    const attempts = getSizeAttempts.get(uri) ?? 0;
+    getSizeAttempts.set(uri, attempts + 1);
+    if (uri.endsWith('/transient-size-error.webp') && attempts === 0) {
+      failure?.();
+      return;
+    }
     success(
       uri.endsWith('/portrait.webp') ? 900 : 1600,
       uri.endsWith('/portrait.webp') ? 1600 : 900,
     );
   },
 });
+const getSizeAttempts = new Map<string, number>();
 
 mock.module('react-native', {
   exports: {
@@ -35,6 +46,7 @@ before(async () => {
 });
 
 afterEach(async () => {
+  getSizeAttempts.clear();
   if (renderer) {
     await act(async () => renderer?.unmount());
     renderer = null;
@@ -59,6 +71,16 @@ describe('PostMediaImage', () => {
     await act(async () => firstOnLoad());
 
     assert.equal(image('landscape').props.onLoad, firstOnLoad);
+  });
+
+  it('초기 크기 조회가 실패해도 성공한 Image load 뒤 원본 비율을 다시 조회한다', async () => {
+    await render(0, media('transient-size-error', '가로 이미지'));
+    assert.equal(frameAspectRatio('transient-size-error'), 1);
+
+    await act(async () => image('transient-size-error').props.onLoad());
+
+    assert.equal(frameAspectRatio('transient-size-error'), 1600 / 900);
+    assert.equal(getSizeAttempts.get(media('transient-size-error', null).url!), 2);
   });
 
   it('오류 뒤 같은 URL로 Image를 다시 mount한다', async () => {

--- a/apps/app/src/components/post/PostMediaImage.test.ts
+++ b/apps/app/src/components/post/PostMediaImage.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, describe, it, mock } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ComponentType } from 'react';
+import type { ReactTestInstance, ReactTestRenderer } from 'react-test-renderer';
+import type { PostMediaItem } from './PostMediaImage';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ImageMock = Object.assign((props: Record<string, unknown>) => createElement('Image', props), {
+  getSize: (uri: string, success: (width: number, height: number) => void) => {
+    success(
+      uri.endsWith('/portrait.webp') ? 900 : 1600,
+      uri.endsWith('/portrait.webp') ? 1600 : 900,
+    );
+  },
+});
+
+mock.module('react-native', {
+  exports: {
+    Image: ImageMock,
+    Pressable: 'Pressable',
+    StyleSheet: { create: <T>(styles: T) => styles },
+    Text: 'Text',
+    View: 'View',
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+
+let PostMediaImage: ComponentType<{ index: number; item: PostMediaItem }>;
+let renderer: ReactTestRenderer | null = null;
+
+before(async () => {
+  ({ PostMediaImage } = await import('./PostMediaImage'));
+});
+
+afterEach(async () => {
+  if (renderer) {
+    await act(async () => renderer?.unmount());
+    renderer = null;
+  }
+});
+
+describe('PostMediaImage', () => {
+  it('nullable Alt Text fallback과 원본 비율을 적용하되 세로 이미지는 정사각형으로 제한한다', async () => {
+    await render(1, media('landscape', null));
+
+    assert.equal(image('landscape').props.accessibilityLabel, '2번째 첨부 이미지');
+    assert.equal(frameAspectRatio('landscape'), 1600 / 900);
+
+    await render(0, media('portrait', '세로 이미지'));
+    assert.equal(frameAspectRatio('portrait'), 1);
+  });
+
+  it('Image 이벤트 callback을 재사용한다', async () => {
+    await render(0, media('landscape', '가로 이미지'));
+    const firstOnLoad = image('landscape').props.onLoad;
+
+    await act(async () => firstOnLoad());
+
+    assert.equal(image('landscape').props.onLoad, firstOnLoad);
+  });
+
+  it('오류 뒤 같은 URL로 Image를 다시 mount한다', async () => {
+    await render(0, media('landscape', '가로 이미지'));
+    const source = image('landscape').props.source;
+
+    await act(async () => image('landscape').props.onError());
+    assert.equal(rendered('Image').length, 0);
+
+    await act(async () => pressable('가로 이미지 다시 시도').props.onPress());
+    assert.deepEqual(image('landscape').props.source, source);
+
+    await act(async () => image('landscape').props.onError());
+    assert.equal(pressable('가로 이미지 다시 시도').props.accessibilityRole, 'button');
+  });
+
+  it('URL이 없으면 재시도 없이 fallback을 표시한다', async () => {
+    await render(0, { ...media('missing', null), url: null });
+
+    assert.ok(byTestId('post-media-error-missing'));
+    assert.equal(rendered('Pressable').length, 0);
+  });
+});
+
+function media(id: string, altText: string | null): PostMediaItem {
+  return { altText, id, url: `https://media.example/${id}.webp` };
+}
+
+async function render(index: number, item: PostMediaItem) {
+  await act(async () => {
+    if (renderer) {
+      renderer.update(createElement(PostMediaImage, { index, item }));
+    } else {
+      renderer = create(createElement(PostMediaImage, { index, item }));
+    }
+  });
+  assert.ok(renderer);
+}
+
+function rendered(type: string): ReactTestInstance[] {
+  assert.ok(renderer);
+  return renderer.root.findAll((node) => node.type === type);
+}
+
+function pressable(accessibilityLabel: string): ReactTestInstance {
+  const result = rendered('Pressable').find(
+    (node) => node.props.accessibilityLabel === accessibilityLabel,
+  );
+  assert.ok(result);
+  return result;
+}
+
+function image(id: string): ReactTestInstance {
+  return byTestId(`post-media-image-${id}`);
+}
+
+function frameAspectRatio(id: string): number | undefined {
+  const style = byTestId(`post-media-frame-${id}`).props.style as ReadonlyArray<{
+    aspectRatio?: number;
+  }>;
+  return style.find(({ aspectRatio }) => aspectRatio !== undefined)?.aspectRatio;
+}
+
+function byTestId(testID: string): ReactTestInstance {
+  assert.ok(renderer);
+  return renderer.root.findByProps({ testID });
+}

--- a/apps/app/src/components/post/PostMediaImage.test.ts
+++ b/apps/app/src/components/post/PostMediaImage.test.ts
@@ -27,7 +27,7 @@ mock.module('react-native', {
   },
 } as unknown as Parameters<typeof mock.module>[1]);
 
-let PostMediaImage: ComponentType<{ index: number; item: PostMediaItem }>;
+let PostMediaImage: ComponentType<{ index: number; interactive?: boolean; item: PostMediaItem }>;
 let renderer: ReactTestRenderer | null = null;
 
 before(async () => {
@@ -81,18 +81,26 @@ describe('PostMediaImage', () => {
     assert.ok(byTestId('post-media-error-missing'));
     assert.equal(rendered('Pressable').length, 0);
   });
+
+  it('비대화형 이미지 오류에서는 재시도 control을 표시하지 않는다', async () => {
+    await render(0, media('landscape', '가로 이미지'), false);
+
+    await act(async () => image('landscape').props.onError());
+    assert.ok(byTestId('post-media-error-landscape'));
+    assert.equal(rendered('Pressable').length, 0);
+  });
 });
 
 function media(id: string, altText: string | null): PostMediaItem {
   return { altText, id, url: `https://media.example/${id}.webp` };
 }
 
-async function render(index: number, item: PostMediaItem) {
+async function render(index: number, item: PostMediaItem, interactive = true) {
   await act(async () => {
     if (renderer) {
-      renderer.update(createElement(PostMediaImage, { index, item }));
+      renderer.update(createElement(PostMediaImage, { index, interactive, item }));
     } else {
-      renderer = create(createElement(PostMediaImage, { index, item }));
+      renderer = create(createElement(PostMediaImage, { index, interactive, item }));
     }
   });
   assert.ok(renderer);

--- a/apps/app/src/components/post/PostMediaImage.tsx
+++ b/apps/app/src/components/post/PostMediaImage.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/theme/ThemeProvider';
+import { radii, spacing, typography } from '@/theme/tokens';
+
+export type PostMediaItem = {
+  readonly altText: string | null;
+  readonly id: string;
+  readonly url: string | null;
+};
+
+export function PostMediaImage({
+  index,
+  item,
+}: {
+  readonly index: number;
+  readonly item: PostMediaItem;
+}) {
+  const theme = useTheme();
+  const [generation, setGeneration] = useState(0);
+  const [aspectRatio, setAspectRatio] = useState(1);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
+  const handleError = useCallback(() => setStatus('error'), []);
+  const handleLoad = useCallback(() => setStatus('ready'), []);
+  const handleLoadStart = useCallback(() => setStatus('loading'), []);
+
+  useEffect(() => {
+    if (!item.url) {
+      return;
+    }
+
+    let active = true;
+    Image.getSize(
+      item.url,
+      (width, height) => {
+        if (active && height > 0 && width > 0) {
+          setAspectRatio(Math.max(width / height, 1));
+        }
+      },
+      () => undefined,
+    );
+
+    return () => {
+      active = false;
+    };
+  }, [generation, item.url]);
+
+  if (!item.url || status === 'error') {
+    return (
+      <View
+        accessibilityLiveRegion="polite"
+        style={[styles.fallback, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        testID={`post-media-error-${item.id}`}
+      >
+        <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
+          {accessibilityLabel}을 불러오지 못했습니다.
+        </Text>
+        {item.url ? (
+          <Pressable
+            accessibilityLabel={`${accessibilityLabel} 다시 시도`}
+            accessibilityRole="button"
+            onPress={() => {
+              setGeneration((value) => value + 1);
+              setStatus('loading');
+            }}
+            style={({ pressed }) => [
+              styles.retryButton,
+              { borderColor: theme.border, opacity: pressed ? 0.7 : 1 },
+            ]}
+          >
+            <Text style={[styles.retryButtonText, { color: theme.text }]}>다시 시도</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.imageFrame, { aspectRatio, backgroundColor: theme.surface }]}
+      testID={`post-media-frame-${item.id}`}
+    >
+      <Image
+        accessibilityLabel={accessibilityLabel}
+        accessibilityState={{ busy: status === 'loading' }}
+        key={`${item.id}:${generation}`}
+        onError={handleError}
+        onLoad={handleLoad}
+        onLoadStart={handleLoadStart}
+        resizeMode="cover"
+        source={{ uri: item.url }}
+        style={styles.image}
+        testID={`post-media-image-${item.id}`}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  imageFrame: { borderRadius: radii.md, overflow: 'hidden', width: '100%' },
+  image: { height: '100%', width: '100%' },
+  fallback: {
+    alignItems: 'center',
+    borderRadius: radii.md,
+    borderWidth: 1,
+    gap: spacing.sm,
+    justifyContent: 'center',
+    minHeight: 144,
+    padding: spacing.lg,
+  },
+  fallbackText: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
+  retryButton: {
+    alignItems: 'center',
+    borderRadius: radii.full,
+    borderWidth: 1,
+    justifyContent: 'center',
+    minHeight: 48,
+    minWidth: 112,
+    paddingHorizontal: spacing.lg,
+  },
+  retryButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
+});

--- a/apps/app/src/components/post/PostMediaImage.tsx
+++ b/apps/app/src/components/post/PostMediaImage.tsx
@@ -11,9 +11,11 @@ export type PostMediaItem = {
 
 export function PostMediaImage({
   index,
+  interactive = true,
   item,
 }: {
   readonly index: number;
+  readonly interactive?: boolean;
   readonly item: PostMediaItem;
 }) {
   const theme = useTheme();
@@ -56,7 +58,7 @@ export function PostMediaImage({
         <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
           {accessibilityLabel}을 불러오지 못했습니다.
         </Text>
-        {item.url ? (
+        {item.url && interactive ? (
           <Pressable
             accessibilityLabel={`${accessibilityLabel} 다시 시도`}
             accessibilityRole="button"

--- a/apps/app/src/components/post/PostMediaImage.tsx
+++ b/apps/app/src/components/post/PostMediaImage.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
+import type { ImageLoadEvent } from 'react-native';
 
 export type PostMediaItem = {
   readonly altText: string | null;
@@ -22,10 +23,40 @@ export function PostMediaImage({
   const [generation, setGeneration] = useState(0);
   const [aspectRatio, setAspectRatio] = useState(1);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const currentUrl = useRef(item.url);
+  const measuredUrl = useRef<string | null>(null);
+  currentUrl.current = item.url;
   const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
   const handleError = useCallback(() => setStatus('error'), []);
-  const handleLoad = useCallback(() => setStatus('ready'), []);
   const handleLoadStart = useCallback(() => setStatus('loading'), []);
+  const updateAspectRatio = useCallback((url: string, width: number, height: number) => {
+    if (currentUrl.current === url && height > 0 && width > 0) {
+      measuredUrl.current = url;
+      setAspectRatio(Math.max(width / height, 1));
+    }
+  }, []);
+  const handleLoad = useCallback(
+    (event?: ImageLoadEvent) => {
+      setStatus('ready');
+      if (!item.url || measuredUrl.current === item.url) {
+        return;
+      }
+
+      const source = event?.nativeEvent?.source;
+      if (source) {
+        updateAspectRatio(item.url, source.width, source.height);
+        return;
+      }
+
+      const url = item.url;
+      Image.getSize(
+        url,
+        (width, height) => updateAspectRatio(url, width, height),
+        () => undefined,
+      );
+    },
+    [item.url, updateAspectRatio],
+  );
 
   useEffect(() => {
     if (!item.url) {
@@ -36,8 +67,8 @@ export function PostMediaImage({
     Image.getSize(
       item.url,
       (width, height) => {
-        if (active && height > 0 && width > 0) {
-          setAspectRatio(Math.max(width / height, 1));
+        if (active) {
+          updateAspectRatio(item.url!, width, height);
         }
       },
       () => undefined,
@@ -46,7 +77,7 @@ export function PostMediaImage({
     return () => {
       active = false;
     };
-  }, [generation, item.url]);
+  }, [generation, item.url, updateAspectRatio]);
 
   if (!item.url || status === 'error') {
     return (

--- a/apps/app/src/components/post/PostSourcePresentationView.tsx
+++ b/apps/app/src/components/post/PostSourcePresentationView.tsx
@@ -231,7 +231,12 @@ function PostBodyPressTarget({
       tabIndex={-1}
       testID={testID}
     >
-      <PostContentRenderer bodyText={content.bodyText} document={content.document} size="md" />
+      <PostContentRenderer
+        bodyText={content.bodyText}
+        document={content.document}
+        media={[]}
+        size="md"
+      />
     </Pressable>
   );
 }

--- a/apps/app/src/components/post/PostSourcePresentationView.tsx
+++ b/apps/app/src/components/post/PostSourcePresentationView.tsx
@@ -170,6 +170,7 @@ export function PostSourcePreview({
             bodyText={source.content.bodyText}
             document={source.content.document}
             interactive={false}
+            media={[]}
             size="md"
           />
         </View>

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -1816,14 +1816,17 @@ export const BodyTimeAndLayoutStates: Story = {
     expect(mediaOnly.queryByRole('img')).not.toBeInTheDocument();
     const revealSensitiveMedia = mediaOnly.getByRole('button', { name: '민감한 이미지 표시' });
     expect(revealSensitiveMedia).toHaveAttribute('aria-expanded', 'false');
-    await userEvent.click(revealSensitiveMedia);
+    revealSensitiveMedia.focus();
+    await userEvent.keyboard('{Enter}');
     expect(mediaOnly.getByRole('img', { name: '1번째 첨부 이미지' })).toBeInTheDocument();
     const hideSensitiveMedia = mediaOnly.getByRole('button', {
       name: '민감한 이미지 다시 가리기',
     });
     expect(hideSensitiveMedia).toHaveAttribute('aria-expanded', 'true');
-    await userEvent.click(hideSensitiveMedia);
+    expect(hideSensitiveMedia).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
     expect(mediaOnly.queryByRole('img')).not.toBeInTheDocument();
+    expect(mediaOnly.getByRole('button', { name: '민감한 이미지 표시' })).toHaveFocus();
 
     const fourMedia = within(canvas.getByTestId('media-four'));
     expect(fourMedia.getAllByRole('img').map((image) => image.getAttribute('alt'))).toEqual([

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -1792,12 +1792,19 @@ export const BodyTimeAndLayoutStates: Story = {
     const mediaText = within(canvas.getByTestId('media-text'));
     expect(mediaText.getByText('document text')).toBeVisible();
     const renderedMediaImage = mediaText.getByTestId('post-media-image-media-story');
+    const renderedMediaFrame = mediaText.getByTestId('post-media-frame-media-story');
     expect(renderedMediaImage).toBeVisible();
     await waitFor(() => {
-      expect(renderedMediaImage.firstElementChild).not.toBeNull();
+      const sourceImage = renderedMediaImage.querySelector('img');
+      expect(sourceImage?.naturalWidth).toBeGreaterThan(0);
+      expect(sourceImage?.naturalHeight).toBeGreaterThan(0);
       expect(getComputedStyle(renderedMediaImage.firstElementChild!).backgroundImage).not.toBe(
         'none',
       );
+      expect(
+        renderedMediaFrame.getBoundingClientRect().width /
+          renderedMediaFrame.getBoundingClientRect().height,
+      ).toBeCloseTo(sourceImage!.naturalWidth / sourceImage!.naturalHeight, 2);
     });
     expect(
       mediaText.getByRole('img', { name: '회색 배경의 첫 번째 첨부 이미지' }),

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -65,6 +65,9 @@ function getColorContrastRatio(foreground: string, background: string) {
   );
 }
 
+const postMediaImageUri =
+  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="640" height="360"%3E%3Crect width="640" height="360" fill="%236b7280"/%3E%3C/svg%3E';
+
 const shortPost = {
   ...post({
     bodyText: '짧은 본문 한 줄.',
@@ -162,6 +165,14 @@ const mediaTextPost = post({
   },
   bodyText: '이미지가 있는 문서는 안전한 Plain Text로 표시합니다.',
   id: 'media-text',
+  media: [
+    {
+      __typename: 'Media',
+      altText: '회색 배경의 첫 번째 첨부 이미지',
+      id: 'media-story',
+      url: postMediaImageUri,
+    },
+  ],
 });
 const mediaOnlyPost = post({
   bodyDocument: {
@@ -171,6 +182,72 @@ const mediaOnlyPost = post({
   },
   bodyText: '',
   id: 'media-only',
+  media: [
+    {
+      __typename: 'Media',
+      altText: null,
+      id: 'media-only-story',
+      url: postMediaImageUri,
+    },
+  ],
+});
+const fourMediaPost = post({
+  bodyDocument: {
+    type: 'doc',
+    content: [
+      { type: 'paragraph', content: [{ type: 'text', text: '네 장의 이미지입니다.' }] },
+      ...Array.from({ length: 4 }, (_, index) => ({
+        type: 'media' as const,
+        attrs: { mediaId: `media-four-${index + 1}` },
+      })),
+    ],
+  },
+  bodyText: '네 장의 이미지입니다.',
+  id: 'media-four',
+  media: Array.from({ length: 4 }, (_, index) => ({
+    __typename: 'Media' as const,
+    altText: index === 1 ? null : `${index + 1}번째 순서 이미지`,
+    id: `media-four-${index + 1}`,
+    url: postMediaImageUri,
+  })),
+});
+const unavailableMediaPost = post({
+  bodyDocument: {
+    type: 'doc',
+    content: [
+      { type: 'paragraph', content: [{ type: 'text', text: '표시 정보가 없는 이미지입니다.' }] },
+      { type: 'media', attrs: { mediaId: 'media-unavailable-story' } },
+    ],
+  },
+  bodyText: '표시 정보가 없는 이미지입니다.',
+  id: 'media-unavailable',
+  media: null,
+});
+const loadErrorMediaPost = post({
+  bodyDocument: {
+    type: 'doc',
+    content: [
+      { type: 'paragraph', content: [{ type: 'text', text: '일부 이미지 로딩 실패입니다.' }] },
+      { type: 'media', attrs: { mediaId: 'media-error-story' } },
+      { type: 'media', attrs: { mediaId: 'media-error-safe-story' } },
+    ],
+  },
+  bodyText: '일부 이미지 로딩 실패입니다.',
+  id: 'media-load-error',
+  media: [
+    {
+      __typename: 'Media',
+      altText: '실패 이미지',
+      id: 'media-error-story',
+      url: 'data:image/png;base64,not-valid',
+    },
+    {
+      __typename: 'Media',
+      altText: '정상 이미지',
+      id: 'media-error-safe-story',
+      url: postMediaImageUri,
+    },
+  ],
 });
 const sourceAuthorAvatarUrl = '/apple-touch-icon.png';
 const repostAuthorAvatarUrl = '/icon-192.png';
@@ -523,6 +600,9 @@ const storyPosts = [
   quoteOfQuotePost,
   mediaTextPost,
   mediaOnlyPost,
+  fourMediaPost,
+  unavailableMediaPost,
+  loadErrorMediaPost,
 ];
 const composerAvatarUrl =
   'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="96" height="96"%3E%3Crect width="96" height="96" fill="%232563eb"/%3E%3C/svg%3E';
@@ -751,6 +831,57 @@ function PostCatalog(_args: PostsStoryArgs) {
             post={requireFragment(
               requirePostById(posts, mediaOnlyPost.id).body,
               'media-only post body',
+            )}
+          />
+        </View>
+        <View testID="media-four">
+          <PostBody
+            post={requireFragment(
+              requirePostById(posts, fourMediaPost.id).body,
+              'four-media post body',
+            )}
+          />
+        </View>
+        <View testID="media-unavailable">
+          <PostBody
+            post={requireFragment(
+              requirePostById(posts, unavailableMediaPost.id).body,
+              'unavailable-media post body',
+            )}
+          />
+        </View>
+        <View testID="media-load-error">
+          <PostBody
+            post={requireFragment(
+              requirePostById(posts, loadErrorMediaPost.id).body,
+              'load-error media post body',
+            )}
+          />
+        </View>
+      </Section>
+
+      <Section title="Post Media · list and detail">
+        <View testID="media-list">
+          <PostListItem
+            post={requireFragment(
+              requirePostById(posts, mediaTextPost.id).listItem,
+              'media post list item',
+            )}
+          />
+        </View>
+        <View testID="media-only-list">
+          <PostListItem
+            post={requireFragment(
+              requirePostById(posts, mediaOnlyPost.id).listItem,
+              'media-only post list item',
+            )}
+          />
+        </View>
+        <View testID="media-detail">
+          <PostLayout
+            post={requireFragment(
+              requirePostById(posts, mediaTextPost.id).layout,
+              'media post detail layout',
             )}
           />
         </View>
@@ -1659,11 +1790,57 @@ export const BodyTimeAndLayoutStates: Story = {
     );
     expect(canvas.getByText('미지원 문서는 안전한 Plain Text로 표시합니다.')).toBeVisible();
     expect(canvas.queryByText('실행하면 안 되는 구조')).not.toBeInTheDocument();
-    expect(canvas.getByTestId('media-text').textContent).toBe('document text');
+    const mediaText = within(canvas.getByTestId('media-text'));
+    expect(mediaText.getByText('document text')).toBeVisible();
+    expect(mediaText.getByTestId('post-media-image-media-story')).toBeVisible();
+    expect(
+      mediaText.getByRole('img', { name: '회색 배경의 첫 번째 첨부 이미지' }),
+    ).toBeInTheDocument();
     expect(
       canvas.queryByText('이미지가 있는 문서는 안전한 Plain Text로 표시합니다.'),
     ).not.toBeInTheDocument();
-    expect(canvas.getByTestId('media-only').textContent).toBe('');
+    const mediaOnly = within(canvas.getByTestId('media-only'));
+    expect(mediaOnly.queryByRole('img')).not.toBeInTheDocument();
+    const revealSensitiveMedia = mediaOnly.getByRole('button', { name: '민감한 이미지 표시' });
+    expect(revealSensitiveMedia).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(revealSensitiveMedia);
+    expect(mediaOnly.getByRole('img', { name: '1번째 첨부 이미지' })).toBeInTheDocument();
+    const hideSensitiveMedia = mediaOnly.getByRole('button', {
+      name: '민감한 이미지 다시 가리기',
+    });
+    expect(hideSensitiveMedia).toHaveAttribute('aria-expanded', 'true');
+    await userEvent.click(hideSensitiveMedia);
+    expect(mediaOnly.queryByRole('img')).not.toBeInTheDocument();
+
+    const fourMedia = within(canvas.getByTestId('media-four'));
+    expect(fourMedia.getAllByRole('img').map((image) => image.getAttribute('alt'))).toEqual([
+      '1번째 순서 이미지',
+      '2번째 첨부 이미지',
+      '3번째 순서 이미지',
+      '4번째 순서 이미지',
+    ]);
+    expect(within(canvas.getByTestId('media-unavailable')).getByRole('alert')).toHaveTextContent(
+      '이미지를 불러올 수 없습니다.',
+    );
+    const loadErrorMedia = within(canvas.getByTestId('media-load-error'));
+    expect(loadErrorMedia.getByRole('img', { name: '정상 이미지' })).toBeInTheDocument();
+    const retryFailedMedia = await loadErrorMedia.findByRole('button', {
+      name: '실패 이미지 다시 시도',
+    });
+    await userEvent.click(retryFailedMedia);
+    await expect(
+      loadErrorMedia.findByRole('button', { name: '실패 이미지 다시 시도' }),
+    ).resolves.toBeVisible();
+    expect(loadErrorMedia.getByRole('img', { name: '정상 이미지' })).toBeInTheDocument();
+    expect(
+      within(canvas.getByTestId('media-list')).getByTestId('post-media-image-media-story'),
+    ).toBeVisible();
+    expect(
+      within(canvas.getByTestId('media-detail')).getByTestId('post-media-image-media-story'),
+    ).toBeVisible();
+    expect(
+      within(canvas.getByTestId('media-only-list')).queryByTestId('post-list-row-body'),
+    ).not.toBeInTheDocument();
     const quoteLayout = within(canvas.getByTestId('detail-quote-layout'));
     expect(quoteLayout.getAllByTestId('source-post-preview')).toHaveLength(1);
     expect(quoteLayout.getByTestId('source-post-body')).toHaveTextContent(

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -4174,3 +4174,30 @@ export const ReplyQuoteParentPresentation: Story = {
   },
   render: () => <ReplyModalPresentationStory parentId={linkedSourceQuote.id} />,
 };
+
+export const ReplyMediaParentPresentation: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoCompact' } },
+  play: async () => {
+    const dialog = await screen.findByRole('dialog', { name: '답글 쓰기' });
+    const parentElement = within(dialog).getByTestId('reply-parent');
+    const parent = within(parentElement);
+    expect(parentElement).toHaveTextContent('document text');
+    expect(parent.getByTestId('post-media-gallery')).toBeVisible();
+    expect(parent.getByTestId('post-media-image-media-story')).toBeVisible();
+    expect(parent.queryByRole('button', { name: '민감한 이미지 표시' })).toBeNull();
+    expect(parent.queryByRole('button', { name: /이미지 다시 시도/ })).toBeNull();
+  },
+  render: () => <ReplyModalPresentationStory parentId={mediaTextPost.id} />,
+};
+
+export const ReplySensitiveMediaParentPresentation: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoCompact' } },
+  play: async () => {
+    const dialog = await screen.findByRole('dialog', { name: '답글 쓰기' });
+    const parent = within(within(dialog).getByTestId('reply-parent'));
+    expect(parent.getByTestId('post-media-sensitive')).toBeVisible();
+    expect(parent.queryByTestId('post-media-gallery')).toBeNull();
+    expect(parent.queryByRole('button', { name: '민감한 이미지 표시' })).toBeNull();
+  },
+  render: () => <ReplyModalPresentationStory parentId={mediaOnlyPost.id} />,
+};

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -65,8 +65,7 @@ function getColorContrastRatio(foreground: string, background: string) {
   );
 }
 
-const postMediaImageUri =
-  'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="640" height="360"%3E%3Crect width="640" height="360" fill="%236b7280"/%3E%3C/svg%3E';
+const postMediaImageUri = '/og-default.png';
 
 const shortPost = {
   ...post({
@@ -1792,7 +1791,14 @@ export const BodyTimeAndLayoutStates: Story = {
     expect(canvas.queryByText('실행하면 안 되는 구조')).not.toBeInTheDocument();
     const mediaText = within(canvas.getByTestId('media-text'));
     expect(mediaText.getByText('document text')).toBeVisible();
-    expect(mediaText.getByTestId('post-media-image-media-story')).toBeVisible();
+    const renderedMediaImage = mediaText.getByTestId('post-media-image-media-story');
+    expect(renderedMediaImage).toBeVisible();
+    await waitFor(() => {
+      expect(renderedMediaImage.firstElementChild).not.toBeNull();
+      expect(getComputedStyle(renderedMediaImage.firstElementChild!).backgroundImage).not.toBe(
+        'none',
+      );
+    });
     expect(
       mediaText.getByRole('img', { name: '회색 배경의 첫 번째 첨부 이미지' }),
     ).toBeInTheDocument();

--- a/apps/app/src/stories/fixtures.ts
+++ b/apps/app/src/stories/fixtures.ts
@@ -79,6 +79,13 @@ export type StoryPostReference = {
   id: string;
 };
 
+export type StoryMedia = {
+  __typename: 'Media';
+  altText: string | null;
+  id: string;
+  url: string | null;
+};
+
 export type StoryPost = {
   __typename: 'Post';
   content: {
@@ -90,6 +97,7 @@ export type StoryPost = {
       version: 1;
     };
     id: string;
+    media: StoryMedia[] | null;
   } | null;
   createdAt: string;
   id: string;
@@ -108,6 +116,7 @@ export function post({
   bodyText = '코스모에서 전하는 첫 번째 소식입니다.',
   createdAt = Temporal.Now.instant().subtract({ minutes: 5 }).toString(),
   id = 'post-1',
+  media = [],
   profile: author = profile(),
   reactionCounts = [],
   repostCount = 0,
@@ -120,6 +129,7 @@ export function post({
   bodyText?: string | null;
   createdAt?: string;
   id?: string;
+  media?: StoryMedia[] | null;
   profile?: StoryProfile;
   reactionCounts?: StoryPost['reactionCounts'];
   repostCount?: number;
@@ -142,6 +152,7 @@ export function post({
             },
             bodyText,
             id: `content-${id}`,
+            media,
           },
     createdAt,
     id,

--- a/docs/design/reply-composer.md
+++ b/docs/design/reply-composer.md
@@ -54,6 +54,8 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
   대화 관계를 표현한다.
 - Parent 영역은 작성 맥락 확인을 위한 비대화형 presentation이다. 작성자·Source·본문을 활성화해 modal 작성
   상태를 잃는 route 이동을 만들지 않는다.
+- 일반 첨부 이미지는 Parent 맥락에 표시하되, Sensitive Media는 가림 placeholder만 유지한다. Sensitive 공개와
+  이미지 오류 재시도처럼 상태를 바꾸는 Media control은 Parent 영역에 노출하지 않는다.
 
 ### editor와 고정 footer
 

--- a/openspec/changes/add-local-reply-creation/specs/post-reply-ui/spec.md
+++ b/openspec/changes/add-local-reply-creation/specs/post-reply-ui/spec.md
@@ -79,6 +79,7 @@
 - **WHEN** Reply surface가 열린다
 - **THEN** 클라이언트는 direct Parent의 작성자·시각·전체 본문과 Quote이면 기존 Source preview를 비대화형으로 표시한다
 - **AND** Source preview는 일반 본문과 같은 background와 semantic border를 사용한다
+- **AND** 일반 첨부 이미지는 표시하되 Sensitive Media는 가림 상태를 유지하고 공개·이미지 오류 재시도 control을 노출하지 않는다
 - **AND** Parent Action Bar·Post menu와 전체 조상 thread를 중복 표시하지 않는다
 
 ### Requirement: Reply surface lifecycle

--- a/openspec/changes/add-local-reply-creation/tasks.md
+++ b/openspec/changes/add-local-reply-creation/tasks.md
@@ -49,6 +49,7 @@
 - Content 없는 Repost의 Reply action은 disabled이며 callback·composer·mutation 진입을 차단한다.
 - 순수 Repost의 Repost action target은 direct Source를 유지하지만 Reply eligibility는 바깥 display Post identity에서 계산한다. 목록·thread coordinator는 selected Profile, surface mode, 하나의 active Parent와 dirty·pending 전환만 공급하고, `PostListItem`/`PostLayout`이 Reply action과 Composer surface를 내부 조립한다.
 - 목록은 Web `>= compact`에서 600px modal, Web `< compact`와 Native에서 전체 화면 composer를 사용하고, 상세는 행별 inline composer를 사용한다. Parent preview는 비대화형이며 Action Bar·menu를 중복 표시하지 않는다.
+- Parent의 일반 첨부 이미지는 표시하되 Sensitive Media 공개와 이미지 오류 재시도 control은 노출하지 않는다.
 - pristine close, dirty 취소 확인, pending close 차단, 실패 상태 유지, 성공 close·focus 복원과 Web modal focus trap·배경 scroll lock을 surface lifecycle로 제공한다.
 - selected Profile이 없는 guest에는 Reply config를 새로 노출하지 않고 guest 인증 위임과 Reply 외 전체 action 조합은 PROD-432에 남긴다.
 - Visibility는 Parent와 독립적이며 validation·pending·실패·성공 상태와 Relay cache는 selected Profile별로 격리한다.
@@ -60,6 +61,7 @@
 - contentful 일반 Post·Reply·Quote의 목록 modal·전체 화면 및 상세 행별 inline composer 진입, display Post/action target 분리와 contentless Repost disabled 호출 차단을 검증한다.
 - Home·Profile·Bookmark·상세 query가 selected Profile fragment와 성공 callback을 필수 coordinator 경계에 전달하고, 각 `PostListItem`/`PostLayout`이 행별 Reply config prop 없이 coordinator를 소비해 action과 Composer를 내부 조립하며, coordinator 누락은 조용한 Reply 제거가 아니라 프로그래밍 오류이고 guest/null Profile 경계에서는 Reply config를 새로 노출하지 않음을 검증한다.
 - Parent와 다른 Visibility, validation·pending·성공·실패 상태와 selected Profile 전환 격리를 검증한다.
+- 일반·Sensitive Media Parent에서 이미지 표시·가림은 유지하면서 Media 상태 변경 control이 제외되는지 검증한다.
 - pristine·dirty·pending·실패·성공 close, focus trap·복원·배경 scroll lock, single central scroll과 selected Profile 없는 surface의 unchanged partial rollout을 검증한다.
 - 상세 current·ancestor·descendant에서 active Parent를 전환할 때 dirty 확인·pending 차단을 거치고, 정확한 한 행만 `expanded` 상태를 받으며 close·성공 뒤 해당 Reply action으로 focus가 복원되는지 검증한다.
 - 성공 payload 뒤 현재 detail route만 targeted refetch되고 현재 query 범위의 결과만 thread에 반영되며, transient 성공 snackbar가 표시되는 동안 `보기`로 결과 Reply를 열 수 있고 자동 이동·다른 actor Store·관련 없는 목록 변경이 없음을 자동화로 검증한다.
@@ -70,6 +72,7 @@
 - [x] 2.3 기존 composer가 `replyParentId`를 포함해 Reply를 제출하고 DIRECT를 제외하며 selected Profile·Relay Environment·Parent별 입력·pending·error와 늦은 completion·callback을 격리하게 확장한다.
 - [x] 2.4 direct Parent preview와 기존 composer를 조립해 Web 목록 modal·좁은 Web/Native 전체 화면·상세 thread 행별 inline surface, pristine/dirty/pending·실패·성공 lifecycle과 focus·scroll 계약을 구현한다.
 - [x] 2.5 성공한 `Post` payload 뒤 현재 detail route만 targeted refetch하고 transient 결과 Reply `보기`를 제공하며 mutation 실패 시 입력·Parent를 유지하고, surface·route·상태 격리·일반 Post 회귀 검증과 Relay compiler/check를 통과시킨다.
+- [x] 2.6 비대화형 Parent가 일반 이미지는 표시하면서 Sensitive 공개·이미지 오류 재시도 control을 제외하도록 Media interaction을 정렬한다.
 
 ## 3. PROD-426 Reply Notification/inbox 통합
 

--- a/openspec/changes/archive/2026-07-31-display-post-media/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-display-post-media/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-31-display-post-media/decisions.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/decisions.md
@@ -1,0 +1,66 @@
+## Context
+
+이 기록은 PROD-571의 Post 목록·상세 Media 표시 계약, PROD-570이 제공한 viewer-authorized 조회 경계,
+canonical Post Content·Media 모델과 공용 앱 접근성·Relay 제약을 구현 가능한 선택으로 정리한다.
+
+## Decision Records
+
+### 현재 Post Content의 viewer-authorized Media만 표시한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, PROD-570,
+  PROD-571
+- Status: Active
+- Context / Problem: document Media node는 identity와 순서를 소유하지만 표시 URL·Media Type과 현재 viewer의
+  조회 가능 여부는 `PostContent.media` projection이 소유한다.
+- Decision Outcome: UI는 현재 Post Content fragment의 `media` 결과만 사용하고 Media Storage Service 호출,
+  raw storage reference 조립 또는 standalone Media 조회로 우회하지 않는다.
+- Alternatives Considered: document의 Media ID로 standalone Node를 조회하는 방식은 PROD-570의 Post
+  viewer scope를 우회하고 별도 권한 정책이 필요하므로 사용하지 않는다.
+- Consequences: `PostContent.media === null`은 필요한 표시 정보 unavailable fallback이 되고 `[]`만
+  media-less로 해석한다.
+- Confirmation / Follow-up: 목록·상세 Relay fixture에서 ordered Media, empty와 null을 각각 검증한다.
+
+### Sensitive Media 공개 전에는 Image를 mount하지 않는다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`,
+  `docs/design/accessibility.md`, PROD-571
+- Status: Active
+- Context / Problem: blur나 opaque overlay만 사용하면 가림 UI 뒤에서 image byte를 미리 요청하거나 표시할 수
+  있고, 보조 기술 tree에도 실제 이미지가 노출될 수 있다.
+- Decision Outcome: `sensitiveMedia`가 true인 Post는 로컬 reveal state가 false인 동안 실제 `Image`를 mount하지
+  않고 placeholder와 하나의 표시 button만 제공한다. 같은 button은 공개 뒤 expanded 상태와 다시 가리기
+  동작을 제공한다.
+- Alternatives Considered: blur overlay와 image preload는 기본 비공개 의미를 약화시키므로 선택하지 않는다.
+  Media마다 별도 공개 state를 두는 방식은 document root의 전체 Media 가림 계약과 맞지 않는다.
+- Consequences: 사용자가 표시하기 전에는 네트워크 이미지 요청도 시작하지 않는다. 목록과 상세에 같은 Post가
+  각각 mount되면 reveal state는 공유하지 않는다.
+- Confirmation / Follow-up: Storybook interaction과 component test에서 초기 미요청, 표시, 다시 가리기와
+  accessible state를 확인한다.
+
+### Retry는 현재 표시 URL의 Image load만 다시 시작한다
+
+- Decision Date: 2026-07-30
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-570, PROD-571
+- Status: Active
+- Context / Problem: PROD-571은 URL unavailable·image load 실패의 재시도를 요구하지만 현재 backend 계약은
+  UI용 URL 재발급 mutation이나 refetch 정책을 제공하지 않는다.
+- Decision Outcome: 각 Media item은 독립 오류 상태를 소유하고 재시도 시 현재 viewer-authorized `url`을 가진
+  `Image`를 remount한다. GraphQL refetch, cache-busting URL 변형과 새 URL 발급은 수행하지 않는다.
+- Alternatives Considered: URL에 query parameter를 붙이면 저장된 canonical 표현을 임의로 바꾸며, backend
+  refetch나 재발급은 승인된 범위를 확장하므로 선택하지 않는다.
+- Consequences: URL 자체가 영구적으로 무효하면 재시도도 실패하며 fallback이 유지된다. 새 URL 발급이
+  필요해지면 backend 계약과 별도 이슈가 선행되어야 한다.
+- Confirmation / Follow-up: 개별 실패, 다른 Media 유지, retry remount와 반복 실패를 component test로 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-31-display-post-media/decisions.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/decisions.md
@@ -37,9 +37,28 @@ canonical Post Content·Media 모델과 공용 앱 접근성·Relay 제약을 �
 - Alternatives Considered: blur overlay와 image preload는 기본 비공개 의미를 약화시키므로 선택하지 않는다.
   Media마다 별도 공개 state를 두는 방식은 document root의 전체 Media 가림 계약과 맞지 않는다.
 - Consequences: 사용자가 표시하기 전에는 네트워크 이미지 요청도 시작하지 않는다. 목록과 상세에 같은 Post가
-  각각 mount되면 reveal state는 공유하지 않는다.
+  각각 mount되면 reveal state는 공유하지 않는다. Web에서는 공개·가리기 전환에도 같은 control을 mount
+  상태로 유지해 keyboard focus를 보존한다.
 - Confirmation / Follow-up: Storybook interaction과 component test에서 초기 미요청, 표시, 다시 가리기와
-  accessible state를 확인한다.
+  accessible state를 확인하고 Web keyboard focus가 같은 control에 남는지 검증한다.
+
+### 앱 표시용 V1 guard는 소비하지 않는 추가 속성을 무시한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post-content.md`, ADR-0022, PROD-571
+- Status: Active
+- Context / Problem: V1 안에서 허용되는 additive 속성이나 이전 초안의 `media.attrs.altText`처럼 앱이 소비하지
+  않는 속성 때문에 exact-shape guard가 전체 document 표시를 fallback으로 전환했다.
+- Decision Outcome: 유니버설 앱의 runtime-independent guard는 필수 V1 구조·타입, 지원 node·mark와 안전한
+  URL을 검증하되 소비하지 않는 추가 object 속성은 무시한다. 서버 canonical write validation은 계속 strict
+  schema를 적용하고 저장 전에 불필요한 속성을 제거한다.
+- Alternatives Considered: 알려진 legacy 속성을 하나씩 허용 목록에 추가하면 다음 additive 확장마다 같은
+  표시 장애가 반복되고, 서버 validator까지 완화하면 canonical 저장 계약을 약화하므로 선택하지 않는다.
+- Consequences: additive 속성이 있는 유효한 V1은 표시되지만 알 수 없는 node·mark, 잘못된 필수 값, 위험한
+  URL과 지원하지 않는 version은 계속 안전한 fallback으로 처리된다.
+- Confirmation / Follow-up: core unit test에서 여러 계층의 추가 속성과 legacy `altText`를 포함한 V1 수용,
+  미지원 node 거부를 함께 검증한다.
 
 ### Retry는 현재 표시 URL의 Image load만 다시 시작한다
 

--- a/openspec/changes/archive/2026-07-31-display-post-media/decisions.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/decisions.md
@@ -57,10 +57,27 @@ canonical Post Content·Media 모델과 공용 앱 접근성·Relay 제약을 �
   필요해지면 backend 계약과 별도 이슈가 선행되어야 한다.
 - Confirmation / Follow-up: 개별 실패, 다른 Media 유지, retry remount와 반복 실패를 component test로 검증한다.
 
+### 원본 비율을 따르되 세로 Media 높이는 surface 폭으로 제한한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: PROD-571
+- Status: Active
+- Context / Problem: 모든 Media를 16:9로 고정하면 가로 이미지도 불필요하게 crop되고, 원본 비율을 제한 없이
+  적용하면 긴 세로 이미지 하나가 목록과 상세의 과도한 높이를 차지한다.
+- Decision Outcome: `Image.getSize()`의 원본 `width / height`를 사용한다. surface는 가로 폭을 모두 채우고,
+  가로·정사각형 이미지는 원본 비율을 유지하며 세로 이미지는 최대 1:1 frame에서 `cover` crop한다.
+- Alternatives Considered: 16:9 고정 frame은 가로 원본의 구도를 잃고, 세로 원본 높이를 그대로 표시하는
+  방식은 피드 밀도를 예측하기 어려워 선택하지 않는다.
+- Consequences: 원본 크기를 알기 전에는 1:1 frame을 사용하며 가로 이미지 load 뒤 높이가 줄어들 수 있다.
+  별도 thumbnail 생성이나 Media metadata GraphQL 확장은 필요하지 않다.
+- Confirmation / Follow-up: component test에서 가로 원본 비율과 세로 1:1 clamp를 검증하고 실제 Web 화면에서
+  frame 크기를 확인한다.
+
 ## Remaining Decisions
 
 - 없음.
 
 ## Superseded Decisions
 
-- 없음.
+- 2026-07-30의 16:9 고정 image box 구현 선택은 원본 비율 기반·세로 1:1 제한으로 대체한다.

--- a/openspec/changes/archive/2026-07-31-display-post-media/design.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/design.md
@@ -1,0 +1,89 @@
+## Context
+
+`PostBody`는 목록과 상세가 공유하는 Relay fragment 경계이고 `PostContentRenderer`는 V1 document에서 현재
+paragraph/text/hard-break/link만 표시한다. 목록의 `PostListRow`는 `bodyText`가 truthy일 때만 `PostBody`를
+mount하므로 media-only Post는 renderer에 도달하지 않는다. PROD-570은 `PostContent.media`를 document의
+Media node 순서로 제공하고, 각 Media의 global `id`, nullable `url`, `mediaType`, `altText`를 viewer scope로
+보호한다.
+
+공용 앱은 React Native primitive와 Relay fragment colocation을 사용해야 한다. 기존 document scalar는 앱에서
+native-safe JSON으로 판별하며 ProseMirror runtime을 bundle에 포함하지 않는다. Web과 Native의 접근성·입력
+검증 범위는 서로 대체할 수 없다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `PostBody`가 현재 Post Content의 document, ordered Media와 Sensitive Media 상태를 함께 소비한다.
+- 목록·상세가 동일한 Media 표시, 접근성, 가림·공개와 실패·재시도 동작을 사용한다.
+- media-only Post도 실제 Post body surface를 mount한다.
+- Media 한 건의 실패를 Post 나머지 내용과 action에서 격리한다.
+
+**Non-Goals:**
+
+- Composer 업로드·작성, backend URL 발급·권한과 Media Storage Service를 변경하지 않는다.
+- Quote/Reply 전용 preview layout, fullscreen viewer, swipe, zoom, 다운로드를 추가하지 않는다.
+- thumbnail, crop, 파생 이미지와 Remote Media fetch/proxy를 추가하지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `PostContentRenderer`가 전체 document를 하나의 `Text` tree로 만들기 때문에 `Image`, fallback, control을 그
+  내부에 바로 추가할 수 없다.
+- document Media node는 global Media ID를 가지고 PROD-570의 `PostContent.media`도 같은 document 순서의
+  실제 Node를 제공한다. UI에서 raw URL만 별도 query하거나 Media Storage Service를 호출하면 조회 권한과
+  Relay ownership을 우회한다.
+- `PostContent.media`는 필요한 표시 정보가 하나라도 불완전하면 partial list 대신 null이 된다. UI는 이
+  상태와 개별 `Image` onError를 구분해야 한다.
+- `PostListRow`의 현재 `bodyText` 조건은 media-only document를 숨긴다.
+
+### Recommended Approach
+
+- `PostBody` fragment에 `content.media { id url mediaType altText }`를 colocate하고 fragment 결과를
+  `PostContentRenderer`에 전달한다. renderer는 기존 text/link projection을 유지하면서 document Media node
+  순서와 같은 Media list를 별도 공용 Media surface에 넘긴다.
+- text projection과 Media surface를 sibling으로 구성해 React Native `Text` 안에 View/Image를 넣지 않는다.
+  Media surface는 최대 네 항목을 document 순서로 표시하고 theme spacing/radius/color를 사용한다.
+- Sensitive Media 상태는 각 mounted Post body가 로컬 boolean으로 소유한다. true인 document는 Image를
+  mount하지 않은 placeholder에서 시작하고, 하나의 button이 모든 Media를 표시하거나 다시 가린다.
+- 각 Media item은 독립적인 load/error 상태와 retry generation을 소유한다. retry는 GraphQL refetch나 새 URL
+  발급을 만들지 않고 현재 `url`을 가진 `Image`를 새 key로 remount한다.
+- 목록은 `bodyText`가 아니라 `content` 존재를 기준으로 `PostBody`를 mount한다. 목록 row navigation wrapper와
+  Media의 공개·재시도 button이 중첩 Pressable이 되지 않도록 body 전체 navigation Pressable을 제거하거나
+  text-only navigation과 Media control 경계를 분리한다.
+
+### Allowed Alternatives
+
+- Media item의 상태를 gallery parent의 ID-keyed reducer로 관리해도 된다. 각 Media 실패·재시도 격리,
+  document 순서, Sensitive Media 전체 가림과 접근성 결과가 같아야 한다.
+
+### Known Traps
+
+- document의 internal UUID를 URL key 또는 새 network query에 사용하지 않는다. 앱에서 받는 Media identity는
+  GraphQL global ID다.
+- `PostContent.media === null`을 빈 목록으로 취급하지 않는다. 빈 목록은 media-less이고 null은 필요한 표시
+  정보 unavailable이다.
+- Alt Text null을 `accessible={false}`로 바꿔 Post의 의미 있는 첨부 이미지를 보조 기술에서 숨기지 않는다.
+- blur overlay 아래 Image를 미리 mount하면 기본 가림 상태에서도 image byte와 시각 정보가 노출될 수 있으므로
+  Sensitive Media 공개 전에는 Image를 mount하지 않는다.
+- Storybook Web a11y 통과를 Native VoiceOver/TalkBack runtime 검증 완료로 일반화하지 않는다.
+
+## Risks / Trade-offs
+
+- [현재 URL 자체가 더 이상 유효하지 않으면 같은 URL 재시도도 실패한다] → fallback을 유지하고 URL 재발급이나
+  Relay refetch는 backend 계약이 생기기 전까지 추가하지 않는다.
+- [목록의 기존 전체 body Pressable 안에 Media control을 넣으면 interaction이 중첩된다] → Post navigation과
+  Media action의 Pressable 경계를 분리하고 기존 시간 링크·상세 route를 유지한다.
+- [고정된 image box는 원본 종횡비를 보존하지 못한다] → `resizeMode="cover"`로 layout stability를 우선하고
+  crop/thumbnail/fullscreen 정책은 제외 범위로 남긴다.
+
+## Migration Plan
+
+1. PROD-570 위 stacked branch에서 Relay schema/document를 동기화한다.
+2. 공용 Media renderer, 목록·상세 연결, Storybook fixture와 검증을 함께 배포한다.
+3. 회귀가 있으면 frontend change만 되돌린다. backend schema와 저장 데이터 migration은 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-31-display-post-media/design.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/design.md
@@ -23,7 +23,7 @@ native-safe JSON으로 판별하며 ProseMirror runtime을 bundle에 포함하�
 
 - Composer 업로드·작성, backend URL 발급·권한과 Media Storage Service를 변경하지 않는다.
 - Quote/Reply 전용 preview layout, fullscreen viewer, swipe, zoom, 다운로드를 추가하지 않는다.
-- thumbnail, crop, 파생 이미지와 Remote Media fetch/proxy를 추가하지 않는다.
+- 파생 thumbnail, fullscreen viewer와 Remote Media fetch/proxy를 추가하지 않는다.
 
 ## Implementation Guidance
 
@@ -64,6 +64,8 @@ native-safe JSON으로 판별하며 ProseMirror runtime을 bundle에 포함하�
   GraphQL global ID다.
 - `PostContent.media === null`을 빈 목록으로 취급하지 않는다. 빈 목록은 media-less이고 null은 필요한 표시
   정보 unavailable이다.
+- 각 Image는 `Image.getSize()`의 원본 크기로 frame 비율을 계산한다. surface 폭은 모두 채우고 가로·정사각형은
+  원본 종횡비를 유지하며, 세로는 높이가 surface 폭을 넘지 않도록 1:1 frame에서 `cover` crop한다.
 - Alt Text null을 `accessible={false}`로 바꿔 Post의 의미 있는 첨부 이미지를 보조 기술에서 숨기지 않는다.
 - blur overlay 아래 Image를 미리 mount하면 기본 가림 상태에서도 image byte와 시각 정보가 노출될 수 있으므로
   Sensitive Media 공개 전에는 Image를 mount하지 않는다.
@@ -75,8 +77,10 @@ native-safe JSON으로 판별하며 ProseMirror runtime을 bundle에 포함하�
   Relay refetch는 backend 계약이 생기기 전까지 추가하지 않는다.
 - [목록의 기존 전체 body Pressable 안에 Media control을 넣으면 interaction이 중첩된다] → Post navigation과
   Media action의 Pressable 경계를 분리하고 기존 시간 링크·상세 route를 유지한다.
-- [고정된 image box는 원본 종횡비를 보존하지 못한다] → `resizeMode="cover"`로 layout stability를 우선하고
-  crop/thumbnail/fullscreen 정책은 제외 범위로 남긴다.
+- [원본 크기를 알기 전과 조회 뒤 frame 높이가 달라질 수 있다] → 초기 frame은 최대 높이인 1:1로 두고,
+  `Image.getSize()`의 원본 비율이 1보다 크면 해당 비율로 줄여 가로 이미지의 전체 구도를 보존한다.
+- [세로 이미지의 전체 높이를 표시하면 긴 Post가 피드를 과도하게 점유한다] → frame 높이를 surface 폭으로
+  제한하고 `resizeMode="cover"`로 중앙 crop한다. 파생 thumbnail과 fullscreen 정책은 제외 범위로 남긴다.
 
 ## Migration Plan
 

--- a/openspec/changes/archive/2026-07-31-display-post-media/proposal.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Post Composer는 Ready Media가 첨부된 Post를 만들 수 있지만 공용 목록·상세 renderer는 현재 Media node를
+표시하지 않는다. PROD-570이 권한 있는 viewer에게 현재 Post Content의 실제 Media 표시 정보를 제공하므로,
+media-only와 text+media Post를 Web·iOS·Android에서 동일하고 접근 가능하게 읽을 수 있는 UI 계약이 필요하다.
+
+## What Changes
+
+- 일반 Post 목록과 상세가 현재 Post Content의 Media를 document 순서대로 최대 4개 표시한다.
+- media-only와 text+media Post가 같은 공용 React Native renderer를 사용하고 기존 본문·안전한 링크 의미를
+  보존한다.
+- nullable Alt Text를 이미지의 접근 가능한 설명에 반영하고, 설명이 없을 때 장식 이미지로 잘못 숨기지 않는
+  안전한 기본 이름을 제공한다.
+- Sensitive Media는 기본적으로 가리고 사용자가 명시적으로 표시하거나 다시 가릴 수 있는 control을 제공한다.
+- 이미지 로딩 실패는 해당 Media만 fallback으로 대체하며 같은 표시 URL을 다시 로드하는 재시도 action을
+  제공한다.
+- Storybook 상태와 Web keyboard, iOS·Android touch·screen reader 경로를 검증 가능한 공용 UI로 제공한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`,
+  `docs/design/accessibility.md`, `memory/frontend-react-native.md`
+- Linear Contract: PROD-571
+- Linear Implementations: PROD-570
+
+## Capabilities
+
+### New Capabilities
+
+- `post-media-display`: 현재 Post Content의 ordered Media를 목록·상세에서 접근 가능하고 오류에 안전하게
+  표시하는 공용 UI 계약
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/app`의 Post Relay fragment, 공용 Post Content/Media renderer, theme style과 Storybook fixture·state가
+  변경된다.
+- PROD-570의 `PostContent.media`와 Media `url`, `mediaType`, `altText`, 그리고 canonical document root의
+  `sensitiveMedia`를 사용한다.
+- GraphQL backend 계약, Media Storage Service, Composer 업로드·작성, fullscreen viewer와 Remote Media는
+  변경하지 않는다.

--- a/openspec/changes/archive/2026-07-31-display-post-media/proposal.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/proposal.md
@@ -32,7 +32,8 @@ media-only와 text+media Post를 Web·iOS·Android에서 동일하고 접근 가
 
 ### Modified Capabilities
 
-없음.
+- `post-content-document`: 앱 표시용 V1 guard가 필수 구조·타입과 안전한 URL을 검증하면서 소비하지 않는
+  additive object 속성을 허용하고, 미지원 document fallback 경계를 해당 계약과 정렬한다.
 
 ## Impact
 

--- a/openspec/changes/archive/2026-07-31-display-post-media/specs/post-content-document/spec.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/specs/post-content-document/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: server-only ProseMirror runtime boundary
+
+시스템은 `prosemirror-model` runtime을 서버 전용 경계에만 포함하고 유니버설 앱에는 native-safe JSON 타입만 제공해야 한다(MUST).
+
+#### Scenario: 서버와 앱 import 경계
+
+- **WHEN** 서버가 document를 검증, 변환 또는 canonicalize한다
+- **THEN** 서버 전용 core subpath가 `prosemirror-model`을 사용할 수 있다
+- **AND** 앱이 사용하는 core subpath는 JSON 타입과 runtime-independent type guard만 제공한다
+- **AND** React Native/Web bundle은 `prosemirror-model`, ProseMirror editor/view, TipTap 또는 WebView editor runtime을 포함하지 않는다
+
+#### Scenario: 앱 표시용 V1 guard의 additive 속성 호환
+
+- **WHEN** version `1` document가 필수 구조·타입과 안전한 absolute HTTP(S) link를 만족하면서 앱이 소비하지 않는 추가 object 속성을 포함한다
+- **THEN** runtime-independent type guard는 추가 속성을 무시하고 document를 유효한 V1 표시 입력으로 판정한다
+- **AND** 알 수 없는 node·mark, 누락되거나 잘못된 필수 값, 지원하지 않는 version과 안전하지 않은 link는 계속 거부한다
+- **AND** 서버의 canonical write validation과 저장 표현 정규화 경계는 완화하지 않는다
+
+### Requirement: limited native and web renderer
+
+유니버설 앱은 V1 JSON의 paragraph, text, hard break와 link만 React Native primitive로 렌더링해야 한다(MUST).
+
+#### Scenario: 지원 document 렌더링
+
+- **WHEN** 앱이 version `1`의 유효한 document를 표시한다
+- **THEN** paragraph 순서와 경계를 보존한다
+- **AND** text와 hard break를 표시한다
+- **AND** link label을 본문에 표시하고 검증된 absolute HTTP(S) href만 platform link action으로 연다
+- **AND** link는 접근성 link role과 목적지를 식별할 수 있는 label을 가진다
+
+#### Scenario: 미지원 document 방어
+
+- **WHEN** 앱이 알 수 없는 document version·node·mark, 잘못된 필수 attr 또는 안전하지 않은 link를 받는다
+- **THEN** 앱은 해당 값을 실행 가능한 UI로 렌더링하지 않는다
+- **AND** GraphQL이 제공한 파생 `bodyText`를 안전한 fallback으로 표시한다

--- a/openspec/changes/archive/2026-07-31-display-post-media/specs/post-media-display/spec.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/specs/post-media-display/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: 현재 Post Content Media 표시
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, PROD-571 — 공용 Post renderer는 현재 Post Content document의 Media node와 viewer-authorized `PostContent.media`를 사용해 일반 Post 목록과 상세에 최대 4개 이미지를 MUST 표시한다. Media node의 document 순서를 바꾸거나 본문·안전한 링크 의미를 MUST NOT 제거한다.
+
+#### Scenario: 본문과 Media가 함께 있는 Post
+
+- **WHEN** 조회 가능한 현재 Post Content document가 paragraph와 Media node를 함께 가진다
+- **THEN** 목록과 상세는 기존 본문·안전한 링크와 각 이미지를 모두 표시한다
+- **AND** 이미지는 Media node의 document 순서를 유지한다
+
+#### Scenario: Media-only Post
+
+- **WHEN** 조회 가능한 현재 Post Content document가 Plain Text 없이 하나 이상의 Media node를 가진다
+- **THEN** 목록과 상세는 빈 Post 대신 실제 이미지를 표시한다
+
+#### Scenario: Media가 없는 기존 Post
+
+- **WHEN** 현재 Post Content document가 Media node를 가지지 않는다
+- **THEN** 기존 본문·안전한 링크 renderer와 목록·상세 navigation 동작을 그대로 유지한다
+
+### Requirement: Media 접근성 설명
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 공용 Post Media UI는 Media의 nullable Alt Text를 이미지의 접근 가능한 설명으로 MUST 제공한다. Alt Text가 없을 때도 의미 있는 Post 첨부 이미지가 보조 기술에서 장식 이미지로 숨겨지지 않도록 안전한 기본 이름을 MUST 제공한다.
+
+#### Scenario: Alt Text가 있는 이미지
+
+- **WHEN** Media의 `altText`가 non-empty 문자열이다
+- **THEN** Web·iOS·Android 이미지의 accessible name은 해당 Alt Text를 사용한다
+
+#### Scenario: Alt Text가 없는 이미지
+
+- **WHEN** Media의 `altText`가 null이거나 빈 문자열이다
+- **THEN** 이미지는 document 순서에 대응하는 한국어 기본 이름으로 보조 기술에 노출된다
+
+### Requirement: Sensitive Media 명시적 공개
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 현재 Post Content document root의 `sensitiveMedia`가 true이면 공용 Post Media UI는 해당 revision의 모든 Media를 기본적으로 MUST 가린다. 사용자가 같은 Post 안에서 이미지를 명시적으로 표시하고 다시 가릴 수 있는 접근 가능한 control을 MUST 제공한다.
+
+#### Scenario: Sensitive Media 기본 상태
+
+- **WHEN** `sensitiveMedia`가 true인 Post를 처음 표시한다
+- **THEN** 이미지 byte는 보이지 않고 민감한 이미지임을 설명하는 placeholder와 표시 action이 제공된다
+- **AND** 표시 action은 Web keyboard와 iOS·Android touch·screen reader에서 같은 결과를 제공한다
+
+#### Scenario: Sensitive Media 표시와 다시 가리기
+
+- **WHEN** 사용자가 민감한 이미지 표시 action을 실행한다
+- **THEN** 같은 Post의 Media가 표시되고 control은 expanded 상태와 다시 가리기 action을 전달한다
+- **AND** 다시 가리기 action을 실행하면 같은 Post의 모든 Media가 가려진 기본 상태로 돌아간다
+
+#### Scenario: 일반 Media
+
+- **WHEN** `sensitiveMedia`가 false이거나 생략된다
+- **THEN** 별도 공개 action 없이 이미지를 표시한다
+
+### Requirement: Media 로딩 실패 격리와 재시도
+
+**Authority / Provenance:** `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 공용 Post Media UI는 URL을 사용할 수 없거나 이미지 로딩이 실패해도 Post 전체 rendering을 MUST NOT 실패시킨다. 실패한 Media 자리에 상태 설명과 현재 viewer-authorized 표시 URL을 다시 로드하는 접근 가능한 재시도 action을 MUST 제공한다.
+
+#### Scenario: 한 이미지 로딩 실패
+
+- **WHEN** 여러 Media 중 하나의 URL 로딩이 실패한다
+- **THEN** 실패한 자리만 오류 fallback과 재시도 action으로 바뀐다
+- **AND** 기존 본문, 다른 이미지, Post action과 navigation은 계속 사용할 수 있다
+
+#### Scenario: Media 표시 정보 unavailable
+
+- **WHEN** 현재 Post Content의 필요한 Media 표시 정보가 partial list 대신 unavailable이다
+- **THEN** Post는 Media unavailable fallback을 표시하고 본문·Post action·navigation을 유지한다
+
+#### Scenario: 실패한 이미지 재시도
+
+- **WHEN** 사용자가 실패한 Media의 재시도 action을 실행한다
+- **THEN** UI는 해당 Media의 현재 표시 URL로 새 이미지 load를 시작하고 loading 상태를 전달한다
+- **AND** 다시 실패하면 같은 fallback과 재시도 action으로 돌아간다

--- a/openspec/changes/archive/2026-07-31-display-post-media/specs/post-media-display/spec.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/specs/post-media-display/spec.md
@@ -64,6 +64,7 @@
 - **WHEN** 사용자가 민감한 이미지 표시 action을 실행한다
 - **THEN** 같은 Post의 Media가 표시되고 control은 expanded 상태와 다시 가리기 action을 전달한다
 - **AND** 다시 가리기 action을 실행하면 같은 Post의 모든 Media가 가려진 기본 상태로 돌아간다
+- **AND** Web keyboard focus는 두 상태 전환 뒤에도 같은 visibility control에 유지된다
 
 #### Scenario: 일반 Media
 

--- a/openspec/changes/archive/2026-07-31-display-post-media/specs/post-media-display/spec.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/specs/post-media-display/spec.md
@@ -20,6 +20,21 @@
 - **WHEN** 현재 Post Content document가 Media node를 가지지 않는다
 - **THEN** 기존 본문·안전한 링크 renderer와 목록·상세 navigation 동작을 그대로 유지한다
 
+### Requirement: Media surface 비율
+
+**Authority / Provenance:** PROD-571 — 공용 Post Media UI는 각 이미지를 Post body surface 폭으로 MUST 표시하고, 가로·정사각형 원본은 원본 종횡비를 MUST 유지하며, 세로 원본의 표시 높이는 surface 폭을 MUST 초과하지 않는다.
+
+#### Scenario: 가로 또는 정사각형 이미지
+
+- **WHEN** 원본 이미지의 `width / height`가 1 이상이다
+- **THEN** Media frame은 surface 폭을 채우고 원본 종횡비를 유지한다
+
+#### Scenario: 세로 이미지
+
+- **WHEN** 원본 이미지의 `width / height`가 1보다 작다
+- **THEN** Media frame은 surface 폭과 같은 높이의 1:1 경계를 사용한다
+- **AND** 이미지는 해당 경계를 채우도록 중앙 기준으로 crop된다
+
 ### Requirement: Media 접근성 설명
 
 **Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 공용 Post Media UI는 Media의 nullable Alt Text를 이미지의 접근 가능한 설명으로 MUST 제공한다. Alt Text가 없을 때도 의미 있는 Post 첨부 이미지가 보조 기술에서 장식 이미지로 숨겨지지 않도록 안전한 기본 이름을 MUST 제공한다.

--- a/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
@@ -37,6 +37,7 @@ Alt Text, Sensitive Media와 이미지 오류·재시도를 접근 가능한 공
 - [x] 1.2 Alt Text fallback, Sensitive Media 공개 control과 Media unavailable·load failure·retry 동작을 구현한다.
 - [x] 1.3 목록·상세 Storybook 상태와 공용 component interaction·accessibility·navigation 회귀 검증을 추가한다.
 - [x] 1.4 Relay·static check·관련 test·Storybook build·format 검증을 실행하고 플랫폼별 증거와 미검증 범위를 기록한다.
+- [x] 1.5 Media가 surface 폭을 채우면서 가로 원본 비율을 유지하고 세로 높이를 1:1로 제한하도록 조정한다.
 
 ## Verification Evidence
 
@@ -49,6 +50,11 @@ Alt Text, Sensitive Media와 이미지 오류·재시도를 접근 가능한 공
 - 2026-07-30 `pnpm --filter @kosmo/app build-storybook`: static build 통과. Storybook a11y는 저장소
   설정상 color contrast를 제외하므로 전체 WCAG 적합성 증거가 아니다.
 - 2026-07-30 관련 ESLint, Prettier check와 `openspec validate display-post-media --strict` 통과.
+- 2026-07-31 `pnpm --filter @kosmo/app test:unit`: 96개 통과. 가로 원본 비율과 세로 1:1 clamp를 포함한다.
+- 2026-07-31 `pnpm --filter @kosmo/app test:storybook`: Chromium에서 전체 17 files, 210 tests 통과.
+  실제 원본과 Media frame의 비율 일치를 포함한다.
+- 2026-07-31 Chrome `localhost:5173/home`: 475px surface에서 가로 원본은 1.085·1.779·1.333 비율을
+  유지하고 세로 원본은 1:1로 제한되며, reload 이후 runtime exception이 없음을 확인했다.
 - iOS VoiceOver·Android TalkBack, 각 플랫폼 touch target과 실제 binary runtime은 현재 환경에서 실행하지
   않았다. 공용 React Native props와 48 logical-unit target을 구현했지만 Native runtime 검증 완료로
   간주하지 않는다.

--- a/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
@@ -1,0 +1,54 @@
+## 1. PROD-571 Post 목록·상세 Media 표시
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post-content.md`
+- `docs/domain/objects/media.md`
+- `docs/design/accessibility.md`
+- `memory/frontend-react-native.md`
+- PROD-570
+- PROD-571
+
+**Deliverable**
+
+일반 Post 목록과 상세가 현재 Post Content의 최대 4개 이미지를 document 순서로 표시하고, media-only Post,
+Alt Text, Sensitive Media와 이미지 오류·재시도를 접근 가능한 공용 Web·iOS·Android UI로 제공한다.
+
+**Guardrails**
+
+- viewer-authorized `PostContent.media`만 사용하고 standalone Media 조회, storage reference 조립 또는 Media
+  Storage Service 호출을 추가하지 않는다.
+- Sensitive Media 공개 전에는 실제 Image를 mount하지 않는다.
+- `PostContent.media`의 empty와 unavailable을 구분하고 한 Media의 load 실패를 Post 나머지 내용에서 격리한다.
+- retry는 현재 표시 URL의 Image load만 다시 시작하며 GraphQL refetch, URL 변형 또는 새 URL 발급을 추가하지
+  않는다.
+- 기존 본문·안전한 링크와 목록·상세 navigation을 회귀시키지 않는다.
+
+**Verification**
+
+- media-only, text+media, Media 없음, 1~4개 순서와 목록·상세 공용 표시를 검증한다.
+- Alt Text/null Alt Text의 accessible name과 Sensitive Media 초기 가림·표시·다시 가리기 state를 검증한다.
+- 표시 정보 unavailable, 개별 load 실패, 다른 내용 유지, retry remount와 반복 실패를 검증한다.
+- Web keyboard interaction과 Storybook a11y/static build를 확인하고 iOS·Android touch·screen reader 검증 결과와
+  미실행 범위를 구분해 기록한다.
+- Relay compiler, app static check, 관련 unit/component test와 formatter를 통과시킨다.
+
+- [x] 1.1 공용 Post body가 viewer-authorized ordered Media를 조회하고 media-only·text+media를 목록·상세에 표시한다.
+- [x] 1.2 Alt Text fallback, Sensitive Media 공개 control과 Media unavailable·load failure·retry 동작을 구현한다.
+- [x] 1.3 목록·상세 Storybook 상태와 공용 component interaction·accessibility·navigation 회귀 검증을 추가한다.
+- [x] 1.4 Relay·static check·관련 test·Storybook build·format 검증을 실행하고 플랫폼별 증거와 미검증 범위를 기록한다.
+
+## Verification Evidence
+
+- 2026-07-30 `pnpm --filter @kosmo/app lint:tsc`: Relay compiler와 TypeScript static check 통과.
+- 2026-07-30 `pnpm --filter @kosmo/app test:unit`: 90개 통과. Media 순서·상한, nullable Alt Text,
+  Sensitive Media 미mount·표시·다시 가리기, 개별 실패·same-URL retry와 unavailable을 포함한다.
+- 2026-07-30 `pnpm --filter @kosmo/app test:storybook`: Chromium에서 전체 17 files, 211 tests 통과.
+  목록·상세의 media-only/text+media, 4개 순서, Web keyboard 공개·가리기, 개별 load 실패·재시도,
+  unavailable과 기존 navigation을 포함한다.
+- 2026-07-30 `pnpm --filter @kosmo/app build-storybook`: static build 통과. Storybook a11y는 저장소
+  설정상 color contrast를 제외하므로 전체 WCAG 적합성 증거가 아니다.
+- 2026-07-30 관련 ESLint, Prettier check와 `openspec validate display-post-media --strict` 통과.
+- iOS VoiceOver·Android TalkBack, 각 플랫폼 touch target과 실제 binary runtime은 현재 환경에서 실행하지
+  않았다. 공용 React Native props와 48 logical-unit target을 구현했지만 Native runtime 검증 완료로
+  간주하지 않는다.

--- a/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
@@ -38,6 +38,8 @@ Alt Text, Sensitive Media와 이미지 오류·재시도를 접근 가능한 공
 - [x] 1.3 목록·상세 Storybook 상태와 공용 component interaction·accessibility·navigation 회귀 검증을 추가한다.
 - [x] 1.4 Relay·static check·관련 test·Storybook build·format 검증을 실행하고 플랫폼별 증거와 미검증 범위를 기록한다.
 - [x] 1.5 Media가 surface 폭을 채우면서 가로 원본 비율을 유지하고 세로 높이를 1:1로 제한하도록 조정한다.
+- [x] 1.6 앱 표시용 V1 guard가 필수 계약은 검증하면서 소비하지 않는 additive 속성을 허용하도록 보완한다.
+- [x] 1.7 Sensitive Media 공개·가리기 전환에서 Web keyboard focus를 같은 control에 보존한다.
 
 ## Verification Evidence
 
@@ -55,6 +57,14 @@ Alt Text, Sensitive Media와 이미지 오류·재시도를 접근 가능한 공
   실제 원본과 Media frame의 비율 일치를 포함한다.
 - 2026-07-31 Chrome `localhost:5173/home`: 475px surface에서 가로 원본은 1.085·1.779·1.333 비율을
   유지하고 세로 원본은 1:1로 제한되며, reload 이후 runtime exception이 없음을 확인했다.
+- 2026-07-31 `pnpm --filter @kosmo/core test:unit`: 51개 통과. 앱 표시용 guard가 여러 계층의 additive
+  속성과 legacy Media `altText`를 허용하면서 미지원 node를 계속 거부하는 검증을 포함한다.
+- 2026-07-31 `pnpm --filter @kosmo/app test:unit`: 129개 통과. Sensitive Media 공개·가리기 전환에서
+  동일한 `Pressable` instance가 유지되는 검증을 포함한다.
+- 2026-07-31 `pnpm --filter @kosmo/app test:storybook`: Chromium에서 전체 17 files, 230 tests 통과.
+  keyboard로 Sensitive Media를 공개하고 다시 가린 뒤 visibility control의 focus가 유지되는 검증을 포함한다.
+- 2026-07-31 `pnpm --filter @kosmo/app lint:tsc`, 관련 ESLint·Prettier와
+  `openspec validate --all --strict`: 모두 통과.
 - iOS VoiceOver·Android TalkBack, 각 플랫폼 touch target과 실제 binary runtime은 현재 환경에서 실행하지
   않았다. 공용 React Native props와 48 logical-unit target을 구현했지만 Native runtime 검증 완료로
   간주하지 않는다.

--- a/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
+++ b/openspec/changes/archive/2026-07-31-display-post-media/tasks.md
@@ -40,6 +40,8 @@ Alt Text, Sensitive Media와 이미지 오류·재시도를 접근 가능한 공
 - [x] 1.5 Media가 surface 폭을 채우면서 가로 원본 비율을 유지하고 세로 높이를 1:1로 제한하도록 조정한다.
 - [x] 1.6 앱 표시용 V1 guard가 필수 계약은 검증하면서 소비하지 않는 additive 속성을 허용하도록 보완한다.
 - [x] 1.7 Sensitive Media 공개·가리기 전환에서 Web keyboard focus를 같은 control에 보존한다.
+- [x] 1.8 비대화형 Reply Composer Parent에서 일반 Media 표시는 유지하고 Media 상태 변경 control을 제외한다.
+- [x] 1.9 변경한 `post-content-document` 계약을 proposal과 archive delta에 동기화한다.
 
 ## Verification Evidence
 
@@ -65,6 +67,14 @@ Alt Text, Sensitive Media와 이미지 오류·재시도를 접근 가능한 공
   keyboard로 Sensitive Media를 공개하고 다시 가린 뒤 visibility control의 focus가 유지되는 검증을 포함한다.
 - 2026-07-31 `pnpm --filter @kosmo/app lint:tsc`, 관련 ESLint·Prettier와
   `openspec validate --all --strict`: 모두 통과.
+- 2026-07-31 `pnpm --filter @kosmo/app test:storybook`: Chromium에서 전체 17 files, 232 tests 통과.
+  비대화형 Reply Composer Parent가 일반 이미지는 표시하고 Sensitive Media는 가린 채 Media 상태 변경
+  control을 제외하는 검증을 포함한다.
+- 2026-07-31 `pnpm --filter @kosmo/app test:unit`: 131개 통과. 비대화형 Sensitive Media가 image·공개
+  control을 mount하지 않고 비대화형 이미지 오류가 재시도 control을 제공하지 않는 검증을 포함한다.
+- 2026-07-31 `post-content-document`의 MODIFIED requirement 두 개를 archive delta에 추가하고 proposal의
+  Modified Capabilities와 동기화했다. archive를 임시 active change로 복원한 strict validation과
+  `openspec validate --all --strict` 60개가 모두 통과했다.
 - iOS VoiceOver·Android TalkBack, 각 플랫폼 touch target과 실제 binary runtime은 현재 환경에서 실행하지
   않았다. 공용 React Native props와 48 logical-unit target을 구현했지만 Native runtime 검증 완료로
   간주하지 않는다.

--- a/openspec/specs/post-content-document/spec.md
+++ b/openspec/specs/post-content-document/spec.md
@@ -116,6 +116,13 @@ PostContent 본문의 versioned ProseMirror document schema, 서버 검증·cano
 - **AND** 앱이 사용하는 core subpath는 JSON 타입과 runtime-independent type guard만 제공한다
 - **AND** React Native/Web bundle은 `prosemirror-model`, ProseMirror editor/view, TipTap 또는 WebView editor runtime을 포함하지 않는다
 
+#### Scenario: 앱 표시용 V1 guard의 additive 속성 호환
+
+- **WHEN** version `1` document가 필수 구조·타입과 안전한 absolute HTTP(S) link를 만족하면서 앱이 소비하지 않는 추가 object 속성을 포함한다
+- **THEN** runtime-independent type guard는 추가 속성을 무시하고 document를 유효한 V1 표시 입력으로 판정한다
+- **AND** 알 수 없는 node·mark, 누락되거나 잘못된 필수 값, 지원하지 않는 version과 안전하지 않은 link는 계속 거부한다
+- **AND** 서버의 canonical write validation과 저장 표현 정규화 경계는 완화하지 않는다
+
 ### Requirement: limited native and web renderer
 
 유니버설 앱은 V1 JSON의 paragraph, text, hard break와 link만 React Native primitive로 렌더링해야 한다(MUST).
@@ -130,6 +137,6 @@ PostContent 본문의 versioned ProseMirror document schema, 서버 검증·cano
 
 #### Scenario: 미지원 document 방어
 
-- **WHEN** 앱이 알 수 없는 document version, node, mark, attr 또는 안전하지 않은 link를 받는다
+- **WHEN** 앱이 알 수 없는 document version·node·mark, 잘못된 필수 attr 또는 안전하지 않은 link를 받는다
 - **THEN** 앱은 해당 값을 실행 가능한 UI로 렌더링하지 않는다
 - **AND** GraphQL이 제공한 파생 `bodyText`를 안전한 fallback으로 표시한다

--- a/openspec/specs/post-media-display/spec.md
+++ b/openspec/specs/post-media-display/spec.md
@@ -26,6 +26,21 @@
 - **WHEN** 현재 Post Content document가 Media node를 가지지 않는다
 - **THEN** 기존 본문·안전한 링크 renderer와 목록·상세 navigation 동작을 그대로 유지한다
 
+### Requirement: Media surface 비율
+
+**Authority / Provenance:** PROD-571 — 공용 Post Media UI는 각 이미지를 Post body surface 폭으로 MUST 표시하고, 가로·정사각형 원본은 원본 종횡비를 MUST 유지하며, 세로 원본의 표시 높이는 surface 폭을 MUST 초과하지 않는다.
+
+#### Scenario: 가로 또는 정사각형 이미지
+
+- **WHEN** 원본 이미지의 `width / height`가 1 이상이다
+- **THEN** Media frame은 surface 폭을 채우고 원본 종횡비를 유지한다
+
+#### Scenario: 세로 이미지
+
+- **WHEN** 원본 이미지의 `width / height`가 1보다 작다
+- **THEN** Media frame은 surface 폭과 같은 높이의 1:1 경계를 사용한다
+- **AND** 이미지는 해당 경계를 채우도록 중앙 기준으로 crop된다
+
 ### Requirement: Media 접근성 설명
 
 **Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 공용 Post Media UI는 Media의 nullable Alt Text를 이미지의 접근 가능한 설명으로 MUST 제공한다. Alt Text가 없을 때도 의미 있는 Post 첨부 이미지가 보조 기술에서 장식 이미지로 숨겨지지 않도록 안전한 기본 이름을 MUST 제공한다.

--- a/openspec/specs/post-media-display/spec.md
+++ b/openspec/specs/post-media-display/spec.md
@@ -1,0 +1,83 @@
+# post-media-display Specification
+
+## Purpose
+
+현재 Post Content의 첨부 이미지를 일반 Post 목록과 상세에서 순서대로 표시하고, Alt Text·Sensitive Media·로딩 실패 상태를 Web·iOS·Android에서 접근 가능하게 제공한다.
+
+## Requirements
+
+### Requirement: 현재 Post Content Media 표시
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, PROD-571 — 공용 Post renderer는 현재 Post Content document의 Media node와 viewer-authorized `PostContent.media`를 사용해 일반 Post 목록과 상세에 최대 4개 이미지를 MUST 표시한다. Media node의 document 순서를 바꾸거나 본문·안전한 링크 의미를 MUST NOT 제거한다.
+
+#### Scenario: 본문과 Media가 함께 있는 Post
+
+- **WHEN** 조회 가능한 현재 Post Content document가 paragraph와 Media node를 함께 가진다
+- **THEN** 목록과 상세는 기존 본문·안전한 링크와 각 이미지를 모두 표시한다
+- **AND** 이미지는 Media node의 document 순서를 유지한다
+
+#### Scenario: Media-only Post
+
+- **WHEN** 조회 가능한 현재 Post Content document가 Plain Text 없이 하나 이상의 Media node를 가진다
+- **THEN** 목록과 상세는 빈 Post 대신 실제 이미지를 표시한다
+
+#### Scenario: Media가 없는 기존 Post
+
+- **WHEN** 현재 Post Content document가 Media node를 가지지 않는다
+- **THEN** 기존 본문·안전한 링크 renderer와 목록·상세 navigation 동작을 그대로 유지한다
+
+### Requirement: Media 접근성 설명
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 공용 Post Media UI는 Media의 nullable Alt Text를 이미지의 접근 가능한 설명으로 MUST 제공한다. Alt Text가 없을 때도 의미 있는 Post 첨부 이미지가 보조 기술에서 장식 이미지로 숨겨지지 않도록 안전한 기본 이름을 MUST 제공한다.
+
+#### Scenario: Alt Text가 있는 이미지
+
+- **WHEN** Media의 `altText`가 non-empty 문자열이다
+- **THEN** Web·iOS·Android 이미지의 accessible name은 해당 Alt Text를 사용한다
+
+#### Scenario: Alt Text가 없는 이미지
+
+- **WHEN** Media의 `altText`가 null이거나 빈 문자열이다
+- **THEN** 이미지는 document 순서에 대응하는 한국어 기본 이름으로 보조 기술에 노출된다
+
+### Requirement: Sensitive Media 명시적 공개
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 현재 Post Content document root의 `sensitiveMedia`가 true이면 공용 Post Media UI는 해당 revision의 모든 Media를 기본적으로 MUST 가린다. 사용자가 같은 Post 안에서 이미지를 명시적으로 표시하고 다시 가릴 수 있는 접근 가능한 control을 MUST 제공한다.
+
+#### Scenario: Sensitive Media 기본 상태
+
+- **WHEN** `sensitiveMedia`가 true인 Post를 처음 표시한다
+- **THEN** 이미지 byte는 보이지 않고 민감한 이미지임을 설명하는 placeholder와 표시 action이 제공된다
+- **AND** 표시 action은 Web keyboard와 iOS·Android touch·screen reader에서 같은 결과를 제공한다
+
+#### Scenario: Sensitive Media 표시와 다시 가리기
+
+- **WHEN** 사용자가 민감한 이미지 표시 action을 실행한다
+- **THEN** 같은 Post의 Media가 표시되고 control은 expanded 상태와 다시 가리기 action을 전달한다
+- **AND** 다시 가리기 action을 실행하면 같은 Post의 모든 Media가 가려진 기본 상태로 돌아간다
+
+#### Scenario: 일반 Media
+
+- **WHEN** `sensitiveMedia`가 false이거나 생략된다
+- **THEN** 별도 공개 action 없이 이미지를 표시한다
+
+### Requirement: Media 로딩 실패 격리와 재시도
+
+**Authority / Provenance:** `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571 — 공용 Post Media UI는 URL을 사용할 수 없거나 이미지 로딩이 실패해도 Post 전체 rendering을 MUST NOT 실패시킨다. 실패한 Media 자리에 상태 설명과 현재 viewer-authorized 표시 URL을 다시 로드하는 접근 가능한 재시도 action을 MUST 제공한다.
+
+#### Scenario: 한 이미지 로딩 실패
+
+- **WHEN** 여러 Media 중 하나의 URL 로딩이 실패한다
+- **THEN** 실패한 자리만 오류 fallback과 재시도 action으로 바뀐다
+- **AND** 기존 본문, 다른 이미지, Post action과 navigation은 계속 사용할 수 있다
+
+#### Scenario: Media 표시 정보 unavailable
+
+- **WHEN** 현재 Post Content의 필요한 Media 표시 정보가 partial list 대신 unavailable이다
+- **THEN** Post는 Media unavailable fallback을 표시하고 본문·Post action·navigation을 유지한다
+
+#### Scenario: 실패한 이미지 재시도
+
+- **WHEN** 사용자가 실패한 Media의 재시도 action을 실행한다
+- **THEN** UI는 해당 Media의 현재 표시 URL로 새 이미지 load를 시작하고 loading 상태를 전달한다
+- **AND** 다시 실패하면 같은 fallback과 재시도 action으로 돌아간다

--- a/openspec/specs/post-media-display/spec.md
+++ b/openspec/specs/post-media-display/spec.md
@@ -70,6 +70,7 @@
 - **WHEN** 사용자가 민감한 이미지 표시 action을 실행한다
 - **THEN** 같은 Post의 Media가 표시되고 control은 expanded 상태와 다시 가리기 action을 전달한다
 - **AND** 다시 가리기 action을 실행하면 같은 Post의 모든 Media가 가려진 기본 상태로 돌아간다
+- **AND** Web keyboard focus는 두 상태 전환 뒤에도 같은 visibility control에 유지된다
 
 #### Scenario: 일반 Media
 

--- a/packages/core/post-content/index.ts
+++ b/packages/core/post-content/index.ts
@@ -38,7 +38,7 @@ export type PostContentBlockNode = PostContentParagraphNode | PostContentMediaNo
 export interface PostContentBodyDocumentV1 {
   readonly type: 'doc';
   readonly attrs?: {
-    readonly sensitiveMedia: boolean;
+    readonly sensitiveMedia?: boolean;
   };
   readonly content: readonly PostContentBlockNode[];
 }
@@ -69,12 +69,13 @@ export function isPostContentBodyDocumentV1(value: unknown): value is PostConten
   if (!isRecord(value) || value.type !== 'doc' || !('content' in value)) {
     return false;
   }
-  if (
-    value.attrs !== undefined &&
-    (!isRecordWithKeys(value.attrs, ['sensitiveMedia']) ||
-      typeof value.attrs.sensitiveMedia !== 'boolean')
-  ) {
-    return false;
+  if (value.attrs !== undefined) {
+    if (!isRecord(value.attrs)) {
+      return false;
+    }
+    if ('sensitiveMedia' in value.attrs && typeof value.attrs.sensitiveMedia !== 'boolean') {
+      return false;
+    }
   }
   if (!Array.isArray(value.content) || value.content.length === 0) {
     return false;

--- a/packages/core/post-content/index.ts
+++ b/packages/core/post-content/index.ts
@@ -66,12 +66,7 @@ export function isPostContentDocumentV1(value: unknown): value is PostContentDoc
 }
 
 export function isPostContentBodyDocumentV1(value: unknown): value is PostContentBodyDocumentV1 {
-  if (
-    !isRecord(value) ||
-    !hasOnlyKeys(value, ['type', 'attrs', 'content']) ||
-    value.type !== 'doc' ||
-    !('content' in value)
-  ) {
+  if (!isRecord(value) || value.type !== 'doc' || !('content' in value)) {
     return false;
   }
   if (
@@ -93,9 +88,6 @@ export function isPostContentBodyDocumentV1(value: unknown): value is PostConten
 
 function isParagraph(value: unknown): value is PostContentParagraphNode {
   if (!isRecord(value) || value.type !== 'paragraph') {
-    return false;
-  }
-  if (!hasOnlyKeys(value, ['type', 'content'])) {
     return false;
   }
   if (value.content === undefined) {
@@ -121,9 +113,9 @@ function isInlineNode(value: unknown): value is PostContentInlineNode {
   }
 
   if (value.type === 'hard_break') {
-    return hasOnlyKeys(value, ['type']);
+    return true;
   }
-  if (value.type !== 'text' || !hasOnlyKeys(value, ['type', 'text', 'marks'])) {
+  if (value.type !== 'text') {
     return false;
   }
   if (typeof value.text !== 'string' || value.text.length === 0) {
@@ -164,10 +156,5 @@ function isRecordWithKeys<const Key extends string>(
   value: unknown,
   keys: readonly Key[],
 ): value is Record<Key, unknown> {
-  return isRecord(value) && hasOnlyKeys(value, keys) && keys.every((key) => key in value);
-}
-
-function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
-  const allowed = new Set(keys);
-  return Object.keys(value).every((key) => allowed.has(key));
+  return isRecord(value) && keys.every((key) => key in value);
 }

--- a/packages/core/post-content/post-content.test.ts
+++ b/packages/core/post-content/post-content.test.ts
@@ -72,6 +72,29 @@ test('preserves ordered Media nodes and omits the default Sensitive Media attr',
   assert.equal(isPostContentDocumentV1(document), true);
 });
 
+test('canonicalizes legacy Media Alt Text attrs away', () => {
+  assert.deepEqual(
+    canonicalizePostContentDocument({
+      version: 1,
+      summary: null,
+      body: {
+        type: 'doc',
+        content: [
+          { type: 'paragraph' },
+          {
+            type: 'media',
+            attrs: {
+              altText: '이전 문서의 대체 텍스트',
+              mediaId: '019f6678-86fa-709b-984e-1520766b8447',
+            },
+          },
+        ],
+      },
+    }),
+    postContentDocumentFromTextAndMedia('', [{ mediaId: '019f6678-86fa-709b-984e-1520766b8447' }]),
+  );
+});
+
 test('canonicalizes media-only content with one empty paragraph and Sensitive Media', () => {
   const document = postContentDocumentFromTextAndMedia(
     '',
@@ -141,6 +164,10 @@ test('rejects invalid Sensitive Media and Media attr scalar types', () => {
     {
       type: 'doc',
       content: [{ type: 'media', attrs: { mediaId: '' } }],
+    },
+    {
+      type: 'doc',
+      content: [{ type: 'media', attrs: { altText: 123, mediaId: 'media' } }],
     },
   ]) {
     assert.throws(() => canonicalizePostContentDocument({ version: 1, summary: null, body }));

--- a/packages/core/post-content/post-content.test.ts
+++ b/packages/core/post-content/post-content.test.ts
@@ -370,6 +370,18 @@ test('native-safe guard accepts additive V1 properties while validating consumed
     isPostContentDocumentV1({
       version: 1,
       summary: null,
+      body: {
+        type: 'doc',
+        attrs: { futureFlag: true },
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'body' }] }],
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isPostContentDocumentV1({
+      version: 1,
+      summary: null,
       ignoredDocumentProperty: true,
       body: {
         type: 'doc',

--- a/packages/core/post-content/post-content.test.ts
+++ b/packages/core/post-content/post-content.test.ts
@@ -364,8 +364,53 @@ test('compares canonical body and summary meaning', () => {
   assert.equal(arePostContentRevisionsEqual(first, { ...second, summary: 'warning' }), false);
 });
 
-test('native-safe guard accepts only the V1 JSON contract', () => {
+test('native-safe guard accepts additive V1 properties while validating consumed values', () => {
   assert.equal(isPostContentDocumentV1(postContentDocumentFromText('body')), true);
+  assert.equal(
+    isPostContentDocumentV1({
+      version: 1,
+      summary: null,
+      ignoredDocumentProperty: true,
+      body: {
+        type: 'doc',
+        ignoredBodyProperty: true,
+        attrs: { sensitiveMedia: true, ignoredBodyAttr: true },
+        content: [
+          {
+            type: 'paragraph',
+            ignoredParagraphProperty: true,
+            content: [
+              {
+                type: 'text',
+                text: '링크',
+                ignoredTextProperty: true,
+                marks: [
+                  {
+                    type: 'link',
+                    ignoredMarkProperty: true,
+                    attrs: {
+                      href: 'https://example.com/',
+                      ignoredLinkAttr: true,
+                    },
+                  },
+                ],
+              },
+              { type: 'hard_break', ignoredHardBreakProperty: true },
+            ],
+          },
+          {
+            type: 'media',
+            ignoredMediaProperty: true,
+            attrs: {
+              mediaId: '019f6678-86fa-709b-984e-1520766b8447',
+              altText: '이전 초안 속성',
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  );
   assert.equal(
     isPostContentDocumentV1({
       version: 1,

--- a/packages/core/post-content/server.ts
+++ b/packages/core/post-content/server.ts
@@ -253,9 +253,16 @@ function assertPostContentJsonKeys(value: unknown): void {
     if (!isRecord(value.attrs)) {
       throw new TypeError('Media attrs must be an object');
     }
-    assertOnlyKeys(value.attrs, ['mediaId']);
+    assertOnlyKeys(value.attrs, ['mediaId', 'altText']);
     if (typeof value.attrs.mediaId !== 'string' || value.attrs.mediaId.length === 0) {
       throw new TypeError('Media ID must be a non-empty string');
+    }
+    if (
+      value.attrs.altText !== undefined &&
+      value.attrs.altText !== null &&
+      typeof value.attrs.altText !== 'string'
+    ) {
+      throw new TypeError('Legacy Media Alt Text must be a string or null');
     }
     return;
   }


### PR DESCRIPTION
## 무엇을 변경했는지

- 공용 Post renderer가 `PostContent.media`를 조회해 목록과 상세에서 최대 4개 이미지를 document 순서대로 표시합니다.
- media-only Post도 이미지가 보이도록 본문과 Media 렌더링 경계를 분리했습니다.
- nullable Alt Text 기본 이름, Sensitive Media 초기 가림·표시·다시 가리기, unavailable·개별 로딩 실패·재시도를 구현했습니다.
- React Native Web `Image`의 load callback identity를 안정화해 실제 background image가 완료 상태로 전환되게 했습니다.
- 이미지 컴포넌트가 `Image.getSize()`로 원본 크기를 계산해 가로 폭을 채우면서 가로·정사각형은 원본 비율을 유지하고, 세로는 최대 1:1로 제한합니다.
- `PostMediaGallery`는 목록·Sensitive Media 제어만 맡고, 한 장의 비율·로딩·오류·재시도는 `PostMediaImage`와 전용 테스트로 분리했습니다.
- 앱 표시용 V1 guard가 필수 구조·타입과 안전한 URL은 검증하면서 소비하지 않는 additive object 속성을
  무시해, 이전 Media `altText` attr가 남은 문서도 Sensitive Media 상태와 함께 표시합니다.
- Sensitive Media 공개·다시 가리기 전환에서 같은 visibility control을 유지해 Web keyboard focus를
  보존합니다.
- 목록·상세 Storybook fixture와 공용 component·PostContent 단위 테스트를 추가했습니다.
- PROD-571 OpenSpec을 root spec에 동기화하고 완료 change를 아카이브했습니다.

## 왜 변경했는지

Post 작성 흐름은 Media를 첨부할 수 있지만 기존 목록·상세 renderer는 Media node를 표시하지 않았습니다. 그 결과 media-only Post는 빈 게시물처럼 보이고 text+media Post에서는 첨부 이미지가 사라졌습니다. 이 PR은 viewer-authorized Media 표시 정보를 기존 Post 본문·링크·navigation과 함께 제공해 해당 표시 공백을 해소합니다.

초기 구현은 매 render마다 새로운 `onLoad`·`onError`·`onLoadStart` callback을 React Native Web `Image`에 전달했습니다. Web Image loader가 callback 변경을 새 effect로 처리하면서 load를 반복 중단해, 접근성용 숨은 `<img>`는 존재하지만 실제 픽셀 layer의 `background-image`는 `none`으로 남았습니다. callback을 안정화하고 실제 computed background image를 확인하는 브라우저 회귀 검증을 추가했습니다.

실제 로컬 홈 타임라인에서는 이미지가 든 기존 PostContent가 구 스키마의 Media `altText` attr를 보존하고
있었습니다. 앱 표시용 guard가 소비하지 않는 속성까지 exact-shape로 검사해 전체 document를 거부하면서
`bodyText` 오류가 `content: null`로 전파되어 이미지 DOM 자체가 생성되지 않았습니다. 표시 guard는 V1의
필수 구조·타입, 지원 node·mark와 안전한 URL을 계속 검증하되 소비하지 않는 추가 속성을 무시하도록
바꿨습니다. 서버 canonical write validation과 ID-only 저장 표현은 strict하게 유지합니다.

## 이번 PR의 주요 결정

최신 canonical 문서와 Linear를 대조한 [아카이브된 OpenSpec](https://github.com/byulmaru/kosmo/tree/prod-571/openspec/changes/archive/2026-07-31-display-post-media)의 결정에 아래 Media surface 비율 선택을 추가했습니다.

- Sensitive Media 공개 전에는 실제 `Image`를 mount하지 않습니다.
- 재시도는 GraphQL refetch나 URL 변형 없이 현재 viewer-authorized URL의 이미지 load만 다시 시작합니다.
- Media surface는 가로 폭을 모두 사용합니다. 가로·정사각형은 원본 비율을 유지하고 세로는 높이가 폭을 넘지 않도록 1:1 frame에서 중앙 crop합니다.
- Reply·Quote 전용 Media preview는 이번 범위에서 제외합니다.
- 앱 표시용 V1 guard는 소비하지 않는 additive 속성을 무시하고, 서버 canonical write validation은 strict하게
  유지합니다.
- Sensitive Media visibility control은 공개·가리기 상태 전환에도 같은 instance를 유지합니다.

## 어떻게 확인할 수 있는지

- 실제 Chrome `localhost:5173/home`에서 GraphQL 오류가 사라지고 Media가 DOM과 픽셀 layer에 생성되는 것을 확인했습니다. 475px surface에서 가로 원본은 1.085·1.779·1.333 비율을 유지하고 세로 원본은 475×475로 제한되며, reload 이후 runtime exception은 0건이었습니다.
- 실제 Storybook 브라우저에서 이미지 wrapper의 크기와 pixel layer의 `background-image`, 원본 이미지 load를 확인했습니다.
- `pnpm --filter @kosmo/app lint:tsc`
- `pnpm --filter @kosmo/app test:unit` — 129개 통과; visibility control instance 유지 assertion 포함
- `pnpm --filter @kosmo/app test:storybook` — 17 files, 230 tests 통과; 실제 computed background image,
  원본/frame 비율과 Sensitive Media keyboard focus assertion 포함
- `pnpm --filter @kosmo/app build-storybook`
- `pnpm --filter @kosmo/core test:unit` — 51개 통과
- `pnpm --filter @kosmo/core test` — 51 unit, 3 migrate, 11 migration, 169 service tests 통과
- `pnpm lint:eslint`
- 변경 파일 Prettier
- `openspec validate --all --strict` — 60개 통과
- `git diff --check`

## 아직 어떤 문제가 남았는지

- iOS VoiceOver·Android TalkBack과 실제 native binary의 touch·screen reader 경로는 현재 환경에서 실행하지 못했습니다. 공용 React Native 접근성 props와 48 logical-unit target까지 검증 범위에 포함했습니다.
- fullscreen viewer, swipe·zoom·다운로드와 Reply·Quote 전용 이미지 layout은 PROD-571 범위 밖입니다.

Stack: `main` → `prod-571` — 선행 PR #442는 `main`에 병합되었습니다.

Linear: [PROD-571](https://linear.app/byulmaru/issue/PROD-571/post-목록과-상세에-첨부-이미지를-표시한다)
