### PR TITLE
Reply 상세 Composer를 thread 경계 안에 배치한다

### DIFF
--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -135,6 +135,12 @@ export function PostListItem({
         triggerRef={replyTriggerRef}
       />
     ) : null;
+  const presentedReplySurface =
+    replySurface && replyBinding?.owner === 'detail' ? (
+      <View style={styles.detailReplySurface}>{replySurface}</View>
+    ) : (
+      replySurface
+    );
   const cardStyle = [
     styles.card,
     showDivider && styles.cardDivider,
@@ -154,7 +160,7 @@ export function PostListItem({
         <View role="article" style={cardStyle}>
           <PostListRow onDeleted={onDeleted} post={post} reply={reply} />
         </View>
-        {replySurface}
+        {presentedReplySurface}
       </>
     );
   }
@@ -192,7 +198,7 @@ export function PostListItem({
           </View>
           <PostListRow onDeleted={onDeleted} post={source} reply={reply} />
         </View>
-        {replySurface}
+        {presentedReplySurface}
       </>
     );
   }
@@ -258,7 +264,7 @@ export function PostListItem({
           />
         </View>
       </View>
-      {replySurface}
+      {presentedReplySurface}
     </>
   );
 }
@@ -344,6 +350,10 @@ const styles = StyleSheet.create({
   },
   avatar: { borderRadius: radii.full },
   actionBarSlot: { paddingBottom: spacing.xs },
+  detailReplySurface: {
+    marginLeft: spacing.xxl * 2,
+    marginRight: spacing.sm,
+  },
   reactionSummary: { marginTop: spacing.xs },
   quoteReactionSummary: { marginTop: spacing.sm },
   quoteSourcePreview: { paddingBottom: spacing.xs },

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -4238,6 +4238,19 @@ export const PostDetailThreadReplyOwnerIntegration: Story = {
       replyButtons.filter((button) => button.getAttribute('aria-expanded') === 'true'),
     ).toEqual([replyButtons[0]]);
 
+    const parentRow = canvas.getByTestId('post-thread-item-route-visible-parent');
+    const parentComposer = within(parentRow).getByLabelText('답글 작성');
+    const parentConnector = canvas.getByTestId(
+      'post-thread-connector-route-visible-parent-route-current-after',
+    );
+    const parentRowBox = parentRow.getBoundingClientRect();
+    const parentComposerBox = parentComposer.getBoundingClientRect();
+    const parentConnectorBox = parentConnector.getBoundingClientRect();
+    expect(parentComposerBox.left - parentRowBox.left).toBe(64);
+    expect(parentRowBox.right - parentComposerBox.right).toBe(8);
+    expect(parentConnector).toBeVisible();
+    expect(parentConnectorBox.right).toBeLessThan(parentComposerBox.left);
+
     const body = canvas.getByRole('textbox', { name: '답글 본문' });
     await userEvent.type(body, '첫 Parent draft');
     await userEvent.click(replyButtons[1]!);

--- a/apps/web/e2e/db-fixtures.ts
+++ b/apps/web/e2e/db-fixtures.ts
@@ -75,6 +75,7 @@ type CreateE2EPostOptions = {
   body?: string;
   createdAt?: string;
   profileId: string;
+  replyParentId?: string;
   state?: PostState;
   visibility?: PostVisibility;
 };
@@ -314,6 +315,7 @@ export async function createE2EPost(options: CreateE2EPostOptions) {
       .insert(Posts)
       .values({
         profileId: options.profileId,
+        ...(options.replyParentId ? { replyParentId: options.replyParentId } : {}),
         state: options.state ?? PostState.ACTIVE,
         visibility: options.visibility ?? PostVisibility.PUBLIC,
         ...(createdAt ? { createdAt } : {}),

--- a/apps/web/e2e/post-detail.e2e.ts
+++ b/apps/web/e2e/post-detail.e2e.ts
@@ -111,3 +111,58 @@ test('연합 프로필 게시글은 relativeHandle URL을 유지하고 정규화
   await expect.poll(() => decodeURIComponent(new URL(page.url()).pathname)).toBe(canonicalPath);
   await expect(page.getByText(body)).toBeVisible();
 });
+
+test('Child Reply 상세에서 Parent inline Reply composer는 connector lane 밖에 표시된다', async ({
+  context,
+  page,
+}) => {
+  await page.setViewportSize({ height: 844, width: 390 });
+  const parentBody = 'E2E parent reply body';
+  const childBody = 'E2E child reply body';
+  const viewer = await createE2ESession({
+    displayName: 'E2E Reply Thread Viewer',
+    handle: 'e2e-reply-thread-viewer',
+  });
+  const parent = await createE2EPost({
+    body: parentBody,
+    profileId: viewer.profile!.id,
+    visibility: PostVisibility.PUBLIC,
+  });
+  const child = await createE2EPost({
+    body: childBody,
+    profileId: viewer.profile!.id,
+    replyParentId: parent.id,
+    visibility: PostVisibility.PUBLIC,
+  });
+  const parentId = toGlobalId('Post', parent.id);
+  const childId = toGlobalId('Post', child.id);
+
+  await setE2ESessionCookie(context, viewer.token);
+  const detailResponse = waitForGraphQLOperation(page, 'PostDetailQuery');
+  await page.goto(`/@${viewer.profile!.handle}/${childId}`);
+  await detailResponse;
+  await expect(page.getByText(childBody)).toBeVisible();
+
+  const parentRow = page.getByTestId(`post-thread-item-${parentId}`);
+  await expect(parentRow).toBeVisible();
+  await parentRow.getByRole('button', { name: '답글' }).click();
+
+  const parentComposer = parentRow.getByLabel('답글 작성');
+  const parentConnector = page.getByTestId(`post-thread-connector-${parentId}-${childId}-after`);
+  await expect(parentComposer).toBeVisible();
+  await expect(parentConnector).toBeVisible();
+
+  const [parentRowBox, parentComposerBox, parentConnectorBox] = await Promise.all([
+    parentRow.boundingBox(),
+    parentComposer.boundingBox(),
+    parentConnector.boundingBox(),
+  ]);
+  expect(parentRowBox).not.toBeNull();
+  expect(parentComposerBox).not.toBeNull();
+  expect(parentConnectorBox).not.toBeNull();
+  expect(parentComposerBox!.x - parentRowBox!.x).toBe(64);
+  expect(
+    parentRowBox!.x + parentRowBox!.width - (parentComposerBox!.x + parentComposerBox!.width),
+  ).toBe(8);
+  expect(parentConnectorBox!.x + parentConnectorBox!.width).toBeLessThan(parentComposerBox!.x);
+});

--- a/docs/design/reply-composer.md
+++ b/docs/design/reply-composer.md
@@ -22,6 +22,11 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
 - Web `< compact`와 Android/iOS 목록 surface에서는 같은 Reply 맥락을 전체 화면 작성기로 연다.
 - Post 상세에서는 compact `ReplyComposer` 진입점을 현재 thread 안에 유지하고, 활성화하면 그 자리에서 기존
   Composer를 인라인으로 펼친다.
+- Post 상세의 ancestor·descendant `PostListItem`에서 inline Composer 외곽은 thread row의 왼쪽 `64px`,
+  오른쪽 `8px` content boundary를 따른다. current Post의 inline Composer는 기존 `PostLayout` content column
+  boundary를 유지한다.
+- 이 boundary는 connector의 위치·길이를 바꾸거나 숨기지 않고 Composer가 connector lane을 침범하지 않게
+  한다. connector는 caller가 공급한 direct relation을 계속 표현한다.
 - 어느 surface에서도 Reply 전용 mutation, 별도 입력 상태 또는 Post kind를 만들지 않는다.
 
 ## Web Reply modal
@@ -153,6 +158,8 @@ Reply 전용 입력·검증·제출 체계를 새로 만들지 않고, surface�
   upload·mutation completion 격리를 확인한다.
 - Web `< compact` 전체 화면과 상세 inline surface의 Parent·Composer 계약을 Storybook에서 확인한다. 실제 API의
   targeted refetch 실패·retry와 Web 짧은-height layout은 통합 runtime 검증으로 분리한다.
+- 상세 ancestor inline Composer가 row 기준 왼쪽 `64px`, 오른쪽 `8px`에 놓이고 connector를 표시한 채
+  `connector.right < composer.left`를 만족하는지 Storybook과 `390px` Web E2E에서 확인한다.
 - Native 전체 화면 구현은 같은 Parent·Composer 계약을 공유하지만, Android·iOS의 scroll, keyboard, safe area,
   platform back과 접근성 runtime은 이번 Web 우선 PR의 Ready 근거로 사용하지 않고 Native 출시 gate에서 별도로
   확인한다.


### PR DESCRIPTION
## 무엇을 변경했나요?

- Reply 상세에서 ancestor Post의 inline Reply Composer를 열 때, 상세 화면이 소유한 Composer에만 왼쪽 64px·오른쪽 8px 외곽 경계를 적용했습니다.
- standard·repost·quote Post 행이 같은 상세 Composer presentation을 사용하도록 정리했습니다.
- Storybook과 실제 Web E2E에 Parent→Child thread connector 표시, Composer 경계, connector lane 비침범 검증을 추가했습니다.
- E2E fixture가 실제 Parent/Child Reply 관계를 만들 수 있도록 `replyParentId`를 지원합니다.
- canonical Reply Composer 디자인 문서에 ancestor·descendant의 64px/8px boundary, current Post의 기존 content column 유지, connector 의미와 Native gate를 동기화했습니다.

## 왜 변경했나요?

Child Reply 상세에서 Parent의 Reply 버튼을 누르면 inline Composer가 thread row 전체 폭을 차지해 Parent→Child connector와 겹쳤습니다. connector는 직접 관계를 표시하는 기존 의미를 유지하면서, Composer만 콘텐츠 영역 안으로 제한해야 했습니다.

## 이번 PR의 주요 결정

- Parent→Child connector의 위치나 길이는 바꾸거나 숨기지 않습니다.
- 상세 화면이 소유한 ancestor Composer만 row 기준 왼쪽 64px·오른쪽 8px 안에 배치합니다.
- 현재 상세 Post의 Composer와 일반 목록의 Composer 동작은 변경하지 않습니다.
- connector 단축·숨김과 modal/fullscreen 전환은 이번 범위에서 제외했습니다.
- 기존 Reply Composer/OpenSpec 및 thread 디자인 계약을 따르는 버그 수정으로 처리하며 새 OpenSpec change는 만들지 않았습니다.
- 결정자: @yeeun-uwu

## 어떻게 확인할 수 있나요?

- Storybook interaction: 20 files, 288 tests 통과
- App unit: 175 tests 통과
- Relay compiler(`--noWatchman`) 및 App TypeScript 통과
- Web TypeScript 통과
- 변경 파일 ESLint·Prettier 통과
- `post-detail.e2e.ts`: 3 tests 통과
  - 390px Web viewport의 실제 Parent/Child 데이터에서 Parent Composer가 left 64px/right 8px이고 connector 오른쪽에 놓이는지 확인
- 호스팅 CI: Lint·Semgrep·Test 성공

## 아직 남은 확인

- Android/iOS 실기기에서의 실제 paint는 확인하지 않았습니다. 공용 React Native `View` 경로는 공유하지만 Native 출시에 필요한 시각 확인은 별도 gate입니다.
- repost·quote는 동일한 공통 wrapper 경로를 코드와 Storybook 전체 회귀로 확인했으며, 각각의 전용 runtime geometry E2E는 추가하지 않았습니다.

Linear: [PROD-651](https://linear.app/byulmaru/issue/PROD-651/reply-상세의-inline-composer가-thread-connector와-겹치는-버그를-수정한다)