### PR TITLE
Mastodon Follow 승인 응답이 pending 관계를 승격하게 한다

### DIFF
--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -25,6 +25,7 @@ import { handleInboundReject } from './inbound-reject';
 import { ensureDrizzleLocalProfileActor } from './local-actor-store';
 import { authorizeLocalPostNote, dispatchLocalPostNote } from './local-post-note';
 import { isCanonicalLocalProfileId } from './local-profile-actor';
+import { dispatchLocalProfileFollow } from './local-profile-follow';
 import { createLocalProfilePerson } from './local-profile-person';
 import { resolveLocalActorIdentifierByHandle } from './webfinger';
 import type { Context, Federation } from '@fedify/fedify';
@@ -134,6 +135,8 @@ federation
 federation
   .setObjectDispatcher(Note, '/ap/note/{id}', dispatchLocalPostNote)
   .authorize(authorizeLocalPostNote);
+
+federation.setObjectDispatcher(Follow, '/ap/follow/{id}', dispatchLocalProfileFollow);
 
 federation
   .setInboxListeners('/ap/actor/{identifier}/inbox', '/inbox')

--- a/packages/fedify/src/fixtures/mastodon-4.1.18-accept-follow.json
+++ b/packages/fedify/src/fixtures/mastodon-4.1.18-accept-follow.json
@@ -1,0 +1,12 @@
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "id": "https://remote.example/activities/accept-mastodon-4.1.18",
+  "type": "Accept",
+  "actor": "https://remote.example/users/alice",
+  "object": {
+    "id": "http://127.0.0.1:4173/ap/follow/019f73b1-2222-7777-8888-123456789abc",
+    "type": "Follow",
+    "actor": "http://127.0.0.1:4173/ap/actor/019f73b1-1111-7777-8888-123456789abc",
+    "object": "https://remote.example/users/alice"
+  }
+}

--- a/packages/fedify/src/inbound-accept-reject.test.ts
+++ b/packages/fedify/src/inbound-accept-reject.test.ts
@@ -1,6 +1,7 @@
 import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { after, before, beforeEach, describe, test } from 'node:test';
 import { Accept, Follow, Note, Reject } from '@fedify/vocab';
 import {
@@ -13,12 +14,14 @@ import { eq, ne } from 'drizzle-orm';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
+import type { federation as productionFederation } from './federation';
 import type * as InboundAccept from './inbound-accept';
 import type * as InboundReject from './inbound-reject';
 
 const publicOrigin = 'http://127.0.0.1:4173';
 const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
 const localProfileId = '019f73b1-1111-7777-8888-123456789abc';
+const mastodonFixtureProjectionId = '019f73b1-2222-7777-8888-123456789abc';
 const localActorUri = new URL(`/ap/actor/${localProfileId}`, publicOrigin);
 const remoteActorUri = new URL('https://remote.example/users/alice');
 
@@ -33,6 +36,7 @@ let Profiles: typeof CoreDb.Profiles;
 let handleInboundAccept: typeof InboundAccept.handleInboundAccept;
 let handleInboundReject: typeof InboundReject.handleInboundReject;
 let localInstanceId: string;
+let federation: typeof productionFederation;
 
 describe('inbound Accept and Reject', () => {
   before(async () => {
@@ -51,6 +55,7 @@ describe('inbound Accept and Reject', () => {
     const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
     ({ handleInboundAccept } = await import('./inbound-accept'));
     ({ handleInboundReject } = await import('./inbound-reject'));
+    ({ federation } = await import('./federation'));
     const { localInstance } = await seedDatabase({ publicOrigin });
     localInstanceId = localInstance.id;
   });
@@ -62,6 +67,129 @@ describe('inbound Accept and Reject', () => {
 
   after(async () => {
     await pg.end();
+  });
+
+  test('routes a Mastodon 4.1.18 Accept through the production Follow document boundary', async () => {
+    const fixture = await createFixture({
+      projection: 'PENDING',
+      projectionId: mastodonFixtureProjectionId,
+    });
+    const acceptJson = JSON.parse(
+      await readFile(
+        new URL('./fixtures/mastodon-4.1.18-accept-follow.json', import.meta.url),
+        'utf8',
+      ),
+    );
+    const accept = await Accept.fromJsonLd(acceptJson);
+    const loadedUrls: string[] = [];
+    const documentLoader: DocumentLoader = async (url) => {
+      loadedUrls.push(url);
+      const response = await federation.fetch(
+        new Request(url, { headers: { Accept: 'application/activity+json' } }),
+        { contextData: undefined },
+      );
+      if (!response.ok) {
+        throw new Error(`Follow document returned ${response.status}: ${url}`);
+      }
+
+      return {
+        contextUrl: null,
+        document: await response.json(),
+        documentUrl: url,
+      };
+    };
+
+    const followResponse = await federation.fetch(
+      new Request(`${publicOrigin}/ap/follow/${fixture.projection.id}`, {
+        headers: { Accept: 'application/activity+json' },
+      }),
+      { contextData: undefined },
+    );
+    assert.equal(followResponse.status, 200, await followResponse.text());
+
+    await handleInboundAccept(createContext(localProfileId, documentLoader), accept);
+    await handleInboundAccept(createContext(localProfileId, documentLoader), accept);
+
+    assert.deepEqual(loadedUrls, [`${publicOrigin}/ap/follow/${fixture.projection.id}`]);
+    assert.equal((await db.select().from(ProfileFollowRequests)).length, 0);
+    assert.equal((await db.select().from(ProfileFollows)).length, 1);
+    assert.deepEqual(await readCounts(fixture), { localFollowing: 1, remoteFollowers: 1 });
+
+    const established = await db.select().from(ProfileFollows).then(firstOrThrow);
+    const establishedFollowResponse = await federation.fetch(
+      new Request(`${publicOrigin}/ap/follow/${established.id}`, {
+        headers: { Accept: 'application/activity+json' },
+      }),
+      { contextData: undefined },
+    );
+    assert.equal(establishedFollowResponse.status, 200);
+    const consumedRequestResponse = await federation.fetch(
+      new Request(`${publicOrigin}/ap/follow/${fixture.projection.id}`, {
+        headers: { Accept: 'application/activity+json' },
+      }),
+      { contextData: undefined },
+    );
+    assert.equal(consumedRequestResponse.status, 404);
+    const unknownResponse = await federation.fetch(
+      new Request(`${publicOrigin}/ap/follow/${crypto.randomUUID()}`, {
+        headers: { Accept: 'application/activity+json' },
+      }),
+      { contextData: undefined },
+    );
+    assert.equal(unknownResponse.status, 404);
+  });
+
+  test('serves only the current available local-to-remote Follow projection', async () => {
+    const fixture = await createFixture({ projection: 'PENDING' });
+    const fetchFollow = (id: string) =>
+      federation.fetch(
+        new Request(`${publicOrigin}/ap/follow/${id}`, {
+          headers: { Accept: 'application/activity+json' },
+        }),
+        { contextData: undefined },
+      );
+
+    assert.equal((await fetchFollow(fixture.projection.id.toUpperCase())).status, 404);
+
+    await db
+      .update(Instances)
+      .set({ state: InstanceState.UNRESPONSIVE })
+      .where(eq(Instances.id, fixture.remoteInstance.id));
+    assert.equal((await fetchFollow(fixture.projection.id)).status, 404);
+    await db
+      .update(Instances)
+      .set({ state: InstanceState.SUSPENDED })
+      .where(eq(Instances.id, fixture.remoteInstance.id));
+    assert.equal((await fetchFollow(fixture.projection.id)).status, 404);
+
+    await db
+      .update(Instances)
+      .set({ state: InstanceState.ACTIVE })
+      .where(eq(Instances.id, fixture.remoteInstance.id));
+    await db
+      .delete(ProfileFollowRequests)
+      .where(eq(ProfileFollowRequests.id, fixture.projection.id));
+    const replacement = await db
+      .insert(ProfileFollowRequests)
+      .values({
+        followeeProfileId: fixture.remoteProfile.id,
+        followerProfileId: fixture.localProfile.id,
+      })
+      .returning()
+      .then(firstOrThrow);
+    assert.equal((await fetchFollow(fixture.projection.id)).status, 404);
+    assert.equal((await fetchFollow(replacement.id)).status, 200);
+
+    await db.delete(ProfileFollowRequests);
+    const reversed = await db
+      .insert(ProfileFollowRequests)
+      .values({
+        followeeProfileId: fixture.localProfile.id,
+        followerProfileId: fixture.remoteProfile.id,
+      })
+      .returning()
+      .then(firstOrThrow);
+    assert.equal((await fetchFollow(reversed.id)).status, 404);
   });
 
   test('promotes an exact pending request once from embedded Accept', async () => {
@@ -235,13 +363,26 @@ describe('inbound Accept and Reject', () => {
     const fixture = await createFixture({ projection: 'PENDING' });
     const object = new URL(`/ap/follow/${fixture.projection.id}`, publicOrigin);
     const context = createContext(localProfileId);
-
-    await handleInboundAccept(context, new Accept({ actor: remoteActorUri, object }));
-    await handleInboundReject(context, new Reject({ actor: remoteActorUri, object }));
+    const errors: unknown[][] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args) => errors.push(args);
+    try {
+      await handleInboundAccept(context, new Accept({ actor: remoteActorUri, object }));
+      await handleInboundReject(context, new Reject({ actor: remoteActorUri, object }));
+    } finally {
+      console.error = originalConsoleError;
+    }
 
     assert.deepEqual(await db.select().from(ProfileFollowRequests), [fixture.projection]);
     assert.equal((await db.select().from(ProfileFollows)).length, 0);
     assert.deepEqual(await readCounts(fixture), { localFollowing: 0, remoteFollowers: 0 });
+    assert.deepEqual(
+      errors.map(([message]) => message),
+      [
+        'Inbound ActivityPub Accept object could not be resolved as Follow',
+        'Inbound ActivityPub Reject object could not be resolved as Follow',
+      ],
+    );
   });
 
   test('keeps an exact established relation idempotently on Accept', async () => {
@@ -422,9 +563,11 @@ describe('inbound Accept and Reject', () => {
 
 const createFixture = async ({
   projection,
+  projectionId,
   remoteInstanceState = InstanceState.ACTIVE,
 }: {
   projection: 'ESTABLISHED' | 'PENDING';
+  projectionId?: string;
   remoteInstanceState?: InstanceState;
 }) => {
   const remoteInstance = await db
@@ -480,6 +623,7 @@ const createFixture = async ({
           .values({
             followeeProfileId: remoteProfile.id,
             followerProfileId: localProfile.id,
+            ...(projectionId ? { id: projectionId } : {}),
           })
           .returning()
           .then(firstOrThrow)
@@ -488,6 +632,7 @@ const createFixture = async ({
           .values({
             followeeProfileId: remoteProfile.id,
             followerProfileId: localProfile.id,
+            ...(projectionId ? { id: projectionId } : {}),
           })
           .returning()
           .then(firstOrThrow);

--- a/packages/fedify/src/inbound-accept.ts
+++ b/packages/fedify/src/inbound-accept.ts
@@ -39,5 +39,11 @@ export const handleInboundAccept = async (
       followeeActorUri: actorUri,
       followeeProfileId: remoteActor.profile.id,
     });
+  } else {
+    console.error('Inbound ActivityPub Accept object could not be resolved as Follow', {
+      acceptId: accept.id?.href,
+      actorUri: actorUri.href,
+      objectUri: accept.objectId?.href,
+    });
   }
 };

--- a/packages/fedify/src/inbound-reject.ts
+++ b/packages/fedify/src/inbound-reject.ts
@@ -41,5 +41,11 @@ export const handleInboundReject = async (
       followeeActorUri: actorUri,
       followeeProfileId: remoteActor.profile.id,
     });
+  } else {
+    console.error('Inbound ActivityPub Reject object could not be resolved as Follow', {
+      actorUri: actorUri.href,
+      objectUri: reject.objectId?.href,
+      rejectId: reject.id?.href,
+    });
   }
 };

--- a/packages/fedify/src/local-profile-follow.ts
+++ b/packages/fedify/src/local-profile-follow.ts
@@ -1,0 +1,117 @@
+import { Follow } from '@fedify/vocab';
+import {
+  ActivityPubActors,
+  db,
+  first,
+  Instances,
+  ProfileFollowRequests,
+  ProfileFollows,
+  Profiles,
+} from '@kosmo/core/db';
+import { InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
+import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
+import { and, eq } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { z } from 'zod';
+import { isHttpUri } from './activitypub-uri';
+import { getFollowActivityUri } from './follow-delivery';
+import type { RequestContext } from '@fedify/fedify';
+
+const FollowerProfiles = alias(Profiles, 'outbound_follow_follower_profile');
+const FollowerInstances = alias(Instances, 'outbound_follow_follower_instance');
+const FollowerActors = alias(ActivityPubActors, 'outbound_follow_follower_actor');
+const FolloweeProfiles = alias(Profiles, 'outbound_follow_followee_profile');
+const FolloweeInstances = alias(Instances, 'outbound_follow_followee_instance');
+const FolloweeActors = alias(ActivityPubActors, 'outbound_follow_followee_actor');
+
+const followIdSchema = z.uuid().refine((value) => value === value.toLowerCase());
+
+type FollowProjectionTable = typeof ProfileFollowRequests | typeof ProfileFollows;
+
+const loadOutboundFollow = async (
+  context: RequestContext<void>,
+  table: FollowProjectionTable,
+  id: string,
+) =>
+  db
+    .select({
+      createdAt: table.createdAt,
+      followeeActorUri: FolloweeActors.uri,
+      followerActorUri: FollowerActors.uri,
+      followerProfileId: FollowerProfiles.id,
+      id: table.id,
+    })
+    .from(table)
+    .innerJoin(FollowerProfiles, eq(FollowerProfiles.id, table.followerProfileId))
+    .innerJoin(FollowerInstances, eq(FollowerInstances.id, FollowerProfiles.instanceId))
+    .innerJoin(FollowerActors, eq(FollowerActors.profileId, FollowerProfiles.id))
+    .innerJoin(FolloweeProfiles, eq(FolloweeProfiles.id, table.followeeProfileId))
+    .innerJoin(FolloweeInstances, eq(FolloweeInstances.id, FolloweeProfiles.instanceId))
+    .innerJoin(FolloweeActors, eq(FolloweeActors.profileId, FolloweeProfiles.id))
+    .where(
+      and(
+        eq(table.id, id),
+        eq(FollowerProfiles.state, ProfileState.ACTIVE),
+        eq(FollowerInstances.kind, InstanceKind.LOCAL),
+        eq(FollowerInstances.state, InstanceState.ACTIVE),
+        eq(FollowerInstances.canonicalOrigin, context.canonicalOrigin),
+        eq(FolloweeProfiles.state, ProfileState.ACTIVE),
+        eq(FolloweeInstances.kind, InstanceKind.ACTIVITYPUB),
+        eq(FolloweeInstances.state, InstanceState.ACTIVE),
+      ),
+    )
+    .limit(1)
+    .then(first);
+
+export const dispatchLocalProfileFollow = async (
+  context: RequestContext<void>,
+  { id }: { id: string },
+): Promise<Follow | null> => {
+  if (
+    context.host !== new URL(context.canonicalOrigin).host ||
+    !followIdSchema.safeParse(id).success
+  ) {
+    return null;
+  }
+
+  const localInstance = await resolveConfiguredLocalInstance();
+  if (
+    localInstance.canonicalOrigin !== context.canonicalOrigin ||
+    localInstance.state !== InstanceState.ACTIVE
+  ) {
+    return null;
+  }
+
+  const [established, pending] = await Promise.all([
+    loadOutboundFollow(context, ProfileFollows, id),
+    loadOutboundFollow(context, ProfileFollowRequests, id),
+  ]);
+  if ((established == null) === (pending == null)) {
+    return null;
+  }
+  const projection = established ?? pending!;
+
+  let followerActorUri: URL;
+  let followeeActorUri: URL;
+  try {
+    followerActorUri = new URL(projection.followerActorUri);
+    followeeActorUri = new URL(projection.followeeActorUri);
+  } catch {
+    return null;
+  }
+  if (
+    !isHttpUri(followerActorUri) ||
+    !isHttpUri(followeeActorUri) ||
+    followerActorUri.href !== context.getActorUri(projection.followerProfileId).href
+  ) {
+    return null;
+  }
+
+  return new Follow({
+    actor: followerActorUri,
+    id: getFollowActivityUri(context.canonicalOrigin, projection.id),
+    object: followeeActorUri,
+    published: projection.createdAt,
+    tos: [followeeActorUri],
+  });
+};


### PR DESCRIPTION
## 무엇을 변경했는지

- `/ap/follow/{id}` Fedify object dispatcher를 추가해 현재 `ProfileFollowRequest` 또는 `ProfileFollow`에서 canonical outbound `Follow`를 복원합니다.
- canonical origin/UUID, local follower와 remote followee 방향, actor URI binding, 활성 profile/instance를 검증하고 unavailable projection은 404로 유지합니다.
- Accept/Reject object가 typed `Follow`로 해석되지 않으면 activity/object 식별자를 오류 로그로 남깁니다.
- Mastodon 4.1.18 serializer 형식 fixture가 production federation router/document-loader를 거쳐 pending request를 한 번만 established relation으로 승격하는 회귀 테스트를 추가했습니다.

## 왜 변경했는지

Mastodon은 승인 응답에 원래 outbound Follow를 embedded object로 포함하고 Kosmo Follow ID를 보존합니다. Fedify는 cross-origin object의 authoritative 문서를 다시 조회하지만, 기존 production federation에는 Follow object dispatcher가 없어 `/ap/follow/{ProfileFollowRequest.id}`가 404를 반환했습니다. 그 결과 remote에서는 승인이 완료돼도 Kosmo에는 pending request가 남았습니다.

Linear: [PROD-608](https://linear.app/byulmaru/issue/PROD-608/mastodon-acceptfollow가-outbound-follow-역참조-404로-pending을-승격하지-못한다)

## 이번 PR의 주요 결정

없음. 최신 Linear와 `activitypub-remote-follow` OpenSpec을 대조한 결과, 새 제품 결정 없이 기존 typed Follow, exact generation, actor/object/recipient, exact-row 및 멱등 계약을 production object 경계에 적용했습니다. 별도 OpenSpec change는 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm test:fedify` — 168 passed
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `pnpm lint:syncpack`
- `pnpm exec openspec validate --all --strict --no-interactive` — 58 passed
- `git diff --check`

## 아직 남은 문제

- 기존에 stuck 상태인 pending request의 일괄 복구는 이 PR에 포함하지 않습니다.
- remote actor `Update(Person)` 기반 followPolicy 갱신은 PROD-607 범위입니다.

Stack: main -> PROD-608