### PR TITLE
emojiReactions 집계 비용을 요청당 한 번으로 제한한다

### DIFF
--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -719,6 +719,22 @@ describe('ActivityPub Local Post Note', () => {
     }
   });
 
+  test('counts more than one page with a single aggregate reaction query', async () => {
+    const author = await createProfile({ kind: InstanceKind.LOCAL });
+    const post = await createPost(author.id);
+    for (let index = 0; index < 51; index++) {
+      const profile = await createProfile({
+        handle: `aggregate-count-${index}`,
+        kind: InstanceKind.LOCAL,
+      });
+      await createReaction(profile.id, post.id, '🥹');
+    }
+
+    const select = mock.method(db, 'select');
+    assert.equal(await countLocalPostEmojiReactions(createContext(), { id: post.id }), 51);
+    assert.equal(select.mock.callCount(), 2);
+  });
+
   test('serves Public and Unlisted collections to anonymous requests', async () => {
     const author = await createProfile({ kind: InstanceKind.LOCAL });
     const federation = createUnsignedCollectionFederation();

--- a/packages/fedify/src/local-post-reaction-collection.ts
+++ b/packages/fedify/src/local-post-reaction-collection.ts
@@ -12,10 +12,11 @@ import {
 } from '@kosmo/core/db';
 import { InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
 import { reactionTypes, reactionTypeSchema } from '@kosmo/core/validation';
-import { and, desc, eq, inArray, isNotNull, lt, ne, or } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNotNull, lt, ne, or, sql } from 'drizzle-orm';
 import { isCanonicalPostId } from './activitypub-post-uri';
 import { loadLocalPostNote } from './local-post-note';
 import type { PageItems, RequestContext } from '@fedify/fedify';
+import type { SQLWrapper } from 'drizzle-orm';
 
 const PAGE_SIZE = 50;
 const FIRST_CURSOR = 'v1:first';
@@ -73,6 +74,11 @@ const parseCursor = (cursor: string | null): Cursor | null => {
 const encodeCursor = (createdAt: Temporal.Instant, id: string): string =>
   `v1:${Buffer.from(JSON.stringify({ createdAt: createdAt.toString(), id }), 'utf8').toString('base64url')}`;
 
+// Authorized write paths store normalized HTTP(S) hrefs. Keep obvious non-HTTP or malformed rows
+// out of the aggregate without materializing vocabulary objects just to count them.
+const httpUriWhere = (column: SQLWrapper) =>
+  sql`${column} ~ ${'^(https?)://[^/?#[:space:]]+([/?#].*)?$'}`;
+
 const eligibleReactionWhere = (postId: string) =>
   and(
     eq(Reactions.postId, postId),
@@ -89,6 +95,19 @@ const eligibleReactionWhere = (postId: string) =>
         ne(Instances.state, InstanceState.SUSPENDED),
         isNotNull(ActivityPubActors.uri),
         isNotNull(ActivityPubReactions.uri),
+      ),
+    ),
+  );
+
+const countableReactionWhere = (postId: string) =>
+  and(
+    eligibleReactionWhere(postId),
+    or(
+      and(eq(Instances.kind, InstanceKind.LOCAL), httpUriWhere(Instances.canonicalOrigin)),
+      and(
+        eq(Instances.kind, InstanceKind.ACTIVITYPUB),
+        httpUriWhere(ActivityPubActors.uri),
+        httpUriWhere(ActivityPubReactions.uri),
       ),
     ),
   );
@@ -269,27 +288,16 @@ export const countLocalPostEmojiReactions = async (
   if (!note) {
     return null;
   }
-  let total = 0;
-  let after: Extract<Cursor, { kind: 'after' }> | null = null;
-  while (true) {
-    const rows = await loadReactionRows(note.id, after, PAGE_SIZE + 1);
-    if (rows.length === 0) {
-      break;
-    }
-    total += rows.reduce(
-      (count, row) => count + (projectReaction(row, note.id, note.canonicalOrigin) ? 1 : 0),
-      0,
-    );
-    if (rows.length < PAGE_SIZE + 1) {
-      break;
-    }
-    const last = rows.at(-1);
-    if (!last) {
-      break;
-    }
-    after = { kind: 'after', createdAt: last.createdAt, id: last.id };
-  }
-  return total;
+  const row = await db
+    .select({ count: count() })
+    .from(Reactions)
+    .innerJoin(Profiles, eq(Profiles.id, Reactions.profileId))
+    .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
+    .leftJoin(ActivityPubActors, eq(ActivityPubActors.profileId, Profiles.id))
+    .leftJoin(ActivityPubReactions, eq(ActivityPubReactions.reactionId, Reactions.id))
+    .where(countableReactionWhere(note.id))
+    .then(first);
+  return row?.count ?? 0;
 };
 
 export const firstLocalPostEmojiReactionsCursor = async (


### PR DESCRIPTION
## 무엇을 변경했는지

- `emojiReactions`의 `totalItems` 계산을 51행 단위 반복 조회에서 단일 SQL `COUNT(*)` 집계로 변경했습니다.
- Local·Remote Reaction의 현재 ActivityPub 표현 가능 조건을 count 전용 predicate로 유지했습니다.
- collection page loader, ordering, page size와 cursor 경로는 변경하지 않았습니다.
- 51개 Reaction에서도 Note 조회와 aggregate count를 합쳐 `db.select`가 2회만 호출되는 회귀 테스트를 추가했습니다.

## 왜 변경했는지

[PROD-500](https://linear.app/byulmaru/issue/PROD-500/activitypub-note의-emojireactions-collection을-제공한다)의 counter는 Reaction을 51개씩 끝까지 순회했습니다. Public·Unlisted collection은 익명 조회가 가능해 Reaction이 많은 Post에서 요청당 DB round trip이 Reaction 수에 비례해 증가합니다.

이 PR은 [PROD-666](https://linear.app/byulmaru/issue/PROD-666/emojireactions-totalitems를-단일-집계-쿼리로-계산한다)과 [PR #501 review finding](https://github.com/byulmaru/kosmo/pull/501#discussion_r3710393201)을 해결합니다.

## 이번 PR의 주요 결정

새로운 wire contract나 저장 계약은 추가하지 않았습니다. production write path가 Local origin과 Remote actor/activity identity를 normalized HTTP(S) URL로 저장한다는 기존 불변식을 사용해 aggregate predicate를 구성했습니다.

비정규 base64url cursor canonicalization은 이 PR 범위에서 제외했습니다.

## 어떻게 확인할 수 있는지

- `pnpm test:fedify` — 201/201 통과
- `pnpm --filter @kosmo/fedify lint:tsc`
- focused ESLint
- Prettier
- `git diff --check`
- correctness 서브에이전트 재리뷰 — 확정 finding 없음

## 아직 어떤 문제가 남았는지

- DB schema 자체가 URI 형식을 강제하지는 않습니다. 다만 모든 production write path가 URL 검증·정규화를 수행하므로 현재 저장 불변식에서는 page와 count 의미가 일치합니다.
- 비정규 cursor 허용 문제는 의도적으로 포함하지 않았습니다.

Stack: main -> PROD-666