### PR TITLE
Byulmaru ID 계정 설정 외부 진입점을 제공한다

### DIFF
--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { afterEach, before, describe, it, mock } from 'node:test';
 import { createRequire } from 'node:module';
+import { afterEach, before, describe, it, mock } from 'node:test';
 import { createElement } from 'react';
 import { act, create } from 'react-test-renderer';
 import type { ComponentType } from 'react';
@@ -20,7 +20,8 @@ const canOpenURL = mock.fn(async () => {
   }
   return canOpenResult;
 });
-const openURL = mock.fn(async (_url: string) => {
+const openURL = mock.fn(async (url: string) => {
+  void url;
   openAttempts += 1;
   if (openImplementation) {
     return await openImplementation();

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, describe, it, mock } from 'node:test';
+import { createRequire } from 'node:module';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ComponentType } from 'react';
+import type { ReactTestInstance, ReactTestRenderer } from 'react-test-renderer';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let canOpenResult = true;
+let canOpenError: Error | null = null;
+let openFailureCount = 0;
+let openImplementation: (() => Promise<void>) | null = null;
+let openAttempts = 0;
+
+const canOpenURL = mock.fn(async () => {
+  if (canOpenError) {
+    throw canOpenError;
+  }
+  return canOpenResult;
+});
+const openURL = mock.fn(async (_url: string) => {
+  openAttempts += 1;
+  if (openImplementation) {
+    return await openImplementation();
+  }
+  if (openAttempts <= openFailureCount) {
+    throw new Error('external navigation failed');
+  }
+});
+
+const require = createRequire(import.meta.url);
+
+mock.module('react-native', {
+  exports: {
+    Linking: { canOpenURL, openURL },
+    Platform: { OS: 'web' },
+    Pressable: 'Pressable',
+    StyleSheet: { create: <T>(styles: T) => styles },
+    Text: 'Text',
+    View: 'View',
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+mock.module(require.resolve('lucide-react-native'), {
+  exports: { ChevronRightIcon: 'ChevronRightIcon' },
+} as unknown as Parameters<typeof mock.module>[1]);
+mock.module(new URL('../../theme/ThemeProvider.tsx', import.meta.url), {
+  exports: {
+    useTheme: () => ({
+      border: '#dddddd',
+      danger: '#aa1010',
+      divider: '#eeeeee',
+      text: '#111111',
+      textSecondary: '#666666',
+    }),
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+
+let Entry: ComponentType;
+let renderer: ReactTestRenderer | null = null;
+
+before(async () => {
+  ({ ByulmaruIdAccountSettingsEntry: Entry } = await import('./ByulmaruIdAccountSettingsEntry'));
+});
+
+afterEach(async () => {
+  canOpenResult = true;
+  canOpenError = null;
+  openFailureCount = 0;
+  openImplementation = null;
+  openAttempts = 0;
+  canOpenURL.mock.resetCalls();
+  openURL.mock.resetCalls();
+  if (renderer) {
+    await act(async () => renderer?.unmount());
+    renderer = null;
+  }
+});
+
+describe('ByulmaruIdAccountSettingsEntry', () => {
+  it('label·link semantics·chevron과 canonical URL 이동을 제공한다', async () => {
+    await render();
+
+    const entry = byTestId('byulmaru-id-account-settings-entry');
+    assert.equal(entry.props.accessibilityLabel, 'Byulmaru ID 계정 설정, 외부 서비스로 이동');
+    assert.equal(entry.props.accessibilityRole, 'link');
+    assert.equal(rendered('ChevronRightIcon').length, 1);
+
+    await act(async () => entry.props.onFocus());
+    assert.equal(
+      byTestId('byulmaru-id-account-settings-entry').props.style({ pressed: false })[1]
+        .outlineWidth,
+      2,
+    );
+    await act(async () => entry.props.onBlur());
+
+    await act(async () => entry.props.onPress());
+
+    assert.equal(canOpenURL.mock.callCount(), 1);
+    assert.equal(openURL.mock.callCount(), 1);
+    assert.equal(openURL.mock.calls[0].arguments[0], 'https://id.byulmaru.co');
+    assert.equal(rendered('byulmaru-id-account-settings-navigation-error').length, 0);
+  });
+
+  it('지원하지 않는 환경에서는 외부 이동을 실행하지 않고 재시도를 표시한다', async () => {
+    canOpenResult = false;
+    await render();
+
+    await act(async () => byTestId('byulmaru-id-account-settings-entry').props.onPress());
+
+    assert.equal(openURL.mock.callCount(), 0);
+    assert.equal(
+      byTestId('byulmaru-id-account-settings-navigation-error').props.accessibilityRole,
+      'alert',
+    );
+    assert.equal(byTestId('byulmaru-id-account-settings-retry').props.accessibilityRole, 'button');
+  });
+
+  it('지원 확인과 외부 이동 rejection을 안전한 오류로 처리한다', async () => {
+    canOpenError = new Error('cannot inspect URL');
+    await render();
+
+    await act(async () => byTestId('byulmaru-id-account-settings-entry').props.onPress());
+    assert.equal(openURL.mock.callCount(), 0);
+    assert.ok(texts().includes('Byulmaru ID 계정 설정을 열지 못했어요.'));
+
+    canOpenError = null;
+    openFailureCount = 1;
+    await act(async () => byTestId('byulmaru-id-account-settings-retry').props.onPress());
+    assert.equal(openURL.mock.callCount(), 1);
+    assert.ok(byTestId('byulmaru-id-account-settings-navigation-error'));
+  });
+
+  it('실패한 외부 이동을 같은 canonical URL로 재시도해 성공하면 오류를 제거한다', async () => {
+    openFailureCount = 1;
+    await render();
+
+    await act(async () => byTestId('byulmaru-id-account-settings-entry').props.onPress());
+    assert.ok(byTestId('byulmaru-id-account-settings-navigation-error'));
+
+    await act(async () => byTestId('byulmaru-id-account-settings-retry').props.onPress());
+
+    assert.equal(openURL.mock.callCount(), 2);
+    assert.equal(queryByTestId('byulmaru-id-account-settings-navigation-error'), undefined);
+    assert.equal(openURL.mock.calls[1].arguments[0], 'https://id.byulmaru.co');
+  });
+
+  it('외부 이동 중 중복 실행을 막고 busy 상태를 노출한다', async () => {
+    let resolveOpen: (() => void) | undefined;
+    openImplementation = () =>
+      new Promise<void>((resolve) => {
+        resolveOpen = resolve;
+      });
+    await render();
+
+    const entry = byTestId('byulmaru-id-account-settings-entry');
+    await act(async () => {
+      void entry.props.onPress();
+      await Promise.resolve();
+    });
+    assert.equal(entry.props.disabled, true);
+    assert.equal(byTestId('byulmaru-id-account-settings-entry').props.disabled, true);
+    assert.equal(
+      byTestId('byulmaru-id-account-settings-entry').props.accessibilityState.busy,
+      true,
+    );
+
+    await act(async () => {
+      void byTestId('byulmaru-id-account-settings-entry').props.onPress();
+      await Promise.resolve();
+    });
+    assert.equal(openURL.mock.callCount(), 1);
+
+    await act(async () => {
+      resolveOpen?.();
+      await Promise.resolve();
+    });
+    assert.equal(byTestId('byulmaru-id-account-settings-entry').props.disabled, false);
+  });
+});
+
+async function render() {
+  await act(async () => {
+    renderer = create(createElement(Entry));
+  });
+  assert.ok(renderer);
+}
+
+function rendered(type: string): ReactTestInstance[] {
+  assert.ok(renderer);
+  return renderer.root.findAll((node) => node.type === type);
+}
+
+function byTestId(testID: string): ReactTestInstance {
+  assert.ok(renderer);
+  return renderer.root.findByProps({ testID });
+}
+
+function queryByTestId(testID: string): ReactTestInstance | undefined {
+  assert.ok(renderer);
+  return renderer.root.findAllByProps({ testID })[0];
+}
+
+function texts(): string[] {
+  return rendered('Text').flatMap((node) =>
+    typeof node.props.children === 'string' ? [node.props.children] : [],
+  );
+}

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import { afterEach, before, describe, it, mock } from 'node:test';
-import { createElement } from 'react';
+import { cloneElement, createElement } from 'react';
 import { act, create } from 'react-test-renderer';
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactElement } from 'react';
 import type { ReactTestInstance, ReactTestRenderer } from 'react-test-renderer';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -33,6 +33,12 @@ const openURL = mock.fn(async (url: string) => {
 
 const require = createRequire(import.meta.url);
 
+mock.module('expo-router', {
+  exports: {
+    Link: ({ children, href }: { children: ReactElement<{ href?: string }>; href: string }) =>
+      createElement('Link', { href }, cloneElement(children, { href })),
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
 mock.module('react-native', {
   exports: {
     Linking: { canOpenURL, openURL },
@@ -86,6 +92,8 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     const entry = byTestId('byulmaru-id-account-settings-entry');
     assert.equal(entry.props.accessibilityLabel, 'Byulmaru ID 계정 설정, 외부 서비스로 이동');
     assert.equal(entry.props.accessibilityRole, 'link');
+    assert.equal(entry.props.href, 'https://id.byulmaru.co');
+    assert.equal(rendered('Link')[0].props.href, 'https://id.byulmaru.co');
     assert.equal(rendered('ChevronRightIcon').length, 1);
 
     await act(async () => entry.props.onFocus());
@@ -96,8 +104,10 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     );
     await act(async () => entry.props.onBlur());
 
-    await act(async () => entry.props.onPress());
+    const event = createWebPressEvent();
+    await act(async () => entry.props.onPress(event));
 
+    assert.equal(event.preventDefault.mock.callCount(), 1);
     assert.equal(canOpenURL.mock.callCount(), 1);
     assert.equal(openURL.mock.callCount(), 1);
     assert.equal(openURL.mock.calls[0].arguments[0], 'https://id.byulmaru.co');
@@ -108,7 +118,7 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     canOpenResult = false;
     await render();
 
-    await act(async () => byTestId('byulmaru-id-account-settings-entry').props.onPress());
+    await pressEntry();
 
     assert.equal(openURL.mock.callCount(), 0);
     assert.equal(
@@ -122,7 +132,7 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     canOpenError = new Error('cannot inspect URL');
     await render();
 
-    await act(async () => byTestId('byulmaru-id-account-settings-entry').props.onPress());
+    await pressEntry();
     assert.equal(openURL.mock.callCount(), 0);
     assert.ok(texts().includes('Byulmaru ID 계정 설정을 열지 못했어요.'));
 
@@ -137,7 +147,7 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     openFailureCount = 1;
     await render();
 
-    await act(async () => byTestId('byulmaru-id-account-settings-entry').props.onPress());
+    await pressEntry();
     assert.ok(byTestId('byulmaru-id-account-settings-navigation-error'));
 
     await act(async () => byTestId('byulmaru-id-account-settings-retry').props.onPress());
@@ -145,6 +155,49 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     assert.equal(openURL.mock.callCount(), 2);
     assert.equal(queryByTestId('byulmaru-id-account-settings-navigation-error'), undefined);
     assert.equal(openURL.mock.calls[1].arguments[0], 'https://id.byulmaru.co');
+  });
+
+  it('Web modifier·보조 버튼은 실제 href의 browser 기본 동작에 맡긴다', async () => {
+    await render();
+    const entry = byTestId('byulmaru-id-account-settings-entry');
+
+    for (const overrides of [{ metaKey: true }, { ctrlKey: true }, { button: 1 }]) {
+      const event = createWebPressEvent(overrides);
+      await act(async () => entry.props.onPress(event));
+      assert.equal(event.preventDefault.mock.callCount(), 0);
+    }
+
+    assert.equal(canOpenURL.mock.callCount(), 0);
+    assert.equal(openURL.mock.callCount(), 0);
+  });
+
+  it('Web 재시도 중 오류와 같은 control·focus 가능한 busy 상태를 유지한다', async () => {
+    openFailureCount = 1;
+    await render();
+    await pressEntry();
+
+    let resolveRetry: (() => void) | undefined;
+    openImplementation = () =>
+      new Promise<void>((resolve) => {
+        resolveRetry = resolve;
+      });
+    const retry = byTestId('byulmaru-id-account-settings-retry');
+
+    await act(async () => {
+      void retry.props.onPress();
+      await Promise.resolve();
+    });
+
+    assert.equal(byTestId('byulmaru-id-account-settings-retry'), retry);
+    assert.ok(byTestId('byulmaru-id-account-settings-navigation-error'));
+    assert.equal(retry.props.disabled, false);
+    assert.deepEqual(retry.props.accessibilityState, { busy: true, disabled: false });
+
+    await act(async () => {
+      resolveRetry?.();
+      await Promise.resolve();
+    });
+    assert.equal(queryByTestId('byulmaru-id-account-settings-navigation-error'), undefined);
   });
 
   it('외부 이동 중 중복 실행을 막고 busy 상태를 노출한다', async () => {
@@ -158,8 +211,8 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     const entry = byTestId('byulmaru-id-account-settings-entry');
     const onPress = entry.props.onPress;
     await act(async () => {
-      void onPress();
-      void onPress();
+      void onPress(createWebPressEvent());
+      void onPress(createWebPressEvent());
       await Promise.resolve();
     });
     assert.equal(canOpenURL.mock.callCount(), 1);
@@ -172,7 +225,7 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     );
 
     await act(async () => {
-      void byTestId('byulmaru-id-account-settings-entry').props.onPress();
+      void byTestId('byulmaru-id-account-settings-entry').props.onPress(createWebPressEvent());
       await Promise.resolve();
     });
     assert.equal(openURL.mock.callCount(), 1);
@@ -190,6 +243,35 @@ async function render() {
     renderer = create(createElement(Entry));
   });
   assert.ok(renderer);
+}
+
+async function pressEntry() {
+  await act(async () =>
+    byTestId('byulmaru-id-account-settings-entry').props.onPress(createWebPressEvent()),
+  );
+}
+
+type WebPressEvent = {
+  altKey?: boolean;
+  button?: number;
+  ctrlKey?: boolean;
+  currentTarget: { target: string | null };
+  defaultPrevented?: boolean;
+  metaKey?: boolean;
+  preventDefault: ReturnType<typeof mock.fn>;
+  shiftKey?: boolean;
+};
+
+function createWebPressEvent(overrides: Partial<WebPressEvent> = {}): WebPressEvent {
+  const event = {
+    button: 0,
+    currentTarget: { target: null },
+    ...overrides,
+  } as WebPressEvent;
+  event.preventDefault = mock.fn(() => {
+    event.defaultPrevented = true;
+  });
+  return event;
 }
 
 function rendered(type: string): ReactTestInstance[] {

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
@@ -156,10 +156,14 @@ describe('ByulmaruIdAccountSettingsEntry', () => {
     await render();
 
     const entry = byTestId('byulmaru-id-account-settings-entry');
+    const onPress = entry.props.onPress;
     await act(async () => {
-      void entry.props.onPress();
+      void onPress();
+      void onPress();
       await Promise.resolve();
     });
+    assert.equal(canOpenURL.mock.callCount(), 1);
+    assert.equal(openURL.mock.callCount(), 1);
     assert.equal(entry.props.disabled, true);
     assert.equal(byTestId('byulmaru-id-account-settings-entry').props.disabled, true);
     assert.equal(

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.test.ts
@@ -8,43 +8,37 @@ import type { ReactTestInstance, ReactTestRenderer } from 'react-test-renderer';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-let canOpenResult = true;
-let canOpenError: Error | null = null;
-let openFailureCount = 0;
-let openImplementation: (() => Promise<void>) | null = null;
-let openAttempts = 0;
-
-const canOpenURL = mock.fn(async () => {
-  if (canOpenError) {
-    throw canOpenError;
-  }
-  return canOpenResult;
-});
-const openURL = mock.fn(async (url: string) => {
-  void url;
-  openAttempts += 1;
-  if (openImplementation) {
-    return await openImplementation();
-  }
-  if (openAttempts <= openFailureCount) {
-    throw new Error('external navigation failed');
-  }
-});
-
 const require = createRequire(import.meta.url);
+let childOnPressBeforeLink: unknown;
+const linkOnPress = () => undefined;
 
 mock.module('expo-router', {
   exports: {
-    Link: ({ children, href }: { children: ReactElement<{ href?: string }>; href: string }) =>
-      createElement('Link', { href }, cloneElement(children, { href })),
+    Link: ({
+      children,
+      href,
+    }: {
+      children: ReactElement<{ href?: string; onPress?: () => void; style?: object }>;
+      href: string;
+    }) => {
+      childOnPressBeforeLink = children.props.onPress;
+      const mergedStyle = { ...(children.props.style as object) };
+      return createElement(
+        'Link',
+        { href },
+        cloneElement(children, { href, onPress: linkOnPress, style: mergedStyle }),
+      );
+    },
   },
 } as unknown as Parameters<typeof mock.module>[1]);
 mock.module('react-native', {
   exports: {
-    Linking: { canOpenURL, openURL },
-    Platform: { OS: 'web' },
     Pressable: 'Pressable',
-    StyleSheet: { create: <T>(styles: T) => styles },
+    StyleSheet: {
+      create: <T>(styles: T) => styles,
+      flatten: (style: unknown) =>
+        Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : style,
+    },
     Text: 'Text',
     View: 'View',
   },
@@ -55,9 +49,8 @@ mock.module(require.resolve('lucide-react-native'), {
 mock.module(new URL('../../theme/ThemeProvider.tsx', import.meta.url), {
   exports: {
     useTheme: () => ({
-      border: '#dddddd',
-      danger: '#aa1010',
       divider: '#eeeeee',
+      focus: '#005fcc',
       text: '#111111',
       textSecondary: '#666666',
     }),
@@ -72,13 +65,7 @@ before(async () => {
 });
 
 afterEach(async () => {
-  canOpenResult = true;
-  canOpenError = null;
-  openFailureCount = 0;
-  openImplementation = null;
-  openAttempts = 0;
-  canOpenURL.mock.resetCalls();
-  openURL.mock.resetCalls();
+  childOnPressBeforeLink = undefined;
   if (renderer) {
     await act(async () => renderer?.unmount());
     renderer = null;
@@ -86,155 +73,37 @@ afterEach(async () => {
 });
 
 describe('ByulmaruIdAccountSettingsEntry', () => {
-  it('label·link semantics·chevron과 canonical URL 이동을 제공한다', async () => {
+  it('계정 설정 label과 Byulmaru ID 외부 Account Settings link를 제공한다', async () => {
     await render();
 
     const entry = byTestId('byulmaru-id-account-settings-entry');
-    assert.equal(entry.props.accessibilityLabel, 'Byulmaru ID 계정 설정, 외부 서비스로 이동');
+    assert.equal(texts().includes('계정 설정'), true);
+    assert.equal(entry.props.accessibilityLabel, 'Byulmaru ID Account Settings 외부 서비스로 이동');
     assert.equal(entry.props.accessibilityRole, 'link');
     assert.equal(entry.props.href, 'https://id.byulmaru.co');
     assert.equal(rendered('Link')[0].props.href, 'https://id.byulmaru.co');
     assert.equal(rendered('ChevronRightIcon').length, 1);
+    assert.equal(childOnPressBeforeLink, undefined);
+  });
+
+  it('focus-visible style과 link target geometry를 유지한다', async () => {
+    await render();
+
+    const entry = byTestId('byulmaru-id-account-settings-entry');
+    assert.equal(entry.props.style.minHeight, 64);
+    assert.equal(entry.props.style.width, '100%');
+    assert.equal(entry.props.style.outlineWidth, undefined);
 
     await act(async () => entry.props.onFocus());
+    const focusedEntry = byTestId('byulmaru-id-account-settings-entry');
+    assert.equal(focusedEntry.props.style.outlineWidth, 2);
+    assert.equal(focusedEntry.props.style.outlineColor, '#005fcc');
+
+    await act(async () => focusedEntry.props.onBlur());
     assert.equal(
-      byTestId('byulmaru-id-account-settings-entry').props.style({ pressed: false })[1]
-        .outlineWidth,
-      2,
+      byTestId('byulmaru-id-account-settings-entry').props.style.outlineWidth,
+      undefined,
     );
-    await act(async () => entry.props.onBlur());
-
-    const event = createWebPressEvent();
-    await act(async () => entry.props.onPress(event));
-
-    assert.equal(event.preventDefault.mock.callCount(), 1);
-    assert.equal(canOpenURL.mock.callCount(), 1);
-    assert.equal(openURL.mock.callCount(), 1);
-    assert.equal(openURL.mock.calls[0].arguments[0], 'https://id.byulmaru.co');
-    assert.equal(rendered('byulmaru-id-account-settings-navigation-error').length, 0);
-  });
-
-  it('지원하지 않는 환경에서는 외부 이동을 실행하지 않고 재시도를 표시한다', async () => {
-    canOpenResult = false;
-    await render();
-
-    await pressEntry();
-
-    assert.equal(openURL.mock.callCount(), 0);
-    assert.equal(
-      byTestId('byulmaru-id-account-settings-navigation-error').props.accessibilityRole,
-      'alert',
-    );
-    assert.equal(byTestId('byulmaru-id-account-settings-retry').props.accessibilityRole, 'button');
-  });
-
-  it('지원 확인과 외부 이동 rejection을 안전한 오류로 처리한다', async () => {
-    canOpenError = new Error('cannot inspect URL');
-    await render();
-
-    await pressEntry();
-    assert.equal(openURL.mock.callCount(), 0);
-    assert.ok(texts().includes('Byulmaru ID 계정 설정을 열지 못했어요.'));
-
-    canOpenError = null;
-    openFailureCount = 1;
-    await act(async () => byTestId('byulmaru-id-account-settings-retry').props.onPress());
-    assert.equal(openURL.mock.callCount(), 1);
-    assert.ok(byTestId('byulmaru-id-account-settings-navigation-error'));
-  });
-
-  it('실패한 외부 이동을 같은 canonical URL로 재시도해 성공하면 오류를 제거한다', async () => {
-    openFailureCount = 1;
-    await render();
-
-    await pressEntry();
-    assert.ok(byTestId('byulmaru-id-account-settings-navigation-error'));
-
-    await act(async () => byTestId('byulmaru-id-account-settings-retry').props.onPress());
-
-    assert.equal(openURL.mock.callCount(), 2);
-    assert.equal(queryByTestId('byulmaru-id-account-settings-navigation-error'), undefined);
-    assert.equal(openURL.mock.calls[1].arguments[0], 'https://id.byulmaru.co');
-  });
-
-  it('Web modifier·보조 버튼은 실제 href의 browser 기본 동작에 맡긴다', async () => {
-    await render();
-    const entry = byTestId('byulmaru-id-account-settings-entry');
-
-    for (const overrides of [{ metaKey: true }, { ctrlKey: true }, { button: 1 }]) {
-      const event = createWebPressEvent(overrides);
-      await act(async () => entry.props.onPress(event));
-      assert.equal(event.preventDefault.mock.callCount(), 0);
-    }
-
-    assert.equal(canOpenURL.mock.callCount(), 0);
-    assert.equal(openURL.mock.callCount(), 0);
-  });
-
-  it('Web 재시도 중 오류와 같은 control·focus 가능한 busy 상태를 유지한다', async () => {
-    openFailureCount = 1;
-    await render();
-    await pressEntry();
-
-    let resolveRetry: (() => void) | undefined;
-    openImplementation = () =>
-      new Promise<void>((resolve) => {
-        resolveRetry = resolve;
-      });
-    const retry = byTestId('byulmaru-id-account-settings-retry');
-
-    await act(async () => {
-      void retry.props.onPress();
-      await Promise.resolve();
-    });
-
-    assert.equal(byTestId('byulmaru-id-account-settings-retry'), retry);
-    assert.ok(byTestId('byulmaru-id-account-settings-navigation-error'));
-    assert.equal(retry.props.disabled, false);
-    assert.deepEqual(retry.props.accessibilityState, { busy: true, disabled: false });
-
-    await act(async () => {
-      resolveRetry?.();
-      await Promise.resolve();
-    });
-    assert.equal(queryByTestId('byulmaru-id-account-settings-navigation-error'), undefined);
-  });
-
-  it('외부 이동 중 중복 실행을 막고 busy 상태를 노출한다', async () => {
-    let resolveOpen: (() => void) | undefined;
-    openImplementation = () =>
-      new Promise<void>((resolve) => {
-        resolveOpen = resolve;
-      });
-    await render();
-
-    const entry = byTestId('byulmaru-id-account-settings-entry');
-    const onPress = entry.props.onPress;
-    await act(async () => {
-      void onPress(createWebPressEvent());
-      void onPress(createWebPressEvent());
-      await Promise.resolve();
-    });
-    assert.equal(canOpenURL.mock.callCount(), 1);
-    assert.equal(openURL.mock.callCount(), 1);
-    assert.equal(entry.props.disabled, true);
-    assert.equal(byTestId('byulmaru-id-account-settings-entry').props.disabled, true);
-    assert.equal(
-      byTestId('byulmaru-id-account-settings-entry').props.accessibilityState.busy,
-      true,
-    );
-
-    await act(async () => {
-      void byTestId('byulmaru-id-account-settings-entry').props.onPress(createWebPressEvent());
-      await Promise.resolve();
-    });
-    assert.equal(openURL.mock.callCount(), 1);
-
-    await act(async () => {
-      resolveOpen?.();
-      await Promise.resolve();
-    });
-    assert.equal(byTestId('byulmaru-id-account-settings-entry').props.disabled, false);
   });
 });
 
@@ -245,35 +114,6 @@ async function render() {
   assert.ok(renderer);
 }
 
-async function pressEntry() {
-  await act(async () =>
-    byTestId('byulmaru-id-account-settings-entry').props.onPress(createWebPressEvent()),
-  );
-}
-
-type WebPressEvent = {
-  altKey?: boolean;
-  button?: number;
-  ctrlKey?: boolean;
-  currentTarget: { target: string | null };
-  defaultPrevented?: boolean;
-  metaKey?: boolean;
-  preventDefault: ReturnType<typeof mock.fn>;
-  shiftKey?: boolean;
-};
-
-function createWebPressEvent(overrides: Partial<WebPressEvent> = {}): WebPressEvent {
-  const event = {
-    button: 0,
-    currentTarget: { target: null },
-    ...overrides,
-  } as WebPressEvent;
-  event.preventDefault = mock.fn(() => {
-    event.defaultPrevented = true;
-  });
-  return event;
-}
-
 function rendered(type: string): ReactTestInstance[] {
   assert.ok(renderer);
   return renderer.root.findAll((node) => node.type === type);
@@ -282,11 +122,6 @@ function rendered(type: string): ReactTestInstance[] {
 function byTestId(testID: string): ReactTestInstance {
   assert.ok(renderer);
   return renderer.root.findByProps({ testID });
-}
-
-function queryByTestId(testID: string): ReactTestInstance | undefined {
-  assert.ok(renderer);
-  return renderer.root.findAllByProps({ testID })[0];
 }
 
 function texts(): string[] {

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
@@ -1,8 +1,10 @@
+import { Link } from 'expo-router';
 import { ChevronRightIcon } from 'lucide-react-native';
 import { useCallback, useRef, useState } from 'react';
 import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';
+import type { LinkProps } from 'expo-router';
 
 export const BYULMARU_ID_ACCOUNT_SETTINGS_URL = 'https://id.byulmaru.co';
 
@@ -12,20 +14,20 @@ const FAILURE_MESSAGE = 'Byulmaru ID 계정 설정을 열지 못했어요.';
 
 export function ByulmaruIdAccountSettingsEntry() {
   const theme = useTheme();
-  const [status, setStatus] = useState<'idle' | 'opening' | 'error'>('idle');
+  const [status, setStatus] = useState<'idle' | 'opening' | 'error' | 'retrying'>('idle');
   const [focused, setFocused] = useState(false);
   const isOpeningRef = useRef(false);
   const web = Platform.OS === 'web';
-  const isOpening = status === 'opening';
-  const hasError = status === 'error';
+  const isOpening = status === 'opening' || status === 'retrying';
+  const hasError = status === 'error' || status === 'retrying';
 
-  const openAccountSettings = useCallback(async () => {
-    if (isOpening || isOpeningRef.current) {
+  const openAccountSettings = useCallback(async (retrying = false) => {
+    if (isOpeningRef.current) {
       return;
     }
 
     isOpeningRef.current = true;
-    setStatus('opening');
+    setStatus(retrying ? 'retrying' : 'opening');
     try {
       if (!(await Linking.canOpenURL(BYULMARU_ID_ACCOUNT_SETTINGS_URL))) {
         throw new Error('unsupported external URL');
@@ -38,38 +40,58 @@ export function ByulmaruIdAccountSettingsEntry() {
     } finally {
       isOpeningRef.current = false;
     }
-  }, [isOpening]);
+  }, []);
+
+  const handleWebPress: NonNullable<LinkProps['onPress']> = (event) => {
+    if (!shouldHandleWebNavigation(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    void openAccountSettings();
+  };
+
+  const entry = (
+    <Pressable
+      accessibilityLabel={ENTRY_ACCESSIBILITY_LABEL}
+      accessibilityRole="link"
+      accessibilityState={{ busy: isOpening, disabled: isOpening || hasError }}
+      aria-busy={web && isOpening ? true : undefined}
+      disabled={isOpening || hasError}
+      onPress={web ? handleWebPress : () => openAccountSettings()}
+      onBlur={() => setFocused(false)}
+      onFocus={() => setFocused(true)}
+      style={({ pressed }) => [
+        styles.entry,
+        web && focused ? styles.entryFocused : null,
+        {
+          borderColor: theme.divider,
+          outlineColor: web && focused ? theme.focus : undefined,
+          opacity: pressed || isOpening || hasError ? 0.6 : 1,
+        },
+      ]}
+      testID="byulmaru-id-account-settings-entry"
+    >
+      <Text style={[styles.label, { color: theme.text }]}>{ENTRY_LABEL}</Text>
+      <ChevronRightIcon
+        accessibilityElementsHidden
+        color={theme.textSecondary}
+        pointerEvents="none"
+        size={20}
+        strokeWidth={2}
+      />
+    </Pressable>
+  );
 
   return (
     <View style={styles.root} testID="byulmaru-id-account-settings-entry-container">
-      <Pressable
-        accessibilityLabel={ENTRY_ACCESSIBILITY_LABEL}
-        accessibilityRole="link"
-        accessibilityState={{ busy: isOpening, disabled: isOpening || hasError }}
-        disabled={isOpening || hasError}
-        onPress={openAccountSettings}
-        onBlur={() => setFocused(false)}
-        onFocus={() => setFocused(true)}
-        style={({ pressed }) => [
-          styles.entry,
-          web && focused ? styles.entryFocused : null,
-          {
-            borderColor: theme.divider,
-            outlineColor: web && focused ? theme.focus : undefined,
-            opacity: pressed || isOpening || hasError ? 0.6 : 1,
-          },
-        ]}
-        testID="byulmaru-id-account-settings-entry"
-      >
-        <Text style={[styles.label, { color: theme.text }]}>{ENTRY_LABEL}</Text>
-        <ChevronRightIcon
-          accessibilityElementsHidden
-          color={theme.textSecondary}
-          pointerEvents="none"
-          size={20}
-          strokeWidth={2}
-        />
-      </Pressable>
+      {web ? (
+        <Link asChild href={BYULMARU_ID_ACCOUNT_SETTINGS_URL}>
+          {entry}
+        </Link>
+      ) : (
+        entry
+      )}
 
       {hasError ? (
         <View
@@ -82,10 +104,19 @@ export function ByulmaruIdAccountSettingsEntry() {
           <Pressable
             accessibilityLabel="Byulmaru ID 계정 설정 다시 시도"
             accessibilityRole="button"
-            onPress={openAccountSettings}
+            accessibilityState={{
+              busy: status === 'retrying',
+              disabled: !web && status === 'retrying',
+            }}
+            aria-busy={web && status === 'retrying' ? true : undefined}
+            disabled={!web && status === 'retrying'}
+            onPress={() => openAccountSettings(true)}
             style={({ pressed }) => [
               styles.retry,
-              { borderColor: theme.border, opacity: pressed ? 0.7 : 1 },
+              {
+                borderColor: theme.border,
+                opacity: pressed || status === 'retrying' ? 0.7 : 1,
+              },
             ]}
             testID="byulmaru-id-account-settings-retry"
           >
@@ -94,6 +125,26 @@ export function ByulmaruIdAccountSettingsEntry() {
         </View>
       ) : null}
     </View>
+  );
+}
+
+function shouldHandleWebNavigation(event: Parameters<NonNullable<LinkProps['onPress']>>[0]) {
+  const webEvent = event as typeof event & {
+    altKey?: boolean;
+    button?: number;
+    ctrlKey?: boolean;
+    currentTarget?: { target?: string | null };
+    metaKey?: boolean;
+    shiftKey?: boolean;
+  };
+  return (
+    !webEvent.defaultPrevented &&
+    !webEvent.metaKey &&
+    !webEvent.altKey &&
+    !webEvent.ctrlKey &&
+    !webEvent.shiftKey &&
+    (webEvent.button == null || webEvent.button === 0) &&
+    [undefined, null, '', 'self'].includes(webEvent.currentTarget?.target)
   );
 }
 

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
@@ -1,150 +1,49 @@
 import { Link } from 'expo-router';
 import { ChevronRightIcon } from 'lucide-react-native';
-import { useCallback, useRef, useState } from 'react';
-import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';
-import type { LinkProps } from 'expo-router';
 
 export const BYULMARU_ID_ACCOUNT_SETTINGS_URL = 'https://id.byulmaru.co';
 
-const ENTRY_LABEL = 'Byulmaru ID 계정 설정';
-const ENTRY_ACCESSIBILITY_LABEL = `${ENTRY_LABEL}, 외부 서비스로 이동`;
-const FAILURE_MESSAGE = 'Byulmaru ID 계정 설정을 열지 못했어요.';
+const ENTRY_LABEL = '계정 설정';
+const ENTRY_ACCESSIBILITY_LABEL = 'Byulmaru ID Account Settings 외부 서비스로 이동';
 
 export function ByulmaruIdAccountSettingsEntry() {
   const theme = useTheme();
-  const [status, setStatus] = useState<'idle' | 'opening' | 'error' | 'retrying'>('idle');
   const [focused, setFocused] = useState(false);
-  const isOpeningRef = useRef(false);
-  const web = Platform.OS === 'web';
-  const isOpening = status === 'opening' || status === 'retrying';
-  const hasError = status === 'error' || status === 'retrying';
-
-  const openAccountSettings = useCallback(async (retrying = false) => {
-    if (isOpeningRef.current) {
-      return;
-    }
-
-    isOpeningRef.current = true;
-    setStatus(retrying ? 'retrying' : 'opening');
-    try {
-      if (!(await Linking.canOpenURL(BYULMARU_ID_ACCOUNT_SETTINGS_URL))) {
-        throw new Error('unsupported external URL');
-      }
-
-      await Linking.openURL(BYULMARU_ID_ACCOUNT_SETTINGS_URL);
-      setStatus('idle');
-    } catch {
-      setStatus('error');
-    } finally {
-      isOpeningRef.current = false;
-    }
-  }, []);
-
-  const handleWebPress: NonNullable<LinkProps['onPress']> = (event) => {
-    if (!shouldHandleWebNavigation(event)) {
-      return;
-    }
-
-    event.preventDefault();
-    void openAccountSettings();
-  };
-
-  const entry = (
-    <Pressable
-      accessibilityLabel={ENTRY_ACCESSIBILITY_LABEL}
-      accessibilityRole="link"
-      accessibilityState={{ busy: isOpening, disabled: isOpening || hasError }}
-      aria-busy={web && isOpening ? true : undefined}
-      disabled={isOpening || hasError}
-      onPress={web ? handleWebPress : () => openAccountSettings()}
-      onBlur={() => setFocused(false)}
-      onFocus={() => setFocused(true)}
-      style={({ pressed }) => [
-        styles.entry,
-        web && focused ? styles.entryFocused : null,
-        {
-          borderColor: theme.divider,
-          outlineColor: web && focused ? theme.focus : undefined,
-          opacity: pressed || isOpening || hasError ? 0.6 : 1,
-        },
-      ]}
-      testID="byulmaru-id-account-settings-entry"
-    >
-      <Text style={[styles.label, { color: theme.text }]}>{ENTRY_LABEL}</Text>
-      <ChevronRightIcon
-        accessibilityElementsHidden
-        color={theme.textSecondary}
-        pointerEvents="none"
-        size={20}
-        strokeWidth={2}
-      />
-    </Pressable>
-  );
+  const entryStyle = StyleSheet.flatten([
+    styles.entry,
+    focused ? styles.entryFocused : null,
+    {
+      borderColor: theme.divider,
+      outlineColor: focused ? theme.focus : undefined,
+    },
+  ]);
 
   return (
     <View style={styles.root} testID="byulmaru-id-account-settings-entry-container">
-      {web ? (
-        <Link asChild href={BYULMARU_ID_ACCOUNT_SETTINGS_URL}>
-          {entry}
-        </Link>
-      ) : (
-        entry
-      )}
-
-      {hasError ? (
-        <View
-          accessibilityLiveRegion="polite"
-          accessibilityRole="alert"
-          style={[styles.error, { borderColor: theme.divider }]}
-          testID="byulmaru-id-account-settings-navigation-error"
+      <Link asChild href={BYULMARU_ID_ACCOUNT_SETTINGS_URL}>
+        <Pressable
+          accessibilityLabel={ENTRY_ACCESSIBILITY_LABEL}
+          accessibilityRole="link"
+          onBlur={() => setFocused(false)}
+          onFocus={() => setFocused(true)}
+          style={entryStyle}
+          testID="byulmaru-id-account-settings-entry"
         >
-          <Text style={[styles.errorMessage, { color: theme.danger }]}>{FAILURE_MESSAGE}</Text>
-          <Pressable
-            accessibilityLabel="Byulmaru ID 계정 설정 다시 시도"
-            accessibilityRole="button"
-            accessibilityState={{
-              busy: status === 'retrying',
-              disabled: !web && status === 'retrying',
-            }}
-            aria-busy={web && status === 'retrying' ? true : undefined}
-            disabled={!web && status === 'retrying'}
-            onPress={() => openAccountSettings(true)}
-            style={({ pressed }) => [
-              styles.retry,
-              {
-                borderColor: theme.border,
-                opacity: pressed || status === 'retrying' ? 0.7 : 1,
-              },
-            ]}
-            testID="byulmaru-id-account-settings-retry"
-          >
-            <Text style={[styles.retryLabel, { color: theme.text }]}>다시 시도</Text>
-          </Pressable>
-        </View>
-      ) : null}
+          <Text style={[styles.label, { color: theme.text }]}>{ENTRY_LABEL}</Text>
+          <ChevronRightIcon
+            accessibilityElementsHidden
+            color={theme.textSecondary}
+            pointerEvents="none"
+            size={20}
+            strokeWidth={2}
+          />
+        </Pressable>
+      </Link>
     </View>
-  );
-}
-
-function shouldHandleWebNavigation(event: Parameters<NonNullable<LinkProps['onPress']>>[0]) {
-  const webEvent = event as typeof event & {
-    altKey?: boolean;
-    button?: number;
-    ctrlKey?: boolean;
-    currentTarget?: { target?: string | null };
-    metaKey?: boolean;
-    shiftKey?: boolean;
-  };
-  return (
-    !webEvent.defaultPrevented &&
-    !webEvent.metaKey &&
-    !webEvent.altKey &&
-    !webEvent.ctrlKey &&
-    !webEvent.shiftKey &&
-    (webEvent.button == null || webEvent.button === 0) &&
-    [undefined, null, '', 'self'].includes(webEvent.currentTarget?.target)
   );
 }
 
@@ -171,22 +70,4 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     ...typography.md,
   },
-  error: {
-    alignItems: 'flex-start',
-    borderBottomWidth: 1,
-    gap: spacing.sm,
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
-  },
-  errorMessage: { fontFamily: 'SUIT', ...typography.sm },
-  retry: {
-    alignItems: 'center',
-    borderRadius: 8,
-    borderWidth: 1,
-    justifyContent: 'center',
-    minHeight: 48,
-    minWidth: 112,
-    paddingHorizontal: spacing.lg,
-  },
-  retryLabel: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
 });

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useState } from 'react';
+import { ChevronRightIcon } from 'lucide-react-native';
+import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/theme/ThemeProvider';
+import { spacing, typography } from '@/theme/tokens';
+
+export const BYULMARU_ID_ACCOUNT_SETTINGS_URL = 'https://id.byulmaru.co';
+
+const ENTRY_LABEL = 'Byulmaru ID 계정 설정';
+const ENTRY_ACCESSIBILITY_LABEL = `${ENTRY_LABEL}, 외부 서비스로 이동`;
+const FAILURE_MESSAGE = 'Byulmaru ID 계정 설정을 열지 못했어요.';
+
+export function ByulmaruIdAccountSettingsEntry() {
+  const theme = useTheme();
+  const [status, setStatus] = useState<'idle' | 'opening' | 'error'>('idle');
+  const [focused, setFocused] = useState(false);
+  const web = Platform.OS === 'web';
+  const isOpening = status === 'opening';
+  const hasError = status === 'error';
+
+  const openAccountSettings = useCallback(async () => {
+    if (isOpening) {
+      return;
+    }
+
+    setStatus('opening');
+    try {
+      if (!(await Linking.canOpenURL(BYULMARU_ID_ACCOUNT_SETTINGS_URL))) {
+        throw new Error('unsupported external URL');
+      }
+
+      await Linking.openURL(BYULMARU_ID_ACCOUNT_SETTINGS_URL);
+      setStatus('idle');
+    } catch {
+      setStatus('error');
+    }
+  }, [isOpening]);
+
+  return (
+    <View style={styles.root} testID="byulmaru-id-account-settings-entry-container">
+      <Pressable
+        accessibilityLabel={ENTRY_ACCESSIBILITY_LABEL}
+        accessibilityRole="link"
+        accessibilityState={{ busy: isOpening, disabled: isOpening || hasError }}
+        disabled={isOpening || hasError}
+        onPress={openAccountSettings}
+        onBlur={() => setFocused(false)}
+        onFocus={() => setFocused(true)}
+        style={({ pressed }) => [
+          styles.entry,
+          web && focused ? styles.entryFocused : null,
+          {
+            borderColor: theme.divider,
+            outlineColor: web && focused ? theme.focus : undefined,
+            opacity: pressed || isOpening || hasError ? 0.6 : 1,
+          },
+        ]}
+        testID="byulmaru-id-account-settings-entry"
+      >
+        <Text style={[styles.label, { color: theme.text }]}>{ENTRY_LABEL}</Text>
+        <ChevronRightIcon
+          accessibilityElementsHidden
+          color={theme.textSecondary}
+          pointerEvents="none"
+          size={20}
+          strokeWidth={2}
+        />
+      </Pressable>
+
+      {hasError ? (
+        <View
+          accessibilityLiveRegion="polite"
+          accessibilityRole="alert"
+          style={[styles.error, { borderColor: theme.divider }]}
+          testID="byulmaru-id-account-settings-navigation-error"
+        >
+          <Text style={[styles.errorMessage, { color: theme.danger }]}>{FAILURE_MESSAGE}</Text>
+          <Pressable
+            accessibilityLabel="Byulmaru ID 계정 설정 다시 시도"
+            accessibilityRole="button"
+            onPress={openAccountSettings}
+            style={({ pressed }) => [
+              styles.retry,
+              { borderColor: theme.border, opacity: pressed ? 0.7 : 1 },
+            ]}
+            testID="byulmaru-id-account-settings-retry"
+          >
+            <Text style={[styles.retryLabel, { color: theme.text }]}>다시 시도</Text>
+          </Pressable>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { width: '100%' },
+  entry: {
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    minHeight: 64,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    width: '100%',
+  },
+  entryFocused: {
+    outlineStyle: 'solid' as never,
+    outlineWidth: 2,
+  },
+  label: {
+    flex: 1,
+    flexShrink: 1,
+    fontFamily: 'SUIT',
+    fontWeight: '700',
+    ...typography.md,
+  },
+  error: {
+    alignItems: 'flex-start',
+    borderBottomWidth: 1,
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  errorMessage: { fontFamily: 'SUIT', ...typography.sm },
+  retry: {
+    alignItems: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+    justifyContent: 'center',
+    minHeight: 48,
+    minWidth: 112,
+    paddingHorizontal: spacing.lg,
+  },
+  retryLabel: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
+});

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from 'lucide-react-native';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';
@@ -14,15 +14,17 @@ export function ByulmaruIdAccountSettingsEntry() {
   const theme = useTheme();
   const [status, setStatus] = useState<'idle' | 'opening' | 'error'>('idle');
   const [focused, setFocused] = useState(false);
+  const isOpeningRef = useRef(false);
   const web = Platform.OS === 'web';
   const isOpening = status === 'opening';
   const hasError = status === 'error';
 
   const openAccountSettings = useCallback(async () => {
-    if (isOpening) {
+    if (isOpening || isOpeningRef.current) {
       return;
     }
 
+    isOpeningRef.current = true;
     setStatus('opening');
     try {
       if (!(await Linking.canOpenURL(BYULMARU_ID_ACCOUNT_SETTINGS_URL))) {
@@ -33,6 +35,8 @@ export function ByulmaruIdAccountSettingsEntry() {
       setStatus('idle');
     } catch {
       setStatus('error');
+    } finally {
+      isOpeningRef.current = false;
     }
   }, [isOpening]);
 

--- a/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
+++ b/apps/app/src/components/settings/ByulmaruIdAccountSettingsEntry.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react';
 import { ChevronRightIcon } from 'lucide-react-native';
+import { useCallback, useState } from 'react';
 import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';

--- a/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
+++ b/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
@@ -1,0 +1,108 @@
+import { Linking, View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import {
+  ByulmaruIdAccountSettingsEntry,
+  BYULMARU_ID_ACCOUNT_SETTINGS_URL,
+} from '@/components/settings/ByulmaruIdAccountSettingsEntry';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Settings/ByulmaruIdAccountSettingsEntry',
+  component: ByulmaruIdAccountSettingsEntry,
+  decorators: [
+    (Story) => (
+      <View style={{ maxWidth: 600, width: '100%' }}>
+        <Story />
+      </View>
+    ),
+  ],
+} satisfies Meta<typeof ByulmaruIdAccountSettingsEntry>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const originalCanOpenURL = Linking.canOpenURL;
+    const originalOpenURL = Linking.openURL;
+    const canOpenURL = fn(async () => true);
+    const openURL = fn(async () => undefined);
+    Linking.canOpenURL = canOpenURL;
+    Linking.openURL = openURL;
+
+    try {
+      const canvas = within(canvasElement);
+      const entry = canvas.getByRole('link', {
+        name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동',
+      });
+      await expect(entry).toBeVisible();
+      await userEvent.click(entry);
+      await expect(openURL).toHaveBeenCalledWith(BYULMARU_ID_ACCOUNT_SETTINGS_URL);
+      await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    } finally {
+      Linking.canOpenURL = originalCanOpenURL;
+      Linking.openURL = originalOpenURL;
+    }
+  },
+};
+
+export const UnsupportedEnvironment: Story = {
+  play: async ({ canvasElement }) => {
+    const originalCanOpenURL = Linking.canOpenURL;
+    const originalOpenURL = Linking.openURL;
+    const canOpenURL = fn(async () => false);
+    const openURL = fn(async () => undefined);
+    Linking.canOpenURL = canOpenURL;
+    Linking.openURL = openURL;
+
+    try {
+      const canvas = within(canvasElement);
+      await userEvent.click(
+        canvas.getByRole('link', { name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동' }),
+      );
+      await expect(canvas.getByRole('alert')).toHaveTextContent(
+        'Byulmaru ID 계정 설정을 열지 못했어요.',
+      );
+      await expect(
+        canvas.getByRole('button', { name: 'Byulmaru ID 계정 설정 다시 시도' }),
+      ).toBeVisible();
+      await expect(openURL).not.toHaveBeenCalled();
+    } finally {
+      Linking.canOpenURL = originalCanOpenURL;
+      Linking.openURL = originalOpenURL;
+    }
+  },
+};
+
+export const NavigationFailureRetry: Story = {
+  play: async ({ canvasElement }) => {
+    const originalCanOpenURL = Linking.canOpenURL;
+    const originalOpenURL = Linking.openURL;
+    let attempts = 0;
+    const canOpenURL = fn(async () => true);
+    const openURL = fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error('story navigation failure');
+      }
+    });
+    Linking.canOpenURL = canOpenURL;
+    Linking.openURL = openURL;
+
+    try {
+      const canvas = within(canvasElement);
+      await userEvent.click(
+        canvas.getByRole('link', { name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동' }),
+      );
+      await expect(canvas.getByRole('alert')).toBeVisible();
+      await userEvent.click(
+        canvas.getByRole('button', { name: 'Byulmaru ID 계정 설정 다시 시도' }),
+      );
+      await expect(openURL).toHaveBeenCalledTimes(2);
+      await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+    } finally {
+      Linking.canOpenURL = originalCanOpenURL;
+      Linking.openURL = originalOpenURL;
+    }
+  },
+};

--- a/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
+++ b/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
@@ -1,5 +1,5 @@
-import { Linking, View } from 'react-native';
-import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { View } from 'react-native';
+import { expect, waitFor, within } from 'storybook/test';
 import {
   BYULMARU_ID_ACCOUNT_SETTINGS_URL,
   ByulmaruIdAccountSettingsEntry,
@@ -23,100 +23,24 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   play: async ({ canvasElement }) => {
-    const originalCanOpenURL = Linking.canOpenURL;
-    const originalOpenURL = Linking.openURL;
-    const canOpenURL = fn(async () => true);
-    const openURL = fn(async () => undefined);
-    Linking.canOpenURL = canOpenURL;
-    Linking.openURL = openURL;
-
-    try {
-      const canvas = within(canvasElement);
-      const entry = canvas.getByRole('link', {
-        name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동',
-      });
-      await expect(entry).toBeVisible();
-      await expect(entry).toHaveAttribute('href', BYULMARU_ID_ACCOUNT_SETTINGS_URL);
-      entry.focus();
-      await userEvent.keyboard('{Enter}');
-      await expect(openURL).toHaveBeenCalledWith(BYULMARU_ID_ACCOUNT_SETTINGS_URL);
-      await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
-    } finally {
-      Linking.canOpenURL = originalCanOpenURL;
-      Linking.openURL = originalOpenURL;
-    }
-  },
-};
-
-export const UnsupportedEnvironment: Story = {
-  play: async ({ canvasElement }) => {
-    const originalCanOpenURL = Linking.canOpenURL;
-    const originalOpenURL = Linking.openURL;
-    const canOpenURL = fn(async () => false);
-    const openURL = fn(async () => undefined);
-    Linking.canOpenURL = canOpenURL;
-    Linking.openURL = openURL;
-
-    try {
-      const canvas = within(canvasElement);
-      await userEvent.click(
-        canvas.getByRole('link', { name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동' }),
-      );
-      await expect(canvas.getByRole('alert')).toHaveTextContent(
-        'Byulmaru ID 계정 설정을 열지 못했어요.',
-      );
-      await expect(
-        canvas.getByRole('button', { name: 'Byulmaru ID 계정 설정 다시 시도' }),
-      ).toBeVisible();
-      await expect(openURL).not.toHaveBeenCalled();
-    } finally {
-      Linking.canOpenURL = originalCanOpenURL;
-      Linking.openURL = originalOpenURL;
-    }
-  },
-};
-
-export const NavigationFailureRetry: Story = {
-  play: async ({ canvasElement }) => {
-    const originalCanOpenURL = Linking.canOpenURL;
-    const originalOpenURL = Linking.openURL;
-    let attempts = 0;
-    let resolveRetry: (() => void) | undefined;
-    const canOpenURL = fn(async () => true);
-    const openURL = fn(() => {
-      attempts += 1;
-      if (attempts === 1) {
-        return Promise.reject(new Error('story navigation failure'));
-      }
-      return new Promise<void>((resolve) => {
-        resolveRetry = resolve;
-      });
+    const canvas = within(canvasElement);
+    const entry = canvas.getByRole('link', {
+      name: 'Byulmaru ID Account Settings 외부 서비스로 이동',
     });
-    Linking.canOpenURL = canOpenURL;
-    Linking.openURL = openURL;
 
-    try {
-      const canvas = within(canvasElement);
-      await userEvent.click(
-        canvas.getByRole('link', { name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동' }),
-      );
-      await expect(canvas.getByRole('alert')).toBeVisible();
-      const retry = canvas.getByRole('button', {
-        name: 'Byulmaru ID 계정 설정 다시 시도',
-      });
-      retry.focus();
-      const retryInteraction = userEvent.keyboard('{Enter}');
-      await waitFor(() => expect(resolveRetry).toBeDefined());
-      await expect(canvas.getByRole('alert')).toBeVisible();
-      await expect(retry).toHaveAttribute('aria-busy', 'true');
-      await expect(retry).toHaveFocus();
-      await expect(openURL).toHaveBeenCalledTimes(2);
-      resolveRetry?.();
-      await retryInteraction;
-      await waitFor(() => expect(canvas.queryByRole('alert')).not.toBeInTheDocument());
-    } finally {
-      Linking.canOpenURL = originalCanOpenURL;
-      Linking.openURL = originalOpenURL;
-    }
+    await expect(canvas.getByText('계정 설정')).toBeVisible();
+    await expect(entry).toBeVisible();
+    await expect(entry).toHaveAttribute('href', BYULMARU_ID_ACCOUNT_SETTINGS_URL);
+    const domEntry = entry as HTMLElement;
+    expect(domEntry.style.minHeight).toBe('64px');
+    expect(domEntry.style.width).toBe('100%');
+
+    entry.focus();
+    await expect(entry).toHaveFocus();
+    await waitFor(() => {
+      const computedStyle = getComputedStyle(domEntry);
+      expect(computedStyle.outlineStyle).toBe('solid');
+      expect(computedStyle.outlineWidth).toBe('2px');
+    });
   },
 };

--- a/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
+++ b/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
@@ -1,8 +1,8 @@
 import { Linking, View } from 'react-native';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import {
-  ByulmaruIdAccountSettingsEntry,
   BYULMARU_ID_ACCOUNT_SETTINGS_URL,
+  ByulmaruIdAccountSettingsEntry,
 } from '@/components/settings/ByulmaruIdAccountSettingsEntry';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
+++ b/apps/app/src/stories/ByulmaruIdAccountSettingsEntry.stories.tsx
@@ -1,5 +1,5 @@
 import { Linking, View } from 'react-native';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import {
   BYULMARU_ID_ACCOUNT_SETTINGS_URL,
   ByulmaruIdAccountSettingsEntry,
@@ -36,7 +36,9 @@ export const Default: Story = {
         name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동',
       });
       await expect(entry).toBeVisible();
-      await userEvent.click(entry);
+      await expect(entry).toHaveAttribute('href', BYULMARU_ID_ACCOUNT_SETTINGS_URL);
+      entry.focus();
+      await userEvent.keyboard('{Enter}');
       await expect(openURL).toHaveBeenCalledWith(BYULMARU_ID_ACCOUNT_SETTINGS_URL);
       await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
     } finally {
@@ -79,12 +81,16 @@ export const NavigationFailureRetry: Story = {
     const originalCanOpenURL = Linking.canOpenURL;
     const originalOpenURL = Linking.openURL;
     let attempts = 0;
+    let resolveRetry: (() => void) | undefined;
     const canOpenURL = fn(async () => true);
-    const openURL = fn(async () => {
+    const openURL = fn(() => {
       attempts += 1;
       if (attempts === 1) {
-        throw new Error('story navigation failure');
+        return Promise.reject(new Error('story navigation failure'));
       }
+      return new Promise<void>((resolve) => {
+        resolveRetry = resolve;
+      });
     });
     Linking.canOpenURL = canOpenURL;
     Linking.openURL = openURL;
@@ -95,11 +101,19 @@ export const NavigationFailureRetry: Story = {
         canvas.getByRole('link', { name: 'Byulmaru ID 계정 설정, 외부 서비스로 이동' }),
       );
       await expect(canvas.getByRole('alert')).toBeVisible();
-      await userEvent.click(
-        canvas.getByRole('button', { name: 'Byulmaru ID 계정 설정 다시 시도' }),
-      );
+      const retry = canvas.getByRole('button', {
+        name: 'Byulmaru ID 계정 설정 다시 시도',
+      });
+      retry.focus();
+      const retryInteraction = userEvent.keyboard('{Enter}');
+      await waitFor(() => expect(resolveRetry).toBeDefined());
+      await expect(canvas.getByRole('alert')).toBeVisible();
+      await expect(retry).toHaveAttribute('aria-busy', 'true');
+      await expect(retry).toHaveFocus();
       await expect(openURL).toHaveBeenCalledTimes(2);
-      await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+      resolveRetry?.();
+      await retryInteraction;
+      await waitFor(() => expect(canvas.queryByRole('alert')).not.toBeInTheDocument());
     } finally {
       Linking.canOpenURL = originalCanOpenURL;
       Linking.openURL = originalOpenURL;

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -29,23 +29,24 @@ Account 설정의 **외부 진입점**과 Kosmo가 소유한 선택 Local Profil
   붙이지 않는다.
 - 본문은 Byulmaru ID Account 외부 진입점과 현재 Local Profile의 Kosmo 설정 content를 이 순서로 제공한다.
   `계정 설정`·`프로필 설정` heading, 소유자 label과 설명을 별도 시각 block으로 반복하지 않는다. Account
-  진입점은 행 label·이동 동작·accessible name에서 **Byulmaru ID 외부 서비스**임을 전달하고, Profile
-  control은 accessible name에서 **Kosmo 내부 기능**과 현재 대상을 전달한다.
+  진입점의 시각 label은 `계정 설정`으로 두고, link의 accessible name과 canonical destination에서
+  **Byulmaru ID가 소유한 외부 Account Settings**임을 전달한다. Profile control은 accessible name에서
+  **Kosmo 내부 기능**과 현재 대상을 전달한다.
 - `계정 설정` section은 Byulmaru ID가 소유하는 canonical Account Settings 페이지로 이동하는 진입점만
   제공한다. Kosmo는 이 section에 Account 데이터, 현재 값, 입력 form, 저장 action 또는 Account 관리 기능을
   구현하지 않는다.
-- Account 진입점을 선택하면 Web은 canonical HTTPS URL로 external navigation하고, Android·iOS는 시스템
-  브라우저 또는 승인된 external link flow를 사용한다. canonical URL 결정, 플랫폼별 외부 이동과 실패 복구는
-  PROD-645가 소유하며 PROD-653 page shell은 이를 내부 route나 저장 기능으로 바꾸지 않는다.
+- Account 진입점은 모든 플랫폼에서 Expo Router의 실제 external `Link`와 canonical HTTPS `href`를 사용한다.
+  브라우저 또는 OS가 외부 navigation을 소유하며 Kosmo는 이를 내부 route나 저장 기능으로 바꾸지 않는다.
+  URL 지원 확인, navigation 성공·실패, loading·error·retry·lock 상태를 Kosmo가 소유하지 않는다.
 - `프로필 설정`은 현재 설정 대상인 Local Profile의 표시 이름과 `relativeHandle`을 section 안에서 함께
   표시한다. shell의 selected Profile을 기본 대상으로 사용하며, Profile 데이터 조회·입력·저장은 Kosmo
   내부 기능으로만 제공한다.
 - Account가 접근할 수 있는 Local Profile이 없거나 selected Profile이 없으면 Byulmaru ID Account 설정 외부
   진입점은 계속 표시하고, `프로필 설정`에는 대상이 없음을 설명하는 empty state와 Profile 선택·생성 흐름으로
   이동할 수 있는 action을 제공한다. 다른 Profile의 마지막 설정값을 대신 표시하지 않는다.
-- 공통 page shell은 두 소유 단위의 순서·구분선과 현재 Profile identity 배치만 소유한다. PROD-645는 Account
-  외부 진입점 label·accessible name과 이동을, PROD-648은 Profile control accessible name, 입력·저장과 세부
-  상태를 소유한다.
+- 공통 page shell은 두 소유 단위의 순서·구분선과 현재 Profile identity 배치만 소유한다. Account 외부
+  진입점 child의 label·accessible name·canonical link는 PROD-645가, Profile child와 그 입력·저장 세부 상태는
+  해당 Profile child 이슈가 소유한다. production 조립과 page-level 검증은 PROD-685가 소유한다.
 
 ## Header와 responsive layout
 
@@ -62,28 +63,28 @@ Account 설정의 **외부 진입점**과 Kosmo가 소유한 선택 Local Profil
 
 - route loading, error, empty와 content 상태에서 page heading과 외부 Account 진입점/내부 Profile 설정의
   소유권 구조를 서로 다른 화면처럼 복제하지 않는다.
-- Account 진입점에는 Kosmo가 조회할 Account 값이 없으므로 Account 데이터 loading·empty·save 상태를 만들지
-  않는다. Profile identity 또는 Profile 설정을 불러오는 동안 확인되지 않은 Profile 값을 확정된 것처럼
-  표시하지 않는다.
+- Account 진입점에는 Kosmo가 조회할 Account 값이나 외부 navigation 상태가 없으므로 Account 데이터 및
+  외부 이동 loading·empty·save·error·retry·lock 상태를 만들지 않는다. Profile identity 또는 Profile 설정을
+  불러오는 동안 확인되지 않은 Profile 값을 확정된 것처럼 표시하지 않는다.
 - route-level error는 안전한 한국어 설명과 재시도 action을 제공한다. 이전 Profile의 설정값을 fallback으로
   남기거나 backend 오류 원문을 그대로 노출하지 않는다.
 - Profile 전환 중에는 새 대상의 identity와 데이터가 일치할 때까지 이전 Profile 설정 control을 새 대상의
   값처럼 표시하지 않는다. 세부 pending·dirty 상태와 늦은 응답 격리는 Profile 설정 기능이 소유한다.
-- PROD-645의 외부 이동 action과 PROD-648의 Profile 조회·저장은 각 section 안에서 독립적으로 실패하고
-  복구할 수 있다. Account 외부 이동 실패를 Account 데이터 조회 실패처럼 표현하거나, 공통 route-level
-  boundary가 정상인 다른 section까지 불필요하게 숨기지 않는다.
+- 외부 Account navigation의 실행과 결과는 브라우저 또는 OS가 소유한다. 이를 Account 데이터 조회 실패나
+  공통 route-level boundary로 표현하지 않으며, 정상인 다른 section을 불필요하게 숨기지 않는다.
 
 ## 접근성
 
 - `설정`을 페이지의 단일 heading으로 programmatic하게 노출하고, 문서·보조기술 읽기 순서는 `설정` page
   heading → Account 외부 진입점 → 비상호작용 Profile identity → Profile control을 따른다. 시각적으로 제거한
   `계정 설정`·`프로필 설정` heading을 screen reader 전용 중복 heading으로 다시 만들지 않는다.
-- Account 진입점은 행 label과 accessible name에서 Byulmaru ID 외부 서비스로 이동한다는 사실을 전달한다.
-  Profile control의 accessible name은 Kosmo 내부 기능과 현재 대상을 전달한다. navigation과 page action은
+- Account 진입점은 시각 label `계정 설정`과 link accessible name·canonical destination에서 Byulmaru ID 외부
+  Account Settings로 이동한다는 사실을 전달한다. Profile control의 accessible name은 Kosmo 내부 기능과 현재
+  대상을 전달한다. navigation과 page action은
   실제 동작에 맞는 role, accessible name, current/disabled/busy 상태를 제공한다.
 - Web keyboard Tab 순서는 Account 외부 진입점 → Profile 선택 control(있는 경우) → Profile control이다. page
-  heading과 비상호작용 Profile identity는 tab stop이 아니다. Account 외부 이동 오류 announcement는 PROD-645가,
-  Profile 저장 결과 announcement는 PROD-648이 중복 없이 소유한다.
+  heading과 비상호작용 Profile identity는 tab stop이 아니다. 외부 이동 결과 announcement나 재시도 상태는
+  Kosmo가 소유하지 않으며, Profile 저장 결과 announcement는 Profile 기능이 소유한다.
 - Web target은 [accessibility.md](./accessibility.md)의 24×24 CSS px minimum과 공식 예외를 따르고, iOS는
   기본 44×44pt, Android는 48×48dp touch target을 사용한다.
 - Web 자동화 결과를 Android·iOS screen reader, font scaling과 touch target 검증의 대체 증거로 사용하지
@@ -91,24 +92,18 @@ Account 설정의 **외부 진입점**과 Kosmo가 소유한 선택 Local Profil
 
 ## 기능 이슈 경계와 완료 검증
 
-- PROD-653은 `/settings` route, 공통 page shell, shell navigation, Byulmaru ID Account 외부 진입점과 Kosmo
-  Profile 설정의 정보 구조 및 페이지 수준 통합 검증만 소유한다.
-- PROD-645는 Byulmaru ID 소유권을 드러내는 Account 외부 진입점 label·accessible name, canonical Account
-  Settings URL, Web HTTPS external navigation, Android·iOS external link flow, 이동 오류 처리와 해당 기능
-  검증을 소유한다.
-- PROD-648은 `프로필 설정` section의 Profile 선택 대상, 기본 게시 공개 범위의 저장·권한·상태와 Composer
-  연결 및 해당 기능 검증을 소유한다.
-- PROD-653의 통합 검증은 PROD-645의 외부 navigation 세부 테스트나 PROD-648의 Profile 기능 테스트를
-  반복하지 않는다. 두 section이 한 route에서 `Account 설정(Byulmaru ID 외부 서비스)`과 `Profile
-설정(Kosmo)`의 소유 경계를 전달하고, 지원 navigation surface와 Web·Android·iOS에서 함께 동작하는지만
-  확인한다.
-- PROD-653이 자신의 OpenSpec 정합성 확인과 archive를 소유하며, PROD-645와 PROD-648의 통합 가능한 결과가
-  준비되기 전에는 완료하지 않는다.
+- PROD-653은 완료된 선행 정보 구조 산출물이며 active integration 또는 archive owner가 아니다.
+- PROD-645는 시각 label `계정 설정`, Byulmaru ID 외부 Account Settings accessible name과 canonical `href`를
+  가진 Expo Router external `Link` child 및 그 기능 계약을 소유한다. 브라우저·OS navigation 결과와
+  loading·error·retry·lock은 소유하지 않는다.
+- PROD-685는 production `/settings` route/navigation, PROD-645·PROD-667 child 조립과 page-level 검증을
+  소유한다.
+- PROD-684는 최종 Settings 통합과 전체 OpenSpec 완료·archive 판단을 소유한다.
 
 ## 제외 범위
 
 - 별마루 ID Account Settings 페이지 자체와 Account 데이터 조회·입력·저장·관리 기능
-- Byulmaru ID canonical URL 결정과 플랫폼별 외부 navigation 구현(PROD-645)
+- 브라우저·OS가 소유하는 외부 navigation 결과와 URL 지원 확인·loading·error·retry·lock 상태
 - Profile 기본 게시 공개 범위의 DB, GraphQL, Relay와 Composer 계약
 - 알림 설정, Follow Approval Policy와 아직 승인되지 않은 설정 category
 - 향후 설정 전체의 장기 정보 구조나 별도 nested route를 미리 확정하는 것

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/.openspec.yaml
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-04

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/decisions.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/decisions.md
@@ -31,9 +31,9 @@ Account 외부 진입점 계약을 독립 대조한 결과를 반영한다. 제�
 - Authority / Provenance: `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645`
 - Status: Active
 - Context / Problem: 별도 heading·소유자 설명을 추가하면 승인된 평면 정보 밀도를 깨뜨리고, generic `계정
-  설정`만 표시하면 Byulmaru ID 외부 서비스라는 사실을 전달하지 못한다.
+설정`만 표시하면 Byulmaru ID 외부 서비스라는 사실을 전달하지 못한다.
 - Decision Outcome: 시각 label은 `Byulmaru ID 계정 설정`, accessible name은 `Byulmaru ID 계정 설정, 외부
-  서비스로 이동`을 사용한다. 전체 행이 하나의 link target이며 chevron은 장식 요소로만 표시한다.
+서비스로 이동`을 사용한다. 전체 행이 하나의 link target이며 chevron은 장식 요소로만 표시한다.
 - Alternatives Considered: `계정 설정` generic label, 별도 `Byulmaru ID` owner label과 설명, chevron을 별도
   button으로 만드는 방식. 각각 서비스 경계를 숨기거나 중복 block·focus target을 만들므로 채택하지 않았다.
 - Consequences: 부모 shell은 child 주변에 `계정 설정` heading·owner copy를 덧붙이지 않는다. copy가 바뀌어도

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/decisions.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/decisions.md
@@ -1,82 +1,82 @@
 ## Context
 
-이 기록은 `docs/design/settings.md`, `docs/design/accessibility.md`와 최신 Linear `PROD-645`·`PROD-653`의
-Account 외부 진입점 계약을 독립 대조한 결과를 반영한다. 제품 소유 경계와 관찰 가능한 동작은 upstream을
-재서술하고, 그 범위 안에서 플랫폼 공용 구현과 실패 복구 방식을 선택한다.
+이 기록은 `docs/design/settings.md`와 최신 Linear `PROD-645`, `PROD-685`, `PROD-684`의 Account 외부
+진입점·소유권 계약을 대조한 결과다. `PROD-653`은 완료된 선행 정보 구조 산출물로 기록하며 active 통합·archive
+owner로 취급하지 않는다.
 
 ## Decision Records
 
-### Byulmaru ID root를 Account Settings의 유일한 외부 destination으로 사용한다
+### canonical Account Settings URL은 external Link의 href로만 사용한다
 
-- Decision Date: 2026-08-04
+- Decision Date: 2026-08-05
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/settings.md`, `PROD-645`
 - Status: Active
 - Context / Problem: Kosmo 내부 route나 추론한 provider subpath를 사용하면 Account Settings의 서비스 소유
-  경계가 흐려지거나 존재하지 않는 destination으로 이동할 수 있다.
-- Decision Outcome: Account 진입점은 `https://id.byulmaru.co`만 외부로 연다. Kosmo 내부 Account route,
-  generic placeholder, query가 붙은 URL 또는 추론한 `/settings` subpath를 사용하지 않는다.
-- Alternatives Considered: Kosmo `/settings/account` route, provider `/settings` subpath, runtime OIDC discovery
-  결과로 Account UI URL을 조립하는 방식. 현재 canonical·Linear authority가 없거나 실제 endpoint와 맞지 않아
-  채택하지 않았다.
-- Consequences: destination 변경은 코드 상수만 임의 수정하지 않고 canonical 디자인과 PROD-645 계약을 먼저
-  갱신해야 한다. Kosmo는 provider 인증 뒤 redirect destination을 소유하지 않는다.
-- Confirmation / Follow-up: exact URL unit test와 Web·Android·iOS 외부 이동 검증에서 내부 Router가 호출되지
-  않는지 확인한다.
+  경계가 흐려진다.
+- Decision Outcome: Account 행은 `https://id.byulmaru.co`를 Expo Router `Link`의 exact external `href`로
+  사용한다. Kosmo 내부 Account route, generic placeholder, query가 붙은 URL 또는 추론한 `/settings` subpath를
+  사용하지 않는다.
+- Alternatives Considered: Kosmo `/settings/account` route, provider `/settings` subpath, runtime discovery로
+  URL을 조립하는 방식. 현재 canonical authority가 없어 채택하지 않았다.
+- Consequences: destination 변경은 canonical 디자인과 PROD-645 계약을 먼저 갱신한다. navigation 결과와
+  provider redirect는 브라우저·OS가 소유한다.
+- Confirmation / Follow-up: component test와 Storybook에서 exact href와 실제 link semantics를 확인하고,
+  production route 조립은 `PROD-685`가 검증한다.
 
-### 소유권과 외부 이동 의미를 하나의 평면 Account 행에 담는다
+### 시각 label과 accessible name으로 서로 다른 소유 정보를 전달한다
 
-- Decision Date: 2026-08-04
+- Decision Date: 2026-08-05
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645`
 - Status: Active
-- Context / Problem: 별도 heading·소유자 설명을 추가하면 승인된 평면 정보 밀도를 깨뜨리고, generic `계정
-설정`만 표시하면 Byulmaru ID 외부 서비스라는 사실을 전달하지 못한다.
-- Decision Outcome: 시각 label은 `Byulmaru ID 계정 설정`, accessible name은 `Byulmaru ID 계정 설정, 외부
-서비스로 이동`을 사용한다. 전체 행이 하나의 link target이며 chevron은 장식 요소로만 표시한다.
-- Alternatives Considered: `계정 설정` generic label, 별도 `Byulmaru ID` owner label과 설명, chevron을 별도
-  button으로 만드는 방식. 각각 서비스 경계를 숨기거나 중복 block·focus target을 만들므로 채택하지 않았다.
-- Consequences: 부모 shell은 child 주변에 `계정 설정` heading·owner copy를 덧붙이지 않는다. copy가 바뀌어도
-  Byulmaru ID, Account 수준 설정과 외부 이동 의미를 모두 보존해야 한다.
-- Confirmation / Follow-up: component/Storybook accessibility tree에서 link role, accessible name, chevron의
-  focus target 부재와 Account/Profile 순서를 확인한다.
+- Context / Problem: 시각적으로 `Byulmaru ID 계정 설정`을 반복하면 평면 정보 구조의 generic section label을
+  대체하고, `계정 설정`만 사용하면 외부 서비스 소유권이 보조기술에 전달되지 않는다.
+- Decision Outcome: 시각 label은 `계정 설정`, accessible name은 `Byulmaru ID Account Settings 외부 서비스로
+이동`으로 둔다. 전체 행이 하나의 link target이며 chevron은 장식 요소다.
+- Alternatives Considered: 시각 label에 owner를 반복하거나, 별도 owner label·설명 block 또는 chevron button을
+  추가하는 방식. 정보 구조와 focus target을 중복하므로 채택하지 않았다.
+- Consequences: 부모 shell은 시각 label·owner 설명을 다시 만들지 않는다. accessible name과 canonical href는
+  Byulmaru ID 외부 Account Settings 의미를 함께 유지해야 한다.
+- Confirmation / Follow-up: component/Storybook accessibility tree에서 visible label, link role, accessible
+  name, href와 chevron의 focus target 부재를 확인한다.
 
-### 외부 이동 확인과 실행 실패를 child-local retry 상태로 처리한다
+### 모든 플랫폼에서 Expo Router external Link가 navigation 경계를 소유한다
 
-- Decision Date: 2026-08-04
+- Decision Date: 2026-08-05
 - Decision Class: Implementation Choice
-- Authority / Provenance: `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645`
+- Authority / Provenance: `docs/design/settings.md`, `PROD-645`
 - Status: Active
-- Context / Problem: 외부 handler가 없거나 navigation API가 거부될 수 있으며 Promise rejection을 버리면
-  사용자가 실패를 알거나 복구할 수 없다. 반대로 page-wide boundary는 정상인 Profile 기능까지 숨긴다.
-- Decision Outcome: 한 action 안에서 canonical URL의 지원 여부를 확인하고 지원될 때만 외부 이동을 실행한다.
-  어느 단계든 실패하면 `Byulmaru ID 계정 설정을 열지 못했어요.`와 `다시 시도`를 Account child 가까이에
-  표시한다. 재시도는 동일한 확인과 이동을 반복하고 성공하면 오류를 제거한다.
-- Alternatives Considered: `openURL` fire-and-forget, page-wide error boundary, toast만 표시하고 retry를
-  제공하지 않는 방식. 실패 관찰·재시도 또는 독립 오류 경계를 충족하지 않아 채택하지 않았다.
-- Consequences: child는 작은 interaction state를 소유하지만 Account 데이터 loading·save state는 만들지 않는다.
-  같은 오류를 alert와 toast로 중복 announce하지 않는다.
-- Confirmation / Follow-up: can-open false/rejection, open rejection, retry success와 중복 announcement를 unit
-  test와 Storybook interaction으로 검증한다.
+- Context / Problem: component가 Platform·Linking API와 JS 상태를 소유하면 browser·OS의 실제 link 의미와
+  modifier, 새 탭, 주소 복사 및 native external flow를 가로채게 된다.
+- Decision Outcome: `Link asChild href={BYULMARU_ID_ACCOUNT_SETTINGS_URL}`와 row UI만 유지한다. component에는
+  JS `onPress`, Platform/Linking, URL support check, navigation success/failure, loading/error/retry/lock
+  상태와 helper를 두지 않는다. focus-visible 표시를 위한 local `useState`와 `onFocus`/`onBlur`는 plain static
+  style object를 만들기 위해 허용한다.
+- Alternatives Considered: `Linking.canOpenURL/openURL`, custom `onPress`, child-local error/retry state,
+  platform별 branch. browser·OS navigation lifecycle을 중복 소유하므로 채택하지 않았다.
+- Consequences: Kosmo는 외부 이동 결과를 확인·복구·잠금하지 않는다. 단위 테스트와 Storybook은 실제 외부 이동을
+  실행하지 않고 정적 link semantics를 검증한다.
+- Confirmation / Follow-up: unit test에서 child custom JS `onPress`와 navigation 상태 요소가 없음을 확인하고,
+  Storybook에서 focus와 href만 확인한다.
 
-### PROD-645는 concrete child를 전달하고 PROD-653이 production page에 통합한다
+### 구현·통합·archive 소유권을 분리한다
 
-- Decision Date: 2026-08-04
+- Decision Date: 2026-08-05
 - Decision Class: Derived Contract
-- Authority / Provenance: `docs/design/settings.md`, `PROD-645`, `PROD-653`
+- Authority / Provenance: `PROD-645`, `PROD-685`, `PROD-684`, `PROD-653`
 - Status: Active
-- Context / Problem: parent settings shell과 route가 아직 production component로 존재하지 않는 상태에서
-  PROD-645가 page shell을 만들면 두 이슈의 책임이 합쳐지고 임시 slot API가 다시 생긴다.
-- Decision Outcome: PROD-645는 concrete Account 외부 진입점, navigation·오류 복구와 기능 검증을 소유한다.
-  PROD-653은 이 child를 `/settings` 첫 행에 직접 통합하고 route·Profile content·page-level 플랫폼 검증을
-  소유한다.
-- Alternatives Considered: PROD-645가 `/settings` 전체와 route navigation을 함께 구현하는 방식, parent가
-  callback/ReactElement slot만 먼저 공개하는 방식. Linear 소유권을 침범하거나 제거된 임시 조립 경계를
-  복원하므로 채택하지 않았다.
-- Consequences: PROD-645 branch의 standalone catalog는 통합 가능한 결과지만 production 노출 증거는 아니다.
-  PROD-653 완료와 `add-settings-page-shell` archive는 두 child 통합 이후에만 가능하다.
-- Confirmation / Follow-up: PROD-645 diff에 route·page shell·Profile 구현이 없는지, PROD-653 통합에서 concrete
-  child가 첫 번째 Account 행으로 사용되는지 확인한다.
+- Context / Problem: 선행 정보 구조 산출물 또는 child 구현 PR의 존재만으로 production 통합·OpenSpec archive
+  책임을 추론할 수 없다.
+- Decision Outcome: `PROD-645`는 concrete Account Link child와 그 기능 계약을 소유한다. `PROD-685`는
+  production `/settings` route/navigation, `PROD-645`·`PROD-667` child 조립과 page-level 검증을 소유한다.
+  `PROD-684`는 최종 Settings 통합과 전체 OpenSpec 완료·archive 판단을 소유한다. `PROD-653`은 완료된 선행
+  정보 구조 산출물이다.
+- Alternatives Considered: `PROD-653`이 계속 active integration/archive owner가 되거나, child PR 완료만으로
+  change archive를 판단하는 방식. 현재 Linear ownership과 완료 gate를 반영하지 못해 채택하지 않았다.
+- Consequences: child handoff, page-level 검증과 최종 archive 증거를 각각 해당 owner가 제공한다.
+- Confirmation / Follow-up: tasks와 proposal에 동일한 owner mapping을 유지하고, `PROD-684`가 전체 scope와
+  delta spec 정합성을 최종 확인한다.
 
 ## Remaining Decisions
 
@@ -84,4 +84,21 @@ Account 외부 진입점 계약을 독립 대조한 결과를 반영한다. 제�
 
 ## Superseded Decisions
 
-- 없음.
+### 외부 이동을 child-local 지원 확인·오류·재시도로 소유한다 (Superseded)
+
+- Original Decision Date: 2026-08-04
+- Original Outcome: `Linking.canOpenURL`·`openURL` 호출, 지원 불가·rejection 오류 표시, retry·loading·lock
+  상태를 component가 소유한다.
+- Superseded Date: 2026-08-05
+- Superseded By: `모든 플랫폼에서 Expo Router external Link가 navigation 경계를 소유한다`
+- Reason: 최신 `PROD-645`는 browser·OS가 external navigation을 소유하고 Kosmo가 URL support, success/failure,
+  loading/error/retry/lock 상태를 소유하지 않도록 계약을 변경했다.
+
+### PROD-653이 production 통합·archive를 소유한다 (Superseded)
+
+- Original Decision Date: 2026-08-04
+- Original Outcome: `PROD-653`이 child를 `/settings`에 통합하고 page-level 검증 및 OpenSpec archive를 소유한다.
+- Superseded Date: 2026-08-05
+- Superseded By: `구현·통합·archive 소유권을 분리한다`
+- Reason: 최신 Linear ownership은 `PROD-685`를 production route/navigation과 child assembly/page-level 검증 owner로,
+  `PROD-684`를 final Settings integration과 OpenSpec completion/archive owner로 지정한다.

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/decisions.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/decisions.md
@@ -1,0 +1,87 @@
+## Context
+
+이 기록은 `docs/design/settings.md`, `docs/design/accessibility.md`와 최신 Linear `PROD-645`·`PROD-653`의
+Account 외부 진입점 계약을 독립 대조한 결과를 반영한다. 제품 소유 경계와 관찰 가능한 동작은 upstream을
+재서술하고, 그 범위 안에서 플랫폼 공용 구현과 실패 복구 방식을 선택한다.
+
+## Decision Records
+
+### Byulmaru ID root를 Account Settings의 유일한 외부 destination으로 사용한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/settings.md`, `PROD-645`
+- Status: Active
+- Context / Problem: Kosmo 내부 route나 추론한 provider subpath를 사용하면 Account Settings의 서비스 소유
+  경계가 흐려지거나 존재하지 않는 destination으로 이동할 수 있다.
+- Decision Outcome: Account 진입점은 `https://id.byulmaru.co`만 외부로 연다. Kosmo 내부 Account route,
+  generic placeholder, query가 붙은 URL 또는 추론한 `/settings` subpath를 사용하지 않는다.
+- Alternatives Considered: Kosmo `/settings/account` route, provider `/settings` subpath, runtime OIDC discovery
+  결과로 Account UI URL을 조립하는 방식. 현재 canonical·Linear authority가 없거나 실제 endpoint와 맞지 않아
+  채택하지 않았다.
+- Consequences: destination 변경은 코드 상수만 임의 수정하지 않고 canonical 디자인과 PROD-645 계약을 먼저
+  갱신해야 한다. Kosmo는 provider 인증 뒤 redirect destination을 소유하지 않는다.
+- Confirmation / Follow-up: exact URL unit test와 Web·Android·iOS 외부 이동 검증에서 내부 Router가 호출되지
+  않는지 확인한다.
+
+### 소유권과 외부 이동 의미를 하나의 평면 Account 행에 담는다
+
+- Decision Date: 2026-08-04
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645`
+- Status: Active
+- Context / Problem: 별도 heading·소유자 설명을 추가하면 승인된 평면 정보 밀도를 깨뜨리고, generic `계정
+  설정`만 표시하면 Byulmaru ID 외부 서비스라는 사실을 전달하지 못한다.
+- Decision Outcome: 시각 label은 `Byulmaru ID 계정 설정`, accessible name은 `Byulmaru ID 계정 설정, 외부
+  서비스로 이동`을 사용한다. 전체 행이 하나의 link target이며 chevron은 장식 요소로만 표시한다.
+- Alternatives Considered: `계정 설정` generic label, 별도 `Byulmaru ID` owner label과 설명, chevron을 별도
+  button으로 만드는 방식. 각각 서비스 경계를 숨기거나 중복 block·focus target을 만들므로 채택하지 않았다.
+- Consequences: 부모 shell은 child 주변에 `계정 설정` heading·owner copy를 덧붙이지 않는다. copy가 바뀌어도
+  Byulmaru ID, Account 수준 설정과 외부 이동 의미를 모두 보존해야 한다.
+- Confirmation / Follow-up: component/Storybook accessibility tree에서 link role, accessible name, chevron의
+  focus target 부재와 Account/Profile 순서를 확인한다.
+
+### 외부 이동 확인과 실행 실패를 child-local retry 상태로 처리한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645`
+- Status: Active
+- Context / Problem: 외부 handler가 없거나 navigation API가 거부될 수 있으며 Promise rejection을 버리면
+  사용자가 실패를 알거나 복구할 수 없다. 반대로 page-wide boundary는 정상인 Profile 기능까지 숨긴다.
+- Decision Outcome: 한 action 안에서 canonical URL의 지원 여부를 확인하고 지원될 때만 외부 이동을 실행한다.
+  어느 단계든 실패하면 `Byulmaru ID 계정 설정을 열지 못했어요.`와 `다시 시도`를 Account child 가까이에
+  표시한다. 재시도는 동일한 확인과 이동을 반복하고 성공하면 오류를 제거한다.
+- Alternatives Considered: `openURL` fire-and-forget, page-wide error boundary, toast만 표시하고 retry를
+  제공하지 않는 방식. 실패 관찰·재시도 또는 독립 오류 경계를 충족하지 않아 채택하지 않았다.
+- Consequences: child는 작은 interaction state를 소유하지만 Account 데이터 loading·save state는 만들지 않는다.
+  같은 오류를 alert와 toast로 중복 announce하지 않는다.
+- Confirmation / Follow-up: can-open false/rejection, open rejection, retry success와 중복 announcement를 unit
+  test와 Storybook interaction으로 검증한다.
+
+### PROD-645는 concrete child를 전달하고 PROD-653이 production page에 통합한다
+
+- Decision Date: 2026-08-04
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/settings.md`, `PROD-645`, `PROD-653`
+- Status: Active
+- Context / Problem: parent settings shell과 route가 아직 production component로 존재하지 않는 상태에서
+  PROD-645가 page shell을 만들면 두 이슈의 책임이 합쳐지고 임시 slot API가 다시 생긴다.
+- Decision Outcome: PROD-645는 concrete Account 외부 진입점, navigation·오류 복구와 기능 검증을 소유한다.
+  PROD-653은 이 child를 `/settings` 첫 행에 직접 통합하고 route·Profile content·page-level 플랫폼 검증을
+  소유한다.
+- Alternatives Considered: PROD-645가 `/settings` 전체와 route navigation을 함께 구현하는 방식, parent가
+  callback/ReactElement slot만 먼저 공개하는 방식. Linear 소유권을 침범하거나 제거된 임시 조립 경계를
+  복원하므로 채택하지 않았다.
+- Consequences: PROD-645 branch의 standalone catalog는 통합 가능한 결과지만 production 노출 증거는 아니다.
+  PROD-653 완료와 `add-settings-page-shell` archive는 두 child 통합 이후에만 가능하다.
+- Confirmation / Follow-up: PROD-645 diff에 route·page shell·Profile 구현이 없는지, PROD-653 통합에서 concrete
+  child가 첫 번째 Account 행으로 사용되는지 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/design.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/design.md
@@ -39,16 +39,20 @@
 - `apps/app`의 settings component 영역에 stateful concrete Account entry component를 둔다. public prop은 parent
   layout이 필요한 범위로 제한하고 canonical URL이나 navigation callback을 caller가 주입하게 하지 않는다.
 - 시각 label은 `Byulmaru ID 계정 설정`, accessible name은 `Byulmaru ID 계정 설정, 외부 서비스로 이동`을
-  기본 copy로 사용한다. 전체 행을 `link` role의 `Pressable`로 만들고 우측에는 `ChevronRight`만 둔다.
-- 한 번의 action은 `Linking.canOpenURL('https://id.byulmaru.co')`를 확인한 뒤 true일 때만 같은 URL로
-  `Linking.openURL()`을 실행한다. 확인 또는 이동이 실패하면 platform 원문을 버리고 child 내부 error state로
-  전환한다.
+  기본 copy로 사용한다. 전체 행은 Web에서 canonical `href`를 가진 Expo Router 외부 `Link`와 `Pressable`을
+  결합하고 Native에서는 `link` role의 `Pressable`로 렌더링하며, 우측에는 `ChevronRight`만 둔다.
+- Web의 수정자·보조 버튼 동작은 실제 anchor의 browser 기본 동작에 맡긴다. 평범한 활성화와 Native action은
+  `Linking.canOpenURL('https://id.byulmaru.co')`를 확인한 뒤 true일 때만 같은 URL로 `Linking.openURL()`을
+  실행한다. 확인 또는 이동이 실패하면 platform 원문을 버리고 child 내부 error state로 전환한다.
 - 오류에는 `Byulmaru ID 계정 설정을 열지 못했어요.`와 별도 button role의 `다시 시도`를 제공한다. 재시도는
   동일한 확인→이동 순서를 다시 수행하고 성공하면 오류를 제거한다.
-- 이동 중에는 중복 실행을 막고 link의 busy/disabled 상태를 노출한다. 오류 container는 live region 또는
-  alert semantics로 한 번만 announce하고 Profile content를 가리지 않는다.
-- component unit test는 지원 가능·지원 불가·확인 rejection·open rejection·재시도 성공, exact URL과 semantics를
-  검증한다. Storybook은 기본 행과 실패→재시도 상태를 catalog하고 Web interaction/a11y를 확인한다.
+- 이동 중에는 중복 실행을 막고 link의 busy/disabled 상태를 노출한다. 재시도 중에는 오류 container와 같은
+  retry focus target을 mount 상태로 유지한다. Web retry는 busy 상태와 instance-local 잠금으로 focus를
+  유지하고 Native retry는 busy/disabled 상태를 노출한다. 오류 container는 live region 또는 alert
+  semantics로 한 번만 announce하고 Profile content를 가리지 않는다.
+- component unit test는 지원 가능·지원 불가·확인 rejection·open rejection·재시도 성공, exact URL과 Web
+  anchor·수정자 동작·재시도 pending semantics를 검증한다. Storybook은 keyboard 외부 이동과 실패→재시도
+  focus 유지 상태를 catalog하고 Web interaction/a11y를 확인한다.
 
 ### Allowed Alternatives
 
@@ -58,7 +62,8 @@
 
 ### Known Traps
 
-- Expo Router 내부 `href`로 canonical URL을 처리해 Kosmo route 또는 SPA fallback으로 보내지 않는다.
+- absolute canonical URL이 아닌 Expo Router 내부 `href`로 처리해 Kosmo route 또는 SPA fallback으로 보내지
+  않는다. Web의 실제 외부 anchor를 JS-only `Pressable`로 대체하지 않는다.
 - `void Linking.openURL(...)`처럼 Promise rejection을 버리거나 `canOpenURL=false`를 성공으로 처리하지 않는다.
 - Web에서 native 전용 browser API를 직접 import하거나 공용 component에서 `window`를 읽지 않는다.
 - chevron을 별도 focus target으로 만들거나 Profile control에 같은 이동 affordance를 복제하지 않는다.

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/design.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/design.md
@@ -1,90 +1,93 @@
 ## Context
 
-`PROD-653`의 canonical `docs/design/settings.md`와 `add-settings-page-shell`은 `/settings`의 평면 정보 구조와
-통합 책임을 소유하지만, child가 없는 상태에서 만든 임시 `SettingsPage` slot API는 제거된 상태다. PROD-645는
-이 shell이 나중에 직접 조립할 수 있는 concrete Account 외부 진입점과 그 navigation·오류 상태만 제공해야
-한다. 현재 앱은 Android·iOS·Web이 같은 React Native component tree를 사용하고, `react-native`의 `Linking`
-경계와 `lucide-react-native`, theme token, Node component test와 React Native Web Storybook을 이미 사용한다.
+`PROD-653`이 완료한 정보 구조와 `docs/design/settings.md`는 `/settings`에서 Byulmaru ID Account Settings를
+외부 진입점으로 구분한다. 이 change는 `PROD-645`가 소유하는 독립 Account 행 child를 제공하고,
+`PROD-685`가 production route/navigation에서 `PROD-645`·`PROD-667` child를 조립할 수 있는 계약을 만든다.
+Web·Android·iOS는 같은 React Native component tree를 사용하며, Expo Router `Link`가 external URL과
+브라우저·OS navigation 경계를 소유한다.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Byulmaru ID Account Settings의 label, canonical URL, 플랫폼별 외부 이동과 재시도를 하나의 concrete child에
-  캡슐화한다.
-- 평면 Account 행, 외부 이동 chevron, link semantics와 플랫폼 target 기준을 제공한다.
-- 외부 이동 실패를 child 가까이에서 복구하고 부모 page heading과 Profile 기능에 오류를 전파하지 않는다.
-- PROD-653이 별도 wrapper나 임시 slot 계약 없이 이 concrete child를 settings page에 통합할 수 있게 한다.
+- 시각 label `계정 설정`, Byulmaru ID 외부 Account Settings accessible name, canonical URL을 하나의 평면
+  행에 제공한다.
+- 모든 플랫폼에서 실제 Expo Router external `Link`와 link semantics를 사용하고, 행의 chevron·target geometry·
+  focus-visible styling을 유지한다.
+- `PROD-685`가 별도 slot API나 플랫폼 분기 없이 concrete child를 `/settings`에 조립할 수 있게 한다.
 
 **Non-Goals:**
 
-- `/settings` route, page heading, Profile identity/control, sidebar·rail·drawer navigation 구현
+- `/settings` production route, page heading, Profile child, shell navigation 또는 page-level 통합
+- URL 지원 확인, navigation 성공·실패, loading·error·retry·lock 상태와 그 복구
 - Kosmo Account 데이터 query·form·save와 내부 Account route
 - Byulmaru ID 화면 또는 인증·OAuth/session 계약 변경
-- PROD-653 `add-settings-page-shell`의 task 완료나 archive
+- `PROD-684`의 최종 Settings 통합, OpenSpec 완료·archive 판단
 
 ## Implementation Guidance
 
 ### Current Constraints
 
-- parent branch에는 production `SettingsPage`가 없으므로 PROD-645에서 page shell이나 route를 다시 만들면
-  PROD-653 소유 범위를 침범한다. standalone child와 독립 catalog/test가 현재 slice의 통합 가능한 결과다.
-- Web과 Native를 하나의 component로 유지하되, navigation은 Expo Router의 내부 route가 아니라 운영체제·
-  browser 외부 URL 경계를 사용해야 한다.
-- `Linking.openURL()`만 호출하고 rejection을 버리면 완료 조건의 지원 불가·실패·재시도를 검증할 수 없다.
-- 외부 이동 오류는 Account 데이터 오류가 아니며 page-wide error boundary로 승격해서는 안 된다.
+- `PROD-653`은 완료된 선행 정보 구조 산출물이다. 이 change와 `PROD-645`는 production route나 page shell을
+  다시 만들지 않는다.
+- 외부 navigation을 component의 JS action으로 대체하지 않고 Expo Router의 실제 external `Link`를 사용한다.
+- 브라우저 또는 OS가 navigation lifecycle과 결과를 소유하므로 Kosmo 코드에 `Platform`, `Linking`,
+  `useRef`, `canOpenURL`, `openURL`, loading/error/retry/lock helper를 두지 않는다. focus-visible 표시를 위한
+  local `useState`와 `onFocus`/`onBlur`는 허용하되 navigation 상태와 섞지 않는다.
 
 ### Recommended Approach
 
-- `apps/app`의 settings component 영역에 stateful concrete Account entry component를 둔다. public prop은 parent
-  layout이 필요한 범위로 제한하고 canonical URL이나 navigation callback을 caller가 주입하게 하지 않는다.
-- 시각 label은 `Byulmaru ID 계정 설정`, accessible name은 `Byulmaru ID 계정 설정, 외부 서비스로 이동`을
-  기본 copy로 사용한다. 전체 행은 Web에서 canonical `href`를 가진 Expo Router 외부 `Link`와 `Pressable`을
-  결합하고 Native에서는 `link` role의 `Pressable`로 렌더링하며, 우측에는 `ChevronRight`만 둔다.
-- Web의 수정자·보조 버튼 동작은 실제 anchor의 browser 기본 동작에 맡긴다. 평범한 활성화와 Native action은
-  `Linking.canOpenURL('https://id.byulmaru.co')`를 확인한 뒤 true일 때만 같은 URL로 `Linking.openURL()`을
-  실행한다. 확인 또는 이동이 실패하면 platform 원문을 버리고 child 내부 error state로 전환한다.
-- 오류에는 `Byulmaru ID 계정 설정을 열지 못했어요.`와 별도 button role의 `다시 시도`를 제공한다. 재시도는
-  동일한 확인→이동 순서를 다시 수행하고 성공하면 오류를 제거한다.
-- 이동 중에는 중복 실행을 막고 link의 busy/disabled 상태를 노출한다. 재시도 중에는 오류 container와 같은
-  retry focus target을 mount 상태로 유지한다. Web retry는 busy 상태와 instance-local 잠금으로 focus를
-  유지하고 Native retry는 busy/disabled 상태를 노출한다. 오류 container는 live region 또는 alert
-  semantics로 한 번만 announce하고 Profile content를 가리지 않는다.
-- component unit test는 지원 가능·지원 불가·확인 rejection·open rejection·재시도 성공, exact URL과 Web
-  anchor·수정자 동작·재시도 pending semantics를 검증한다. Storybook은 keyboard 외부 이동과 실패→재시도
-  focus 유지 상태를 catalog하고 Web interaction/a11y를 확인한다.
+- `BYULMARU_ID_ACCOUNT_SETTINGS_URL = 'https://id.byulmaru.co'`를 canonical constant로 유지한다.
+- 시각 label은 `계정 설정`, accessible name은 `Byulmaru ID Account Settings 외부 서비스로 이동`으로 둔다.
+- 다음 shape만 유지한다.
 
-### Allowed Alternatives
+  ```tsx
+  <Link asChild href={BYULMARU_ID_ACCOUNT_SETTINGS_URL}>
+    <Pressable
+      accessibilityRole="link"
+      accessibilityLabel="Byulmaru ID Account Settings 외부 서비스로 이동"
+    >
+      <Text>계정 설정</Text>
+      <ChevronRightIcon accessibilityElementsHidden pointerEvents="none" />
+    </Pressable>
+  </Link>
+  ```
 
-- `react-native` `Linking`과 동일한 HTTPS 외부 이동·지원 확인·오류 계약을 보존하는 기존 승인 wrapper가 구현
-  시점에 존재하면 사용할 수 있다. caller가 canonical URL 또는 오류 처리 책임을 소유하게 만드는 범용 slot은
-  허용하지 않는다.
+- row에는 JS `onPress`를 두지 않는다. Web에서는 실제 anchor의 browser 기본 동작(새 탭, modifier, 주소 복사
+  등)을, Android·iOS에서는 Expo Router와 OS의 external link flow를 그대로 사용한다.
+- focus-visible 표시를 위한 local focus state로 plain static style object를 구성해 `Link` Slot 병합 뒤에도
+  target geometry와 outline을 유지한다. style callback은 사용하지 않으며, chevron은 별도 focus target이나
+  action이 아닌 장식 요소로 둔다.
+- component unit test는 시각 label, accessible label, link role, exact href, chevron, focus-visible style과 JS
+  `onPress` 부재·정적 상태만 검증한다. Linking/error/retry/modifier/lock mocks와 상태 machine test는 두지 않는다.
+- Storybook은 기본 실제 링크 한 상태만 catalog한다. visible label, accessible external link, canonical href와
+  focus 가능성을 확인하되 click/Enter를 발생시켜 외부 navigation을 실행하지 않는다.
 
 ### Known Traps
 
-- absolute canonical URL이 아닌 Expo Router 내부 `href`로 처리해 Kosmo route 또는 SPA fallback으로 보내지
-  않는다. Web의 실제 외부 anchor를 JS-only `Pressable`로 대체하지 않는다.
-- `void Linking.openURL(...)`처럼 Promise rejection을 버리거나 `canOpenURL=false`를 성공으로 처리하지 않는다.
-- Web에서 native 전용 browser API를 직접 import하거나 공용 component에서 `window`를 읽지 않는다.
-- chevron을 별도 focus target으로 만들거나 Profile control에 같은 이동 affordance를 복제하지 않는다.
-- error message에 exception, OS handler 목록 또는 URL 검사 원문을 포함하지 않는다.
+- absolute canonical URL 대신 Expo Router 내부 route나 SPA fallback을 사용하지 않는다.
+- `Pressable`에 `onPress`를 추가해 실제 link를 JS-only action으로 만들지 않는다.
+- `Platform`, `Linking`, `window` 또는 browser/OS support check를 공용 component에 import하지 않는다.
+- visible label에 Byulmaru ID를 반복해 owner copy를 중복하지 않되, accessible name과 destination에서는 외부
+  Account Settings 소유권이 식별되어야 한다.
+- chevron을 별도 focus target으로 만들거나, link에 disabled/busy/lock state를 추가하지 않는다.
 
 ## Risks / Trade-offs
 
-- [Web의 `canOpenURL`은 HTTPS에 대해 실질적으로 항상 true를 반환한다] → Web은 정상 browser navigation과
-  `openURL` rejection을 검증하고, unsupported-handler 분기는 Android·iOS unit/runtime 검증으로 소유한다.
-- [외부 provider가 root route의 인증 후 destination을 변경할 수 있다] → Kosmo는 Linear가 승인한 origin만
-  상수로 사용하고 query/path를 추론하지 않는다. URL 변경은 canonical·Linear를 먼저 갱신한다.
-- [이 branch만으로 production `/settings`에서 보이지 않는다] → PROD-645는 concrete child와 기능 검증을
-  전달하고, PROD-653이 child 결과를 직접 통합해 route/page-level 완료 증거를 소유한다.
+- [provider가 root URL 이후 destination을 결정한다] → Kosmo는 승인된 canonical origin만 href로 사용하고 provider
+  인증·redirect 결과를 추론하지 않는다.
+- [이 branch만으로 production `/settings`에 노출되지 않는다] → `PROD-685`가 route/navigation과
+  `PROD-645`·`PROD-667` child 조립 및 page-level 검증을 소유한다.
+- [전체 Settings 완료 여부가 child PR만으로 결정되지 않는다] → `PROD-684`가 최종 통합 및 OpenSpec
+  완료/archive 판단을 소유한다.
 
 ## Migration Plan
 
-1. 기존 route나 navigation을 노출하지 않은 채 concrete child, unit test와 Storybook 상태를 배포 가능한
-   artifact로 만든다.
-2. PROD-653 branch가 PROD-645 결과를 settings page의 첫 번째 Account 행으로 통합한다.
-3. 통합 전에는 사용자에게 새 진입점이 노출되지 않으므로 rollback은 PROD-645 component 사용을 제거하는
-   것으로 충분하다. 별도 데이터 migration이나 backend rollback은 없다.
+1. production route나 navigation을 노출하지 않은 채 concrete child, 정적 unit test와 기본 Storybook catalog를
+   전달한다.
+2. `PROD-685`가 `PROD-645`·`PROD-667` child를 production `/settings` route에 조립하고 page-level 검증을
+   수행한다.
+3. `PROD-684`가 최종 Settings 통합과 전체 OpenSpec 완료 증거를 확인한 뒤 archive를 판단한다.
 
 ## Open Questions
 

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/design.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/design.md
@@ -1,0 +1,86 @@
+## Context
+
+`PROD-653`의 canonical `docs/design/settings.md`와 `add-settings-page-shell`은 `/settings`의 평면 정보 구조와
+통합 책임을 소유하지만, child가 없는 상태에서 만든 임시 `SettingsPage` slot API는 제거된 상태다. PROD-645는
+이 shell이 나중에 직접 조립할 수 있는 concrete Account 외부 진입점과 그 navigation·오류 상태만 제공해야
+한다. 현재 앱은 Android·iOS·Web이 같은 React Native component tree를 사용하고, `react-native`의 `Linking`
+경계와 `lucide-react-native`, theme token, Node component test와 React Native Web Storybook을 이미 사용한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Byulmaru ID Account Settings의 label, canonical URL, 플랫폼별 외부 이동과 재시도를 하나의 concrete child에
+  캡슐화한다.
+- 평면 Account 행, 외부 이동 chevron, link semantics와 플랫폼 target 기준을 제공한다.
+- 외부 이동 실패를 child 가까이에서 복구하고 부모 page heading과 Profile 기능에 오류를 전파하지 않는다.
+- PROD-653이 별도 wrapper나 임시 slot 계약 없이 이 concrete child를 settings page에 통합할 수 있게 한다.
+
+**Non-Goals:**
+
+- `/settings` route, page heading, Profile identity/control, sidebar·rail·drawer navigation 구현
+- Kosmo Account 데이터 query·form·save와 내부 Account route
+- Byulmaru ID 화면 또는 인증·OAuth/session 계약 변경
+- PROD-653 `add-settings-page-shell`의 task 완료나 archive
+
+## Implementation Guidance
+
+### Current Constraints
+
+- parent branch에는 production `SettingsPage`가 없으므로 PROD-645에서 page shell이나 route를 다시 만들면
+  PROD-653 소유 범위를 침범한다. standalone child와 독립 catalog/test가 현재 slice의 통합 가능한 결과다.
+- Web과 Native를 하나의 component로 유지하되, navigation은 Expo Router의 내부 route가 아니라 운영체제·
+  browser 외부 URL 경계를 사용해야 한다.
+- `Linking.openURL()`만 호출하고 rejection을 버리면 완료 조건의 지원 불가·실패·재시도를 검증할 수 없다.
+- 외부 이동 오류는 Account 데이터 오류가 아니며 page-wide error boundary로 승격해서는 안 된다.
+
+### Recommended Approach
+
+- `apps/app`의 settings component 영역에 stateful concrete Account entry component를 둔다. public prop은 parent
+  layout이 필요한 범위로 제한하고 canonical URL이나 navigation callback을 caller가 주입하게 하지 않는다.
+- 시각 label은 `Byulmaru ID 계정 설정`, accessible name은 `Byulmaru ID 계정 설정, 외부 서비스로 이동`을
+  기본 copy로 사용한다. 전체 행을 `link` role의 `Pressable`로 만들고 우측에는 `ChevronRight`만 둔다.
+- 한 번의 action은 `Linking.canOpenURL('https://id.byulmaru.co')`를 확인한 뒤 true일 때만 같은 URL로
+  `Linking.openURL()`을 실행한다. 확인 또는 이동이 실패하면 platform 원문을 버리고 child 내부 error state로
+  전환한다.
+- 오류에는 `Byulmaru ID 계정 설정을 열지 못했어요.`와 별도 button role의 `다시 시도`를 제공한다. 재시도는
+  동일한 확인→이동 순서를 다시 수행하고 성공하면 오류를 제거한다.
+- 이동 중에는 중복 실행을 막고 link의 busy/disabled 상태를 노출한다. 오류 container는 live region 또는
+  alert semantics로 한 번만 announce하고 Profile content를 가리지 않는다.
+- component unit test는 지원 가능·지원 불가·확인 rejection·open rejection·재시도 성공, exact URL과 semantics를
+  검증한다. Storybook은 기본 행과 실패→재시도 상태를 catalog하고 Web interaction/a11y를 확인한다.
+
+### Allowed Alternatives
+
+- `react-native` `Linking`과 동일한 HTTPS 외부 이동·지원 확인·오류 계약을 보존하는 기존 승인 wrapper가 구현
+  시점에 존재하면 사용할 수 있다. caller가 canonical URL 또는 오류 처리 책임을 소유하게 만드는 범용 slot은
+  허용하지 않는다.
+
+### Known Traps
+
+- Expo Router 내부 `href`로 canonical URL을 처리해 Kosmo route 또는 SPA fallback으로 보내지 않는다.
+- `void Linking.openURL(...)`처럼 Promise rejection을 버리거나 `canOpenURL=false`를 성공으로 처리하지 않는다.
+- Web에서 native 전용 browser API를 직접 import하거나 공용 component에서 `window`를 읽지 않는다.
+- chevron을 별도 focus target으로 만들거나 Profile control에 같은 이동 affordance를 복제하지 않는다.
+- error message에 exception, OS handler 목록 또는 URL 검사 원문을 포함하지 않는다.
+
+## Risks / Trade-offs
+
+- [Web의 `canOpenURL`은 HTTPS에 대해 실질적으로 항상 true를 반환한다] → Web은 정상 browser navigation과
+  `openURL` rejection을 검증하고, unsupported-handler 분기는 Android·iOS unit/runtime 검증으로 소유한다.
+- [외부 provider가 root route의 인증 후 destination을 변경할 수 있다] → Kosmo는 Linear가 승인한 origin만
+  상수로 사용하고 query/path를 추론하지 않는다. URL 변경은 canonical·Linear를 먼저 갱신한다.
+- [이 branch만으로 production `/settings`에서 보이지 않는다] → PROD-645는 concrete child와 기능 검증을
+  전달하고, PROD-653이 child 결과를 직접 통합해 route/page-level 완료 증거를 소유한다.
+
+## Migration Plan
+
+1. 기존 route나 navigation을 노출하지 않은 채 concrete child, unit test와 Storybook 상태를 배포 가능한
+   artifact로 만든다.
+2. PROD-653 branch가 PROD-645 결과를 settings page의 첫 번째 Account 행으로 통합한다.
+3. 통합 전에는 사용자에게 새 진입점이 노출되지 않으므로 rollback은 PROD-645 component 사용을 제거하는
+   것으로 충분하다. 별도 데이터 migration이나 backend rollback은 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/proposal.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Kosmo의 `/settings`에는 Byulmaru ID가 소유한 Account Settings로 이동할 수 있는 명확하고 안전한 진입점이
+없다. Account 관리 기능을 Kosmo에 중복 구현하지 않고도 인증 사용자가 비밀번호·인증·계정 관리의 실제
+소유 서비스로 이동할 수 있어야 한다.
+
+## What Changes
+
+- `/settings`의 첫 번째 Account 행에 Byulmaru ID Account Settings 외부 진입점을 제공한다.
+- 행 label, 이동 동작과 접근성 이름에서 Byulmaru ID 외부 서비스와 Account 수준 설정임을 전달하고,
+  `계정 설정` heading·소유자 label·설명 block을 별도로 반복하지 않는다.
+- canonical URL `https://id.byulmaru.co`를 사용해 Web에서는 외부 HTTPS navigation을, Android·iOS에서는
+  시스템 브라우저 또는 승인된 external link flow를 실행한다.
+- 지원하지 않는 URL 또는 외부 이동 실패를 조용히 무시하지 않고 안전한 한국어 오류와 같은 동작의 재시도를
+  제공한다.
+- 실제 외부 navigation 행에만 chevron을 표시하고 Kosmo 내부 Account route·UI·데이터 상태를 만들지 않는다.
+- Web·Android·iOS와 keyboard·screen reader 기준에서 label, external navigation, 오류 복구와 접근성 계약을
+  검증한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/design/settings.md`, `docs/design/accessibility.md`
+- Linear Contract: `PROD-645`
+- Linear Implementations: `PROD-645`; page-level integration owner `PROD-653`
+
+## Capabilities
+
+### New Capabilities
+
+- `byulmaru-id-account-settings-entry`: Byulmaru ID Account Settings의 정확한 외부 URL, 플랫폼별 이동,
+  소유권을 드러내는 label·접근성 이름과 실패 후 재시도 계약
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/app`의 universal settings Account 행과 platform-specific external navigation 경계
+- Account 외부 이동 component test와 React Native Web Storybook 상태
+- `PROD-653`이 소유한 `add-settings-page-shell`의 후속 page-level 통합 surface
+- GraphQL, DB, Relay Account 데이터 계약과 Kosmo 내부 Account route에는 변경 없음

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/proposal.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/proposal.md
@@ -1,34 +1,34 @@
 ## Why
 
-Kosmo의 `/settings`에는 Byulmaru ID가 소유한 Account Settings로 이동할 수 있는 명확하고 안전한 진입점이
-없다. Account 관리 기능을 Kosmo에 중복 구현하지 않고도 인증 사용자가 비밀번호·인증·계정 관리의 실제
-소유 서비스로 이동할 수 있어야 한다.
+Kosmo의 `/settings`에는 Byulmaru ID가 소유한 Account Settings로 이동할 수 있는 명확한 외부 링크 진입점이
+필요하다. Account 관리 기능을 Kosmo에 중복 구현하지 않고, 사용자가 실제 소유 서비스로 이동할 수 있어야
+한다.
 
 ## What Changes
 
-- `/settings`의 첫 번째 Account 행에 Byulmaru ID Account Settings 외부 진입점을 제공한다.
-- 행 label, 이동 동작과 접근성 이름에서 Byulmaru ID 외부 서비스와 Account 수준 설정임을 전달하고,
-  `계정 설정` heading·소유자 label·설명 block을 별도로 반복하지 않는다.
-- canonical URL `https://id.byulmaru.co`를 사용해 Web에서는 외부 HTTPS navigation을, Android·iOS에서는
-  시스템 브라우저 또는 승인된 external link flow를 실행한다.
-- 지원하지 않는 URL 또는 외부 이동 실패를 조용히 무시하지 않고 안전한 한국어 오류와 같은 동작의 재시도를
-  제공한다.
-- 실제 외부 navigation 행에만 chevron을 표시하고 Kosmo 내부 Account route·UI·데이터 상태를 만들지 않는다.
-- Web·Android·iOS와 keyboard·screen reader 기준에서 label, external navigation, 오류 복구와 접근성 계약을
-  검증한다.
+- `/settings`의 Account 위치에 시각 label `계정 설정`인 평면 행을 제공한다.
+- 행은 `Byulmaru ID Account Settings 외부 서비스로 이동` accessible name과 canonical
+  `https://id.byulmaru.co` destination으로 소유권과 외부 이동 의미를 전달한다.
+- Web·Android·iOS 모두 Expo Router의 실제 external `Link`를 사용한다. 브라우저 또는 OS가 navigation을
+  소유하며, Kosmo는 URL 지원 확인, navigation 성공·실패, loading·error·retry·lock 상태를 소유하지 않는다.
+- 실제 외부 링크 행에만 chevron을 표시하고, Kosmo 내부 Account route·UI·데이터 상태를 만들지 않는다.
+- unit test와 Storybook은 실제 이동을 실행하지 않고 label·link semantics·exact href·chevron·focus-visible
+  및 browser 기본 링크 증거를 검증한다.
 
 ## Authority / Provenance
 
 - Canonical: `docs/design/settings.md`, `docs/design/accessibility.md`
-- Linear Contract: `PROD-645`
-- Linear Implementations: `PROD-645`; page-level integration owner `PROD-653`
+- Linear Contract / Child: `PROD-645`
+- Linear Integration and page-level verification: `PROD-685` (Backlog)
+- Linear Final Settings integration and OpenSpec completion/archive owner: `PROD-684` (Backlog)
+- Predecessor information-architecture artifact: `PROD-653` (completed; not active integration/archive owner)
 
 ## Capabilities
 
 ### New Capabilities
 
-- `byulmaru-id-account-settings-entry`: Byulmaru ID Account Settings의 정확한 외부 URL, 플랫폼별 이동,
-  소유권을 드러내는 label·접근성 이름과 실패 후 재시도 계약
+- `byulmaru-id-account-settings-entry`: Byulmaru ID Account Settings의 canonical 외부 URL, 소유권을 드러내는
+  label·accessible name과 모든 플랫폼의 external Link semantics
 
 ### Modified Capabilities
 
@@ -36,7 +36,9 @@ Kosmo의 `/settings`에는 Byulmaru ID가 소유한 Account Settings로 이동�
 
 ## Impact
 
-- `apps/app`의 universal settings Account 행과 platform-specific external navigation 경계
-- Account 외부 이동 component test와 React Native Web Storybook 상태
-- `PROD-653`이 소유한 `add-settings-page-shell`의 후속 page-level 통합 surface
+- `apps/app`의 settings Account 행과 Expo Router external Link 접근성 계약
+- Account 외부 링크의 정적 unit test와 React Native Web Storybook catalog
+- `PROD-685`가 소유하는 production `/settings` route/navigation, PROD-645·PROD-667 child 조립 및
+  page-level 검증의 통합 입력
+- `PROD-684`가 소유하는 최종 Settings 통합 및 OpenSpec 완료/archive 판단
 - GraphQL, DB, Relay Account 데이터 계약과 Kosmo 내부 Account route에는 변경 없음

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/specs/byulmaru-id-account-settings-entry/spec.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/specs/byulmaru-id-account-settings-entry/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Byulmaru ID Account Settings 외부 진입점 표시
+
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645` — Kosmo 설정 페이지는 `/settings`의 첫 번째 Account 행에 Byulmaru ID가 소유한 Account Settings 외부 진입점을 제공해야 한다(MUST). 행 label은 Byulmaru ID와 Account 수준 설정임을 전달해야 하고(MUST), accessible name은 Byulmaru ID 외부 서비스로 이동한다는 사실을 전달해야 한다(MUST). 실제 외부 navigation 행에만 chevron을 표시해야 하며(MUST), `계정 설정` heading·소유자 label·설명 block을 별도로 반복해서는 안 된다(MUST NOT).
+
+#### Scenario: 외부 Account 행을 첫 번째로 표시한다
+
+- **WHEN** 인증 사용자가 `/settings`를 연다
+- **THEN** 첫 번째 Account 행은 label과 accessible name에서 Byulmaru ID Account Settings 외부 진입점임을 전달한다
+- **AND** 행은 다른 위치를 여는 chevron을 표시한다
+- **AND** 행 앞뒤에 `계정 설정` heading, 소유자 label 또는 설명 block을 별도로 표시하지 않는다
+
+#### Scenario: Profile control과 이동 의미를 구분한다
+
+- **WHEN** Account 외부 진입점과 Kosmo Profile control이 같은 설정 페이지에 표시된다
+- **THEN** Account 행만 외부 navigation을 실행하고 chevron을 표시한다
+- **AND** Profile control은 Account 외부 이동을 암시하는 label, accessible name 또는 chevron을 사용하지 않는다
+
+### Requirement: Canonical Byulmaru ID URL과 플랫폼별 외부 navigation
+
+**Authority / Provenance:** `docs/design/settings.md`, `PROD-645` — Account 외부 진입점은 canonical URL `https://id.byulmaru.co`만 열어야 한다(MUST). Web은 정상적인 외부 HTTPS navigation을 사용해야 하고(MUST), Android·iOS는 시스템 브라우저 또는 승인된 external link flow를 사용해야 한다(MUST). Kosmo 내부 Account route, generic placeholder 또는 다른 URL로 이동해서는 안 된다(MUST NOT).
+
+#### Scenario: Web에서 canonical Account Settings를 연다
+
+- **WHEN** Web 사용자가 Account 외부 진입점을 실행한다
+- **THEN** 브라우저는 `https://id.byulmaru.co`로 외부 HTTPS navigation한다
+- **AND** Kosmo Router의 내부 Account route나 generic placeholder를 열지 않는다
+
+#### Scenario: Android와 iOS에서 canonical Account Settings를 연다
+
+- **WHEN** Android 또는 iOS 사용자가 Account 외부 진입점을 실행하고 환경이 canonical HTTPS URL을 지원한다
+- **THEN** 시스템 브라우저 또는 승인된 external link flow가 `https://id.byulmaru.co`를 연다
+- **AND** Kosmo 화면을 Account 데이터 화면으로 교체하지 않는다
+
+#### Scenario: Kosmo가 Account 설정 기능을 소유하지 않는다
+
+- **WHEN** Account 외부 진입점을 렌더링하거나 실행한다
+- **THEN** Kosmo는 Account 값을 조회하거나 입력·저장 상태를 만들지 않는다
+- **AND** 비밀번호·패스키·이메일·계정 삭제 UI를 추가하지 않는다
+
+### Requirement: 외부 이동 실패와 재시도
+
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645` — 클라이언트는 canonical URL을 지원하지 않는 환경과 외부 이동 API의 실패를 조용히 무시해서는 안 된다(MUST NOT). 실패한 Account 행 가까이에 backend 또는 platform 오류 원문을 포함하지 않는 안전한 한국어 오류를 표시하고 보조 기술에 알려야 하며(MUST), 사용자가 같은 canonical 외부 이동을 다시 시도할 수 있어야 한다(MUST). 이 오류는 정상인 Profile 설정과 page heading을 숨겨서는 안 된다(MUST NOT).
+
+#### Scenario: 환경이 canonical URL을 지원하지 않는다
+
+- **WHEN** 외부 이동 전 확인에서 환경이 `https://id.byulmaru.co`를 열 수 없다고 응답한다
+- **THEN** Account 행 가까이에 안전한 한국어 오류와 재시도 action을 표시한다
+- **AND** 외부 이동 API를 실행하거나 실패를 조용히 무시하지 않는다
+- **AND** page heading과 정상인 Profile 설정을 계속 표시한다
+
+#### Scenario: 외부 이동 API가 실패한다
+
+- **WHEN** canonical URL의 외부 이동 API가 오류를 반환하거나 거부된다
+- **THEN** Account 행 가까이에 안전한 한국어 오류와 재시도 action을 표시하고 오류 상태를 보조 기술에 알린다
+- **AND** platform 오류 원문을 사용자에게 그대로 노출하지 않는다
+
+#### Scenario: 실패한 외부 이동을 재시도한다
+
+- **WHEN** 사용자가 Account 외부 이동 오류의 재시도 action을 실행한다
+- **THEN** 클라이언트는 `https://id.byulmaru.co` 지원 여부와 외부 이동을 같은 순서로 다시 실행한다
+- **AND** 재시도가 성공하면 이전 오류를 제거한다
+
+### Requirement: 외부 진입점 접근성과 입력 방식
+
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645` — Account 외부 진입점은 실제 동작에 맞는 link role, accessible name과 focus-visible 상태를 제공해야 하며(MUST), Web keyboard와 pointer, Android·iOS touch와 screen reader에서 같은 canonical 이동 결과를 제공해야 한다(MUST). Web pointer target은 최소 24×24 CSS px 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
+
+#### Scenario: Web keyboard로 외부 진입점을 실행한다
+
+- **WHEN** Web keyboard 사용자가 Account 외부 진입점에 focus하고 활성화한다
+- **THEN** focus-visible 상태와 Byulmaru ID 외부 이동 accessible name을 확인할 수 있다
+- **AND** pointer로 실행할 때와 같은 canonical HTTPS navigation을 수행한다
+
+#### Scenario: screen reader로 외부 진입점과 오류를 이해한다
+
+- **WHEN** screen reader 사용자가 Account 외부 진입점과 실패 상태를 탐색한다
+- **THEN** link role과 accessible name에서 Byulmaru ID Account Settings 외부 이동임을 이해할 수 있다
+- **AND** 외부 이동 실패와 재시도 action을 중복 없이 이해하고 실행할 수 있다
+
+#### Scenario: 플랫폼별 interactive target을 유지한다
+
+- **WHEN** Account 외부 진입점을 Web, iOS 또는 Android에서 표시한다
+- **THEN** 각 플랫폼의 24×24 CSS px, 44×44pt 또는 48×48dp target 계약을 충족한다
+- **AND** text scaling과 reflow에서도 label과 action이 잘리거나 가로 scroll에 의존하지 않는다

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/specs/byulmaru-id-account-settings-entry/spec.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/specs/byulmaru-id-account-settings-entry/spec.md
@@ -2,84 +2,76 @@
 
 ### Requirement: Byulmaru ID Account Settings 외부 진입점 표시
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645` — Kosmo 설정 페이지는 `/settings`의 첫 번째 Account 행에 Byulmaru ID가 소유한 Account Settings 외부 진입점을 제공해야 한다(MUST). 행 label은 Byulmaru ID와 Account 수준 설정임을 전달해야 하고(MUST), accessible name은 Byulmaru ID 외부 서비스로 이동한다는 사실을 전달해야 한다(MUST). 실제 외부 navigation 행에만 chevron을 표시해야 하며(MUST), `계정 설정` heading·소유자 label·설명 block을 별도로 반복해서는 안 된다(MUST NOT).
+Kosmo 설정 페이지의 Account 행은 시각 label `계정 설정`을 제공해야 한다(MUST). link accessible name은
+`Byulmaru ID Account Settings 외부 서비스로 이동`처럼 Byulmaru ID가 소유한 외부 Account Settings로 이동한다는
+사실을 전달해야 한다(MUST). 실제 외부 navigation 행에만 chevron을 표시해야 하며(MUST), `계정 설정` heading·
+소유자 label·설명 block을 별도로 반복해서는 안 된다(MUST NOT).
 
-#### Scenario: 외부 Account 행을 첫 번째로 표시한다
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645`
 
-- **WHEN** 인증 사용자가 `/settings`를 연다
-- **THEN** 첫 번째 Account 행은 label과 accessible name에서 Byulmaru ID Account Settings 외부 진입점임을 전달한다
+#### Scenario: Account 외부 행을 표시한다
+
+- **WHEN** 인증 사용자가 `/settings`의 Account content를 본다
+- **THEN** Account 행의 visible label은 `계정 설정`이다
+- **AND** 행의 accessible name은 Byulmaru ID 외부 Account Settings 이동 의미를 전달한다
 - **AND** 행은 다른 위치를 여는 chevron을 표시한다
 - **AND** 행 앞뒤에 `계정 설정` heading, 소유자 label 또는 설명 block을 별도로 표시하지 않는다
 
 #### Scenario: Profile control과 이동 의미를 구분한다
 
 - **WHEN** Account 외부 진입점과 Kosmo Profile control이 같은 설정 페이지에 표시된다
-- **THEN** Account 행만 외부 navigation을 실행하고 chevron을 표시한다
-- **AND** Profile control은 Account 외부 이동을 암시하는 label, accessible name 또는 chevron을 사용하지 않는다
+- **THEN** Account 행만 외부 navigation link와 chevron을 제공한다
+- **AND** Profile control은 Account 외부 이동을 암시하는 accessible name 또는 chevron을 사용하지 않는다
 
-### Requirement: Canonical Byulmaru ID URL과 플랫폼별 외부 navigation
+### Requirement: Canonical Byulmaru ID URL과 실제 external Link
 
-**Authority / Provenance:** `docs/design/settings.md`, `PROD-645` — Account 외부 진입점은 canonical URL `https://id.byulmaru.co`만 열어야 한다(MUST). Web은 정상적인 외부 HTTPS navigation을 사용해야 하고(MUST), Android·iOS는 시스템 브라우저 또는 승인된 external link flow를 사용해야 한다(MUST). Kosmo 내부 Account route, generic placeholder 또는 다른 URL로 이동해서는 안 된다(MUST NOT).
+Account 외부 진입점은 canonical URL `https://id.byulmaru.co`를 Expo Router `Link`의 exact external `href`로 사용해야 한다(MUST).
+Web·Android·iOS
+모두 같은 external Link semantics를 사용해야 하며(MUST), Kosmo 내부 Account route·generic placeholder·다른
+URL로 이동해서는 안 된다(MUST NOT). 브라우저 또는 OS가 navigation을 소유하며, Kosmo는 URL 지원 확인,
+navigation 성공·실패, loading·error·retry·lock 상태를 소유해서는 안 된다(MUST NOT).
 
-#### Scenario: Web에서 canonical Account Settings를 연다
+**Authority / Provenance:** `docs/design/settings.md`, `PROD-645`
 
-- **WHEN** Web 사용자가 Account 외부 진입점을 실행한다
-- **THEN** 브라우저는 `https://id.byulmaru.co`로 외부 HTTPS navigation한다
-- **AND** Kosmo Router의 내부 Account route나 generic placeholder를 열지 않는다
+#### Scenario: 모든 플랫폼에서 canonical external Link를 제공한다
 
-#### Scenario: Android와 iOS에서 canonical Account Settings를 연다
+- **WHEN** Web, Android 또는 iOS에서 Account 외부 진입점을 렌더링한다
+- **THEN** 렌더링된 행은 `Link asChild href={BYULMARU_ID_ACCOUNT_SETTINGS_URL}` 구조의 link semantics를 가진다
+- **AND** href는 정확히 `https://id.byulmaru.co`다
+- **AND** 브라우저 또는 OS가 외부 navigation을 실행하며 Kosmo 내부 Account route를 열지 않는다
 
-- **WHEN** Android 또는 iOS 사용자가 Account 외부 진입점을 실행하고 환경이 canonical HTTPS URL을 지원한다
-- **THEN** 시스템 브라우저 또는 승인된 external link flow가 `https://id.byulmaru.co`를 연다
-- **AND** Kosmo 화면을 Account 데이터 화면으로 교체하지 않는다
+#### Scenario: Kosmo가 Account 설정 또는 navigation lifecycle을 소유하지 않는다
 
-#### Scenario: Kosmo가 Account 설정 기능을 소유하지 않는다
-
-- **WHEN** Account 외부 진입점을 렌더링하거나 실행한다
+- **WHEN** Account 외부 진입점을 렌더링하거나 활성화한다
 - **THEN** Kosmo는 Account 값을 조회하거나 입력·저장 상태를 만들지 않는다
+- **AND** Kosmo component에는 Platform/Linking 기반 support check, JS `onPress`, navigation 결과 처리,
+  loading·error·retry·lock 상태가 없다
 - **AND** 비밀번호·패스키·이메일·계정 삭제 UI를 추가하지 않는다
-
-### Requirement: 외부 이동 실패와 재시도
-
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645` — 클라이언트는 canonical URL을 지원하지 않는 환경과 외부 이동 API의 실패를 조용히 무시해서는 안 된다(MUST NOT). 실패한 Account 행 가까이에 backend 또는 platform 오류 원문을 포함하지 않는 안전한 한국어 오류를 표시하고 보조 기술에 알려야 하며(MUST), 사용자가 같은 canonical 외부 이동을 다시 시도할 수 있어야 한다(MUST). 이 오류는 정상인 Profile 설정과 page heading을 숨겨서는 안 된다(MUST NOT).
-
-#### Scenario: 환경이 canonical URL을 지원하지 않는다
-
-- **WHEN** 외부 이동 전 확인에서 환경이 `https://id.byulmaru.co`를 열 수 없다고 응답한다
-- **THEN** Account 행 가까이에 안전한 한국어 오류와 재시도 action을 표시한다
-- **AND** 외부 이동 API를 실행하거나 실패를 조용히 무시하지 않는다
-- **AND** page heading과 정상인 Profile 설정을 계속 표시한다
-
-#### Scenario: 외부 이동 API가 실패한다
-
-- **WHEN** canonical URL의 외부 이동 API가 오류를 반환하거나 거부된다
-- **THEN** Account 행 가까이에 안전한 한국어 오류와 재시도 action을 표시하고 오류 상태를 보조 기술에 알린다
-- **AND** platform 오류 원문을 사용자에게 그대로 노출하지 않는다
-
-#### Scenario: 실패한 외부 이동을 재시도한다
-
-- **WHEN** 사용자가 Account 외부 이동 오류의 재시도 action을 실행한다
-- **THEN** 클라이언트는 `https://id.byulmaru.co` 지원 여부와 외부 이동을 같은 순서로 다시 실행한다
-- **AND** 재시도가 성공하면 이전 오류를 제거한다
 
 ### Requirement: 외부 진입점 접근성과 입력 방식
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645` — Account 외부 진입점은 실제 동작에 맞는 link role, accessible name과 focus-visible 상태를 제공해야 하며(MUST), Web keyboard와 pointer, Android·iOS touch와 screen reader에서 같은 canonical 이동 결과를 제공해야 한다(MUST). Web pointer target은 최소 24×24 CSS px 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
+Account 외부 진입점은 실제 동작에 맞는 link role, accessible name과 focus-visible 상태를 제공해야 한다(MUST).
+Web keyboard·pointer와 Android·iOS touch·screen reader에서 같은 canonical link destination을 제공해야 하며(MUST),
+Web pointer target은 최소 24×24 CSS px 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는
+48×48dp touch target을 사용해야 한다(MUST).
 
-#### Scenario: Web keyboard로 외부 진입점을 실행한다
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-645`
 
-- **WHEN** Web keyboard 사용자가 Account 외부 진입점에 focus하고 활성화한다
-- **THEN** focus-visible 상태와 Byulmaru ID 외부 이동 accessible name을 확인할 수 있다
-- **AND** pointer로 실행할 때와 같은 canonical HTTPS navigation을 수행한다
+#### Scenario: Web keyboard로 외부 진입점을 탐색한다
 
-#### Scenario: screen reader로 외부 진입점과 오류를 이해한다
+- **WHEN** Web keyboard 사용자가 Account 외부 link에 focus한다
+- **THEN** link role과 Byulmaru ID 외부 Account Settings accessible name을 확인할 수 있다
+- **AND** focus-visible 상태와 canonical `href`를 확인할 수 있다
+- **AND** 활성화 시 browser 기본 link navigation 의미를 유지한다
 
-- **WHEN** screen reader 사용자가 Account 외부 진입점과 실패 상태를 탐색한다
-- **THEN** link role과 accessible name에서 Byulmaru ID Account Settings 외부 이동임을 이해할 수 있다
-- **AND** 외부 이동 실패와 재시도 action을 중복 없이 이해하고 실행할 수 있다
+#### Scenario: screen reader로 외부 진입점을 이해한다
+
+- **WHEN** screen reader 사용자가 Account 외부 진입점을 탐색한다
+- **THEN** 하나의 link target과 accessible name에서 Byulmaru ID 외부 Account Settings 이동임을 이해할 수 있다
+- **AND** 장식용 chevron은 별도 focus target이나 interactive element로 노출되지 않는다
 
 #### Scenario: 플랫폼별 interactive target을 유지한다
 
 - **WHEN** Account 외부 진입점을 Web, iOS 또는 Android에서 표시한다
 - **THEN** 각 플랫폼의 24×24 CSS px, 44×44pt 또는 48×48dp target 계약을 충족한다
-- **AND** text scaling과 reflow에서도 label과 action이 잘리거나 가로 scroll에 의존하지 않는다
+- **AND** text scaling과 reflow에서도 label과 link가 잘리거나 가로 scroll에 의존하지 않는다

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/tasks.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/tasks.md
@@ -60,4 +60,4 @@ PROD-653이 임시 slot API 없이 `/settings` 첫 번째 Account 행에 직접 
 
 - [x] 2.1 Account 행의 정상·지원 불가·확인 실패·이동 실패·재시도 성공과 접근성 계약을 검증하는 component test를 추가한다.
 - [x] 2.2 기본 행과 실패·재시도 상태를 검토할 Storybook catalog와 interaction 검증을 추가한다.
-- [ ] 2.3 관련 자동 검증과 strict OpenSpec validation을 통과시키고 PROD-653 통합에 필요한 concrete child handoff를 기록한다.
+- [x] 2.3 관련 자동 검증과 strict OpenSpec validation을 통과시키고 PROD-653 통합에 필요한 concrete child handoff를 기록한다.

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/tasks.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/tasks.md
@@ -1,0 +1,63 @@
+## 1. PROD-645 Byulmaru ID Account 외부 진입점
+
+**Authority / Provenance**
+
+- `docs/design/settings.md`
+- `docs/design/accessibility.md`
+- `PROD-645`
+
+**Deliverable**
+
+사용자가 Byulmaru ID 소유의 Account 수준 설정임을 이해할 수 있는 평면 행을 실행해 canonical Account
+Settings로 외부 이동하고, 지원 불가·이동 실패 뒤 같은 동작을 재시도할 수 있다.
+
+**Guardrails**
+
+- destination은 `https://id.byulmaru.co`이며 Kosmo 내부 route, generic placeholder 또는 추론한 provider
+  subpath로 바꾸지 않는다.
+- 별도 `계정 설정` heading·소유자 label·설명 block, Account 데이터 query·form·save 상태를 만들지 않는다.
+- 전체 행만 link target으로 제공하고 외부 navigation을 가진 Account 행에만 chevron을 표시한다.
+- 실패는 Account child 가까이에서 복구하고 정상인 page heading과 Profile 기능을 숨기지 않는다.
+
+**Verification**
+
+- label·accessible name·link role·chevron, exact URL과 지원 확인→외부 이동 순서를 component test로 검증한다.
+- 지원 불가, 지원 확인 rejection, 이동 rejection과 재시도 성공에서 안전한 오류·announcement·상태 복구를
+  검증한다.
+
+- [x] 1.1 Byulmaru ID 소유권·Account 수준 설정·외부 이동 의미와 플랫폼 target을 전달하는 concrete 평면 Account 행을 구현한다.
+- [x] 1.2 canonical URL의 플랫폼별 외부 이동, 중복 실행 방지와 child-local 실패·재시도 동작을 구현한다.
+
+## 2. PROD-645 독립 기능 검증과 통합 handoff
+
+**Authority / Provenance**
+
+- `docs/design/settings.md`
+- `docs/design/accessibility.md`
+- `PROD-645`
+- `PROD-653`
+
+**Deliverable**
+
+PROD-653이 임시 slot API 없이 `/settings` 첫 번째 Account 행에 직접 통합할 수 있는 concrete child와 기능
+검증 증거가 준비된다.
+
+**Guardrails**
+
+- PROD-645 diff에 `/settings` route, 공통 page shell, Profile identity/control 또는 shell navigation을
+  추가하지 않는다.
+- standalone Storybook 결과를 production `/settings` 통합 또는 Android·iOS runtime 완료 증거로 표현하지
+  않는다.
+- PROD-653이 page-level 통합, platform runtime 검증과 `add-settings-page-shell` 정합성·archive를 계속
+  소유한다.
+
+**Verification**
+
+- component unit test가 happy path, 실패 분기, exact copy·semantics와 retry를 통과한다.
+- React Native Web Storybook에서 기본 행과 실패→재시도 interaction 및 자동 접근성 검증을 통과한다.
+- TypeScript, formatting과 이 change의 strict OpenSpec validation을 통과하고 구현 diff에 범위 외 route·shell
+  변경이 없는지 확인한다.
+
+- [x] 2.1 Account 행의 정상·지원 불가·확인 실패·이동 실패·재시도 성공과 접근성 계약을 검증하는 component test를 추가한다.
+- [x] 2.2 기본 행과 실패·재시도 상태를 검토할 Storybook catalog와 interaction 검증을 추가한다.
+- [ ] 2.3 관련 자동 검증과 strict OpenSpec validation을 통과시키고 PROD-653 통합에 필요한 concrete child handoff를 기록한다.

--- a/openspec/changes/add-byulmaru-id-account-settings-entry/tasks.md
+++ b/openspec/changes/add-byulmaru-id-account-settings-entry/tasks.md
@@ -1,4 +1,4 @@
-## 1. PROD-645 Byulmaru ID Account 외부 진입점
+## 1. PROD-645 Byulmaru ID Account 외부 링크 child
 
 **Authority / Provenance**
 
@@ -8,56 +8,60 @@
 
 **Deliverable**
 
-사용자가 Byulmaru ID 소유의 Account 수준 설정임을 이해할 수 있는 평면 행을 실행해 canonical Account
-Settings로 외부 이동하고, 지원 불가·이동 실패 뒤 같은 동작을 재시도할 수 있다.
+사용자가 `계정 설정` 행의 accessible name과 canonical destination을 통해 Byulmaru ID가 소유한 외부 Account
+Settings임을 이해하고, 모든 플랫폼에서 실제 external link를 사용할 수 있는 concrete child를 제공한다.
 
 **Guardrails**
 
-- destination은 `https://id.byulmaru.co`이며 Kosmo 내부 route, generic placeholder 또는 추론한 provider
-  subpath로 바꾸지 않는다.
-- 별도 `계정 설정` heading·소유자 label·설명 block, Account 데이터 query·form·save 상태를 만들지 않는다.
-- 전체 행만 link target으로 제공하고 외부 navigation을 가진 Account 행에만 chevron을 표시한다.
-- 실패는 Account child 가까이에서 복구하고 정상인 page heading과 Profile 기능을 숨기지 않는다.
+- destination은 `https://id.byulmaru.co`인 Expo Router external `Link`의 exact `href`다.
+- 시각 label은 `계정 설정`이며 accessible name은 `Byulmaru ID Account Settings 외부 서비스로 이동`이다.
+- 전체 행만 link target으로 제공하고 외부 navigation 행에만 chevron을 표시한다.
+- component에 Platform/Linking, JS `onPress`, URL support check, navigation success/failure, loading/error/
+  retry/lock 상태와 helper를 만들지 않는다.
+- `/settings` route, page shell, Profile 구현과 production navigation을 추가하지 않는다.
 
 **Verification**
 
-- label·accessible name·link role·chevron, exact URL과 지원 확인→외부 이동 순서를 component test로 검증한다.
-- 지원 불가, 지원 확인 rejection, 이동 rejection과 재시도 성공에서 안전한 오류·announcement·상태 복구를
+- label·accessible label·link role·exact href·chevron·focus-visible style과 JS `onPress` 부재를 component test로
   검증한다.
+- Storybook은 기본 실제 link 한 상태에서 visible label, accessible external link, canonical href와 focus 가능성을
+  검증하며 실제 navigation을 실행하지 않는다.
 
-- [x] 1.1 Byulmaru ID 소유권·Account 수준 설정·외부 이동 의미와 플랫폼 target을 전달하는 concrete 평면 Account 행을 구현한다.
-- [x] 1.2 canonical URL의 플랫폼별 외부 이동, 중복 실행 방지와 child-local 실패·재시도 동작을 구현한다.
+- [x] 1.1 `계정 설정` label과 Byulmaru ID 외부 Account Settings accessible name을 가진 평면 link 행을 구현한다.
+- [x] 1.2 모든 플랫폼에 `Link asChild href={BYULMARU_ID_ACCOUNT_SETTINGS_URL}`를 적용하고 chevron·target
+      geometry·focus-visible styling을 유지한다.
 
 ## 2. PROD-645 독립 기능 검증과 통합 handoff
 
 **Authority / Provenance**
 
 - `docs/design/settings.md`
-- `docs/design/accessibility.md`
 - `PROD-645`
-- `PROD-653`
+- `PROD-685`
+- `PROD-684`
+- `PROD-653` (completed predecessor information architecture)
 
 **Deliverable**
 
-PROD-653이 임시 slot API 없이 `/settings` 첫 번째 Account 행에 직접 통합할 수 있는 concrete child와 기능
-검증 증거가 준비된다.
+`PROD-685`가 별도 slot API 없이 `PROD-645`·`PROD-667` child를 production `/settings` route/navigation에 조립할
+수 있는 static child와 검증·문서 정합성 증거를 전달한다.
 
 **Guardrails**
 
-- PROD-645 diff에 `/settings` route, 공통 page shell, Profile identity/control 또는 shell navigation을
-  추가하지 않는다.
-- standalone Storybook 결과를 production `/settings` 통합 또는 Android·iOS runtime 완료 증거로 표현하지
-  않는다.
-- PROD-653이 page-level 통합, platform runtime 검증과 `add-settings-page-shell` 정합성·archive를 계속
-  소유한다.
+- `PROD-645` diff에 production `/settings` route, page shell, Profile 또는 shell navigation을 추가하지 않는다.
+- standalone Storybook과 unit test를 production route·Web/Android/iOS page-level 완료 증거로 표현하지 않는다.
+- `PROD-685`가 route/navigation, child assembly와 page-level 검증을, `PROD-684`가 최종 Settings 통합 및
+  OpenSpec completion/archive를 소유한다. `PROD-653`은 active integration/archive owner가 아니다.
 
 **Verification**
 
-- component unit test가 happy path, 실패 분기, exact copy·semantics와 retry를 통과한다.
-- React Native Web Storybook에서 기본 행과 실패→재시도 interaction 및 자동 접근성 검증을 통과한다.
-- TypeScript, formatting과 이 change의 strict OpenSpec validation을 통과하고 구현 diff에 범위 외 route·shell
-  변경이 없는지 확인한다.
+- component unit test가 새 static label·semantics·href·focus 계약을 통과한다.
+- React Native Web Storybook이 기본 링크의 접근성 tree·focus·href 검증을 통과하며 외부 navigation을 실행하지
+  않는다.
+- TypeScript, formatting, strict OpenSpec validation과 diff 범위 검증을 수행한다.
 
-- [x] 2.1 Account 행의 정상·지원 불가·확인 실패·이동 실패·재시도 성공과 접근성 계약을 검증하는 component test를 추가한다.
-- [x] 2.2 기본 행과 실패·재시도 상태를 검토할 Storybook catalog와 interaction 검증을 추가한다.
-- [x] 2.3 관련 자동 검증과 strict OpenSpec validation을 통과시키고 PROD-653 통합에 필요한 concrete child handoff를 기록한다.
+- [x] 2.1 Account 행의 label·accessible name·link role·exact href·chevron·focus-visible·JS onPress 부재를
+      검증하는 component test를 추가한다.
+- [x] 2.2 기본 실제 link와 visible label·canonical href·focus 가능성을 검증하는 단일 Storybook story를 추가한다.
+- [x] 2.3 관련 자동 검증과 strict OpenSpec validation을 통과시키고 `PROD-685`·`PROD-684` ownership에 맞는
+      concrete child handoff와 문서 정합성을 기록한다.


### PR DESCRIPTION
## 변경 사항

- 설정 Account 행의 visible label을 `계정 설정`으로 정리했습니다.
- Web·Android·iOS 모두 Expo Router의 실제 external `Link asChild`와 canonical `https://id.byulmaru.co` href를 사용합니다.
- `Platform`/`Linking`, support check, custom `onPress`, navigation loading·error·retry·lock 상태를 제거했습니다.
- Slot이 child props를 병합해도 focus outline과 최소 target geometry가 유지되도록 plain style object를 전달합니다.
- unit mock과 Storybook 검증을 actual link semantics, href, focus, target geometry 중심으로 갱신했습니다.
- 설계 문서와 OpenSpec의 integration/archive ownership을 PROD-685/PROD-684로 동기화했습니다. 완료된 PROD-653은 선행 산출물로만 유지합니다.

## 결정 근거

최신 PROD-645 계약에 따라 외부 navigation lifecycle은 브라우저/OS가 소유하고 Kosmo는 실제 external link만 제공합니다. production `/settings` 조립과 page-level/platform 검증은 PROD-685, 전체 OpenSpec 완료 및 archive 판단은 PROD-684가 소유합니다.

## 검증

- ✅ App check: Relay compiler + TypeScript
- ✅ 관련 ESLint
- ✅ Prettier
- ✅ Storybook static build
- ✅ 대상 Byulmaru ID Storybook play
- ✅ OpenSpec strict validation
- ✅ `git diff --check`
- ✅ 독립 재리뷰 finding 0
- ✅ Ponytail review: 추가 단순화 finding 없음
- ⚠️ App 전체 unit suite: 현재 Node `mock.module` 환경에서 `react-native` mock이 적용되지 않아 대상 및 동일 패턴의 기존 테스트가 함께 실패
- ⚠️ Storybook 전체 runner: 289개 중 대상 포함 288개 통과, 무관한 `Notifications.stories.tsx > Mobile Header Owned By Shell` 1개 실패
- ⏳ Android/iOS 실제 runtime 및 production page-level integration: PROD-685에서 수행

## 리뷰 대응 커밋

- `f27537d5 PROD-645 외부 링크 계약을 간소화한다`
