### PR TITLE
ActivityPub actor Update로 원격 팔로우 정책을 갱신한다

### DIFF
--- a/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/decisions.md
+++ b/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/decisions.md
@@ -1,0 +1,46 @@
+## Context
+
+PROD-607과 canonical Profile/Follow 계약에 따라 inbound actor Update가 저장 remote profile 정책을 즉시
+갱신하는 범위를 기록한다. 제안과 delta spec의 행동 계약 및 design의 기존 materialization 재사용 접근을
+반영한다.
+
+## Decision Records
+
+### Update는 저장된 동일 remote actor만 갱신한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`,
+  `docs/domain/objects/follow-relationship.md`, `docs/domain/objects/follow-request.md`, `PROD-607`
+- Status: Active
+- Context / Problem: actor Update를 remote actor discovery로도 사용하면 검증된 handle lookup 없이 profile을
+  만들거나 기존 identity를 재연결할 수 있다.
+- Decision Outcome: Update actor, embedded actor object와 저장된 ActivityPub actor identity가 모두 같을 때만
+  기존 remote profile을 갱신하고, 저장 actor가 없으면 무시한다.
+- Alternatives Considered: Update만으로 새 actor materialization, object URL을 추가 fetch해 actor를 생성.
+- Consequences: unknown actor Update는 저장 상태를 만들지 않으며, actor discovery는 기존 WebFinger 기반
+  materialization이 계속 소유한다.
+- Confirmation / Follow-up: mismatch, unsupported object, local collision과 unknown actor 테스트로 확인한다.
+
+### 검증된 embedded actor를 기존 materialization refresh 경계에 적용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/profile.md`, `PROD-607`
+- Status: Active
+- Context / Problem: Update 전용 profile projection과 endpoint 저장 로직을 별도로 구현하면 handle, timestamp,
+  collision 및 transaction 규칙이 기존 materialization과 갈라질 수 있다.
+- Decision Outcome: embedded actor는 네트워크 lookup 없이 검증하고, 검증이 끝난 actor를 기존
+  materialization의 기존-actor refresh 경계에 전달해 TTL을 우회한다.
+- Alternatives Considered: Update handler에 별도 update query 구현, materialization transaction의 공용 helper
+  추출. 공용 helper 추출도 같은 규칙을 공유한다면 허용되지만 현재 범위에는 호출 경계 재사용이 더 작다.
+- Consequences: projection, endpoint, `lastFetchedAt`, stale ordering과 충돌 처리가 하나의 구현 경계를 유지한다.
+- Confirmation / Follow-up: 양방향 follow policy, endpoint, timestamp와 중복 Update 테스트로 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/design.md
+++ b/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/design.md
@@ -1,0 +1,71 @@
+## Context
+
+현재 `packages/fedify`는 remote actor를 WebFinger/Fedify lookup으로 materialize하고, 같은 actor URI가 이미
+저장돼 있으면 profile projection과 endpoint metadata를 갱신한다. 그러나 inbox listener는 `Update`를 등록하지
+않으므로 actor가 정책을 바꿔도 7일 stale refresh 전까지 저장값이 바뀌지 않는다.
+
+canonical Profile 계약과 PROD-607은 inbound Update가 새 actor discovery 수단이 아니라 이미 저장된 remote actor의
+즉시 refresh 신호가 되도록 제한한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- embedded actor Update의 actor/object/storage identity를 검증한다.
+- 검증 뒤 기존 materialization의 projection, endpoint metadata와 ordering 경계를 재사용한다.
+- Follow policy 양방향 전이와 기존 Follow/Accept 상태 머신의 연결을 검증한다.
+
+**Non-Goals:**
+
+- Update만으로 미등록 actor를 새로 materialize하지 않는다.
+- established relation 복구·역전, Note Update/Delete, local outbound actor Update는 다루지 않는다.
+- DB나 GraphQL schema를 바꾸지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- remote actor materialization은 handle lookup, identity 충돌 검증, profile/metadata transaction을 하나의 공개
+  함수에 묶고 있다.
+- inbox Update의 embedded object를 일반 document loader로 해석하면 검증 전에 추가 네트워크 lookup이 일어나거나
+  activity object URI와 다른 객체를 가져올 수 있다.
+- Follow mutation과 Accept handler는 저장된 `followPolicy` 및 기존 request/relation 서비스를 이미 권위로
+  사용하므로 별도 상태 머신을 추가하면 중복 계약이 된다.
+
+### Recommended Approach
+
+Update handler는 단일 HTTP(S) actor identity와 embedded actor object를 네트워크 lookup 없이 읽고, actor URI와
+object URI 및 embedded object ID가 모두 같은지 확인한다. 저장된 ActivityPub remote actor가 있을 때만 그
+profile의 기존 handle을 입력으로 materialization refresh 경계를 직접 호출하되 lookup 결과는 검증된 embedded
+actor로 고정한다. 이렇게 하면 TTL을 우회하면서 projection, endpoint, lastFetchedAt, identity collision과
+transaction ordering을 중복 구현하지 않는다.
+
+listener에 actor `Update`를 등록하고 handler 단위 테스트로 거부/멱등/양방향 projection을 검증한다. 기존 remote
+Follow 및 Accept 통합 테스트가 최신 저장 policy를 소비하는 경계를 회귀 검증한다.
+
+### Allowed Alternatives
+
+materialization의 기존-actor update transaction을 별도 공용 함수로 추출해 handler에서 호출해도 된다. 다만
+handle lookup 경로와 Update 경로가 projection, endpoint 및 timestamp 규칙을 공유해야 한다.
+
+### Known Traps
+
+- actor/object ID 중 하나만 검사하거나 `getObject()`가 원격 문서를 가져오도록 두지 않는다.
+- Update를 미등록 actor materialization 또는 handle 재연결 근거로 사용하지 않는다.
+- policy 변경 시 기존 relation/request/count를 직접 수정하지 않는다.
+
+## Risks / Trade-offs
+
+- [embedded actor를 요구하면 object URL만 가진 Update를 무시할 수 있음] → PROD-607의 검증 가능한 identity와
+  네트워크 비의존 경계를 우선하고, 별도 fetch 계약이 필요하면 후속 이슈에서 정의한다.
+- [기존 materialization 재호출이 instance 상태도 갱신할 수 있음] → 저장 actor와 canonical identity를 먼저
+  검증하고 기존 remote refresh 규칙만 적용한다.
+
+## Migration Plan
+
+schema migration 없이 listener와 handler를 배포한다. rollback은 listener 등록을 제거하면 되며 기존 저장
+profile과 관계 데이터는 그대로 유지된다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/proposal.md
+++ b/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+원격 ActivityPub actor가 팔로워 승인 정책을 바꿔도 Kosmo는 7일 refresh TTL 동안 저장된
+`Profile.followPolicy`를 유지한다. 그 결과 최신 정책이 `APPROVAL_REQUIRED`인데도 신규 Follow가 즉시 성립할 수
+있으므로, 검증된 inbound `Update(Actor)`를 remote profile refresh 신호로 처리해야 한다.
+
+## What Changes
+
+- `Update(Person/Application/Group/Organization/Service)` inbox activity를 검증해 저장된 동일 remote actor
+  profile을 즉시 refresh한다.
+- Update actor, embedded object와 저장된 ActivityPub actor identity가 모두 일치할 때만 기존 actor
+  materialization의 profile projection과 endpoint metadata 갱신을 재사용한다.
+- `manuallyApprovesFollowers`를 `OPEN`과 `APPROVAL_REQUIRED` 양방향으로 반영한다.
+- unsupported object, identity mismatch, local actor 충돌은 저장 상태를 변경하지 않고, 중복 Update는 멱등
+  처리한다.
+- policy 변경 전 이미 성립한 관계는 유지하며, 변경 뒤 신규 Follow와 후속 `Accept(Follow)`가 최신 정책을
+  따르는지 검증한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/profile.md`, `docs/domain/objects/follow-relationship.md`,
+  `docs/domain/objects/follow-request.md`
+- Linear Contract: `PROD-607`
+- Linear Implementations: `PROD-607`
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `activitypub-remote-profile-federation`: 검증된 inbound actor Update가 TTL과 무관하게 기존 remote profile
+  projection과 actor endpoint metadata를 갱신하는 계약을 추가한다.
+
+## Impact
+
+- `packages/fedify` inbox listener와 remote actor materialization 경계
+- remote actor Update, Follow, Accept 통합 테스트
+- 기존 DB schema와 GraphQL schema에는 변경이 없다.

--- a/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/specs/activitypub-remote-profile-federation/spec.md
+++ b/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/specs/activitypub-remote-profile-federation/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Refresh stored remote actor from inbound Update
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/objects/follow-relationship.md`, `docs/domain/objects/follow-request.md`, `PROD-607` 시스템은 검증된 remote ActivityPub actor `Update`를 수신하면 refresh TTL과 무관하게 동일한 저장 remote `Profile`의 원격 표현 속성, Follow Approval Policy와 actor endpoint metadata를 즉시 갱신해야 한다(MUST).
+
+#### Scenario: Refresh the matching stored remote actor
+
+- **WHEN** remote `Person`, `Application`, `Group`, `Organization` 또는 `Service` actor가 자기 identity와 같은
+  embedded actor object를 포함한 `Update`를 보내고 그 identity에 연결된 remote profile이 저장되어 있다
+- **THEN** 시스템은 기존 actor materialization과 같은 projection으로 그 profile과 actor endpoint metadata를
+  갱신한다
+- **AND** `manuallyApprovesFollowers=true`이면 `followPolicy=APPROVAL_REQUIRED`, 아니면
+  `followPolicy=OPEN`으로 양방향 반영한다
+- **AND** actor metadata의 `lastFetchedAt`을 Update 처리 시각으로 갱신한다
+
+#### Scenario: Reject mismatched or unsupported Update
+
+- **WHEN** Update actor와 embedded object identity가 다르거나 embedded object가 지원 actor type이 아니다
+- **THEN** 시스템은 어떤 저장 profile이나 ActivityPub actor metadata도 변경하지 않는다
+
+#### Scenario: Reject local actor collision
+
+- **WHEN** Update identity가 configured local actor 또는 local profile actor metadata와 충돌한다
+- **THEN** 시스템은 local profile을 remote profile로 갱신하지 않고 저장 상태를 변경하지 않는다
+
+#### Scenario: Ignore unknown remote actor
+
+- **WHEN** 검증된 Update identity에 연결된 저장 remote profile이 없다
+- **THEN** 시스템은 Update만으로 새 remote profile을 materialize하지 않는다
+
+#### Scenario: Process duplicate Update idempotently
+
+- **WHEN** 같은 actor Update를 둘 이상 수신한다
+- **THEN** 시스템은 같은 remote profile과 actor metadata를 동일한 최신 projection으로 유지한다
+- **AND** 중복 profile, follow request 또는 follow relationship을 만들지 않는다
+
+#### Scenario: Preserve established relationship across policy refresh
+
+- **WHEN** remote profile에 이미 established follow relationship이 있고 actor Update로 follow policy가 바뀐다
+- **THEN** 시스템은 기존 relationship과 저장 count를 유지한다
+
+#### Scenario: Apply refreshed approval-required policy to a new Follow
+
+- **WHEN** actor Update가 remote profile policy를 `APPROVAL_REQUIRED`로 갱신한 뒤 active local profile이 신규
+  Follow를 요청한다
+- **THEN** 시스템은 established relationship과 count 증가 없이 pending follow request를 만든다
+- **AND** GraphQL과 FollowButton은 pending 상태를 표시한다
+- **AND** 후속 `Accept(Follow)`를 받으면 request를 제거하고 relationship과 count를 한 번 생성해 established
+  상태를 표시한다
+
+#### Scenario: Apply refreshed open policy to a new Follow
+
+- **WHEN** actor Update가 remote profile policy를 `OPEN`으로 갱신한 뒤 active local profile이 신규 Follow를
+  요청한다
+- **THEN** 시스템은 pending request 없이 relationship과 count를 한 번 생성한다
+- **AND** GraphQL과 FollowButton은 established 상태를 표시한다

--- a/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/tasks.md
+++ b/openspec/changes/archive/2026-07-31-refresh-remote-profile-from-activitypub-update/tasks.md
@@ -1,0 +1,77 @@
+## 1. PROD-607 Remote actor Update 처리
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `PROD-607`
+
+**Deliverable**
+
+검증된 inbound actor Update가 저장된 동일 remote profile의 projection, follow policy와 endpoint metadata를
+TTL과 무관하게 즉시 갱신한다.
+
+**Guardrails**
+
+- Update actor, embedded object와 저장 actor identity가 모두 일치해야 한다.
+- unsupported object, unknown actor와 local actor 충돌은 저장 상태를 변경하지 않는다.
+- Update만으로 새 remote profile을 만들거나 기존 identity를 재연결하지 않는다.
+
+**Verification**
+
+- actor type, identity mismatch, unsupported/unknown/local actor, 양방향 policy, endpoint, timestamp와 중복
+  Update handler 테스트를 통과시킨다.
+
+- [x] 1.1 검증된 embedded actor Update를 저장 remote profile refresh 경계에 연결한다.
+- [x] 1.2 inbox listener에 actor Update 처리를 등록한다.
+- [x] 1.3 성공, 거부, 양방향 projection과 멱등성 handler 테스트를 추가한다.
+
+## 2. PROD-607 Follow lifecycle 회귀 검증
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/domain/objects/follow-relationship.md`
+- `docs/domain/objects/follow-request.md`
+- `PROD-607`
+
+**Deliverable**
+
+policy refresh 전의 established 관계는 유지되고, refresh 뒤 신규 Follow와 후속 Accept가 최신 policy에 맞는
+pending/established DB, GraphQL, count와 FollowButton 상태를 만든다.
+
+**Guardrails**
+
+- policy 변경만으로 기존 relation이나 pending request를 변경하지 않는다.
+- count는 established relationship 전이에만 한 번 반영한다.
+
+**Verification**
+
+- 기존 core/API/web Follow 상태 머신 테스트와 Update 뒤 Follow/Accept 연결 테스트를 통과시킨다.
+
+- [x] 2.1 policy refresh가 기존 relation과 count를 유지하고 신규 Follow 결과를 바꾸는지 검증한다.
+- [x] 2.2 approval-required Update 뒤 pending request와 후속 Accept 승격을 검증한다.
+- [x] 2.3 관련 core, API와 FollowButton 회귀 테스트를 실행한다.
+
+## 3. PROD-607 계약 및 완료 검증
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/domain/objects/follow-relationship.md`
+- `docs/domain/objects/follow-request.md`
+- `PROD-607`
+
+**Deliverable**
+
+구현, 테스트와 OpenSpec delta가 같은 PROD-607 계약을 표현하고 strict validation을 통과한다.
+
+**Guardrails**
+
+- Note lifecycle, outbound local actor Update와 기존 잘못된 relation 일괄 복구를 포함하지 않는다.
+
+**Verification**
+
+- 대상 package test, typecheck/lint 및 `openspec validate --strict`를 통과시킨다.
+
+- [x] 3.1 관련 package test와 정적 검사를 통과시킨다.
+- [x] 3.2 OpenSpec strict validation과 diff 검사를 통과시킨다.

--- a/openspec/specs/activitypub-remote-profile-federation/spec.md
+++ b/openspec/specs/activitypub-remote-profile-federation/spec.md
@@ -198,3 +198,59 @@ kosmo가 Fedify로 조회한 저장된 remote ActivityPub actor를 기존 `Profi
 - **WHEN** remote actor가 속한 instance 상태가 `SUSPENDED`이다
 - **THEN** 시스템은 actor refresh와 remote actor materialization을 시도하지 않는다
 - **AND** 시스템은 해당 instance의 remote profile을 GraphQL object로 노출하지 않는다
+
+### Requirement: Refresh stored remote actor from inbound Update
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/objects/follow-relationship.md`, `docs/domain/objects/follow-request.md`, `PROD-607` 시스템은 검증된 remote ActivityPub actor `Update`를 수신하면 refresh TTL과 무관하게 동일한 저장 remote `Profile`의 원격 표현 속성, Follow Approval Policy와 actor endpoint metadata를 즉시 갱신해야 한다(MUST).
+
+#### Scenario: Refresh the matching stored remote actor
+
+- **WHEN** remote `Person`, `Application`, `Group`, `Organization` 또는 `Service` actor가 자기 identity와 같은
+  embedded actor object를 포함한 `Update`를 보내고 그 identity에 연결된 remote profile이 저장되어 있다
+- **THEN** 시스템은 기존 actor materialization과 같은 projection으로 그 profile과 actor endpoint metadata를
+  갱신한다
+- **AND** `manuallyApprovesFollowers=true`이면 `followPolicy=APPROVAL_REQUIRED`, 아니면
+  `followPolicy=OPEN`으로 양방향 반영한다
+- **AND** actor metadata의 `lastFetchedAt`을 Update 처리 시각으로 갱신한다
+
+#### Scenario: Reject mismatched or unsupported Update
+
+- **WHEN** Update actor와 embedded object identity가 다르거나 embedded object가 지원 actor type이 아니다
+- **THEN** 시스템은 어떤 저장 profile이나 ActivityPub actor metadata도 변경하지 않는다
+
+#### Scenario: Reject local actor collision
+
+- **WHEN** Update identity가 configured local actor 또는 local profile actor metadata와 충돌한다
+- **THEN** 시스템은 local profile을 remote profile로 갱신하지 않고 저장 상태를 변경하지 않는다
+
+#### Scenario: Ignore unknown remote actor
+
+- **WHEN** 검증된 Update identity에 연결된 저장 remote profile이 없다
+- **THEN** 시스템은 Update만으로 새 remote profile을 materialize하지 않는다
+
+#### Scenario: Process duplicate Update idempotently
+
+- **WHEN** 같은 actor Update를 둘 이상 수신한다
+- **THEN** 시스템은 같은 remote profile과 actor metadata를 동일한 최신 projection으로 유지한다
+- **AND** 중복 profile, follow request 또는 follow relationship을 만들지 않는다
+
+#### Scenario: Preserve established relationship across policy refresh
+
+- **WHEN** remote profile에 이미 established follow relationship이 있고 actor Update로 follow policy가 바뀐다
+- **THEN** 시스템은 기존 relationship과 저장 count를 유지한다
+
+#### Scenario: Apply refreshed approval-required policy to a new Follow
+
+- **WHEN** actor Update가 remote profile policy를 `APPROVAL_REQUIRED`로 갱신한 뒤 active local profile이 신규
+  Follow를 요청한다
+- **THEN** 시스템은 established relationship과 count 증가 없이 pending follow request를 만든다
+- **AND** GraphQL과 FollowButton은 pending 상태를 표시한다
+- **AND** 후속 `Accept(Follow)`를 받으면 request를 제거하고 relationship과 count를 한 번 생성해 established
+  상태를 표시한다
+
+#### Scenario: Apply refreshed open policy to a new Follow
+
+- **WHEN** actor Update가 remote profile policy를 `OPEN`으로 갱신한 뒤 active local profile이 신규 Follow를
+  요청한다
+- **THEN** 시스템은 pending request 없이 relationship과 count를 한 번 생성한다
+- **AND** GraphQL과 FollowButton은 established 상태를 표시한다

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -10,6 +10,7 @@ import {
   Note,
   Reject,
   Undo,
+  Update,
 } from '@fedify/vocab';
 import { db, first, Profiles } from '@kosmo/core/db';
 import { ProfileState } from '@kosmo/core/enums';
@@ -22,6 +23,7 @@ import { handleInboundDelete } from './inbound-delete';
 import { handleInboundFollow, handleInboundUndo } from './inbound-follow';
 import { handleInboundReaction } from './inbound-reaction';
 import { handleInboundReject } from './inbound-reject';
+import { handleInboundUpdate } from './inbound-update';
 import { ensureDrizzleLocalProfileActor } from './local-actor-store';
 import { authorizeLocalPostNote, dispatchLocalPostNote } from './local-post-note';
 import { isCanonicalLocalProfileId } from './local-profile-actor';
@@ -145,4 +147,5 @@ federation
   .on(Follow, handleInboundFollow)
   .on(Like, handleInboundReaction)
   .on(Reject, handleInboundReject)
-  .on(Undo, handleInboundUndo);
+  .on(Undo, handleInboundUndo)
+  .on(Update, handleInboundUpdate);

--- a/packages/fedify/src/inbound-update.test.ts
+++ b/packages/fedify/src/inbound-update.test.ts
@@ -1,0 +1,441 @@
+import '@kosmo/core/polyfill';
+
+import assert from 'node:assert/strict';
+import { after, afterEach, before, beforeEach, describe, mock, test } from 'node:test';
+import { Accept, Endpoints, Follow, Note, Person, Update } from '@fedify/vocab';
+import {
+  ActivityPubActorType,
+  InstanceKind,
+  InstanceState,
+  ProfileFollowPolicy,
+} from '@kosmo/core/enums';
+import { and, eq, inArray } from 'drizzle-orm';
+import type { DocumentLoader, InboxContext } from '@fedify/fedify';
+import type * as CoreDb from '@kosmo/core/db';
+import type * as CoreSeed from '@kosmo/core/db/seed';
+import type * as CoreServices from '@kosmo/core/services';
+import type { handleInboundAccept as HandleInboundAccept } from './inbound-accept';
+import type { handleInboundUpdate as HandleInboundUpdate } from './inbound-update';
+
+const publicOrigin = 'http://127.0.0.1:4173';
+const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+const remoteActorUri = new URL('https://remote.example/users/alice');
+const firstLocalProfileId = '019f7abc-1111-7777-8888-123456789abc';
+const secondLocalProfileId = '019f7abc-2222-7777-8888-123456789abc';
+
+let ActivityPubActors: typeof CoreDb.ActivityPubActors;
+let db: typeof CoreDb.db;
+let first: typeof CoreDb.first;
+let firstOrThrow: typeof CoreDb.firstOrThrow;
+let Instances: typeof CoreDb.Instances;
+let pg: typeof CoreDb.pg;
+let ProfileFollowRequests: typeof CoreDb.ProfileFollowRequests;
+let ProfileFollows: typeof CoreDb.ProfileFollows;
+let Profiles: typeof CoreDb.Profiles;
+let followProfile: typeof CoreServices.followProfile;
+let handleInboundAccept: typeof HandleInboundAccept;
+let handleInboundUpdate: typeof HandleInboundUpdate;
+let localInstanceId: string;
+
+describe('inbound actor Update', () => {
+  before(async () => {
+    process.env.DATABASE_URL = databaseUrl;
+    process.env.PUBLIC_ORIGIN = publicOrigin;
+    ({
+      ActivityPubActors,
+      db,
+      first,
+      firstOrThrow,
+      Instances,
+      pg,
+      ProfileFollowRequests,
+      ProfileFollows,
+      Profiles,
+    } = await import('@kosmo/core/db'));
+    const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
+    ({ followProfile } = await import('@kosmo/core/services'));
+    ({ handleInboundAccept } = await import('./inbound-accept'));
+    ({ handleInboundUpdate } = await import('./inbound-update'));
+    const { localInstance } = await seedDatabase({ publicOrigin });
+    localInstanceId = localInstance.id;
+  });
+
+  beforeEach(async () => {
+    await cleanFixtures();
+    mock.restoreAll();
+  });
+
+  afterEach(async () => {
+    await cleanFixtures();
+  });
+
+  after(async () => {
+    await pg.end();
+  });
+
+  test('refreshes profile projection and endpoint metadata in both policy directions', async () => {
+    const fixture = await createRemoteActor(ProfileFollowPolicy.OPEN);
+    const firstReceivedAt = Temporal.Instant.from('2026-07-31T05:00:00Z');
+    const context = createContext();
+    const approvalRequired = createActor({
+      manuallyApprovesFollowers: true,
+      name: 'Alice Updated',
+      summary: '<p>Updated <strong>bio</strong></p>',
+    });
+
+    await handleInboundUpdate(
+      context,
+      new Update({ actor: remoteActorUri, object: approvalRequired }),
+      firstReceivedAt,
+    );
+
+    let stored = await readRemoteActor(fixture.profile.id);
+    assert.equal(stored.profile.displayName, 'Alice Updated');
+    assert.equal(stored.profile.bio, 'Updated bio');
+    assert.equal(stored.profile.followPolicy, ProfileFollowPolicy.APPROVAL_REQUIRED);
+    assert.equal(stored.actor.inboxUri, 'https://remote.example/users/alice/inbox-updated');
+    assert.equal(stored.actor.sharedInboxUri, 'https://remote.example/inbox-updated');
+    assert.equal(stored.actor.lastFetchedAt?.toString(), firstReceivedAt.toString());
+
+    const secondReceivedAt = firstReceivedAt.add({ seconds: 1 });
+    await handleInboundUpdate(
+      context,
+      new Update({
+        actor: remoteActorUri,
+        object: createActor({ manuallyApprovesFollowers: false }),
+      }),
+      secondReceivedAt,
+    );
+
+    stored = await readRemoteActor(fixture.profile.id);
+    assert.equal(stored.profile.followPolicy, ProfileFollowPolicy.OPEN);
+    assert.equal(stored.actor.lastFetchedAt?.toString(), secondReceivedAt.toString());
+  });
+
+  test('ignores mismatched, unsupported, unknown, and local actor updates without document loading', async () => {
+    const fixture = await createRemoteActor(ProfileFollowPolicy.OPEN);
+    const localProfile = await createLocalActor(firstLocalProfileId, 'update-local-collision');
+    const before = await readRemoteActor(fixture.profile.id);
+    const documentLoader = mock.fn(async () => {
+      throw new Error('inbox document loader must not run');
+    });
+    const context = createContext(null, documentLoader);
+    const otherActorUri = new URL('https://remote.example/users/mallory');
+    const unknownActorUri = new URL('https://unknown.example/users/alice');
+    const localActorUri = new URL(`/ap/actor/${firstLocalProfileId}`, publicOrigin);
+
+    const rejected = [
+      new Update({ actor: remoteActorUri, object: createActor({ id: otherActorUri }) }),
+      new Update({ actor: remoteActorUri, object: new Note({ id: remoteActorUri }) }),
+      new Update({ actor: unknownActorUri, object: createActor({ id: unknownActorUri }) }),
+      new Update({
+        actor: localActorUri,
+        object: createActor({ id: localActorUri, preferredUsername: 'local' }),
+      }),
+      new Update({
+        actors: [remoteActorUri, otherActorUri],
+        object: createActor(),
+      }),
+    ];
+
+    for (const update of rejected) {
+      await handleInboundUpdate(context, update);
+    }
+
+    assert.deepEqual(await readRemoteActor(fixture.profile.id), before);
+    assert.equal(
+      await db
+        .select({ displayName: Profiles.displayName })
+        .from(Profiles)
+        .where(eq(Profiles.id, localProfile.id))
+        .then(firstOrThrow)
+        .then(({ displayName }) => displayName),
+      'update-local-collision',
+    );
+    assert.equal(documentLoader.mock.calls.length, 0);
+    assert.equal(
+      await db
+        .select()
+        .from(ActivityPubActors)
+        .where(eq(ActivityPubActors.uri, unknownActorUri.href))
+        .then((rows) => rows.length),
+      0,
+    );
+  });
+
+  test('processes a duplicate update idempotently', async () => {
+    const fixture = await createRemoteActor(ProfileFollowPolicy.OPEN);
+    const receivedAt = Temporal.Instant.from('2026-07-31T05:00:00Z');
+    const update = new Update({
+      actor: remoteActorUri,
+      id: new URL('https://remote.example/activities/update-1'),
+      object: createActor({ manuallyApprovesFollowers: true }),
+    });
+
+    await handleInboundUpdate(createContext(), update, receivedAt);
+    await handleInboundUpdate(createContext(), update, receivedAt);
+
+    const stored = await readRemoteActor(fixture.profile.id);
+    assert.equal(stored.profile.followPolicy, ProfileFollowPolicy.APPROVAL_REQUIRED);
+    assert.equal(stored.actor.lastFetchedAt?.toString(), receivedAt.toString());
+    assert.equal(
+      await countPair(ProfileFollowRequests, firstLocalProfileId, fixture.profile.id),
+      0,
+    );
+    assert.equal(await countPair(ProfileFollows, firstLocalProfileId, fixture.profile.id), 0);
+  });
+
+  test('preserves an established relation and applies refreshed policy to new Follow and Accept', async () => {
+    const remote = await createRemoteActor(ProfileFollowPolicy.OPEN);
+    const establishedLocal = await createLocalActor(firstLocalProfileId, 'established');
+    const pendingLocal = await createLocalActor(secondLocalProfileId, 'pending');
+    await db.insert(ProfileFollows).values({
+      followeeProfileId: remote.profile.id,
+      followerProfileId: establishedLocal.id,
+    });
+    await db
+      .update(Profiles)
+      .set({ followingCount: 1 })
+      .where(eq(Profiles.id, establishedLocal.id));
+    await db.update(Profiles).set({ followersCount: 1 }).where(eq(Profiles.id, remote.profile.id));
+
+    await handleInboundUpdate(
+      createContext(),
+      new Update({
+        actor: remoteActorUri,
+        object: createActor({ manuallyApprovesFollowers: true }),
+      }),
+    );
+
+    assert.equal(await countPair(ProfileFollows, establishedLocal.id, remote.profile.id), 1);
+    assert.deepEqual(await readCounts(establishedLocal.id, remote.profile.id), {
+      follower: 1,
+      followee: 1,
+    });
+
+    mock.method(console, 'error', () => undefined);
+    const followed = await followProfile({
+      followerProfileId: pendingLocal.id,
+      followeeProfileId: remote.profile.id,
+    });
+    assert.equal(followed.result.kind, 'PENDING');
+    assert.equal(await countPair(ProfileFollows, pendingLocal.id, remote.profile.id), 0);
+    assert.equal(await countPair(ProfileFollowRequests, pendingLocal.id, remote.profile.id), 1);
+    assert.deepEqual(await readCounts(pendingLocal.id, remote.profile.id), {
+      follower: 0,
+      followee: 1,
+    });
+
+    if (followed.result.kind !== 'PENDING') {
+      assert.fail('Expected pending follow request');
+    }
+    const request = followed.result.profileFollowRequest;
+    const follow = new Follow({
+      actor: new URL(`/ap/actor/${pendingLocal.id}`, publicOrigin),
+      id: new URL(`/ap/follow/${request.id}`, publicOrigin),
+      object: remoteActorUri,
+      published: request.createdAt,
+    });
+    await handleInboundAccept(
+      createContext(pendingLocal.id),
+      new Accept({ actor: remoteActorUri, object: follow }),
+    );
+
+    assert.equal(await countPair(ProfileFollowRequests, pendingLocal.id, remote.profile.id), 0);
+    assert.equal(await countPair(ProfileFollows, establishedLocal.id, remote.profile.id), 1);
+    assert.equal(await countPair(ProfileFollows, pendingLocal.id, remote.profile.id), 1);
+    assert.deepEqual(await readCounts(pendingLocal.id, remote.profile.id), {
+      follower: 1,
+      followee: 2,
+    });
+  });
+
+  test('creates an established Follow immediately after policy refreshes to open', async () => {
+    const remote = await createRemoteActor(ProfileFollowPolicy.APPROVAL_REQUIRED);
+    const local = await createLocalActor(firstLocalProfileId, 'update-local-open');
+
+    await handleInboundUpdate(
+      createContext(),
+      new Update({
+        actor: remoteActorUri,
+        object: createActor({ manuallyApprovesFollowers: false }),
+      }),
+    );
+
+    mock.method(console, 'error', () => undefined);
+    const followed = await followProfile({
+      followerProfileId: local.id,
+      followeeProfileId: remote.profile.id,
+    });
+
+    assert.equal(followed.result.kind, 'ESTABLISHED');
+    assert.equal(await countPair(ProfileFollowRequests, local.id, remote.profile.id), 0);
+    assert.equal(await countPair(ProfileFollows, local.id, remote.profile.id), 1);
+    assert.deepEqual(await readCounts(local.id, remote.profile.id), {
+      follower: 1,
+      followee: 1,
+    });
+  });
+});
+
+type PersonOptions = ConstructorParameters<typeof Person>[0];
+
+const createActor = (overrides: Partial<PersonOptions> = {}) =>
+  new Person({
+    endpoints: new Endpoints({ sharedInbox: new URL('https://remote.example/inbox-updated') }),
+    followers: new URL('https://remote.example/users/alice/followers-updated'),
+    following: new URL('https://remote.example/users/alice/following-updated'),
+    id: remoteActorUri,
+    inbox: new URL('https://remote.example/users/alice/inbox-updated'),
+    manuallyApprovesFollowers: false,
+    name: 'Alice',
+    outbox: new URL('https://remote.example/users/alice/outbox-updated'),
+    preferredUsername: 'alice',
+    summary: 'Remote bio',
+    ...overrides,
+  });
+
+const createContext = (
+  recipient: string | null = null,
+  documentLoader: DocumentLoader = async (url) => {
+    throw new Error(`Unexpected document load: ${url}`);
+  },
+): InboxContext<void> =>
+  ({
+    canonicalOrigin: publicOrigin,
+    documentLoader,
+    getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
+    recipient,
+  }) as unknown as InboxContext<void>;
+
+const createRemoteActor = async (followPolicy: ProfileFollowPolicy) => {
+  const instance = await db
+    .insert(Instances)
+    .values({
+      canonicalOrigin: 'https://remote.example',
+      domain: 'remote.example',
+      kind: InstanceKind.ACTIVITYPUB,
+      state: InstanceState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  const profile = await db
+    .insert(Profiles)
+    .values({
+      displayName: 'Alice',
+      followPolicy,
+      handle: 'alice',
+      instanceId: instance.id,
+      normalizedHandle: 'alice',
+    })
+    .returning()
+    .then(firstOrThrow);
+  const actor = await db
+    .insert(ActivityPubActors)
+    .values({
+      inboxUri: 'https://remote.example/users/alice/inbox',
+      lastFetchedAt: Temporal.Instant.from('2026-07-01T00:00:00Z'),
+      profileId: profile.id,
+      type: ActivityPubActorType.PERSON,
+      uri: remoteActorUri.href,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+  return { actor, instance, profile };
+};
+
+const createLocalActor = async (id: string, handle: string) => {
+  const profile = await db
+    .insert(Profiles)
+    .values({
+      displayName: handle,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle,
+      id,
+      instanceId: localInstanceId,
+      normalizedHandle: handle,
+    })
+    .returning()
+    .then(firstOrThrow);
+  await db.insert(ActivityPubActors).values({
+    profileId: profile.id,
+    type: ActivityPubActorType.PERSON,
+    uri: new URL(`/ap/actor/${profile.id}`, publicOrigin).href,
+  });
+  return profile;
+};
+
+const readRemoteActor = (profileId: string) =>
+  db
+    .select({ actor: ActivityPubActors, profile: Profiles })
+    .from(Profiles)
+    .innerJoin(ActivityPubActors, eq(ActivityPubActors.profileId, Profiles.id))
+    .where(eq(Profiles.id, profileId))
+    .limit(1)
+    .then(firstOrThrow);
+
+const readCounts = async (followerProfileId: string, followeeProfileId: string) => {
+  const follower = await db
+    .select({ count: Profiles.followingCount })
+    .from(Profiles)
+    .where(eq(Profiles.id, followerProfileId))
+    .limit(1)
+    .then(first);
+  const followee = await db
+    .select({ count: Profiles.followersCount })
+    .from(Profiles)
+    .where(eq(Profiles.id, followeeProfileId))
+    .limit(1)
+    .then(first);
+
+  return { follower: follower?.count, followee: followee?.count };
+};
+
+const countPair = (
+  table: typeof ProfileFollows | typeof ProfileFollowRequests,
+  followerProfileId: string,
+  followeeProfileId: string,
+) =>
+  db
+    .select()
+    .from(table)
+    .where(
+      and(
+        eq(table.followerProfileId, followerProfileId),
+        eq(table.followeeProfileId, followeeProfileId),
+      ),
+    )
+    .then((rows) => rows.length);
+
+const cleanFixtures = async () => {
+  const remoteInstances = await db
+    .select({ id: Instances.id })
+    .from(Instances)
+    .where(eq(Instances.domain, 'remote.example'));
+  await db.delete(Profiles).where(
+    inArray(Profiles.id, [
+      firstLocalProfileId,
+      secondLocalProfileId,
+      ...(
+        await db
+          .select({ id: Profiles.id })
+          .from(Profiles)
+          .where(
+            inArray(
+              Profiles.instanceId,
+              remoteInstances.map(({ id }) => id),
+            ),
+          )
+      ).map(({ id }) => id),
+    ]),
+  );
+  if (remoteInstances.length > 0) {
+    await db.delete(Instances).where(
+      inArray(
+        Instances.id,
+        remoteInstances.map(({ id }) => id),
+      ),
+    );
+  }
+};

--- a/packages/fedify/src/inbound-update.ts
+++ b/packages/fedify/src/inbound-update.ts
@@ -1,0 +1,62 @@
+import '@kosmo/core/polyfill';
+
+import { isActor } from '@fedify/vocab';
+import { ConflictError } from '@kosmo/core/error';
+import { isHttpUri, uniqueHref } from './activitypub-uri';
+import {
+  findStoredRemoteProfileActorByUri,
+  materializeRemoteProfileActor,
+  RemoteActorMaterializationError,
+} from './remote-actor-materialization';
+import type { InboxContext } from '@fedify/fedify';
+import type { Object as ActivityPubObject, Update } from '@fedify/vocab';
+
+const noNetworkDocumentLoader = async (url: string) => {
+  throw new Error(`Network lookup is disabled for inbound Update: ${url}`);
+};
+
+export const handleInboundUpdate = async (
+  _context: InboxContext<void>,
+  update: Update,
+  receivedAt: Temporal.Instant = Temporal.Now.instant(),
+): Promise<void> => {
+  const actorHref = uniqueHref(update.actorIds);
+  const objectHref = uniqueHref(update.objectIds);
+  const actorUri = actorHref ? new URL(actorHref) : null;
+  const objectUri = objectHref ? new URL(objectHref) : null;
+
+  if (!isHttpUri(actorUri) || !isHttpUri(objectUri) || actorUri.href !== objectUri.href) {
+    return;
+  }
+
+  const object = await update.getObject({
+    crossOrigin: 'trust',
+    documentLoader: noNetworkDocumentLoader,
+    suppressError: true,
+  });
+
+  if (!isActor(object) || object.id?.href !== actorUri.href) {
+    return;
+  }
+
+  const stored = await findStoredRemoteProfileActorByUri(actorUri);
+  if (!stored) {
+    return;
+  }
+
+  try {
+    await materializeRemoteProfileActor({
+      context: {
+        lookupObject: async (): Promise<ActivityPubObject> => object,
+      },
+      handle: `${stored.profile.handle}@${stored.instance.domain}`,
+      now: receivedAt,
+      reactivateUnresponsive: true,
+    });
+  } catch (error) {
+    if (error instanceof ConflictError || error instanceof RemoteActorMaterializationError) {
+      return;
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
## 무엇을 변경했는지

- 검증된 inbound `Update`의 actor 객체를 기존 remote actor materialization 경로에 연결했습니다.
- actor/object/storage identity와 actor 유형을 검증하고 unknown actor, local URI 충돌, identity mismatch를 안전하게 무시합니다.
- 프로필 projection, shared inbox, 팔로우 정책, `lastFetchedAt`을 즉시 갱신하고 unresponsive actor를 복구합니다.
- 기존 관계 보존과 신규 Follow의 OPEN/APPROVAL_REQUIRED 상태 전이를 통합 테스트로 검증했습니다.
- PROD-607 OpenSpec을 active spec에 동기화하고 완료된 change를 archive했습니다.

## 왜 변경했는지

원격 서버에서 팔로우 승인 정책을 바꿔도 기존 7일 TTL 동안 Kosmo의 저장 상태가 stale하게 유지되어 신규 Follow 동작이 실제 원격 정책과 어긋날 수 있었습니다. 신뢰 가능한 actor `Update`를 받는 즉시 저장 상태를 갱신해 이 지연을 제거합니다.

## 이번 PR의 주요 결정

- 네트워크 재조회 없이 서명 검증된 embedded actor만 사용합니다.
- `Update.actor`, `Update.object.id`, 저장된 actor URI가 모두 같은 경우에만 갱신합니다.
- 기존 materialization transaction을 재사용해 projection과 ActivityPub 상태를 원자적으로 갱신합니다.
- 이미 성립했거나 대기 중인 관계는 재작성하지 않고, 이후 신규 Follow부터 갱신된 정책을 적용합니다.

## 어떻게 확인할 수 있는지

- `pnpm test:fedify`
- `pnpm --filter @kosmo/app test:unit`
- `pnpm --filter @kosmo/api test:integration`
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm lint:prettier`
- `openspec validate --all --strict`
- `git diff --check`

## 아직 어떤 문제가 남았는지

없습니다. 이 PR은 기존 관계 repair, Note lifecycle, outbound local actor `Update`는 포함하지 않습니다.

Linear: https://linear.app/byulmaru/issue/PROD-607