### PR TITLE
PostgreSQL이 환경과 관계없이 리소스를 보장받게 한다

### DIFF
--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -15,9 +15,9 @@ spec:
   instances: {{ ternary 3 1 (eq .Values.env "prod") }}
 {{- if eq .Values.env "dev" }}
   enablePDB: false
-  resources:
-{{ toYaml .Values.postgres.devResources | indent 4 }}
 {{- end }}
+  resources:
+{{ toYaml .Values.postgres.resources | indent 4 }}
 {{- if eq .Values.env "prod" }}
   serviceAccountName: kosmo-postgres-backup
   postgresql:

--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -15,6 +15,8 @@ spec:
   instances: {{ ternary 3 1 (eq .Values.env "prod") }}
 {{- if eq .Values.env "dev" }}
   enablePDB: false
+  resources:
+{{ toYaml .Values.postgres.devResources | indent 4 }}
 {{- end }}
 {{- if eq .Values.env "prod" }}
   serviceAccountName: kosmo-postgres-backup

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -135,6 +135,32 @@ for marker in "${dev_forbidden_markers[@]}"; do
   fi
 done
 
+if ! awk '
+  $0 == "kind: Cluster" { in_cluster = 1 }
+  in_cluster && $0 == "  resources:" { resources = 1 }
+  resources && $0 == "    limits:" { limits = 1; requests = 0; seen_limits = 1 }
+  resources && $0 == "    requests:" { requests = 1; limits = 0; seen_requests = 1 }
+  limits && $0 == "      cpu: 250m" { limit_cpu = 1 }
+  limits && $0 == "      memory: 1Gi" { limit_memory = 1 }
+  requests && $0 == "      cpu: 250m" { request_cpu = 1 }
+  requests && $0 == "      memory: 1Gi" { request_memory = 1 }
+  in_cluster && /^---$/ { exit }
+  END { exit !(resources && seen_limits && seen_requests && limit_cpu && limit_memory && request_cpu && request_memory) }
+' "${render_dir}/dev.yaml"; then
+  echo "dev PostgreSQL must render the expected resource requests and limits" >&2
+  exit 1
+fi
+
+if ! awk '
+  $0 == "kind: Cluster" { in_cluster = 1 }
+  in_cluster && $0 == "  resources:" { found = 1 }
+  in_cluster && /^---$/ { exit }
+  END { exit found }
+' "${render_dir}/prod.yaml"; then
+  echo "prod PostgreSQL unexpectedly inherited dev resource settings" >&2
+  exit 1
+fi
+
 if [[ "$(grep -Fc 'image: "ghcr.io/byulmaru/kosmo:main"' "${render_dir}/dev.yaml")" -ne 3 ]]; then
   echo "dev migration, API, and Web must keep the mutable main image" >&2
   exit 1

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -135,32 +135,6 @@ for marker in "${dev_forbidden_markers[@]}"; do
   fi
 done
 
-if ! awk '
-  $0 == "kind: Cluster" { in_cluster = 1 }
-  in_cluster && $0 == "  resources:" { resources = 1 }
-  resources && $0 == "    limits:" { limits = 1; requests = 0; seen_limits = 1 }
-  resources && $0 == "    requests:" { requests = 1; limits = 0; seen_requests = 1 }
-  limits && $0 == "      cpu: 250m" { limit_cpu = 1 }
-  limits && $0 == "      memory: 1Gi" { limit_memory = 1 }
-  requests && $0 == "      cpu: 250m" { request_cpu = 1 }
-  requests && $0 == "      memory: 1Gi" { request_memory = 1 }
-  in_cluster && /^---$/ { exit }
-  END { exit !(resources && seen_limits && seen_requests && limit_cpu && limit_memory && request_cpu && request_memory) }
-' "${render_dir}/dev.yaml"; then
-  echo "dev PostgreSQL must render the expected resource requests and limits" >&2
-  exit 1
-fi
-
-if ! awk '
-  $0 == "kind: Cluster" { in_cluster = 1 }
-  in_cluster && $0 == "  resources:" { found = 1 }
-  in_cluster && /^---$/ { exit }
-  END { exit found }
-' "${render_dir}/prod.yaml"; then
-  echo "prod PostgreSQL unexpectedly inherited dev resource settings" >&2
-  exit 1
-fi
-
 if [[ "$(grep -Fc 'image: "ghcr.io/byulmaru/kosmo:main"' "${render_dir}/dev.yaml")" -ne 3 ]]; then
   echo "dev migration, API, and Web must keep the mutable main image" >&2
   exit 1

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -10,3 +10,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
 migration:
   enabled: false
+postgres:
+  devResources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 250m
+      memory: 1Gi

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -11,7 +11,7 @@ autoscaling:
 migration:
   enabled: false
 postgres:
-  devResources:
+  resources:
     requests:
       cpu: 250m
       memory: 1Gi


### PR DESCRIPTION
## 무엇을 변경했는지

- 모든 환경의 CloudNativePG Cluster에 CPU 250m, 메모리 1Gi를 요청량과 제한량으로 동일하게 설정했습니다.
- 공통 `postgres.resources` 값을 Cluster `spec.resources`에 적용합니다.

## 왜 변경했는지

PostgreSQL Pod가 resource request/limit 없이 BestEffort QoS로 실행되고 있었습니다. 노드 자원 경합 시 DB probe가 지연되어 liveness 재시작으로 이어질 수 있으므로, 환경과 관계없이 DB가 스케줄링 단계부터 리소스를 확보하고 Guaranteed QoS로 보호받게 합니다.

## 이번 PR의 주요 결정

### 모든 PostgreSQL 환경에 Guaranteed QoS 적용

- 결정자: PR 작성자
- 선택: CPU 250m와 메모리 1Gi를 request/limit에 동일하게 적용
- 고려한 대안: dev에만 적용하거나 request보다 큰 limit을 설정
- 이유: DB 리소스 격리는 환경별 예외가 아니라 공통 운영 기준이어야 하며, 동일한 request/limit이 Guaranteed QoS 조건을 충족합니다.
- 감수한 결과: 기존 과밀 노드에는 배치되지 않을 수 있어 Karpenter가 추가 용량을 마련해야 합니다.
- 관련 근거: 2026-07-31 dev 장애의 Kubernetes 이벤트, Pod 상태와 Prometheus 노드 메트릭

Linear 이슈와 OpenSpec은 요청에 따라 만들지 않았습니다.

## 어떻게 확인할 수 있는지

문자열 비교 기반 렌더 테스트는 추가하지 않았습니다.

- dev Helm lint 통과
- production Helm lint 통과
- dev Helm template 렌더 성공
- production Helm template 렌더 성공
- `git diff --check` 통과

## 아직 어떤 문제가 남았는지

- 적용 시 PostgreSQL Pod 재생성 및 재스케줄링이 발생할 수 있습니다.
- 배포 후 각 환경의 PostgreSQL Pod `status.qosClass`가 `Guaranteed`인지 최종 확인해야 합니다.