### PR TITLE
PROD-626 Post 첨부 이미지를 분할 갤러리로 표시한다

### DIFF
--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -42,6 +42,125 @@ afterEach(async () => {
 });
 
 describe('PostMediaGallery', () => {
+  it('개수별 surface와 tile geometry를 document 순서대로 구성한다', async () => {
+    for (const count of [1, 2, 3, 4]) {
+      await render({
+        media: Array.from({ length: count }, (_, index) => media(index + 1, null)),
+        sensitive: false,
+      });
+
+      const gallery = byTestId('post-media-gallery');
+      const galleryStyle = flattenStyle(gallery.props.style);
+      const tileRows = rendered('View').filter(
+        (node) =>
+          typeof node.props.testID === 'string' &&
+          node.props.testID.startsWith(`post-media-row-${count}-`),
+      );
+      const tiles = rendered('PostMediaImage');
+      const tileWrappers = rendered('View').filter((node) =>
+        node.props.testID?.startsWith(`post-media-tile-${count}-`),
+      );
+
+      assert.equal(tiles.length, count);
+      assert.deepEqual(
+        tiles.map(({ props }) => props.item.id),
+        Array.from({ length: count }, (_, index) => `media-${index + 1}`),
+      );
+      assert.equal(
+        tiles.every(({ props }) => Boolean(props.fill) === count > 1),
+        true,
+      );
+
+      if (count === 1) {
+        assert.equal(galleryStyle.aspectRatio, undefined);
+        assert.equal(tileRows.length, 0);
+        assert.equal(tileWrappers.length, 0);
+      } else {
+        assert.equal(galleryStyle.borderWidth, 1);
+        assert.equal(galleryStyle.gap, 8);
+        assert.equal(galleryStyle.aspectRatio, count === 2 ? undefined : count === 3 ? 4 / 3 : 1);
+        assert.equal(tileRows.length, count === 2 ? 1 : count === 3 ? 2 : 2);
+        assert.equal(tileWrappers.length, count);
+        assert.equal(
+          tileWrappers.every((node) => flattenStyle(node.props.style).flex === 1),
+          true,
+        );
+        assert.equal(
+          tileWrappers.every(
+            (node) => flattenStyle(node.props.style).aspectRatio === (count === 2 ? 1 : undefined),
+          ),
+          true,
+        );
+      }
+    }
+  });
+
+  it('다중 tile은 3장 1+2, 4장 2x2 구조의 row 순서를 유지한다', async () => {
+    await render({ media: [media(1, null), media(2, null), media(3, null)], sensitive: false });
+    const threeRows = rendered('View').filter((node) =>
+      node.props.testID?.startsWith('post-media-row-3-'),
+    );
+    assert.equal(threeRows.length, 2);
+    assert.deepEqual(mediaIds(threeRows[0]!.children[0]), ['media-1']);
+    assert.deepEqual(mediaIds(threeRows[0]!.children[1]), ['media-2', 'media-3']);
+    assert.equal(
+      flattenStyle((threeRows[0]!.children[0] as ReactTestInstance).props.style).flex,
+      1,
+    );
+    assert.equal(
+      flattenStyle((threeRows[0]!.children[1] as ReactTestInstance).props.style).flex,
+      1,
+    );
+
+    await render({
+      media: [media(1, null), media(2, null), media(3, null), media(4, null)],
+      sensitive: false,
+    });
+    const fourRows = rendered('View').filter((node) =>
+      node.props.testID?.startsWith('post-media-row-4-'),
+    );
+    assert.equal(fourRows.length, 2);
+    assert.deepEqual(mediaIds(fourRows[0]!.children[0]), ['media-1']);
+    assert.deepEqual(mediaIds(fourRows[0]!.children[1]), ['media-2']);
+    assert.deepEqual(mediaIds(fourRows[1]!.children[0]), ['media-3']);
+    assert.deepEqual(mediaIds(fourRows[1]!.children[1]), ['media-4']);
+  });
+
+  it('Sensitive 다중 surface는 공개 전후 동일 geometry를 예약하고 비대화형이면 control을 숨긴다', async () => {
+    for (const count of [2, 3, 4]) {
+      if (renderer) {
+        await act(async () => renderer?.unmount());
+        renderer = null;
+      }
+      const mediaItems = Array.from({ length: count }, (_, index) => media(index + 1, null));
+      await render({ media: mediaItems, sensitive: true });
+      const hiddenStyle = flattenStyle(byTestId('post-media-sensitive').props.style);
+      const hiddenGeometry = hiddenStyle.aspectRatio;
+      const hiddenTiles = rendered('View').filter((node) =>
+        node.props.testID?.startsWith('post-media-sensitive-tile-'),
+      );
+
+      assert.equal(rendered('PostMediaImage').length, 0);
+      assert.equal(hiddenTiles.length, count);
+      assert.equal(
+        hiddenTiles.every(
+          (node) => flattenStyle(node.props.style).aspectRatio === (count === 2 ? 1 : undefined),
+        ),
+        true,
+      );
+      assert.ok(pressable('민감한 이미지 표시'));
+      await act(async () => pressable('민감한 이미지 표시').props.onPress());
+      assert.equal(
+        flattenStyle(byTestId('post-media-gallery').props.style).aspectRatio,
+        hiddenGeometry,
+      );
+
+      await render({ interactive: false, media: mediaItems, sensitive: true });
+      assert.equal(rendered('Pressable').length, 0);
+      assert.equal(rendered('PostMediaImage').length, 0);
+    }
+  });
+
   it('document 순서대로 이미지를 최대 네 개 표시한다', async () => {
     await render({
       media: Array.from({ length: 5 }, (_, index) =>
@@ -122,4 +241,28 @@ function pressable(accessibilityLabel: string): ReactTestInstance {
 function byTestId(testID: string): ReactTestInstance {
   assert.ok(renderer);
   return renderer.root.findByProps({ testID });
+}
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (result, value) => ({ ...result, ...flattenStyle(value) }),
+      {},
+    );
+  }
+  return (style ?? {}) as Record<string, unknown>;
+}
+
+function mediaIds(value: unknown): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+  const node = value as ReactTestInstance;
+  if (node.props?.item?.id) {
+    return [node.props.item.id];
+  }
+  const children = Array.isArray(node.props?.children)
+    ? node.props.children
+    : [node.props?.children];
+  return children.flatMap(mediaIds);
 }

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -76,9 +76,9 @@ describe('PostMediaGallery', () => {
         assert.equal(tileRows.length, 0);
         assert.equal(tileWrappers.length, 0);
       } else {
-        assert.equal(galleryStyle.borderWidth, 1);
+        assert.equal(galleryStyle.borderWidth, undefined);
         assert.equal(galleryStyle.gap, 8);
-        assert.equal(galleryStyle.aspectRatio, count === 2 ? undefined : count === 3 ? 4 / 3 : 1);
+        assert.equal(galleryStyle.aspectRatio, count === 2 ? undefined : count === 3 ? 16 / 9 : 1);
         assert.equal(tileRows.length, count === 2 ? 1 : count === 3 ? 2 : 2);
         assert.equal(tileWrappers.length, count);
         assert.equal(
@@ -134,26 +134,36 @@ describe('PostMediaGallery', () => {
       }
       const mediaItems = Array.from({ length: count }, (_, index) => media(index + 1, null));
       await render({ media: mediaItems, sensitive: true });
-      const hiddenStyle = flattenStyle(byTestId('post-media-sensitive').props.style);
-      const hiddenGeometry = hiddenStyle.aspectRatio;
+      const hiddenSurface = byTestId('post-media-sensitive');
+      const hiddenStyle = flattenStyle(hiddenSurface.props.style);
       const hiddenTiles = rendered('View').filter((node) =>
         node.props.testID?.startsWith('post-media-sensitive-tile-'),
       );
+      const hiddenSizers = rendered('View').filter(
+        (node) => node.props.testID === 'post-media-sensitive-two-item-sizer',
+      );
 
       assert.equal(rendered('PostMediaImage').length, 0);
-      assert.equal(hiddenTiles.length, count);
-      assert.equal(
-        hiddenTiles.every(
-          (node) => flattenStyle(node.props.style).aspectRatio === (count === 2 ? 1 : undefined),
-        ),
-        true,
-      );
+      assert.equal(hiddenTiles.length, 0);
+      assert.equal(hiddenStyle.borderWidth, undefined);
+      assert.equal(hiddenStyle.gap, undefined);
+      assert.equal(hiddenStyle.height, undefined);
+      assert.equal(hiddenStyle.aspectRatio, count === 3 ? 16 / 9 : count === 4 ? 1 : undefined);
+      assert.equal(hiddenSizers.length, count === 2 ? 1 : 0);
+      if (count === 2) {
+        const sizerStyle = flattenStyle(hiddenSizers[0]!.props.style);
+        assert.equal(sizerStyle.aspectRatio, 1);
+        assert.equal(sizerStyle.marginBottom, -4);
+        assert.equal(sizerStyle.width, '50%');
+      }
       assert.ok(pressable('민감한 이미지 표시'));
       await act(async () => pressable('민감한 이미지 표시').props.onPress());
-      assert.equal(
-        flattenStyle(byTestId('post-media-gallery').props.style).aspectRatio,
-        hiddenGeometry,
-      );
+      if (count > 2) {
+        assert.equal(
+          flattenStyle(byTestId('post-media-gallery').props.style).aspectRatio,
+          hiddenStyle.aspectRatio,
+        );
+      }
 
       await render({ interactive: false, media: mediaItems, sensitive: true });
       assert.equal(rendered('Pressable').length, 0);

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
 import { PostMediaImage } from './PostMediaImage';
+import type { ReactNode } from 'react';
 import type { PostMediaItem } from './PostMediaImage';
 
 export type { PostMediaItem } from './PostMediaImage';
@@ -39,47 +40,126 @@ export function PostMediaGallery({
     return null;
   }
 
-  if (sensitive) {
+  const multi = items.length > 1;
+  const isRevealed = interactive && revealed;
+  const gallery = (
+    <View
+      style={
+        multi
+          ? [styles.surface, surfaceGeometry(items.length), { borderColor: theme.border }]
+          : styles.root
+      }
+      testID="post-media-gallery"
+    >
+      {renderMediaSurface(items, (item, index) =>
+        multi ? (
+          <View
+            key={item.id}
+            style={tileStyle(items.length)}
+            testID={`post-media-tile-${items.length}-${index}`}
+          >
+            <PostMediaImage fill index={index} interactive={interactive} item={item} />
+          </View>
+        ) : (
+          <PostMediaImage index={index} interactive={interactive} item={item} key={item.id} />
+        ),
+      )}
+    </View>
+  );
+
+  if (!sensitive) {
+    return gallery;
+  }
+
+  return (
+    <View style={styles.root}>
+      {interactive ? (
+        <MediaVisibilityButton
+          expanded={isRevealed}
+          key="media-visibility"
+          onPress={() => setRevealed((current) => !current)}
+        />
+      ) : null}
+      {isRevealed ? (
+        gallery
+      ) : (
+        <View
+          style={[
+            multi ? styles.surface : styles.sensitive,
+            multi ? surfaceGeometry(items.length) : styles.singleSensitive,
+            { backgroundColor: theme.surface, borderColor: theme.border },
+          ]}
+          testID="post-media-sensitive"
+        >
+          {multi
+            ? renderMediaSurface(items, (item) => (
+                <View
+                  key={item.id}
+                  style={[tileStyle(items.length), { backgroundColor: theme.background }]}
+                  testID={`post-media-sensitive-tile-${item.id}`}
+                />
+              ))
+            : null}
+          <View style={styles.sensitiveContent}>
+            <Text style={[styles.sensitiveTitle, { color: theme.text }]}>민감한 이미지</Text>
+            <Text style={[styles.sensitiveDescription, { color: theme.textSecondary }]}>
+              작성자가 민감한 내용으로 표시했습니다.
+            </Text>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function renderMediaSurface(
+  items: ReadonlyArray<PostMediaItem>,
+  renderTile: (item: PostMediaItem, index: number) => ReactNode,
+): ReactNode {
+  if (items.length === 1) {
+    return renderTile(items[0]!, 0);
+  }
+
+  if (items.length === 2) {
     return (
-      <View
-        style={
-          revealed
-            ? styles.root
-            : [styles.sensitive, { backgroundColor: theme.surface, borderColor: theme.border }]
-        }
-        testID={revealed ? 'post-media-gallery' : 'post-media-sensitive'}
-      >
-        {revealed ? null : (
-          <Text style={[styles.sensitiveTitle, { color: theme.text }]}>민감한 이미지</Text>
-        )}
-        {revealed ? null : (
-          <Text style={[styles.sensitiveDescription, { color: theme.textSecondary }]}>
-            작성자가 민감한 내용으로 표시했습니다.
-          </Text>
-        )}
-        {interactive ? (
-          <MediaVisibilityButton
-            expanded={revealed}
-            key="media-visibility"
-            onPress={() => setRevealed((current) => !current)}
-          />
-        ) : null}
-        {revealed
-          ? items.map((item, index) => (
-              <PostMediaImage index={index} interactive={interactive} item={item} key={item.id} />
-            ))
-          : null}
+      <View style={styles.twoTileRow} testID="post-media-row-2-0">
+        {items.map((item, index) => renderTile(item, index))}
+      </View>
+    );
+  }
+
+  if (items.length === 3) {
+    return (
+      <View style={styles.surfaceRow} testID="post-media-row-3-0">
+        {renderTile(items[0]!, 0)}
+        <View style={styles.surfaceColumn} testID="post-media-row-3-1">
+          {renderTile(items[1]!, 1)}
+          {renderTile(items[2]!, 2)}
+        </View>
       </View>
     );
   }
 
   return (
-    <View style={styles.root} testID="post-media-gallery">
-      {items.map((item, index) => (
-        <PostMediaImage index={index} interactive={interactive} item={item} key={item.id} />
-      ))}
-    </View>
+    <>
+      <View style={styles.surfaceRow} testID="post-media-row-4-0">
+        {renderTile(items[0]!, 0)}
+        {renderTile(items[1]!, 1)}
+      </View>
+      <View style={styles.surfaceRow} testID="post-media-row-4-1">
+        {renderTile(items[2]!, 2)}
+        {renderTile(items[3]!, 3)}
+      </View>
+    </>
   );
+}
+
+function surfaceGeometry(count: number) {
+  return count === 2 ? null : { aspectRatio: count === 3 ? 4 / 3 : 1 };
+}
+
+function tileStyle(count: number) {
+  return count === 2 ? styles.squareTile : styles.tile;
 }
 
 function MediaVisibilityButton({
@@ -119,18 +199,32 @@ const styles = StyleSheet.create({
     gap: spacing.xs,
     padding: spacing.lg,
   },
-  sensitiveTitle: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
-  sensitiveDescription: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
-  visibilityButton: {
+  sensitiveContent: {
     alignItems: 'center',
-    borderRadius: radii.full,
+    bottom: 0,
+    gap: spacing.xs,
     justifyContent: 'center',
-    marginTop: spacing.xs,
-    minHeight: 48,
-    minWidth: 120,
-    paddingHorizontal: spacing.lg,
+    left: 0,
+    padding: spacing.lg,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
-  visibilityButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
+  sensitiveDescription: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
+  sensitiveTitle: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
+  singleSensitive: { aspectRatio: 1, width: '100%' },
+  surface: {
+    borderRadius: radii.md,
+    borderWidth: 1,
+    gap: spacing.sm,
+    overflow: 'hidden',
+    width: '100%',
+  },
+  surfaceColumn: { flex: 1, gap: spacing.sm, minHeight: 0 },
+  surfaceRow: { flex: 1, flexDirection: 'row', gap: spacing.sm, minHeight: 0 },
+  squareTile: { aspectRatio: 1, flex: 1, minWidth: 0, overflow: 'hidden' },
+  tile: { flex: 1, minHeight: 0, minWidth: 0, overflow: 'hidden' },
+  twoTileRow: { flexDirection: 'row', gap: spacing.sm, width: '100%' },
   unavailable: {
     alignItems: 'center',
     borderRadius: radii.md,
@@ -141,4 +235,14 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   unavailableText: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
+  visibilityButton: {
+    alignItems: 'center',
+    borderRadius: radii.full,
+    justifyContent: 'center',
+    marginTop: spacing.xs,
+    minHeight: 48,
+    minWidth: 120,
+    paddingHorizontal: spacing.lg,
+  },
+  visibilityButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
 });

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -44,11 +44,7 @@ export function PostMediaGallery({
   const isRevealed = interactive && revealed;
   const gallery = (
     <View
-      style={
-        multi
-          ? [styles.surface, surfaceGeometry(items.length), { borderColor: theme.border }]
-          : styles.root
-      }
+      style={multi ? [styles.surface, surfaceGeometry(items.length)] : styles.root}
       testID="post-media-gallery"
     >
       {renderMediaSurface(items, (item, index) =>
@@ -85,21 +81,19 @@ export function PostMediaGallery({
       ) : (
         <View
           style={[
-            multi ? styles.surface : styles.sensitive,
+            multi ? styles.sensitiveSurface : styles.sensitive,
             multi ? surfaceGeometry(items.length) : styles.singleSensitive,
-            { backgroundColor: theme.surface, borderColor: theme.border },
+            { backgroundColor: theme.surface },
+            multi ? null : { borderColor: theme.border },
           ]}
           testID="post-media-sensitive"
         >
-          {multi
-            ? renderMediaSurface(items, (item) => (
-                <View
-                  key={item.id}
-                  style={[tileStyle(items.length), { backgroundColor: theme.background }]}
-                  testID={`post-media-sensitive-tile-${item.id}`}
-                />
-              ))
-            : null}
+          {items.length === 2 ? (
+            <View
+              style={styles.twoItemSensitiveSizer}
+              testID="post-media-sensitive-two-item-sizer"
+            />
+          ) : null}
           <View style={styles.sensitiveContent}>
             <Text style={[styles.sensitiveTitle, { color: theme.text }]}>민감한 이미지</Text>
             <Text style={[styles.sensitiveDescription, { color: theme.textSecondary }]}>
@@ -155,7 +149,7 @@ function renderMediaSurface(
 }
 
 function surfaceGeometry(count: number) {
-  return count === 2 ? null : { aspectRatio: count === 3 ? 4 / 3 : 1 };
+  return count === 2 ? null : { aspectRatio: count === 3 ? 16 / 9 : 1 };
 }
 
 function tileStyle(count: number) {
@@ -213,9 +207,13 @@ const styles = StyleSheet.create({
   sensitiveDescription: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
   sensitiveTitle: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
   singleSensitive: { aspectRatio: 1, width: '100%' },
+  sensitiveSurface: {
+    borderRadius: radii.md,
+    overflow: 'hidden',
+    width: '100%',
+  },
   surface: {
     borderRadius: radii.md,
-    borderWidth: 1,
     gap: spacing.sm,
     overflow: 'hidden',
     width: '100%',
@@ -224,6 +222,7 @@ const styles = StyleSheet.create({
   surfaceRow: { flex: 1, flexDirection: 'row', gap: spacing.sm, minHeight: 0 },
   squareTile: { aspectRatio: 1, flex: 1, minWidth: 0, overflow: 'hidden' },
   tile: { flex: 1, minHeight: 0, minWidth: 0, overflow: 'hidden' },
+  twoItemSensitiveSizer: { aspectRatio: 1, marginBottom: -spacing.sm / 2, width: '50%' },
   twoTileRow: { flexDirection: 'row', gap: spacing.sm, width: '100%' },
   unavailable: {
     alignItems: 'center',

--- a/apps/app/src/components/post/PostMediaImage.test.ts
+++ b/apps/app/src/components/post/PostMediaImage.test.ts
@@ -88,13 +88,13 @@ describe('PostMediaImage', () => {
     assert.equal(getSizeAttempts.get(media('transient-size-error', null).url!), 2);
   });
 
-  it('오류 뒤 같은 URL로 Image를 다시 mount한다', async () => {
+  it('단일 이미지 오류에서 action만 표시하고 같은 URL로 Image를 다시 mount한다', async () => {
     await render(0, media('landscape', '가로 이미지'));
     const source = image('landscape').props.source;
 
     await act(async () => image('landscape').props.onError());
     assert.equal(rendered('Image').length, 0);
-    assert.equal(textContents().includes('가로 이미지을 불러오지 못했습니다.'), true);
+    assert.deepEqual(textContents(), ['다시 시도']);
 
     await act(async () => pressable('가로 이미지 다시 시도').props.onPress());
     assert.deepEqual(image('landscape').props.source, source);

--- a/apps/app/src/components/post/PostMediaImage.test.ts
+++ b/apps/app/src/components/post/PostMediaImage.test.ts
@@ -38,7 +38,12 @@ mock.module('react-native', {
   },
 } as unknown as Parameters<typeof mock.module>[1]);
 
-let PostMediaImage: ComponentType<{ index: number; interactive?: boolean; item: PostMediaItem }>;
+let PostMediaImage: ComponentType<{
+  fill?: boolean;
+  index: number;
+  interactive?: boolean;
+  item: PostMediaItem;
+}>;
 let renderer: ReactTestRenderer | null = null;
 
 before(async () => {
@@ -111,18 +116,36 @@ describe('PostMediaImage', () => {
     assert.ok(byTestId('post-media-error-landscape'));
     assert.equal(rendered('Pressable').length, 0);
   });
+
+  it('tile 경계에서는 measured aspect ratio 대신 frame을 채우고 fallback도 같은 경계를 채운다', async () => {
+    await render(0, media('landscape', '가로 이미지'), true, true);
+
+    const frameStyle = flattenStyle(byTestId('post-media-frame-landscape').props.style);
+    assert.equal(frameStyle.height, '100%');
+    assert.equal(frameStyle.aspectRatio, undefined);
+    assert.equal(flattenStyle(image('landscape').props.style).height, '100%');
+
+    await act(async () => image('landscape').props.onError());
+    const fallbackStyle = flattenStyle(byTestId('post-media-error-landscape').props.style);
+    assert.equal(fallbackStyle.height, '100%');
+    assert.equal(fallbackStyle.minHeight, 0);
+    const retryStyle = flattenPressableStyle(pressable('가로 이미지 다시 시도').props.style);
+    assert.equal(retryStyle.minHeight, 48);
+    assert.equal(retryStyle.minWidth, 0);
+    assert.equal(retryStyle.width, '100%');
+  });
 });
 
 function media(id: string, altText: string | null): PostMediaItem {
   return { altText, id, url: `https://media.example/${id}.webp` };
 }
 
-async function render(index: number, item: PostMediaItem, interactive = true) {
+async function render(index: number, item: PostMediaItem, interactive = true, fill = false) {
   await act(async () => {
     if (renderer) {
-      renderer.update(createElement(PostMediaImage, { index, interactive, item }));
+      renderer.update(createElement(PostMediaImage, { fill, index, interactive, item }));
     } else {
-      renderer = create(createElement(PostMediaImage, { index, interactive, item }));
+      renderer = create(createElement(PostMediaImage, { fill, index, interactive, item }));
     }
   });
   assert.ok(renderer);
@@ -155,4 +178,18 @@ function frameAspectRatio(id: string): number | undefined {
 function byTestId(testID: string): ReactTestInstance {
   assert.ok(renderer);
   return renderer.root.findByProps({ testID });
+}
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (result, value) => ({ ...result, ...flattenStyle(value) }),
+      {},
+    );
+  }
+  return (style ?? {}) as Record<string, unknown>;
+}
+
+function flattenPressableStyle(style: unknown): Record<string, unknown> {
+  return flattenStyle(typeof style === 'function' ? style({ pressed: false }) : style);
 }

--- a/apps/app/src/components/post/PostMediaImage.test.ts
+++ b/apps/app/src/components/post/PostMediaImage.test.ts
@@ -94,6 +94,7 @@ describe('PostMediaImage', () => {
 
     await act(async () => image('landscape').props.onError());
     assert.equal(rendered('Image').length, 0);
+    assert.equal(textContents().includes('가로 이미지을 불러오지 못했습니다.'), true);
 
     await act(async () => pressable('가로 이미지 다시 시도').props.onPress());
     assert.deepEqual(image('landscape').props.source, source);
@@ -103,18 +104,20 @@ describe('PostMediaImage', () => {
   });
 
   it('URL이 없으면 재시도 없이 fallback을 표시한다', async () => {
-    await render(0, { ...media('missing', null), url: null });
+    await render(0, { ...media('missing', null), url: null }, true, true);
 
     assert.ok(byTestId('post-media-error-missing'));
     assert.equal(rendered('Pressable').length, 0);
+    assert.equal(textContents().includes('1번째 첨부 이미지을 불러오지 못했습니다.'), true);
   });
 
   it('비대화형 이미지 오류에서는 재시도 control을 표시하지 않는다', async () => {
-    await render(0, media('landscape', '가로 이미지'), false);
+    await render(0, media('landscape', '가로 이미지'), false, true);
 
     await act(async () => image('landscape').props.onError());
     assert.ok(byTestId('post-media-error-landscape'));
     assert.equal(rendered('Pressable').length, 0);
+    assert.equal(textContents().includes('가로 이미지을 불러오지 못했습니다.'), true);
   });
 
   it('tile 경계에서는 measured aspect ratio 대신 frame을 채우고 fallback도 같은 경계를 채운다', async () => {
@@ -129,6 +132,7 @@ describe('PostMediaImage', () => {
     const fallbackStyle = flattenStyle(byTestId('post-media-error-landscape').props.style);
     assert.equal(fallbackStyle.height, '100%');
     assert.equal(fallbackStyle.minHeight, 0);
+    assert.deepEqual(textContents(), ['다시 시도']);
     const retryStyle = flattenPressableStyle(pressable('가로 이미지 다시 시도').props.style);
     assert.equal(retryStyle.minHeight, 48);
     assert.equal(retryStyle.minWidth, 0);
@@ -178,6 +182,12 @@ function frameAspectRatio(id: string): number | undefined {
 function byTestId(testID: string): ReactTestInstance {
   assert.ok(renderer);
   return renderer.root.findByProps({ testID });
+}
+
+function textContents(): string[] {
+  return rendered('Text').map((node) =>
+    node.children.filter((child): child is string => typeof child === 'string').join(''),
+  );
 }
 
 function flattenStyle(style: unknown): Record<string, unknown> {

--- a/apps/app/src/components/post/PostMediaImage.tsx
+++ b/apps/app/src/components/post/PostMediaImage.tsx
@@ -29,7 +29,7 @@ export function PostMediaImage({
   const measuredUrl = useRef<string | null>(null);
   currentUrl.current = item.url;
   const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
-  const compactRetry = fill && Boolean(item.url) && interactive;
+  const canRetry = Boolean(item.url) && Boolean(interactive);
   const handleError = useCallback(() => setStatus('error'), []);
   const handleLoadStart = useCallback(() => setStatus('loading'), []);
   const updateAspectRatio = useCallback((url: string, width: number, height: number) => {
@@ -93,12 +93,12 @@ export function PostMediaImage({
         ]}
         testID={`post-media-error-${item.id}`}
       >
-        {compactRetry ? null : (
+        {canRetry ? null : (
           <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
             {accessibilityLabel}을 불러오지 못했습니다.
           </Text>
         )}
-        {item.url && interactive ? (
+        {canRetry ? (
           <Pressable
             accessibilityLabel={`${accessibilityLabel} 다시 시도`}
             accessibilityRole="button"

--- a/apps/app/src/components/post/PostMediaImage.tsx
+++ b/apps/app/src/components/post/PostMediaImage.tsx
@@ -11,10 +11,12 @@ export type PostMediaItem = {
 };
 
 export function PostMediaImage({
+  fill = false,
   index,
   interactive = true,
   item,
 }: {
+  readonly fill?: boolean;
   readonly index: number;
   readonly interactive?: boolean;
   readonly item: PostMediaItem;
@@ -38,7 +40,7 @@ export function PostMediaImage({
   const handleLoad = useCallback(
     (event?: ImageLoadEvent) => {
       setStatus('ready');
-      if (!item.url || measuredUrl.current === item.url) {
+      if (fill || !item.url || measuredUrl.current === item.url) {
         return;
       }
 
@@ -55,11 +57,11 @@ export function PostMediaImage({
         () => undefined,
       );
     },
-    [item.url, updateAspectRatio],
+    [fill, item.url, updateAspectRatio],
   );
 
   useEffect(() => {
-    if (!item.url) {
+    if (fill || !item.url) {
       return;
     }
 
@@ -77,13 +79,17 @@ export function PostMediaImage({
     return () => {
       active = false;
     };
-  }, [generation, item.url, updateAspectRatio]);
+  }, [fill, generation, item.url, updateAspectRatio]);
 
   if (!item.url || status === 'error') {
     return (
       <View
         accessibilityLiveRegion="polite"
-        style={[styles.fallback, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        style={[
+          styles.fallback,
+          fill ? styles.fillFallback : null,
+          { backgroundColor: theme.surface, borderColor: theme.border },
+        ]}
         testID={`post-media-error-${item.id}`}
       >
         <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
@@ -99,6 +105,7 @@ export function PostMediaImage({
             }}
             style={({ pressed }) => [
               styles.retryButton,
+              fill ? styles.fillRetryButton : null,
               { borderColor: theme.border, opacity: pressed ? 0.7 : 1 },
             ]}
           >
@@ -111,7 +118,11 @@ export function PostMediaImage({
 
   return (
     <View
-      style={[styles.imageFrame, { aspectRatio, backgroundColor: theme.surface }]}
+      style={[
+        styles.imageFrame,
+        fill ? styles.fillFrame : { aspectRatio },
+        { backgroundColor: theme.surface },
+      ]}
       testID={`post-media-frame-${item.id}`}
     >
       <Image
@@ -142,7 +153,10 @@ const styles = StyleSheet.create({
     minHeight: 144,
     padding: spacing.lg,
   },
+  fillFallback: { height: '100%', minHeight: 0, padding: spacing.xs, width: '100%' },
   fallbackText: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
+  fillFrame: { height: '100%', minHeight: 0, width: '100%' },
+  fillRetryButton: { minWidth: 0, paddingHorizontal: spacing.xs, width: '100%' },
   retryButton: {
     alignItems: 'center',
     borderRadius: radii.full,

--- a/apps/app/src/components/post/PostMediaImage.tsx
+++ b/apps/app/src/components/post/PostMediaImage.tsx
@@ -29,6 +29,7 @@ export function PostMediaImage({
   const measuredUrl = useRef<string | null>(null);
   currentUrl.current = item.url;
   const accessibilityLabel = item.altText?.trim() || `${index + 1}번째 첨부 이미지`;
+  const compactRetry = fill && Boolean(item.url) && interactive;
   const handleError = useCallback(() => setStatus('error'), []);
   const handleLoadStart = useCallback(() => setStatus('loading'), []);
   const updateAspectRatio = useCallback((url: string, width: number, height: number) => {
@@ -92,9 +93,11 @@ export function PostMediaImage({
         ]}
         testID={`post-media-error-${item.id}`}
       >
-        <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
-          {accessibilityLabel}을 불러오지 못했습니다.
-        </Text>
+        {compactRetry ? null : (
+          <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
+            {accessibilityLabel}을 불러오지 못했습니다.
+          </Text>
+        )}
         {item.url && interactive ? (
           <Pressable
             accessibilityLabel={`${accessibilityLabel} 다시 시도`}

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -198,6 +198,27 @@ const mediaOnlyPost = post({
     },
   ],
 });
+const sensitiveTwoMediaPost = post({
+  bodyDocument: {
+    type: 'doc',
+    attrs: { sensitiveMedia: true },
+    content: [
+      { type: 'paragraph' },
+      ...Array.from({ length: 2 }, (_, index) => ({
+        type: 'media' as const,
+        attrs: { mediaId: `media-sensitive-two-${index + 1}` },
+      })),
+    ],
+  },
+  bodyText: '',
+  id: 'media-sensitive-two',
+  media: Array.from({ length: 2 }, (_, index) => ({
+    __typename: 'Media' as const,
+    altText: `${index + 1}번째 Sensitive 이미지`,
+    id: `media-sensitive-two-${index + 1}`,
+    url: postMediaImageUri,
+  })),
+});
 const threeMediaPost = post({
   bodyDocument: {
     type: 'doc',
@@ -627,6 +648,7 @@ const storyPosts = [
   quoteOfQuotePost,
   mediaTextPost,
   mediaOnlyPost,
+  sensitiveTwoMediaPost,
   threeMediaPost,
   fourMediaPost,
   unavailableMediaPost,
@@ -859,6 +881,14 @@ function PostCatalog(_args: PostsStoryArgs) {
             post={requireFragment(
               requirePostById(posts, mediaOnlyPost.id).body,
               'media-only post body',
+            )}
+          />
+        </View>
+        <View testID="media-sensitive-two">
+          <PostBody
+            post={requireFragment(
+              requirePostById(posts, sensitiveTwoMediaPost.id).body,
+              'two-media sensitive post body',
             )}
           />
         </View>
@@ -2204,6 +2234,24 @@ export const BodyTimeAndLayoutStates: Story = {
     expect(mediaOnly.queryByRole('img')).not.toBeInTheDocument();
     expect(mediaOnly.getByRole('button', { name: '민감한 이미지 표시' })).toHaveFocus();
 
+    const sensitiveTwoMedia = within(canvas.getByTestId('media-sensitive-two'));
+    const hiddenSensitiveTwo = sensitiveTwoMedia.getByTestId('post-media-sensitive');
+    const hiddenSensitiveTwoBounds = hiddenSensitiveTwo.getBoundingClientRect();
+    expect(hiddenSensitiveTwoBounds.height).toBeCloseTo(
+      (hiddenSensitiveTwoBounds.width - 8) / 2,
+      0,
+    );
+    expect(getComputedStyle(hiddenSensitiveTwo).borderTopWidth).toBe('0px');
+    expect(
+      hiddenSensitiveTwo.querySelector('[data-testid^="post-media-sensitive-tile-"]'),
+    ).toBeNull();
+    await userEvent.click(sensitiveTwoMedia.getByRole('button', { name: '민감한 이미지 표시' }));
+    const revealedSensitiveTwoBounds = sensitiveTwoMedia
+      .getByTestId('post-media-gallery')
+      .getBoundingClientRect();
+    expect(revealedSensitiveTwoBounds.height).toBeCloseTo(hiddenSensitiveTwoBounds.height, 0);
+    expect(sensitiveTwoMedia.getAllByRole('img')).toHaveLength(2);
+
     const threeMedia = within(canvas.getByTestId('media-three'));
     expect(threeMedia.getAllByRole('img').map((image) => image.getAttribute('alt'))).toEqual([
       '1번째 3장 gallery 이미지',
@@ -2216,7 +2264,8 @@ export const BodyTimeAndLayoutStates: Story = {
     );
     expect(
       threeGallery.getBoundingClientRect().width / threeGallery.getBoundingClientRect().height,
-    ).toBeCloseTo(4 / 3, 1);
+    ).toBeCloseTo(16 / 9, 1);
+    expect(getComputedStyle(threeGallery).borderTopWidth).toBe('0px');
     expect(firstThreeTile!.height).toBeGreaterThan(secondThreeTile!.height);
     expect(firstThreeTile!.left).toBeLessThan(secondThreeTile!.left);
     expect(secondThreeTile!.left).toBeCloseTo(thirdThreeTile!.left, 0);
@@ -2236,6 +2285,7 @@ export const BodyTimeAndLayoutStates: Story = {
     expect(
       fourGallery.getBoundingClientRect().width / fourGallery.getBoundingClientRect().height,
     ).toBeCloseTo(1, 1);
+    expect(getComputedStyle(fourGallery).borderTopWidth).toBe('0px');
     for (const tile of fourTiles.slice(1)) {
       expect(tile.width).toBeCloseTo(fourTiles[0]!.width, 0);
       expect(tile.height).toBeCloseTo(fourTiles[0]!.height, 0);
@@ -2268,11 +2318,14 @@ export const BodyTimeAndLayoutStates: Story = {
       expect(tile.width / tile.height).toBeCloseTo(1, 1);
     }
     expect(twoTileBounds[0]!.width).toBeCloseTo(twoTileBounds[1]!.width, 0);
-    expect(twoGalleryBounds.height).toBeCloseTo(twoTileBounds[0]!.height + 2, 0);
+    expect(twoGalleryBounds.height).toBeCloseTo(twoTileBounds[0]!.height, 0);
     expect(twoGalleryBounds.width).toBeCloseTo(
-      twoTileBounds[0]!.width + twoTileBounds[1]!.width + 8 + 2,
+      twoTileBounds[0]!.width + twoTileBounds[1]!.width + 8,
       0,
     );
+    expect(
+      getComputedStyle(loadErrorMediaList.getByTestId('post-media-gallery')).borderTopWidth,
+    ).toBe('0px');
     const compactRetryBounds = (
       await loadErrorMediaList.findByRole('button', { name: '실패 이미지 다시 시도' })
     ).getBoundingClientRect();

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -198,6 +198,26 @@ const mediaOnlyPost = post({
     },
   ],
 });
+const threeMediaPost = post({
+  bodyDocument: {
+    type: 'doc',
+    content: [
+      { type: 'paragraph', content: [{ type: 'text', text: '세 장의 이미지입니다.' }] },
+      ...Array.from({ length: 3 }, (_, index) => ({
+        type: 'media' as const,
+        attrs: { mediaId: `media-three-${index + 1}` },
+      })),
+    ],
+  },
+  bodyText: '세 장의 이미지입니다.',
+  id: 'media-three',
+  media: Array.from({ length: 3 }, (_, index) => ({
+    __typename: 'Media' as const,
+    altText: `${index + 1}번째 3장 gallery 이미지`,
+    id: `media-three-${index + 1}`,
+    url: postMediaImageUri,
+  })),
+});
 const fourMediaPost = post({
   bodyDocument: {
     type: 'doc',
@@ -607,6 +627,7 @@ const storyPosts = [
   quoteOfQuotePost,
   mediaTextPost,
   mediaOnlyPost,
+  threeMediaPost,
   fourMediaPost,
   unavailableMediaPost,
   loadErrorMediaPost,
@@ -841,6 +862,14 @@ function PostCatalog(_args: PostsStoryArgs) {
             )}
           />
         </View>
+        <View testID="media-three">
+          <PostBody
+            post={requireFragment(
+              requirePostById(posts, threeMediaPost.id).body,
+              'three-media post body',
+            )}
+          />
+        </View>
         <View testID="media-four">
           <PostBody
             post={requireFragment(
@@ -881,6 +910,14 @@ function PostCatalog(_args: PostsStoryArgs) {
             post={requireFragment(
               requirePostById(posts, mediaOnlyPost.id).listItem,
               'media-only post list item',
+            )}
+          />
+        </View>
+        <View testID="media-load-error-list">
+          <PostListItem
+            post={requireFragment(
+              requirePostById(posts, loadErrorMediaPost.id).listItem,
+              'load-error media post list item',
             )}
           />
         </View>
@@ -2105,6 +2142,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const BodyTimeAndLayoutStates: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     expect(canvas.getByText('짧은 본문 한 줄.')).toHaveAttribute('data-openpanel-replay-block', '');
@@ -2166,6 +2204,24 @@ export const BodyTimeAndLayoutStates: Story = {
     expect(mediaOnly.queryByRole('img')).not.toBeInTheDocument();
     expect(mediaOnly.getByRole('button', { name: '민감한 이미지 표시' })).toHaveFocus();
 
+    const threeMedia = within(canvas.getByTestId('media-three'));
+    expect(threeMedia.getAllByRole('img').map((image) => image.getAttribute('alt'))).toEqual([
+      '1번째 3장 gallery 이미지',
+      '2번째 3장 gallery 이미지',
+      '3번째 3장 gallery 이미지',
+    ]);
+    const threeGallery = threeMedia.getByTestId('post-media-gallery');
+    const [firstThreeTile, secondThreeTile, thirdThreeTile] = [0, 1, 2].map((index) =>
+      threeMedia.getByTestId(`post-media-tile-3-${index}`).getBoundingClientRect(),
+    );
+    expect(
+      threeGallery.getBoundingClientRect().width / threeGallery.getBoundingClientRect().height,
+    ).toBeCloseTo(4 / 3, 1);
+    expect(firstThreeTile!.height).toBeGreaterThan(secondThreeTile!.height);
+    expect(firstThreeTile!.left).toBeLessThan(secondThreeTile!.left);
+    expect(secondThreeTile!.left).toBeCloseTo(thirdThreeTile!.left, 0);
+    expect(secondThreeTile!.top).toBeLessThan(thirdThreeTile!.top);
+
     const fourMedia = within(canvas.getByTestId('media-four'));
     expect(fourMedia.getAllByRole('img').map((image) => image.getAttribute('alt'))).toEqual([
       '1번째 순서 이미지',
@@ -2173,6 +2229,21 @@ export const BodyTimeAndLayoutStates: Story = {
       '3번째 순서 이미지',
       '4번째 순서 이미지',
     ]);
+    const fourGallery = fourMedia.getByTestId('post-media-gallery');
+    const fourTiles = [0, 1, 2, 3].map((index) =>
+      fourMedia.getByTestId(`post-media-tile-4-${index}`).getBoundingClientRect(),
+    );
+    expect(
+      fourGallery.getBoundingClientRect().width / fourGallery.getBoundingClientRect().height,
+    ).toBeCloseTo(1, 1);
+    for (const tile of fourTiles.slice(1)) {
+      expect(tile.width).toBeCloseTo(fourTiles[0]!.width, 0);
+      expect(tile.height).toBeCloseTo(fourTiles[0]!.height, 0);
+    }
+    expect(fourTiles[0]!.top).toBeCloseTo(fourTiles[1]!.top, 0);
+    expect(fourTiles[0]!.left).toBeCloseTo(fourTiles[2]!.left, 0);
+    expect(fourTiles[0]!.left).toBeLessThan(fourTiles[1]!.left);
+    expect(fourTiles[0]!.top).toBeLessThan(fourTiles[2]!.top);
     expect(within(canvas.getByTestId('media-unavailable')).getByRole('alert')).toHaveTextContent(
       '이미지를 불러올 수 없습니다.',
     );
@@ -2186,6 +2257,28 @@ export const BodyTimeAndLayoutStates: Story = {
       loadErrorMedia.findByRole('button', { name: '실패 이미지 다시 시도' }),
     ).resolves.toBeVisible();
     expect(loadErrorMedia.getByRole('img', { name: '정상 이미지' })).toBeInTheDocument();
+    const loadErrorMediaList = within(canvas.getByTestId('media-load-error-list'));
+    const twoGalleryBounds = loadErrorMediaList
+      .getByTestId('post-media-gallery')
+      .getBoundingClientRect();
+    const twoTileBounds = [0, 1].map((index) =>
+      loadErrorMediaList.getByTestId(`post-media-tile-2-${index}`).getBoundingClientRect(),
+    );
+    for (const tile of twoTileBounds) {
+      expect(tile.width / tile.height).toBeCloseTo(1, 1);
+    }
+    expect(twoTileBounds[0]!.width).toBeCloseTo(twoTileBounds[1]!.width, 0);
+    expect(twoGalleryBounds.height).toBeCloseTo(twoTileBounds[0]!.height + 2, 0);
+    expect(twoGalleryBounds.width).toBeCloseTo(
+      twoTileBounds[0]!.width + twoTileBounds[1]!.width + 8 + 2,
+      0,
+    );
+    const compactRetryBounds = (
+      await loadErrorMediaList.findByRole('button', { name: '실패 이미지 다시 시도' })
+    ).getBoundingClientRect();
+    expect(compactRetryBounds.left).toBeGreaterThanOrEqual(twoTileBounds[0]!.left);
+    expect(compactRetryBounds.right).toBeLessThanOrEqual(twoTileBounds[0]!.right);
+    expect(compactRetryBounds.width).toBeLessThanOrEqual(twoTileBounds[0]!.width);
     expect(
       within(canvas.getByTestId('media-list')).getByTestId('post-media-image-media-story'),
     ).toBeVisible();

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -297,6 +297,42 @@ const loadErrorMediaPost = post({
     },
   ],
 });
+const loadErrorThreeMediaPost = post({
+  bodyDocument: {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: '세 장 gallery의 오른쪽 이미지 로딩 실패입니다.' }],
+      },
+      { type: 'media', attrs: { mediaId: 'media-three-error-safe-first-story' } },
+      { type: 'media', attrs: { mediaId: 'media-three-error-story' } },
+      { type: 'media', attrs: { mediaId: 'media-three-error-safe-last-story' } },
+    ],
+  },
+  bodyText: '세 장 gallery의 오른쪽 이미지 로딩 실패입니다.',
+  id: 'media-load-error-three',
+  media: [
+    {
+      __typename: 'Media',
+      altText: '첫 번째 정상 이미지',
+      id: 'media-three-error-safe-first-story',
+      url: postMediaImageUri,
+    },
+    {
+      __typename: 'Media',
+      altText: '오른쪽 실패 이미지',
+      id: 'media-three-error-story',
+      url: 'data:image/png;base64,not-valid',
+    },
+    {
+      __typename: 'Media',
+      altText: '세 번째 정상 이미지',
+      id: 'media-three-error-safe-last-story',
+      url: postMediaImageUri,
+    },
+  ],
+});
 const sourceAuthorAvatarUrl = '/apple-touch-icon.png';
 const repostAuthorAvatarUrl = '/icon-192.png';
 const sourceAuthor = profile({
@@ -653,6 +689,7 @@ const storyPosts = [
   fourMediaPost,
   unavailableMediaPost,
   loadErrorMediaPost,
+  loadErrorThreeMediaPost,
 ];
 const composerAvatarUrl =
   'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="96" height="96"%3E%3Crect width="96" height="96" fill="%232563eb"/%3E%3C/svg%3E';
@@ -948,6 +985,14 @@ function PostCatalog(_args: PostsStoryArgs) {
             post={requireFragment(
               requirePostById(posts, loadErrorMediaPost.id).listItem,
               'load-error media post list item',
+            )}
+          />
+        </View>
+        <View testID="media-load-error-three-list">
+          <PostListItem
+            post={requireFragment(
+              requirePostById(posts, loadErrorThreeMediaPost.id).listItem,
+              'three-image load-error media post list item',
             )}
           />
         </View>
@@ -2332,6 +2377,20 @@ export const BodyTimeAndLayoutStates: Story = {
     expect(compactRetryBounds.left).toBeGreaterThanOrEqual(twoTileBounds[0]!.left);
     expect(compactRetryBounds.right).toBeLessThanOrEqual(twoTileBounds[0]!.right);
     expect(compactRetryBounds.width).toBeLessThanOrEqual(twoTileBounds[0]!.width);
+    const loadErrorThreeMediaList = within(canvas.getByTestId('media-load-error-three-list'));
+    const threeErrorGalleryBounds = loadErrorThreeMediaList
+      .getByTestId('post-media-gallery')
+      .getBoundingClientRect();
+    expect(threeErrorGalleryBounds.width / threeErrorGalleryBounds.height).toBeCloseTo(16 / 9, 1);
+    const compactThreeErrorTileBounds = loadErrorThreeMediaList
+      .getByTestId('post-media-tile-3-1')
+      .getBoundingClientRect();
+    const compactThreeRetryBounds = (
+      await loadErrorThreeMediaList.findByRole('button', { name: '오른쪽 실패 이미지 다시 시도' })
+    ).getBoundingClientRect();
+    expect(compactThreeRetryBounds.height).toBeGreaterThanOrEqual(48);
+    expect(compactThreeRetryBounds.top).toBeGreaterThanOrEqual(compactThreeErrorTileBounds.top);
+    expect(compactThreeRetryBounds.bottom).toBeLessThanOrEqual(compactThreeErrorTileBounds.bottom);
     expect(
       within(canvas.getByTestId('media-list')).getByTestId('post-media-image-media-story'),
     ).toBeVisible();

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -13,6 +13,7 @@ KOSMO의 UI/프로덕트 디자인 결정을 기록하고 공유하는 문서 �
 - [typography.md](./typography.md) — 폰트 사용 규칙
 - [breakpoints.md](./breakpoints.md) — 레이아웃 브레이크포인트 단계와 컨벤션
 - [post-action-bar.md](./post-action-bar.md) — Post Action Bar의 28px geometry, 배치, Repost 메뉴와 오류 toast 계약
+- [post-media-gallery.md](./post-media-gallery.md) — Post 첨부 이미지 1~4장의 surface, Sensitive·오류·상호작 경계
 - [reply-composer.md](./reply-composer.md) — 목록 modal·좁은 화면 전체 작성기·상세 inline Reply Composer 계약
 - [post-thread.md](./post-thread.md) — Post 상세 thread의 renderer·connector·row boundary 소유권과 geometry
 - [reactions.md](./reactions.md) — Reaction Quick Picker, 요약 token toggle과 Profile 목록의 형태·상태·대상 Post 계약

--- a/docs/design/post-media-gallery.md
+++ b/docs/design/post-media-gallery.md
@@ -1,0 +1,38 @@
+# Post Media Gallery
+
+Post 목록과 상세는 `PostContent.media`의 document 순서를 그대로 소비하는 공용 Media renderer를 사용한다. Gallery는 최대 4장을 Post body의 사용 가능한 폭 안에 배치하며 Home·Profile·상세나 Web·Android·iOS별 별도 markup과 breakpoint를 두지 않는다.
+
+## 이미지 개수별 geometry
+
+| 개수 | Gallery surface                                      | Tile 배치                                                                                                     |
+| ---- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| 1장  | 가로·정사각 원본은 원본 비율, 세로 원본은 최대 1:1   | 한 장을 surface 전체에 표시하고 세로 이미지는 중앙 `cover` crop                                               |
+| 2장  | 외곽 border와 tile 사이 gap을 제외한 이미지 영역 2:1 | 같은 크기의 1:1 tile 두 개. 외곽 높이는 tile 한 변과 border에서 파생하므로 최종 외곽 비율은 2:1보다 조금 넓음 |
+| 3장  | 외곽 4:3                                             | 첫 이미지는 왼쪽 전체 높이, 두·세 번째는 같은 폭의 오른쪽 열 위·아래                                          |
+| 4장  | 외곽 1:1                                             | 같은 크기의 2×2 tile                                                                                          |
+
+다중 tile은 `spacing.sm` gap, `radii.md` radius, theme border를 사용한다. 이미지·loading·error fallback은 같은 tile 경계를 채우고 원본을 늘이거나 찌그러뜨리지 않은 채 `cover`로 crop한다. 한 tile의 상태가 바뀌어도 인접 tile의 순서와 gallery surface를 밀지 않는다.
+
+## Sensitive Media
+
+- 가림 상태에서는 이미지를 mount하거나 byte를 load하지 않는다.
+- 1장의 가림 surface는 1:1이고, 공개 뒤에는 위의 단일 이미지 비율을 사용한다.
+- 2장은 정사각 tile에서 계산한 높이, 3장은 4:3, 4장은 1:1 surface를 공개 전후에 같게 사용한다.
+- 일반 목록·상세에서는 공개·다시 가리기 control을 같은 위치의 안정된 형제로 유지해 Web focus와 `expanded` 상태를 보존한다.
+- `interactive=false`인 Reply Composer 부모 preview는 같은 gallery geometry를 사용하지만 Sensitive 이미지를 가린 채 공개 control을 표시하지 않는다.
+
+## 상호작과 접근성
+
+정상 이미지 tile 자체는 PROD-650 viewer가 소유할 선택·navigation을 미리 구현하지 않으며 button·link role이나 press action을 갖지 않는다. Alt Text가 없으면 document 순서 기반의 `N번째 첨부 이미지`를 사용한다.
+
+일반 목록·상세의 Sensitive 공개·다시 가리기와 실패 이미지 재시도는 독립된 control이다. 기존 role, accessible name, state, keyboard·touch 입력을 유지하고 실행할 때 주변 Post navigation을 함께 실행하지 않는다. 비대화형 부모 preview의 error fallback은 같은 tile에 남지만 재시도 control을 제공하지 않는다.
+
+## 검증 경계
+
+- Component test는 1·2·3·4장의 구조·순서·surface·tile geometry, 단일 이미지 비율, Sensitive 미mount·공개 전후, error·retry 격리와 비대화형 예외를 확인한다.
+- Storybook은 일반 Post 폭과 compact viewport에서 1·2·3·4장, Sensitive, 부분 로딩 실패와 Reply 부모 preview를 확인한다. 현재 a11y 실행은 `color-contrast`를 제외하므로 전체 WCAG 적합성 증거가 아니다.
+- Web runtime의 keyboard·focus·pointer 관찰은 iOS VoiceOver·touch와 Android TalkBack·touch 결과를 대체하지 않는다. 자동화와 플랫폼별 runtime 증거를 PR에 구분해 기록한다.
+
+## 제외 범위
+
+이미지 viewer, zoom·pan·gesture, tile navigation, 다운로드·공유, Composer 업로드·선택, Reply·Quote 전용 layout, Media URL·authorization·metadata와 서버·DB 계약은 이 gallery의 소유가 아니다.

--- a/docs/design/post-media-gallery.md
+++ b/docs/design/post-media-gallery.md
@@ -28,6 +28,8 @@ Post 목록과 상세는 `PostContent.media`의 document 순서를 그대로 소
 
 일반 목록·상세의 Sensitive 공개·다시 가리기와 실패 이미지 재시도는 독립된 control이다. 기존 role, accessible name, state, keyboard·touch 입력을 유지하고 실행할 때 주변 Post navigation을 함께 실행하지 않는다. 비대화형 부모 preview의 error fallback은 같은 tile에 남지만 재시도 control을 제공하지 않는다.
 
+3장 16:9처럼 분할 tile의 높이가 긴 오류 설명과 48 logical unit 재시도 control을 함께 수용하지 못하는 경우, interactive gallery는 긴 시각 설명을 생략하고 영향받은 이미지 맥락이 포함된 재시도 accessible name을 사용한다. 재시도 control은 48 logical unit 높이 전체가 tile 안에 남아야 한다. URL이 없거나 비대화형 부모 preview여서 재시도 control이 없는 fallback은 기존 오류 설명을 계속 표시한다.
+
 ## 검증 경계
 
 - Component test는 1·2·3·4장의 구조·순서·surface·tile geometry, 단일 이미지 비율, Sensitive 미mount·공개 전후, error·retry 격리와 비대화형 예외를 확인한다.

--- a/docs/design/post-media-gallery.md
+++ b/docs/design/post-media-gallery.md
@@ -4,20 +4,21 @@ Post 목록과 상세는 `PostContent.media`의 document 순서를 그대로 소
 
 ## 이미지 개수별 geometry
 
-| 개수 | Gallery surface                                      | Tile 배치                                                                                                     |
-| ---- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| 1장  | 가로·정사각 원본은 원본 비율, 세로 원본은 최대 1:1   | 한 장을 surface 전체에 표시하고 세로 이미지는 중앙 `cover` crop                                               |
-| 2장  | 외곽 border와 tile 사이 gap을 제외한 이미지 영역 2:1 | 같은 크기의 1:1 tile 두 개. 외곽 높이는 tile 한 변과 border에서 파생하므로 최종 외곽 비율은 2:1보다 조금 넓음 |
-| 3장  | 외곽 4:3                                             | 첫 이미지는 왼쪽 전체 높이, 두·세 번째는 같은 폭의 오른쪽 열 위·아래                                          |
-| 4장  | 외곽 1:1                                             | 같은 크기의 2×2 tile                                                                                          |
+| 개수 | Gallery surface                                    | Tile 배치                                                                                            |
+| ---- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 1장  | 가로·정사각 원본은 원본 비율, 세로 원본은 최대 1:1 | 한 장을 surface 전체에 표시하고 세로 이미지는 중앙 `cover` crop                                      |
+| 2장  | tile 사이 gap을 제외한 이미지 영역 2:1             | 같은 크기의 1:1 tile 두 개. 외곽 높이는 tile 한 변에서 파생하므로 최종 외곽 비율은 2:1보다 조금 넓음 |
+| 3장  | 외곽 16:9                                          | 첫 이미지는 왼쪽 전체 높이, 두·세 번째는 같은 폭의 오른쪽 열 위·아래                                 |
+| 4장  | 외곽 1:1                                           | 같은 크기의 2×2 tile                                                                                 |
 
-다중 tile은 `spacing.sm` gap, `radii.md` radius, theme border를 사용한다. 이미지·loading·error fallback은 같은 tile 경계를 채우고 원본을 늘이거나 찌그러뜨리지 않은 채 `cover`로 crop한다. 한 tile의 상태가 바뀌어도 인접 tile의 순서와 gallery surface를 밀지 않는다.
+다중 tile은 `spacing.sm` gap과 `radii.md` gallery radius를 사용하되 gallery 외곽 border는 사용하지 않는다. 이미지·loading·error fallback은 같은 tile 경계를 채우고 원본을 늘이거나 찌그러뜨리지 않은 채 `cover`로 crop한다. 한 tile의 상태가 바뀌어도 인접 tile의 순서와 gallery surface를 밀지 않는다.
 
 ## Sensitive Media
 
 - 가림 상태에서는 이미지를 mount하거나 byte를 load하지 않는다.
 - 1장의 가림 surface는 1:1이고, 공개 뒤에는 위의 단일 이미지 비율을 사용한다.
-- 2장은 정사각 tile에서 계산한 높이, 3장은 4:3, 4장은 1:1 surface를 공개 전후에 같게 사용한다.
+- 2장은 정사각 tile에서 계산한 높이, 3장은 16:9, 4장은 1:1 surface를 공개 전후에 같게 사용한다.
+- 가림 상태는 실제 gallery tile이나 내부 gap을 렌더하지 않는 단일 placeholder로 같은 surface 높이만 예약하고, 공개 뒤에만 개수별 분할 gallery를 표시한다.
 - 일반 목록·상세에서는 공개·다시 가리기 control을 같은 위치의 안정된 형제로 유지해 Web focus와 `expanded` 상태를 보존한다.
 - `interactive=false`인 Reply Composer 부모 preview는 같은 gallery geometry를 사용하지만 Sensitive 이미지를 가린 채 공개 control을 표시하지 않는다.
 

--- a/docs/design/post-media-gallery.md
+++ b/docs/design/post-media-gallery.md
@@ -28,7 +28,7 @@ Post 목록과 상세는 `PostContent.media`의 document 순서를 그대로 소
 
 일반 목록·상세의 Sensitive 공개·다시 가리기와 실패 이미지 재시도는 독립된 control이다. 기존 role, accessible name, state, keyboard·touch 입력을 유지하고 실행할 때 주변 Post navigation을 함께 실행하지 않는다. 비대화형 부모 preview의 error fallback은 같은 tile에 남지만 재시도 control을 제공하지 않는다.
 
-3장 16:9처럼 분할 tile의 높이가 긴 오류 설명과 48 logical unit 재시도 control을 함께 수용하지 못하는 경우, interactive gallery는 긴 시각 설명을 생략하고 영향받은 이미지 맥락이 포함된 재시도 accessible name을 사용한다. 재시도 control은 48 logical unit 높이 전체가 tile 안에 남아야 한다. URL이 없거나 비대화형 부모 preview여서 재시도 control이 없는 fallback은 기존 오류 설명을 계속 표시한다.
+현재 표시 URL이 있고 interactive여서 재시도할 수 있는 오류 fallback은 단일·다중 이미지 모두 시각 오류 설명을 생략하고, 영향받은 이미지 맥락이 포함된 accessible name과 재시도 control만 표시한다. 재시도 control은 48 logical unit 높이를 사용하며 분할 tile에서는 전체 높이가 tile 안에 남아야 한다. URL이 없거나 비대화형 부모 preview여서 재시도할 수 없는 fallback은 기존 오류 설명을 계속 표시한다.
 
 ## 검증 경계
 

--- a/openspec/changes/add-compact-post-media-gallery/.openspec.yaml
+++ b/openspec/changes/add-compact-post-media-gallery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-03

--- a/openspec/changes/add-compact-post-media-gallery/decisions.md
+++ b/openspec/changes/add-compact-post-media-gallery/decisions.md
@@ -1,0 +1,49 @@
+## Context
+
+이 결정 기록은 PROD-626의 최신 확정 레이아웃·포함/제외 범위, Post Content·Media canonical 문서, 전역 접근성·breakpoint 기준과 이에 맞춘 gallery spec·design을 반영한다. 구현은 기존 `post-media-display` capability를 확장하며 후속 viewer인 PROD-650의 선택·navigation lifecycle을 포함하지 않는다.
+
+## Decision Records
+
+### 이미지 개수별 gallery surface를 사용한다
+
+- Decision Date: 2026-08-03
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/breakpoints.md`, PROD-626
+- Status: Active
+- Context / Problem: 모든 다중 이미지를 세로 나열하면 타임라인이 과도하게 길어지고, 하나의 고정 비율만 모든 개수에 적용하면 특정 개수의 tile이 지나치게 세로로 길어져 crop과 밀도가 불균형해진다.
+- Decision Outcome: 한 장은 기존 원본 비율 규칙을 유지한다. 두 장은 token gap·외곽 border를 제외한 이미지 영역 2:1 안에 같은 크기의 정사각 tile 두 개를 배치하고 gallery 높이를 tile 한 변과 외곽 border로 결정한다. 세 장은 전체 4:3에서 첫 이미지 왼쪽 전체 높이와 나머지 오른쪽 위·아래, 네 장은 전체 1:1의 2×2 배치를 사용한다. 모든 배치는 document 순서를 유지한다.
+- Alternatives Considered: 외곽 surface를 정확히 2:1로 고정하면서 양수 gap을 layout 공간으로 소비하는 안은 두 tile을 정사각형으로 만들 수 없다. separator를 이미지 위에 겹치는 안은 tile 일부를 가리킨다. 다중 이미지를 모두 4:3 또는 1:1 surface로 표시하는 안은 특정 개수의 tile을 지나치게 세로로 길게 만든다.
+- Consequences: 개수별 surface를 별도로 검증해야 하며 다중 tile은 `cover` crop을 허용한다. 새 breakpoint나 route별 배치는 필요하지 않다.
+- Confirmation / Follow-up: component/layout test와 Storybook에서 1·2·3·4장의 순서·구조·surface 비율을 검증하고 Web·iOS·Android runtime 결과를 구분해 기록한다.
+
+### Sensitive Media는 개수별 가림 surface를 예약한다
+
+- Decision Date: 2026-08-03
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-626
+- Status: Active
+- Context / Problem: 공개 전 이미지를 mount하지 않는 기존 Sensitive 계약을 지키면서 다중 gallery 공개 전후의 큰 layout 이동을 막아야 한다. 한 장은 서버가 원본 크기를 제공하지 않아 공개 전에 실제 비율을 알 수 없다.
+- Decision Outcome: 한 장의 가림 surface는 1:1을 사용하고 공개 뒤 기존 단일 이미지 비율 계약으로 전환한다. 두 장은 정사각 tile에서 계산한 gallery 높이, 세 장은 4:3, 네 장은 1:1 surface를 공개 전후에 유지한다. 일반 목록·상세의 공개·다시 가리기 control은 두 상태에서 같은 의미와 focus 경계를 유지한다. 비대화형 Reply Composer 부모 preview는 같은 배치를 사용하되 Sensitive 이미지를 가린 채 공개 control을 제공하지 않는다.
+- Alternatives Considered: 공개 전에 이미지를 mount하거나 metadata를 fetch해 한 장 비율을 측정하는 안은 byte 미로드 계약과 서버 범위를 침범한다. 모든 가림 surface에 임의의 공통 높이를 쓰는 안은 다중 gallery 공개 시 layout 이동을 만든다.
+- Consequences: 가로 한 장은 공개 뒤 1:1 placeholder보다 낮아질 수 있다. 다중 이미지는 공개 전후 gallery surface 높이가 유지된다.
+- Confirmation / Follow-up: Sensitive 1장과 다중 fixture에서 공개 전 이미지 미mount, surface 비율, 공개·다시 가리기와 Web focus 유지 여부를 검증한다.
+
+### 이미지 tile은 viewer 전까지 비상호작용으로 유지한다
+
+- Decision Date: 2026-08-03
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/accessibility.md`, PROD-626
+- Status: Active
+- Context / Problem: Post 목록 shortcut·상세 link와 이미지 tile을 동시에 interactive하게 만들면 중첩 role·focus·event propagation이 생기며 후속 viewer lifecycle을 선점한다.
+- Decision Outcome: 정상 이미지 tile 자체에는 button·link role이나 press action을 추가하지 않는다. 일반 목록·상세에서는 Sensitive 공개·다시 가리기와 실패한 이미지 재시도 control을 독립 interactive element로 유지한다. 비대화형 Reply Composer 부모 preview는 같은 gallery 배치와 fallback을 사용하되 내부 control을 제공하지 않는다.
+- Alternatives Considered: tile을 바로 상세 viewer trigger로 만드는 안은 PROD-650의 modal·선택 index·navigation 계약에 속하므로 제외한다. Post 전체 navigation을 tile에 복제하는 안은 중첩 semantics를 만든다.
+- Consequences: 이번 change는 presentation layout만 독립 완료할 수 있다. PROD-650은 이후 tile interaction을 추가할 때 현재 document 순서와 상태 경계를 소비한다.
+- Confirmation / Follow-up: component test와 Web runtime에서 정상 tile이 별도 interactive role을 갖지 않고 내부 control 실행이 Post navigation을 함께 발생시키지 않는지 확인한다. Reply Composer 부모 preview는 Sensitive 공개·재시도 control을 표시하지 않는 기존 동작을 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-compact-post-media-gallery/decisions.md
+++ b/openspec/changes/add-compact-post-media-gallery/decisions.md
@@ -4,6 +4,18 @@
 
 ## Decision Records
 
+### 짧은 interactive 오류 tile은 전체 재시도 control을 우선한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-media-gallery.md`, `docs/design/accessibility.md`, PROD-626
+- Status: Active
+- Context / Problem: 3장 16:9 gallery의 오른쪽 tile은 compact Post 폭에서 긴 오류 설명과 48 logical unit 재시도 control을 함께 수용하지 못해, tile의 `overflow: hidden` 경계에서 재시도 control 하단이 잘린다.
+- Decision Outcome: URL이 있고 interactive인 다중 tile 오류 fallback은 긴 시각 설명을 생략하고, 영향받은 이미지 맥락이 포함된 기존 재시도 accessible name과 48 logical unit control 전체를 tile 안에 유지한다. URL이 없거나 비대화형 부모 preview여서 재시도 control이 없는 fallback은 기존 오류 설명을 표시한다.
+- Alternatives Considered: 3장 surface 높이를 다시 늘리는 안은 승인된 16:9 compact geometry를 깨뜨린다. 재시도 control을 줄이는 안은 Android 48dp 기본 target과 기존 component 계약을 약화한다. 긴 설명과 control을 모두 유지하는 안은 compact 오른쪽 tile에서 잘림을 피할 수 없다.
+- Consequences: interactive 다중 오류 tile은 시각적으로 재시도 action만 표시하지만 오류 대상은 accessible name으로 식별된다. 한 장·URL 없음·비대화형 오류 fallback의 설명은 바뀌지 않는다.
+- Confirmation / Follow-up: compact 3장 Storybook fixture에서 16:9 surface와 48px 재시도 button의 상·하단이 오류 tile 안에 남는지 검증하고, component test에서 compact interactive 예외와 기존 accessible name을 확인한다.
+
 ### 3장 16:9와 borderless 다중 gallery surface를 사용한다
 
 - Decision Date: 2026-08-04

--- a/openspec/changes/add-compact-post-media-gallery/decisions.md
+++ b/openspec/changes/add-compact-post-media-gallery/decisions.md
@@ -4,12 +4,38 @@
 
 ## Decision Records
 
+### 3장 16:9와 borderless 다중 gallery surface를 사용한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-media-gallery.md`, PROD-626
+- Status: Active
+- Supersedes: 2026-08-03 `이미지 개수별 gallery surface를 사용한다` 결정
+- Context / Problem: 3장 4:3 surface는 실제 Post 폭에서 정사각형에 가깝게 보여 타임라인을 예상보다 크게 점유하고, 다중 gallery의 외곽 border는 이미지 자체와 tile 사이 분할보다 별도의 frame을 강조한다.
+- Decision Outcome: 한 장은 기존 원본 비율 규칙을 유지한다. 두 장은 token gap을 제외한 이미지 영역 2:1 안에 같은 크기의 정사각 tile 두 개를 배치하고 gallery 높이를 tile 한 변으로 결정한다. 세 장은 전체 16:9에서 첫 이미지를 왼쪽 전체 높이와 나머지를 오른쪽 위·아래에 배치하고, 네 장은 전체 1:1의 2×2 배치를 사용한다. 다중 gallery는 `spacing.sm` gap과 `radii.md` radius를 유지하되 외곽 border를 사용하지 않는다. 모든 배치는 document 순서를 유지한다.
+- Alternatives Considered: 3장 4:3은 오른쪽 tile을 4:3에 가깝게 만들지만 전체 surface가 타임라인에서 높게 보인다. 3:2는 중간 높이를 제공하지만 승인된 compact 목표가 덜 분명하다. theme border를 유지하는 안은 이미지 분할과 별개인 외곽 frame을 계속 노출한다.
+- Consequences: 3장 왼쪽 tile은 기존보다 정사각형에 가까워지고 오른쪽 tile은 가로형 crop이 커진다. 두 장의 최종 외곽 비율은 gap 때문에 2:1보다 조금 넓으며, 다중 gallery의 경계는 radius clipping과 Post background가 정의한다.
+- Confirmation / Follow-up: component/layout test와 Storybook에서 1·2·3·4장의 순서·구조·surface 비율과 외곽 border 부재를 검증하고 Web·iOS·Android runtime 결과를 구분해 기록한다.
+
+### Sensitive Media는 단일 가림 placeholder로 개수별 높이를 예약한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-media-gallery.md`, `docs/design/accessibility.md`, PROD-626
+- Status: Active
+- Supersedes: 2026-08-03 `Sensitive Media는 개수별 가림 surface를 예약한다` 결정
+- Context / Problem: 가림 상태에서 실제 gallery tile wrapper를 렌더하면 이미지 byte는 load하지 않더라도 빈 tile 사이 gap과 외곽 frame이 노출되어 하나의 Sensitive placeholder가 분할된 빈 패널처럼 보인다.
+- Decision Outcome: 한 장의 가림 surface는 1:1을 사용하고 공개 뒤 기존 단일 이미지 비율 계약으로 전환한다. 두 장은 정사각 tile에서 계산한 gallery 높이, 세 장은 16:9, 네 장은 1:1 surface를 공개 전후에 유지한다. 가림 상태는 실제 gallery tile·내부 gap을 렌더하지 않는 단일 placeholder를 사용하고 공개 뒤에만 개수별 분할 gallery를 표시한다. 일반 목록·상세의 기존 공개·다시 가리기 control과 focus 경계는 유지하며 버튼 크기·배치를 변경하지 않는다. 비대화형 Reply Composer 부모 preview는 같은 단일 placeholder를 사용하되 공개 control을 제공하지 않는다.
+- Alternatives Considered: 가림 상태에서도 빈 tile과 gap을 유지하는 안은 분할 구조가 노출되어 시각적 잡음을 만든다. 공개 control의 크기·배치를 함께 바꾸는 안은 현재 문제와 무관하고 기존 focus·입력 검증 범위를 넓힌다.
+- Consequences: 가림 상태에서는 이미지 개수별 내부 분할을 시각적으로 알 수 없지만 공개 전후의 외곽 높이는 유지된다. 공개 뒤에는 기존 document 순서와 tile 구조가 그대로 나타난다.
+- Confirmation / Follow-up: Sensitive 다중 fixture에서 가림 surface의 tile 미렌더, 공개 전후 surface 비율, 공개 뒤 tile 순서와 기존 control focus를 검증한다.
+
 ### 이미지 개수별 gallery surface를 사용한다
 
 - Decision Date: 2026-08-03
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/breakpoints.md`, PROD-626
-- Status: Active
+- Status: Superseded
 - Context / Problem: 모든 다중 이미지를 세로 나열하면 타임라인이 과도하게 길어지고, 하나의 고정 비율만 모든 개수에 적용하면 특정 개수의 tile이 지나치게 세로로 길어져 crop과 밀도가 불균형해진다.
 - Decision Outcome: 한 장은 기존 원본 비율 규칙을 유지한다. 두 장은 token gap·외곽 border를 제외한 이미지 영역 2:1 안에 같은 크기의 정사각 tile 두 개를 배치하고 gallery 높이를 tile 한 변과 외곽 border로 결정한다. 세 장은 전체 4:3에서 첫 이미지 왼쪽 전체 높이와 나머지 오른쪽 위·아래, 네 장은 전체 1:1의 2×2 배치를 사용한다. 모든 배치는 document 순서를 유지한다.
 - Alternatives Considered: 외곽 surface를 정확히 2:1로 고정하면서 양수 gap을 layout 공간으로 소비하는 안은 두 tile을 정사각형으로 만들 수 없다. separator를 이미지 위에 겹치는 안은 tile 일부를 가리킨다. 다중 이미지를 모두 4:3 또는 1:1 surface로 표시하는 안은 특정 개수의 tile을 지나치게 세로로 길게 만든다.
@@ -21,7 +47,7 @@
 - Decision Date: 2026-08-03
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-626
-- Status: Active
+- Status: Superseded
 - Context / Problem: 공개 전 이미지를 mount하지 않는 기존 Sensitive 계약을 지키면서 다중 gallery 공개 전후의 큰 layout 이동을 막아야 한다. 한 장은 서버가 원본 크기를 제공하지 않아 공개 전에 실제 비율을 알 수 없다.
 - Decision Outcome: 한 장의 가림 surface는 1:1을 사용하고 공개 뒤 기존 단일 이미지 비율 계약으로 전환한다. 두 장은 정사각 tile에서 계산한 gallery 높이, 세 장은 4:3, 네 장은 1:1 surface를 공개 전후에 유지한다. 일반 목록·상세의 공개·다시 가리기 control은 두 상태에서 같은 의미와 focus 경계를 유지한다. 비대화형 Reply Composer 부모 preview는 같은 배치를 사용하되 Sensitive 이미지를 가린 채 공개 control을 제공하지 않는다.
 - Alternatives Considered: 공개 전에 이미지를 mount하거나 metadata를 fetch해 한 장 비율을 측정하는 안은 byte 미로드 계약과 서버 범위를 침범한다. 모든 가림 surface에 임의의 공통 높이를 쓰는 안은 다중 gallery 공개 시 layout 이동을 만든다.
@@ -46,4 +72,5 @@
 
 ## Superseded Decisions
 
-- 없음.
+- 2026-08-03 `이미지 개수별 gallery surface를 사용한다`: 2026-08-04 `3장 16:9와 borderless 다중 gallery surface를 사용한다`가 대체한다.
+- 2026-08-03 `Sensitive Media는 개수별 가림 surface를 예약한다`: 2026-08-04 `Sensitive Media는 단일 가림 placeholder로 개수별 높이를 예약한다`가 대체한다.

--- a/openspec/changes/add-compact-post-media-gallery/decisions.md
+++ b/openspec/changes/add-compact-post-media-gallery/decisions.md
@@ -4,12 +4,26 @@
 
 ## Decision Records
 
-### 짧은 interactive 오류 tile은 전체 재시도 control을 우선한다
+### 재시도 가능한 오류 fallback은 action만 표시한다
 
 - Decision Date: 2026-08-04
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/post-media-gallery.md`, `docs/design/accessibility.md`, PROD-626
 - Status: Active
+- Supersedes: 2026-08-04 `짧은 interactive 오류 tile은 전체 재시도 control을 우선한다` 결정
+- Context / Problem: 기존 compact tile 예외는 같은 이미지 로딩 실패라도 단일 이미지에는 일반 오류 설명과 재시도 control을 함께 표시하고 다중 이미지는 control만 표시해, 실패 원인이나 별도 조치를 설명하지 않는 문구를 gallery geometry에 따라 다르게 노출한다.
+- Decision Outcome: 현재 표시 URL이 있고 interactive여서 재시도할 수 있는 오류 fallback은 단일·다중 이미지 모두 시각 오류 설명을 생략하고, 영향받은 이미지 맥락이 포함된 accessible name과 재시도 control만 표시한다. 재시도 control은 48 logical unit 높이를 사용하며 분할 tile에서는 전체 높이가 경계 안에 남아야 한다. URL이 없거나 비대화형 부모 preview여서 재시도할 수 없는 fallback은 기존 오류 설명을 표시한다.
+- Alternatives Considered: 단일 이미지에서만 기존 설명을 유지하는 안은 원인이나 추가 조치를 제공하지 않는 같은 문구를 gallery geometry에 따라 다르게 노출한다. 모든 fallback에서 설명을 제거하는 안은 URL 없음·비대화형 preview처럼 사용자가 복구 action을 실행할 수 없는 상태의 안내까지 없앤다.
+- Consequences: 재시도 가능한 단일·다중 오류는 시각적으로 같은 action-only 표현을 사용한다. 오류 대상은 재시도 accessible name으로 식별되고, 재시도 불가능한 fallback은 설명으로 상태를 전달한다.
+- Confirmation / Follow-up: component test에서 단일·다중 재시도 가능 오류가 설명 없이 action만 표시하는지와 URL 없음·비대화형 fallback이 설명을 유지하는지 확인한다. compact 3장 fixture의 48 logical unit containment 검증은 계속 유지한다.
+
+### 짧은 interactive 오류 tile은 전체 재시도 control을 우선한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/post-media-gallery.md`, `docs/design/accessibility.md`, PROD-626
+- Status: Superseded
+- Superseded By: 2026-08-04 `재시도 가능한 오류 fallback은 action만 표시한다` 결정
 - Context / Problem: 3장 16:9 gallery의 오른쪽 tile은 compact Post 폭에서 긴 오류 설명과 48 logical unit 재시도 control을 함께 수용하지 못해, tile의 `overflow: hidden` 경계에서 재시도 control 하단이 잘린다.
 - Decision Outcome: URL이 있고 interactive인 다중 tile 오류 fallback은 긴 시각 설명을 생략하고, 영향받은 이미지 맥락이 포함된 기존 재시도 accessible name과 48 logical unit control 전체를 tile 안에 유지한다. URL이 없거나 비대화형 부모 preview여서 재시도 control이 없는 fallback은 기존 오류 설명을 표시한다.
 - Alternatives Considered: 3장 surface 높이를 다시 늘리는 안은 승인된 16:9 compact geometry를 깨뜨린다. 재시도 control을 줄이는 안은 Android 48dp 기본 target과 기존 component 계약을 약화한다. 긴 설명과 control을 모두 유지하는 안은 compact 오른쪽 tile에서 잘림을 피할 수 없다.

--- a/openspec/changes/add-compact-post-media-gallery/design.md
+++ b/openspec/changes/add-compact-post-media-gallery/design.md
@@ -39,7 +39,7 @@ Sensitive Media는 별도 surface 안에서 단일 가림 placeholder와 공개�
 
 다중 gallery는 기존 theme의 spacing·radius token을 재사용하되 외곽 border를 두지 않고 tile은 `cover`로 경계를 채운다. tile 자체에는 press handler나 interactive role을 추가하지 않는다. 기존 재시도와 Sensitive control은 interactive 목록·상세에서만 상호작용 가능하게 유지한다.
 
-3장 16:9의 오른쪽 tile처럼 높이가 짧은 interactive 오류 fallback은 긴 시각 설명보다 전체 48 logical unit 재시도 control을 우선한다. 영향받은 이미지 맥락은 기존 재시도 accessible name으로 유지하고 긴 설명은 이 compact 경계에서만 생략한다. URL이 없거나 `interactive=false`라 재시도 control이 없는 fallback은 기존 오류 설명을 계속 표시한다.
+현재 표시 URL이 있고 interactive여서 재시도할 수 있는 오류 fallback은 단일·다중 이미지 모두 시각 오류 설명을 생략하고 재시도 control만 표시한다. 영향받은 이미지 맥락은 기존 재시도 accessible name으로 유지하며 control은 48 logical unit 높이를 사용하고 분할 tile 경계 안에 온전히 남는다. URL이 없거나 `interactive=false`라 재시도할 수 없는 fallback은 기존 오류 설명을 계속 표시한다.
 
 ### Allowed Alternatives
 

--- a/openspec/changes/add-compact-post-media-gallery/design.md
+++ b/openspec/changes/add-compact-post-media-gallery/design.md
@@ -27,17 +27,17 @@ PROD-571이 제공한 공용 Post Media renderer는 `PostContent.media`를 docum
 - gallery는 현재 최대 네 항목을 세로 `View`에 map하며 개수별 row/column 구조나 고정 surface가 없다.
 - 각 이미지 frame은 `Image.getSize` 결과를 자체 `aspectRatio`로 사용한다. 이 동작은 한 장에는 필요하지만 다중 tile에 그대로 적용하면 부모 surface를 채우지 못한다.
 - unavailable·error fallback은 현재 최소 높이를 가지므로 다중 tile 안에서 고정 경계를 채우도록 조정하지 않으면 gallery가 넘치거나 인접 tile을 밀 수 있다.
-- Sensitive 상태는 공개 control과 이미지 목록을 같은 일반 flow에 렌더한다. 다중 공개 전후 높이를 유지하려면 가림/이미지 surface와 항상 존재하는 control의 layout 경계를 분리해야 한다.
+- Sensitive 상태는 공개 control과 이미지 surface를 같은 일반 flow에 렌더한다. 다중 공개 전후 높이를 유지하되 가림 상태에서 실제 tile을 그리지 않으려면 단일 placeholder/공개 gallery와 항상 존재하는 control의 layout 경계를 분리해야 한다.
 - Reply Composer 부모 preview는 같은 공용 renderer에 `interactive=false` 경계를 전달해 Sensitive 공개와 오류 재시도 control을 의도적으로 생략한다. 목록·상세의 interactive control 계약을 이 preview에 확장하면 기존 범위를 바꾼다.
 - React Native와 React Native Web을 함께 지원하므로 Web 전용 CSS Grid나 viewport별 별도 markup에 의존할 수 없다.
 
 ### Recommended Approach
 
-공용 gallery가 Media 개수를 기준으로 React Native `View`의 중첩된 row/column flex layout을 선택한다. 한 장은 현재 이미지 컴포넌트의 측정 비율 경로를 그대로 사용한다. 두 장은 gallery 내부 폭에서 token gap과 외곽 border를 제외한 나머지를 같은 flex 폭으로 나누고 각 tile에 1:1 비율을 적용해 row 높이를 결정한다. 세 장·네 장은 승인된 전체 `aspectRatio` 안에서 tile 경계를 나눈다. 다중 이미지는 gallery가 tile 경계를 소유한 뒤 이미지·loading·error 표현이 그 경계를 채우도록 전달한다. 이 방식은 목록·상세 소비자를 바꾸지 않고 기존 데이터·상태 책임을 유지한다.
+공용 gallery가 Media 개수를 기준으로 React Native `View`의 중첩된 row/column flex layout을 선택한다. 한 장은 현재 이미지 컴포넌트의 측정 비율 경로를 그대로 사용한다. 두 장은 gallery 내부 폭에서 token gap을 제외한 나머지를 같은 flex 폭으로 나누고 각 tile에 1:1 비율을 적용해 row 높이를 결정한다. 세 장은 16:9, 네 장은 1:1의 승인된 전체 `aspectRatio` 안에서 tile 경계를 나눈다. 다중 이미지는 gallery가 tile 경계를 소유한 뒤 이미지·loading·error 표현이 그 경계를 채우도록 전달한다. 이 방식은 목록·상세 소비자를 바꾸지 않고 기존 데이터·상태 책임을 유지한다.
 
-Sensitive Media는 별도 surface 안에서 가림 placeholder와 공개된 gallery를 교체한다. 한 장의 가림 surface는 1:1이며 공개 뒤 기존 한 장 비율로 전환할 수 있다. 두 장은 같은 정사각 tile row geometry, 세 장은 4:3, 네 장은 1:1 surface를 가림과 공개 상태에 함께 사용한다. 일반 목록·상세의 공개·다시 가리기 control은 두 상태에 공통인 안정된 형제로 유지한다. 비대화형 Reply Composer 부모 preview는 같은 surface를 사용하지만 공개·재시도 control을 렌더하지 않는다.
+Sensitive Media는 별도 surface 안에서 단일 가림 placeholder와 공개된 gallery를 교체한다. 한 장의 가림 surface는 1:1이며 공개 뒤 기존 한 장 비율로 전환할 수 있다. 두 장은 같은 정사각 tile row geometry의 높이, 세 장은 16:9, 네 장은 1:1 surface를 가림과 공개 상태에 함께 사용하되 가림 상태에서는 실제 tile과 내부 gap을 렌더하지 않는다. 일반 목록·상세의 공개·다시 가리기 control은 두 상태에 공통인 안정된 형제로 유지한다. 비대화형 Reply Composer 부모 preview는 같은 단일 placeholder surface를 사용하지만 공개·재시도 control을 렌더하지 않는다.
 
-다중 gallery 외곽은 기존 theme의 spacing·radius·border token을 재사용하고 tile은 `cover`로 경계를 채운다. tile 자체에는 press handler나 interactive role을 추가하지 않는다. 기존 재시도와 Sensitive control은 interactive 목록·상세에서만 상호작용 가능하게 유지한다.
+다중 gallery는 기존 theme의 spacing·radius token을 재사용하되 외곽 border를 두지 않고 tile은 `cover`로 경계를 채운다. tile 자체에는 press handler나 interactive role을 추가하지 않는다. 기존 재시도와 Sensitive control은 interactive 목록·상세에서만 상호작용 가능하게 유지한다.
 
 ### Allowed Alternatives
 
@@ -50,6 +50,7 @@ Sensitive Media는 별도 surface 안에서 가림 placeholder와 공개된 gall
 - `stretch` 또는 원본 비율과 무관한 이미지 확대는 금지되며, fixed tile에서는 `cover` crop을 사용해야 한다.
 - error fallback의 기존 `minHeight`와 padding을 그대로 두면 작은 tile을 넘을 수 있다.
 - Sensitive 이미지를 가림 상태에서 미리 mount하거나 크기 측정용으로 load하면 기존 공개 전 byte 미로드 계약을 깨뜨린다.
+- Sensitive 가림 상태에서 공개 gallery의 빈 tile wrapper를 렌더하면 실제 이미지를 가렸는데도 분할선과 내부 gap이 노출된다.
 - visibility control을 상태별로 다른 element로 교체하면 Web focus 유지와 screen reader state가 깨질 수 있다.
 - 일반 목록·상세의 control을 `interactive=false` 부모 preview에도 강제로 추가하면 Reply Composer의 기존 비대화형 의미와 Storybook 계약을 깨뜨린다.
 - 이미지 tile을 `Pressable`로 감싸면 Post shortcut·상세 link와 중첩된 interactive semantics가 생기며 PROD-650 범위를 선점한다.
@@ -57,7 +58,7 @@ Sensitive Media는 별도 surface 안에서 가림 placeholder와 공개된 gall
 ## Risks / Trade-offs
 
 - [고정 tile의 `cover`로 이미지 일부가 crop된다] → 개수별 surface를 compact하게 유지하는 승인된 trade-off이며 원본을 늘이거나 찌그러뜨리지 않고 중앙 crop을 사용한다.
-- [두 장 gallery의 최종 외곽 비율은 token gap·border 때문에 정확한 2:1보다 조금 넓다] → 이미지 영역의 2:1과 두 정사각 tile을 우선하고 실제 외곽 높이를 tile 한 변과 border에서 파생한다.
+- [두 장 gallery의 최종 외곽 비율은 token gap 때문에 정확한 2:1보다 조금 넓다] → 이미지 영역의 2:1과 두 정사각 tile을 우선하고 실제 외곽 높이를 tile 한 변에서 파생한다.
 - [한 장 Sensitive placeholder는 공개 뒤 가로 원본 비율로 줄어들 수 있다] → 공개 전 byte 미로드와 서버 계약 제외를 우선하고, 사용자가 승인한 1:1 초기 surface를 명시한다.
 - [Native flex·aspectRatio 결과가 Web과 미세하게 다를 수 있다] → component/layout 자동화와 Web·iOS·Android runtime 관찰을 분리해 기록한다.
 - [기존 Post navigation과 내부 control 이벤트가 충돌할 수 있다] → tile은 비상호작용으로 유지하고 재시도·visibility control 실행이 부모 navigation을 함께 발생시키지 않는지 검증한다.

--- a/openspec/changes/add-compact-post-media-gallery/design.md
+++ b/openspec/changes/add-compact-post-media-gallery/design.md
@@ -39,6 +39,8 @@ Sensitive Media는 별도 surface 안에서 단일 가림 placeholder와 공개�
 
 다중 gallery는 기존 theme의 spacing·radius token을 재사용하되 외곽 border를 두지 않고 tile은 `cover`로 경계를 채운다. tile 자체에는 press handler나 interactive role을 추가하지 않는다. 기존 재시도와 Sensitive control은 interactive 목록·상세에서만 상호작용 가능하게 유지한다.
 
+3장 16:9의 오른쪽 tile처럼 높이가 짧은 interactive 오류 fallback은 긴 시각 설명보다 전체 48 logical unit 재시도 control을 우선한다. 영향받은 이미지 맥락은 기존 재시도 accessible name으로 유지하고 긴 설명은 이 compact 경계에서만 생략한다. URL이 없거나 `interactive=false`라 재시도 control이 없는 fallback은 기존 오류 설명을 계속 표시한다.
+
 ### Allowed Alternatives
 
 - gallery가 tile wrapper를 두고 이미지 표현을 채우게 하거나, 이미지 컴포넌트에 frame을 채우는 presentation prop을 전달하는 방식 모두 허용한다. 한 장의 측정 비율과 다중 fixed tile 책임이 분리되고 loading·error 표현까지 같은 경계를 채워야 한다.
@@ -49,6 +51,7 @@ Sensitive Media는 별도 surface 안에서 단일 가림 placeholder와 공개�
 - 다중 tile에도 원본 측정 `aspectRatio`를 적용하면 승인된 전체 surface와 같은 크기 배치가 깨진다.
 - `stretch` 또는 원본 비율과 무관한 이미지 확대는 금지되며, fixed tile에서는 `cover` crop을 사용해야 한다.
 - error fallback의 기존 `minHeight`와 padding을 그대로 두면 작은 tile을 넘을 수 있다.
+- 짧은 tile에 긴 오류 설명과 48 logical unit 재시도 control을 함께 쌓으면 tile의 `overflow: hidden`에 control 일부가 잘릴 수 있다.
 - Sensitive 이미지를 가림 상태에서 미리 mount하거나 크기 측정용으로 load하면 기존 공개 전 byte 미로드 계약을 깨뜨린다.
 - Sensitive 가림 상태에서 공개 gallery의 빈 tile wrapper를 렌더하면 실제 이미지를 가렸는데도 분할선과 내부 gap이 노출된다.
 - visibility control을 상태별로 다른 element로 교체하면 Web focus 유지와 screen reader state가 깨질 수 있다.

--- a/openspec/changes/add-compact-post-media-gallery/design.md
+++ b/openspec/changes/add-compact-post-media-gallery/design.md
@@ -1,0 +1,71 @@
+## Context
+
+PROD-571이 제공한 공용 Post Media renderer는 `PostContent.media`를 document 순서대로 최대 4개 받아 목록과 상세에서 같은 이미지·Alt Text·Sensitive·오류·재시도 동작을 제공한다. 현재 gallery는 각 이미지를 세로로 나열하고 각 이미지 컴포넌트가 측정한 원본 비율을 자신의 frame에 적용하므로, 다중 이미지를 고정 surface의 tile로 바꾸려면 layout 책임과 이미지 상태 책임을 분리해야 한다.
+
+현재 Post 목록과 상세은 같은 `PostBody`와 Media renderer 경로를 사용한다. 따라서 이 변경은 API·Relay·route별 분기 없이 presentation 경계에서 완료할 수 있으며, PROD-650의 상세 viewer나 이미지 tile navigation을 미리 추가하지 않는다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 한 장의 기존 비율 동작을 보존하면서 두 장부터 네 장까지 승인된 개수별 surface와 document 순서로 배치한다.
+- gallery가 Post body 폭 안에서 Web·iOS·Android에 동일한 React Native layout 계약을 사용하게 한다.
+- loading·ready·error와 Sensitive 공개 전후에도 tile 경계와 다중 gallery 높이를 안정적으로 유지한다.
+- 기존 Alt Text, 오류 재시도, Sensitive 공개·다시 가리기와 Post navigation 의미를 보존한다.
+- layout·접근성 결정과 자동화·runtime 검증 경계를 canonical design 문서에 남긴다.
+
+**Non-Goals:**
+
+- 이미지 viewer, tile 선택·navigation, zoom·pan·gesture, 다운로드·공유를 추가하지 않는다.
+- Composer 이미지 선택·업로드, Reply·Quote 전용 배치, 서버 Media URL·authorization·metadata 계약을 변경하지 않는다.
+- 새 breakpoint, 이미지 파생물, crop 위치 선택, 새 dependency나 test harness를 추가하지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- gallery는 현재 최대 네 항목을 세로 `View`에 map하며 개수별 row/column 구조나 고정 surface가 없다.
+- 각 이미지 frame은 `Image.getSize` 결과를 자체 `aspectRatio`로 사용한다. 이 동작은 한 장에는 필요하지만 다중 tile에 그대로 적용하면 부모 surface를 채우지 못한다.
+- unavailable·error fallback은 현재 최소 높이를 가지므로 다중 tile 안에서 고정 경계를 채우도록 조정하지 않으면 gallery가 넘치거나 인접 tile을 밀 수 있다.
+- Sensitive 상태는 공개 control과 이미지 목록을 같은 일반 flow에 렌더한다. 다중 공개 전후 높이를 유지하려면 가림/이미지 surface와 항상 존재하는 control의 layout 경계를 분리해야 한다.
+- Reply Composer 부모 preview는 같은 공용 renderer에 `interactive=false` 경계를 전달해 Sensitive 공개와 오류 재시도 control을 의도적으로 생략한다. 목록·상세의 interactive control 계약을 이 preview에 확장하면 기존 범위를 바꾼다.
+- React Native와 React Native Web을 함께 지원하므로 Web 전용 CSS Grid나 viewport별 별도 markup에 의존할 수 없다.
+
+### Recommended Approach
+
+공용 gallery가 Media 개수를 기준으로 React Native `View`의 중첩된 row/column flex layout을 선택한다. 한 장은 현재 이미지 컴포넌트의 측정 비율 경로를 그대로 사용한다. 두 장은 gallery 내부 폭에서 token gap과 외곽 border를 제외한 나머지를 같은 flex 폭으로 나누고 각 tile에 1:1 비율을 적용해 row 높이를 결정한다. 세 장·네 장은 승인된 전체 `aspectRatio` 안에서 tile 경계를 나눈다. 다중 이미지는 gallery가 tile 경계를 소유한 뒤 이미지·loading·error 표현이 그 경계를 채우도록 전달한다. 이 방식은 목록·상세 소비자를 바꾸지 않고 기존 데이터·상태 책임을 유지한다.
+
+Sensitive Media는 별도 surface 안에서 가림 placeholder와 공개된 gallery를 교체한다. 한 장의 가림 surface는 1:1이며 공개 뒤 기존 한 장 비율로 전환할 수 있다. 두 장은 같은 정사각 tile row geometry, 세 장은 4:3, 네 장은 1:1 surface를 가림과 공개 상태에 함께 사용한다. 일반 목록·상세의 공개·다시 가리기 control은 두 상태에 공통인 안정된 형제로 유지한다. 비대화형 Reply Composer 부모 preview는 같은 surface를 사용하지만 공개·재시도 control을 렌더하지 않는다.
+
+다중 gallery 외곽은 기존 theme의 spacing·radius·border token을 재사용하고 tile은 `cover`로 경계를 채운다. tile 자체에는 press handler나 interactive role을 추가하지 않는다. 기존 재시도와 Sensitive control은 interactive 목록·상세에서만 상호작용 가능하게 유지한다.
+
+### Allowed Alternatives
+
+- gallery가 tile wrapper를 두고 이미지 표현을 채우게 하거나, 이미지 컴포넌트에 frame을 채우는 presentation prop을 전달하는 방식 모두 허용한다. 한 장의 측정 비율과 다중 fixed tile 책임이 분리되고 loading·error 표현까지 같은 경계를 채워야 한다.
+- 개수별 row/column 구조를 작은 내부 presentation component나 순수 layout descriptor로 분리할 수 있다. 공개 API나 새 범용 layout abstraction을 만들지 않고 이 gallery 안에 한정해야 한다.
+
+### Known Traps
+
+- 다중 tile에도 원본 측정 `aspectRatio`를 적용하면 승인된 전체 surface와 같은 크기 배치가 깨진다.
+- `stretch` 또는 원본 비율과 무관한 이미지 확대는 금지되며, fixed tile에서는 `cover` crop을 사용해야 한다.
+- error fallback의 기존 `minHeight`와 padding을 그대로 두면 작은 tile을 넘을 수 있다.
+- Sensitive 이미지를 가림 상태에서 미리 mount하거나 크기 측정용으로 load하면 기존 공개 전 byte 미로드 계약을 깨뜨린다.
+- visibility control을 상태별로 다른 element로 교체하면 Web focus 유지와 screen reader state가 깨질 수 있다.
+- 일반 목록·상세의 control을 `interactive=false` 부모 preview에도 강제로 추가하면 Reply Composer의 기존 비대화형 의미와 Storybook 계약을 깨뜨린다.
+- 이미지 tile을 `Pressable`로 감싸면 Post shortcut·상세 link와 중첩된 interactive semantics가 생기며 PROD-650 범위를 선점한다.
+
+## Risks / Trade-offs
+
+- [고정 tile의 `cover`로 이미지 일부가 crop된다] → 개수별 surface를 compact하게 유지하는 승인된 trade-off이며 원본을 늘이거나 찌그러뜨리지 않고 중앙 crop을 사용한다.
+- [두 장 gallery의 최종 외곽 비율은 token gap·border 때문에 정확한 2:1보다 조금 넓다] → 이미지 영역의 2:1과 두 정사각 tile을 우선하고 실제 외곽 높이를 tile 한 변과 border에서 파생한다.
+- [한 장 Sensitive placeholder는 공개 뒤 가로 원본 비율로 줄어들 수 있다] → 공개 전 byte 미로드와 서버 계약 제외를 우선하고, 사용자가 승인한 1:1 초기 surface를 명시한다.
+- [Native flex·aspectRatio 결과가 Web과 미세하게 다를 수 있다] → component/layout 자동화와 Web·iOS·Android runtime 관찰을 분리해 기록한다.
+- [기존 Post navigation과 내부 control 이벤트가 충돌할 수 있다] → tile은 비상호작용으로 유지하고 재시도·visibility control 실행이 부모 navigation을 함께 발생시키지 않는지 검증한다.
+
+## Migration Plan
+
+DB·API·저장 데이터 migration 없이 공용 presentation을 한 번에 교체한다. 자동화와 플랫폼 runtime 검증 결과를 PR에 구분해 기록하고, 회귀가 확인되면 renderer 변경과 design/spec delta를 함께 되돌려 기존 세로 나열 동작으로 복구한다. PROD-650은 이 change의 전체 완료와 archive 뒤 착수할 수 있다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-compact-post-media-gallery/proposal.md
+++ b/openspec/changes/add-compact-post-media-gallery/proposal.md
@@ -5,9 +5,9 @@
 ## What Changes
 
 - Post 목록과 상세의 공용 Media renderer가 첨부 이미지 1~4장을 개수별 surface 비율과 분할 배치로 표시한다.
-- 1장은 기존 원본 비율 규칙을 유지하고, 2장은 token gap·외곽 border를 제외한 이미지 영역 2:1의 정사각 2열, 3장은 4:3의 첫 이미지+오른쪽 2분할, 4장은 1:1의 2×2 배치를 사용한다.
-- 다중 이미지 tile은 document 순서를 유지하고 공용 theme token의 간격·외곽선·radius 안에서 `cover`로 표시한다.
-- Sensitive Media 가림 상태는 1장은 1:1, 2장은 정사각 tile에서 계산한 높이, 3장은 4:3, 4장은 1:1 surface를 예약한다.
+- 1장은 기존 원본 비율 규칙을 유지하고, 2장은 token gap을 제외한 이미지 영역 2:1의 정사각 2열, 3장은 16:9의 첫 이미지+오른쪽 2분할, 4장은 1:1의 2×2 배치를 사용한다.
+- 다중 이미지 tile은 document 순서를 유지하고 공용 theme token의 간격·radius 안에서 외곽 border 없이 `cover`로 표시한다.
+- Sensitive Media 가림 상태는 1장은 1:1, 2장은 정사각 tile에서 계산한 높이, 3장은 16:9, 4장은 1:1 surface를 단일 placeholder로 예약하며 공개 뒤에만 분할 gallery를 표시한다.
 - 이미지 tile 자체는 이번 변경에서 새 navigation control이 되지 않는다. 일반 목록·상세에서는 기존 공개·다시 가리기와 오류 재시도 control을 유지하고, 비대화형 Reply Composer 부모 preview는 같은 gallery 배치를 사용하되 기존처럼 Sensitive 이미지를 가린 채 내부 control을 표시하지 않는다.
 - 개수별 배치와 접근성 결정을 `docs/design`에 기록하고 Web·Android·iOS 자동화와 runtime 증거를 구분한다.
 

--- a/openspec/changes/add-compact-post-media-gallery/proposal.md
+++ b/openspec/changes/add-compact-post-media-gallery/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+현재 Post 목록과 상세는 최대 4개의 첨부 이미지를 각각 전체 폭으로 세로 나열해, 여러 이미지가 있는 Post가 타임라인을 과도하게 점유하고 이미지 묶음의 순서와 관계를 한눈에 파악하기 어렵다. PROD-626은 기존 Media 조회·가림·오류 계약을 유지하면서 이미지 개수에 맞는 compact 분할 갤러리로 이 임시 배치를 교체한다.
+
+## What Changes
+
+- Post 목록과 상세의 공용 Media renderer가 첨부 이미지 1~4장을 개수별 surface 비율과 분할 배치로 표시한다.
+- 1장은 기존 원본 비율 규칙을 유지하고, 2장은 token gap·외곽 border를 제외한 이미지 영역 2:1의 정사각 2열, 3장은 4:3의 첫 이미지+오른쪽 2분할, 4장은 1:1의 2×2 배치를 사용한다.
+- 다중 이미지 tile은 document 순서를 유지하고 공용 theme token의 간격·외곽선·radius 안에서 `cover`로 표시한다.
+- Sensitive Media 가림 상태는 1장은 1:1, 2장은 정사각 tile에서 계산한 높이, 3장은 4:3, 4장은 1:1 surface를 예약한다.
+- 이미지 tile 자체는 이번 변경에서 새 navigation control이 되지 않는다. 일반 목록·상세에서는 기존 공개·다시 가리기와 오류 재시도 control을 유지하고, 비대화형 Reply Composer 부모 preview는 같은 gallery 배치를 사용하되 기존처럼 Sensitive 이미지를 가린 채 내부 control을 표시하지 않는다.
+- 개수별 배치와 접근성 결정을 `docs/design`에 기록하고 Web·Android·iOS 자동화와 runtime 증거를 구분한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, `docs/design/breakpoints.md`
+- Linear Contract: PROD-626
+- Linear Implementations: PROD-626. PROD-571은 완료된 선행 구현이며 PROD-650은 이 변경이 막고 있는 후속 viewer 구현이다.
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `post-media-display`: 기존 최대 4개 Media의 세로 나열 surface 계약을 이미지 개수별 compact 분할 갤러리 계약으로 변경한다.
+
+## Impact
+
+- `apps/app`의 공용 Post Media gallery/image presentation과 직접 component test·Storybook fixture가 영향을 받는다.
+- Post 목록과 Post 상세은 같은 공용 renderer를 계속 사용하며 Home·Profile·상세별 별도 배치를 추가하지 않는다.
+- `docs/design`에 Post Media gallery의 durable layout·접근성 결정을 추가한다.
+- GraphQL, Relay fragment, Media URL·authorization, DB, ActivityPub, 새 dependency에는 변화가 없다.

--- a/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
+++ b/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
@@ -98,7 +98,7 @@
 
 ### Requirement: Media 로딩 실패 격리와 재시도
 
-**Authority / Provenance:** `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571, PROD-626 — 공용 Post Media UI는 URL을 사용할 수 없거나 이미지 로딩이 실패해도 Post 전체 rendering을 MUST NOT 실패시킨다. 일반 목록·상세의 interactive gallery는 실패한 Media 자리에 상태 설명과 현재 viewer-authorized 표시 URL을 다시 로드하는 접근 가능한 재시도 action을 MUST 제공한다. 비대화형 Reply Composer 부모 preview는 같은 오류 fallback을 표시하되 재시도 action을 MUST NOT 제공한다. 이미지별 loading·ready·error 상태는 해당 tile 경계를 채우고 전체 gallery의 geometry·순서·인접 tile 배치를 변경하지 MUST NOT 한다.
+**Authority / Provenance:** `docs/domain/objects/media.md`, `docs/design/accessibility.md`, `docs/design/post-media-gallery.md`, PROD-571, PROD-626 — 공용 Post Media UI는 URL을 사용할 수 없거나 이미지 로딩이 실패해도 Post 전체 rendering을 MUST NOT 실패시킨다. 일반 목록·상세의 interactive gallery는 실패한 Media 자리에 상태 설명과 현재 viewer-authorized 표시 URL을 다시 로드하는 접근 가능한 재시도 action을 MUST 제공한다. 높이가 짧은 다중 tile에서는 영향받은 이미지 맥락을 재시도 action의 accessible name으로 전달하고 48 logical unit control 전체를 tile 안에 유지하기 위해 긴 시각 설명을 생략할 수 있다. 비대화형 Reply Composer 부모 preview는 같은 오류 fallback을 표시하되 재시도 action을 MUST NOT 제공한다. 이미지별 loading·ready·error 상태는 해당 tile 경계를 채우고 전체 gallery의 geometry·순서·인접 tile 배치를 변경하지 MUST NOT 한다.
 
 #### Scenario: 한 이미지 로딩 실패
 
@@ -117,6 +117,13 @@
 - **WHEN** 사용자가 실패한 Media의 재시도 action을 실행한다
 - **THEN** UI는 같은 tile 경계에서 해당 Media의 현재 표시 URL로 새 이미지 load를 시작하고 loading 상태를 전달한다
 - **AND** 다시 실패하면 같은 tile의 fallback과 재시도 action으로 돌아간다
+
+#### Scenario: 짧은 분할 tile의 이미지 로딩 실패
+
+- **WHEN** interactive gallery의 오류 tile 높이가 긴 상태 설명과 48 logical unit 재시도 action을 함께 수용하지 못한다
+- **THEN** UI는 영향받은 이미지 맥락을 재시도 action의 accessible name으로 전달한다
+- **AND** 재시도 action의 전체 48 logical unit 높이를 tile 경계 안에 유지한다
+- **AND** gallery surface 비율을 바꾸거나 재시도 action을 축소하지 않는다
 
 #### Scenario: 비대화형 preview의 이미지 로딩 실패
 

--- a/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
+++ b/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: Media gallery 상호작용 경계
+
+**Authority / Provenance:** `docs/design/accessibility.md`, PROD-626 — 공용 Post Media gallery는 이번 계약에서 이미지 tile 자체를 새 button이나 link로 만들지 MUST NOT 하며, Post shortcut·상세 navigation과 중첩된 interactive semantics를 만들지 MUST NOT 한다. 일반 목록·상세의 interactive gallery는 Sensitive Media 공개·다시 가리기와 실패한 이미지 재시도 control의 독립적인 role, accessible name, state와 입력 동작을 MUST 유지한다. 비대화형 Reply Composer 부모 preview는 같은 개수별 gallery 배치를 사용하되 내부 control을 MUST NOT 표시한다.
+
+#### Scenario: 일반 이미지 tile
+
+- **WHEN** 사용자가 목록이나 상세에서 정상적으로 표시된 이미지 tile을 탐색한다
+- **THEN** tile은 별도 button이나 link role 없이 이미지의 접근 가능한 설명만 제공한다
+- **AND** Post의 기존 shortcut과 상세 navigation 의미를 중첩하거나 대체하지 않는다
+
+#### Scenario: gallery 안의 기존 control
+
+- **WHEN** gallery가 Sensitive Media 공개·다시 가리기 또는 실패한 이미지 재시도 action을 표시한다
+- **THEN** 각 action은 기존 접근 가능한 이름·상태와 Web keyboard 및 iOS·Android touch·screen reader 동작을 유지한다
+- **AND** action 실행은 주변 Post navigation을 함께 실행하지 않는다
+
+#### Scenario: 비대화형 Reply Composer 부모 preview
+
+- **WHEN** Reply Composer가 부모 Post Media를 비대화형 preview로 표시한다
+- **THEN** preview는 같은 개수별 gallery 배치와 이미지 설명을 사용한다
+- **AND** Sensitive Media는 가려진 상태를 유지하며 공개·재시도 같은 내부 action을 표시하지 않는다
+
+## MODIFIED Requirements
+
+### Requirement: Media surface 비율
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/breakpoints.md`, PROD-571, PROD-626 — 공용 Post Media UI는 현재 Post Content의 Media 개수와 document 순서에 따라 목록과 상세에서 같은 surface를 MUST 사용한다. 한 장은 기존 Post body surface 폭과 원본 비율 규칙을 MUST 유지한다. 두 장은 token gap과 외곽 border가 차지하는 폭을 제외한 이미지 영역을 2:1로 두고 같은 크기의 정사각 tile 두 개를 한 행에 배치하며, gallery 높이는 정사각 tile 한 변과 외곽 border로 결정해야 한다. 세 장은 전체 4:3 surface에서 첫 이미지를 왼쪽 전체 높이에 두고 나머지를 오른쪽 위·아래에 둔 1+2 분할, 네 장은 전체 1:1 surface의 동일한 2×2 분할을 MUST 사용한다. 다중 이미지 tile은 공용 theme token의 간격·radius·border 안에서 `cover`로 경계를 채우되 원본을 늘이거나 찌그러뜨리지 MUST NOT 하며 gallery는 Post body 폭과 작은 viewport를 초과하지 MUST NOT 한다.
+
+#### Scenario: 한 장의 가로 또는 정사각형 이미지
+
+- **WHEN** 현재 Post Content가 한 장의 이미지를 가지며 원본 `width / height`가 1 이상이다
+- **THEN** Media frame은 surface 폭을 채우고 원본 종횡비를 유지한다
+
+#### Scenario: 한 장의 세로 이미지
+
+- **WHEN** 현재 Post Content가 한 장의 이미지를 가지며 원본 `width / height`가 1보다 작다
+- **THEN** Media frame은 surface 폭과 같은 높이의 1:1 경계를 사용한다
+- **AND** 이미지는 해당 경계를 채우도록 중앙 기준으로 crop된다
+
+#### Scenario: 두 장의 이미지
+
+- **WHEN** 현재 Post Content가 두 장의 이미지를 가진다
+- **THEN** gallery는 token gap·외곽 border를 제외한 이미지 영역을 2:1로 사용한다
+- **AND** document 순서대로 같은 크기의 정사각 tile 두 개를 한 행에 표시한다
+- **AND** gallery 높이는 정사각 tile 한 변과 외곽 border를 합친 값이다
+
+#### Scenario: 세 장의 이미지
+
+- **WHEN** 현재 Post Content가 세 장의 이미지를 가진다
+- **THEN** gallery는 전체 4:3 surface에서 document 순서의 첫 이미지를 왼쪽 전체 높이에 표시한다
+- **AND** 두 번째와 세 번째 이미지를 오른쪽 위·아래에 같은 크기로 표시한다
+
+#### Scenario: 네 장의 이미지
+
+- **WHEN** 현재 Post Content가 네 장의 이미지를 가진다
+- **THEN** gallery는 전체 1:1 surface 안에 document 순서대로 같은 크기의 2×2 tile을 표시한다
+
+#### Scenario: 작은 viewport의 다중 이미지
+
+- **WHEN** 다중 이미지 Post가 Post body 최대 폭보다 작은 Web viewport 또는 iOS·Android 화면에 표시된다
+- **THEN** gallery와 모든 tile은 Post body의 사용 가능한 폭 안에서 개수별 geometry와 순서를 유지한다
+
+### Requirement: Sensitive Media 명시적 공개
+
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571, PROD-626 — 현재 Post Content document root의 `sensitiveMedia`가 true이면 공용 Post Media UI는 해당 revision의 모든 Media를 기본적으로 MUST 가린다. 일반 목록·상세의 interactive gallery는 사용자가 같은 Post 안에서 이미지를 명시적으로 표시하고 다시 가릴 수 있는 접근 가능한 control을 MUST 제공한다. 비대화형 Reply Composer 부모 preview는 같은 gallery 배치를 사용하되 Sensitive 이미지를 가린 상태로 유지하고 공개 control을 MUST NOT 제공한다. 가림 surface는 한 장일 때 1:1, 두 장은 정사각 tile에서 계산한 gallery 높이, 세 장은 4:3, 네 장은 1:1을 사용해 다중 이미지 공개 전후의 gallery 높이를 MUST 유지한다.
+
+#### Scenario: 한 장의 Sensitive Media 기본 상태
+
+- **WHEN** interactive gallery가 한 장의 Media를 가진 Sensitive Post를 처음 표시한다
+- **THEN** 이미지 byte를 load하거나 표시하지 않고 1:1 가림 surface와 설명·표시 action을 제공한다
+- **AND** 공개 뒤 이미지는 한 장의 Media surface 비율 계약을 사용한다
+
+#### Scenario: 다중 Sensitive Media 기본 상태
+
+- **WHEN** interactive gallery가 두 장부터 네 장까지의 Media를 가진 Sensitive Post를 처음 표시한다
+- **THEN** 이미지 byte를 load하거나 표시하지 않고 해당 개수의 gallery와 같은 높이의 가림 surface와 설명·표시 action을 제공한다
+
+#### Scenario: Sensitive Media 표시와 다시 가리기
+
+- **WHEN** 사용자가 민감한 이미지 표시 action을 실행한다
+- **THEN** 같은 Post의 Media가 개수별 분할 gallery로 표시되고 control은 expanded 상태와 다시 가리기 action을 전달한다
+- **AND** 다시 가리기 action을 실행하면 같은 Post의 모든 Media가 가려진 기본 surface로 돌아간다
+- **AND** Web keyboard focus는 두 상태 전환 뒤에도 같은 visibility control에 유지된다
+
+#### Scenario: 비대화형 Sensitive 부모 preview
+
+- **WHEN** Reply Composer가 Sensitive 부모 Post Media를 비대화형 preview로 표시한다
+- **THEN** 이미지 byte를 load하거나 표시하지 않고 해당 개수의 가림 surface를 유지한다
+- **AND** 공개 control을 제공하지 않는다
+
+#### Scenario: 일반 Media
+
+- **WHEN** `sensitiveMedia`가 false이거나 생략된다
+- **THEN** 별도 공개 action 없이 이미지를 표시한다
+
+### Requirement: Media 로딩 실패 격리와 재시도
+
+**Authority / Provenance:** `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571, PROD-626 — 공용 Post Media UI는 URL을 사용할 수 없거나 이미지 로딩이 실패해도 Post 전체 rendering을 MUST NOT 실패시킨다. 일반 목록·상세의 interactive gallery는 실패한 Media 자리에 상태 설명과 현재 viewer-authorized 표시 URL을 다시 로드하는 접근 가능한 재시도 action을 MUST 제공한다. 비대화형 Reply Composer 부모 preview는 같은 오류 fallback을 표시하되 재시도 action을 MUST NOT 제공한다. 이미지별 loading·ready·error 상태는 해당 tile 경계를 채우고 전체 gallery의 geometry·순서·인접 tile 배치를 변경하지 MUST NOT 한다.
+
+#### Scenario: 한 이미지 로딩 실패
+
+- **WHEN** interactive gallery의 여러 Media 중 하나의 URL 로딩이 실패한다
+- **THEN** 실패한 tile만 같은 경계 안의 오류 fallback과 재시도 action으로 바뀐다
+- **AND** gallery의 surface 비율·순서·다른 tile 배치는 유지된다
+- **AND** 기존 본문, 다른 이미지, Post action과 navigation은 계속 사용할 수 있다
+
+#### Scenario: Media 표시 정보 unavailable
+
+- **WHEN** 현재 Post Content의 필요한 Media 표시 정보가 partial list 대신 unavailable이다
+- **THEN** Post는 Media unavailable fallback을 표시하고 본문·Post action·navigation을 유지한다
+
+#### Scenario: 실패한 이미지 재시도
+
+- **WHEN** 사용자가 실패한 Media의 재시도 action을 실행한다
+- **THEN** UI는 같은 tile 경계에서 해당 Media의 현재 표시 URL로 새 이미지 load를 시작하고 loading 상태를 전달한다
+- **AND** 다시 실패하면 같은 tile의 fallback과 재시도 action으로 돌아간다
+
+#### Scenario: 비대화형 preview의 이미지 로딩 실패
+
+- **WHEN** Reply Composer 부모 preview의 Media URL 로딩이 실패한다
+- **THEN** 실패한 tile은 같은 경계 안의 오류 fallback으로 바뀐다
+- **AND** 재시도 action을 제공하지 않고 다른 tile과 부모 Post preview를 유지한다

--- a/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
+++ b/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
@@ -26,7 +26,7 @@
 
 ### Requirement: Media surface 비율
 
-**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/breakpoints.md`, PROD-571, PROD-626 — 공용 Post Media UI는 현재 Post Content의 Media 개수와 document 순서에 따라 목록과 상세에서 같은 surface를 MUST 사용한다. 한 장은 기존 Post body surface 폭과 원본 비율 규칙을 MUST 유지한다. 두 장은 token gap과 외곽 border가 차지하는 폭을 제외한 이미지 영역을 2:1로 두고 같은 크기의 정사각 tile 두 개를 한 행에 배치하며, gallery 높이는 정사각 tile 한 변과 외곽 border로 결정해야 한다. 세 장은 전체 4:3 surface에서 첫 이미지를 왼쪽 전체 높이에 두고 나머지를 오른쪽 위·아래에 둔 1+2 분할, 네 장은 전체 1:1 surface의 동일한 2×2 분할을 MUST 사용한다. 다중 이미지 tile은 공용 theme token의 간격·radius·border 안에서 `cover`로 경계를 채우되 원본을 늘이거나 찌그러뜨리지 MUST NOT 하며 gallery는 Post body 폭과 작은 viewport를 초과하지 MUST NOT 한다.
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/breakpoints.md`, PROD-571, PROD-626 — 공용 Post Media UI는 현재 Post Content의 Media 개수와 document 순서에 따라 목록과 상세에서 같은 surface를 MUST 사용한다. 한 장은 기존 Post body surface 폭과 원본 비율 규칙을 MUST 유지한다. 두 장은 token gap이 차지하는 폭을 제외한 이미지 영역을 2:1로 두고 같은 크기의 정사각 tile 두 개를 한 행에 배치하며, gallery 높이는 정사각 tile 한 변으로 결정해야 한다. 세 장은 전체 16:9 surface에서 첫 이미지를 왼쪽 전체 높이에 두고 나머지를 오른쪽 위·아래에 둔 1+2 분할, 네 장은 전체 1:1 surface의 동일한 2×2 분할을 MUST 사용한다. 다중 이미지 tile은 공용 theme token의 간격·radius 안에서 외곽 border 없이 `cover`로 경계를 채우되 원본을 늘이거나 찌그러뜨리지 MUST NOT 하며 gallery는 Post body 폭과 작은 viewport를 초과하지 MUST NOT 한다.
 
 #### Scenario: 한 장의 가로 또는 정사각형 이미지
 
@@ -42,14 +42,14 @@
 #### Scenario: 두 장의 이미지
 
 - **WHEN** 현재 Post Content가 두 장의 이미지를 가진다
-- **THEN** gallery는 token gap·외곽 border를 제외한 이미지 영역을 2:1로 사용한다
+- **THEN** gallery는 token gap을 제외한 이미지 영역을 2:1로 사용한다
 - **AND** document 순서대로 같은 크기의 정사각 tile 두 개를 한 행에 표시한다
-- **AND** gallery 높이는 정사각 tile 한 변과 외곽 border를 합친 값이다
+- **AND** gallery 높이는 정사각 tile 한 변과 같다
 
 #### Scenario: 세 장의 이미지
 
 - **WHEN** 현재 Post Content가 세 장의 이미지를 가진다
-- **THEN** gallery는 전체 4:3 surface에서 document 순서의 첫 이미지를 왼쪽 전체 높이에 표시한다
+- **THEN** gallery는 전체 16:9 surface에서 document 순서의 첫 이미지를 왼쪽 전체 높이에 표시한다
 - **AND** 두 번째와 세 번째 이미지를 오른쪽 위·아래에 같은 크기로 표시한다
 
 #### Scenario: 네 장의 이미지
@@ -64,7 +64,7 @@
 
 ### Requirement: Sensitive Media 명시적 공개
 
-**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571, PROD-626 — 현재 Post Content document root의 `sensitiveMedia`가 true이면 공용 Post Media UI는 해당 revision의 모든 Media를 기본적으로 MUST 가린다. 일반 목록·상세의 interactive gallery는 사용자가 같은 Post 안에서 이미지를 명시적으로 표시하고 다시 가릴 수 있는 접근 가능한 control을 MUST 제공한다. 비대화형 Reply Composer 부모 preview는 같은 gallery 배치를 사용하되 Sensitive 이미지를 가린 상태로 유지하고 공개 control을 MUST NOT 제공한다. 가림 surface는 한 장일 때 1:1, 두 장은 정사각 tile에서 계산한 gallery 높이, 세 장은 4:3, 네 장은 1:1을 사용해 다중 이미지 공개 전후의 gallery 높이를 MUST 유지한다.
+**Authority / Provenance:** `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/design/accessibility.md`, PROD-571, PROD-626 — 현재 Post Content document root의 `sensitiveMedia`가 true이면 공용 Post Media UI는 해당 revision의 모든 Media를 기본적으로 MUST 가린다. 일반 목록·상세의 interactive gallery는 사용자가 같은 Post 안에서 이미지를 명시적으로 표시하고 다시 가릴 수 있는 접근 가능한 control을 MUST 제공한다. 비대화형 Reply Composer 부모 preview는 같은 gallery 배치를 사용하되 Sensitive 이미지를 가린 상태로 유지하고 공개 control을 MUST NOT 제공한다. 가림 surface는 한 장일 때 1:1, 두 장은 정사각 tile에서 계산한 gallery 높이, 세 장은 16:9, 네 장은 1:1을 사용해 다중 이미지 공개 전후의 gallery 높이를 MUST 유지한다. 다중 이미지 가림 상태는 실제 gallery tile·내부 gap을 렌더하지 않는 단일 placeholder로 surface 높이만 예약하고 공개 뒤에만 개수별 분할 gallery를 표시해야 한다.
 
 #### Scenario: 한 장의 Sensitive Media 기본 상태
 
@@ -76,6 +76,7 @@
 
 - **WHEN** interactive gallery가 두 장부터 네 장까지의 Media를 가진 Sensitive Post를 처음 표시한다
 - **THEN** 이미지 byte를 load하거나 표시하지 않고 해당 개수의 gallery와 같은 높이의 가림 surface와 설명·표시 action을 제공한다
+- **AND** 가림 surface는 실제 gallery tile이나 내부 gap 없이 하나의 placeholder로 표시된다
 
 #### Scenario: Sensitive Media 표시와 다시 가리기
 

--- a/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
+++ b/openspec/changes/add-compact-post-media-gallery/specs/post-media-display/spec.md
@@ -98,12 +98,13 @@
 
 ### Requirement: Media 로딩 실패 격리와 재시도
 
-**Authority / Provenance:** `docs/domain/objects/media.md`, `docs/design/accessibility.md`, `docs/design/post-media-gallery.md`, PROD-571, PROD-626 — 공용 Post Media UI는 URL을 사용할 수 없거나 이미지 로딩이 실패해도 Post 전체 rendering을 MUST NOT 실패시킨다. 일반 목록·상세의 interactive gallery는 실패한 Media 자리에 상태 설명과 현재 viewer-authorized 표시 URL을 다시 로드하는 접근 가능한 재시도 action을 MUST 제공한다. 높이가 짧은 다중 tile에서는 영향받은 이미지 맥락을 재시도 action의 accessible name으로 전달하고 48 logical unit control 전체를 tile 안에 유지하기 위해 긴 시각 설명을 생략할 수 있다. 비대화형 Reply Composer 부모 preview는 같은 오류 fallback을 표시하되 재시도 action을 MUST NOT 제공한다. 이미지별 loading·ready·error 상태는 해당 tile 경계를 채우고 전체 gallery의 geometry·순서·인접 tile 배치를 변경하지 MUST NOT 한다.
+**Authority / Provenance:** `docs/domain/objects/media.md`, `docs/design/accessibility.md`, `docs/design/post-media-gallery.md`, PROD-571, PROD-626 — 공용 Post Media UI는 URL을 사용할 수 없거나 이미지 로딩이 실패해도 Post 전체 rendering을 MUST NOT 실패시킨다. 일반 목록·상세의 interactive gallery는 현재 viewer-authorized 표시 URL을 다시 로드하는 접근 가능한 재시도 action을 MUST 제공하고, 재시도할 수 있는 오류 fallback은 단일·다중 이미지 모두 시각 오류 설명을 생략한 채 영향받은 이미지 맥락을 action의 accessible name으로 전달해야 한다. URL이 없거나 비대화형 Reply Composer 부모 preview여서 재시도할 수 없는 fallback은 상태 설명을 MUST 제공하고 재시도 action을 MUST NOT 제공한다. 재시도 control은 48 logical unit 높이를 사용하고 분할 tile에서는 전체 높이가 경계 안에 남아야 한다. 이미지별 loading·ready·error 상태는 해당 tile 경계를 채우고 전체 gallery의 geometry·순서·인접 tile 배치를 변경하지 MUST NOT 한다.
 
 #### Scenario: 한 이미지 로딩 실패
 
 - **WHEN** interactive gallery의 여러 Media 중 하나의 URL 로딩이 실패한다
 - **THEN** 실패한 tile만 같은 경계 안의 오류 fallback과 재시도 action으로 바뀐다
+- **AND** fallback은 시각 오류 설명을 생략하고 영향받은 이미지 맥락을 재시도 action의 accessible name으로 전달한다
 - **AND** gallery의 surface 비율·순서·다른 tile 배치는 유지된다
 - **AND** 기존 본문, 다른 이미지, Post action과 navigation은 계속 사용할 수 있다
 
@@ -129,4 +130,4 @@
 
 - **WHEN** Reply Composer 부모 preview의 Media URL 로딩이 실패한다
 - **THEN** 실패한 tile은 같은 경계 안의 오류 fallback으로 바뀐다
-- **AND** 재시도 action을 제공하지 않고 다른 tile과 부모 Post preview를 유지한다
+- **AND** 상태 설명을 제공하되 재시도 action은 제공하지 않고 다른 tile과 부모 Post preview를 유지한다

--- a/openspec/changes/add-compact-post-media-gallery/tasks.md
+++ b/openspec/changes/add-compact-post-media-gallery/tasks.md
@@ -35,10 +35,10 @@ Post 목록과 상세가 같은 공용 renderer를 사용해 한 장의 기존 �
 
 - 새 screenshot harness, 광범위 snapshot, route별 중복 fixture, viewer·Composer·API·DB 테스트와 테스트 인프라 변경.
 
-- [ ] 1.1 개수별 gallery layout·crop·접근성 결정을 적용되는 `docs/design` canonical 문서에 기록한다.
-- [ ] 1.2 한 장의 기존 비율, 두 장의 token 공간을 제외한 정사각 tile geometry와 3·4장 구조·순서·surface 비율을 직접 검증하는 최소 회귀 테스트와 3장 Storybook 사례를 추가하고 기존 구현에서 실패함을 확인한다.
-- [ ] 1.3 승인된 개수별 surface와 tile 배치를 공용 Post Media presentation에 구현하되 한 장의 측정 비율 경로와 목록·상세 소비자 계약을 유지한다.
-- [ ] 1.4 targeted Post Media unit test와 Storybook 검증을 통과시키고 1·2·3·4장 visual geometry를 확인한다.
+- [x] 1.1 개수별 gallery layout·crop·접근성 결정을 적용되는 `docs/design` canonical 문서에 기록한다.
+- [x] 1.2 한 장의 기존 비율, 두 장의 token 공간을 제외한 정사각 tile geometry와 3·4장 구조·순서·surface 비율을 직접 검증하는 최소 회귀 테스트와 3장 Storybook 사례를 추가하고 기존 구현에서 실패함을 확인한다.
+- [x] 1.3 승인된 개수별 surface와 tile 배치를 공용 Post Media presentation에 구현하되 한 장의 측정 비율 경로와 목록·상세 소비자 계약을 유지한다.
+- [x] 1.4 targeted Post Media unit test와 Storybook 검증을 통과시키고 1·2·3·4장 visual geometry를 확인한다.
 
 ## 2. PROD-626 Sensitive·오류·상호작용 안정성
 
@@ -78,9 +78,9 @@ Sensitive 공개 전후와 이미지별 loading·ready·error·retry 상태가 �
 
 - screen reader 자동화 harness, color-contrast debt 해소, 새 navigation mock, PROD-650 viewer interaction과 관련 없는 접근성 coverage 확대.
 
-- [ ] 2.1 Sensitive 공개 전후와 단일 tile loading·error·retry가 개수별 surface를 유지하고 정상 tile이 비상호작용이며 Reply Composer 부모 preview가 내부 control을 표시하지 않음을 검증하는 최소 회귀 테스트를 추가해 기존 구현에서 실패함을 확인한다.
-- [ ] 2.2 이미지·loading·error 표현이 다중 tile 경계를 채우고 Sensitive placeholder·gallery·visibility control이 승인된 높이와 기존 접근성 의미를 유지하도록 구현한다.
-- [ ] 2.3 targeted Post Media unit test와 Storybook a11y에서 상태 격리·control semantics·document 순서를 확인한다.
+- [x] 2.1 Sensitive 공개 전후와 단일 tile loading·error·retry가 개수별 surface를 유지하고 정상 tile이 비상호작용이며 Reply Composer 부모 preview가 내부 control을 표시하지 않음을 검증하는 최소 회귀 테스트를 추가해 기존 구현에서 실패함을 확인한다.
+- [x] 2.2 이미지·loading·error 표현이 다중 tile 경계를 채우고 Sensitive placeholder·gallery·visibility control이 승인된 높이와 기존 접근성 의미를 유지하도록 구현한다.
+- [x] 2.3 targeted Post Media unit test와 Storybook a11y에서 상태 격리·control semantics·document 순서를 확인한다.
 
 ## 3. PROD-626 통합 검증과 OpenSpec 완료
 
@@ -119,7 +119,14 @@ Sensitive 공개 전후와 이미지별 loading·ready·error·retry 상태가 �
 
 - 저장소 전체 coverage 확대, e2e 인프라 추가, unrelated fixture·snapshot·interaction test.
 
-- [ ] 3.1 App type/Relay check, 관련 unit test, Storybook build/test, ESLint·Prettier와 strict OpenSpec validation을 통과시킨다.
-- [ ] 3.2 Web의 작은 viewport와 일반 Post 폭에서 목록·상세 layout, keyboard·pointer, Sensitive·retry와 중첩 navigation 부재를 관찰해 기록한다.
+- [x] 3.1 App type/Relay check, 관련 unit test, Storybook build/test, ESLint·Prettier와 strict OpenSpec validation을 통과시킨다.
+- [x] 3.2 Web의 작은 viewport와 일반 Post 폭에서 목록·상세 layout, keyboard·pointer, Sensitive·retry와 중첩 navigation 부재를 관찰해 기록한다.
 - [ ] 3.3 iOS·Android binary에서 개수별 layout, 화면 폭, touch·VoiceOver·TalkBack, Sensitive·retry를 관찰해 기록한다.
 - [ ] 3.4 모든 task와 필수 runtime 증거가 완료되면 delta spec과 canonical design 정합성을 확인하고 이 change를 archive한다. 미실행 platform이 있으면 해당 task와 archive를 완료 처리하지 않는다.
+
+### 2026-08-03 Web runtime 증거
+
+- Storybook `BodyTimeAndLayoutStates`를 390×844 Web viewport에서 관찰했다. 목록의 2장 tile은 각각 136×136, gallery는 282×138이었고 재시도 control은 실패 tile bounds 안에 남았다. 3장 gallery는 358×268.5, 4장 gallery는 358×358이었다.
+- 900×900 Web viewport의 일반 600px Post 폭에서 3장은 600×450, 4장은 600×600을 유지했고 정상 tile에 button·link가 추가되지 않았다.
+- Sensitive 공개·다시 가리기를 pointer로 실행했을 때 같은 control이 focus와 `expanded`를 유지했고 가림 상태에서 image가 없었다. Storybook play test의 keyboard `Enter` 경로도 같은 focus 보존을 통과했다.
+- 목록의 실패 tile 재시도 후 Storybook route가 바뀌지 않았고 재시도 control과 인접 정상 이미지가 유지되었다.

--- a/openspec/changes/add-compact-post-media-gallery/tasks.md
+++ b/openspec/changes/add-compact-post-media-gallery/tasks.md
@@ -180,3 +180,52 @@ Sensitive 공개 전후와 이미지별 loading·ready·error·retry 상태가 �
 - Storybook에 2장 Sensitive fixture를 추가해 최초 가림 높이 `(width - spacing.sm) / 2`, 공개 전후 동일 높이, tile 미렌더와 border 부재를 실제 browser layout에서 검증했다. Watchman 없이 Expo Web 정적 export도 다시 생성해 localhost:5173에서 Post 폭 475의 2장 일반 gallery와 2장 Sensitive 단일 placeholder가 모두 475×233.5이고 3장 gallery가 475×267.1875로 정확히 16:9임을 확인했다. 두 다중 surface의 computed border는 0px였고 가림 상태의 Sensitive tile test id는 0개였다.
 - 2장 Sensitive 공개 뒤 gallery도 475×233.5를 유지했고 공개·다시 가리기 후 같은 control에 Web focus가 남았다. 버튼 크기·배치와 PROD-650 viewer interaction은 변경하지 않았다.
 - 기존 iOS·Android binary runtime과 archive gate는 각각 3.3·3.4에서 계속 미완료로 유지한다.
+
+## 5. PROD-626 compact 오류 tile 재시도 안정성
+
+**Authority / Provenance**
+
+- `docs/design/post-media-gallery.md`
+- `docs/design/accessibility.md`
+- PROD-626
+
+**Deliverable**
+
+3장 16:9 gallery의 짧은 오른쪽 오류 tile에서도 48 logical unit 재시도 control 전체가 잘리지 않고, 영향받은 이미지 맥락이 accessible name으로 유지된다.
+
+**Guardrails**
+
+- 승인된 3장 16:9 surface와 다중 gallery geometry를 변경하지 않는다.
+- 재시도 control을 48 logical unit보다 줄이지 않는다.
+- URL 없음·비대화형 부모 preview의 오류 설명과 재시도 미표시 계약을 변경하지 않는다.
+- GitHub 리뷰 답글·thread resolve는 구현과 별도 승인 대상으로 유지한다.
+
+**Verification**
+
+- compact 3장 Storybook fixture에서 오른쪽 오류 tile의 재시도 control 높이와 상·하단 containment를 직접 측정한다.
+- Post Media Image component test에서 compact interactive fallback의 긴 시각 설명 생략, 기존 accessible name과 48 logical unit control을 확인한다.
+
+**테스트 코드 범위**
+
+- `apps/app/src/components/post/PostMediaImage.test.ts`
+- `apps/app/src/stories/Posts.stories.tsx`의 3장 오류 fixture와 기존 interaction
+
+**테스트 필요성**
+
+- 16:9 오른쪽 tile의 `overflow: hidden`에 재시도 control 일부가 잘리는 실제 회귀를 직접 차단한다.
+
+**테스트 제외 범위**
+
+- 새 screenshot harness, 3장 surface 재설계, 전역 fallback copy 변경, viewer interaction과 unrelated Storybook coverage.
+
+- [x] 5.1 compact 3장 오류 fixture와 재시도 control containment assertion을 추가하고 기존 구현에서 하단이 약 5.84px 잘리는 RED를 확인한다.
+- [x] 5.2 짧은 interactive tile에서 긴 시각 설명만 생략하고 기존 accessible name·48 logical unit 재시도 control을 보존하며 canonical design·spec·decision을 동기화한다.
+- [x] 5.3 targeted unit·Storybook·정적 검사·strict OpenSpec validation과 localhost:5173 Web runtime을 확인한다.
+
+### 2026-08-04 compact 오류 tile 검증 증거
+
+- compact 3장 Storybook fixture에서 기존 구현의 재시도 button 하단 `1826.125px`가 tile 하단 `1820.28125px`를 약 `5.84px` 넘어가는 RED를 확인했다.
+- 긴 시각 설명을 compact interactive fallback에서만 생략한 뒤 같은 fixture가 16:9 surface, 48px 재시도 button과 tile 상·하단 containment assertion을 통과했다. URL 없음·비대화형 fallback의 기존 설명과 재시도 미표시는 component test로 유지했다.
+- App unit test 169개, Storybook test 267개, production Storybook build, `tsc --noEmit`, 변경 TypeScript ESLint, 변경 파일 Prettier check와 strict OpenSpec validation이 통과했다.
+- Watchman 없이 Expo Web export를 다시 생성했고, 기존 localhost:5173 서버를 재시작하지 않은 채 Home runtime에서 3장 gallery가 `476×267.75`로 정확히 16:9이고 오른쪽 두 tile이 각각 `234×129.875`인 것을 확인했다.
+- 기존 iOS·Android binary runtime과 archive gate는 각각 3.3·3.4에서 계속 미완료로 유지한다.

--- a/openspec/changes/add-compact-post-media-gallery/tasks.md
+++ b/openspec/changes/add-compact-post-media-gallery/tasks.md
@@ -1,0 +1,125 @@
+## 1. PROD-626 개수별 Post Media gallery
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post-content.md`
+- `docs/domain/objects/media.md`
+- `docs/design/breakpoints.md`
+- PROD-626
+
+**Deliverable**
+
+Post 목록과 상세가 같은 공용 renderer를 사용해 한 장의 기존 비율을 보존하고, 두 장은 token gap·외곽 border를 제외한 이미지 영역 2:1의 정사각 2열, 세 장은 4:3의 왼쪽 첫 이미지+오른쪽 2분할, 네 장은 1:1의 2×2 gallery로 document 순서대로 표시한다.
+
+**Guardrails**
+
+- 다중 tile은 공용 theme token의 간격·radius·border 안에서 `cover`로 표시하며 원본을 늘이거나 찌그러뜨리지 않는다.
+- gallery는 Post body 폭과 작은 Web viewport·iOS·Android 화면을 초과하지 않는다.
+- Home·Profile·Post 상세별 별도 layout, 새 breakpoint, API·Relay·서버·DB 계약과 새 dependency를 추가하지 않는다.
+- 구현 출발점과 허용 대안은 `design.md`의 비규범적 guidance를 따를 수 있으나 공개 범용 abstraction을 만들지 않는다.
+
+**Verification**
+
+- 한 장의 가로·정사각 원본 비율과 세로 1:1 crop 유지, 두 장의 정사각 tile·token 공간·계산된 높이, 세 장·네 장의 surface 비율·row/column 구조·Media 순서를 component test로 확인한다.
+- 1·2·3·4장 Storybook 사례에서 Post 폭과 compact viewport 안의 visual geometry를 확인한다.
+
+**테스트 코드 범위**
+
+- 기존 Post Media gallery component test의 1·2·3·4장 구조·순서·surface 비율과 빠진 3장 Storybook fixture.
+
+**테스트 필요성**
+
+- 승인된 개수별 배치가 기존 세로 나열을 실제로 교체하고 목록·상세 공용 renderer에서 같은 결과를 내는지 직접 증명한다.
+
+**테스트 제외 범위**
+
+- 새 screenshot harness, 광범위 snapshot, route별 중복 fixture, viewer·Composer·API·DB 테스트와 테스트 인프라 변경.
+
+- [ ] 1.1 개수별 gallery layout·crop·접근성 결정을 적용되는 `docs/design` canonical 문서에 기록한다.
+- [ ] 1.2 한 장의 기존 비율, 두 장의 token 공간을 제외한 정사각 tile geometry와 3·4장 구조·순서·surface 비율을 직접 검증하는 최소 회귀 테스트와 3장 Storybook 사례를 추가하고 기존 구현에서 실패함을 확인한다.
+- [ ] 1.3 승인된 개수별 surface와 tile 배치를 공용 Post Media presentation에 구현하되 한 장의 측정 비율 경로와 목록·상세 소비자 계약을 유지한다.
+- [ ] 1.4 targeted Post Media unit test와 Storybook 검증을 통과시키고 1·2·3·4장 visual geometry를 확인한다.
+
+## 2. PROD-626 Sensitive·오류·상호작용 안정성
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post-content.md`
+- `docs/domain/objects/media.md`
+- `docs/design/accessibility.md`
+- PROD-626
+
+**Deliverable**
+
+Sensitive 공개 전후와 이미지별 loading·ready·error·retry 상태가 개수별 gallery 경계와 순서를 유지하고, 이미지 tile은 후속 viewer 전까지 비상호작용으로 남는다.
+
+**Guardrails**
+
+- Sensitive 가림 상태에서 이미지 byte를 미리 load하지 않는다.
+- 한 장 가림 surface는 1:1이고 공개 뒤 기존 단일 이미지 비율을 사용한다. 두 장은 정사각 tile에서 계산한 높이, 세 장은 4:3, 네 장은 1:1 surface를 공개 전후에 유지한다.
+- 실패·loading 표현은 해당 tile만 대체하고 gallery surface·인접 tile·Post 본문·action·navigation을 밀거나 실패시키지 않는다.
+- 정상 tile에 button·link role이나 press action을 추가하지 않는다. 일반 목록·상세에서는 공개·다시 가리기와 재시도 control의 기존 role·name·state·focus·입력 동작을 유지한다. 비대화형 Reply Composer 부모 preview는 같은 gallery 배치와 fallback을 사용하되 Sensitive 공개·재시도 control을 표시하지 않는다.
+
+**Verification**
+
+- Sensitive 1장과 다중 gallery의 공개 전 이미지 미mount, surface 비율, 공개·다시 가리기와 Web focus 유지를 확인한다.
+- 여러 이미지 중 한 URL의 loading·failure·retry가 같은 tile 경계에 격리되고 다른 Media 순서와 Post navigation이 유지되는지 확인한다.
+- 정상 이미지 tile이 별도 interactive role을 갖지 않고 내부 control 실행이 부모 Post navigation을 함께 발생시키지 않는지 component test와 Web runtime에서 확인한다. Reply Composer 부모 preview의 비대화형 예외도 기존 Storybook surface에서 확인한다.
+
+**테스트 코드 범위**
+
+- 기존 Post Media gallery/image test 안의 Sensitive surface, 단일 tile 오류 격리·재시도, non-interactive tile과 일반 목록·상세 control semantics 및 Reply Composer 부모 preview 예외.
+
+**테스트 필요성**
+
+- fixed gallery로 전환할 때 기존 Sensitive·fallback의 일반 flow와 최소 높이가 surface를 깨뜨리는 회귀를 직접 방지한다.
+
+**테스트 제외 범위**
+
+- screen reader 자동화 harness, color-contrast debt 해소, 새 navigation mock, PROD-650 viewer interaction과 관련 없는 접근성 coverage 확대.
+
+- [ ] 2.1 Sensitive 공개 전후와 단일 tile loading·error·retry가 개수별 surface를 유지하고 정상 tile이 비상호작용이며 Reply Composer 부모 preview가 내부 control을 표시하지 않음을 검증하는 최소 회귀 테스트를 추가해 기존 구현에서 실패함을 확인한다.
+- [ ] 2.2 이미지·loading·error 표현이 다중 tile 경계를 채우고 Sensitive placeholder·gallery·visibility control이 승인된 높이와 기존 접근성 의미를 유지하도록 구현한다.
+- [ ] 2.3 targeted Post Media unit test와 Storybook a11y에서 상태 격리·control semantics·document 순서를 확인한다.
+
+## 3. PROD-626 통합 검증과 OpenSpec 완료
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/breakpoints.md`
+- PROD-626
+
+**Deliverable**
+
+승인된 gallery가 Web·iOS·Android의 목록과 상세에서 검증되고, 자동화와 실제 runtime 증거가 구분된 상태로 `post-media-display` 계약과 OpenSpec change가 동기화된다.
+
+**Guardrails**
+
+- 자동화 통과를 Web·iOS·Android runtime 또는 screen reader 검증으로 일반화하지 않는다.
+- Storybook a11y의 `color-contrast` 제외를 현재 change에서 해소하거나 전체 WCAG 적합성을 주장하지 않는다.
+- PROD-650 viewer, Composer, Reply·Quote 전용 layout과 서버 Media lifecycle을 현재 완료 범위에 포함하지 않는다.
+- Web·iOS·Android 필수 runtime과 delta spec 정합성이 완료되기 전에는 이 change를 archive하지 않는다. PR readiness와 change archive는 별도로 판단한다.
+
+**Verification**
+
+- `pnpm --filter @kosmo/app check`, Post Media unit test, Storybook build/test, ESLint·Prettier와 strict OpenSpec validation을 실행한다.
+- Web에서 작은 viewport와 일반 Post 폭의 목록·상세, keyboard·pointer, Sensitive·retry를 관찰한다.
+- iOS VoiceOver·touch와 Android TalkBack·touch에서 1·2·3·4장, Sensitive·retry와 화면 폭 초과 여부를 관찰한다.
+
+**테스트 코드 범위**
+
+- 없음. 1·2번 그룹의 최소 회귀 테스트로 전체 자동화와 runtime 검증을 수행한다.
+
+**테스트 필요성**
+
+- 없음. 이 그룹은 추가 coverage가 아니라 승인된 구현의 통합 증거와 플랫폼별 미검증 경계를 소유한다.
+
+**테스트 제외 범위**
+
+- 저장소 전체 coverage 확대, e2e 인프라 추가, unrelated fixture·snapshot·interaction test.
+
+- [ ] 3.1 App type/Relay check, 관련 unit test, Storybook build/test, ESLint·Prettier와 strict OpenSpec validation을 통과시킨다.
+- [ ] 3.2 Web의 작은 viewport와 일반 Post 폭에서 목록·상세 layout, keyboard·pointer, Sensitive·retry와 중첩 navigation 부재를 관찰해 기록한다.
+- [ ] 3.3 iOS·Android binary에서 개수별 layout, 화면 폭, touch·VoiceOver·TalkBack, Sensitive·retry를 관찰해 기록한다.
+- [ ] 3.4 모든 task와 필수 runtime 증거가 완료되면 delta spec과 canonical design 정합성을 확인하고 이 change를 archive한다. 미실행 platform이 있으면 해당 task와 archive를 완료 처리하지 않는다.

--- a/openspec/changes/add-compact-post-media-gallery/tasks.md
+++ b/openspec/changes/add-compact-post-media-gallery/tasks.md
@@ -229,3 +229,50 @@ Sensitive 공개 전후와 이미지별 loading·ready·error·retry 상태가 �
 - App unit test 169개, Storybook test 267개, production Storybook build, `tsc --noEmit`, 변경 TypeScript ESLint, 변경 파일 Prettier check와 strict OpenSpec validation이 통과했다.
 - Watchman 없이 Expo Web export를 다시 생성했고, 기존 localhost:5173 서버를 재시작하지 않은 채 Home runtime에서 3장 gallery가 `476×267.75`로 정확히 16:9이고 오른쪽 두 tile이 각각 `234×129.875`인 것을 확인했다.
 - 기존 iOS·Android binary runtime과 archive gate는 각각 3.3·3.4에서 계속 미완료로 유지한다.
+
+## 6. PROD-626 재시도 가능 오류 표현 통일
+
+**Authority / Provenance**
+
+- `docs/design/post-media-gallery.md`
+- `docs/design/accessibility.md`
+- PROD-626
+
+**Deliverable**
+
+현재 표시 URL이 있고 interactive여서 재시도할 수 있는 이미지 오류는 단일·다중 gallery 모두 시각 오류 설명 없이 이미지 맥락이 포함된 재시도 control만 표시한다. URL이 없거나 비대화형 preview여서 재시도할 수 없을 때만 기존 오류 설명을 유지한다.
+
+**Guardrails**
+
+- 기존 재시도 accessible name·동작과 48 logical unit control을 유지한다.
+- URL 없음·비대화형 부모 preview의 오류 설명과 재시도 미표시를 변경하지 않는다.
+- gallery geometry, Sensitive 동작, Storybook fixture와 PROD-650 viewer 범위를 변경하지 않는다.
+- GitHub 리뷰 답글·thread resolve는 구현과 별도 승인 대상으로 유지한다.
+
+**Verification**
+
+- 기존 Post Media Image component test에서 단일·다중 재시도 가능 오류가 action만 표시하고 URL 없음·비대화형 오류가 설명을 유지하는지 확인한다.
+- App unit·Storybook·정적 검사·strict OpenSpec validation과 Web runtime에서 기존 compact containment와 새 단일 이미지 표현을 확인한다.
+
+**테스트 코드 범위**
+
+- `apps/app/src/components/post/PostMediaImage.test.ts`의 기존 단일 interactive 오류 사례.
+
+**테스트 필요성**
+
+- 같은 재시도 가능 상태가 gallery geometry에 따라 서로 다른 시각 표현으로 돌아가는 회귀를 직접 차단한다.
+
+**테스트 제외 범위**
+
+- 새 Storybook fixture·screenshot harness, gallery geometry, viewer interaction, unrelated fallback copy·coverage와 테스트 인프라 변경.
+
+- [x] 6.1 재시도 가능 여부 기준을 canonical design과 Linear PROD-626에 동기화한다.
+- [x] 6.2 단일 interactive 오류의 action-only 표현을 기존 component test에서 RED로 확인한 뒤 공용 이미지 fallback을 최소 수정하고 OpenSpec 계약을 동기화한다.
+- [x] 6.3 targeted unit·Storybook·정적 검사·strict OpenSpec validation과 Web runtime을 확인한다.
+
+### 2026-08-04 재시도 가능 오류 표현 검증 증거
+
+- 단일 interactive 오류의 기존 설명+버튼 표현을 `['가로 이미지을 불러오지 못했습니다.', '다시 시도']` 대 `['다시 시도']`의 component test RED로 먼저 확인했다. URL·interactive 공통 재시도 가능 조건을 적용한 뒤 targeted `PostMediaImage` test 7개와 전체 App unit test 169개가 통과했고, 같은 URL로의 Image remount·URL 없음·비대화형 설명 유지·compact 48 logical unit containment 회귀도 함께 확인했다.
+- Storybook test 267개와 production build, `tsc --noEmit`, 변경 TypeScript ESLint, 변경 파일 Prettier check, strict OpenSpec validation, `git diff --check`와 Watchman 없는 Expo Web export가 통과했다. Storybook test의 기존 fixture console log·React `act` warning과 App unit의 `react-test-renderer` deprecation warning은 exit 0인 기존 경고로 남는다.
+- 별도 임시 포트의 production Storybook Web runtime에서 재시도 가능한 오류 fallback이 시각 설명 없이 이미지 맥락을 포함한 `실패 이미지 다시 시도` control만 표시하는 것을 확인했다. 기존 3장 오류 fixture는 `524×294.75`의 정확한 16:9 surface에서 오른쪽 실패 tile 안에 높이 48px control을 유지했다.
+- 단일 이미지 표현 변경은 새 fixture를 추가하지 않는 승인 범위에 따라 component RED/GREEN으로 직접 검증했고, Web runtime은 기존 다중 fixture에서 공용 fallback의 action-only 표현과 compact containment를 재확인했다. 기존 iOS·Android binary runtime과 archive gate는 각각 3.3·3.4에서 계속 미완료로 유지한다.

--- a/openspec/changes/add-compact-post-media-gallery/tasks.md
+++ b/openspec/changes/add-compact-post-media-gallery/tasks.md
@@ -9,11 +9,11 @@
 
 **Deliverable**
 
-Post 목록과 상세가 같은 공용 renderer를 사용해 한 장의 기존 비율을 보존하고, 두 장은 token gap·외곽 border를 제외한 이미지 영역 2:1의 정사각 2열, 세 장은 4:3의 왼쪽 첫 이미지+오른쪽 2분할, 네 장은 1:1의 2×2 gallery로 document 순서대로 표시한다.
+Post 목록과 상세가 같은 공용 renderer를 사용해 한 장의 기존 비율을 보존하고, 두 장은 token gap을 제외한 이미지 영역 2:1의 정사각 2열, 세 장은 16:9의 왼쪽 첫 이미지+오른쪽 2분할, 네 장은 1:1의 2×2 gallery로 document 순서대로 표시한다.
 
 **Guardrails**
 
-- 다중 tile은 공용 theme token의 간격·radius·border 안에서 `cover`로 표시하며 원본을 늘이거나 찌그러뜨리지 않는다.
+- 다중 tile은 공용 theme token의 간격·radius 안에서 외곽 border 없이 `cover`로 표시하며 원본을 늘이거나 찌그러뜨리지 않는다.
 - gallery는 Post body 폭과 작은 Web viewport·iOS·Android 화면을 초과하지 않는다.
 - Home·Profile·Post 상세별 별도 layout, 새 breakpoint, API·Relay·서버·DB 계약과 새 dependency를 추가하지 않는다.
 - 구현 출발점과 허용 대안은 `design.md`의 비규범적 guidance를 따를 수 있으나 공개 범용 abstraction을 만들지 않는다.
@@ -56,7 +56,7 @@ Sensitive 공개 전후와 이미지별 loading·ready·error·retry 상태가 �
 **Guardrails**
 
 - Sensitive 가림 상태에서 이미지 byte를 미리 load하지 않는다.
-- 한 장 가림 surface는 1:1이고 공개 뒤 기존 단일 이미지 비율을 사용한다. 두 장은 정사각 tile에서 계산한 높이, 세 장은 4:3, 네 장은 1:1 surface를 공개 전후에 유지한다.
+- 한 장 가림 surface는 1:1이고 공개 뒤 기존 단일 이미지 비율을 사용한다. 두 장은 정사각 tile에서 계산한 높이, 세 장은 16:9, 네 장은 1:1 surface를 공개 전후에 유지한다. 다중 가림 상태는 실제 gallery tile·내부 gap을 렌더하지 않는 단일 placeholder를 사용한다.
 - 실패·loading 표현은 해당 tile만 대체하고 gallery surface·인접 tile·Post 본문·action·navigation을 밀거나 실패시키지 않는다.
 - 정상 tile에 button·link role이나 press action을 추가하지 않는다. 일반 목록·상세에서는 공개·다시 가리기와 재시도 control의 기존 role·name·state·focus·입력 동작을 유지한다. 비대화형 Reply Composer 부모 preview는 같은 gallery 배치와 fallback을 사용하되 Sensitive 공개·재시도 control을 표시하지 않는다.
 
@@ -126,7 +126,57 @@ Sensitive 공개 전후와 이미지별 loading·ready·error·retry 상태가 �
 
 ### 2026-08-03 Web runtime 증거
 
+> 2026-08-04 geometry 결정으로 3장 4:3·다중 외곽 border 관련 관찰은 superseded되었다. 나머지 상호작용·접근성 관찰은 유지된다.
+
 - Storybook `BodyTimeAndLayoutStates`를 390×844 Web viewport에서 관찰했다. 목록의 2장 tile은 각각 136×136, gallery는 282×138이었고 재시도 control은 실패 tile bounds 안에 남았다. 3장 gallery는 358×268.5, 4장 gallery는 358×358이었다.
 - 900×900 Web viewport의 일반 600px Post 폭에서 3장은 600×450, 4장은 600×600을 유지했고 정상 tile에 button·link가 추가되지 않았다.
 - Sensitive 공개·다시 가리기를 pointer로 실행했을 때 같은 control이 focus와 `expanded`를 유지했고 가림 상태에서 image가 없었다. Storybook play test의 keyboard `Enter` 경로도 같은 focus 보존을 통과했다.
 - 목록의 실패 tile 재시도 후 Storybook route가 바뀌지 않았고 재시도 control과 인접 정상 이미지가 유지되었다.
+
+## 4. PROD-626 2026-08-04 gallery geometry 정정
+
+**Authority / Provenance**
+
+- `docs/design/post-media-gallery.md`
+- PROD-626
+
+**Deliverable**
+
+3장 gallery는 16:9 surface를 사용하고 모든 다중 gallery는 외곽 border 없이 내부 gap·radius를 유지한다. Sensitive 가림 상태는 같은 개수별 높이의 단일 placeholder를 사용하고 공개 뒤에만 실제 gallery tile을 표시한다.
+
+**Guardrails**
+
+- 1·2·4장 비율, document 순서, `cover` crop, 기존 공개·다시 가리기 control과 focus 의미를 변경하지 않는다.
+- Sensitive 가림 상태에서 image byte와 실제 gallery tile·내부 gap을 렌더하지 않는다.
+- PROD-650 viewer의 tile click·navigation을 선점하지 않는다.
+
+**Verification**
+
+- 3장 16:9, 다중 외곽 border 부재와 Sensitive tile 미렌더를 기존 component test에서 직접 검증한다.
+- targeted Post Media test, 변경 없는 Relay generation을 제외한 App TypeScript check, format·lint, strict OpenSpec validation과 Web runtime geometry를 확인한다.
+- 기존 iOS·Android runtime 미실행과 archive gate는 완료 처리하지 않는다.
+
+**테스트 코드 범위**
+
+- `apps/app/src/components/post/PostMediaGallery.test.ts`의 개수별 geometry와 Sensitive 가림 surface assertion.
+
+**테스트 필요성**
+
+- 이전 4:3·border·빈 tile 구현으로 돌아가는 회귀를 직접 차단한다.
+
+**테스트 제외 범위**
+
+- 새 screenshot harness, viewer interaction, 버튼 크기·배치, unrelated fixture·snapshot·테스트 인프라 변경.
+
+- [x] 4.1 Linear PROD-626, canonical design과 active OpenSpec의 16:9·borderless·단일 Sensitive placeholder 계약을 동기화한다.
+- [x] 4.2 변경 동작을 검증하는 기존 component test를 RED로 확인한 뒤 공용 gallery 구현을 최소 수정한다.
+- [x] 4.3 targeted 자동화·strict OpenSpec validation과 localhost:5173 Web runtime geometry를 확인하고 기존 native/archive 미완료 경계를 유지한다.
+
+### 2026-08-04 geometry 정정 검증 증거
+
+- component test를 먼저 수정해 기존 구현에서 다중 `borderWidth: 1`과 Sensitive 빈 tile 2개 렌더를 각각 실패로 확인했다. 단일 placeholder 구현 뒤 5173 runtime에서 2장 Sensitive 높이가 0인 회귀를 발견했고, 폭 320에서 token gap 8을 제외한 높이 156을 요구하는 두 번째 RED를 확인했다.
+- 초기 `onLayout` state 보완은 독립 리뷰에서 최초 0 높이와 공개 중 resize 뒤 stale 높이 위험이 확인됐다. 측정 state 대신 하나의 비시각적 sizing element가 `width: 50%`, `aspectRatio: 1`, `marginBottom: -spacing.sm / 2`로 첫 layout부터 정확한 높이를 만들도록 바꿨고, 해당 구조가 없는 구현에서 component test가 다시 실패함을 확인했다.
+- 최소 구현 뒤 App unit test 169개, Storybook test 267개, `tsc --noEmit`, 변경 파일 ESLint·Prettier check와 strict OpenSpec validation이 통과했다. 전체 App `check`의 선행 Relay compiler는 Watchman 상태 파일 접근에 실패했으며 이번 변경에는 GraphQL·Relay source 변경이 없어 정정 slice의 필수 gate에서 제외했다.
+- Storybook에 2장 Sensitive fixture를 추가해 최초 가림 높이 `(width - spacing.sm) / 2`, 공개 전후 동일 높이, tile 미렌더와 border 부재를 실제 browser layout에서 검증했다. Watchman 없이 Expo Web 정적 export도 다시 생성해 localhost:5173에서 Post 폭 475의 2장 일반 gallery와 2장 Sensitive 단일 placeholder가 모두 475×233.5이고 3장 gallery가 475×267.1875로 정확히 16:9임을 확인했다. 두 다중 surface의 computed border는 0px였고 가림 상태의 Sensitive tile test id는 0개였다.
+- 2장 Sensitive 공개 뒤 gallery도 475×233.5를 유지했고 공개·다시 가리기 후 같은 control에 Web focus가 남았다. 버튼 크기·배치와 PROD-650 viewer interaction은 변경하지 않았다.
+- 기존 iOS·Android binary runtime과 archive gate는 각각 3.3·3.4에서 계속 미완료로 유지한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- Post 목록·상세의 공용 Media renderer가 첨부 이미지 1~4장을 개수별 분할 갤러리로 표시합니다.
- 1장은 기존 원본 비율과 세로 이미지 최대 1:1 crop을 유지합니다.
- 2장은 `spacing.sm` gap을 제외한 영역에 같은 크기의 정사각 tile 두 개를 배치하고, 3장은 16:9의 1+2 분할, 4장은 1:1의 2×2 분할을 사용합니다.
- 다중 갤러리는 `spacing.sm` gap과 `radii.md` radius를 유지하되 외곽 border를 표시하지 않습니다.
- Sensitive 다중 이미지는 공개 전 실제 이미지·gallery tile·내부 gap을 렌더하지 않고, 공개 뒤와 같은 높이의 단일 placeholder만 표시합니다.
- 일반 목록·상세의 공개·다시 가리기·재시도 control과 Reply 부모 preview의 비대화형 예외를 유지합니다.
- 재시도 가능한 이미지 오류는 단일·다중 모두 대상 이미지 맥락이 포함된 `다시 시도` control만 표시하고, URL이 없거나 비대화형 preview여서 재시도할 수 없을 때만 오류 설명을 유지합니다.
- 구현·Storybook·canonical 디자인 문서·OpenSpec delta와 검증 기록을 같은 계약으로 동기화했습니다.

## 왜 변경했는지

기존 다중 이미지의 세로 나열은 타임라인을 과도하게 점유했습니다. 초기 4:3의 3장 surface는 실제 Post 폭에서 정사각형에 가깝게 보였고, 다중 갤러리 외곽 border와 Sensitive 가림 상태의 빈 tile 분할은 이미지 묶음보다 별도 frame을 강조했습니다. 승인된 compact geometry와 하나의 가림 surface로 이 시각적 잡음을 줄입니다.

## 이번 PR의 주요 결정

### 3장 16:9와 borderless 다중 gallery를 사용한다

- 결정자: @yeeun-uwu
- 선택: 3장은 16:9, 다중 gallery는 외곽 border 없이 내부 token gap과 radius만 사용합니다.
- 고려한 대안: 3장 4:3 또는 3:2, theme border 유지.
- 이유: 4:3보다 타임라인 점유를 줄이고 이미지 분할과 무관한 외곽 frame을 제거하기 위해서입니다.
- 감수한 결과: 3장 오른쪽 tile의 가로형 crop이 커집니다.
- 관련 근거: [`docs/design/post-media-gallery.md`](docs/design/post-media-gallery.md), [OpenSpec decisions](openspec/changes/add-compact-post-media-gallery/decisions.md), [PROD-626](https://linear.app/byulmaru/issue/PROD-626/post-첨부-이미지를-개수별-분할-갤러리로-표시한다)

### Sensitive 다중 이미지는 단일 placeholder로 가린다

- 결정자: @yeeun-uwu
- 선택: 공개 전에는 실제 gallery tile과 내부 gap 없이 개수별 높이만 예약합니다. 기존 공개 control의 크기·배치는 바꾸지 않습니다.
- 고려한 대안: 가림 상태에서도 빈 tile 분할 유지, 공개 control까지 함께 재설계.
- 이유: 가림 상태에서 분할 frame이 보이는 문제만 현재 범위에서 해결하고 기존 focus·입력 계약을 보존하기 위해서입니다.
- 감수한 결과: 공개 전에는 이미지 개수를 내부 분할로 구분할 수 없습니다.
- 관련 근거: [`docs/design/post-media-gallery.md`](docs/design/post-media-gallery.md), [OpenSpec decisions](openspec/changes/add-compact-post-media-gallery/decisions.md), [PROD-626](https://linear.app/byulmaru/issue/PROD-626/post-첨부-이미지를-개수별-분할-갤러리로-표시한다)

### 재시도 가능한 오류 fallback은 action만 표시한다

- 결정자: @yeeun-uwu
- 선택: 현재 표시 URL이 있고 interactive이면 단일·다중 모두 시각 오류 설명 없이 대상 이미지 맥락이 포함된 재시도 control만 표시합니다. URL 없음·비대화형 preview에서는 기존 오류 설명을 유지합니다.
- 고려한 대안: 단일 이미지만 기존 설명과 control을 함께 유지하는 안, 모든 fallback에서 설명을 제거하는 안.
- 이유: 기존 설명은 실패 원인이나 별도 조치를 제공하지 않고, 재시도 control의 accessible name이 이미 대상 이미지 맥락을 전달하므로 gallery geometry에 따라 표현을 나눌 이유가 없습니다.
- 감수한 결과: 재시도 가능한 오류는 시각 상태 설명을 별도로 노출하지 않으며, 대상 식별은 accessible name에 의존합니다.
- 관련 근거: [`docs/design/post-media-gallery.md`](docs/design/post-media-gallery.md), [OpenSpec decisions](openspec/changes/add-compact-post-media-gallery/decisions.md), [PROD-626](https://linear.app/byulmaru/issue/PROD-626/post-첨부-이미지를-개수별-분할-갤러리로-표시한다)

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app test:unit` — 169/169 통과
- `pnpm --filter @kosmo/app build-storybook` — 통과
- `pnpm --filter @kosmo/app test:storybook` — 19 files, 267/267 통과
- `pnpm --filter @kosmo/app exec tsc --noEmit` — 통과
- 변경 파일 ESLint·Prettier — 통과
- `pnpm exec openspec validate add-compact-post-media-gallery --strict` — 통과
- `git diff --check` — 통과
- localhost:5173 Web runtime에서 Post 폭 475 기준 2장 일반·Sensitive가 모두 475×233.5, 3장이 475×267.1875(16:9), 다중 border 0px, 가림 tile 0개임을 확인했습니다.
- production Storybook Web runtime에서 재시도 가능한 오류가 시각 설명 없이 이미지 맥락을 포함한 control만 표시하고, 3장 16:9의 48px 재시도 control이 실패 tile 안에 남는 것을 확인했습니다.
- 새 head `c0c8f773`의 GitHub CI 9/9가 통과했습니다.
- 저장소 지침 적용, 지침 비의존 코드 검토, 문서–코드 정합성 검토의 세 독립 리뷰에서 확인된 finding이 없었습니다.

전체 App `check`의 Relay compiler는 로컬 Watchman 상태 파일 권한 때문에 실행하지 못했습니다. 이번 정정에는 GraphQL·Relay source 변경이 없으며, Relay 단계를 제외한 TypeScript 검사는 통과했습니다.

## 아직 어떤 문제가 남았는지

- iOS·Android binary의 Yoga geometry, touch, VoiceOver·TalkBack runtime은 확인하지 않았습니다.
- 위 Native 검증 전에는 OpenSpec task 3.3·3.4를 완료하거나 change를 archive하지 않습니다. PR readiness와 OpenSpec 전체 완료를 별도로 판단합니다.
- 이미지 tile 클릭·상세 viewer·이전/다음 탐색은 후속 [PROD-650](https://linear.app/byulmaru/issue/PROD-650/post-이미지를-선택해-상세-viewer에서-탐색할-수-있게-한다) 범위입니다.

## 연결

- Linear: [PROD-626](https://linear.app/byulmaru/issue/PROD-626/post-첨부-이미지를-개수별-분할-갤러리로-표시한다)
- 후속: [PROD-650](https://linear.app/byulmaru/issue/PROD-650/post-이미지를-선택해-상세-viewer에서-탐색할-수-있게-한다)
