### PR TITLE
액션 혼잡 동안 보안 스캔을 GitHub runner에서 실행한다

### DIFF
--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -20,7 +20,8 @@ concurrency:
 jobs:
   nuclei:
     name: Nuclei scan
-    runs-on: [self-hosted]
+    # runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     env:
       DEFAULT_TARGETS: |
         https://kos.moe

--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -66,6 +66,7 @@ jobs:
         continue-on-error: true
         uses: projectdiscovery/nuclei-action@cc153d0541e1adf8a42bbe31c0a4fb2376147538 # v3.1.1
         with:
+          cache: true
           # Cloudflare controls the default targets' edge cipher suites on the current plan.
           args: >-
             ${{ env.NUCLEI_ARGS }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -23,7 +23,8 @@ jobs:
   trivy_scan:
     name: Trivy Scan
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted, ARM64]
+    # runs-on: [self-hosted, ARM64]
+    runs-on: ubuntu-24.04-arm
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -56,24 +56,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Find local Trivy
-        id: trivy-binary
-        shell: bash
-        run: |
-          trivy_dir="${RUNNER_TOOL_CACHE}/kosmo-trivy-v0.70.0/trivy-bin"
-          echo "${trivy_dir}" >> "${GITHUB_PATH}"
-          if [[ -x "${trivy_dir}/trivy" ]]; then
-            echo "installed=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "installed=false" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Install Trivy
-        if: steps.trivy-binary.outputs.installed != 'true'
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
         with:
           version: v0.70.0
-          cache: false
+          cache: true
           path: ${{ runner.tool_cache }}/kosmo-trivy-v0.70.0
 
       - name: Run Trivy image scan
@@ -91,8 +78,8 @@ jobs:
           vuln-type: os,library
           scanners: vuln
           severity: HIGH,CRITICAL
-          cache: false
-          cache-dir: ${{ runner.tool_cache }}/kosmo-trivy-cache
+          cache: true
+          cache-dir: ${{ github.workspace }}/.cache/trivy
           skip-setup-trivy: true
 
       - name: Upload Trivy report


### PR DESCRIPTION
## 무엇을 변경했는지

- Nuclei 잡을 임시로 `ubuntu-latest`에서 실행합니다.
- Trivy 잡을 GitHub-hosted ARM64 환경인 `ubuntu-24.04-arm`에서 실행합니다.
- Nuclei 바이너리·템플릿 캐시를 명시적으로 활성화했습니다.
- Trivy 바이너리와 취약점 DB에 GitHub Actions cache를 적용하고, 영속 자체 호스팅 머신을 전제로 한 로컬 바이너리 탐색을 제거했습니다.
- 혼잡 해소 후 바로 복구할 수 있도록 기존 자체 호스팅 `runs-on` 설정을 주석으로 보존했습니다.

## 왜 변경했는지

자체 호스팅 액션 러너 혼잡을 완화하면서 예약·수동 보안 스캔을 계속 실행하기 위한 임시 우회입니다. Trivy는 GitHub의 표준 ARM64 hosted runner인 `ubuntu-24.04-arm`을 사용해 현재 스캔 대상과 같은 아키텍처를 유지합니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/nuclei.yml .github/workflows/trivy-scan.yml`
- `./node_modules/.bin/prettier --check .github/workflows/nuclei.yml .github/workflows/trivy-scan.yml`
- `git diff --check`
- [Nuclei hosted canary](https://github.com/byulmaru/kosmo/actions/runs/30610296139): 성공, 6분 41초
  - `nuclei-action-linux-amd64` cache hit
  - `nuclei-templates-linux-amd64` cache hit
- [Trivy ARM cache 생성 canary](https://github.com/byulmaru/kosmo/actions/runs/30610297720): 성공, 23초
- [Trivy ARM cache hit canary](https://github.com/byulmaru/kosmo/actions/runs/30610392791): 성공, 13초
  - `trivy-binary-v0.70.0-Linux-ARM64` cache hit
  - `cache-trivy-2026-07-31` cache hit
- PR Lint와 Semgrep 통과

## 아직 어떤 문제가 남았는지

- 자체 호스팅 러너 혼잡이 해소되면 주석으로 남긴 기존 설정으로 복구해야 합니다.