### PR TITLE
ActivityPub Local actor가 완전한 프로필 표현을 제공하게 한다

### DIFF
--- a/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/decisions.md
+++ b/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/decisions.md
@@ -1,0 +1,70 @@
+## Context
+
+PROD-628과 canonical Profile/Media 계약에 따라 Local ActivityPub actor가 최신 Profile 표현과 Follow Approval
+Policy를 제공하는 범위를 기록한다. delta spec의 actor document 행동 계약과 design의 기존 actor/key 경계 재사용
+접근을 반영한다.
+
+## Decision Records
+
+### Local Profile의 현재 공개 표현을 canonical Person에 투영한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, `docs/domain/objects/media.md`,
+  `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`, `PROD-628`
+- Status: Active
+- Context / Problem: Local Profile은 displayName, bio, avatar/header와 Follow Approval Policy를 소유하지만 기존
+  actor document는 avatar/header와 policy를 제공하지 않아 원격 consumer가 최신 공개 표현을 얻을 수 없다.
+- Decision Outcome: `Person.name`은 displayName, 평문 `summary`는 bio, Ready Local avatar는 `icon`, Ready
+  Local header는 `image`로 제공한다. Follow Approval Policy는 `APPROVAL_REQUIRED=true`, `OPEN=false`의
+  `manuallyApprovesFollowers`로 제공한다.
+- Alternatives Considered: 기존 최소 actor 문서를 유지하거나 이미지와 policy를 outbound Update에서만
+  제공하는 방안. actor 역참조 자체가 불완전하게 남고 같은 actor identity가 caller에 따라 다른 표현을 가지므로
+  채택하지 않는다.
+- Consequences: actor 역참조만으로 현재 저장된 Local Profile 표현을 읽을 수 있다. Profile Tag·Profile Link와
+  outbound delivery는 이 결정의 범위가 아니다.
+- Confirmation / Follow-up: actor HTTP 응답에서 값 존재·부재, policy 양방향과 기존 identity·endpoint·key
+  보존을 검증한다.
+
+### ActivityPub 이미지는 저장된 유효한 Ready Local Media만 사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, `docs/domain/objects/media.md`,
+  `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`, `PROD-628`
+- Status: Active
+- Context / Problem: ProfileMedia 관계만으로 Uploading/Remote/다른 Profile Media 또는 공개 metadata가 없는
+  Media까지 actor에 노출하면 Profile 조회 정책과 Media Storage Service 경계를 우회할 수 있다.
+- Decision Outcome: actor projection은 같은 Profile이 소유한 Source=Local, State=Ready Media의 저장 URL과
+  Media Type만 사용하고, 조건을 만족하는 선택 Media가 없으면 `icon`/`image`를 제공하지 않는다.
+- Alternatives Considered: storage reference에서 URL 재조립, placeholder 사용, 관계가 있으면 Media 상태와
+  무관하게 노출. 모두 저장 서비스의 공개 표현 권위나 선택값 부재 계약을 위반하므로 채택하지 않는다.
+- Consequences: 잘못되거나 불완전한 선택 Media는 actor document 전체를 위한 대체 표현이 되지 않으며 노출되지
+  않는다. DB migration이나 Media backfill은 필요하지 않다.
+- Confirmation / Follow-up: Local/Ready/소유권/metadata 조건과 avatar/header 제거 뒤 stale 값 부재를
+  통합 테스트로 검증한다.
+
+### 모든 local actor caller가 Fedify vocabulary projection을 공유한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/profile.md`, `docs/domain/objects/media.md`, `PROD-628`
+- Status: Active
+- Context / Problem: actor HTTP dispatcher와 후속 outbound Update가 각각 JSON 또는 `Person`을 조립하면 필드,
+  identity, key와 선택값 처리 규칙이 갈라질 수 있다.
+- Decision Outcome: 저장 Profile/Media projection을 Fedify `Person`과 `Image` vocabulary object로 만드는 기존
+  local actor 생성 경계를 확장해 caller들이 재사용할 수 있게 한다. 내부 JSON shape를 별도로 만들지 않는다.
+- Alternatives Considered: actor dispatcher 전용 inline JSON, outbound 전용 projection 복제. 현재도 Fedify가
+  JSON-LD와 key 직렬화를 소유하며 중복 경계가 실제 호환성 위험을 만들기 때문에 채택하지 않는다.
+- Consequences: actor identity, endpoint, key와 Profile 표현이 하나의 생성 경계에서 함께 유지된다. 구체 DB
+  join 방식과 내부 타입 이름은 고정하지 않는다.
+- Confirmation / Follow-up: actor HTTP 통합 테스트와 `Person` projection 테스트에서 동일한 저장 입력이 같은
+  표현을 만드는지 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/design.md
+++ b/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/design.md
@@ -1,0 +1,91 @@
+## Context
+
+현재 Local actor dispatcher는 `ensureDrizzleLocalProfileActor`를 통해 active Local Profile과 actor key를
+보장한 뒤 `createLocalProfilePerson`에서 `Person`을 만든다. Profile 조회 projection에는 id, handle,
+displayName, bio와 createdAt만 있어 `Profile.followPolicy`, `ProfileMedia`와 `Media`의 공개 표현을 직렬화할 수
+없다.
+
+`ProfileMedia`는 profile별 `AVATAR`/`HEADER` 관계를 하나씩 저장하고, Ready Local `Media`는 Media Storage
+Service가 확정한 nullable하지 않은 URL과 Media Type을 가진다. actor/key lazy 생성과 stable actor identity는
+이미 별도 경계에서 검증되고 있으므로 이번 변경은 Profile 표현 조회와 `Person` 직렬화만 확장한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- actor 역참조가 최신 displayName, 평문 bio, avatar, header와 Follow Approval Policy를 제공한다.
+- actor document와 후속 outbound Update가 재사용할 수 있는 canonical `Person` projection을 유지한다.
+- Ready Local Media의 저장된 공개 URL과 Media Type만 ActivityPub 이미지로 제공한다.
+- 기존 actor/key lazy 생성과 identity·endpoint 계약을 보존한다.
+
+**Non-Goals:**
+
+- outbound `Update(Person)` activity 생성과 전달
+- Profile Tag·Profile Link federation 표현
+- Remote Media materialization, 이미지 proxy/cache 또는 추가 metadata fetch
+- DB/GraphQL schema, Profile 편집 UI, actor key lifecycle 변경
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `LocalActorStore.findActiveLocalProfile`은 actor/key 생성 전 같은 transaction에서 Profile을 읽고 있으며 현재
+  Media 관계를 반환하지 않는다.
+- avatar와 header는 같은 `ProfileMedia`/`Media` 테이블을 서로 다른 kind로 참조하므로 단순 join 하나로 두
+  관계를 구분할 수 없다.
+- `ProfileMedia.profileId`와 `Media.profileId`는 각각 FK지만 서로 같은 Profile이라는 DB constraint는 없다.
+  actor projection은 편집 service가 보장한 소유 관계를 조회 조건에서도 확인해야 한다.
+- Fedify `Person`은 `icon`/`image`에 vocabulary `Image` object를, `manuallyApprovesFollowers`에 boolean을
+  받는다. 저장 문자열을 그대로 임의 JSON으로 조립하면 JSON-LD와 media type 직렬화가 기존 library 경계와
+  갈라진다.
+- actor document 요청은 local actor metadata와 key가 없으면 이를 lazy 생성한다. 표현 조회 확장이 이 기존
+  idempotent transaction 흐름을 제거하거나 별도 key identity를 만들면 안 된다.
+
+### Recommended Approach
+
+Local Profile projection에 `followPolicy`와 선택적 avatar/header의 URL·Media Type을 추가한다. Drizzle 조회는
+avatar/header 각각에 alias를 둔 left join을 사용하고, 같은 Profile 소유·Local source·Ready state·공개
+metadata 존재 조건을 만족하는 Media만 projection에 포함하는 방식을 기본으로 한다.
+
+`createLocalProfilePerson`은 이 projection에서 avatar/header가 있을 때만 Fedify `Image`를 만들고 각각
+`icon`/`image`로 전달한다. `manuallyApprovesFollowers`는 follow policy를 명시적인 boolean으로 매핑한다.
+displayName, 평문 bio, identity, endpoint와 key 구성은 기존 `Person` 생성 경계에 유지한다. 따라서 actor
+dispatcher와 후속 delivery caller가 같은 생성 함수를 사용하면 같은 object 표현을 얻는다.
+
+통합 테스트는 실제 actor HTTP 응답 JSON을 기준으로 OPEN/APPROVAL_REQUIRED, bio와 Media의 존재·부재,
+이미지 교체·제거 뒤 최신 표현, 기존 actor/key row 재사용을 검증한다. 순수 `Person` 생성 단위 테스트가
+projection mapping 실패를 더 명확히 드러내면 함께 둘 수 있다.
+
+### Allowed Alternatives
+
+avatar/header를 alias join 대신 Profile 조회 뒤 최대 두 개의 bounded Media 조회로 조합해도 된다. 같은
+transaction snapshot, Profile 소유·Local/Ready·metadata 조건과 단일 canonical `Person` 생성 경계를
+유지해야 한다.
+
+### Known Traps
+
+- `ProfileMedia` kind만 확인하고 `Media.profileId`를 확인하지 않아 잘못 연결된 다른 Profile Media를 공개하는
+  것
+- Uploading, Remote 또는 URL/Media Type이 없는 Media를 placeholder나 불완전한 `Image`로 제공하는 것
+- avatar/header URL을 storage reference나 origin path에서 다시 조립하는 것
+- actor HTTP 응답과 outbound Update용 `Person`을 별도 helper에서 서로 다르게 조립하는 것
+- Media 표현을 추가하면서 actor/key lazy 생성이나 기존 endpoint identity를 바꾸는 것
+
+## Risks / Trade-offs
+
+- [actor 조회 join이 늘어나 read 비용이 증가한다] → profile별 최대 두 관계이며 index와 unique constraint가
+  있으므로 bounded 조회를 유지하고 통합 테스트에서 query 결과 중복을 확인한다.
+- [legacy 또는 손상된 Media 관계가 actor 응답을 실패시킬 수 있다] → projection eligibility를 조회 경계에서
+  확인하고 유효한 공개 URL/Media Type을 만들 수 없는 선택 관계는 노출하지 않는다.
+- [일부 원격 구현이 header `image` 또는 명시적 false policy를 다르게 소비할 수 있다] → ActivityPub vocabulary
+  object와 boolean을 Fedify로 직렬화하고 Kosmo 내부 JSON shape를 별도로 만들지 않는다.
+
+## Migration Plan
+
+DB migration과 backfill은 없다. 배포 뒤 actor 역참조는 즉시 최신 저장 Profile/Media를 반영한다. 문제가
+발생하면 projection 필드 추가를 되돌려 기존 최소 actor 문서로 rollback할 수 있으며 저장 데이터와 actor/key
+identity에는 영향이 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/proposal.md
+++ b/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+현재 Local ActivityPub `Person` 문서는 Profile의 표시 이름과 bio만 표현하고, 이미 편집 가능한
+avatar/header와 Follow Approval Policy를 누락한다. 원격 서버가 actor를 다시 조회하거나 후속
+`Update(Person)`을 받아도 완전한 최신 Profile 표현을 얻을 수 있도록 canonical local actor projection을
+완성해야 한다.
+
+## What Changes
+
+- Local Profile의 표시 이름, bio, Ready Local avatar/header Media와 Follow Approval Policy를 하나의
+  canonical ActivityPub `Person` projection으로 제공한다.
+- avatar는 `icon`, header는 `image`로 저장된 공개 URL과 Media Type을 투영한다.
+- `APPROVAL_REQUIRED`는 `manuallyApprovesFollowers=true`, `OPEN`은 `false`로 투영한다.
+- 선택적 bio/avatar/header의 부재와 이미지 교체·제거를 최신 저장 상태대로 표현한다.
+- 기존 actor identity, Web URL, endpoint, collection URI와 key 계약은 유지한다.
+- Profile Tag·Profile Link 표현과 outbound `Update(Person)` 전달은 포함하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/profile.md`, `docs/domain/objects/media.md`,
+  `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`
+- Linear Contract: `PROD-628`
+- Linear Implementations: `PROD-628`
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `activitypub-actor-discovery`: Local actor document가 현재 확정된 Profile 표현과 Follow Approval Policy를
+  완전하게 제공하도록 확장한다.
+
+## Impact
+
+- `packages/fedify`: Local Profile/Media projection 조회와 ActivityPub `Person` 직렬화
+- `openspec/specs/activitypub-actor-discovery`: Local actor document 표현 계약
+- DB schema, GraphQL schema, Profile 편집 UI와 outbound activity delivery에는 변경이 없다.

--- a/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/specs/activitypub-actor-discovery/spec.md
+++ b/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/specs/activitypub-actor-discovery/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Local actor document
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/objects/media.md`, `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`, `PROD-560`, `PROD-628`; Local actor document를 MUST 제공한다.
+시스템은 local active profile의 actor URI에서 read-only ActivityPub `Person` document를 반환하고, 현재 확정된
+Profile 표현 속성과 Follow Approval Policy를 완전하게 투영하며, 지원되는 ActivityPub inbox delivery를
+federation inbox 처리 경계로 연결하는 것을 MUST 보장한다.
+
+#### Scenario: Read local actor document
+
+- **WHEN** 외부 서버가 `GET /ap/actor/{profile.id}`를 ActivityPub JSON으로 요청한다
+- **THEN** 시스템은 해당 ID의 local active profile을 조회한다
+- **AND** 시스템은 HTTP 200과 `application/activity+json` content type으로 응답한다
+- **AND** `Person` document는 `id`, `preferredUsername`, `name`, `url`, `published`, `inbox`, `outbox`,
+  `followers`, `following`, `endpoints`, `publicKey`, `assertionMethod`, `manuallyApprovesFollowers`를 포함한다
+- **AND** `id`는 canonical local actor URI `{localOrigin}/ap/actor/{profile.id}`와 같다
+- **AND** `preferredUsername`은 local profile handle이다
+- **AND** `name`은 local profile의 최신 displayName이다
+- **AND** local profile에 bio가 있으면 `summary`는 해당 평문 bio이고, 없으면 `summary`를 제공하지 않는다
+- **AND** `url`은 기존 웹 프로필 URL `{localOrigin}/@{handle}`이다
+- **AND** `inbox`는 actor URI에 `/inbox` path suffix를 붙인 actor-scoped URI이다
+- **AND** `outbox`는 actor URI에 `/outbox` path suffix를 붙인 actor-scoped URI이다
+- **AND** `followers`는 actor URI에 `/followers` path suffix를 붙인 URI이다
+- **AND** `following`은 actor URI에 `/following` path suffix를 붙인 URI이다
+- **AND** `endpoints.sharedInbox`는 shared inbox URI `{localOrigin}/inbox`이다
+- **AND** Follow Approval Policy가 `APPROVAL_REQUIRED`이면 `manuallyApprovesFollowers`는 `true`이고,
+  `OPEN`이면 `false`이다
+
+#### Scenario: Expose local profile avatar and header
+
+- **WHEN** local active profile에 Source가 Local이고 State가 Ready이며 공개 URL과 Media Type이 저장된 avatar
+  또는 header Media가 연결되어 있다
+- **THEN** 시스템은 avatar를 `icon`, header를 `image` ActivityPub 이미지로 제공한다
+- **AND** 각 이미지의 `url`과 `mediaType`은 연결된 Media에 저장된 공개 URL과 Media Type이다
+- **AND** 시스템은 저장된 공개 표현을 요청 중 다시 조립하거나 byte와 Media Type을 재검증하지 않는다
+
+#### Scenario: Omit unavailable optional profile representation
+
+- **WHEN** local active profile에 bio, 유효한 Ready Local avatar 또는 유효한 Ready Local header가 없다
+- **THEN** 시스템은 존재하지 않는 선택적 값을 위한 `summary`, `icon` 또는 `image`를 제공하지 않는다
+- **AND** 이전 관계, placeholder 또는 깨진 URL을 actor document에 남기지 않는다
+
+#### Scenario: Preserve canonical actor identity and security metadata
+
+- **WHEN** local profile의 displayName, bio, avatar, header 또는 Follow Approval Policy가 바뀐 뒤 actor document를
+  다시 요청한다
+- **THEN** 시스템은 최신 Profile 표현을 반환한다
+- **AND** 기존 actor `id`, Web `url`, inbox/outbox, followers/following, shared inbox와 공개 key identity는
+  변경하지 않는다
+
+#### Scenario: Missing local actor document
+
+- **WHEN** actor URI의 UUID와 일치하는 local active profile이 없다
+- **THEN** 시스템은 HTTP 404로 응답한다
+
+#### Scenario: Delegate supported inbox delivery
+
+- **WHEN** 외부 서버가 actor-scoped `/ap/actor/{profile.id}/inbox` 또는 shared `/inbox`로 ActivityPub activity를
+  전달한다
+- **THEN** 시스템은 해당 요청을 federation inbox 처리 경계로 전달한다
+- **AND** 검증된 typed activity와 등록된 activity capability handler가 있으면 시스템은 그 handler로 위임한다
+- **AND** activity의 검증, 저장과 side effect는 해당 activity capability가 정의하며 local actor discovery는
+  이를 직접 정의하지 않는다
+- **AND** 시스템은 해당 요청을 `/graphql` proxy 또는 API 서버로 전달하지 않는다

--- a/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/tasks.md
+++ b/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/tasks.md
@@ -1,0 +1,82 @@
+## 1. PROD-628 Canonical local actor Profile 표현
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/domain/objects/media.md`
+- `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`
+- `PROD-628`
+
+**Deliverable**
+
+Local active Profile의 actor document가 최신 displayName, bio, avatar, header와 Follow Approval Policy를
+canonical ActivityPub `Person`으로 제공한다.
+
+**Guardrails**
+
+- actor identity, Web URL, endpoint, collection URI와 key identity를 변경하지 않는다.
+- 같은 Profile이 소유한 Source=Local, State=Ready Media의 저장된 공개 URL과 Media Type만 이미지로 제공한다.
+- actor 역참조와 후속 outbound caller가 서로 다른 `Person` projection을 만들지 않는다.
+- Profile Tag·Profile Link와 outbound `Update(Person)` delivery를 포함하지 않는다.
+
+**Verification**
+
+- 저장 Profile/Media projection과 Fedify `Person` 결과에서 최신 값, 선택값 부재와 기존 identity를 검증한다.
+
+- [x] 1.1 Local actor Profile projection이 follow policy와 유효한 선택적 avatar/header 공개 표현을 반환하게 한다.
+- [x] 1.2 canonical `Person`에 displayName, 평문 bio, `icon`, `image`와 `manuallyApprovesFollowers`를 연결한다.
+- [x] 1.3 선택값이 없거나 eligibility를 만족하지 않는 Media가 stale 또는 불완전한 actor 표현을 만들지 않게 한다.
+
+## 2. PROD-628 Actor 역참조 회귀 검증
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/domain/objects/media.md`
+- `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`
+- `PROD-628`
+
+**Deliverable**
+
+외부 서버가 actor document를 요청할 때 Profile 표현의 존재·부재와 변경 결과를 실제 ActivityPub JSON으로
+검증하고 기존 discovery/key 계약의 회귀를 막는다.
+
+**Guardrails**
+
+- OPEN과 APPROVAL_REQUIRED를 모두 검증한다.
+- 이미지 교체·제거 뒤 이전 URL을 반환하지 않는다.
+- 반복 actor 조회가 actor metadata 또는 key row를 중복 생성하지 않는다.
+
+**Verification**
+
+- Fedify actor HTTP 통합 테스트와 필요한 projection 단위 테스트를 통과시킨다.
+
+- [x] 2.1 bio와 avatar/header가 있는 actor JSON의 URL, Media Type과 follow policy 양방향 표현을 검증한다.
+- [x] 2.2 bio/avatar/header 부재, 이미지 교체·제거와 eligibility 밖 Media의 비노출을 검증한다.
+- [x] 2.3 기존 actor identity, endpoint, collection URI와 key lazy 생성·재사용 회귀를 검증한다.
+
+## 3. PROD-628 계약 및 완료 검증
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/domain/objects/media.md`
+- `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`
+- `PROD-628`
+
+**Deliverable**
+
+구현, 테스트와 active `activitypub-actor-discovery` 계약이 같은 PROD-628 범위를 표현하고 change 전체가 완료된다.
+
+**Guardrails**
+
+- DB/GraphQL schema, Profile 편집 UI와 PROD-629 outbound delivery를 변경하지 않는다.
+- change의 전체 task와 검증이 완료되기 전에는 archive하지 않는다.
+
+**Verification**
+
+- 관련 package test와 정적 검사, OpenSpec strict validation과 archive 후 active spec 동기화를 확인한다.
+
+- [x] 3.1 관련 package test, typecheck와 formatting/lint 검사를 통과시킨다.
+- [x] 3.2 OpenSpec strict validation과 diff를 검토해 구현·계약 정합성을 확인한다.
+- [x] 3.3 전체 task 완료 뒤 delta spec을 active spec에 동기화하고 change를 archive한다.

--- a/openspec/specs/activitypub-actor-discovery/spec.md
+++ b/openspec/specs/activitypub-actor-discovery/spec.md
@@ -61,9 +61,10 @@ canonical 웹 origin에서 local ActivityPub actor를 발견하고 actor documen
 
 ### Requirement: Local actor document
 
-**Authority / Provenance:** `docs/domain/objects/profile.md`, PROD-560; Local actor document를 MUST 제공한다.
-시스템은 local active profile의 actor URI에서 read-only ActivityPub `Person` document를 반환하고, 지원되는
-ActivityPub inbox delivery는 federation inbox 처리 경계로 연결하는 것을 MUST 보장한다.
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/objects/media.md`, `docs/domain/decisions/0018-media-upload-lifecycle-without-file.md`, `PROD-560`, `PROD-628`; Local actor document를 MUST 제공한다.
+시스템은 local active profile의 actor URI에서 read-only ActivityPub `Person` document를 반환하고, 현재 확정된
+Profile 표현 속성과 Follow Approval Policy를 완전하게 투영하며, 지원되는 ActivityPub inbox delivery를
+federation inbox 처리 경계로 연결하는 것을 MUST 보장한다.
 
 #### Scenario: Read local actor document
 
@@ -71,15 +72,41 @@ ActivityPub inbox delivery는 federation inbox 처리 경계로 연결하는 것
 - **THEN** 시스템은 해당 ID의 local active profile을 조회한다
 - **AND** 시스템은 HTTP 200과 `application/activity+json` content type으로 응답한다
 - **AND** `Person` document는 `id`, `preferredUsername`, `name`, `url`, `published`, `inbox`, `outbox`,
-  `followers`, `following`, `endpoints`, `publicKey`, `assertionMethod`를 포함한다
+  `followers`, `following`, `endpoints`, `publicKey`, `assertionMethod`, `manuallyApprovesFollowers`를 포함한다
 - **AND** `id`는 canonical local actor URI `{localOrigin}/ap/actor/{profile.id}`와 같다
 - **AND** `preferredUsername`은 local profile handle이다
+- **AND** `name`은 local profile의 최신 displayName이다
+- **AND** local profile에 bio가 있으면 `summary`는 해당 평문 bio이고, 없으면 `summary`를 제공하지 않는다
 - **AND** `url`은 기존 웹 프로필 URL `{localOrigin}/@{handle}`이다
 - **AND** `inbox`는 actor URI에 `/inbox` path suffix를 붙인 actor-scoped URI이다
 - **AND** `outbox`는 actor URI에 `/outbox` path suffix를 붙인 actor-scoped URI이다
 - **AND** `followers`는 actor URI에 `/followers` path suffix를 붙인 URI이다
 - **AND** `following`은 actor URI에 `/following` path suffix를 붙인 URI이다
 - **AND** `endpoints.sharedInbox`는 shared inbox URI `{localOrigin}/inbox`이다
+- **AND** Follow Approval Policy가 `APPROVAL_REQUIRED`이면 `manuallyApprovesFollowers`는 `true`이고,
+  `OPEN`이면 `false`이다
+
+#### Scenario: Expose local profile avatar and header
+
+- **WHEN** local active profile에 Source가 Local이고 State가 Ready이며 공개 URL과 Media Type이 저장된 avatar
+  또는 header Media가 연결되어 있다
+- **THEN** 시스템은 avatar를 `icon`, header를 `image` ActivityPub 이미지로 제공한다
+- **AND** 각 이미지의 `url`과 `mediaType`은 연결된 Media에 저장된 공개 URL과 Media Type이다
+- **AND** 시스템은 저장된 공개 표현을 요청 중 다시 조립하거나 byte와 Media Type을 재검증하지 않는다
+
+#### Scenario: Omit unavailable optional profile representation
+
+- **WHEN** local active profile에 bio, 유효한 Ready Local avatar 또는 유효한 Ready Local header가 없다
+- **THEN** 시스템은 존재하지 않는 선택적 값을 위한 `summary`, `icon` 또는 `image`를 제공하지 않는다
+- **AND** 이전 관계, placeholder 또는 깨진 URL을 actor document에 남기지 않는다
+
+#### Scenario: Preserve canonical actor identity and security metadata
+
+- **WHEN** local profile의 displayName, bio, avatar, header 또는 Follow Approval Policy가 바뀐 뒤 actor document를
+  다시 요청한다
+- **THEN** 시스템은 최신 Profile 표현을 반환한다
+- **AND** 기존 actor `id`, Web `url`, inbox/outbox, followers/following, shared inbox와 공개 key identity는
+  변경하지 않는다
 
 #### Scenario: Missing local actor document
 

--- a/packages/fedify/src/local-actor-store.ts
+++ b/packages/fedify/src/local-actor-store.ts
@@ -1,8 +1,22 @@
 import '@kosmo/core/polyfill';
 
-import { ActivityPubActorKeys, ActivityPubActors, db, first, Profiles } from '@kosmo/core/db';
-import { ActivityPubActorType, ProfileState } from '@kosmo/core/enums';
-import { and, eq } from 'drizzle-orm';
+import {
+  ActivityPubActorKeys,
+  ActivityPubActors,
+  db,
+  first,
+  Media,
+  ProfileMedia,
+  Profiles,
+} from '@kosmo/core/db';
+import {
+  ActivityPubActorType,
+  MediaSource,
+  MediaState,
+  ProfileMediaKind,
+  ProfileState,
+} from '@kosmo/core/enums';
+import { and, eq, isNotNull } from 'drizzle-orm';
 import { ensureLocalProfileActor } from './local-profile-actor';
 import type { Database } from '@kosmo/core/db';
 import type {
@@ -10,6 +24,7 @@ import type {
   CreateLocalActorRowInput,
   EnsureLocalProfileActorOptions,
   LocalActorStore,
+  LocalProfileActorMedia,
   LocalProfileActorProfile,
   LocalProfileActorResult,
   StoredLocalActorKey,
@@ -20,12 +35,16 @@ type LocalActorDbClient = Pick<Database, 'insert' | 'select'>;
 
 const toLocalProfileActorProfile = (
   profile: typeof Profiles.$inferSelect,
+  mediaByKind: ReadonlyMap<string, LocalProfileActorMedia>,
 ): LocalProfileActorProfile => ({
+  avatar: mediaByKind.get(ProfileMediaKind.AVATAR) ?? null,
   id: profile.id,
   handle: profile.handle,
   name: profile.displayName,
   bio: profile.bio,
   createdAt: profile.createdAt,
+  followPolicy: profile.followPolicy,
+  header: mediaByKind.get(ProfileMediaKind.HEADER) ?? null,
 });
 
 const findActorByProfileId = async (
@@ -98,7 +117,38 @@ export const createDrizzleLocalActorStore = (client: LocalActorDbClient = db): L
       .limit(1)
       .then(first);
 
-    return profile ? toLocalProfileActorProfile(profile) : undefined;
+    if (!profile) {
+      return undefined;
+    }
+
+    const media = await client
+      .select({
+        kind: ProfileMedia.kind,
+        mediaType: Media.mediaType,
+        url: Media.url,
+      })
+      .from(ProfileMedia)
+      .innerJoin(
+        Media,
+        and(eq(Media.id, ProfileMedia.mediaId), eq(Media.profileId, ProfileMedia.profileId)),
+      )
+      .where(
+        and(
+          eq(ProfileMedia.profileId, profile.id),
+          eq(Media.source, MediaSource.LOCAL),
+          eq(Media.state, MediaState.READY),
+          isNotNull(Media.url),
+          isNotNull(Media.mediaType),
+        ),
+      );
+    const mediaByKind = new Map<string, LocalProfileActorMedia>();
+    for (const item of media) {
+      if (item.url && item.mediaType) {
+        mediaByKind.set(item.kind, { mediaType: item.mediaType, url: item.url });
+      }
+    }
+
+    return toLocalProfileActorProfile(profile, mediaByKind);
   },
 
   findActorByProfileId(profileId) {

--- a/packages/fedify/src/local-actor-store.ts
+++ b/packages/fedify/src/local-actor-store.ts
@@ -17,6 +17,7 @@ import {
   ProfileState,
 } from '@kosmo/core/enums';
 import { and, eq, isNotNull } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { ensureLocalProfileActor } from './local-profile-actor';
 import type { Database } from '@kosmo/core/db';
 import type {
@@ -33,18 +34,29 @@ import type {
 
 type LocalActorDbClient = Pick<Database, 'insert' | 'select'>;
 
+const AvatarProfileMedia = alias(ProfileMedia, 'avatar_profile_media');
+const AvatarMedia = alias(Media, 'avatar_media');
+const HeaderProfileMedia = alias(ProfileMedia, 'header_profile_media');
+const HeaderMedia = alias(Media, 'header_media');
+
+const toLocalProfileActorMedia = (
+  media: { mediaType: string | null; url: string | null } | null,
+): LocalProfileActorMedia | null =>
+  media?.mediaType && media.url ? { mediaType: media.mediaType, url: media.url } : null;
+
 const toLocalProfileActorProfile = (
   profile: typeof Profiles.$inferSelect,
-  mediaByKind: ReadonlyMap<string, LocalProfileActorMedia>,
+  avatar: LocalProfileActorMedia | null,
+  header: LocalProfileActorMedia | null,
 ): LocalProfileActorProfile => ({
-  avatar: mediaByKind.get(ProfileMediaKind.AVATAR) ?? null,
+  avatar,
   id: profile.id,
   handle: profile.handle,
   name: profile.displayName,
   bio: profile.bio,
   createdAt: profile.createdAt,
   followPolicy: profile.followPolicy,
-  header: mediaByKind.get(ProfileMediaKind.HEADER) ?? null,
+  header,
 });
 
 const findActorByProfileId = async (
@@ -104,9 +116,55 @@ const requireExistingActorKey = async (
 
 export const createDrizzleLocalActorStore = (client: LocalActorDbClient = db): LocalActorStore => ({
   async findActiveLocalProfile({ localInstanceId, profileId }) {
-    const profile = await client
-      .select()
+    const row = await client
+      .select({
+        avatar: {
+          mediaType: AvatarMedia.mediaType,
+          url: AvatarMedia.url,
+        },
+        header: {
+          mediaType: HeaderMedia.mediaType,
+          url: HeaderMedia.url,
+        },
+        profile: Profiles,
+      })
       .from(Profiles)
+      .leftJoin(
+        AvatarProfileMedia,
+        and(
+          eq(AvatarProfileMedia.profileId, Profiles.id),
+          eq(AvatarProfileMedia.kind, ProfileMediaKind.AVATAR),
+        ),
+      )
+      .leftJoin(
+        AvatarMedia,
+        and(
+          eq(AvatarMedia.id, AvatarProfileMedia.mediaId),
+          eq(AvatarMedia.profileId, Profiles.id),
+          eq(AvatarMedia.source, MediaSource.LOCAL),
+          eq(AvatarMedia.state, MediaState.READY),
+          isNotNull(AvatarMedia.url),
+          isNotNull(AvatarMedia.mediaType),
+        ),
+      )
+      .leftJoin(
+        HeaderProfileMedia,
+        and(
+          eq(HeaderProfileMedia.profileId, Profiles.id),
+          eq(HeaderProfileMedia.kind, ProfileMediaKind.HEADER),
+        ),
+      )
+      .leftJoin(
+        HeaderMedia,
+        and(
+          eq(HeaderMedia.id, HeaderProfileMedia.mediaId),
+          eq(HeaderMedia.profileId, Profiles.id),
+          eq(HeaderMedia.source, MediaSource.LOCAL),
+          eq(HeaderMedia.state, MediaState.READY),
+          isNotNull(HeaderMedia.url),
+          isNotNull(HeaderMedia.mediaType),
+        ),
+      )
       .where(
         and(
           eq(Profiles.id, profileId),
@@ -117,38 +175,15 @@ export const createDrizzleLocalActorStore = (client: LocalActorDbClient = db): L
       .limit(1)
       .then(first);
 
-    if (!profile) {
+    if (!row) {
       return undefined;
     }
 
-    const media = await client
-      .select({
-        kind: ProfileMedia.kind,
-        mediaType: Media.mediaType,
-        url: Media.url,
-      })
-      .from(ProfileMedia)
-      .innerJoin(
-        Media,
-        and(eq(Media.id, ProfileMedia.mediaId), eq(Media.profileId, ProfileMedia.profileId)),
-      )
-      .where(
-        and(
-          eq(ProfileMedia.profileId, profile.id),
-          eq(Media.source, MediaSource.LOCAL),
-          eq(Media.state, MediaState.READY),
-          isNotNull(Media.url),
-          isNotNull(Media.mediaType),
-        ),
-      );
-    const mediaByKind = new Map<string, LocalProfileActorMedia>();
-    for (const item of media) {
-      if (item.url && item.mediaType) {
-        mediaByKind.set(item.kind, { mediaType: item.mediaType, url: item.url });
-      }
-    }
-
-    return toLocalProfileActorProfile(profile, mediaByKind);
+    return toLocalProfileActorProfile(
+      row.profile,
+      toLocalProfileActorMedia(row.avatar),
+      toLocalProfileActorMedia(row.header),
+    );
   },
 
   findActorByProfileId(profileId) {

--- a/packages/fedify/src/local-profile-actor.ts
+++ b/packages/fedify/src/local-profile-actor.ts
@@ -1,16 +1,27 @@
 import { exportJwk, generateCryptoKeyPair, importJwk } from '@fedify/fedify';
 import { ActivityPubActorKeyKind } from '@kosmo/core/enums';
 import { z } from 'zod';
-import type { ActivityPubActorKeyKind as ActivityPubActorKeyKindValue } from '@kosmo/core/enums';
+import type {
+  ActivityPubActorKeyKind as ActivityPubActorKeyKindValue,
+  ProfileFollowPolicy,
+} from '@kosmo/core/enums';
 
 export type JsonWebKeyRecord = Record<string, unknown>;
 
+export interface LocalProfileActorMedia {
+  readonly mediaType: string;
+  readonly url: string;
+}
+
 export interface LocalProfileActorProfile {
+  readonly avatar: LocalProfileActorMedia | null;
   readonly id: string;
   readonly handle: string;
   readonly name: string;
   readonly bio: string | null;
   readonly createdAt: Temporal.Instant;
+  readonly followPolicy: ProfileFollowPolicy;
+  readonly header: LocalProfileActorMedia | null;
 }
 
 export interface StoredLocalActorRow {

--- a/packages/fedify/src/local-profile-person.ts
+++ b/packages/fedify/src/local-profile-person.ts
@@ -1,6 +1,8 @@
-import { Endpoints, Person } from '@fedify/vocab';
+import { Endpoints, Image, Person } from '@fedify/vocab';
+import { ProfileFollowPolicy } from '@kosmo/core/enums';
+import { isHttpUri } from './activitypub-uri';
 import type { ActorKeyPair, Context } from '@fedify/fedify';
-import type { LocalProfileActorProfile } from './local-profile-actor';
+import type { LocalProfileActorMedia, LocalProfileActorProfile } from './local-profile-actor';
 
 export interface CreateLocalProfilePersonOptions {
   readonly context: Context<void>;
@@ -10,6 +12,19 @@ export interface CreateLocalProfilePersonOptions {
 
 const getPublicKeyAlgorithmName = (keyPair: ActorKeyPair): string =>
   keyPair.publicKey.algorithm.name;
+
+const createProfileImage = (media: LocalProfileActorMedia | null): Image | null => {
+  if (!media) {
+    return null;
+  }
+
+  try {
+    const url = new URL(media.url);
+    return isHttpUri(url) ? new Image({ mediaType: media.mediaType, url }) : null;
+  } catch {
+    return null;
+  }
+};
 
 export const createLocalProfilePerson = ({
   context,
@@ -36,6 +51,8 @@ export const createLocalProfilePerson = ({
 
   return new Person({
     id: actorUri,
+    icon: createProfileImage(profile.avatar),
+    image: createProfileImage(profile.header),
     preferredUsername: profile.handle,
     name: profile.name,
     summary: profile.bio,
@@ -47,6 +64,7 @@ export const createLocalProfilePerson = ({
     following: context.getFollowingUri(profile.id),
     publicKey: rsaKeyPair.cryptographicKey,
     assertionMethods: ed25519KeyPairs.map((keyPair) => keyPair.multikey),
+    manuallyApprovesFollowers: profile.followPolicy === ProfileFollowPolicy.APPROVAL_REQUIRED,
     endpoints: new Endpoints({ sharedInbox: sharedInboxUri }),
   });
 };

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -1,7 +1,17 @@
 import assert from 'node:assert/strict';
 import { after, before, beforeEach, describe, test } from 'node:test';
-import { InstanceKind, InstanceState, ProfileFollowPolicy, ProfileState } from '@kosmo/core/enums';
+import {
+  AccountState,
+  InstanceKind,
+  InstanceState,
+  MediaSource,
+  MediaState,
+  ProfileFollowPolicy,
+  ProfileMediaKind,
+  ProfileState,
+} from '@kosmo/core/enums';
 import { normalizeHandle } from '@kosmo/core/utils';
+import { and, eq } from 'drizzle-orm';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as FederationModule from './federation';
@@ -12,10 +22,13 @@ const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhos
 
 let db: typeof CoreDb.db;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
+let Accounts: typeof CoreDb.Accounts;
 let ActivityPubActorKeys: typeof CoreDb.ActivityPubActorKeys;
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let Instances: typeof CoreDb.Instances;
+let Media: typeof CoreDb.Media;
 let pg: typeof CoreDb.pg;
+let ProfileMedia: typeof CoreDb.ProfileMedia;
 let Profiles: typeof CoreDb.Profiles;
 let seedDatabase: typeof CoreSeed.seedDatabase;
 let federation: typeof FederationModule.federation;
@@ -29,8 +42,18 @@ describe('WebFinger local profile handle mapping', () => {
     process.env.DATABASE_URL = databaseUrl;
     process.env.PUBLIC_ORIGIN = publicOrigin;
 
-    ({ ActivityPubActorKeys, ActivityPubActors, db, firstOrThrow, Instances, pg, Profiles } =
-      await import('@kosmo/core/db'));
+    ({
+      Accounts,
+      ActivityPubActorKeys,
+      ActivityPubActors,
+      db,
+      firstOrThrow,
+      Instances,
+      Media,
+      pg,
+      ProfileMedia,
+      Profiles,
+    } = await import('@kosmo/core/db'));
     ({ federation } = await import('./federation'));
     ({ seedDatabase } = await import('@kosmo/core/db/seed'));
     ({ resolveLocalActorIdentifierByHandle } = await import('./webfinger'));
@@ -43,6 +66,7 @@ describe('WebFinger local profile handle mapping', () => {
   });
 
   beforeEach(async () => {
+    await db.delete(Media);
     await db.delete(Profiles);
   });
 
@@ -190,7 +214,25 @@ describe('WebFinger local profile handle mapping', () => {
   });
 
   test('serves the canonical actor document and reuses its stored key pairs', async () => {
-    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
+    const profile = await createProfile({
+      bio: 'Local profile bio',
+      displayName: 'Alice Profile',
+      followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED,
+      handle: 'alice',
+      instanceId: localInstanceId,
+    });
+    const avatar = await createLocalMedia({
+      kind: ProfileMediaKind.AVATAR,
+      mediaType: 'image/webp',
+      profileId: profile.id,
+      url: 'https://media.example/alice-avatar.webp',
+    });
+    const header = await createLocalMedia({
+      kind: ProfileMediaKind.HEADER,
+      mediaType: 'image/png',
+      profileId: profile.id,
+      url: 'https://media.example/alice-header.png',
+    });
     const requestActor = () =>
       federation.fetch(
         new Request(`${publicOrigin}/ap/actor/${profile.id}`, {
@@ -205,12 +247,16 @@ describe('WebFinger local profile handle mapping', () => {
       followers?: string;
       following?: string;
       id?: string;
+      icon?: { mediaType?: string; type?: string; url?: string };
+      image?: { mediaType?: string; type?: string; url?: string };
       inbox?: string;
+      manuallyApprovesFollowers?: boolean;
       name?: string;
       outbox?: string;
       preferredUsername?: string;
       publicKey?: { id?: string; owner?: string };
       published?: string;
+      summary?: string;
       url?: string;
     };
 
@@ -218,7 +264,19 @@ describe('WebFinger local profile handle mapping', () => {
     assert.match(response.headers.get('content-type') ?? '', /application\/activity\+json/);
     assert.equal(actor.id, `${publicOrigin}/ap/actor/${profile.id}`);
     assert.equal(actor.preferredUsername, 'alice');
-    assert.equal(actor.name, 'alice');
+    assert.equal(actor.name, 'Alice Profile');
+    assert.equal(actor.summary, 'Local profile bio');
+    assert.deepEqual(actor.icon, {
+      mediaType: avatar.mediaType,
+      type: 'Image',
+      url: avatar.url,
+    });
+    assert.deepEqual(actor.image, {
+      mediaType: header.mediaType,
+      type: 'Image',
+      url: header.url,
+    });
+    assert.equal(actor.manuallyApprovesFollowers, true);
     assert.equal(actor.url, `${publicOrigin}/@alice`);
     assert.equal(actor.published, profile.createdAt.toString());
     assert.equal(actor.inbox, `${publicOrigin}/ap/actor/${profile.id}/inbox`);
@@ -245,6 +303,81 @@ describe('WebFinger local profile handle mapping', () => {
     const keysAfterSecondRequest = await db.select().from(ActivityPubActorKeys);
     assert.deepEqual(actorsAfterSecondRequest, actorsAfterFirstRequest);
     assert.deepEqual(keysAfterSecondRequest, keysAfterFirstRequest);
+  });
+
+  test('reflects optional media replacement and removal while omitting ineligible media', async () => {
+    const profile = await createProfile({ handle: 'alice', instanceId: localInstanceId });
+    const requestActor = async () => {
+      const response = await federation.fetch(
+        new Request(`${publicOrigin}/ap/actor/${profile.id}`, {
+          headers: { accept: 'application/activity+json' },
+        }),
+        { contextData: undefined },
+      );
+
+      assert.equal(response.status, 200);
+      return (await response.json()) as {
+        icon?: { mediaType?: string; type?: string; url?: string };
+        image?: { mediaType?: string; type?: string; url?: string };
+        manuallyApprovesFollowers?: boolean;
+        summary?: string;
+      };
+    };
+
+    const initial = await requestActor();
+    assert.equal(initial.icon, undefined);
+    assert.equal(initial.image, undefined);
+    assert.equal(initial.summary, undefined);
+    assert.equal(initial.manuallyApprovesFollowers, false);
+
+    await createLocalMedia({
+      kind: ProfileMediaKind.AVATAR,
+      profileId: profile.id,
+      state: MediaState.UPLOADING,
+    });
+    assert.equal((await requestActor()).icon, undefined);
+    await db.delete(ProfileMedia).where(eq(ProfileMedia.profileId, profile.id));
+
+    const otherProfile = await createProfile({ handle: 'other', instanceId: localInstanceId });
+    const otherAvatar = await createLocalMedia({
+      kind: ProfileMediaKind.AVATAR,
+      profileId: otherProfile.id,
+      url: 'https://media.example/other-avatar.png',
+    });
+    await db.insert(ProfileMedia).values({
+      kind: ProfileMediaKind.AVATAR,
+      mediaId: otherAvatar.id,
+      profileId: profile.id,
+    });
+    assert.equal((await requestActor()).icon, undefined);
+    await db.delete(ProfileMedia).where(eq(ProfileMedia.profileId, profile.id));
+
+    const firstAvatar = await createLocalMedia({
+      kind: ProfileMediaKind.AVATAR,
+      profileId: profile.id,
+      url: 'https://media.example/avatar-first.png',
+    });
+    assert.equal((await requestActor()).icon?.url, firstAvatar.url);
+
+    const replacementAvatar = await createLocalMedia({
+      link: false,
+      profileId: profile.id,
+      url: 'https://media.example/avatar-replacement.png',
+    });
+    await db
+      .update(ProfileMedia)
+      .set({ mediaId: replacementAvatar.id })
+      .where(
+        and(eq(ProfileMedia.profileId, profile.id), eq(ProfileMedia.kind, ProfileMediaKind.AVATAR)),
+      );
+    assert.equal((await requestActor()).icon?.url, replacementAvatar.url);
+
+    await db.delete(ProfileMedia).where(eq(ProfileMedia.profileId, profile.id));
+    const removed = await requestActor();
+    assert.equal(removed.icon, undefined);
+    assert.equal(removed.image, undefined);
+    assert.equal(removed.summary, undefined);
+    assert.equal(removed.manuallyApprovesFollowers, false);
   });
 
   test('serves count-only followers and following collections without creating actor keys', async () => {
@@ -410,6 +543,9 @@ const createRemoteInstance = async () =>
     .then((instance) => instance.id);
 
 const createProfile = async ({
+  bio,
+  displayName,
+  followPolicy = ProfileFollowPolicy.OPEN,
   followersCount,
   followingCount,
   handle,
@@ -417,6 +553,9 @@ const createProfile = async ({
   instanceId,
   state = ProfileState.ACTIVE,
 }: {
+  bio?: string | null;
+  displayName?: string;
+  followPolicy?: ProfileFollowPolicy;
   followersCount?: number;
   followingCount?: number;
   handle: string;
@@ -427,8 +566,9 @@ const createProfile = async ({
   db
     .insert(Profiles)
     .values({
-      displayName: handle,
-      followPolicy: ProfileFollowPolicy.OPEN,
+      bio,
+      displayName: displayName ?? handle,
+      followPolicy,
       ...(followersCount == null ? {} : { followersCount }),
       ...(followingCount == null ? {} : { followingCount }),
       handle,
@@ -439,3 +579,54 @@ const createProfile = async ({
     })
     .returning()
     .then(firstOrThrow);
+
+const createLocalMedia = async ({
+  kind,
+  link = true,
+  mediaType = 'image/png',
+  profileId,
+  state = MediaState.READY,
+  url = 'https://media.example/profile.png',
+}: {
+  kind?: ProfileMediaKind;
+  link?: boolean;
+  mediaType?: string;
+  profileId: string;
+  state?: MediaState;
+  url?: string;
+}) => {
+  const now = Temporal.Instant.from('2026-07-31T00:00:00Z');
+  const account = await db
+    .insert(Accounts)
+    .values({
+      displayName: 'Media owner',
+      oidcSubject: `actor-media-${crypto.randomUUID()}`,
+      state: AccountState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  const media = await db
+    .insert(Media)
+    .values({
+      accountId: account.id,
+      mediaType: state === MediaState.READY ? mediaType : null,
+      profileId,
+      readyAt: state === MediaState.READY ? now : null,
+      source: MediaSource.LOCAL,
+      state,
+      storageReference: `actor-media-${crypto.randomUUID()}`,
+      uploadExpiresAt: now.add({ hours: 1 }),
+      url: state === MediaState.READY ? url : null,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+  if (link) {
+    if (!kind) {
+      throw new Error('Profile media kind is required when linking media');
+    }
+    await db.insert(ProfileMedia).values({ kind, mediaId: media.id, profileId });
+  }
+
+  return media;
+};


### PR DESCRIPTION
## 무엇을 변경했는지

- Local actor projection이 Profile의 follow policy와 같은 Profile이 소유한 Ready Local avatar/header Media를 함께 조회합니다.
- canonical ActivityPub `Person`에 최신 displayName, bio, `icon`, `image`, `manuallyApprovesFollowers`를 제공합니다.
- 값 부재, Uploading·다른 Profile 소유 Media, 이미지 교체·제거와 기존 actor identity/key 재사용을 실제 actor HTTP 응답으로 검증합니다.
- PROD-628 OpenSpec change를 archive하고 active `activitypub-actor-discovery` spec에 동기화했습니다.

## 왜 변경했는지

기존 Local actor document는 Profile에 저장된 avatar, header와 Follow Approval Policy를 제공하지 않아 원격 서버가 actor를 다시 조회해도 현재 공개 프로필 표현을 알 수 없었습니다. 후속 `Update(Person)` 전달도 같은 완전한 projection을 재사용할 수 있도록 actor 표현 경계를 먼저 완성합니다.

- Linear: [PROD-628](https://linear.app/byulmaru/issue/PROD-628/activitypub-local-actor에-프로필-표현을-완전하게-제공한다)

## 이번 PR의 주요 결정

새로 내린 주요 결정은 없습니다. 최신 canonical 문서와 Linear를 대조한 [archived OpenSpec 결정](https://github.com/byulmaru/kosmo/blob/prod-628/openspec/changes/archive/2026-07-31-complete-activitypub-local-actor-profile/decisions.md)을 변경 없이 적용했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/fedify test` — 180개 통과
- `pnpm --filter @kosmo/fedify lint:tsc`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `openspec validate --all --strict` — 65개 통과
- `git diff --check`

## 아직 어떤 문제가 남았는지

- Profile 변경 시 outbound `Update(Person)`을 전달하는 동작은 이 PR에 포함하지 않습니다. [PROD-629](https://linear.app/byulmaru/issue/PROD-629/local-profile-변경을-activitypub-updateperson으로-전달한다)에서 이어서 구현합니다.
- transactional outbox와 durable retry는 기존 [PROD-448](https://linear.app/byulmaru/issue/PROD-448/activitypub-outbound-delivery-intent를-transactional-outbox와-fedify) 범위입니다.
