### PR TITLE
Web 피드백 화면을 KOSMO 페이지 패턴에 맞춘다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/feedback.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/feedback.tsx
@@ -1,15 +1,3 @@
-import { ScrollView, StyleSheet } from 'react-native';
-import { FeedbackForm } from '@/components/feedback/FeedbackForm';
-import { spacing } from '@/theme/tokens';
+import { FeedbackPage } from '@/components/feedback/FeedbackPage';
 
-export default function FeedbackScreen() {
-  return (
-    <ScrollView contentContainerStyle={styles.root} keyboardShouldPersistTaps="handled">
-      <FeedbackForm />
-    </ScrollView>
-  );
-}
-
-const styles = StyleSheet.create({
-  root: { flexGrow: 1, paddingHorizontal: spacing.xl, paddingVertical: spacing.xxl },
-});
+export default FeedbackPage;

--- a/apps/app/src/components/feedback/FeedbackForm.tsx
+++ b/apps/app/src/components/feedback/FeedbackForm.tsx
@@ -251,6 +251,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
   },
   webOption: {
+    borderRadius: radii.sm,
     borderBottomWidth: 1,
     paddingHorizontal: spacing.sm,
   },

--- a/apps/app/src/components/feedback/FeedbackForm.tsx
+++ b/apps/app/src/components/feedback/FeedbackForm.tsx
@@ -28,6 +28,7 @@ const SubmitFeedbackMutation = graphql`
 
 export function FeedbackForm() {
   const theme = useTheme();
+  const web = Platform.OS === 'web';
   const [kind, setKind] = useState<FeedbackKind>('POSITIVE');
   const [body, setBody] = useState('');
   const [bodyTouched, setBodyTouched] = useState(false);
@@ -77,17 +78,29 @@ export function FeedbackForm() {
   };
 
   return (
-    <View style={[styles.root, { backgroundColor: theme.card, borderColor: theme.border }]}>
+    <View
+      style={[
+        styles.root,
+        web ? null : styles.nativeRoot,
+        web ? null : { backgroundColor: theme.card, borderColor: theme.border },
+      ]}
+    >
       <View style={styles.header}>
-        <Text accessibilityRole="header" style={[styles.title, { color: theme.text }]}>
-          피드백 보내기
-        </Text>
+        {web ? null : (
+          <Text accessibilityRole="header" style={[styles.title, { color: theme.text }]}>
+            피드백 보내기
+          </Text>
+        )}
         <Text style={[styles.description, { color: theme.textSecondary }]}>
           KOSMO를 더 좋게 만들 수 있도록 의견을 들려주세요.
         </Text>
       </View>
 
-      <View accessibilityLabel="피드백 종류" role="radiogroup" style={styles.options}>
+      <View
+        accessibilityLabel="피드백 종류"
+        role="radiogroup"
+        style={web ? styles.webOptions : styles.nativeOptions}
+      >
         {feedbackOptions.map((option, index) => {
           const selected = option.value === kind;
           const focused = option.value === focusedKind;
@@ -133,13 +146,20 @@ export function FeedbackForm() {
               role="radio"
               style={({ pressed }) => [
                 styles.option,
+                web ? styles.webOption : styles.nativeOption,
+                web && index === feedbackOptions.length - 1 ? styles.webOptionLast : null,
+                web && focused ? styles.webOptionFocused : null,
                 {
-                  backgroundColor: selected
-                    ? theme.surface
-                    : pressed
-                      ? theme.surface
-                      : 'transparent',
-                  borderColor: focused ? theme.text : selected ? theme.primary : theme.border,
+                  backgroundColor: selected || pressed ? theme.surface : 'transparent',
+                  borderBottomColor: web ? theme.divider : undefined,
+                  borderColor: web
+                    ? undefined
+                    : focused
+                      ? theme.text
+                      : selected
+                        ? theme.primary
+                        : theme.border,
+                  outlineColor: web && focused ? theme.focus : undefined,
                 },
               ]}
               tabIndex={Platform.OS === 'web' ? (selected ? 0 : -1) : undefined}
@@ -190,7 +210,7 @@ export function FeedbackForm() {
         </Text>
       ) : null}
 
-      <View style={styles.actions}>
+      <View style={web ? styles.webActions : styles.nativeActions}>
         <Button
           accessibilityLabel={status === 'error' ? '피드백 다시 시도' : '피드백 보내기'}
           accessibilityState={{ busy: submitting, disabled: !canSubmit }}
@@ -198,7 +218,7 @@ export function FeedbackForm() {
           disabled={!canSubmit}
           loading={submitting}
           onPress={submit}
-          style={styles.submitButton}
+          style={[styles.submitButton, web ? styles.webSubmitButton : null]}
         >
           {actionLabel}
         </Button>
@@ -209,26 +229,40 @@ export function FeedbackForm() {
 
 const styles = StyleSheet.create({
   root: {
+    gap: spacing.lg,
+    width: '100%',
+  },
+  nativeRoot: {
     borderRadius: radii.md,
     borderWidth: 1,
-    gap: spacing.lg,
     maxWidth: 680,
     padding: spacing.xl,
-    width: '100%',
   },
   header: { gap: spacing.xs },
   title: { fontFamily: 'SUIT', fontSize: 24, fontWeight: '700', lineHeight: 32 },
   description: { fontFamily: 'SUIT', ...typography.md },
-  options: { gap: spacing.sm },
+  webOptions: { gap: 0 },
+  nativeOptions: { gap: spacing.sm },
   option: {
     alignItems: 'center',
-    borderRadius: radii.sm,
-    borderWidth: 1,
     flexDirection: 'row',
     gap: spacing.sm,
     minHeight: 48,
-    paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
+  },
+  webOption: {
+    borderBottomWidth: 1,
+    paddingHorizontal: spacing.sm,
+  },
+  webOptionLast: { borderBottomWidth: 0 },
+  webOptionFocused: {
+    outlineStyle: 'solid' as never,
+    outlineWidth: 2,
+  },
+  nativeOption: {
+    borderRadius: radii.sm,
+    borderWidth: 1,
+    paddingHorizontal: spacing.md,
   },
   radio: {
     alignItems: 'center',
@@ -243,5 +277,7 @@ const styles = StyleSheet.create({
   success: { fontFamily: 'SUIT', ...typography.sm },
   error: { fontFamily: 'SUIT', ...typography.sm },
   submitButton: { minHeight: 48 },
-  actions: { alignItems: 'flex-start' },
+  webSubmitButton: { width: '100%' },
+  webActions: { width: '100%' },
+  nativeActions: { alignItems: 'flex-start' },
 });

--- a/apps/app/src/components/feedback/FeedbackPage.tsx
+++ b/apps/app/src/components/feedback/FeedbackPage.tsx
@@ -1,0 +1,40 @@
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { PageHeader } from '@/components/PageHeader';
+import { spacing } from '@/theme/tokens';
+import { FeedbackForm } from './FeedbackForm';
+
+export function FeedbackPage() {
+  const web = Platform.OS === 'web';
+
+  return (
+    <ScrollView
+      contentContainerStyle={web ? styles.webRoot : styles.nativeRoot}
+      keyboardShouldPersistTaps="handled"
+    >
+      {web ? <PageHeader title="피드백 보내기" /> : null}
+      {web ? (
+        <View style={styles.webContent}>
+          <FeedbackForm />
+        </View>
+      ) : (
+        <FeedbackForm />
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  webRoot: { flexGrow: 1, width: '100%' },
+  webContent: {
+    alignSelf: 'center',
+    maxWidth: 600,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.xxl,
+    width: '100%',
+  },
+  nativeRoot: {
+    flexGrow: 1,
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.xxl,
+  },
+});

--- a/apps/app/src/stories/Feedback.stories.tsx
+++ b/apps/app/src/stories/Feedback.stories.tsx
@@ -38,8 +38,10 @@ export const BugReport: Story = {
   render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('radio', { name: '버그를 발견했어요' }));
-    expect(canvas.getByRole('radio', { name: '버그를 발견했어요' })).toBeChecked();
+    const bugReport = canvas.getByRole('radio', { name: '버그를 발견했어요' });
+    await userEvent.click(bugReport);
+    expect(bugReport).toBeChecked();
+    expect(bugReport).toHaveStyle({ borderRadius: '8px' });
     expect(canvas.getAllByRole('textbox')).toHaveLength(1);
   },
 };

--- a/apps/app/src/stories/Feedback.stories.tsx
+++ b/apps/app/src/stories/Feedback.stories.tsx
@@ -1,37 +1,41 @@
 import { expect, fireEvent, userEvent, within } from 'storybook/test';
-import { FeedbackForm } from '@/components/feedback/FeedbackForm';
-import { Catalog, Section } from './StoryFrame';
+import { FeedbackPage } from '@/components/feedback/FeedbackPage';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta = {
-  component: FeedbackForm,
+  component: FeedbackPage,
   parameters: {
+    layout: 'fullscreen',
     router: { pathname: '/feedback' },
   },
-  title: 'KOSMO/Feedback/Form',
-} satisfies Meta<typeof FeedbackForm>;
+  title: 'KOSMO/Feedback/Page',
+} satisfies Meta<typeof FeedbackPage>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Idle: Story = {
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · 기본">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  render: () => <FeedbackPage />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getAllByRole('heading', { name: '피드백 보내기' })).toHaveLength(1);
+    expect(canvas.getByRole('button', { name: '피드백 보내기' })).toBeDisabled();
+  },
+};
+
+export const CompactIdle: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoCompact' } },
+  render: () => <FeedbackPage />,
+};
+
+export const FullIdle: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoFull' } },
+  render: () => <FeedbackPage />,
 };
 
 export const BugReport: Story = {
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · 버그 리포트">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('radio', { name: '버그를 발견했어요' }));
@@ -41,13 +45,7 @@ export const BugReport: Story = {
 };
 
 export const KeyboardNavigation: Story = {
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · 키보드 라디오">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const radios = canvas.getAllByRole('radio');
@@ -76,13 +74,7 @@ export const TrimmedBodyBoundary: Story = {
   parameters: {
     relay: { mutationResponse: { submitFeedback: { completed: true } } },
   },
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · trim 경계">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const body = canvas.getByRole('textbox', { name: '피드백 내용' });
@@ -95,13 +87,7 @@ export const TrimmedBodyBoundary: Story = {
 };
 
 export const BodyTooLong: Story = {
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · 본문 길이 검증">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const body = canvas.getByRole('textbox', { name: '피드백 내용' });
@@ -114,13 +100,7 @@ export const BodyTooLong: Story = {
 
 export const Pending: Story = {
   parameters: { relay: { mutationLoading: true } },
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · 전달 중">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const bugReport = canvas.getByRole('radio', { name: '버그를 발견했어요' });
@@ -143,13 +123,7 @@ export const Success: Story = {
   parameters: {
     relay: { mutationResponse: { submitFeedback: { completed: true } } },
   },
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · 성공">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const body = canvas.getByRole('textbox', { name: '피드백 내용' });
@@ -164,13 +138,7 @@ export const Success: Story = {
 
 export const DeliveryFailureKeepsInput: Story = {
   parameters: { relay: { mutationError: 'Slack delivery failed' } },
-  render: () => (
-    <Catalog width={760}>
-      <Section title="피드백 · 재시도">
-        <FeedbackForm />
-      </Section>
-    </Catalog>
-  ),
+  render: () => <FeedbackPage />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const message = '다시 시도할 수 있어야 해요.';

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,6 +9,7 @@ KOSMO의 UI/프로덕트 디자인 결정을 기록하고 공유하는 문서 �
 - [colors.md](./colors.md) — 컬러 토큰 정책
 - [logo.md](./logo.md) — 확정 로고 자산, clear space와 플랫폼별 소비처
 - [page-header.md](./page-header.md) — 주요 화면 공용 헤더의 variant, 높이와 소유권
+- [feedback.md](./feedback.md) — Web 피드백 page의 정보 위계와 후속 popup 재사용 경계
 - [typography.md](./typography.md) — 폰트 사용 규칙
 - [breakpoints.md](./breakpoints.md) — 레이아웃 브레이크포인트 단계와 컨벤션
 - [post-action-bar.md](./post-action-bar.md) — Post Action Bar의 28px geometry, 배치, Repost 메뉴와 오류 toast 계약

--- a/docs/design/feedback.md
+++ b/docs/design/feedback.md
@@ -1,0 +1,80 @@
+# 피드백 화면
+
+인증된 Web 사용자의 피드백 화면은 KOSMO의 공용 페이지 위계 안에서 의견 종류와 내용을 입력하고 제출하는
+집중된 폼을 제공한다. 제출 계약은 [PROD-487](https://linear.app/byulmaru/issue/PROD-487)에 따르고, 이 문서는
+[PROD-547](https://linear.app/byulmaru/issue/PROD-547)의 Web 시각 구조와 후속
+[PROD-594](https://linear.app/byulmaru/issue/PROD-594)를 위한 presentation 소유권 경계를 정한다.
+
+## 정보 위계
+
+- `/feedback` route는 공용 `PageHeader`의 `text` variant로 `피드백 보내기` 제목을 한 번 표시한다.
+- 폼은 제목을 다시 표시하지 않고 `KOSMO를 더 좋게 만들 수 있도록 의견을 들려주세요.` 설명으로 시작한다.
+- 설명 다음에는 피드백 종류, 피드백 내용, 제출 상태, primary action 순으로 배치한다.
+- 피드백 종류는 outer card나 항목별 bordered card를 사용하지 않는 평면 목록이다. 항목 사이의 낮은 강도
+  구분선과 선택된 행의 theme surface, radio indicator를 함께 사용해 선택 상태를 나타낸다.
+- 피드백 내용은 공용 `TextField`의 multiline 입력을 사용하고, 입력 경계가 필요한 surface이므로 `border`
+  token을 유지한다.
+- `피드백 보내기` primary action은 폼의 전체 너비를 사용한다. 작은 독립 버튼이나 별도 action card로
+  표현하지 않는다.
+- 색상, 간격, 반경과 typography는 공용 theme token과 UI primitive를 사용한다. component-local hex나 새
+  breakpoint를 만들지 않는다.
+
+## 반응형 Page Surface
+
+- Web `< compact`와 `compact` 이상 Web은 같은 정보 위계와 평면 폼을 사용한다.
+- route가 `PageHeader`, document scroll, page padding과 중앙 콘텐츠 최대 폭을 소유한다. 폼은 route와 popup의
+  chrome을 소유하지 않는다.
+- `< compact`에서는 모바일 셸과 하단 탭을 유지하며 가용 중앙 폭을 사용한다. outer card를 추가하지 않는다.
+- `compact`와 `full` Web에서는 기존 shell의 중앙 route column 안에 폼을 배치한다. 넓은 화면에서도 별도
+  desktop card를 추가하지 않는다.
+- breakpoint는 [breakpoints.md](./breakpoints.md)의 `compact=768`, `full=1280`을 그대로 사용한다.
+- `PageHeader`의 높이, heading과 scroll 소유권은 [page-header.md](./page-header.md)를 따른다.
+
+## Form과 Presentation 소유권
+
+피드백 form은 입력, 검증, 제출과 결과 상태를 소유하되 자신이 page인지 popup인지 판단하지 않는다.
+
+- form 소유: 피드백 종류와 본문 draft, validation, `submitFeedback` 호출, pending 입력 차단, 성공·실패 표시,
+  성공 시 초기화와 실패 시 draft 유지
+- page 소유: `PageHeader`, page padding, document scroll, 중앙 콘텐츠 폭
+- 후속 popup 소유: dialog/sheet 제목, 닫기 action, 크기와 위치, backdrop, navigation과 browser history,
+  뒤로가기와 `Escape`, focus trap·복원, 배경 상호작용 차단
+
+[PROD-594](https://linear.app/byulmaru/issue/PROD-594)는 같은 form을 popup body에 조립한다. 현재 page 작업은
+아직 결정되지 않은 popup 전용 `variant`, 닫기 callback이나 성공 후 자동 닫기 정책을 form에 미리 추가하지
+않는다. popup 성공 후 유지·닫기 정책과 `/feedback` route의 fallback·deep-link 역할은 PROD-594에서 결정한다.
+
+Android와 iOS 피드백 화면은 PROD-547 범위가 아니다. 공용 form의 상태·제출 로직은 공유할 수 있지만 이번 Web
+surface 변경으로 Native의 기존 page chrome이나 시각 구조를 바꾸지 않는다.
+
+## 상태와 동작 불변조건
+
+- idle 상태는 기본 `좋아요` 종류와 빈 본문으로 시작하며, 유효한 본문이 입력되기 전 제출을 비활성화한다.
+- validation error는 기존 body schema와 오류 문구를 유지한다.
+- pending은 종류, 본문과 제출 action의 중복 입력을 차단하고 busy 상태를 유지한다.
+- 성공은 기존 성공 문구를 표시하고 종류와 본문을 초기화한다.
+- delivery failure와 GraphQL failure는 기존 오류 문구와 재시도 action을 표시하고 종류와 본문을 유지한다.
+- `submitFeedback` mutation, Slack payload, route와 인증 경계, 기존 radio·status·busy semantics는 변경하지
+  않는다.
+
+## 검증
+
+- Storybook에서 idle, validation error, pending, success, delivery failure와 실패 후 입력 유지를 확인한다.
+- 각 상태의 page surface를 `390px` mobile, `900px` compact, `1400px` full Web viewport에서 확인한다.
+- 실제 Web `/feedback`에서 `< compact`와 desktop viewport의 `PageHeader`, 평면 목록, multiline 입력과 full-width
+  primary action을 확인한다.
+- 기존 Web E2E로 인증된 진입, 제출 payload, 성공 초기화, 실패 후 입력 유지가 바뀌지 않았음을 검증한다.
+- 자동화와 Storybook 결과는 실제 Web reflow, focus indicator, contrast와 keyboard/document scroll 관찰을
+  대신하지 않는다.
+
+## 제외 범위
+
+- `submitFeedback` mutation과 Slack delivery payload 변경
+- `/feedback` route 및 인증 경계 변경
+- PROD-594가 소유하는 popup 진입, shell navigation과 dialog/sheet lifecycle
+- Android/iOS 피드백 화면 변경
+- PROD-487이 소유한 접근성 semantics 재설계
+
+PROD-547은 새 사용자 행동이나 제출 계약을 추가하지 않고 기존 행동을 보존한 채 Web 시각 구조를 정리한다.
+따라서 별도 OpenSpec change를 만들지 않고, 기존 `web-app-shell`의 피드백 진입과 `/feedback` 보존 계약을
+유지한다. PROD-594가 popup의 navigation·lifecycle 행동을 확정할 때 필요한 OpenSpec 범위를 별도로 판단한다.

--- a/docs/design/feedback.md
+++ b/docs/design/feedback.md
@@ -11,7 +11,9 @@
 - 폼은 제목을 다시 표시하지 않고 `KOSMO를 더 좋게 만들 수 있도록 의견을 들려주세요.` 설명으로 시작한다.
 - 설명 다음에는 피드백 종류, 피드백 내용, 제출 상태, primary action 순으로 배치한다.
 - 피드백 종류는 outer card나 항목별 bordered card를 사용하지 않는 평면 목록이다. 항목 사이의 낮은 강도
-  구분선과 선택된 행의 theme surface, radio indicator를 함께 사용해 선택 상태를 나타낸다.
+  구분선과 선택된 행의 theme surface, radio indicator를 함께 사용해 선택 상태를 나타낸다. Web의 선택·누름
+  surface는 공용 `radii.sm=8px` 반경을 사용하되 행 사이 간격이나 border를 추가하지 않아 카드 목록처럼
+  분리하지 않는다.
 - 피드백 내용은 공용 `TextField`의 multiline 입력을 사용하고, 입력 경계가 필요한 surface이므로 `border`
   token을 유지한다.
 - `피드백 보내기` primary action은 폼의 전체 너비를 사용한다. 작은 독립 버튼이나 별도 action card로
@@ -56,6 +58,8 @@ surface 변경으로 Native의 기존 page chrome이나 시각 구조를 바꾸�
 - delivery failure와 GraphQL failure는 기존 오류 문구와 재시도 action을 표시하고 종류와 본문을 유지한다.
 - `submitFeedback` mutation, Slack payload, route와 인증 경계, 기존 radio·status·busy semantics는 변경하지
   않는다.
+- 재현 환경은 별도 필드로 수집하지 않는다. 사용자는 필요한 기기·플랫폼 정보를 피드백 본문에 함께 적을 수
+  있으며, 자동 감지 metadata나 환경 선택값을 제출 계약에 추가하지 않는다.
 
 ## 검증
 
@@ -63,6 +67,8 @@ surface 변경으로 Native의 기존 page chrome이나 시각 구조를 바꾸�
 - 각 상태의 page surface를 `390px` mobile, `900px` compact, `1400px` full Web viewport에서 확인한다.
 - 실제 Web `/feedback`에서 `< compact`와 desktop viewport의 `PageHeader`, 평면 목록, multiline 입력과 full-width
   primary action을 확인한다.
+- 첫 번째·중간·마지막 종류를 각각 선택해 8px 선택 surface, 구분선 연속성, 누름·keyboard focus 표시가 평면
+  목록 위계를 유지하는지 확인한다.
 - 기존 Web E2E로 인증된 진입, 제출 payload, 성공 초기화, 실패 후 입력 유지가 바뀌지 않았음을 검증한다.
 - 자동화와 Storybook 결과는 실제 Web reflow, focus indicator, contrast와 keyboard/document scroll 관찰을
   대신하지 않는다.
@@ -70,6 +76,7 @@ surface 변경으로 Native의 기존 page chrome이나 시각 구조를 바꾸�
 ## 제외 범위
 
 - `submitFeedback` mutation과 Slack delivery payload 변경
+- 기기·플랫폼 자동 감지 metadata와 재현 환경 선택 필드
 - `/feedback` route 및 인증 경계 변경
 - PROD-594가 소유하는 popup 진입, shell navigation과 dialog/sheet lifecycle
 - Android/iOS 피드백 화면 변경


### PR DESCRIPTION
## 무엇을 변경했는지

- `/feedback`에 공용 `PageHeader`를 적용했습니다.
- Web 피드백 폼을 평면 목록과 전체 너비 primary action으로 정리했습니다.
- 기존 Native 카드 표현과 제출·성공·실패·입력 유지 동작을 보존했습니다.
- 후속 PROD-594 popup이 같은 `FeedbackForm`을 재사용할 수 있도록 page chrome과 form 책임을 분리했습니다.
- canonical `docs/design/feedback.md`에 시각 구조와 소유권을 기록했습니다.

## 왜 변경했는지

기존 Web 화면은 큰 bordered card 안에 bordered option을 반복하고 작은 독립 제출 버튼을 사용해 KOSMO의 주요 page 정보 위계와 달랐습니다. PROD-547은 제출 기능을 바꾸지 않고 Web 시각 구조만 공용 pattern에 맞춥니다.

## 이번 PR의 주요 결정

### Page와 popup이 같은 평면 form을 재사용한다

- 결정자: 이예은
- 선택: page와 popup chrome을 `FeedbackForm` 밖에서 소유하고 Web form은 평면 구조로 유지합니다.
- 고려한 대안: mobile만 평면화하고 desktop card를 유지하는 방식, popup variant를 지금 추가하는 방식, popup용 form을 복제하는 방식
- 이유: Web 폭에 관계없이 같은 정보 위계를 사용하고, 아직 확정되지 않은 PROD-594 lifecycle을 현재 form API에 미리 넣지 않기 위해서입니다.
- 감수한 결과: popup 성공 후 닫기와 `/feedback` fallback 정책은 PROD-594에서 별도로 결정해야 합니다.
- 관련 근거: `docs/design/feedback.md`, PROD-547, PROD-594

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app exec vitest run --project=storybook src/stories/Feedback.stories.tsx`
- `pnpm --filter @kosmo/app check`
- Web E2E와 390px·900px·1400px 수동 검증은 진행 중입니다.

## 아직 어떤 문제가 남았는지

- PROD-594 popup presentation·navigation·focus lifecycle은 이번 PR 범위가 아닙니다.
- Android/iOS runtime QA는 이번 Web-only 이슈 범위에서 실행하지 않습니다.
