### PR TITLE
Reaction Profile modal이 유효한 Web ARIA 구조를 제공하게 한다

### DIFF
--- a/apps/app/src/components/reaction/ReactionProfilesModal.tsx
+++ b/apps/app/src/components/reaction/ReactionProfilesModal.tsx
@@ -72,17 +72,16 @@ export function ReactionProfilesModal({
   return (
     <Modal
       accessibilityLabel={title}
+      accessibilityViewIsModal
       animationType="fade"
       onRequestClose={onClose}
+      role="dialog"
       transparent
       visible
     >
       <Pressable accessibilityLabel={`${title} 닫기`} onPress={onClose} style={styles.backdrop}>
         <Pressable
-          accessibilityLabel={title}
-          accessibilityViewIsModal
           onPress={(event) => event.stopPropagation()}
-          role="dialog"
           style={[styles.surface, { backgroundColor: theme.card, borderColor: theme.border }]}
         >
           <ScrollView

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -695,9 +695,8 @@ export const NoSelectedProfileDisablesReaction: Story = {
     expect(reactionMutationRequest).not.toHaveBeenCalled();
 
     await userEvent.click(moreProfiles);
-    await expect(
-      screen.findByRole('dialog', { name: '반응한 프로필' }),
-    ).resolves.toBeInTheDocument();
+    const dialog = await screen.findByRole('dialog', { name: '반응한 프로필' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
     await expect(screen.findByText('아직 이 반응을 남긴 프로필이 없어요')).resolves.toBeVisible();
   },
   render: () => (


### PR DESCRIPTION
## 무엇을 변경했는지

- `ReactionProfilesModal`의 dialog label·role·modal 상태를 바깥 React Native `Modal`이 한 번만 소유하게 했습니다.
- 내부 surface `Pressable`의 중복 `accessibilityLabel`, `accessibilityViewIsModal`, `role`을 제거했습니다.
- Post Action Bar Storybook에서 `반응한 프로필` dialog가 `aria-modal="true"`를 소유하는지 고정했습니다.

## 왜 변경했는지

#409 merge queue의 Storybook a11y 검증에서 내부 일반 `div`에 `aria-modal="true"`가 생성되어 axe `aria-allowed-attr` 위반이 발생했습니다. React Native Web `Modal` root가 이미 dialog/modal semantics를 제공하므로 내부 surface의 중복 선언을 제거해야 합니다.

- Linear: [PROD-599](https://linear.app/byulmaru/issue/PROD-599/reaction-profiles-modal의-web-aria-modal-역할을-올바른-노드에-둔다)
- 실패한 merge-group Test: https://github.com/byulmaru/kosmo/actions/runs/30552584907

## 이번 PR의 주요 결정

### 현재 실패를 소유한 modal만 수정

- 결정자: @robin-maki
- 선택: 현재 merge queue 실패를 만든 `ReactionProfilesModal`만 이번 PR에서 수정합니다.
- 고려한 대안: 같은 패턴의 `ReactionPopover`와 `ModalSheet`까지 함께 수정
- 이유: 각 modal surface의 focus·dismiss 검증 책임이 다르므로 현재 실패의 책임만 좁게 수정합니다.
- 감수한 결과: 나머지 두 컴포넌트는 [PROD-600](https://linear.app/byulmaru/issue/PROD-600/reactionpopover와-modalsheet의-중복-modal-semantics를-정리한다) Backlog에서 별도로 검증하고 수정합니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app test:storybook -- src/stories/PostActionBar.stories.tsx`
  - 17 files, 210 tests 통과
  - Storybook axe 검증 포함
- `pnpm exec prettier --check apps/app/src/components/reaction/ReactionProfilesModal.tsx apps/app/src/stories/PostActionBar.stories.tsx`
  - 통과
- 로컬 `pnpm --filter @kosmo/app check`는 생성된 Expo route type이 `[profileHandle]/[postId].tsx:122`의 문자열 navigation을 거부해 완료하지 못했습니다. 변경 파일과 무관하며 GitHub CI에서 깨끗한 생성 환경으로 재검증합니다.

## 아직 어떤 문제가 남았는지

- `ReactionPopover`와 `ModalSheet`의 동일 패턴은 PROD-600 범위로 남겼습니다.