### PR TITLE
Reply Composer에서 이미지 첨부를 지원한다

### DIFF
--- a/apps/app/src/components/post/PostComposer.tsx
+++ b/apps/app/src/components/post/PostComposer.tsx
@@ -177,11 +177,13 @@ function PostComposerContents({
   const dirty =
     body !== '' ||
     visibility !== PostVisibility.UNLISTED ||
-    (!replyMode && (media.items.length > 0 || media.hasPendingMedia || media.sensitiveMedia));
+    media.items.length > 0 ||
+    media.hasPendingMedia ||
+    media.sensitiveMedia;
   const disabled =
     submitting ||
-    (bodyText.length === 0 && (replyMode || media.items.length === 0)) ||
-    (!replyMode && media.hasPendingMedia) ||
+    (bodyText.length === 0 && media.items.length === 0) ||
+    media.hasPendingMedia ||
     remaining < 0;
   const selectedVisibility =
     availableVisibilityOptions.find((option) => option.value === visibility) ??
@@ -204,7 +206,8 @@ function PostComposerContents({
       variables: {
         input: {
           ...createPostComposerMutationInput(bodyText, visibility, replyParentId),
-          ...(!replyMode ? { media: media.items, sensitiveMedia: media.sensitiveMedia } : {}),
+          media: media.items,
+          sensitiveMedia: media.sensitiveMedia,
         },
       },
       onCompleted: (response, errors) => {
@@ -512,14 +515,12 @@ function PostComposerContents({
             {error}
           </Text>
         ) : null}
-        {replyMode ? null : (
-          <PostComposerMediaControls
-            actions={submitActions}
-            disabled={submitting}
-            key={mediaGeneration}
-            onValueChange={setMedia}
-          />
-        )}
+        <PostComposerMediaControls
+          actions={replyMode ? null : submitActions}
+          disabled={submitting}
+          key={mediaGeneration}
+          onValueChange={setMedia}
+        />
       </View>
     </>
   );

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -1846,6 +1846,25 @@ function createReplyComposerEnvironment({
           },
         } as GraphQLResponse;
       }
+      if (request.name === 'PostComposerIssueMediaUploadUrlMutation') {
+        return {
+          data: {
+            issueMediaUploadUrl: {
+              media: { id: 'media-reply-environment' },
+              uploadUrl: 'https://upload.example/reply-environment',
+            },
+          },
+        } as GraphQLResponse;
+      }
+      if (request.name === 'PostComposerCompleteMediaUploadMutation') {
+        return {
+          data: {
+            completeMediaUpload: {
+              media: { id: 'media-reply-environment', state: 'READY' },
+            },
+          },
+        } as GraphQLResponse;
+      }
       return { data: {} } as GraphQLResponse;
     }),
     store: new Store(new RecordSource()),
@@ -4831,6 +4850,56 @@ export const ComposerReplyEnvironmentIsolation: Story = {
     await userEvent.type(currentBody, '새 Environment의 답글');
     expect(currentBody).toHaveValue('새 Environment의 답글');
     expect(canvas.getByTestId('reply-environment-created-log')).toHaveTextContent('[]');
+  },
+  render: () => <ReplyComposerEnvironmentIsolationStory />,
+};
+
+export const ComposerReplyEnvironmentMediaIsolation: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const originalFetch = globalThis.fetch;
+    let finishUpload!: (response: Response) => void;
+    const upload = fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishUpload = resolve;
+        }),
+    );
+    globalThis.fetch = upload;
+    setNextImagePickerResult({
+      assets: [
+        {
+          ...composerMediaAsset,
+          file: new File(['reply-image'], 'reply-image.png', { type: 'image/png' }),
+          mimeType: 'image/png',
+          uri: 'blob:https://kosmo.example/reply-environment',
+        },
+      ],
+      canceled: false,
+    });
+
+    try {
+      await userEvent.click(screen.getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' }));
+      await waitFor(() => {
+        expect(screen.getByLabelText('첨부 이미지 1, 업로드 중')).toBeVisible();
+      });
+
+      await userEvent.click(canvas.getByRole('button', { name: 'Relay Environment 교체' }));
+      await waitFor(() =>
+        expect(canvas.getByTestId('reply-environment-first-committed-state')).toHaveTextContent(
+          JSON.stringify({ body: '', closeDisabled: false }),
+        ),
+      );
+      expect(screen.queryByLabelText('첨부 이미지 1, 업로드 중')).toBeNull();
+      expect(screen.getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' })).toBeVisible();
+
+      finishUpload(new Response(null, { status: 200 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(screen.queryByLabelText('첨부 이미지 1, 업로드 완료')).toBeNull();
+      expect(screen.getByRole('button', { name: '답글 게시' })).toBeDisabled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   },
   render: () => <ReplyComposerEnvironmentIsolationStory />,
 };

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -1603,46 +1603,64 @@ function ReplyDetailInlineStory() {
 
 type ReplyComposerRequest = Readonly<{
   bodyText: string;
+  media: readonly Readonly<{ altText: string | null; mediaId: string }>[];
   replyParentId?: string;
+  sensitiveMedia: boolean;
   visibility: string;
 }>;
 
 function ReplyComposerContractStory() {
   const [createdPostIds, setCreatedPostIds] = useState<string[]>([]);
   const [requests, setRequests] = useState<ReplyComposerRequest[]>([]);
-  const environment = useMemo(
-    () =>
-      new Environment({
-        network: Network.create((request: RequestParameters, variables: Variables) => {
-          if (request.name === 'PostsStoriesQuery') {
-            return Promise.resolve({
-              data: {
-                alternateComposerProfile,
-                composerProfile,
-                contentPostsProfile,
-                emptyPostsProfile,
-                homeTimeline,
-                nodes: storyPosts.map(withReactionViewerState),
+  const environment = useMemo(() => {
+    let nextMediaId = 0;
+    return new Environment({
+      network: Network.create((request: RequestParameters, variables: Variables) => {
+        if (request.name === 'PostsStoriesQuery') {
+          return Promise.resolve({
+            data: {
+              alternateComposerProfile,
+              composerProfile,
+              contentPostsProfile,
+              emptyPostsProfile,
+              homeTimeline,
+              nodes: storyPosts.map(withReactionViewerState),
+            },
+          } as GraphQLResponse);
+        }
+        if (request.name === 'PostComposerCreatePostMutation') {
+          const input = variables.input as ReplyComposerRequest;
+          setRequests((current) => [...current, input]);
+          return Promise.resolve({
+            data: {
+              createPost: {
+                post: { __typename: 'Post', id: 'reply-created-in-story' },
               },
-            } as GraphQLResponse);
-          }
-          if (request.name === 'PostComposerCreatePostMutation') {
-            const input = variables.input as ReplyComposerRequest;
-            setRequests((current) => [...current, input]);
-            return Promise.resolve({
-              data: {
-                createPost: {
-                  post: { __typename: 'Post', id: 'reply-created-in-story' },
-                },
+            },
+          } as GraphQLResponse);
+        }
+        if (request.name === 'PostComposerIssueMediaUploadUrlMutation') {
+          nextMediaId += 1;
+          return Promise.resolve({
+            data: {
+              issueMediaUploadUrl: {
+                media: { id: `media-reply-story-${nextMediaId}` },
+                uploadUrl: `https://upload.example/reply/${nextMediaId}`,
               },
-            } as GraphQLResponse);
-          }
-          return Promise.resolve({ data: {} } as GraphQLResponse);
-        }),
-        store: new Store(new RecordSource()),
+            },
+          } as GraphQLResponse);
+        }
+        if (request.name === 'PostComposerCompleteMediaUploadMutation') {
+          const input = variables.input as Readonly<{ id: string }>;
+          return Promise.resolve({
+            data: { completeMediaUpload: { media: { id: input.id, state: 'READY' } } },
+          } as GraphQLResponse);
+        }
+        return Promise.resolve({ data: {} } as GraphQLResponse);
       }),
-    [],
-  );
+      store: new Store(new RecordSource()),
+    });
+  }, []);
 
   return (
     <RelayEnvironmentProvider environment={environment}>
@@ -1703,6 +1721,25 @@ function ReplyComposerContextIsolationStory() {
             return {
               data: {
                 createPost: { post: { __typename: 'Post', id: 'late-reply-created-in-story' } },
+              },
+            } as GraphQLResponse;
+          }
+          if (request.name === 'PostComposerIssueMediaUploadUrlMutation') {
+            return {
+              data: {
+                issueMediaUploadUrl: {
+                  media: { id: 'media-reply-context' },
+                  uploadUrl: 'https://upload.example/reply-context',
+                },
+              },
+            } as GraphQLResponse;
+          }
+          if (request.name === 'PostComposerCompleteMediaUploadMutation') {
+            return {
+              data: {
+                completeMediaUpload: {
+                  media: { id: 'media-reply-context', state: 'READY' },
+                },
               },
             } as GraphQLResponse;
           }
@@ -4582,6 +4619,8 @@ export const ComposerReplyMutationContract: Story = {
             bodyText: '부모 게시물에 작성한 답글입니다.',
             replyParentId: 'post-parent',
             visibility: 'FOLLOWERS',
+            media: [],
+            sensitiveMedia: false,
           },
         ]),
       );
@@ -4592,6 +4631,159 @@ export const ComposerReplyMutationContract: Story = {
     expect(body).toHaveValue('');
   },
   render: () => <ReplyComposerContractStory />,
+};
+
+export const ComposerReplyMediaMutationContract: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const originalFetch = globalThis.fetch;
+    const upload = fn(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = upload;
+    setNextImagePickerResult({
+      assets: [
+        {
+          ...composerMediaAsset,
+          file: new File(['reply-image'], 'reply-image.png', { type: 'image/png' }),
+          mimeType: 'image/png',
+          uri: 'blob:https://kosmo.example/reply',
+        },
+      ],
+      canceled: false,
+    });
+
+    try {
+      await userEvent.click(canvas.getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' }));
+      await waitFor(() => {
+        expect(canvas.getByLabelText('첨부 이미지 1, 업로드 완료')).toBeVisible();
+      });
+      await userEvent.type(
+        canvas.getByRole('textbox', { name: '첨부 이미지 1 대체 텍스트' }),
+        '답글 이미지',
+      );
+      await userEvent.click(canvas.getByRole('switch', { name: '민감한 이미지로 표시' }));
+      await userEvent.click(canvas.getByRole('button', { name: '답글 게시' }));
+
+      await waitFor(() => {
+        expect(canvas.getByTestId('reply-composer-request-log')).toHaveTextContent(
+          JSON.stringify([
+            {
+              bodyText: '',
+              replyParentId: 'post-parent',
+              visibility: 'UNLISTED',
+              media: [{ altText: '답글 이미지', mediaId: 'media-reply-story-1' }],
+              sensitiveMedia: true,
+            },
+          ]),
+        );
+      });
+      expect(upload).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+  render: () => <ReplyComposerContractStory />,
+};
+
+export const ComposerReplyMediaFailureLifecycle: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const originalFetch = globalThis.fetch;
+    let finishFirstUpload!: (response: Response) => void;
+    let uploadCount = 0;
+    globalThis.fetch = fn(() => {
+      uploadCount += 1;
+      if (uploadCount === 1) {
+        return new Promise<Response>((resolve) => {
+          finishFirstUpload = resolve;
+        });
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+    setNextImagePickerResult({
+      assets: [
+        {
+          ...composerMediaAsset,
+          file: new File(['reply-image'], 'reply-image.png', { type: 'image/png' }),
+          mimeType: 'image/png',
+          uri: 'blob:https://kosmo.example/reply-failure',
+        },
+      ],
+      canceled: false,
+    });
+
+    try {
+      await userEvent.click(canvas.getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' }));
+      await waitFor(() => {
+        expect(canvas.getByLabelText('첨부 이미지 1, 업로드 중')).toBeVisible();
+      });
+      expect(canvas.getByRole('button', { name: '답글 게시' })).toBeDisabled();
+
+      finishFirstUpload(new Response(null, { status: 500 }));
+      await waitFor(() => {
+        expect(canvas.getByLabelText('첨부 이미지 1, 업로드 실패')).toBeVisible();
+      });
+      expect(canvas.getByRole('button', { name: '답글 게시' })).toBeDisabled();
+
+      await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 1 업로드 재시도' }));
+      await waitFor(() => {
+        expect(canvas.getByLabelText('첨부 이미지 1, 업로드 완료')).toBeVisible();
+      });
+      expect(canvas.getByRole('button', { name: '답글 게시' })).toBeEnabled();
+
+      await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 1 제거' }));
+      expect(canvas.getByRole('button', { name: '답글 게시' })).toBeDisabled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+  render: () => <ReplyComposerContractStory />,
+};
+
+export const ComposerReplyMediaContextIsolation: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const originalFetch = globalThis.fetch;
+    let finishUpload!: (response: Response) => void;
+    const upload = fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishUpload = resolve;
+        }),
+    );
+    globalThis.fetch = upload;
+    setNextImagePickerResult({
+      assets: [
+        {
+          ...composerMediaAsset,
+          file: new File(['reply-image'], 'reply-image.png', { type: 'image/png' }),
+          mimeType: 'image/png',
+          uri: 'blob:https://kosmo.example/reply-context',
+        },
+      ],
+      canceled: false,
+    });
+
+    try {
+      await userEvent.click(canvas.getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' }));
+      await waitFor(() => {
+        expect(canvas.getByLabelText('첨부 이미지 1, 업로드 중')).toBeVisible();
+      });
+
+      await userEvent.click(canvas.getByRole('button', { name: '다른 Parent로 전환' }));
+      expect(canvas.queryByLabelText('첨부 이미지 1, 업로드 중')).toBeNull();
+      expect(canvas.getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' })).toBeVisible();
+      expect(canvas.getByRole('button', { name: '답글 게시' })).toBeDisabled();
+
+      finishUpload(new Response(null, { status: 200 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(canvas.queryByLabelText('첨부 이미지 1, 업로드 완료')).toBeNull();
+      expect(canvas.getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' })).toBeVisible();
+      expect(upload).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+  render: () => <ReplyComposerContextIsolationStory />,
 };
 
 export const ComposerReplyContextIsolation: Story = {
@@ -4641,6 +4833,79 @@ export const ComposerReplyEnvironmentIsolation: Story = {
     expect(canvas.getByTestId('reply-environment-created-log')).toHaveTextContent('[]');
   },
   render: () => <ReplyComposerEnvironmentIsolationStory />,
+};
+
+export const ReplyModalMediaUploadDirtyClose: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoCompact' } },
+  parameters: {
+    relay: {
+      operationResponses: {
+        PostComposerCompleteMediaUploadMutation: {
+          data: {
+            completeMediaUpload: {
+              media: { id: 'media-reply-dirty-close', state: 'READY' },
+            },
+          },
+        },
+        PostComposerIssueMediaUploadUrlMutation: {
+          data: {
+            issueMediaUploadUrl: {
+              media: { id: 'media-reply-dirty-close' },
+              uploadUrl: 'https://upload.example/reply-dirty-close',
+            },
+          },
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const originalFetch = globalThis.fetch;
+    let finishUpload!: (response: Response) => void;
+    globalThis.fetch = fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishUpload = resolve;
+        }),
+    );
+    setNextImagePickerResult({
+      assets: [
+        {
+          ...composerMediaAsset,
+          file: new File(['reply-image'], 'reply-image.png', { type: 'image/png' }),
+          mimeType: 'image/png',
+          uri: 'blob:https://kosmo.example/reply-dirty-close',
+        },
+      ],
+      canceled: false,
+    });
+
+    try {
+      const dialog = await screen.findByRole('dialog', { name: '답글 쓰기' });
+      await userEvent.click(
+        within(dialog).getByRole('button', { name: '이미지 추가, 4개 더 선택 가능' }),
+      );
+      await waitFor(() => {
+        expect(within(dialog).getByLabelText('첨부 이미지 1, 업로드 중')).toBeVisible();
+      });
+      expect(within(dialog).getByRole('button', { name: '답글 게시' })).toBeDisabled();
+
+      await userEvent.click(within(dialog).getByRole('button', { name: '닫기' }));
+      const confirm = await screen.findByRole('alertdialog', {
+        name: '답글 작성을 취소할까요?',
+      });
+      await userEvent.click(within(confirm).getByRole('button', { name: '작성 취소' }));
+      expect(canvas.getByTestId('reply-modal-open-state')).toHaveTextContent('closed');
+
+      finishUpload(new Response(null, { status: 200 }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(canvas.getByTestId('reply-modal-open-state')).toHaveTextContent('closed');
+      expect(screen.queryByRole('dialog', { name: '답글 쓰기' })).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+  render: () => <ReplyModalPresentationStory />,
 };
 
 export const ReplyModalPresentation: Story = {

--- a/docs/design/reply-composer.md
+++ b/docs/design/reply-composer.md
@@ -11,8 +11,8 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
   [`Edit / Reply` node 277:73](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=277-73),
   상세 진입점은
   [`ReplyComposer` node 693:518](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=693-518)을 기준으로 한다.
-- 일반 Post Composer가 지원하는 Plain Text 본문, Visibility, 글자 수, validation, pending과 오류 상태를
-  그대로 재사용한다.
+- 일반 Post Composer가 지원하는 Plain Text 본문, Visibility, 글자 수, Media 선택·업로드·미리보기·제거·재시도,
+  Alt Text, Sensitive Media, validation, pending과 오류 상태를 그대로 재사용한다.
 - Parent가 일반 Post, Reply 또는 Quote이면 화면에 표시되는 direct Parent의 자체 Content와 Source preview를
   보여준다. Action Bar와 Post menu는 Parent 맥락 안에 중복 표시하지 않는다.
 
@@ -65,10 +65,16 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
   상태에서는 같은 경계를 semantic danger border로 바꾼다. placeholder는 `답글을 입력하세요…`다.
 - 제목·control label·button에는 공용 UI typography를, Parent·입력 본문에는 공용 body typography를 사용한다.
   modal 전용 raw font size나 font family를 만들지 않는다.
+- 기존 Composer의 Media control은 editor 안에서 본문 아래에 둔다. 선택한 이미지의 미리보기, 업로드 상태,
+  제거·재시도, nullable Alt Text와 Sensitive Media control이 늘어나면 Parent와 editor가 공유하는 중앙 영역에서
+  함께 스크롤하고 고정 footer를 밀어내지 않는다.
 - footer 좌측에는 Visibility control을 둔다.
 - footer 우측에는 남은 글자 수와 `답글 게시` primary button을 이 순서로 둔다.
 - 남은 글자 수는 `500`에서 시작해 항상 표시하며 초과 시 semantic danger 상태로 표시한다.
-- 빈 본문, 500자 초과와 제출 중에는 `답글 게시`를 disabled로 표시한다.
+- trim한 본문과 업로드를 완료한 Media가 모두 없거나, 본문이 500자를 초과하거나, Media가 업로드 중·실패
+  상태이거나, Reply 제출 중이면 `답글 게시`를 disabled로 표시한다. 본문이 없어도 Ready Media가 하나 이상
+  있으면 Media-only Reply를 제출할 수 있다.
+- Media 업로드 실패는 현재 preview와 Parent 맥락을 유지한 채 같은 위치에서 재시도하거나 제거할 수 있게 한다.
 - 제출 중에는 button에 spinner와 `게시 중` 상태를 표시하고 본문·Visibility의 중복 변경과 닫기를 막는다.
 - validation 또는 network 오류는 editor 아래, 고정 footer 위에 inline alert로 표시한다.
 
@@ -84,15 +90,17 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
 
 - modal을 열면 Reply action은 expanded 상태를 노출하고 본문 editor로 focus를 이동한다.
 - 빈 상태에서는 `X`, backdrop과 `Escape`로 즉시 닫는다.
-- 본문 또는 Visibility가 초기값에서 바뀐 상태로 닫기를 시도하면 `답글 작성을 취소할까요?` 확인을 표시한다.
-  사용자는 `계속 작성` 또는 `작성 취소`를 선택한다.
+- 본문·Visibility가 초기값에서 바뀌었거나 Media 선택·업로드·Alt Text·Sensitive Media 상태가 있으면 dirty로
+  취급한다. 이 상태로 닫기를 시도하면 `답글 작성을 취소할까요?` 확인을 표시하고 사용자가 `계속 작성` 또는
+  `작성 취소`를 선택하게 한다. Media 업로드 중에도 확인 뒤 작성 전체를 폐기할 수 있으며, 늦은 업로드 완료는
+  닫힌 surface를 다시 열거나 상태를 변경하지 않는다.
 - 상세 inline surface에서 현재 Reply action을 다시 활성화하거나 다른 Parent의 Reply action을 선택하는 동작도
-  같은 close 요청으로 처리한다. dirty 상태에서는 확인 뒤 닫거나 Parent를 전환하고, pending 상태에서는
-  현재 작성과 active Parent를 유지한다.
-- 제출 실패 시 modal, direct Parent 맥락, 본문과 Visibility를 유지한다.
+  같은 close 요청으로 처리한다. dirty 상태에서는 확인 뒤 닫거나 Parent를 전환하고, Reply 제출 pending
+  상태에서는 현재 작성과 active Parent를 유지한다.
+- 제출 실패 시 modal, direct Parent 맥락, 본문, Visibility와 Media 작성 상태를 유지한다.
 - selected Profile, direct Parent 또는 Relay Environment가 바뀌면 새 문맥의 첫 Composer commit부터 본문,
-  Visibility, error와 pending을 초기 상태로 시작한다. 이전 문맥의 늦은 mutation completion은 새 문맥의 상태나
-  성공 callback을 변경하지 않는다.
+  Visibility, Media, error와 pending을 초기 상태로 시작한다. 이전 문맥의 늦은 upload·mutation completion은 새
+  문맥의 상태나 성공 callback을 변경하지 않는다.
 - 제출 성공 시 modal을 닫고 원래 Reply action으로 focus를 복원한 뒤 `답글을 게시했어요` 성공 snackbar와
   `보기` action을 표시한다. 이 snackbar는 기존 공용 toast처럼 약 3초 뒤 자동으로 사라지며, 표시 중 사용자가
   `보기`를 활성화할 때만 생성된 Reply 상세로 이동하고 자동으로 route를 바꾸지 않는다.
@@ -105,6 +113,8 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
 - Web modal은 이름이 `답글 쓰기`인 modal dialog semantics와 focus trap을 제공한다.
 - `X`, backdrop, `Escape`, 취소 확인과 성공 close에서 focus 이동을 각각 검증한다.
 - 오류는 alert semantics, Visibility와 Reply action은 name/state, 남은 글자 수는 입력과 연관된 설명을 제공한다.
+- Media 추가·제거·재시도, 업로드 상태, Alt Text와 Sensitive Media control은 기존 일반 Composer와 같은
+  accessible name·state·live feedback을 제공한다.
 - interactive target 수치는 이 문서에서 고정하지 않는다. Web·Android·iOS의 최신 승인 접근성 지침과 runtime
   관찰을 source of truth로 삼고, 이전 target-size 수치를 자동으로 이식하지 않는다.
 - 중앙 scroll은 keyboard focus가 Parent 또는 editor의 현재 위치를 가리지 않게 유지한다. Parent 전용 nested
@@ -113,7 +123,8 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
 ## 제외 범위
 
 - Mentioned Profiles recipient와 `DIRECT` Reply
-- Media, Poll, Content Warning과 Sensitive Media를 포함한 Reply 작성
+- Poll과 Content Warning을 포함한 Reply 작성
+- 새 Media 형식·제한, Reply 전용 Media 모델·storage·API·uploader 또는 일반 Composer Media UI 재설계
 - Reply+Quote 동시 작성
 - ActivityPub Reply와 Notification inbox
 - modal 안의 전체 조상 thread, Parent Action Bar와 Post menu
@@ -121,8 +132,9 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
 
 ## 구현 정렬 gate
 
-- 이 디자인의 목록 modal, 좁은 화면 전체 작성기와 상세 inline surface를 구현하기 전에 PROD-425와
-  `add-local-reply-creation`의 UI scope를 이 문서와 동기화한다.
+- 이 디자인의 목록 modal, 좁은 화면 전체 작성기와 상세 inline surface는 PROD-425의 기본 Reply 작성 계약과
+  PROD-640의 기존 Media 계약 복구를 함께 적용한다. `add-local-reply-creation`의 최종 delta 동기화와 archive는
+  전체 통합 검증을 소유한 PROD-423에서 수행한다.
 - Figma component와 screen state를 먼저 검토한 뒤 구현 계획을 확정한다. 디자인 문서나 Figma 완료만으로
   Reply 작성·cache 통합 또는 runtime 검증 완료를 주장하지 않는다.
 
@@ -133,8 +145,12 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
 - content가 중앙 영역을 넘을 때 header/footer는 유지되고 중앙 영역 하나만 스크롤되는지 확인한다.
 - 일반 Post, Reply, Quote Parent의 Content/Source 표시와 Action Bar/menu 제외, thread connector를 확인한다.
 - Visibility 독립성, `UNLISTED` 기본값, `DIRECT` 제외, 500자 count와 disabled/pending/error 상태를 확인한다.
+- 모든 지원 Reply surface에서 이미지 선택·업로드·미리보기·제거·재시도, Alt Text, Sensitive Media와
+  Media-only Reply payload를 확인한다. 업로드 중·실패 상태는 제출을 차단하고 재시도 또는 제거 뒤 유효성을
+  다시 계산해야 한다.
 - pristine/dirty/pending/success close, 취소 확인, focus open/restore, 성공 snackbar의 `보기` 이동과 자동 이동
-  없음, selected Profile·Parent·Relay Environment 전환의 첫 commit과 늦은 completion 격리를 확인한다.
+  없음, Media upload 중 dirty close, selected Profile·Parent·Relay Environment 전환의 첫 commit과 늦은
+  upload·mutation completion 격리를 확인한다.
 - Web `< compact` 전체 화면과 상세 inline surface의 Parent·Composer 계약을 Storybook에서 확인한다. 실제 API의
   targeted refetch 실패·retry와 Web 짧은-height layout은 통합 runtime 검증으로 분리한다.
 - Native 전체 화면 구현은 같은 Parent·Composer 계약을 공유하지만, Android·iOS의 scroll, keyboard, safe area,

--- a/openspec/changes/add-local-reply-creation/design.md
+++ b/openspec/changes/add-local-reply-creation/design.md
@@ -1,8 +1,8 @@
 ## Context
 
-`origin/main`에는 Post table의 nullable Reply Parent self-reference, `createPost(replyParentId?)` API, Reply thread와 Notification 기반이 병합되어 있다. 클라이언트의 기존 composer와 actual 목록·상세 Action Bar surface는 아직 Reply 작성 맥락, controlled `expanded`와 성공 결과 반영 경계를 연결하지 않았다.
+`origin/main`에는 Post table의 nullable Reply Parent self-reference, `createPost(replyParentId?)` API, Reply thread·Notification 기반과 목록·상세 Reply Composer surface가 병합되어 있다. 그러나 `PostComposer`는 Reply mode에서 기존 Media control, dirty·pending 판정과 mutation의 Media/Sensitive Media 입력을 제외해 canonical Reply Media 계약을 충족하지 못한다.
 
-PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox는 하나의 Local Reply 사용자 흐름을 구성하고, 후행 PROD-423은 전체 통합 검증과 OpenSpec 동기화·archive를 수행한다. Reply 조상·하위 조회와 thread rendering은 `add-post-replies`/PROD-422, 공통 Notification projection·connection·Read·badge는 `add-in-app-notifications`의 선행 기반이다.
+PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox는 하나의 Local Reply 사용자 흐름을 구성하고, PROD-640은 후행 Media 계약을 기존 Reply Composer surface에 복구한다. 후행 PROD-423은 전체 통합 검증과 OpenSpec 동기화·archive를 수행한다. Reply 조상·하위 조회와 thread rendering은 `add-post-replies`/PROD-422, 공통 Notification projection·connection·Read·badge는 `add-in-app-notifications`의 선행 기반이다.
 
 ## Goals / Non-Goals
 
@@ -10,12 +10,13 @@ PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox는 하나의 L
 
 - 기존 Plain Text Post mutation을 nullable Reply Parent 입력으로 확장하고 Parent 권한·Content 검증과 Reply 저장을 원자적으로 수행한다.
 - 목록에서는 폭과 platform에 맞는 modal·전체 화면 surface로, 상세에서는 현재 thread의 inline surface로 기존 composer를 Reply 맥락에 재사용한다. 성공 시 현재 화면을 유지한 채 결과 Reply를 열 수 있는 feedback을 제공하고, 상세의 현재 query 범위에 포함되는 결과만 기존 thread 정렬에 따라 반영한다.
+- 모든 지원 Reply Composer surface에서 기존 Post Media lifecycle과 입력 계약을 재사용하고 Parent·본문·Media를 하나의 Reply 결과로 저장한다.
 - Reply Notification을 기존 Notification projection·GraphQL·inbox·Read·badge 흐름에 수직적으로 추가한다.
-- backend, UI, Notification 각 slice를 독립적으로 검증하고 PROD-423에서 전체 flow와 archive gate를 검증한다.
+- backend, UI, Reply Media, Notification 각 slice를 독립적으로 검증하고 PROD-423에서 전체 flow와 archive gate를 검증한다.
 
 **Non-Goals:**
 
-- Content Warning, Media/Sensitive Media, Mentioned Profile recipient·Mentioned Profiles/DIRECT 작성·조회
+- Content Warning, Media/Sensitive Media capability 자체의 신규 설계·변경, Mentioned Profile recipient·Mentioned Profiles/DIRECT 작성·조회
 - Reply Parent와 Repost Source를 동시에 입력하는 Reply+Quote 작성
 - ActivityPub Reply, Reply 외 Action Bar의 최종 action 조합·guest 인증 위임, retry/outbox/backfill, Reply Tombstone 후 동기 Notification cleanup
 - `add-post-replies`의 Reply 조상·하위 GraphQL 계약과 thread rendering, `add-in-app-notifications`의 공통 inbox 기반을 다시 설계하는 작업
@@ -24,9 +25,9 @@ PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox는 하나의 L
 
 ### Current Constraints
 
-- PROD-424 구현은 API의 Parent 입력·viewer visibility 검증과 core write를 같은 caller transaction에 연결하며, 승인된 OpenSpec과의 독립 대조가 남아 있다.
-- Parent visibility 검증과 core write가 서로 다른 connection/transaction에서 수행되면 검증 후 상태 변경 또는 부분 저장 경계가 생길 수 있다.
-- `PostComposer` 성공 처리는 현재 본문 초기화에 초점이 있고 Parent, callback, context generation과 surface lifecycle 입력이 없다. `PostDetailThread_replyDescendants` connection은 선행 `add-post-replies` 구현이 제공한다.
+- API는 기존 `createPost` 입력에서 `replyParentId`, ordered Media item, nullable Alt Text와 Sensitive Media를 함께 허용하고 같은 transaction에서 PostContent로 저장한다.
+- `PostComposer`와 `ReplyComposerSurface`는 selected Profile·Relay Environment·Parent별 context generation과 늦은 mutation completion 격리를 제공하지만, Reply mode에서 Media state와 control을 제외한다.
+- 기존 Media control의 active upload guard와 composer keyed remount를 유지해 제거된 upload 또는 이전 Profile·Parent·Environment의 늦은 completion이 새 Reply 문맥을 오염시키지 않아야 한다.
 - Notification kind, source predicate, concrete Node loader, connection/count/Read 쿼리와 client item이 Follow 구조에 결합되어 있어, Reply branch를 item 표시만으로 추가하면 hidden item이 page limit·count·Node·Read 간에 다르게 보일 수 있다.
 - PROD-273은 실제 Mute·Block 정책 capability가 연결되기 전 Notification 생성 정책을 기본 allow로 정의한다. PROD-426은 아직 구현되지 않은 Profile Mute·Block·Domain Block·Domain Block Instance, Notification scope Word·Hashtag Mute와 Root Post thread Notification Mute capability 및 Reply source 연동을 구현하지 않는다.
 - Relay generated artifact는 commit하지 않으며, selected Profile 전환은 Environment/Store 재생성을 통해 cache를 격리한다.
@@ -35,9 +36,10 @@ PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox는 하나의 L
 
 1. PROD-424에서 `CreatePostInput`에 nullable `replyParentId: ID`를 추가하고 concrete `Post` global ID를 decode한다. 요청 Profile 기준 Parent visibility/eligibility·Content를 검증한 같은 transaction 내에서 기존 core Reply 저장 경계를 호출하고 기존 `CreatePostPayload.post`를 반환한다.
 2. PROD-425에서 기존 `PostComposer`에 optional Parent ID와 성공 callback을 추가하고 selected Profile·Relay Environment·Parent별 draft·pending·error와 늦은 completion을 격리한다. collection·thread coordinator는 selected Profile, surface mode, 하나의 active Parent와 dirty·pending 전환만 관리하고 Provider 또는 동등한 내부 adapter로 공급한다. `PostListItem`과 `PostLayout`은 coordinator를 소비해 Reply action의 존재·배치와 `ReplyComposerSurface`를 내부 조립한다. 목록 surface는 Web `>= compact`에서 600px modal, Web `< compact`와 Native에서 전체 화면 composer를 열고, 상세 thread는 현재·조상·하위 행의 Reply를 하나의 active Parent로 제어해 해당 행에 inline으로 펼친다. display Post와 Action Bar target을 분리해 순수 Repost의 Repost action은 Source target을 유지하면서 Reply eligibility는 바깥 contentless Repost에서 disabled로 전달한다. selected Profile이 없는 guest에는 PROD-425 Reply config를 새로 노출하지 않고 최종 인증 위임은 PROD-432에 남긴다. 성공 시 surface를 닫고 focus를 복원한 뒤 결과 Reply로 이동하는 `보기` action을 가진 약 3초의 transient snackbar를 표시하되 자동 이동하지 않는다. 상세 route는 coordinator에 공급한 성공 callback에서 현재 query의 제한된 targeted refetch를 시작하고 전역 Post 목록 membership이나 다른 actor Store를 추측하지 않는다.
-3. PROD-426에서 Reply source에서 Recipient·Related Post·Related Profile을 파생하는 멱등 Notification 저장 경계를 추가한다. 같은 Reply 생성 transaction의 별도 savepoint에서 이 경계를 await/catch하여 Notification 실패만 rollback한다.
-4. Notification visibility predicate를 kind별 source relation에 따라 SQL에서 구성하고 page limit 전에 적용한다. Reply branch는 source PK에서 시작하는 nested `EXISTS`로 Parent Author/Recipient mapping과 Reply Author visibility를 확인하며 Parent lifecycle predicate는 두지 않는다. concrete `ReplyNotification` Node의 `post`/`profile` source hydration은 request-scoped `ctx.loader`로 batch하고, mixed connection/count/Read가 동일 predicate를 사용하게 한 뒤 client의 discriminated item branch를 결과 Reply 이동과 기존 Best Effort Read/cache 경계에 연결한다.
-5. PROD-423에서 Post 상세 Reply 작성 → thread 반영 → Parent Author inbox/count → item 읽음/결과 Reply 이동을 통합 검증한다. 세 자식 계약과 선행 change의 task·delta spec이 모두 맞을 때만 archive한다.
+3. PROD-640에서 Reply mode의 Media control 차단을 제거하고 Media item이 dirty·media-only 유효성·pending 제출 차단과 기존 `createPost` 입력에 일반 Post와 동일하게 참여하게 한다. 기존 uploader, Alt Text·Sensitive Media, remove·retry와 context generation을 재사용하며 Reply 전용 Media state나 cache updater를 만들지 않는다.
+4. PROD-426에서 Reply source에서 Recipient·Related Post·Related Profile을 파생하는 멱등 Notification 저장 경계를 추가한다. 같은 Reply 생성 transaction의 별도 savepoint에서 이 경계를 await/catch하여 Notification 실패만 rollback한다.
+5. Notification visibility predicate를 kind별 source relation에 따라 SQL에서 구성하고 page limit 전에 적용한다. Reply branch는 source PK에서 시작하는 nested `EXISTS`로 Parent Author/Recipient mapping과 Reply Author visibility를 확인하며 Parent lifecycle predicate는 두지 않는다. concrete `ReplyNotification` Node의 `post`/`profile` source hydration은 request-scoped `ctx.loader`로 batch하고, mixed connection/count/Read가 동일 predicate를 사용하게 한 뒤 client의 discriminated item branch를 결과 Reply 이동과 기존 Best Effort Read/cache 경계에 연결한다.
+6. PROD-423에서 Post 상세 Reply 작성 → thread 반영 → Parent Author inbox/count → item 읽음/결과 Reply 이동을 통합 검증한다. PROD-424·425·426·640의 담당 task와 선행 change의 delta spec이 모두 맞을 때만 archive한다.
 
 ### Allowed Alternatives
 
@@ -55,6 +57,9 @@ PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox는 하나의 L
 - 순수 Repost의 direct Source를 Action Bar target으로 사용하더라도 바깥 display Post identity를 잃고 Reply eligibility를 Source Content에서 다시 계산하지 않는다.
 - 상세 thread에서 재사용되는 `PostListItem`이 목록 폭만 보고 modal·전체 화면 surface를 열게 하지 않고, thread coordinator가 inline surface mode와 하나의 active Parent를 공급한다. 이 coordination을 이유로 `PostDetailThread`가 각 행의 Reply action과 Composer config까지 조립하지 않는다.
 - active Parent 상태를 각 Post 행 안으로 분산하거나 완성된 Reply controller prop을 caller가 선택적으로 조립하지 않는다. 전자는 single-active·dirty/pending 전환을 깨뜨리고 후자는 새 surface caller의 Reply UI 누락을 허용한다.
+- Reply mode에서 Media-only 입력을 빈 Reply로 거부하거나 Media upload pending 상태를 제출 가능하게 만들지 않는다.
+- selected Profile·Parent·Relay Environment가 바뀔 때 Composer만 새 문맥으로 교체하고 이전 Media control의 늦은 upload completion을 새 state에 반영하지 않는다.
+- Reply 전용 Media state, uploader, GraphQL 입력 또는 Relay connection updater를 만들지 않는다.
 - 기존 `ModalSheet`의 420px geometry와 단순 close lifecycle을 600px Reply modal 계약으로 간주하지 않는다.
 - Notification을 Reply write와 같은 savepoint에 넣거나 fire-and-forget으로 호출하지 않는다. 별도 savepoint로 실패를 격리하고 transaction 인자의 존재 여부로 lifecycle을 분기하지 않는다.
 - client에서 hidden Notification을 사후 filtering해 서버 connection·count·Node·Read의 불일치를 감추지 않는다.
@@ -66,13 +71,15 @@ PROD-424 backend, PROD-425 UI/thread, PROD-426 Notification/inbox는 하나의 L
 - [mixed Notification kind의 SQL predicate가 복잡해짐] → kind별 source 정합성을 공통 visible contract에서 조합하고 connection·count·Node·Read 통합 테스트로 드리프트를 막는다.
 - [mutation 성공 후 targeted refetch를 사용하면 추가 network request가 생김] → 현재 상세 query의 fetch key만 갱신하고, connection edge·cursor 또는 전역 목록 membership을 합성하지 않는다.
 - [현재 query 범위 밖의 새 Reply가 즉시 인라인 표시되지 않으면 성공 여부가 모호해질 수 있음] → 성공 snackbar와 결과 Reply `보기` action을 항상 제공하되 사용자의 현재 읽기 문맥을 보존한다.
+- [Reply Media upload와 Parent·Profile 전환이 겹치면 이전 preview 또는 completion이 새 draft를 오염시킬 수 있음] → 기존 keyed remount와 active upload/context generation guard를 유지하고 겹친 completion 회귀를 검증한다.
 
 ## Migration Plan
 
 1. additive GraphQL input·Reply 생성 경계와 테스트를 배포한다. 기존 `replyParentId` 생략 호출은 일반 Post 작성으로 계속 동작한다.
 2. 선행 Reply thread 기반을 확인한 뒤 composer·action·thread cache 통합을 배포한다.
-3. 기존 Notification 기반에 Reply kind, source predicate, API와 client item을 additive로 배포한다. schema enum migration이 필요하면 expand 단계로 먼저 반영한다.
-4. 롤백 시 client/UI 통합과 Reply Notification branch를 역순으로 제거해도 기존 Reply Post 및 Follow Notification 데이터는 유지된다. additive input과 enum 값의 스토리지 contract 제거는 별도 contract 단계 없이 즉시 수행하지 않는다.
+3. 기존 Post Media lifecycle을 Reply Composer surface에 적용하고 일반 Post·Reply 회귀와 문맥 격리를 검증한다.
+4. 기존 Notification 기반에 Reply kind, source predicate, API와 client item을 additive로 배포한다. schema enum migration이 필요하면 expand 단계로 먼저 반영한다.
+5. 롤백 시 Reply Media client 연결, 나머지 client/UI 통합과 Reply Notification branch를 역순으로 제거해도 기존 Reply Post 및 Follow Notification 데이터는 유지된다. additive input과 Media 스토리지 contract 제거는 별도 contract 단계 없이 즉시 수행하지 않는다.
 
 ## Open Questions
 

--- a/openspec/changes/add-local-reply-creation/proposal.md
+++ b/openspec/changes/add-local-reply-creation/proposal.md
@@ -1,19 +1,20 @@
 ## Why
 
-Kosmo의 Reply Parent 저장·조회와 thread 표시 기반은 있지만, 사용자가 Local Reply를 작성하고 현재 thread에서 확인하며 Parent Author가 기존 inbox에서 알림을 받는 수직 흐름은 아직 연결되지 않았다. PROD-424·425·426이 공유할 작성 계약을 하나의 `add-local-reply-creation` OpenSpec Gate에서 정렬하고, 후행 PROD-423에서 전체 흐름을 통합 검증해 archive할 수 있어야 한다.
+Kosmo의 Reply Parent 저장·조회와 thread 표시 기반은 있지만, 사용자가 Local Reply를 작성하고 현재 thread에서 확인하며 Parent Author가 기존 inbox에서 알림을 받는 수직 흐름은 아직 연결되지 않았다. PROD-424·425·426이 공유할 작성 계약을 하나의 `add-local-reply-creation` OpenSpec Gate에서 정렬하고, 후행 PROD-423에서 전체 흐름을 통합 검증해 archive할 수 있어야 한다. 후행 Media 계약이 일반 Post와 Reply에 공통 적용된 뒤에도 Reply Composer가 해당 입력과 lifecycle을 차단하는 결손은 PROD-640에서 기존 계약 복구로 해결한다.
 
 ## What Changes
 
 - 기존 `createPost` 입력에 nullable `replyParentId`를 추가하고, 요청 Profile이 조회할 수 있는 contentful Parent에 현재 지원 본문·Visibility를 가진 일반 Reply를 생성한다.
 - 목록의 Reply action은 화면 폭과 platform에 맞는 modal 또는 전체 화면 surface에서, Post 상세의 Reply action은 현재 thread 안의 inline surface에서 기존 composer를 Parent 맥락으로 연다. 성공하면 현재 화면과 focus를 유지하면서 결과 Reply로 이동할 수 있는 `보기` action을 제공하고 현재 detail query만 갱신하며, Content 없는 Repost의 action은 표시하되 진입을 차단한다.
+- Reply Composer는 일반 Post와 같은 기존 Media 선택·업로드·미리보기·제거·재시도, Alt Text와 Sensitive Media 계약을 적용하고 Parent·본문·Media를 기존 `createPost` 결과 하나로 저장한다.
 - 다른 Profile의 Post에 새 Reply가 생성되면 origin과 무관하게 Parent Author에게 Reply Notification을 같은 생성 lifecycle의 격리된 Best Effort savepoint로 생성하고, 기존 connection·Unread count·Read·badge/cache·inbox 흐름에 연결한다.
-- Content Warning, Media/Sensitive Media capability 자체의 변경, Mentioned Profile recipient·Mentioned Profiles 작성/조회, Reply+Quote 작성, ActivityPub Reply materialization·delivery, Action Bar 전체 rollout, retry/outbox와 동기 cleanup은 제외한다. 이미 materialize된 새 ActivityPub Reply의 기존 Notification integration은 포함하며, 기존 `createPost`의 Media/Sensitive Media 계약은 이 change가 수정하거나 제거하지 않는다.
+- Content Warning, Media/Sensitive Media capability 자체의 신규 설계·변경, Mentioned Profile recipient·Mentioned Profiles 작성/조회, Reply+Quote 작성, ActivityPub Reply materialization·delivery, Action Bar 전체 rollout, retry/outbox와 동기 cleanup은 제외한다. 이미 materialize된 새 ActivityPub Reply의 기존 Notification integration은 포함하며, PROD-640은 기존 `createPost`의 Media/Sensitive Media 계약을 Reply Composer에 적용할 뿐 모델·storage·API 정책을 수정하지 않는다.
 
 ## Authority / Provenance
 
-- Canonical: `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/objects/post.md`, `docs/domain/objects/notification.md`, `docs/domain/policies/post-list.md`, `docs/design/README.md`, `docs/design/reply-composer.md`, `docs/design/colors.md`, `docs/design/typography.md`, `docs/design/breakpoints.md`
-- Linear Contract: [PROD-424](https://linear.app/byulmaru/issue/PROD-424), [PROD-425](https://linear.app/byulmaru/issue/PROD-425), [PROD-426](https://linear.app/byulmaru/issue/PROD-426), [PROD-507](https://linear.app/byulmaru/issue/PROD-507)
-- Linear Implementations: [PROD-424](https://linear.app/byulmaru/issue/PROD-424), [PROD-425](https://linear.app/byulmaru/issue/PROD-425), [PROD-426](https://linear.app/byulmaru/issue/PROD-426), [PROD-507](https://linear.app/byulmaru/issue/PROD-507)
+- Canonical: `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0022-post-content-revision-media-nodes.md`, `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/domain/objects/notification.md`, `docs/domain/policies/post-list.md`, `docs/design/README.md`, `docs/design/reply-composer.md`, `docs/design/colors.md`, `docs/design/typography.md`, `docs/design/breakpoints.md`
+- Linear Contract: [PROD-424](https://linear.app/byulmaru/issue/PROD-424), [PROD-425](https://linear.app/byulmaru/issue/PROD-425), [PROD-426](https://linear.app/byulmaru/issue/PROD-426), [PROD-507](https://linear.app/byulmaru/issue/PROD-507), [PROD-640](https://linear.app/byulmaru/issue/PROD-640)
+- Linear Implementations: [PROD-424](https://linear.app/byulmaru/issue/PROD-424), [PROD-425](https://linear.app/byulmaru/issue/PROD-425), [PROD-426](https://linear.app/byulmaru/issue/PROD-426), [PROD-507](https://linear.app/byulmaru/issue/PROD-507), [PROD-640](https://linear.app/byulmaru/issue/PROD-640)
 
 ## Capabilities
 
@@ -29,8 +30,8 @@ Kosmo의 Reply Parent 저장·조회와 thread 표시 기반은 있지만, 사�
 
 ## Impact
 
-- Linear: 구현 계약 PROD-424·425·426과 후행 통합·archive 이슈 PROD-423
+- Linear: 구현 계약 PROD-424·425·426·640과 후행 통합·archive 이슈 PROD-423
 - Core/API: 기존 Reply Parent 저장 경계, Post visibility predicate, `CreatePostInput`, Reply Notification source·concrete Node·visible predicate
-- Universal client: 목록 modal·전체 화면 Reply surface, 상세 inline Reply surface, 기존 composer mutation, thread Relay cache, Notification inbox item·Read·badge cache
+- Universal client: 목록 modal·전체 화면 Reply surface, 상세 inline Reply surface, 기존 composer mutation·Media lifecycle, thread Relay cache, Notification inbox item·Read·badge cache
 - Verification: backend service/schema/resolver, client component/route/cache, Notification connection·count·Read·Node와 통합 flow
 - Dependencies: `add-post-replies`의 Reply Parent·thread 기반과 `add-in-app-notifications`의 공통 Notification 기반을 재사용한다. `add-post-reposts`의 merged Repost Notification loader·bounded source visibility 구조와 같은 request-scoped loader contract를 공유한다.

--- a/openspec/changes/add-local-reply-creation/tasks.md
+++ b/openspec/changes/add-local-reply-creation/tasks.md
@@ -110,7 +110,52 @@
 - [x] 3.7 inbox 표시·이동·Read·cache·Profile 전환 client 검증과 Relay compiler/check를 통과시킨다.
 - [x] 3.8 PROD-507에서 Local·ActivityPub Reply가 transaction 인자와 무관한 공통 Best Effort Notification lifecycle을 사용하도록 정렬하고, duplicate no-op·outer transaction 회귀를 검증한다.
 
-## 4. PROD-423 통합 검증·OpenSpec 완료
+## 4. PROD-640 Reply Composer Media 계약 복구
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/post-content.md`
+- `docs/domain/objects/media.md`
+- `docs/domain/decisions/0014-post-structure-relations.md`
+- `docs/domain/decisions/0022-post-content-revision-media-nodes.md`
+- `PROD-640`
+
+**Deliverable**
+
+모든 지원 Reply Composer surface에서 기존 일반 Post의 이미지 선택·업로드·미리보기·제거·재시도, Alt Text와 Sensitive Media lifecycle을 사용하고 Parent·본문·Media가 하나의 Reply 결과로 저장된다.
+
+**Guardrails**
+
+- 기존 `PostComposer`, Media control·uploader와 `createPost`의 ordered Media item·nullable Alt Text·Sensitive Media 입력을 재사용하고 Reply 전용 Media state, 모델, storage, API 또는 cache updater를 만들지 않는다.
+- Media-only Reply는 유효하고, uploading 또는 failed Media item이 남아 있는 동안 제출을 차단하며 실패·재시도·제거가 일반 Post와 같은 lifecycle을 따른다.
+- Media state는 기존 Reply surface의 dirty·discard confirmation에 참여하고, close·Parent 전환의 강제 차단은 Reply mutation 제출 pending에만 적용한다.
+- selected Profile·Parent·Relay Environment 전환 시 Reply body·Media·pending·error와 늦은 upload/mutation completion을 새 문맥과 격리한다.
+- clipboard paste, 새 파일 형식·크기 정책, Media Storage Service, 일반 Post 갤러리·viewer 재설계는 포함하지 않는다.
+- 성공 결과 반영은 기존 Reply surface callback과 detail targeted refetch를 사용하며 다른 actor Store나 전역 목록 membership을 합성하지 않는다.
+
+**Verification**
+
+- 목록 modal·좁은 Web/Native 전체 화면·상세 inline surface에서 선택·preview·Alt Text·Sensitive Media·제거·실패·재시도와 최대 4개 계약을 검증한다.
+- 본문+Media와 Media-only Reply가 `replyParentId`, ordered `{ mediaId, altText }`, `sensitiveMedia`를 함께 제출하고 uploading 또는 failed item이 남아 있으면 제출을 차단하며 재시도·제거 뒤에만 제출할 수 있는지 검증한다.
+- Media 선택·upload 상태가 dirty에 반영되어 close·Parent 전환 시 기존 discard confirmation을 거치고, 확인된 폐기 뒤 늦은 upload completion이 닫힌 문맥을 복원하지 않는지 검증한다.
+- selected Profile·Parent·Relay Environment 전환과 늦은 upload/mutation completion, 일반 Post Composer 회귀를 자동화로 검증한다.
+- Web runtime과 Android·iOS picker·keyboard·safe area·platform back·접근성은 실행한 환경의 증거를 분리해 기록하고 미실행 Native 항목을 Ready 근거로 주장하지 않는다.
+
+- [x] 4.1 Reply mode에서 기존 Media control을 노출하고 Media state를 dirty·media-only 유효성·pending 제출 차단과 `createPost` 입력에 연결한다.
+- [x] 4.2 Reply Media payload·lifecycle·일반 Post 회귀와 selected Profile·Parent·Relay Environment 전환의 늦은 completion 격리 테스트를 추가한다.
+- [x] 4.3 App unit·Storybook·Relay/TypeScript·lint/format·build와 실행 가능한 Web·Android·iOS 검증을 수행하고 결과와 미실행 platform gate를 기록한다.
+
+**Verification Evidence (2026-08-03)**
+
+- `pnpm --filter @kosmo/app test:unit`: 166 passed
+- `pnpm --filter @kosmo/app test:storybook`: 277 passed; Reply Media 집중 계약 5개도 별도 통과
+- `pnpm --filter @kosmo/app check`: Relay compiler와 TypeScript 통과
+- 변경 TSX의 ESLint와 변경 파일의 Prettier check 통과
+- `pnpm --filter @kosmo/app build-storybook`과 `pnpm --filter @kosmo/app build` Web production export 통과
+- Web은 Chromium Storybook interaction과 production export까지만 검증했다. 실제 API/BFF 연동 Web runtime과 Android·iOS picker·keyboard·safe area·platform back·접근성 runtime은 실행하지 않았으며 Ready 전 별도 platform gate로 남긴다.
+
+## 5. PROD-423 통합 검증·OpenSpec 완료
 
 **Authority / Provenance**
 
@@ -122,6 +167,7 @@
 - `PROD-424`
 - `PROD-425`
 - `PROD-426`
+- `PROD-640`
 
 **Deliverable**
 
@@ -129,7 +175,7 @@ Local Reply 작성에서 thread 반영과 Parent Author Notification inbox·Read
 
 **Guardrails**
 
-- PROD-424·425·426 전체 Deliverable·Guardrail·Verification과 필수 dependency가 완료되기 전에 change를 archive하지 않는다.
+- PROD-424·425·426·640 전체 Deliverable·Guardrail·Verification과 필수 dependency가 완료되기 전에 change를 archive하지 않는다.
 - PROD-460·461·462와 Reply+Quote·ActivityPub·retry/outbox 범위를 통합 완료 조건으로 승격시키지 않는다.
 - Pull Request readiness와 OpenSpec archive를 별도로 판단한다.
 
@@ -137,10 +183,10 @@ Local Reply 작성에서 thread 반영과 Parent Author Notification inbox·Read
 
 - 두 Local Profile로 Reply 작성 → Parent thread 반영 → Parent Author inbox/count → item Read 및 결과 Reply 이동을 검증한다.
 - self-reply, Parent와 독립 Visibility, contentless Repost disabled, Notification 실패 격리와 selected Profile 전환 회귀를 검증한다.
-- 관련 전체 check, OpenSpec strict validation, task 완료와 canonical delta 동기화 결과를 기록한다.
+- Reply Media를 포함한 관련 전체 check, OpenSpec strict validation, task 완료와 canonical delta 동기화 결과를 기록한다.
 
-- [ ] 4.1 PROD-424·425·426의 구현·검증·dependency 완료와 제외 범위 유지를 확인한다.
-- [ ] 4.2 Local Reply 작성·thread·Notification·Read·이동 수직 flow와 필수 회귀 시나리오를 최종 검증한다.
-- [ ] 4.3 구현 결과에 맞게 delta spec, decision, task와 필요한 canonical 문서를 동기화한다.
-- [ ] 4.4 전체 필수 check와 `openspec validate add-local-reply-creation --strict`를 통과시키고 검증 evidence를 기록한다.
-- [ ] 4.5 전체 scope와 task가 완료되고 delta spec이 동기화된 뒤 `add-local-reply-creation`을 archive한다.
+- [ ] 5.1 PROD-424·425·426·640의 구현·검증·dependency 완료와 제외 범위 유지를 확인한다.
+- [ ] 5.2 Local Reply 작성·Media·thread·Notification·Read·이동 수직 flow와 필수 회귀 시나리오를 최종 검증한다.
+- [ ] 5.3 구현 결과에 맞게 delta spec, decision, task와 필요한 canonical 문서를 동기화한다.
+- [ ] 5.4 전체 필수 check와 `openspec validate add-local-reply-creation --strict`를 통과시키고 검증 evidence를 기록한다.
+- [ ] 5.5 전체 scope와 task가 완료되고 delta spec이 동기화된 뒤 `add-local-reply-creation`을 archive한다.

--- a/openspec/changes/add-local-reply-creation/tasks.md
+++ b/openspec/changes/add-local-reply-creation/tasks.md
@@ -149,11 +149,11 @@
 **Verification Evidence (2026-08-03)**
 
 - `pnpm --filter @kosmo/app test:unit`: 166 passed
-- `pnpm --filter @kosmo/app test:storybook`: 277 passed; Reply Media 집중 계약 5개도 별도 통과
+- `pnpm --filter @kosmo/app test:storybook`: 278 passed; 새 Relay Environment Media 격리 Story는 focused run 1 passed
 - `pnpm --filter @kosmo/app check`: Relay compiler와 TypeScript 통과
 - 변경 TSX의 ESLint와 변경 파일의 Prettier check 통과
 - `pnpm --filter @kosmo/app build-storybook`과 `pnpm --filter @kosmo/app build` Web production export 통과
-- Web은 Chromium Storybook interaction과 production export까지만 검증했다. 실제 API/BFF 연동 Web runtime과 Android·iOS picker·keyboard·safe area·platform back·접근성 runtime은 실행하지 않았으며 Ready 전 별도 platform gate로 남긴다.
+- Web 자동화와 공용 코드는 현재 PR의 Ready 근거로 검증했다. 격리 API 3100·BFF 5184·App 5183 runtime에서는 인증 화면, picker와 upload URL 발급까지 확인했지만 Media Storage의 local CORS가 기본 `http://localhost:5173`만 허용해 5183 origin의 PUT은 환경 제한으로 완료하지 못했다. 기본 5173 origin의 실제 cross-service upload lifecycle은 통합 테스트로 통과했다. Android·iOS picker·keyboard·safe area·platform back·접근성 runtime은 이번 Web 우선 PR의 Ready 조건이 아니며 Native 출시 gate에서 별도로 확인한다.
 
 ## 5. PROD-423 통합 검증·OpenSpec 완료
 


### PR DESCRIPTION
## 무엇을 변경했나요?

- 모든 기존 Reply Composer surface에서 일반 Post와 같은 이미지 선택·업로드·미리보기·제거·재시도 control을 노출합니다.
- Media state를 Reply의 dirty·media-only 유효성·uploading/failed 제출 차단에 연결합니다.
- `replyParentId`와 ordered Media/Alt Text/Sensitive Media를 기존 `createPost` 입력 하나로 전달합니다.
- Profile·Parent·Relay Environment 전환 및 surface 폐기 뒤 늦은 업로드 completion이 새 문맥을 오염시키지 않는 회귀 검증을 추가했습니다.
- `docs/design/reply-composer.md`를 Media-only 유효성, upload dirty close, submit pending, context 격리와 제외 범위에 맞게 동기화했습니다.
- `add-local-reply-creation` OpenSpec에 PROD-640 구현·검증 ownership을 추가하고, PROD-423의 통합·delta 최종 동기화·archive task는 5.x 미완료로 유지했습니다.

## 왜 필요한가요?

API와 canonical PostContent 계약은 Reply에도 Media를 허용하지만, `PostComposer`가 Reply mode에서 기존 Media control과 mutation 입력을 제외하고 있어 Reply에서 이미지를 첨부할 수 없었습니다.

## 주요 결정

새로운 material implementation decision은 없습니다. Linear PROD-640, canonical Media/PostContent 계약과 `add-local-reply-creation` OpenSpec에서 확인된 기존 결정을 적용했습니다. Reply 전용 Media state, uploader, 모델, API 또는 Relay cache updater는 추가하지 않았습니다.

## 검증

- `pnpm --filter @kosmo/app test:unit` — 166 passed
- `pnpm --filter @kosmo/app test:storybook` — 278 passed
- Relay Environment Media 격리 focused Storybook — 1 passed
- `pnpm --filter @kosmo/app exec relay-compiler --noWatchman`
- `pnpm --filter @kosmo/app exec tsc --noEmit`
- 변경 TSX ESLint 및 변경 파일 Prettier check
- `pnpm --filter @kosmo/app build-storybook`
- `pnpm --filter @kosmo/app build` Web production export
- `openspec validate add-local-reply-creation --strict`
- Sol medium 독립 구현 리뷰 및 canonical 문서 재리뷰 — PASS
- GitHub Actions Lint·Semgrep·App·API·Core·Fedify·Root·Web·aggregate Test — 새 HEAD `3c57de76`에서 모두 통과. Web의 기존 navigation scroll E2E가 timing으로 1회 실패했지만 failed job 재실행에서 81/81 passed

기본 `pnpm --filter @kosmo/app check`는 로컬의 global Watchman FSEvents 상태 때문에 완료하지 못했습니다. 동일 범위의 Relay compiler는 `--noWatchman`으로, TypeScript는 `tsc --noEmit`으로 각각 통과했습니다.

## Runtime 확인과 남은 gate

- 격리 API 3100·BFF 5184·App 5183 runtime에서 인증 화면, picker와 upload URL 발급까지 확인했습니다.
- Media Storage local CORS가 기본 `http://localhost:5173`만 허용하므로 격리 5183 origin의 PUT은 완료하지 못했습니다. 기본 5173 origin의 실제 cross-service upload lifecycle 통합 테스트는 통과했습니다.
- Android·iOS picker, keyboard, safe area, platform back 및 접근성 runtime은 실행하지 않았습니다. 이번 Web 우선 PR의 Ready 조건이 아니라 별도 Native 출시 gate에서 확인합니다.
- PROD-423의 전체 수직 흐름 통합·OpenSpec delta 최종 동기화·archive는 이 PR의 완료 범위가 아닙니다.

## 관련 이슈

- Linear: PROD-640
- Integration/archive owner: PROD-423
