### PR TITLE
프로덕션 migration이 runtime DB 권한을 보존하게 한다

### DIFF
--- a/apps/helm/templates/database-migration-job.yaml
+++ b/apps/helm/templates/database-migration-job.yaml
@@ -53,6 +53,8 @@ spec:
               value: "5432"
             - name: PGDATABASE
               value: "kosmo"
+            - name: DATABASE_MIGRATION_ROLE
+              value: "kosmo"
             - name: PGUSER
               valueFrom:
                 secretKeyRef:

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -240,6 +240,7 @@ required_migration_markers=(
   'value: "kosmo-postgres-rw"'
   "name: PGDATABASE"
   'value: "kosmo"'
+  "name: DATABASE_MIGRATION_ROLE"
   "name: PGUSER"
   "key: username"
   "name: PGPASSWORD"

--- a/memory/database-migrations.md
+++ b/memory/database-migrations.md
@@ -88,6 +88,10 @@ Argo CD `PostSync` 성공만으로 이 gate를 대체하지 않는다. `PostSync
 
 현재 `migrate` command는 runtime image의 `drizzle/` 아래에서 Drizzle history에 없는 migration을 모두 읽어 한
 번에 적용한다. PostgreSQL advisory lock은 동시 runner를 막지만 migration phase를 선택하지 않는다.
+Production은 별도 `kosmo_migration` login/credential로 연결한 뒤 `DATABASE_MIGRATION_ROLE=kosmo`에 따라
+database owner role로 전환해 migration을 실행한다. PostgreSQL role membership은 member가 owner의 기존
+객체를 변경할 수 있게 할 뿐 owner에게 member가 새로 만든 객체 권한을 역으로 주지 않으므로, 이 role 전환을
+제거하면 새 schema 객체가 runtime owner에게 보이지 않을 수 있다.
 
 따라서 다음 규칙을 지킨다.
 

--- a/openspec/changes/add-production-runtime/decisions.md
+++ b/openspec/changes/add-production-runtime/decisions.md
@@ -64,6 +64,18 @@
 - Consequences: Runtime과 migration은 서로 다른 login과 credential을 갖지만 migration role은 기존 owner 권한을 상속하므로 권한 수준 자체를 축소하는 계약은 아니다. Application/manifest가 제거되어도 schema object를 소유할 수 있는 login은 자동 삭제되지 않으며, 제거 또는 rotation에는 명시적인 운영 확인이 필요하다. Migration Job이 이 identity를 소비하는 연결은 PROD-564까지 존재하지 않는다.
 - Confirmation / Follow-up: Render와 live 상태에서 `DatabaseRole`, basic-auth Secret 참조와 role membership을 확인하고 API/Web이 migration credential을 참조하지 않는지 검사한다.
 
+### Migration login membership은 owner role 전환과 함께 사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-562`, `PROD-564`, `PROD-616`; production incident evidence
+- Status: Active
+- Context / Problem: 첫 production migration에서 `kosmo_migration`은 `kosmo`의 member였지만 role을 전환하지 않은 채 schema 객체를 생성했다. PostgreSQL membership은 member가 owner의 기존 객체 권한을 상속하게 할 뿐 owner에게 member 소유 객체 권한을 역으로 부여하지 않아 API가 `permission denied for table instance`로 시작하지 못했다.
+- Decision Outcome: Production migration은 별도 `kosmo_migration` login/Secret으로 인증한 뒤 runner 내부에서 `SET ROLE kosmo`를 실행하고 Drizzle migration을 적용한다. API/Web credential 경계와 단일 `migrate` command는 유지한다.
+- Alternatives Considered: Runtime credential로 migration을 실행하는 방식은 credential 분리를 없애므로 제외했다. `kosmo_migration` 소유 객체에 table/sequence별 grant와 default privilege를 추가하는 방식은 현재 runtime이 bootstrap owner인 계약에 불필요한 두 번째 ownership 체계를 만들므로 제외했다.
+- Consequences: Session identity와 credential은 migration 전용으로 유지되지만 생성되는 schema 객체는 `kosmo`가 소유한다. Migration role membership 또는 owner role 이름이 어긋나면 Job은 SQL 적용 전에 실패한다.
+- Confirmation / Follow-up: 별도 login이 owner role로 전환해 Drizzle history와 새 table을 owner 소유로 만드는 integration test, production Helm render의 고정 role, live table ownership과 API readiness를 확인한다.
+
 ### 기존 platform add-on과 TLS의 소비
 
 - Decision Date: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-add-production-migration-gate/specs/production-migration-gate/spec.md
+++ b/openspec/changes/archive/2026-07-30-add-production-migration-gate/specs/production-migration-gate/spec.md
@@ -2,12 +2,13 @@
 
 ### Requirement: 분리된 production migration 권한
 
-**Authority / Provenance:** `PROD-564`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), API와 Web runtime credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-564`, `PROD-616`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), API와 Web runtime credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
 
 #### Scenario: Migration credential로 실행
 
 - **WHEN** production migration Job이 시작된다
 - **THEN** Job은 production migration 전용 Secret과 database identity로 연결한다
+- **AND** 연결 후 명시적인 database owner role로 전환해 새 schema 객체가 runtime owner의 권한 경계에 남게 한다
 - **AND** 접속 대상은 현재 Helm release의 PostgreSQL read-write Service와 `kosmo` database로 고정된다
 - **AND** API와 Web workload는 같은 credential을 mount하거나 참조하지 않는다
 

--- a/openspec/specs/production-migration-gate/spec.md
+++ b/openspec/specs/production-migration-gate/spec.md
@@ -8,12 +8,13 @@ Production migration이 고정된 database 대상과 분리된 credential을 사
 
 ### Requirement: 분리된 production migration 권한
 
-**Authority / Provenance:** `PROD-564`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), API와 Web runtime credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-564`, `PROD-616`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), API와 Web runtime credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
 
 #### Scenario: Migration credential로 실행
 
 - **WHEN** production migration Job이 시작된다
 - **THEN** Job은 production migration 전용 Secret과 database identity로 연결한다
+- **AND** 연결 후 명시적인 database owner role로 전환해 새 schema 객체가 runtime owner의 권한 경계에 남게 한다
 - **AND** 접속 대상은 현재 Helm release의 PostgreSQL read-write Service와 `kosmo` database로 고정된다
 - **AND** API와 Web workload는 같은 credential을 mount하거나 참조하지 않는다
 

--- a/packages/core/db/migrate.test.ts
+++ b/packages/core/db/migrate.test.ts
@@ -150,6 +150,64 @@ test('PostgreSQL 환경 변수로 마이그레이션 database에 연결한다', 
   }
 });
 
+test('별도 로그인으로 연결해도 지정한 database owner role로 객체를 생성한다', async () => {
+  const control = postgres(databaseUrl, { max: 1 });
+  const ownerRole = `migration_owner_${process.pid}`;
+  const validMigrations = await migrationFolder(
+    '20260712000000_owner',
+    'CREATE TABLE migration_owner_probe (id integer PRIMARY KEY);',
+  );
+  const [{ currentUser }] = await control<
+    { currentUser: string }[]
+  >`SELECT current_user AS "currentUser"`;
+  const [{ databaseName }] = await control<
+    { databaseName: string }[]
+  >`SELECT current_database() AS "databaseName"`;
+  let roleCreated = false;
+
+  try {
+    await control`CREATE ROLE ${control(ownerRole)}`;
+    roleCreated = true;
+    await control`GRANT ${control(ownerRole)} TO ${control(currentUser)}`;
+    await control`GRANT CREATE ON DATABASE ${control(databaseName)} TO ${control(ownerRole)}`;
+    await control.unsafe('DROP SCHEMA IF EXISTS drizzle CASCADE; DROP SCHEMA public CASCADE;');
+    await control.unsafe('CREATE SCHEMA public;');
+    await control`GRANT ALL ON SCHEMA public TO ${control(ownerRole)}`;
+
+    await runDatabaseMigrations({
+      databaseUrl,
+      migrationRole: ownerRole,
+      migrationsFolder: validMigrations,
+    });
+
+    const owners = await control<{ owner: string }[]>`
+      SELECT pg_get_userbyid(relowner) AS owner
+      FROM pg_class
+      WHERE oid IN (
+        'public.migration_owner_probe'::regclass,
+        'drizzle.__drizzle_migrations'::regclass
+      )
+      ORDER BY relname
+    `;
+    assert.deepEqual(
+      owners.map(({ owner }) => owner),
+      [ownerRole, ownerRole],
+    );
+  } finally {
+    await control.unsafe('DROP SCHEMA IF EXISTS drizzle CASCADE; DROP SCHEMA public CASCADE;');
+    await control.unsafe('CREATE SCHEMA public;');
+
+    if (roleCreated) {
+      await control`REVOKE CREATE ON DATABASE ${control(databaseName)} FROM ${control(ownerRole)}`;
+      await control`REVOKE ${control(ownerRole)} FROM ${control(currentUser)}`;
+      await control`DROP ROLE ${control(ownerRole)}`;
+    }
+
+    await control.end({ timeout: 5 });
+    await rm(validMigrations, { force: true, recursive: true });
+  }
+});
+
 test('현재 마이그레이션 이력을 빈 데이터베이스에 적용한다', async () => {
   const control = postgres(databaseUrl, { max: 1 });
 

--- a/packages/core/db/migrate.ts
+++ b/packages/core/db/migrate.ts
@@ -9,9 +9,11 @@ export const migrationLock = [0x4b4f534d, 0x4d494752] as const;
 
 export async function runDatabaseMigrations({
   databaseUrl = process.env.DATABASE_URL,
+  migrationRole = process.env.DATABASE_MIGRATION_ROLE,
   migrationsFolder = join(dirname(fileURLToPath(import.meta.url)), '../../../drizzle'),
 }: {
   databaseUrl?: string;
+  migrationRole?: string;
   migrationsFolder?: string;
 } = {}): Promise<void> {
   if (!databaseUrl) {
@@ -46,6 +48,11 @@ export async function runDatabaseMigrations({
     }
 
     lockAcquired = true;
+
+    if (migrationRole) {
+      await client`SET ROLE ${client(migrationRole)}`;
+    }
+
     await migrate(drizzle({ client }), { migrationsFolder });
   } finally {
     if (lockAcquired) {


### PR DESCRIPTION
## 무엇을 변경했는지

- production migration runner가 advisory lock을 획득한 뒤 `DATABASE_MIGRATION_ROLE`로 PostgreSQL role을 전환하고 Drizzle migration을 실행하게 했습니다.
- production Helm migration Job이 별도 `kosmo_migration` credential로 연결하면서 database owner role `kosmo`를 고정해 전달하게 했습니다.
- 별도 session login에서 owner role로 전환한 뒤 새 table과 Drizzle history가 owner role 소유로 생성되는 integration test를 추가했습니다.
- canonical/archived production migration spec, active production runtime decision과 DB migration 운영 문서를 실제 PostgreSQL role membership 동작에 맞췄습니다.

## 왜 변경했는지

첫 production migration은 `kosmo_migration`으로 인증한 뒤 role 전환 없이 객체를 생성했습니다. PostgreSQL role membership은 member가 owner의 기존 권한을 상속하게 하지만 owner가 member 소유 객체 권한을 역으로 얻지는 않습니다.

그 결과 `public`/`drizzle` 객체가 `kosmo_migration` 소유가 되었고 API runtime login `kosmo`가 `instance` table을 읽지 못해 `SQLSTATE 42501`로 CrashLoopBackOff에 빠졌습니다. 라이브 DB는 객체 소유권 재할당과 configured Local Instance bootstrap으로 복구했으며, 이 PR은 다음 migration에서 같은 소유권 역전이 재발하지 않게 합니다.

Linear: [PROD-616](https://linear.app/byulmaru/issue/PROD-616/프로덕션-migration-객체를-runtime-owner-소유로-생성한다)

## 이번 PR의 주요 결정

새 제품·보안 정책 결정은 없습니다. PROD-564가 확정한 migration 전용 login/credential 경계를 유지하면서, migration session이 기존 database owner role로 명시적으로 전환하도록 PostgreSQL 실행 의미를 바로잡았습니다. Runtime credential 재사용이나 table/sequence별 grant와 default privilege의 별도 ownership 체계는 도입하지 않습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/core test:migrate` — 4/4 통과
- `PATH=/Users/jiyu/.local/share/mise/installs/helm/4.2.2/darwin-arm64:$PATH bash apps/helm/test-render.sh` — dev/prod Helm lint/render 통과
- `pnpm --filter @kosmo/api lint:tsc` — 통과
- `pnpm exec eslint packages/core/db/migrate.ts packages/core/db/migrate.test.ts` — 통과
- `pnpm lint:prettier` — 통과
- `pnpm exec openspec validate --all --strict` — 60/60 통과
- `git diff --check` — 통과
- 라이브 확인: API Rollout 1/1 Ready, 새 Pod restart 0회, public `/health` 200, runtime table DML/sequence access 정상

## 아직 어떤 문제가 남았는지

- 현재 production DB의 긴급 복구는 이 PR과 별도로 이미 적용했습니다. 이 PR이 merge된 뒤 새 image로 배포해야 다음 migration부터 재발 방지가 적용됩니다.
- 빈 production DB의 configured Local Instance bootstrap 자동화는 이 PR 범위에 포함하지 않습니다. 첫 배포에서는 공식 bootstrap helper로 `kos.moe` row를 생성했습니다.