### PR TITLE
주요 Web route 이동 시 document scroll을 최상단으로 초기화한다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -393,13 +393,13 @@ export default function SearchScreen() {
     }, 0);
   };
 
-  const preserveQueryNavigationPosition = () => {
+  const preserveQueryNavigationPosition = (restoreFocus = focused) => {
     if (Platform.OS !== 'web') {
       return;
     }
 
     recordQueryNavigation({
-      restoreFocus: focused,
+      restoreFocus,
       scrollY: window.scrollY,
     });
   };
@@ -450,7 +450,7 @@ export default function SearchScreen() {
                 accessibilityLabel="뒤로"
                 accessibilityRole="link"
                 onPress={() => {
-                  preserveQueryNavigationPosition();
+                  preserveQueryNavigationPosition(false);
                   setInput('');
                   setFocused(false);
                 }}

--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -227,6 +227,31 @@ function searchHref(query: string, tab: SearchTab): Href {
   return `/search?${params.toString()}` as Href;
 }
 
+function isPrimarySearchLinkActivation(event: unknown) {
+  if (Platform.OS !== 'web') {
+    return true;
+  }
+
+  const webEvent = event as {
+    altKey?: boolean;
+    button?: number;
+    currentTarget?: { target?: string | null };
+    ctrlKey?: boolean;
+    defaultPrevented?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
+  };
+  return (
+    !webEvent.defaultPrevented &&
+    !webEvent.metaKey &&
+    !webEvent.altKey &&
+    !webEvent.ctrlKey &&
+    !webEvent.shiftKey &&
+    (webEvent.button == null || webEvent.button === 0) &&
+    [undefined, null, '', 'self'].includes(webEvent.currentTarget?.target)
+  );
+}
+
 export default function SearchScreen() {
   const theme = useTheme();
   const router = useRouter();
@@ -250,6 +275,17 @@ export default function SearchScreen() {
     let frame = 0;
     let attempts = 0;
     let settledFrames = 0;
+    let lastScrollHeight: number | null = null;
+    const maxLayoutAttempts = 60;
+    const stableFrameCount = 2;
+    const cancelRestore = () => {
+      clearQueryNavigation(navigation);
+      window.cancelAnimationFrame(frame);
+      frame = 0;
+    };
+    const handleUserInput = () => {
+      cancelRestore();
+    };
     let restoredFocus = false;
     const restore = () => {
       if (getQueryNavigation() !== navigation) {
@@ -257,14 +293,14 @@ export default function SearchScreen() {
       }
 
       const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
-      if (navigation.scrollY > maxScrollY && attempts < 60) {
+      if (navigation.scrollY > maxScrollY && attempts < maxLayoutAttempts) {
         attempts += 1;
         frame = window.requestAnimationFrame(restore);
         return;
       }
 
-      window.scrollTo({ behavior: 'auto', left: 0, top: Math.min(navigation.scrollY, maxScrollY) });
-      settledFrames += 1;
+      const nextScrollY = Math.min(navigation.scrollY, maxScrollY);
+      window.scrollTo({ behavior: 'auto', left: 0, top: nextScrollY });
       if (navigation.restoreFocus && !restoredFocus) {
         inputRef.current?.focus();
         restoredFocus = true;
@@ -272,7 +308,15 @@ export default function SearchScreen() {
           setFocused(false);
         }
       }
-      if (settledFrames < 60) {
+
+      const scrollHeight = document.documentElement.scrollHeight;
+      if (window.scrollY === nextScrollY && scrollHeight === lastScrollHeight) {
+        settledFrames += 1;
+      } else {
+        settledFrames = 0;
+      }
+      lastScrollHeight = scrollHeight;
+      if (settledFrames < stableFrameCount) {
         frame = window.requestAnimationFrame(restore);
         return;
       }
@@ -280,8 +324,17 @@ export default function SearchScreen() {
       clearQueryNavigation(navigation);
     };
 
+    for (const eventName of ['keydown', 'pointerdown', 'touchstart', 'wheel']) {
+      window.addEventListener(eventName, handleUserInput, { capture: true, passive: true });
+    }
     frame = window.requestAnimationFrame(restore);
-    return () => window.cancelAnimationFrame(frame);
+    return () => {
+      clearQueryNavigation(navigation);
+      window.cancelAnimationFrame(frame);
+      for (const eventName of ['keydown', 'pointerdown', 'touchstart', 'wheel']) {
+        window.removeEventListener(eventName, handleUserInput, true);
+      }
+    };
   }, [activeTab, clearQueryNavigation, getQueryNavigation, query]);
 
   useEffect(() => {
@@ -350,6 +403,8 @@ export default function SearchScreen() {
       scrollY: window.scrollY,
     });
   };
+  const isCurrentSearchTarget = (nextQuery: string, nextTab: SearchTab) =>
+    nextQuery.trim() === query && nextTab === activeTab;
 
   const navigate = (
     nextQuery: string,
@@ -360,6 +415,10 @@ export default function SearchScreen() {
     if (normalized) {
       remember(normalized);
       trackAnalytics('search_submitted', { source, tab });
+    }
+    if (isCurrentSearchTarget(normalized, tab)) {
+      setFocused(false);
+      return;
     }
     preserveQueryNavigationPosition();
     setFocused(false);
@@ -440,8 +499,14 @@ export default function SearchScreen() {
                   <Link asChild href={searchHref(term, activeTab)}>
                     <Pressable
                       accessibilityRole="link"
-                      onPress={() => {
-                        preserveQueryNavigationPosition();
+                      onPress={(event) => {
+                        const currentTarget = isCurrentSearchTarget(term, activeTab);
+                        const primaryActivation = isPrimarySearchLinkActivation(event);
+                        if (currentTarget && primaryActivation) {
+                          event.preventDefault();
+                        } else if (primaryActivation) {
+                          preserveQueryNavigationPosition();
+                        }
                         setFocused(false);
                         remember(term);
                         trackAnalytics('search_submitted', { source: 'recent', tab: activeTab });

--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -1,12 +1,13 @@
 import { parseSearchTab, SearchTab } from '@kosmo/core/search';
 import { Link, useLocalSearchParams, useRouter } from 'expo-router';
 import { ArrowLeft, History, Search as SearchIcon, X } from 'lucide-react-native';
-import { useEffect, useRef, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { graphql, usePaginationFragment, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import { trackAnalytics } from '@/analytics/client';
 import { ProfileListItem } from '@/components/profile/ProfileListItem';
 import { RouteBoundary } from '@/components/RouteBoundary';
+import { usePrimaryNavigationScroll } from '@/components/shell/PrimaryNavigationScrollContext';
 import { Button } from '@/components/ui/Button';
 import { StateView } from '@/components/ui/StateView';
 import { addRecentSearch, readRecentSearches, writeRecentSearches } from '@/lib/recentSearches';
@@ -237,6 +238,51 @@ export default function SearchScreen() {
   const [recent, setRecent] = useState<string[]>([]);
   const [focused, setFocused] = useState(false);
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { clearQueryNavigation, getQueryNavigation, recordQueryNavigation } =
+    usePrimaryNavigationScroll();
+
+  useLayoutEffect(() => {
+    const navigation = getQueryNavigation();
+    if (Platform.OS !== 'web' || !navigation) {
+      return;
+    }
+
+    let frame = 0;
+    let attempts = 0;
+    let settledFrames = 0;
+    let restoredFocus = false;
+    const restore = () => {
+      if (getQueryNavigation() !== navigation) {
+        return;
+      }
+
+      const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      if (navigation.scrollY > maxScrollY && attempts < 60) {
+        attempts += 1;
+        frame = window.requestAnimationFrame(restore);
+        return;
+      }
+
+      window.scrollTo({ behavior: 'auto', left: 0, top: Math.min(navigation.scrollY, maxScrollY) });
+      settledFrames += 1;
+      if (navigation.restoreFocus && !restoredFocus) {
+        inputRef.current?.focus();
+        restoredFocus = true;
+        if (query) {
+          setFocused(false);
+        }
+      }
+      if (settledFrames < 60) {
+        frame = window.requestAnimationFrame(restore);
+        return;
+      }
+
+      clearQueryNavigation(navigation);
+    };
+
+    frame = window.requestAnimationFrame(restore);
+    return () => window.cancelAnimationFrame(frame);
+  }, [activeTab, clearQueryNavigation, getQueryNavigation, query]);
 
   useEffect(() => {
     let current = true;
@@ -294,6 +340,17 @@ export default function SearchScreen() {
     }, 0);
   };
 
+  const preserveQueryNavigationPosition = () => {
+    if (Platform.OS !== 'web') {
+      return;
+    }
+
+    recordQueryNavigation({
+      restoreFocus: focused,
+      scrollY: window.scrollY,
+    });
+  };
+
   const navigate = (
     nextQuery: string,
     tab: SearchTab = activeTab,
@@ -304,6 +361,7 @@ export default function SearchScreen() {
       remember(normalized);
       trackAnalytics('search_submitted', { source, tab });
     }
+    preserveQueryNavigationPosition();
     setFocused(false);
     router.push(searchHref(normalized, tab));
   };
@@ -312,6 +370,7 @@ export default function SearchScreen() {
     setInput('');
     keepSearchFocused();
     if (query) {
+      preserveQueryNavigationPosition();
       router.setParams({ q: undefined });
     }
     inputRef.current?.focus();
@@ -332,6 +391,7 @@ export default function SearchScreen() {
                 accessibilityLabel="뒤로"
                 accessibilityRole="link"
                 onPress={() => {
+                  preserveQueryNavigationPosition();
                   setInput('');
                   setFocused(false);
                 }}
@@ -381,6 +441,7 @@ export default function SearchScreen() {
                     <Pressable
                       accessibilityRole="link"
                       onPress={() => {
+                        preserveQueryNavigationPosition();
                         setFocused(false);
                         remember(term);
                         trackAnalytics('search_submitted', { source: 'recent', tab: activeTab });

--- a/apps/app/src/components/shell/BottomTabBar.tsx
+++ b/apps/app/src/components/shell/BottomTabBar.tsx
@@ -123,7 +123,7 @@ export function BottomTabBar({
         );
 
         return tab.href ? (
-          <GuardedLink href={tab.href} key={tab.label}>
+          <GuardedLink href={tab.href} key={tab.label} primary>
             {content}
           </GuardedLink>
         ) : (

--- a/apps/app/src/components/shell/GuardedLink.test.ts
+++ b/apps/app/src/components/shell/GuardedLink.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, before, describe, it, mock } from 'node:test';
 import { createElement, useEffect } from 'react';
 import { act, create } from 'react-test-renderer';
-import type { LinkProps } from 'expo-router';
+import type { Href, LinkProps } from 'expo-router';
 import type { ReactElement, ReactNode } from 'react';
 import type { ReactTestRenderer } from 'react-test-renderer';
 import type { GuardedLink as GuardedLinkExport } from './GuardedLink';
@@ -12,6 +12,10 @@ import type {
   NavigationRequestHandler,
   useNavigationGuard as useNavigationGuardExport,
 } from './NavigationGuardContext';
+import type {
+  PrimaryNavigationScrollProvider as PrimaryNavigationScrollProviderExport,
+  usePrimaryNavigationScroll as usePrimaryNavigationScrollExport,
+} from './PrimaryNavigationScrollContext';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -35,6 +39,8 @@ type RenderedLinkProps = {
 };
 
 const navigations: string[] = [];
+let currentPathname = '/home';
+let consumeIntent: ((pathname: string) => boolean) | undefined;
 let linkPress: LinkPress | undefined;
 let composedLinkPress: LinkPress | undefined;
 let rootLinkPress: LinkPress | undefined;
@@ -62,6 +68,7 @@ mockModule('expo-router', {
   useRouter: () => ({
     navigate: (href: string) => navigations.push(href),
   }),
+  usePathname: () => currentPathname,
 });
 mockModule('react-native', {
   Platform: { OS: 'web' },
@@ -70,10 +77,14 @@ mockModule('react-native', {
 let GuardedLink: typeof GuardedLinkExport;
 let NavigationGuardProvider: typeof NavigationGuardProviderExport;
 let useNavigationGuard: typeof useNavigationGuardExport;
+let PrimaryNavigationScrollProvider: typeof PrimaryNavigationScrollProviderExport;
+let usePrimaryNavigationScroll: typeof usePrimaryNavigationScrollExport;
 
 before(async () => {
   ({ GuardedLink } = await import('./GuardedLink'));
   ({ NavigationGuardProvider, useNavigationGuard } = await import('./NavigationGuardContext'));
+  ({ PrimaryNavigationScrollProvider, usePrimaryNavigationScroll } =
+    await import('./PrimaryNavigationScrollContext'));
 });
 
 afterEach(async () => {
@@ -84,6 +95,8 @@ afterEach(async () => {
   linkPress = undefined;
   composedLinkPress = undefined;
   rootLinkPress = undefined;
+  consumeIntent = undefined;
+  currentPathname = '/home';
   navigations.length = 0;
   mock.restoreAll();
 });
@@ -96,6 +109,11 @@ function GuardRegistrar({ handler }: { handler: NavigationRequestHandler }) {
 
 function TestPressable(props: { onPress?: LinkPress }) {
   return createElement('Pressable', props);
+}
+
+function PrimaryNavigationProbe() {
+  consumeIntent = usePrimaryNavigationScroll().consume;
+  return null;
 }
 
 function createPressEvent(overrides: Omit<LinkPressEvent, 'preventDefault'> = {}) {
@@ -120,18 +138,28 @@ function shouldHandleNavigation(event: LinkPressEvent) {
   );
 }
 
-const renderLink = async (handler: NavigationRequestHandler, onNavigate?: () => void) => {
+const renderLink = async (
+  handler: NavigationRequestHandler,
+  onNavigate?: () => void,
+  options: { href?: Href; primary?: boolean } = {},
+) => {
   await act(async () => {
     renderer = create(
       createElement(
-        NavigationGuardProvider,
+        PrimaryNavigationScrollProvider,
         null,
-        createElement(GuardRegistrar, { handler }),
-        createElement(GuardedLink, {
-          children: createElement(TestPressable),
-          href: '/timeline',
-          onNavigate,
-        }),
+        createElement(
+          NavigationGuardProvider,
+          null,
+          createElement(PrimaryNavigationProbe),
+          createElement(GuardRegistrar, { handler }),
+          createElement(GuardedLink, {
+            children: createElement(TestPressable),
+            href: options.href ?? '/timeline',
+            onNavigate,
+            primary: options.primary,
+          }),
+        ),
       ),
     );
   });
@@ -172,6 +200,54 @@ describe('GuardedLink', () => {
     assert.equal(event.preventDefault.mock.callCount(), 1);
     assert.equal(onNavigate.mock.callCount(), 1);
     assert.deepEqual(navigations, ['/timeline']);
+  });
+
+  it('실제 무guard primary navigation에서만 scroll intent를 기록한다', async () => {
+    currentPathname = '/home';
+    await renderLink(() => false, undefined, { href: '/search', primary: true });
+    const event: LinkPressEvent = { preventDefault: mock.fn() };
+
+    await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
+
+    assert.equal(consumeIntent?.('/search'), true);
+  });
+
+  it('guard 승인 action에서 scroll intent를 기록하고 취소 시에는 기록하지 않는다', async () => {
+    let pendingAction: GuardedNavigationAction | null = null;
+    await renderLink(
+      (action) => {
+        pendingAction = action;
+        return true;
+      },
+      undefined,
+      { href: '/timeline', primary: true },
+    );
+    const event: LinkPressEvent = { preventDefault: mock.fn() };
+
+    await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
+    assert.equal(consumeIntent?.('/timeline'), false);
+
+    const approvedAction = pendingAction as GuardedNavigationAction | null;
+    assert.ok(approvedAction);
+    approvedAction();
+    assert.equal(consumeIntent?.('/timeline'), true);
+
+    await act(async () => renderer?.unmount());
+    renderer = null;
+    pendingAction = null;
+    await renderLink(() => true, undefined, { href: '/notifications', primary: true });
+    await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
+    assert.equal(consumeIntent?.('/notifications'), false);
+  });
+
+  it('현재 primary route 재선택은 scroll intent를 기록하지 않는다', async () => {
+    currentPathname = '/home';
+    await renderLink(() => false, undefined, { href: '/home', primary: true });
+    const event: LinkPressEvent = { preventDefault: mock.fn() };
+
+    await act(async () => linkPress?.(event as unknown as Parameters<LinkPress>[0]));
+
+    assert.equal(consumeIntent?.('/home'), false);
   });
 
   it('Web modifier click은 현재 편집 route를 떠나지 않으므로 guard가 가로채지 않는다', async () => {

--- a/apps/app/src/components/shell/GuardedLink.tsx
+++ b/apps/app/src/components/shell/GuardedLink.tsx
@@ -1,7 +1,8 @@
-import { Link, useRouter } from 'expo-router';
+import { Link, usePathname, useRouter } from 'expo-router';
 import { cloneElement } from 'react';
 import { Platform } from 'react-native';
 import { useNavigationGuard } from './NavigationGuardContext';
+import { usePrimaryNavigationScroll } from './PrimaryNavigationScrollContext';
 import type { Href, LinkProps } from 'expo-router';
 import type { ReactElement } from 'react';
 
@@ -13,17 +14,31 @@ type Props = Omit<LinkProps, 'asChild' | 'children' | 'href' | 'onPress'> & {
   children: ReactElement<ChildProps>;
   href: Href;
   onNavigate?: () => void;
+  primary?: boolean;
 };
 
-export function GuardedLink({ children, href, onNavigate, ...props }: Props) {
+export function GuardedLink({ children, href, onNavigate, primary = false, ...props }: Props) {
   const router = useRouter();
+  const pathname = usePathname();
   const { request } = useNavigationGuard();
+  const { record } = usePrimaryNavigationScroll();
+  const recordPrimaryNavigation = () => {
+    if (!primary) {
+      return;
+    }
+
+    const targetPathname = getHrefPathname(href);
+    if (targetPathname && targetPathname !== pathname) {
+      record(targetPathname);
+    }
+  };
   const handlePress: NonNullable<LinkProps['onPress']> = (event) => {
     children.props.onPress?.(event);
     if (!shouldHandleNavigation(event)) {
       return;
     }
     const navigate = () => {
+      recordPrimaryNavigation();
       onNavigate?.();
       router.navigate(href);
     };
@@ -32,6 +47,7 @@ export function GuardedLink({ children, href, onNavigate, ...props }: Props) {
       return;
     }
     onNavigate?.();
+    recordPrimaryNavigation();
   };
 
   return (
@@ -39,6 +55,14 @@ export function GuardedLink({ children, href, onNavigate, ...props }: Props) {
       {cloneElement(children, { onPress: handlePress })}
     </Link>
   );
+}
+
+function getHrefPathname(href: Href): string | null {
+  if (typeof href === 'string') {
+    return href.split(/[?#]/, 1)[0] || '/';
+  }
+
+  return typeof href.pathname === 'string' ? href.pathname : null;
 }
 
 function shouldHandleNavigation(event: Parameters<NonNullable<LinkProps['onPress']>>[0]) {

--- a/apps/app/src/components/shell/PrimaryNavigationScrollContext.test.ts
+++ b/apps/app/src/components/shell/PrimaryNavigationScrollContext.test.ts
@@ -15,6 +15,35 @@ const platform = { OS: 'web' };
 const scrollTo = mock.fn();
 let renderer: ReactTestRenderer | null = null;
 let recordIntent: ((pathname: string) => void) | undefined;
+let currentScrollY = 0;
+let nextAnimationFrame = 0;
+const animationFrames = new Map<number, FrameRequestCallback>();
+const eventListeners = new Map<string, Set<EventListener>>();
+const historyWindow = {
+  scrollTo: (options: { top: number }) => {
+    scrollTo(options);
+    currentScrollY = options.top;
+  },
+  cancelAnimationFrame: (id: number) => {
+    animationFrames.delete(id);
+  },
+  requestAnimationFrame: (callback: FrameRequestCallback) => {
+    const id = ++nextAnimationFrame;
+    animationFrames.set(id, callback);
+    return id;
+  },
+  addEventListener: (type: string, listener: EventListener) => {
+    const listeners = eventListeners.get(type) ?? new Set<EventListener>();
+    listeners.add(listener);
+    eventListeners.set(type, listeners);
+  },
+  removeEventListener: (type: string, listener: EventListener) => {
+    eventListeners.get(type)?.delete(listener);
+  },
+  history: { state: { id: 'entry-a' } },
+  location: { href: 'https://example.test/home' },
+  innerHeight: 100,
+};
 
 const mockModule = (specifier: string | URL, exports: object) =>
   mock.module(specifier, {
@@ -30,7 +59,9 @@ let usePrimaryNavigationScroll: typeof usePrimaryNavigationScrollExport;
 before(async () => {
   ({ PrimaryNavigationScrollProvider, PrimaryNavigationScrollReset, usePrimaryNavigationScroll } =
     await import('./PrimaryNavigationScrollContext'));
-  (globalThis as unknown as { window?: { scrollTo: typeof scrollTo } }).window = { scrollTo };
+  (globalThis as unknown as { window?: { scrollTo: typeof scrollTo } }).window = {
+    scrollTo,
+  };
 });
 
 afterEach(async () => {
@@ -40,9 +71,43 @@ afterEach(async () => {
   }
   recordIntent = undefined;
   platform.OS = 'web';
+  currentScrollY = 0;
+  animationFrames.clear();
+  eventListeners.clear();
+  nextAnimationFrame = 0;
   scrollTo.mock.resetCalls();
+  (globalThis as unknown as { window?: unknown }).window = { scrollTo };
+  delete (globalThis as { document?: unknown }).document;
   mock.restoreAll();
 });
+
+function installHistoryWindow() {
+  historyWindow.history.state = { id: 'entry-a' };
+  historyWindow.location.href = 'https://example.test/home';
+  Object.defineProperty(historyWindow, 'scrollY', {
+    configurable: true,
+    get: () => currentScrollY,
+  });
+  (globalThis as unknown as { window?: unknown }).window = historyWindow;
+  (globalThis as unknown as { document?: unknown }).document = {
+    documentElement: { scrollHeight: 1000 },
+  };
+}
+
+function dispatchWindowEvent(type: string) {
+  for (const listener of eventListeners.get(type) ?? []) {
+    listener(new Event(type));
+  }
+}
+
+async function flushAnimationFrames() {
+  const callbacks = [...animationFrames.values()];
+  animationFrames.clear();
+  for (const callback of callbacks) {
+    callback(0);
+  }
+  await act(async () => undefined);
+}
 
 function IntentProbe() {
   recordIntent = usePrimaryNavigationScroll().record;
@@ -100,5 +165,63 @@ describe('PrimaryNavigationScrollContext', () => {
       renderer?.update(renderReset('/profile'));
     });
     assert.equal(scrollTo.mock.callCount(), 0);
+  });
+
+  it('기록되지 않은 history key의 popstate는 browser restoration을 덮지 않는다', async () => {
+    installHistoryWindow();
+    await act(async () => {
+      renderer = create(renderReset('/home'));
+    });
+
+    historyWindow.history.state = { id: 'entry-b' };
+    historyWindow.location.href = 'https://example.test/notifications';
+    dispatchWindowEvent('popstate');
+    await flushAnimationFrames();
+
+    assert.equal(scrollTo.mock.callCount(), 0);
+  });
+
+  it('history replay는 새 primary forward intent가 기록되면 즉시 취소한다', async () => {
+    installHistoryWindow();
+    currentScrollY = 120;
+    await act(async () => {
+      renderer = create(renderReset('/home'));
+    });
+
+    historyWindow.history.state = { id: 'entry-b' };
+    historyWindow.location.href = 'https://example.test/notifications';
+    dispatchWindowEvent('scroll');
+    historyWindow.history.state = { id: 'entry-a' };
+    historyWindow.location.href = 'https://example.test/home';
+    dispatchWindowEvent('popstate');
+    recordIntent?.('/search');
+    await flushAnimationFrames();
+
+    assert.equal(scrollTo.mock.callCount(), 0);
+  });
+
+  it('history replay는 목표 offset과 layout 안정 뒤 짧게 종료한다', async () => {
+    installHistoryWindow();
+    currentScrollY = 80;
+    await act(async () => {
+      renderer = create(renderReset('/home'));
+    });
+
+    historyWindow.history.state = { id: 'entry-b' };
+    historyWindow.location.href = 'https://example.test/notifications';
+    currentScrollY = 240;
+    dispatchWindowEvent('scroll');
+    historyWindow.history.state = { id: 'entry-a' };
+    historyWindow.location.href = 'https://example.test/home';
+    currentScrollY = 0;
+    dispatchWindowEvent('popstate');
+
+    for (let index = 0; index < 10 && animationFrames.size; index += 1) {
+      await flushAnimationFrames();
+    }
+
+    assert.equal(currentScrollY, 80);
+    assert.ok(scrollTo.mock.callCount() <= 4);
+    assert.equal(animationFrames.size, 0);
   });
 });

--- a/apps/app/src/components/shell/PrimaryNavigationScrollContext.test.ts
+++ b/apps/app/src/components/shell/PrimaryNavigationScrollContext.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, describe, it, mock } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import type {
+  PrimaryNavigationScrollProvider as PrimaryNavigationScrollProviderExport,
+  PrimaryNavigationScrollReset as PrimaryNavigationScrollResetExport,
+  usePrimaryNavigationScroll as usePrimaryNavigationScrollExport,
+} from './PrimaryNavigationScrollContext';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const platform = { OS: 'web' };
+const scrollTo = mock.fn();
+let renderer: ReactTestRenderer | null = null;
+let recordIntent: ((pathname: string) => void) | undefined;
+
+const mockModule = (specifier: string | URL, exports: object) =>
+  mock.module(specifier, {
+    exports,
+  } as unknown as Parameters<typeof mock.module>[1]);
+
+mockModule('react-native', { Platform: platform });
+
+let PrimaryNavigationScrollProvider: typeof PrimaryNavigationScrollProviderExport;
+let PrimaryNavigationScrollReset: typeof PrimaryNavigationScrollResetExport;
+let usePrimaryNavigationScroll: typeof usePrimaryNavigationScrollExport;
+
+before(async () => {
+  ({ PrimaryNavigationScrollProvider, PrimaryNavigationScrollReset, usePrimaryNavigationScroll } =
+    await import('./PrimaryNavigationScrollContext'));
+  (globalThis as unknown as { window?: { scrollTo: typeof scrollTo } }).window = { scrollTo };
+});
+
+afterEach(async () => {
+  if (renderer) {
+    await act(async () => renderer?.unmount());
+    renderer = null;
+  }
+  recordIntent = undefined;
+  platform.OS = 'web';
+  scrollTo.mock.resetCalls();
+  mock.restoreAll();
+});
+
+function IntentProbe() {
+  recordIntent = usePrimaryNavigationScroll().record;
+  return null;
+}
+
+function renderReset(pathname: string) {
+  return createElement(
+    PrimaryNavigationScrollProvider,
+    null,
+    createElement(IntentProbe),
+    createElement(PrimaryNavigationScrollReset, { pathname }),
+  );
+}
+
+describe('PrimaryNavigationScrollContext', () => {
+  it('pathname commit에서 일치하는 최신 intent만 한 번 소비한다', async () => {
+    await act(async () => {
+      renderer = create(renderReset('/home'));
+    });
+    recordIntent?.('/search');
+    recordIntent?.('/notifications');
+
+    await act(async () => {
+      renderer?.update(renderReset('/notifications'));
+    });
+
+    assert.equal(scrollTo.mock.callCount(), 1);
+    assert.deepEqual(scrollTo.mock.calls[0].arguments[0], {
+      behavior: 'auto',
+      left: 0,
+      top: 0,
+    });
+
+    await act(async () => {
+      renderer?.update(renderReset('/notifications'));
+    });
+    assert.equal(scrollTo.mock.callCount(), 1);
+  });
+
+  it('일치하지 않는 pathname과 Native에서는 document scroll을 변경하지 않는다', async () => {
+    await act(async () => {
+      renderer = create(renderReset('/home'));
+    });
+    recordIntent?.('/search');
+
+    await act(async () => {
+      renderer?.update(renderReset('/notifications'));
+    });
+    assert.equal(scrollTo.mock.callCount(), 0);
+
+    platform.OS = 'ios';
+    recordIntent?.('/profile');
+    await act(async () => {
+      renderer?.update(renderReset('/profile'));
+    });
+    assert.equal(scrollTo.mock.callCount(), 0);
+  });
+});

--- a/apps/app/src/components/shell/PrimaryNavigationScrollContext.tsx
+++ b/apps/app/src/components/shell/PrimaryNavigationScrollContext.tsx
@@ -1,0 +1,182 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { Platform } from 'react-native';
+import type { ReactNode } from 'react';
+
+type PrimaryNavigationScrollContextValue = {
+  clearQueryNavigation: (expected?: QueryNavigation) => void;
+  consume: (pathname: string) => boolean;
+  getQueryNavigation: () => QueryNavigation | null;
+  record: (targetPathname: string) => void;
+  recordQueryNavigation: (navigation: QueryNavigation) => void;
+};
+
+type QueryNavigation = {
+  restoreFocus: boolean;
+  scrollY: number;
+};
+
+type PendingIntent = {
+  targetPathname: string;
+  token: number;
+};
+
+const PrimaryNavigationScrollContext = createContext<PrimaryNavigationScrollContextValue>({
+  clearQueryNavigation: () => undefined,
+  consume: () => false,
+  getQueryNavigation: () => null,
+  record: () => undefined,
+  recordQueryNavigation: () => undefined,
+});
+
+export function PrimaryNavigationScrollProvider({ children }: { children: ReactNode }) {
+  const pendingIntentRef = useRef<PendingIntent | null>(null);
+  const queryNavigationRef = useRef<QueryNavigation | null>(null);
+  const tokenRef = useRef(0);
+
+  // Keep browser scroll restoration enabled; replay the entry offset if Expo Router writes top after popstate.
+  useEffect(() => {
+    if (
+      Platform.OS !== 'web' ||
+      typeof window === 'undefined' ||
+      !window.history ||
+      !window.addEventListener
+    ) {
+      return;
+    }
+
+    const scrollPositions = new Map<string, number>();
+    let frame = 0;
+    let pendingHistoryKey: string | null = null;
+    let attempts = 0;
+    let settledFrames = 0;
+    const getHistoryKey = () => {
+      const state = window.history.state as { id?: unknown } | null;
+      return typeof state?.id === 'string' ? state.id : window.location.href;
+    };
+    const saveScrollPosition = () => {
+      if (!pendingHistoryKey) {
+        scrollPositions.set(getHistoryKey(), window.scrollY);
+      }
+    };
+    const restoreHistoryScroll = () => {
+      if (!pendingHistoryKey) {
+        return;
+      }
+
+      const targetScrollY = scrollPositions.get(pendingHistoryKey) ?? 0;
+      const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+      if (targetScrollY > maxScrollY && attempts < 60) {
+        attempts += 1;
+        frame = window.requestAnimationFrame(restoreHistoryScroll);
+        return;
+      }
+
+      window.scrollTo({ behavior: 'auto', left: 0, top: Math.min(targetScrollY, maxScrollY) });
+      settledFrames += 1;
+      if (settledFrames < 60) {
+        frame = window.requestAnimationFrame(restoreHistoryScroll);
+        return;
+      }
+
+      pendingHistoryKey = null;
+    };
+    const handlePopState = () => {
+      pendingHistoryKey = getHistoryKey();
+      attempts = 0;
+      settledFrames = 0;
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(restoreHistoryScroll);
+    };
+
+    saveScrollPosition();
+    window.addEventListener('scroll', saveScrollPosition, { passive: true });
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', saveScrollPosition);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
+  const record = useCallback((targetPathname: string) => {
+    if (Platform.OS !== 'web') {
+      return;
+    }
+
+    pendingIntentRef.current = {
+      targetPathname,
+      token: ++tokenRef.current,
+    };
+  }, []);
+  const consume = useCallback((pathname: string) => {
+    const pendingIntent = pendingIntentRef.current;
+    if (!pendingIntent || pendingIntent.targetPathname !== pathname) {
+      return false;
+    }
+
+    pendingIntentRef.current = null;
+    return true;
+  }, []);
+  const recordQueryNavigation = useCallback((navigation: QueryNavigation) => {
+    if (Platform.OS === 'web') {
+      queryNavigationRef.current = navigation;
+    }
+  }, []);
+  const getQueryNavigation = useCallback(() => queryNavigationRef.current, []);
+  const clearQueryNavigation = useCallback((expected?: QueryNavigation) => {
+    if (!expected || queryNavigationRef.current === expected) {
+      queryNavigationRef.current = null;
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      clearQueryNavigation,
+      consume,
+      getQueryNavigation,
+      record,
+      recordQueryNavigation,
+    }),
+    [clearQueryNavigation, consume, getQueryNavigation, record, recordQueryNavigation],
+  );
+
+  return (
+    <PrimaryNavigationScrollContext.Provider value={value}>
+      {children}
+    </PrimaryNavigationScrollContext.Provider>
+  );
+}
+
+export function usePrimaryNavigationScroll() {
+  return useContext(PrimaryNavigationScrollContext);
+}
+
+export function PrimaryNavigationScrollReset({ pathname }: { pathname: string }) {
+  const { clearQueryNavigation, consume } = usePrimaryNavigationScroll();
+
+  useLayoutEffect(() => {
+    if (Platform.OS !== 'web') {
+      return;
+    }
+
+    if (pathname !== '/search') {
+      clearQueryNavigation();
+    }
+    if (!consume(pathname)) {
+      return;
+    }
+
+    window.scrollTo({ behavior: 'auto', left: 0, top: 0 });
+  }, [clearQueryNavigation, consume, pathname]);
+
+  return null;
+}

--- a/apps/app/src/components/shell/PrimaryNavigationScrollContext.tsx
+++ b/apps/app/src/components/shell/PrimaryNavigationScrollContext.tsx
@@ -25,7 +25,6 @@ type QueryNavigation = {
 
 type PendingIntent = {
   targetPathname: string;
-  token: number;
 };
 
 const PrimaryNavigationScrollContext = createContext<PrimaryNavigationScrollContextValue>({
@@ -39,7 +38,7 @@ const PrimaryNavigationScrollContext = createContext<PrimaryNavigationScrollCont
 export function PrimaryNavigationScrollProvider({ children }: { children: ReactNode }) {
   const pendingIntentRef = useRef<PendingIntent | null>(null);
   const queryNavigationRef = useRef<QueryNavigation | null>(null);
-  const tokenRef = useRef(0);
+  const cancelHistoryRestoreRef = useRef<(() => void) | null>(null);
 
   // Keep browser scroll restoration enabled; replay the entry offset if Expo Router writes top after popstate.
   useEffect(() => {
@@ -53,57 +52,113 @@ export function PrimaryNavigationScrollProvider({ children }: { children: ReactN
     }
 
     const scrollPositions = new Map<string, number>();
+    const maxLayoutAttempts = 60;
+    const stableFrameCount = 2;
     let frame = 0;
-    let pendingHistoryKey: string | null = null;
+    let pendingHistoryEntry: { href: string; key: string } | null = null;
     let attempts = 0;
     let settledFrames = 0;
+    let lastScrollHeight: number | null = null;
     const getHistoryKey = () => {
       const state = window.history.state as { id?: unknown } | null;
       return typeof state?.id === 'string' ? state.id : window.location.href;
     };
+    const getHistoryEntry = () => ({ href: window.location.href, key: getHistoryKey() });
+    const cancelHistoryRestore = () => {
+      pendingHistoryEntry = null;
+      attempts = 0;
+      settledFrames = 0;
+      lastScrollHeight = null;
+      window.cancelAnimationFrame(frame);
+      frame = 0;
+    };
+    cancelHistoryRestoreRef.current = cancelHistoryRestore;
     const saveScrollPosition = () => {
-      if (!pendingHistoryKey) {
+      if (!pendingHistoryEntry) {
         scrollPositions.set(getHistoryKey(), window.scrollY);
       }
     };
     const restoreHistoryScroll = () => {
-      if (!pendingHistoryKey) {
+      const pendingEntry = pendingHistoryEntry;
+      if (!pendingEntry) {
         return;
       }
 
-      const targetScrollY = scrollPositions.get(pendingHistoryKey) ?? 0;
+      const currentEntry = getHistoryEntry();
+      if (currentEntry.key !== pendingEntry.key || currentEntry.href !== pendingEntry.href) {
+        cancelHistoryRestore();
+        return;
+      }
+
+      const targetScrollY = scrollPositions.get(pendingEntry.key);
+      if (targetScrollY === undefined) {
+        cancelHistoryRestore();
+        return;
+      }
+
       const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
-      if (targetScrollY > maxScrollY && attempts < 60) {
+      if (targetScrollY > maxScrollY && attempts < maxLayoutAttempts) {
         attempts += 1;
         frame = window.requestAnimationFrame(restoreHistoryScroll);
         return;
       }
 
-      window.scrollTo({ behavior: 'auto', left: 0, top: Math.min(targetScrollY, maxScrollY) });
-      settledFrames += 1;
-      if (settledFrames < 60) {
-        frame = window.requestAnimationFrame(restoreHistoryScroll);
+      const nextScrollY = Math.min(targetScrollY, maxScrollY);
+      window.scrollTo({ behavior: 'auto', left: 0, top: nextScrollY });
+
+      const entryAfterScroll = getHistoryEntry();
+      if (
+        entryAfterScroll.key !== pendingEntry.key ||
+        entryAfterScroll.href !== pendingEntry.href
+      ) {
+        cancelHistoryRestore();
         return;
       }
 
-      pendingHistoryKey = null;
+      const scrollHeight = document.documentElement.scrollHeight;
+      if (window.scrollY === nextScrollY && scrollHeight === lastScrollHeight) {
+        settledFrames += 1;
+      } else {
+        settledFrames = 0;
+      }
+      lastScrollHeight = scrollHeight;
+      if (settledFrames >= stableFrameCount) {
+        cancelHistoryRestore();
+        return;
+      }
+
+      if (pendingHistoryEntry) {
+        frame = window.requestAnimationFrame(restoreHistoryScroll);
+      }
     };
     const handlePopState = () => {
-      pendingHistoryKey = getHistoryKey();
+      cancelHistoryRestore();
+      const pendingEntry = getHistoryEntry();
+      if (!scrollPositions.has(pendingEntry.key)) {
+        return;
+      }
+
+      pendingHistoryEntry = pendingEntry;
       attempts = 0;
       settledFrames = 0;
-      window.cancelAnimationFrame(frame);
       frame = window.requestAnimationFrame(restoreHistoryScroll);
     };
 
     saveScrollPosition();
     window.addEventListener('scroll', saveScrollPosition, { passive: true });
     window.addEventListener('popstate', handlePopState);
+    for (const eventName of ['keydown', 'pointerdown', 'touchstart', 'wheel']) {
+      window.addEventListener(eventName, cancelHistoryRestore, { capture: true, passive: true });
+    }
 
     return () => {
-      window.cancelAnimationFrame(frame);
+      cancelHistoryRestore();
+      cancelHistoryRestoreRef.current = null;
       window.removeEventListener('scroll', saveScrollPosition);
       window.removeEventListener('popstate', handlePopState);
+      for (const eventName of ['keydown', 'pointerdown', 'touchstart', 'wheel']) {
+        window.removeEventListener(eventName, cancelHistoryRestore, true);
+      }
     };
   }, []);
 
@@ -112,10 +167,8 @@ export function PrimaryNavigationScrollProvider({ children }: { children: ReactN
       return;
     }
 
-    pendingIntentRef.current = {
-      targetPathname,
-      token: ++tokenRef.current,
-    };
+    cancelHistoryRestoreRef.current?.();
+    pendingIntentRef.current = { targetPathname };
   }, []);
   const consume = useCallback((pathname: string) => {
     const pendingIntent = pendingIntentRef.current;

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -165,7 +165,7 @@ export function SidebarNavigation({
             );
 
             return href ? (
-              <GuardedLink href={href} key={item.label} onNavigate={onNavigate}>
+              <GuardedLink href={href} key={item.label} onNavigate={onNavigate} primary>
                 {control}
               </GuardedLink>
             ) : (
@@ -173,7 +173,7 @@ export function SidebarNavigation({
             );
           })}
           {compact ? (
-            <GuardedLink href="/compose" onNavigate={onNavigate}>
+            <GuardedLink href="/compose" onNavigate={onNavigate} primary>
               <Pressable
                 accessibilityLabel="글쓰기"
                 accessibilityRole="link"

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -20,6 +20,10 @@ import { useTheme } from '@/theme/ThemeProvider';
 import { spacing } from '@/theme/tokens';
 import { BottomTabBar } from './BottomTabBar';
 import { NavigationGuardProvider } from './NavigationGuardContext';
+import {
+  PrimaryNavigationScrollProvider,
+  PrimaryNavigationScrollReset,
+} from './PrimaryNavigationScrollContext';
 import { RightRail, RightRailPrivacyLink } from './RightRail';
 import { ShellChromeProvider } from './ShellChromeContext';
 import { getShellLayout, webMobileShellHeaderHeight } from './shellLayout';
@@ -78,13 +82,15 @@ export function UniversalShell() {
   return (
     <UnreadNotificationBadgeController>
       <NavigationGuardProvider>
-        <RouteBoundary
-          loading={<Splash label="앱을 불러오는 중입니다." />}
-          onRetry={retry}
-          title="앱을 불러오지 못했어요"
-        >
-          <UniversalShellContent revision={revision} />
-        </RouteBoundary>
+        <PrimaryNavigationScrollProvider>
+          <RouteBoundary
+            loading={<Splash label="앱을 불러오는 중입니다." />}
+            onRetry={retry}
+            title="앱을 불러오지 못했어요"
+          >
+            <UniversalShellContent revision={revision} />
+          </RouteBoundary>
+        </PrimaryNavigationScrollProvider>
       </NavigationGuardProvider>
     </UnreadNotificationBadgeController>
   );
@@ -153,6 +159,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
 
   return (
     <ShellChromeProvider openProfileSwitcher={openProfileSwitcher}>
+      <PrimaryNavigationScrollReset pathname={pathname} />
       <View
         {...swipeToOpenDrawer.panHandlers}
         style={[

--- a/apps/web/e2e/navigation-scroll.e2e.ts
+++ b/apps/web/e2e/navigation-scroll.e2e.ts
@@ -207,6 +207,12 @@ test('search query-only 이동은 document scroll과 입력 focus를 보존하�
   expect(offsetAfterWheel).toBeLessThan(offsetBeforeWheel);
   await expect(input).toBeFocused();
 
+  await page.getByRole('link', { name: '뒤로', exact: true }).click();
+  await expect(page).toHaveURL(/\/search\?tab=people$/);
+  await expect(page.getByText('프로필을 검색해보세요')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'e2e-query-second', exact: true })).not.toBeVisible();
+  await expect(input).not.toBeFocused();
+
   await page.goto('/home');
   await expect(page.getByRole('heading', { name: '홈' })).toBeVisible();
   await scrollDocument(page);

--- a/apps/web/e2e/navigation-scroll.e2e.ts
+++ b/apps/web/e2e/navigation-scroll.e2e.ts
@@ -1,0 +1,194 @@
+import {
+  createE2EPost,
+  createE2EProfile,
+  createE2ESession,
+  resetE2EDatabase,
+  setE2ESessionCookie,
+} from './db-fixtures';
+import { expect, test } from './fixtures';
+import { isGraphQLOperation } from './graphql';
+import type { Locator, Page } from '@playwright/test';
+
+const recentSearchesKey = 'kosmo:recent-searches';
+
+test.beforeEach(async () => {
+  await resetE2EDatabase();
+});
+
+test.use({ hasTouch: true });
+
+async function signIn(page: Page, handle = 'e2e-navigation-scroll') {
+  const session = await createE2ESession({ handle });
+  await setE2ESessionCookie(page.context(), session.token);
+  return session;
+}
+
+async function visiblePrimaryNavigation(page: Page): Promise<Locator> {
+  for (const navigation of await page.getByRole('navigation', { name: '주요 메뉴' }).all()) {
+    if (await navigation.isVisible()) {
+      return navigation;
+    }
+  }
+
+  throw new Error('Visible primary navigation was not found.');
+}
+
+async function scrollDocument(page: Page) {
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+}
+
+test('주요 Web navigation은 mobile bottom tab, drawer, compact rail과 full sidebar에서 document top으로 이동한다', async ({
+  page,
+}) => {
+  await signIn(page);
+
+  for (const surface of [
+    { name: 'full sidebar', viewport: { height: 360, width: 1440 }, target: '알림' },
+    { name: 'compact rail', viewport: { height: 360, width: 1024 }, target: '알림' },
+    { name: 'mobile bottom tab', viewport: { height: 360, width: 390 }, target: '알림' },
+  ]) {
+    await page.setViewportSize(surface.viewport);
+    await page.goto('/compose');
+    await expect(page.getByRole('textbox', { name: '게시글 본문' }).first()).toBeVisible();
+    await scrollDocument(page);
+
+    const navigation = await visiblePrimaryNavigation(page);
+    const targetLink = navigation.getByRole('link', { name: surface.target, exact: true });
+    if (surface.name === 'mobile bottom tab') {
+      await targetLink.tap();
+    } else {
+      await targetLink.click();
+    }
+
+    await expect(page).toHaveURL(/\/notifications$/);
+    await expect(page.getByText('아직 알림이 없어요')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+  }
+
+  await page.setViewportSize({ height: 360, width: 390 });
+  await page.goto('/compose');
+  await expect(page.getByRole('textbox', { name: '게시글 본문' }).first()).toBeVisible();
+  await scrollDocument(page);
+  await page.getByRole('button', { name: '메뉴 열기' }).click();
+  const drawerNavigation = page
+    .locator('#mobile-sidebar')
+    .getByRole('navigation', { name: '주요 메뉴' });
+  await drawerNavigation.getByRole('link', { name: '홈', exact: true }).tap();
+
+  await expect(page).toHaveURL(/\/home$/);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+test('loading target도 pathname commit 직후 이전 document offset을 노출하지 않는다', async ({
+  page,
+}) => {
+  await signIn(page, 'e2e-navigation-loading');
+  await page.setViewportSize({ height: 360, width: 1440 });
+  await page.goto('/compose');
+  await expect(page.getByRole('textbox', { name: '게시글 본문' }).first()).toBeVisible();
+  await scrollDocument(page);
+
+  let releaseHomeQuery!: () => void;
+  let resolveHomeQueryStarted!: () => void;
+  let resolveHomeQueryHandled!: () => void;
+  const homeQueryStarted = new Promise<void>((resolve) => {
+    resolveHomeQueryStarted = resolve;
+  });
+  const homeQueryHandled = new Promise<void>((resolve) => {
+    resolveHomeQueryHandled = resolve;
+  });
+  const homeQueryRelease = new Promise<void>((resolve) => {
+    releaseHomeQuery = resolve;
+  });
+
+  await page.route('**/graphql', async (route) => {
+    if (isGraphQLOperation(route.request().postData(), 'HomePageQuery')) {
+      resolveHomeQueryStarted();
+      const response = await route.fetch();
+      await homeQueryRelease;
+      await route.fulfill({ response });
+      resolveHomeQueryHandled();
+      return;
+    }
+    await route.continue();
+  });
+
+  try {
+    const navigation = await visiblePrimaryNavigation(page);
+    await navigation.getByRole('link', { name: '홈', exact: true }).click();
+    await expect(page).toHaveURL(/\/home$/);
+    await homeQueryStarted;
+    await expect(page.getByText('홈을 불러오는 중입니다.')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+
+    await navigation.getByRole('link', { name: '알림', exact: true }).click();
+    await expect(page).toHaveURL(/\/notifications$/);
+    await expect(page.getByText('아직 알림이 없어요')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+  } finally {
+    releaseHomeQuery();
+    await homeQueryHandled;
+    await page.unroute('**/graphql');
+  }
+});
+
+test('search query-only 이동은 document scroll과 입력 focus를 보존하고 history traversal을 reset하지 않는다', async ({
+  page,
+}) => {
+  const session = await signIn(page, 'e2e-navigation-search');
+  const firstQueryProfiles = Array.from({ length: 20 }, (_, index) => `e2e-query-first-${index}`);
+  const secondQueryProfiles = Array.from({ length: 20 }, (_, index) => `e2e-query-second-${index}`);
+
+  for (const handle of [...firstQueryProfiles, ...secondQueryProfiles]) {
+    await createE2EProfile({ handle });
+  }
+  for (let index = 0; index < 20; index += 1) {
+    await createE2EPost({
+      body: `E2E navigation history post ${index} ${'긴 본문 '.repeat(20)}`,
+      profileId: session.profile!.id,
+    });
+  }
+
+  await page.setViewportSize({ height: 360, width: 1440 });
+  await page.addInitScript(
+    ({ storageKey }) => {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify([
+          'e2e-query-second',
+          ...Array.from({ length: 20 }, (_, index) => `e2e-recent-${index}`),
+        ]),
+      );
+    },
+    { storageKey: recentSearchesKey },
+  );
+  await page.goto('/search?q=e2e-query-first&tab=people');
+  const input = page.getByRole('textbox', { name: '검색어' });
+  await expect(input).toBeVisible();
+  await expect(page.getByRole('link', { name: /e2e-query-first-0/ })).toBeVisible();
+  await input.focus();
+  await expect(page.getByRole('link', { name: 'e2e-query-second', exact: true })).toBeVisible();
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  await page.getByRole('link', { name: 'e2e-query-second', exact: true }).click();
+
+  await expect(page).toHaveURL(/q=e2e-query-second/);
+  await expect(page.getByRole('link', { name: /e2e-query-second-0/ })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  await expect(input).toBeFocused();
+
+  await page.goto('/home');
+  await expect(page.getByRole('heading', { name: '홈' })).toBeVisible();
+  await scrollDocument(page);
+  const homeScroll = await page.evaluate(() => window.scrollY);
+  await (await visiblePrimaryNavigation(page))
+    .getByRole('link', { name: '검색', exact: true })
+    .click();
+  await expect(page).toHaveURL(/\/search$/);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/home$/);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThanOrEqual(homeScroll);
+});

--- a/apps/web/e2e/navigation-scroll.e2e.ts
+++ b/apps/web/e2e/navigation-scroll.e2e.ts
@@ -38,6 +38,23 @@ async function scrollDocument(page: Page) {
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
 }
 
+async function waitAnimationFrames(page: Page, count = 4) {
+  await page.evaluate((frameCount) => {
+    return new Promise<void>((resolve) => {
+      let completed = 0;
+      const tick = () => {
+        completed += 1;
+        if (completed >= frameCount) {
+          resolve();
+          return;
+        }
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    });
+  }, count);
+}
+
 test('주요 Web navigation은 mobile bottom tab, drawer, compact rail과 full sidebar에서 document top으로 이동한다', async ({
   page,
 }) => {
@@ -175,7 +192,19 @@ test('search query-only 이동은 document scroll과 입력 focus를 보존하�
 
   await expect(page).toHaveURL(/q=e2e-query-second/);
   await expect(page.getByRole('link', { name: /e2e-query-second-0/ })).toBeVisible();
+  const offsetBeforeWheel = await page.evaluate(() => {
+    const maxScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+    window.scrollTo(0, Math.min(320, maxScrollY));
+    return window.scrollY;
+  });
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  await page.mouse.wheel(0, -120);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(offsetBeforeWheel);
+  const offsetAfterWheel = await page.evaluate(() => window.scrollY);
+  await waitAnimationFrames(page);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(offsetAfterWheel);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(offsetBeforeWheel);
+  expect(offsetAfterWheel).toBeLessThan(offsetBeforeWheel);
   await expect(input).toBeFocused();
 
   await page.goto('/home');
@@ -191,4 +220,25 @@ test('search query-only 이동은 document scroll과 입력 focus를 보존하�
   await page.goBack();
   await expect(page).toHaveURL(/\/home$/);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThanOrEqual(homeScroll);
+
+  await page.goto('/search?q=e2e-query-first&tab=people');
+  const repeatedQueryInput = page.getByRole('textbox', { name: '검색어' });
+  await expect(repeatedQueryInput).toBeVisible();
+  await expect(page.getByRole('link', { name: /e2e-query-first-0/ })).toBeVisible();
+  await repeatedQueryInput.focus();
+  const historyLengthBeforeSameQuery = await page.evaluate(() => window.history.length);
+  await repeatedQueryInput.press('Enter');
+  await expect
+    .poll(() => page.evaluate(() => window.history.length))
+    .toBe(historyLengthBeforeSameQuery);
+
+  await repeatedQueryInput.fill('e2e-query-second');
+  await repeatedQueryInput.press('Enter');
+  await expect(page).toHaveURL(/q=e2e-query-second/);
+  await expect(page.getByRole('link', { name: /e2e-query-second-0/ })).toBeVisible();
+  await page.goBack();
+  await expect(page).toHaveURL(/q=e2e-query-first/);
+  await expect(page.getByRole('link', { name: /e2e-query-first-0/ })).toBeVisible();
+  await waitAnimationFrames(page);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
 });

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -97,7 +97,13 @@ React Native Web의 `(tabs)` 셸은 document/window scroll을 기본 scroll owne
 - `≥ full` profile picker가 열렸을 때는 overlay 안의 프로필 목록만 internal scroll owner가 된다. overlay 밖의
   wheel 입력은 기존 document scroll 흐름을 유지하고 navigation의 layout 위치는 닫힌 상태와 같게 유지한다.
 - 우측 레일 콘텐츠가 viewport보다 긴 경우 rail 내부 overflow를 허용할 수 있지만, 중앙 피드를 별도 internal scroller로 만들지는 않는다.
-- 일반 route 이동과 back/forward는 Expo Router와 browser history의 document scroll policy에 맞춘다. 검색 화면의 query-only `router.push`/`setParams` 이동은 현재 document scroll과 입력 focus를 보존하도록 명시적으로 검증한다.
+- Web 하단 탭, mobile drawer, compact 아이콘 레일과 full sidebar에서 현재와 다른 shell-level 주요 route를
+  여는 forward navigation은 대상 route가 준비된 뒤 document 최상단에서 표시한다. 로딩·빈 상태에서도 이전
+  route의 document scroll offset을 대상 route에 노출하지 않는다.
+- 브라우저 뒤로/앞으로 history traversal은 browser scroll restoration을 유지한다. 검색 화면의 query-only
+  `router.push`/`setParams` 이동은 현재 document scroll과 입력 focus를 보존한다.
+- 이미 선택된 홈을 다시 실행하는 최상단 이동과 새로고침은 `PROD-610`이 소유한다. 이 정책은 다른 현재
+  route 재선택에 최상단 이동이나 데이터 새로고침을 추가하지 않는다.
 - shell chrome에서 중앙 피드로 wheel 이벤트를 인위적으로 전달하지 않는다.
 
 ## 구현 위치

--- a/openspec/changes/reset-primary-navigation-scroll/.openspec.yaml
+++ b/openspec/changes/reset-primary-navigation-scroll/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-31

--- a/openspec/changes/reset-primary-navigation-scroll/decisions.md
+++ b/openspec/changes/reset-primary-navigation-scroll/decisions.md
@@ -1,0 +1,90 @@
+## Context
+
+이 결정 기록은 `docs/design/breakpoints.md`와 최신 Linear `PROD-619`가 확정한 주요 Web route scroll 정책,
+`PROD-219`의 document scroll 소유권, `PROD-610`의 홈 재선택 경계와 `PROD-617`의 통합 검증 책임을 반영한다.
+Expo Router 셸의 현재 `GuardedLink`·`usePathname` 실행 흐름과 `web-app-shell` delta를 기준으로 구현자가 반드시
+보존할 분류와 lifecycle을 기록한다.
+
+## Decision Records
+
+### 서로 다른 주요 Web route의 실제 forward navigation만 최상단으로 초기화한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/breakpoints.md`, `PROD-619`; document scroll 전제 `PROD-219`
+- Status: Active
+- Context / Problem: Pathname이 바뀐다는 사실만으로는 shell 주요 navigation, browser history traversal과 다른
+  route 진입을 구분할 수 없고, source route에서 너무 일찍 scroll하면 이동 전 화면이 튄다.
+- Decision Outcome: Web 하단 탭, mobile drawer, compact 아이콘 레일과 full sidebar가 현재와 다른 주요 target으로
+  실제 forward navigation을 실행하고 target pathname이 반영된 뒤 document top으로 초기화한다.
+- Alternatives Considered: Expo Router/browser 기본 동작에 계속 맡기는 방식은 재현된 offset 잔류를 해결하지 못해
+  제외한다. 모든 pathname 변화 또는 모든 Link를 초기화하는 방식은 승인 범위보다 넓어 제외한다.
+- Consequences: Shell navigation source와 target route commit 사이의 의도를 연결해야 하며, loading·empty 상태와
+  연속 navigation의 마지막 target에도 같은 결과가 적용된다.
+- Confirmation / Follow-up: mobile bottom tab/drawer와 compact/full sidebar의 targeted component·browser 검증으로
+  target pathname 반영 뒤 `window.scrollY`가 top인지 확인한다.
+
+### History·query-only·reselection·Native 경계를 유지한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/breakpoints.md`, `PROD-619`, `PROD-610`
+- Status: Active
+- Context / Problem: 주요 route reset이 browser history restoration, 검색 입력 흐름, 현재 홈 재선택 refetch 또는
+  Native `ScrollView`까지 확장되면 별도 소유 계약을 침범한다.
+- Decision Outcome: Browser back/forward에는 top reset을 강제하지 않고 search query-only 이동의 document
+  scroll·focus를 보존한다. 현재 pathname 재선택에는 이 change의 reset/refetch를 적용하지 않으며 현재 홈
+  재선택은 `PROD-610`에 남긴다. Android/iOS navigation scroll은 변경하지 않는다.
+- Alternatives Considered: `history.scrollRestoration`을 manual로 전환하는 방식, query 변경도 reset하는 방식,
+  모든 현재 tab 재선택을 홈과 같이 처리하는 방식은 각각 current browser/search/PROD-610 계약을 위반해 제외한다.
+- Consequences: 구현은 forward primary navigation을 명시적으로 분류해야 하고 pathname-only effect나 전역
+  history 설정을 사용할 수 없다. Relay refetch를 이 change에 추가할 수 없다.
+- Confirmation / Follow-up: Browser back/forward의 restored position, search query-only scroll·focus, current route
+  reselect 무동작과 Native no-op을 각각 검증한다.
+
+### 실제 navigation intent와 target pathname commit을 짝짓는다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/breakpoints.md`, `PROD-619`; navigation guard 계약을 포함한 현재
+  `apps/app/src/components/shell` 실행 흐름
+- Status: Active
+- Context / Problem: `GuardedLink`는 무guard 기본 `Link`와 guard 승인 뒤 imperative navigation 두 경로를 가지며,
+  press 시점 marker나 pathname-only effect는 취소된 navigation과 history traversal을 잘못 reset할 수 있다.
+- Decision Outcome: Shell 주요 navigation이 실제 action을 실행할 때 current와 다른 target pathname intent를
+  기록하고, shell이 commit된 pathname과 일치할 때 Web document top reset을 한 번 소비한다. 연속 intent는 최신
+  token/target만 유효하게 하고 이전 지연 callback을 취소한다. 내부 helper·파일명·state 소유 형태는 고정하지 않는다.
+- Alternatives Considered: 모든 pathname 변화 effect는 history를 구분하지 못해 제외한다. `popstate`만 별도로
+  감시해 skip하는 방식은 Expo Router 내부 navigation과 source 분류가 분산돼 기본안에서 제외한다. Route별 reset
+  복제는 surface 정책이 갈라져 제외한다.
+- Consequences: Guard가 navigation을 허용한 시점과 marker 생성 시점이 같아야 한다. Browser frame이 필요하면
+  target/token을 재확인하고 취소 가능해야 하며 smooth scroll은 사용하지 않는다.
+- Confirmation / Follow-up: 무guard·guard 승인·guard 취소, 연속 target 교체와 stale callback 취소를 가까운
+  component test로 고정하고 실제 browser timing을 E2E로 확인한다.
+
+### PROD-619가 change 완료와 archive를 소유한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-619`, `PROD-617`; `memory/issue-openspec-workflow.md`
+- Status: Active
+- Context / Problem: Parent integration issue의 완료를 기다릴지, 독립 하위 issue가 자신의 행동 계약을 언제
+  archive할지 명시하지 않으면 active delta의 완료 책임이 모호해진다.
+- Decision Outcome: PROD-619 구현 PR이 이 change의 구현, 개별 verification, delta 정합성과 전체 task 완료를
+  증명하면 PROD-619 담당자가 archive한다. PROD-617은 다섯 하위 issue 결과의 이후 mobile Web 통합 검증만 소유한다.
+- Alternatives Considered: PROD-617 완료까지 active change를 유지하는 방식은 PROD-619와 독립 sibling의
+  lifecycle을 불필요하게 결합해 제외한다. Archive-only issue/PR을 추가하는 방식도 별도 결과가 없어 제외한다.
+- Consequences: PROD-619의 targeted verification은 parent 통합 검증을 대체하지 않지만, parent 미완료가 이
+  change archive를 막지는 않는다.
+- Confirmation / Follow-up: 구현·테스트 handoff에 archive owner와 PROD-617로 전달할 evidence를 명시한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- Legacy `add-web-app-shell-sticky-rails`의 SvelteKit/browser 기본 path-changing navigation 의존은 Expo Router
+  migration과 최신 `docs/design/breakpoints.md`·`PROD-619` 계약으로 더 이상 current 구현 선택이 아니다. 이
+  change의 “서로 다른 주요 Web route의 실제 forward navigation만 최상단으로 초기화한다” 결정이 현재 Expo
+  Router 셸의 적용 기준을 대신한다. Document/window scroll 소유권과 history restoration 보존 자체는 유지한다.

--- a/openspec/changes/reset-primary-navigation-scroll/design.md
+++ b/openspec/changes/reset-primary-navigation-scroll/design.md
@@ -1,0 +1,109 @@
+## Context
+
+Expo Router의 `(tabs)` route tree는 `UniversalShell` 안에서 렌더링되고, Web 셸은 document/window를 기본
+scroll owner로 사용한다. 하단 탭과 sidebar 계열은 공통 `GuardedLink`를 사용하지만 navigation guard가 없는
+경로는 `Link`의 기본 이동을, dirty guard가 있는 경로는 승인 뒤 `router.navigate`를 실행한다. 현재 셸에는
+path-changing 주요 navigation과 browser history traversal을 구분해 document scroll을 초기화하는 경계가 없다.
+
+`usePathname`은 search query 변경을 제외한 pathname만 제공하므로 query-only 보존에는 유리하지만, pathname
+변화만 관찰하면 주요 forward navigation과 browser back/forward를 구분할 수 없다. 또한 post detail pagination은
+Web의 `window.scrollY`와 document 높이를 소비하므로 중앙 internal scroller를 새로 만들거나 전역 history
+restoration을 끄면 기존 계약을 깨뜨린다. PROD-622·PROD-623의 drawer scroll/close 변경은 같은 shell 파일을
+건드릴 수 있지만 별도 행동 계약과 검증 생명주기를 가진다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 실제로 실행된 Web 주요 forward navigation만 식별해 대상 pathname이 반영된 뒤 document top으로 이동한다.
+- loading·empty route와 빠른 연속 전환에서도 마지막 대상 route의 위치에 안정적으로 수렴한다.
+- browser history restoration, search query-only scroll/focus와 navigation guard를 보존한다.
+- mobile, compact, full 셸의 서로 다른 navigation surface가 같은 정책 경계를 사용하게 한다.
+
+**Non-Goals:**
+
+- Android/iOS `ScrollView` 위치 정책 또는 Web shell scroll owner 변경
+- 현재 홈 재선택의 최상단 이동·refetch와 다른 현재 route 재선택 정책 구현
+- Relay refetch, route loading 정책 또는 전체 반응형 navigation E2E suite 변경
+- PROD-622의 drawer 내부 scroll/body lock이나 PROD-623의 drawer close lifecycle 구현
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Shell navigation은 guard가 없는 기본 `Link` 경로와 guard 승인 뒤 실행되는 action 경로가 있어, press 시점에
+  scroll reset을 예약하면 취소된 navigation에도 부작용이 남을 수 있다.
+- Pathname 변화만 구독하는 무조건적인 reset은 browser back/forward도 최상단으로 덮어쓴다.
+- Search 내부의 `router.push`/`setParams`는 pathname이 같고 현재 scroll·focus를 유지해야 한다.
+- 대상 route는 Relay loading 또는 empty surface부터 commit될 수 있으므로 데이터 완료를 기다리면 이전 offset이
+  노출되고, source route에서 너무 일찍 reset하면 화면이 이동 전에 튈 수 있다.
+- 빠른 연속 navigation에서 취소되지 않은 timer나 animation frame은 마지막 route가 표시된 뒤 stale reset을
+  실행할 수 있다.
+- 같은 shell 파일에 sibling issue 변경이 병렬로 존재할 수 있으므로 drawer scroll/close diff를 이 change에
+  흡수하지 않고 현재 branch 기준으로 통합해야 한다.
+
+### Recommended Approach
+
+Shell-level 주요 navigation source가 현재 pathname과 다른 target pathname으로 **실제 navigation action을
+실행할 때** Web-only pending intent를 기록하고, `(tabs)` shell이 이후 commit된 pathname과 그 intent의 target을
+대조하는 방식을 기본으로 한다. Guard가 있는 경우에는 사용자의 첫 press가 아니라 guard가 허용한 action 안에서
+intent를 기록해 취소된 이동을 제외한다. Guard가 없는 `Link` 경로도 같은 intent 경계를 통과하게 해 surface별
+동작 차이를 만들지 않는다.
+
+대상 pathname이 commit되면 shell의 post-commit effect에서 document를 즉시 top으로 이동하고 intent를
+소비한다. Layout 준비를 위해 browser frame을 사용해야 한다면 pathname과 단조 증가 token을 다시 확인하고 이전
+frame을 취소해 마지막 navigation만 유효하게 한다. Scroll은 smooth animation 없이 `auto` 동작을 사용해 이전
+offset 노출과 연속 전환 race를 줄인다.
+
+Browser back/forward와 search 내부 query-only 이동은 shell primary-navigation intent를 만들지 않으므로 기존
+browser/Expo Router 정책을 따른다. 현재 pathname과 같은 target도 intent를 만들지 않아 PROD-610과 다른
+reselection 정책을 침범하지 않는다. Native에서는 이 coordination 경계가 no-op이어야 한다.
+
+검증은 navigation intent의 생성·소비·취소와 guard 승인 시점을 가까운 component test로 고정하고, Web E2E에서
+스크롤된 source → 다른 target의 top, loading/empty target, 연속 전환, history back/forward, search query-only
+scroll/focus를 확인한다. Mobile bottom tab/drawer와 compact/full sidebar는 전체 IA suite가 아니라 같은 scroll
+정책을 공유한다는 targeted assertion으로 검증한다.
+
+### Allowed Alternatives
+
+- Pending intent를 shell-local state, 전용 context 또는 좁은 hook으로 소유할 수 있다. 어느 방식이든 실제
+  navigation action과 post-commit pathname을 짝지어야 하며 history/query-only/reselection 경계를 보존해야 한다.
+- Commit 직후 동기 layout effect 또는 취소 가능한 한 번의 animation frame을 사용할 수 있다. 대상 route가
+  표시되기 전 source 화면을 움직이거나 stale callback이 마지막 route에 개입해서는 안 된다.
+- 기존 `GuardedLink`를 확장하거나 shell navigation 전용 wrapper에서 intent를 연결할 수 있다. 콘텐츠 내부의
+  모든 Link에 전역 적용하거나 route별 reset을 복제해서는 안 된다.
+
+### Known Traps
+
+- `useEffect([pathname])`만으로 모든 pathname 변경을 top으로 보내 browser history restoration을 깨뜨리는 방식
+- Press 시점이나 drawer close 시점에 `window.scrollTo`를 호출해 guard 취소·지연과 source route에 적용하는 방식
+- 취소되지 않은 `setTimeout`/animation frame으로 연속 전환 뒤 stale reset을 실행하는 방식
+- `history.scrollRestoration = "manual"`, smooth scroll 또는 중앙 internal scroller로 문제를 우회하는 방식
+- Search query/tab 변경, 현재 route 재선택, Native navigation 또는 Relay refetch까지 정책을 확장하는 방식
+- PROD-622·PROD-623의 병렬 drawer 변경을 current issue task나 commit에 함께 포함하는 방식
+
+## Risks / Trade-offs
+
+- [Risk] Expo Router `Link` 기본 이동과 guarded imperative 이동의 실행 시점이 다르다. → 두 경로가 동일한 실제
+  navigation intent 경계를 통과하는 component test를 둔다.
+- [Risk] Post-commit effect가 target layout보다 빠르거나 늦어 flicker가 생길 수 있다. → loading surface를 포함한
+  실제 browser assertion으로 timing을 확인하고, 필요한 경우 한 번의 취소 가능한 frame만 사용한다.
+- [Risk] 연속 navigation에서 이전 intent가 마지막 route를 오염시킬 수 있다. → target pathname과 token을 함께
+  검증하고 새 intent가 이전 callback을 무효화한다.
+- [Risk] Sibling drawer 변경과 같은 파일을 수정해 merge conflict가 날 수 있다. → behavioral ownership을 섞지
+  않고 최신 parent/base에 맞춰 작은 integration diff로 유지한다.
+
+## Migration Plan
+
+1. Canonical scroll 정책과 `web-app-shell` delta를 먼저 반영한다.
+2. Shell primary-navigation intent와 post-commit reset을 Web-only로 추가한다.
+3. Component test와 targeted Web E2E로 forward/history/query/reselection 경계를 검증한다.
+4. PROD-619의 구현·개별 검증과 delta spec 정합성이 모두 완료되면 이 change를 archive한다. PROD-617의 다섯
+   하위 이슈 통합 검증은 이후 별도 책임으로 남는다.
+
+Rollback은 shell intent/reset integration과 관련 테스트를 되돌려 Expo Router/browser의 기존 scroll 동작으로
+복귀한다. DB, schema 또는 데이터 migration은 없다.
+
+## Open Questions
+
+없음. 2026-07-31 사용자 승인과 최신 `PROD-619` 본문이 forward/history/query/reselection/Native 경계를 확정했다.

--- a/openspec/changes/reset-primary-navigation-scroll/proposal.md
+++ b/openspec/changes/reset-primary-navigation-scroll/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+KOSMO Web의 주요 내비게이션은 SPA route를 바꾸면서 이전 document scroll offset을 그대로 남길 수 있어,
+스크롤된 화면에서 다른 탭으로 이동하면 대상 화면의 header와 첫 콘텐츠 대신 중간 빈 영역이 먼저 보인다.
+Document/window scroll 소유권은 유지하되 forward route 이동, history traversal과 query-only 이동의 정책을
+분리해 대상 화면을 예측 가능한 위치에서 시작하게 해야 한다.
+
+## What Changes
+
+- Web 하단 탭, mobile drawer, compact 아이콘 레일과 full sidebar에서 현재와 다른 shell-level 주요 route를
+  선택하면 대상 route가 준비된 뒤 document 최상단에서 표시한다.
+- 로딩·빈 상태와 연속 route 전환에서도 이전 route의 document scroll offset을 대상 route에 노출하지 않는다.
+- 브라우저 뒤로/앞으로 history traversal의 scroll restoration과 검색 화면 query-only 이동의 scroll·focus
+  보존을 유지한다.
+- 현재 홈 재선택의 최상단 이동·단일 refetch는 `PROD-610` 범위로 유지하고, 다른 현재 route 재선택이나 Relay
+  데이터 새로고침을 이 변경에 포함하지 않는다.
+- `docs/design/breakpoints.md`와 `web-app-shell` 계약을 Expo Router 기반 Web 동작에 맞게 구체화하고, 가장
+  가까운 컴포넌트·브라우저 회귀 검증을 추가한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/design/breakpoints.md`
+- Linear Contract: `PROD-619`; 경계 근거 `PROD-219`, `PROD-610`; 통합 검증 소유 `PROD-617`
+- Linear Implementations: `PROD-619`이 구현·개별 검증·change 정합성 확인과 archive를 소유한다. `PROD-617`은
+  하위 이슈 완료 뒤의 mobile Web 통합 검증만 소유한다.
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `web-app-shell`: 주요 Web forward navigation의 document scroll 초기화, history traversal과 검색 query-only
+  이동 보존, 현재 route 재선택의 소유권 경계를 추가한다.
+
+## Impact
+
+- `docs/design/breakpoints.md`
+- `apps/app/src/components/shell`의 Web 주요 내비게이션 경계와 관련 컴포넌트 테스트
+- `apps/app/src/app/(tabs)`의 Expo Router path/query 구분과 Web route commit 관찰 경계
+- `apps/web/e2e`의 mobile Web route scroll, history traversal, 검색 query-only 회귀 검증
+- GraphQL schema, Relay 데이터 새로고침 정책, Android/iOS Native navigation, dependency와 migration에는 영향이
+  없다.

--- a/openspec/changes/reset-primary-navigation-scroll/specs/web-app-shell/spec.md
+++ b/openspec/changes/reset-primary-navigation-scroll/specs/web-app-shell/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Web 주요 route 이동의 document scroll 정책
+
+**Authority / Provenance:** `docs/design/breakpoints.md`, `PROD-619`; 경계 근거 `PROD-219`, `PROD-610` — Web 앱 셸은 하단 탭, mobile drawer, compact 아이콘 레일 또는 full sidebar에서 현재 pathname과 다른 shell-level 주요 route를 선택한 forward navigation이 대상 route에 반영된 뒤 document scroll을 최상단으로 초기화해야 한다(MUST). 이 정책은 해당 breakpoint에서 제공되는 홈, 검색, 알림, 북마크, 선택 Profile과 글쓰기 진입점에 동일하게 적용해야 한다(MUST). 대상 route의 Relay 데이터가 loading·empty 상태여도 이전 route의 document scroll offset을 노출해서는 안 된다(MUST NOT). 브라우저 뒤로/앞으로 history traversal은 browser scroll restoration을 유지해야 하고(MUST), 검색 화면의 query-only `router.push`/`setParams`는 현재 document scroll과 입력 focus를 보존해야 한다(MUST). 현재 pathname을 다시 선택한 동작에는 이 route-change 초기화를 적용해서는 안 되며(MUST NOT), 현재 홈 재선택의 최상단 이동과 단일 refetch는 `PROD-610` 계약에 남겨야 한다(MUST). 이 요구사항은 Relay 데이터 새로고침 또는 Android/iOS Native navigation scroll 정책을 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: 다른 주요 route를 document 최상단에서 연다
+
+- **WHEN** 사용자가 스크롤된 Web route에서 하단 탭, mobile drawer, compact 아이콘 레일 또는 full sidebar의
+  현재 pathname과 다른 주요 route를 선택한다
+- **THEN** 대상 pathname이 반영된 뒤 document scroll은 최상단에 있다
+- **AND** 대상 route의 header와 첫 콘텐츠가 이전 route의 scroll offset 없이 표시된다
+
+#### Scenario: 로딩 또는 빈 대상 route에서도 이전 offset을 노출하지 않는다
+
+- **WHEN** 사용자가 스크롤된 Web route에서 Relay 데이터가 loading 또는 empty 상태인 다른 주요 route로 이동한다
+- **THEN** 대상 상태는 document 최상단에서 표시된다
+- **AND** 이전 route의 scroll offset 때문에 header나 첫 상태 surface가 viewport 위로 벗어나지 않는다
+
+#### Scenario: 연속 route 전환은 마지막 대상 route에 수렴한다
+
+- **WHEN** 사용자가 첫 route 전환이 완료되기 전에 서로 다른 주요 route를 연속으로 선택한다
+- **THEN** 마지막으로 반영된 대상 route가 document 최상단에서 표시된다
+- **AND** 이전 전환의 지연된 scroll 처리가 마지막 route의 위치를 다시 변경하지 않는다
+
+#### Scenario: 브라우저 history traversal의 scroll 위치를 유지한다
+
+- **WHEN** 사용자가 브라우저 뒤로 또는 앞으로 이동으로 이전 history entry를 연다
+- **THEN** 앱 셸은 해당 traversal을 주요 forward navigation으로 취급해 document 최상단을 강제하지 않는다
+- **AND** 브라우저의 history scroll restoration 결과를 유지한다
+
+#### Scenario: 검색 query-only 이동의 scroll과 focus를 유지한다
+
+- **WHEN** 사용자가 검색 route에서 query 또는 검색 탭만 변경해 pathname이 그대로 유지된다
+- **THEN** 현재 document scroll 위치를 보존한다
+- **AND** 검색 입력 focus를 route-change 초기화 때문에 잃지 않는다
+
+#### Scenario: 현재 route 재선택의 소유권을 확장하지 않는다
+
+- **WHEN** 사용자가 현재 pathname과 같은 shell navigation 항목을 다시 선택한다
+- **THEN** 이 요구사항은 document 최상단 이동이나 Relay refetch를 실행하지 않는다
+- **AND** 현재 홈 재선택의 최상단 이동과 단일 refetch는 `PROD-610` 계약으로만 처리한다
+
+#### Scenario: Native navigation scroll은 변경하지 않는다
+
+- **WHEN** 사용자가 Android 또는 iOS Native 앱의 shell navigation으로 route를 이동한다
+- **THEN** 이 Web document scroll 요구사항은 Native `ScrollView` 위치 정책을 변경하지 않는다

--- a/openspec/changes/reset-primary-navigation-scroll/tasks.md
+++ b/openspec/changes/reset-primary-navigation-scroll/tasks.md
@@ -103,7 +103,7 @@ archive된 뒤 PROD-617 담당자가 mobile Web 통합 검증에 사용할 수 �
 - Archive 전 모든 task, required validation, linked PR 상태와 delta spec 정합성을 확인하고 archive 후 strict
   validation을 다시 실행한다.
 
-- [ ] 3.1 구현·검증 diff와 branch/HEAD/commit/push 결과, 남은 위험과 실행하지 못한 검증을 handoff에 기록한다.
+- [x] 3.1 구현·검증 diff와 branch/HEAD/commit/push 결과, 남은 위험과 실행하지 못한 검증을 handoff에 기록한다.
 - [x] 3.2 Canonical·Linear·OpenSpec과 실제 구현의 forward/history/query/reselection/Native 경계를 대조하고 strict
       validation을 통과시킨다.
 - [ ] 3.3 PROD-619 전체 task와 linked PR 완료 evidence가 충족되면 change를 archive하고, mobile Web 통합 검증용

--- a/openspec/changes/reset-primary-navigation-scroll/tasks.md
+++ b/openspec/changes/reset-primary-navigation-scroll/tasks.md
@@ -1,0 +1,110 @@
+## 1. PROD-619 주요 Web navigation scroll 초기화
+
+**Authority / Provenance**
+
+- `docs/design/breakpoints.md`
+- `PROD-619`
+- Document scroll 전제 `PROD-219`; 현재 홈 재선택 경계 `PROD-610`
+
+**Deliverable**
+
+사용자가 Web 하단 탭, mobile drawer, compact 아이콘 레일 또는 full sidebar에서 현재와 다른 주요 route를
+선택하면 target route가 document 최상단에서 표시되고, loading·empty 상태와 연속 전환에서도 source route의
+scroll offset이 남지 않는다.
+
+**Guardrails**
+
+- 실제로 실행된 current-to-different 주요 forward navigation과 target pathname commit을 짝지어 한 번만
+  초기화한다.
+- Browser back/forward, search query-only 이동, current route 재선택과 Android/iOS Native navigation에는 이
+  초기화를 적용하지 않는다.
+- 현재 홈 재선택의 최상단 이동·단일 refetch는 `PROD-610`에 남기고 Relay 데이터 정책을 바꾸지 않는다.
+- Document/window scroll ownership과 navigation guard를 유지하며 `history.scrollRestoration` manual 전환,
+  smooth scroll, 중앙 internal scroller 또는 route별 reset 복제를 도입하지 않는다.
+- PROD-622·PROD-623의 drawer scroll/close 변경을 이 task diff나 commit에 흡수하지 않는다.
+
+**Verification**
+
+- 무guard 이동, guard 승인·취소, current route 재선택, 마지막 target이 다른 연속 navigation에서 scroll intent의
+  생성·소비·취소를 자동화한다.
+- 각 breakpoint의 shell surface가 같은 route-scroll 정책을 사용하고 Native에서는 no-op임을 검증한다.
+
+- [ ] 1.1 하단 탭, mobile drawer, compact 아이콘 레일과 full sidebar의 실제 navigation action이 current와 다른
+      target pathname intent를 동일한 경계로 전달하게 한다.
+- [ ] 1.2 target pathname이 commit된 뒤 Web document를 최상단으로 초기화하고, 새 navigation이 이전의 지연
+      처리를 무효화해 마지막 target에 수렴하게 한다.
+- [ ] 1.3 Guard 승인 전·취소, current route 재선택, search query-only와 Native 경로가 reset/refetch를 실행하지
+      않으며 browser history restoration을 건드리지 않는지 implementation diff로 확인한다.
+
+## 2. PROD-619 targeted Web 회귀 검증
+
+**Authority / Provenance**
+
+- `docs/design/breakpoints.md`
+- `docs/design/accessibility.md`
+- `PROD-619`
+- 현재 홈 재선택 경계 `PROD-610`; broad navigation E2E 소유 `PROD-233`
+
+**Deliverable**
+
+주요 route의 top 초기화와 history/query/reselection 보존이 component automation, Chromium E2E와 iPhone급 mobile
+Web touch 관찰로 재현 가능하게 증명된다.
+
+**Guardrails**
+
+- 전체 반응형 navigation IA suite는 `PROD-233`에 남기고 PROD-619의 scroll 결과와 회귀 경계만 targeted
+  assertion으로 추가한다.
+- 단순 style·scrollHeight assertion으로 top 초기화나 browser restoration을 대신하지 않는다.
+- Query-only 검증은 URL뿐 아니라 document scroll과 검색 입력 focus를 확인한다.
+- Web 검증을 Android/iOS Native runtime 검증으로 일반화하지 않는다.
+
+**Verification**
+
+- `pnpm --filter @kosmo/app check`
+- 관련 `pnpm --filter @kosmo/app test:unit`과 `pnpm --filter @kosmo/app test:storybook`
+- 관련 `pnpm --filter @kosmo/web test:e2e -- <PROD-619 E2E file>`
+- iPhone급 mobile Web viewport에서 touch로 profile/home 및 다른 bottom-tab route 전환을 수동 관찰한다.
+
+- [ ] 2.1 Shell navigation의 무guard·guard 승인/취소, current/different pathname, 연속 target 교체와 Native no-op을
+      가장 가까운 component test로 검증한다.
+- [ ] 2.2 Mobile bottom tab/drawer와 compact/full sidebar에서 스크롤된 source → 다른 target의 pathname 반영,
+      `window.scrollY` top, loading·empty target과 연속 route 전환을 targeted Web E2E로 검증한다.
+- [ ] 2.3 Browser back/forward의 restored position, search query-only의 scroll·focus 보존, current route 재선택의
+      reset/refetch 비실행을 Web E2E로 검증한다.
+- [ ] 2.4 관련 app check/unit/Storybook와 Web E2E를 통과시키고 iPhone급 mobile Web touch 관찰의 viewport·입력·
+      결과와 실행하지 못한 검증을 기록한다.
+
+## 3. PROD-619 완료·handoff·archive
+
+**Authority / Provenance**
+
+- `docs/design/breakpoints.md`
+- `PROD-619`
+- 통합 검증 소유 `PROD-617`
+
+**Deliverable**
+
+PROD-619의 구현과 개별 검증, canonical·delta spec 정합성과 task 완료 evidence가 기록되고, 완료된 change가
+archive된 뒤 PROD-617 담당자가 mobile Web 통합 검증에 사용할 수 있다.
+
+**Guardrails**
+
+- PR readiness와 OpenSpec archive를 분리하고, 이 change의 전체 task와 required validation이 완료되기 전에는
+  archive하지 않는다.
+- PROD-617의 다섯 sibling 통합 검증 완료를 PROD-619 change archive의 선행 조건으로 만들지 않는다.
+- Sibling issue 변경이나 미검증 결과를 PROD-619 완료 evidence로 포함하지 않는다.
+- 구현 중 새로운 제품 행동 또는 durable decision이 필요하면 canonical → Linear → OpenSpec 순서로 갱신하고
+  다시 승인받는다.
+
+**Verification**
+
+- `pnpm exec openspec validate reset-primary-navigation-scroll --strict`
+- `git diff`와 staged diff에서 PROD-619 owned 파일·hunk만 포함됐는지 확인한다.
+- Archive 전 모든 task, required validation, linked PR 상태와 delta spec 정합성을 확인하고 archive 후 strict
+  validation을 다시 실행한다.
+
+- [ ] 3.1 구현·검증 diff와 branch/HEAD/commit/push 결과, 남은 위험과 실행하지 못한 검증을 handoff에 기록한다.
+- [ ] 3.2 Canonical·Linear·OpenSpec과 실제 구현의 forward/history/query/reselection/Native 경계를 대조하고 strict
+      validation을 통과시킨다.
+- [ ] 3.3 PROD-619 전체 task와 linked PR 완료 evidence가 충족되면 change를 archive하고, mobile Web 통합 검증용
+      결과를 PROD-617 담당자에게 전달한다.

--- a/openspec/changes/reset-primary-navigation-scroll/tasks.md
+++ b/openspec/changes/reset-primary-navigation-scroll/tasks.md
@@ -29,11 +29,11 @@ scroll offset이 남지 않는다.
   생성·소비·취소를 자동화한다.
 - 각 breakpoint의 shell surface가 같은 route-scroll 정책을 사용하고 Native에서는 no-op임을 검증한다.
 
-- [ ] 1.1 하단 탭, mobile drawer, compact 아이콘 레일과 full sidebar의 실제 navigation action이 current와 다른
+- [x] 1.1 하단 탭, mobile drawer, compact 아이콘 레일과 full sidebar의 실제 navigation action이 current와 다른
       target pathname intent를 동일한 경계로 전달하게 한다.
-- [ ] 1.2 target pathname이 commit된 뒤 Web document를 최상단으로 초기화하고, 새 navigation이 이전의 지연
+- [x] 1.2 target pathname이 commit된 뒤 Web document를 최상단으로 초기화하고, 새 navigation이 이전의 지연
       처리를 무효화해 마지막 target에 수렴하게 한다.
-- [ ] 1.3 Guard 승인 전·취소, current route 재선택, search query-only와 Native 경로가 reset/refetch를 실행하지
+- [x] 1.3 Guard 승인 전·취소, current route 재선택, search query-only와 Native 경로가 reset/refetch를 실행하지
       않으며 browser history restoration을 건드리지 않는지 implementation diff로 확인한다.
 
 ## 2. PROD-619 targeted Web 회귀 검증
@@ -65,13 +65,13 @@ Web touch 관찰로 재현 가능하게 증명된다.
 - 관련 `pnpm --filter @kosmo/web test:e2e -- <PROD-619 E2E file>`
 - iPhone급 mobile Web viewport에서 touch로 profile/home 및 다른 bottom-tab route 전환을 수동 관찰한다.
 
-- [ ] 2.1 Shell navigation의 무guard·guard 승인/취소, current/different pathname, 연속 target 교체와 Native no-op을
+- [x] 2.1 Shell navigation의 무guard·guard 승인/취소, current/different pathname, 연속 target 교체와 Native no-op을
       가장 가까운 component test로 검증한다.
-- [ ] 2.2 Mobile bottom tab/drawer와 compact/full sidebar에서 스크롤된 source → 다른 target의 pathname 반영,
+- [x] 2.2 Mobile bottom tab/drawer와 compact/full sidebar에서 스크롤된 source → 다른 target의 pathname 반영,
       `window.scrollY` top, loading·empty target과 연속 route 전환을 targeted Web E2E로 검증한다.
-- [ ] 2.3 Browser back/forward의 restored position, search query-only의 scroll·focus 보존, current route 재선택의
+- [x] 2.3 Browser back/forward의 restored position, search query-only의 scroll·focus 보존, current route 재선택의
       reset/refetch 비실행을 Web E2E로 검증한다.
-- [ ] 2.4 관련 app check/unit/Storybook와 Web E2E를 통과시키고 iPhone급 mobile Web touch 관찰의 viewport·입력·
+- [x] 2.4 관련 app check/unit/Storybook와 Web E2E를 통과시키고 iPhone급 mobile Web touch 관찰의 viewport·입력·
       결과와 실행하지 못한 검증을 기록한다.
 
 ## 3. PROD-619 완료·handoff·archive
@@ -104,7 +104,7 @@ archive된 뒤 PROD-617 담당자가 mobile Web 통합 검증에 사용할 수 �
   validation을 다시 실행한다.
 
 - [ ] 3.1 구현·검증 diff와 branch/HEAD/commit/push 결과, 남은 위험과 실행하지 못한 검증을 handoff에 기록한다.
-- [ ] 3.2 Canonical·Linear·OpenSpec과 실제 구현의 forward/history/query/reselection/Native 경계를 대조하고 strict
+- [x] 3.2 Canonical·Linear·OpenSpec과 실제 구현의 forward/history/query/reselection/Native 경계를 대조하고 strict
       validation을 통과시킨다.
 - [ ] 3.3 PROD-619 전체 task와 linked PR 완료 evidence가 충족되면 change를 archive하고, mobile Web 통합 검증용
       결과를 PROD-617 담당자에게 전달한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- Web 하단 탭, mobile drawer, compact rail, full sidebar의 서로 다른 주요 route forward navigation을 target pathname commit과 연결해 document scroll을 최상단으로 초기화했습니다.
- navigation guard 승인/취소, 연속 전환, loading target을 고려해 최신 intent만 소비하도록 했습니다.
- browser history traversal, search query-only 이동, current route 재선택, Native navigation의 기존 경계를 보존했습니다.
- review에서 확인된 history/query 복원 경쟁 조건과 검색 뒤로가기 focus 회귀를 수정하고 회귀 테스트를 보강했습니다.
- 관련 component test와 targeted Web E2E를 추가하고 `docs/design/breakpoints.md` 및 OpenSpec delta를 정합화했습니다.

## 왜 변경했는지

스크롤된 Web 화면에서 다른 주요 route로 이동할 때 이전 document scroll offset이 대상 화면에 남아 header와 첫 콘텐츠가 보이지 않는 문제를 해결합니다.

## 이번 PR의 주요 결정

새로운 제품 결정은 없습니다. PROD-619와 `reset-primary-navigation-scroll` OpenSpec에 확정된 forward/history/query-only/reselection/Native 경계를 구현했습니다.

## 어떻게 확인할 수 있는지

최신 `origin/main` 리베이스 및 HEAD `3850d1b6` 기준입니다.

- `pnpm exec openspec validate reset-primary-navigation-scroll --strict` ✅
- `pnpm --filter @kosmo/app check` ✅
- `pnpm --filter @kosmo/web check` ✅
- app unit — 35 suites, 165 tests ✅
- `pnpm --filter @kosmo/app test:storybook` — 19 files, 266 tests ✅
- 격리 테스트 DB를 사용한 `navigation-scroll.e2e.ts` — 3 tests ✅
- 변경 파일 ESLint, Prettier, `git diff --check` ✅
- correctness/risk 독립 재리뷰 — actionable finding 0건 ✅

## 아직 남은 문제

- iPhone급 실제 기기/브라우저의 수동 touch 관찰은 이 세션에서 실행하지 않았습니다. Chromium의 mobile touch 조건은 targeted E2E에 포함했습니다.
- PROD-617이 소유한 전체 mobile Web 통합 검증은 별도 범위입니다.
- PR readiness와 OpenSpec archive는 별도입니다. change task 3.3 archive는 linked PR 완료 evidence를 확인한 뒤 수행합니다.