### PR TITLE
[PROD-621] 모바일 글쓰기 공개 범위 변경 후 포커스를 정리한다

### DIFF
--- a/apps/app/src/components/post/PostComposer.tsx
+++ b/apps/app/src/components/post/PostComposer.tsx
@@ -363,6 +363,7 @@ function PostComposerContents({
             disabled={submitting}
             key={option.value}
             onPress={() => {
+              setEditorFocused(false);
               setVisibility(option.value);
               setVisibilityOpen(false);
               if (Platform.OS === 'web') {
@@ -408,6 +409,7 @@ function PostComposerContents({
         accessibilityRole="button"
         accessibilityState={{ disabled: submitting }}
         disabled={submitting}
+        onPressIn={() => setEditorFocused(false)}
         onPress={() => setVisibilityOpen(!visibilityOpen)}
         style={({ pressed }) => [
           styles.visibilityTrigger,

--- a/apps/app/src/components/post/PostComposer.tsx
+++ b/apps/app/src/components/post/PostComposer.tsx
@@ -363,7 +363,10 @@ function PostComposerContents({
             disabled={submitting}
             key={option.value}
             onPress={() => {
-              setEditorFocused(false);
+              if (Platform.OS === 'web') {
+                editor.current?.blur();
+                setEditorFocused(false);
+              }
               setVisibility(option.value);
               setVisibilityOpen(false);
               if (Platform.OS === 'web') {
@@ -409,8 +412,13 @@ function PostComposerContents({
         accessibilityRole="button"
         accessibilityState={{ disabled: submitting }}
         disabled={submitting}
-        onPressIn={() => setEditorFocused(false)}
-        onPress={() => setVisibilityOpen(!visibilityOpen)}
+        onPress={() => {
+          if (Platform.OS === 'web') {
+            editor.current?.blur();
+            setEditorFocused(false);
+          }
+          setVisibilityOpen(!visibilityOpen);
+        }}
         style={({ pressed }) => [
           styles.visibilityTrigger,
           {
@@ -483,6 +491,7 @@ function PostComposerContents({
                 : theme.border,
           },
         ]}
+        testID="post-composer-editor-surface"
       >
         {replyMode ? null : visibilitySelector}
         <TextArea

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -3496,6 +3496,53 @@ export const ComposerVisibilityAndSubmitInteraction: Story = {
   render: () => <ComposerStory />,
 };
 
+export const ComposerVisibilityFocusLifecycle: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = canvas.getByRole('textbox', { name: '게시글 본문' });
+    const trigger = canvas.getByRole('button', { name: '조용한 공개' });
+    const editorSurface = body.parentElement?.parentElement;
+    if (!editorSurface) {
+      throw new Error('Post composer editor surface is missing.');
+    }
+
+    const pressTouch = async (target: Element) => {
+      const rect = target.getBoundingClientRect();
+      await userEvent.pointer({
+        coords: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+        keys: '[TouchA]',
+        target,
+      });
+    };
+
+    await userEvent.type(body, '터치 경로에서 포커스 상태를 확인합니다.');
+    expect(body).toHaveFocus();
+    await pressTouch(trigger);
+
+    const menu = await canvas.findByRole('menu', { name: '게시글 공개 설정' });
+    await pressTouch(within(menu).getByRole('menuitemradio', { name: /^공개/ }));
+    await waitFor(() => expect(canvas.queryByRole('menu')).not.toBeInTheDocument());
+    expect(body).not.toHaveFocus();
+    expect(trigger).toHaveFocus();
+    expect(getComputedStyle(editorSurface).borderColor).not.toBe('rgb(252, 231, 154)');
+
+    await userEvent.keyboard('{Enter}');
+    const keyboardMenu = await canvas.findByRole('menu', { name: '게시글 공개 설정' });
+    const keyboardOption = within(keyboardMenu).getByRole('menuitemradio', {
+      name: /^조용한 공개/,
+    });
+    await userEvent.keyboard('{ArrowDown}');
+    expect(keyboardOption).toHaveFocus();
+    await userEvent.click(keyboardOption);
+    await waitFor(() => expect(canvas.queryByRole('menu')).not.toBeInTheDocument());
+    expect(body).not.toHaveFocus();
+    expect(trigger).toHaveFocus();
+    expect(getComputedStyle(editorSurface).borderColor).not.toBe('rgb(252, 231, 154)');
+  },
+  render: () => <ComposerStory />,
+};
+
 export const ComposerErrorInteraction: Story = {
   parameters: { relay: { mutationError: '게시글 작성 실패' } },
   play: async ({ canvasElement }) => {

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -3530,6 +3530,7 @@ export const ComposerVisibilityFocusLifecycle: Story = {
         keys: '[/TouchA]',
         target: canvasElement,
       });
+      await new Promise((resolve) => setTimeout(resolve, 100));
     };
 
     await userEvent.type(body, '터치 경로에서 포커스 상태를 확인합니다.');

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -3502,10 +3502,8 @@ export const ComposerVisibilityFocusLifecycle: Story = {
     const canvas = within(canvasElement);
     const body = canvas.getByRole('textbox', { name: '게시글 본문' });
     const trigger = canvas.getByRole('button', { name: '조용한 공개' });
-    const editorSurface = body.parentElement?.parentElement;
-    if (!editorSurface) {
-      throw new Error('Post composer editor surface is missing.');
-    }
+    const editorSurface = canvas.getByTestId('post-composer-editor-surface');
+    const baselineBorderColor = getComputedStyle(editorSurface).borderColor;
 
     const pressTouch = async (target: Element) => {
       const rect = target.getBoundingClientRect();
@@ -3515,30 +3513,78 @@ export const ComposerVisibilityFocusLifecycle: Story = {
         target,
       });
     };
+    const cancelTouch = async (target: Element) => {
+      const rect = target.getBoundingClientRect();
+      await userEvent.pointer({
+        coords: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+        keys: '[TouchA>]',
+        target,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await userEvent.pointer({
+        coords: { x: rect.left - 32, y: rect.top - 32 },
+        target: canvasElement,
+      });
+      await userEvent.pointer({
+        coords: { x: rect.left - 32, y: rect.top - 32 },
+        keys: '[/TouchA]',
+        target: canvasElement,
+      });
+    };
 
     await userEvent.type(body, '터치 경로에서 포커스 상태를 확인합니다.');
     expect(body).toHaveFocus();
+    const focusedBorderColor = getComputedStyle(editorSurface).borderColor;
+    expect(focusedBorderColor).not.toBe(baselineBorderColor);
+
+    await cancelTouch(trigger);
+    expect(canvas.queryByRole('menu', { name: '게시글 공개 설정' })).not.toBeInTheDocument();
+    expect(body).toHaveFocus();
+    expect(getComputedStyle(editorSurface).borderColor).toBe(focusedBorderColor);
+
     await pressTouch(trigger);
 
     const menu = await canvas.findByRole('menu', { name: '게시글 공개 설정' });
+    expect(body).not.toHaveFocus();
+    await waitFor(() =>
+      expect(within(menu).getByRole('menuitemradio', { name: /^조용한 공개/ })).toHaveFocus(),
+    );
+    expect(getComputedStyle(editorSurface).borderColor).toBe(baselineBorderColor);
     await pressTouch(within(menu).getByRole('menuitemradio', { name: /^공개/ }));
     await waitFor(() => expect(canvas.queryByRole('menu')).not.toBeInTheDocument());
     expect(body).not.toHaveFocus();
     expect(trigger).toHaveFocus();
-    expect(getComputedStyle(editorSurface).borderColor).not.toBe('rgb(252, 231, 154)');
+    expect(getComputedStyle(editorSurface).borderColor).toBe(baselineBorderColor);
+  },
+  render: () => <ComposerStory />,
+};
 
+export const ComposerVisibilityKeyboardFocusLifecycle: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = canvas.getByRole('textbox', { name: '게시글 본문' });
+    const trigger = canvas.getByRole('button', { name: '조용한 공개' });
+    const editorSurface = canvas.getByTestId('post-composer-editor-surface');
+    const baselineBorderColor = getComputedStyle(editorSurface).borderColor;
+
+    await userEvent.type(body, '키보드 경로에서 포커스 상태를 확인합니다.');
+    expect(body).toHaveFocus();
+    expect(getComputedStyle(editorSurface).borderColor).not.toBe(baselineBorderColor);
+
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(trigger).toHaveFocus();
     await userEvent.keyboard('{Enter}');
     const keyboardMenu = await canvas.findByRole('menu', { name: '게시글 공개 설정' });
     const keyboardOption = within(keyboardMenu).getByRole('menuitemradio', {
       name: /^조용한 공개/,
     });
-    await userEvent.keyboard('{ArrowDown}');
     expect(keyboardOption).toHaveFocus();
-    await userEvent.click(keyboardOption);
+    await userEvent.keyboard('{Enter}');
     await waitFor(() => expect(canvas.queryByRole('menu')).not.toBeInTheDocument());
     expect(body).not.toHaveFocus();
     expect(trigger).toHaveFocus();
-    expect(getComputedStyle(editorSurface).borderColor).not.toBe('rgb(252, 231, 154)');
+    expect(getComputedStyle(editorSurface).borderColor).toBe(baselineBorderColor);
   },
   render: () => <ComposerStory />,
 };
@@ -3856,8 +3902,7 @@ export const ReplyDetailInlineIntegration: Story = {
     expect(body).toBeVisible();
     await waitFor(() => expect(body).toHaveFocus());
     expect(getComputedStyle(body).outlineStyle).toBe('none');
-    const editorSurface = body.parentElement?.parentElement;
-    expect(editorSurface).not.toBeNull();
+    const editorSurface = canvas.getByTestId('post-composer-editor-surface');
     const editorStyle = getComputedStyle(editorSurface!);
     expect(
       getColorContrastRatio(editorStyle.borderColor, editorStyle.backgroundColor),

--- a/apps/web/e2e/compose.e2e.ts
+++ b/apps/web/e2e/compose.e2e.ts
@@ -99,3 +99,67 @@ test('compose에서 공개 범위와 500자 제한을 적용해 createPost를 �
   await page.goto('/@e2e-composer');
   await expect(page.getByText(body)).toBeVisible();
 });
+
+test('compose의 touch 취소가 본문 포커스와 편집기 강조 상태를 유지한다', async ({
+  context,
+  page,
+}) => {
+  const viewer = await createE2ESession({
+    displayName: 'E2E Touch Composer',
+    handle: 'e2e-touch-composer',
+  });
+  await setE2ESessionCookie(context, viewer.token);
+  await page.setViewportSize({ width: 280, height: 720 });
+  await page.goto('/compose');
+
+  const composer = page.getByLabel('새 게시글 작성').first();
+  const input = composer.getByRole('textbox', { name: '게시글 본문' });
+  const editorSurface = composer.getByTestId('post-composer-editor-surface');
+  const visibilityTrigger = composer.getByRole('button', { name: '조용한 공개' });
+  const unfocusedBorderColor = await editorSurface.evaluate(
+    (element) => getComputedStyle(element).borderColor,
+  );
+
+  await input.fill('touch 취소 뒤에도 포커스를 유지하는 본문입니다.');
+  await expect(input).toBeFocused();
+  await expect
+    .poll(() => editorSurface.evaluate((element) => getComputedStyle(element).borderColor))
+    .not.toBe(unfocusedBorderColor);
+  const focusedBorderColor = await editorSurface.evaluate(
+    (element) => getComputedStyle(element).borderColor,
+  );
+  expect(focusedBorderColor).not.toBe(unfocusedBorderColor);
+
+  const triggerBox = await visibilityTrigger.boundingBox();
+  expect(triggerBox).not.toBeNull();
+  const session = await context.newCDPSession(page);
+  try {
+    const x = triggerBox!.x + triggerBox!.width / 2;
+    const y = triggerBox!.y + triggerBox!.height / 2;
+    await session.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x, y }],
+    });
+    await page.waitForTimeout(100);
+    await session.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: x + 180, y: y + 180 }],
+    });
+    await page.waitForTimeout(50);
+    await session.send('Input.dispatchTouchEvent', {
+      type: 'touchEnd',
+      touchPoints: [],
+    });
+    await page.waitForTimeout(100);
+
+    await expect(input).toBeFocused();
+    await expect(page.getByRole('menu', { name: '게시글 공개 설정' })).toHaveCount(0);
+    const borderAfterCancel = await editorSurface.evaluate(
+      (element) => getComputedStyle(element).borderColor,
+    );
+    expect(borderAfterCancel).toBe(focusedBorderColor);
+    expect(borderAfterCancel).not.toBe(unfocusedBorderColor);
+  } finally {
+    await session.detach();
+  }
+});


### PR DESCRIPTION
## 무엇을 변경했는지

- 모바일 Web에서 공개 범위 trigger 또는 option을 성공적으로 활성화하면 본문 editor를 실제로 blur하고 시각 focus 상태를 함께 정리합니다.
- 취소된 touch에서는 본문 focus와 editor focus border를 유지합니다.
- touch와 keyboard 경로를 독립된 Storybook interaction으로 검증하고, 안정적인 editor surface selector와 runtime baseline 색상 비교를 사용합니다.
- Playwright CDP touch sequence로 press 시작 후 취소되는 실제 Web 회귀 E2E를 추가했습니다.

## 왜 변경했는지

모바일 Web 글쓰기에서 공개 범위를 변경한 뒤 실제 입력 focus와 editor의 시각적 focus가 어긋날 수 있었습니다. 초기 수정의 `onPressIn` 상태 변경은 취소된 touch에서도 indicator만 먼저 지우는 역회귀를 만들 수 있어, 성공한 activation에서 실제 blur와 상태 변경을 결합하도록 고쳤습니다.

Linear: [PROD-621](https://linear.app/byulmaru/issue/PROD-621/모바일-글쓰기-공개-범위-변경-후-본문-입력-포커스가-남는-버그)

## 이번 PR의 주요 결정

- Web의 성공한 공개 범위 activation만 editor blur를 소유합니다.
- Native 동작은 이번 버그 수정 범위에서 변경하지 않습니다.
- Storybook의 합성 touch는 보조 검증으로 두고, RN Web `onPressIn` 지연을 실제로 통과하는 CDP E2E를 touch-cancel 회귀의 권위 있는 검증으로 사용합니다.
- 기존 공개 범위 종류, 작성 API와 layout 계약은 변경하지 않습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check` ✅
- `pnpm --filter @kosmo/web check` ✅
- `pnpm --filter @kosmo/app test:storybook` ✅ 19 files / 251 tests
- `pnpm --filter @kosmo/app build-storybook` ✅
- 격리 DB 기반 `e2e/compose.e2e.ts` ✅ 2/2
- red-green: repair HEAD에서는 CDP touch-cancel E2E가 통과하고, repair 직전 bad `onPressIn` 구현을 임시 주입하면 focused border가 neutral border로 바뀌어 새 E2E만 실패함
- 변경 파일 Prettier, ESLint, `git diff --check` ✅

## 아직 어떤 문제가 남았는지

- 실제 iOS Safari·Android Chrome 및 screen reader runtime은 실행하지 않았습니다.
- Chromium CDP와 Storybook에서 touch·keyboard focus 계약을 검증했으며, 브라우저별 가상 키보드와 announcement 차이는 남은 runtime 위험입니다.