### PR TITLE
반응형 내비게이션에서 팔로워 요청 화면으로 이동할 수 있게 한다

### DIFF
--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -55,8 +55,8 @@ const navigation: NavigationItem[] = [
   { href: '/search', Icon: Search, label: '검색' },
   { href: '/notifications', Icon: Bell, label: '알림' },
   { Icon: UserRound, label: '프로필', profile: true },
-  { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
   { href: '/follow-requests', Icon: UserRoundPlus, label: '팔로워 요청' },
+  { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
 ];
 
 type Props = {

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -1,5 +1,14 @@
 import { usePathname } from 'expo-router';
-import { Bell, Bookmark, House, Mail, PenLine, Search, UserRound } from 'lucide-react-native';
+import {
+  Bell,
+  Bookmark,
+  House,
+  Mail,
+  PenLine,
+  Search,
+  UserRound,
+  UserRoundPlus,
+} from 'lucide-react-native';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -47,6 +56,7 @@ const navigation: NavigationItem[] = [
   { href: '/notifications', Icon: Bell, label: '알림' },
   { Icon: UserRound, label: '프로필', profile: true },
   { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
+  { href: '/follow-requests', Icon: UserRoundPlus, label: '팔로워 요청' },
 ];
 
 type Props = {

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -269,7 +269,9 @@ export const SharedNavigation: Story = {
     const canvas = within(canvasElement);
     expect(canvas.getByRole('link', { name: '북마크' })).toHaveAttribute('href', '/bookmarks');
     expect(canvas.getByRole('link', { name: '프로필' })).toHaveAttribute('href', '/@selected');
-    expect(canvas.queryByRole('link', { name: '팔로워 요청' })).not.toBeInTheDocument();
+    const followRequests = canvas.getByRole('link', { name: '팔로워 요청' });
+    expect(followRequests).toHaveAttribute('href', '/follow-requests');
+    expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
     expect(canvas.getByRole('link', { name: '피드백 보내기' })).toHaveAttribute(
       'href',
       '/feedback',
@@ -293,6 +295,7 @@ export const BottomNavigation: Story = {
     const avatar = canvas.getByLabelText(`${selectedProfile.displayName} 프로필 이미지`);
     expect(canvas.getByRole('link', { name: '글쓰기' })).toHaveAttribute('href', '/compose');
     expect(avatar.querySelector('img')).toHaveAttribute('src', selectedAvatarUrl);
+    expect(canvas.queryByRole('link', { name: '팔로워 요청' })).not.toBeInTheDocument();
   },
   render: () => <BottomNavigationStory />,
 };
@@ -302,7 +305,9 @@ export const CompactSidebar: Story = {
     const canvas = within(canvasElement);
     expect(canvas.getByRole('link', { name: '북마크' })).toHaveAttribute('href', '/bookmarks');
     expect(canvas.getByRole('link', { name: '프로필' })).toHaveAttribute('href', '/@selected');
-    expect(canvas.queryByRole('link', { name: '팔로워 요청' })).not.toBeInTheDocument();
+    const followRequests = canvas.getByRole('link', { name: '팔로워 요청' });
+    expect(followRequests).toHaveAttribute('href', '/follow-requests');
+    expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
     expect(canvas.getByRole('link', { name: '피드백 보내기' })).toHaveAttribute(
       'href',
       '/feedback',
@@ -361,6 +366,18 @@ export const FeedbackNavigationCurrentState: Story = {
       'd',
       'm22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7',
     );
+  },
+  render: () => <FeedbackNavigationFullStory />,
+};
+
+export const FollowRequestsNavigationCurrentState: Story = {
+  parameters: { router: { pathname: '/follow-requests' } },
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: '팔로워 요청' });
+    expect(link).toHaveAttribute('href', '/follow-requests');
+    expect(link).toHaveAttribute('aria-current', 'page');
+    expect(link).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
   },
   render: () => <FeedbackNavigationFullStory />,
 };
@@ -1167,7 +1184,9 @@ export const UniversalMobile: Story = {
       'href',
       '/@selected',
     );
-    expect(within(drawer).queryByRole('link', { name: '팔로워 요청' })).not.toBeInTheDocument();
+    const followRequests = within(drawer).getByRole('link', { name: '팔로워 요청' });
+    expect(followRequests).toHaveAttribute('href', '/follow-requests');
+    expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
     const feedback = page.getByRole('link', { name: '피드백 보내기' });
     expect(feedback).toHaveAttribute('href', '/feedback');
     expect(within(drawer).queryByRole('link', { name: '글쓰기' })).not.toBeInTheDocument();

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -267,11 +267,15 @@ type Story = StoryObj<typeof meta>;
 export const SharedNavigation: Story = {
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    expect(canvas.getByRole('link', { name: '북마크' })).toHaveAttribute('href', '/bookmarks');
+    const bookmarks = canvas.getByRole('link', { name: '북마크' });
+    expect(bookmarks).toHaveAttribute('href', '/bookmarks');
     expect(canvas.getByRole('link', { name: '프로필' })).toHaveAttribute('href', '/@selected');
     const followRequests = canvas.getByRole('link', { name: '팔로워 요청' });
     expect(followRequests).toHaveAttribute('href', '/follow-requests');
     expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
+    expect(
+      followRequests.compareDocumentPosition(bookmarks) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(canvas.getByRole('link', { name: '피드백 보내기' })).toHaveAttribute(
       'href',
       '/feedback',

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -272,7 +272,6 @@ export const SharedNavigation: Story = {
     expect(canvas.getByRole('link', { name: '프로필' })).toHaveAttribute('href', '/@selected');
     const followRequests = canvas.getByRole('link', { name: '팔로워 요청' });
     expect(followRequests).toHaveAttribute('href', '/follow-requests');
-    expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
     expect(
       followRequests.compareDocumentPosition(bookmarks) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
@@ -311,7 +310,6 @@ export const CompactSidebar: Story = {
     expect(canvas.getByRole('link', { name: '프로필' })).toHaveAttribute('href', '/@selected');
     const followRequests = canvas.getByRole('link', { name: '팔로워 요청' });
     expect(followRequests).toHaveAttribute('href', '/follow-requests');
-    expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
     expect(canvas.getByRole('link', { name: '피드백 보내기' })).toHaveAttribute(
       'href',
       '/feedback',
@@ -1190,7 +1188,6 @@ export const UniversalMobile: Story = {
     );
     const followRequests = within(drawer).getByRole('link', { name: '팔로워 요청' });
     expect(followRequests).toHaveAttribute('href', '/follow-requests');
-    expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
     const feedback = page.getByRole('link', { name: '피드백 보내기' });
     expect(feedback).toHaveAttribute('href', '/feedback');
     expect(within(drawer).queryByRole('link', { name: '글쓰기' })).not.toBeInTheDocument();

--- a/apps/web/e2e/navigation-scroll.e2e.ts
+++ b/apps/web/e2e/navigation-scroll.e2e.ts
@@ -24,7 +24,10 @@ async function signIn(page: Page, handle = 'e2e-navigation-scroll') {
 }
 
 async function visiblePrimaryNavigation(page: Page): Promise<Locator> {
-  for (const navigation of await page.getByRole('navigation', { name: '주요 메뉴' }).all()) {
+  const navigations = page.getByRole('navigation', { name: '주요 메뉴' });
+  await expect(navigations.first()).toBeAttached();
+
+  for (const navigation of await navigations.all()) {
     if (await navigation.isVisible()) {
       return navigation;
     }
@@ -95,6 +98,55 @@ test('주요 Web navigation은 mobile bottom tab, drawer, compact rail과 full s
 
   await expect(page).toHaveURL(/\/home$/);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+test('팔로워 요청 진입점은 full, compact와 mobile drawer에서 canonical route를 연다', async ({
+  page,
+}) => {
+  await signIn(page, 'e2e-follow-request-navigation');
+
+  for (const viewport of [
+    { height: 720, width: 1440 },
+    { height: 720, width: 1024 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto('/home');
+    const navigation = await visiblePrimaryNavigation(page);
+    const link = navigation.getByRole('link', { name: '팔로워 요청', exact: true });
+    await expect(link).toHaveAttribute('href', '/follow-requests');
+    await expect(navigation.locator('a[href="/menu"]')).toHaveCount(0);
+    await link.click();
+    await expect(page).toHaveURL(/\/follow-requests$/);
+    await expect(page.getByRole('heading', { name: '팔로워 요청' })).toBeVisible();
+    await expect(
+      (await visiblePrimaryNavigation(page)).getByRole('link', {
+        name: '팔로워 요청',
+        exact: true,
+      }),
+    ).toHaveAttribute('aria-current', 'page');
+  }
+
+  await page.setViewportSize({ height: 720, width: 390 });
+  await page.goto('/home');
+  await expect(
+    (await visiblePrimaryNavigation(page)).getByRole('link', {
+      name: '팔로워 요청',
+      exact: true,
+    }),
+  ).toHaveCount(0);
+  await page.getByRole('button', { name: '메뉴 열기' }).click();
+  const drawer = page.locator('#mobile-sidebar');
+  const drawerNavigation = drawer.getByRole('navigation', { name: '주요 메뉴' });
+  const drawerLink = drawerNavigation.getByRole('link', {
+    name: '팔로워 요청',
+    exact: true,
+  });
+  await expect(drawerLink).toHaveAttribute('href', '/follow-requests');
+  await expect(drawerNavigation.locator('a[href="/menu"]')).toHaveCount(0);
+  await drawerLink.tap();
+  await expect(page).toHaveURL(/\/follow-requests$/);
+  await expect(page.getByRole('heading', { name: '팔로워 요청' })).toBeVisible();
+  await expect(drawer).toHaveCount(0);
 });
 
 test('loading target도 pathname commit 직후 이전 document offset을 노출하지 않는다', async ({

--- a/openspec/changes/add-incoming-follow-request-management/decisions.md
+++ b/openspec/changes/add-incoming-follow-request-management/decisions.md
@@ -59,10 +59,22 @@
 - Authority / Provenance: `docs/design/breakpoints.md`, `PROD-566`, `PROD-654`
 - Status: Active
 - Context / Problem: 화면·Relay 구현과 세 shell surface 복원은 별도로 리뷰 가능한 변경이지만 route 없이 진입점만 배포할 수는 없고 하나의 통합 결과가 필요하다.
-- Decision Outcome: PROD-566이 route·화면·Relay 처리와 최종 통합·정합성·archive를 소유하고, PROD-654가 full Web sidebar·compact Web rail·mobile drawer 진입점과 shell 검증을 소유한다. 두 이슈는 이 change를 공유하며 화면 slice를 먼저 전달한다.
+- Decision Outcome: PROD-566이 route·화면·Relay 처리와 최종 통합·정합성·archive를 소유하고, PROD-654가 full Web sidebar·compact Web rail·mobile Web drawer 진입점과 shell 검증을 소유한다. 두 이슈는 이 change를 공유하며 화면 slice를 먼저 전달한다.
 - Alternatives Considered: 한 이슈·PR에 모두 포함, 별도 OpenSpec 두 개, bottom tab까지 navigation 확장. 리뷰 단위가 크거나 하나의 완료 계약이 분리되고 승인 범위를 넘기 때문에 제외했다.
 - Consequences: PROD-654는 `UserRoundPlus`와 `/follow-requests`만 복원하며 mobile bottom tab과 `/menu`를 수정하지 않는다. change는 두 slice와 통합 검증이 끝나기 전 archive하지 않는다.
 - Confirmation / Follow-up: 각 이슈의 담당 tests와 결합된 responsive navigation 흐름을 확인한 뒤 PROD-566 담당자가 archive한다.
+
+### PROD-654 navigation slice를 Web surface로 한정한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/accessibility.md`, `docs/design/breakpoints.md`, `PROD-654`
+- Status: Active
+- Context / Problem: PROD-654는 준비된 route에 정적 navigation item을 연결하는 좁은 slice이며, 공통 component가 Native에서도 사용된다는 사실만으로 Android/iOS UI·runtime QA와 개별 glyph DOM 검증까지 완료 조건에 포함하면 승인된 Web 전달 범위를 넘는다.
+- Decision Outcome: PROD-654는 full Web sidebar, compact Web rail과 mobile Web drawer만 소유한다. Android/iOS UI·runtime QA와 Native touch target은 제외하고, 기존 shared navigation의 role·accessible name·current state·focus·keyboard·drawer lifecycle 계약을 재사용한다. 제품 구현은 Lucide `UserRoundPlus`를 유지하지만 자동화는 Lucide 내부 SVG path를 고정하지 않는다.
+- Alternatives Considered: Android/iOS target 수정까지 같은 PR에 포함, 항목별 수동 Web keyboard·screen reader QA 추가, Lucide SVG path를 1:1 assertion으로 유지. 첫 번째는 승인 범위와 Native QA 책임을 확장하고, 나머지는 새 semantics가 없는 정적 shared item에 중복 검증 또는 라이브러리 내부 구현 결합을 만들기 때문에 제외했다.
+- Consequences: PROD-654 자동화는 label·destination·current state·순서·drawer close와 bottom tab·`/menu` 비노출을 검증한다. 기존 Native shell은 변경하지 않으며 PROD-566 화면·Relay slice와 최종 통합·archive 책임은 그대로 유지한다.
+- Confirmation / Follow-up: Shell Storybook addon-a11y와 Web E2E 통과, production navigation mapping의 `UserRoundPlus` 사용과 Android/iOS diff 부재를 확인한다.
 
 ## Remaining Decisions
 

--- a/openspec/changes/add-incoming-follow-request-management/design.md
+++ b/openspec/changes/add-incoming-follow-request-management/design.md
@@ -4,7 +4,7 @@ Follow Request의 pending-only lifecycle, selected Profile 전용 incoming conne
 
 현재 `apps/app`의 protected route는 top-level query에서 `currentSession.selectedProfile`을 조회하고 Relay actor revision을 route boundary의 key와 fetch key로 사용한다. Profile 전환은 actor environment를 교체하므로 selected Profile 전용 데이터와 local component state를 함께 격리할 수 있다. 기존 Profile connection과 Notification 목록은 refetchable pagination fragment, loading·empty·error와 다음 페이지 복구의 가까운 구현 선례다.
 
-PROD-566은 화면·Relay 처리·통합 검증·archive를, PROD-654는 준비된 route로 향하는 full/compact/mobile navigation 복원을 소유한다.
+PROD-566은 화면·Relay 처리·통합 검증·archive를, PROD-654는 준비된 route로 향하는 full Web sidebar·compact Web rail·mobile Web drawer navigation 복원을 소유한다.
 
 ## Goals / Non-Goals
 
@@ -13,7 +13,7 @@ PROD-566은 화면·Relay 처리·통합 검증·archive를, PROD-654는 준비�
 - `/follow-requests`에서 selected Profile의 받은 요청을 조회하고 승인·거절한다.
 - 공통 `PageHeader`, 기존 list/pagination와 Relay actor 경계를 재사용한다.
 - unavailable requester, mutation 실패와 추가 페이지 실패를 사용자가 정리·복구할 수 있는 상태로 표시한다.
-- route가 준비된 뒤 세 shell surface의 진입점을 함께 복원한다.
+- route가 준비된 뒤 세 Web shell surface의 진입점을 함께 복원한다.
 - 각 구현 이슈가 자신의 테스트를 소유하고 PROD-566이 두 slice의 통합을 검증한다.
 
 **Non-Goals:**
@@ -31,7 +31,9 @@ PROD-566은 화면·Relay 처리·통합 검증·archive를, PROD-654는 준비�
 - request의 requester Profile은 unavailable participant 정책 때문에 nullable이다. null node를 client에서 제거하면 사용자가 거절로 pending row를 정리할 수 없다.
 - approve/reject payload는 삭제된 request global ID를 반환하지만 삭제된 Node 자체나 현재 connection edge를 반환하지 않는다. 성공 payload만 정규화해 두면 connection에 stale edge가 남을 수 있다.
 - Profile 전환 중 이전 environment의 비동기 응답과 행별 local pending/error가 새 actor 화면에 남지 않아야 한다.
-- shell navigation은 full sidebar, compact rail과 mobile drawer가 공유하는 navigation ownership을 사용한다. route보다 진입점이 먼저 배포되면 PROD-541에서 제거한 dead entry가 다시 생긴다.
+- shell navigation은 full Web sidebar, compact Web rail과 mobile Web drawer가 공유하는 navigation ownership을 사용한다. route보다 진입점이 먼저 배포되면 PROD-541에서 제거한 dead entry가 다시 생긴다.
+- PROD-654 navigation slice는 Web 전용이다. Android/iOS UI·runtime QA와 Native touch target은 이 slice의 범위가 아니며 기존 Native shell 동작은 변경하지 않는다.
+- `팔로워 요청`은 기존 shared navigation의 정적 link item이다. 공통 role·accessible name·current state·focus·keyboard·drawer lifecycle 계약을 재사용하며, 이 항목만을 위한 수동 keyboard·screen reader 1:1 QA나 Lucide 내부 SVG path assertion을 추가하지 않는다.
 - Storybook a11y automation은 keyboard, screen reader와 모든 color contrast를 완전히 증명하지 않으므로 runtime 검증을 대체하지 않는다.
 
 ### Recommended Approach
@@ -42,7 +44,7 @@ PROD-566은 화면·Relay 처리·통합 검증·archive를, PROD-654는 준비�
 - 성공 payload의 삭제 ID로 현재 selected Profile connection의 정확한 edge를 제거하고 request record도 정리한다. Relay declarative directive 또는 좁은 store updater 중 현재 compiler·connection 계약에 맞는 최소 방식을 사용한다.
 - approve 성공 payload의 `ProfileFollow`와 participant Profile은 Relay normalization에 맡기고, reject는 follow 관계를 만들지 않는다.
 - requester가 null이면 fallback row를 렌더링하고 reject mutation만 연결한다.
-- PROD-654는 shared shell navigation source에 `팔로워 요청`·`UserRoundPlus`·`/follow-requests` 항목을 복원한다. bottom tab collection은 수정하지 않는다.
+- PROD-654는 shared shell navigation source에 `팔로워 요청`·`UserRoundPlus`·`/follow-requests` 항목을 복원한다. Web shell surface만 검증하고 bottom tab collection은 수정하지 않는다.
 
 ### Allowed Alternatives
 
@@ -64,12 +66,12 @@ PROD-566은 화면·Relay 처리·통합 검증·archive를, PROD-654는 준비�
 - [Profile 전환 race가 새 actor state를 오염] → 기존 actor environment 교체 경계를 사용하고 늦은 응답 격리 회귀 test를 둔다.
 - [unavailable requester를 숨겨 정리 불가] → fallback row와 reject-only 동작을 Storybook/component test로 고정한다.
 - [두 PR의 배포 순서로 dead navigation 노출] → screen route slice를 먼저 전달하고 PROD-654 진입점 slice가 준비된 route를 기준으로 stack·검증한다.
-- [자동화가 platform 접근성을 과대평가] → Web keyboard·screen reader와 Android/iOS target을 별도 runtime QA로 기록한다.
+- [정적 link 항목을 라이브러리 내부 구조에 과결합] → PROD-654는 사용자 관찰 가능한 label·destination·current state·순서·drawer close를 검증하고 Lucide 내부 SVG path를 고정하지 않는다. PROD-566 화면의 platform runtime QA는 별도 책임으로 유지한다.
 
 ## Migration Plan
 
 1. PROD-566 slice에서 `/follow-requests`, 목록·행 UI와 Relay 검증을 먼저 전달한다. 이 단계에서는 shell 진입점을 복원하지 않아 direct route만 존재할 수 있다.
-2. PROD-654 slice에서 full Web sidebar, compact Web rail과 mobile drawer 진입점을 함께 복원하고 shell 검증을 수행한다.
+2. PROD-654 slice에서 full Web sidebar, compact Web rail과 mobile Web drawer 진입점을 함께 복원하고 shell 검증을 수행한다. Android/iOS는 이 slice에서 명시적으로 제외한다.
 3. PROD-566 담당자가 두 slice를 결합해 route navigation, Profile 전환, 승인·거절과 responsive/accessibility 흐름을 검증하고 active specs와 정합성을 확인한 뒤 archive한다.
 
 Rollback은 PROD-654의 shell 진입점을 먼저 제거해 dead entry를 차단하고, 필요하면 `/follow-requests` route·UI를 뒤이어 되돌린다. 기존 GraphQL·DB 계약에는 migration이나 rollback 작업이 없다.

--- a/openspec/changes/add-incoming-follow-request-management/implementation-plan-prod-654.md
+++ b/openspec/changes/add-incoming-follow-request-management/implementation-plan-prod-654.md
@@ -11,6 +11,7 @@
 ## Global Constraints
 
 - Canonical destination은 `/follow-requests`, label은 `팔로워 요청`, glyph는 Lucide `UserRoundPlus`다.
+- shared navigation에서 `팔로워 요청`은 `북마크` 바로 위에 표시한다.
 - full Web sidebar, compact Web rail과 mobile drawer는 동일한 shared navigation item을 사용한다.
 - mobile bottom tab과 generic `/menu`를 추가하거나 복원하지 않는다.
 - `UniversalShell`, `BottomTabBar`, Follow Request 화면·Relay·API·DB, notification/push/realtime은 수정하지 않는다.
@@ -134,7 +135,7 @@
 
 - [x] **Step 4: 최소 production 변경으로 GREEN을 만든다**
 
-  `SidebarNavigation.tsx`의 Lucide import에 `UserRoundPlus`를 추가하고 기존 복원 위치인 `북마크` 뒤에 item 하나만 추가한다.
+  `SidebarNavigation.tsx`의 Lucide import에 `UserRoundPlus`를 추가하고 `북마크` 바로 위에 item 하나만 추가한다.
 
   ```tsx
   import {
@@ -153,8 +154,8 @@
     { href: '/search', Icon: Search, label: '검색' },
     { href: '/notifications', Icon: Bell, label: '알림' },
     { Icon: UserRound, label: '프로필', profile: true },
-    { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
     { href: '/follow-requests', Icon: UserRoundPlus, label: '팔로워 요청' },
+    { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
   ];
   ```
 

--- a/openspec/changes/add-incoming-follow-request-management/implementation-plan-prod-654.md
+++ b/openspec/changes/add-incoming-follow-request-management/implementation-plan-prod-654.md
@@ -1,0 +1,212 @@
+# PROD-654 반응형 팔로워 요청 진입점 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 준비된 `/follow-requests` 화면으로 이동하는 `팔로워 요청` 진입점을 full Web sidebar, compact Web rail과 mobile drawer에 복원한다.
+
+**Architecture:** `SidebarNavigation`의 단일 navigation 배열에 static route item을 복원한다. `UniversalShell`이 이 컴포넌트를 세 surface에서 공유하므로 별도 prop, feature gate나 surface별 분기를 추가하지 않는다. 기존 Shell Storybook과 `navigation-scroll` Playwright E2E를 확장해 노출, 아이콘, destination, active state, drawer close와 제외 범위를 검증한다.
+
+**Tech Stack:** Expo Router, React Native Web, Lucide React Native, Storybook Vitest browser tests, Playwright, OpenSpec.
+
+## Global Constraints
+
+- Canonical destination은 `/follow-requests`, label은 `팔로워 요청`, glyph는 Lucide `UserRoundPlus`다.
+- full Web sidebar, compact Web rail과 mobile drawer는 동일한 shared navigation item을 사용한다.
+- mobile bottom tab과 generic `/menu`를 추가하거나 복원하지 않는다.
+- `UniversalShell`, `BottomTabBar`, Follow Request 화면·Relay·API·DB, notification/push/realtime은 수정하지 않는다.
+- 기존 feedback, Profile, Bookmark, logout, active state와 drawer close 동작을 유지한다.
+- 테스트 코드 범위: `Shell.stories.tsx`와 기존 `navigation-scroll.e2e.ts`의 최소 assertion·interaction만 변경한다.
+- 테스트 필요성: 세 surface가 준비된 route에 연결되고 PROD-541의 dead-entry 제거 범위를 넘지 않음을 증명한다.
+- 테스트 제외 범위: 새 fixture/helper/harness, PROD-566 목록·mutation, unrelated shell snapshot·coverage 확대.
+- Web keyboard·screen-reader와 Android/iOS drawer touch target은 실제 runtime에서 관찰한 범위만 기록한다. 증거가 없으면 OpenSpec task 3.3을 완료 처리하지 않는다.
+
+---
+
+### Task 1: shared navigation 진입점과 직접 회귀 검증
+
+**Files:**
+
+- Modify: `apps/app/src/stories/Shell.stories.tsx`
+- Modify: `apps/web/e2e/navigation-scroll.e2e.ts`
+- Modify: `apps/app/src/components/shell/SidebarNavigation.tsx`
+
+**Interfaces:**
+
+- Consumes: 기존 `NavigationItem`, `GuardedLink`, `visiblePrimaryNavigation(page)`와 mobile drawer `#mobile-sidebar`.
+- Produces: `{ href: '/follow-requests', Icon: UserRoundPlus, label: '팔로워 요청' }` static shared item. 공개 component prop이나 GraphQL fragment는 변경하지 않는다.
+
+- [x] **Step 1: Storybook에 실패하는 shared surface 계약을 먼저 작성한다**
+
+  `SharedNavigation`, `CompactSidebar`, `UniversalMobile`의 기존 비노출 assertion을 실제 link 계약으로 바꾼다. exact glyph는 사용자에게 렌더되는 Lucide path로 확인한다.
+
+  ```tsx
+  const followRequests = canvas.getByRole('link', { name: '팔로워 요청' });
+  expect(followRequests).toHaveAttribute('href', '/follow-requests');
+  expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
+  ```
+
+  `BottomNavigation`에는 다음 비노출 assertion을 유지·추가한다.
+
+  ```tsx
+  expect(canvas.queryByRole('link', { name: '팔로워 요청' })).not.toBeInTheDocument();
+  ```
+
+  `/follow-requests` pathname에서 current state를 직접 검증하는 story를 추가한다.
+
+  ```tsx
+  export const FollowRequestsNavigationCurrentState: Story = {
+    parameters: { router: { pathname: '/follow-requests' } },
+    play: ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+      const link = canvas.getByRole('link', { name: '팔로워 요청' });
+      expect(link).toHaveAttribute('href', '/follow-requests');
+      expect(link).toHaveAttribute('aria-current', 'page');
+      expect(link).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
+    },
+  };
+  ```
+
+- [x] **Step 2: Playwright에 실패하는 responsive route 계약을 작성한다**
+
+  `navigation-scroll.e2e.ts`에 기존 session/database fixture를 재사용하는 별도 test를 추가한다.
+
+  ```ts
+  test('팔로워 요청 진입점은 full, compact와 mobile drawer에서 canonical route를 연다', async ({
+    page,
+  }) => {
+    await signIn(page, 'e2e-follow-request-navigation');
+
+    for (const viewport of [
+      { height: 720, width: 1440 },
+      { height: 720, width: 1024 },
+    ]) {
+      await page.setViewportSize(viewport);
+      await page.goto('/home');
+      const navigation = await visiblePrimaryNavigation(page);
+      const link = navigation.getByRole('link', { name: '팔로워 요청', exact: true });
+      await expect(link).toHaveAttribute('href', '/follow-requests');
+      await expect(navigation.locator('a[href="/menu"]')).toHaveCount(0);
+      await link.click();
+      await expect(page).toHaveURL(/\/follow-requests$/);
+      await expect(page.getByRole('heading', { name: '팔로워 요청' })).toBeVisible();
+      await expect(
+        (await visiblePrimaryNavigation(page)).getByRole('link', {
+          name: '팔로워 요청',
+          exact: true,
+        }),
+      ).toHaveAttribute('aria-current', 'page');
+    }
+
+    await page.setViewportSize({ height: 720, width: 390 });
+    await page.goto('/home');
+    await expect(
+      (await visiblePrimaryNavigation(page)).getByRole('link', {
+        name: '팔로워 요청',
+        exact: true,
+      }),
+    ).toHaveCount(0);
+    await page.getByRole('button', { name: '메뉴 열기' }).click();
+    const drawer = page.locator('#mobile-sidebar');
+    const drawerNavigation = drawer.getByRole('navigation', { name: '주요 메뉴' });
+    const drawerLink = drawerNavigation.getByRole('link', {
+      name: '팔로워 요청',
+      exact: true,
+    });
+    await expect(drawerLink).toHaveAttribute('href', '/follow-requests');
+    await expect(drawerNavigation.locator('a[href="/menu"]')).toHaveCount(0);
+    await drawerLink.tap();
+    await expect(page).toHaveURL(/\/follow-requests$/);
+    await expect(page.getByRole('heading', { name: '팔로워 요청' })).toBeVisible();
+    await expect(drawer).toHaveCount(0);
+  });
+  ```
+
+- [x] **Step 3: RED를 확인한다**
+
+  Run:
+
+  ```bash
+  pnpm --filter @kosmo/app test:storybook -- src/stories/Shell.stories.tsx
+  node scripts/test-db.mjs run -- pnpm test:e2e:database -- navigation-scroll.e2e.ts
+  ```
+
+  Expected: Storybook의 full/compact/mobile link 조회와 Playwright의 첫 `팔로워 요청` link 조회가 현재 item 부재 때문에 실패한다. Watchman/FSEvents가 local E2E build를 막으면 제품 실패와 구분해 기록하고, Relay `--noWatchman` 컴파일을 사용하는 비커밋 local test config로 같은 Playwright spec을 실행한다.
+
+- [x] **Step 4: 최소 production 변경으로 GREEN을 만든다**
+
+  `SidebarNavigation.tsx`의 Lucide import에 `UserRoundPlus`를 추가하고 기존 복원 위치인 `북마크` 뒤에 item 하나만 추가한다.
+
+  ```tsx
+  import {
+    Bell,
+    Bookmark,
+    House,
+    Mail,
+    PenLine,
+    Search,
+    UserRound,
+    UserRoundPlus,
+  } from 'lucide-react-native';
+
+  const navigation: NavigationItem[] = [
+    { href: '/home', Icon: House, label: '홈' },
+    { href: '/search', Icon: Search, label: '검색' },
+    { href: '/notifications', Icon: Bell, label: '알림' },
+    { Icon: UserRound, label: '프로필', profile: true },
+    { href: '/bookmarks', Icon: Bookmark, label: '북마크' },
+    { href: '/follow-requests', Icon: UserRoundPlus, label: '팔로워 요청' },
+  ];
+  ```
+
+- [x] **Step 5: targeted GREEN과 회귀를 확인한다**
+
+  Run:
+
+  ```bash
+  pnpm --filter @kosmo/app test:storybook -- src/stories/Shell.stories.tsx
+  node scripts/test-db.mjs run -- pnpm test:e2e:database -- navigation-scroll.e2e.ts
+  pnpm --filter @kosmo/app check
+  ```
+
+  Expected: Storybook과 navigation E2E가 통과하고 Relay compiler/TypeScript가 새 import와 route href를 허용한다.
+
+### Task 2: OpenSpec evidence와 repository 검증
+
+**Files:**
+
+- Modify: `openspec/changes/add-incoming-follow-request-management/tasks.md`
+- Keep: `openspec/changes/add-incoming-follow-request-management/implementation-plan-prod-654.md`
+
+**Interfaces:**
+
+- Consumes: Task 1의 passing Storybook/E2E/check 결과와 실제 runtime 관찰.
+- Produces: OpenSpec task 3.1·3.2 완료 evidence. Task 3.3은 자동화와 platform runtime QA가 모두 존재할 때만 완료한다.
+
+- [x] **Step 1: task 3.1과 3.2를 완료 처리하고 검증 기록을 추가한다**
+
+  `tasks.md`에서 실제 코드와 tests가 통과한 뒤에만 3.1·3.2를 `- [x]`로 바꾼다. 날짜가 있는 검증 기록에는 명령별 pass/fail과 다음 runtime 상태를 분리한다.
+
+  ```md
+  - not run — 실제 Web keyboard·screen-reader와 Android/iOS drawer touch target runtime QA. 해당 증거가 없으면 3.3은 완료 처리하지 않는다.
+  ```
+
+- [x] **Step 2: OpenSpec과 repository 검증을 실행한다**
+
+  Run:
+
+  ```bash
+  pnpm exec openspec validate add-incoming-follow-request-management --strict
+  pnpm --filter @kosmo/app test:unit
+  pnpm lint:eslint
+  pnpm lint:prettier
+  ```
+
+  Expected: 모든 명령이 exit 0이다. 실제로 실행하지 못한 Web/Android/iOS runtime QA는 passing automation과 구분한다.
+
+- [x] **Step 3: 구현 diff를 독립 리뷰한다**
+
+  Review scope: `SidebarNavigation.tsx`, `Shell.stories.tsx`, `navigation-scroll.e2e.ts`, `tasks.md`, 이 계획 파일. 승인 범위, 정확성, 접근성 semantics, drawer close, bottom tab·`/menu` 비노출과 검증 공백을 확인한다.
+
+- [x] **Step 4: 승인된 파일만 하나의 checkpoint commit으로 준비한다**
+
+  `$kosmo-codex-workflows:commit-safely`를 사용해 `.superpowers/**`, `docs/superpowers/**`가 staged되지 않았음을 확인한다. 커밋·push·Draft PR·Linear 상태 변경은 사용자에게 정확한 diff와 외부 변경 초안을 보여주고 승인받은 뒤 수행한다.

--- a/openspec/changes/add-incoming-follow-request-management/implementation-plan-prod-654.md
+++ b/openspec/changes/add-incoming-follow-request-management/implementation-plan-prod-654.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** 준비된 `/follow-requests` 화면으로 이동하는 `팔로워 요청` 진입점을 full Web sidebar, compact Web rail과 mobile drawer에 복원한다.
+**Goal:** 준비된 `/follow-requests` 화면으로 이동하는 `팔로워 요청` 진입점을 full Web sidebar, compact Web rail과 mobile Web drawer에 복원한다.
 
 **Architecture:** `SidebarNavigation`의 단일 navigation 배열에 static route item을 복원한다. `UniversalShell`이 이 컴포넌트를 세 surface에서 공유하므로 별도 prop, feature gate나 surface별 분기를 추가하지 않는다. 기존 Shell Storybook과 `navigation-scroll` Playwright E2E를 확장해 노출, 아이콘, destination, active state, drawer close와 제외 범위를 검증한다.
 
@@ -12,14 +12,16 @@
 
 - Canonical destination은 `/follow-requests`, label은 `팔로워 요청`, glyph는 Lucide `UserRoundPlus`다.
 - shared navigation에서 `팔로워 요청`은 `북마크` 바로 위에 표시한다.
-- full Web sidebar, compact Web rail과 mobile drawer는 동일한 shared navigation item을 사용한다.
+- full Web sidebar, compact Web rail과 mobile Web drawer는 동일한 shared navigation item을 사용한다.
 - mobile bottom tab과 generic `/menu`를 추가하거나 복원하지 않는다.
 - `UniversalShell`, `BottomTabBar`, Follow Request 화면·Relay·API·DB, notification/push/realtime은 수정하지 않는다.
 - 기존 feedback, Profile, Bookmark, logout, active state와 drawer close 동작을 유지한다.
 - 테스트 코드 범위: `Shell.stories.tsx`와 기존 `navigation-scroll.e2e.ts`의 최소 assertion·interaction만 변경한다.
 - 테스트 필요성: 세 surface가 준비된 route에 연결되고 PROD-541의 dead-entry 제거 범위를 넘지 않음을 증명한다.
 - 테스트 제외 범위: 새 fixture/helper/harness, PROD-566 목록·mutation, unrelated shell snapshot·coverage 확대.
-- Web keyboard·screen-reader와 Android/iOS drawer touch target은 실제 runtime에서 관찰한 범위만 기록한다. 증거가 없으면 OpenSpec task 3.3을 완료 처리하지 않는다.
+- Android/iOS UI·runtime QA와 Native touch target은 이 Web-only navigation slice에서 제외한다.
+- 새 semantics가 없는 정적 shared item에는 항목별 수동 Web keyboard·screen reader 1:1 QA를 추가하지 않고, 기존 공통 navigation 계약과 Storybook addon-a11y·Web E2E를 재사용한다.
+- 제품 구현은 `UserRoundPlus`를 사용하되 테스트는 Lucide 내부 SVG/path 구조에 결합하지 않는다.
 
 ---
 
@@ -38,12 +40,11 @@
 
 - [x] **Step 1: Storybook에 실패하는 shared surface 계약을 먼저 작성한다**
 
-  `SharedNavigation`, `CompactSidebar`, `UniversalMobile`의 기존 비노출 assertion을 실제 link 계약으로 바꾼다. exact glyph는 사용자에게 렌더되는 Lucide path로 확인한다.
+  `SharedNavigation`, `CompactSidebar`, `UniversalMobile`의 기존 비노출 assertion을 실제 link 계약으로 바꾼다. 사용자 관찰 가능한 label과 destination을 확인하고 Lucide 내부 path는 고정하지 않는다.
 
   ```tsx
   const followRequests = canvas.getByRole('link', { name: '팔로워 요청' });
   expect(followRequests).toHaveAttribute('href', '/follow-requests');
-  expect(followRequests.querySelector('path')).toHaveAttribute('d', 'M2 21a8 8 0 0 1 13.292-6');
   ```
 
   `BottomNavigation`에는 다음 비노출 assertion을 유지·추가한다.
@@ -72,7 +73,7 @@
   `navigation-scroll.e2e.ts`에 기존 session/database fixture를 재사용하는 별도 test를 추가한다.
 
   ```ts
-  test('팔로워 요청 진입점은 full, compact와 mobile drawer에서 canonical route를 연다', async ({
+  test('팔로워 요청 진입점은 full, compact와 mobile Web drawer에서 canonical route를 연다', async ({
     page,
   }) => {
     await signIn(page, 'e2e-follow-request-navigation');
@@ -181,14 +182,14 @@
 **Interfaces:**
 
 - Consumes: Task 1의 passing Storybook/E2E/check 결과와 실제 runtime 관찰.
-- Produces: OpenSpec task 3.1·3.2 완료 evidence. Task 3.3은 자동화와 platform runtime QA가 모두 존재할 때만 완료한다.
+- Produces: OpenSpec task 3.1–3.3 완료 evidence. Task 3.3은 승인된 Web-only 범위의 자동화와 제외 범위를 기록한 뒤 완료한다.
 
 - [x] **Step 1: task 3.1과 3.2를 완료 처리하고 검증 기록을 추가한다**
 
   `tasks.md`에서 실제 코드와 tests가 통과한 뒤에만 3.1·3.2를 `- [x]`로 바꾼다. 날짜가 있는 검증 기록에는 명령별 pass/fail과 다음 runtime 상태를 분리한다.
 
   ```md
-  - not run — 실제 Web keyboard·screen-reader와 Android/iOS drawer touch target runtime QA. 해당 증거가 없으면 3.3은 완료 처리하지 않는다.
+  - excluded by approved PROD-654 scope — Android/iOS UI·runtime QA, Native touch target과 항목별 수동 Web keyboard·screen reader 1:1 QA.
   ```
 
 - [x] **Step 2: OpenSpec과 repository 검증을 실행한다**
@@ -202,7 +203,7 @@
   pnpm lint:prettier
   ```
 
-  Expected: 모든 명령이 exit 0이다. 실제로 실행하지 못한 Web/Android/iOS runtime QA는 passing automation과 구분한다.
+  Expected: 모든 명령이 exit 0이다. Android/iOS와 항목별 수동 Web 접근성 QA는 승인된 제외 범위로 passing automation과 구분해 기록한다.
 
 - [x] **Step 3: 구현 diff를 독립 리뷰한다**
 

--- a/openspec/changes/add-incoming-follow-request-management/implementation-plan.md
+++ b/openspec/changes/add-incoming-follow-request-management/implementation-plan.md
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- 구현 대상은 OpenSpec task 1.1–2.4와 Linear PROD-566뿐이다. task 3.x의 full sidebar, compact rail, mobile drawer, `UserRoundPlus`는 PROD-654에 남긴다.
+- 구현 대상은 OpenSpec task 1.1–2.4와 Linear PROD-566뿐이다. task 3.x의 full Web sidebar, compact Web rail, mobile Web drawer, `UserRoundPlus`는 PROD-654에 남긴다.
 - 공통 `PageHeader`의 제목은 `팔로워 요청`이며 loading, error, profile-required, empty, content 상태 모두 같은 header를 유지한다.
 - 요청 목록은 selected Profile의 nullable `incomingProfileFollowRequests`만 사용하고 root query나 다른 Profile connection을 만들지 않는다.
 - requester가 null인 request를 숨기지 않고 `확인할 수 없는 프로필`과 `거절`만 제공한다. 요청 시각은 조회하거나 표시하지 않는다.
@@ -343,7 +343,7 @@
 
 - [ ] **Step 3: OpenSpec progress update**
 
-  Mark only 1.1–2.4 complete after their verification evidence exists. Leave 3.1–3.3 and 4.1–4.4 unchecked and do not archive the change.
+  Mark only 1.1–2.4 complete from this PROD-566 plan after their verification evidence exists. Do not change 3.1–3.3 here; PROD-654 owns those tasks independently. Leave 4.1–4.4 unchecked and do not archive the change.
 
 - [ ] **Step 4: Independent implementation review**
 

--- a/openspec/changes/add-incoming-follow-request-management/proposal.md
+++ b/openspec/changes/add-incoming-follow-request-management/proposal.md
@@ -9,7 +9,7 @@ Follow Request의 pending-only 저장·GraphQL 처리 계약은 이미 제공되
 - 각 요청 행에서 승인·거절을 처리하고, 서버 성공 후 삭제된 request ID로 현재 connection을 정리하며 실패 시 행과 재시도를 유지한다.
 - unavailable requester가 있는 요청도 숨기지 않고 fallback 행과 거절 동작을 제공한다.
 - Profile 전환 시 이전 actor의 요청, pending, error와 Relay cache state가 새 Profile에 섞이지 않게 한다.
-- 화면이 준비된 뒤 full Web sidebar, compact Web rail과 mobile drawer에 `UserRoundPlus` 진입점을 복원한다.
+- 화면이 준비된 뒤 full Web sidebar, compact Web rail과 mobile Web drawer에 `UserRoundPlus` 진입점을 복원한다.
 - mobile bottom tab과 generic `/menu` placeholder는 복원하지 않으며 Follow Request API·저장 모델·알림 전달 계약은 변경하지 않는다.
 
 ## Authority / Provenance
@@ -26,7 +26,7 @@ Follow Request의 pending-only 저장·GraphQL 처리 계약은 이미 제공되
 
 ### Modified Capabilities
 
-- `web-app-shell`: 관리 화면이 제공된 이후 full Web sidebar, compact Web rail과 mobile drawer가 동일한 `/follow-requests` route를 노출하도록 기존 임시 비노출 계약을 확장
+- `web-app-shell`: 관리 화면이 제공된 이후 full Web sidebar, compact Web rail과 mobile Web drawer가 동일한 `/follow-requests` route를 노출하도록 기존 임시 비노출 계약을 확장
 
 ## Impact
 

--- a/openspec/changes/add-incoming-follow-request-management/specs/web-app-shell/spec.md
+++ b/openspec/changes/add-incoming-follow-request-management/specs/web-app-shell/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: 준비되지 않은 sidebar 진입점 비노출
 
-**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/breakpoints.md`, `PROD-541`, `PROD-487`, `PROD-566`, `PROD-654` — 유니버설 애플리케이션은 준비되지 않은 sidebar navigation 진입점을 노출하지 않고 현재 제공하는 feedback과 실제 동작하는 진입점을 유지해야 한다(MUST). 받은 팔로우 요청 관리 화면이 제공되면 full Web sidebar, compact Web rail과 mobile drawer는 같은 canonical route 진입점을 제공해야 한다(MUST).
+**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/breakpoints.md`, `PROD-541`, `PROD-487`, `PROD-566`, `PROD-654` — 유니버설 애플리케이션은 준비되지 않은 sidebar navigation 진입점을 노출하지 않고 현재 제공하는 feedback과 실제 동작하는 진입점을 유지해야 한다(MUST). 받은 팔로우 요청 관리 화면이 제공되면 full Web sidebar, compact Web rail과 mobile Web drawer는 같은 canonical route 진입점을 제공해야 한다(MUST).
 
 #### Scenario: responsive sidebar에서 프로필 설정 비노출
 
@@ -18,11 +18,11 @@
 
 #### Scenario: 관리 화면 준비 후 responsive navigation 진입점
 
-- **WHEN** `/follow-requests` 받은 팔로우 요청 관리 화면이 제공된 상태에서 인증된 사용자가 full Web sidebar, compact Web rail 또는 mobile drawer를 연다
+- **WHEN** `/follow-requests` 받은 팔로우 요청 관리 화면이 제공된 상태에서 인증된 사용자가 full Web sidebar, compact Web rail 또는 mobile Web drawer를 연다
 - **THEN** 시스템은 `팔로워 요청` label과 Lucide `UserRoundPlus` glyph를 사용하는 진입점을 표시한다
 - **AND** 세 shell surface의 진입점은 모두 `/follow-requests`로 이동한다
 - **AND** mobile bottom tab에는 팔로워 요청 진입점을 추가하지 않는다
-- **AND** mobile drawer에서 진입하면 기존 route navigation과 drawer close 동작을 유지한다
+- **AND** mobile Web drawer에서 진입하면 기존 route navigation과 drawer close 동작을 유지한다
 
 #### Scenario: 실제 동작하는 navigation 유지
 

--- a/openspec/changes/add-incoming-follow-request-management/tasks.md
+++ b/openspec/changes/add-incoming-follow-request-management/tasks.md
@@ -101,9 +101,20 @@
 - 테스트 제외 범위: PROD-566 목록·mutation 동작, notification activation, unrelated shell snapshot·fixture 확대.
 - Web breakpoint별 keyboard·screen-reader와 Android/iOS drawer touch target을 runtime에서 확인한다.
 
-- [ ] 3.1 full Web sidebar, compact Web rail과 mobile drawer의 shared navigation ownership에 `팔로워 요청`·`UserRoundPlus`·`/follow-requests` 진입점을 복원한다.
-- [ ] 3.2 기존 navigation 동작을 유지하고 bottom tab·`/menu`가 추가되지 않음을 검증한다.
+- [x] 3.1 full Web sidebar, compact Web rail과 mobile drawer의 shared navigation ownership에 `팔로워 요청`·`UserRoundPlus`·`/follow-requests` 진입점을 복원한다.
+- [x] 3.2 기존 navigation 동작을 유지하고 bottom tab·`/menu`가 추가되지 않음을 검증한다.
 - [ ] 3.3 최소 shell component/Storybook/Web E2E 검증과 platform runtime QA 결과를 기록한다.
+
+**2026-08-04 검증 기록**
+
+- passed — targeted `Shell.stories.tsx`: 전체 20 files / 289 interactions, including full·compact·mobile drawer의 `팔로워 요청` label·`UserRoundPlus`·`/follow-requests`, active state와 bottom tab 비노출
+- passed — `node scripts/test-db.mjs run -- pnpm test:e2e:database -- navigation-scroll.e2e.ts`: 4 tests, including full·compact·mobile drawer route 진입, drawer close와 bottom tab·`/menu` 비노출
+- passed — `pnpm --filter @kosmo/app check`: Relay 99 reader / 63 normalization / 107 operation text와 TypeScript 검사. 현재 worktree의 Watchman FSEvents 등록 실패는 비커밋 `relay-compiler --noWatchman` local workaround로 우회했다.
+- passed — `pnpm --filter @kosmo/app test:unit`: 175 tests
+- passed — 기존 local Storybook executable의 `build --disable-telemetry`: production bundle 생성
+- passed — `pnpm lint:eslint`, 기존 local executable의 Prettier 전체 check와 `openspec validate add-incoming-follow-request-management --strict`
+- passed — 승인 범위, shared ownership, 접근성 semantics와 테스트 증명력을 독립 구현 리뷰했으며 finding 없음
+- not run — 실제 Web keyboard·screen-reader와 Android/iOS drawer touch target runtime QA. 해당 증거가 없으므로 3.3은 완료 처리하지 않는다.
 
 ## 4. PROD-566 통합 검증과 OpenSpec 완료
 

--- a/openspec/changes/add-incoming-follow-request-management/tasks.md
+++ b/openspec/changes/add-incoming-follow-request-management/tasks.md
@@ -85,7 +85,7 @@
 
 **Deliverable**
 
-준비된 `/follow-requests` 화면으로 이동하는 `팔로워 요청` 진입점이 full Web sidebar, compact Web rail과 mobile drawer에 동일하게 제공된다.
+준비된 `/follow-requests` 화면으로 이동하는 `팔로워 요청` 진입점이 full Web sidebar, compact Web rail과 mobile Web drawer에 동일하게 제공된다.
 
 **Guardrails**
 
@@ -93,28 +93,30 @@
 - route가 준비되기 전에 진입점만 노출하지 않는다.
 - mobile bottom tab과 generic `/menu`를 추가하지 않는다.
 - 기존 feedback, Profile, Bookmark, logout, active state와 drawer close 동작을 유지한다.
+- Android/iOS UI·runtime QA와 Native touch target은 이 navigation slice에서 제외하고 기존 Native shell 동작을 변경하지 않는다.
+- 기존 shared navigation의 role·accessible name·current state·focus·keyboard·drawer lifecycle 계약을 재사용한다.
 
 **Verification**
 
-- 테스트 코드 범위: shared navigation item의 full/compact/mobile 표시, label·icon·destination, drawer close·active state와 bottom tab·`/menu` 비노출을 직접 검증하는 최소 shell component/Storybook/Web E2E 영역.
-- 테스트 필요성: PROD-541의 dead-entry 제거 회귀 없이 세 surface가 준비된 route로 연결됨을 증명한다.
-- 테스트 제외 범위: PROD-566 목록·mutation 동작, notification activation, unrelated shell snapshot·fixture 확대.
-- Web breakpoint별 keyboard·screen-reader와 Android/iOS drawer touch target을 runtime에서 확인한다.
+- 테스트 코드 범위: shared navigation item의 full/compact/mobile Web 표시, label·destination·순서, drawer close·active state와 bottom tab·`/menu` 비노출을 직접 검증하는 최소 shell component/Storybook/Web E2E 영역.
+- 테스트 필요성: PROD-541의 dead-entry 제거 회귀 없이 세 Web surface가 준비된 route로 연결되고 기존 shared navigation semantics를 유지함을 증명한다.
+- 테스트 제외 범위: Lucide 내부 SVG/path 1:1 assertion, 항목별 수동 Web keyboard·screen reader QA, Android/iOS UI·runtime QA, Native touch target, PROD-566 목록·mutation 동작, notification activation, unrelated shell snapshot·fixture 확대.
+- production navigation mapping의 `UserRoundPlus` 사용은 코드 리뷰와 Storybook 표시로 확인하고, 자동화는 라이브러리 내부 DOM 구조에 결합하지 않는다.
 
-- [x] 3.1 full Web sidebar, compact Web rail과 mobile drawer의 shared navigation ownership에 `팔로워 요청`·`UserRoundPlus`·`/follow-requests` 진입점을 복원한다.
+- [x] 3.1 full Web sidebar, compact Web rail과 mobile Web drawer의 shared navigation ownership에 `팔로워 요청`·`UserRoundPlus`·`/follow-requests` 진입점을 복원한다.
 - [x] 3.2 기존 navigation 동작을 유지하고 bottom tab·`/menu`가 추가되지 않음을 검증한다.
-- [ ] 3.3 최소 shell component/Storybook/Web E2E 검증과 platform runtime QA 결과를 기록한다.
+- [x] 3.3 최소 shell component/Storybook/Web E2E 검증과 승인된 Web-only 제외 범위를 기록한다.
 
 **2026-08-04 검증 기록**
 
-- passed — targeted `Shell.stories.tsx`: 전체 20 files / 289 interactions, including full·compact·mobile drawer의 `팔로워 요청` label·`UserRoundPlus`·`/follow-requests`, active state와 bottom tab 비노출
-- passed — `node scripts/test-db.mjs run -- pnpm test:e2e:database -- navigation-scroll.e2e.ts`: 4 tests, including full·compact·mobile drawer route 진입, drawer close와 bottom tab·`/menu` 비노출
+- passed — targeted `Shell.stories.tsx`: 전체 20 files / 289 interactions, including full·compact·mobile Web drawer의 `팔로워 요청` label·`/follow-requests`, 항목 순서, active state와 bottom tab 비노출. production mapping은 `UserRoundPlus`를 사용하며 test는 Lucide 내부 SVG path를 고정하지 않는다.
+- passed — `node scripts/test-db.mjs run -- pnpm test:e2e:database -- navigation-scroll.e2e.ts`: 4 tests, including full·compact·mobile Web drawer route 진입, drawer close와 bottom tab·`/menu` 비노출
 - passed — `pnpm --filter @kosmo/app check`: Relay 99 reader / 63 normalization / 107 operation text와 TypeScript 검사. 현재 worktree의 Watchman FSEvents 등록 실패는 비커밋 `relay-compiler --noWatchman` local workaround로 우회했다.
 - passed — `pnpm --filter @kosmo/app test:unit`: 175 tests
 - passed — 기존 local Storybook executable의 `build --disable-telemetry`: production bundle 생성
 - passed — `pnpm lint:eslint`, 기존 local executable의 Prettier 전체 check와 `openspec validate add-incoming-follow-request-management --strict`
-- passed — 승인 범위, shared ownership, 접근성 semantics와 테스트 증명력을 독립 구현 리뷰했으며 finding 없음
-- not run — 실제 Web keyboard·screen-reader와 Android/iOS drawer touch target runtime QA. 해당 증거가 없으므로 3.3은 완료 처리하지 않는다.
+- excluded by approved PROD-654 scope — Android/iOS UI·runtime QA, Native touch target과 항목별 수동 Web keyboard·screen reader 1:1 QA. 기존 shared navigation 접근성 계약과 Storybook addon-a11y·Web E2E를 재사용한다.
+- not rerun by explicit user direction — Web-only 문서 정렬과 Lucide 내부 SVG path assertion 3개 제거 후 local 검증은 다시 실행하지 않았다. 위 passing evidence는 production navigation 동작이 같은 이전 HEAD에서 확보했으며, push 이후 hosted CI가 새 HEAD를 검증한다.
 
 ## 4. PROD-566 통합 검증과 OpenSpec 완료
 


### PR DESCRIPTION
## 무엇을 변경했는지

- full Web sidebar, compact Web rail과 mobile Web drawer가 공유하는 내비게이션에 `팔로워 요청` 진입점을 복원했습니다.
- `팔로워 요청`을 `북마크` 바로 위에 배치했습니다.
- 제품 구현은 Lucide `UserRoundPlus`와 canonical `/follow-requests` 경로를 사용합니다.
- Shell Storybook과 Web E2E는 label·destination·순서·active state·drawer close, bottom tab 비노출과 `/menu` 미사용을 검증합니다.
- Lucide 내부 SVG path를 1:1로 고정하던 Storybook assertion 3개를 제거했습니다.
- Linear PROD-654와 공유 OpenSpec을 Web-only navigation slice로 정렬하고 PROD-654 task 3.3을 완료 처리했습니다.

## 왜 변경했는지

PROD-541에서는 받은 요청 화면이 준비되지 않아 generic `/menu`로 이동하던 진입점을 임시 제거했습니다. PROD-566과 PR #492가 `/follow-requests` 화면을 제공했으므로, 준비된 화면을 Web 반응형 내비게이션에 다시 연결합니다.

- Linear: [PROD-654](https://linear.app/byulmaru/issue/PROD-654/팔로우-요청-진입점을-반응형-내비게이션에-복원한다)
- 선행 구현: #492

## 이번 PR의 주요 결정

### 팔로워 요청을 북마크보다 먼저 표시한다

- 결정자: @yeeun-uwu
- 선택: shared navigation에서 `팔로워 요청`을 `북마크` 바로 위에 둡니다.
- 고려한 대안: `팔로워 요청`을 `북마크` 뒤에 두는 기존 구현 순서를 유지합니다.
- 이유: 두 항목의 정보 위계는 `팔로워 요청`이 먼저인 편이 더 적절하다고 결정했습니다.
- 감수한 결과: full Web sidebar, compact Web rail, mobile Web drawer의 항목 순서가 함께 바뀝니다.
- 관련 근거: 사용자 확인, [PROD-654](https://linear.app/byulmaru/issue/PROD-654/팔로우-요청-진입점을-반응형-내비게이션에-복원한다), OpenSpec implementation plan

### PROD-654 navigation slice를 Web surface로 한정한다

- 결정자: @yeeun-uwu
- 선택: full Web sidebar, compact Web rail과 mobile Web drawer만 이 PR의 완료 범위로 둡니다. Android/iOS UI·runtime QA와 Native touch target, 정적 항목별 수동 Web keyboard·screen reader 1:1 QA는 제외합니다.
- 고려한 대안: Android/iOS target 수정과 platform runtime QA를 같은 PR에 포함하거나, Lucide 내부 SVG path를 자동화에서 1:1 검증합니다.
- 이유: 이 PR은 새 interaction이나 semantics를 만들지 않고 기존 shared navigation에 정적 link item을 추가합니다. 기존 role·accessible name·current state·focus·keyboard·drawer lifecycle 계약과 Storybook addon-a11y·Web E2E를 재사용하는 것이 승인된 Web 범위에 맞고, SVG path assertion은 라이브러리 내부 구현에 과결합됩니다.
- 감수한 결과: Android/iOS 동작은 이 PR의 완료 증거가 아니며 기존 Native shell을 변경하지 않습니다. 자동화는 `UserRoundPlus`의 내부 path가 아니라 사용자 관찰 가능한 link 계약을 검증합니다.
- 관련 근거: [PROD-654](https://linear.app/byulmaru/issue/PROD-654/팔로우-요청-진입점을-반응형-내비게이션에-복원한다), `docs/design/accessibility.md`, `docs/design/breakpoints.md`, OpenSpec decision

mobile bottom tab과 generic `/menu`는 기존 범위대로 추가하지 않았습니다.

## 어떻게 확인할 수 있는지

제품 navigation 동작이 같은 이전 HEAD에서 다음 검증을 통과했습니다.

- `pnpm --filter @kosmo/app test:storybook -- src/stories/Shell.stories.tsx` — 289 tests
- `node scripts/test-db.mjs run -- pnpm test:e2e:database -- navigation-scroll.e2e.ts` — 4 tests
- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:unit` — 175 tests
- `pnpm lint:eslint`
- Prettier 전체 check
- Storybook production build
- `openspec validate add-incoming-follow-request-management --strict`

최신 commit `1c51e457`은 문서 범위 정렬과 Lucide 내부 SVG path assertion 3개 제거만 포함합니다. 사용자 지시에 따라 이 정렬 뒤 로컬 검증은 다시 실행하지 않았고, 최신 HEAD의 hosted CI가 실행 중입니다.

## 아직 어떤 문제가 남았는지

- PROD-566이 소유한 화면·Relay slice의 runtime QA, 최종 통합 검증과 OpenSpec archive는 이 PR에서 수행하지 않습니다.
- Android/iOS와 항목별 수동 Web keyboard·screen reader 1:1 QA는 미실행 누락이 아니라 승인된 PROD-654 제외 범위입니다.
- 최신 HEAD의 hosted CI 결과는 아직 확정되지 않았습니다.
