### PR TITLE
승인된 프로덕션 배포만 명시적으로 동기화한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -209,7 +209,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          image_ref="ghcr.io/${GITHUB_REPOSITORY}@${IMAGE_DIGEST}"
           version="${GITHUB_SHA:0:12}"
           argocd --server "${ARGOCD_SERVER}" --grpc-web app set kosmo-prod \
             -p "version=${version}" \
@@ -217,22 +216,6 @@ jobs:
             -p "workloads.enabled=true" \
             -p "migration.enabled=true" \
             --validate
-
-          manifests="${RUNNER_TEMP}/kosmo-prod.yaml"
-          argocd --server "${ARGOCD_SERVER}" --grpc-web app manifests kosmo-prod --source git > "${manifests}"
-
-          kosmo_images="$(
-            sed -En "s/^[[:space:]]*-?[[:space:]]*image:[[:space:]]*['\"]?([^'\"[:space:]]+)['\"]?[[:space:]]*$/\1/p" "${manifests}" \
-              | grep -E '^ghcr\.io/byulmaru/kosmo(@|:)' \
-              || true
-          )"
-          expected_images="$(grep -Fxc "${image_ref}" <<<"${kosmo_images}" || true)"
-          kosmo_image_count="$(grep -c . <<<"${kosmo_images}" || true)"
-          presync_jobs="$(grep -Ec "argocd\.argoproj\.io/hook: ['\"]?PreSync" "${manifests}" || true)"
-          if [[ "${expected_images}" -ne 3 || "${kosmo_image_count}" -ne 3 || "${presync_jobs}" -ne 1 ]]; then
-            echo "::error::Production migration, API, and Web must use ${image_ref} with one PreSync migration job."
-            exit 1
-          fi
 
           argocd --server "${ARGOCD_SERVER}" --grpc-web app sync kosmo-prod --timeout 600
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -217,7 +217,7 @@ jobs:
             -p "migration.enabled=true" \
             --validate
 
-          argocd --server "${ARGOCD_SERVER}" --grpc-web app sync kosmo-prod --timeout 600
+          argocd --server "${ARGOCD_SERVER}" --grpc-web app sync kosmo-prod --prune --timeout 600
 
       - name: Record production deployment
         if: always()

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -302,7 +302,7 @@ jobs:
 
           pr_api="repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls"
           merged_prs="$(gh api --paginate --slurp -H "Accept: application/vnd.github+json" "${pr_api}?per_page=100" \
-            | jq -r '[.[][] | select(.merged_at != null)] | sort_by(.number)[] | [.number, .head.sha] | @tsv')"
+            --jq '[.[][] | select(.merged_at != null)] | sort_by(.number)[] | [.number, .head.sha] | @tsv')"
           if [[ -z "${merged_prs}" ]]; then
             echo "No merged pull request is associated with ${GITHUB_SHA}; refusing to apply an unreviewed plan." >&2
             exit 1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -302,7 +302,7 @@ jobs:
 
           pr_api="repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls"
           merged_prs="$(gh api --paginate --slurp -H "Accept: application/vnd.github+json" "${pr_api}?per_page=100" \
-            --jq '[.[][] | select(.merged_at != null)] | sort_by(.number)[] | [.number, .head.sha] | @tsv')"
+            | jq -r '[.[][] | select(.merged_at != null)] | sort_by(.number)[] | [.number, .head.sha] | @tsv')"
           if [[ -z "${merged_prs}" ]]; then
             echo "No merged pull request is associated with ${GITHUB_SHA}; refusing to apply an unreviewed plan." >&2
             exit 1

--- a/apps/terraform/argocd.tf
+++ b/apps/terraform/argocd.tf
@@ -112,11 +112,6 @@ resource "argocd_application" "kosmo_prod" {
     }
 
     sync_policy {
-      automated {
-        prune     = true
-        self_heal = true
-      }
-
       sync_options = ["CreateNamespace=true"]
     }
   }


### PR DESCRIPTION
## 무엇을 변경했는지

- kosmo-prod Application의 automated sync를 제거했습니다.
- production deploy job의 rendered manifest 문자열 개수 검사를 제거했습니다.
- 승인 job은 build digest를 설정한 뒤 Argo CD app sync 결과만 기다립니다.
- Terraform Apply의 reviewed plan 조회가 현재 gh CLI에서도 동작하도록 jq 처리를 한 줄 수정했습니다.

## 왜 변경했는지

첫 production release attempt 2에서 app set 직후 automated sync가 먼저 시작했고, workflow는 갱신 전 manifest를 문자열로 검사하다 실패했습니다. 그 사이 PreSync migration은 별도로 실행되어 workflow 상태와 실제 cluster 상태가 어긋났습니다. 또한 target revision이 main인 production Application에 automated sync가 남아 있으면 이후 main 변경이 tag와 prod Environment 승인 없이 동기화될 수 있습니다.

이 변경을 적용할 Terraform workflow도 reviewed plan을 찾는 단계에서 gh api --slurp와 --jq를 함께 사용해 실패했으므로 같은 PR에서 한 줄로 바로잡습니다.

## 이번 PR의 주요 결정

### Production sync는 승인 workflow 하나가 소유한다

- 결정자: @robin-maki
- 선택: prod Environment 승인 뒤 app set → app sync만 수행합니다.
- 고려한 대안: automated sync를 유지하고 app wait로 관찰하는 방식, rendered YAML 문자열 검사를 유지하는 방식
- 이유: tag build와 사용자 승인이라는 기존 production 경계를 실제 상태 변경의 단일 호출자로 유지하고, Argo CD PreSync 결과를 그대로 성공 기준으로 사용합니다.
- 감수한 결과: tag workflow가 실행되지 않으면 production desired state는 자동 적용되지 않습니다.
- 관련 근거: PROD-545, openspec/specs/production-release/spec.md, openspec/specs/production-migration-gate/spec.md

동일 digest 계약은 Helm의 단일 imageDigest 입력과 production render-time digest 검증을 그대로 유지합니다.

## 어떻게 확인할 수 있는지

- actionlint .github/workflows/docker-build.yml .github/workflows/terraform.yml
- terraform -chdir=apps/terraform fmt -check
- terraform -chdir=apps/terraform validate
- openspec validate --specs --strict: 36 passed
- 실제 GitHub API 응답으로 수정한 merged PR lookup 실행: PR #455 head를 반환
- git diff --check

## 아직 어떤 문제가 남았는지

- 새 HEAD의 Terraform plan에서 기존 main 미적용 WIF 변경과 kosmo-prod automated sync 제거만 포함되는지 확인해야 합니다.
- 병합·Terraform Apply 후 실패한 첫 production tag 배포를 다시 실행해야 합니다.