### PR TITLE
iOS 홈 화면에서 Web 앱을 standalone으로 실행한다

### DIFF
--- a/apps/app/public/index.html
+++ b/apps/app/public/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="흩어진 타임라인을 한곳에서." />
     <meta name="theme-color" content="#FEFEFE" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="KOSMO" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://kos.moe/" />
     <meta property="og:site_name" content="KOSMO" />

--- a/apps/app/src/components/brand-assets.test.ts
+++ b/apps/app/src/components/brand-assets.test.ts
@@ -179,3 +179,11 @@ test('browser, PWA, and share assets expose the expected delivery sizes', async 
     },
   ]);
 });
+
+test('web shell opts into iOS standalone mode', async () => {
+  const html = await readFile(new URL('index.html', publicDirectory), 'utf8');
+
+  assert.match(html, /<meta name="apple-mobile-web-app-capable" content="yes" \/>/);
+  assert.match(html, /<meta name="apple-mobile-web-app-title" content="KOSMO" \/>/);
+  assert.match(html, /<meta name="apple-mobile-web-app-status-bar-style" content="default" \/>/);
+});


### PR DESCRIPTION
## 무엇을 변경했는지

- Web HTML에 iOS standalone 실행 메타데이터를 추가했습니다.
- 홈 화면 앱 이름을 `KOSMO`, 상태 표시줄 스타일을 `default`로 명시했습니다.
- Apple 메타데이터가 유지되는지 단위 테스트로 고정했습니다.

## 왜 변경했는지

iOS Safari에서 KOSMO를 홈 화면에 추가했을 때 브라우저 UI가 있는 일반 웹 페이지가 아니라 앱 형태의 standalone 화면으로 실행되게 하기 위함입니다.

Linear: [PROD-618](https://linear.app/byulmaru/issue/PROD-618/ios-홈-화면에서-web-앱을-standalone으로-실행한다)

## 이번 PR의 주요 결정

### iOS standalone 표시만 지원한다

- 결정자: @robin-maki
- 선택: Apple Web App 메타데이터만 추가합니다.
- 고려한 대안: 서비스 워커, 오프라인 캐시, 일반적인 PWA 설치 기능까지 확장합니다.
- 이유: 현재 요구사항은 iOS 홈 화면에서 앱처럼 보이게 실행하는 것이며 오프라인/PWA 전체 지원은 필요하지 않습니다.
- 감수한 결과: 이 PR은 오프라인 실행, Web Push, Android PWA 설치 경험을 제공하지 않습니다.
- 관련 근거: PROD-618

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app test:unit` — 127개 통과
- `pnpm --filter @kosmo/app export:web` — Expo Web export 성공
- export된 `dist/index.html`에 Apple standalone 메타데이터가 포함되는 것을 확인했습니다.

## 아직 어떤 문제가 남았는지

- 실제 iOS 기기에서 배포본을 홈 화면에 다시 추가하는 최종 확인은 배포 후 필요합니다.
- 서비스 워커, 오프라인 캐시, Web Push는 의도적으로 범위에서 제외했습니다.