### PR TITLE
작성자가 자신의 게시글을 삭제할 수 있게 한다

### DIFF
--- a/apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx
+++ b/apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx
@@ -9,6 +9,7 @@ import { StateView } from '@/components/ui/StateView';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing } from '@/theme/tokens';
+import type { Href } from 'expo-router';
 import type { PostDetailQuery } from './__generated__/PostDetailQuery.graphql';
 
 const PostQuery = graphql`
@@ -119,6 +120,7 @@ function PostDetailContent({
   threadIdentity: string;
 }) {
   const router = useRouter();
+  const [locallyDeleted, setLocallyDeleted] = useState(false);
   const data = useLazyLoadQuery<PostDetailQuery>(
     PostQuery,
     { postId },
@@ -126,9 +128,13 @@ function PostDetailContent({
   );
   const post = data.node?.__typename === 'Post' ? data.node : null;
   const pureRepostSource = post && !post.content && !post.replyParent ? post.repostSource : null;
-  const pureRepostSourceHref = pureRepostSource
+  const pureRepostSourceHref: Href | null = pureRepostSource
     ? `/${pureRepostSource.profile.relativeHandle}/${pureRepostSource.id}`
     : null;
+
+  useEffect(() => {
+    setLocallyDeleted(false);
+  }, [fetchKey]);
 
   useEffect(() => {
     if (pureRepostSourceHref) {
@@ -138,7 +144,11 @@ function PostDetailContent({
     }
   }, [post, postId, pureRepostSourceHref, routeRelativeHandle, router]);
 
-  return pureRepostSourceHref ? null : !post ? (
+  return pureRepostSourceHref ? null : locallyDeleted ? (
+    <PostDetailFrame header={<PostDetailHeader />}>
+      <StateView description="작성자가 이 게시글을 삭제했어요." title="삭제된 게시글이에요" />
+    </PostDetailFrame>
+  ) : !post ? (
     <PostDetailFrame header={<PostDetailHeader />}>
       <StateView
         description="이미 삭제되었거나 존재하지 않는 게시글이에요."
@@ -160,6 +170,7 @@ function PostDetailContent({
     <PostDetailThread
       header={<PostDetailHeader />}
       identity={threadIdentity}
+      onPostDeleted={() => setLocallyDeleted(true)}
       onReplyCreated={onReplyCreated}
       post={post.thread}
       replyProfile={data.currentSession?.selectedProfile ?? null}

--- a/apps/app/src/components/post/PostActionBar.tsx
+++ b/apps/app/src/components/post/PostActionBar.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { spacing } from '@/theme/tokens';
 import { PostActionControl } from './PostActionControl';
+import { PostDeletionAction } from './PostDeletionAction';
 import { ReactionAction } from './ReactionAction';
 import { RepostAction } from './RepostAction';
 import type { Ref } from 'react';
@@ -26,6 +27,7 @@ type MoreActionConfig = { accessibilityLabel: string; onPress: () => void };
 export type PostActionBarProps = {
   bookmark?: BookmarkActionConfig;
   more?: MoreActionConfig;
+  onDeleted?: (postId: string) => void;
   onRepostError?: (failure: RepostActionFailure) => void;
   post?: PostActionBar_post$key | null;
   reactionController?: PostReactionController;
@@ -35,12 +37,14 @@ export type PostActionBarProps = {
 const postActionBarPostFragment = graphql`
   fragment PostActionBar_post on Post {
     ...RepostAction_post @alias(as: "repost")
+    ...PostDeletionAction_post @alias(as: "deletion")
   }
 `;
 
 export function PostActionBar({
   bookmark,
   more,
+  onDeleted,
   onRepostError,
   post,
   reactionController,
@@ -102,6 +106,8 @@ export function PostActionBar({
           stateful={false}
           testID="more"
         />
+      ) : data?.deletion ? (
+        <PostDeletionAction onDeleted={onDeleted} post={data.deletion} />
       ) : null}
     </View>
   );

--- a/apps/app/src/components/post/PostActionBar.tsx
+++ b/apps/app/src/components/post/PostActionBar.tsx
@@ -27,7 +27,7 @@ type MoreActionConfig = { accessibilityLabel: string; onPress: () => void };
 export type PostActionBarProps = {
   bookmark?: BookmarkActionConfig;
   more?: MoreActionConfig;
-  onDeleted?: (postId: string) => void;
+  onDeleted?: () => void;
   onRepostError?: (failure: RepostActionFailure) => void;
   post?: PostActionBar_post$key | null;
   reactionController?: PostReactionController;

--- a/apps/app/src/components/post/PostDeletionAction.test.ts
+++ b/apps/app/src/components/post/PostDeletionAction.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  createOperationDescriptor,
+  Environment,
+  getRequest,
+  Network,
+  RecordSource,
+  Store,
+} from 'relay-runtime';
+import deletePostMutation from './__generated__/PostDeletionActionDeletePostMutation.graphql';
+
+const postId = 'post-author-owned';
+
+function createEnvironment() {
+  const source = new RecordSource();
+  source.set(postId, {
+    __id: postId,
+    __typename: 'Post',
+    content: { __ref: 'content:post-author-owned' },
+    id: postId,
+    profile: { __ref: 'profile:author' },
+  });
+  source.set('content:post-author-owned', {
+    __id: 'content:post-author-owned',
+    __typename: 'PostContent',
+    id: 'content:post-author-owned',
+  });
+  source.set('profile:author', {
+    __id: 'profile:author',
+    __typename: 'Profile',
+    id: 'profile:author',
+  });
+
+  return new Environment({
+    network: Network.create(() => Promise.reject(new Error('network is not used'))),
+    store: new Store(source),
+  });
+}
+
+describe('PostDeletionAction Relay cache contract', () => {
+  it('deletes only the post record in the actor Store after server success', () => {
+    const actorA = createEnvironment();
+    const actorB = createEnvironment();
+    const operation = createOperationDescriptor(getRequest(deletePostMutation), { id: postId });
+
+    actorA.commitPayload(operation, { deletePost: { postId } });
+
+    assert.equal(actorA.getStore().getSource().get(postId), null);
+    assert.ok(actorA.getStore().getSource().get('content:post-author-owned'));
+    assert.ok(actorB.getStore().getSource().get(postId));
+  });
+});

--- a/apps/app/src/components/post/PostDeletionAction.test.ts
+++ b/apps/app/src/components/post/PostDeletionAction.test.ts
@@ -31,6 +31,12 @@ function createEnvironment() {
     __typename: 'Profile',
     id: 'profile:author',
   });
+  source.set('home-edge', {
+    __id: 'home-edge',
+    __typename: 'PostConnectionEdge',
+    cursor: 'home-edge-cursor',
+    node: { __ref: postId },
+  });
 
   return new Environment({
     network: Network.create(() => Promise.reject(new Error('network is not used'))),
@@ -49,5 +55,16 @@ describe('PostDeletionAction Relay cache contract', () => {
     assert.equal(actorA.getStore().getSource().get(postId), null);
     assert.ok(actorA.getStore().getSource().get('content:post-author-owned'));
     assert.ok(actorB.getStore().getSource().get(postId));
+  });
+
+  it('captures the stale connection edge that PostList must guard after record deletion', () => {
+    const actor = createEnvironment();
+    const operation = createOperationDescriptor(getRequest(deletePostMutation), { id: postId });
+
+    actor.commitPayload(operation, { deletePost: { postId } });
+
+    const staleEdge = actor.getStore().getSource().get('home-edge');
+    assert.deepEqual(staleEdge?.node, { __ref: postId });
+    assert.equal(actor.getStore().getSource().get(postId), null);
   });
 });

--- a/apps/app/src/components/post/PostDeletionAction.tsx
+++ b/apps/app/src/components/post/PostDeletionAction.tsx
@@ -25,6 +25,7 @@ const deletePostMutation = graphql`
 const postDeletionActionFragment = graphql`
   fragment PostDeletionAction_post on Post {
     id
+    state
     content {
       id
     }
@@ -35,7 +36,7 @@ const postDeletionActionFragment = graphql`
 `;
 
 type Props = {
-  onDeleted?: (postId: string) => void;
+  onDeleted?: () => void;
   post: PostDeletionAction_post$key;
 };
 
@@ -55,6 +56,7 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
   const currentEnvironment = useRef(environment);
   const mounted = useRef(false);
   const cancelRef = useRef<View>(null);
+  const restoreFocusRef = useRef<() => void>(() => undefined);
 
   currentEnvironment.current = environment;
 
@@ -84,15 +86,37 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
     return () => clearTimeout(timer);
   }, [confirmationOpen]);
 
-  const eligible = Boolean(
-    selectedProfileId && data.content && data.profile.id === selectedProfileId,
-  );
-
   const closeConfirmation = useCallback(() => {
-    if (!requesting && !isDeleting) {
-      setConfirmationOpen(false);
+    if (requesting || isDeleting) {
+      return;
     }
+    setConfirmationOpen(false);
+    setTimeout(() => restoreFocusRef.current(), 0);
   }, [isDeleting, requesting]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !confirmationOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || requesting || isDeleting) {
+        return;
+      }
+      event.preventDefault();
+      closeConfirmation();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [closeConfirmation, confirmationOpen, isDeleting, requesting]);
+
+  const eligible = Boolean(
+    selectedProfileId &&
+    data.state === 'ACTIVE' &&
+    data.content &&
+    data.profile.id === selectedProfileId,
+  );
 
   const fail = useCallback(
     (error: Error) => {
@@ -141,7 +165,7 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
         inFlight.current = false;
         setRequesting(false);
         setConfirmationOpen(false);
-        onDeleted?.(postId);
+        onDeleted?.();
       },
       onError: fail,
       variables: { id: data.id },
@@ -153,10 +177,16 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
   }
 
   const confirmation = (
-    <Pressable accessible={false} onPress={closeConfirmation} style={styles.backdrop}>
+    <Pressable
+      accessible={false}
+      onPress={closeConfirmation}
+      style={styles.backdrop}
+      testID="post-deletion-backdrop"
+    >
       <View
         accessibilityLabel="게시글 삭제 확인"
         accessibilityViewIsModal
+        onAccessibilityEscape={closeConfirmation}
         role="alertdialog"
         style={styles.dialogShell}
       >
@@ -207,19 +237,22 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
             tone: 'danger',
           },
         ]}
-        renderTrigger={({ expanded, onPress, ref }) => (
-          <PostActionControl
-            accessibilityLabel="더 보기"
-            alignToEnd
-            controlRef={ref}
-            icon={MoreHorizontal}
-            menuExpanded={expanded}
-            onPress={onPress}
-            popupRole="menu"
-            processing={requesting || isDeleting ? 'pending' : 'default'}
-            testID="more"
-          />
-        )}
+        renderTrigger={({ expanded, focusTrigger, onPress, ref }) => {
+          restoreFocusRef.current = focusTrigger;
+          return (
+            <PostActionControl
+              accessibilityLabel="더 보기"
+              alignToEnd
+              controlRef={ref}
+              icon={MoreHorizontal}
+              menuExpanded={expanded}
+              onPress={onPress}
+              popupRole="menu"
+              processing={requesting || isDeleting ? 'pending' : 'default'}
+              testID="more"
+            />
+          );
+        }}
       />
       {Platform.OS === 'web' ? (
         confirmationOpen ? (

--- a/apps/app/src/components/post/PostDeletionAction.tsx
+++ b/apps/app/src/components/post/PostDeletionAction.tsx
@@ -298,6 +298,13 @@ const styles = StyleSheet.create({
     width: '100%',
     ...shadow,
   } satisfies ViewStyle,
-  webModal: { bottom: 0, left: 0, position: 'fixed', right: 0, top: 0, zIndex: 100 },
+  webModal: {
+    bottom: 0,
+    left: 0,
+    position: 'fixed',
+    right: 0,
+    top: 0,
+    zIndex: 100,
+  } as unknown as ViewStyle,
   title: { fontFamily: 'SUIT', fontWeight: '700', ...typography.lg },
 });

--- a/apps/app/src/components/post/PostDeletionAction.tsx
+++ b/apps/app/src/components/post/PostDeletionAction.tsx
@@ -1,0 +1,270 @@
+import { MoreHorizontal, Trash2 } from 'lucide-react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Modal, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { graphql, useFragment, useMutation, useRelayEnvironment } from 'react-relay';
+import { ActionMenu } from '@/components/ui/ActionMenu';
+import { ActionMenuPortal } from '@/components/ui/ActionMenuPortal';
+import { Button } from '@/components/ui/Button';
+import { useToast } from '@/components/ui/ToastProvider';
+import { useSession } from '@/session/SessionProvider';
+import { useTheme } from '@/theme/ThemeProvider';
+import { radii, shadow, spacing, typography } from '@/theme/tokens';
+import { PostActionControl } from './PostActionControl';
+import type { ViewStyle } from 'react-native';
+import type { PostDeletionAction_post$key } from './__generated__/PostDeletionAction_post.graphql';
+import type { PostDeletionActionDeletePostMutation } from './__generated__/PostDeletionActionDeletePostMutation.graphql';
+
+const deletePostMutation = graphql`
+  mutation PostDeletionActionDeletePostMutation($id: ID!) {
+    deletePost(input: { id: $id }) {
+      postId @deleteRecord
+    }
+  }
+`;
+
+const postDeletionActionFragment = graphql`
+  fragment PostDeletionAction_post on Post {
+    id
+    content {
+      id
+    }
+    profile {
+      id
+    }
+  }
+`;
+
+type Props = {
+  onDeleted?: (postId: string) => void;
+  post: PostDeletionAction_post$key;
+};
+
+const failureMessage = '게시글을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+
+export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
+  const theme = useTheme();
+  const { selectedProfileId } = useSession();
+  const environment = useRelayEnvironment();
+  const { showToast } = useToast();
+  const data = useFragment(postDeletionActionFragment, postKey);
+  const [commitDelete, isDeleting] =
+    useMutation<PostDeletionActionDeletePostMutation>(deletePostMutation);
+  const [confirmationOpen, setConfirmationOpen] = useState(false);
+  const [requesting, setRequesting] = useState(false);
+  const inFlight = useRef(false);
+  const currentEnvironment = useRef(environment);
+  const mounted = useRef(false);
+  const cancelRef = useRef<View>(null);
+
+  currentEnvironment.current = environment;
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      inFlight.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    inFlight.current = false;
+    setRequesting(false);
+    setConfirmationOpen(false);
+  }, [environment]);
+
+  useEffect(() => {
+    if (!confirmationOpen) {
+      return;
+    }
+
+    const focusCancel = () => {
+      (cancelRef.current as unknown as { focus?: () => void } | null)?.focus?.();
+    };
+    const timer = setTimeout(focusCancel, 0);
+    return () => clearTimeout(timer);
+  }, [confirmationOpen]);
+
+  const eligible = Boolean(
+    selectedProfileId && data.content && data.profile.id === selectedProfileId,
+  );
+
+  const closeConfirmation = useCallback(() => {
+    if (!requesting && !isDeleting) {
+      setConfirmationOpen(false);
+    }
+  }, [isDeleting, requesting]);
+
+  const fail = useCallback(
+    (error: Error) => {
+      if (!mounted.current || currentEnvironment.current !== environment || !inFlight.current) {
+        return;
+      }
+      inFlight.current = false;
+      setRequesting(false);
+      showToast(failureMessage);
+      void error;
+    },
+    [environment, showToast],
+  );
+
+  const confirmDelete = useCallback(() => {
+    if (inFlight.current || requesting || isDeleting || !eligible) {
+      return;
+    }
+
+    inFlight.current = true;
+    setRequesting(true);
+    const requestEnvironment = environment;
+    commitDelete({
+      onCompleted: (
+        response: PostDeletionActionDeletePostMutation['response'],
+        errors: ReadonlyArray<{ message: string }> | null | undefined,
+      ) => {
+        if (errors?.length) {
+          fail(new Error(errors[0]?.message ?? failureMessage));
+          return;
+        }
+
+        const postId = response?.deletePost?.postId;
+        if (!postId) {
+          fail(new Error(failureMessage));
+          return;
+        }
+        if (
+          !mounted.current ||
+          currentEnvironment.current !== requestEnvironment ||
+          !inFlight.current
+        ) {
+          return;
+        }
+
+        inFlight.current = false;
+        setRequesting(false);
+        setConfirmationOpen(false);
+        onDeleted?.(postId);
+      },
+      onError: fail,
+      variables: { id: data.id },
+    });
+  }, [commitDelete, data.id, eligible, environment, fail, isDeleting, onDeleted, requesting]);
+
+  if (!eligible) {
+    return null;
+  }
+
+  const confirmation = (
+    <Pressable accessible={false} onPress={closeConfirmation} style={styles.backdrop}>
+      <View
+        accessibilityLabel="게시글 삭제 확인"
+        accessibilityViewIsModal
+        role="alertdialog"
+        style={styles.dialogShell}
+      >
+        <Pressable
+          onPress={(event) => event.stopPropagation()}
+          style={[styles.dialog, { backgroundColor: theme.card, borderColor: theme.border }]}
+        >
+          <Text style={[styles.title, { color: theme.text }]}>게시글을 삭제할까요?</Text>
+          <Text style={[styles.description, { color: theme.textSecondary }]}>
+            삭제한 게시글은 복구할 수 없습니다.
+          </Text>
+          <View style={styles.actions}>
+            <Button
+              controlRef={cancelRef}
+              disabled={requesting || isDeleting}
+              onPress={closeConfirmation}
+              tone="secondary"
+            >
+              취소
+            </Button>
+            <Button
+              accessibilityState={{ busy: requesting || isDeleting }}
+              disabled={requesting || isDeleting}
+              loading={requesting || isDeleting}
+              onPress={confirmDelete}
+              tone="danger"
+            >
+              삭제
+            </Button>
+          </View>
+        </Pressable>
+      </View>
+    </Pressable>
+  );
+
+  return (
+    <>
+      <ActionMenu
+        accessibilityLabel="더 보기 메뉴"
+        disabled={requesting || isDeleting}
+        items={[
+          {
+            accessibilityLabel: '게시글 삭제',
+            icon: Trash2,
+            key: 'delete-post',
+            label: '삭제',
+            onSelect: () => setConfirmationOpen(true),
+            tone: 'danger',
+          },
+        ]}
+        renderTrigger={({ expanded, onPress, ref }) => (
+          <PostActionControl
+            accessibilityLabel="더 보기"
+            alignToEnd
+            controlRef={ref}
+            icon={MoreHorizontal}
+            menuExpanded={expanded}
+            onPress={onPress}
+            popupRole="menu"
+            processing={requesting || isDeleting ? 'pending' : 'default'}
+            testID="more"
+          />
+        )}
+      />
+      {Platform.OS === 'web' ? (
+        confirmationOpen ? (
+          <ActionMenuPortal>
+            <View style={styles.webModal}>{confirmation}</View>
+          </ActionMenuPortal>
+        ) : null
+      ) : (
+        <Modal
+          animationType="fade"
+          onRequestClose={closeConfirmation}
+          transparent
+          visible={confirmationOpen}
+        >
+          {confirmation}
+        </Modal>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    justifyContent: 'flex-end',
+    marginTop: spacing.lg,
+  },
+  backdrop: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    flex: 1,
+    justifyContent: 'center',
+    padding: spacing.lg,
+  },
+  description: { fontFamily: 'SUIT', marginTop: spacing.sm, ...typography.sm },
+  dialogShell: { maxWidth: 480, pointerEvents: 'box-none', width: '100%' },
+  dialog: {
+    borderRadius: radii.lg,
+    borderWidth: 1,
+    maxWidth: 480,
+    padding: spacing.lg,
+    width: '100%',
+    ...shadow,
+  } satisfies ViewStyle,
+  webModal: { bottom: 0, left: 0, position: 'fixed', right: 0, top: 0, zIndex: 100 },
+  title: { fontFamily: 'SUIT', fontWeight: '700', ...typography.lg },
+});

--- a/apps/app/src/components/post/PostDeletionAction.tsx
+++ b/apps/app/src/components/post/PostDeletionAction.tsx
@@ -56,6 +56,7 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
   const currentEnvironment = useRef(environment);
   const mounted = useRef(false);
   const cancelRef = useRef<View>(null);
+  const dialogRef = useRef<View>(null);
   const restoreFocusRef = useRef<() => void>(() => undefined);
 
   currentEnvironment.current = environment;
@@ -100,6 +101,22 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
     }
 
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Tab') {
+        const dialog = dialogRef.current as unknown as HTMLElement | null;
+        const focusable = Array.from(
+          dialog?.querySelectorAll<HTMLElement>('button:not([disabled])') ?? [],
+        );
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last?.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first?.focus();
+        }
+        return;
+      }
       if (event.key !== 'Escape' || requesting || isDeleting) {
         return;
       }
@@ -187,6 +204,7 @@ export function PostDeletionAction({ onDeleted, post: postKey }: Props) {
         accessibilityLabel="게시글 삭제 확인"
         accessibilityViewIsModal
         onAccessibilityEscape={closeConfirmation}
+        ref={dialogRef}
         role="alertdialog"
         style={styles.dialogShell}
       >

--- a/apps/app/src/components/post/PostDetailThread.tsx
+++ b/apps/app/src/components/post/PostDetailThread.tsx
@@ -95,12 +95,14 @@ export function PostDetailThread({
   header,
   identity,
   onReplyCreated,
+  onPostDeleted,
   post: postKey,
   replyProfile,
 }: {
   header: ReactNode;
   identity: string;
   onReplyCreated?: (post: PostComposerCreatedPost) => void;
+  onPostDeleted?: () => void;
   post: PostDetailThread_post$key;
   replyProfile?: ReplyComposerSurface_profile$key | null;
 }) {
@@ -109,6 +111,7 @@ export function PostDetailThread({
       header={header}
       key={identity}
       onReplyCreated={onReplyCreated}
+      onPostDeleted={onPostDeleted}
       post={postKey}
       replyProfile={replyProfile}
     />
@@ -118,11 +121,13 @@ export function PostDetailThread({
 function PostDetailThreadContent({
   header,
   onReplyCreated,
+  onPostDeleted,
   post: postKey,
   replyProfile,
 }: {
   header: ReactNode;
   onReplyCreated?: (post: PostComposerCreatedPost) => void;
+  onPostDeleted?: () => void;
   post: PostDetailThread_post$key;
   replyProfile?: ReplyComposerSurface_profile$key | null;
 }) {
@@ -210,16 +215,18 @@ function PostDetailThreadContent({
       window.removeEventListener('resize', check);
     };
   }, [data.replyDescendants.edges.length, maybeLoadNextPage]);
-  const ancestors = [...data.replyAncestors].reverse().map((post, index) => ({
-    connectedToPrevious: index > 0,
-    id: post.id,
-    post: {
-      detail: null,
+  const ancestors = [...data.replyAncestors.filter((post) => post != null)]
+    .reverse()
+    .map((post, index) => ({
+      connectedToPrevious: index > 0,
       id: post.id,
-      listItem: post.listItem,
-    } satisfies ThreadRenderablePost,
-  }));
-  const descendantEdges = data.replyDescendants.edges;
+      post: {
+        detail: null,
+        id: post.id,
+        listItem: post.listItem,
+      } satisfies ThreadRenderablePost,
+    }));
+  const descendantEdges = data.replyDescendants.edges.filter(({ node }) => node != null);
   const descendants = descendantEdges.map(({ node }, index) => ({
     connectedToPrevious:
       node.replyParent?.id === (index === 0 ? data.id : descendantEdges[index - 1]?.node.id),
@@ -254,7 +261,10 @@ function PostDetailThreadContent({
           renderPost={({ item, role }) => (
             <View>
               {role === 'current' ? (
-                <PostLayout post={requireThreadFragment(item.post.detail, 'current detail')} />
+                <PostLayout
+                  onDeleted={onPostDeleted}
+                  post={requireThreadFragment(item.post.detail, 'current detail')}
+                />
               ) : (
                 <PostListItem
                   post={requireThreadFragment(item.post.listItem, `${role} list item`)}

--- a/apps/app/src/components/post/PostDetailThread.tsx
+++ b/apps/app/src/components/post/PostDetailThread.tsx
@@ -215,7 +215,8 @@ function PostDetailThreadContent({
       window.removeEventListener('resize', check);
     };
   }, [data.replyDescendants.edges.length, maybeLoadNextPage]);
-  const ancestors = [...data.replyAncestors.filter((post) => post != null)]
+  const ancestors = data.replyAncestors
+    .filter((post) => post != null)
     .reverse()
     .map((post, index) => ({
       connectedToPrevious: index > 0,

--- a/apps/app/src/components/post/PostLayout.tsx
+++ b/apps/app/src/components/post/PostLayout.tsx
@@ -66,7 +66,13 @@ const visibilityLabels: Record<string, string> = {
   DIRECT: '다이렉트',
 };
 
-export function PostLayout({ post: postKey }: { post: PostLayout_post$key }) {
+export function PostLayout({
+  onDeleted,
+  post: postKey,
+}: {
+  onDeleted?: (postId: string) => void;
+  post: PostLayout_post$key;
+}) {
   const theme = useTheme();
   const onRepostError = useRepostFailureToast();
   const post = useFragment(PostLayoutFragment, postKey);
@@ -122,6 +128,7 @@ export function PostLayout({ post: postKey }: { post: PostLayout_post$key }) {
           </Text>
           <PostReactionSummary controller={reactionController} style={styles.reactionSummary} />
           <PostActionBar
+            onDeleted={onDeleted}
             onRepostError={onRepostError}
             post={actionBarPost}
             reactionController={reactionController}

--- a/apps/app/src/components/post/PostLayout.tsx
+++ b/apps/app/src/components/post/PostLayout.tsx
@@ -70,7 +70,7 @@ export function PostLayout({
   onDeleted,
   post: postKey,
 }: {
-  onDeleted?: (postId: string) => void;
+  onDeleted?: () => void;
   post: PostLayout_post$key;
 }) {
   const theme = useTheme();

--- a/apps/app/src/components/post/PostList.tsx
+++ b/apps/app/src/components/post/PostList.tsx
@@ -57,6 +57,10 @@ export function PostList({
   const profile = useFragment(PostListProfileFragment, profileKey ?? null);
   const timeline = useFragment(PostListHomeTimelineFragment, timelineKey ?? null);
   const edges = timeline?.edges ?? profile?.posts.edges ?? [];
+  // A successful delete can remove the node record before Relay prunes an
+  // unhandled connection edge. Treat that stale edge as empty until the next
+  // server payload instead of passing a missing fragment ref to PostListItem.
+  const visibleEdges = edges.filter((edge) => edge.node != null);
   const hasData = Boolean(timeline || profile);
 
   if (loading && !hasData) {
@@ -74,7 +78,7 @@ export function PostList({
     );
   }
 
-  if (edges.length === 0) {
+  if (visibleEdges.length === 0) {
     return (
       <PostListState
         description="첫 게시글이 올라오면 여기에 표시돼요."
@@ -86,7 +90,7 @@ export function PostList({
   return (
     <PostReplyCoordinatorProvider owner="list" profile={replyProfile ?? null}>
       <View style={styles.root}>
-        {edges.map((edge) => (
+        {visibleEdges.map((edge) => (
           <PostListItem key={edge.cursor} post={edge.node} />
         ))}
       </View>

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -1,5 +1,5 @@
 import { Link, useRouter } from 'expo-router';
-import { useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
@@ -89,8 +89,10 @@ export function PostListItem({
 }) {
   const theme = useTheme();
   const onRepostError = useRepostFailureToast();
+  const [deleted, setDeleted] = useState(false);
   const post = useFragment(PostListItemFragment, postKey);
   const replyBinding = usePostReplyBinding(post.id);
+  const onDeleted = useCallback(() => setDeleted(true), []);
   const profileHref = `/${post.profile.relativeHandle}` as const;
   const replyTriggerRef = useRef<View>(null);
   const reply = replyBinding
@@ -121,11 +123,23 @@ export function PostListItem({
     showDivider && { borderColor: theme.divider },
   ];
 
+  if (deleted) {
+    return null;
+  }
+
   if (!post.repostSource) {
+    if (!post.content) {
+      return null;
+    }
     return (
       <>
         <View role="article" style={cardStyle}>
-          <PostListRow onRepostError={onRepostError} post={post} reply={reply} />
+          <PostListRow
+            onDeleted={onDeleted}
+            onRepostError={onRepostError}
+            post={post}
+            reply={reply}
+          />
         </View>
         {replySurface}
       </>
@@ -163,7 +177,12 @@ export function PostListItem({
               </Link>
             </View>
           </View>
-          <PostListRow onRepostError={onRepostError} post={source} reply={reply} />
+          <PostListRow
+            onDeleted={onDeleted}
+            onRepostError={onRepostError}
+            post={source}
+            reply={reply}
+          />
         </View>
         {replySurface}
       </>
@@ -219,6 +238,7 @@ export function PostListItem({
           <PostReactionActions
             actionBar={post.actionBar!}
             controllerPost={post.reactionController!}
+            onDeleted={onDeleted}
             onRepostError={onRepostError}
             quote
             reply={reply}
@@ -231,10 +251,12 @@ export function PostListItem({
 }
 
 function PostListRow({
+  onDeleted,
   onRepostError,
   post: postKey,
   reply,
 }: {
+  onDeleted: () => void;
   onRepostError: NonNullable<PostActionBarProps['onRepostError']>;
   post: PostListRow_post$key;
   reply?: PostActionBarProps['reply'];
@@ -286,6 +308,7 @@ function PostListRow({
         <PostReactionActions
           actionBar={post.actionBar!}
           controllerPost={post.reactionController!}
+          onDeleted={onDeleted}
           onRepostError={onRepostError}
           reply={reply}
         />
@@ -297,12 +320,14 @@ function PostListRow({
 function PostReactionActions({
   actionBar,
   controllerPost,
+  onDeleted,
   onRepostError,
   quote = false,
   reply,
 }: {
   actionBar: PostActionBar_post$key;
   controllerPost: PostReactionController_post$key;
+  onDeleted?: () => void;
   onRepostError: NonNullable<PostActionBarProps['onRepostError']>;
   quote?: boolean;
   reply?: PostActionBarProps['reply'];
@@ -317,6 +342,7 @@ function PostReactionActions({
       />
       <View style={styles.actionBarSlot}>
         <PostActionBar
+          onDeleted={onDeleted}
           onRepostError={onRepostError}
           post={actionBar}
           reactionController={controller}

--- a/apps/app/src/components/ui/ActionMenu.tsx
+++ b/apps/app/src/components/ui/ActionMenu.tsx
@@ -23,6 +23,7 @@ export type ActionMenuItem = Readonly<{
 
 export type ActionMenuTriggerRenderProps = Readonly<{
   expanded: boolean;
+  focusTrigger: () => void;
   onPress: () => void;
   ref: Ref<View>;
 }>;
@@ -246,7 +247,12 @@ export function ActionMenu({
   if (web) {
     return (
       <View ref={controlRef} style={[styles.control, { zIndex: open ? 50 : 0 }]}>
-        {renderTrigger({ expanded: open, onPress: toggle, ref: triggerRef })}
+        {renderTrigger({
+          expanded: open,
+          focusTrigger,
+          onPress: toggle,
+          ref: triggerRef,
+        })}
         {open ? (
           <ActionMenuPortal>
             <View style={[styles.webPosition, webPosition]}>
@@ -295,7 +301,12 @@ export function ActionMenu({
 
   return (
     <>
-      {renderTrigger({ expanded: open, onPress: toggle, ref: triggerRef })}
+      {renderTrigger({
+        expanded: open,
+        focusTrigger,
+        onPress: toggle,
+        ref: triggerRef,
+      })}
       <Modal
         accessibilityLabel={accessibilityLabel}
         animationType="fade"

--- a/apps/app/src/components/ui/ActionMenu.tsx
+++ b/apps/app/src/components/ui/ActionMenu.tsx
@@ -13,10 +13,12 @@ type ActionMenuIcon = ComponentType<{
 }>;
 
 export type ActionMenuItem = Readonly<{
+  accessibilityLabel?: string;
   icon?: ActionMenuIcon;
   key: string;
   label: string;
   onSelect: () => void;
+  tone?: 'default' | 'danger';
 }>;
 
 export type ActionMenuTriggerRenderProps = Readonly<{
@@ -256,8 +258,10 @@ export function ActionMenu({
               >
                 {items.map((item, index) => {
                   const Icon = item.icon;
+                  const itemColor = item.tone === 'danger' ? theme.danger : theme.text;
                   return (
                     <Pressable
+                      accessibilityLabel={item.accessibilityLabel ?? item.label}
                       key={item.key}
                       onPress={() => select(item)}
                       role="menuitem"
@@ -272,10 +276,10 @@ export function ActionMenu({
                       ) : null}
                       {Icon ? (
                         <View accessible={false} aria-hidden style={styles.webIcon}>
-                          <Icon color={theme.text} size={18} strokeWidth={2.4} />
+                          <Icon color={itemColor} size={18} strokeWidth={2.4} />
                         </View>
                       ) : null}
-                      <Text style={[styles.label, styles.webLabel, { color: theme.text }]}>
+                      <Text style={[styles.label, styles.webLabel, { color: itemColor }]}>
                         {item.label}
                       </Text>
                     </Pressable>
@@ -325,17 +329,34 @@ export function ActionMenu({
             <View {...sheetDismissResponder.panHandlers} style={styles.dragHandleTarget}>
               <View style={[styles.dragHandle, { backgroundColor: theme.border }]} />
             </View>
-            {items.map((item) => (
-              <Pressable
-                accessibilityLabel={item.label}
-                accessibilityRole="button"
-                key={item.key}
-                onPress={() => select(item)}
-                style={styles.item}
-              >
-                <Text style={[styles.label, { color: theme.text }]}>{item.label}</Text>
-              </Pressable>
-            ))}
+            {items.map((item) => {
+              const Icon = item.icon;
+              return (
+                <Pressable
+                  accessibilityLabel={item.accessibilityLabel ?? item.label}
+                  accessibilityRole="menuitem"
+                  key={item.key}
+                  onPress={() => select(item)}
+                  style={[styles.item, styles.nativeItem]}
+                >
+                  {Icon ? (
+                    <Icon
+                      color={item.tone === 'danger' ? theme.danger : theme.text}
+                      size={20}
+                      strokeWidth={2.4}
+                    />
+                  ) : null}
+                  <Text
+                    style={[
+                      styles.label,
+                      { color: item.tone === 'danger' ? theme.danger : theme.text },
+                    ]}
+                  >
+                    {item.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
           </View>
         </View>
       </Modal>
@@ -354,6 +375,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
   },
+  nativeItem: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm },
   label: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
   sheet: {
     borderTopLeftRadius: radii.lg,

--- a/apps/app/src/components/ui/Button.tsx
+++ b/apps/app/src/components/ui/Button.tsx
@@ -2,7 +2,7 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-nati
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
 import type { PropsWithChildren, Ref } from 'react';
-import type { PressableProps, View } from 'react-native';
+import type { PressableProps } from 'react-native';
 
 type ButtonProps = PropsWithChildren<
   PressableProps & {

--- a/apps/app/src/components/ui/Button.tsx
+++ b/apps/app/src/components/ui/Button.tsx
@@ -1,11 +1,12 @@
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
-import type { PropsWithChildren } from 'react';
-import type { PressableProps } from 'react-native';
+import type { PropsWithChildren, Ref } from 'react';
+import type { PressableProps, View } from 'react-native';
 
 type ButtonProps = PropsWithChildren<
   PressableProps & {
+    controlRef?: Ref<View>;
     loading?: boolean;
     loadingText?: string;
     tone?: 'primary' | 'secondary' | 'danger';
@@ -15,6 +16,7 @@ type ButtonProps = PropsWithChildren<
 export function Button({
   accessibilityLabel,
   children,
+  controlRef,
   disabled,
   loading = false,
   loadingText,
@@ -35,6 +37,7 @@ export function Button({
       accessibilityLabel={label}
       accessibilityRole="button"
       disabled={disabled || loading}
+      ref={controlRef}
       style={(state) => [
         styles.root,
         {

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -668,7 +668,14 @@ export const AuthorPostDeletion: Story = {
     );
     expect(deletionMutationRequest).not.toHaveBeenCalled();
 
-    await userEvent.click(within(dialog).getByRole('button', { name: '취소' }));
+    const cancel = within(dialog).getByRole('button', { name: '취소' });
+    const confirm = within(dialog).getByRole('button', { name: '삭제' });
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(canvasElement.ownerDocument.activeElement).toBe(confirm);
+    await userEvent.keyboard('{Tab}');
+    expect(canvasElement.ownerDocument.activeElement).toBe(cancel);
+
+    await userEvent.click(cancel);
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeNull(),
     );

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -30,6 +30,7 @@ import type { PostActionBarStoryQuery } from './__generated__/PostActionBarStory
 const reply = fn();
 const bookmark = fn();
 const more = fn();
+const deletionMutationRequest = fn();
 const reactionMutationRequest = fn();
 const reactionLifecycleConsoleErrors: unknown[][] = [];
 
@@ -53,7 +54,9 @@ const actionBarProps = {
 const sourcePostId = 'post-source';
 const activeRepostId = 'post-repost-active';
 type RepostFixtureState = 'hidden' | 'unselected' | 'selected' | 'pending';
+type DeleteOutcome = 'graphql-error' | 'network-error' | 'success';
 type FixtureProps = Omit<PostActionBarProps, 'post'> & {
+  deleteOutcome?: DeleteOutcome;
   onMutationRequest?: (requestName: string) => void;
   repostState?: RepostFixtureState;
   selectedProfileId?: string | null;
@@ -73,7 +76,9 @@ const postActionBarStoryQuery = graphql`
 
 const unselectedSource = {
   __typename: 'Post',
+  content: { __typename: 'PostContent', id: 'content-source' },
   id: sourcePostId,
+  profile: { __typename: 'Profile', id: 'profile-author' },
   repostCount: 12_345,
   reactionCounts: [
     { count: 12, type: '❤️' },
@@ -94,6 +99,7 @@ const selectedSource = {
 };
 
 function PostActionBarFixture({
+  deleteOutcome = 'success',
   onMutationRequest,
   repostState = 'unselected',
   selectedProfileId = 'profile-story',
@@ -107,6 +113,17 @@ function PostActionBarFixture({
       network: Network.create((request) => {
         if (request.operationKind === 'mutation') {
           onMutationRequest?.(request.name);
+          if (request.name === 'PostDeletionActionDeletePostMutation') {
+            if (deleteOutcome === 'network-error') {
+              return Promise.reject(new Error('delete failed'));
+            }
+            if (deleteOutcome === 'graphql-error') {
+              return Promise.resolve({
+                data: { deletePost: null },
+                errors: [{ message: 'delete failed' }],
+              } as GraphQLResponse);
+            }
+          }
         }
         return request.operationKind !== 'mutation'
           ? Promise.resolve({
@@ -132,17 +149,19 @@ function PostActionBarFixture({
             ? Observable.create(() => undefined)
             : Promise.resolve({
                 data:
-                  request.name === 'RepostActionDeletePostMutation'
-                    ? { deletePost: { postId: activeRepostId } }
-                    : {
-                        repostPost: {
-                          repost: {
-                            __typename: 'Post',
-                            id: activeRepostId,
-                            repostSource: selectedSource,
+                  request.name === 'PostDeletionActionDeletePostMutation'
+                    ? { deletePost: { postId: sourcePostId } }
+                    : request.name === 'RepostActionDeletePostMutation'
+                      ? { deletePost: { postId: activeRepostId } }
+                      : {
+                          repostPost: {
+                            repost: {
+                              __typename: 'Post',
+                              id: activeRepostId,
+                              repostSource: selectedSource,
+                            },
                           },
                         },
-                      },
               });
       }),
       store: new Store(new RecordSource()),
@@ -152,7 +171,7 @@ function PostActionBarFixture({
       { node: source },
     );
     return result;
-  }, [onMutationRequest, repostState, selectedProfileId]);
+  }, [deleteOutcome, onMutationRequest, repostState, selectedProfileId]);
   const createEnvironment = useCallback(() => environment, [environment]);
 
   if (repostState === 'hidden') {
@@ -174,17 +193,50 @@ function PostActionBarFixtureContents({
   showReactionSummary = false,
   ...props
 }: Omit<PostActionBarProps, 'post' | 'reactionController'> & { showReactionSummary?: boolean }) {
+  const [deleted, setDeleted] = useState(false);
   const data = useLazyLoadQuery<PostActionBarStoryQuery>(
     postActionBarStoryQuery,
     { id: sourcePostId },
     { fetchPolicy: 'store-only' },
   );
-  const controller = usePostReactionController(data.node!.reactionController!);
+  if (deleted || !data.node) {
+    return <Text>삭제된 게시글</Text>;
+  }
 
+  return (
+    <PostActionBarFixtureLoaded
+      data={data.node}
+      onDeleted={(postId) => {
+        setDeleted(true);
+        props.onDeleted?.(postId);
+      }}
+      props={props}
+      showReactionSummary={showReactionSummary}
+    />
+  );
+}
+
+function PostActionBarFixtureLoaded({
+  data,
+  onDeleted,
+  props,
+  showReactionSummary,
+}: {
+  data: NonNullable<PostActionBarStoryQuery['response']['node']>;
+  onDeleted: (postId: string) => void;
+  props: Omit<PostActionBarProps, 'post' | 'reactionController'>;
+  showReactionSummary: boolean;
+}) {
+  const controller = usePostReactionController(data.reactionController!);
   return (
     <>
       {showReactionSummary ? <PostReactionSummary controller={controller} /> : null}
-      <PostActionBar {...props} post={data.node!.actionBar!} reactionController={controller} />
+      <PostActionBar
+        {...props}
+        onDeleted={onDeleted}
+        post={data.actionBar!}
+        reactionController={controller}
+      />
     </>
   );
 }
@@ -591,6 +643,97 @@ export const ActionBarCatalog: Story = {
     expect(reactionButtons[2]?.querySelector('svg')).not.toHaveAttribute('fill', 'none');
     expect(bookmarkButtons[2]?.querySelector('svg')).not.toHaveAttribute('fill', 'none');
   },
+};
+
+export const AuthorPostDeletion: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    deletionMutationRequest.mockClear();
+
+    const trigger = canvas.getByRole('button', { name: '더 보기' });
+    await userEvent.click(trigger);
+    const menu = await screen.findByRole('menu', { name: '더 보기 메뉴' });
+    expect(within(menu).getByRole('menuitem', { name: '게시글 삭제' })).toBeVisible();
+    await userEvent.click(within(menu).getByRole('menuitem', { name: '게시글 삭제' }));
+
+    const dialog = await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
+    expect(dialog).toHaveTextContent('게시글을 삭제할까요?');
+    expect(dialog).toHaveTextContent('삭제한 게시글은 복구할 수 없습니다.');
+    expect(deletionMutationRequest).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: '취소' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeNull(),
+    );
+    expect(deletionMutationRequest).not.toHaveBeenCalled();
+
+    await userEvent.click(trigger);
+    await userEvent.click(
+      within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
+        name: '게시글 삭제',
+      }),
+    );
+    await userEvent.click(
+      within(await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' })).getByRole(
+        'button',
+        { name: '삭제' },
+      ),
+    );
+    await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(1));
+  },
+  render: () => (
+    <PostActionBarFixture
+      onMutationRequest={deletionMutationRequest}
+      selectedProfileId="profile-author"
+    />
+  ),
+};
+
+export const NonAuthorPostDeletionHidden: Story = {
+  play: ({ canvasElement }) => {
+    expect(within(canvasElement).queryByRole('button', { name: '더 보기' })).toBeNull();
+  },
+  render: () => <PostActionBarFixture selectedProfileId="profile-other" />,
+};
+
+export const GuestPostDeletionHidden: Story = {
+  play: ({ canvasElement }) => {
+    expect(within(canvasElement).queryByRole('button', { name: '더 보기' })).toBeNull();
+  },
+  render: () => <PostActionBarFixture selectedProfileId={null} />,
+};
+
+export const AuthorPostDeletionFailureRetry: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    deletionMutationRequest.mockClear();
+    await userEvent.click(canvas.getByRole('button', { name: '더 보기' }));
+    await userEvent.click(
+      within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
+        name: '게시글 삭제',
+      }),
+    );
+    const dialog = await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
+    await userEvent.click(within(dialog).getByRole('button', { name: '삭제' }));
+    await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(1));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('게시글을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+    expect(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeVisible();
+
+    await userEvent.click(
+      within(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).getByRole('button', {
+        name: '삭제',
+      }),
+    );
+    await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(2));
+  },
+  render: () => (
+    <PostActionBarFixture
+      deleteOutcome="network-error"
+      onMutationRequest={deletionMutationRequest}
+      selectedProfileId="profile-author"
+    />
+  ),
 };
 
 export const ControlledReply: Story = {

--- a/apps/app/src/stories/PostActionBar.stories.tsx
+++ b/apps/app/src/stories/PostActionBar.stories.tsx
@@ -54,7 +54,7 @@ const actionBarProps = {
 const sourcePostId = 'post-source';
 const activeRepostId = 'post-repost-active';
 type RepostFixtureState = 'hidden' | 'unselected' | 'selected' | 'pending';
-type DeleteOutcome = 'graphql-error' | 'network-error' | 'success';
+type DeleteOutcome = 'graphql-error' | 'network-error' | 'pending' | 'success';
 type FixtureProps = Omit<PostActionBarProps, 'post'> & {
   deleteOutcome?: DeleteOutcome;
   onMutationRequest?: (requestName: string) => void;
@@ -79,6 +79,7 @@ const unselectedSource = {
   content: { __typename: 'PostContent', id: 'content-source' },
   id: sourcePostId,
   profile: { __typename: 'Profile', id: 'profile-author' },
+  state: 'ACTIVE',
   repostCount: 12_345,
   reactionCounts: [
     { count: 12, type: '❤️' },
@@ -114,6 +115,9 @@ function PostActionBarFixture({
         if (request.operationKind === 'mutation') {
           onMutationRequest?.(request.name);
           if (request.name === 'PostDeletionActionDeletePostMutation') {
+            if (deleteOutcome === 'pending') {
+              return Observable.create(() => undefined);
+            }
             if (deleteOutcome === 'network-error') {
               return Promise.reject(new Error('delete failed'));
             }
@@ -206,9 +210,9 @@ function PostActionBarFixtureContents({
   return (
     <PostActionBarFixtureLoaded
       data={data.node}
-      onDeleted={(postId) => {
+      onDeleted={() => {
         setDeleted(true);
-        props.onDeleted?.(postId);
+        props.onDeleted?.();
       }}
       props={props}
       showReactionSummary={showReactionSummary}
@@ -223,7 +227,7 @@ function PostActionBarFixtureLoaded({
   showReactionSummary,
 }: {
   data: NonNullable<PostActionBarStoryQuery['response']['node']>;
-  onDeleted: (postId: string) => void;
+  onDeleted: () => void;
   props: Omit<PostActionBarProps, 'post' | 'reactionController'>;
   showReactionSummary: boolean;
 }) {
@@ -659,13 +663,43 @@ export const AuthorPostDeletion: Story = {
     const dialog = await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
     expect(dialog).toHaveTextContent('게시글을 삭제할까요?');
     expect(dialog).toHaveTextContent('삭제한 게시글은 복구할 수 없습니다.');
+    await waitFor(() =>
+      expect(canvasElement.ownerDocument.activeElement).toHaveTextContent('취소'),
+    );
     expect(deletionMutationRequest).not.toHaveBeenCalled();
 
     await userEvent.click(within(dialog).getByRole('button', { name: '취소' }));
     await waitFor(() =>
       expect(screen.queryByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeNull(),
     );
+    expect(canvasElement.ownerDocument.activeElement).toBe(trigger);
     expect(deletionMutationRequest).not.toHaveBeenCalled();
+
+    await userEvent.click(trigger);
+    await userEvent.click(
+      within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
+        name: '게시글 삭제',
+      }),
+    );
+    await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeNull(),
+    );
+    expect(canvasElement.ownerDocument.activeElement).toBe(trigger);
+
+    await userEvent.click(trigger);
+    await userEvent.click(
+      within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
+        name: '게시글 삭제',
+      }),
+    );
+    await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
+    await userEvent.click(screen.getByTestId('post-deletion-backdrop'));
+    await waitFor(() =>
+      expect(screen.queryByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeNull(),
+    );
+    expect(canvasElement.ownerDocument.activeElement).toBe(trigger);
 
     await userEvent.click(trigger);
     await userEvent.click(
@@ -689,6 +723,38 @@ export const AuthorPostDeletion: Story = {
   ),
 };
 
+export const AuthorPostDeletionPending: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    deletionMutationRequest.mockClear();
+    const trigger = canvas.getByRole('button', { name: '더 보기' });
+    await userEvent.click(trigger);
+    await userEvent.click(
+      within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
+        name: '게시글 삭제',
+      }),
+    );
+    const dialog = await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
+    const confirm = within(dialog).getByRole('button', { name: '삭제' });
+    await userEvent.click(confirm);
+    await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(1));
+    expect(confirm).toBeDisabled();
+    expect(within(dialog).getByRole('button', { name: '취소' })).toBeDisabled();
+    await userEvent.keyboard('{Escape}');
+    expect(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeVisible();
+    await userEvent.click(screen.getByTestId('post-deletion-backdrop'));
+    expect(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeVisible();
+    expect(deletionMutationRequest).toHaveBeenCalledTimes(1);
+  },
+  render: () => (
+    <PostActionBarFixture
+      deleteOutcome="pending"
+      onMutationRequest={deletionMutationRequest}
+      selectedProfileId="profile-author"
+    />
+  ),
+};
+
 export const NonAuthorPostDeletionHidden: Story = {
   play: ({ canvasElement }) => {
     expect(within(canvasElement).queryByRole('button', { name: '더 보기' })).toBeNull();
@@ -703,33 +769,50 @@ export const GuestPostDeletionHidden: Story = {
   render: () => <PostActionBarFixture selectedProfileId={null} />,
 };
 
-export const AuthorPostDeletionFailureRetry: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    deletionMutationRequest.mockClear();
-    await userEvent.click(canvas.getByRole('button', { name: '더 보기' }));
-    await userEvent.click(
-      within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
-        name: '게시글 삭제',
-      }),
-    );
-    const dialog = await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
-    await userEvent.click(within(dialog).getByRole('button', { name: '삭제' }));
-    await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(1));
-    const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent('게시글을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.');
-    expect(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeVisible();
+async function authorPostDeletionFailureRetryPlay({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) {
+  const canvas = within(canvasElement);
+  deletionMutationRequest.mockClear();
+  await userEvent.click(canvas.getByRole('button', { name: '더 보기' }));
+  await userEvent.click(
+    within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
+      name: '게시글 삭제',
+    }),
+  );
+  const dialog = await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
+  await userEvent.click(within(dialog).getByRole('button', { name: '삭제' }));
+  await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(1));
+  const alert = await screen.findByRole('alert');
+  expect(alert).toHaveTextContent('게시글을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.');
+  expect(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).toBeVisible();
 
-    await userEvent.click(
-      within(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).getByRole('button', {
-        name: '삭제',
-      }),
-    );
-    await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(2));
-  },
+  await userEvent.click(
+    within(screen.getByRole('alertdialog', { name: '게시글 삭제 확인' })).getByRole('button', {
+      name: '삭제',
+    }),
+  );
+  await waitFor(() => expect(deletionMutationRequest).toHaveBeenCalledTimes(2));
+}
+
+export const AuthorPostDeletionFailureRetry: Story = {
+  play: authorPostDeletionFailureRetryPlay,
   render: () => (
     <PostActionBarFixture
       deleteOutcome="network-error"
+      onMutationRequest={deletionMutationRequest}
+      selectedProfileId="profile-author"
+    />
+  ),
+};
+
+export const AuthorPostDeletionGraphQLErrorRetry: Story = {
+  play: authorPostDeletionFailureRetryPlay,
+  render: () => (
+    <PostActionBarFixture
+      deleteOutcome="graphql-error"
       onMutationRequest={deletionMutationRequest}
       selectedProfileId="profile-author"
     />

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -27,12 +27,13 @@ import {
   resetImagePickerMock,
   setNextImagePickerResult,
 } from '../../.storybook/mocks/expo-image-picker';
-import { longBody, post, profile, profileWithPosts, timeline } from './fixtures';
+import { longBody, post, profile, profileWithPosts, shellQuery, timeline } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { GraphQLResponse, RequestParameters, Variables } from 'relay-runtime';
 import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
 import type { PostSourcePresentationData } from '@/components/post/PostSourcePresentationView';
+import type { PostDeletionListEdgeSafetyQuery as PostDeletionListEdgeSafetyQueryType } from './__generated__/PostDeletionListEdgeSafetyQuery.graphql';
 import type { PostDetailThreadIdentityStoryQuery } from './__generated__/PostDetailThreadIdentityStoryQuery.graphql';
 import type { PostsStoriesQuery as PostsStoriesQueryType } from './__generated__/PostsStoriesQuery.graphql';
 import type { StoryPost } from './fixtures';
@@ -526,11 +527,15 @@ const contentPostsProfile = profileWithPosts(
   [shortPost, pureRepostOfQuote, quotePost, quoteWithoutSource].map(withReactionViewerState),
   { id: 'profile-posts-content' },
 );
+const deletionProfile = profileWithPosts([withReactionViewerState(shortPost)], {
+  id: 'profile-posts-deletion',
+});
 const homeTimeline = timeline(
   ...[shortPost, pureRepost, quotePost, replyQuotePost, quoteOfQuotePost, linkedSourceQuote].map(
     withReactionViewerState,
   ),
 );
+const deletionHomeTimeline = timeline(withReactionViewerState(shortPost));
 
 const PostsStoriesQuery = graphql`
   query PostsStoriesQuery($ids: [ID!]!) {
@@ -578,6 +583,21 @@ const PostsStoriesQuery = graphql`
       }
     }
     homeTimeline(first: 20) {
+      ...PostList_homeTimeline
+    }
+  }
+`;
+
+const PostDeletionListEdgeSafetyQuery = graphql`
+  query PostDeletionListEdgeSafetyQuery {
+    deletionProfile: node(id: "profile-posts-deletion") {
+      __typename
+      ... on Profile {
+        id
+        ...PostList_profile @alias(as: "postList")
+      }
+    }
+    deletionHomeTimeline: homeTimeline(first: 1) {
       ...PostList_homeTimeline
     }
   }
@@ -823,6 +843,31 @@ function ProductionRepostQuoteLists() {
         <PostList profile={data.contentPostsProfile} />
       </View>
     </Catalog>
+  );
+}
+
+function PostDeletionListEdgeSafety() {
+  const data = useLazyLoadQuery<PostDeletionListEdgeSafetyQueryType>(
+    PostDeletionListEdgeSafetyQuery,
+    {},
+  );
+  if (data.deletionProfile?.__typename !== 'Profile' || !data.deletionHomeTimeline) {
+    throw new Error('PostDeletionListEdgeSafetyQuery must return both list fixtures.');
+  }
+
+  return (
+    <SessionProvider>
+      <Catalog>
+        <View testID="post-deletion-home-list">
+          <PostList homeTimeline={data.deletionHomeTimeline} />
+        </View>
+        <View testID="post-deletion-profile-list">
+          <PostList
+            profile={requireFragment(data.deletionProfile.postList, 'deletion profile list')}
+          />
+        </View>
+      </Catalog>
+    </SessionProvider>
   );
 }
 
@@ -1564,8 +1609,12 @@ const meta = {
         alternateComposerProfile,
         composerProfile,
         contentPostsProfile,
+        currentSession: shellQuery().currentSession,
+        deletionHomeTimeline,
+        deletionProfile,
         emptyPostsProfile,
         homeTimeline,
+        me: shellQuery().me,
         nodes: storyPosts.map(withReactionViewerState),
       },
       mutationResponse: { createPost: { post: { id: 'post-created-in-story' } } },
@@ -1847,6 +1896,34 @@ export const ProductionRepostQuoteListIntegration: Story = {
     }
   },
   render: () => <ProductionRepostQuoteLists />,
+};
+
+export const ProductionPostDeletionListEdgeSafety: Story = {
+  parameters: {
+    relay: { mutationResponse: { deletePost: { postId: shortPost.id } } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const home = within(canvas.getByTestId('post-deletion-home-list'));
+    const profile = within(canvas.getByTestId('post-deletion-profile-list'));
+
+    await userEvent.click(home.getByRole('button', { name: '더 보기' }));
+    await userEvent.click(
+      within(await screen.findByRole('menu', { name: '더 보기 메뉴' })).getByRole('menuitem', {
+        name: '게시글 삭제',
+      }),
+    );
+    const dialog = await screen.findByRole('alertdialog', { name: '게시글 삭제 확인' });
+    await userEvent.click(within(dialog).getByRole('button', { name: '삭제' }));
+
+    await waitFor(() => {
+      expect(home.getByText('아직 게시글이 없어요')).toBeVisible();
+      expect(profile.getByText('아직 게시글이 없어요')).toBeVisible();
+    });
+    expect(home.queryByRole('article')).toBeNull();
+    expect(profile.queryByRole('article')).toBeNull();
+  },
+  render: () => <PostDeletionListEdgeSafety />,
 };
 
 export const ProductionReactionMutationTargets: Story = {

--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -79,12 +79,43 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 - 실패 시 pending만 종료하고 이전 서버 확정 selected 상태, `repostCount`와 Relay cache를 유지한다. 사용자는
   메뉴를 다시 열고 같은 action을 선택해 재시도한다. 성공 toast는 표시하지 않는다.
 
+## Post 삭제 More menu
+
+- Action Bar의 16px `MoreHorizontal` 케밥 icon은 삭제를 즉시 실행하는 button이 아니라 기존 `ActionMenu`를
+  여는 More trigger다. trigger의 접근성 이름은 `더 보기`이고 menu open 상태를 노출한다.
+- `삭제` 항목은 현재 selected Profile과 Action Bar target Post의 Author Profile이 같고, target이 Content를
+  가진 Active Post일 때만 표시한다. 일반 Post, Reply, Quote와 Reply이면서 Quote를 포함하며 guest, 다른
+  Profile, Tombstone과 Content 없는 Repost에는 표시하지 않는다.
+- 순수 Repost surface의 Action Bar target은 기존 배치 계약대로 direct Repost Source다. 따라서 More의 삭제
+  eligibility와 mutation ID도 Source를 기준으로 하며, 바깥 Repost의 취소는 Repost action menu가 계속
+  소유한다.
+- `링크 복사`와 `삭제`가 함께 제공되면 일반 action인 `링크 복사`를 먼저, destructive action인 `삭제`를
+  마지막에 둔다. `삭제` item은 `Trash2` icon, theme `danger` 색과 접근성 이름 `게시글 삭제`로 파괴적 결과를
+  label과 색상 모두로 구분한다.
+- `삭제` item을 선택하면 More menu를 닫고 확인 dialog를 연다. 이 선택만으로 mutation이나 cache 변경을
+  시작하지 않는다. dialog title은 `게시글을 삭제할까요?`, 설명은 `삭제한 게시글은 복구할 수 없습니다.`,
+  action은 `취소`와 `삭제`를 사용한다.
+- 확인 dialog는 Web에서 `alertdialog`, Android·iOS에서 modal 접근성 의미를 제공한다. 처음 열릴 때 안전한
+  `취소`에 focus를 두고 pending 전에는 Escape, platform back과 backdrop으로 취소할 수 있으며 닫은 뒤 More
+  trigger로 focus를 돌려보낸다.
+- 사용자가 dialog의 `삭제`를 확인한 경우에만 target Post ID로 기존 GraphQL `deletePost` mutation을 한 번
+  실행한다. pending 중에는 두 action과 dismiss 입력을 막고 destructive action에 busy 상태를 노출한다.
+- 서버 성공 payload의 `postId`를 확인한 뒤에만 현재 Relay actor Store에서 해당 Post를 Active content로
+  제거한다. Home·Profile 목록은 삭제된 Post edge를 표시하지 않고 상세는 기존 삭제됨·접근 불가 상태로
+  전환하며, 다른 selected Profile의 actor Store는 변경하지 않는다. 성공하면 dialog를 닫고 성공 toast는
+  표시하지 않는다.
+- 실패에는 optimistic 삭제를 적용하지 않고 서버 확정 Post와 cache를 유지한다. dialog는 열린 상태에서 다시
+  입력할 수 있게 복구하고 공용 toast host에 `게시글을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.`를
+  alert semantics로 표시한다.
+
 ## 소유권과 후속 범위
 
 - `PROD-414`는 실제 Action Bar surface 배치, Repost menu, 생성·취소 action과 실패 toast를 소유한다.
 - `PROD-415`는 목록의 Source 이동과 순수 Repost ID 직접 접근의 Source detail redirect를 소유한다.
 - `PROD-431`은 `인용하기` 메뉴 항목과 Quote 작성 흐름을 소유한다.
 - `PROD-471`은 Repost 취소 뒤 서버 확정 Source 상태를 같은 actor Store에 정규화하는 cache 갱신을 소유한다.
+- `PROD-598`은 기존 Post 삭제 domain과 GraphQL resolver를 재사용해 More의 작성자 삭제 항목, 확인 dialog,
+  Relay cache 동기화와 실패 복구를 소유한다.
 - Reaction, Reply, Bookmark, More의 실제 연결과 여러 action의 최종 통합 범위는 각 구현 이슈와 `PROD-432`에
   남긴다.
 
@@ -109,3 +140,10 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
 - 실패 문구, latest-replace, 동일 문구 반복 시 새 alert instance와 dismiss timer 재시작, 자동 dismiss,
   alert semantics, light `#262626` accent와 message 2px optical shift, 실패 뒤 상태 유지·다음 입력 재시도를
   검증한다.
+- 작성자·selected Profile 일치, Active contentful target과 guest·다른 Profile·Tombstone·Content 없는 Repost의
+  `삭제` 노출 여부, Source를 target으로 하는 순수 Repost surface, 링크 복사와 destructive item 순서를
+  검증한다.
+- 삭제 확인 전 취소와 dismiss, dialog의 title·설명·안전한 초기 focus·modal/alertdialog 의미, 정확한 Post ID의
+  단일 mutation, pending 중 중복·dismiss 차단과 busy 상태를 검증한다.
+- 성공 뒤 Home·Profile 목록 제거와 상세의 삭제됨·접근 불가 상태, selected Profile별 actor Store 격리, 실패
+  뒤 cache 유지·dialog 재시도와 접근 가능한 한국어 toast를 검증한다.

--- a/openspec/changes/add-author-post-deletion/.openspec.yaml
+++ b/openspec/changes/add-author-post-deletion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-31

--- a/openspec/changes/add-author-post-deletion/decisions.md
+++ b/openspec/changes/add-author-post-deletion/decisions.md
@@ -1,0 +1,97 @@
+## Context
+
+이 기록은 PROD-598의 승인된 Domain/Issue Gate, `docs/domain/objects/post.md`의 Account 요청 Post 삭제, `docs/design/post-action-bar.md`의 Post 삭제 More menu와 접근성 계약을 구현자가 지켜야 할 결정으로 정리한다. 기존 Core/GraphQL 경계와 새 사용자 surface를 연결하되 `add-post-action-bar`의 링크 복사·통합 생명주기와는 독립적으로 완료한다.
+
+## Decision Records
+
+### 기존 Core 삭제 계약과 GraphQL resolver 경계를 재사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `PROD-598`
+- Status: Active
+- Context / Problem: Post 삭제 service와 GraphQL mutation이 이미 있는데 사용자 surface 추가를 이유로 Core·DB·schema를 다시 만들면 같은 lifecycle과 권한 계약이 중복된다.
+- Decision Outcome: Account 요청은 `usingProfile`으로 검증된 selected Profile과 concrete Post ID를 기존 Core 삭제 service에 전달하고, 성공 payload로 삭제된 Post의 global `postId`를 반환하는 현재 GraphQL 경계를 재사용한다. 현재 구현이 이 결과를 이미 만족하면 새 backend source diff를 강제하지 않고 integration evidence로 완료를 증명한다.
+- Alternatives Considered: 새 삭제 mutation이나 별도 UI 전용 service를 추가하는 방식은 기존 공개 계약을 중복하므로 채택하지 않았다. Core/DB를 함께 재구현하는 방식은 승인된 제외 범위라 채택하지 않았다.
+- Consequences: backend 작업은 resolver 경계 재검증과 필요한 최소 test 보완에 한정된다. GraphQL schema, DB migration과 Core lifecycle 변경은 없다.
+- Confirmation / Follow-up: Author·비Author·guest·잘못된 concrete ID와 global `postId` payload를 API integration evidence에서 확인한다.
+
+### 케밥 icon은 작성자 삭제 More menu를 연다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`, `PROD-598`
+- Status: Active
+- Context / Problem: 케밥 icon을 직접 삭제 button으로 해석하면 기존 More action 의미와 확인 단계를 우회하고, guest·다른 Profile에도 destructive affordance가 노출될 수 있다.
+- Decision Outcome: `MoreHorizontal`은 `더 보기` ActionMenu trigger이며, selected Profile이 Action Bar target의 Author이고 target이 Active contentful Post일 때만 `삭제` item을 표시한다. 링크 복사가 함께 있으면 삭제를 마지막 danger item으로 둔다.
+- Alternatives Considered: icon 활성화 즉시 삭제하거나 권한 없는 viewer에게 disabled item을 표시하는 방식은 승인된 확인·노출 계약과 맞지 않아 채택하지 않았다.
+- Consequences: 현재 삭제 item이 하나도 없고 링크 복사도 아직 연결되지 않은 surface에서는 More trigger를 표시할 이유가 없다. 후속 링크 복사는 같은 item 배열 앞에 결합할 수 있다.
+- Confirmation / Follow-up: 일반 Post·Reply·Quote·Reply이면서 Quote와 guest·다른 Profile·Tombstone·Content 없는 Repost fixture를 검증한다.
+
+### 순수 Repost의 삭제 target은 direct Source다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-action-bar.md`, `PROD-598`
+- Status: Active
+- Context / Problem: 순수 Repost surface는 Source 콘텐츠와 Source Action Bar를 표시하므로 바깥 Repost ID와 Source ID 중 어느 것을 More 삭제가 사용해야 하는지 일관되어야 한다.
+- Decision Outcome: 기존 Action Bar 배치 계약과 같이 More 삭제 eligibility, Author 비교와 mutation ID는 direct Repost Source를 사용한다. 바깥 Repost 취소는 Repost action menu가 계속 소유한다.
+- Alternatives Considered: More 삭제가 바깥 Repost를 지우는 방식은 Repost 취소와 중복되고 표시 콘텐츠의 Author 삭제 의미와 어긋나므로 채택하지 않았다.
+- Consequences: cache update는 target Source뿐 아니라 현재 표시한 pure Repost representation이 eligibility를 잃는 결과도 처리해야 한다.
+- Confirmation / Follow-up: Source Author와 Repost Author가 다른 fixture에서 정확한 menu 노출과 mutation ID를 확인한다.
+
+### 확인 뒤 단일 실행하고 pending에는 입력을 잠근다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-action-bar.md`, `docs/design/accessibility.md`, `PROD-598`
+- Status: Active
+- Context / Problem: Post 삭제는 복구를 제공하지 않는 destructive action이므로 menu 선택만으로 실행하거나 pending 중 중복 요청을 허용하면 사용자가 의도하지 않은 삭제와 focus 혼란이 생긴다.
+- Decision Outcome: menu 선택은 확인 dialog만 열고 `삭제` 확인으로 mutation을 한 번 실행한다. 확인 copy는 `게시글을 삭제할까요?`, `삭제한 게시글은 복구할 수 없습니다.`, `취소`, `삭제`로 고정하며 안전한 취소에 초기 focus를 둔다. pending에는 action과 dismiss를 잠그고 busy 상태를 노출한다.
+- Alternatives Considered: native에서만 system alert를 사용해 플랫폼별 copy·focus를 달리하는 방식과 확인 없는 즉시 실행은 Web·Native 공통 계약을 깨뜨려 채택하지 않았다.
+- Consequences: menu dismiss focus와 dialog initial focus 순서를 조정해야 하며, 성공하면 제거되는 trigger에 focus를 복구하지 않는다.
+- Confirmation / Follow-up: Web keyboard/Escape와 Native back/backdrop, pending 중복 활성화와 접근성 state를 검증한다.
+
+### 서버 성공 뒤 현재 actor Store만 갱신한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-action-bar.md`, `PROD-598`
+- Status: Active
+- Context / Problem: optimistic 삭제는 실패 시 여러 목록 edge와 상세 상태를 복원해야 하고, selected Profile 전환 뒤 이전 callback이 새 Store를 바꾸면 actor 격리가 깨진다.
+- Decision Outcome: optimistic cache 삭제를 사용하지 않고 성공 payload의 `postId`를 확인한 뒤 요청을 시작한 현재 Relay actor Store의 목록·상세만 갱신한다. 실패에는 cache를 유지하고 dialog와 한국어 alert toast를 재시도 가능한 상태로 복구한다.
+- Alternatives Considered: mutation 시작 시 record 제거는 복구 비용과 오류 위험 때문에 채택하지 않았다. 모든 actor Store를 초기화하는 방식은 다른 Profile의 독립 cache를 불필요하게 버리므로 채택하지 않았다.
+- Consequences: 성공 updater 또는 surface refetch가 비관리 connection, reply thread와 pure Repost Source representation을 명시적으로 검증해야 한다. 구체 Relay cleanup mechanism은 spec 결과를 만족하는 범위에서 구현이 선택할 수 있다.
+- Confirmation / Follow-up: Home·Profile 목록, 상세, actor 전환, network/GraphQL 실패와 재시도 payload test를 분리해 확인한다.
+
+### More menu의 도메인 상태는 private child가 소유한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/post-action-bar.md`, `PROD-598`
+- Status: Active
+- Context / Problem: 목록과 상세 surface마다 Author 비교, menu, mutation과 pending을 조립하면 계약이 중복되고 `PostActionBar` container가 target 정책과 mutation payload를 직접 알게 될 수 있다.
+- Decision Outcome: Repost action과 같은 private child 경계가 target Post fragment, selected Profile 비교, ActionMenu, 확인과 deletion mutation state를 함께 소유한다. `PostActionBar`는 고정 순서와 공통 control 조립 책임을 유지한다.
+- Alternatives Considered: 각 surface가 callback과 modal state를 따로 만드는 방식은 목록·상세 drift가 생겨 채택하지 않았다. toolbar container에 모든 mutation 로직을 인라인하는 방식은 child ownership을 깨뜨려 채택하지 않았다.
+- Consequences: 공용 ActionMenu는 optional destructive presentation만 확장하고, Post 삭제 domain 의미는 post feature child에 남는다.
+- Confirmation / Follow-up: 목록·상세가 같은 child fragment와 mutation identity를 사용하는지 component test에서 확인한다.
+
+### PROD-598 change를 Action Bar 통합 change와 독립적으로 완료한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-action-bar.md`, `PROD-598`
+- Status: Active
+- Context / Problem: active `add-post-action-bar` change는 링크 복사 외 More 항목을 제외하고 여러 선행 action의 최종 통합을 기다리므로 author deletion을 그 생명주기에 결합하면 독립 구현·검증·출시가 지연된다.
+- Decision Outcome: `add-author-post-deletion`은 PROD-598의 삭제 menu·확인·cache 동기화와 통합 증거만 소유하며, 완료 조건이 충족되면 PROD-598이 archive한다. PROD-432의 링크 복사와 전체 Action Bar archive 책임은 그대로 남긴다.
+- Alternatives Considered: 기존 `add-post-action-bar` tasks에 삭제를 추가하는 방식은 서로 다른 범위와 완료 시점을 결합하므로 채택하지 않았다.
+- Consequences: 같은 component를 수정하더라도 각 change의 spec과 task는 자기 행동 계약만 검증한다. 후속 통합은 이미 구현된 삭제 item을 회귀시키지 않아야 한다.
+- Confirmation / Follow-up: 이 change의 tasks와 PR이 PROD-598 범위만 포함하고 독립 archive evidence를 남긴다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-author-post-deletion/design.md
+++ b/openspec/changes/add-author-post-deletion/design.md
@@ -1,0 +1,76 @@
+## Context
+
+Post 삭제 domain, Core service와 GraphQL `deletePost` resolver는 이미 Author 권한, Active→Tombstone 전이와 `postId` payload를 구현한다. 앱은 이 mutation을 Repost 취소에만 사용하며, `PostActionBar`의 More는 현재 optional callback-only control이고 실제 목록·상세 surface에서는 연결되지 않았다. 공용 `ActionMenu`는 Web anchored menu와 Native bottom action sheet를 이미 제공하지만 destructive item tone과 삭제 확인 UI는 없다.
+
+PROD-598은 기존 server behavior를 바꾸지 않고 Home·Profile Post List와 Post 상세의 Action Bar target에 작성자 삭제를 연결한다. Relay environment는 selected Profile 전환마다 교체되므로 mutation completion과 cache update는 요청을 시작한 actor Store에만 적용되어야 한다. 목록 fragment 일부는 Relay `@connection`으로 관리되지 않으므로 record 삭제만으로 모든 표시 edge가 안전하게 사라진다고 가정할 수 없다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 기존 GraphQL resolver 경계를 integration evidence로 고정하고 Core/DB 계약을 재사용한다.
+- Action Bar의 케밥 More trigger에서 작성자에게만 삭제 항목과 확인 flow를 제공한다.
+- 서버 성공 이후 현재 actor Store의 목록·상세를 삭제 결과에 맞추고 실패·취소에는 cache를 보존한다.
+- Web·Android·iOS의 기존 menu 패턴, 접근성, focus 복구와 pending 중복 차단을 유지한다.
+- 일반 Post·Reply·Quote·Reply이면서 Quote와 순수 Repost Source target을 같은 계약으로 검증한다.
+
+**Non-Goals:**
+
+- Core service, DB schema, GraphQL schema shape와 ActivityPub Delete delivery를 재설계하지 않는다.
+- physical delete, 복구·삭제 취소, 원격 Post 사용자 삭제와 PROD-121 조회 정책을 구현하지 않는다.
+- PROD-432의 링크 복사 또는 전체 Action Bar 통합을 대신 완료하지 않는다.
+- 신고·숨기기·차단 등 다른 More 항목을 미리 추가하지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `apps/api/src/graphql/resolvers/post/mutation/delete.ts`는 이미 `usingProfile`, concrete Post global ID, Core service 호출과 global `postId` payload를 제공한다. behavior가 spec과 일치하면 source 변경보다 기존·추가 integration test가 완료 증거다.
+- `PostActionBar`는 More callback과 접근성 label만 받으며 menu state를 소유하지 않는다. menu·mutation을 toolbar container에 직접 섞으면 private child가 자기 fragment와 처리 상태를 소유하는 기존 구조가 깨진다.
+- `RepostAction`은 fragment, `ActionMenu`, mutation, actor environment 전환과 중복 입력을 함께 처리하는 가까운 선행 패턴이다.
+- 순수 Repost의 Action Bar는 바깥 Repost가 아니라 direct Source fragment를 target으로 사용한다. 삭제 mutation ID와 Author eligibility도 이 target을 따라야 한다.
+- `PostList_profile`과 `PostList_homeTimeline`은 모두 Post connection shape를 읽지만 현재 모든 connection이 Relay declarative connection handle로 등록된 것은 아니다. `postId @deleteRecord` 또는 `store.delete(postId)`만 적용하면 edge·nested Source reference가 남거나 non-null fragment 가정을 깨뜨릴 수 있다.
+- More menu가 item을 선택하며 trigger focus를 복구하는 시점과 확인 dialog가 초기 focus를 받는 시점이 겹칠 수 있다. menu dismiss가 끝난 뒤 dialog focus를 확정해야 한다.
+
+### Recommended Approach
+
+- Repost action과 같은 post-module private child로 More menu를 구성한다. child는 target Post fragment에서 ID, lifecycle/content 존재와 Author ID를 읽고 `useSession()`의 selected Profile ID와 비교해 `삭제` item을 파생한다. `PostActionBar`는 고정 순서와 control 조립만 유지한다.
+- 공용 `ActionMenuItem`에는 기존 item을 깨뜨리지 않는 optional destructive tone·accessible name을 추가한다. default item은 현재 색과 semantics를 유지하고 삭제 item만 `Trash2`와 theme `danger`를 사용한다.
+- 확인 UI는 현재 한 곳에서만 필요하므로 post feature 안의 작은 modal component로 시작한다. Web `alertdialog`, Native modal semantics, 안전한 초기 focus, pending 전 dismiss와 focus return을 한 경계에서 처리하고 실제 재사용 요구가 생길 때만 공용 primitive로 승격한다.
+- 삭제 mutation에는 optimistic response/updater를 두지 않는다. 요청 시작 environment와 현재 environment를 비교하는 guard와 별도 in-flight ref를 사용해 actor 전환 뒤 이전 callback이 새 UI state나 Store를 바꾸지 않게 한다.
+- 성공 updater는 payload의 `postId`를 source of truth로 사용해 현재 actor Store의 target record와 표시 surface를 정리한다. default는 target record 제거와 함께 Home·Profile 목록, 상세 thread 및 pure Repost의 nested Source가 현재 render에서 남지 않는지 실제 Relay payload test로 확인하고 필요한 edge/reference 정리를 같은 updater 또는 surface reader에 추가하는 방식이다. 구현 세부 방식보다 모든 관련 surface가 Active content를 더 이상 표시하지 않는 결과를 우선한다.
+- 실패는 mutation state만 복구하고 확인 dialog를 유지한 채 기존 toast host로 error callback을 전달한다. GraphQL `onCompleted`의 `errors`와 transport `onError`를 모두 동일한 실패 경계로 처리한다.
+- API integration은 기존 resolver가 Author·비Author·guest·잘못된 global ID에서 Core 호출과 결과를 올바르게 전달하는지 재검증한다. 이미 충분한 test가 있으면 중복 test를 추가하지 않고 현재 증거를 task 결과에 기록한다.
+
+### Allowed Alternatives
+
+- Relay 성공 동기화는 declarative `@deleteRecord`와 explicit connection cleanup, feature-local updater, 또는 성공 뒤 현재 surface refetch 중 하나를 사용할 수 있다. 서버 성공 전 cache를 바꾸지 않고 현재 actor Store만 갱신하며 목록·상세·pure Repost Source 시나리오가 독립 테스트로 증명되면 허용한다.
+- 확인 UI는 같은 semantics, copy, focus와 pending 계약을 만족하는 기존 공용 modal primitive가 구현 시점에 존재하면 재사용할 수 있다.
+
+### Known Traps
+
+- selected Profile/Author ID 비교를 server 권한 판정의 대체물로 사용하면 안 된다. client 비교는 item 노출만 결정하고 mutation은 항상 resolver/Core 권한 검증을 통과해야 한다.
+- 순수 Repost 화면에서 바깥 Repost ID를 More 삭제 mutation에 전달하면 Repost 취소와 Author Post 삭제 의미가 섞인다.
+- server 성공 전에 record나 edge를 제거하면 실패·취소에서 cache를 정확히 복구하기 어렵다.
+- actor environment 전환 뒤 이전 요청 callback이 현재 dialog/toast 또는 새 Store를 갱신하면 Profile별 격리가 깨진다.
+- Relay record만 제거하고 비관리 connection edge, reply thread entry 또는 pure Repost의 Source reference를 방치하면 null fragment crash나 빈 Post row가 남을 수 있다.
+- menu dismiss focus와 dialog initial focus를 같은 tick에 경쟁시키면 Web keyboard 사용자가 trigger로 튕길 수 있다.
+
+## Risks / Trade-offs
+
+- [여러 목록 shape의 cache 정리가 누락될 수 있음] → Home·Profile·상세 thread와 pure Repost Source를 각각 Relay payload test로 재현하고, 결과 기준으로 updater·reader를 함께 보완한다.
+- [More child가 아직 완료되지 않은 PROD-432 링크 복사와 같은 surface를 수정함] → item 배열과 ActionMenu boundary를 확장 가능하게 유지하되 링크 복사를 미리 구현하지 않고, `삭제`가 존재할 때만 현재 trigger를 표시한다.
+- [확인 modal을 feature-local로 두면 후속 destructive action에서 중복될 수 있음] → 현재 단일 use case에는 최소 구현을 유지하고 실제 두 번째 소비자가 생길 때 공용화한다.
+- [Native 접근성 runtime은 Web 자동화로 증명할 수 없음] → universal component/Storybook test와 플랫폼별 semantics를 검증하고 VoiceOver·TalkBack 실기기 확인 여부를 별도 기록한다.
+
+## Migration Plan
+
+1. 기존 API resolver와 integration evidence를 재검증한다.
+2. ActionMenu destructive item 표현과 More 삭제 child·확인 UI를 추가한다.
+3. 목록·상세 surface에 target fragment와 오류 callback을 연결하고 server-success cache update를 구현한다.
+4. Relay artifact, component/Storybook/API integration, typecheck·lint와 Web runtime을 검증한다.
+5. 문제가 발생하면 client More 연결과 cache updater를 되돌린다. Core/DB/API schema와 migration을 바꾸지 않으므로 server rollback이나 data migration은 필요하지 않다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-author-post-deletion/proposal.md
+++ b/openspec/changes/add-author-post-deletion/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Kosmo의 Post domain과 GraphQL `deletePost` mutation은 Author가 Active Post를 Tombstone으로 전환하는 삭제를 이미 지원하지만, 일반 Post·Reply·Quote의 작성자는 Home·Profile 목록과 Post 상세에서 이 행동을 실행할 수 없다. PROD-598은 기존 서버 계약을 재사용하면서 Action Bar의 More 메뉴에 작성자 삭제 흐름을 연결해, 이미 지원되는 삭제를 실제 사용자 surface에서 완결한다.
+
+## What Changes
+
+- 기존 Core Post 삭제 service를 재사용하는 GraphQL `deletePost` resolver가 선택된 Profile과 입력 Post를 정확히 전달하고 삭제된 Post의 global `postId`를 반환하는 경계를 검증한다.
+- Action Bar의 `MoreHorizontal` 케밥 icon을 기존 `ActionMenu` trigger로 사용하고, selected Profile이 Author인 Active contentful Post에만 `삭제` 항목을 제공한다.
+- 삭제 항목 선택 뒤 별도 확인 dialog를 열고 사용자가 확인한 경우에만 mutation을 한 번 실행하며, pending 중 중복 입력과 dismiss를 막는다.
+- 서버 성공 뒤 현재 Relay actor Store의 Home·Profile 목록과 상세를 삭제 결과에 맞게 갱신하고, 실패·취소에는 서버 확정 cache를 유지하며 접근 가능한 한국어 오류 안내와 재시도를 제공한다.
+- 일반 Post·Reply·Quote·Reply이면서 Quote, 순수 Repost Source target, guest·다른 Profile, Web·Android·iOS 흐름과 Repost 취소 회귀를 component·integration test로 검증한다.
+- 기존 `add-post-action-bar` change의 링크 복사·전체 통합 생명주기와 독립적으로 PROD-598이 이 change의 구현, 통합 검증과 archive를 소유한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`, `docs/design/accessibility.md`
+- Linear Contract: `PROD-598`
+- Linear Implementations: `PROD-598`
+
+## Capabilities
+
+### New Capabilities
+
+- `author-post-deletion`: 기존 Post 삭제 mutation을 Action Bar의 작성자 전용 More 메뉴, 확인, Relay cache 동기화와 실패 복구에 연결하는 사용자 삭제 흐름
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/api/src/graphql/resolvers/post/mutation/delete.ts`와 관련 GraphQL integration test의 기존 resolver 경계를 재검증한다. Core service, DB schema와 GraphQL schema shape는 변경하지 않는다.
+- `apps/app/src/components/post`의 Action Bar·목록·상세 surface, 공용 `ActionMenu`와 toast/확인 UI, Relay mutation updater 및 component/Storybook test가 영향을 받는다.
+- Home·Profile Post connection과 Post 상세의 현재 actor Store cache가 서버 성공 뒤 갱신되며, selected Profile별 Store 격리는 유지된다.
+- 새 외부 dependency, DB migration, physical delete, 복구, 원격 Post 사용자 삭제와 ActivityPub delivery 재설계는 없다.

--- a/openspec/changes/add-author-post-deletion/specs/author-post-deletion/spec.md
+++ b/openspec/changes/add-author-post-deletion/specs/author-post-deletion/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: GraphQL 작성자 Post 삭제 경계
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `PROD-598` — GraphQL `deletePost(input: { id })` mutation은 `usingProfile` 인증으로 검증된 selected Profile을 Account 요청의 행동 주체로 사용해야 하며(MUST), 입력을 concrete Post global ID로 제한하고 decode된 Post ID와 행동 주체 Profile ID를 기존 Core Post 삭제 service에 전달해야 한다(MUST). 성공 payload는 Tombstone으로 전이된 Post의 concrete global `postId`를 반환해야 하며(MUST), Core/DB 삭제 계약이나 GraphQL schema shape를 다시 정의해서는 안 된다(MUST NOT).
+
+#### Scenario: Author가 Active Post를 삭제한다
+
+- **WHEN** Active Account의 selected Profile이 자신이 작성한 Active Post의 global ID로 `deletePost`를 호출한다
+- **THEN** resolver는 selected Profile ID와 decode된 Post ID로 기존 Core 삭제 service를 한 번 호출한다
+- **AND** 성공 payload는 삭제된 Post의 concrete global `postId`를 반환한다
+
+#### Scenario: Author가 아닌 Profile이 삭제를 요청한다
+
+- **WHEN** selected Profile이 다른 Author의 Post ID로 `deletePost`를 호출한다
+- **THEN** 기존 Post 삭제 권한 계약에 따라 요청은 실패하고 대상 Post는 Active 상태를 유지한다
+
+#### Scenario: 인증되지 않았거나 Post가 아닌 ID를 입력한다
+
+- **WHEN** guest가 mutation을 호출하거나 입력 global ID의 concrete type이 Post가 아니다
+- **THEN** resolver 경계는 Core 삭제를 실행하지 않고 요청을 거부한다
+
+### Requirement: 작성자 전용 More 삭제 항목
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`, `PROD-598` — Action Bar는 16px `MoreHorizontal` 케밥 icon을 삭제를 즉시 실행하는 별도 button이 아니라 기존 `ActionMenu`를 여는 `더 보기` trigger로 제공해야 한다(MUST). More menu는 current selected Profile과 Action Bar target Post의 Author Profile이 같고 target이 Content를 가진 Active Post일 때만 `삭제` 항목을 표시해야 하며(MUST), guest·다른 Profile·Tombstone·Content 없는 Repost에는 표시해서는 안 된다(MUST NOT). `링크 복사`와 함께 제공할 때 `삭제`는 마지막에 배치하고 `Trash2` icon, theme `danger` 색과 접근성 이름 `게시글 삭제`를 사용해야 한다(MUST).
+
+#### Scenario: 작성자가 contentful Post의 More menu를 연다
+
+- **WHEN** selected Profile이 작성한 Active 일반 Post, Reply, Quote 또는 Reply이면서 Quote의 More trigger를 활성화한다
+- **THEN** menu는 `삭제` 항목을 표시한다
+- **AND** `링크 복사`도 있으면 `삭제`를 그 뒤 마지막 destructive item으로 표시한다
+
+#### Scenario: 삭제 권한이 없는 viewer가 More menu를 연다
+
+- **WHEN** guest 또는 target Post의 Author가 아닌 selected Profile이 More trigger를 활성화한다
+- **THEN** menu는 `삭제` 항목을 표시하지 않는다
+
+#### Scenario: 순수 Repost surface의 삭제 target
+
+- **WHEN** Content와 Reply Parent가 없고 Repost Source만 있는 Post가 목록 또는 상세에 표시된다
+- **THEN** More 삭제 eligibility와 mutation ID는 기존 Action Bar 배치 계약의 direct Repost Source를 기준으로 한다
+- **AND** 바깥 Repost 취소는 Repost action menu가 계속 소유하며 More 삭제 항목으로 대체하지 않는다
+
+### Requirement: 삭제 확인과 단일 실행
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, `docs/design/accessibility.md`, `PROD-598` — 사용자가 `삭제` menu item을 선택하면 앱은 More menu를 닫고 title `게시글을 삭제할까요?`, 설명 `삭제한 게시글은 복구할 수 없습니다.`, action `취소`와 `삭제`를 가진 확인 dialog를 열어야 한다(MUST). menu item 선택만으로 mutation이나 cache 변경을 시작해서는 안 되며(MUST NOT), 사용자가 dialog의 `삭제`를 확인한 경우에만 target Post ID로 `deletePost`를 한 번 실행해야 한다(MUST). pending 중에는 중복 action과 dismiss 입력을 막고 destructive action에 busy 상태를 노출해야 한다(MUST).
+
+#### Scenario: 사용자가 삭제를 취소한다
+
+- **WHEN** 사용자가 확인 dialog에서 `취소`, Escape, platform back 또는 backdrop dismiss를 선택한다
+- **THEN** 앱은 mutation과 cache 변경 없이 dialog를 닫고 More trigger로 focus를 돌려보낸다
+
+#### Scenario: 사용자가 삭제를 확인한다
+
+- **WHEN** 사용자가 확인 dialog의 `삭제`를 활성화한다
+- **THEN** 앱은 Action Bar target Post의 global ID로 `deletePost`를 정확히 한 번 실행한다
+- **AND** 요청이 끝날 때까지 확인 action의 중복 활성화와 dialog dismiss를 막는다
+
+#### Scenario: 삭제 확인 전 입력
+
+- **WHEN** 사용자가 More menu의 `삭제` 항목만 선택하고 확인 dialog의 `삭제`를 아직 활성화하지 않았다
+- **THEN** 앱은 Post mutation이나 Relay cache 변경을 실행하지 않는다
+
+### Requirement: 서버 확정 삭제와 Relay actor Store 동기화
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`, `PROD-598` — 앱은 GraphQL 성공 payload의 `postId`를 확인한 뒤에만 현재 Relay actor Store에서 해당 Post를 Active content로 제거해야 한다(MUST). Home·Profile Post List는 삭제된 Post edge를 계속 표시해서는 안 되고(MUST NOT), Post 상세는 기존 삭제됨·접근 불가 상태로 전환해야 하며(MUST), 다른 selected Profile의 Relay actor Store를 변경해서는 안 된다(MUST NOT). 성공하면 menu와 확인 dialog를 닫고 성공 toast는 표시하지 않아야 한다(MUST NOT).
+
+#### Scenario: 목록에서 삭제가 성공한다
+
+- **WHEN** Home 또는 Profile Post List에서 `deletePost`가 성공하고 payload가 target `postId`를 반환한다
+- **THEN** 현재 actor Store의 관련 목록은 삭제된 Post를 Active edge로 계속 표시하지 않는다
+- **AND** 다른 actor Store의 같은 Post record와 connection은 변경되지 않는다
+
+#### Scenario: 상세에서 삭제가 성공한다
+
+- **WHEN** Post 상세에서 `deletePost`가 성공한다
+- **THEN** 상세 surface는 기존 삭제됨·접근 불가 상태로 전환하고 확인 UI를 닫는다
+- **AND** 성공 toast는 표시하지 않는다
+
+#### Scenario: 서버 성공 전 cache 상태
+
+- **WHEN** 삭제 mutation이 아직 pending이거나 서버가 실패 응답을 반환한다
+- **THEN** 앱은 target Post나 관련 connection에 optimistic 삭제를 적용하지 않는다
+
+### Requirement: 실패 복구와 접근 가능한 오류 안내
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, `docs/design/accessibility.md`, `PROD-598` — 삭제 mutation이 실패하면 앱은 서버 확정 Post와 Relay cache를 유지하고 확인 dialog를 열린 상태에서 재시도 가능한 상태로 복구해야 한다(MUST). 공용 toast host는 `게시글을 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.`를 alert semantics로 표시해야 하며(MUST), 다음 `삭제` 입력은 같은 target Post로 새 mutation을 실행할 수 있어야 한다(MUST).
+
+#### Scenario: 삭제 mutation이 실패한다
+
+- **WHEN** `deletePost`가 GraphQL 또는 network 오류로 실패한다
+- **THEN** target Post와 목록 connection은 mutation 전 서버 확정 상태를 유지한다
+- **AND** 확인 dialog는 destructive action과 dismiss를 다시 활성화해 재시도 또는 취소할 수 있게 한다
+- **AND** 공용 toast host는 한국어 실패 문구를 새 alert instance로 표시한다
+
+#### Scenario: 실패 뒤 재시도한다
+
+- **WHEN** 실패 안내 뒤 사용자가 같은 확인 dialog에서 `삭제`를 다시 활성화한다
+- **THEN** 앱은 같은 target Post ID로 새 `deletePost` 요청을 한 번 실행한다
+
+### Requirement: Web·Android·iOS 삭제 흐름 접근성
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, `docs/design/accessibility.md`, `PROD-598` — More trigger는 button role, `더 보기` accessible name과 menu expanded 상태를 제공해야 하며(MUST), Web은 기존 anchored menu의 keyboard·focus·dismiss 계약을, Android·iOS는 기존 safe-area bottom action sheet와 modal/menu 계약을 재사용해야 한다(MUST). 삭제 확인은 Web에서 `alertdialog`, Android·iOS에서 modal 접근성 의미를 제공하고 처음 열릴 때 안전한 `취소` action에 focus를 두어야 하며(MUST), pending 전 취소로 닫으면 More trigger에 focus를 복구해야 한다(MUST).
+
+#### Scenario: Web keyboard 삭제 흐름
+
+- **WHEN** Web 사용자가 keyboard로 More menu의 `삭제`를 선택한다
+- **THEN** anchored menu가 닫히고 `alertdialog`가 열리며 `취소` action이 초기 focus를 받는다
+- **AND** pending 전 Escape로 닫으면 More trigger가 focus를 돌려받는다
+
+#### Scenario: Native 삭제 흐름
+
+- **WHEN** Android 또는 iOS 사용자가 bottom action sheet의 `삭제`를 선택한다
+- **THEN** sheet가 닫히고 modal 의미를 가진 확인 UI가 열린다
+- **AND** pending 전 platform back이나 backdrop dismiss는 mutation 없이 확인 UI를 닫는다
+
+#### Scenario: pending 접근성 상태
+
+- **WHEN** 삭제 mutation이 pending이다
+- **THEN** destructive confirmation action은 busy·disabled 상태를 보조 기술에 노출하고 중복 입력을 받지 않는다
+
+### Requirement: 삭제 흐름의 surface 일관성과 회귀 방지
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, `PROD-598` — Home Post List, Profile Post List와 Post 상세는 같은 author deletion 계약을 사용해야 하며(MUST), 삭제 action을 navigation `Link`나 Post detail `Pressable` 안에 중첩해서는 안 된다(MUST NOT). 새 More 삭제 흐름은 Repost 생성·취소, Reaction, Reply, Bookmark와 기존 More `링크 복사` action의 target·pending·cache 의미를 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: 목록과 상세에서 같은 계약을 사용한다
+
+- **WHEN** 같은 Author Post가 Home·Profile 목록과 상세에 표시된다
+- **THEN** 각 surface는 같은 More 삭제 eligibility, 확인, mutation identity와 실패 복구 계약을 사용한다
+
+#### Scenario: 다른 Post action이 함께 표시된다
+
+- **WHEN** 삭제 가능한 Post의 Action Bar에 Repost·Reaction·Reply·Bookmark 또는 `링크 복사`도 표시된다
+- **THEN** 삭제 menu의 open·pending·성공·실패 상태는 다른 action의 입력과 상태를 불필요하게 차단하거나 변경하지 않는다

--- a/openspec/changes/add-author-post-deletion/tasks.md
+++ b/openspec/changes/add-author-post-deletion/tasks.md
@@ -1,0 +1,113 @@
+## 1. PROD-598 GraphQL 작성자 삭제 경계
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `PROD-598`
+
+**Deliverable**
+
+GraphQL `deletePost`가 검증된 selected Profile과 concrete Post ID를 기존 Core 삭제 service에 전달하고 삭제된 Post의 global `postId`를 반환한다.
+
+**Guardrails**
+
+- 기존 Core/DB 삭제 lifecycle과 GraphQL schema shape를 재구현하거나 변경하지 않는다.
+- 현재 resolver와 test가 이미 계약을 충족하면 중복 backend source나 test를 추가하지 않고 검증 증거로 완료한다.
+
+**Verification**
+
+- Author 성공, 비Author·guest 거부, Post가 아닌 global ID 거부, target global `postId` payload와 대상 Post 상태를 API integration에서 확인한다.
+- 기존 resolver가 현재 Core service를 한 번 호출하는 경계와 관련 type/schema check를 확인한다.
+
+- [ ] 1.1 현재 GraphQL resolver와 API integration coverage를 계약에 대조하고 누락된 resolver behavior만 최소 구현한다.
+- [ ] 1.2 Author·비Author·guest·잘못된 concrete ID와 global `postId` 결과를 검증하고 backend 경계 증거를 기록한다.
+
+## 2. PROD-598 작성자 More menu와 삭제 확인
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/design/post-action-bar.md`
+- `docs/design/accessibility.md`
+- `PROD-598`
+
+**Deliverable**
+
+작성자는 Home·Profile 목록과 상세의 Action Bar 케밥 More menu에서 자신의 Active contentful Post 삭제를 선택하고 접근 가능한 확인 UI에서 실행 여부를 결정할 수 있다.
+
+**Guardrails**
+
+- guest·다른 Profile·Tombstone·Content 없는 Repost에는 삭제 item을 표시하지 않는다.
+- 순수 Repost surface는 direct Source를 삭제 target으로 사용하고 바깥 Repost 취소는 기존 Repost menu에 남긴다.
+- 링크 복사가 함께 있으면 삭제를 마지막 danger item으로 두며, menu 선택만으로 mutation을 시작하지 않는다.
+- 확인 copy, 초기 취소 focus, pending 중 action·dismiss 차단과 Web·Native modal semantics를 유지한다.
+- More menu의 target·mutation 상태는 private child가 소유하고 Action Bar container는 고정 순서와 control 조립 책임을 유지한다.
+
+**Verification**
+
+- 일반 Post·Reply·Quote·Reply이면서 Quote, guest·다른 Profile, pure Repost Source와 링크 복사 item 순서를 component/Storybook fixture로 확인한다.
+- menu open·dismiss·focus return, 확인 copy·cancel·confirm, Web keyboard/Escape, Native back/backdrop와 pending busy·disabled 상태를 검증한다.
+
+- [ ] 2.1 작성자 eligibility와 direct Source target을 파생하는 private More action을 기존 ActionMenu와 Action Bar에 연결한다.
+- [ ] 2.2 기존 item과 호환되는 destructive menu 표현과 승인된 copy·focus·dismiss·pending semantics의 삭제 확인 UI를 구현한다.
+- [ ] 2.3 작성자별 노출, item 순서, 정확한 target ID, 취소·확인·중복 입력과 Web·Native 접근성 component/Storybook 검증을 추가한다.
+
+## 3. PROD-598 서버 성공 기반 Relay 동기화와 실패 복구
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/design/post-action-bar.md`
+- `docs/design/accessibility.md`
+- `PROD-598`
+
+**Deliverable**
+
+사용자가 확인한 삭제가 서버에서 성공하면 현재 selected Profile의 Home·Profile 목록과 상세가 삭제 결과를 반영하고, 실패·취소에는 기존 Post와 cache를 유지한 채 재시도할 수 있다.
+
+**Guardrails**
+
+- server 성공 전에 target record나 connection을 optimistic 삭제하지 않는다.
+- 성공 payload의 `postId`를 기준으로 요청을 시작한 actor Store만 갱신하고 다른 selected Profile Store는 변경하지 않는다.
+- current surface의 direct Post, reply thread entry와 pure Repost Source representation에 Active content가 남지 않게 한다.
+- 실패에는 dialog를 재시도·취소 가능한 상태로 복구하고 승인된 한국어 문구를 공용 alert toast로 표시한다.
+- Repost 생성·취소와 다른 Post action의 상태·pending·cache 의미를 변경하지 않는다.
+
+**Verification**
+
+- Home·Profile 목록, 상세, reply thread와 pure Repost Source success payload를 각각 Relay environment test로 검증한다.
+- server pending·GraphQL/network failure에는 cache 유지, dialog 복구, alert toast와 같은 ID 재시도를 검증한다.
+- mutation 중 selected Profile 전환 fixture에서 이전 callback이 새 actor Store나 UI state를 바꾸지 않는지 확인한다.
+
+- [ ] 3.1 확인 뒤 정확한 Post ID로 단일 mutation을 실행하고 actor 전환에 안전한 성공·실패 callback 경계를 구현한다.
+- [ ] 3.2 payload `postId` 기반으로 현재 actor Store의 목록·상세·pure Repost representation을 server 확정 상태에 맞추고 성공 UI를 종료한다.
+- [ ] 3.3 실패 cache 유지·dialog 재시도·한국어 alert toast와 Home·Profile·상세·actor 격리 Relay test를 구현한다.
+
+## 4. PROD-598 통합 검증과 완료 증거
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/design/post-action-bar.md`
+- `docs/design/accessibility.md`
+- `PROD-598`
+
+**Deliverable**
+
+PROD-598의 backend resolver 경계와 Web·Android·iOS 공용 삭제 흐름이 repository 검증을 통과하고, 기존 Post action 회귀 없이 독립적으로 review 가능한 완료 증거를 가진다.
+
+**Guardrails**
+
+- PROD-432의 링크 복사·전체 Action Bar 통합, 다른 More 항목, Core/DB/API schema 변경과 Native 출시 gate를 이 change의 완료로 주장하지 않는다.
+- 구현에서 canonical 또는 Linear 계약과 충돌이 발견되면 canonical→Linear→OpenSpec 순서로 다시 정렬한다.
+
+**Verification**
+
+- Relay artifact 생성, app typecheck·lint, 관련 component/Storybook test와 API integration test를 통과시킨다.
+- Web runtime에서 menu·alertdialog·keyboard focus와 목록·상세 결과를 확인한다.
+- Repost 취소 및 인접 Action Bar action 회귀 검증과 `openspec validate add-author-post-deletion --strict`를 통과시킨다.
+- 실행하지 못한 Native 실기기·VoiceOver·TalkBack 검증은 완료 증거와 분리해 기록한다.
+
+- [ ] 4.1 Relay artifact와 관련 API·app component/Storybook·typecheck·lint 검증을 실행하고 발견된 범위 내 결함을 수정한다.
+- [ ] 4.2 Web 목록·상세의 삭제 menu·확인·성공·실패와 기존 Repost/Action Bar 회귀를 통합 검증한다.
+- [ ] 4.3 OpenSpec strict validation, 구현 diff, 미실행 Native runtime과 남은 위험을 handoff에 기록한다.

--- a/openspec/changes/add-author-post-deletion/tasks.md
+++ b/openspec/changes/add-author-post-deletion/tasks.md
@@ -19,8 +19,8 @@ GraphQL `deletePost`가 검증된 selected Profile과 concrete Post ID를 기존
 - Author 성공, 비Author·guest 거부, Post가 아닌 global ID 거부, target global `postId` payload와 대상 Post 상태를 API integration에서 확인한다.
 - 기존 resolver가 현재 Core service를 한 번 호출하는 경계와 관련 type/schema check를 확인한다.
 
-- [ ] 1.1 현재 GraphQL resolver와 API integration coverage를 계약에 대조하고 누락된 resolver behavior만 최소 구현한다.
-- [ ] 1.2 Author·비Author·guest·잘못된 concrete ID와 global `postId` 결과를 검증하고 backend 경계 증거를 기록한다.
+- [x] 1.1 현재 GraphQL resolver와 API integration coverage를 계약에 대조하고 누락된 resolver behavior만 최소 구현한다.
+- [x] 1.2 Author·비Author·guest·잘못된 concrete ID와 global `postId` 결과를 검증하고 backend 경계 증거를 기록한다.
 
 ## 2. PROD-598 작성자 More menu와 삭제 확인
 
@@ -48,8 +48,8 @@ GraphQL `deletePost`가 검증된 selected Profile과 concrete Post ID를 기존
 - 일반 Post·Reply·Quote·Reply이면서 Quote, guest·다른 Profile, pure Repost Source와 링크 복사 item 순서를 component/Storybook fixture로 확인한다.
 - menu open·dismiss·focus return, 확인 copy·cancel·confirm, Web keyboard/Escape, Native back/backdrop와 pending busy·disabled 상태를 검증한다.
 
-- [ ] 2.1 작성자 eligibility와 direct Source target을 파생하는 private More action을 기존 ActionMenu와 Action Bar에 연결한다.
-- [ ] 2.2 기존 item과 호환되는 destructive menu 표현과 승인된 copy·focus·dismiss·pending semantics의 삭제 확인 UI를 구현한다.
+- [x] 2.1 작성자 eligibility와 direct Source target을 파생하는 private More action을 기존 ActionMenu와 Action Bar에 연결한다.
+- [x] 2.2 기존 item과 호환되는 destructive menu 표현과 승인된 copy·focus·dismiss·pending semantics의 삭제 확인 UI를 구현한다.
 - [ ] 2.3 작성자별 노출, item 순서, 정확한 target ID, 취소·확인·중복 입력과 Web·Native 접근성 component/Storybook 검증을 추가한다.
 
 ## 3. PROD-598 서버 성공 기반 Relay 동기화와 실패 복구
@@ -79,8 +79,8 @@ GraphQL `deletePost`가 검증된 selected Profile과 concrete Post ID를 기존
 - server pending·GraphQL/network failure에는 cache 유지, dialog 복구, alert toast와 같은 ID 재시도를 검증한다.
 - mutation 중 selected Profile 전환 fixture에서 이전 callback이 새 actor Store나 UI state를 바꾸지 않는지 확인한다.
 
-- [ ] 3.1 확인 뒤 정확한 Post ID로 단일 mutation을 실행하고 actor 전환에 안전한 성공·실패 callback 경계를 구현한다.
-- [ ] 3.2 payload `postId` 기반으로 현재 actor Store의 목록·상세·pure Repost representation을 server 확정 상태에 맞추고 성공 UI를 종료한다.
+- [x] 3.1 확인 뒤 정확한 Post ID로 단일 mutation을 실행하고 actor 전환에 안전한 성공·실패 callback 경계를 구현한다.
+- [x] 3.2 payload `postId` 기반으로 현재 actor Store의 목록·상세·pure Repost representation을 server 확정 상태에 맞추고 성공 UI를 종료한다.
 - [ ] 3.3 실패 cache 유지·dialog 재시도·한국어 alert toast와 Home·Profile·상세·actor 격리 Relay test를 구현한다.
 
 ## 4. PROD-598 통합 검증과 완료 증거


### PR DESCRIPTION
## 무엇을 변경했는지

- 작성자 전용 More 메뉴에서 게시글 삭제와 접근 가능한 확인 dialog를 제공
- 확인 후 기존 GraphQL `deletePost` mutation을 정확한 Post global ID로 한 번 실행
- 서버 성공 시 현재 actor Store의 Post record를 갱신하고, stale Home·Profile edge와 삭제된 thread node를 렌더 경계에서 제외
- 목록·상세·순수 Repost 인접 흐름에 삭제 action을 연결
- Web에서 초기 취소 focus, Escape·취소·backdrop dismiss와 More trigger focus 복귀를 보장
- Active 작성자 Post만 삭제 메뉴를 노출하고 pending·GraphQL/network 실패 뒤 안전하게 재시도

## 왜 변경했는지

작성자가 자신의 Active Post·Reply·Quote를 Home·Profile 목록과 상세에서 삭제할 진입점이 없었습니다. 기존 Core/GraphQL 삭제 계약을 재사용해 사용자 surface에서 삭제 흐름을 완결합니다.

리뷰에서 Relay `@deleteRecord`만으로는 목록 edge가 남아 재진입 시 null Post를 렌더할 수 있고, Web 확인 dialog가 Escape와 focus 복귀 계약을 충족하지 못하는 문제를 확인해 함께 보완했습니다.

## 이번 PR의 주요 결정

- 최신 canonical 문서·Linear `PROD-598`·OpenSpec의 결정과 구현 범위를 변경 없이 적용했습니다.
- 삭제 target은 Action Bar private child가 소유하고, Relay 성공 payload의 `postId`는 요청 actor Store에만 반영합니다.
- Relay가 삭제 record를 참조하는 edge를 즉시 정리하지 않는 경우를 전역 Store scan 없이 공용 `PostList`와 thread 렌더 경계에서 안전하게 제외합니다.
- Native 실기기 접근성은 별도 출시 gate로 남기고, 현재 PR에서는 공용 Modal 계약과 Web runtime을 검증했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check` ✅
- `pnpm --filter @kosmo/app test:unit` — 124 passed ✅
- `pnpm --filter @kosmo/app test:storybook` — 17 files / 237 tests passed ✅
- `pnpm --filter @kosmo/app build-storybook` ✅
- 변경 파일 ESLint / Prettier / `git diff --check` ✅
- API `post.test.ts` 25개, `post-repost.test.ts` 15개 — Test Gate의 격리 DB 실행 통과 ✅
- `openspec validate add-author-post-deletion --strict` ✅
- correctness 재리뷰 finding 0, ponytail 재리뷰 finding 0 ✅
- 리뷰 대응 후 `pnpm --filter @kosmo/app check` 재통과 ✅
- `pnpm --filter @kosmo/app exec vitest run --project=storybook src/stories/PostActionBar.stories.tsx` — 1 file / 19 tests passed ✅
- 리뷰 대응 변경 파일 ESLint / Prettier / `git diff --check` 재통과 ✅
- GitHub Actions Lint / Test / Semgrep — final head `1db58d61` 통과 ✅

## 아직 어떤 문제가 남았는지

- Native 실기기에서의 Android/iOS back·backdrop, VoiceOver·TalkBack 검증은 실행하지 않았습니다.
- 앱 repair 뒤 API 테스트 재실행은 로컬 Docker daemon이 꺼져 시작하지 못했습니다. Backend/API 파일은 repair에서 변경하지 않았으며, 위 격리 DB Test Gate 결과를 유지합니다.
- Storybook 테스트 출력의 Relay mock/경계 fixture console warning은 기존 fixture가 의도적으로 발생시키며 테스트는 통과했습니다.
- OpenSpec change archive는 PR Ready와 별개이며 전체 change 완료·통합 검증 책임에 따라 후속 판단합니다.

Stack: main -> PROD-598