### PR TITLE
운영 Slack alert allowlist 계약과 구현 handoff를 기록한다

### DIFF
--- a/openspec/changes/route-operational-alerts-to-slack/.openspec.yaml
+++ b/openspec/changes/route-operational-alerts-to-slack/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-31

--- a/openspec/changes/route-operational-alerts-to-slack/decisions.md
+++ b/openspec/changes/route-operational-alerts-to-slack/decisions.md
@@ -1,0 +1,73 @@
+## Context
+
+이 기록은 PROD-530에서 승인된 allowlist v0, 현재 `byulmaru/kubernetes`의 kube-prometheus-stack·Alertmanager·Vault 구성, 그리고 실제 운영 데이터 기반 고도화를 PROD-597로 분리한 결과를 반영한다. 구현 메커니즘의 비규범적 기본안은 design에 두고, 저장소와 구현 slice를 넘어 유지되어야 하는 계약만 기록한다.
+
+## Decision Records
+
+### severity 전체가 아닌 명시적 allowlist를 사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, Linear PROD-530 (2026-07-31)
+- Status: Active
+- Context / Problem: live Prometheus의 warning·critical rule 전체를 Slack으로 route하면 즉시 대응 가치가 낮은 파생·용량 진단 alert까지 전달되어 alert fatigue가 발생한다.
+- Decision Outcome: alert name과 필요한 namespace를 명시한 allowlist v0만 `#monitoring`에 route한다. severity는 메시지 정보로 사용하되 route를 여는 충분조건으로 사용하지 않는다.
+- Alternatives Considered: 모든 warning·critical 일괄 route는 운영 신호 대 잡음비를 보장하지 못해 제외했다. critical만 route하는 방식도 actionability와 root cause 여부를 표현하지 못해 제외했다.
+- Consequences: 새 alert는 선정 기준, owner, runbook을 충족하고 계약을 갱신한 뒤 추가해야 한다. allowlist 밖 alert는 Grafana·Prometheus에서 계속 관찰할 수 있지만 Slack으로 즉시 전송되지 않는다.
+- Confirmation / Follow-up: 렌더링된 matcher와 allowlist 내·외 대표 notification test로 확인한다.
+
+### v0 alert와 핵심 workload namespace를 고정한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, Linear PROD-530 (2026-07-31)
+- Status: Active
+- Context / Problem: 초기 운영 경로의 범위가 모호하면 구현자마다 alert와 namespace를 다르게 해석해 불필요한 notification 또는 중요 장애 누락이 생긴다.
+- Decision Outcome: monitoring 전달 경로 7개, API/node 8개, workload 8개, data/storage/security 4개와 기존 `KarpenterSpotInterruption`을 v0로 고정한다. workload 8개는 `kosmo-prod`, `prometheus`, `vault`, `argocd`, `argo-rollouts`, `cnpg-system`, `kube-system`, `tailscale`, `cert-manager`, `vault-secrets-operator`에서만 route한다.
+- Alternatives Considered: alert 범주만 정의하고 구현 중 이름을 선택하는 방식은 변경 범위를 검증할 수 없어 제외했다. 모든 namespace 적용은 비핵심 workload의 반복 장애까지 즉시 알림화하므로 제외했다.
+- Consequences: chart 업그레이드로 rule name이 바뀌면 matcher와 계약을 함께 검토해야 한다. namespace label이 없는 비-workload alert에는 workload 제한을 적용하지 않는다.
+- Confirmation / Follow-up: live 또는 렌더링된 rule name 대조와 허용·비허용 namespace test로 확인한다.
+
+### 기존 Alertmanager·Vault·Slack 경로를 재사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, `byulmaru/kubernetes/modules/vault/grafana-oauth.tf`, `byulmaru/kubernetes/docs/bootstrap-apps.md`, Linear PROD-530 (2026-07-31)
+- Status: Active
+- Context / Problem: 이미 운영 중인 kube-prometheus-stack Alertmanager와 Vault-backed webhook 경로가 있어 새 알림 플랫폼이나 secret 전달 경로를 만들 이유가 없다.
+- Decision Outcome: 기존 AlertmanagerConfig와 Slack `#monitoring` receiver, Vault KV `secret/kubernetes/alertmanager/slack`에서 동기화되는 Kubernetes Secret reference를 재사용한다. secret 값 자체는 어떤 코드·상태 출력·문서·로그·payload에도 기록하지 않는다.
+- Alternatives Considered: 새 Slack app, 별도 webhook secret 또는 별도 notification service 도입은 운영·보안 표면을 늘리고 PROD-530 범위를 벗어나므로 제외했다.
+- Consequences: 실제 routing 구현과 platform runbook은 `byulmaru/kubernetes`가 소유한다. Kosmo 저장소는 교차 저장소 계약과 완료 증거를 유지한다.
+- Confirmation / Follow-up: Terraform plan과 배포된 receiver가 기존 Secret reference만 사용하는지 확인하고 민감 출력이 없는지 검토한다.
+
+### 운영 notification의 grouping과 상태 계약을 통일한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, Linear PROD-530 (2026-07-31)
+- Status: Active
+- Context / Problem: 기존 Karpenter 전용 route와 신규 운영 route의 반복 주기·receiver가 분리되면 동일 장애가 중복되거나 alert별 복구 상태가 일관되지 않을 수 있다.
+- Decision Outcome: 모든 v0 운영 notification을 `cluster`, `namespace`, `alertname`으로 그룹화하고 30초 group wait, 5분 group interval, 4시간 repeat interval, firing·resolved 전달을 사용한다. 기존 inhibition·silence 동작은 유지한다.
+- Alternatives Considered: 기존 Karpenter의 12시간 반복 주기 유지와 alert별 개별 전송은 일관된 운영 계약과 중복 억제를 어렵게 해 제외했다. 반복 알림을 끄는 방식은 장기 장애 인지를 약화해 제외했다.
+- Consequences: Karpenter route도 공통 계약에 맞춰야 하며 겹치는 route에서 중복 전송이 없음을 확인해야 한다. 실제 반복 주기 최적화는 운영 데이터가 쌓인 뒤 수행한다.
+- Confirmation / Follow-up: route tree 검토와 동일 group·resolved·지속 firing notification test로 확인한다.
+
+### 운영 데이터 기반 고도화는 별도 issue가 소유한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear PROD-530, Linear PROD-597 (2026-07-31)
+- Status: Active
+- Context / Problem: 초기 안전 경로 구축과 실제 firing 데이터에 근거한 최적화를 한 완료 단위로 묶으면 v0 배포가 지연되고, 아직 존재하지 않는 운영 증거를 현재 구현의 조건으로 삼게 된다.
+- Decision Outcome: PROD-530은 allowlist v0 구현, notification test와 전체 change 완료·archive를 소유한다. PROD-597은 PROD-530 완료 후 최소 7일의 운영 데이터를 바탕으로 promote·demote·grouping·inhibition·repeat interval 고도화를 독립적으로 소유한다.
+- Alternatives Considered: 고도화를 PROD-530 task로 포함하는 방식은 서로 독립적으로 승인·연기 가능한 결과를 결합하므로 제외했다.
+- Consequences: PROD-597 작업은 이 change의 task나 완료 조건에 포함하지 않는다. PROD-530 완료 뒤 운영 기록을 별도로 수집해야 한다.
+- Confirmation / Follow-up: PROD-597의 blocked-by 관계와 PROD-530 완료 증거를 확인한 뒤 후속 작업을 시작한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/route-operational-alerts-to-slack/design.md
+++ b/openspec/changes/route-operational-alerts-to-slack/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`byulmaru/kubernetes/modules/helm-apps/prometheus.tf`는 kube-prometheus-stack과 기존 `KarpenterSpotInterruption` PrometheusRule, `#monitoring` Slack receiver를 가진 AlertmanagerConfig를 배포한다. webhook은 `modules/vault/grafana-oauth.tf`를 통해 Vault에서 Kubernetes Secret으로 동기화된다. 현재 나머지 alert는 Slack route에 연결되지 않으며, live Prometheus에는 warning·critical rule이 다수 존재해 severity 전체를 route하면 운영 알림의 신호 대 잡음비가 급격히 낮아진다.
+
+운영자와 PROD-530 구현자가 주요 이해관계자다. Kosmo 저장소는 계약과 완료 증거를 소유하지만 실제 Terraform/Helm 설정과 notification test는 `byulmaru/kubernetes`에서 수행한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 명시적인 alert name allowlist와 workload namespace 범위를 Alertmanager routing에 반영한다.
+- 기존 Karpenter 알림을 포함한 운영 알림의 receiver, grouping, firing·resolved 메시지 동작을 일관되게 만든다.
+- 기존 inhibition·silence와 Vault-backed secret reference를 보존한다.
+- 배포 전 Terraform 검증과 배포 후 대표 notification test가 재현 가능하도록 운영 문서를 보완한다.
+
+**Non-Goals:**
+
+- 새로운 alert rule, SLI/SLO, metric exporter 또는 dashboard를 설계하지 않는다.
+- 모든 warning·critical alert를 Slack으로 전달하지 않는다.
+- 용량 계획·CPU·quota·generic target alert의 승격이나 Kubernetes resource tuning을 수행하지 않는다.
+- 운영 데이터 기반 고도화 PROD-597을 미리 구현하지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- AlertmanagerConfig는 chart가 선택하는 namespace·label 조건과 기존 kube-prometheus-stack route tree 안에서 병합되므로, route의 matcher와 순서가 잘못되면 allowlist 밖 alert가 receiver에 도달하거나 허용 alert가 누락될 수 있다.
+- workload alert에만 namespace matcher가 필요하다. monitoring-path, API/node, storage, Vault alert 중 일부는 namespace label이 없으므로 모든 allowlist를 하나의 namespace 제한 route에 넣으면 안 된다.
+- 일부 kube-prometheus-stack rule의 summary·description·runbook annotation은 alert마다 다르다. Slack template은 누락 값을 안전하게 처리해야 하고 임의의 모든 label·annotation을 그대로 출력하면 안 된다.
+- 기존 Karpenter route의 12시간 반복 주기는 v0 계약의 4시간과 다르며, 별도 receiver를 중복 유지하면 같은 alert가 두 번 전송될 수 있다.
+
+### Recommended Approach
+
+기존 AlertmanagerConfig 안에 하나의 공통 운영 Slack receiver를 두고, alert 범주별 child route로 allowlist를 표현하는 방식을 기본으로 한다. namespace 제한이 없는 alert 범주와 핵심 workload 범주를 별도 matcher 조합으로 만들고, workload route에서만 alert name과 허용 namespace를 함께 매치한다. 기존 Karpenter route는 공통 receiver와 v0 grouping 정책을 사용하도록 정렬하고 중복 route를 제거한다.
+
+receiver template은 Alertmanager가 제공하는 common labels·annotations와 개별 alert 상태를 사용해 계약 필드만 명시적으로 렌더링한다. 값이 없는 owner·runbook은 배포 전에 해당 rule annotation 또는 운영자가 관리하는 안전한 매핑으로 보완한다. silence 링크는 현재 Alertmanager endpoint를 기준으로 alert의 안전한 matcher만 미리 채운다.
+
+검증은 다음 층으로 나눈다.
+
+1. Terraform formatting·validation과 plan으로 AlertmanagerConfig, PrometheusRule annotation, Secret reference 변경만 포함되는지 확인한다.
+2. 렌더링된 route tree 또는 Alertmanager configuration API에서 allowlist·namespace matcher, grouping interval, receiver reference를 확인한다.
+3. secret 값을 노출하지 않는 대표 test alert로 monitoring-path, node/workload, storage 범주의 firing·resolved 수신을 확인한다.
+4. allowlist 밖 alert와 허용되지 않은 namespace의 workload alert가 `#monitoring`에 도달하지 않는지 확인한다.
+
+### Allowed Alternatives
+
+AlertmanagerConfig의 matcher 길이·가독성 또는 Kubernetes CRD 제약 때문에 범주별 receiver를 여러 개로 나눌 수 있다. 단, 같은 Kubernetes Secret reference와 동일한 Slack 채널을 사용하고, v0의 선택·grouping·message·보안 계약과 중복 미발생을 동일하게 검증해야 한다.
+
+### Known Traps
+
+- `severity=warning|critical`만으로 route를 열어 현재 rule 전체를 전송하지 않는다.
+- `continue: true` 또는 겹치는 sibling route로 같은 alert가 기존 Karpenter receiver와 공통 receiver에 중복 전달되지 않게 한다.
+- label이 없는 alert에 존재하지 않는 namespace 조건을 강제하지 않는다.
+- webhook 값, Terraform sensitive output, 전체 alert label·annotation map을 plan·CI log·Slack message에 출력하지 않는다.
+- notification test를 위해 실제 장애를 유발하거나 운영 alert의 `for` 시간을 임시로 약화하지 않는다.
+
+## Risks / Trade-offs
+
+- [v0에서 중요한 alert가 빠질 수 있음] → 보수적인 초기 범위를 유지하고 배포 후 최소 7일 데이터를 PROD-597에서 재평가한다.
+- [allowlist가 chart rule 이름 변경으로 조용히 깨질 수 있음] → 배포 전 live/rerendered rule name과 matcher를 대조하고 runbook에 업그레이드 점검 절차를 둔다.
+- [grouping이 서로 다른 장애를 과도하게 묶을 수 있음] → `cluster`, `namespace`, `alertname`을 사용하고 실제 운영 중 grouping 품질은 PROD-597에서 조정한다.
+- [Slack 자체 장애로 알림 경로가 사라질 수 있음] → Alertmanager 전송 실패·cluster 상태 alert와 Prometheus/Grafana 직접 확인 절차를 runbook에 유지한다.
+
+## Migration Plan
+
+1. 현재 live rule name, Alertmanager route, Secret reference를 다시 확인한다.
+2. allowlist matcher, 공통 receiver template, owner·runbook 보완과 운영 문서를 `byulmaru/kubernetes`에서 변경한다.
+3. Terraform formatting·validation과 plan을 검토한 뒤 배포한다.
+4. Alertmanager configuration과 대표 firing·resolved·미전달 사례를 검증하고 증거를 PROD-530에 남긴다.
+5. 문제가 발생하면 AlertmanagerConfig 변경을 직전 revision으로 되돌려 기존 Karpenter 전용 route를 복구한다. Vault secret은 회전하거나 값 자체를 변경하지 않는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/route-operational-alerts-to-slack/proposal.md
+++ b/openspec/changes/route-operational-alerts-to-slack/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Prometheus, Grafana, Alertmanager는 이미 Kubernetes에 운영 중이지만 Karpenter Spot interruption 외의 장애 alert는 Slack으로 전달되지 않는다. 현재 활성 warning·critical rule 전체를 연결하면 alert fatigue가 생기므로, 즉시 대응 가능한 항목만 보수적인 allowlist v0로 고정해 안전한 운영 알림 경로를 먼저 만든다.
+
+## What Changes
+
+- 기존 Kubernetes·monitoring alert 중 사용자 경로, 프로덕션 데이터 또는 monitoring 전달 경로의 중단과 임박한 손실을 나타내는 항목만 allowlist v0로 선정한다.
+- workload alert는 핵심 운영 namespace로 제한하고 allowlist 밖의 alert는 Slack `#monitoring` receiver에 전달하지 않는다.
+- 동일 장애를 `cluster`, `namespace`, `alertname` 기준으로 묶고 firing과 resolved 상태, 안전한 영향 정보, source·runbook·silence 진입점을 전달한다.
+- 기존 kube-prometheus-stack inhibition·silence와 Vault-backed Slack webhook을 재사용하며 secret과 사용자 식별 정보가 설정·로그·메시지에 노출되지 않게 한다.
+- 실제 운영 데이터에 따른 allowlist·grouping·inhibition 고도화는 PROD-597로 분리한다.
+
+## Authority / Provenance
+
+- Canonical: `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, `byulmaru/kubernetes/docs/bootstrap-apps.md`; Kosmo의 `docs/domain/README.md`는 infrastructure를 domain object 범위에서 제외하며 이 변경에 적용되는 `docs/design` 문서는 없음.
+- Linear Contract: PROD-530 `서버 장애 지표를 Slack으로 알린다` (2026-07-31 갱신)
+- Linear Implementations: PROD-530. 후속 고도화 PROD-597은 이 변경의 구현 범위에서 제외한다.
+
+## Capabilities
+
+### New Capabilities
+
+- `operational-alert-routing`: 기존 Kubernetes·monitoring alert의 allowlist v0, namespace 범위, Slack routing·message·보안·검증 계약을 정의한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `byulmaru/kubernetes`: kube-prometheus-stack의 Alertmanager route·receiver, alert annotation, Terraform/Helm 검증, 운영 runbook과 notification test가 영향을 받는다.
+- `byulmaru/kosmo`: PROD-530의 교차 저장소 OpenSpec 계약과 완료 증거를 소유하며 제품 API·데이터 모델·사용자 UI는 변경하지 않는다.
+- 운영 시스템: 기존 Prometheus, Grafana, Alertmanager, Vault Secret reference와 Slack `#monitoring`을 그대로 사용한다.

--- a/openspec/changes/route-operational-alerts-to-slack/specs/operational-alert-routing/spec.md
+++ b/openspec/changes/route-operational-alerts-to-slack/specs/operational-alert-routing/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: 운영 alert allowlist v0
+
+**Authority / Provenance:** `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, `byulmaru/kubernetes/docs/bootstrap-apps.md`, Linear PROD-530 (2026-07-31). 시스템은 monitoring 전달 경로의 `AlertmanagerFailedToSendAlerts`, `AlertmanagerClusterDown`, `PrometheusNotConnectedToAlertmanagers`, `PrometheusErrorSendingAlertsToAnyAlertmanager`, `PrometheusBadConfig`, `PrometheusNotIngestingSamples`, `PrometheusRuleFailures`; Kubernetes API와 node 가용성의 `KubeAPIDown`, `KubeAPIInstanceUnreachable`, `KubeAPIErrorBudgetBurn`, `KubeNodeNotReady`, `KubeNodeUnreachable`, `KubeNodeEviction`, `KubeletDown`, `KubeletInstanceUnreachable`; 핵심 workload 가용성의 `KubePodNotReady`, `KubePodCrashLooping`, `KubeDeploymentReplicasMismatch`, `KubeDeploymentRolloutStuck`, `KubeStatefulSetReplicasMismatch`, `KubeStatefulSetUpdateNotRolledOut`, `KubeDaemonSetRolloutStuck`, `KubeJobFailed`; 데이터·storage·보안 기반의 `KubePersistentVolumeErrors`, `NodeFilesystemAlmostOutOfSpace`, `VaultSealed`, `VaultTelemetryDown`; 기존 운영 alert `KarpenterSpotInterruption`만 Slack `#monitoring` 운영 receiver의 allowlist v0로 취급해야 한다(MUST). 새 alert를 v0에 추가하려면 사용자 요청 경로, 프로덕션 데이터 또는 monitoring 전달 경로의 중단·임박한 손실을 나타내고, 운영자가 수분 내 실행할 구체적인 조치와 owner·runbook이 있어야 하며, root-cause alert의 단순 파생 신호나 용량 계획용 진단 신호가 아니어야 한다(MUST).
+
+#### Scenario: allowlist alert 수신
+
+- **WHEN** allowlist v0의 alert가 firing 상태가 된다
+- **THEN** 시스템은 해당 alert를 `#monitoring` 운영 receiver의 routing 후보로 선택해야 한다
+
+#### Scenario: severity만 일치하는 alert 제외
+
+- **WHEN** warning 또는 critical alert가 firing하지만 이름이 allowlist v0에 없거나 선정 기준을 충족하지 않는다
+- **THEN** 시스템은 해당 alert를 `#monitoring` 운영 receiver로 보내지 않아야 한다
+
+### Requirement: 핵심 workload namespace 제한
+
+**Authority / Provenance:** `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, Linear PROD-530 (2026-07-31). 핵심 workload 가용성 alert는 `kosmo-prod`, `prometheus`, `vault`, `argocd`, `argo-rollouts`, `cnpg-system`, `kube-system`, `tailscale`, `cert-manager`, `vault-secrets-operator` namespace에 속할 때만 Slack routing 대상으로 삼아야 한다(MUST). 다른 범주의 allowlist alert는 alert 자체의 label 구조에 따라 이 namespace 제한을 강제로 적용하지 않아야 한다(MUST).
+
+#### Scenario: 핵심 namespace의 workload 장애
+
+- **WHEN** allowlist의 workload alert가 허용된 namespace에서 firing한다
+- **THEN** 시스템은 해당 alert를 운영 receiver의 routing 후보로 선택해야 한다
+
+#### Scenario: 비핵심 namespace의 workload 장애
+
+- **WHEN** 동일한 workload alert가 허용 목록 밖의 namespace에서 firing한다
+- **THEN** 시스템은 해당 alert를 `#monitoring` 운영 receiver로 보내지 않아야 한다
+
+### Requirement: 그룹화와 상태 전달
+
+**Authority / Provenance:** `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, `byulmaru/kubernetes/docs/bootstrap-apps.md`, Linear PROD-530 (2026-07-31). 시스템은 운영 alert를 `cluster`, `namespace`, `alertname`으로 그룹화하고 `groupWait` 30초, `groupInterval` 5분, `repeatInterval` 4시간을 적용해야 한다(MUST). firing과 resolved 상태를 모두 전달하고, 기존 kube-prometheus-stack inhibition과 silence 동작을 유지해야 한다(MUST).
+
+#### Scenario: 동일 장애 중복 억제
+
+- **WHEN** 같은 cluster·namespace·alertname에 속하는 여러 alert instance가 짧은 시간 안에 firing한다
+- **THEN** 시스템은 이를 30초의 최초 대기 뒤 하나의 group notification으로 묶고 같은 group의 추가 상태는 최소 5분 간격으로 전달해야 한다
+
+#### Scenario: 지속 장애 반복 알림
+
+- **WHEN** 동일 group이 계속 firing 상태로 남는다
+- **THEN** 시스템은 마지막 notification 이후 4시간이 지나기 전에는 반복 notification을 보내지 않아야 한다
+
+#### Scenario: 장애 복구 알림
+
+- **WHEN** notification을 보낸 alert group이 resolved 상태가 된다
+- **THEN** 시스템은 같은 운영 receiver로 resolved notification을 전달해야 한다
+
+### Requirement: 조치 가능한 안전한 Slack 메시지
+
+**Authority / Provenance:** `byulmaru/kubernetes/docs/bootstrap-apps.md`, Linear PROD-530 (2026-07-31). Slack 메시지는 status, severity, alert name, summary, description, 안전한 영향 label subset, startsAt·endsAt, generator 또는 source, owner, 실행 가능한 runbook과 silence 진입점을 제공해야 한다(MUST). 메시지와 alert label은 사용자 ID, 계정·프로필·게시물 ID, raw URL, GraphQL document 또는 error 원문, credential, webhook 값을 포함하지 않아야 한다(MUST).
+
+#### Scenario: firing 메시지로 초기 대응
+
+- **WHEN** allowlist alert의 firing notification이 생성된다
+- **THEN** 운영자는 메시지에서 영향 대상과 시작 시점, owner, source, runbook, silence 진입점을 확인할 수 있어야 한다
+
+#### Scenario: 민감 정보 제외
+
+- **WHEN** 원본 장애 컨텍스트에 사용자 식별 정보, 요청 URL, 오류 원문 또는 secret이 존재한다
+- **THEN** 시스템은 해당 값을 alert label, Slack payload와 notification log에 포함하지 않아야 한다
+
+### Requirement: 기존 secret 경로 재사용
+
+**Authority / Provenance:** `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`, `byulmaru/kubernetes/modules/vault/grafana-oauth.tf`, `byulmaru/kubernetes/docs/bootstrap-apps.md`, Linear PROD-530 (2026-07-31). 시스템은 Vault KV `secret/kubernetes/alertmanager/slack`의 `SLACK_WEBHOOK_URL`에서 Kubernetes Secret으로 동기화되는 기존 reference를 사용해야 한다(MUST). webhook secret 값은 repository, Terraform state 출력, CI log, Linear, OpenSpec 또는 Slack payload에 기록하지 않아야 한다(MUST).
+
+#### Scenario: receiver가 webhook을 참조
+
+- **WHEN** Alertmanager Slack receiver가 배포된다
+- **THEN** receiver는 secret 값 자체가 아니라 기존 Kubernetes Secret reference를 사용해야 한다
+
+#### Scenario: 검증 산출물의 secret 보호
+
+- **WHEN** Terraform validation·plan 또는 notification test 증거를 저장한다
+- **THEN** 산출물에는 webhook secret 값이 평문으로 나타나지 않아야 한다
+
+### Requirement: 배포 전후 검증과 운영 절차
+
+**Authority / Provenance:** `byulmaru/kubernetes/docs/bootstrap-apps.md`, Linear PROD-530 (2026-07-31). 변경은 Terraform formatting·validation과 실제 plan으로 의도한 rule·route·secret reference만 바뀌는지 검증해야 한다(MUST). 배포 후에는 monitoring 전달 경로, node 또는 workload, storage 범주의 대표 alert에 대해 firing과 resolved 수신을 확인하고, 모든 v0 alert의 owner·runbook과 Slack 전달 실패·잘못된 설정·silence·escalation 절차를 운영 문서에 기록해야 한다(MUST).
+
+#### Scenario: 배포 전 plan 검토
+
+- **WHEN** 운영 alert routing 변경을 배포 후보로 준비한다
+- **THEN** 검토자는 Terraform validation 성공과 plan의 의도된 변경 범위, secret 비노출을 확인할 수 있어야 한다
+
+#### Scenario: 대표 notification 검증
+
+- **WHEN** 변경이 운영 환경에 배포된다
+- **THEN** 대표 alert의 firing·resolved 메시지와 allowlist 밖 alert의 미전달 증거가 기록되어야 한다
+
+#### Scenario: 전달 경로 장애 대응
+
+- **WHEN** Slack 전달이 실패하거나 Alertmanager 설정이 유효하지 않다
+- **THEN** 운영자는 runbook을 통해 실패를 탐지하고 원인을 확인하며 안전하게 복구할 수 있어야 한다

--- a/openspec/changes/route-operational-alerts-to-slack/tasks.md
+++ b/openspec/changes/route-operational-alerts-to-slack/tasks.md
@@ -26,10 +26,10 @@
 - monitoring 전달 경로, node 또는 workload, storage 범주의 대표 firing·resolved 메시지와 allowlist 밖·비허용 namespace 미전달을 검증한다.
 - 모든 v0 alert의 owner·runbook과 전달 실패·잘못된 설정·silence·escalation 절차가 운영 문서에 있는지 확인한다.
 
-- [ ] 1.1 구현 직전 Linear PROD-530과 `byulmaru/kubernetes`의 live rule·route·Secret reference를 다시 조회해 authority snapshot을 남긴다.
-- [ ] 1.2 `byulmaru/kubernetes`에서 정확한 alert name allowlist와 workload namespace 범위를 운영 Slack routing에 반영하고 기존 Karpenter route의 중복을 제거한다.
-- [ ] 1.3 grouping interval, firing·resolved와 계약 필드만 출력하는 안전한 Slack 메시지를 적용하고 기존 inhibition·silence·Secret reference를 보존한다.
-- [ ] 1.4 v0 alert의 owner·runbook을 보완하고 allowlist 변경, 전달 실패, 설정 오류, silence, escalation과 rollback 절차를 platform 운영 문서에 기록한다.
+- [x] 1.1 구현 직전 Linear PROD-530과 `byulmaru/kubernetes`의 live rule·route·Secret reference를 다시 조회해 authority snapshot을 남긴다.
+- [x] 1.2 `byulmaru/kubernetes`에서 정확한 alert name allowlist와 workload namespace 범위를 운영 Slack routing에 반영하고 기존 Karpenter route의 중복을 제거한다.
+- [x] 1.3 grouping interval, firing·resolved와 계약 필드만 출력하는 안전한 Slack 메시지를 적용하고 기존 inhibition·silence·Secret reference를 보존한다.
+- [x] 1.4 v0 alert의 owner·runbook을 보완하고 allowlist 변경, 전달 실패, 설정 오류, silence, escalation과 rollback 절차를 platform 운영 문서에 기록한다.
 - [ ] 1.5 Terraform formatting·validation과 실제 plan을 실행해 의도한 범위와 secret 비노출을 확인한다.
 - [ ] 1.6 대표 alert의 firing·resolved 수신과 allowlist 밖·비허용 namespace alert의 미전달을 안전한 방식으로 검증하고 증거를 PROD-530에 남긴다.
 - [ ] 1.7 Kosmo와 Kubernetes 저장소의 변경·검증 증거를 대조하고 PROD-530 전체 범위가 끝난 뒤에만 OpenSpec change를 archive한다.

--- a/openspec/changes/route-operational-alerts-to-slack/tasks.md
+++ b/openspec/changes/route-operational-alerts-to-slack/tasks.md
@@ -1,0 +1,35 @@
+## 1. PROD-530 운영 alert allowlist v0
+
+**Authority / Provenance**
+
+- `byulmaru/kubernetes/modules/helm-apps/prometheus.tf`
+- `byulmaru/kubernetes/modules/vault/grafana-oauth.tf`
+- `byulmaru/kubernetes/docs/bootstrap-apps.md`
+- Linear PROD-530 (2026-07-31)
+
+**Deliverable**
+
+즉시 대응 가능한 기존 Kubernetes·monitoring alert만 allowlist v0와 핵심 namespace 범위에 따라 Slack `#monitoring`으로 전달되고, 운영자는 중복이 억제된 firing·resolved 메시지에서 안전한 영향 정보와 실행 가능한 대응 경로를 확인할 수 있다.
+
+**Guardrails**
+
+- allowlist 이름과 workload namespace 범위 밖 alert는 `#monitoring` 운영 receiver로 새로 전달하지 않는다.
+- `cluster`, `namespace`, `alertname` grouping, 30초 group wait, 5분 group interval, 4시간 repeat interval과 firing·resolved 전달을 유지한다.
+- 기존 kube-prometheus-stack inhibition·silence와 Vault-backed Kubernetes Secret reference를 재사용한다.
+- 사용자 식별 정보, raw URL, GraphQL 원문, credential과 webhook 값을 label·메시지·repository·Terraform state 출력·CI log·문서에 노출하지 않는다.
+- 운영 데이터 기반 allowlist 고도화 PROD-597과 새 SLI/SLO·metric·dashboard·resource tuning은 이 task group에 포함하지 않는다.
+
+**Verification**
+
+- live 또는 렌더링된 rule·route에서 정확한 allowlist, workload namespace matcher, grouping interval, receiver와 Secret reference를 대조한다.
+- Terraform formatting·validation과 실제 plan이 의도한 alert route·annotation·문서·Secret reference만 변경하며 민감 값을 출력하지 않는지 확인한다.
+- monitoring 전달 경로, node 또는 workload, storage 범주의 대표 firing·resolved 메시지와 allowlist 밖·비허용 namespace 미전달을 검증한다.
+- 모든 v0 alert의 owner·runbook과 전달 실패·잘못된 설정·silence·escalation 절차가 운영 문서에 있는지 확인한다.
+
+- [ ] 1.1 구현 직전 Linear PROD-530과 `byulmaru/kubernetes`의 live rule·route·Secret reference를 다시 조회해 authority snapshot을 남긴다.
+- [ ] 1.2 `byulmaru/kubernetes`에서 정확한 alert name allowlist와 workload namespace 범위를 운영 Slack routing에 반영하고 기존 Karpenter route의 중복을 제거한다.
+- [ ] 1.3 grouping interval, firing·resolved와 계약 필드만 출력하는 안전한 Slack 메시지를 적용하고 기존 inhibition·silence·Secret reference를 보존한다.
+- [ ] 1.4 v0 alert의 owner·runbook을 보완하고 allowlist 변경, 전달 실패, 설정 오류, silence, escalation과 rollback 절차를 platform 운영 문서에 기록한다.
+- [ ] 1.5 Terraform formatting·validation과 실제 plan을 실행해 의도한 범위와 secret 비노출을 확인한다.
+- [ ] 1.6 대표 alert의 firing·resolved 수신과 allowlist 밖·비허용 namespace alert의 미전달을 안전한 방식으로 검증하고 증거를 PROD-530에 남긴다.
+- [ ] 1.7 Kosmo와 Kubernetes 저장소의 변경·검증 증거를 대조하고 PROD-530 전체 범위가 끝난 뒤에만 OpenSpec change를 archive한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- PROD-530의 운영 Slack alert allowlist v0, namespace scope, routing·메시지 계약을 OpenSpec으로 기록했습니다.
- `byulmaru/kubernetes`에서 소유하는 실제 Alertmanager 구현과 notification test의 handoff 및 완료 책임을 tasks에 반영했습니다.
- secret 비노출, 기존 Karpenter route·inhibition·silence 보존, 후속 PROD-597 범위를 명시했습니다.

## 왜 변경했는지

모든 warning/critical alert를 일괄 Slack 전달하지 않고, 운영자가 수분 안에 조치할 수 있는 명시적 allowlist만 `#monitoring`으로 전달하기 위한 계약과 저장소 경계를 고정합니다.

## 이번 PR의 주요 결정

없음. Linear PROD-530과 기존 운영 authority를 대조한 OpenSpec 결정을 기록하고, 실제 routing 구현은 `byulmaru/kubernetes` 책임으로 유지했습니다.

## 어떻게 확인할 수 있는지

- PASS: `openspec validate route-operational-alerts-to-slack --strict`
- PASS: 변경 OpenSpec 문서 Prettier check
- PASS: `pnpm test:eslint`
- PASS: `pnpm test:helm`

## 아직 어떤 문제가 남았는지

- 실제 Alertmanager/Terraform 변경, plan, 대표 firing·resolved 및 미전달 notification 증거는 `byulmaru/kubernetes`에서 수행해야 합니다.
- 해당 구현과 운영 증거가 완료되기 전까지 Draft로 유지합니다.

Stack: main -> PROD-530