### PR TITLE
Local Profile 변경을 ActivityPub Update로 전달한다

### DIFF
--- a/apps/api/src/graphql/resolvers/profile/mutation/update.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/update.ts
@@ -23,17 +23,20 @@ builder.mutationField('updateProfile', (t) =>
     },
     resolve: async (_, { input }, ctx) => {
       try {
+        const result = await updateProfile({
+          accountId: ctx.session.accountId,
+          profileId: ctx.session.profileId,
+          displayName: input.displayName ?? undefined,
+          bio: input.bio,
+          followPolicy: input.followPolicy ?? undefined,
+          tags: input.tags,
+          avatarMediaId: input.avatarId === undefined ? undefined : (input.avatarId?.id ?? null),
+          headerMediaId: input.headerId === undefined ? undefined : (input.headerId?.id ?? null),
+        });
+        await result.postCommit();
+
         return {
-          profile: await updateProfile({
-            accountId: ctx.session.accountId,
-            profileId: ctx.session.profileId,
-            displayName: input.displayName ?? undefined,
-            bio: input.bio,
-            followPolicy: input.followPolicy ?? undefined,
-            tags: input.tags,
-            avatarMediaId: input.avatarId === undefined ? undefined : (input.avatarId?.id ?? null),
-            headerMediaId: input.headerId === undefined ? undefined : (input.headerId?.id ?? null),
-          }),
+          profile: result.profile,
         };
       } catch (error) {
         if (

--- a/apps/api/tests/integration/graphql/profile.test.ts
+++ b/apps/api/tests/integration/graphql/profile.test.ts
@@ -955,6 +955,62 @@ describe('GraphQL remote profile boundary', () => {
     });
   });
 
+  test('Profile Update delivery 실패 뒤에도 committed GraphQL payload를 반환한다', async () => {
+    const auth = await createAuthenticatedSession();
+    const remoteInstance = await createRemoteInstance({ domain: 'profile-update.remote.example' });
+    const remote = await createProfile({
+      handle: 'profile-update-follower',
+      instanceId: remoteInstance.id,
+    });
+    await createRemoteActor(remote.id, remoteInstance.domain);
+    await db.insert(ProfileFollows).values({
+      followeeProfileId: auth.profile.id,
+      followerProfileId: remote.id,
+    });
+    const delivery = mock.method(globalThis, 'fetch', async () => {
+      throw new Error('delivery failed');
+    });
+    const errorLog = mock.method(console, 'error', () => undefined);
+
+    try {
+      const result = await requestGraphQL<{
+        updateProfile: { profile: { bio: string | null; id: string } };
+      }>(
+        `mutation UpdateProfileAfterDeliveryFailure {
+          updateProfile(input: { bio: "Committed bio" }) {
+            profile { bio id }
+          }
+        }`,
+        {},
+        auth.token,
+      );
+
+      assertNoGraphQLErrors(result);
+      assert.deepEqual(result.data?.updateProfile.profile, {
+        bio: 'Committed bio',
+        id: globalId('Profile', auth.profile.id),
+      });
+      assert.ok(delivery.mock.callCount() > 0);
+      assert.equal(errorLog.mock.callCount(), 1);
+      assert.equal(
+        errorLog.mock.calls[0]?.arguments[0],
+        'Post-commit ActivityPub Local Profile Update delivery failed',
+      );
+      assert.equal(
+        await db
+          .select({ bio: Profiles.bio })
+          .from(Profiles)
+          .where(eq(Profiles.id, auth.profile.id))
+          .then(firstOrThrow)
+          .then(({ bio }) => bio),
+        'Committed bio',
+      );
+    } finally {
+      delivery.mock.restore();
+      errorLog.mock.restore();
+    }
+  });
+
   test('returns only the selected editable local Owner Profile without exposing auth errors', async () => {
     const guest = await requestGraphQL<{
       selectedProfileForEdit: { id: string } | null;

--- a/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-07-31

--- a/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/decisions.md
+++ b/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/decisions.md
@@ -1,0 +1,101 @@
+## Context
+
+PROD-629와 canonical Profile/core service 계약을 ActivityPub Local Profile Update delivery spec과 구현 경계로
+번역한다. PROD-628의 canonical `Person`, PROD-512의 recipient dispatcher와 현재 Reaction post-commit 선례를
+함께 적용한다.
+
+## Decision Records
+
+### 실제 canonical actor 표현 변경만 Update lifecycle을 만든다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, `PROD-629`
+- Status: Active
+- Context / Problem: update input이 존재하거나 SQL UPDATE가 실행됐다는 사실만으로는 원격 actor 표현이 달라졌다고
+  볼 수 없다. 같은 값 재저장과 Profile Tag 전용 변경은 canonical `Person`을 바꾸지 않는다.
+- Decision Outcome: 정규화된 displayName/bio, Follow Approval Policy와 avatar/header Media relation의 write 전
+  current value를 비교해 하나라도 달라질 때만 Update lifecycle을 만든다.
+- Alternatives Considered: input field 존재, UPDATE row count 또는 모든 Profile edit를 trigger로 사용. no-op과
+  projection 비대상 변경까지 불필요한 Update를 만들므로 채택하지 않는다.
+- Consequences: 실제 actor 표현 변경과 delivery lifecycle이 일치한다. change 판정은 같은 Profile update
+  transaction 안에서 수행해야 한다.
+- Confirmation / Follow-up: scalar·Media 교체/제거, same-value, omitted, Tag-only와 rollback test로 검증한다.
+
+### Profile update는 명시적 one-shot post-commit lifecycle을 반환한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/architecture/core-services.md`, `PROD-629`
+- Status: Active
+- Context / Problem: caller-owned transaction에는 after-commit hook이 없으며 `tx` 유무로 lifecycle을 생략하면 같은
+  domain action이 caller에 따라 다른 결과를 만든다. transaction 안에서 delivery하면 rollback된 변경이 외부로
+  나갈 수 있다.
+- Decision Outcome: `updateProfile`은 Profile과 동일 Promise를 재사용하는 `postCommit()` lifecycle을 함께
+  반환한다. transaction 유무와 무관하게 actual change가 lifecycle을 결정하며 transaction owner가 outer commit 뒤
+  실행한다.
+- Alternatives Considered: `tx`가 없을 때만 core 내부 delivery, transaction 안 direct delivery, optional callback
+  injection. 각각 caller-owned lifecycle 누락, rollback 외부 노출 또는 필수 lifecycle 우회 가능한 public contract를
+  만들므로 채택하지 않는다.
+- Consequences: GraphQL resolver가 lifecycle을 명시적으로 실행해야 하며 다른 caller transaction도 commit 조정을
+  소유한다. repeated call은 추가 delivery를 시작하지 않는다.
+- Confirmation / Follow-up: top-level/outer transaction, rollback, repeated/concurrent invocation과 delivery failure
+  test로 검증한다.
+
+### Embedded Person은 canonical Local actor projection을 재사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, `PROD-628`, `PROD-629`
+- Status: Active
+- Context / Problem: actor dispatcher와 outbound Update가 별도 object serializer를 가지면 optional 이미지, follow
+  policy, identity와 key 표현이 갈라질 수 있다.
+- Decision Outcome: Update delivery 시점에 committed DB 상태를 다시 읽고 PROD-628의 Fedify `Person` projection
+  경계를 재사용한다. Update actor, embedded object ID와 followers audience는 같은 local actor identity에서 만든다.
+- Alternatives Considered: update transaction input으로 inline JSON 생성, Update 전용 `Person` projection. 최신
+  committed state와 actor 역참조의 단일 표현 계약을 깨므로 채택하지 않는다.
+- Consequences: 연속 edit가 있으면 delivery 시작 시점의 최신 actor 표현을 전달할 수 있다. key lazy 생성과 endpoint
+  identity도 기존 경계를 따른다.
+- Confirmation / Follow-up: actor/object identity, scalar·Media·policy와 key/endpoint 회귀를 Fedify test로 검증한다.
+
+### Profile Update activity마다 새로운 IRI를 사용한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-629`
+- Status: Active
+- Context / Problem: 하나의 Local Profile은 여러 번 변경될 수 있다. 고정된 `#update` IRI를 반복 사용하면 remote
+  server가 이후 Update를 이미 처리한 activity로 중복 제거할 수 있다.
+- Decision Outcome: actual Profile update lifecycle마다 actor URI 아래 UUID를 포함한 새로운 Update activity IRI를
+  만들고, 같은 one-shot lifecycle의 반복 호출에서는 처음 만든 activity와 실행 Promise를 재사용한다.
+- Alternatives Considered: actor별 고정 Update IRI, wall-clock timestamp, 별도 durable activity row. 고정 IRI는
+  remote deduplication 충돌이 있고 timestamp는 동시성 identity로 불충분하며 durable row는 PROD-448 범위를
+  선행 구현하므로 채택하지 않는다.
+- Consequences: direct delivery의 각 update event는 구분되지만 activity 역참조와 durable retry identity는 제공하지
+  않는다. UUID는 domain row나 GraphQL contract에 저장하지 않는다.
+- Confirmation / Follow-up: 서로 다른 update 결과의 activity ID 차이와 동일 lifecycle repeated call 단일 delivery를
+  검증한다.
+
+### Direct delivery failure와 유실 창을 committed Profile에서 격리한다
+
+- Decision Date: 2026-07-31
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/architecture/core-services.md`, `PROD-448`, `PROD-629`
+- Status: Active
+- Context / Problem: remote HTTP 실패는 이미 commit된 Profile을 rollback할 수 없고, 현재 direct delivery에는
+  durable intent가 없다.
+- Decision Outcome: projection/delivery failure를 Profile ID와 함께 기록하고 post-commit lifecycle은 성공적으로
+  resolve해 GraphQL 결과를 유지한다. process 종료·retry·ordering 보장은 제공하지 않는다.
+- Alternatives Considered: GraphQL failure 반환, 보상 rollback, PROD-448 완료까지 기능 보류. commit된 상태와 응답
+  불일치 또는 독립 delivery slice 지연을 만들므로 채택하지 않는다.
+- Consequences: 원격 서버가 일부 Update를 놓칠 수 있으며 actor 재조회 전까지 stale 표현을 유지할 수 있다.
+  durable 보장은 PROD-448로 남는다.
+- Confirmation / Follow-up: follower 없음, remote failure와 committed GraphQL payload 유지 test로 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/design.md
+++ b/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/design.md
@@ -1,0 +1,95 @@
+## Context
+
+`updateProfile`은 optional caller transaction에 참여해 Profile scalar, ProfileMedia와 Profile Tag를 원자적으로
+저장하고 현재 Profile row를 반환한다. 현재 actual actor projection 변경 여부를 구분하지 않으며 commit 이후
+side effect도 없다. `addReaction`/`deleteReaction`은 transaction 유무와 독립적으로 one-shot `postCommit()`
+lifecycle을 반환하고 entry point가 commit 뒤 실행하는 선례를 제공한다.
+
+PROD-628은 Local Profile, Ready Local avatar/header, follow policy와 key/endpoint를 canonical Fedify `Person`으로
+만드는 경계를 완성했다. PROD-512의 dispatcher는 author followers를 active remote ActivityPub recipient로 확장하고
+actor/shared inbox 중복과 empty recipient를 처리한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- actual federation-visible Profile 변경만 post-commit lifecycle로 표현한다.
+- caller-owned transaction에서도 lifecycle을 유지하고 outer commit 뒤 실행할 수 있게 한다.
+- canonical Local `Person`과 공통 recipient dispatcher를 재사용해 `Update(Person)`을 전달한다.
+- direct delivery 실패를 committed application 결과에서 격리하고 관측한다.
+
+**Non-Goals:**
+
+- Profile Tag·Link ActivityPub 표현, actor Delete/Tombstone, GraphQL schema 또는 UI 변경
+- transactional outbox, durable retry/history, worker와 process 종료 유실 방지
+- remote inbound Update와 Local actor projection 자체 변경
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `updateProfile`의 scalar input은 생략과 명시 값을 구분하지만 같은 저장값을 명시해도 현재 UPDATE를 실행한다.
+- avatar/header change 판정에는 write 전 ProfileMedia의 현재 media ID가 필요하다. 관계 제거 대상이 이미 없거나
+  같은 Media ID를 다시 지정한 경우는 delivery no-op이어야 한다.
+- Profile Tag 변경은 같은 transaction에 포함되지만 canonical ActivityPub actor projection에는 포함되지 않는다.
+- caller-owned Drizzle transaction에는 after-commit hook이 없으므로 core가 remote I/O를 transaction 안에서
+  실행할 수 없다.
+- outbound delivery는 commit 뒤 최신 DB projection을 다시 읽어야 하며 update transaction에서 조립한 임시
+  `Person`을 전달하면 actor 역참조와 representation 경계가 갈라진다.
+- 하나의 Profile은 여러 번 수정될 수 있으므로 고정된 Update activity ID를 반복 사용하면 remote deduplication이
+  이후 변경을 버릴 수 있다.
+
+### Recommended Approach
+
+1. `updateProfile` transaction에서 현재 scalar와 avatar/header Media relation을 읽고 정규화된 요청값과 비교해
+   actor projection change flag를 계산한다. 기존 validation과 원자 write 경계는 유지한다.
+2. action 결과를 `{ profile, postCommit }`으로 확장한다. change flag가 없으면 no-op lifecycle을, 있으면 동일
+   Promise를 재사용하는 one-shot lifecycle을 반환한다. transaction 유무로 lifecycle 생성 여부를 분기하지 않는다.
+3. GraphQL resolver는 core action 결과를 받은 뒤 `postCommit()`을 await하고 기존 payload에는 `profile`만
+   mapping한다. caller-owned transaction은 transaction owner가 outer commit 뒤 같은 lifecycle을 실행한다.
+4. post-commit effect는 Fedify delivery helper를 동적 import해 호출하고, 실패를 Profile ID와 함께 기록한 뒤
+   resolve한다.
+5. delivery helper는 Active Local Profile과 canonical origin을 확인하고 Local outbound context를 만든다. PROD-628
+   저장 projection과 `createLocalProfilePerson` 경계를 통해 최신 embedded `Person`을 만들고, unique Update IRI와
+   followers audience를 갖는 `Update`를 구성한다.
+6. `dispatchActivityPubActivity`에 direct target 없이 author Profile ID를 전달해 established remote followers만
+   확장·중복 제거하고 shared inbox preference로 전송한다.
+
+### Allowed Alternatives
+
+- 기존 actor dispatcher와 outbound helper가 공유하는 더 높은 수준의 Local `Person` projection helper를 추출할
+  수 있다. 다만 현재 production caller가 실제로 사용하고 identity/key/optional field 규칙을 우회할 수 없어야 한다.
+- actor projection change 판정은 관계 조회와 scalar 조회를 한 statement로 합치거나 동일 transaction의 별도
+  bounded query로 수행할 수 있다. write 전 current state와 비교하고 원자성·검증 순서를 유지해야 한다.
+
+### Known Traps
+
+- `tx` 존재 여부로 Update lifecycle을 생략하거나 origin을 추론하지 않는다.
+- outer commit 전에 `postCommit()` 또는 Fedify remote I/O를 실행하지 않는다.
+- input field 존재만으로 change를 판정하지 않고 정규화 후 저장 current value와 비교한다.
+- Profile Tag 변경을 actor Update trigger로 확대하지 않는다.
+- update transaction 안의 임시 object나 별도 JSON serializer로 embedded `Person`을 만들지 않는다.
+- Profile Update마다 같은 activity ID를 재사용하지 않는다.
+- delivery 실패를 GraphQL error로 다시 throw하거나 committed Profile을 보상 rollback하지 않는다.
+
+## Risks / Trade-offs
+
+- [Risk] commit 뒤 delivery 시작 전 process가 종료되면 Update가 유실된다. → PROD-448의 durable outbox 범위로
+  명시하고 현재 direct-delivery slice의 선행 조건으로 만들지 않는다.
+- [Risk] 연속 Profile update의 HTTP delivery 완료 순서는 보장되지 않는다. → embedded object는 delivery 시작 시
+  최신 committed projection을 읽고, durable ordering은 outbox/worker 설계로 미룬다.
+- [Risk] `postCommit()` 반환 contract를 caller가 실행하지 않으면 delivery가 누락된다. → production GraphQL caller를
+  같은 PR에서 연결하고 caller-owned transaction test로 실행 책임을 명시한다.
+- [Risk] Update projection 중 key가 처음 생성될 수 있다. → PROD-628의 기존 lazy key identity 경계를 재사용하고
+  별도 key lifecycle을 만들지 않는다.
+
+## Migration Plan
+
+1. additive code와 test만 배포하며 DB/GraphQL schema migration은 없다.
+2. 기존 Profile update 응답 shape를 유지한 채 post-commit delivery를 활성화한다.
+3. rollback은 delivery lifecycle 연결을 제거하는 코드 rollback으로 수행한다. 이미 원격에 전달된 Update를
+   회수하거나 보상 activity로 되돌리지는 않는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/proposal.md
+++ b/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Local Profile 편집은 federation-visible actor 표현을 DB에 commit하지만 원격 follower에게 변경을 알리는
+ActivityPub lifecycle이 없다. PROD-628이 완성한 canonical `Person` projection을 재사용해 실제 표현 변경만
+`Update(Person)`으로 전달해야 한다.
+
+## What Changes
+
+- displayName, bio, avatar, header 또는 Follow Approval Policy가 실제로 달라진 Local Profile update에만
+  post-commit ActivityPub delivery lifecycle을 만든다.
+- stable local actor identity와 PROD-628의 canonical `Person`을 사용하는 `Update(Person)` activity를 구성한다.
+- 공통 outbound recipient dispatcher로 active ActivityPub remote followers에게 direct delivery하고 actor와
+  shared inbox 중복을 제거한다.
+- rollback, validation 실패, no-op, Profile Tag 전용 변경과 follower 부재에서는 delivery를 시작하지 않는다.
+- delivery 실패를 committed Profile과 GraphQL 성공 결과에서 격리해 관측한다.
+- caller-owned transaction은 lifecycle을 반환하고 transaction owner가 outer commit 뒤 명시적으로 실행한다.
+- transactional outbox, durable retry와 process 종료 시 유실 방지는 PROD-448에 남긴다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`
+- Linear Contract: `PROD-629`
+- Linear Implementations: `PROD-629`
+
+## Capabilities
+
+### New Capabilities
+
+- `activitypub-local-profile-update-delivery`: committed Local Profile actor 표현 변경을 canonical
+  `Update(Person)`으로 remote followers에게 전달하는 lifecycle
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- Core: `updateProfile`의 실제 actor projection 변경 판정과 명시적 post-commit lifecycle 결과
+- Fedify: canonical Local `Person` 재사용, `Update` activity identity와 공통 recipient dispatch
+- API: GraphQL `updateProfile` commit 뒤 post-commit lifecycle 실행과 실패 격리
+- Verification: core transaction/no-op/rollback, Fedify projection·recipient, GraphQL 성공 결과 회귀 테스트
+- 제외 시스템: GraphQL schema·Profile 편집 UI, Profile Tag/Link ActivityPub 표현, transactional outbox와 worker

--- a/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/specs/activitypub-local-profile-update-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/specs/activitypub-local-profile-update-delivery/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: Federation-visible Profile 변경 판정
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-629`; MUST 준수한다.
+
+시스템은 Local Profile update가 canonical ActivityPub actor 표현을 실제로 변경한 경우에만 outbound Profile
+Update lifecycle을 만드는 것을 MUST 보장한다.
+
+#### Scenario: Scalar actor 표현 변경
+
+- **WHEN** Local Profile의 displayName, bio 또는 Follow Approval Policy가 저장된 현재 값과 다른 값으로 commit된다
+- **THEN** 시스템은 해당 Profile을 위한 outbound Update lifecycle을 만든다
+
+#### Scenario: Avatar 또는 header 관계 변경
+
+- **WHEN** Local Profile의 avatar 또는 header Media 관계가 다른 Ready Local Media로 교체되거나 제거되어 commit된다
+- **THEN** 시스템은 해당 Profile을 위한 outbound Update lifecycle을 만든다
+
+#### Scenario: Actor 표현 no-op
+
+- **WHEN** 요청된 displayName, bio, Follow Approval Policy, avatar와 header가 저장된 actor 표현과 모두 같다
+- **THEN** 시스템은 outbound Update lifecycle을 만들지 않는다
+- **AND** 같은 값의 명시적 입력과 생략된 입력을 delivery 관점에서 동일한 no-op으로 취급한다
+
+#### Scenario: Projection 비대상 변경
+
+- **WHEN** Profile Tag처럼 현재 canonical actor projection에 포함되지 않는 값만 commit된다
+- **THEN** 시스템은 outbound Update lifecycle을 만들지 않는다
+
+### Requirement: Commit 이후 Profile Update lifecycle
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-629`; 이 요구사항을 MUST 준수한다.
+
+시스템은 Profile 변경 transaction이 성공적으로 commit된 뒤에만 outbound ActivityPub Profile Update를 실행하고,
+caller-owned transaction에서도 lifecycle을 생략하거나 outer commit 전에 원격 I/O를 수행하지 않는 것을 MUST
+보장한다.
+
+#### Scenario: Top-level Profile update commit
+
+- **WHEN** application이 별도 caller transaction 없이 federation-visible Local Profile 변경을 commit한다
+- **THEN** action은 commit된 결과와 실행 가능한 post-commit lifecycle을 반환한다
+- **AND** GraphQL entry는 mutation 결과를 반환하기 전에 그 lifecycle을 실행한다
+
+#### Scenario: Caller-owned transaction commit
+
+- **WHEN** application이 caller-owned transaction 안에서 federation-visible Local Profile 변경을 수행한다
+- **THEN** action은 transaction 존재 여부와 무관하게 같은 post-commit lifecycle을 반환한다
+- **AND** transaction owner는 outer commit이 성공한 뒤 lifecycle을 실행한다
+- **AND** outer commit 전에는 Fedify delivery 또는 remote HTTP I/O를 수행하지 않는다
+
+#### Scenario: Validation failure 또는 rollback
+
+- **WHEN** Profile update가 validation·authorization 실패로 거부되거나 포함된 transaction이 rollback된다
+- **THEN** 시스템은 해당 미반영 변경을 위한 ActivityPub Update를 만들거나 전달하지 않는다
+
+#### Scenario: Repeated lifecycle invocation
+
+- **WHEN** 같은 action 결과의 post-commit lifecycle을 반복 또는 동시에 호출한다
+- **THEN** 시스템은 같은 실행 Promise를 재사용한다
+- **AND** 그 action 결과를 위한 direct delivery를 둘 이상 시작하지 않는다
+
+### Requirement: Canonical Update Person projection
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `PROD-628`, `PROD-629`; 이 요구사항을 MUST 준수한다.
+
+시스템은 committed Local Profile의 stable actor identity와 canonical `Person` projection을 재사용한
+ActivityPub `Update(Person)`을 구성하는 것을 MUST 보장한다.
+
+#### Scenario: Construct Local Profile Update
+
+- **WHEN** federation-visible Local Profile 변경의 post-commit lifecycle이 실행된다
+- **THEN** `Update.actor`는 변경된 Profile의 canonical local actor URI다
+- **AND** embedded `Update.object`는 PROD-628의 canonical `Person` projection이다
+- **AND** embedded `Person.id`는 `Update.actor`와 같다
+- **AND** Update는 해당 actor의 followers collection을 audience로 표현한다
+
+#### Scenario: Preserve latest committed representation
+
+- **WHEN** displayName, bio, avatar, header 또는 Follow Approval Policy 변경 뒤 Update를 구성한다
+- **THEN** embedded `Person`은 delivery 시점의 최신 committed Profile/Media 표현을 사용한다
+- **AND** actor dispatcher와 다른 전용 JSON projection을 만들지 않는다
+- **AND** actor key identity, inbox/outbox, followers/following과 shared inbox identity를 변경하지 않는다
+
+### Requirement: Remote follower direct delivery
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-512`, `PROD-629`; MUST 준수한다.
+
+시스템은 Local Profile Update를 공통 outbound recipient dispatcher를 통해 usable established ActivityPub remote
+followers에게 직접 전달하고, follower 부재와 delivery 실패를 committed Profile 결과에서 격리하는 것을 MUST
+보장한다.
+
+#### Scenario: Deliver to active remote followers
+
+- **WHEN** 변경된 Local Profile에 usable established ActivityPub remote follower가 있다
+- **THEN** 시스템은 공통 recipient dispatcher로 같은 Update activity를 전달한다
+- **AND** 동일 actor는 한 recipient로 중복 제거한다
+- **AND** 유효한 shared inbox가 있으면 Fedify shared inbox preference를 적용한다
+
+#### Scenario: No remote followers
+
+- **WHEN** 변경된 Local Profile에 usable established ActivityPub remote follower가 없다
+- **THEN** 시스템은 remote HTTP delivery를 호출하지 않는다
+- **AND** committed Profile update를 성공 결과로 유지한다
+
+#### Scenario: Delivery failure isolation
+
+- **WHEN** commit 이후 Update projection 또는 remote delivery가 실패한다
+- **THEN** 시스템은 Profile ID와 오류를 post-commit 관측 경계에 기록한다
+- **AND** committed Profile과 GraphQL mutation 성공 결과를 rollback하거나 실패로 바꾸지 않는다
+
+#### Scenario: Accepted direct-delivery loss window
+
+- **WHEN** application process가 Profile commit 이후 direct delivery 시작 또는 완료 전에 종료된다
+- **THEN** 이번 capability는 durable intent, retry 또는 delivery history를 보장하지 않는다
+- **AND** 해당 보장은 PROD-448의 transactional outbox와 worker 범위에 남는다

--- a/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/tasks.md
+++ b/openspec/changes/archive/2026-07-31-deliver-activitypub-local-profile-update/tasks.md
@@ -1,0 +1,94 @@
+## 1. PROD-629 Profile update change 판정과 post-commit lifecycle
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/architecture/core-services.md`
+- `PROD-629`
+
+**Deliverable**
+
+Local Profile의 canonical actor 표현이 실제로 바뀐 commit만 one-shot post-commit lifecycle을 반환하고, transaction
+owner가 outer commit 뒤 안전하게 실행할 수 있다.
+
+**Guardrails**
+
+- transaction 인자 존재 여부로 lifecycle을 선택하거나 생략하지 않는다.
+- normalized current value와 avatar/header relation을 기준으로 actual change를 판정한다.
+- Profile Tag 전용 변경, same-value, omitted input, validation 실패와 rollback은 Update delivery를 만들지 않는다.
+- remote I/O를 Profile update transaction 안에서 실행하지 않는다.
+
+**Verification**
+
+- scalar·policy·Media 교체/제거, same-value·Tag-only·no-op, validation/rollback과 caller-owned transaction을 core
+  service test로 검증한다.
+- repeated/concurrent `postCommit()`이 같은 Promise와 단일 실행을 유지하는지 확인한다.
+
+- [x] 1.1 Profile scalar와 avatar/header 관계의 write 전 current value를 기준으로 federation-visible actual change를 판정한다.
+- [x] 1.2 Profile update 결과가 transaction 유무와 독립적인 no-op 또는 one-shot post-commit lifecycle을 제공하게 한다.
+- [x] 1.3 actual change·no-op·Tag-only·rollback·caller-owned transaction과 lifecycle 반복 호출을 core test로 검증한다.
+
+## 2. PROD-629 Canonical Update(Person) remote follower delivery
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/architecture/core-services.md`
+- `PROD-512`
+- `PROD-628`
+- `PROD-629`
+
+**Deliverable**
+
+committed Local Profile actor 표현 변경이 unique ActivityPub `Update`와 최신 canonical embedded `Person`으로
+usable established remote followers에게 전달된다.
+
+**Guardrails**
+
+- Update actor와 embedded object ID는 같은 stable local actor identity를 사용한다.
+- embedded object는 PROD-628의 canonical Fedify `Person` projection을 재사용한다.
+- 각 actual update lifecycle은 remote deduplication과 충돌하지 않는 새로운 activity IRI를 사용한다.
+- followers audience와 recipient expansion은 공통 outbound dispatcher를 사용한다.
+- follower 없음은 remote HTTP no-op이며 Profile update를 실패시키지 않는다.
+- Profile Tag·Link, actor Delete와 durable outbox 범위를 추가하지 않는다.
+
+**Verification**
+
+- Update identity, audience, scalar·avatar/header·policy projection과 서로 다른 update ID를 Fedify test로 검증한다.
+- active/unavailable follower, follower 없음, actor/shared inbox 중복과 delivery failure를 실제 dispatcher 경계에서
+  확인한다.
+
+- [x] 2.1 committed Local Profile을 최신 canonical `Person`으로 투영하고 unique `Update(Person)` activity를 구성한다.
+- [x] 2.2 공통 recipient dispatcher를 통해 established active ActivityPub remote followers에게 전달한다.
+- [x] 2.3 identity·audience·projection·unique ID와 follower eligibility·중복·empty·failure 경로를 Fedify test로 검증한다.
+
+## 3. PROD-629 GraphQL 연결, 실패 격리와 완료 검증
+
+**Authority / Provenance**
+
+- `docs/architecture/core-services.md`
+- `PROD-448`
+- `PROD-629`
+
+**Deliverable**
+
+GraphQL Profile update가 commit 뒤 lifecycle을 실행하고 direct delivery 실패에도 기존 성공 payload를 유지하며,
+구현과 active OpenSpec 계약이 동기화된다.
+
+**Guardrails**
+
+- GraphQL schema와 Profile 편집 UI를 변경하지 않는다.
+- projection/delivery 실패는 Profile ID와 오류를 관측 가능하게 남기고 committed result를 실패로 바꾸지 않는다.
+- process 종료 유실, retry, ordering과 delivery history를 보장하지 않는다.
+- 전체 task와 검증이 완료되기 전에는 change를 archive하지 않는다.
+
+**Verification**
+
+- GraphQL 성공 payload, no-op과 injected delivery failure를 API integration test로 검증한다.
+- core/API/fedify test, typecheck/lint/formatting과 OpenSpec strict validation을 통과한다.
+- delta spec을 active spec에 동기화하고 archive 후 strict validation을 다시 확인한다.
+
+- [x] 3.1 GraphQL update entry가 commit된 core 결과의 post-commit lifecycle을 실행하고 기존 payload shape를 유지하게 한다.
+- [x] 3.2 delivery failure가 committed Profile과 GraphQL 성공을 바꾸지 않고 관측되는지 통합 검증한다.
+- [x] 3.3 관련 core/API/fedify test와 typecheck·lint·formatting 검사를 통과시킨다.
+- [x] 3.4 OpenSpec strict validation과 diff를 검토하고 전체 task 완료 뒤 active spec 동기화·archive를 수행한다.

--- a/openspec/specs/activitypub-local-profile-update-delivery/spec.md
+++ b/openspec/specs/activitypub-local-profile-update-delivery/spec.md
@@ -1,0 +1,123 @@
+# activitypub-local-profile-update-delivery Specification
+
+## Purpose
+
+Local Profile의 federation-visible 표현 변경을 commit 이후 canonical ActivityPub `Update(Person)`으로
+active remote follower에게 전달하는 계약을 정의한다.
+
+## Requirements
+
+### Requirement: Federation-visible Profile 변경 판정
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-629`; MUST 준수한다.
+
+시스템은 Local Profile update가 canonical ActivityPub actor 표현을 실제로 변경한 경우에만 outbound Profile
+Update lifecycle을 만드는 것을 MUST 보장한다.
+
+#### Scenario: Scalar actor 표현 변경
+
+- **WHEN** Local Profile의 displayName, bio 또는 Follow Approval Policy가 저장된 현재 값과 다른 값으로 commit된다
+- **THEN** 시스템은 해당 Profile을 위한 outbound Update lifecycle을 만든다
+
+#### Scenario: Avatar 또는 header 관계 변경
+
+- **WHEN** Local Profile의 avatar 또는 header Media 관계가 다른 Ready Local Media로 교체되거나 제거되어 commit된다
+- **THEN** 시스템은 해당 Profile을 위한 outbound Update lifecycle을 만든다
+
+#### Scenario: Actor 표현 no-op
+
+- **WHEN** 요청된 displayName, bio, Follow Approval Policy, avatar와 header가 저장된 actor 표현과 모두 같다
+- **THEN** 시스템은 outbound Update lifecycle을 만들지 않는다
+- **AND** 같은 값의 명시적 입력과 생략된 입력을 delivery 관점에서 동일한 no-op으로 취급한다
+
+#### Scenario: Projection 비대상 변경
+
+- **WHEN** Profile Tag처럼 현재 canonical actor projection에 포함되지 않는 값만 commit된다
+- **THEN** 시스템은 outbound Update lifecycle을 만들지 않는다
+
+### Requirement: Commit 이후 Profile Update lifecycle
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-629`; 이 요구사항을 MUST 준수한다.
+
+시스템은 Profile 변경 transaction이 성공적으로 commit된 뒤에만 outbound ActivityPub Profile Update를 실행하고,
+caller-owned transaction에서도 lifecycle을 생략하거나 outer commit 전에 원격 I/O를 수행하지 않는 것을 MUST
+보장한다.
+
+#### Scenario: Top-level Profile update commit
+
+- **WHEN** application이 별도 caller transaction 없이 federation-visible Local Profile 변경을 commit한다
+- **THEN** action은 commit된 결과와 실행 가능한 post-commit lifecycle을 반환한다
+- **AND** GraphQL entry는 mutation 결과를 반환하기 전에 그 lifecycle을 실행한다
+
+#### Scenario: Caller-owned transaction commit
+
+- **WHEN** application이 caller-owned transaction 안에서 federation-visible Local Profile 변경을 수행한다
+- **THEN** action은 transaction 존재 여부와 무관하게 같은 post-commit lifecycle을 반환한다
+- **AND** transaction owner는 outer commit이 성공한 뒤 lifecycle을 실행한다
+- **AND** outer commit 전에는 Fedify delivery 또는 remote HTTP I/O를 수행하지 않는다
+
+#### Scenario: Validation failure 또는 rollback
+
+- **WHEN** Profile update가 validation·authorization 실패로 거부되거나 포함된 transaction이 rollback된다
+- **THEN** 시스템은 해당 미반영 변경을 위한 ActivityPub Update를 만들거나 전달하지 않는다
+
+#### Scenario: Repeated lifecycle invocation
+
+- **WHEN** 같은 action 결과의 post-commit lifecycle을 반복 또는 동시에 호출한다
+- **THEN** 시스템은 같은 실행 Promise를 재사용한다
+- **AND** 그 action 결과를 위한 direct delivery를 둘 이상 시작하지 않는다
+
+### Requirement: Canonical Update Person projection
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `PROD-628`, `PROD-629`; 이 요구사항을 MUST 준수한다.
+
+시스템은 committed Local Profile의 stable actor identity와 canonical `Person` projection을 재사용한
+ActivityPub `Update(Person)`을 구성하는 것을 MUST 보장한다.
+
+#### Scenario: Construct Local Profile Update
+
+- **WHEN** federation-visible Local Profile 변경의 post-commit lifecycle이 실행된다
+- **THEN** `Update.actor`는 변경된 Profile의 canonical local actor URI다
+- **AND** embedded `Update.object`는 PROD-628의 canonical `Person` projection이다
+- **AND** embedded `Person.id`는 `Update.actor`와 같다
+- **AND** Update는 해당 actor의 followers collection을 audience로 표현한다
+
+#### Scenario: Preserve latest committed representation
+
+- **WHEN** displayName, bio, avatar, header 또는 Follow Approval Policy 변경 뒤 Update를 구성한다
+- **THEN** embedded `Person`은 delivery 시점의 최신 committed Profile/Media 표현을 사용한다
+- **AND** actor dispatcher와 다른 전용 JSON projection을 만들지 않는다
+- **AND** actor key identity, inbox/outbox, followers/following과 shared inbox identity를 변경하지 않는다
+
+### Requirement: Remote follower direct delivery
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-512`, `PROD-629`; MUST 준수한다.
+
+시스템은 Local Profile Update를 공통 outbound recipient dispatcher를 통해 usable established ActivityPub remote
+followers에게 직접 전달하고, follower 부재와 delivery 실패를 committed Profile 결과에서 격리하는 것을 MUST
+보장한다.
+
+#### Scenario: Deliver to active remote followers
+
+- **WHEN** 변경된 Local Profile에 usable established ActivityPub remote follower가 있다
+- **THEN** 시스템은 공통 recipient dispatcher로 같은 Update activity를 전달한다
+- **AND** 동일 actor는 한 recipient로 중복 제거한다
+- **AND** 유효한 shared inbox가 있으면 Fedify shared inbox preference를 적용한다
+
+#### Scenario: No remote followers
+
+- **WHEN** 변경된 Local Profile에 usable established ActivityPub remote follower가 없다
+- **THEN** 시스템은 remote HTTP delivery를 호출하지 않는다
+- **AND** committed Profile update를 성공 결과로 유지한다
+
+#### Scenario: Delivery failure isolation
+
+- **WHEN** commit 이후 Update projection 또는 remote delivery가 실패한다
+- **THEN** 시스템은 Profile ID와 오류를 post-commit 관측 경계에 기록한다
+- **AND** committed Profile과 GraphQL mutation 성공 결과를 rollback하거나 실패로 바꾸지 않는다
+
+#### Scenario: Accepted direct-delivery loss window
+
+- **WHEN** application process가 Profile commit 이후 direct delivery 시작 또는 완료 전에 종료된다
+- **THEN** 이번 capability는 durable intent, retry 또는 delivery history를 보장하지 않는다
+- **AND** 해당 보장은 PROD-448의 transactional outbox와 worker 범위에 남는다

--- a/packages/core/services/profile-update.test.ts
+++ b/packages/core/services/profile-update.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
-import { after, test } from 'node:test';
+import { after, afterEach, mock, test } from 'node:test';
 import { and, eq, inArray } from 'drizzle-orm';
 import {
   AccountProfiles,
   Accounts,
+  ActivityPubActors,
   db,
   firstOrThrow,
   Hashtags,
@@ -11,6 +12,7 @@ import {
   Media,
   pg,
   ProfileFollowRequests,
+  ProfileFollows,
   ProfileHashtags,
   ProfileMedia,
   Profiles,
@@ -18,6 +20,7 @@ import {
 import {
   AccountProfileRole,
   AccountState,
+  ActivityPubActorType,
   InstanceKind,
   InstanceState,
   MediaSource,
@@ -31,21 +34,28 @@ import { updateProfile } from './profile-update';
 
 after(async () => pg.end());
 
+afterEach(() => {
+  mock.restoreAll();
+});
+
 const createProfileFixture = async ({
   instanceKind = InstanceKind.LOCAL,
   profileState = ProfileState.ACTIVE,
   accountState = AccountState.ACTIVE,
+  canonicalOrigin,
   role = AccountProfileRole.OWNER,
 }: {
   instanceKind?: InstanceKind;
   profileState?: ProfileState;
   accountState?: AccountState;
+  canonicalOrigin?: string;
   role?: AccountProfileRole;
 } = {}) => {
   const suffix = crypto.randomUUID();
   const instance = await db
     .insert(Instances)
     .values({
+      canonicalOrigin,
       domain: `${suffix}.example`,
       kind: instanceKind,
       state: InstanceState.ACTIVE,
@@ -123,6 +133,22 @@ const readProfileMedia = (profileId: string) =>
     .from(ProfileMedia)
     .where(eq(ProfileMedia.profileId, profileId))
     .then((rows) => rows.toSorted((a, b) => a.kind.localeCompare(b.kind)));
+
+const createRemoteFollower = async (followeeProfileId: string) => {
+  const remote = await createProfileFixture({ instanceKind: InstanceKind.ACTIVITYPUB });
+  const actorUri = `https://${remote.instance.domain}/users/${remote.profile.id}`;
+  await db.insert(ActivityPubActors).values({
+    inboxUri: `${actorUri}/inbox`,
+    profileId: remote.profile.id,
+    sharedInboxUri: `https://${remote.instance.domain}/inbox`,
+    type: ActivityPubActorType.PERSON,
+    uri: actorUri,
+  });
+  await db.insert(ProfileFollows).values({
+    followeeProfileId,
+    followerProfileId: remote.profile.id,
+  });
+};
 
 test('Profile Media 관계는 kind별 하나만 허용하고 관계 삭제 시 Media를 보존한다', async () => {
   const { account, profile } = await createProfileFixture();
@@ -290,7 +316,7 @@ test('변경한 displayName은 Unicode code point 40자를 허용하고 41자를
     displayName: `  ${valid}  `,
     profileId: profile.id,
   });
-  assert.equal(updated.displayName, valid);
+  assert.equal(updated.profile.displayName, valid);
 
   await assert.rejects(
     updateProfile({
@@ -325,8 +351,8 @@ test('40 code point 초과 legacy displayName은 저장 원문과 같을 때만 
     displayName: legacyDisplayName,
     profileId: profile.id,
   });
-  assert.equal(updated.displayName, legacyDisplayName);
-  assert.equal(updated.bio, 'legacy preserved');
+  assert.equal(updated.profile.displayName, legacyDisplayName);
+  assert.equal(updated.profile.bio, 'legacy preserved');
 
   await assert.rejects(
     updateProfile({
@@ -347,7 +373,7 @@ test('bio는 trim 후 JavaScript UTF-16 길이 500자를 적용한다', async ()
     bio: `  ${valid}  `,
     profileId: profile.id,
   });
-  assert.equal(updated.bio, valid);
+  assert.equal(updated.profile.bio, valid);
 
   await assert.rejects(
     updateProfile({
@@ -379,8 +405,8 @@ test('Owner는 scalar와 정규화된 tags를 하나의 update로 저장한다',
     tags: [' #Ｆｏｏ ', 'Straße', 'ı'],
   });
 
-  assert.equal(updated.displayName, 'Updated');
-  assert.equal(updated.bio, 'Bio');
+  assert.equal(updated.profile.displayName, 'Updated');
+  assert.equal(updated.profile.bio, 'Bio');
   assert.deepEqual(await readTags(profile.id), ['foo', 'straße', 'ı'].sort());
   assert.equal((await readHashtag('foo')).displayName, 'Foo');
   assert.equal((await readHashtag('straße')).displayName, 'Straße');
@@ -608,4 +634,145 @@ test('동시 partial scalar update는 서로 다른 필드를 모두 보존한�
     .where(eq(Profiles.id, profile.id))
     .then(firstOrThrow);
   assert.deepEqual(persisted, { displayName: 'Display name', bio: 'Bio' });
+});
+
+test('실제 actor 표현 변경만 one-shot postCommit delivery lifecycle을 만든다', async () => {
+  const fixture = await createProfileFixture({
+    canonicalOrigin: `https://${crypto.randomUUID()}.local.example`,
+  });
+  const avatar = await createMedia({
+    accountId: fixture.account.id,
+    profileId: fixture.profile.id,
+  });
+  const header = await createMedia({
+    accountId: fixture.account.id,
+    profileId: fixture.profile.id,
+  });
+  await createRemoteFollower(fixture.profile.id);
+  const delivery = mock.method(
+    globalThis,
+    'fetch',
+    async () => new Response(null, { status: 202 }),
+  );
+
+  const first = await updateProfile({
+    accountId: fixture.account.id,
+    displayName: 'Changed',
+    profileId: fixture.profile.id,
+  });
+  const firstPostCommit = first.postCommit();
+  assert.equal(first.postCommit(), firstPostCommit);
+  await firstPostCommit;
+  assert.equal(delivery.mock.callCount(), 1);
+
+  for (const input of [
+    { bio: 'Changed bio' },
+    { followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED },
+    { avatarMediaId: avatar.id },
+    { headerMediaId: header.id },
+    { avatarMediaId: null },
+    { headerMediaId: null },
+  ]) {
+    const result = await updateProfile({
+      accountId: fixture.account.id,
+      profileId: fixture.profile.id,
+      ...input,
+    });
+    await result.postCommit();
+  }
+  assert.equal(delivery.mock.callCount(), 7);
+
+  const noOp = await updateProfile({
+    accountId: fixture.account.id,
+    avatarMediaId: null,
+    bio: '  Changed bio  ',
+    displayName: 'Changed',
+    followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED,
+    headerMediaId: null,
+    profileId: fixture.profile.id,
+    tags: ['tag_only'],
+  });
+  await noOp.postCommit();
+  assert.equal(delivery.mock.callCount(), 7);
+});
+
+test('caller-owned transaction은 outer commit 뒤 실행할 postCommit lifecycle을 반환한다', async () => {
+  const fixture = await createProfileFixture({
+    canonicalOrigin: `https://${crypto.randomUUID()}.local.example`,
+  });
+  await createRemoteFollower(fixture.profile.id);
+  const delivery = mock.method(
+    globalThis,
+    'fetch',
+    async () => new Response(null, { status: 202 }),
+  );
+  let result: Awaited<ReturnType<typeof updateProfile>> | undefined;
+
+  await db.transaction(async (tx) => {
+    result = await updateProfile(
+      {
+        accountId: fixture.account.id,
+        displayName: 'Committed',
+        profileId: fixture.profile.id,
+      },
+      tx,
+    );
+    assert.equal(delivery.mock.callCount(), 0);
+  });
+
+  assert.ok(result);
+  await result.postCommit();
+  assert.equal(delivery.mock.callCount(), 1);
+
+  await assert.rejects(
+    db.transaction(async (tx) => {
+      await updateProfile(
+        {
+          accountId: fixture.account.id,
+          displayName: 'Rolled back',
+          profileId: fixture.profile.id,
+        },
+        tx,
+      );
+      throw new Error('rollback');
+    }),
+    /rollback/,
+  );
+  assert.equal(delivery.mock.callCount(), 1);
+});
+
+test('postCommit delivery 실패는 committed Profile 결과를 유지하고 관측한다', async () => {
+  const fixture = await createProfileFixture({
+    canonicalOrigin: `https://${crypto.randomUUID()}.local.example`,
+  });
+  await createRemoteFollower(fixture.profile.id);
+  const delivery = mock.method(globalThis, 'fetch', async () => {
+    throw new Error('delivery failed');
+  });
+  const errorLog = mock.method(console, 'error', () => undefined);
+
+  const result = await updateProfile({
+    accountId: fixture.account.id,
+    bio: 'Committed despite delivery failure',
+    profileId: fixture.profile.id,
+  });
+  await result.postCommit();
+
+  assert.ok(delivery.mock.callCount() > 0);
+  assert.equal(result.profile.bio, 'Committed despite delivery failure');
+  assert.equal(
+    await db
+      .select({ bio: Profiles.bio })
+      .from(Profiles)
+      .where(eq(Profiles.id, fixture.profile.id))
+      .then(firstOrThrow)
+      .then(({ bio }) => bio),
+    'Committed despite delivery failure',
+  );
+  assert.equal(errorLog.mock.callCount(), 1);
+  assert.equal(
+    errorLog.mock.calls[0]?.arguments[0],
+    'Post-commit ActivityPub Local Profile Update delivery failed',
+  );
+  assert.equal(errorLog.mock.calls[0]?.arguments[1]?.profileId, fixture.profile.id);
 });

--- a/packages/core/services/profile-update.ts
+++ b/packages/core/services/profile-update.ts
@@ -37,6 +37,19 @@ export type UpdateProfileInput = {
   readonly tags?: readonly string[] | null;
 };
 
+export type UpdateProfileResult = {
+  readonly postCommit: () => Promise<void>;
+  readonly profile: typeof Profiles.$inferSelect;
+};
+
+const noPostCommit = async (): Promise<void> => {};
+
+const oncePostCommit = (effect: () => Promise<void>): (() => Promise<void>) => {
+  let pending: Promise<void> | undefined;
+
+  return () => (pending ??= effect());
+};
+
 const normalizeDisplayName = (next: string | undefined, current: string) => {
   if (next === undefined) {
     return undefined;
@@ -85,8 +98,11 @@ const normalizeTags = (tags: UpdateProfileInput['tags']) => {
   return result.data;
 };
 
-export const updateProfile = async (input: UpdateProfileInput, tx?: Transaction) =>
-  getDatabaseConnection(tx).transaction(async (tx) => {
+export const updateProfile = async (
+  input: UpdateProfileInput,
+  tx?: Transaction,
+): Promise<UpdateProfileResult> => {
+  const result = await getDatabaseConnection(tx).transaction(async (tx) => {
     const profile = await tx
       .select({ profile: Profiles, actorRole: AccountProfiles.role })
       .from(Profiles)
@@ -149,20 +165,45 @@ export const updateProfile = async (input: UpdateProfileInput, tx?: Transaction)
       }
     }
 
+    const currentMediaByKind = new Map(
+      (
+        await tx
+          .select({ kind: ProfileMedia.kind, mediaId: ProfileMedia.mediaId })
+          .from(ProfileMedia)
+          .where(
+            and(
+              eq(ProfileMedia.profileId, input.profileId),
+              inArray(ProfileMedia.kind, [ProfileMediaKind.AVATAR, ProfileMediaKind.HEADER]),
+            ),
+          )
+      ).map(({ kind, mediaId }) => [kind, mediaId]),
+    );
+
     const scalarChanges: {
       displayName?: string;
       bio?: string | null;
       followPolicy?: ProfileFollowPolicy;
     } = {};
-    if (displayName !== undefined) {
+    if (displayName !== undefined && displayName !== profile.profile.displayName) {
       scalarChanges.displayName = displayName;
     }
-    if (bio !== undefined) {
+    if (bio !== undefined && bio !== profile.profile.bio) {
       scalarChanges.bio = bio;
     }
-    if (input.followPolicy !== undefined) {
+    if (input.followPolicy !== undefined && input.followPolicy !== profile.profile.followPolicy) {
       scalarChanges.followPolicy = input.followPolicy;
     }
+
+    const mediaChanges: [ProfileMediaKind, string | null][] = [];
+    for (const [kind, mediaId] of [
+      [ProfileMediaKind.AVATAR, input.avatarMediaId],
+      [ProfileMediaKind.HEADER, input.headerMediaId],
+    ] as const) {
+      if (mediaId !== undefined && (currentMediaByKind.get(kind) ?? null) !== mediaId) {
+        mediaChanges.push([kind, mediaId]);
+      }
+    }
+    const actorProjectionChanged = Object.keys(scalarChanges).length > 0 || mediaChanges.length > 0;
 
     const updatedProfile =
       Object.keys(scalarChanges).length > 0
@@ -201,13 +242,7 @@ export const updateProfile = async (input: UpdateProfileInput, tx?: Transaction)
       }
     }
 
-    for (const [kind, mediaId] of [
-      [ProfileMediaKind.AVATAR, input.avatarMediaId],
-      [ProfileMediaKind.HEADER, input.headerMediaId],
-    ] as const) {
-      if (mediaId === undefined) {
-        continue;
-      }
+    for (const [kind, mediaId] of mediaChanges) {
       if (mediaId === null) {
         await tx
           .delete(ProfileMedia)
@@ -224,5 +259,23 @@ export const updateProfile = async (input: UpdateProfileInput, tx?: Transaction)
         });
     }
 
-    return updatedProfile;
+    return { actorProjectionChanged, profile: updatedProfile };
   });
+
+  return {
+    profile: result.profile,
+    postCommit: result.actorProjectionChanged
+      ? oncePostCommit(async () => {
+          try {
+            const { sendLocalProfileUpdate } = await import('@kosmo/fedify');
+            await sendLocalProfileUpdate(result.profile.id);
+          } catch (error) {
+            console.error('Post-commit ActivityPub Local Profile Update delivery failed', {
+              error,
+              profileId: result.profile.id,
+            });
+          }
+        })
+      : noPostCommit,
+  };
+};

--- a/packages/fedify/index.ts
+++ b/packages/fedify/index.ts
@@ -2,6 +2,7 @@ export { resolveActivityPubPostUri } from './src/activitypub-post-uri';
 export { federation } from './src/federation';
 export { sendAcceptFollowActivity } from './src/follow-delivery';
 export { sendLocalPostCreate, sendLocalPostDelete } from './src/local-post-delivery';
+export { sendLocalProfileUpdate } from './src/local-profile-update-delivery';
 export { sendProfileFollow, sendProfileUnfollow } from './src/profile-follow-delivery';
 export { sendReaction, sendReactionUndo } from './src/reaction-delivery';
 export {

--- a/packages/fedify/src/local-outbound-federation.ts
+++ b/packages/fedify/src/local-outbound-federation.ts
@@ -21,3 +21,6 @@ localOutboundFederation
 
     return result ? [...result.keyPairs] : [];
   });
+
+localOutboundFederation.setFollowersDispatcher('/ap/actor/{identifier}/followers', () => null);
+localOutboundFederation.setFollowingDispatcher('/ap/actor/{identifier}/following', () => null);

--- a/packages/fedify/src/local-profile-person.ts
+++ b/packages/fedify/src/local-profile-person.ts
@@ -4,8 +4,8 @@ import { isHttpUri } from './activitypub-uri';
 import type { ActorKeyPair, Context } from '@fedify/fedify';
 import type { LocalProfileActorMedia, LocalProfileActorProfile } from './local-profile-actor';
 
-export interface CreateLocalProfilePersonOptions {
-  readonly context: Context<void>;
+export interface CreateLocalProfilePersonOptions<TContextData> {
+  readonly context: Context<TContextData>;
   readonly profile: LocalProfileActorProfile;
   readonly keyPairs: readonly ActorKeyPair[];
 }
@@ -26,11 +26,11 @@ const createProfileImage = (media: LocalProfileActorMedia | null): Image | null 
   }
 };
 
-export const createLocalProfilePerson = ({
+export const createLocalProfilePerson = <TContextData>({
   context,
   keyPairs,
   profile,
-}: CreateLocalProfilePersonOptions): Person => {
+}: CreateLocalProfilePersonOptions<TContextData>): Person => {
   const rsaKeyPair = keyPairs.find(
     (keyPair) => getPublicKeyAlgorithmName(keyPair) === 'RSASSA-PKCS1-v1_5',
   );

--- a/packages/fedify/src/local-profile-update-delivery.test.ts
+++ b/packages/fedify/src/local-profile-update-delivery.test.ts
@@ -1,0 +1,252 @@
+import '@kosmo/core/polyfill';
+
+import assert from 'node:assert/strict';
+import { after, afterEach, mock, test } from 'node:test';
+import { Image, Person, Update } from '@fedify/vocab';
+import {
+  Accounts,
+  ActivityPubActors,
+  db,
+  firstOrThrow,
+  Instances,
+  Media,
+  pg,
+  ProfileFollows,
+  ProfileMedia,
+  Profiles,
+} from '@kosmo/core/db';
+import {
+  AccountState,
+  ActivityPubActorType,
+  InstanceKind,
+  InstanceState,
+  MediaSource,
+  MediaState,
+  ProfileFollowPolicy,
+  ProfileMediaKind,
+  ProfileState,
+} from '@kosmo/core/enums';
+import { localOutboundFederation } from './local-outbound-federation';
+import { sendLocalProfileUpdate } from './local-profile-update-delivery';
+import type { Context } from '@fedify/fedify';
+import type { Activity, Recipient } from '@fedify/vocab';
+import type { LocalOutboundContextData } from './local-outbound-federation';
+
+afterEach(() => {
+  mock.restoreAll();
+});
+
+after(async () => pg.end());
+
+test('Update(Person)는 canonical actor 표현·followers audience·unique activity identity를 쓴다', async () => {
+  const local = await createLocalProfile();
+  const avatar = await createMedia(local.accountId, local.profile.id, 'avatar');
+  const header = await createMedia(local.accountId, local.profile.id, 'header');
+  await db.insert(ProfileMedia).values([
+    { kind: ProfileMediaKind.AVATAR, mediaId: avatar.id, profileId: local.profile.id },
+    { kind: ProfileMediaKind.HEADER, mediaId: header.id, profileId: local.profile.id },
+  ]);
+  const active = await createRemoteActor({ sharedInbox: true });
+  const suspended = await createRemoteActor({ instanceState: InstanceState.SUSPENDED });
+  await db.insert(ProfileFollows).values([
+    { followeeProfileId: local.profile.id, followerProfileId: active.profileId },
+    { followeeProfileId: local.profile.id, followerProfileId: suspended.profileId },
+  ]);
+  const fixture = await createContextFixture(local);
+  mock.method(localOutboundFederation, 'createContext', () => fixture.context);
+
+  await sendLocalProfileUpdate(local.profile.id);
+  await sendLocalProfileUpdate(local.profile.id);
+
+  assert.equal(fixture.calls.length, 2);
+  const [first, second] = fixture.calls;
+  assert.ok(first?.activity instanceof Update);
+  assert.ok(second?.activity instanceof Update);
+  assert.notEqual(first.activity.id?.href, second.activity.id?.href);
+  assert.equal(first.activity.actorId?.href, fixture.actorUri.href);
+  assert.deepEqual(
+    first.activity.toIds.map((uri) => uri.href),
+    [fixture.followersUri.href],
+  );
+  const object = await first.activity.getObject();
+  assert.ok(object instanceof Person);
+  assert.equal(object.id?.href, fixture.actorUri.href);
+  assert.equal(object.name?.toString(), local.profile.displayName);
+  assert.equal(object.summary?.toString(), local.profile.bio);
+  assert.equal(object.manuallyApprovesFollowers, true);
+  const icon = await object.getIcon();
+  const image = await object.getImage();
+  assert.ok(icon instanceof Image);
+  assert.ok(image instanceof Image);
+  assert.equal(icon.url?.toString(), avatar.url);
+  assert.equal(image.url?.toString(), header.url);
+  assert.deepEqual(first.sender, { identifier: local.profile.id });
+  assert.deepEqual(first.options, { preferSharedInbox: true });
+  assert.deepEqual(
+    first.recipients.map((recipient) => recipient.id?.href),
+    [active.actorUri],
+  );
+  assert.equal(first.recipients[0]?.endpoints?.sharedInbox?.href, active.sharedInboxUri);
+});
+
+test('remote follower가 없으면 HTTP delivery를 시작하지 않는다', async () => {
+  const local = await createLocalProfile();
+  const fixture = await createContextFixture(local);
+  mock.method(localOutboundFederation, 'createContext', () => fixture.context);
+
+  await sendLocalProfileUpdate(local.profile.id);
+
+  assert.equal(fixture.calls.length, 0);
+});
+
+test('recipient delivery 실패는 caller가 격리할 수 있도록 reject한다', async () => {
+  const local = await createLocalProfile();
+  const active = await createRemoteActor({});
+  await db.insert(ProfileFollows).values({
+    followeeProfileId: local.profile.id,
+    followerProfileId: active.profileId,
+  });
+  const fixture = await createContextFixture(local, true);
+  mock.method(localOutboundFederation, 'createContext', () => fixture.context);
+
+  await assert.rejects(sendLocalProfileUpdate(local.profile.id), /delivery failed/);
+});
+
+type LocalFixture = Awaited<ReturnType<typeof createLocalProfile>>;
+
+interface SendActivityCall {
+  readonly activity: Activity;
+  readonly options: { readonly preferSharedInbox: boolean };
+  readonly recipients: Recipient[];
+  readonly sender: { readonly identifier: string };
+}
+
+const createContextFixture = async (local: LocalFixture, fail = false) => {
+  const actual = localOutboundFederation.createContext(new URL(local.canonicalOrigin), {
+    localInstanceId: local.instanceId,
+  });
+  const keyPairs = await actual.getActorKeyPairs(local.profile.id);
+  const calls: SendActivityCall[] = [];
+  const context = {
+    canonicalOrigin: actual.canonicalOrigin,
+    getActorKeyPairs: async () => keyPairs,
+    getActorUri: actual.getActorUri.bind(actual),
+    getFollowersUri: actual.getFollowersUri.bind(actual),
+    getFollowingUri: actual.getFollowingUri.bind(actual),
+    sendActivity: async (
+      sender: { identifier: string },
+      recipients: Recipient | Recipient[],
+      activity: Activity,
+      options: { preferSharedInbox: boolean },
+    ) => {
+      if (fail) {
+        throw new Error('delivery failed');
+      }
+      calls.push({
+        activity,
+        options,
+        recipients: Array.isArray(recipients) ? recipients : [recipients],
+        sender,
+      });
+    },
+  } as unknown as Context<LocalOutboundContextData>;
+
+  return {
+    actorUri: actual.getActorUri(local.profile.id),
+    calls,
+    context,
+    followersUri: actual.getFollowersUri(local.profile.id),
+  };
+};
+
+const createLocalProfile = async () => {
+  const suffix = crypto.randomUUID();
+  const canonicalOrigin = `https://${suffix}.local.example`;
+  const instance = await db
+    .insert(Instances)
+    .values({
+      canonicalOrigin,
+      domain: `${suffix}.local.example`,
+      kind: InstanceKind.LOCAL,
+      state: InstanceState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  const profile = await db
+    .insert(Profiles)
+    .values({
+      bio: 'Canonical bio',
+      displayName: 'Canonical name',
+      followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED,
+      handle: suffix,
+      instanceId: instance.id,
+      normalizedHandle: suffix,
+      state: ProfileState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  const account = await db
+    .insert(Accounts)
+    .values({ displayName: suffix, oidcSubject: suffix, state: AccountState.ACTIVE })
+    .returning()
+    .then(firstOrThrow);
+  return { accountId: account.id, canonicalOrigin, instanceId: instance.id, profile };
+};
+
+const createMedia = async (accountId: string, profileId: string, kind: string) =>
+  db
+    .insert(Media)
+    .values({
+      accountId,
+      mediaType: 'image/webp',
+      profileId,
+      readyAt: Temporal.Now.instant(),
+      source: MediaSource.LOCAL,
+      state: MediaState.READY,
+      storageReference: `${kind}-${crypto.randomUUID()}`,
+      uploadExpiresAt: Temporal.Now.instant().add({ minutes: 5 }),
+      url: `https://media.example/${kind}-${crypto.randomUUID()}.webp`,
+    })
+    .returning()
+    .then(firstOrThrow);
+
+const createRemoteActor = async ({
+  instanceState = InstanceState.ACTIVE,
+  sharedInbox = false,
+}: {
+  instanceState?: InstanceState;
+  sharedInbox?: boolean;
+}) => {
+  const suffix = crypto.randomUUID();
+  const instance = await db
+    .insert(Instances)
+    .values({
+      domain: `${suffix}.remote.example`,
+      kind: InstanceKind.ACTIVITYPUB,
+      state: instanceState,
+    })
+    .returning()
+    .then(firstOrThrow);
+  const profile = await db
+    .insert(Profiles)
+    .values({
+      displayName: suffix,
+      followPolicy: ProfileFollowPolicy.OPEN,
+      handle: suffix,
+      instanceId: instance.id,
+      normalizedHandle: suffix,
+      state: ProfileState.ACTIVE,
+    })
+    .returning()
+    .then(firstOrThrow);
+  const actorUri = `https://${instance.domain}/users/${suffix}`;
+  const sharedInboxUri = sharedInbox ? `https://${instance.domain}/inbox` : null;
+  await db.insert(ActivityPubActors).values({
+    inboxUri: `${actorUri}/inbox`,
+    profileId: profile.id,
+    sharedInboxUri,
+    type: ActivityPubActorType.PERSON,
+    uri: actorUri,
+  });
+  return { actorUri, profileId: profile.id, sharedInboxUri };
+};

--- a/packages/fedify/src/local-profile-update-delivery.ts
+++ b/packages/fedify/src/local-profile-update-delivery.ts
@@ -1,0 +1,65 @@
+import { Update } from '@fedify/vocab';
+import { db, first, Instances, Profiles } from '@kosmo/core/db';
+import { InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
+import { and, eq, isNotNull } from 'drizzle-orm';
+import { ensureDrizzleLocalProfileActor } from './local-actor-store';
+import { localOutboundFederation } from './local-outbound-federation';
+import { createLocalProfilePerson } from './local-profile-person';
+import { dispatchActivityPubActivity } from './outbound-recipient-dispatch';
+
+export const sendLocalProfileUpdate = async (profileId: string): Promise<void> => {
+  const source = await db
+    .select({
+      canonicalOrigin: Instances.canonicalOrigin,
+      localInstanceId: Instances.id,
+    })
+    .from(Profiles)
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .where(
+      and(
+        eq(Profiles.id, profileId),
+        eq(Profiles.state, ProfileState.ACTIVE),
+        eq(Instances.kind, InstanceKind.LOCAL),
+        eq(Instances.state, InstanceState.ACTIVE),
+        isNotNull(Instances.canonicalOrigin),
+      ),
+    )
+    .limit(1)
+    .then(first);
+  if (!source?.canonicalOrigin) {
+    return;
+  }
+
+  const context = localOutboundFederation.createContext(new URL(source.canonicalOrigin), {
+    localInstanceId: source.localInstanceId,
+  });
+  const actorUri = context.getActorUri(profileId);
+  const projection = await ensureDrizzleLocalProfileActor({
+    actorUri,
+    localInstanceId: source.localInstanceId,
+    profileId,
+  });
+  if (!projection) {
+    return;
+  }
+
+  const object = createLocalProfilePerson({
+    context,
+    keyPairs: await context.getActorKeyPairs(profileId),
+    profile: projection.profile,
+  });
+  const actorPathname = actorUri.pathname.replace(/\/$/, '');
+  const activity = new Update({
+    actor: actorUri,
+    id: new URL(`${actorPathname}/updates/${crypto.randomUUID()}`, actorUri),
+    object,
+    tos: [context.getFollowersUri(profileId)],
+  });
+
+  await dispatchActivityPubActivity({
+    activity,
+    actorProfileId: profileId,
+    context,
+    directProfileIds: [],
+  });
+};


### PR DESCRIPTION
## 무엇을 변경했는지

- Local Profile의 federation-visible 값이 실제로 변경된 경우에만 commit 이후 `Update(Person)` delivery를 실행합니다.
- canonical Local Profile actor projection을 재사용해 active remote follower에게 shared inbox 우선으로 전달합니다.
- caller-owned transaction에서는 outer commit 이후에만 전송하고, 전송 실패가 이미 commit된 GraphQL 결과를 실패시키지 않도록 격리합니다.
- OpenSpec `deliver-activitypub-local-profile-update`를 구현·검증하고 active spec으로 동기화한 뒤 archive했습니다.

## 왜 변경했는지

프로필을 변경해도 remote follower에게 ActivityPub `Update`가 전달되지 않아, 원격 서버의 actor 표현이 최신 상태로 갱신되지 않았습니다.

- Linear: [PROD-629](https://linear.app/byulmaru/issue/PROD-629/local-profile-변경을-activitypub-updateperson으로-전달한다)

## 이번 PR의 주요 결정

- 결정자: Jiyu Park
- 선택: 이 PR에서는 Reaction 선례의 명시적 one-shot `postCommit` lifecycle을 임시 경계로 수용합니다.
- 대안: transactional outbox와 메시지큐를 함께 도입해 transaction 안에서 durable delivery intent를 기록합니다.
- 이유: 메시지큐/outbox 도입은 PROD-629가 소유하기엔 책임과 검증 범위가 너무 큽니다.
- 결과: 현재 production caller는 commit 뒤 `postCommit`을 실행하며, callback 누락과 process 종료 시 유실 가능성은 후속 범위로 남습니다. `tx` 유무에 따른 lifecycle 생략·pre-commit I/O 안티패턴은 [PROD-655](https://linear.app/byulmaru/issue/PROD-655/core-activity-lifecycle이-transaction-인자에-따라-생략되지-않게-한다), durable outbox/queue 기반은 [PROD-448](https://linear.app/byulmaru/issue/PROD-448/activitypub-outbound-delivery-intent를-transactional-outbox와-fedify)가 소유합니다.

## 어떻게 확인할 수 있는지

- core services: 160/160 통과
- fedify: 188/188 통과
- API integration: 211 통과, 1 skip
- Fedify/API TypeScript 검사 통과
- `pnpm lint:prettier` 통과
- `openspec validate --all --strict` 68/68 통과
- GitHub Lint, Semgrep, Root/Core/Fedify/API/App/Web 테스트 전체 통과

## 아직 남은 문제

- 명시적 `postCommit` 호출 누락 가능성과 transaction 인자에 따른 기존 lifecycle 불일치는 PROD-655에서 다룹니다.
- process 종료 구간까지 보장하는 durable retry/outbox는 PROD-448에서 다룹니다.