### PR TITLE
reviewed Terraform plan을 그대로 적용한다

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -351,12 +351,44 @@ jobs:
             echo "TF_PLAN_SOURCE_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${plan_run_id}"
           } >> "${GITHUB_ENV}"
 
+      - name: Compare reviewed and current Terraform plans
+        working-directory: ${{ env.TF_ROOT }}
+        run: |
+          set -euo pipefail
+
+          cleanup_plan_comparison() {
+            rm -f current.tfplan current.tfplan.txt
+          }
+          trap cleanup_plan_comparison EXIT
+
+          terraform plan -input=false -out=current.tfplan
+          terraform show -no-color current.tfplan > current.tfplan.txt
+
+          if ! cmp -s terraform.tfplan.txt current.tfplan.txt; then
+            {
+              echo "## Terraform plan mismatch"
+              echo
+              echo "The current main plan differs from the reviewed plan; refusing to apply either plan."
+              echo
+              echo "<details>"
+              echo "<summary>Current main plan</summary>"
+              echo
+              echo '```terraform'
+              sed -n '1,600p' current.tfplan.txt
+              echo '```'
+              echo "</details>"
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "Current main plan differs from the reviewed pull request plan; refusing to apply." >&2
+            exit 1
+          fi
+
       - name: Summarize Terraform apply
         run: |
           {
             echo "## Terraform apply"
             echo
-            echo "Applying the reviewed saved plan from \`${TF_PLAN_SOURCE_EVENT}\` commit \`${TF_PLAN_SOURCE_COMMIT}\`."
+            echo "The current main plan matches the reviewed plan from \`${TF_PLAN_SOURCE_EVENT}\` commit \`${TF_PLAN_SOURCE_COMMIT}\`."
+            echo "Applying that reviewed saved plan."
             echo "Terraform will perform its native stale-plan validation before changing infrastructure."
             echo "- Plan workflow run: [${TF_PLAN_SOURCE_RUN_ID}](${TF_PLAN_SOURCE_URL})"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -133,7 +133,7 @@ jobs:
             echo
             echo "- Commit: \`${GITHUB_SHA}\`"
             echo "- Workflow run: [${GITHUB_RUN_ID}](${plan_url})"
-            echo "- Apply: main will apply this saved plan only if its current plan is equivalent"
+            echo "- Apply: main will apply this saved plan with Terraform's native stale-plan validation"
             echo
             echo "<details>"
             echo "<summary>terraform show -no-color terraform.tfplan</summary>"
@@ -177,7 +177,7 @@ jobs:
             echo
             echo "- Commit: \`${PR_HEAD_SHA}\`"
             echo "- Workflow run: [${GITHUB_RUN_ID}](${plan_url})"
-            echo "- Apply: main will apply this reviewed saved plan only if its current plan is equivalent"
+            echo "- Apply: main will apply this reviewed saved plan with Terraform's native stale-plan validation"
             echo "- Artifact retention: ${GITHUB_RETENTION_DAYS} days; rerun this plan before merging if it expires"
             echo
             echo "<details open>"
@@ -351,54 +351,13 @@ jobs:
             echo "TF_PLAN_SOURCE_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${plan_run_id}"
           } >> "${GITHUB_ENV}"
 
-      - name: Compare reviewed and current Terraform plans
-        working-directory: ${{ env.TF_ROOT }}
-        run: |
-          set -euo pipefail
-
-          cleanup_plan_comparison() {
-            rm -f current.tfplan current.tfplan.txt current.tfplan.json reviewed.tfplan.json
-          }
-          trap cleanup_plan_comparison EXIT
-
-          terraform plan -input=false -out=current.tfplan
-          terraform show -json terraform.tfplan \
-            | jq -S '{configuration, variables, resource_changes: [.resource_changes[] | select(.change.actions != ["no-op"])], output_changes, checks}' \
-            > reviewed.tfplan.json
-          terraform show -json current.tfplan \
-            | jq -S '{configuration, variables, resource_changes: [.resource_changes[] | select(.change.actions != ["no-op"])], output_changes, checks}' \
-            > current.tfplan.json
-
-          if ! cmp -s reviewed.tfplan.json current.tfplan.json; then
-            terraform show -no-color current.tfplan > current.tfplan.txt
-            total_lines="$(wc -l < current.tfplan.txt)"
-            {
-              echo "## Terraform plan mismatch"
-              echo
-              echo "The current main plan differs from the reviewed plan; refusing to apply either plan."
-              echo
-              echo "<details>"
-              echo "<summary>Current main plan</summary>"
-              echo
-              echo '```terraform'
-              sed -n '1,600p' current.tfplan.txt
-              if [[ "${total_lines}" -gt 600 ]]; then
-                echo "... truncated ..."
-              fi
-              echo '```'
-              echo "</details>"
-            } >> "${GITHUB_STEP_SUMMARY}"
-            echo "Current main plan differs from the reviewed pull request plan; refusing to apply." >&2
-            exit 1
-          fi
-
       - name: Summarize Terraform apply
         run: |
           {
             echo "## Terraform apply"
             echo
-            echo "The current main plan is equivalent to the reviewed plan from \`${TF_PLAN_SOURCE_EVENT}\` commit \`${TF_PLAN_SOURCE_COMMIT}\`."
-            echo "Applying the reviewed saved plan so Terraform retains its native stale-plan validation."
+            echo "Applying the reviewed saved plan from \`${TF_PLAN_SOURCE_EVENT}\` commit \`${TF_PLAN_SOURCE_COMMIT}\`."
+            echo "Terraform will perform its native stale-plan validation before changing infrastructure."
             echo "- Plan workflow run: [${TF_PLAN_SOURCE_RUN_ID}](${TF_PLAN_SOURCE_URL})"
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -357,14 +357,59 @@ jobs:
           set -euo pipefail
 
           cleanup_plan_comparison() {
-            rm -f current.tfplan current.tfplan.txt
+            rm -f current.tfplan current.tfplan.txt current.tfplan.json reviewed.tfplan.json
           }
           trap cleanup_plan_comparison EXIT
 
-          terraform plan -input=false -out=current.tfplan
-          terraform show -no-color current.tfplan > current.tfplan.txt
+          normalize_plan() {
+            terraform show -json "$1" \
+              | jq -S '
+                  def changed_values($before; $after):
+                    if $before == $after then
+                      []
+                    elif ($before | type) == "object" and ($after | type) == "object" then
+                      [
+                        ((($before | keys_unsorted) + ($after | keys_unsorted)) | unique[]) as $key
+                        | changed_values($before[$key]; $after[$key])[]
+                        | .path = [$key] + .path
+                      ]
+                    elif ($before | type) == "array" and ($after | type) == "array" then
+                      [
+                        range(0; ([($before | length), ($after | length)] | max)) as $index
+                        | changed_values($before[$index]; $after[$index])[]
+                        | .path = [$index] + .path
+                      ]
+                    else
+                      [{ path: [], before: $before, after: $after }]
+                    end;
 
-          if ! cmp -s terraform.tfplan.txt current.tfplan.txt; then
+                  {
+                    configuration,
+                    variables,
+                    resource_changes: [
+                      (.resource_changes // [])[]
+                      | select(.change.actions != ["no-op"])
+                      | .change.changed_values = changed_values(.change.before; .change.after)
+                      | del(.change.before, .change.after)
+                    ],
+                    output_changes: (
+                      (.output_changes // {})
+                      | with_entries(
+                          .value.changed_values = changed_values(.value.before; .value.after)
+                          | del(.value.before, .value.after)
+                        )
+                    ),
+                    checks
+                  }
+                ' > "$2"
+          }
+
+          terraform plan -input=false -out=current.tfplan
+          normalize_plan terraform.tfplan reviewed.tfplan.json
+          normalize_plan current.tfplan current.tfplan.json
+
+          if ! cmp -s reviewed.tfplan.json current.tfplan.json; then
+            terraform show -no-color current.tfplan > current.tfplan.txt
             {
               echo "## Terraform plan mismatch"
               echo

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -364,23 +364,20 @@ jobs:
           normalize_plan() {
             terraform show -json "$1" \
               | jq -S '
-                  def changed_values($before; $after):
-                    if $before == $after then
-                      []
-                    elif ($before | type) == "object" and ($after | type) == "object" then
-                      [
-                        ((($before | keys_unsorted) + ($after | keys_unsorted)) | unique[]) as $key
-                        | changed_values($before[$key]; $after[$key])[]
-                        | .path = [$key] + .path
-                      ]
-                    elif ($before | type) == "array" and ($after | type) == "array" then
-                      [
-                        range(0; ([($before | length), ($after | length)] | max)) as $index
-                        | changed_values($before[$index]; $after[$index])[]
-                        | .path = [$index] + .path
-                      ]
+                  def normalize_argocd_application:
+                    if .type == "argocd_application" then
+                      del(
+                        .change.before.status,
+                        .change.after.status,
+                        .change.before.metadata[]?.generation,
+                        .change.after.metadata[]?.generation,
+                        .change.before.metadata[]?.resource_version,
+                        .change.after.metadata[]?.resource_version,
+                        .change.before.metadata[]?.uid,
+                        .change.after.metadata[]?.uid
+                      )
                     else
-                      [{ path: [], before: $before, after: $after }]
+                      .
                     end;
 
                   {
@@ -389,16 +386,9 @@ jobs:
                     resource_changes: [
                       (.resource_changes // [])[]
                       | select(.change.actions != ["no-op"])
-                      | .change.changed_values = changed_values(.change.before; .change.after)
-                      | del(.change.before, .change.after)
+                      | normalize_argocd_application
                     ],
-                    output_changes: (
-                      (.output_changes // {})
-                      | with_entries(
-                          .value.changed_values = changed_values(.value.before; .value.after)
-                          | del(.value.before, .value.after)
-                        )
-                    ),
+                    output_changes,
                     checks
                   }
                 ' > "$2"


### PR DESCRIPTION
## 문제

main Apply 30615384937은 reviewed plan 다운로드에는 성공했지만, JSON 전체 비교가 Argo Application의 실행마다 바뀌는 computed 상태까지 포함해 중단됐습니다.

## 변경

- configuration, variables, 실제 non-no-op resource changes, output changes와 checks를 구조화해 비교하는 기존 gate를 유지합니다.
- `argocd_application`에서 computed-only `status`와 metadata의 `generation`, `resource_version`, `uid`만 비교 전에 제외합니다.
- release workflow가 소유하는 ignored Helm parameter, sensitive 실제 값, create/delete 의미는 그대로 비교합니다.
- plan이 같으면 reviewed saved plan을 적용하고 Terraform native stale-plan 검증도 유지합니다.

## 검증

- #457과 #471 artifact가 좁은 Argo 정규화 후 동일함을 확인
- ignored release parameter 차이는 서로 다른 결과로 남음을 확인
- delete plan의 computed Argo 관측값 차이만 제거됨을 확인
- sensitive 값을 포함한 나머지 structured plan은 보존됨
- `actionlint .github/workflows/terraform.yml`
- `git diff --check`