### PR TITLE
리뷰된 Terraform plan 출력을 그대로 비교한다

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -368,15 +368,20 @@ jobs:
           set -euo pipefail
 
           cleanup_plan_comparison() {
-            rm -f current.tfplan current.tfplan.txt reviewed.tfplan.txt
+            rm -f current.tfplan current.tfplan.txt current.tfplan.json reviewed.tfplan.json
           }
           trap cleanup_plan_comparison EXIT
 
           terraform plan -input=false -out=current.tfplan
-          terraform show -no-color terraform.tfplan > reviewed.tfplan.txt
-          terraform show -no-color current.tfplan > current.tfplan.txt
+          terraform show -json terraform.tfplan \
+            | jq -S '{configuration, variables, resource_changes: [.resource_changes[] | select(.change.actions != ["no-op"])], output_changes, checks}' \
+            > reviewed.tfplan.json
+          terraform show -json current.tfplan \
+            | jq -S '{configuration, variables, resource_changes: [.resource_changes[] | select(.change.actions != ["no-op"])], output_changes, checks}' \
+            > current.tfplan.json
 
-          if ! cmp -s reviewed.tfplan.txt current.tfplan.txt; then
+          if ! cmp -s reviewed.tfplan.json current.tfplan.json; then
+            terraform show -no-color current.tfplan > current.tfplan.txt
             total_lines="$(wc -l < current.tfplan.txt)"
             {
               echo "## Terraform plan mismatch"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -368,20 +368,15 @@ jobs:
           set -euo pipefail
 
           cleanup_plan_comparison() {
-            rm -f current.tfplan current.tfplan.txt current.tfplan.json reviewed.tfplan.json
+            rm -f current.tfplan current.tfplan.txt reviewed.tfplan.txt
           }
           trap cleanup_plan_comparison EXIT
 
           terraform plan -input=false -out=current.tfplan
-          terraform show -json terraform.tfplan \
-            | jq -S '{configuration, variables, planned_values, resource_drift, resource_changes, output_changes, checks}' \
-            > reviewed.tfplan.json
-          terraform show -json current.tfplan \
-            | jq -S '{configuration, variables, planned_values, resource_drift, resource_changes, output_changes, checks}' \
-            > current.tfplan.json
+          terraform show -no-color terraform.tfplan > reviewed.tfplan.txt
+          terraform show -no-color current.tfplan > current.tfplan.txt
 
-          if ! cmp -s reviewed.tfplan.json current.tfplan.json; then
-            terraform show -no-color current.tfplan > current.tfplan.txt
+          if ! cmp -s reviewed.tfplan.txt current.tfplan.txt; then
             total_lines="$(wc -l < current.tfplan.txt)"
             {
               echo "## Terraform plan mismatch"

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -54,7 +54,7 @@ Production PostgreSQL backup은 `s3://byulmaru-kosmo-prod-postgresql-backups-822
 
 그 뒤 `apps/terraform/**` 또는 Terraform workflow가 바뀐 PR에서는 GCP/Firebase/IAM/WIF plan을 실행해 PR comment와 artifact로 남긴다. Merge queue에서는 같은 배치에 포함된 PR 전체와 최신 `main`을 합친 commit으로 reviewed plan을 다시 만든다. Plan artifact는 저장소의 Actions 보존 기간만큼 유지하며 apply는 최종 main commit과 일치하는 미만료 merge queue artifact만 선택한다.
 
-PR 배치가 `main`에 병합되면 현재 main에서 plan을 새로 만들고, 생성 시각과 이전 state snapshot을 제외한 Terraform JSON 표현이 merge queue의 reviewed plan과 같은지 확인한다. Configuration, variables, planned values, drift와 resource/output changes, checks가 모두 같을 때만 reviewed saved plan을 그대로 apply한다. plan이 다르면 current plan을 자동 적용하지 않고 중단하며, reviewed saved plan을 실제로 apply하므로 Terraform의 native stale-plan 검증도 유지된다. 비교용 JSON은 로그나 artifact에 남기지 않고 job 안에서 삭제한다. plan과 apply는 같은 GCP 서비스 계정과 AWS role을 사용한다.
+PR 배치가 `main`에 병합되면 현재 main에서 plan을 새로 만들고, PR 댓글과 artifact에서 검토한 `terraform show -no-color` 결과가 같은지 확인한다. 이 표현은 plan의 실제 resource/output 변경을 보여 주되 Argo CD Application의 resource version이나 reconcile 시각처럼 실행 사이에 바뀌는 no-op 관측 상태는 포함하지 않는다. plan이 다르면 current plan을 자동 적용하지 않고 중단하며, 같으면 reviewed saved plan을 그대로 apply하므로 Terraform의 native stale-plan 검증도 유지된다. 비교용 텍스트는 추가 artifact에 남기지 않고 job 안에서 삭제한다. plan과 apply는 같은 GCP 서비스 계정과 AWS role을 사용한다.
 
 Merge queue plan은 OIDC trust를 먼저 배포한 뒤 활성화한다. 이 변경을 배포할 때는 repository variable을 설정하기 전에 PR plan으로 GCP WIF condition을 apply하고, 관리자 AWS credential로 `./scripts/ensure-ci-aws-role.sh`를 다시 실행한다. 활성화 전 main apply는 PR plan fallback을 사용한다.
 

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -54,7 +54,7 @@ Production PostgreSQL backup은 `s3://byulmaru-kosmo-prod-postgresql-backups-822
 
 그 뒤 `apps/terraform/**` 또는 Terraform workflow가 바뀐 PR에서는 GCP/Firebase/IAM/WIF plan을 실행해 PR comment와 artifact로 남긴다. Merge queue에서는 같은 배치에 포함된 PR 전체와 최신 `main`을 합친 commit으로 reviewed plan을 다시 만든다. Plan artifact는 저장소의 Actions 보존 기간만큼 유지하며 apply는 최종 main commit과 일치하는 미만료 merge queue artifact만 선택한다.
 
-PR 배치가 `main`에 병합되면 현재 main에서 plan을 새로 만들고, PR 댓글과 artifact에서 검토한 `terraform show -no-color` 결과가 같은지 확인한다. 이 표현은 plan의 실제 resource/output 변경을 보여 주되 Argo CD Application의 resource version이나 reconcile 시각처럼 실행 사이에 바뀌는 no-op 관측 상태는 포함하지 않는다. plan이 다르면 current plan을 자동 적용하지 않고 중단하며, 같으면 reviewed saved plan을 그대로 apply하므로 Terraform의 native stale-plan 검증도 유지된다. 비교용 텍스트는 추가 artifact에 남기지 않고 job 안에서 삭제한다. plan과 apply는 같은 GCP 서비스 계정과 AWS role을 사용한다.
+PR 배치가 `main`에 병합되면 현재 main에서 plan을 새로 만들고, configuration, variables, 실제 action이 `no-op`이 아닌 resource changes, output changes와 checks가 reviewed plan과 같은지 확인한다. 이 JSON 비교는 sensitive value의 차이를 보존하되 Argo CD Application의 resource version이나 reconcile 시각처럼 실행 사이에 바뀌는 no-op 관측 상태는 제외한다. plan이 다르면 current plan을 자동 적용하지 않고 중단하며, 같으면 reviewed saved plan을 그대로 apply하므로 Terraform의 native stale-plan 검증도 유지된다. 비교용 JSON은 로그나 artifact에 남기지 않고 job 안에서 삭제한다. plan과 apply는 같은 GCP 서비스 계정과 AWS role을 사용한다.
 
 Merge queue plan은 OIDC trust를 먼저 배포한 뒤 활성화한다. 이 변경을 배포할 때는 repository variable을 설정하기 전에 PR plan으로 GCP WIF condition을 apply하고, 관리자 AWS credential로 `./scripts/ensure-ci-aws-role.sh`를 다시 실행한다. 활성화 전 main apply는 PR plan fallback을 사용한다.
 


### PR DESCRIPTION
## 요약

- reviewed saved plan과 current main plan을 `terraform show -no-color` 출력으로 비교합니다.
- 실행마다 바뀌는 Argo CD no-op 관측 상태 때문에 동등한 plan이 거부되는 문제를 제거합니다.
- plan이 다르면 중단하고 reviewed saved plan만 apply하는 기존 안전 장치와 Terraform native stale-plan 검증은 유지합니다.

## 배경

PR #450은 JSON 비교 범위를 줄였지만 main Apply run `30601709751`도 비교 단계에서 중단됐고 saved plan은 적용되지 않았습니다.

동등한 PR #449와 #450 artifact를 Terraform 1.15.6으로 대조한 결과:

- `configuration`, `variables`, `output_changes`, `checks`는 동일
- `planned_values`, `resource_drift`, `resource_changes`는 Argo CD Application의 `generation`, `resource_version`, `reconciled_at`, synced revision 때문에 차이
- 두 artifact의 `terraform.tfplan.txt`는 바이트 단위로 동일

즉 사람이 리뷰한 실제 변경 plan은 같고, JSON의 no-op 관측 상태만 달랐습니다.

## 검증

- `pnpm exec prettier --check .github/workflows/terraform.yml apps/terraform/README.md`
- `actionlint .github/workflows/terraform.yml`
- `git diff --check`
- PR #449와 #450의 `terraform.tfplan.txt`를 `cmp`로 비교해 동일함을 확인

## 결정

plan 동등성 기준을 PR 댓글과 artifact에 표시되는 `terraform show -no-color` 결과로 단순화했습니다. 현재 plan이 달라지면 계속 중단하며, 적용 대상은 current plan이 아니라 reviewed saved plan입니다.
