### PR TITLE
프로덕션 API와 Web이 부하에 따라 확장되게 한다

### DIFF
--- a/apps/helm/templates/api/hpa.yaml
+++ b/apps/helm/templates/api/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.workloads.enabled (eq .Values.env "prod") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: api
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.version | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/apps/helm/templates/api/rollout.yaml
+++ b/apps/helm/templates/api/rollout.yaml
@@ -10,7 +10,9 @@ metadata:
     app.kubernetes.io/version: {{ .Values.version | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  {{- if ne .Values.env "prod" }}
   replicas: 1
+  {{- end }}
   strategy:
     blueGreen:
       activeService: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}

--- a/apps/helm/templates/web/hpa.yaml
+++ b/apps/helm/templates/web/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.workloads.enabled (eq .Values.env "prod") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: web
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.version | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    name: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/apps/helm/templates/web/rollout.yaml
+++ b/apps/helm/templates/web/rollout.yaml
@@ -10,7 +10,9 @@ metadata:
     app.kubernetes.io/version: {{ .Values.version | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  {{- if ne .Values.env "prod" }}
   replicas: 1
+  {{- end }}
   strategy:
     blueGreen:
       activeService: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" }}

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -53,11 +53,6 @@ if grep -Eq '^kind: (Rollout|Service|HTTPRoute)$' "${render_dir}/prod-runtime.ya
   exit 1
 fi
 
-if grep -Fq 'kind: HorizontalPodAutoscaler' "${render_dir}/prod-runtime.yaml"; then
-  echo "prod runtime bootstrap unexpectedly rendered application autoscaling" >&2
-  exit 1
-fi
-
 if grep -Fq 'kind: "argo.Rollout"' "${render_dir}/prod-runtime.yaml"; then
   echo "prod runtime bootstrap unexpectedly references workload restart targets" >&2
   exit 1
@@ -136,54 +131,6 @@ dev_forbidden_markers=(
 for marker in "${dev_forbidden_markers[@]}"; do
   if grep -Fq "${marker}" "${render_dir}/dev.yaml"; then
     echo "dev manifest unexpectedly contains production marker: ${marker}" >&2
-    exit 1
-  fi
-done
-
-if grep -Fq 'kind: HorizontalPodAutoscaler' "${render_dir}/dev.yaml"; then
-  echo "dev manifest unexpectedly contains application autoscaling" >&2
-  exit 1
-fi
-
-if [[ "$(grep -Fc 'kind: HorizontalPodAutoscaler' "${render_dir}/prod.yaml")" -ne 2 ]]; then
-  echo "prod API and Web must each render a HorizontalPodAutoscaler" >&2
-  exit 1
-fi
-
-if grep -Fq '  replicas:' "${render_dir}/prod.yaml"; then
-  echo "prod Rollouts must leave replicas under HPA ownership" >&2
-  exit 1
-fi
-
-if [[ "$(grep -Fc '  replicas: 1' "${render_dir}/dev.yaml")" -ne 2 ]]; then
-  echo "dev API and Web Rollouts must each keep one fixed replica" >&2
-  exit 1
-fi
-
-for workload in api web; do
-  if ! awk -v name="kosmo-${workload}" '
-    $0 == "kind: HorizontalPodAutoscaler" { in_resource = 1 }
-    in_resource && $0 == "  name: " name { named = 1 }
-    in_resource && $0 == "    apiVersion: argoproj.io/v1alpha1" { rollout_api = 1 }
-    in_resource && $0 == "    kind: Rollout" { rollout_kind = 1 }
-    in_resource && $0 == "    name: " name { rollout_name = 1 }
-    in_resource && $0 == "  minReplicas: 2" { min_replicas = 1 }
-    in_resource && $0 == "  maxReplicas: 10" { max_replicas = 1 }
-    in_resource && $0 == "          averageUtilization: 80" { cpu_target = 1 }
-    /^---$/ {
-      if (in_resource && named && rollout_api && rollout_kind && rollout_name && min_replicas && max_replicas && cpu_target) {
-        found = 1
-      }
-      in_resource = named = rollout_api = rollout_kind = rollout_name = min_replicas = max_replicas = cpu_target = 0
-    }
-    END {
-      if (in_resource && named && rollout_api && rollout_kind && rollout_name && min_replicas && max_replicas && cpu_target) {
-        found = 1
-      }
-      exit !found
-    }
-  ' "${render_dir}/prod.yaml"; then
-    echo "prod ${workload} HPA must target its Rollout with min 2, max 10, and 80% CPU utilization" >&2
     exit 1
   fi
 done

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -53,6 +53,11 @@ if grep -Eq '^kind: (Rollout|Service|HTTPRoute)$' "${render_dir}/prod-runtime.ya
   exit 1
 fi
 
+if grep -Fq 'kind: HorizontalPodAutoscaler' "${render_dir}/prod-runtime.yaml"; then
+  echo "prod runtime bootstrap unexpectedly rendered application autoscaling" >&2
+  exit 1
+fi
+
 if grep -Fq 'kind: "argo.Rollout"' "${render_dir}/prod-runtime.yaml"; then
   echo "prod runtime bootstrap unexpectedly references workload restart targets" >&2
   exit 1
@@ -131,6 +136,44 @@ dev_forbidden_markers=(
 for marker in "${dev_forbidden_markers[@]}"; do
   if grep -Fq "${marker}" "${render_dir}/dev.yaml"; then
     echo "dev manifest unexpectedly contains production marker: ${marker}" >&2
+    exit 1
+  fi
+done
+
+if grep -Fq 'kind: HorizontalPodAutoscaler' "${render_dir}/dev.yaml"; then
+  echo "dev manifest unexpectedly contains application autoscaling" >&2
+  exit 1
+fi
+
+if [[ "$(grep -Fc 'kind: HorizontalPodAutoscaler' "${render_dir}/prod.yaml")" -ne 2 ]]; then
+  echo "prod API and Web must each render a HorizontalPodAutoscaler" >&2
+  exit 1
+fi
+
+for workload in api web; do
+  if ! awk -v name="kosmo-${workload}" '
+    $0 == "kind: HorizontalPodAutoscaler" { in_resource = 1 }
+    in_resource && $0 == "  name: " name { named = 1 }
+    in_resource && $0 == "    apiVersion: argoproj.io/v1alpha1" { rollout_api = 1 }
+    in_resource && $0 == "    kind: Rollout" { rollout_kind = 1 }
+    in_resource && $0 == "    name: " name { rollout_name = 1 }
+    in_resource && $0 == "  minReplicas: 2" { min_replicas = 1 }
+    in_resource && $0 == "  maxReplicas: 10" { max_replicas = 1 }
+    in_resource && $0 == "          averageUtilization: 80" { cpu_target = 1 }
+    /^---$/ {
+      if (in_resource && named && rollout_api && rollout_kind && rollout_name && min_replicas && max_replicas && cpu_target) {
+        found = 1
+      }
+      in_resource = named = rollout_api = rollout_kind = rollout_name = min_replicas = max_replicas = cpu_target = 0
+    }
+    END {
+      if (in_resource && named && rollout_api && rollout_kind && rollout_name && min_replicas && max_replicas && cpu_target) {
+        found = 1
+      }
+      exit !found
+    }
+  ' "${render_dir}/prod.yaml"; then
+    echo "prod ${workload} HPA must target its Rollout with min 2, max 10, and 80% CPU utilization" >&2
     exit 1
   fi
 done

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -150,6 +150,16 @@ if [[ "$(grep -Fc 'kind: HorizontalPodAutoscaler' "${render_dir}/prod.yaml")" -n
   exit 1
 fi
 
+if grep -Fq '  replicas:' "${render_dir}/prod.yaml"; then
+  echo "prod Rollouts must leave replicas under HPA ownership" >&2
+  exit 1
+fi
+
+if [[ "$(grep -Fc '  replicas: 1' "${render_dir}/dev.yaml")" -ne 2 ]]; then
+  echo "dev API and Web Rollouts must each keep one fixed replica" >&2
+  exit 1
+fi
+
 for workload in api web; do
   if ! awk -v name="kosmo-${workload}" '
     $0 == "kind: HorizontalPodAutoscaler" { in_resource = 1 }

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -4,5 +4,9 @@ imageDigest: ''
 version: main
 workloads:
   enabled: true
+autoscaling:
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
 migration:
   enabled: false


### PR DESCRIPTION
## 무엇을 변경했는지

- production에서만 API와 Web Rollout을 대상으로 하는 `autoscaling/v2` HPA를 각각 추가했습니다.
- 두 workload 모두 최소 2, 최대 10 replicas와 CPU 평균 utilization 80%를 사용합니다.
- production Rollout에서는 정적 `spec.replicas`를 생략해 HPA가 replica 수를 단독 관리하고, dev는 기존 `replicas: 1`을 유지합니다.

## 왜 변경했는지

프로덕션 API와 Web이 1 replica에 고정되지 않고 부하에 따라 자동으로 확장되어야 합니다. 상위 통합 범위인 PROD-545에 요구를 반영하고, 독립 구현 단위인 PROD-624에서 이 변경을 추적합니다.

## 이번 PR의 주요 결정

### API와 Web의 초기 autoscaling 범위

- 결정자: @robin-maki
- 선택: API/Web 공통 최소 2, 최대 10 replicas와 CPU 목표 80%
- 고려한 대안: 다른 min/max 및 CPU 목표치, memory/custom metric 추가
- 이유: 사용자가 이 초기 운영값과 CPU 기반 HPA를 명시적으로 확정했습니다.
- 감수한 결과: 현재 HPA는 container CPU request를 기준으로만 조정하며, memory/custom metric과 부하별 별도 튜닝은 후속 운영 범위입니다.
- 관련 근거: [PROD-624](https://linear.app/byulmaru/issue/PROD-624/프로덕션-api와-web에-hpa를-구성한다)

## 어떻게 확인할 수 있는지

- HPA 전용 렌더 문자열 검증은 추가하지 않았습니다.

## 아직 어떤 문제가 남았는지

- 실제 production metrics-server 입력과 부하에 따른 scale-up/down 동작은 배포 후 PROD-545 통합 검증에서 확인해야 합니다.
- Memory/custom metric, node capacity 조정과 workload별 튜닝은 이번 범위에 포함하지 않습니다.
