### PR TITLE
모바일 팔로잉·팔로워 이동 시 드로어를 닫는다

### DIFF
--- a/apps/app/.storybook/mocks/expo-router.tsx
+++ b/apps/app/.storybook/mocks/expo-router.tsx
@@ -19,6 +19,17 @@ type RouterContextValue = {
   slotLabel: string;
 };
 
+type LinkPressEvent = {
+  altKey?: boolean;
+  button?: number;
+  ctrlKey?: boolean;
+  currentTarget?: { target?: string | null };
+  defaultPrevented?: boolean;
+  metaKey?: boolean;
+  preventDefault?: () => void;
+  shiftKey?: boolean;
+};
+
 const RouterContext = createContext<RouterContextValue>({
   params: {},
   pathname: '/home',
@@ -89,12 +100,26 @@ export function Link({
 
   return cloneElement(children, {
     href: typeof href === 'string' ? href : href.pathname,
-    onPress: (event: { preventDefault?: () => void }) => {
-      event.preventDefault?.();
+    onPress: (event: LinkPressEvent) => {
       children.props.onPress?.(event);
-      setPathname(href);
+      if (shouldHandleNavigation(event)) {
+        event.preventDefault?.();
+        setPathname(href);
+      }
     },
   });
+}
+
+function shouldHandleNavigation(event: LinkPressEvent) {
+  return (
+    !event.defaultPrevented &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    (event.button == null || event.button === 0) &&
+    [undefined, null, '', 'self'].includes(event.currentTarget?.target)
+  );
 }
 
 export function Slot() {

--- a/apps/app/src/components/shell/GuardedLink.test.ts
+++ b/apps/app/src/components/shell/GuardedLink.test.ts
@@ -16,10 +16,14 @@ import type {
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 type LinkPressEvent = {
+  altKey?: boolean;
   button?: number;
+  ctrlKey?: boolean;
+  currentTarget?: { target?: string | null };
   defaultPrevented?: boolean;
   metaKey?: boolean;
   preventDefault: ReturnType<typeof mock.fn>;
+  shiftKey?: boolean;
 };
 
 type LinkPress = NonNullable<LinkProps['onPress']>;
@@ -105,19 +109,22 @@ const renderLink = async (handler: NavigationRequestHandler, onNavigate?: () => 
 describe('GuardedLink', () => {
   it('guard가 이탈을 보류하면 기본 Link를 막고 승인된 action만 실행한다', async () => {
     let pendingAction: GuardedNavigationAction | null = null;
+    const onNavigate = mock.fn();
     await renderLink((action) => {
       pendingAction = action;
       return true;
-    });
+    }, onNavigate);
     const event: LinkPressEvent = { preventDefault: mock.fn() };
 
     await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
 
     assert.equal(event.preventDefault.mock.callCount(), 1);
+    assert.equal(onNavigate.mock.callCount(), 0);
     assert.deepEqual(navigations, []);
     const approvedAction = pendingAction as GuardedNavigationAction | null;
     assert.ok(approvedAction);
-    approvedAction();
+    await act(async () => approvedAction());
+    assert.equal(onNavigate.mock.callCount(), 1);
     assert.deepEqual(navigations, ['/timeline']);
   });
 
@@ -144,5 +151,24 @@ describe('GuardedLink', () => {
     assert.equal(handler.mock.callCount(), 0);
     assert.equal(onNavigate.mock.callCount(), 0);
     assert.equal(event.preventDefault.mock.callCount(), 0);
+  });
+
+  it('defaultPrevented와 middle click은 surface를 닫거나 guard를 실행하지 않는다', async () => {
+    const handler = mock.fn(() => true);
+    const onNavigate = mock.fn();
+    await renderLink(handler, onNavigate);
+
+    await act(async () =>
+      linkPress?.({
+        defaultPrevented: true,
+        preventDefault: mock.fn(),
+      } as unknown as Parameters<LinkPress>[0]),
+    );
+    await act(async () =>
+      linkPress?.({ button: 1, preventDefault: mock.fn() } as unknown as Parameters<LinkPress>[0]),
+    );
+
+    assert.equal(handler.mock.callCount(), 0);
+    assert.equal(onNavigate.mock.callCount(), 0);
   });
 });

--- a/apps/app/src/components/shell/GuardedLink.test.ts
+++ b/apps/app/src/components/shell/GuardedLink.test.ts
@@ -30,11 +30,13 @@ type LinkPress = NonNullable<LinkProps['onPress']>;
 
 type RenderedLinkProps = {
   children: ReactElement<{ onPress?: LinkPress }>;
+  href: string;
   onPress?: LinkPress;
 };
 
 const navigations: string[] = [];
 let linkPress: LinkPress | undefined;
+let composedLinkPress: LinkPress | undefined;
 let rootLinkPress: LinkPress | undefined;
 let renderer: ReactTestRenderer | null = null;
 
@@ -45,7 +47,15 @@ const mockModule = (specifier: string | URL, exports: object) =>
 
 mockModule('expo-router', {
   Link: (props: RenderedLinkProps & { children: ReactNode }) => {
-    linkPress = props.children.props.onPress;
+    const childPress = props.children.props.onPress;
+    linkPress = childPress;
+    composedLinkPress = (event) => {
+      childPress?.(event as unknown as Parameters<LinkPress>[0]);
+      if (shouldHandleNavigation(event as unknown as LinkPressEvent)) {
+        event.preventDefault();
+        navigations.push(props.href);
+      }
+    };
     rootLinkPress = props.onPress;
     return createElement('Link', props, props.children);
   },
@@ -72,6 +82,7 @@ afterEach(async () => {
     renderer = null;
   }
   linkPress = undefined;
+  composedLinkPress = undefined;
   rootLinkPress = undefined;
   navigations.length = 0;
   mock.restoreAll();
@@ -85,6 +96,28 @@ function GuardRegistrar({ handler }: { handler: NavigationRequestHandler }) {
 
 function TestPressable(props: { onPress?: LinkPress }) {
   return createElement('Pressable', props);
+}
+
+function createPressEvent(overrides: Omit<LinkPressEvent, 'preventDefault'> = {}) {
+  const event = {
+    ...overrides,
+    preventDefault: mock.fn(() => {
+      event.defaultPrevented = true;
+    }),
+  } as LinkPressEvent;
+  return event;
+}
+
+function shouldHandleNavigation(event: LinkPressEvent) {
+  return (
+    !event.defaultPrevented &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    (event.button == null || event.button === 0) &&
+    [undefined, null, '', 'self'].includes(event.currentTarget?.target)
+  );
 }
 
 const renderLink = async (handler: NavigationRequestHandler, onNavigate?: () => void) => {
@@ -104,6 +137,7 @@ const renderLink = async (handler: NavigationRequestHandler, onNavigate?: () => 
   });
   assert.equal(rootLinkPress, undefined);
   assert.ok(linkPress);
+  assert.ok(composedLinkPress);
 };
 
 describe('GuardedLink', () => {
@@ -114,9 +148,9 @@ describe('GuardedLink', () => {
       pendingAction = action;
       return true;
     }, onNavigate);
-    const event: LinkPressEvent = { preventDefault: mock.fn() };
+    const event = createPressEvent();
 
-    await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
+    await act(async () => composedLinkPress?.(event as unknown as Parameters<LinkPress>[0]));
 
     assert.equal(event.preventDefault.mock.callCount(), 1);
     assert.equal(onNavigate.mock.callCount(), 0);
@@ -131,22 +165,22 @@ describe('GuardedLink', () => {
   it('guard가 없으면 Link 기본 navigation과 surface 닫기를 유지한다', async () => {
     const onNavigate = mock.fn();
     await renderLink(() => false, onNavigate);
-    const event: LinkPressEvent = { preventDefault: mock.fn() };
+    const event = createPressEvent();
 
-    await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
+    await act(async () => composedLinkPress?.(event as unknown as Parameters<LinkPress>[0]));
 
-    assert.equal(event.preventDefault.mock.callCount(), 0);
+    assert.equal(event.preventDefault.mock.callCount(), 1);
     assert.equal(onNavigate.mock.callCount(), 1);
-    assert.deepEqual(navigations, []);
+    assert.deepEqual(navigations, ['/timeline']);
   });
 
   it('Web modifier click은 현재 편집 route를 떠나지 않으므로 guard가 가로채지 않는다', async () => {
     const handler = mock.fn(() => true);
     const onNavigate = mock.fn();
     await renderLink(handler, onNavigate);
-    const event: LinkPressEvent = { metaKey: true, preventDefault: mock.fn() };
+    const event = createPressEvent({ metaKey: true });
 
-    await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
+    await act(async () => composedLinkPress?.(event as unknown as Parameters<LinkPress>[0]));
 
     assert.equal(handler.mock.callCount(), 0);
     assert.equal(onNavigate.mock.callCount(), 0);
@@ -159,13 +193,12 @@ describe('GuardedLink', () => {
     await renderLink(handler, onNavigate);
 
     await act(async () =>
-      linkPress?.({
-        defaultPrevented: true,
-        preventDefault: mock.fn(),
-      } as unknown as Parameters<LinkPress>[0]),
+      composedLinkPress?.(
+        createPressEvent({ defaultPrevented: true }) as unknown as Parameters<LinkPress>[0],
+      ),
     );
     await act(async () =>
-      linkPress?.({ button: 1, preventDefault: mock.fn() } as unknown as Parameters<LinkPress>[0]),
+      composedLinkPress?.(createPressEvent({ button: 1 }) as unknown as Parameters<LinkPress>[0]),
     );
 
     assert.equal(handler.mock.callCount(), 0);

--- a/apps/app/src/components/shell/GuardedLink.tsx
+++ b/apps/app/src/components/shell/GuardedLink.tsx
@@ -23,10 +23,15 @@ export function GuardedLink({ children, href, onNavigate, ...props }: Props) {
     if (!shouldHandleNavigation(event)) {
       return;
     }
-    onNavigate?.();
-    if (request(() => router.navigate(href))) {
+    const navigate = () => {
+      onNavigate?.();
+      router.navigate(href);
+    };
+    if (request(navigate)) {
       event.preventDefault();
+      return;
     }
+    onNavigate?.();
   };
 
   return (

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -125,13 +125,20 @@ const avatarShadow = {
 } as ViewStyle;
 
 type Props = {
+  onNavigate?: () => void;
   onOpenChange?: (open: boolean) => void;
   open?: boolean;
   query: ProfileSwitcher_query$key;
   surface: ProfileSwitcherSurface;
 };
 
-export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, surface }: Props) {
+export function ProfileSwitcher({
+  onNavigate,
+  onOpenChange,
+  open: controlledOpen,
+  query,
+  surface,
+}: Props) {
   const theme = useTheme();
   const data = useFragment(ProfileSwitcherFragment, query);
   const { resetActor } = useRelayActor();
@@ -489,6 +496,7 @@ export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, sur
       )}
     </Pressable>
   );
+  const profileSummaryOnPress = onNavigate ?? (fullWeb && open ? dismissPicker : undefined);
   const profileDetails = active ? (
     <>
       <Text
@@ -499,13 +507,11 @@ export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, sur
         {active.relativeHandle}
       </Text>
       <View style={styles.counts}>
-        <GuardedLink
-          href={`/${active.relativeHandle}/following`}
-          onNavigate={fullWeb && open ? dismissPicker : undefined}
-        >
+        <GuardedLink href={`/${active.relativeHandle}/following`}>
           <Pressable
             accessibilityRole="link"
             onFocus={fullWeb && open ? dismissPicker : undefined}
+            onPress={profileSummaryOnPress}
             style={styles.countLink}
           >
             <Text style={[styles.count, { color: theme.text }]}>
@@ -514,13 +520,11 @@ export function ProfileSwitcher({ onOpenChange, open: controlledOpen, query, sur
             <Text style={[styles.countLabel, { color: theme.text }]}>팔로잉</Text>
           </Pressable>
         </GuardedLink>
-        <GuardedLink
-          href={`/${active.relativeHandle}/followers`}
-          onNavigate={fullWeb && open ? dismissPicker : undefined}
-        >
+        <GuardedLink href={`/${active.relativeHandle}/followers`}>
           <Pressable
             accessibilityRole="link"
             onFocus={fullWeb && open ? dismissPicker : undefined}
+            onPress={profileSummaryOnPress}
             style={styles.countLink}
           >
             <Text style={[styles.count, { color: theme.text }]}>

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -496,7 +496,7 @@ export function ProfileSwitcher({
       )}
     </Pressable>
   );
-  const profileSummaryOnPress = onNavigate ?? (fullWeb && open ? dismissPicker : undefined);
+  const profileSummaryOnNavigate = onNavigate ?? (fullWeb && open ? dismissPicker : undefined);
   const profileDetails = active ? (
     <>
       <Text
@@ -507,11 +507,13 @@ export function ProfileSwitcher({
         {active.relativeHandle}
       </Text>
       <View style={styles.counts}>
-        <GuardedLink href={`/${active.relativeHandle}/following`}>
+        <GuardedLink
+          href={`/${active.relativeHandle}/following`}
+          onNavigate={profileSummaryOnNavigate}
+        >
           <Pressable
             accessibilityRole="link"
             onFocus={fullWeb && open ? dismissPicker : undefined}
-            onPress={profileSummaryOnPress}
             style={styles.countLink}
           >
             <Text style={[styles.count, { color: theme.text }]}>
@@ -520,11 +522,13 @@ export function ProfileSwitcher({
             <Text style={[styles.countLabel, { color: theme.text }]}>팔로잉</Text>
           </Pressable>
         </GuardedLink>
-        <GuardedLink href={`/${active.relativeHandle}/followers`}>
+        <GuardedLink
+          href={`/${active.relativeHandle}/followers`}
+          onNavigate={profileSummaryOnNavigate}
+        >
           <Pressable
             accessibilityRole="link"
             onFocus={fullWeb && open ? dismissPicker : undefined}
-            onPress={profileSummaryOnPress}
             style={styles.countLink}
           >
             <Text style={[styles.count, { color: theme.text }]}>

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -93,6 +93,7 @@ export function SidebarNavigation({
       ]}
     >
       <ProfileSwitcher
+        onNavigate={onNavigate}
         onOpenChange={onSwitcherOpenChange}
         open={switcherOpen}
         query={data}

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -1208,6 +1208,18 @@ export const UniversalMobile: Story = {
     expect(openNavigationRect).toEqual(navigationRect);
     expect(pickerRect.top).toBeGreaterThanOrEqual(triggerRect.bottom);
     expect(pickerRect.top - triggerRect.bottom).toBeLessThanOrEqual(12);
+
+    await userEvent.click(profileTrigger);
+    expect(profileTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(within(profileSummary).getByRole('link', { name: /팔로잉/ }));
+    await waitFor(() => expect(page.queryByRole('button', { name: '사이드바 닫기' })).toBeNull());
+
+    await userEvent.click(canvas.getByRole('button', { name: '메뉴 열기' }));
+    await page.findByRole('navigation', { name: '주요 메뉴' });
+    const reopenedProfileSummary = page.getByLabelText('활성 프로필');
+    await userEvent.click(within(reopenedProfileSummary).getByRole('link', { name: /팔로워/ }));
+    await waitFor(() => expect(page.queryByRole('button', { name: '사이드바 닫기' })).toBeNull());
   },
   render: () => (
     <View style={{ height: 844 }}>


### PR DESCRIPTION
## 무엇을 변경했는지

- 모바일 Web 메인 드로어의 프로필 요약에서 팔로잉·팔로워 링크를 선택하면 공용 `onNavigate` callback으로 드로어를 닫도록 연결했습니다.
- `GuardedLink`가 modifier/middle click, `defaultPrevented`, 편집 이탈 guard를 존중하고 실제 navigation이 허용된 뒤에만 surface를 닫도록 실행 순서를 정리했습니다.
- Storybook Expo Router mock을 실제 `Link asChild`의 child handler → navigation 판정 순서와 맞추고, guard 승인·취소 및 모바일 drawer 회귀 테스트를 보강했습니다.

## 왜 변경했는지

PROD-623의 재현 경로에서는 팔로잉·팔로워 목록으로 이동한 뒤에도 모바일 메인 드로어가 열린 채 남았습니다. 일반 내비게이션과 같은 닫힘 규칙을 적용하되, 사용자가 편집 이탈을 취소하거나 새 탭으로 여는 경우에는 현재 drawer 상태를 유지해야 했습니다.

## 이번 PR의 주요 결정

- drawer close는 링크 press 자체가 아니라 유효한 same-tab navigation 또는 guard 승인 action에 결합합니다.
- Storybook router mock도 실제 Expo Router의 event 합성 순서를 따라 테스트가 production interaction을 대표하도록 합니다.
- 기존 선행 ancestry를 제거하고 PROD-623의 세 커밋만 최신 `main` 위에 재배치했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app test:unit` — 128/128 통과
- `pnpm --filter @kosmo/app test:storybook` — 19개 파일, 250/250 통과
- `pnpm --filter @kosmo/app check` — Relay compiler 및 TypeScript 통과
- `pnpm --filter @kosmo/app build-storybook` — production Storybook build 통과
- `pnpm lint:eslint` — 통과
- 독립 correctness 재리뷰 — finding 0
- ponytail 단순화 재리뷰 — `Lean already. Ship.`

## 아직 어떤 문제가 남았는지

- 테스트 실행 중 Relay fixture 경고와 의도된 error-boundary fixture 로그가 출력되지만 테스트는 모두 통과했습니다.
- 실제 브라우저 수동 검증은 별도로 수행하지 않았습니다.

Stack: main -> PROD-623

Linear: PROD-623