### PR TITLE
Barman recovery window 상태를 기록할 수 있게 한다

### DIFF
--- a/apps/helm/templates/postgres-backup.yaml
+++ b/apps/helm/templates/postgres-backup.yaml
@@ -27,6 +27,14 @@ rules:
       - kosmo-postgres-backup
     verbs:
       - get
+  - apiGroups:
+      - barmancloud.cnpg.io
+    resources:
+      - objectstores/status
+    resourceNames:
+      - kosmo-postgres-backup
+    verbs:
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/apps/helm/test-render.sh
+++ b/apps/helm/test-render.sh
@@ -209,6 +209,8 @@ done
 
 required_prod_markers=(
   "kind: ServiceAccount"
+  "kind: Role"
+  "name: kosmo-postgres-backup-objectstore-reader"
   "name: kosmo-postgres-backup"
   "kind: ObjectStore"
   "destinationPath: s3://byulmaru-kosmo-prod-postgresql-backups-822638974464/kosmo-prod/"
@@ -232,6 +234,119 @@ for marker in "${required_prod_markers[@]}"; do
     exit 1
   fi
 done
+
+if ! awk '
+  function reset_document() {
+    kind = ""
+    name = ""
+    current_resource = ""
+    body_name = body_get = 0
+    status_name = status_update = 0
+    in_resources = in_resource_names = in_verbs = 0
+    resource_count = resource_name_count = verb_count = 0
+    forbidden_resource = forbidden_name = forbidden_verb = 0
+    rule_count = 0
+  }
+  function check_document() {
+    if (kind != "Role" || name != "kosmo-postgres-backup-objectstore-reader") {
+      return 0
+    }
+    found = 1
+    return rule_count == 2 && resource_count == 2 && resource_name_count == 2 && verb_count == 2 &&
+      body_name && body_get && status_name && status_update &&
+      !forbidden_resource && !forbidden_name && !forbidden_verb
+  }
+  BEGIN { reset_document() }
+  /^---$/ {
+    if (check_document()) {
+      valid = 1
+    }
+    reset_document()
+    next
+  }
+  $0 == "kind: Role" { kind = "Role"; next }
+  kind == "Role" && $0 == "  name: kosmo-postgres-backup-objectstore-reader" {
+    name = "kosmo-postgres-backup-objectstore-reader"
+    next
+  }
+  name != "" && $0 == "  - apiGroups:" {
+    in_resources = in_resource_names = in_verbs = 0
+    next
+  }
+  name != "" && $0 == "    resources:" {
+    current_resource = ""
+    in_resources = 1
+    in_resource_names = in_verbs = 0
+    rule_count++
+    next
+  }
+  name != "" && in_resources && $0 == "      - objectstores" {
+    current_resource = "objectstores"
+    resource_count++
+    next
+  }
+  name != "" && in_resources && $0 == "      - objectstores/status" {
+    current_resource = "objectstores/status"
+    resource_count++
+    next
+  }
+  name != "" && in_resources && $0 ~ /^      - / {
+    forbidden_resource = 1
+    next
+  }
+  name != "" && $0 == "    resourceNames:" {
+    in_resources = in_verbs = 0
+    in_resource_names = 1
+    next
+  }
+  name != "" && in_resource_names && $0 == "      - kosmo-postgres-backup" && current_resource == "objectstores" {
+    body_name = 1
+    resource_name_count++
+    next
+  }
+  name != "" && in_resource_names && $0 == "      - kosmo-postgres-backup" && current_resource == "objectstores/status" {
+    status_name = 1
+    resource_name_count++
+    next
+  }
+  name != "" && in_resource_names && $0 ~ /^      - / {
+    forbidden_name = 1
+    next
+  }
+  name != "" && $0 == "    verbs:" {
+    in_resources = in_resource_names = 0
+    in_verbs = 1
+    next
+  }
+  name != "" && in_verbs && $0 == "      - get" && current_resource == "objectstores" {
+    body_get = 1
+    verb_count++
+    next
+  }
+  name != "" && in_verbs && $0 == "      - update" && current_resource == "objectstores/status" {
+    status_update = 1
+    verb_count++
+    next
+  }
+  name != "" && in_verbs && $0 ~ /^      - / {
+    forbidden_verb = 1
+    next
+  }
+  END {
+    if (check_document()) {
+      valid = 1
+    }
+    exit !(found && valid)
+  }
+' "${render_dir}/prod-runtime.yaml"; then
+  echo "prod ObjectStore Role must grant only exact-name get and status update" >&2
+  exit 1
+fi
+
+if grep -Fq 'objectstores/status' "${render_dir}/dev.yaml" || grep -Fq 'kosmo-postgres-backup-objectstore-reader' "${render_dir}/dev.yaml"; then
+  echo "dev manifest unexpectedly contains ObjectStore RBAC" >&2
+  exit 1
+fi
 
 required_migration_markers=(
   "ghcr.io/byulmaru/kosmo@${image_digest}"

--- a/docs/operations/postgres-backup.md
+++ b/docs/operations/postgres-backup.md
@@ -31,8 +31,13 @@ kubectl get backup -n kosmo-prod --sort-by=.metadata.creationTimestamp
 ```sh
 kubectl describe objectstore kosmo-postgres-backup -n kosmo-prod
 kubectl get serviceaccount kosmo-postgres-backup -n kosmo-prod -o yaml
-kubectl auth can-i get objectstores.barmancloud.cnpg.io \
-  --resource-name=kosmo-postgres-backup \
+kubectl auth whoami \
+  --as=system:serviceaccount:kosmo-prod:kosmo-postgres-backup
+kubectl auth can-i get objectstores.barmancloud.cnpg.io/kosmo-postgres-backup \
+  --namespace=kosmo-prod \
+  --as=system:serviceaccount:kosmo-prod:kosmo-postgres-backup
+kubectl auth can-i update objectstores.barmancloud.cnpg.io/kosmo-postgres-backup \
+  --subresource=status \
   --namespace=kosmo-prod \
   --as=system:serviceaccount:kosmo-prod:kosmo-postgres-backup
 aws eks list-pod-identity-associations --cluster-name byulmaru --region ap-northeast-2
@@ -49,7 +54,7 @@ kubectl logs -n kosmo-prod POD_NAME -c PLUGIN_SIDECAR_NAME --since=30m
 
 - `AccessDenied`: association의 namespace, ServiceAccount, role ARN과 요청된 S3 prefix를 확인한다.
 - credential endpoint 오류: `eks-pod-identity-agent` 상태와 Pod 재생성 후 credential 주입 여부를 확인한다.
-- ObjectStore/plugin 연결 오류: `cnpg-system`의 plugin Deployment, client/server Certificate와 ObjectStore condition을 확인한다.
+- ObjectStore/plugin 연결 오류: `cnpg-system`의 plugin Deployment, client/server Certificate와 ObjectStore condition을 확인한다. `auth whoami`가 요청한 ServiceAccount가 아니라 관리자 identity를 반환하면 proxy가 impersonation을 무시한 것이므로 이어지는 `can-i`의 `yes`를 workload 권한 증거로 사용하지 않는다. 유효한 ServiceAccount identity에서 두 `can-i` 결과가 각각 `yes`인지 확인한다. 첫 번째는 정확한 `kosmo-postgres-backup` ObjectStore 본문 조회이고, 두 번째는 같은 이름의 `objectstores/status` recovery-window 상태 갱신이다. 본문 `update`·`patch`·`create`·`delete`나 다른 ObjectStore 이름에 대한 권한은 `no`여야 한다.
 - WAL archive 오류가 지속되면 새 base backup을 실행하기 전에 원인을 해결한다. WAL 연속성이 끊긴 기간은 복구 가능 시점에서 제외될 수 있다.
 
 ## On-demand base backup

--- a/openspec/changes/add-production-postgres-s3-backups/decisions.md
+++ b/openspec/changes/add-production-postgres-s3-backups/decisions.md
@@ -59,10 +59,22 @@
 - Authority / Provenance: Linear `PROD-546`, `PROD-551`
 - Status: Active
 - Context / Problem: 아직 production Application이 없는 동안 선언을 먼저 병합하되 dev database에 backup 자원이나 AWS identity 의존성을 추가하면 안 된다.
-- Decision Outcome: `kosmo-postgres-backup` ServiceAccount, ObjectStore, Cluster plugin/WAL 설정과 ScheduledBackup은 prod values에서만 렌더한다. PostgreSQL Pod의 plugin이 ObjectStore를 읽을 수 있도록 같은 ServiceAccount에 동명 ObjectStore 하나의 `get`만 허용하는 namespaced Role/RoleBinding을 함께 렌더한다. Dev manifest는 현재 상태를 유지한다.
+- Decision Outcome: `kosmo-postgres-backup` ServiceAccount, ObjectStore, Cluster plugin/WAL 설정과 ScheduledBackup은 prod values에서만 렌더한다. PostgreSQL Pod의 plugin이 ObjectStore를 읽고 recovery window 상태를 기록할 수 있도록 같은 ServiceAccount에 동명 ObjectStore 본문 `get`과 `objectstores/status` `update`만 허용하는 namespaced Role/RoleBinding을 함께 렌더한다. Dev manifest는 현재 상태를 유지한다.
 - Alternatives Considered: 모든 환경에 resource를 만들고 dev에서 비활성화하는 방식은 불필요한 CR과 identity 계약을 남겨 제외했다. 별도 chart는 공통 Cluster 선언이 중복되어 제외했다.
-- Consequences: dev/prod 양쪽의 render test가 필요하고 production 값이 활성화되기 전에는 live backup 검증이 불가능하다. ServiceAccount는 다른 ObjectStore나 write verb를 사용할 수 없다.
-- Confirmation / Follow-up: Role/RoleBinding은 API server dry-run을 통과해야 하고, 적용 후 exact ObjectStore `get`은 `kubectl auth can-i`로 검증한다. Backup과 WAL archive 성공을 실제 상태로 확인한다.
+- Consequences: dev/prod 양쪽의 render test가 필요하고 production 값이 활성화되기 전에는 live backup 검증이 불가능하다. ServiceAccount는 다른 ObjectStore, ObjectStore 본문 write 또는 status `update` 이외의 write verb를 사용할 수 없다.
+- Confirmation / Follow-up: Role/RoleBinding은 API server dry-run을 통과해야 하고, 적용 후 exact ObjectStore 본문 `get`과 status `update`는 유효한 workload identity의 `kubectl auth can-i`로 검증한다. Backup, WAL archive와 recovery window 상태 갱신 성공을 실제 상태로 확인한다.
+
+### ObjectStore recovery window 상태 갱신 최소 권한
+
+- Decision Date: 2026-08-04
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-546`
+- Status: Active
+- Context / Problem: 2026-08-04 live activation에서 최근 `Backup` CR은 completed이고 S3 Barman catalog에는 DONE backup 5개, `ContinuousArchiving=True`와 WAL 정상 상태가 있었지만, `Backup completed` 직후 plugin이 recovery window를 갱신하면서 `cannot update resource objectstores/status`를 기록했다. 기존 `get` 전용 RBAC는 이 실제 plugin 동작을 허용하지 않았다.
+- Decision Outcome: `kosmo-prod/kosmo-postgres-backup` ServiceAccount를 계속 namespaced Role/RoleBinding으로 제한하되, `objectstores`의 exact-name `kosmo-postgres-backup`에는 `get`만, `objectstores/status`의 같은 exact name에는 `update`만 추가한다. ObjectStore 본문 또는 status에 `patch`·`create`·`delete`를 허용하지 않고, 다른 ObjectStore 이름·list/watch·cluster-wide 접근도 허용하지 않는다.
+- Alternatives Considered: ObjectStore 전체에 `update` 또는 `patch`를 허용하는 방식은 recovery-window 상태보다 넓은 쓰기 범위를 만들어 제외했다. `create`·`delete`나 resourceNames 없는 Role, ClusterRole은 이름·namespace 경계를 잃으므로 제외했다. `get`만 유지하는 방식은 live plugin 오류를 해결하지 못해 제외했다.
+- Consequences: plugin이 Backup 완료 후 exact ObjectStore status를 갱신할 수 있는 최소 추가 권한을 얻는다. 선언형 render와 API server dry-run·`kubectl auth can-i`로 권한을 확인할 수 있지만, post-merge live plugin 성공과 recovery-window 관측은 별도 증거가 생길 때까지 미완료다.
+- Confirmation / Follow-up: Helm prod/dev render assertion, OpenSpec strict validation, server-side dry-run과 exact-name `get`·`objectstores/status` `update` `can-i` 결과를 PR에 기록한다. 실제 production에 manifest를 apply하지 않으며, merge 뒤 plugin 로그와 ObjectStore status를 다시 확인한다.
 
 ### 원본 쓰기 없는 격리 PITR rehearsal
 
@@ -106,4 +118,4 @@
 
 ## Superseded Decisions
 
-- 없음.
+- `Production 전용 렌더 경계` (2026-07-29)의 `kosmo-postgres-backup` ObjectStore `get` 전용 wording은 2026-08-04 live plugin evidence와 `ObjectStore recovery window 상태 갱신 최소 권한` 결정으로 대체했다. Production-only render, namespaced Role/RoleBinding과 exact-name 경계는 유지하고 `objectstores/status` exact-name `update`만 추가한다.

--- a/openspec/changes/add-production-postgres-s3-backups/design.md
+++ b/openspec/changes/add-production-postgres-s3-backups/design.md
@@ -32,12 +32,13 @@ CloudNativePG 1.30.0에서는 내장 `barmanObjectStore` 경로가 deprecated되
 - Kubernetes CI의 `iam:PassRole` 범위는 `byulmaru*` role 이름에 한정되어 있다.
 - Kosmo Terraform bootstrap policy는 새 bucket과 role을 관리할 최소 권한을 plan 전에 먼저 받아야 한다.
 - production Application과 Cluster가 아직 없으므로 선언형 검증은 가능하지만 live backup/restore 검증은 `PROD-545` 준비 이후에만 가능하다.
+- 2026-08-04 live activation에서는 최근 `Backup` CR이 completed이고 S3 Barman catalog에 DONE backup 5개, `ContinuousArchiving=True`와 WAL 정상 상태가 확인되었지만, backup 완료 직후 plugin이 recovery window를 갱신하면서 `cannot update resource objectstores/status`를 기록했다. 따라서 기존 ObjectStore 본문 `get`만으로는 현재 plugin 동작 계약을 충족하지 않는다.
 
 ### Recommended Approach
 
 1. `PROD-549`에서 `ap-northeast-2`의 `byulmaru-kosmo-prod-postgresql-backups-822638974464` bucket과 `byulmaru-kosmo-prod-postgres-backup` role을 만든다. Role은 Barman의 `HeadBucket` 확인에 필요한 bucket-level list 권한을 이 전용 bucket에만 허용하고 객체 작업은 `kosmo-prod/` prefix로 제한한다. Bucket 객체는 S3의 기본 SSE-S3 암호화를 사용하며 별도 default encryption resource를 관리하지 않는다. Bucket에는 public access block, TLS-only policy, versioning, current 10일/non-current 30일/incomplete multipart 1일 lifecycle, `prevent_destroy = true`, `force_destroy = false`를 적용한다.
 2. `PROD-550`에서 공식 CNPG Helm repository의 `plugin-barman-cloud` chart 0.7.0(app v0.13.0)을 `cnpg-system`에 설치한다. CloudNativePG operator와 cert-manager 이후 준비되게 하고 같은 role을 `kosmo-prod/kosmo-postgres-backup`, `kosmo-prod-restore/kosmo-postgres-backup`에 연결한다.
-3. `PROD-551`에서 prod 값에만 ServiceAccount, ObjectStore, Cluster plugin과 ScheduledBackup을 렌더한다. ObjectStore는 IAM role을 상속하고 7일 retention을 사용한다. Cluster는 plugin을 WAL archiver로 지정하고 `archive_timeout=4min`을 사용한다. ScheduledBackup은 plugin method, self ownership, immediate 실행과 6-field UTC cron `0 0 18 * * *`을 사용한다.
+3. `PROD-551`에서 prod 값에만 ServiceAccount, ObjectStore, Cluster plugin과 ScheduledBackup을 렌더한다. ObjectStore는 IAM role을 상속하고 7일 retention을 사용한다. Cluster는 plugin을 WAL archiver로 지정하고 `archive_timeout=4min`을 사용한다. ScheduledBackup은 plugin method, self ownership, immediate 실행과 6-field UTC cron `0 0 18 * * *`을 사용한다. Backup ServiceAccount의 namespaced Role은 `kosmo-postgres-backup` 본문에 exact-name `get` 하나와 `objectstores/status`에 exact-name `update` 하나만 허용하며, 본문·status의 `patch`·`create`·`delete` 및 다른 이름·cluster-wide 권한을 부여하지 않는다.
 4. runbook은 on-demand backup, 상태·접근 장애 확인, 격리된 PITR restore, 검증과 정리를 포함한다. Application write pause 중 불변 snapshot과 named restore point를 만들고 WAL 전환을 강제하지 않은 상태에서 실제 workload 또는 `archive_timeout`에 따른 대상 WAL의 자연 archive 성공을 확인한 뒤 restore를 시작한다. 이후 현재 production count를 비교 기준으로 사용하지 않는다. Restore workload는 source prefix를 읽을 수 있지만 ScheduledBackup 또는 WAL archiver destination을 구성하지 않는다.
 
 ### Allowed Alternatives
@@ -53,6 +54,7 @@ CloudNativePG 1.30.0에서는 내장 `barmanObjectStore` 경로가 deprecated되
 - S3/IAM 적용 전에 Pod Identity association을 만들거나 plugin 준비 전에 workload backup을 활성화하지 않는다.
 - restore Cluster에 production과 같은 WAL archiver destination 또는 ScheduledBackup을 연결하지 않는다.
 - dev render에 ServiceAccount, ObjectStore, plugin 또는 ScheduledBackup이 섞이지 않게 한다.
+- `objectstores` 본문과 `objectstores/status`는 Kubernetes RBAC에서 별도 resource rule이다. status 갱신을 위해 ObjectStore 전체에 `update`·`patch`를 주거나 `resourceNames`를 생략하지 않는다.
 - CloudNativePG schedule은 일반 5-field cron이 아니라 초를 포함한 6-field 표현식이다.
 - S3 lifecycle이 7일 recovery window보다 먼저 필요한 current object를 지우지 않게 한다.
 - 실제 backup/restore 증거가 없는데 `PROD-546` 또는 OpenSpec을 완료·archive하지 않는다.
@@ -61,6 +63,7 @@ CloudNativePG 1.30.0에서는 내장 `barmanObjectStore` 경로가 deprecated되
 
 - [S3 lifecycle과 Barman retention 정리 시점이 어긋날 수 있음] → current object에 10일 여유를 두고 versioning/non-current 30일을 유지하며 최초 backup 후 실제 object 만료 상태를 확인한다.
 - [S3 또는 Pod Identity 장애가 WAL archive를 지연시킬 수 있음] → Cluster/ObjectStore/plugin 상태와 로그를 runbook에서 수동 확인하고 자동 알림은 `PROD-552`에서 추가한다.
+- [plugin이 recovery window 상태를 갱신하지 못할 수 있음] → exact-name `objectstores/status` `update`만 추가하고 Helm render, API server dry-run과 `kubectl auth can-i`로 본문 `get`·status `update`를 각각 검증한다. 실제 post-merge plugin 상태는 live 검증이 끝날 때까지 완료로 표시하지 않는다.
 - [일일 base backup이 database I/O를 증가시킬 수 있음] → 초기 10Gi 규모에서는 plugin 기본 압축·병렬화로 시작하고 실제 소요 시간과 영향이 문제일 때만 후속 조정한다.
 - [서울 단일 bucket은 리전 재해를 방어하지 못함] → 이번 RPO/RTO는 cluster/PVC와 운영 장애 범위로 한정하고 cross-region/account DR은 별도 계약으로 남긴다.
 - [production 준비 지연으로 복구 가능성이 선언만 된 상태가 지속될 수 있음] → 선언형 PR은 병합하되 live rehearsal task, `PROD-546`과 OpenSpec을 열린 상태로 유지한다.
@@ -69,8 +72,8 @@ CloudNativePG 1.30.0에서는 내장 `barmanObjectStore` 경로가 deprecated되
 
 1. `PROD-549`의 Kosmo Terraform plan을 검토·적용해 bucket과 role을 먼저 준비한다.
 2. `PROD-550`의 Kubernetes Terraform plan을 검토·적용해 plugin과 두 Pod Identity association을 준비하고 live 상태를 확인한다.
-3. `PROD-551`의 Helm/runbook 변경을 병합한다. dev render에는 변화가 없어야 한다.
-4. `PROD-545`가 production Cluster를 제공하면 production Application을 동기화하고 immediate backup, WAL archive와 S3 object를 확인한다.
+3. `PROD-551`의 Helm/runbook 변경을 병합한다. dev render에는 변화가 없어야 한다. 변경 전후 Role/RoleBinding을 API server server-side dry-run으로 검증하고, 실제 ServiceAccount identity로 인증된 context에서 exact-name `get`과 `objectstores/status` `update`의 `kubectl auth can-i` 결과를 기록한다. 관리자 proxy가 반환한 `yes`는 workload permission evidence로 사용하지 않는다. 어떠한 manifest도 production에 apply하지 않는다.
+4. `PROD-545`가 production Cluster를 제공하면 production Application을 동기화하고 immediate backup, WAL archive와 S3 object를 확인한다. 이 post-merge live 검증 전에는 recovery-window 갱신 성공을 가정하지 않는다.
 5. 별도 restore namespace에서 PITR rehearsal과 RPO/RTO·데이터 검증을 수행하고 증거를 `PROD-546`에 남긴 뒤 namespace를 제거한다.
 6. 이후 월 1회 같은 rehearsal을 수행한다. 최초 live 검증 전에는 이 change를 archive하지 않는다.
 

--- a/openspec/changes/add-production-postgres-s3-backups/specs/production-postgres-backup/spec.md
+++ b/openspec/changes/add-production-postgres-s3-backups/specs/production-postgres-backup/spec.md
@@ -18,7 +18,7 @@
 
 **Authority / Provenance:** `PROD-546`. 시스템은 production backup과 별도 restore workload가 EKS Pod Identity로 같은 최소 권한 IAM role의 단기 자격 증명을 받게 해야 한다(MUST). 시스템은 AWS access key, secret key 또는 session token을 repository, Kubernetes Secret이나 workflow 입력으로 저장해서는 안 된다. 이 role은 Barman의 `HeadBucket` 확인에 필요한 bucket-level list 권한을 전용 backup bucket 하나에만 가져야 하며(MUST), 객체 읽기·쓰기·삭제와 multipart 권한은 prod prefix로 제한해야 한다(MUST).
 
-Production backup ServiceAccount는 같은 namespace의 `kosmo-postgres-backup` ObjectStore 하나를 읽을 수 있어야 하며(MUST), 다른 ObjectStore나 write verb 권한을 받아서는 안 된다(MUST NOT).
+Production backup ServiceAccount는 같은 namespace에서 이름이 `kosmo-postgres-backup`인 ObjectStore 본문을 `get`할 수 있어야 하며, 같은 exact-name `objectstores/status` 서브리소스를 `update`할 수 있어야 한다(MUST). 다른 ObjectStore 이름이나 ObjectStore 본문에 대한 `update`, `patch`, `create`, `delete` 및 `list`·`watch` 권한은 받아서는 안 되며, cluster-wide 권한도 없어야 한다(MUST NOT).
 
 #### Scenario: Production backup Pod의 S3 접근
 
@@ -30,10 +30,15 @@ Production backup ServiceAccount는 같은 namespace의 `kosmo-postgres-backup` 
 - **WHEN** `kosmo-prod-restore`의 복구 Pod가 source backup을 읽는다
 - **THEN** 같은 이름의 restore ServiceAccount에 연결된 Pod Identity role로 source prefix를 읽고 static credential을 사용하지 않는다
 
-#### Scenario: Production plugin의 ObjectStore 조회
+#### Scenario: Production plugin의 ObjectStore 조회와 recovery window 상태 갱신
 
 - **WHEN** production PostgreSQL Pod의 Barman plugin이 backup 설정을 해석한다
-- **THEN** `kosmo-postgres-backup` ServiceAccount는 같은 namespace의 동명 ObjectStore에 대한 `get`만 허용받고 WAL archive와 base backup을 시작할 수 있다
+- **THEN** `kosmo-postgres-backup` ServiceAccount는 같은 namespace의 동명 ObjectStore 본문을 `get`하고 `objectstores/status`를 `update`해 recovery window 상태를 갱신할 수 있으며 WAL archive와 base backup을 시작할 수 있다
+
+#### Scenario: ObjectStore RBAC의 exact-name 최소 권한
+
+- **WHEN** 해당 ServiceAccount가 다른 ObjectStore나 ObjectStore 본문·서브리소스에 쓰기 또는 cluster-wide 조회를 시도한다
+- **THEN** `update`, `patch`, `create`, `delete`, `list`, `watch`가 거부되고 `kosmo-postgres-backup`의 `objectstores/status` `update`만 허용된다
 
 ### Requirement: 연속 WAL archive와 매일 base backup
 

--- a/openspec/changes/add-production-postgres-s3-backups/tasks.md
+++ b/openspec/changes/add-production-postgres-s3-backups/tasks.md
@@ -72,7 +72,7 @@ Production CNPG Cluster가 5분 WAL archive 목표와 매일 03:00 KST base back
 
 - Backup resource와 Cluster 설정은 prod에서만 렌더하며 dev manifest에는 나타나지 않는다.
 - Production Cluster는 `kosmo-postgres-backup` ServiceAccount를 사용하고 ObjectStore는 IAM role 상속으로 고정 bucket의 `kosmo-prod/` prefix에 연결한다.
-- Production ServiceAccount에는 같은 namespace의 동명 ObjectStore 하나를 읽는 `get`만 허용하고 다른 ObjectStore나 write verb 권한을 부여하지 않는다.
+- Production ServiceAccount에는 같은 namespace의 exact-name `kosmo-postgres-backup` ObjectStore 본문 `get`과 같은 이름의 `objectstores/status` `update`만 허용한다. 다른 ObjectStore 이름, 본문·status의 `patch`·`create`·`delete`·`list`·`watch`와 cluster-wide 권한은 부여하지 않는다.
 - 공식 plugin을 WAL archiver와 ScheduledBackup method로 사용하며 `archive_timeout=4min`, retention 7일, immediate 실행과 UTC 6-field cron `0 0 18 * * *`을 사용한다.
 - Restore Cluster는 별도 `kosmo-prod-restore` namespace에서 source를 recovery source로만 읽고 같은 destination에 WAL 또는 새 backup을 쓰지 않는다.
 - Restore 검증은 application write pause 중 생성한 named restore point와 직전 불변 snapshot을 기준으로 하며 이후 현재 production count와 비교하지 않는다. RPO 측정에서는 WAL 전환을 강제하지 않고 대상 WAL의 자연 archive 성공을 확인한 뒤 restore를 시작한다.
@@ -82,7 +82,8 @@ Production CNPG Cluster가 5분 WAL archive 목표와 매일 03:00 KST base back
 
 - OpenSpec strict validation과 Helm dev/prod render test를 통과시킨다.
 - Dev에는 backup 관련 resource/field가 없고 prod에는 정확한 ServiceAccount, ObjectStore, Cluster plugin/WAL 설정과 ScheduledBackup이 있는지 확인한다.
-- Runbook의 on-demand, 상태 확인, 접근 장애 진단, restore, 검증·정리 명령이 선언된 이름과 일치하는지 검토한다.
+- Runbook의 on-demand, 상태 확인, 접근 장애 진단, restore, 검증·정리 명령이 선언된 이름과 일치하는지 검토하고 exact-name ObjectStore `get`과 `objectstores/status` `update` `kubectl auth can-i` 확인을 포함한다.
+- 현재 Tailscale API endpoint의 `kubectl auth can-i --as`는 요청한 ServiceAccount 대신 관리자 identity를 반환하므로, 그 `yes` 결과를 3.7 완료 evidence로 사용하지 않는다. 실제 workload identity로 다시 확인할 때까지 3.7은 미완료로 유지한다.
 
 - [x] 3.1 Prod 전용 ServiceAccount와 ObjectStore를 선언하고 Cluster가 해당 identity와 plugin WAL archiver를 사용하게 한다.
 - [x] 3.2 Immediate 실행과 일일 schedule을 갖는 plugin 방식 ScheduledBackup을 선언한다.
@@ -90,7 +91,7 @@ Production CNPG Cluster가 5분 WAL archive 목표와 매일 03:00 KST base back
 - [x] 3.4 On-demand backup, 상태 확인과 S3/Pod Identity/plugin 장애 진단 절차를 운영 문서에 기록한다.
 - [x] 3.5 격리 PITR manifest 작성, named restore point와 WAL archive gate, 데이터 검증과 namespace 정리 절차를 운영 문서에 기록한다.
 - [x] 3.6 OpenSpec strict validation과 관련 Helm 검증을 통과시키고 결과를 `PROD-551`에 기록한다.
-- [ ] 3.7 Live activation에서 확인된 ObjectStore 조회 권한 누락을 namespaced 최소 Role/RoleBinding으로 보완하고 API server dry-run, `kubectl auth can-i`와 OpenSpec strict validation을 통과시킨다.
+- [ ] 3.7 Live activation에서 확인된 recovery-window `objectstores/status` 갱신 권한 누락을 namespaced 최소 Role/RoleBinding으로 보완하고, 렌더 결과의 API server server-side dry-run, exact-name `get`·status `update` `kubectl auth can-i`와 OpenSpec strict validation evidence를 기록한다. 이 task만으로 post-merge live plugin 성공이나 recovery-window 관측을 완료로 표시하지 않는다.
 
 ## 4. PROD-546 운영 통합 검증과 archive gate
 
@@ -113,6 +114,7 @@ Production CNPG Cluster가 5분 WAL archive 목표와 매일 03:00 KST base back
 **Verification**
 
 - Plugin sidecar, WAL archive, immediate base backup과 S3 versioned object의 live 상태를 확인한다.
+- 2026-08-04 status-RBAC 수정 전의 completed `Backup`, DONE catalog와 `ContinuousArchiving=True` 관측은 진단 근거일 뿐이며, 이 task를 완료하려면 merge 후 같은 성공 증거를 새로 수집한다.
 - Write pause 중 불변 snapshot과 named restore point를 만들고 WAL 전환을 강제하지 않은 상태에서 대상 WAL의 archive 성공을 확인한 뒤 별도 Cluster를 해당 restore point로 복구한다.
 - Restore point 직전 snapshot과 schema, Drizzle migration history, 대표 row count와 최소 read를 비교하고 target LSN 도달을 확인한다.
 - Restore point 생성부터 대상 WAL archive 성공 관측까지와 rehearsal 시작부터 restore Ready까지를 측정해 `PROD-546`에 기록한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- Production backup ServiceAccount의 namespaced Role에 정확한 `kosmo-postgres-backup` `objectstores/status` `update` 규칙을 추가합니다.
- 기존 ObjectStore 본문 권한은 exact-name `get`만 유지하고, Helm render test에서 resource·resourceName·verb가 두 규칙과 정확히 일치하는지 검증합니다.
- runbook에 ObjectStore 본문 조회와 recovery-window status 갱신 권한 확인 절차를 추가합니다.
- `add-production-postgres-s3-backups` OpenSpec의 기존 get-only 파생 결정을 2026-08-04 live evidence와 최소 status 권한 결정으로 정렬합니다.

## 왜 변경했는지

Production에는 base backup과 WAL이 실제로 정상 저장되고 있습니다.

- 최근 정기 Backup CR 4개 연속 `completed`
- S3 Barman catalog의 base backup 5개 모두 `DONE`
- `ContinuousArchiving=True`, WAL archiving `OK`, 대기 WAL 0

하지만 Barman plugin v0.13.0은 backup 완료 후 `ObjectStore.status.serverRecoveryWindow`를 갱신하면서 다음 오류를 기록했습니다.

```text
cannot update resource "objectstores/status"
```

그 결과 `cnpg status`가 실제 backup catalog와 무관하게 `No recovery window information found`를 표시했습니다. PROD-546의 “마지막 성공 backup과 실패를 운영자가 확인할 수 있다”는 계약을 충족하려면 status subresource 갱신 권한이 필요합니다.

## 이번 PR의 주요 결정

### ObjectStore 본문과 status 권한을 분리한다

- 결정자: @robin-maki
- 선택: 같은 namespace의 `kosmo-postgres-backup` 하나에 대해 ObjectStore 본문 `get`과 `objectstores/status` `update`만 허용합니다.
- 고려한 대안: ObjectStore 전체 `update`/`patch`, resourceName 제한 없는 Role, ClusterRole, 기존 get-only 유지
- 이유: Barman plugin이 실제로 사용하는 recovery-window status 갱신만 허용하면서 선언형 ObjectStore 본문과 다른 이름의 ObjectStore를 변경하지 못하게 하기 위해서입니다.
- 감수한 결과: plugin은 해당 ObjectStore의 status만 기록할 수 있습니다. merge 후 실제 권한 적용과 다음 backup의 recovery-window 갱신은 별도로 확인해야 합니다.
- 관련 근거: [Linear PROD-546](https://linear.app/byulmaru/issue/PROD-546/프로덕션-postgresql을-s3에-백업하고-복구를-검증한다), [OpenSpec 결정](openspec/changes/add-production-postgres-s3-backups/decisions.md#objectstore-recovery-window-상태-갱신-최소-권한)

## 어떻게 확인할 수 있는지

- `PATH=/Users/jiyu/.local/share/mise/installs/helm/4.2.2/darwin-arm64:$PATH pnpm test:helm`
- `pnpm exec openspec validate add-production-postgres-s3-backups --strict`
- `pnpm lint:prettier`
- `bash -n apps/helm/test-render.sh`
- `git diff --check`
- 렌더된 Role/RoleBinding의 `kubectl apply --dry-run=server --validate=strict`: 둘 다 통과
- production에는 manifest를 apply하지 않음

## 아직 어떤 문제가 남았는지

- 현재 Tailscale Kubernetes API endpoint는 `kubectl auth can-i --as` 요청을 ServiceAccount가 아니라 관리자 identity로 평가하므로, 반환된 `yes`를 workload 권한 증거로 사용하지 않았습니다.
- merge·Argo sync 후 유효한 workload identity에서 exact-name 본문 `get`과 status `update`를 확인하고, 다음 base backup 뒤 `ObjectStore.status.serverRecoveryWindow.kosmo-postgres`와 `cnpg status` recovery window를 확인해야 합니다.
- OpenSpec task 3.7과 4.2, 실제 application 데이터를 기준으로 한 PITR rehearsal/archive gate는 계속 미완료입니다.

Stack: `main -> prod-546`
