### PR TITLE
액션 혼잡 동안 lint와 Semgrep을 GitHub runner에서 실행한다

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,8 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: [self-hosted]
+    # runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,7 +26,8 @@ env:
 jobs:
   semgrep:
     name: Semgrep scan
-    runs-on: [self-hosted]
+    # runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 무엇을 변경했는지

- lint 잡의 실행 환경을 임시로 `ubuntu-latest`로 변경했습니다.
- Semgrep 잡의 실행 환경을 임시로 `ubuntu-latest`로 변경했습니다.
- 혼잡이 해소되면 바로 복구할 수 있도록 기존 `[self-hosted]` 설정을 각 잡에 주석으로 남겼습니다.

## 왜 변경했는지

현재 자체 호스팅 액션 러너 혼잡을 완화하면서 필수 lint와 Semgrep 검증은 계속 실행하기 위한 임시 우회입니다.

## 이번 PR의 주요 결정

### GitHub-hosted runner를 임시 사용한다

- 결정자: @robin-maki
- 선택: lint와 Semgrep만 `ubuntu-latest`에서 실행합니다.
- 고려한 대안: 기존 자체 호스팅 러너 대기열을 그대로 사용합니다.
- 이유: 다른 잡의 실행 환경은 건드리지 않고 현재 혼잡을 즉시 줄일 수 있습니다.
- 감수한 결과: GitHub-hosted runner 사용량이 발생하며, 혼잡 해소 후 기존 설정으로 되돌려야 합니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/lint.yml .github/workflows/semgrep.yml`
- `pnpm exec prettier --check .github/workflows/lint.yml .github/workflows/semgrep.yml`
- `git diff --check`
- GitHub-hosted runner: Lint 통과 (1분 17초)
- GitHub-hosted runner: Semgrep scan 통과 (51초)

## 아직 어떤 문제가 남았는지

- 자체 호스팅 러너 혼잡이 해소되면 주석으로 남긴 기존 `runs-on` 설정으로 복구해야 합니다.