### PR TITLE
main push의 reviewed Terraform plan을 찾는다

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -300,11 +300,15 @@ jobs:
               | jq -r "[.[].artifacts[] | select(.expired == false and .workflow_run.head_sha == \"${commit_sha}\")] | sort_by(.created_at) | last | .workflow_run.id // empty"
           }
 
-          pr_api="repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls"
-          merged_prs="$(gh api --paginate --slurp -H "Accept: application/vnd.github+json" "${pr_api}?per_page=100" \
-            | jq -r '[.[][] | select(.merged_at != null)] | sort_by(.number)[] | [.number, .head.sha] | @tsv')"
+          merged_prs="$(
+            while read -r commit_sha; do
+              gh api --paginate --slurp -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/pulls?per_page=100" \
+                | jq -r '.[][] | select(.merged_at != null) | [.number, .head.sha] | @tsv'
+            done < <(jq -r '.commits[].id' "${GITHUB_EVENT_PATH}")
+          )"
           if [[ -z "${merged_prs}" ]]; then
-            echo "No merged pull request is associated with ${GITHUB_SHA}; refusing to apply an unreviewed plan." >&2
+            echo "No merged pull request is associated with this main push; refusing to apply an unreviewed plan." >&2
             exit 1
           fi
 
@@ -318,7 +322,7 @@ jobs:
               pr_head_sha="${candidate_head_sha}"
               plan_run_id="${candidate_plan_run_id}"
             fi
-          done <<< "${merged_prs}"
+          done < <(sort -n -u <<< "${merged_prs}")
 
           if [[ -z "${plan_run_id}" ]]; then
             echo "No associated merged pull request has an unexpired Terraform plan artifact; rerun the Terraform PR plan before merging." >&2

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -322,7 +322,7 @@ jobs:
               pr_head_sha="${candidate_head_sha}"
               plan_run_id="${candidate_plan_run_id}"
             fi
-          done < <(sort -n -u <<< "${merged_prs}")
+          done < <(awk '!seen[$0]++' <<< "${merged_prs}")
 
           if [[ -z "${plan_run_id}" ]]; then
             echo "No associated merged pull request has an unexpired Terraform plan artifact; rerun the Terraform PR plan before merging." >&2


### PR DESCRIPTION
## 문제

머지 큐가 여러 PR을 한 번에 main으로 push하면 Terraform Apply가 최종 커밋에 직접 연결된 PR만 조회했습니다. 그래서 Terraform 변경과 reviewed plan을 가진 #457이 같은 push의 앞 커밋에 있어도 누락됐습니다. 실제 main run 30613461888이 이 이유로 실패했습니다.

## 변경

- push event의 모든 commit에 연결된 merged PR을 조회합니다.
- 중복 후보를 정리한 뒤 기존 방식대로 유효한 reviewed Terraform plan artifact를 선택합니다.
- plan metadata 검증, 현재 plan 동등성 비교, saved-plan apply는 그대로 유지합니다.

## 검증

- `actionlint .github/workflows/terraform.yml`
- `git diff --check`
- 실패했던 실제 main push 범위를 재현해 #457을 포함한 merged PR 후보 조회
- 후보 중 #457 head의 Terraform plan artifact만 선택됨을 확인