### PR TITLE
액션 혼잡 동안 Test를 GitHub-hosted ARM runner에서 실행한다

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: [self-hosted]
+    # runs-on: [self-hosted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -19,17 +21,33 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: false
+          cache: true
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: pnpm --filter @kosmo/app exec playwright install chromium
+        run: pnpm --filter @kosmo/app exec playwright install --with-deps chromium
 
-      - name: Install Helm
-        working-directory: apps/helm
-        run: mise install helm
+      - name: Set up Helm
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: true
+          install_args: helm
+          working_directory: apps/helm
 
       - name: Run module tests
         run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: Test
     # runs-on: [self-hosted]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
       - name: Checkout repository

--- a/apps/api/tests/integration/graphql/profile-follow-graph.test.ts
+++ b/apps/api/tests/integration/graphql/profile-follow-graph.test.ts
@@ -22,7 +22,7 @@ import type { yoga as YogaRouter } from '../../../src/graphql';
 
 const publicOrigin = 'http://127.0.0.1:4173';
 const remoteDomain = 'remote.example';
-const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+process.env.DATABASE_URL ??= 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
 
 let AccountProfiles: typeof CoreDb.AccountProfiles;
 let Accounts: typeof CoreDb.Accounts;
@@ -42,7 +42,6 @@ let localInstanceId: string;
 
 describe('GraphQL profile follow graph', () => {
   before(async () => {
-    process.env.DATABASE_URL = databaseUrl;
     process.env.NODE_ENV = 'production';
     process.env.PUBLIC_ORIGIN = publicOrigin;
 
@@ -851,7 +850,9 @@ const resetFixtures = async () => {
 };
 
 const truncateDatabase = async () => {
-  assert.equal(new URL(process.env.DATABASE_URL ?? '').pathname, '/kosmo_test');
+  const databaseUrl = new URL(process.env.DATABASE_URL ?? '');
+  assert.ok(['127.0.0.1', '[::1]', 'localhost'].includes(databaseUrl.hostname));
+  assert.match(decodeURIComponent(databaseUrl.pathname.slice(1)), /^kosmo_test(?:_[a-z0-9_]+)?$/);
   await pg.unsafe(`
     DO $$
     DECLARE

--- a/apps/api/tests/integration/graphql/profile-follow-graph.test.ts
+++ b/apps/api/tests/integration/graphql/profile-follow-graph.test.ts
@@ -22,7 +22,7 @@ import type { yoga as YogaRouter } from '../../../src/graphql';
 
 const publicOrigin = 'http://127.0.0.1:4173';
 const remoteDomain = 'remote.example';
-const databaseUrl = 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
+const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
 
 let AccountProfiles: typeof CoreDb.AccountProfiles;
 let Accounts: typeof CoreDb.Accounts;


### PR DESCRIPTION
## 무엇을 변경했는지

- Test 잡을 임시로 `ubuntu-24.04-arm`에서 실행합니다.
- 혼잡 해소 후 바로 복구할 수 있도록 기존 `[self-hosted]` 설정을 주석으로 보존했습니다.
- mise 도구와 pnpm store에 GitHub Actions cache를 설정했습니다.
- Playwright Chromium을 Linux 시스템 의존성과 함께 설치합니다.
- Helm도 hosted runner에서 mise action으로 설치합니다.
- 실행이 무제한으로 늘어나지 않도록 60분 timeout을 설정했습니다.
- `profile-follow-graph` 통합 테스트가 공통 Test DB 래퍼가 주입하는 격리 `DATABASE_URL`을 사용하도록 정리했습니다.

## 왜 변경했는지

자체 호스팅 액션 러너 혼잡을 완화하고 Test가 Lint·Semgrep·보안 스캔과 머신, workspace, Docker 환경을 공유하지 않은 채 병렬 실행되게 하기 위한 임시 우회입니다. Test의 PostgreSQL은 실행별 hosted VM 내부 Docker Compose와 공통 Test DB 래퍼로 격리됩니다.

## 어떻게 확인했는지

- `actionlint .github/workflows/test.yml`
- `prettier --check`
- 변경된 통합 테스트 ESLint
- `git diff --check`
- 공통 `scripts/test-db.mjs run` 경로에서 `profile-follow-graph` 통합 테스트 15개 통과
- GitHub-hosted ARM Test 전체 성공: https://github.com/byulmaru/kosmo/actions/runs/30612098531 (10분 44초)

## 아직 어떤 문제가 남았는지

- 캐시는 이번 PR에서 설정만 적용했으며 hit 여부와 성능 효과는 완료 조건으로 검증하지 않았습니다. 실제 미적중 문제가 발견되면 후속 PR로 수정합니다.
- 자체 호스팅 러너 혼잡이 해소되면 주석으로 남긴 기존 설정으로 복구해야 합니다.