### PR TITLE
Terraform apply의 gh api pagination 호환성을 수정한다

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -302,7 +302,7 @@ jobs:
 
           pr_api="repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls"
           merged_prs="$(gh api --paginate --slurp -H "Accept: application/vnd.github+json" "${pr_api}?per_page=100" \
-            --jq '[.[][] | select(.merged_at != null)] | sort_by(.number)[] | [.number, .head.sha] | @tsv')"
+            | jq -r '[.[][] | select(.merged_at != null)] | sort_by(.number)[] | [.number, .head.sha] | @tsv')"
           if [[ -z "${merged_prs}" ]]; then
             echo "No merged pull request is associated with ${GITHUB_SHA}; refusing to apply an unreviewed plan." >&2
             exit 1


### PR DESCRIPTION
## 문제

PR #455 merge 후 main Terraform apply가 reviewed plan 다운로드 단계에서 실패했습니다. self-hosted runner의 gh 2.95.0은 `gh api --slurp`와 `--jq` 동시 사용을 허용하지 않습니다.

- 실패 run: https://github.com/byulmaru/kosmo/actions/runs/30607135596
- Linear: PROD-612

## 변경

- paginated 연결 PR 응답은 `gh api --paginate --slurp`로 출력합니다.
- 필터링과 TSV 변환은 pipe의 `jq -r`에서 수행합니다.
- reviewed plan metadata 검증과 semantic plan 비교, saved plan apply 계약은 변경하지 않습니다.

## 검증

- 실패한 merge commit의 실제 GitHub API 응답에서 PR #455와 head SHA가 반환됨
- `actionlint -verbose .github/workflows/terraform.yml`
- `node_modules/.bin/prettier --check --ignore-unknown .github/workflows/terraform.yml`
- `git diff --check`