### PR TITLE
모바일 drawer와 프로필 목록의 스크롤 소유권을 보장한다

### DIFF
--- a/apps/app/.storybook/mocks/expo-router.tsx
+++ b/apps/app/.storybook/mocks/expo-router.tsx
@@ -92,7 +92,7 @@ export function Link({
     !asChild ||
     !isValidElement<{
       href?: string;
-      onPress?: (event: { preventDefault?: () => void }) => void;
+      onPress?: (event: LinkPressEvent) => void;
     }>(children)
   ) {
     return <Fragment>{children}</Fragment>;

--- a/apps/app/.storybook/mocks/expo-router.tsx
+++ b/apps/app/.storybook/mocks/expo-router.tsx
@@ -102,8 +102,9 @@ export function Link({
     href: typeof href === 'string' ? href : href.pathname,
     onPress: (event: LinkPressEvent) => {
       children.props.onPress?.(event);
-      if (shouldHandleNavigation(event)) {
-        event.preventDefault?.();
+      const shouldNavigate = shouldHandleNavigation(event);
+      event.preventDefault?.();
+      if (shouldNavigate) {
         setPathname(href);
       }
     },

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -114,10 +114,6 @@ const webFullPickerBounds = {
 const webDrawerPickerBounds = {
   maxHeight: 'min(430px, calc(100vh - 206px))',
 } as unknown as ViewStyle;
-const webInternalScroll = {
-  overflowY: 'auto',
-  touchAction: 'pan-y',
-} as unknown as ViewStyle;
 const countFormatter = new Intl.NumberFormat('en', {
   maximumFractionDigits: 1,
   notation: 'compact',
@@ -167,7 +163,8 @@ export function ProfileSwitcher({
   const compact = surface === 'compact';
   const fullWeb = Platform.OS === 'web' && surface === 'full';
   const mobileWebDrawer = Platform.OS === 'web' && surface === 'drawer';
-  const redesignedWeb = Platform.OS === 'web';
+  const redesignedWeb = Platform.OS === 'web' && surface !== 'drawer';
+  const scrollableWebPicker = Platform.OS === 'web';
   const open = controlledOpen ?? internalOpen;
   const webExpandedChevron = Platform.OS === 'web' && open;
   const setOpen = (nextOpen: boolean) => {
@@ -305,7 +302,7 @@ export function ProfileSwitcher({
     action();
   };
 
-  const surfaceBounds = !redesignedWeb
+  const surfaceBounds = !scrollableWebPicker
     ? undefined
     : surface === 'compact'
       ? webCompactPickerBounds
@@ -356,7 +353,7 @@ export function ProfileSwitcher({
       ref={pickerRef}
       style={[
         styles.menu,
-        redesignedWeb ? styles.redesignedMenu : undefined,
+        scrollableWebPicker ? styles.redesignedMenu : undefined,
         surfaceBounds,
         { backgroundColor: theme.card, borderColor: theme.border },
       ]}
@@ -365,14 +362,14 @@ export function ProfileSwitcher({
         accessibilityLabel="프로필 전환"
         accessibilityRole={Platform.OS === 'web' ? undefined : 'menu'}
         role={Platform.OS === 'web' && !redesignedWeb ? 'menu' : undefined}
-        style={redesignedWeb ? styles.redesignedMenuRegion : styles.menuItems}
+        style={scrollableWebPicker ? styles.redesignedMenuRegion : styles.menuItems}
       >
-        {redesignedWeb ? (
+        {scrollableWebPicker ? (
           <ScrollView
             accessibilityLabel="전환할 프로필 목록"
             contentContainerStyle={styles.profileListContent}
             role="group"
-            style={[styles.profileList, webInternalScroll]}
+            style={styles.profileList}
           >
             {profileOptions}
           </ScrollView>

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -111,6 +111,13 @@ const webCompactPickerBounds = {
 const webFullPickerBounds = {
   maxHeight: 'min(430px, calc(100vh - 276px))',
 } as unknown as ViewStyle;
+const webDrawerPickerBounds = {
+  maxHeight: 'min(430px, calc(100vh - 206px))',
+} as unknown as ViewStyle;
+const webInternalScroll = {
+  overflowY: 'auto',
+  touchAction: 'pan-y',
+} as unknown as ViewStyle;
 const countFormatter = new Intl.NumberFormat('en', {
   maximumFractionDigits: 1,
   notation: 'compact',
@@ -160,7 +167,7 @@ export function ProfileSwitcher({
   const compact = surface === 'compact';
   const fullWeb = Platform.OS === 'web' && surface === 'full';
   const mobileWebDrawer = Platform.OS === 'web' && surface === 'drawer';
-  const redesignedWeb = Platform.OS === 'web' && surface !== 'drawer';
+  const redesignedWeb = Platform.OS === 'web';
   const open = controlledOpen ?? internalOpen;
   const webExpandedChevron = Platform.OS === 'web' && open;
   const setOpen = (nextOpen: boolean) => {
@@ -302,7 +309,9 @@ export function ProfileSwitcher({
     ? undefined
     : surface === 'compact'
       ? webCompactPickerBounds
-      : webFullPickerBounds;
+      : surface === 'drawer'
+        ? webDrawerPickerBounds
+        : webFullPickerBounds;
   const profileOptions = profiles.map((profile) => {
     const selected = active?.id === profile.id;
     return (
@@ -363,7 +372,7 @@ export function ProfileSwitcher({
             accessibilityLabel="전환할 프로필 목록"
             contentContainerStyle={styles.profileListContent}
             role="group"
-            style={styles.profileList}
+            style={[styles.profileList, webInternalScroll]}
           >
             {profileOptions}
           </ScrollView>

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -1,6 +1,6 @@
 import { usePathname } from 'expo-router';
 import { Bell, Bookmark, House, Mail, PenLine, Search, UserRound } from 'lucide-react-native';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing } from '@/theme/tokens';
@@ -12,6 +12,7 @@ import { useUnreadNotificationCount } from './UnreadNotificationBadgeController'
 import { getUnreadNotificationAccessibilityLabel } from './unreadNotificationBadgeState';
 import type { Href } from 'expo-router';
 import type { LucideIcon } from 'lucide-react-native';
+import type { ViewStyle } from 'react-native';
 import type { SidebarNavigation_query$key } from './__generated__/SidebarNavigation_query.graphql';
 
 const SidebarNavigationFragment = graphql`
@@ -48,6 +49,11 @@ const navigation: NavigationItem[] = [
   { Icon: UserRound, label: '프로필', profile: true },
   { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
 ];
+
+const webDrawerScroll = {
+  overflowY: 'auto',
+  touchAction: 'pan-y',
+} as unknown as ViewStyle;
 
 type Props = {
   compact?: boolean;
@@ -108,8 +114,10 @@ export function SidebarNavigation({
         style={[
           styles.navigationArea,
           compact && styles.compactNavigationArea,
+          surface === 'drawer' && Platform.OS === 'web' && webDrawerScroll,
           { borderColor: theme.border },
         ]}
+        testID={surface === 'drawer' ? 'mobile-sidebar-scroll' : undefined}
       >
         <View accessibilityLabel="주요 메뉴" role="navigation" style={styles.navigation}>
           {navigation.map((item) => {
@@ -247,7 +255,7 @@ export function SidebarNavigation({
 }
 
 const styles = StyleSheet.create({
-  root: { flex: 1 },
+  root: { flex: 1, minHeight: 0 },
   iconWithBadge: { position: 'relative' },
   compactRoot: {
     alignItems: 'center',

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -1,6 +1,6 @@
 import { usePathname } from 'expo-router';
 import { Bell, Bookmark, House, Mail, PenLine, Search, UserRound } from 'lucide-react-native';
-import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing } from '@/theme/tokens';
@@ -12,7 +12,6 @@ import { useUnreadNotificationCount } from './UnreadNotificationBadgeController'
 import { getUnreadNotificationAccessibilityLabel } from './unreadNotificationBadgeState';
 import type { Href } from 'expo-router';
 import type { LucideIcon } from 'lucide-react-native';
-import type { ViewStyle } from 'react-native';
 import type { SidebarNavigation_query$key } from './__generated__/SidebarNavigation_query.graphql';
 
 const SidebarNavigationFragment = graphql`
@@ -49,11 +48,6 @@ const navigation: NavigationItem[] = [
   { Icon: UserRound, label: '프로필', profile: true },
   { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
 ];
-
-const webDrawerScroll = {
-  overflowY: 'auto',
-  touchAction: 'pan-y',
-} as unknown as ViewStyle;
 
 type Props = {
   compact?: boolean;
@@ -114,7 +108,6 @@ export function SidebarNavigation({
         style={[
           styles.navigationArea,
           compact && styles.compactNavigationArea,
-          surface === 'drawer' && Platform.OS === 'web' && webDrawerScroll,
           { borderColor: theme.border },
         ]}
         testID={surface === 'drawer' ? 'mobile-sidebar-scroll' : undefined}

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -1,6 +1,6 @@
 import { Slot, usePathname } from 'expo-router';
 import { Menu } from 'lucide-react-native';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Modal,
   PanResponder,
@@ -109,6 +109,18 @@ function UniversalShellContent({ revision }: { revision: number }) {
   const full = layout === 'full';
   const mobile = layout === 'mobile';
   const home = pathname === '/home';
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !drawerOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [drawerOpen]);
 
   const swipeToOpenDrawer = useMemo(
     () =>
@@ -302,12 +314,19 @@ const styles = StyleSheet.create({
     minHeight: 44,
     width: 44,
   },
-  drawerBackdrop: { backgroundColor: 'rgba(0,0,0,0.35)', flex: 1, flexDirection: 'row' },
+  drawerBackdrop: {
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    flex: 1,
+    flexDirection: 'row',
+    minHeight: 0,
+  },
   drawer: {
     borderBottomRightRadius: 16,
     borderTopRightRadius: 16,
     boxShadow: '4px 0 4px rgba(0, 0, 0, 0.4)',
+    height: '100%',
     maxWidth: '85%',
+    minHeight: 0,
     overflow: 'hidden',
     width: 320,
   },

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -115,10 +115,28 @@ function UniversalShellContent({ revision }: { revision: number }) {
       return;
     }
 
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    const bodyStyle = document.body.style;
+    const previousBodyStyle = {
+      left: bodyStyle.left,
+      overflow: bodyStyle.overflow,
+      position: bodyStyle.position,
+      right: bodyStyle.right,
+      top: bodyStyle.top,
+      width: bodyStyle.width,
+    };
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+    Object.assign(bodyStyle, {
+      left: `-${scrollX}px`,
+      overflow: 'hidden',
+      position: 'fixed',
+      right: '0px',
+      top: `-${scrollY}px`,
+      width: '100%',
+    });
     return () => {
-      document.body.style.overflow = previousOverflow;
+      Object.assign(bodyStyle, previousBodyStyle);
+      window.scrollTo(scrollX, scrollY);
     };
   }, [drawerOpen]);
 

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -1148,11 +1148,6 @@ export const UniversalMobile: Story = {
     await userEvent.click(menuButton);
     const page = within(canvasElement.ownerDocument.body);
     const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
-    expect(canvasElement.ownerDocument.body.style.overflow).toBe('hidden');
-    expect(page.getByTestId('mobile-sidebar-scroll')).toHaveStyle({
-      overflowY: 'auto',
-      touchAction: 'pan-y',
-    });
     const profileTrigger = page.getByRole('button', { name: '프로필 목록' });
     const triggerName = within(profileTrigger).getByText('코스모 작가');
     const profileHandle = page.getByLabelText('활성 프로필 핸들');
@@ -1234,42 +1229,85 @@ export const UniversalMobile: Story = {
 };
 
 export const UniversalMobileLongProfilePickerScroll: Story = {
-  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  globals: { viewport: { isRotated: false, value: 'shellMobileShort' } },
   parameters: {
     ...universalParameters,
     relay: { data: longProfileQuery },
+    viewport: {
+      options: {
+        shellMobileShort: {
+          name: 'Shell mobile short',
+          styles: { height: '480px', width: '390px' },
+          type: 'mobile',
+        },
+      },
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const ownerDocument = canvasElement.ownerDocument;
+    const page = within(ownerDocument.body);
     await userEvent.click(canvas.getByRole('button', { name: '메뉴 열기' }));
 
-    const page = within(canvasElement.ownerDocument.body);
     const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
     const drawerScroll = page.getByTestId('mobile-sidebar-scroll');
     const profileTrigger = page.getByRole('button', { name: '프로필 목록' });
 
     expect(drawer).toBeVisible();
-    expect(drawerScroll).toHaveStyle({ overflowY: 'auto', touchAction: 'pan-y' });
-    expect(canvasElement.ownerDocument.body.style.overflow).toBe('hidden');
+    expect(getComputedStyle(drawerScroll).overflowY).toBe('auto');
+    expect(drawerScroll.scrollHeight).toBeGreaterThan(drawerScroll.clientHeight);
+    expect(ownerDocument.body.style.overflow).toBe('hidden');
+    const drawerScrollTop = drawerScroll.scrollTop;
+    drawerScroll.scrollTop = Math.max(1, drawerScroll.scrollHeight - drawerScroll.clientHeight);
+    await waitFor(() => expect(drawerScroll.scrollTop).toBeGreaterThan(drawerScrollTop));
+    drawerScroll.scrollTop = 0;
 
     await userEvent.click(profileTrigger);
     const list = await page.findByLabelText('전환할 프로필 목록');
-    const picker = page.getByLabelText('프로필 전환');
-    const options = within(list).getAllByRole('button');
-    const addProfile = page.getByRole('button', { name: '새 프로필 추가' });
+    const picker = await page.findByRole('menu', { name: '프로필 전환' });
+    const options = within(list).getAllByRole('menuitemradio');
+    const addProfile = within(picker).getByRole('menuitem', { name: '새 프로필 추가' });
 
     expect(picker).toBeVisible();
     expect(options).toHaveLength(12);
     expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+    expect(getComputedStyle(list).overflowY).toBe('auto');
     expect(addProfile).toBeVisible();
-    list.scrollTop = list.scrollHeight;
-    expect(list.scrollTop).toBeGreaterThan(0);
+    const listScrollTop = list.scrollTop;
+    list.scrollTop = Math.max(1, list.scrollHeight - list.clientHeight);
+    await waitFor(() => expect(list.scrollTop).toBeGreaterThan(listScrollTop));
+
+    drawerScroll.scrollTop = 0;
+    await userEvent.click(addProfile);
+    const handle = page.getByRole('textbox', { name: '프로필 핸들' });
+    const createButton = page.getByRole('button', { name: '만들기' });
+    const pickerViewport = picker.parentElement;
+    expect(pickerViewport).not.toBeNull();
+    const pickerBounds = pickerViewport!.getBoundingClientRect();
+    const drawerBounds = drawer.getBoundingClientRect();
+    for (const control of [handle, createButton]) {
+      const bounds = control.getBoundingClientRect();
+      expect(bounds.left).toBeGreaterThanOrEqual(pickerBounds.left);
+      expect(bounds.right).toBeLessThanOrEqual(pickerBounds.right);
+      expect(bounds.top).toBeGreaterThanOrEqual(pickerBounds.top);
+      expect(bounds.bottom).toBeLessThanOrEqual(pickerBounds.bottom);
+      expect(bounds.top).toBeGreaterThanOrEqual(drawerBounds.top);
+      expect(bounds.bottom).toBeLessThanOrEqual(drawerBounds.bottom);
+    }
+
+    await userEvent.type(handle, 'drawer_draft');
+    await userEvent.click(profileTrigger);
+    await waitFor(() => expect(page.queryByRole('menu', { name: '프로필 전환' })).toBeNull());
+    await userEvent.click(profileTrigger);
+    const reopenedPicker = await page.findByRole('menu', { name: '프로필 전환' });
+    await userEvent.click(within(reopenedPicker).getByRole('menuitem', { name: '새 프로필 추가' }));
+    expect(page.getByRole('textbox', { name: '프로필 핸들' })).toHaveValue('drawer_draft');
 
     await userEvent.click(page.getByRole('button', { name: '사이드바 닫기' }));
-    expect(canvasElement.ownerDocument.body.style.overflow).toBe('');
+    await waitFor(() => expect(ownerDocument.body.style.overflow).toBe(''));
   },
   render: () => (
-    <View style={{ height: 844 }}>
+    <View style={{ height: 480 }}>
       <UniversalShellStory />
     </View>
   ),

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -1148,6 +1148,11 @@ export const UniversalMobile: Story = {
     await userEvent.click(menuButton);
     const page = within(canvasElement.ownerDocument.body);
     const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
+    expect(canvasElement.ownerDocument.body.style.overflow).toBe('hidden');
+    expect(page.getByTestId('mobile-sidebar-scroll')).toHaveStyle({
+      overflowY: 'auto',
+      touchAction: 'pan-y',
+    });
     const profileTrigger = page.getByRole('button', { name: '프로필 목록' });
     const triggerName = within(profileTrigger).getByText('코스모 작가');
     const profileHandle = page.getByLabelText('활성 프로필 핸들');
@@ -1198,7 +1203,7 @@ export const UniversalMobile: Story = {
     await userEvent.click(profileTrigger);
     expect(profileTrigger).toHaveAttribute('aria-expanded', 'true');
     expect(profileTrigger.querySelector('path')).toHaveAttribute('d', 'm18 15-6-6-6 6');
-    const menu = await page.findByRole('menu', { name: '프로필 전환' });
+    const menu = await page.findByLabelText('프로필 전환');
     const picker = menu.parentElement;
     const openTriggerRect = profileTrigger.getBoundingClientRect();
     const openNavigationRect = drawer.getBoundingClientRect();
@@ -1209,7 +1214,6 @@ export const UniversalMobile: Story = {
     expect(openNavigationRect).toEqual(navigationRect);
     expect(pickerRect.top).toBeGreaterThanOrEqual(triggerRect.bottom);
     expect(pickerRect.top - triggerRect.bottom).toBeLessThanOrEqual(12);
-
     await userEvent.click(profileTrigger);
     expect(profileTrigger).toHaveAttribute('aria-expanded', 'false');
 
@@ -1221,6 +1225,48 @@ export const UniversalMobile: Story = {
     const reopenedProfileSummary = page.getByLabelText('활성 프로필');
     await userEvent.click(within(reopenedProfileSummary).getByRole('link', { name: /팔로워/ }));
     await waitFor(() => expect(page.queryByRole('button', { name: '사이드바 닫기' })).toBeNull());
+  },
+  render: () => (
+    <View style={{ height: 844 }}>
+      <UniversalShellStory />
+    </View>
+  ),
+};
+
+export const UniversalMobileLongProfilePickerScroll: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  parameters: {
+    ...universalParameters,
+    relay: { data: longProfileQuery },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '메뉴 열기' }));
+
+    const page = within(canvasElement.ownerDocument.body);
+    const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
+    const drawerScroll = page.getByTestId('mobile-sidebar-scroll');
+    const profileTrigger = page.getByRole('button', { name: '프로필 목록' });
+
+    expect(drawer).toBeVisible();
+    expect(drawerScroll).toHaveStyle({ overflowY: 'auto', touchAction: 'pan-y' });
+    expect(canvasElement.ownerDocument.body.style.overflow).toBe('hidden');
+
+    await userEvent.click(profileTrigger);
+    const list = await page.findByLabelText('전환할 프로필 목록');
+    const picker = page.getByLabelText('프로필 전환');
+    const options = within(list).getAllByRole('button');
+    const addProfile = page.getByRole('button', { name: '새 프로필 추가' });
+
+    expect(picker).toBeVisible();
+    expect(options).toHaveLength(12);
+    expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+    expect(addProfile).toBeVisible();
+    list.scrollTop = list.scrollHeight;
+    expect(list.scrollTop).toBeGreaterThan(0);
+
+    await userEvent.click(page.getByRole('button', { name: '사이드바 닫기' }));
+    expect(canvasElement.ownerDocument.body.style.overflow).toBe('');
   },
   render: () => (
     <View style={{ height: 844 }}>

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -1257,9 +1257,8 @@ export const UniversalMobileLongProfilePickerScroll: Story = {
     expect(getComputedStyle(drawerScroll).overflowY).toBe('auto');
     expect(drawerScroll.scrollHeight).toBeGreaterThan(drawerScroll.clientHeight);
     expect(ownerDocument.body.style.overflow).toBe('hidden');
-    const drawerScrollTop = drawerScroll.scrollTop;
-    drawerScroll.scrollTop = Math.max(1, drawerScroll.scrollHeight - drawerScroll.clientHeight);
-    await waitFor(() => expect(drawerScroll.scrollTop).toBeGreaterThan(drawerScrollTop));
+    drawerScroll.scrollTop = drawerScroll.scrollHeight;
+    expect(drawerScroll.scrollTop).toBeGreaterThan(0);
     drawerScroll.scrollTop = 0;
 
     await userEvent.click(profileTrigger);
@@ -1273,11 +1272,9 @@ export const UniversalMobileLongProfilePickerScroll: Story = {
     expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
     expect(getComputedStyle(list).overflowY).toBe('auto');
     expect(addProfile).toBeVisible();
-    const listScrollTop = list.scrollTop;
-    list.scrollTop = Math.max(1, list.scrollHeight - list.clientHeight);
-    await waitFor(() => expect(list.scrollTop).toBeGreaterThan(listScrollTop));
+    list.scrollTop = list.scrollHeight;
+    expect(list.scrollTop).toBeGreaterThan(0);
 
-    drawerScroll.scrollTop = 0;
     await userEvent.click(addProfile);
     const handle = page.getByRole('textbox', { name: '프로필 핸들' });
     const createButton = page.getByRole('button', { name: '만들기' });
@@ -1285,15 +1282,11 @@ export const UniversalMobileLongProfilePickerScroll: Story = {
     expect(pickerViewport).not.toBeNull();
     const pickerBounds = pickerViewport!.getBoundingClientRect();
     const drawerBounds = drawer.getBoundingClientRect();
-    for (const control of [handle, createButton]) {
-      const bounds = control.getBoundingClientRect();
-      expect(bounds.left).toBeGreaterThanOrEqual(pickerBounds.left);
-      expect(bounds.right).toBeLessThanOrEqual(pickerBounds.right);
-      expect(bounds.top).toBeGreaterThanOrEqual(pickerBounds.top);
-      expect(bounds.bottom).toBeLessThanOrEqual(pickerBounds.bottom);
-      expect(bounds.top).toBeGreaterThanOrEqual(drawerBounds.top);
-      expect(bounds.bottom).toBeLessThanOrEqual(drawerBounds.bottom);
-    }
+    const createButtonBounds = createButton.getBoundingClientRect();
+    expect(createButtonBounds.top).toBeGreaterThanOrEqual(pickerBounds.top);
+    expect(createButtonBounds.bottom).toBeLessThanOrEqual(pickerBounds.bottom);
+    expect(createButtonBounds.top).toBeGreaterThanOrEqual(drawerBounds.top);
+    expect(createButtonBounds.bottom).toBeLessThanOrEqual(drawerBounds.bottom);
 
     await userEvent.type(handle, 'drawer_draft');
     await userEvent.click(profileTrigger);

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -1182,9 +1182,6 @@ export const UniversalMobile: Story = {
     expect(profileSummary).toBeInTheDocument();
     expect(followingCountLink).toHaveAttribute('href', '/@selected/following');
     expect(followersCountLink).toHaveAttribute('href', '/@selected/followers');
-    ownerDocument.defaultView?.addEventListener('click', (event) => event.preventDefault(), {
-      once: true,
-    });
     fireEvent.click(followingCountLink, { metaKey: true });
     expect(ownerDocument.getElementById('mobile-sidebar')).not.toBeNull();
     expect(canvas.getByRole('heading', { name: '홈' })).toBeInTheDocument();

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -1182,6 +1182,9 @@ export const UniversalMobile: Story = {
     expect(profileSummary).toBeInTheDocument();
     expect(followingCountLink).toHaveAttribute('href', '/@selected/following');
     expect(followersCountLink).toHaveAttribute('href', '/@selected/followers');
+    ownerDocument.defaultView?.addEventListener('click', (event) => event.preventDefault(), {
+      once: true,
+    });
     fireEvent.click(followingCountLink, { metaKey: true });
     expect(ownerDocument.getElementById('mobile-sidebar')).not.toBeNull();
     expect(canvas.getByRole('heading', { name: '홈' })).toBeInTheDocument();

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRelayEnvironment } from 'react-relay';
 import { commitLocalUpdate } from 'relay-runtime';
-import { expect, mocked, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fireEvent, mocked, userEvent, waitFor, within } from 'storybook/test';
 import { trackAnalytics } from '@/analytics/client';
 import { FollowButton } from '@/components/profile/FollowButton';
 import { ProfileHero } from '@/components/profile/ProfileHero';
@@ -1145,8 +1145,9 @@ export const UniversalMobile: Story = {
     expect(menuButton.getBoundingClientRect().width).toBe(44);
     expect(canvas.getAllByRole('heading', { name: '홈' })).toHaveLength(1);
     expect(canvas.queryByRole('link', { name: '북마크' })).not.toBeInTheDocument();
-    await userEvent.click(menuButton);
-    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole('button', { name: '메뉴 열기' }));
+    const ownerDocument = canvasElement.ownerDocument;
+    const page = within(ownerDocument.body);
     const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
     const profileTrigger = page.getByRole('button', { name: '프로필 목록' });
     const triggerName = within(profileTrigger).getByText('코스모 작가');
@@ -1176,15 +1177,14 @@ export const UniversalMobile: Story = {
     expect(logout.querySelector('svg')).toHaveAttribute('stroke-width', '2');
     expect(within(drawer).queryByRole('link', { name: '프로필 설정' })).not.toBeInTheDocument();
     const profileSummary = page.getByLabelText('활성 프로필');
+    const followingCountLink = within(profileSummary).getByRole('link', { name: /팔로잉/ });
+    const followersCountLink = within(profileSummary).getByRole('link', { name: /팔로워/ });
     expect(profileSummary).toBeInTheDocument();
-    expect(within(profileSummary).getByRole('link', { name: /팔로잉/ })).toHaveAttribute(
-      'href',
-      '/@selected/following',
-    );
-    expect(within(profileSummary).getByRole('link', { name: /팔로워/ })).toHaveAttribute(
-      'href',
-      '/@selected/followers',
-    );
+    expect(followingCountLink).toHaveAttribute('href', '/@selected/following');
+    expect(followersCountLink).toHaveAttribute('href', '/@selected/followers');
+    fireEvent.click(followingCountLink, { metaKey: true });
+    expect(ownerDocument.getElementById('mobile-sidebar')).not.toBeNull();
+    expect(canvas.getByRole('heading', { name: '홈' })).toBeInTheDocument();
     expect(triggerIcon.querySelector('path')).toHaveAttribute('d', 'm6 9 6 6 6-6');
     expect(
       nameRect.top + nameRect.height / 2 - (triggerRect.top + triggerRect.height / 2),
@@ -1209,17 +1209,27 @@ export const UniversalMobile: Story = {
     expect(openNavigationRect).toEqual(navigationRect);
     expect(pickerRect.top).toBeGreaterThanOrEqual(triggerRect.bottom);
     expect(pickerRect.top - triggerRect.bottom).toBeLessThanOrEqual(12);
-    await userEvent.click(profileTrigger);
-    expect(profileTrigger).toHaveAttribute('aria-expanded', 'false');
 
-    await userEvent.click(within(profileSummary).getByRole('link', { name: /팔로잉/ }));
-    await waitFor(() => expect(page.queryByRole('button', { name: '사이드바 닫기' })).toBeNull());
-
+    await userEvent.click(followingCountLink);
+    await waitFor(() => {
+      expect(ownerDocument.getElementById('mobile-sidebar')).toBeNull();
+    });
     await userEvent.click(canvas.getByRole('button', { name: '메뉴 열기' }));
-    await page.findByRole('navigation', { name: '주요 메뉴' });
-    const reopenedProfileSummary = page.getByLabelText('활성 프로필');
-    await userEvent.click(within(reopenedProfileSummary).getByRole('link', { name: /팔로워/ }));
-    await waitFor(() => expect(page.queryByRole('button', { name: '사이드바 닫기' })).toBeNull());
+    await waitFor(() => {
+      expect(ownerDocument.getElementById('mobile-sidebar')).not.toBeNull();
+    });
+    expect(page.getByRole('button', { name: '프로필 목록' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    await userEvent.click(
+      within(page.getByLabelText('활성 프로필')).getByRole('link', {
+        name: /팔로워/,
+      }),
+    );
+    await waitFor(() => {
+      expect(ownerDocument.getElementById('mobile-sidebar')).toBeNull();
+    });
   },
   render: () => (
     <View style={{ height: 844 }}>
@@ -1246,7 +1256,26 @@ export const UniversalMobileLongProfilePickerScroll: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const ownerDocument = canvasElement.ownerDocument;
+    const storyWindow = ownerDocument.defaultView;
     const page = within(ownerDocument.body);
+    const previousScrollPosition = {
+      x: storyWindow?.scrollX ?? 0,
+      y: storyWindow?.scrollY ?? 0,
+    };
+    const previousBodyStyle = {
+      left: ownerDocument.body.style.left,
+      overflow: ownerDocument.body.style.overflow,
+      position: ownerDocument.body.style.position,
+      right: ownerDocument.body.style.right,
+      top: ownerDocument.body.style.top,
+      width: ownerDocument.body.style.width,
+    };
+    expect(storyWindow).not.toBeNull();
+    storyWindow!.scrollTo(8, 120);
+    await waitFor(() => {
+      expect(storyWindow!.scrollX).toBe(8);
+      expect(storyWindow!.scrollY).toBe(120);
+    });
     await userEvent.click(canvas.getByRole('button', { name: '메뉴 열기' }));
 
     const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
@@ -1257,6 +1286,11 @@ export const UniversalMobileLongProfilePickerScroll: Story = {
     expect(getComputedStyle(drawerScroll).overflowY).toBe('auto');
     expect(drawerScroll.scrollHeight).toBeGreaterThan(drawerScroll.clientHeight);
     expect(ownerDocument.body.style.overflow).toBe('hidden');
+    expect(ownerDocument.body.style.position).toBe('fixed');
+    expect(ownerDocument.body.style.top).toBe('-120px');
+    expect(ownerDocument.body.style.left).toBe('-8px');
+    expect(ownerDocument.body.style.right).toBe('0px');
+    expect(ownerDocument.body.style.width).toBe('100%');
     drawerScroll.scrollTop = drawerScroll.scrollHeight;
     expect(drawerScroll.scrollTop).toBeGreaterThan(0);
     drawerScroll.scrollTop = 0;
@@ -1297,12 +1331,20 @@ export const UniversalMobileLongProfilePickerScroll: Story = {
     expect(page.getByRole('textbox', { name: '프로필 핸들' })).toHaveValue('drawer_draft');
 
     await userEvent.click(page.getByRole('button', { name: '사이드바 닫기' }));
-    await waitFor(() => expect(ownerDocument.body.style.overflow).toBe(''));
+    await waitFor(() => {
+      expect(ownerDocument.body.style).toMatchObject(previousBodyStyle);
+      expect(storyWindow!.scrollX).toBe(8);
+      expect(storyWindow!.scrollY).toBe(120);
+    });
+    storyWindow!.scrollTo(previousScrollPosition.x, previousScrollPosition.y);
   },
   render: () => (
-    <View style={{ height: 480 }}>
-      <UniversalShellStory />
-    </View>
+    <>
+      <View style={{ height: 480 }}>
+        <UniversalShellStory />
+      </View>
+      <View aria-hidden style={{ height: 480, width: 800 }} />
+    </>
   ),
 };
 

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -90,6 +90,7 @@ Web profile picker는 breakpoint별 사이드바 구조에 맞는 surface를 사
 React Native Web의 `(tabs)` 셸은 document/window scroll을 기본 scroll owner로 둔다. 중앙 피드만 별도 internal scroller가 되는 앱형 shell은 이 기준의 목표가 아니다. 사용자가 피드 바깥의 비스크롤 sidebar, 우측 rail, 빈 레이아웃 영역에서 wheel/trackpad를 사용해도 브라우저 기본 document scroll 흐름으로 페이지가 움직여야 한다. Android/iOS 화면은 platform의 `ScrollView`를 사용하되 이 web scroll 계약을 바꾸지 않는다.
 
 - `< compact`에서는 64px 모바일 header가 document scroll 위의 sticky chrome으로 동작하고, 하단 탭 바는 safe-area를 포함한 fixed bottom chrome으로 유지된다. 콘텐츠는 하단 탭 높이와 safe-area를 고려한 bottom padding 또는 scroll padding으로 겹침을 피한다.
+- `< compact`에서 mobile drawer가 열리면 drawer 안의 navigation content가 세로 internal scroll owner가 된다. drawer 안에서 profile picker를 연 경우에는 프로필 목록만 그 picker 안에서 다시 스크롤하며, drawer 바깥의 document/body scroll은 잠근다.
 - `compact`~`full`에서는 아이콘 레일이 layout flow 안에서 sticky viewport column으로 고정된다. 레일 자체가 스크롤 가능한 콘텐츠를 갖지 않는 한 wheel 입력은 document scroll로 이어진다.
 - `compact`~`full` profile picker가 열렸을 때는 overlay drawer 안의 프로필 목록만 internal scroll owner가 된다.
   drawer 밖의 wheel 입력은 기존 document scroll 흐름을 유지한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- 모바일 Web drawer의 navigation content를 viewport 안의 세로 스크롤 owner로 조정했습니다.
- 프로필 picker의 긴 목록만 내부에서 스크롤하고 새 프로필 추가·생성 UI는 고정 영역에서 접근할 수 있게 했습니다.
- drawer가 열린 동안 `document.body`를 fixed 상태로 잠그고, 닫을 때 기존 inline style과 X/Y scroll 위치를 복원해 iOS Safari에서도 배경 위치가 움직이지 않게 했습니다.
- 팔로잉·팔로워 카운트 링크를 drawer의 close lifecycle에 연결해, 실제 navigation에서 drawer와 profile switcher가 함께 닫히게 했습니다.
- 수정키 클릭은 브라우저 기본 navigation에 맡기고 drawer와 현재 route를 유지합니다.
- 모바일 drawer의 기존 menu/선택 의미와 닫았다 다시 열 때의 profile handle draft 보존 동작을 유지했습니다.
- 390×480 짧은 viewport에서 drawer와 12개 프로필 목록의 overflow·scroll, 생성 UI 경계, draft 보존, body lock 복원, 카운트 링크의 일반/수정키 클릭을 검증하는 Storybook 회귀를 추가했습니다.
- `docs/design/breakpoints.md`의 mobile drawer/profile picker 스크롤 소유권 계약을 맞췄습니다.

## 왜 변경했는지

모바일 Web에서 drawer와 프로필 목록 위의 touch scroll이 뒤 본문으로 전달되어, 긴 프로필 목록의 최근 프로필과 새 프로필 추가 UI에 도달할 수 없는 문제를 해결합니다. 또한 프로필 카운트 링크로 이동한 뒤 drawer가 화면을 계속 덮는 상태를 방지합니다.

## 이번 PR의 주요 결정

없음. 최신 Linear PROD-622와 `docs/design/breakpoints.md`, active `web-app-shell` 계약을 변경 없이 적용했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app exec relay-compiler --noWatchman` ✅
- `pnpm --filter @kosmo/app exec tsc --noEmit` ✅
- `pnpm --filter @kosmo/app test:unit` ✅ (127 tests)
- `CI=true pnpm --filter @kosmo/app test:storybook -- Shell` ✅ (19 files, 253 tests)
- `pnpm --filter @kosmo/app build-storybook` ✅
- 변경 파일 ESLint·Prettier와 `git show --check HEAD` ✅
- 독립 correctness 재리뷰 finding 0

Storybook 실행 중 기존 Relay fixture/React `act(...)` 콘솔 경고와 번들 크기 경고가 출력되지만 테스트와 빌드는 성공했습니다.

## 아직 어떤 문제가 남았는지

- 실제 모바일 브라우저 기기, 특히 iOS Safari/PWA에서의 touch gesture·관성 스크롤·overscroll 동작은 자동 검증 범위 밖입니다.

Closes PROD-622

Stack: main -> PROD-622