### PR TITLE
프로필 수정 헤더 메뉴가 아바타를 가리지 않게 한다

### DIFF
--- a/apps/app/src/components/ui/ActionMenu.tsx
+++ b/apps/app/src/components/ui/ActionMenu.tsx
@@ -246,7 +246,7 @@ export function ActionMenu({
 
   if (web) {
     return (
-      <View ref={controlRef} style={[styles.control, { zIndex: open ? 50 : 0 }]}>
+      <View ref={controlRef} style={styles.control}>
         {renderTrigger({
           expanded: open,
           focusTrigger,

--- a/apps/app/src/stories/ProfileEdit.stories.tsx
+++ b/apps/app/src/stories/ProfileEdit.stories.tsx
@@ -263,40 +263,14 @@ export const HeaderMenuKeepsAvatarOverlap: Story = {
     const page = within(canvasElement.ownerDocument.body);
     const headerButton = canvas.getByRole('button', { name: '헤더 이미지 변경' });
     const avatarButton = canvas.getByRole('button', { name: '아바타 이미지 편집' });
-    const headerRectBefore = headerButton.getBoundingClientRect();
-    const avatarRectBefore = avatarButton.getBoundingClientRect();
 
     await userEvent.click(headerButton);
 
     expect(page.getByRole('menuitem', { name: '이미지 변경' })).toBeVisible();
-    const headerRectAfter = headerButton.getBoundingClientRect();
-    const avatarRectAfter = avatarButton.getBoundingClientRect();
-    expect({
-      height: headerRectAfter.height,
-      left: headerRectAfter.left,
-      top: headerRectAfter.top,
-      width: headerRectAfter.width,
-    }).toEqual({
-      height: headerRectBefore.height,
-      left: headerRectBefore.left,
-      top: headerRectBefore.top,
-      width: headerRectBefore.width,
-    });
-    expect({
-      height: avatarRectAfter.height,
-      left: avatarRectAfter.left,
-      top: avatarRectAfter.top,
-      width: avatarRectAfter.width,
-    }).toEqual({
-      height: avatarRectBefore.height,
-      left: avatarRectBefore.left,
-      top: avatarRectBefore.top,
-      width: avatarRectBefore.width,
-    });
-
+    const avatarRect = avatarButton.getBoundingClientRect();
     const overlapElements = canvasElement.ownerDocument.elementsFromPoint(
-      avatarRectAfter.left + avatarRectAfter.width / 2,
-      avatarRectAfter.top + 24,
+      avatarRect.left + avatarRect.width / 2,
+      avatarRect.top + 24,
     );
     const avatarStackIndex = overlapElements.findIndex(
       (element) => element === avatarButton || avatarButton.contains(element),

--- a/apps/app/src/stories/ProfileEdit.stories.tsx
+++ b/apps/app/src/stories/ProfileEdit.stories.tsx
@@ -253,6 +253,65 @@ export const CurrentImageMenu: Story = {
   },
 };
 
+export const HeaderMenuKeepsAvatarOverlap: Story = {
+  args: {
+    avatar: { kind: 'current', previewUri: '/apple-touch-icon.png' },
+    header: { kind: 'current', previewUri: '/apple-touch-icon.png' },
+  },
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+    const headerButton = canvas.getByRole('button', { name: '헤더 이미지 변경' });
+    const avatarButton = canvas.getByRole('button', { name: '아바타 이미지 편집' });
+    const headerRectBefore = headerButton.getBoundingClientRect();
+    const avatarRectBefore = avatarButton.getBoundingClientRect();
+
+    await userEvent.click(headerButton);
+
+    expect(page.getByRole('menuitem', { name: '이미지 변경' })).toBeVisible();
+    const headerRectAfter = headerButton.getBoundingClientRect();
+    const avatarRectAfter = avatarButton.getBoundingClientRect();
+    expect({
+      height: headerRectAfter.height,
+      left: headerRectAfter.left,
+      top: headerRectAfter.top,
+      width: headerRectAfter.width,
+    }).toEqual({
+      height: headerRectBefore.height,
+      left: headerRectBefore.left,
+      top: headerRectBefore.top,
+      width: headerRectBefore.width,
+    });
+    expect({
+      height: avatarRectAfter.height,
+      left: avatarRectAfter.left,
+      top: avatarRectAfter.top,
+      width: avatarRectAfter.width,
+    }).toEqual({
+      height: avatarRectBefore.height,
+      left: avatarRectBefore.left,
+      top: avatarRectBefore.top,
+      width: avatarRectBefore.width,
+    });
+
+    const overlapElements = canvasElement.ownerDocument.elementsFromPoint(
+      avatarRectAfter.left + avatarRectAfter.width / 2,
+      avatarRectAfter.top + 24,
+    );
+    const avatarStackIndex = overlapElements.findIndex(
+      (element) => element === avatarButton || avatarButton.contains(element),
+    );
+    const headerStackIndex = overlapElements.findIndex(
+      (element) => element === headerButton || headerButton.contains(element),
+    );
+    expect(avatarStackIndex).toBeGreaterThanOrEqual(0);
+    expect(headerStackIndex).toBeGreaterThanOrEqual(0);
+    expect(avatarStackIndex).toBeLessThan(headerStackIndex);
+
+    await userEvent.click(page.getByRole('menuitem', { name: '취소' }));
+  },
+};
+
 export const ImageFieldsWide: Story = {
   parameters: {
     viewport: { defaultViewport: 'kosmoPickerWide' },


### PR DESCRIPTION
## 무엇을 변경했는지

- Web `ActionMenu`가 열릴 때 trigger wrapper에 적용하던 동적 `zIndex`를 제거했습니다.
- 프로필 수정 header 메뉴를 열었을 때 실제 overlap 지점의 paint 순서에서 avatar가 header보다 앞에 남는지 직접 확인하는 Storybook 회귀 테스트를 추가했습니다.
- 최신 main의 ActionMenu 접근성 변경(`focusTrigger`, menu item 접근성 표현)은 그대로 보존했습니다.

## 왜 변경했는지

프로필 수정 화면에서 현재 header 이미지를 누르면 메뉴가 열린 동안 header 전체가 앞 stacking context로 올라와, header 위에 겹쳐 보여야 하는 avatar의 상단을 가렸습니다.

메뉴는 이미 `ActionMenuPortal`을 통해 별도 layer에 렌더링되므로 trigger까지 높일 필요가 없었습니다. 동적 `zIndex`가 메뉴가 아니라 header preview 전체의 stacking order를 바꾸는 것이 직접 원인이었습니다.

관련 이슈: [PROD-614](https://linear.app/byulmaru/issue/PROD-614/프로필-수정에서-헤더-메뉴를-열어도-아바타-겹침-순서를-유지한다)

## 이번 PR의 주요 결정

### 메뉴 trigger wrapper의 동적 z-index를 제거한다

- 결정자: @robin-maki
- 선택: Web ActionMenu trigger wrapper의 open 상태 `zIndex: 50`을 제거하고, 메뉴 layer는 기존 portal이 계속 소유하게 합니다.
- 고려한 대안: Profile edit의 avatar에 더 높은 z-index를 추가하거나, header trigger만 예외 처리하는 방법
- 이유: 메뉴와 trigger의 layer 책임을 분리하면 공용 ActionMenu가 소비 화면의 기존 stacking order를 바꾸지 않으며, Profile edit 전용 z-index 경쟁도 만들지 않습니다.
- 감수한 결과: 메뉴 open 상태에서 trigger 자체는 별도 elevation을 얻지 않습니다. 실제 메뉴는 portal의 `zIndex: 100`으로 계속 정상 표시됩니다.
- 관련 근거: `docs/design/profile-edit.md`의 header 위 avatar overlap 계약과 PROD-614

그 외 새로운 제품·도메인 결정은 없습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/api test:integration`
  - 208 tests 통과, 1 test skip
  - 최신 main의 격리 test database에서 기존 `profile-follow-graph` FK 실패가 재현되지 않음을 확인
- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:storybook -- ProfileEdit.stories.tsx`
  - 전체 19 files, 250 tests 통과
  - 새 회귀 테스트가 수정 전에는 stacking 순서 불일치로 실패하고 수정 후 통과하는 것을 확인
- 변경 파일 ESLint 및 Prettier 검사
- `git diff --check`
- 이전 PR head와 최신 main rebase 결과의 `git range-diff` 일치 확인

## 아직 어떤 문제가 남았는지

없음.

Stack: `main -> PROD-614`