### PR TITLE
Test를 독립 GitHub-hosted ARM job으로 병렬화한다

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: false
+          cache: true
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: false
+          cache: true
           mise_toml: |
             [tools]
             python = "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,51 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test
+  test-suites:
+    name: Test (${{ matrix.name }})
     # runs-on: [self-hosted]
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Root
+            command: pnpm test:eslint && pnpm test:helm
+            database: false
+            helm: true
+            id: root
+            playwright: false
+          - name: Core
+            command: pnpm --filter @kosmo/core test
+            database: true
+            helm: false
+            id: core
+            playwright: false
+          - name: Fedify
+            command: pnpm --filter @kosmo/fedify test
+            database: true
+            helm: false
+            id: fedify
+            playwright: false
+          - name: API
+            command: pnpm --filter @kosmo/api test
+            database: true
+            helm: false
+            id: api
+            playwright: false
+          - name: App
+            command: pnpm --filter @kosmo/app test
+            database: false
+            helm: false
+            id: app
+            playwright: true
+          - name: Web
+            command: pnpm --filter @kosmo/web test
+            database: true
+            helm: false
+            id: web
+            playwright: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -40,23 +80,25 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
+        if: matrix.playwright
         run: pnpm --filter @kosmo/app exec playwright install --with-deps chromium
 
       - name: Set up Helm
+        if: matrix.helm
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: true
           install_args: helm
           working_directory: apps/helm
 
-      - name: Run module tests
-        run: pnpm test
+      - name: Run ${{ matrix.name }} tests
+        run: ${{ matrix.command }}
 
       - name: Upload Playwright artifacts
-        if: failure()
+        if: failure() && matrix.id == 'web'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-artifacts
+          name: playwright-artifacts-${{ matrix.id }}
           path: |
             apps/web/playwright-report
             apps/web/test-results
@@ -64,5 +106,17 @@ jobs:
           retention-days: 7
 
       - name: Clean up test database
-        if: always()
+        if: always() && matrix.database
         run: pnpm db:test:drop
+
+  test:
+    name: Test
+    if: always()
+    needs: test-suites
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every test suite
+        env:
+          TEST_SUITES_RESULT: ${{ needs.test-suites.result }}
+        run: test "${TEST_SUITES_RESULT}" = success


### PR DESCRIPTION
## 무엇을 변경했는지

- Test를 Root, Core, Fedify, API, App, Web의 6개 GitHub-hosted ARM matrix job으로 분리했습니다.
- DB를 사용하는 Core, Fedify, API, Web은 서로 다른 hosted VM과 PostgreSQL에서 실행됩니다.
- Playwright Chromium은 App과 Web에만, Helm은 Root에만 설치합니다.
- 모든 matrix job 결과를 기존 필수 체크 이름인 `Test`로 집계합니다.
- Lint와 Semgrep의 mise GitHub Actions cache를 활성화했습니다.

## 왜 변경했는지

기존 Test는 `workspace-concurrency=1`로 모든 패키지를 직렬 실행했습니다. GitHub-hosted runner로 전환하면서 job별 머신과 PostgreSQL이 격리되므로 패키지 테스트를 안전하게 병렬 실행할 수 있습니다.

## 사용자와 개발자에게 미치는 영향

- 실패한 패키지를 독립적으로 확인할 수 있습니다.
- 전체 Test 대기 시간은 가장 오래 걸리는 Web job을 중심으로 줄어듭니다.
- 기존 `Test` 필수 체크 이름은 유지됩니다.
- 캐시 적중 여부와 성능 효과는 이번 PR의 완료 조건으로 삼지 않습니다.

## 확인 방법

- `actionlint .github/workflows/test.yml .github/workflows/lint.yml .github/workflows/semgrep.yml`
- `prettier --check .github/workflows/test.yml .github/workflows/lint.yml .github/workflows/semgrep.yml`
- `git diff --check`
- 6개 ARM matrix job이 1초 간격으로 동시에 시작하고 모두 통과했습니다.
  - Core 1분 29초
  - Fedify 1분 59초
  - API 2분 6초
  - Root 2분 42초
  - App 2분 45초
  - Web 4분 41초
  - 최종 `Test` 집계 3초
- Test 실행: https://github.com/byulmaru/kosmo/actions/runs/30613451200
- 스택 base에서는 자동 생성되지 않는 Semgrep을 최신 브랜치에서 수동 실행해 통과했습니다.
- Semgrep 실행: https://github.com/byulmaru/kosmo/actions/runs/30613749496

## 의존 관계

병합된 PR #464의 GitHub-hosted ARM Test 전환에 대한 후속 PR입니다.
