### PR TITLE
모바일 Web 검색창 자동 확대를 방지한다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -2,7 +2,7 @@ import { parseSearchTab, SearchTab } from '@kosmo/core/search';
 import { Link, useLocalSearchParams, useRouter } from 'expo-router';
 import { ArrowLeft, History, Search as SearchIcon, X } from 'lucide-react-native';
 import { useEffect, useRef, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { graphql, usePaginationFragment, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import { trackAnalytics } from '@/analytics/client';
 import { ProfileListItem } from '@/components/profile/ProfileListItem';
@@ -354,7 +354,11 @@ export default function SearchScreen() {
               placeholder="검색어를 입력하세요"
               placeholderTextColor={theme.textSecondary}
               returnKeyType="search"
-              style={[styles.input, { color: theme.text }]}
+              style={[
+                styles.input,
+                Platform.OS === 'web' ? styles.webInput : null,
+                { color: theme.text },
+              ]}
               value={input}
             />
             {input ? (
@@ -503,6 +507,7 @@ const styles = StyleSheet.create({
     paddingVertical: 0,
     ...typography.sm,
   },
+  webInput: { fontSize: 16 },
   clearButton: { alignItems: 'center', height: 44, justifyContent: 'center', width: 44 },
   recent: { width: '100%' },
   sectionTitle: {

--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -502,7 +502,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.sm,
     paddingVertical: 0,
     ...typography.sm,
-    fontSize: 16,
+    fontSize: typography.md.fontSize,
   },
   clearButton: { alignItems: 'center', height: 44, justifyContent: 'center', width: 44 },
   recent: { width: '100%' },

--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -2,7 +2,7 @@ import { parseSearchTab, SearchTab } from '@kosmo/core/search';
 import { Link, useLocalSearchParams, useRouter } from 'expo-router';
 import { ArrowLeft, History, Search as SearchIcon, X } from 'lucide-react-native';
 import { useEffect, useRef, useState } from 'react';
-import { Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { graphql, usePaginationFragment, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import { trackAnalytics } from '@/analytics/client';
 import { ProfileListItem } from '@/components/profile/ProfileListItem';
@@ -354,11 +354,7 @@ export default function SearchScreen() {
               placeholder="검색어를 입력하세요"
               placeholderTextColor={theme.textSecondary}
               returnKeyType="search"
-              style={[
-                styles.input,
-                Platform.OS === 'web' ? styles.webInput : null,
-                { color: theme.text },
-              ]}
+              style={[styles.input, { color: theme.text }]}
               value={input}
             />
             {input ? (
@@ -506,8 +502,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.sm,
     paddingVertical: 0,
     ...typography.sm,
+    fontSize: 16,
   },
-  webInput: { fontSize: 16 },
   clearButton: { alignItems: 'center', height: 44, justifyContent: 'center', width: 44 },
   recent: { width: '100%' },
   sectionTitle: {

--- a/apps/app/src/stories/Search.stories.tsx
+++ b/apps/app/src/stories/Search.stories.tsx
@@ -87,6 +87,7 @@ export const KeyboardSubmissionTracksAnalytics: Story = {
   parameters: { router: { params: {}, pathname: '/search' } },
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole('textbox', { name: '검색어' });
+    expect(getComputedStyle(input).fontSize).toBe('16px');
     await userEvent.type(input, '검색 원문{enter}');
     expect(trackAnalytics).toHaveBeenCalledOnce();
     expect(trackAnalytics).toHaveBeenCalledWith('search_submitted', {


### PR DESCRIPTION
## 무엇을 변경했는지

- 검색 입력 자체의 폰트 크기를 플랫폼 분기 없이 16으로 지정했습니다.
- 검색 Storybook의 계산된 Web 폰트 크기 16px 회귀 검증을 유지했습니다.

## 왜 변경했는지

iOS Safari는 입력 요소의 폰트 크기가 16px보다 작을 때 포커스 시 자동 확대할 수 있습니다. 검색 입력의 목표 크기는 플랫폼별 예외가 아니라 컴포넌트 자체의 16px 계약이므로 Web 전용 분기 없이 동일하게 적용했습니다.

## 이번 PR의 주요 결정

### 검색 입력에 플랫폼 공통 16px 적용

- 결정자: @HJSmiley
- 선택: 검색 입력의 공용 style에 `fontSize: 16`을 직접 지정
- 고려한 대안: Web에서만 `Platform.OS === 'web'` 분기로 16px 보정
- 이유: 검색 입력 자체의 폰트 크기를 16px로 정의하는 것이 의도이며 플랫폼별 분기가 불필요함
- 감수한 결과: Android/iOS Native 검색 입력도 기존 14px에서 16px로 변경됨
- 관련 근거: Linear PROD-620 범위와 완료 조건을 같은 결정으로 갱신함

사용자 pinch zoom과 브라우저 기본 확대 기능은 제한하지 않습니다.

## 어떻게 확인할 수 있는지

- 변경 파일 Prettier 통과
- Relay compiler 통과
- TypeScript `tsc --noEmit` 통과
- 새 head `80205ba5` GitHub Actions 전체 통과
  - Lint
  - Semgrep
  - Test: Root, Core, Fedify, API, App, Web 및 최종 gate
- 격리 worktree의 targeted Storybook 단독 재실행은 브라우저가 원본 workspace symlink의 외부 setup module을 거부해 실행하지 못했습니다. 같은 Storybook test를 포함한 새 head의 App CI는 통과했습니다.

## 아직 어떤 문제가 남았는지

- 실제 iOS Safari 실기기에서 약 390px viewport로 검색 입력 포커스 전후 자동 확대 미발생과 사용자 pinch zoom 유지를 직접 확인하는 검증은 아직 수행하지 않았습니다.
- 이 필수 runtime gate가 완료될 때까지 PR을 Draft로 유지합니다.