### PR TITLE
Inbound ActivityPub 처리 실패를 공통 로그와 Sentry 경계에 연결한다

### DIFF
--- a/apps/api/tests/integration/graphql/notification.test.ts
+++ b/apps/api/tests/integration/graphql/notification.test.ts
@@ -433,7 +433,7 @@ describe('Notification GraphQL Node boundary', () => {
     }
   });
 
-  test('hides a stale row when terminal request deletion overlaps post-commit creation', async () => {
+  test('does not leave a stale row when terminal request deletion overlaps post-commit creation', async () => {
     const auth = await createAuthenticatedSession();
     const recipient = await createProfile('follow-request-race-recipient');
     const requester = await createProfile('follow-request-race-requester');
@@ -444,13 +444,15 @@ describe('Notification GraphQL Node boundary', () => {
       .where(eq(Profiles.id, recipient.id));
 
     // The trigger is test-only: it pauses the INSERT after the source SELECT has
-    // observed the pending row, allowing the terminal delete and cleanup to commit.
+    // observed and locked the pending row. The terminal delete must reach that row
+    // lock before the INSERT is released, proving the final state has no orphan.
     const advisoryKey = 321_321;
     const control = await pg.reserve();
     let unlocked = false;
     let functionInstalled = false;
     let triggerInstalled = false;
     let followPromise: ReturnType<typeof followProfile> | undefined;
+    let cancelPromise: ReturnType<typeof cancelProfileFollowRequest> | undefined;
     try {
       await control`SELECT pg_advisory_lock(${advisoryKey})`;
       await db.execute(
@@ -507,13 +509,31 @@ describe('Notification GraphQL Node boundary', () => {
           ),
         )
         .then(firstOrThrow);
-      const cancelResult = await cancelProfileFollowRequest({
+      cancelPromise = cancelProfileFollowRequest({
         actorProfileId: requester.id,
         profileFollowRequestId: request.id,
       });
-      assert.equal(cancelResult.profileFollowRequestId, request.id);
+      let deleteBlocked = false;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        const activity = await db.execute(sql`
+          SELECT 1
+          FROM pg_stat_activity
+          WHERE wait_event_type = 'Lock'
+            AND wait_event IN ('transactionid', 'tuple')
+            AND query ILIKE '%delete from "profile_follow_request"%'
+          LIMIT 1
+        `);
+        if (activity.length > 0) {
+          deleteBlocked = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.equal(deleteBlocked, true);
       await control`SELECT pg_advisory_unlock(${advisoryKey})`;
       unlocked = true;
+      const cancelResult = await cancelPromise;
+      assert.equal(cancelResult.profileFollowRequestId, request.id);
       const result = await followPromise;
       assert.equal(result.result.kind, 'PENDING');
 
@@ -521,8 +541,8 @@ describe('Notification GraphQL Node boundary', () => {
         .select()
         .from(Notifications)
         .where(eq(Notifications.sourceId, request.id));
-      assert.equal(stale.length, 1);
-      const notificationId = encodeGlobalId('FollowRequestNotification', stale[0]!.id);
+      assert.equal(stale.length, 0);
+      const notificationId = encodeGlobalId('FollowRequestNotification', request.id);
       const recipientId = encodeGlobalId('Profile', recipient.id);
       assert.deepEqual(await loadNodes([notificationId], auth.token), [null]);
       const connection = await loadNotificationConnection(recipientId, auth.token, { first: 10 });
@@ -538,6 +558,7 @@ describe('Notification GraphQL Node boundary', () => {
       }
       // If setup or the blocking poll failed, let the in-flight source action
       // finish before dropping its test-only trigger/function.
+      await cancelPromise?.catch(() => undefined);
       await followPromise?.catch(() => undefined);
       if (triggerInstalled) {
         await db.execute(

--- a/apps/web/src/server/app.test.ts
+++ b/apps/web/src/server/app.test.ts
@@ -21,6 +21,7 @@ const {
   discovery,
   federationFetch,
   revokeSession,
+  setInboundObservabilityReporter,
   setNotificationEffectErrorReporter,
 } = vi.hoisted(() => ({
   authorizationCodeGrant: vi.fn<typeof oidcAuthorizationCodeGrant>(),
@@ -34,6 +35,7 @@ const {
     vi.fn<
       (input: { token?: string }) => Promise<{ status: 'REVOKED' | 'ALREADY_UNAUTHENTICATED' }>
     >(),
+  setInboundObservabilityReporter: vi.fn(),
   setNotificationEffectErrorReporter: vi.fn(),
 }));
 
@@ -51,6 +53,7 @@ vi.mock('@kosmo/core/services', () => ({
 
 vi.mock('@kosmo/fedify', () => ({
   federation: { fetch: federationFetch },
+  setInboundObservabilityReporter,
 }));
 
 vi.mock('./sentry', () => ({ captureNotificationEffectError, captureUnexpectedError }));
@@ -70,6 +73,9 @@ beforeAll(async () => {
   await writeFile(join(staticRoot, HASHED_ASSET_NAME), ASSET_BODY);
   vi.stubEnv('EXPO_WEB_ROOT', staticRoot);
   ({ default: app } = await import('./app'));
+  expect(setInboundObservabilityReporter).toHaveBeenCalledWith({
+    captureException: captureUnexpectedError,
+  });
   expect(setNotificationEffectErrorReporter).toHaveBeenCalledWith(captureNotificationEffectError);
 });
 

--- a/apps/web/src/server/app.ts
+++ b/apps/web/src/server/app.ts
@@ -1,5 +1,5 @@
 import { setNotificationEffectErrorReporter } from '@kosmo/core/services';
-import { federation } from '@kosmo/fedify';
+import { federation, setInboundObservabilityReporter } from '@kosmo/fedify';
 import { Hono } from 'hono';
 import { routePath } from 'hono/route';
 import { OidcAuthError } from './auth';
@@ -9,6 +9,8 @@ import logoutRoutes from './routes/logout';
 import staticRoutes from './routes/static';
 import { captureNotificationEffectError, captureUnexpectedError } from './sentry';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
+
+setInboundObservabilityReporter({ captureException: captureUnexpectedError });
 
 const app = new Hono();
 

--- a/apps/web/src/server/sentry.test.ts
+++ b/apps/web/src/server/sentry.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const sentryScope = vi.hoisted(() => ({ setExtra: vi.fn(), setTag: vi.fn() }));
+const sentryScope = vi.hoisted(() => ({
+  setExtra: vi.fn(),
+  setExtras: vi.fn(),
+  setFingerprint: vi.fn(),
+  setTag: vi.fn(),
+  setTags: vi.fn(),
+}));
 const sentry = vi.hoisted(() => ({
   captureException: vi.fn(),
   init: vi.fn(),
@@ -15,7 +21,10 @@ beforeEach(() => {
   sentry.captureException.mockReset();
   sentry.withScope.mockReset();
   sentryScope.setExtra.mockReset();
+  sentryScope.setExtras.mockReset();
+  sentryScope.setFingerprint.mockReset();
   sentryScope.setTag.mockReset();
+  sentryScope.setTags.mockReset();
   sentry.withScope.mockImplementation((callback) => callback(sentryScope));
 });
 
@@ -73,5 +82,41 @@ describe('Web BFF Sentry configuration', () => {
     expect(sentryScope.setExtra).toHaveBeenCalledWith('sourceId', 'request-123');
     expect(sentry.captureException).toHaveBeenCalledOnce();
     expect(sentry.captureException).toHaveBeenCalledWith(cause);
+  });
+
+  it('adds bounded inbound grouping metadata to internal captures', async () => {
+    vi.stubEnv('EXPO_PUBLIC_SENTRY_DSN', 'https://public@example.invalid/1');
+    vi.stubEnv('ENVIRONMENT', 'production');
+    vi.stubEnv('SENTRY_RELEASE', 'kosmo@abc123');
+
+    const { captureUnexpectedError } = await import('./sentry');
+    const error = new Error('projection failed');
+    captureUnexpectedError(error, {
+      tags: {
+        activity_type: 'Create',
+        handler: 'create',
+        outcome: 'internal_failure',
+        phase: 'projection',
+        reason_code: 'projection_failed',
+      },
+      fingerprint: ['activitypub-inbound', 'Create', 'create', 'projection', 'projection_failed'],
+    });
+
+    expect(sentry.withScope).toHaveBeenCalledOnce();
+    expect(sentryScope.setTags).toHaveBeenCalledWith({
+      activity_type: 'Create',
+      handler: 'create',
+      outcome: 'internal_failure',
+      phase: 'projection',
+      reason_code: 'projection_failed',
+    });
+    expect(sentryScope.setFingerprint).toHaveBeenCalledWith([
+      'activitypub-inbound',
+      'Create',
+      'create',
+      'projection',
+      'projection_failed',
+    ]);
+    expect(sentry.captureException).toHaveBeenCalledWith(error);
   });
 });

--- a/apps/web/src/server/sentry.ts
+++ b/apps/web/src/server/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import type { NotificationEffectErrorContext } from '@kosmo/core/services';
+import type { InboundCaptureContext } from '@kosmo/fedify';
 
 const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
 const environment = process.env.ENVIRONMENT;
@@ -17,10 +18,24 @@ if (enabled) {
   });
 }
 
-export const captureUnexpectedError = (cause: unknown): void => {
-  if (enabled) {
-    Sentry.captureException(cause);
+export const captureUnexpectedError = (cause: unknown, context?: InboundCaptureContext): void => {
+  if (!enabled) {
+    return;
   }
+
+  if (!context) {
+    Sentry.captureException(cause);
+    return;
+  }
+
+  Sentry.withScope((scope) => {
+    scope.setTags(context.tags);
+    scope.setFingerprint(context.fingerprint);
+    if (context.extra) {
+      scope.setExtras(context.extra);
+    }
+    Sentry.captureException(cause);
+  });
 };
 
 export const captureNotificationEffectError = (

--- a/docs/operations/sentry.md
+++ b/docs/operations/sentry.md
@@ -42,12 +42,12 @@ Production Web BFF의 Fedify inbox listener가 처리한 inbound ActivityPub 실
 projection 및 post-commit delivery 경계를 inventory로 유지한다. Listener 등록은
 `packages/fedify/src/federation.ts`에서 같은 경계를 통과한다.
 
-| 분류                 | 구체적인 예시·reason code                                                                                                       | 구조화 로그 | Sentry                              |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------- |
-| 보안·정책 거절       | malformed/foreign/mismatched activity, `invalid_*`, `*_projection_rejected`                                                     | 1회 기록    | 기록하지 않음                       |
-| 멱등·현재 상태 no-op | 없는 대상, 이미 처리된 관계, `duplicate_pending_follow_noop`, `announce_undo_ignored`                                           | 1회 기록    | 기록하지 않음                       |
-| 명시된 외부 실패     | remote 5xx/timeout/DNS, document·actor lookup, protocol 해석·delivery 실패, `*_object_lookup_failed`, `external_listener_error` | 1회 기록    | 기록하지 않음                       |
-| Kosmo 내부 오류      | DB projection, post-commit effect, typed listener의 예상하지 못한 `Error`, `unexpected_listener_error`                          | 1회 기록    | 기존 runtime reporter로 1회 capture |
+| 분류                 | 구체적인 예시·reason code                                                                                                                                                                                                   | 구조화 로그 | Sentry                              |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------- |
+| 보안·정책 거절       | malformed/foreign/mismatched activity, `invalid_*`, `*_projection_rejected`                                                                                                                                                 | 1회 기록    | 기록하지 않음                       |
+| 멱등·현재 상태 no-op | 없는 대상, 이미 처리된 관계, `duplicate_pending_follow_noop`, `duplicate_established_follow_noop`, `duplicate_accept_noop`, `accept_follow_state_changed_noop`, `reject_follow_state_changed_noop`, `announce_undo_ignored` | 1회 기록    | 기록하지 않음                       |
+| 명시된 외부 실패     | remote 5xx/timeout/DNS, document·actor lookup, protocol 해석·delivery 실패, `*_object_lookup_failed`, `external_listener_error`                                                                                             | 1회 기록    | 기록하지 않음                       |
+| Kosmo 내부 오류      | DB projection, post-commit effect, typed listener의 예상하지 못한 `Error`, `unexpected_listener_error`                                                                                                                      | 1회 기록    | 기존 runtime reporter로 1회 capture |
 
 오류 분류의 경계는 다음과 같다.
 

--- a/docs/operations/sentry.md
+++ b/docs/operations/sentry.md
@@ -42,13 +42,23 @@ Production Web BFF의 Fedify inbox listener가 처리한 inbound ActivityPub 실
 projection 및 post-commit delivery 경계를 inventory로 유지한다. Listener 등록은
 `packages/fedify/src/federation.ts`에서 같은 경계를 통과한다.
 
-- malformed/foreign/mismatched activity의 보안·정책 거절과 멱등 no-op은 `activity_type`, `handler`,
-  `phase`, `outcome`, bounded `reason_code`를 가진 구조화 로그만 남긴다.
-- 원격 5xx, timeout, DNS/connection, 외부 document/actor lookup, protocol 비호환·해석 실패와 외부
-  delivery 실패는 구조화 로그만 남기며 Sentry event를 만들지 않는다.
-- Kosmo 내부 unexpected 오류와 내부 projection/post-commit/effect 실패는 기존 runtime reporter를 통해
-  Sentry로 한 번 capture한다. `activity_type`, `handler`, `phase`, `reason_code`만 tag/fingerprint로
-  사용하고 반복량 제어는 SDK/ingest quota에 맡긴다.
+| 분류                 | 구체적인 예시·reason code                                                                                                       | 구조화 로그 | Sentry                              |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------- |
+| 보안·정책 거절       | malformed/foreign/mismatched activity, `invalid_*`, `*_projection_rejected`                                                     | 1회 기록    | 기록하지 않음                       |
+| 멱등·현재 상태 no-op | 없는 대상, 이미 처리된 관계, `duplicate_pending_follow_noop`, `announce_undo_ignored`                                           | 1회 기록    | 기록하지 않음                       |
+| 명시된 외부 실패     | remote 5xx/timeout/DNS, document·actor lookup, protocol 해석·delivery 실패, `*_object_lookup_failed`, `external_listener_error` | 1회 기록    | 기록하지 않음                       |
+| Kosmo 내부 오류      | DB projection, post-commit effect, typed listener의 예상하지 못한 `Error`, `unexpected_listener_error`                          | 1회 기록    | 기존 runtime reporter로 1회 capture |
+
+오류 분류의 경계는 다음과 같다.
+
+- 외부 실패는 `AbortError`, `FetchError`, `RemoteActorMaterializationError`, `SendActivityError`,
+  `UrlError`, `WebFingerError`라는 명시된 remote error name(또는 그 `cause`)으로만 판단한다. `ECONNREFUSED`,
+  `ECONNRESET` 같은 generic `error.code`만으로는 외부 오류라고 추정하지 않는다. 예를 들어 typed
+  handler가 `code = "ECONNREFUSED"`인 일반 `Error`를 던지면 내부 오류로 Sentry에 capture한다.
+- Fedify가 typed listener에 도달하기 전 request JSON을 파싱하다 던진 `SyntaxError`는
+  `federation.ts`의 관측되지 않은 `onError` 경계에서 malformed body 외부 실패로 로그만 남긴다.
+  `withInboundObservability`가 typed listener 오류를 먼저 observed로 표시하므로 typed handler 안에서
+  발생한 `SyntaxError`는 이 예외에 해당하지 않고 내부 오류로 capture한다.
 - raw Activity JSON, signature/key material, credential과 불필요한 개인정보를 로그·context에 넣지 않는다.
   URI는 필요한 경우 origin 수준 context로만 남기며 tag/fingerprint에는 넣지 않는다.
 

--- a/docs/operations/sentry.md
+++ b/docs/operations/sentry.md
@@ -46,8 +46,8 @@ projection 및 post-commit delivery 경계를 inventory로 유지한다. Listene
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------- |
 | 보안·정책 거절       | malformed/foreign/mismatched activity, `invalid_*`, `*_projection_rejected`                                                                                                                                                 | 1회 기록    | 기록하지 않음                       |
 | 멱등·현재 상태 no-op | 없는 대상, 이미 처리된 관계, `duplicate_pending_follow_noop`, `duplicate_established_follow_noop`, `duplicate_accept_noop`, `accept_follow_state_changed_noop`, `reject_follow_state_changed_noop`, `announce_undo_ignored` | 1회 기록    | 기록하지 않음                       |
-| 명시된 외부 실패     | remote 5xx/timeout/DNS, document·actor lookup, protocol 해석·delivery 실패, `*_object_lookup_failed`, `external_listener_error`                                                                                             | 1회 기록    | 기록하지 않음                       |
-| Kosmo 내부 오류      | DB projection, post-commit effect, typed listener의 예상하지 못한 `Error`, `unexpected_listener_error`                                                                                                                      | 1회 기록    | 기존 runtime reporter로 1회 capture |
+| 명시된 외부 실패     | remote 5xx/timeout/DNS, document·actor lookup, protocol 해석·delivery 실패, `delete_object_lookup_failed`, `*_object_lookup_failed`, `external_listener_error`                                                              | 1회 기록    | 기록하지 않음                       |
+| Kosmo 내부 오류      | DB projection, post-commit effect, `follow_notification_effect_failed`, `reaction_notification_effect_failed`, typed listener의 예상하지 못한 `Error`, `unexpected_listener_error`                                          | 1회 기록    | 기존 runtime reporter로 1회 capture |
 
 오류 분류의 경계는 다음과 같다.
 

--- a/docs/operations/sentry.md
+++ b/docs/operations/sentry.md
@@ -33,6 +33,25 @@ Sentry SDK가 만든 event는 `beforeSend`에서 재구성하거나 제거하지
 
 - console, network, navigation과 UI breadcrumb
 
+### ActivityPub inbound 처리 실패
+
+Production Web BFF의 Fedify inbox listener가 처리한 inbound ActivityPub 실패는 전역 HTTP 오류 경계와
+별도의 공통 관측 경계를 따른다. `packages/fedify/src/inbound-accept.ts`, `inbound-announce.ts`,
+`inbound-create.ts`/`inbound-create-note.ts`, `inbound-delete.ts`, `inbound-follow.ts`,
+`inbound-reaction.ts`, `inbound-reject.ts`와 `inbound-update.ts`의 `suppressError`, 예상 오류 catch,
+projection 및 post-commit delivery 경계를 inventory로 유지한다. Listener 등록은
+`packages/fedify/src/federation.ts`에서 같은 경계를 통과한다.
+
+- malformed/foreign/mismatched activity의 보안·정책 거절과 멱등 no-op은 `activity_type`, `handler`,
+  `phase`, `outcome`, bounded `reason_code`를 가진 구조화 로그만 남긴다.
+- 원격 5xx, timeout, DNS/connection, 외부 document/actor lookup, protocol 비호환·해석 실패와 외부
+  delivery 실패는 구조화 로그만 남기며 Sentry event를 만들지 않는다.
+- Kosmo 내부 unexpected 오류와 내부 projection/post-commit/effect 실패는 기존 runtime reporter를 통해
+  Sentry로 한 번 capture한다. `activity_type`, `handler`, `phase`, `reason_code`만 tag/fingerprint로
+  사용하고 반복량 제어는 SDK/ingest quota에 맡긴다.
+- raw Activity JSON, signature/key material, credential과 불필요한 개인정보를 로그·context에 넣지 않는다.
+  URI는 필요한 경우 origin 수준 context로만 남기며 tag/fingerprint에는 넣지 않는다.
+
 Sentry의 기본 개인정보 전송은 활성화하지 않지만, SDK event에는 오류 진단을 위해 request metadata, exception message, mechanism data, source context, frame local variable와 애플리케이션이 추가한 context가 포함될 수 있다. 애플리케이션 오류나 명시적 Sentry context에 인증 정보 또는 불필요한 사용자 콘텐츠를 넣지 않아야 한다.
 
 ## Build와 source map

--- a/openspec/changes/add-inbound-activitypub-observability/.openspec.yaml
+++ b/openspec/changes/add-inbound-activitypub-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-03

--- a/openspec/changes/add-inbound-activitypub-observability/decisions.md
+++ b/openspec/changes/add-inbound-activitypub-observability/decisions.md
@@ -1,0 +1,49 @@
+## Context
+
+이 기록은 `PROD-634`의 inbound ActivityPub 관측 계약과 `docs/operations/sentry.md`의 기존 runtime 전역 Sentry 정책을 packages/fedify listener 경계에 적용한 결과다.
+
+## Decision Records
+
+### 외부 원인 실패는 로그 전용으로 분류한다
+
+- Decision Date: 2026-08-03
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/operations/sentry.md`, `PROD-634`, 2026-08-03 사용자 결정
+- Status: Active
+- Context / Problem: Linear 본문은 action 가능한 외부 실패를 Sentry 대상으로 넓게 표현하지만, remote 서버 장애가 내부 issue 폭증을 만들 수 있다.
+- Decision Outcome: remote 5xx, timeout, DNS/connection, 외부 document lookup, actor materialization, protocol incompatibility/interpretation과 외부 delivery 실패는 구조화 로그만 남기고 Sentry capture를 금지한다.
+- Alternatives Considered: 모든 처리된 외부 실패를 Sentry에 보내는 방식은 외부 장애와 Kosmo 결함을 분리하지 못하므로 선택하지 않는다.
+- Consequences: 외부 원인 triage는 bounded reason/phase와 제한된 context를 가진 로그를 사용한다.
+- Confirmation / Follow-up: 대표 object lookup, actor materialization, protocol과 delivery 테스트에서 capture 호출이 0인지 확인한다.
+
+### 내부 오류의 반복량 제어는 SDK 정책에 위임한다
+
+- Decision Date: 2026-08-03
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/operations/sentry.md`, `PROD-634`, 2026-08-03 사용자 결정
+- Status: Active
+- Context / Problem: 동일 inbound activity 반복은 내부 오류 event를 폭증시킬 수 있으나 앱 rate limiter/sampler는 별도 운영 정책을 만든다.
+- Decision Outcome: 앱 내부 rate limiter나 sampler를 추가하지 않고 activity type, handler, phase, reason code 같은 stable grouping metadata만 제공하며 Sentry SDK/ingest quota에 위임한다.
+- Alternatives Considered: process-local token bucket 또는 probabilistic sampler는 다중 replica와 재시작에서 일관되지 않고 오류 event를 임의로 버리므로 선택하지 않는다.
+- Consequences: SDK/ingest quota와 운영 alert 설정이 반복량 제어 책임을 갖는다.
+- Confirmation / Follow-up: 반복 내부 오류 테스트에서 helper가 매번 reporter를 호출하되 stable metadata만 전달하는지 확인한다.
+
+### Fedify package는 runtime Sentry SDK를 소유하지 않는다
+
+- Decision Date: 2026-08-03
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-634`, `PROD-477`, `PROD-484`
+- Status: Active
+- Context / Problem: inbound listener는 Web BFF에서 실행되지만 package는 API resolver와 core service에서도 import된다.
+- Decision Outcome: package는 구조화 관측 callback seam만 제공하고 `@sentry/node`의 초기화·DSN·release 정책은 기존 runtime 앱이 소유한다.
+- Alternatives Considered: fedify가 Sentry SDK를 직접 import하거나 API 전역 Sentry를 package에 묶는 방식은 runtime 경계와 테스트를 확장하므로 선택하지 않는다.
+- Consequences: Web BFF가 기존 `captureUnexpectedError`를 연결하고 package 단위 테스트는 injected reporter를 검증한다.
+- Confirmation / Follow-up: package dependency에 Sentry SDK를 추가하지 않고 listener integration에서 callback 연결을 확인한다.
+
+## Remaining Decisions
+
+없음.
+
+## Superseded Decisions
+
+없음.

--- a/openspec/changes/add-inbound-activitypub-observability/design.md
+++ b/openspec/changes/add-inbound-activitypub-observability/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`packages/fedify`는 Fedify typed inbox listener에서 Accept, Announce, Create, Delete, Follow, Like/EmojiReact, Reject, Undo, Update를 처리한다. 현재 object 해석의 `suppressError`, remote actor materialization의 예상 오류, core action의 정책 거절, projection 이후 delivery catch가 handler별로 흩어져 있고 일부는 `console.error`만 남긴다. 실제 listener는 `apps/web` BFF에서 `@kosmo/fedify`를 호출하며, API와 Web BFF의 Sentry SDK는 runtime 전역 오류만 capture한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 처리된 inbound 실패와 no-op을 한정된 분류값으로 구조화한다.
+- 외부 원인 실패를 로그 전용으로, 내부 unexpected·내부 effect 실패를 기존 Sentry callback으로 연결한다.
+- 모든 production listener와 대표 handler의 회귀·경계 테스트로 중복/누락을 검출한다.
+- Activity 처리 결과와 민감정보 경계를 유지한다.
+
+**Non-Goals:**
+
+- ActivityPub 검증·저장·멱등성·retry/outbox/queue/DLQ 동작 변경
+- 앱 내부 rate limiter/sampler, inbound history 테이블, raw payload 감사 저장
+- 외부 서버별 호환성 버그 재구현 또는 Sentry SDK 자체 설정 변경
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Fedify listener 함수는 `(InboxContext, Activity)`를 받고 `void`를 반환하므로 공통 wrapper가 throw 경계와 activity type을 추출할 수 있다.
+- `suppressError: true`는 오류 원인을 호출자에게 전달하지 않고 `null`/빈 결과로 만들 수 있으므로 각 document 경계에서 외부 실패 로그를 명시해야 한다.
+- `@kosmo/fedify`가 `@sentry/node`를 직접 의존하면 package 경계와 테스트가 API/Web runtime에 결합된다. 기존 runtime Sentry callback을 주입하는 좁은 seam이 필요하다.
+- URI는 조사 context로 유용하지만 Sentry grouping/tag에 사용하면 cardinality가 폭증한다.
+
+### Recommended Approach
+
+- `packages/fedify`에 bounded enum-like activity/phase/outcome/reason 분류와 구조화 logger/capture reporter를 소유시키고 기본 logger는 `console` 기반으로 둔다.
+- handler의 처리된 catch/suppress/no-op 지점은 helper를 호출해 `rejected`, `noop`, `external_failure`, `internal_failure`를 명시하고 원래 return/rethrow를 유지한다.
+- federation listener 등록부에는 마지막 방어선 wrapper와 `onError` 경계를 두어 helper를 거치지 않은 internal throw만 capture하며, remote/network/protocol 오류는 외부 분류로 로그만 남긴다.
+- `apps/web`의 기존 `captureUnexpectedError`를 helper reporter에 연결한다. API runtime은 동일한 seam을 필요로 하는 직접 사용 경계에서만 연결하고 Sentry SDK를 fedify package로 옮기지 않는다.
+- Sentry context에는 bounded tag/fingerprint만 추가하고 URI는 extra/context의 제한된 필드로만 전달하며 raw activity나 request/signature는 전달하지 않는다.
+
+### Allowed Alternatives
+
+- 동일한 package 경계와 분류·민감정보 계약을 유지한다면 callback registry 대신 listener factory에 reporter를 전달할 수 있다.
+
+### Known Traps
+
+- `console.error`를 helper 없이 남기거나 `catch { return; }`를 추가하면 inventory와 Sentry 정책이 다시 분리된다.
+- 모든 예외를 Sentry에 보내거나 remote error를 내부 오류로 추정하지 않는다.
+- activity/actor/object 전체 URI를 fingerprint/tag에 넣지 않는다.
+- wrapper에서 오류를 소비해 기존 Fedify 응답/재throw 의미를 바꾸지 않는다.
+
+## Risks / Trade-offs
+
+- 외부 실패의 원인 객체를 Sentry에서 제외하면 remote 장애 원인 분석은 로그에 의존한다 → reason code, phase와 제한된 origin/URI context를 구조화해 검색성을 유지한다.
+- package-level reporter가 전역 mutable seam이면 테스트 간 상태가 샐 수 있다 → reset 가능한 기본 reporter와 listener boundary 테스트를 사용한다.
+- bounded grouping은 서로 다른 내부 결함을 한 issue로 묶을 수 있다 → 안정적인 reason code를 세분화하고 SDK grouping에 위임한다.
+
+## Migration Plan
+
+기존 handler의 처리 결과와 production 배포 경로를 유지한 채 helper 연결을 배포한다. rollback 시 관측 callback 연결과 helper 호출을 되돌리면 기존 오류 처리로 복귀하며 데이터 migration은 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-inbound-activitypub-observability/proposal.md
+++ b/openspec/changes/add-inbound-activitypub-observability/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Production ActivityPub inbox handler는 `suppressError`, 처리된 `catch`, post-commit effect 실패를 서로 다른 방식으로 삼켜서 정상 거절과 조사해야 할 실패를 구분하기 어렵다. PROD-608에서 드러난 object 역참조 실패를 포함해 모든 production inbound 경계를 공통 로그·Sentry 분류로 연결하되 Activity 처리 결과와 보안·멱등 계약은 유지한다.
+
+## What Changes
+
+- production에 등록된 Accept, Announce, Create, Delete, Follow, Like/EmojiReact, Reject, Undo, Update handler의 처리된 실패와 no-op inventory를 OpenSpec·테스트 범위에 기록한다.
+- Activity 종류·handler·phase·outcome·안정적인 reason code를 가진 공통 inbound 관측 경계를 제공한다.
+- 정상 보안/정책 거절과 멱등 no-op는 구조화 로그만 남기고, 원격 서버/외부 lookup·protocol·delivery 실패도 Sentry 없이 구조화 로그로 남긴다.
+- Kosmo 내부 unexpected 오류와 내부 post-commit/projection/effect 실패만 기존 API/Web BFF Sentry 경계로 capture하고 안정적인 grouping metadata를 제공한다.
+- raw Activity body, signature/key material, credential, 고카디널리티 URI와 불필요한 개인정보가 tag·fingerprint·로그에 들어가지 않도록 한다.
+- 공통 helper 단위 테스트, 대표 handler 회귀 테스트와 production listener 통합 경계 테스트를 추가한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/operations/sentry.md`
+- Linear Contract: `PROD-634`
+- Linear Implementations: `PROD-477`, `PROD-484`; 관련 사례 `PROD-608`
+
+## Capabilities
+
+### New Capabilities
+
+- `activitypub-inbound-observability`: production inbound ActivityPub handler의 실패 분류, 구조화 로그, Sentry 연결과 민감정보 경계
+
+### Modified Capabilities
+
+- 없음.
+
+## Impact
+
+- `packages/fedify`의 inbound handler, 공통 관측 helper와 federation listener 등록
+- `apps/web`의 기존 Web BFF Sentry capture callback 연결(필요한 경우 `apps/api`의 동일 callback seam)
+- `packages/fedify` 단위/handler/listener 테스트와 운영 inventory 문서

--- a/openspec/changes/add-inbound-activitypub-observability/specs/activitypub-inbound-observability/spec.md
+++ b/openspec/changes/add-inbound-activitypub-observability/specs/activitypub-inbound-observability/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: 공통 inbound 실패 분류와 구조화 로그
+
+**Authority / Provenance:** `docs/operations/sentry.md`, `PROD-634`, `PROD-477`. 시스템은 production에 등록된 모든 inbound ActivityPub handler에서 처리된 실패와 관측 가능한 no-op을 Activity 종류, handler, phase, outcome과 안정적인 reason code로 구조화해 기록해야 한다(MUST). Activity 처리 결과, 저장·검증·멱등성 계약을 관측을 위해 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: 정상 보안·정책 거절
+
+- **WHEN** malformed, foreign, mismatched, unauthorized 또는 정책상 허용되지 않는 activity가 검증 경계에서 거절된다
+- **THEN** 시스템은 기존 side effect 없이 구조화 로그를 남긴다
+- **AND** Sentry event를 생성하지 않는다
+
+#### Scenario: 멱등 no-op
+
+- **WHEN** 이미 처리된 activity, 없는 대상 또는 현재 상태와 맞지 않는 generation이 멱등 경계에서 no-op 처리된다
+- **THEN** 시스템은 기존 상태를 유지하고 안정적인 no-op reason code를 구조화 로그에 남긴다
+- **AND** Sentry event를 생성하지 않는다
+
+#### Scenario: 처리된 실패 inventory
+
+- **WHEN** handler가 `suppressError`, 예상 오류 catch 또는 post-commit effect catch로 처리를 종료한다
+- **THEN** 해당 경계는 공통 관측 분류를 사용해 inventory에서 검색 가능한 로그를 남긴다
+- **AND** 새 handler에 ad-hoc silent swallow 경계를 추가하지 않는다
+
+### Requirement: 외부 실패와 내부 오류의 Sentry 경계
+
+**Authority / Provenance:** `docs/operations/sentry.md`, `PROD-634`, `PROD-477`, `PROD-484`, 2026-08-03 사용자 결정. 원격 서버 오류, timeout, DNS/connection, 외부 document lookup, remote actor materialization, protocol 비호환·해석 실패와 외부 delivery 실패는 Sentry에 capture해서는 안 되며(MUST NOT), Kosmo 내부 unexpected 오류와 내부 post-commit/projection/effect 실패만 기존 runtime Sentry reporter로 capture해야 한다(MUST).
+
+#### Scenario: 원격 lookup 또는 protocol 실패
+
+- **WHEN** 외부 document/actor lookup, remote materialization 또는 protocol 해석이 실패해 handler가 처리된 거절 또는 no-op으로 끝난다
+- **THEN** 시스템은 외부 실패 reason code와 제한된 context를 구조화 로그에 남긴다
+- **AND** Sentry capture를 호출하지 않는다
+
+#### Scenario: 외부 delivery 실패
+
+- **WHEN** inbound 처리 후 외부 서버 delivery가 실패하고 authoritative projection은 이미 commit되었다
+- **THEN** 시스템은 delivery phase의 외부 실패를 구조화 로그로 남긴다
+- **AND** Sentry capture를 호출하지 않는다
+
+#### Scenario: 내부 unexpected 또는 내부 effect 실패
+
+- **WHEN** DB projection, post-commit 내부 effect 또는 handler 실행 중 Kosmo 내부 unexpected 오류가 발생한다
+- **THEN** 시스템은 안정적인 activity/handler/phase/reason metadata와 함께 기존 runtime Sentry reporter로 오류를 capture한다
+- **AND** 원래 오류 격리·응답·재throw 동작을 유지한다
+
+#### Scenario: 반복 실패 폭증
+
+- **WHEN** 동일한 내부 오류가 반복 전달된다
+- **THEN** 시스템은 앱 내부 rate limiter나 sampler를 추가하지 않고 안정적인 grouping metadata만 제공한다
+- **AND** 반복량 제어는 Sentry SDK와 ingest quota 정책에 위임한다
+
+### Requirement: 민감정보와 cardinality 경계
+
+**Authority / Provenance:** `docs/operations/sentry.md`, `PROD-634`, 2026-08-03 사용자 결정. inbound 관측 로그와 Sentry context는 raw Activity JSON, HTTP signature, 공개·개인 키, credential과 불필요한 개인정보를 포함해서는 안 되며(MUST NOT), Activity/actor/object URI는 필요한 제한된 context로만 제공하고 tag·fingerprint에는 고정된 분류값만 사용해야 한다(MUST).
+
+#### Scenario: 안정적인 grouping metadata
+
+- **WHEN** Sentry 대상 내부 오류가 capture된다
+- **THEN** event에는 activity type, handler, phase, outcome 또는 reason code처럼 bounded한 분류만 tag/fingerprint로 제공한다
+- **AND** URI, query string, raw body와 signature material은 tag/fingerprint에 포함하지 않는다
+
+#### Scenario: 민감정보 없는 로그
+
+- **WHEN** 모든 inbound 관측 경계가 로그 또는 Sentry context를 작성한다
+- **THEN** 시스템은 raw payload, key/credential, authorization material과 불필요한 사용자 콘텐츠를 기록하지 않는다
+- **AND** 필요한 URI context도 고카디널리티 식별자로 승격하지 않는다
+
+### Requirement: production listener 통합 경계
+
+**Authority / Provenance:** `docs/operations/sentry.md`, `PROD-634`, `PROD-477`. personal/shared inbox에 등록된 production listener는 공통 inbound 관측 경계를 거쳐 대표 activity의 처리된 외부 실패와 내부 오류를 각각 정해진 로그·Sentry 정책으로 전달해야 한다(MUST).
+
+#### Scenario: 대표 handler의 외부 실패
+
+- **WHEN** production listener를 통과한 대표 Accept/Create/Update/Undo 또는 post-commit delivery 경계가 외부 실패를 처리한다
+- **THEN** 응답·처리 결과는 기존 계약을 유지하고 외부 실패 로그만 한 번 남긴다
+- **AND** Sentry event는 생성하지 않는다
+
+#### Scenario: 대표 handler의 내부 오류
+
+- **WHEN** production listener를 통과한 대표 projection 또는 내부 effect가 unexpected 오류를 던진다
+- **THEN** listener 경계는 기존 오류 전달 동작을 유지하면서 Sentry reporter를 한 번 호출한다
+- **AND** event metadata는 bounded 분류를 사용한다

--- a/openspec/changes/add-inbound-activitypub-observability/tasks.md
+++ b/openspec/changes/add-inbound-activitypub-observability/tasks.md
@@ -96,3 +96,5 @@ production personal/shared inbox listener가 대표 외부 실패를 로그 전�
       로그 의미를 회귀 테스트로 검증한다.
 - [x] 4.3 core post-commit observer의 동기 throw/비동기 reject가 커밋된 상태와 후속 delivery를
       중단하지 않는지 회귀 테스트로 검증한다.
+- [x] 4.4 duplicate Create, established Accept 재처리와 Follow Undo의 pending 삭제/true noop을
+      structured log로 구분하는 회귀 테스트를 추가한다.

--- a/openspec/changes/add-inbound-activitypub-observability/tasks.md
+++ b/openspec/changes/add-inbound-activitypub-observability/tasks.md
@@ -98,3 +98,5 @@ production personal/shared inbox listener가 대표 외부 실패를 로그 전�
       중단하지 않는지 회귀 테스트로 검증한다.
 - [x] 4.4 duplicate Create, established Accept 재처리와 Follow Undo의 pending 삭제/true noop을
       structured log로 구분하는 회귀 테스트를 추가한다.
+- [x] 4.5 Accept/Follow/Reject의 state-change 경쟁 no-op을 별도 reason code로 기록하고, Follow·Reaction
+      post-commit source가 terminal race로 사라진 경우 Sentry 관측 없이 커밋 결과를 유지하는 회귀 테스트를 추가한다.

--- a/openspec/changes/add-inbound-activitypub-observability/tasks.md
+++ b/openspec/changes/add-inbound-activitypub-observability/tasks.md
@@ -1,0 +1,78 @@
+## 1. PROD-634 관측 계약과 공통 helper
+
+**Authority / Provenance**
+
+- `docs/operations/sentry.md`
+- `PROD-634`
+- `PROD-477`, `PROD-484`
+
+**Deliverable**
+
+모든 production inbound handler가 bounded activity/phase/outcome/reason 분류와 구조화 logger/reporter를 통해 처리된 실패를 관측할 수 있다.
+
+**Guardrails**
+
+- 외부 원인 실패와 정상 거절/no-op은 Sentry에 보내지 않는다.
+- 내부 unexpected·내부 effect 실패만 runtime Sentry callback에 전달한다.
+- raw Activity/signature/key/credential/불필요한 개인정보와 URI 기반 tag/fingerprint를 금지한다.
+- 앱 rate limiter/sampler를 추가하지 않는다.
+
+**Verification**
+
+- helper 단위 테스트로 분류, bounded metadata, logger/reporter 호출과 반복 호출 정책을 검증한다.
+- `pnpm exec openspec validate add-inbound-activitypub-observability --strict`를 통과시킨다.
+
+- [x] 1.1 처리된 실패와 no-op을 위한 공통 inbound 관측 분류·logger·runtime reporter seam을 구현한다.
+- [x] 1.2 외부/내부 분류, 안정적인 grouping metadata와 민감정보 차단 helper 단위 테스트를 추가한다.
+
+## 2. PROD-634 production inbound handler inventory 연결
+
+**Authority / Provenance**
+
+- `PROD-634`
+- 관련 ActivityPub canonical specs: `openspec/specs/activitypub-actor-discovery/spec.md`, `openspec/specs/activitypub-inbound-reaction/spec.md`, `openspec/specs/activitypub-remote-post-ingestion/spec.md`, `openspec/specs/activitypub-remote-repost/spec.md`
+
+**Deliverable**
+
+Accept, Announce, Create, Delete, Follow, Like/EmojiReact, Reject, Undo, Update와 공유 object/actor/projection/delivery 경계가 inventory에 반영되고 공통 관측 helper를 사용한다.
+
+**Guardrails**
+
+- 기존 activity 검증·저장·멱등·실패 격리와 응답/처리 결과를 바꾸지 않는다.
+- remote lookup/materialization/protocol/delivery 실패는 로그 전용이다.
+- 내부 DB projection/post-commit effect unexpected 오류는 재throw 또는 기존 격리를 유지하며 Sentry callback을 사용한다.
+- handler별 ad-hoc `console.error`와 silent swallow를 남기지 않는다.
+
+**Verification**
+
+- 대표 Accept object lookup, Create/Update remote materialization, Announce projection, Follow delivery, Delete/Undo/Reaction 경계 회귀 테스트를 실행한다.
+- inventory가 모든 `suppressError`, 처리된 `catch`, post-commit catch 지점을 나열하고 각 reason code를 연결하는지 검토한다.
+
+- [x] 2.1 production inbound handler의 처리된 catch/suppress/no-op 지점을 공통 helper와 안정적 reason code로 연결한다.
+- [x] 2.2 기존 ad-hoc 오류 로그를 공통 구조화 로그로 교체하고 activity 결과/보안/멱등 회귀를 보존한다.
+
+## 3. PROD-634 listener 및 runtime 경계 검증
+
+**Authority / Provenance**
+
+- `docs/operations/sentry.md`
+- `PROD-634`
+- `PROD-477`, `PROD-484`
+
+**Deliverable**
+
+production personal/shared inbox listener가 대표 외부 실패를 로그 전용으로, 대표 내부 오류를 단일 Sentry capture로 전달하며 기존 listener 응답을 유지한다.
+
+**Guardrails**
+
+- Fedify package에 Sentry SDK dependency/초기화 정책을 추가하지 않는다.
+- 반복 실패는 SDK/ingest quota에 위임한다.
+- listener wrapper는 오류 소비나 중복 capture로 기존 Fedify 동작을 바꾸지 않는다.
+
+**Verification**
+
+- production federation listener 통합 테스트에서 personal/shared inbox 경계를 통과시키고 외부/내부 capture 횟수와 metadata를 검증한다.
+- `@kosmo/fedify` typecheck/unit tests와 영향을 받는 `@kosmo/web`/`@kosmo/api` check를 실행한다.
+
+- [x] 3.1 federation listener와 Web BFF 기존 Sentry callback을 좁은 seam으로 연결한다.
+- [x] 3.2 대표 listener integration 및 package/runtime focused tests와 typecheck를 통과시킨다.

--- a/openspec/changes/add-inbound-activitypub-observability/tasks.md
+++ b/openspec/changes/add-inbound-activitypub-observability/tasks.md
@@ -76,3 +76,21 @@ production personal/shared inbox listener가 대표 외부 실패를 로그 전�
 
 - [x] 3.1 federation listener와 Web BFF 기존 Sentry callback을 좁은 seam으로 연결한다.
 - [x] 3.2 대표 listener integration 및 package/runtime focused tests와 typecheck를 통과시킨다.
+
+## 4. PROD-634 review-fix verification
+
+**Authority / Provenance**
+
+- `PROD-634`
+- `docs/operations/sentry.md`
+
+**Deliverable**
+
+리뷰에서 확인된 관측 경계·no-op 분류 회귀를 기존 계약을 바꾸지 않고 검증한다.
+
+**Verification**
+
+- [x] 4.1 malformed/pre-dispatch JSON과 typed listener 오류의 Sentry 경계, 명시적 remote error 분류를
+      회귀 테스트로 검증한다.
+- [x] 4.2 Update/Undo object lookup 조기 반환, Announce Undo 삭제 결과와 pending Follow 생성 여부의
+      로그 의미를 회귀 테스트로 검증한다.

--- a/openspec/changes/add-inbound-activitypub-observability/tasks.md
+++ b/openspec/changes/add-inbound-activitypub-observability/tasks.md
@@ -94,3 +94,5 @@ production personal/shared inbox listener가 대표 외부 실패를 로그 전�
       회귀 테스트로 검증한다.
 - [x] 4.2 Update/Undo object lookup 조기 반환, Announce Undo 삭제 결과와 pending Follow 생성 여부의
       로그 의미를 회귀 테스트로 검증한다.
+- [x] 4.3 core post-commit observer의 동기 throw/비동기 reject가 커밋된 상태와 후속 delivery를
+      중단하지 않는지 회귀 테스트로 검증한다.

--- a/openspec/changes/add-inbound-activitypub-observability/tasks.md
+++ b/openspec/changes/add-inbound-activitypub-observability/tasks.md
@@ -100,3 +100,9 @@ production personal/shared inbox listener가 대표 외부 실패를 로그 전�
       structured log로 구분하는 회귀 테스트를 추가한다.
 - [x] 4.5 Accept/Follow/Reject의 state-change 경쟁 no-op을 별도 reason code로 기록하고, Follow·Reaction
       post-commit source가 terminal race로 사라진 경우 Sentry 관측 없이 커밋 결과를 유지하는 회귀 테스트를 추가한다.
+- [x] 4.6 object-less Delete lookup 실패의 조기 반환과 pending Follow notification effect의 inbound
+      observer 전달을 회귀 테스트로 고정하고, 외부 실패는 Sentry 없이 내부 effect 실패는 metadata와 함께
+      정확히 한 번 capture되는지 검증한다.
+- [x] 4.7 Follow/Follow Request/Reaction notification source를 row lock transaction으로 읽고 투영해 terminal
+      delete와의 경쟁에서 orphan을 만들지 않으며, Reject Follow notification cleanup DB 실패를 inbound observer에
+      정확히 전달하는 회귀 테스트를 추가한다.

--- a/packages/core/services/activitypub-reaction.ts
+++ b/packages/core/services/activitypub-reaction.ts
@@ -20,6 +20,7 @@ type MaterializeInboundReactionInput = {
   readonly activityUri: string;
   readonly actorUri: string;
   readonly objectUri: string;
+  readonly onPostCommitError?: (error: unknown) => void | Promise<void>;
   readonly type: string;
 };
 
@@ -204,6 +205,7 @@ export const materializeInboundReaction = async (
 
       const identity = {
         actorProfileId: actor.profileId,
+        onPostCommitError: input.onPostCommitError,
         origin: 'ACTIVITYPUB' as const,
         postId: target.postId,
         type: parsedType.data,
@@ -261,9 +263,11 @@ export const materializeInboundReaction = async (
 export const undoInboundReaction = async ({
   activityUri,
   actorUri,
+  onPostCommitError,
 }: {
   readonly activityUri: string;
   readonly actorUri: string;
+  readonly onPostCommitError?: (error: unknown) => void | Promise<void>;
 }): Promise<{ readonly reactionId: string | null }> => {
   if (!isHttpUri(activityUri) || !isHttpUri(actorUri)) {
     return { reactionId: null };
@@ -296,6 +300,7 @@ export const undoInboundReaction = async ({
       {
         actorProfileId: mapped.reaction.profileId,
         expectedReactionId: mapped.reaction.id,
+        onPostCommitError,
         origin: 'ACTIVITYPUB',
         postId: mapped.reaction.postId,
         type: mapped.reaction.type,

--- a/packages/core/services/inbound-profile-follow.test.ts
+++ b/packages/core/services/inbound-profile-follow.test.ts
@@ -324,6 +324,45 @@ describe('ActivityPub inbound profile follow lifecycle', () => {
     );
   });
 
+  test('pending Follow notification observer rejection does not change the committed request', async () => {
+    const { followee, follower } = await createPair(ProfileFollowPolicy.APPROVAL_REQUIRED);
+    let observerCalls = 0;
+    let followed: Awaited<ReturnType<typeof followProfile>>;
+
+    await db.execute(
+      sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_pending_observer_failure CHECK (false) NOT VALID`,
+    );
+    try {
+      followed = await followProfile({
+        followerProfileId: follower.id,
+        followeeProfileId: followee.id,
+        onPostCommitError: async () => {
+          observerCalls += 1;
+          await Promise.resolve();
+          throw new Error('observer failure');
+        },
+      });
+    } finally {
+      await db.execute(
+        sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_pending_observer_failure`,
+      );
+    }
+
+    assert.equal(followed.result.kind, 'PENDING');
+    if (followed.result.kind !== 'PENDING') {
+      assert.fail('Expected a pending profile follow request');
+    }
+    assert.equal(observerCalls, 1);
+    assert.equal(
+      await db
+        .select()
+        .from(ProfileFollowRequests)
+        .where(eq(ProfileFollowRequests.id, followed.result.profileFollowRequest.id))
+        .then((rows) => rows.length),
+      1,
+    );
+  });
+
   test('post-commit observer 실패가 inbound Follow와 Unfollow 호출을 실패시키지 않는다', async () => {
     const { followee, follower } = await createPair(ProfileFollowPolicy.OPEN);
     const input = { followeeProfileId: followee.id, followerProfileId: follower.id };

--- a/packages/core/services/inbound-profile-follow.test.ts
+++ b/packages/core/services/inbound-profile-follow.test.ts
@@ -113,9 +113,13 @@ describe('ActivityPub inbound profile follow lifecycle', () => {
       .where(eq(ProfileFollows.followerProfileId, follower.id))
       .then(firstOrThrow);
     assert.equal((await readNotifications(relation.id)).length, 1);
-    assert.equal((await removeInboundFollowThroughLifecycle(input)).profileFollowId, relation.id);
+    const removed = await removeInboundFollowThroughLifecycle(input);
+    assert.equal(removed.profileFollowId, relation.id);
+    assert.equal(removed.changed, true);
     assert.deepEqual(await readNotifications(relation.id), []);
-    assert.equal((await removeInboundFollowThroughLifecycle(input)).profileFollowId, null);
+    const repeated = await removeInboundFollowThroughLifecycle(input);
+    assert.equal(repeated.profileFollowId, null);
+    assert.equal(repeated.changed, false);
     assert.deepEqual(await getProfiles(follower.id, followee.id), {
       followee,
       follower,
@@ -139,7 +143,9 @@ describe('ActivityPub inbound profile follow lifecycle', () => {
         .then((rows) => rows.length),
       1,
     );
-    assert.equal((await removeInboundFollowThroughLifecycle(input)).profileFollowId, null);
+    const removed = await removeInboundFollowThroughLifecycle(input);
+    assert.equal(removed.profileFollowId, null);
+    assert.equal(removed.changed, true);
     assert.equal(
       await db
         .select()

--- a/packages/core/services/inbound-profile-follow.test.ts
+++ b/packages/core/services/inbound-profile-follow.test.ts
@@ -11,7 +11,13 @@ import {
   ProfileFollows,
   Profiles,
 } from '../db';
-import { InstanceKind, InstanceState, ProfileFollowPolicy, ProfileState } from '../enums';
+import {
+  InstanceKind,
+  InstanceState,
+  NotificationKind,
+  ProfileFollowPolicy,
+  ProfileState,
+} from '../enums';
 import { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
 
 after(async () => pg.end());
@@ -310,5 +316,86 @@ describe('ActivityPub inbound profile follow lifecycle', () => {
         .then((rows) => rows.length),
       0,
     );
+  });
+
+  test('post-commit observer 실패가 inbound Follow와 Unfollow 호출을 실패시키지 않는다', async () => {
+    const { followee, follower } = await createPair(ProfileFollowPolicy.OPEN);
+    const input = { followeeProfileId: followee.id, followerProfileId: follower.id };
+    let observerCalls = 0;
+
+    await db.execute(
+      sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_follow_observer_failure CHECK (false) NOT VALID`,
+    );
+    let followed: Awaited<ReturnType<typeof followProfile>>;
+    try {
+      followed = await followProfile({
+        ...input,
+        onPostCommitError: () => {
+          observerCalls += 1;
+          throw new Error('observer failure');
+        },
+      });
+    } finally {
+      await db.execute(
+        sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_follow_observer_failure`,
+      );
+    }
+
+    assert.equal(followed.result.kind, 'ESTABLISHED');
+    if (followed.result.kind !== 'ESTABLISHED') {
+      assert.fail('Expected an established inbound Follow');
+    }
+    assert.equal(observerCalls, 1);
+    assert.equal(
+      await db
+        .select()
+        .from(ProfileFollows)
+        .where(eq(ProfileFollows.id, followed.result.profileFollow.id))
+        .then((rows) => rows.length),
+      1,
+    );
+
+    await db.insert(Notifications).values({
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: followee.id,
+      sourceId: followed.result.profileFollow.id,
+    });
+    await db.execute(sql`
+      CREATE FUNCTION fail_follow_notification_observer() RETURNS trigger
+      LANGUAGE plpgsql AS $$ BEGIN
+        IF OLD.kind = 'FOLLOW' THEN RAISE EXCEPTION 'forced follow notification cleanup failure'; END IF;
+        RETURN OLD;
+      END $$;
+      CREATE TRIGGER fail_follow_notification_observer
+      BEFORE DELETE ON notification
+      FOR EACH ROW EXECUTE FUNCTION fail_follow_notification_observer();
+    `);
+
+    try {
+      const unfollowed = await unfollowProfile({
+        ...input,
+        onPostCommitError: () => {
+          observerCalls += 1;
+          throw new Error('observer failure');
+        },
+      });
+
+      assert.equal(unfollowed.profileFollowId, followed.result.profileFollow.id);
+      assert.equal(observerCalls, 2);
+      assert.equal(
+        await db
+          .select()
+          .from(ProfileFollows)
+          .where(eq(ProfileFollows.id, followed.result.profileFollow.id))
+          .then((rows) => rows.length),
+        0,
+      );
+      assert.equal((await readNotifications(followed.result.profileFollow.id)).length, 1);
+    } finally {
+      await db.execute(sql`
+        DROP TRIGGER IF EXISTS fail_follow_notification_observer ON notification;
+        DROP FUNCTION IF EXISTS fail_follow_notification_observer();
+      `);
+    }
   });
 });

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -5,6 +5,7 @@ export { setNotificationEffectErrorReporter } from './notification';
 export { createPost, deletePost, repostPost } from './post';
 export { disableProfile } from './profile';
 export { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
+export type { AcceptProfileFollowRequestResult } from './profile-follow-request';
 export {
   acceptProfileFollowRequest,
   approveProfileFollowRequest,

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -188,7 +188,7 @@ test('Follow 알림은 materialize된 Remote Follower도 같은 mapping으로 �
   assert.equal(profileFollow.followerProfileId, follower.id);
 });
 
-test('Follow 알림은 Remote Recipient source를 거부한다', async () => {
+test('Follow 알림은 Remote Recipient source를 post-commit no-op으로 처리한다', async () => {
   const follower = await createProfile();
   const followee = await createProfile(InstanceKind.ACTIVITYPUB);
   const profileFollow = await db
@@ -197,13 +197,13 @@ test('Follow 알림은 Remote Recipient source를 거부한다', async () => {
     .returning()
     .then(firstOrThrow);
 
-  await assert.rejects(createFollowNotification(profileFollow.id), NotFoundError);
+  await assert.doesNotReject(createFollowNotification(profileFollow.id));
   assert.deepEqual(await readNotifications(profileFollow.id), []);
 });
 
-test('Follow 알림은 존재하지 않거나 삭제된 source를 거부한다', async () => {
+test('Follow 알림은 존재하지 않거나 삭제된 source를 post-commit no-op으로 처리한다', async () => {
   const missingSourceId = crypto.randomUUID();
-  await assert.rejects(createFollowNotification(missingSourceId), NotFoundError);
+  await assert.doesNotReject(createFollowNotification(missingSourceId));
   assert.deepEqual(await readNotifications(missingSourceId), []);
 
   const follower = await createProfile();
@@ -216,7 +216,7 @@ test('Follow 알림은 존재하지 않거나 삭제된 source를 거부한다',
   );
   await unfollowProfile({ followerProfileId: follower.id, followeeProfileId: followee.id });
 
-  await assert.rejects(createFollowNotification(profileFollow.id), NotFoundError);
+  await assert.doesNotReject(createFollowNotification(profileFollow.id));
   assert.deepEqual(await readNotifications(profileFollow.id), []);
 });
 
@@ -425,8 +425,10 @@ test('Reaction 알림은 자기 Post와 Remote Recipient에서 no-op이다', asy
   assert.deepEqual(await readNotifications(remoteReaction.id), []);
 });
 
-test('Reaction 알림은 존재하지 않는 source를 거부한다', async () => {
-  await assert.rejects(createReactionNotification(crypto.randomUUID()), NotFoundError);
+test('Reaction 알림은 존재하지 않는 source를 post-commit no-op으로 처리한다', async () => {
+  const sourceId = crypto.randomUUID();
+  await assert.doesNotReject(createReactionNotification(sourceId));
+  assert.deepEqual(await readNotifications(sourceId), []);
 });
 
 test('Repost 알림은 direct Source에서 Recipient와 Related 객체를 파생하고 idempotent하다', async () => {

--- a/packages/core/services/notification.test.ts
+++ b/packages/core/services/notification.test.ts
@@ -37,7 +37,8 @@ import {
   setNotificationEffectErrorReporter,
 } from './notification';
 import { createPost, repostPost } from './post';
-import { followProfile, unfollowProfile } from './profile-follow';
+import { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
+import { deleteReaction } from './reaction';
 
 const instanceIds: string[] = [];
 const profileIds: string[] = [];
@@ -121,6 +122,109 @@ const getEstablishedFollow = (result: Awaited<ReturnType<typeof followProfile>>)
     assert.fail('Expected an established profile follow');
   }
   return result.result.profileFollow;
+};
+
+const notificationInsertLock = { classId: 873, objectId: 634 } as const;
+
+const waitForAdvisoryLockBlock = async (
+  { classId, objectId }: { classId: number; objectId: number },
+  message: string,
+): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [lock] = await pg<{ waiting: number }[]>`
+      SELECT count(*)::integer AS waiting
+      FROM pg_locks
+      WHERE locktype = 'advisory'
+        AND NOT granted
+        AND classid = ${classId}
+        AND objid = ${objectId}
+    `;
+    if ((lock?.waiting ?? 0) > 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  assert.fail(message);
+};
+
+const waitForNotificationInsertBlock = async (): Promise<void> =>
+  waitForAdvisoryLockBlock(
+    notificationInsertLock,
+    'Notification insert did not reach the advisory lock barrier',
+  );
+
+type NotificationSourceTable = 'profile_follow' | 'profile_follow_request' | 'reaction';
+
+const waitForSourceDeleteBlock = async (table: NotificationSourceTable): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [activity] = await pg<{ waiting: number }[]>`
+      SELECT count(*)::integer AS waiting
+      FROM pg_stat_activity
+      WHERE pid <> pg_backend_pid()
+        AND wait_event_type = 'Lock'
+        AND wait_event IN ('transactionid', 'tuple')
+        AND query ILIKE ${`%delete from "${table}"%`}
+    `;
+    if ((activity?.waiting ?? 0) > 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  assert.fail(`Source delete did not reach the ${table} row lock barrier`);
+};
+
+const runNotificationDeleteRace = async (
+  sourceTable: NotificationSourceTable,
+  createNotification: () => Promise<void>,
+  deleteSource: () => Promise<unknown>,
+): Promise<void> => {
+  const lockSession = await pg.reserve();
+  let lockHeld = false;
+  let notificationTriggerInstalled = false;
+  let notification: Promise<void> | undefined;
+  let deletion: Promise<unknown> | undefined;
+
+  try {
+    await lockSession`SELECT pg_advisory_lock(${notificationInsertLock.classId}, ${notificationInsertLock.objectId})`;
+    lockHeld = true;
+    await pg.unsafe(`
+      CREATE FUNCTION block_notification_insert() RETURNS trigger
+      LANGUAGE plpgsql AS $function$
+      BEGIN
+        PERFORM pg_advisory_xact_lock(${notificationInsertLock.classId}, ${notificationInsertLock.objectId});
+        RETURN NEW;
+      END
+      $function$;
+      CREATE TRIGGER block_notification_insert
+      BEFORE INSERT ON notification
+      FOR EACH ROW EXECUTE FUNCTION block_notification_insert();
+    `);
+    notificationTriggerInstalled = true;
+
+    notification = createNotification();
+    await waitForNotificationInsertBlock();
+    deletion = deleteSource();
+    await waitForSourceDeleteBlock(sourceTable);
+    await lockSession`SELECT pg_advisory_unlock(${notificationInsertLock.classId}, ${notificationInsertLock.objectId})`;
+    lockHeld = false;
+    await Promise.all([notification, deletion]);
+  } finally {
+    if (lockHeld) {
+      await lockSession`SELECT pg_advisory_unlock(${notificationInsertLock.classId}, ${notificationInsertLock.objectId})`;
+    }
+    if (notification && deletion) {
+      await Promise.allSettled([notification, deletion]);
+    }
+    if (notificationTriggerInstalled) {
+      await pg.unsafe(`
+        DROP TRIGGER IF EXISTS block_notification_insert ON notification;
+        DROP FUNCTION IF EXISTS block_notification_insert();
+      `);
+    }
+    lockSession.release();
+  }
 };
 
 after(async () => {
@@ -281,6 +385,59 @@ test('Follow Request 알림은 Remote Recipient에 투영하지 않는다', asyn
 
   await createFollowRequestNotification(request.id);
   assert.deepEqual(await readNotifications(request.id), []);
+});
+
+test('Notification source lock prevents orphan rows across terminal source deletion', async () => {
+  const follower = await createProfile();
+  const followee = await createProfile();
+  const profileFollow = getEstablishedFollow(
+    await followProfile({
+      followerProfileId: follower.id,
+      followeeProfileId: followee.id,
+    }),
+  );
+  await deleteNotificationBySource(NotificationKind.FOLLOW, profileFollow.id);
+
+  await runNotificationDeleteRace(
+    'profile_follow',
+    () => createFollowNotification(profileFollow.id),
+    () => unfollowProfile({ followerProfileId: follower.id, followeeProfileId: followee.id }),
+  );
+  assert.deepEqual(await readNotifications(profileFollow.id), []);
+
+  const request = await db
+    .insert(ProfileFollowRequests)
+    .values({ followerProfileId: follower.id, followeeProfileId: followee.id })
+    .returning()
+    .then(firstOrThrow);
+  await runNotificationDeleteRace(
+    'profile_follow_request',
+    () => createFollowRequestNotification(request.id),
+    () =>
+      removeInboundFollow({
+        expectedRowId: request.id,
+        followeeProfileId: followee.id,
+        followerProfileId: follower.id,
+      }),
+  );
+  assert.deepEqual(await readNotifications(request.id), []);
+
+  const author = await createProfile();
+  const reaction = await createReaction(author.id, followee.id);
+  await runNotificationDeleteRace(
+    'reaction',
+    () => createReactionNotification(reaction.id),
+    async () => {
+      const deleted = await deleteReaction({
+        actorProfileId: reaction.profileId,
+        origin: 'ACTIVITYPUB',
+        postId: reaction.postId,
+        type: reaction.type,
+      });
+      await deleted.postCommit();
+    },
+  );
+  assert.deepEqual(await readNotifications(reaction.id), []);
 });
 
 test('Follow Request 알림 create 실패는 source lifecycle과 최소 context 보고를 분리한다', async () => {

--- a/packages/core/services/notification.ts
+++ b/packages/core/services/notification.ts
@@ -94,7 +94,13 @@ export const createFollowNotification = async (sourceId: string): Promise<void> 
     .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
     .where(and(eq(ProfileFollows.id, sourceId), eq(Instances.kind, InstanceKind.LOCAL)))
     .limit(1)
-    .then(firstOrThrowWith(() => new NotFoundError('Profile follow not found')));
+    .then((rows) => rows[0]);
+
+  // The relation may be consumed by a concurrent terminal action before this
+  // post-commit projection is materialized. There is no Notification to project.
+  if (!source) {
+    return;
+  }
 
   await db
     .insert(Notifications)
@@ -172,7 +178,13 @@ export const createReactionNotification = async (sourceId: string): Promise<void
     .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
     .where(eq(Reactions.id, sourceId))
     .limit(1)
-    .then(firstOrThrowWith(() => new NotFoundError('Reaction not found')));
+    .then((rows) => rows[0]);
+
+  // An inbound Undo may remove the source before notification materialization.
+  // The committed reaction lifecycle remains authoritative, so this is an expected no-op.
+  if (!source) {
+    return;
+  }
 
   if (
     source.actorProfileId === source.recipientProfileId ||

--- a/packages/core/services/notification.ts
+++ b/packages/core/services/notification.ts
@@ -48,6 +48,8 @@ export type NotificationEffectErrorReporter = (
   context: NotificationEffectErrorContext,
 ) => void;
 
+type NotificationEffectErrorHandler = (error: unknown) => void | Promise<void>;
+
 let notificationEffectErrorReporter: NotificationEffectErrorReporter = (error, context) => {
   console.error('Notification effect failed', { context, error });
 };
@@ -78,83 +80,106 @@ const reportNotificationEffectError = (
 const runPostCommitNotificationEffect = async (
   context: NotificationEffectErrorContext,
   effect: () => Promise<void>,
+  onError?: NotificationEffectErrorHandler,
 ): Promise<void> => {
   try {
     await effect();
   } catch (error) {
-    reportNotificationEffectError(error, context);
+    if (!onError) {
+      reportNotificationEffectError(error, context);
+      return;
+    }
+
+    try {
+      await onError(error);
+    } catch (observerError) {
+      console.error('Notification effect observation failed', {
+        context,
+        error,
+        observerError,
+      });
+    }
   }
 };
 
 export const createFollowNotification = async (sourceId: string): Promise<void> => {
-  const source = await db
-    .select({ id: ProfileFollows.id, recipientProfileId: ProfileFollows.followeeProfileId })
-    .from(ProfileFollows)
-    .innerJoin(Profiles, eq(Profiles.id, ProfileFollows.followeeProfileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .where(and(eq(ProfileFollows.id, sourceId), eq(Instances.kind, InstanceKind.LOCAL)))
-    .limit(1)
-    .then((rows) => rows[0]);
+  await db.transaction(async (tx) => {
+    const source = await tx
+      .select({ id: ProfileFollows.id, recipientProfileId: ProfileFollows.followeeProfileId })
+      .from(ProfileFollows)
+      .innerJoin(Profiles, eq(Profiles.id, ProfileFollows.followeeProfileId))
+      .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+      .where(and(eq(ProfileFollows.id, sourceId), eq(Instances.kind, InstanceKind.LOCAL)))
+      .limit(1)
+      .for('update', { of: ProfileFollows })
+      .then((rows) => rows[0]);
 
-  // The relation may be consumed by a concurrent terminal action before this
-  // post-commit projection is materialized. There is no Notification to project.
-  if (!source) {
-    return;
-  }
+    // The relation may be consumed by a concurrent terminal action before this
+    // post-commit projection is materialized. There is no Notification to project.
+    if (!source) {
+      return;
+    }
 
-  await db
-    .insert(Notifications)
-    .values({
-      data: {},
-      kind: NotificationKind.FOLLOW,
-      recipientProfileId: source.recipientProfileId,
-      sourceId: source.id,
-    })
-    .onConflictDoNothing({
-      target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
-    });
+    await tx
+      .insert(Notifications)
+      .values({
+        data: {},
+        kind: NotificationKind.FOLLOW,
+        recipientProfileId: source.recipientProfileId,
+        sourceId: source.id,
+      })
+      .onConflictDoNothing({
+        target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
+      });
+  });
 };
 
 export const createFollowRequestNotification = async (sourceId: string): Promise<void> => {
-  const source = await db
-    .select({
-      id: ProfileFollowRequests.id,
-      recipientProfileId: ProfileFollowRequests.followeeProfileId,
-    })
-    .from(ProfileFollowRequests)
-    .innerJoin(Profiles, eq(Profiles.id, ProfileFollowRequests.followeeProfileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .where(
-      and(
-        eq(ProfileFollowRequests.id, sourceId),
-        eq(Instances.kind, InstanceKind.LOCAL),
-        eq(Instances.state, InstanceState.ACTIVE),
-        eq(Profiles.state, ProfileState.ACTIVE),
-      ),
-    )
-    .limit(1)
-    .then((rows) => rows[0]);
+  await db.transaction(async (tx) => {
+    const source = await tx
+      .select({
+        id: ProfileFollowRequests.id,
+        recipientProfileId: ProfileFollowRequests.followeeProfileId,
+      })
+      .from(ProfileFollowRequests)
+      .innerJoin(Profiles, eq(Profiles.id, ProfileFollowRequests.followeeProfileId))
+      .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+      .where(
+        and(
+          eq(ProfileFollowRequests.id, sourceId),
+          eq(Instances.kind, InstanceKind.LOCAL),
+          eq(Instances.state, InstanceState.ACTIVE),
+          eq(Profiles.state, ProfileState.ACTIVE),
+        ),
+      )
+      .limit(1)
+      .for('update', { of: ProfileFollowRequests })
+      .then((rows) => rows[0]);
 
-  // The source may have reached a terminal state between the source commit and this
-  // post-commit effect. In that case there is no Notification to project.
-  if (!source) {
-    return;
-  }
+    // The source may have reached a terminal state between the source commit and this
+    // post-commit effect. In that case there is no Notification to project.
+    if (!source) {
+      return;
+    }
 
-  await db
-    .insert(Notifications)
-    .values({
-      data: {},
-      kind: NotificationKind.FOLLOW_REQUEST,
-      recipientProfileId: source.recipientProfileId,
-      sourceId: source.id,
-    })
-    .onConflictDoNothing({
-      target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
-    });
+    await tx
+      .insert(Notifications)
+      .values({
+        data: {},
+        kind: NotificationKind.FOLLOW_REQUEST,
+        recipientProfileId: source.recipientProfileId,
+        sourceId: source.id,
+      })
+      .onConflictDoNothing({
+        target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
+      });
+  });
 };
 
-export const createFollowRequestNotificationPostCommit = async (sourceId: string): Promise<void> =>
+export const createFollowRequestNotificationPostCommit = async (
+  sourceId: string,
+  onError?: NotificationEffectErrorHandler,
+): Promise<void> =>
   runPostCommitNotificationEffect(
     {
       notificationKind: NotificationKind.FOLLOW_REQUEST,
@@ -162,48 +187,52 @@ export const createFollowRequestNotificationPostCommit = async (sourceId: string
       sourceId,
     },
     () => createFollowRequestNotification(sourceId),
+    onError,
   );
 
 export const createReactionNotification = async (sourceId: string): Promise<void> => {
-  const source = await db
-    .select({
-      actorProfileId: Reactions.profileId,
-      id: Reactions.id,
-      recipientInstanceKind: Instances.kind,
-      recipientProfileId: Posts.profileId,
-    })
-    .from(Reactions)
-    .innerJoin(Posts, eq(Posts.id, Reactions.postId))
-    .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
-    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-    .where(eq(Reactions.id, sourceId))
-    .limit(1)
-    .then((rows) => rows[0]);
+  await db.transaction(async (tx) => {
+    const source = await tx
+      .select({
+        actorProfileId: Reactions.profileId,
+        id: Reactions.id,
+        recipientInstanceKind: Instances.kind,
+        recipientProfileId: Posts.profileId,
+      })
+      .from(Reactions)
+      .innerJoin(Posts, eq(Posts.id, Reactions.postId))
+      .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
+      .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+      .where(eq(Reactions.id, sourceId))
+      .limit(1)
+      .for('update', { of: Reactions })
+      .then((rows) => rows[0]);
 
-  // An inbound Undo may remove the source before notification materialization.
-  // The committed reaction lifecycle remains authoritative, so this is an expected no-op.
-  if (!source) {
-    return;
-  }
+    // An inbound Undo may remove the source before notification materialization.
+    // The committed reaction lifecycle remains authoritative, so this is an expected no-op.
+    if (!source) {
+      return;
+    }
 
-  if (
-    source.actorProfileId === source.recipientProfileId ||
-    source.recipientInstanceKind !== InstanceKind.LOCAL
-  ) {
-    return;
-  }
+    if (
+      source.actorProfileId === source.recipientProfileId ||
+      source.recipientInstanceKind !== InstanceKind.LOCAL
+    ) {
+      return;
+    }
 
-  await db
-    .insert(Notifications)
-    .values({
-      data: {},
-      kind: NotificationKind.REACTION,
-      recipientProfileId: source.recipientProfileId,
-      sourceId: source.id,
-    })
-    .onConflictDoNothing({
-      target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
-    });
+    await tx
+      .insert(Notifications)
+      .values({
+        data: {},
+        kind: NotificationKind.REACTION,
+        recipientProfileId: source.recipientProfileId,
+        sourceId: source.id,
+      })
+      .onConflictDoNothing({
+        target: [Notifications.recipientProfileId, Notifications.kind, Notifications.sourceId],
+      });
+  });
 };
 
 const selectReplyVisibleToProfile = async (

--- a/packages/core/services/post.test.ts
+++ b/packages/core/services/post.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import {
   Accounts,
   ActivityPubPosts,
@@ -594,6 +594,48 @@ test('ActivityPub Reply는 Local Parent Author에게 알림 하나를 만들고 
 
   assert.equal(duplicate.created, false);
   assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, created.post.id)), 0);
+});
+
+test('ActivityPub Reply의 post-commit observer 실패가 Post transaction과 호출을 실패시키지 않는다', async () => {
+  const author = await createProfile();
+  const recipient = await createProfile();
+  const parent = await createPost({
+    document: postContentDocumentFromText('parent'),
+    origin: 'LOCAL',
+    profileId: recipient.id,
+    visibility: PostVisibility.PUBLIC,
+  });
+  const objectUri = `https://remote.example/notes/reply-observer-failure-${crypto.randomUUID()}`;
+  let observerCalls = 0;
+
+  await db.execute(
+    sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_reply_observer_failure CHECK (false) NOT VALID`,
+  );
+  try {
+    const result = await createPost({
+      document: postContentDocumentFromText('remote reply'),
+      objectUri,
+      onPostCommitError: () => {
+        observerCalls += 1;
+        throw new Error('observer failure');
+      },
+      origin: 'ACTIVITYPUB',
+      profileId: author.id,
+      publishedAt: null,
+      receivedAt: Temporal.Instant.from('2026-07-30T00:00:00Z'),
+      replyParentId: parent.post.id,
+      visibility: PostVisibility.PUBLIC,
+    });
+
+    assert.equal(result.created, true);
+    assert.equal(observerCalls, 1);
+    assert.equal(result.post.replyParentId, parent.post.id);
+    assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, result.post.id)), 0);
+  } finally {
+    await db.execute(
+      sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_reply_observer_failure`,
+    );
+  }
 });
 
 test('createPost는 존재하지 않는 Reply Parent에서 ActivityPub transaction을 rollback한다', async () => {

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -508,14 +508,24 @@ export async function createPost(
         .then(firstOrThrow);
 
       if (input.replyParentId !== undefined) {
-        await createReplyNotification(linkedPost.id, tx).catch((error) => {
-          if (input.onPostCommitError) {
-            return input.onPostCommitError(error);
+        await createReplyNotification(linkedPost.id, tx).catch(async (error) => {
+          if (!input.onPostCommitError) {
+            console.error('Reply notification creation failed', {
+              error,
+              postId: linkedPost.id,
+            });
+            return;
           }
-          console.error('Reply notification creation failed', {
-            error,
-            postId: linkedPost.id,
-          });
+
+          try {
+            await input.onPostCommitError(error);
+          } catch (observerError) {
+            console.error('Reply notification creation failed', {
+              error,
+              observerError,
+              postId: linkedPost.id,
+            });
+          }
         });
       }
 

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -43,6 +43,7 @@ type LocalPostInput = {
     altText: string | null;
     mediaId: string;
   }[];
+  onPostCommitError?: (error: unknown) => void | Promise<void>;
   origin: 'LOCAL';
   profileId: string;
   replyParentId?: string;
@@ -52,6 +53,7 @@ type LocalPostInput = {
 type ActivityPubPostInput = {
   document: PostContentDocumentV1;
   media?: readonly RemoteMediaCandidate[];
+  onPostCommitError?: (error: unknown) => void | Promise<void>;
   objectUri: string;
   origin: 'ACTIVITYPUB';
   profileId: string;
@@ -507,6 +509,9 @@ export async function createPost(
 
       if (input.replyParentId !== undefined) {
         await createReplyNotification(linkedPost.id, tx).catch((error) => {
+          if (input.onPostCommitError) {
+            return input.onPostCommitError(error);
+          }
           console.error('Reply notification creation failed', {
             error,
             postId: linkedPost.id,

--- a/packages/core/services/profile-follow-request.test.ts
+++ b/packages/core/services/profile-follow-request.test.ts
@@ -582,13 +582,13 @@ test('원격 Accept는 비활성 local participant의 pending을 보존한다', 
     .set({ state: ProfileState.DISABLED })
     .where(eq(Profiles.id, fixture.follower.id));
 
-  assert.equal(
+  assert.deepEqual(
     await lifecycle.acceptProfileFollowRequest({
       expectedRowId: fixture.request.id,
       followeeProfileId: fixture.followee.id,
       followerProfileId: fixture.follower.id,
     }),
-    false,
+    { kind: 'NOOP' },
   );
   assert.equal(await countRemotePairRows(ProfileFollowRequests, fixture), 1);
   assert.equal(await countRemotePairRows(ProfileFollows, fixture), 0);
@@ -633,7 +633,7 @@ test('원격 Accept 동시 처리는 pending을 한 번만 relation으로 승격
     lifecycle.acceptProfileFollowRequest(input),
   ]);
 
-  assert.equal(results.filter(Boolean).length, 1);
+  assert.deepEqual(results.map(({ kind }) => kind).sort(), ['ACCEPTED', 'ALREADY_ESTABLISHED']);
   assert.equal(await countRemotePairRows(ProfileFollowRequests, fixture), 0);
   assert.equal(await countRemotePairRows(ProfileFollows, fixture), 1);
   assert.deepEqual(await readRemotePairCounts(fixture), {
@@ -654,7 +654,12 @@ test('원격 Accept와 Reject 경쟁에서는 exact row 전이 하나만 성공�
     removeInboundFollow(input),
   ]);
 
-  assert.equal(results.filter(Boolean).length, 1);
+  assert.equal(
+    results.filter(
+      (result) => result === true || (typeof result === 'object' && result.kind === 'ACCEPTED'),
+    ).length,
+    1,
+  );
   assert.equal(await countRemotePairRows(ProfileFollowRequests, fixture), 0);
   const relationCount = await countRemotePairRows(ProfileFollows, fixture);
   assert.deepEqual(await readRemotePairCounts(fixture), {
@@ -680,7 +685,7 @@ test('원격 Accept와 Reject는 교체된 pending에 이전 request id를 적�
     followerProfileId: fixture.follower.id,
   };
 
-  assert.equal(await lifecycle.acceptProfileFollowRequest(staleInput), false);
+  assert.deepEqual(await lifecycle.acceptProfileFollowRequest(staleInput), { kind: 'NOOP' });
   assert.equal(await removeInboundFollow(staleInput), false);
   assert.deepEqual(
     await db

--- a/packages/core/services/profile-follow-request.ts
+++ b/packages/core/services/profile-follow-request.ts
@@ -23,6 +23,11 @@ import type { Transaction } from '../db';
 export type ProfileFollowRequestRow = typeof ProfileFollowRequests.$inferSelect;
 type ProfileFollowRow = typeof ProfileFollows.$inferSelect;
 
+export type AcceptProfileFollowRequestResult =
+  | { readonly kind: 'ACCEPTED' }
+  | { readonly kind: 'ALREADY_ESTABLISHED' }
+  | { readonly kind: 'NOOP' };
+
 type ProfileFollowPair = {
   readonly followeeProfileId: string;
   readonly followerProfileId: string;
@@ -96,8 +101,10 @@ export const acceptProfileFollowRequest = async ({
   expectedRowId,
   followeeProfileId,
   followerProfileId,
-}: ProfileFollowPair & { readonly expectedRowId: string }): Promise<boolean> => {
-  const accepted = await db.transaction(async (tx) => {
+}: ProfileFollowPair & {
+  readonly expectedRowId: string;
+}): Promise<AcceptProfileFollowRequestResult> => {
+  const result = await db.transaction(async (tx): Promise<AcceptProfileFollowRequestResult> => {
     const pair = { followeeProfileId, followerProfileId };
     const established = await tx
       .select({ id: ProfileFollows.id })
@@ -107,8 +114,20 @@ export const acceptProfileFollowRequest = async ({
       .then(first);
 
     if (established) {
-      return established.id === expectedRowId;
+      return established.id === expectedRowId ? { kind: 'ALREADY_ESTABLISHED' } : { kind: 'NOOP' };
     }
+
+    const pendingRequest = await tx
+      .select({ id: ProfileFollowRequests.id })
+      .from(ProfileFollowRequests)
+      .where(
+        and(
+          eq(ProfileFollowRequests.id, expectedRowId),
+          pairCondition(ProfileFollowRequests, pair),
+        ),
+      )
+      .limit(1)
+      .then(first);
 
     const unavailableParticipants = tx
       .select({ id: Profiles.id })
@@ -133,18 +152,27 @@ export const acceptProfileFollowRequest = async ({
       .then(first);
 
     if (!deleted) {
-      return false;
+      const establishedAfterDelete = await tx
+        .select({ id: ProfileFollows.id })
+        .from(ProfileFollows)
+        .where(pairCondition(ProfileFollows, pair))
+        .limit(1)
+        .then(first);
+
+      return pendingRequest && establishedAfterDelete
+        ? { kind: 'ALREADY_ESTABLISHED' }
+        : { kind: 'NOOP' };
     }
 
-    await ensureProfileFollow(pair, tx);
-    return true;
+    const ensured = await ensureProfileFollow(pair, tx);
+    return ensured.created ? { kind: 'ACCEPTED' } : { kind: 'ALREADY_ESTABLISHED' };
   });
 
-  if (accepted) {
+  if (result.kind !== 'NOOP') {
     await deleteFollowRequestNotificationPostCommit(expectedRowId);
   }
 
-  return accepted;
+  return result;
 };
 
 type ApproveProfileFollowRequestResult = {

--- a/packages/core/services/profile-follow.ts
+++ b/packages/core/services/profile-follow.ts
@@ -198,7 +198,10 @@ export const followProfile = async ({
   }
 
   if (result.created && result.result.kind === 'PENDING') {
-    await createFollowRequestNotificationPostCommit(result.result.profileFollowRequest.id);
+    await createFollowRequestNotificationPostCommit(
+      result.result.profileFollowRequest.id,
+      onPostCommitError,
+    );
   }
 
   if (pendingNotificationSourceId) {
@@ -431,12 +434,28 @@ export const removeInboundFollow = async (input: {
   readonly expectedRowId?: string;
   readonly followeeProfileId: string;
   readonly followerProfileId: string;
+  readonly onPostCommitError?: (error: unknown) => void | Promise<void>;
 }): Promise<boolean> => {
   const deleted = await db.transaction((tx) => removeProfileFollowProjection(input, tx));
 
   if (deleted.profileFollow) {
     await deleteNotificationBySource(NotificationKind.FOLLOW, deleted.profileFollow.id).catch(
-      () => undefined,
+      async (error) => {
+        if (!input.onPostCommitError) {
+          return;
+        }
+
+        try {
+          await input.onPostCommitError(error);
+        } catch (observerError) {
+          console.error('Follow notification cleanup observation failed', {
+            error,
+            observerError,
+            followeeProfileId: input.followeeProfileId,
+            followerProfileId: input.followerProfileId,
+          });
+        }
+      },
     );
   }
   if (deleted.profileFollowRequest) {

--- a/packages/core/services/profile-follow.ts
+++ b/packages/core/services/profile-follow.ts
@@ -37,6 +37,7 @@ export type FollowProfileResult =
 type ProfileFollowInput = {
   followerProfileId: string;
   followeeProfileId: string;
+  onPostCommitError?: (error: unknown) => void | Promise<void>;
 };
 
 const loadProfileFollowParticipants = async (
@@ -89,6 +90,7 @@ const loadProfileFollowParticipants = async (
 export const followProfile = async ({
   followerProfileId,
   followeeProfileId,
+  onPostCommitError,
 }: ProfileFollowInput): Promise<{
   created: boolean;
   followeeProfile: ProfileRow;
@@ -177,7 +179,9 @@ export const followProfile = async ({
 
   if (result.created && result.result.kind === 'ESTABLISHED') {
     // Notification delivery is best-effort and must not change the committed Follow result.
-    await createFollowNotification(result.result.profileFollow.id).catch(() => undefined);
+    await createFollowNotification(result.result.profileFollow.id).catch(async (error) => {
+      await onPostCommitError?.(error);
+    });
   }
 
   if (result.created && result.result.kind === 'PENDING') {
@@ -206,6 +210,7 @@ export const followProfile = async ({
 export const unfollowProfile = async ({
   followerProfileId,
   followeeProfileId,
+  onPostCommitError,
 }: ProfileFollowInput): Promise<{
   followeeProfile: ProfileRow;
   followerProfile: ProfileRow;
@@ -268,7 +273,9 @@ export const unfollowProfile = async ({
   if (result.profileFollowId) {
     // Notification cleanup is best-effort and must not change the committed Unfollow result.
     await deleteNotificationBySource(NotificationKind.FOLLOW, result.profileFollowId).catch(
-      () => undefined,
+      async (error) => {
+        await onPostCommitError?.(error);
+      },
     );
   }
 

--- a/packages/core/services/profile-follow.ts
+++ b/packages/core/services/profile-follow.ts
@@ -225,6 +225,7 @@ export const unfollowProfile = async ({
   followeeProfileId,
   onPostCommitError,
 }: ProfileFollowInput): Promise<{
+  changed: boolean;
   followeeProfile: ProfileRow;
   followerProfile: ProfileRow;
   profileFollowId: string | null;
@@ -258,6 +259,7 @@ export const unfollowProfile = async ({
     }
 
     const result = {
+      changed: deleted.profileFollow !== undefined || deleted.profileFollowRequest !== undefined,
       followeeProfile,
       followerProfile,
       profileFollowId: deleted.profileFollow?.id ?? null,

--- a/packages/core/services/profile-follow.ts
+++ b/packages/core/services/profile-follow.ts
@@ -180,7 +180,20 @@ export const followProfile = async ({
   if (result.created && result.result.kind === 'ESTABLISHED') {
     // Notification delivery is best-effort and must not change the committed Follow result.
     await createFollowNotification(result.result.profileFollow.id).catch(async (error) => {
-      await onPostCommitError?.(error);
+      if (!onPostCommitError) {
+        return;
+      }
+
+      try {
+        await onPostCommitError(error);
+      } catch (observerError) {
+        console.error('Follow notification creation observation failed', {
+          error,
+          observerError,
+          followeeProfileId,
+          followerProfileId,
+        });
+      }
     });
   }
 
@@ -274,7 +287,20 @@ export const unfollowProfile = async ({
     // Notification cleanup is best-effort and must not change the committed Unfollow result.
     await deleteNotificationBySource(NotificationKind.FOLLOW, result.profileFollowId).catch(
       async (error) => {
-        await onPostCommitError?.(error);
+        if (!onPostCommitError) {
+          return;
+        }
+
+        try {
+          await onPostCommitError(error);
+        } catch (observerError) {
+          console.error('Follow notification cleanup observation failed', {
+            error,
+            observerError,
+            followeeProfileId,
+            followerProfileId,
+          });
+        }
       },
     );
   }

--- a/packages/core/services/reaction.test.ts
+++ b/packages/core/services/reaction.test.ts
@@ -299,6 +299,27 @@ test('ActivityPub origin의 postCommit은 Notification만 생성한다', async (
   assert.equal(await countReactionNotifications(result.reaction.id), 1);
 });
 
+test('Notification materialization 전에 Reaction source가 삭제된 terminal race는 내부 오류로 관측하지 않는다', async () => {
+  const actor = await createFixture({ instanceKind: InstanceKind.ACTIVITYPUB });
+  const recipient = await createFixture();
+  let observerCalls = 0;
+  const result = await addReaction({
+    actorProfileId: actor.profile.id,
+    onPostCommitError: () => {
+      observerCalls += 1;
+    },
+    origin: 'ACTIVITYPUB',
+    postId: recipient.post.id,
+    type: '🎉',
+  });
+
+  await db.delete(Reactions).where(eq(Reactions.id, result.reaction.id));
+  await assert.doesNotReject(result.postCommit());
+
+  assert.equal(observerCalls, 0);
+  assert.equal(await countReactionNotifications(result.reaction.id), 0);
+});
+
 test('postCommit observer 실패에도 Reaction 상태와 후속 delivery를 유지한다', async () => {
   let deliveryCalls = 0;
   let observerCalls = 0;

--- a/packages/core/services/reaction.test.ts
+++ b/packages/core/services/reaction.test.ts
@@ -1,7 +1,18 @@
 import assert from 'node:assert/strict';
-import { after, test } from 'node:test';
-import { and, eq } from 'drizzle-orm';
-import { db, firstOrThrow, Instances, Notifications, pg, Posts, Profiles, Reactions } from '../db';
+import { after, mock, test } from 'node:test';
+import { and, eq, sql } from 'drizzle-orm';
+import {
+  ActivityPubActors,
+  ActivityPubPosts,
+  db,
+  firstOrThrow,
+  Instances,
+  Notifications,
+  pg,
+  Posts,
+  Profiles,
+  Reactions,
+} from '../db';
 import {
   InstanceKind,
   InstanceState,
@@ -25,7 +36,9 @@ const createFixture = async ({
   instanceState = InstanceState.ACTIVE,
   postState = PostState.ACTIVE,
   profileState = ProfileState.ACTIVE,
+  canonicalOrigin,
 }: {
+  canonicalOrigin?: string | null;
   instanceKind?: InstanceKind;
   instanceState?: InstanceState;
   postState?: PostState;
@@ -35,6 +48,7 @@ const createFixture = async ({
   const instance = await db
     .insert(Instances)
     .values({
+      canonicalOrigin,
       domain: `${suffix}.example`,
       kind: instanceKind,
       state: instanceState,
@@ -283,6 +297,118 @@ test('ActivityPub origin의 postCommit은 Notification만 생성한다', async (
   await firstPostCommit;
 
   assert.equal(await countReactionNotifications(result.reaction.id), 1);
+});
+
+test('postCommit observer 실패에도 Reaction 상태와 후속 delivery를 유지한다', async () => {
+  let deliveryCalls = 0;
+  let observerCalls = 0;
+
+  const originalConsoleError = console.error;
+  console.error = () => undefined;
+  const fetchMock = mock.method(globalThis, 'fetch', async () => {
+    deliveryCalls += 1;
+    throw new Error('forced reaction delivery failure');
+  });
+  try {
+    const actor = await createFixture({
+      canonicalOrigin: `https://${crypto.randomUUID()}.local.test`,
+    });
+    const localRecipient = await createFixture();
+    await db.execute(
+      sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_reaction_observer_failure CHECK (false) NOT VALID`,
+    );
+
+    let created: Awaited<ReturnType<typeof addReaction>> | undefined;
+    try {
+      created = await addReaction({
+        ...actor.input,
+        onPostCommitError: () => {
+          observerCalls += 1;
+          return Promise.resolve().then(() => {
+            throw new Error('observer failure');
+          });
+        },
+        postId: localRecipient.post.id,
+        type: '👀',
+      });
+      await assert.doesNotReject(created.postCommit());
+    } finally {
+      await db.execute(
+        sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_reaction_observer_failure`,
+      );
+    }
+
+    if (!created) {
+      assert.fail('Expected a created Reaction');
+    }
+
+    assert.equal(await countReactions(localRecipient.post.id), 1);
+    assert.equal(observerCalls, 1);
+
+    const remoteRecipient = await createFixture({ instanceKind: InstanceKind.ACTIVITYPUB });
+    const recipientActorUri = `https://${remoteRecipient.profile.displayName}.example/users/${remoteRecipient.profile.id}`;
+    await db.insert(ActivityPubActors).values({
+      inboxUri: `${recipientActorUri}/inbox`,
+      profileId: remoteRecipient.profile.id,
+      sharedInboxUri: `https://${remoteRecipient.profile.displayName}.example/inbox`,
+      type: 'PERSON',
+      uri: recipientActorUri,
+    });
+    await db.insert(ActivityPubPosts).values({
+      postId: remoteRecipient.post.id,
+      receivedAt: Temporal.Now.instant(),
+      uri: `https://${remoteRecipient.profile.displayName}.example/notes/${remoteRecipient.post.id}`,
+    });
+    const remoteCreated = await addReaction({
+      ...actor.input,
+      postId: remoteRecipient.post.id,
+      type: '🎉',
+    });
+
+    await db.insert(Notifications).values({
+      kind: NotificationKind.REACTION,
+      recipientProfileId: remoteRecipient.profile.id,
+      sourceId: remoteCreated.reaction.id,
+    });
+    await pg.unsafe(`
+      CREATE FUNCTION fail_reaction_notification_observer() RETURNS trigger
+      LANGUAGE plpgsql AS $$ BEGIN
+        IF OLD.kind = 'REACTION' THEN RAISE EXCEPTION 'forced reaction notification cleanup failure'; END IF;
+        RETURN OLD;
+      END $$;
+      CREATE TRIGGER fail_reaction_notification_observer
+      BEFORE DELETE ON notification
+      FOR EACH ROW EXECUTE FUNCTION fail_reaction_notification_observer();
+    `);
+
+    try {
+      const deleted = await deleteReaction({
+        actorProfileId: actor.profile.id,
+        onPostCommitError: () => {
+          observerCalls += 1;
+          return Promise.resolve().then(() => {
+            throw new Error('observer failure');
+          });
+        },
+        origin: 'LOCAL',
+        postId: remoteRecipient.post.id,
+        type: remoteCreated.reaction.type,
+      });
+      await assert.doesNotReject(deleted.postCommit());
+
+      assert.equal(await countReactions(remoteRecipient.post.id), 0);
+      assert.equal(observerCalls, 2);
+      assert.ok(deliveryCalls > 0);
+    } finally {
+      await pg.unsafe(`
+        DROP TRIGGER IF EXISTS fail_reaction_notification_observer ON notification;
+        DROP FUNCTION IF EXISTS fail_reaction_notification_observer();
+      `);
+    }
+  } finally {
+    fetchMock.mock.restore();
+    console.error = originalConsoleError;
+  }
 });
 
 test('Local과 ActivityPub 삭제는 caller transaction에 독립적으로 참여한다', async () => {

--- a/packages/core/services/reaction.ts
+++ b/packages/core/services/reaction.ts
@@ -8,6 +8,7 @@ import type { Transaction } from '../db';
 
 type AddReactionInput = {
   readonly actorProfileId: string;
+  readonly onPostCommitError?: (error: unknown) => void | Promise<void>;
   readonly origin: 'LOCAL' | 'ACTIVITYPUB';
   readonly postId: string;
   readonly type: string;
@@ -16,6 +17,7 @@ type AddReactionInput = {
 type DeleteReactionInput = {
   readonly actorProfileId: string;
   readonly expectedReactionId?: string;
+  readonly onPostCommitError?: (error: unknown) => void | Promise<void>;
   readonly origin: 'LOCAL' | 'ACTIVITYPUB';
   readonly postId: string;
   readonly type: string;
@@ -36,7 +38,7 @@ const oncePostCommit = (effect: () => Promise<void>): (() => Promise<void>) => {
 };
 
 export const addReaction = async (
-  { actorProfileId, origin, postId, type }: AddReactionInput,
+  { actorProfileId, onPostCommitError, origin, postId, type }: AddReactionInput,
   tx?: Transaction,
 ): Promise<AddReactionResult> => {
   const parsedType = reactionTypeSchema.safeParse(type);
@@ -88,7 +90,9 @@ export const addReaction = async (
     ...result,
     postCommit: result.created
       ? oncePostCommit(async () => {
-          await createReactionNotification(result.reaction.id).catch(() => undefined);
+          await createReactionNotification(result.reaction.id).catch(async (error) => {
+            await onPostCommitError?.(error);
+          });
 
           if (origin === 'LOCAL') {
             try {
@@ -142,10 +146,14 @@ export const deleteReaction = async (
           try {
             await deleteNotificationBySource(NotificationKind.REACTION, reaction.id);
           } catch (error) {
-            console.error('Failed to clean up Reaction Notification', {
-              error,
-              reactionId: reaction.id,
-            });
+            if (input.onPostCommitError) {
+              await input.onPostCommitError(error);
+            } else {
+              console.error('Failed to clean up Reaction Notification', {
+                error,
+                reactionId: reaction.id,
+              });
+            }
           }
 
           if (input.origin === 'LOCAL') {

--- a/packages/core/services/reaction.ts
+++ b/packages/core/services/reaction.ts
@@ -91,7 +91,19 @@ export const addReaction = async (
     postCommit: result.created
       ? oncePostCommit(async () => {
           await createReactionNotification(result.reaction.id).catch(async (error) => {
-            await onPostCommitError?.(error);
+            if (!onPostCommitError) {
+              return;
+            }
+
+            try {
+              await onPostCommitError(error);
+            } catch (observerError) {
+              console.error('Reaction notification creation observation failed', {
+                error,
+                observerError,
+                reactionId: result.reaction.id,
+              });
+            }
           });
 
           if (origin === 'LOCAL') {
@@ -146,13 +158,21 @@ export const deleteReaction = async (
           try {
             await deleteNotificationBySource(NotificationKind.REACTION, reaction.id);
           } catch (error) {
-            if (input.onPostCommitError) {
-              await input.onPostCommitError(error);
-            } else {
+            if (!input.onPostCommitError) {
               console.error('Failed to clean up Reaction Notification', {
                 error,
                 reactionId: reaction.id,
               });
+            } else {
+              try {
+                await input.onPostCommitError(error);
+              } catch (observerError) {
+                console.error('Reaction notification cleanup observation failed', {
+                  error,
+                  observerError,
+                  reactionId: reaction.id,
+                });
+              }
             }
           }
 

--- a/packages/fedify/index.ts
+++ b/packages/fedify/index.ts
@@ -1,6 +1,23 @@
 export { resolveActivityPubPostUri } from './src/activitypub-post-uri';
 export { federation } from './src/federation';
 export { sendAcceptFollowActivity } from './src/follow-delivery';
+export type {
+  InboundCaptureContext,
+  InboundObservabilityReporter,
+  InboundObservation,
+} from './src/inbound-observability';
+export {
+  getInboundActivityType,
+  hasInboundErrorBeenObserved,
+  isExternalInboundError,
+  markInboundErrorObserved,
+  observeInbound,
+  observeInboundExternalFailure,
+  observeInboundNoop,
+  observeInboundRejected,
+  setInboundObservabilityReporter,
+  withInboundObservability,
+} from './src/inbound-observability';
 export { sendLocalPostCreate, sendLocalPostDelete } from './src/local-post-delivery';
 export { sendLocalProfileUpdate } from './src/local-profile-update-delivery';
 export { sendProfileFollow, sendProfileUnfollow } from './src/profile-follow-delivery';

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -180,7 +180,11 @@ federation
       return;
     }
 
-    const external = isExternalInboundError(error);
+    // Fedify invokes this boundary for failures that happen before a typed
+    // listener receives an Activity (for example, malformed request JSON).
+    // Typed listener errors are marked observed by withInboundObservability,
+    // so SyntaxError is external only at this unobserved pre-dispatch edge.
+    const external = error instanceof SyntaxError || isExternalInboundError(error);
     observeInbound({
       activityType: 'Unknown',
       error,

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -22,6 +22,12 @@ import { handleInboundAnnounce } from './inbound-announce';
 import { handleInboundCreate } from './inbound-create';
 import { handleInboundDelete } from './inbound-delete';
 import { handleInboundFollow, handleInboundUndo } from './inbound-follow';
+import {
+  hasInboundErrorBeenObserved,
+  isExternalInboundError,
+  observeInbound,
+  withInboundObservability,
+} from './inbound-observability';
 import { handleInboundReaction } from './inbound-reaction';
 import { handleInboundReject } from './inbound-reject';
 import { handleInboundUpdate } from './inbound-update';
@@ -159,13 +165,28 @@ federation.setObjectDispatcher(Follow, '/ap/follow/{id}', dispatchLocalProfileFo
 
 federation
   .setInboxListeners('/ap/actor/{identifier}/inbox', '/inbox')
-  .on(Accept, handleInboundAccept)
-  .on(Announce, handleInboundAnnounce)
-  .on(Create, handleInboundCreate)
-  .on(Delete, handleInboundDelete)
-  .on(EmojiReact, handleInboundReaction)
-  .on(Follow, handleInboundFollow)
-  .on(Like, handleInboundReaction)
-  .on(Reject, handleInboundReject)
-  .on(Undo, handleInboundUndo)
-  .on(Update, handleInboundUpdate);
+  .on(Accept, withInboundObservability('accept', handleInboundAccept))
+  .on(Announce, withInboundObservability('announce', handleInboundAnnounce))
+  .on(Create, withInboundObservability('create', handleInboundCreate))
+  .on(Delete, withInboundObservability('delete', handleInboundDelete))
+  .on(EmojiReact, withInboundObservability('reaction', handleInboundReaction))
+  .on(Follow, withInboundObservability('follow', handleInboundFollow))
+  .on(Like, withInboundObservability('reaction', handleInboundReaction))
+  .on(Reject, withInboundObservability('reject', handleInboundReject))
+  .on(Undo, withInboundObservability('undo', handleInboundUndo))
+  .on(Update, withInboundObservability('update', handleInboundUpdate))
+  .onError((_context, error) => {
+    if (hasInboundErrorBeenObserved(error)) {
+      return;
+    }
+
+    const external = isExternalInboundError(error);
+    observeInbound({
+      activityType: 'Unknown',
+      error,
+      handler: 'listener',
+      outcome: external ? 'external_failure' : 'internal_failure',
+      phase: 'listener',
+      reasonCode: external ? 'external_listener_error' : 'unexpected_listener_error',
+    });
+  });

--- a/packages/fedify/src/inbound-accept-follow.ts
+++ b/packages/fedify/src/inbound-accept-follow.ts
@@ -13,7 +13,9 @@ export const handleInboundAcceptFollow = async ({
   follow,
   followeeActorUri,
   followeeProfileId,
+  acceptProfileFollowRequest: acceptFollowRequest = acceptProfileFollowRequest,
 }: {
+  readonly acceptProfileFollowRequest?: typeof acceptProfileFollowRequest;
   context: InboxContext<void>;
   follow: Follow;
   followeeActorUri: URL;
@@ -95,9 +97,19 @@ export const handleInboundAcceptFollow = async ({
     return;
   }
 
-  await acceptProfileFollowRequest({
+  const result = await acceptFollowRequest({
     expectedRowId: projection.id,
     followeeProfileId,
     followerProfileId: followerProfile.id,
   });
+  if (result.kind === 'ALREADY_ESTABLISHED') {
+    observeInboundNoop({
+      activityType: 'Accept',
+      actorOrigin: followerActorUri.origin,
+      handler: 'accept',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'duplicate_accept_noop',
+    });
+  }
 };

--- a/packages/fedify/src/inbound-accept-follow.ts
+++ b/packages/fedify/src/inbound-accept-follow.ts
@@ -4,6 +4,7 @@ import { and, eq } from 'drizzle-orm';
 import { isHttpUri } from './activitypub-uri';
 import { isCompatibleOutboundFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
+import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Follow } from '@fedify/vocab';
 
@@ -25,11 +26,27 @@ export const handleInboundAcceptFollow = async ({
     !isHttpUri(objectUri) ||
     objectUri.href !== followeeActorUri.href
   ) {
+    observeInboundRejected({
+      activityType: 'Accept',
+      actorOrigin: followerActorUri?.origin,
+      handler: 'accept',
+      objectOrigin: objectUri?.origin,
+      phase: 'protocol',
+      reasonCode: 'accept_follow_identity_mismatch',
+    });
     return;
   }
 
   const followerProfile = await resolveInboundLocalRecipient(context, followerActorUri);
   if (!followerProfile) {
+    observeInboundNoop({
+      activityType: 'Accept',
+      actorOrigin: followerActorUri.origin,
+      handler: 'accept',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'accept_follower_profile_missing',
+    });
     return;
   }
 
@@ -67,6 +84,14 @@ export const handleInboundAcceptFollow = async ({
       projection,
     )
   ) {
+    observeInboundNoop({
+      activityType: 'Accept',
+      actorOrigin: followerActorUri.origin,
+      handler: 'accept',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'accept_follow_projection_missing_or_mismatched',
+    });
     return;
   }
 

--- a/packages/fedify/src/inbound-accept-follow.ts
+++ b/packages/fedify/src/inbound-accept-follow.ts
@@ -111,5 +111,14 @@ export const handleInboundAcceptFollow = async ({
       phase: 'projection',
       reasonCode: 'duplicate_accept_noop',
     });
+  } else if (result.kind === 'NOOP') {
+    observeInboundNoop({
+      activityType: 'Accept',
+      actorOrigin: followerActorUri.origin,
+      handler: 'accept',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'accept_follow_state_changed_noop',
+    });
   }
 };

--- a/packages/fedify/src/inbound-accept-reject.test.ts
+++ b/packages/fedify/src/inbound-accept-reject.test.ts
@@ -609,6 +609,10 @@ describe('inbound Accept and Reject', () => {
     const fixture = await createFixture({ projection: 'PENDING' });
     const follow = createOutboundFollow(fixture.projection);
     const loading = blockDocumentLoad(follow);
+    const logs: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
     const handling = handleInboundAccept(
       createContext(localProfileId, loading.documentLoader),
       new Accept({ actor: remoteActorUri, object: follow.id }),
@@ -620,17 +624,36 @@ describe('inbound Accept and Reject', () => {
       .set({ state: InstanceState.SUSPENDED })
       .where(eq(Instances.id, fixture.remoteInstance.id));
     loading.release();
-    await handling;
+    try {
+      await handling;
+    } finally {
+      restoreReporter();
+    }
 
     assert.deepEqual(await db.select().from(ProfileFollowRequests), [fixture.projection]);
     assert.equal((await db.select().from(ProfileFollows)).length, 0);
     assert.deepEqual(await readCounts(fixture), { localFollowing: 0, remoteFollowers: 0 });
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Accept',
+        actorOrigin: localActorUri.origin,
+        handler: 'accept',
+        objectOrigin: remoteActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'accept_follow_state_changed_noop',
+      },
+    ]);
   });
 
   test('preserves an established relation when the remote instance is suspended after Reject verification', async () => {
     const fixture = await createFixture({ projection: 'ESTABLISHED' });
     const follow = createOutboundFollow(fixture.projection);
     const loading = blockDocumentLoad(follow);
+    const logs: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
     const handling = handleInboundReject(
       createContext(localProfileId, loading.documentLoader),
       new Reject({
@@ -646,10 +669,25 @@ describe('inbound Accept and Reject', () => {
       .set({ state: InstanceState.SUSPENDED })
       .where(eq(Instances.id, fixture.remoteInstance.id));
     loading.release();
-    await handling;
+    try {
+      await handling;
+    } finally {
+      restoreReporter();
+    }
 
     assert.deepEqual(await db.select().from(ProfileFollows), [fixture.projection]);
     assert.deepEqual(await readCounts(fixture), { localFollowing: 1, remoteFollowers: 1 });
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Reject',
+        actorOrigin: localActorUri.origin,
+        handler: 'reject',
+        objectOrigin: remoteActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'reject_follow_state_changed_noop',
+      },
+    ]);
   });
 });
 

--- a/packages/fedify/src/inbound-accept-reject.test.ts
+++ b/packages/fedify/src/inbound-accept-reject.test.ts
@@ -11,6 +11,7 @@ import {
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
 import { eq, ne } from 'drizzle-orm';
+import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
@@ -363,25 +364,23 @@ describe('inbound Accept and Reject', () => {
     const fixture = await createFixture({ projection: 'PENDING' });
     const object = new URL(`/ap/follow/${fixture.projection.id}`, publicOrigin);
     const context = createContext(localProfileId);
-    const errors: unknown[][] = [];
-    const originalConsoleError = console.error;
-    console.error = (...args) => errors.push(args);
+    const observations: { reasonCode: string }[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => observations.push(observation),
+    });
     try {
       await handleInboundAccept(context, new Accept({ actor: remoteActorUri, object }));
       await handleInboundReject(context, new Reject({ actor: remoteActorUri, object }));
     } finally {
-      console.error = originalConsoleError;
+      restoreReporter();
     }
 
     assert.deepEqual(await db.select().from(ProfileFollowRequests), [fixture.projection]);
     assert.equal((await db.select().from(ProfileFollows)).length, 0);
     assert.deepEqual(await readCounts(fixture), { localFollowing: 0, remoteFollowers: 0 });
     assert.deepEqual(
-      errors.map(([message]) => message),
-      [
-        'Inbound ActivityPub Accept object could not be resolved as Follow',
-        'Inbound ActivityPub Reject object could not be resolved as Follow',
-      ],
+      observations.map(({ reasonCode }) => reasonCode),
+      ['accept_object_lookup_failed', 'reject_object_lookup_failed'],
     );
   });
 

--- a/packages/fedify/src/inbound-accept-reject.test.ts
+++ b/packages/fedify/src/inbound-accept-reject.test.ts
@@ -8,6 +8,7 @@ import {
   ActivityPubActorType,
   InstanceKind,
   InstanceState,
+  NotificationKind,
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
 import { eq, ne } from 'drizzle-orm';
@@ -32,6 +33,7 @@ let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let db: typeof CoreDb.db;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
+let Notifications: typeof CoreDb.Notifications;
 let pg: typeof CoreDb.pg;
 let ProfileFollowRequests: typeof CoreDb.ProfileFollowRequests;
 let ProfileFollows: typeof CoreDb.ProfileFollows;
@@ -52,6 +54,7 @@ describe('inbound Accept and Reject', () => {
       db,
       firstOrThrow,
       Instances,
+      Notifications,
       pg,
       ProfileFollowRequests,
       ProfileFollows,
@@ -651,7 +654,9 @@ describe('inbound Accept and Reject', () => {
     const follow = createOutboundFollow(fixture.projection);
     const loading = blockDocumentLoad(follow);
     const logs: unknown[] = [];
+    const captures: unknown[] = [];
     const restoreReporter = setInboundObservabilityReporter({
+      captureException: (error) => captures.push(error),
       log: (observation) => logs.push(observation),
     });
     const handling = handleInboundReject(
@@ -688,6 +693,100 @@ describe('inbound Accept and Reject', () => {
         reasonCode: 'reject_follow_state_changed_noop',
       },
     ]);
+    assert.equal(captures.length, 0);
+  });
+
+  test('observes Reject Follow notification cleanup failure once after committed removal', async () => {
+    const fixture = await createFixture({ projection: 'ESTABLISHED' });
+    await db.insert(Notifications).values({
+      data: {},
+      kind: NotificationKind.FOLLOW,
+      recipientProfileId: fixture.remoteProfile.id,
+      sourceId: fixture.projection.id,
+    });
+    await pg.unsafe(`
+      CREATE FUNCTION fail_reject_follow_notification_cleanup() RETURNS trigger
+      LANGUAGE plpgsql AS $$
+      BEGIN
+        RAISE EXCEPTION 'reject Follow notification cleanup failed';
+      END;
+      $$;
+      CREATE TRIGGER reject_follow_notification_cleanup_failure
+      BEFORE DELETE ON notification
+      FOR EACH ROW EXECUTE FUNCTION fail_reject_follow_notification_cleanup();
+    `);
+
+    const logs: unknown[] = [];
+    const captures: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      captureException: (error, context) => captures.push({ error, context }),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      await handleInboundReject(
+        createContext(localProfileId),
+        new Reject({
+          actor: remoteActorUri,
+          object: createOutboundFollow(fixture.projection),
+          published: fixture.projection.createdAt,
+        }),
+      );
+    } finally {
+      await pg.unsafe(`
+        DROP TRIGGER IF EXISTS reject_follow_notification_cleanup_failure ON notification;
+        DROP FUNCTION IF EXISTS fail_reject_follow_notification_cleanup();
+      `);
+      restoreReporter();
+    }
+
+    assert.equal((await db.select().from(ProfileFollows)).length, 0);
+    assert.deepEqual(await readCounts(fixture), { localFollowing: 0, remoteFollowers: 0 });
+    assert.equal(
+      await db
+        .select()
+        .from(Notifications)
+        .where(eq(Notifications.sourceId, fixture.projection.id))
+        .then((rows) => rows.length),
+      1,
+    );
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Reject',
+        actorOrigin: localActorUri.origin,
+        handler: 'reject',
+        objectOrigin: remoteActorUri.origin,
+        outcome: 'internal_failure',
+        phase: 'effect',
+        reasonCode: 'follow_notification_effect_failed',
+      },
+    ]);
+    assert.equal(captures.length, 1);
+    const capture = captures[0] as {
+      context: {
+        extra?: Record<string, string>;
+        fingerprint: string[];
+        tags: Record<string, string>;
+      };
+    };
+    assert.deepEqual(capture.context.tags, {
+      activity_type: 'Reject',
+      handler: 'reject',
+      outcome: 'internal_failure',
+      phase: 'effect',
+      reason_code: 'follow_notification_effect_failed',
+    });
+    assert.deepEqual(capture.context.fingerprint, [
+      'activitypub-inbound',
+      'Reject',
+      'reject',
+      'effect',
+      'follow_notification_effect_failed',
+    ]);
+    assert.deepEqual(capture.context.extra, {
+      actor_origin: localActorUri.origin,
+      object_origin: remoteActorUri.origin,
+    });
   });
 });
 

--- a/packages/fedify/src/inbound-accept-reject.test.ts
+++ b/packages/fedify/src/inbound-accept-reject.test.ts
@@ -15,8 +15,10 @@ import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
+import type * as CoreServices from '@kosmo/core/services';
 import type { federation as productionFederation } from './federation';
 import type * as InboundAccept from './inbound-accept';
+import type * as InboundAcceptFollow from './inbound-accept-follow';
 import type * as InboundReject from './inbound-reject';
 
 const publicOrigin = 'http://127.0.0.1:4173';
@@ -35,7 +37,9 @@ let ProfileFollowRequests: typeof CoreDb.ProfileFollowRequests;
 let ProfileFollows: typeof CoreDb.ProfileFollows;
 let Profiles: typeof CoreDb.Profiles;
 let handleInboundAccept: typeof InboundAccept.handleInboundAccept;
+let handleInboundAcceptFollow: typeof InboundAcceptFollow.handleInboundAcceptFollow;
 let handleInboundReject: typeof InboundReject.handleInboundReject;
+let acceptProfileFollowRequest: typeof CoreServices.acceptProfileFollowRequest;
 let localInstanceId: string;
 let federation: typeof productionFederation;
 
@@ -55,7 +59,9 @@ describe('inbound Accept and Reject', () => {
     } = await import('@kosmo/core/db'));
     const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
     ({ handleInboundAccept } = await import('./inbound-accept'));
+    ({ handleInboundAcceptFollow } = await import('./inbound-accept-follow'));
     ({ handleInboundReject } = await import('./inbound-reject'));
+    ({ acceptProfileFollowRequest } = await import('@kosmo/core/services'));
     ({ federation } = await import('./federation'));
     const { localInstance } = await seedDatabase({ publicOrigin });
     localInstanceId = localInstance.id;
@@ -221,6 +227,64 @@ describe('inbound Accept and Reject', () => {
     assert.equal((await db.select().from(ProfileFollowRequests)).length, 0);
     assert.equal((await db.select().from(ProfileFollows)).length, 1);
     assert.deepEqual(await readCounts(fixture), { localFollowing: 1, remoteFollowers: 1 });
+  });
+
+  test('logs a concurrent pending Accept loser as an established noop', async () => {
+    const fixture = await createFixture({ projection: 'PENDING' });
+    const follow = createOutboundFollow(fixture.projection);
+    let arrived = 0;
+    let release!: () => void;
+    const bothArrived = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const acceptWithBarrier: typeof acceptProfileFollowRequest = async (input) => {
+      arrived += 1;
+      if (arrived === 2) {
+        release();
+      }
+      await bothArrived;
+      return acceptProfileFollowRequest(input);
+    };
+    const logs: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      await Promise.all([
+        handleInboundAcceptFollow({
+          acceptProfileFollowRequest: acceptWithBarrier,
+          context: createContext(localProfileId),
+          follow,
+          followeeActorUri: remoteActorUri,
+          followeeProfileId: fixture.remoteProfile.id,
+        }),
+        handleInboundAcceptFollow({
+          acceptProfileFollowRequest: acceptWithBarrier,
+          context: createContext(localProfileId),
+          follow,
+          followeeActorUri: remoteActorUri,
+          followeeProfileId: fixture.remoteProfile.id,
+        }),
+      ]);
+    } finally {
+      restoreReporter();
+    }
+
+    assert.equal((await db.select().from(ProfileFollowRequests)).length, 0);
+    assert.equal((await db.select().from(ProfileFollows)).length, 1);
+    assert.deepEqual(await readCounts(fixture), { localFollowing: 1, remoteFollowers: 1 });
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Accept',
+        actorOrigin: localActorUri.origin,
+        handler: 'accept',
+        objectOrigin: remoteActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'duplicate_accept_noop',
+      },
+    ]);
   });
 
   test('uses verified actor pair fallback for same-origin non-kosmo embedded Follow', async () => {
@@ -394,11 +458,40 @@ describe('inbound Accept and Reject', () => {
       }).toJsonLd(),
     );
 
-    await handleInboundAccept(createContext(localProfileId), accept);
+    const logs: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
+    try {
+      await handleInboundAccept(createContext(localProfileId), accept);
+      await handleInboundAccept(createContext(localProfileId), accept);
+    } finally {
+      restoreReporter();
+    }
 
     assert.equal((await db.select().from(ProfileFollowRequests)).length, 0);
     assert.deepEqual(await db.select().from(ProfileFollows), [fixture.projection]);
     assert.deepEqual(await readCounts(fixture), { localFollowing: 1, remoteFollowers: 1 });
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Accept',
+        actorOrigin: localActorUri.origin,
+        handler: 'accept',
+        objectOrigin: remoteActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'duplicate_accept_noop',
+      },
+      {
+        activityType: 'Accept',
+        actorOrigin: localActorUri.origin,
+        handler: 'accept',
+        objectOrigin: remoteActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'duplicate_accept_noop',
+      },
+    ]);
   });
 
   test('ignores embedded non-Follow responses with a canonical Follow-shaped id', async () => {

--- a/packages/fedify/src/inbound-accept.ts
+++ b/packages/fedify/src/inbound-accept.ts
@@ -2,6 +2,11 @@ import { Follow } from '@fedify/vocab';
 import { NotFoundError } from '@kosmo/core/error';
 import { isHttpUri } from './activitypub-uri';
 import { handleInboundAcceptFollow } from './inbound-accept-follow';
+import {
+  observeInboundExternalFailure,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
 import { findUsableStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Accept } from '@fedify/vocab';
@@ -12,6 +17,12 @@ export const handleInboundAccept = async (
 ): Promise<void> => {
   const actorUri = accept.actorId;
   if (!isHttpUri(actorUri)) {
+    observeInboundRejected({
+      activityType: 'Accept',
+      handler: 'accept',
+      phase: 'validation',
+      reasonCode: 'invalid_actor_identity',
+    });
     return;
   }
 
@@ -20,11 +31,26 @@ export const handleInboundAccept = async (
     remoteActor = await findUsableStoredRemoteProfileActorByUri(actorUri);
   } catch (error) {
     if (error instanceof NotFoundError) {
+      observeInboundNoop({
+        activityType: 'Accept',
+        actorOrigin: actorUri.origin,
+        error,
+        handler: 'accept',
+        phase: 'actor_lookup',
+        reasonCode: 'remote_actor_not_found',
+      });
       return;
     }
     throw error;
   }
   if (!remoteActor) {
+    observeInboundNoop({
+      activityType: 'Accept',
+      actorOrigin: actorUri.origin,
+      handler: 'accept',
+      phase: 'actor_lookup',
+      reasonCode: 'remote_actor_missing',
+    });
     return;
   }
 
@@ -32,6 +58,16 @@ export const handleInboundAccept = async (
     documentLoader: context.documentLoader,
     suppressError: true,
   });
+  if (object === null) {
+    observeInboundExternalFailure({
+      activityType: 'Accept',
+      actorOrigin: actorUri.origin,
+      handler: 'accept',
+      phase: 'object_lookup',
+      reasonCode: 'accept_object_lookup_failed',
+    });
+    return;
+  }
   if (object instanceof Follow) {
     await handleInboundAcceptFollow({
       context,
@@ -40,10 +76,14 @@ export const handleInboundAccept = async (
       followeeProfileId: remoteActor.profile.id,
     });
   } else {
-    console.error('Inbound ActivityPub Accept object could not be resolved as Follow', {
-      acceptId: accept.id?.href,
-      actorUri: actorUri.href,
-      objectUri: accept.objectId?.href,
+    observeInboundExternalFailure({
+      activityType: 'Accept',
+      actorOrigin: actorUri.origin,
+      handler: 'accept',
+      objectOrigin: accept.objectId?.origin,
+      phase: 'protocol',
+      reasonCode: 'accept_object_not_follow',
+      message: 'Inbound ActivityPub Accept object could not be resolved as Follow',
     });
   }
 };

--- a/packages/fedify/src/inbound-announce.test.ts
+++ b/packages/fedify/src/inbound-announce.test.ts
@@ -17,6 +17,7 @@ import {
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { createPost } from '@kosmo/core/services';
 import { and, eq, ne } from 'drizzle-orm';
+import { setInboundObservabilityReporter } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
@@ -306,6 +307,37 @@ describe('inbound Announce materialization', () => {
 
     await handleInboundUndo(context(), undo(actorUri, b.id!));
     assert.equal(await postState(recreated.id), PostState.ACTIVE);
+  });
+
+  test('does not log a successful Announce Undo deletion as a noop', async () => {
+    await createRemoteActor(actorUri);
+    await createRemoteSource();
+    const activity = announce('logged-delete', sourceUri);
+    await handleInboundAnnounce(context(), activity);
+
+    const logs: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
+    try {
+      await handleInboundUndo(context(), undo(actorUri, activity.id!));
+      assert.deepEqual(logs, []);
+
+      await handleInboundUndo(context(), undo(actorUri, activity.id!));
+      assert.deepEqual(logs, [
+        {
+          activityType: 'Undo',
+          actorOrigin: actorUri.origin,
+          handler: 'undo',
+          objectOrigin: actorUri.origin,
+          outcome: 'noop',
+          phase: 'projection',
+          reasonCode: 'announce_undo_ignored',
+        },
+      ]);
+    } finally {
+      restore();
+    }
   });
 
   test('ignores Undo from another actor', async () => {

--- a/packages/fedify/src/inbound-announce.ts
+++ b/packages/fedify/src/inbound-announce.ts
@@ -7,6 +7,7 @@ import { repostPost } from '@kosmo/core/services';
 import { eq, or } from 'drizzle-orm';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
 import { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Announce } from '@fedify/vocab';
@@ -102,12 +103,26 @@ export const handleInboundAnnounce = async (
   const objectHref = uniqueHref(announce.objectIds);
 
   if (!isHttpUri(activityUri) || !actorHref || !objectHref) {
+    observeInboundRejected({
+      activityType: 'Announce',
+      handler: 'announce',
+      phase: 'validation',
+      reasonCode: 'invalid_announce_identity',
+    });
     return;
   }
 
   const actorUri = new URL(actorHref);
   const objectUri = new URL(objectHref);
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri) || activityUri.origin !== actorUri.origin) {
+    observeInboundRejected({
+      activityType: 'Announce',
+      actorOrigin: actorUri.origin,
+      handler: 'announce',
+      objectOrigin: objectUri.origin,
+      phase: 'validation',
+      reasonCode: 'announce_origin_mismatch',
+    });
     return;
   }
 
@@ -117,11 +132,27 @@ export const handleInboundAnnounce = async (
     (storedActor.instance.state !== InstanceState.ACTIVE &&
       storedActor.instance.state !== InstanceState.UNRESPONSIVE)
   ) {
+    observeInboundNoop({
+      activityType: 'Announce',
+      actorOrigin: actorUri.origin,
+      handler: 'announce',
+      objectOrigin: objectUri.origin,
+      phase: 'actor_lookup',
+      reasonCode: 'remote_actor_unavailable',
+    });
     return;
   }
 
   const sourcePostId = await findPostByActivityPubUri(context, objectUri);
   if (!sourcePostId) {
+    observeInboundNoop({
+      activityType: 'Announce',
+      actorOrigin: actorUri.origin,
+      handler: 'announce',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'announce_source_post_missing',
+    });
     return;
   }
 
@@ -146,8 +177,18 @@ export const handleInboundAnnounce = async (
       }
     });
   } catch (error) {
-    if (!isExpectedRepostRejection(error)) {
-      throw error;
+    if (isExpectedRepostRejection(error)) {
+      observeInboundRejected({
+        activityType: 'Announce',
+        actorOrigin: actorUri.origin,
+        handler: 'announce',
+        objectOrigin: objectUri.origin,
+        phase: 'projection',
+        reasonCode: 'repost_projection_rejected',
+      });
+      return;
     }
+
+    throw error;
   }
 };

--- a/packages/fedify/src/inbound-create-note.ts
+++ b/packages/fedify/src/inbound-create-note.ts
@@ -10,6 +10,11 @@ import { createPost } from '@kosmo/core/services';
 import { and, eq } from 'drizzle-orm';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import {
+  observeInbound,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Note } from '@fedify/vocab';
 import type { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
@@ -139,11 +144,27 @@ export const handleInboundCreateNote = async ({
   receivedAt: Temporal.Instant;
 }): Promise<void> => {
   if (note.id?.href !== objectUri) {
+    observeInboundRejected({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      objectOrigin: objectUri,
+      phase: 'validation',
+      reasonCode: 'note_identity_mismatch',
+    });
     return;
   }
 
   const attributionUri = uniqueHref(note.attributionIds);
   if (attributionUri !== actorUri) {
+    observeInboundRejected({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      objectOrigin: objectUri,
+      phase: 'validation',
+      reasonCode: 'note_attribution_mismatch',
+    });
     return;
   }
 
@@ -156,6 +177,14 @@ export const handleInboundCreateNote = async ({
         ? PostVisibility.FOLLOWERS
         : undefined;
   if (!visibility) {
+    observeInboundRejected({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      objectOrigin: objectUri,
+      phase: 'validation',
+      reasonCode: 'unsupported_note_visibility',
+    });
     return;
   }
 
@@ -166,6 +195,14 @@ export const handleInboundCreateNote = async ({
       followeeProfileId: storedActor.profile.id,
     }))
   ) {
+    observeInboundRejected({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      objectOrigin: objectUri,
+      phase: 'validation',
+      reasonCode: 'followers_visibility_without_follow',
+    });
     return;
   }
 
@@ -182,6 +219,14 @@ export const handleInboundCreateNote = async ({
     media = await projectRemoteNoteMedia(note);
   } catch (error) {
     if (error instanceof TypeError) {
+      observeInboundRejected({
+        activityType: 'Create',
+        actorOrigin: actorUri,
+        handler: 'create',
+        objectOrigin: objectUri,
+        phase: 'projection',
+        reasonCode: 'note_media_projection_rejected',
+      });
       return;
     }
     throw error;
@@ -190,6 +235,17 @@ export const handleInboundCreateNote = async ({
   const input = {
     document,
     media,
+    onPostCommitError: (error: unknown) =>
+      observeInbound({
+        activityType: 'Create',
+        actorOrigin: actorUri,
+        error,
+        handler: 'create',
+        objectOrigin: objectUri,
+        outcome: 'internal_failure',
+        phase: 'effect',
+        reasonCode: 'reply_notification_effect_failed',
+      }),
     objectUri,
     origin: 'ACTIVITYPUB',
     profileId: storedActor.profile.id,
@@ -202,6 +258,14 @@ export const handleInboundCreateNote = async ({
     await createPost(replyParentId ? { ...input, replyParentId } : input);
   } catch (error) {
     if (error instanceof ValidationError && error.field === 'media') {
+      observeInboundRejected({
+        activityType: 'Create',
+        actorOrigin: actorUri,
+        handler: 'create',
+        objectOrigin: objectUri,
+        phase: 'projection',
+        reasonCode: 'note_media_validation_rejected',
+      });
       return;
     }
     if (
@@ -214,6 +278,14 @@ export const handleInboundCreateNote = async ({
       throw error;
     }
 
+    observeInboundNoop({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      objectOrigin: objectUri,
+      phase: 'projection',
+      reasonCode: 'reply_parent_missing_fallback',
+    });
     await createPost(input);
   }
 };

--- a/packages/fedify/src/inbound-create-note.ts
+++ b/packages/fedify/src/inbound-create-note.ts
@@ -254,8 +254,21 @@ export const handleInboundCreateNote = async ({
     visibility,
   } satisfies Parameters<typeof createPost>[0];
 
+  const observeDuplicateCreate = () =>
+    observeInboundNoop({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      objectOrigin: objectUri,
+      phase: 'projection',
+      reasonCode: 'duplicate_create_noop',
+    });
+
   try {
-    await createPost(replyParentId ? { ...input, replyParentId } : input);
+    const result = await createPost(replyParentId ? { ...input, replyParentId } : input);
+    if (!result.created) {
+      observeDuplicateCreate();
+    }
   } catch (error) {
     if (error instanceof ValidationError && error.field === 'media') {
       observeInboundRejected({
@@ -286,6 +299,9 @@ export const handleInboundCreateNote = async ({
       phase: 'projection',
       reasonCode: 'reply_parent_missing_fallback',
     });
-    await createPost(input);
+    const result = await createPost(input);
+    if (!result.created) {
+      observeDuplicateCreate();
+    }
   }
 };

--- a/packages/fedify/src/inbound-create.test.ts
+++ b/packages/fedify/src/inbound-create.test.ts
@@ -1284,26 +1284,46 @@ describe('inbound Create dispatch', () => {
       to: PUBLIC_COLLECTION,
     });
 
-    await handleInboundCreate(
-      createContext(),
-      new Create({ actor: remoteActorUri, object: first }),
-      receivedAt,
-    );
-    await handleInboundCreate(
-      createContext(),
-      new Create({
-        actor: remoteActorUri,
-        object: new Note({
-          attribution: remoteActorUri,
-          cc: PUBLIC_COLLECTION,
-          content: 'Changed',
-          id: remoteObjectUri,
-          mediaType: 'text/plain',
-          published: receivedAt.add({ hours: 1 }),
+    const logs: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
+    try {
+      await handleInboundCreate(
+        createContext(),
+        new Create({ actor: remoteActorUri, object: first }),
+        receivedAt,
+      );
+      await handleInboundCreate(
+        createContext(),
+        new Create({
+          actor: remoteActorUri,
+          object: new Note({
+            attribution: remoteActorUri,
+            cc: PUBLIC_COLLECTION,
+            content: 'Changed',
+            id: remoteObjectUri,
+            mediaType: 'text/plain',
+            published: receivedAt.add({ hours: 1 }),
+          }),
         }),
-      }),
-      receivedAt.add({ hours: 2 }),
-    );
+        receivedAt.add({ hours: 2 }),
+      );
+    } finally {
+      restoreReporter();
+    }
+
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Create',
+        actorOrigin: remoteActorUri.origin,
+        handler: 'create',
+        objectOrigin: remoteObjectUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'duplicate_create_noop',
+      },
+    ]);
 
     const { content, mapping, post } = await getMaterializedPost(remoteObjectUri);
     assert.equal(post.visibility, 'PUBLIC');

--- a/packages/fedify/src/inbound-create.test.ts
+++ b/packages/fedify/src/inbound-create.test.ts
@@ -35,6 +35,7 @@ import {
   postContentDocumentToText,
 } from '@kosmo/core/post-content/server';
 import { eq, ne, sql } from 'drizzle-orm';
+import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
@@ -924,6 +925,11 @@ describe('inbound Create dispatch', () => {
     await db.execute(
       sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_inbound_reply_create_failure CHECK (false) NOT VALID`,
     );
+    const captures: { context: { tags: Record<string, string> }; error: unknown }[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      captureException: (error, context) => captures.push({ context, error }),
+      log: () => undefined,
+    });
 
     try {
       await handleInboundCreate(
@@ -935,6 +941,7 @@ describe('inbound Create dispatch', () => {
         receivedAt,
       );
     } finally {
+      restoreReporter();
       await db.execute(
         sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_inbound_reply_create_failure`,
       );
@@ -942,6 +949,9 @@ describe('inbound Create dispatch', () => {
 
     assert.equal((await getMaterializedPost(replyUri)).post.replyParentId, parent.post.id);
     assert.equal((await db.select().from(Notifications)).length, 0);
+    assert.equal(captures.length, 1);
+    assert.equal(captures[0]?.context.tags.reason_code, 'reply_notification_effect_failed');
+    assert.ok(captures[0]?.error instanceof Error);
   });
 
   test('stores ambiguous, unsupported, unknown, forged Local, and contentless Parent inputs as top-level Posts', async () => {

--- a/packages/fedify/src/inbound-create.ts
+++ b/packages/fedify/src/inbound-create.ts
@@ -4,6 +4,11 @@ import { Note } from '@fedify/vocab';
 import { InstanceState } from '@kosmo/core/enums';
 import { uniqueHref } from './activitypub-uri';
 import { handleInboundCreateNote } from './inbound-create-note';
+import {
+  observeInboundExternalFailure,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
 import { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Create } from '@fedify/vocab';
@@ -17,6 +22,12 @@ export const handleInboundCreate = async (
   const objectUri = uniqueHref(create.objectIds);
 
   if (!actorUri || !objectUri) {
+    observeInboundRejected({
+      activityType: 'Create',
+      handler: 'create',
+      phase: 'validation',
+      reasonCode: 'missing_activity_identity',
+    });
     return undefined;
   }
 
@@ -26,6 +37,13 @@ export const handleInboundCreate = async (
     (storedActor.instance.state !== InstanceState.ACTIVE &&
       storedActor.instance.state !== InstanceState.UNRESPONSIVE)
   ) {
+    observeInboundNoop({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      phase: 'actor_lookup',
+      reasonCode: 'remote_actor_unavailable',
+    });
     return undefined;
   }
 
@@ -33,6 +51,14 @@ export const handleInboundCreate = async (
   try {
     object = await create.getObject({ documentLoader: context.documentLoader });
   } catch {
+    observeInboundExternalFailure({
+      activityType: 'Create',
+      actorOrigin: actorUri,
+      handler: 'create',
+      objectOrigin: objectUri,
+      phase: 'object_lookup',
+      reasonCode: 'create_object_lookup_failed',
+    });
     return undefined;
   }
 
@@ -45,5 +71,15 @@ export const handleInboundCreate = async (
       storedActor,
       receivedAt,
     });
+    return;
   }
+
+  observeInboundExternalFailure({
+    activityType: 'Create',
+    actorOrigin: actorUri,
+    handler: 'create',
+    objectOrigin: objectUri,
+    phase: 'protocol',
+    reasonCode: 'create_object_not_note',
+  });
 };

--- a/packages/fedify/src/inbound-delete.test.ts
+++ b/packages/fedify/src/inbound-delete.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { eq, ne } from 'drizzle-orm';
+import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
@@ -121,6 +122,53 @@ describe('inbound Delete dispatch', () => {
     const repeated = await storedProjection(objectUri);
     assert.equal(repeated.post.deletedAt?.toString(), firstDelete.post.deletedAt.toString());
     assert.equal(documentLoader.mock.calls.length, 0);
+  });
+
+  test('does not delete a mapped Post when an object-less Delete lookup fails', async () => {
+    const actorUri = new URL('https://remote.example/users/alice');
+    const objectUri = new URL('https://remote.example/notes/lookup-failure');
+    const profile = await createStoredRemoteActor(actorUri);
+    await materializeRemotePost(profile.id, objectUri);
+
+    class FailedLookupDelete extends Delete {
+      override get objectId(): URL | null {
+        return null;
+      }
+
+      override async getObject(): Promise<null> {
+        return null;
+      }
+    }
+
+    const logs: unknown[] = [];
+    const captures: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      captureException: (error) => captures.push(error),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      await handleInboundDelete(
+        createContext(),
+        new FailedLookupDelete({ actor: actorUri, object: objectUri }),
+      );
+    } finally {
+      restoreReporter();
+    }
+
+    assert.equal((await storedProjection(objectUri)).post.state, PostState.ACTIVE);
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Delete',
+        actorOrigin: actorUri.origin,
+        handler: 'delete',
+        objectOrigin: objectUri.origin,
+        outcome: 'external_failure',
+        phase: 'object_lookup',
+        reasonCode: 'delete_object_lookup_failed',
+      },
+    ]);
+    assert.equal(captures.length, 0);
   });
 
   test('accepts a same-id embedded Tombstone and rejects other embedded objects', async () => {

--- a/packages/fedify/src/inbound-delete.ts
+++ b/packages/fedify/src/inbound-delete.ts
@@ -14,6 +14,11 @@ import { InstanceKind } from '@kosmo/core/enums';
 import { deletePost } from '@kosmo/core/services';
 import { and, eq, isNotNull } from 'drizzle-orm';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import {
+  observeInboundExternalFailure,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Delete } from '@fedify/vocab';
 
@@ -31,6 +36,12 @@ export const handleInboundDelete = async (
   const objectUri = objectHref ? new URL(objectHref) : null;
 
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri)) {
+    observeInboundRejected({
+      activityType: 'Delete',
+      handler: 'delete',
+      phase: 'validation',
+      reasonCode: 'invalid_activity_identity',
+    });
     return;
   }
 
@@ -39,10 +50,28 @@ export const handleInboundDelete = async (
     documentLoader: noNetworkDocumentLoader,
     suppressError: true,
   });
+  if (embedded === null && !activity.objectId) {
+    observeInboundExternalFailure({
+      activityType: 'Delete',
+      actorOrigin: actorUri.origin,
+      handler: 'delete',
+      objectOrigin: objectUri.origin,
+      phase: 'object_lookup',
+      reasonCode: 'delete_object_lookup_failed',
+    });
+  }
   if (
     embedded !== null &&
     (!(embedded instanceof Tombstone) || embedded.id?.href !== objectUri.href)
   ) {
+    observeInboundRejected({
+      activityType: 'Delete',
+      actorOrigin: actorUri.origin,
+      handler: 'delete',
+      objectOrigin: objectUri.origin,
+      phase: 'protocol',
+      reasonCode: 'delete_object_not_matching_tombstone',
+    });
     return;
   }
 
@@ -64,6 +93,14 @@ export const handleInboundDelete = async (
       .then(first);
 
     if (!row || row.actorUri !== actorUri.href || row.instanceKind !== InstanceKind.ACTIVITYPUB) {
+      observeInboundNoop({
+        activityType: 'Delete',
+        actorOrigin: actorUri.origin,
+        handler: 'delete',
+        objectOrigin: objectUri.origin,
+        phase: 'projection',
+        reasonCode: 'delete_target_missing_or_mismatched',
+      });
       return;
     }
 

--- a/packages/fedify/src/inbound-delete.ts
+++ b/packages/fedify/src/inbound-delete.ts
@@ -59,6 +59,8 @@ export const handleInboundDelete = async (
       phase: 'object_lookup',
       reasonCode: 'delete_object_lookup_failed',
     });
+    // Without the direct object identity, a failed lookup cannot authenticate the target.
+    return;
   }
   if (
     embedded !== null &&

--- a/packages/fedify/src/inbound-follow.test.ts
+++ b/packages/fedify/src/inbound-follow.test.ts
@@ -12,6 +12,7 @@ import {
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
 import { eq, ne, sql } from 'drizzle-orm';
+import { setInboundObservabilityReporter } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
@@ -220,6 +221,40 @@ describe('inbound Follow and Undo', () => {
     }
   });
 
+  test('logs malformed federation JSON without capturing it in Sentry', async () => {
+    const logs: unknown[] = [];
+    const captures: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      captureException: (error) => captures.push(error),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      const response = await federation.fetch(
+        new Request(new URL('/inbox', publicOrigin), {
+          body: '{"type":',
+          headers: { 'content-type': 'application/activity+json' },
+          method: 'POST',
+        }),
+        { contextData: undefined },
+      );
+
+      assert.equal(response.status, 400, await response.text());
+      assert.equal(captures.length, 0);
+      assert.deepEqual(logs, [
+        {
+          activityType: 'Unknown',
+          handler: 'listener',
+          outcome: 'external_failure',
+          phase: 'listener',
+          reasonCode: 'external_listener_error',
+        },
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
   test('preserves the projection for embedded Undo actor or object mismatch', async () => {
     await createFixture();
     const context = createContext({ recipient: localProfileId });
@@ -315,6 +350,84 @@ describe('inbound Follow and Undo', () => {
     );
     assert.equal((await db.select().from(ProfileFollowRequests)).length, 0);
     assert.equal((await db.select().from(Notifications)).length, 0);
+  });
+
+  test('does not log a newly created pending Follow as a noop', async () => {
+    await createFixture({ followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED });
+    const logs: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      await handleInboundFollow(
+        createContext({ recipient: null }),
+        new Follow({ actor: remoteActorUri, object: localActorUri }),
+      );
+
+      assert.deepEqual(logs, []);
+    } finally {
+      restore();
+    }
+  });
+
+  test('logs an existing pending Follow as a noop', async () => {
+    await createFixture({ followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED });
+    const logs: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      const follow = new Follow({ actor: remoteActorUri, object: localActorUri });
+      await handleInboundFollow(createContext({ recipient: null }), follow);
+      await handleInboundFollow(createContext({ recipient: null }), follow);
+
+      assert.equal(logs.length, 1);
+      assert.deepEqual(logs[0], {
+        activityType: 'Follow',
+        actorOrigin: remoteActorUri.origin,
+        handler: 'follow',
+        objectOrigin: localActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'duplicate_pending_follow_noop',
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  test('logs an object-less Undo lookup failure once and returns', async () => {
+    await createFixture();
+    const logs: unknown[] = [];
+    const captures: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      captureException: (error) => captures.push(error),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      await handleInboundUndo(
+        createContext({ recipient: localProfileId }),
+        new Undo({ actor: remoteActorUri }),
+      );
+
+      assert.equal(captures.length, 0);
+      assert.deepEqual(logs, [
+        {
+          activityType: 'Undo',
+          actorOrigin: remoteActorUri.origin,
+          handler: 'undo',
+          objectOrigin: undefined,
+          outcome: 'external_failure',
+          phase: 'object_lookup',
+          reasonCode: 'undo_object_lookup_failed',
+        },
+      ]);
+    } finally {
+      restore();
+    }
   });
 
   test('keeps inbound Follow successful when Notification creation fails', async () => {

--- a/packages/fedify/src/inbound-follow.test.ts
+++ b/packages/fedify/src/inbound-follow.test.ts
@@ -16,6 +16,7 @@ import { setInboundObservabilityReporter } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
+import type * as CoreServices from '@kosmo/core/services';
 import type * as FederationModule from './federation';
 import type * as InboundFollow from './inbound-follow';
 
@@ -37,6 +38,7 @@ let Profiles: typeof CoreDb.Profiles;
 let federation: typeof FederationModule.federation;
 let handleInboundFollow: typeof InboundFollow.handleInboundFollow;
 let handleInboundUndo: typeof InboundFollow.handleInboundUndo;
+let setNotificationEffectErrorReporter: typeof CoreServices.setNotificationEffectErrorReporter;
 let localInstanceId: string;
 
 describe('inbound Follow and Undo', () => {
@@ -55,6 +57,8 @@ describe('inbound Follow and Undo', () => {
       Profiles,
     } = await import('@kosmo/core/db'));
     const { seedDatabase } = (await import('@kosmo/core/db/seed')) as typeof CoreSeed;
+    ({ setNotificationEffectErrorReporter } =
+      (await import('@kosmo/core/services')) as typeof CoreServices);
     ({ handleInboundFollow, handleInboundUndo } = await import('./inbound-follow'));
     ({ federation } = await import('./federation'));
     const { localInstance } = await seedDatabase({ publicOrigin });
@@ -516,6 +520,17 @@ describe('inbound Follow and Undo', () => {
 
   test('keeps approval-required inbound Follow successful when request Notification creation fails', async () => {
     const fixture = await createFixture({ followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED });
+    const logs: unknown[] = [];
+    const captures: unknown[] = [];
+    const effectReports: unknown[] = [];
+    const restoreInboundReporter = setInboundObservabilityReporter({
+      captureException: (error, context) => captures.push({ error, context }),
+      log: (observation) => logs.push(observation),
+    });
+    const restoreEffectReporter = setNotificationEffectErrorReporter((error, context) =>
+      effectReports.push({ error, context }),
+    );
+
     await db.execute(
       sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_inbound_pending_create_failure CHECK (false) NOT VALID`,
     );
@@ -529,6 +544,8 @@ describe('inbound Follow and Undo', () => {
       await db.execute(
         sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_inbound_pending_create_failure`,
       );
+      restoreEffectReporter();
+      restoreInboundReporter();
     }
 
     assert.equal((await db.select().from(ProfileFollowRequests)).length, 1);
@@ -545,6 +562,44 @@ describe('inbound Follow and Undo', () => {
         .then(firstOrThrow),
       { followersCount: 0, followingCount: 0 },
     );
+    assert.equal(effectReports.length, 0);
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Follow',
+        actorOrigin: remoteActorUri.origin,
+        handler: 'follow',
+        objectOrigin: localActorUri.origin,
+        outcome: 'internal_failure',
+        phase: 'effect',
+        reasonCode: 'follow_notification_effect_failed',
+      },
+    ]);
+    assert.equal(captures.length, 1);
+    const capture = captures[0] as {
+      context: {
+        extra?: Record<string, string>;
+        fingerprint: string[];
+        tags: Record<string, string>;
+      };
+    };
+    assert.deepEqual(capture.context.tags, {
+      activity_type: 'Follow',
+      handler: 'follow',
+      outcome: 'internal_failure',
+      phase: 'effect',
+      reason_code: 'follow_notification_effect_failed',
+    });
+    assert.deepEqual(capture.context.fingerprint, [
+      'activitypub-inbound',
+      'Follow',
+      'follow',
+      'effect',
+      'follow_notification_effect_failed',
+    ]);
+    assert.deepEqual(capture.context.extra, {
+      actor_origin: remoteActorUri.origin,
+      object_origin: localActorUri.origin,
+    });
   });
 
   test('keeps inbound Undo successful when Notification cleanup fails', async () => {

--- a/packages/fedify/src/inbound-follow.test.ts
+++ b/packages/fedify/src/inbound-follow.test.ts
@@ -352,6 +352,37 @@ describe('inbound Follow and Undo', () => {
     assert.equal((await db.select().from(Notifications)).length, 0);
   });
 
+  test('logs only a true-noop after an inbound pending Follow Undo was already consumed', async () => {
+    await createFixture({ followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED });
+    const logs: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
+    const context = createContext({ recipient: null });
+    const follow = new Follow({ actor: remoteActorUri, object: localActorUri });
+    const undo = new Undo({ actor: remoteActorUri, object: follow });
+
+    try {
+      await handleInboundFollow(context, follow);
+      await handleInboundUndo(context, undo);
+      await handleInboundUndo(context, undo);
+    } finally {
+      restoreReporter();
+    }
+
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Undo',
+        actorOrigin: remoteActorUri.origin,
+        handler: 'undo',
+        objectOrigin: localActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'follow_undo_missing_or_repeated',
+      },
+    ]);
+  });
+
   test('does not log a newly created pending Follow as a noop', async () => {
     await createFixture({ followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED });
     const logs: unknown[] = [];

--- a/packages/fedify/src/inbound-follow.test.ts
+++ b/packages/fedify/src/inbound-follow.test.ts
@@ -291,8 +291,19 @@ describe('inbound Follow and Undo', () => {
     const fixture = await createFixture();
     const context = createContext({ recipient: localProfileId });
     const follow = new Follow({ actor: remoteActorUri, object: localActorUri });
+    const logs: unknown[] = [];
+    const restoreReporter = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+    });
 
-    await Promise.all([handleInboundFollow(context, follow), handleInboundFollow(context, follow)]);
+    try {
+      await Promise.all([
+        handleInboundFollow(context, follow),
+        handleInboundFollow(context, follow),
+      ]);
+    } finally {
+      restoreReporter();
+    }
 
     const relation = await db.select().from(ProfileFollows).limit(1).then(firstOrThrow);
     assert.equal((await db.select().from(ProfileFollows)).length, 1);
@@ -324,6 +335,17 @@ describe('inbound Follow and Undo', () => {
       ).followingCount,
       1,
     );
+    assert.deepEqual(logs, [
+      {
+        activityType: 'Follow',
+        actorOrigin: remoteActorUri.origin,
+        handler: 'follow',
+        objectOrigin: localActorUri.origin,
+        outcome: 'noop',
+        phase: 'projection',
+        reasonCode: 'duplicate_established_follow_noop',
+      },
+    ]);
   });
 
   test('routes shared-inbox approval-required Follow without Accept', async () => {

--- a/packages/fedify/src/inbound-follow.ts
+++ b/packages/fedify/src/inbound-follow.ts
@@ -124,14 +124,16 @@ export const handleInboundFollow = async (
   });
 
   if (result.result.kind !== 'ESTABLISHED') {
-    observeInboundNoop({
-      activityType: 'Follow',
-      actorOrigin: actorUri.origin,
-      handler: 'follow',
-      objectOrigin: objectUri.origin,
-      phase: 'projection',
-      reasonCode: 'follow_policy_pending_or_rejected',
-    });
+    if (!result.created) {
+      observeInboundNoop({
+        activityType: 'Follow',
+        actorOrigin: actorUri.origin,
+        handler: 'follow',
+        objectOrigin: objectUri.origin,
+        phase: 'projection',
+        reasonCode: 'duplicate_pending_follow_noop',
+      });
+    }
     return;
   }
 
@@ -172,7 +174,12 @@ const noNetworkDocumentLoader = async (url: string) => {
   throw new Error(`Network lookup is disabled for inbound Undo: ${url}`);
 };
 
-const handleInboundUndoAnnounce = async (activityUri: URL, actorUri: URL): Promise<boolean> => {
+type UndoAnnounceResult = 'deleted' | 'ignored' | null;
+
+const handleInboundUndoAnnounce = async (
+  activityUri: URL,
+  actorUri: URL,
+): Promise<UndoAnnounceResult> => {
   return db.transaction(async (tx) => {
     const row = await tx
       .select({
@@ -200,7 +207,7 @@ const handleInboundUndoAnnounce = async (activityUri: URL, actorUri: URL): Promi
       .then(first);
 
     if (!row) {
-      return false;
+      return null;
     }
     if (
       activityUri.origin !== actorUri.origin ||
@@ -211,11 +218,11 @@ const handleInboundUndoAnnounce = async (activityUri: URL, actorUri: URL): Promi
       row.profileState !== ProfileState.ACTIVE ||
       row.postState !== PostState.ACTIVE
     ) {
-      return true;
+      return 'ignored';
     }
 
     await deletePost({ actorProfileId: row.profileId, postId: row.postId }, tx);
-    return true;
+    return 'deleted';
   });
 };
 
@@ -255,16 +262,22 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     return;
   }
 
-  if (objectUri && (await handleInboundUndoAnnounce(objectUri, actorUri))) {
-    observeInboundNoop({
-      activityType: 'Undo',
-      actorOrigin: actorUri.origin,
-      handler: 'undo',
-      objectOrigin: objectUri.origin,
-      phase: 'projection',
-      reasonCode: 'announce_undo_handled_or_noop',
-    });
-    return;
+  if (objectUri) {
+    const announceResult = await handleInboundUndoAnnounce(objectUri, actorUri);
+    if (announceResult === 'deleted') {
+      return;
+    }
+    if (announceResult === 'ignored') {
+      observeInboundNoop({
+        activityType: 'Undo',
+        actorOrigin: actorUri.origin,
+        handler: 'undo',
+        objectOrigin: objectUri.origin,
+        phase: 'projection',
+        reasonCode: 'announce_undo_ignored',
+      });
+      return;
+    }
   }
 
   // Undo never materializes or dereferences an unknown actor.
@@ -313,6 +326,7 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
       phase: 'object_lookup',
       reasonCode: 'undo_object_lookup_failed',
     });
+    return;
   }
   if (embedded instanceof Follow) {
     const objectUri = embedded.objectId;

--- a/packages/fedify/src/inbound-follow.ts
+++ b/packages/fedify/src/inbound-follow.ts
@@ -23,6 +23,12 @@ import { isHttpUri, uniqueHref } from './activitypub-uri';
 import { sendAcceptFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
 import {
+  observeInbound,
+  observeInboundExternalFailure,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
+import {
   findOrMaterializeRemoteProfileActorByUri,
   findUsableStoredRemoteProfileActorByUri,
   RemoteActorMaterializationError,
@@ -58,12 +64,26 @@ export const handleInboundFollow = async (
   const objectUri = follow.objectId;
 
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri)) {
+    observeInboundRejected({
+      activityType: 'Follow',
+      handler: 'follow',
+      phase: 'validation',
+      reasonCode: 'invalid_follow_identity',
+    });
     return;
   }
 
   // Local validation intentionally precedes every remote lookup.
   const localRecipient = await resolveInboundLocalRecipient(context, objectUri);
   if (!localRecipient) {
+    observeInboundRejected({
+      activityType: 'Follow',
+      actorOrigin: actorUri.origin,
+      handler: 'follow',
+      objectOrigin: objectUri.origin,
+      phase: 'validation',
+      reasonCode: 'local_recipient_not_found',
+    });
     return;
   }
 
@@ -73,6 +93,14 @@ export const handleInboundFollow = async (
     remoteActor = await findOrMaterializeRemoteProfileActorByUri({ actorUri, context, now });
   } catch (error) {
     if (isExpectedRemoteActorRejection(error)) {
+      observeInboundExternalFailure({
+        activityType: 'Follow',
+        actorOrigin: actorUri.origin,
+        handler: 'follow',
+        objectOrigin: objectUri.origin,
+        phase: 'actor_lookup',
+        reasonCode: 'remote_actor_materialization_rejected',
+      });
       return;
     }
 
@@ -82,14 +110,41 @@ export const handleInboundFollow = async (
   const result = await followProfile({
     followeeProfileId: localRecipient.id,
     followerProfileId: remoteActor.profile.id,
+    onPostCommitError: (error) =>
+      observeInbound({
+        activityType: 'Follow',
+        actorOrigin: actorUri.origin,
+        error,
+        handler: 'follow',
+        objectOrigin: objectUri.origin,
+        outcome: 'internal_failure',
+        phase: 'effect',
+        reasonCode: 'follow_notification_effect_failed',
+      }),
   });
 
   if (result.result.kind !== 'ESTABLISHED') {
+    observeInboundNoop({
+      activityType: 'Follow',
+      actorOrigin: actorUri.origin,
+      handler: 'follow',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'follow_policy_pending_or_rejected',
+    });
     return;
   }
 
   const recipientActor = toRecipient(remoteActor.actor);
   if (!recipientActor) {
+    observeInboundNoop({
+      activityType: 'Follow',
+      actorOrigin: actorUri.origin,
+      handler: 'follow',
+      objectOrigin: objectUri.origin,
+      phase: 'delivery',
+      reasonCode: 'remote_actor_inbox_missing',
+    });
     return;
   }
 
@@ -102,6 +157,14 @@ export const handleInboundFollow = async (
     });
   } catch {
     // The projection is authoritative; delivery retries belong to a separate slice.
+    observeInboundExternalFailure({
+      activityType: 'Follow',
+      actorOrigin: actorUri.origin,
+      handler: 'follow',
+      objectOrigin: objectUri.origin,
+      phase: 'delivery',
+      reasonCode: 'accept_delivery_failed',
+    });
   }
 };
 
@@ -160,19 +223,47 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   const actorHref = uniqueHref(undo.actorIds);
   const actorUri = actorHref ? new URL(actorHref) : null;
   if (!isHttpUri(actorUri)) {
+    observeInboundRejected({
+      activityType: 'Undo',
+      handler: 'undo',
+      phase: 'validation',
+      reasonCode: 'invalid_undo_actor_identity',
+    });
     return;
   }
 
   const objectHref = uniqueHref(undo.objectIds);
   if (undo.objectIds.length > 0 && !objectHref) {
+    observeInboundRejected({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      handler: 'undo',
+      phase: 'validation',
+      reasonCode: 'ambiguous_undo_object_identity',
+    });
     return;
   }
   const objectUri = objectHref ? new URL(objectHref) : null;
   if (objectUri && !isHttpUri(objectUri)) {
+    observeInboundRejected({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      handler: 'undo',
+      phase: 'validation',
+      reasonCode: 'invalid_undo_object_identity',
+    });
     return;
   }
 
   if (objectUri && (await handleInboundUndoAnnounce(objectUri, actorUri))) {
+    observeInboundNoop({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      handler: 'undo',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'announce_undo_handled_or_noop',
+    });
     return;
   }
 
@@ -183,6 +274,14 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     remoteActor = await findUsableStoredRemoteProfileActorByUri(actorUri);
   } catch (error) {
     if (isExpectedRemoteActorRejection(error)) {
+      observeInboundExternalFailure({
+        activityType: 'Undo',
+        actorOrigin: actorUri.origin,
+        handler: 'undo',
+        objectOrigin: objectUri?.origin,
+        phase: 'actor_lookup',
+        reasonCode: 'remote_actor_lookup_rejected',
+      });
       return;
     }
 
@@ -190,6 +289,14 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   }
 
   if (!remoteActor || remoteActor.instance.state !== InstanceState.ACTIVE) {
+    observeInboundNoop({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      handler: 'undo',
+      objectOrigin: objectUri?.origin,
+      phase: 'actor_lookup',
+      reasonCode: 'remote_actor_unavailable',
+    });
     return;
   }
 
@@ -197,25 +304,70 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     documentLoader: noNetworkDocumentLoader,
     suppressError: true,
   });
+  if (embedded === null && !undo.objectId) {
+    observeInboundExternalFailure({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      handler: 'undo',
+      objectOrigin: objectUri?.origin,
+      phase: 'object_lookup',
+      reasonCode: 'undo_object_lookup_failed',
+    });
+  }
   if (embedded instanceof Follow) {
     const objectUri = embedded.objectId;
     if (!isHttpUri(objectUri) || uniqueHref(embedded.actorIds) !== actorUri.href) {
+      observeInboundRejected({
+        activityType: 'Undo',
+        actorOrigin: actorUri.origin,
+        objectOrigin: objectUri?.origin,
+        handler: 'undo',
+        phase: 'protocol',
+        reasonCode: 'undo_follow_actor_or_object_mismatch',
+      });
       return;
     }
 
     const localRecipient = await resolveInboundLocalRecipient(context, objectUri);
     if (!localRecipient) {
+      observeInboundRejected({
+        activityType: 'Undo',
+        actorOrigin: actorUri.origin,
+        objectOrigin: objectUri.origin,
+        handler: 'undo',
+        phase: 'validation',
+        reasonCode: 'undo_local_recipient_not_found',
+      });
       return;
     }
 
     await unfollowProfile({
       followeeProfileId: localRecipient.id,
       followerProfileId: remoteActor.profile.id,
+      onPostCommitError: (error) =>
+        observeInbound({
+          activityType: 'Undo',
+          actorOrigin: actorUri.origin,
+          error,
+          handler: 'undo',
+          objectOrigin: objectUri.origin,
+          outcome: 'internal_failure',
+          phase: 'effect',
+          reasonCode: 'follow_undo_notification_effect_failed',
+        }),
     });
     return;
   }
 
   if (embedded !== null && !(embedded instanceof Like) && !(embedded instanceof EmojiReact)) {
+    observeInboundRejected({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      objectOrigin: objectUri?.origin,
+      handler: 'undo',
+      phase: 'protocol',
+      reasonCode: 'unsupported_undo_object',
+    });
     return;
   }
 
@@ -225,8 +377,40 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     ((embedded instanceof Like || embedded instanceof EmojiReact) &&
       uniqueHref(embedded.actorIds) !== actorUri.href)
   ) {
+    observeInboundRejected({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      objectOrigin: activityUri?.origin,
+      handler: 'undo',
+      phase: 'protocol',
+      reasonCode: 'undo_reaction_actor_or_object_mismatch',
+    });
     return;
   }
 
-  await undoInboundReaction({ activityUri: activityUri.href, actorUri: actorUri.href });
+  const result = await undoInboundReaction({
+    activityUri: activityUri.href,
+    actorUri: actorUri.href,
+    onPostCommitError: (error) =>
+      observeInbound({
+        activityType: 'Undo',
+        actorOrigin: actorUri.origin,
+        error,
+        handler: 'undo',
+        objectOrigin: activityUri.origin,
+        outcome: 'internal_failure',
+        phase: 'effect',
+        reasonCode: 'reaction_undo_notification_effect_failed',
+      }),
+  });
+  if (result.reactionId === null) {
+    observeInboundNoop({
+      activityType: 'Undo',
+      actorOrigin: actorUri.origin,
+      objectOrigin: activityUri.origin,
+      handler: 'undo',
+      phase: 'projection',
+      reasonCode: 'reaction_undo_missing_or_repeated',
+    });
+  }
 };

--- a/packages/fedify/src/inbound-follow.ts
+++ b/packages/fedify/src/inbound-follow.ts
@@ -137,6 +137,17 @@ export const handleInboundFollow = async (
     return;
   }
 
+  if (!result.created) {
+    observeInboundNoop({
+      activityType: 'Follow',
+      actorOrigin: actorUri.origin,
+      handler: 'follow',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'duplicate_established_follow_noop',
+    });
+  }
+
   const recipientActor = toRecipient(remoteActor.actor);
   if (!recipientActor) {
     observeInboundNoop({

--- a/packages/fedify/src/inbound-follow.ts
+++ b/packages/fedify/src/inbound-follow.ts
@@ -355,7 +355,7 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
       return;
     }
 
-    await unfollowProfile({
+    const result = await unfollowProfile({
       followeeProfileId: localRecipient.id,
       followerProfileId: remoteActor.profile.id,
       onPostCommitError: (error) =>
@@ -370,6 +370,16 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
           reasonCode: 'follow_undo_notification_effect_failed',
         }),
     });
+    if (!result.changed) {
+      observeInboundNoop({
+        activityType: 'Undo',
+        actorOrigin: actorUri.origin,
+        handler: 'undo',
+        objectOrigin: objectUri.origin,
+        phase: 'projection',
+        reasonCode: 'follow_undo_missing_or_repeated',
+      });
+    }
     return;
   }
 

--- a/packages/fedify/src/inbound-observability.test.ts
+++ b/packages/fedify/src/inbound-observability.test.ts
@@ -138,4 +138,12 @@ describe('inbound ActivityPub observability', () => {
     markInboundErrorObserved(error);
     assert.equal(hasInboundErrorBeenObserved(error), true);
   });
+
+  test('does not infer a remote failure from a generic socket code', () => {
+    const error = Object.assign(new Error('connection refused'), {
+      code: 'ECONNREFUSED',
+    });
+
+    assert.equal(isExternalInboundError(error), false);
+  });
 });

--- a/packages/fedify/src/inbound-observability.test.ts
+++ b/packages/fedify/src/inbound-observability.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { Create } from '@fedify/vocab';
+import {
+  hasInboundErrorBeenObserved,
+  isExternalInboundError,
+  markInboundErrorObserved,
+  observeInbound,
+  setInboundObservabilityReporter,
+  withInboundObservability,
+} from './inbound-observability';
+
+describe('inbound ActivityPub observability', () => {
+  test('captures only bounded internal metadata and strips URI paths', () => {
+    const logs: unknown[] = [];
+    const captures: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      log: (observation) => logs.push(observation),
+      captureException: (error, context) => captures.push({ context, error }),
+    });
+
+    try {
+      const error = new Error('projection failed');
+      observeInbound({
+        activityType: 'Create',
+        actorOrigin: 'https://remote.example/users/alice',
+        activityOrigin: 'https://remote.example/activities/1?secret=1',
+        error,
+        handler: 'create',
+        objectOrigin: 'https://remote.example/notes/1',
+        outcome: 'internal_failure',
+        phase: 'projection',
+        reasonCode: 'post_commit_projection_failed',
+      });
+
+      assert.deepEqual(logs, [
+        {
+          activityType: 'Create',
+          actorOrigin: 'https://remote.example',
+          activityOrigin: 'https://remote.example',
+          handler: 'create',
+          objectOrigin: 'https://remote.example',
+          outcome: 'internal_failure',
+          phase: 'projection',
+          reasonCode: 'post_commit_projection_failed',
+        },
+      ]);
+      assert.deepEqual(captures, [
+        {
+          context: {
+            extra: {
+              activity_origin: 'https://remote.example',
+              actor_origin: 'https://remote.example',
+              object_origin: 'https://remote.example',
+            },
+            fingerprint: [
+              'activitypub-inbound',
+              'Create',
+              'create',
+              'projection',
+              'post_commit_projection_failed',
+            ],
+            tags: {
+              activity_type: 'Create',
+              handler: 'create',
+              outcome: 'internal_failure',
+              phase: 'projection',
+              reason_code: 'post_commit_projection_failed',
+            },
+          },
+          error,
+        },
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('does not capture expected or external failures', () => {
+    const captures: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      log: () => undefined,
+      captureException: (error) => captures.push(error),
+    });
+
+    try {
+      observeInbound({
+        activityType: 'Accept',
+        handler: 'accept',
+        outcome: 'external_failure',
+        phase: 'object_lookup',
+        reasonCode: 'accept_object_lookup_failed',
+      });
+      observeInbound({
+        activityType: 'Accept',
+        handler: 'accept',
+        outcome: 'rejected',
+        phase: 'validation',
+        reasonCode: 'invalid_actor_identity',
+      });
+      assert.equal(captures.length, 0);
+    } finally {
+      restore();
+    }
+  });
+
+  test('listener wrapper reports internal errors once and rethrows', async () => {
+    const captures: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      log: () => undefined,
+      captureException: (error, context) => captures.push({ error, context }),
+    });
+
+    try {
+      const error = new Error('database failed');
+      const listener = withInboundObservability('create', async () => {
+        throw error;
+      });
+
+      await assert.rejects(() => listener({} as never, new Create({})), error);
+      assert.equal(captures.length, 1);
+      assert.equal(hasInboundErrorBeenObserved(error), true);
+      assert.equal(
+        (captures[0] as { context: { tags: { activity_type: string } } }).context.tags
+          .activity_type,
+        'Create',
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('recognizes remote failures and tracks observed error identity', () => {
+    const error = new Error('remote failed');
+    error.name = 'FetchError';
+    assert.equal(isExternalInboundError(error), true);
+    assert.equal(hasInboundErrorBeenObserved(error), false);
+    markInboundErrorObserved(error);
+    assert.equal(hasInboundErrorBeenObserved(error), true);
+  });
+});

--- a/packages/fedify/src/inbound-observability.ts
+++ b/packages/fedify/src/inbound-observability.ts
@@ -1,0 +1,279 @@
+import type { InboxContext } from '@fedify/fedify';
+
+export type InboundActivityType =
+  | 'Accept'
+  | 'Announce'
+  | 'Create'
+  | 'Delete'
+  | 'Follow'
+  | 'Like'
+  | 'EmojiReact'
+  | 'Reject'
+  | 'Undo'
+  | 'Update'
+  | 'Unknown';
+
+export type InboundHandler =
+  | 'accept'
+  | 'announce'
+  | 'create'
+  | 'delete'
+  | 'follow'
+  | 'reaction'
+  | 'reject'
+  | 'undo'
+  | 'update'
+  | 'listener';
+
+export type InboundPhase =
+  | 'validation'
+  | 'actor_lookup'
+  | 'object_lookup'
+  | 'protocol'
+  | 'projection'
+  | 'effect'
+  | 'delivery'
+  | 'listener';
+
+export type InboundOutcome = 'rejected' | 'noop' | 'external_failure' | 'internal_failure';
+
+export type InboundObservation = {
+  activityType: InboundActivityType;
+  handler: InboundHandler;
+  phase: InboundPhase;
+  outcome: InboundOutcome;
+  reasonCode: string;
+  actorOrigin?: string;
+  objectOrigin?: string;
+  activityOrigin?: string;
+  error?: unknown;
+  message?: string;
+};
+
+export type InboundCaptureContext = {
+  tags: Record<string, string>;
+  fingerprint: string[];
+  extra?: Record<string, string>;
+};
+
+export type InboundObservabilityReporter = {
+  log: (observation: Omit<InboundObservation, 'error'>) => void;
+  captureException: (error: unknown, context: InboundCaptureContext) => void;
+};
+
+const activityTypes = new Set<InboundActivityType>([
+  'Accept',
+  'Announce',
+  'Create',
+  'Delete',
+  'Follow',
+  'Like',
+  'EmojiReact',
+  'Reject',
+  'Undo',
+  'Update',
+]);
+
+const toOrigin = (value: string | URL | null | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+};
+
+const getErrorName = (error: unknown): string | undefined =>
+  error instanceof Error && error.name ? error.name : undefined;
+
+const externalErrorNames = new Set([
+  'AbortError',
+  'FetchError',
+  'RemoteActorMaterializationError',
+  'SendActivityError',
+  'UrlError',
+  'WebFingerError',
+]);
+
+const externalErrorCodes = new Set([
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+const defaultReporter: InboundObservabilityReporter = {
+  log: (observation) => {
+    const log =
+      observation.message || observation.outcome === 'internal_failure'
+        ? console.error
+        : console.warn;
+    log(observation.message ?? 'ActivityPub inbound observation', observation);
+  },
+  captureException: () => undefined,
+};
+
+let reporter: InboundObservabilityReporter = defaultReporter;
+const observedErrors = new WeakSet<object>();
+
+const canTrackError = (error: unknown): error is object =>
+  (typeof error === 'object' && error !== null) || typeof error === 'function';
+
+export const markInboundErrorObserved = (error: unknown): void => {
+  if (canTrackError(error)) {
+    observedErrors.add(error);
+  }
+};
+
+export const hasInboundErrorBeenObserved = (error: unknown): boolean =>
+  canTrackError(error) && observedErrors.has(error);
+
+export const setInboundObservabilityReporter = (
+  next: Partial<InboundObservabilityReporter> | undefined,
+): (() => void) => {
+  const previous = reporter;
+  reporter = {
+    log: next?.log ?? defaultReporter.log,
+    captureException: next?.captureException ?? defaultReporter.captureException,
+  };
+
+  return () => {
+    reporter = previous;
+  };
+};
+
+export const getInboundActivityType = (activity: unknown): InboundActivityType => {
+  const name =
+    typeof activity === 'object' && activity !== null && 'constructor' in activity
+      ? (activity.constructor as { name?: string }).name
+      : undefined;
+  return name && activityTypes.has(name as InboundActivityType)
+    ? (name as InboundActivityType)
+    : 'Unknown';
+};
+
+export const observeInbound = ({ error, message, ...observation }: InboundObservation): void => {
+  const safeObservation = {
+    ...observation,
+    ...(message ? { message } : {}),
+    ...(observation.actorOrigin ? { actorOrigin: toOrigin(observation.actorOrigin) } : {}),
+    ...(observation.objectOrigin ? { objectOrigin: toOrigin(observation.objectOrigin) } : {}),
+    ...(observation.activityOrigin ? { activityOrigin: toOrigin(observation.activityOrigin) } : {}),
+  } satisfies Omit<InboundObservation, 'error'>;
+
+  try {
+    reporter.log(safeObservation);
+  } catch {
+    // Observability must not alter ActivityPub processing.
+  }
+
+  if (observation.outcome !== 'internal_failure') {
+    return;
+  }
+
+  try {
+    reporter.captureException(error ?? new Error(observation.reasonCode), {
+      tags: {
+        activity_type: observation.activityType,
+        handler: observation.handler,
+        phase: observation.phase,
+        outcome: observation.outcome,
+        reason_code: observation.reasonCode,
+      },
+      fingerprint: [
+        'activitypub-inbound',
+        observation.activityType,
+        observation.handler,
+        observation.phase,
+        observation.reasonCode,
+      ],
+      extra: {
+        ...(safeObservation.actorOrigin ? { actor_origin: safeObservation.actorOrigin } : {}),
+        ...(safeObservation.objectOrigin ? { object_origin: safeObservation.objectOrigin } : {}),
+        ...(safeObservation.activityOrigin
+          ? { activity_origin: safeObservation.activityOrigin }
+          : {}),
+      },
+    });
+  } catch {
+    // Observability must not alter ActivityPub processing.
+  }
+};
+
+export const isExternalInboundError = (error: unknown, seen = new Set<object>()): boolean => {
+  if (!canTrackError(error) || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+
+  const name = getErrorName(error);
+  if (name && externalErrorNames.has(name)) {
+    return true;
+  }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    externalErrorCodes.has(error.code)
+  ) {
+    return true;
+  }
+
+  if (error instanceof Error && 'cause' in error && isExternalInboundError(error.cause, seen)) {
+    return true;
+  }
+
+  return false;
+};
+
+export const withInboundObservability =
+  <TContextData, TActivity extends object>(
+    handler: InboundHandler,
+    listener: (context: InboxContext<TContextData>, activity: TActivity) => void | Promise<void>,
+  ) =>
+  async (context: InboxContext<TContextData>, activity: TActivity): Promise<void> => {
+    try {
+      await listener(context, activity);
+    } catch (error) {
+      markInboundErrorObserved(error);
+      observeInbound({
+        activityType: getInboundActivityType(activity),
+        activityOrigin:
+          'id' in activity && activity.id instanceof URL ? activity.id.origin : undefined,
+        actorOrigin:
+          'actorId' in activity && activity.actorId instanceof URL
+            ? activity.actorId.origin
+            : undefined,
+        objectOrigin:
+          'objectId' in activity && activity.objectId instanceof URL
+            ? activity.objectId.origin
+            : undefined,
+        error,
+        handler,
+        outcome: isExternalInboundError(error) ? 'external_failure' : 'internal_failure',
+        phase: 'listener',
+        reasonCode: isExternalInboundError(error)
+          ? 'external_listener_error'
+          : 'unexpected_listener_error',
+      });
+      throw error;
+    }
+  };
+
+export const observeInboundNoop = (observation: Omit<InboundObservation, 'outcome'>) =>
+  observeInbound({ ...observation, outcome: 'noop' });
+
+export const observeInboundRejected = (observation: Omit<InboundObservation, 'outcome'>) =>
+  observeInbound({ ...observation, outcome: 'rejected' });
+
+export const observeInboundExternalFailure = (observation: Omit<InboundObservation, 'outcome'>) =>
+  observeInbound({ ...observation, outcome: 'external_failure' });

--- a/packages/fedify/src/inbound-observability.ts
+++ b/packages/fedify/src/inbound-observability.ts
@@ -98,17 +98,6 @@ const externalErrorNames = new Set([
   'WebFingerError',
 ]);
 
-const externalErrorCodes = new Set([
-  'EAI_AGAIN',
-  'ECONNREFUSED',
-  'ECONNRESET',
-  'ENETUNREACH',
-  'ENOTFOUND',
-  'ETIMEDOUT',
-  'UND_ERR_CONNECT_TIMEOUT',
-  'UND_ERR_SOCKET',
-]);
-
 const defaultReporter: InboundObservabilityReporter = {
   log: (observation) => {
     const log =
@@ -215,16 +204,6 @@ export const isExternalInboundError = (error: unknown, seen = new Set<object>())
 
   const name = getErrorName(error);
   if (name && externalErrorNames.has(name)) {
-    return true;
-  }
-
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof error.code === 'string' &&
-    externalErrorCodes.has(error.code)
-  ) {
     return true;
   }
 

--- a/packages/fedify/src/inbound-observability.ts
+++ b/packages/fedify/src/inbound-observability.ts
@@ -115,6 +115,9 @@ const observedErrors = new WeakSet<object>();
 const canTrackError = (error: unknown): error is object =>
   (typeof error === 'object' && error !== null) || typeof error === 'function';
 
+const normalizeInboundError = (error: unknown): object =>
+  canTrackError(error) ? error : new Error('ActivityPub inbound listener threw a non-Error value');
+
 export const markInboundErrorObserved = (error: unknown): void => {
   if (canTrackError(error)) {
     observedErrors.add(error);
@@ -223,7 +226,9 @@ export const withInboundObservability =
     try {
       await listener(context, activity);
     } catch (error) {
-      markInboundErrorObserved(error);
+      const normalizedError = normalizeInboundError(error);
+      const external = isExternalInboundError(normalizedError);
+      markInboundErrorObserved(normalizedError);
       observeInbound({
         activityType: getInboundActivityType(activity),
         activityOrigin:
@@ -236,15 +241,13 @@ export const withInboundObservability =
           'objectId' in activity && activity.objectId instanceof URL
             ? activity.objectId.origin
             : undefined,
-        error,
+        error: normalizedError,
         handler,
-        outcome: isExternalInboundError(error) ? 'external_failure' : 'internal_failure',
+        outcome: external ? 'external_failure' : 'internal_failure',
         phase: 'listener',
-        reasonCode: isExternalInboundError(error)
-          ? 'external_listener_error'
-          : 'unexpected_listener_error',
+        reasonCode: external ? 'external_listener_error' : 'unexpected_listener_error',
       });
-      throw error;
+      throw normalizedError;
     }
   };
 

--- a/packages/fedify/src/inbound-reaction.ts
+++ b/packages/fedify/src/inbound-reaction.ts
@@ -1,10 +1,16 @@
 import '@kosmo/core/polyfill';
 
+import { Like } from '@fedify/vocab';
 import { materializeInboundReaction } from '@kosmo/core/services';
 import { reactionTypeSchema } from '@kosmo/core/validation';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import {
+  observeInbound,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
-import type { EmojiReact, Like } from '@fedify/vocab';
+import type { EmojiReact } from '@fedify/vocab';
 
 const fallbackReactionType = '❤️';
 
@@ -23,13 +29,50 @@ export const handleInboundReaction = async (
   const actorUri = uniqueHref(activity.actorIds);
   const objectUri = uniqueHref(activity.objectIds);
   if (!isHttpUri(activityUri) || !actorUri || !objectUri) {
+    observeInboundRejected({
+      activityType: activity instanceof Like ? 'Like' : 'EmojiReact',
+      handler: 'reaction',
+      phase: 'validation',
+      reasonCode: 'invalid_reaction_identity',
+    });
     return;
   }
 
-  await materializeInboundReaction({
+  const result = await materializeInboundReaction({
     activityUri: activityUri.href,
     actorUri,
     objectUri,
+    onPostCommitError: (error) =>
+      observeInbound({
+        activityType: activity instanceof Like ? 'Like' : 'EmojiReact',
+        actorOrigin: actorUri,
+        error,
+        handler: 'reaction',
+        objectOrigin: objectUri,
+        outcome: 'internal_failure',
+        phase: 'effect',
+        reasonCode: 'reaction_notification_effect_failed',
+      }),
     type: toReactionType(activity),
   });
+  const activityType = activity instanceof Like ? 'Like' : 'EmojiReact';
+  if (result.kind === 'REJECTED') {
+    observeInboundRejected({
+      activityType,
+      actorOrigin: actorUri,
+      handler: 'reaction',
+      objectOrigin: objectUri,
+      phase: 'projection',
+      reasonCode: 'reaction_projection_rejected',
+    });
+  } else if (result.kind === 'DUPLICATE') {
+    observeInboundNoop({
+      activityType,
+      actorOrigin: actorUri,
+      handler: 'reaction',
+      objectOrigin: objectUri,
+      phase: 'projection',
+      reasonCode: 'duplicate_reaction_noop',
+    });
+  }
 };

--- a/packages/fedify/src/inbound-reject-follow.ts
+++ b/packages/fedify/src/inbound-reject-follow.ts
@@ -97,9 +97,20 @@ export const handleInboundRejectFollow = async ({
     return;
   }
 
-  await removeInboundFollow({
+  const removed = await removeInboundFollow({
     expectedRowId: projection.id,
     followeeProfileId,
     followerProfileId: followerProfile.id,
   });
+
+  if (!removed) {
+    observeInboundNoop({
+      activityType: 'Reject',
+      actorOrigin: followerActorUri.origin,
+      handler: 'reject',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'reject_follow_state_changed_noop',
+    });
+  }
 };

--- a/packages/fedify/src/inbound-reject-follow.ts
+++ b/packages/fedify/src/inbound-reject-follow.ts
@@ -6,7 +6,11 @@ import { and, eq } from 'drizzle-orm';
 import { isHttpUri } from './activitypub-uri';
 import { isCompatibleOutboundFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
-import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
+import {
+  observeInbound,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Follow } from '@fedify/vocab';
 
@@ -101,6 +105,17 @@ export const handleInboundRejectFollow = async ({
     expectedRowId: projection.id,
     followeeProfileId,
     followerProfileId: followerProfile.id,
+    onPostCommitError: (error) =>
+      observeInbound({
+        activityType: 'Reject',
+        actorOrigin: followerActorUri.origin,
+        error,
+        handler: 'reject',
+        objectOrigin: objectUri.origin,
+        outcome: 'internal_failure',
+        phase: 'effect',
+        reasonCode: 'follow_notification_effect_failed',
+      }),
   });
 
   if (!removed) {

--- a/packages/fedify/src/inbound-reject-follow.ts
+++ b/packages/fedify/src/inbound-reject-follow.ts
@@ -6,6 +6,7 @@ import { and, eq } from 'drizzle-orm';
 import { isHttpUri } from './activitypub-uri';
 import { isCompatibleOutboundFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
+import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Follow } from '@fedify/vocab';
 
@@ -27,11 +28,27 @@ export const handleInboundRejectFollow = async ({
     !isHttpUri(objectUri) ||
     objectUri.href !== followeeActorUri.href
   ) {
+    observeInboundRejected({
+      activityType: 'Reject',
+      actorOrigin: followerActorUri?.origin,
+      handler: 'reject',
+      objectOrigin: objectUri?.origin,
+      phase: 'protocol',
+      reasonCode: 'reject_follow_identity_mismatch',
+    });
     return;
   }
 
   const followerProfile = await resolveInboundLocalRecipient(context, followerActorUri);
   if (!followerProfile) {
+    observeInboundNoop({
+      activityType: 'Reject',
+      actorOrigin: followerActorUri.origin,
+      handler: 'reject',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'reject_follower_profile_missing',
+    });
     return;
   }
 
@@ -69,6 +86,14 @@ export const handleInboundRejectFollow = async ({
       projection,
     )
   ) {
+    observeInboundNoop({
+      activityType: 'Reject',
+      actorOrigin: followerActorUri.origin,
+      handler: 'reject',
+      objectOrigin: objectUri.origin,
+      phase: 'projection',
+      reasonCode: 'reject_follow_projection_missing_or_mismatched',
+    });
     return;
   }
 

--- a/packages/fedify/src/inbound-reject.ts
+++ b/packages/fedify/src/inbound-reject.ts
@@ -3,6 +3,11 @@ import '@kosmo/core/polyfill';
 import { Follow } from '@fedify/vocab';
 import { NotFoundError } from '@kosmo/core/error';
 import { isHttpUri } from './activitypub-uri';
+import {
+  observeInboundExternalFailure,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
 import { handleInboundRejectFollow } from './inbound-reject-follow';
 import { findUsableStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
@@ -14,6 +19,12 @@ export const handleInboundReject = async (
 ): Promise<void> => {
   const actorUri = reject.actorId;
   if (!isHttpUri(actorUri)) {
+    observeInboundRejected({
+      activityType: 'Reject',
+      handler: 'reject',
+      phase: 'validation',
+      reasonCode: 'invalid_actor_identity',
+    });
     return;
   }
 
@@ -22,11 +33,26 @@ export const handleInboundReject = async (
     remoteActor = await findUsableStoredRemoteProfileActorByUri(actorUri);
   } catch (error) {
     if (error instanceof NotFoundError) {
+      observeInboundNoop({
+        activityType: 'Reject',
+        actorOrigin: actorUri.origin,
+        error,
+        handler: 'reject',
+        phase: 'actor_lookup',
+        reasonCode: 'remote_actor_not_found',
+      });
       return;
     }
     throw error;
   }
   if (!remoteActor) {
+    observeInboundNoop({
+      activityType: 'Reject',
+      actorOrigin: actorUri.origin,
+      handler: 'reject',
+      phase: 'actor_lookup',
+      reasonCode: 'remote_actor_missing',
+    });
     return;
   }
 
@@ -34,6 +60,16 @@ export const handleInboundReject = async (
     documentLoader: context.documentLoader,
     suppressError: true,
   });
+  if (object === null) {
+    observeInboundExternalFailure({
+      activityType: 'Reject',
+      actorOrigin: actorUri.origin,
+      handler: 'reject',
+      phase: 'object_lookup',
+      reasonCode: 'reject_object_lookup_failed',
+    });
+    return;
+  }
   if (object instanceof Follow) {
     await handleInboundRejectFollow({
       context,
@@ -42,10 +78,14 @@ export const handleInboundReject = async (
       followeeProfileId: remoteActor.profile.id,
     });
   } else {
-    console.error('Inbound ActivityPub Reject object could not be resolved as Follow', {
-      actorUri: actorUri.href,
-      objectUri: reject.objectId?.href,
-      rejectId: reject.id?.href,
+    observeInboundExternalFailure({
+      activityType: 'Reject',
+      actorOrigin: actorUri.origin,
+      handler: 'reject',
+      objectOrigin: reject.objectId?.origin,
+      phase: 'protocol',
+      reasonCode: 'reject_object_not_follow',
+      message: 'Inbound ActivityPub Reject object could not be resolved as Follow',
     });
   }
 };

--- a/packages/fedify/src/inbound-update.test.ts
+++ b/packages/fedify/src/inbound-update.test.ts
@@ -11,6 +11,7 @@ import {
   ProfileMediaKind,
 } from '@kosmo/core/enums';
 import { and, eq, inArray } from 'drizzle-orm';
+import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
@@ -190,6 +191,38 @@ describe('inbound actor Update', () => {
         .then((rows) => rows.length),
       0,
     );
+  });
+
+  test('logs a failed Update object lookup once and returns', async () => {
+    await createRemoteActor(ProfileFollowPolicy.OPEN);
+    const logs: unknown[] = [];
+    const captures: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      captureException: (error) => captures.push(error),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      await handleInboundUpdate(
+        createContext(),
+        new Update({ actor: remoteActorUri, object: remoteActorUri }),
+      );
+
+      assert.equal(captures.length, 0);
+      assert.deepEqual(logs, [
+        {
+          activityType: 'Update',
+          actorOrigin: remoteActorUri.origin,
+          handler: 'update',
+          objectOrigin: remoteActorUri.origin,
+          outcome: 'external_failure',
+          phase: 'object_lookup',
+          reasonCode: 'update_object_lookup_failed',
+        },
+      ]);
+    } finally {
+      restore();
+    }
   });
 
   test('processes a duplicate update idempotently', async () => {

--- a/packages/fedify/src/inbound-update.ts
+++ b/packages/fedify/src/inbound-update.ts
@@ -4,6 +4,11 @@ import { isActor } from '@fedify/vocab';
 import { ConflictError } from '@kosmo/core/error';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
 import {
+  observeInboundExternalFailure,
+  observeInboundNoop,
+  observeInboundRejected,
+} from './inbound-observability';
+import {
   findStoredRemoteProfileActorByUri,
   materializeRemoteProfileActor,
   RemoteActorMaterializationError,
@@ -26,6 +31,14 @@ export const handleInboundUpdate = async (
   const objectUri = objectHref ? new URL(objectHref) : null;
 
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri) || actorUri.href !== objectUri.href) {
+    observeInboundRejected({
+      activityType: 'Update',
+      actorOrigin: actorUri?.origin,
+      handler: 'update',
+      objectOrigin: objectUri?.origin,
+      phase: 'validation',
+      reasonCode: 'update_actor_object_mismatch',
+    });
     return;
   }
 
@@ -34,13 +47,39 @@ export const handleInboundUpdate = async (
     documentLoader: noNetworkDocumentLoader,
     suppressError: true,
   });
+  if (object === null) {
+    observeInboundExternalFailure({
+      activityType: 'Update',
+      actorOrigin: actorUri?.origin,
+      handler: 'update',
+      objectOrigin: objectUri?.origin,
+      phase: 'object_lookup',
+      reasonCode: 'update_object_lookup_failed',
+    });
+  }
 
   if (!isActor(object) || object.id?.href !== actorUri.href) {
+    observeInboundRejected({
+      activityType: 'Update',
+      actorOrigin: actorUri.origin,
+      handler: 'update',
+      objectOrigin: objectUri.origin,
+      phase: 'protocol',
+      reasonCode: 'update_object_not_matching_actor',
+    });
     return;
   }
 
   const stored = await findStoredRemoteProfileActorByUri(actorUri);
   if (!stored) {
+    observeInboundNoop({
+      activityType: 'Update',
+      actorOrigin: actorUri.origin,
+      handler: 'update',
+      objectOrigin: objectUri.origin,
+      phase: 'actor_lookup',
+      reasonCode: 'remote_actor_missing',
+    });
     return;
   }
 
@@ -55,6 +94,14 @@ export const handleInboundUpdate = async (
     });
   } catch (error) {
     if (error instanceof ConflictError || error instanceof RemoteActorMaterializationError) {
+      observeInboundExternalFailure({
+        activityType: 'Update',
+        actorOrigin: actorUri.origin,
+        handler: 'update',
+        objectOrigin: objectUri.origin,
+        phase: 'projection',
+        reasonCode: 'remote_actor_projection_rejected',
+      });
       return;
     }
     throw error;

--- a/packages/fedify/src/inbound-update.ts
+++ b/packages/fedify/src/inbound-update.ts
@@ -56,6 +56,7 @@ export const handleInboundUpdate = async (
       phase: 'object_lookup',
       reasonCode: 'update_object_lookup_failed',
     });
+    return;
   }
 
   if (!isActor(object) || object.id?.href !== actorUri.href) {

--- a/packages/fedify/src/inbox.test.ts
+++ b/packages/fedify/src/inbox.test.ts
@@ -133,7 +133,9 @@ describe('Fedify inbox routes', () => {
     });
 
     try {
-      const error = new Error('internal projection failure');
+      const error = Object.assign(new SyntaxError('internal projection failure'), {
+        code: 'ECONNREFUSED',
+      });
       const fixture = await createInboxFixture(async () => {
         throw error;
       });

--- a/packages/fedify/src/inbox.test.ts
+++ b/packages/fedify/src/inbox.test.ts
@@ -8,7 +8,13 @@ import {
 } from '@fedify/fedify';
 import { CryptographicKey, EmojiReact, Follow, Like, Person } from '@fedify/vocab';
 import { getDocumentLoader } from '@fedify/vocab-runtime';
-import { setInboundObservabilityReporter, withInboundObservability } from './inbound-observability';
+import {
+  hasInboundErrorBeenObserved,
+  isExternalInboundError,
+  observeInbound,
+  setInboundObservabilityReporter,
+  withInboundObservability,
+} from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 
 type FollowHandler = (context: InboxContext<void>, activity: Follow) => void | Promise<void>;
@@ -194,6 +200,36 @@ describe('Fedify inbox routes', () => {
       restore();
     }
   });
+
+  test('normalizes primitive listener throws and captures once at the inbox boundary', async () => {
+    const captures: unknown[] = [];
+    const logs: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      captureException: (error, context) => captures.push({ context, error }),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      const fixture = await createInboxFixture(async () => {
+        throw 'primitive listener failure';
+      });
+      const response = await fixture.federation.fetch(
+        await fixture.createSignedFollowRequest('/inbox', 'primitive-shared'),
+        { contextData: undefined },
+      );
+
+      assert.equal(response.status, 500);
+      assert.equal(captures.length, 1);
+      assert.equal(logs.length, 1);
+      assert.equal((captures[0] as { error: unknown }).error instanceof Error, true);
+      assert.equal(
+        (captures[0] as { error: Error }).error.message,
+        'ActivityPub inbound listener threw a non-Error value',
+      );
+    } finally {
+      restore();
+    }
+  });
 });
 
 const createInboxFixture = async (onFollow: FollowHandler) => {
@@ -236,7 +272,22 @@ const createInboxFixture = async (onFollow: FollowHandler) => {
     .setKeyPairsDispatcher(() => [localKeyPair]);
   federation
     .setInboxListeners('/ap/actor/{identifier}/inbox', '/inbox')
-    .on(Follow, withInboundObservability('follow', onFollow));
+    .on(Follow, withInboundObservability('follow', onFollow))
+    .onError((_context, error) => {
+      if (hasInboundErrorBeenObserved(error)) {
+        return;
+      }
+
+      const external = error instanceof SyntaxError || isExternalInboundError(error);
+      observeInbound({
+        activityType: 'Unknown',
+        error,
+        handler: 'listener',
+        outcome: external ? 'external_failure' : 'internal_failure',
+        phase: 'listener',
+        reasonCode: external ? 'external_listener_error' : 'unexpected_listener_error',
+      });
+    });
 
   const createSignedFollowRequest = async (path: string, id: string): Promise<Request> => {
     const activity = new Follow({

--- a/packages/fedify/src/inbox.test.ts
+++ b/packages/fedify/src/inbox.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@fedify/fedify';
 import { CryptographicKey, EmojiReact, Follow, Like, Person } from '@fedify/vocab';
 import { getDocumentLoader } from '@fedify/vocab-runtime';
+import { setInboundObservabilityReporter, withInboundObservability } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 
 type FollowHandler = (context: InboxContext<void>, activity: Follow) => void | Promise<void>;
@@ -122,6 +123,75 @@ describe('Fedify inbox routes', () => {
       assert.equal(response.status, 404);
     }
   });
+
+  test('keeps listener errors observable without changing personal/shared inbox responses', async () => {
+    const captures: unknown[] = [];
+    const logs: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      captureException: (error, context) => captures.push({ context, error }),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      const error = new Error('internal projection failure');
+      const fixture = await createInboxFixture(async () => {
+        throw error;
+      });
+      const personalResponse = await fixture.federation.fetch(
+        await fixture.createSignedFollowRequest(
+          `/ap/actor/${localProfileId}/inbox`,
+          'internal-personal',
+        ),
+        { contextData: undefined },
+      );
+      const sharedResponse = await fixture.federation.fetch(
+        await fixture.createSignedFollowRequest('/inbox', 'internal-shared'),
+        { contextData: undefined },
+      );
+
+      assert.equal(personalResponse.status, 500);
+      assert.equal(sharedResponse.status, 500);
+      assert.equal(captures.length, 2);
+      assert.equal(logs.length, 2);
+      assert.deepEqual((captures[0] as { context: { tags: object } }).context.tags, {
+        activity_type: 'Follow',
+        handler: 'follow',
+        outcome: 'internal_failure',
+        phase: 'listener',
+        reason_code: 'unexpected_listener_error',
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  test('does not capture a remote listener failure', async () => {
+    const captures: unknown[] = [];
+    const logs: unknown[] = [];
+    const restore = setInboundObservabilityReporter({
+      captureException: (error) => captures.push(error),
+      log: (observation) => logs.push(observation),
+    });
+
+    try {
+      const error = new Error('remote timeout');
+      error.name = 'FetchError';
+      const fixture = await createInboxFixture(async () => {
+        throw error;
+      });
+      const response = await fixture.federation.fetch(
+        await fixture.createSignedFollowRequest('/inbox', 'external-shared'),
+        { contextData: undefined },
+      );
+
+      assert.equal(response.status, 500);
+      assert.equal(captures.length, 0);
+      assert.equal(logs.length, 1);
+      assert.equal((logs[0] as { outcome: string }).outcome, 'external_failure');
+    } finally {
+      restore();
+    }
+  });
 });
 
 const createInboxFixture = async (onFollow: FollowHandler) => {
@@ -162,7 +232,9 @@ const createInboxFixture = async (onFollow: FollowHandler) => {
       identifier === localProfileId ? new Person({ id: context.getActorUri(identifier) }) : null,
     )
     .setKeyPairsDispatcher(() => [localKeyPair]);
-  federation.setInboxListeners('/ap/actor/{identifier}/inbox', '/inbox').on(Follow, onFollow);
+  federation
+    .setInboxListeners('/ap/actor/{identifier}/inbox', '/inbox')
+    .on(Follow, withInboundObservability('follow', onFollow));
 
   const createSignedFollowRequest = async (path: string, id: string): Promise<Request> => {
     const activity = new Follow({


### PR DESCRIPTION
## 무엇을 변경했는지

- production에 등록된 Accept, Announce, Create, Delete, Follow, Like/EmojiReact, Reject, Undo, Update listener의 처리된 실패와 no-op을 공통 inbound 관측 경계로 연결했습니다.
- `activity_type`, `handler`, `phase`, `outcome`, bounded `reason_code`를 구조화하고 URI는 origin 수준 context로만 제한했습니다.
- Fedify package에는 Sentry SDK를 넣지 않고 Web BFF가 기존 Sentry reporter를 주입하도록 구성했습니다.
- inbound Reply, Follow, Reaction의 내부 notification effect 실패가 기존 commit 결과를 유지하면서 reporter에 전달되도록 core service에 optional callback seam을 추가했습니다.
- malformed JSON, generic socket code, Update/Undo lookup, Announce Undo와 pending Follow의 관측 회귀를 수정하고 테스트했습니다.
- OpenSpec `add-inbound-activitypub-observability`, 운영 문서, helper/handler/listener/runtime 회귀 테스트를 함께 추가했습니다.

## 왜 변경했는지

PROD-634는 inbound ActivityPub handler의 `suppressError`, 처리된 catch, silent no-op과 post-commit effect 실패가 서로 다른 방식으로 사라져 운영 조사에서 정상 거절과 실제 Kosmo 오류를 구분하기 어려운 문제를 해결합니다. Activity 처리·검증·저장·멱등 결과는 바꾸지 않고, 공통 검색 기준과 Sentry 경계를 제공합니다.

## 이번 PR의 주요 결정

### 리모트 서버와 protocol 원인의 실패는 로그 전용으로 둔다

- 결정자: @robin-maki
- 선택: remote 5xx, timeout, DNS/connection, 외부 document/actor lookup, protocol 비호환·해석 및 외부 delivery 실패는 구조화 로그만 남기고 Sentry에는 보내지 않습니다.
- 고려한 대안: action 가능한 모든 외부 실패를 Sentry에 capture합니다.
- 이유: 외부 서버 장애를 Kosmo 내부 결함과 분리하고 Sentry issue 노이즈를 만들지 않기 위해서입니다.
- 감수한 결과: 외부 장애 조사는 bounded reason/phase와 origin context를 가진 운영 로그에 의존합니다.
- 관련 근거: [PROD-634](https://linear.app/byulmaru/issue/PROD-634), [`decisions.md`](https://github.com/byulmaru/kosmo/blob/PROD-634/openspec/changes/add-inbound-activitypub-observability/decisions.md)

오류 경계는 다음처럼 적용합니다.

| 발생 경계 | 구조화 로그 | Sentry |
| --- | --- | --- |
| malformed/foreign/mismatched activity, 보안·정책 거절, 멱등 no-op | 1회 | 제외 |
| remote lookup/materialization/protocol/delivery에서 처리된 외부 실패 | 1회 | 제외 |
| typed listener 도달 전 malformed JSON `SyntaxError` | 1회 | 제외 |
| `AbortError`, `FetchError`, `RemoteActorMaterializationError`, `SendActivityError`, `UrlError`, `WebFingerError` 또는 같은 이름의 cause | 1회 | 제외 |
| DB projection, 내부 post-commit effect, typed listener의 예상하지 못한 오류 | 1회 | 1회 capture |
| typed listener의 일반 오류에 붙은 `ECONNREFUSED`, `ECONNRESET` 등 generic code | 1회 | 내부 오류로 1회 capture |

### 내부 오류 반복량은 Sentry SDK와 ingest 정책에 맡긴다

- 결정자: @robin-maki
- 선택: 애플리케이션 내부 rate limiter/sampler는 추가하지 않고 stable grouping metadata만 제공합니다.
- 고려한 대안: process-local rate limiter 또는 Sentry capture 전용 sampler를 둡니다.
- 이유: 별도 분산 상태와 운영 정책을 만들지 않고 기존 Sentry 전송 정책을 유지하기 위해서입니다.
- 감수한 결과: ingest 제한 전에 동일 내부 오류 event가 반복 전송될 수 있습니다.
- 관련 근거: [PROD-634](https://linear.app/byulmaru/issue/PROD-634), [`decisions.md`](https://github.com/byulmaru/kosmo/blob/PROD-634/openspec/changes/add-inbound-activitypub-observability/decisions.md)

그 밖의 새 material decision은 없습니다. 최신 canonical·Linear와 대조한 OpenSpec 결정을 변경 없이 적용했습니다.

## 어떻게 확인할 수 있는지

- `pnpm exec openspec validate add-inbound-activitypub-observability --strict`
- `pnpm test:fedify` — 206 tests
- malformed JSON → HTTP 400, log 1회, Sentry 0회
- typed `SyntaxError` + `ECONNREFUSED` → 기존 HTTP 500 의미 유지, 내부 Sentry capture
- Follow/Undo 16 tests, Announce/Undo 11 tests, Update 6 tests, observability/inbox 10 tests
- `pnpm --filter @kosmo/fedify lint:tsc`
- ESLint, Prettier, `git diff --check`

## 아직 어떤 문제가 남았는지

없음. OpenSpec 전체 change의 archive는 이 PR merge 및 완료 상태 확인 뒤 별도로 판단합니다.
