### PR TITLE
OpenSpec Gate 승인 전에 스펙 설명을 거치게 한다

### DIFF
--- a/memory/issue-openspec-workflow.md
+++ b/memory/issue-openspec-workflow.md
@@ -342,7 +342,7 @@ OpenSpec만을 만들기 위한 Linear 이슈는 두지 않는다. 여러 PR이 
 검토·merge가 필요하더라도 별도 spec-only 이슈를 만들지 않고 실제 구현·검증 결과를 소유한 이슈들에 책임을
 배정한다. 특정 부모가 존재한다는 이유만으로 change 전체를 그 부모의 소유로 간주하지 않는다.
 
-OpenSpec Gate artifacts가 준비된 뒤 승인 요청을 작성하기 전에 primary agent는 가능하면 경량 모델의 subagent를 활용해
+OpenSpec Gate artifacts가 준비된 뒤 승인 요청을 작성하기 전에 primary agent는 가능하면 경량 모델의 subagent로 Luna Max를 활용해
 `proposal.md`, `specs/**/spec.md`의 requirements·scenarios, `design.md`, `decisions.md`,
 `tasks.md`, 포함·제외 범위, 각 항목의 authority/provenance, 각 decision의 `Active | Blocked | Superseded` 상태,
 이슈별 구현·검증·archive 책임, 이전 gate 승인과 달라진 점과 승인 후 다음 단계를 사용자가 검토할 수 있는

--- a/memory/issue-openspec-workflow.md
+++ b/memory/issue-openspec-workflow.md
@@ -342,13 +342,14 @@ OpenSpec만을 만들기 위한 Linear 이슈는 두지 않는다. 여러 PR이 
 검토·merge가 필요하더라도 별도 spec-only 이슈를 만들지 않고 실제 구현·검증 결과를 소유한 이슈들에 책임을
 배정한다. 특정 부모가 존재한다는 이유만으로 change 전체를 그 부모의 소유로 간주하지 않는다.
 
-OpenSpec Gate artifacts가 준비된 뒤 승인 요청을 작성하기 전에 primary agent는 반드시 Luna Max subagent를
-사용해 `proposal.md`, `specs/**/spec.md`의 requirements·scenarios, `design.md`, `decisions.md`,
+OpenSpec Gate artifacts가 준비된 뒤 승인 요청을 작성하기 전에 primary agent는 가능하면 경량 모델의 subagent를 활용해
+`proposal.md`, `specs/**/spec.md`의 requirements·scenarios, `design.md`, `decisions.md`,
 `tasks.md`, 포함·제외 범위, 각 항목의 authority/provenance, 각 decision의 `Active | Blocked | Superseded` 상태,
 이슈별 구현·검증·archive 책임, 이전 gate 승인과 달라진 점과 승인 후 다음 단계를 사용자가 검토할 수 있는
-한국어 설명으로 합성한다. primary agent는 Luna 설명을 증거로 검토·정정하고 누락·불일치·미결정을 해결하거나
-명시한 후에만 최종 승인을 요청한다. Luna 결과는 승인 자체를 대체하지 않는다. Luna Max를 사용할 수 없거나
-설명이 완료되지 않으면 이 필수 절차를 생략한 채 승인 요청을 제시하지 않고 blocker를 보고한다. 이 절차는
+한국어 설명으로 합성한다. subagent를 사용할 수 없으면 primary agent가 같은 범위를 직접 합성·검토한다. primary agent는
+설명을 증거로 검토·정정하고 누락·불일치·미결정을 해결하거나 명시한 후에만 최종 승인을 요청한다. subagent 결과는
+승인 자체를 대체하지 않으며, subagent의 가용성 자체는 blocker가 아니다. 설명이 불완전하고 primary agent가 보완하지
+못하면 필수 절차를 완료하지 못한 blocker와 미결정을 보고한다. 이 절차는
 기존 OpenSpec Gate의 source-of-truth, authority와 approval semantics를 변경하지 않는다.
 
 OpenSpec Gate 승인 요청은 requirement와 scenario, Active/Blocked/Superseded decision, 구현 이슈별 task

--- a/memory/issue-openspec-workflow.md
+++ b/memory/issue-openspec-workflow.md
@@ -342,6 +342,15 @@ OpenSpec만을 만들기 위한 Linear 이슈는 두지 않는다. 여러 PR이 
 검토·merge가 필요하더라도 별도 spec-only 이슈를 만들지 않고 실제 구현·검증 결과를 소유한 이슈들에 책임을
 배정한다. 특정 부모가 존재한다는 이유만으로 change 전체를 그 부모의 소유로 간주하지 않는다.
 
+OpenSpec Gate artifacts가 준비된 뒤 승인 요청을 작성하기 전에 primary agent는 반드시 Luna Max subagent를
+사용해 `proposal.md`, `specs/**/spec.md`의 requirements·scenarios, `design.md`, `decisions.md`,
+`tasks.md`, 포함·제외 범위, 각 항목의 authority/provenance, 각 decision의 `Active | Blocked | Superseded` 상태,
+이슈별 구현·검증·archive 책임, 이전 gate 승인과 달라진 점과 승인 후 다음 단계를 사용자가 검토할 수 있는
+한국어 설명으로 합성한다. primary agent는 Luna 설명을 증거로 검토·정정하고 누락·불일치·미결정을 해결하거나
+명시한 후에만 최종 승인을 요청한다. Luna 결과는 승인 자체를 대체하지 않는다. Luna Max를 사용할 수 없거나
+설명이 완료되지 않으면 이 필수 절차를 생략한 채 승인 요청을 제시하지 않고 blocker를 보고한다. 이 절차는
+기존 OpenSpec Gate의 source-of-truth, authority와 approval semantics를 변경하지 않는다.
+
 OpenSpec Gate 승인 요청은 requirement와 scenario, Active/Blocked/Superseded decision, 구현 이슈별 task
 ownership, 권장 접근과 허용 대안, 검증 계획, canonical 문서·Linear와 달라진 점을 나열한다. 각 규범 단위,
 Decision Class, 상위 근거와 새로 추가한 내용을 함께 제시한다. 명시적 승인, 독립 authority 대조와 strict


### PR DESCRIPTION
## 무엇을 변경했는지

- OpenSpec Gate 승인 요청 전에 전체 스펙을 사용자가 검토할 수 있는 한국어 설명으로 합성하도록 workflow에 추가했습니다.
- 설명 범위에 proposal, requirements/scenarios, design, decisions, tasks, 포함·제외 범위, authority/provenance, decision 상태, 이슈별 구현·검증·archive 책임, 이전 gate 대비 변경과 승인 후 단계를 명시했습니다.
- 가능하면 경량 모델의 subagent로 Luna Max를 활용하되, 사용할 수 없으면 primary agent가 같은 범위를 직접 합성·검토하도록 했습니다.
- subagent 가용성 자체는 blocker가 아니며, 설명이 불완전하고 primary agent도 보완하지 못한 경우에만 blocker와 미결정을 보고하도록 했습니다.

## 왜 변경했는지

OpenSpec Gate 승인 요청 전에 스펙 전체와 책임·미결정을 일관된 형태로 검토할 수 있게 하면서, Luna Max나 subagent 기능의 가용성 때문에 workflow가 불필요하게 중단되지 않도록 하기 위해서입니다.

## 이번 PR의 주요 결정

### 스펙 설명은 필수이고 Luna Max subagent 사용은 권장이다

- 결정자: @robin-maki
- 선택: 전체 스펙의 한국어 설명과 primary agent의 검토·정정은 필수로 두고, 가능하면 경량 모델의 subagent로 Luna Max를 활용합니다.
- fallback: Luna Max 또는 subagent를 사용할 수 없으면 primary agent가 동일 범위를 직접 합성·검토합니다.
- 승인 의미: subagent 결과는 승인 자체를 대체하지 않으며, 기존 source-of-truth, authority와 명시적 approval semantics는 변경하지 않습니다.
- blocker: subagent 가용성 자체가 아니라, 설명이 불완전하고 primary agent도 보완하지 못한 경우에만 보고합니다.

## 어떻게 확인할 수 있는지

- Luna worker로 문구와 기존 Gate 절차의 정합성을 검토했습니다.
- Prettier로 대상 Markdown 포맷 검사를 통과했습니다.
- git diff --check를 통과했습니다.
- PR diff가 memory/issue-openspec-workflow.md 한 파일만 포함하는지 확인했습니다.

## 아직 어떤 문제가 남았는지

없음.