### PR TITLE
Native 미지원 상태를 영구 제품 계약과 분리한다

### DIFF
--- a/memory/issue-openspec-workflow.md
+++ b/memory/issue-openspec-workflow.md
@@ -255,6 +255,17 @@ OpenSpec decision은 다음 세 종류로 구분한다.
 - `Upstream Change Required`: OpenSpec 작성 중 새 제품 행동이나 범위를 발견한 상태다. 현재 Authority는
   없으며 canonical·Linear가 갱신될 때까지 `Blocked`로 유지한다.
 
+### 플랫폼 지원 상태와 제품 계약을 분리한다
+
+Native 또는 다른 플랫폼이 현재 배포되지 않았거나 실행 가능한 QA 환경이 없다는 사실은 지원·검증 상태다.
+이를 `현재 Web 출시·검증 범위`, `Native runtime 증거 미실행`, `Native 출시 gate로 이관`처럼 시점과 증거
+범위로 기록하고, 공용 코드·route·API가 이미 존재하는 경우 해당 플랫폼에 행동이 영구히 적용되지 않는 제품
+계약으로 쓰지 않는다. `Native에는 적용하지 않는다`, `지원하지 않는다`와 같은 영구적 비적용은 canonical
+domain/design 또는 Linear authority가 제품 결정을 명시한 경우에만 normative requirement/decision으로 기록한다.
+검증하지 않은 플랫폼을 완료로 일반화하지 않되, 미래 지원을 막지 않는 후속 owner와 gate를 함께 적는다.
+Hover처럼 지원 상태와 무관한 실제 platform 입력 모델의 차이는 이 원칙의 대상이 아니며, 해당 행동 경계를
+정당화하는 근거를 함께 기록한다.
+
 단일 `Accepted` 상태는 사용하지 않는다. 각 decision은 날짜, Decision Class, 정확한 canonical·Linear
 Authority / Provenance와 `Active | Blocked | Superseded` 상태를 기록한다. `Blocked` decision은 spec
 requirement, task Guardrail 또는 checkbox의 구현 근거가 될 수 없다.

--- a/memory/issue-openspec-workflow.md
+++ b/memory/issue-openspec-workflow.md
@@ -258,11 +258,13 @@ OpenSpec decision은 다음 세 종류로 구분한다.
 ### 플랫폼 지원 상태와 제품 계약을 분리한다
 
 Native 또는 다른 플랫폼이 현재 배포되지 않았거나 실행 가능한 QA 환경이 없다는 사실은 지원·검증 상태다.
-이를 `현재 Web 출시·검증 범위`, `Native runtime 증거 미실행`, `Native 출시 gate로 이관`처럼 시점과 증거
-범위로 기록하고, 공용 코드·route·API가 이미 존재하는 경우 해당 플랫폼에 행동이 영구히 적용되지 않는 제품
-계약으로 쓰지 않는다. `Native에는 적용하지 않는다`, `지원하지 않는다`와 같은 영구적 비적용은 canonical
-domain/design 또는 Linear authority가 제품 결정을 명시한 경우에만 normative requirement/decision으로 기록한다.
-검증하지 않은 플랫폼을 완료로 일반화하지 않되, 미래 지원을 막지 않는 후속 owner와 gate를 함께 적는다.
+이를 `현재 Web 출시·검증 범위`, `Native runtime 증거 미실행`처럼 시점과 증거 범위로 기록하고, 공용
+코드·route·API가 이미 존재하는 경우 해당 플랫폼에 행동이 영구히 적용되지 않는 제품 계약으로 쓰지 않는다.
+`Native에는 적용하지 않는다`, `지원하지 않는다`와 같은 영구적 비적용은 canonical domain/design 또는 Linear
+authority가 제품 결정을 명시한 경우에만 normative requirement/decision으로 기록한다. 검증하지 않은 플랫폼을
+완료로 일반화하지 않으며, Native 지원 작업이 현재 canonical·Linear authority에 의해 계획되었거나 요구된 경우에만
+후속 owner와 gate를 기록한다. 그 외에는 현재 Native 상태를 미검증으로 기록하고, 지원이 재개될 때 범위와 검증
+책임을 정한다.
 Hover처럼 지원 상태와 무관한 실제 platform 입력 모델의 차이는 이 원칙의 대상이 아니며, 해당 행동 경계를
 정당화하는 근거를 함께 기록한다.
 

--- a/openspec/changes/add-local-profile-edit/decisions.md
+++ b/openspec/changes/add-local-profile-edit/decisions.md
@@ -127,8 +127,8 @@
 - Alternatives Considered: Web 기준의 더 작은 공통 높이는 Native 뒤로가기 target을 줄여 제외했다. safe-area까지
   포함한 고정 `48px`은 기기별 inset을 침범하므로 제외했다.
 - Consequences: Web과 Native의 header content rhythm은 같고, safe-area padding은 외부 shell이 별도로 소유한다.
-- Confirmation / Follow-up: Storybook에서 content row와 뒤로가기 target이 `48px`인지 검증하고 Native 실제 safe-area
-  배치는 현재 이슈·PR 완료 조건에서 제외한 뒤 Native 출시 gate에서 확인한다.
+- Confirmation / Follow-up: Storybook에서 content row와 뒤로가기 target이 `48px`인지 검증한다. Native 실제 safe-area
+  배치는 아직 실행하지 않았고 현재 Web 완료 증거에 포함하지 않는다.
 
 ### 40 code point를 초과한 legacy 표시 이름은 변경하지 않은 경우에만 통과시킨다
 
@@ -370,8 +370,8 @@
 - Consequences: 공용 component에서 compact visual과 platform별 실제 입력 target을 분리하고 제거 action의
   접근성 label/state를 유지한다.
 - Confirmation / Follow-up: Storybook에서 Web `32×32 CSS px` target을 검증하고 iOS `44×44 pt`, Android
-  `48×48 dp` mapping을 구현한다. Native 실제 기기 검증은 현재 이슈·PR 완료 증거로 삼지 않고 Native 출시
-  gate에서 수행한다.
+  `48×48 dp` mapping을 구현한다. Native 실제 기기 QA는 아직 실행하지 않았고 현재 Web 완료 증거에 포함하지
+  않는다.
 
 ### 현재 출시와 수동 runtime QA 범위는 Web으로 한정한다
 
@@ -383,16 +383,16 @@
 - Context / Problem: 공용 React Native Profile edit 구현은 Web·Android·iOS를 지원하지만 현재 출시 대상은
   Web이다. iOS·Android 실제 기기 QA를 현재 PR 완료 조건으로 유지하면 출시 범위와 검증 gate가 어긋난다.
 - Decision Outcome: 현재 출시와 수동 runtime QA 범위는 Web으로 한정한다. iOS·Android 실제 기기 QA는
-  PROD-491·492와 PROD-490 통합 완료 조건에서 제외하고 Native 출시 gate에서 별도로 수행한다. 공용 React Native
-  구현과 자동화 검증은 유지하되 Web 검증을 Native runtime 완료 증거로 사용하지 않는다.
+  PROD-491·492와 PROD-490 통합 완료 조건에 포함하지 않으며 현재 Web 완료 증거로도 사용하지 않는다. 공용 React
+  Native 구현과 자동화 검증은 유지하되 Web 검증을 Native runtime 완료 증거로 사용하지 않는다.
 - Alternatives Considered: iOS·Android 실제 기기 QA를 현재 완료 조건으로 유지하는 방식은 출시 대상이 아닌
   플랫폼 때문에 Web PR readiness를 지연하므로 제외했다. Native 검증을 완료한 것으로 간주하는 방식도 실제
   runtime 증거가 없어 제외했다.
-- Consequences: PROD-492는 필수 자동화와 Web runtime 증거로 PR readiness를 판단할 수 있다. Native 출시 전에는
-  safe area, Android hardware back, touch target, VoiceOver·TalkBack과 플랫폼별 picker/upload 동작을 별도 gate에서
-  검증해야 한다.
-- Confirmation / Follow-up: PROD-492 PR에 Web 수동 검증과 iOS·Android 미실행 상태를 함께 기록하고, Native
-  출시 작업에서 실제 기기 QA를 다시 연다. 이 미실행 상태를 Native의 영구 비적용으로 해석하지 않는다.
+- Consequences: PROD-492는 필수 자동화와 Web runtime 증거로 PR readiness를 판단할 수 있다. Native 실제 기기 QA는
+  아직 실행하지 않았으며 현재 Web 완료 증거에 포함하지 않는다. Native 지원이 재개될 때 필요한 범위와 검증을
+  정하며, 현재 별도 Native owner나 gate를 배정하지 않는다.
+- Confirmation / Follow-up: PROD-492 PR에 Web 수동 검증과 iOS·Android 실제 기기 QA 미실행 상태를 함께 기록한다.
+  이 미실행 상태를 Native의 영구 비적용으로 해석하지 않는다.
 
 ## Remaining Decisions
 

--- a/openspec/changes/add-local-profile-edit/decisions.md
+++ b/openspec/changes/add-local-profile-edit/decisions.md
@@ -370,7 +370,7 @@
 - Consequences: 공용 component에서 compact visual과 platform별 실제 입력 target을 분리하고 제거 action의
   접근성 label/state를 유지한다.
 - Confirmation / Follow-up: Storybook에서 Web `32×32 CSS px` target을 검증하고 iOS `44×44 pt`, Android
-  `48×48 dp` mapping을 구현한다. Native 실제 기기 검증은 현재 이슈·PR 완료 조건에서 제외한 뒤 Native 출시
+  `48×48 dp` mapping을 구현한다. Native 실제 기기 검증은 현재 이슈·PR 완료 증거로 삼지 않고 Native 출시
   gate에서 수행한다.
 
 ### 현재 출시와 수동 runtime QA 범위는 Web으로 한정한다
@@ -391,8 +391,8 @@
 - Consequences: PROD-492는 필수 자동화와 Web runtime 증거로 PR readiness를 판단할 수 있다. Native 출시 전에는
   safe area, Android hardware back, touch target, VoiceOver·TalkBack과 플랫폼별 picker/upload 동작을 별도 gate에서
   검증해야 한다.
-- Confirmation / Follow-up: PROD-492 PR에 Web 수동 검증과 iOS·Android 미실행·명시적 제외를 함께 기록하고,
-  Native 출시 작업에서 실제 기기 QA를 다시 연다.
+- Confirmation / Follow-up: PROD-492 PR에 Web 수동 검증과 iOS·Android 미실행 상태를 함께 기록하고, Native
+  출시 작업에서 실제 기기 QA를 다시 연다. 이 미실행 상태를 Native의 영구 비적용으로 해석하지 않는다.
 
 ## Remaining Decisions
 

--- a/openspec/changes/add-local-profile-edit/design.md
+++ b/openspec/changes/add-local-profile-edit/design.md
@@ -46,7 +46,8 @@ BFF body 종료, browser JSON parse와 Relay `onCompleted`까지 끝난 뒤 영�
 - orphan Media cleanup, thumbnail·variant, Remote Profile Media, Fedify/ActivityPub projection
 - Admin role 제거, client-side Owner 추측과 API 미연결 local persistence
 - 근거 없는 이미지 압축·resize, Media Storage Service 성능 개선, 전체 GraphQL 요청에 대한 범용 tracing·
-  timeout 정책, Native 실제 기기 QA
+  timeout 정책. Native 실제 기기 QA는 현재 Web 출시·검증 범위의 완료 증거로 삼지 않고 Native 출시 gate에서
+  별도로 수행한다.
 
 ## Implementation Guidance
 
@@ -140,8 +141,8 @@ BFF body 종료, browser JSON parse와 Relay `onCompleted`까지 끝난 뒤 영�
     보호한다. navigation no-op/실패에도 draft와 Ready Media ID를 유지하며 mutation 자동 재전송·이미지 자동
     재업로드를 실행하지 않는다.
 14. text-only·Ready Media ID 성공, 비동기 `beforeRemove`, navigation no-op/실패, 기존 discard와 transport 실패를
-    자동화하고 실제 Web dev에서 재검증한다. API/BFF timeout·buffering은 변경하지 않으며 Native 실제 기기 QA
-    미실행과 PROD-490 통합 검증 handoff를 기록한다.
+    자동화하고 실제 Web dev에서 재검증한다. API/BFF timeout·buffering은 변경하지 않으며 Native 실제 기기 QA가
+    아직 실행되지 않았다는 상태와 PROD-490 통합 검증 handoff를 기록한다.
 
 ### Allowed Alternatives
 

--- a/openspec/changes/add-local-profile-edit/design.md
+++ b/openspec/changes/add-local-profile-edit/design.md
@@ -46,8 +46,7 @@ BFF body 종료, browser JSON parse와 Relay `onCompleted`까지 끝난 뒤 영�
 - orphan Media cleanup, thumbnail·variant, Remote Profile Media, Fedify/ActivityPub projection
 - Admin role 제거, client-side Owner 추측과 API 미연결 local persistence
 - 근거 없는 이미지 압축·resize, Media Storage Service 성능 개선, 전체 GraphQL 요청에 대한 범용 tracing·
-  timeout 정책. Native 실제 기기 QA는 현재 Web 출시·검증 범위의 완료 증거로 삼지 않고 Native 출시 gate에서
-  별도로 수행한다.
+  timeout 정책. Native 실제 기기 QA는 아직 실행하지 않았고 현재 Web 출시·검증 범위의 완료 증거로 삼지 않는다.
 
 ## Implementation Guidance
 
@@ -142,7 +141,7 @@ BFF body 종료, browser JSON parse와 Relay `onCompleted`까지 끝난 뒤 영�
     재업로드를 실행하지 않는다.
 14. text-only·Ready Media ID 성공, 비동기 `beforeRemove`, navigation no-op/실패, 기존 discard와 transport 실패를
     자동화하고 실제 Web dev에서 재검증한다. API/BFF timeout·buffering은 변경하지 않으며 Native 실제 기기 QA가
-    아직 실행되지 않았다는 상태와 PROD-490 통합 검증 handoff를 기록한다.
+    아직 실행되지 않았고 현재 Web 완료 증거에 포함되지 않는다는 상태와 PROD-490 통합 검증 handoff를 기록한다.
 
 ### Allowed Alternatives
 

--- a/openspec/changes/add-local-profile-edit/tasks.md
+++ b/openspec/changes/add-local-profile-edit/tasks.md
@@ -14,8 +14,8 @@
 
 route·GraphQL 없이 displayName, bio, `followPolicy` enum draft와 한 줄 `팔로우 요청 자동 승인` Switch,
 avatar/header controlled state와 Profile Tag 로컬 편집을 표현하는 React Native 공용 Profile edit component와 현재
-Web Storybook 상태 카탈로그를 전달한다. Native route 연결과 자동화 검증은 PROD-492 공용 구현에 포함하되 실제 기기
-검증은 Native 출시 gate에서 수행한다.
+Web Storybook 상태 카탈로그를 전달한다. Native route 연결과 자동화 검증은 PROD-492 공용 구현에 포함한다. Native
+실제 기기 QA는 아직 실행하지 않았고 현재 Web 완료 증거에 포함하지 않는다.
 
 **Guardrails**
 
@@ -58,7 +58,7 @@ Web Storybook 상태 카탈로그를 전달한다. Native route 연결과 자동
   action의 `32×32 CSS px` target을 확인한다.
 - displayName 40자 경계, 40자 초과 legacy 초기값 그대로+다른 field 변경, 40자 초과 초기값 변경 거부를 확인한다.
 - Native safe area·layout과 Profile Tag 제거 action의 iOS `44×44 pt`, Android `48×48 dp` mapping은 공용 구현과
-  자동화로 유지한다. 실제 기기 검증은 현재 이슈·PR 완료 조건에서 제외하고 Native 출시 gate에서 수행한다.
+  자동화로 유지한다. Native 실제 기기 QA는 아직 실행하지 않았고 현재 Web 완료 증거에 포함하지 않는다.
 - 테스트 코드 범위는 Profile edit form/editor의 승인 동작을 직접 검증하는 최소 component test로 제한하고 중복
   snapshot·새 harness·관련 없는 fixture 확대는 제외한다.
 
@@ -135,8 +135,8 @@ avatar/header·`followPolicy` 저장, viewer-authorized Profile image read, Prof
 - Relay 동일 Media identity, ProfileHero 갱신, 한쪽 upload 실패/다른 쪽 Ready, field retry, save retry의 Ready ID
   재사용, stale completion과 preview cleanup을 확인한다.
 - route/Web back/Android hardware back discard, saving 차단, 성공 guard 해제→normalize→replace를 확인한다.
-- Web 실제 runtime QA는 자동화 통과와 별도 증거로 기록한다. iOS·Android 실제 기기 QA는 현재 Web 출시 완료
-  증거에 포함하지 않고 Native 출시 gate로 이관하며, 실행하지 않은 플랫폼을 통과로 적지 않는다.
+- Web 실제 runtime QA는 자동화 통과와 별도 증거로 기록한다. iOS·Android 실제 기기 QA는 아직 실행하지 않았고
+  현재 Web 완료 증거에 포함하지 않으며, 실행하지 않은 플랫폼을 통과로 적지 않는다.
 - 테스트 코드 범위: `profile_media` DB/core service, Profile GraphQL query/mutation integration, Profile route와
   upload/navigation/Relay를 직접 검증하는 기존 API/app test surface.
 - 테스트 필요성: 초기 부적격 권한 거부, tri-state 관계 원자성, 공개 Profile read, 부분 upload 실패와 navigation race가
@@ -159,7 +159,8 @@ avatar/header·`followPolicy` 저장, viewer-authorized Profile image read, Prof
 - [x] 2.7 dirty route/Web/Android back confirmation, saving navigation 차단과 성공 guard 해제→Relay normalize→
       relativeHandle Profile replace를 구현하고 route test를 추가한다.
 - [x] 2.8 core·API·app·Web 필수 검증을 통과하고 실제 Web QA 증거와 iOS·Android 실제 기기 QA의 미실행 상태를
-      구분해 PROD-492 PR에 권한·Media·Relay·navigation 증거와 Native 출시 gate를 기록한다.
+      구분해 PROD-492 PR에 권한·Media·Relay·navigation 증거와 현재 Web 완료에 포함하지 않는 Native QA 상태를
+      기록한다.
 
 ## 3. PROD-613 post-commit 응답·Relay·navigation 회귀 수정
 
@@ -205,7 +206,7 @@ race를 수정한다. 정상 저장은 실제 Profile route commit으로 끝나�
 - 기존 dirty navigation guard, Relay normalized Profile 갱신, avatar/header omitted/ID/null과 validation이
   회귀하지 않는지 관련 app·API·BFF·core test로 확인한다.
 - Web dev 환경에서 실제 저장을 재검증하고 원인, 수정 경계, 자동화 결과와 Native 실제 기기 QA 미실행을
-  PROD-613 PR에 기록한다.
+  현재 Web 완료 증거에 포함하지 않는 상태로 PROD-613 PR에 기록한다.
 
 - [x] 3.1 조사 단계 임시 correlation 계측으로 text-only와 Ready avatar/header ID 저장을 재현해 최초 정지
       경계가 `router.replace` callback return 뒤 실제 Web route commit임을 PROD-613에 기록하고 계측 코드를 제거한다.

--- a/openspec/changes/add-local-profile-edit/tasks.md
+++ b/openspec/changes/add-local-profile-edit/tasks.md
@@ -136,7 +136,7 @@ avatar/header·`followPolicy` 저장, viewer-authorized Profile image read, Prof
   재사용, stale completion과 preview cleanup을 확인한다.
 - route/Web back/Android hardware back discard, saving 차단, 성공 guard 해제→normalize→replace를 확인한다.
 - Web 실제 runtime QA는 자동화 통과와 별도 증거로 기록한다. iOS·Android 실제 기기 QA는 현재 Web 출시 완료
-  조건에서 명시적으로 제외하고 Native 출시 gate로 이관하며, 실행하지 않은 플랫폼을 통과로 적지 않는다.
+  증거에 포함하지 않고 Native 출시 gate로 이관하며, 실행하지 않은 플랫폼을 통과로 적지 않는다.
 - 테스트 코드 범위: `profile_media` DB/core service, Profile GraphQL query/mutation integration, Profile route와
   upload/navigation/Relay를 직접 검증하는 기존 API/app test surface.
 - 테스트 필요성: 초기 부적격 권한 거부, tri-state 관계 원자성, 공개 Profile read, 부분 upload 실패와 navigation race가
@@ -158,7 +158,7 @@ avatar/header·`followPolicy` 저장, viewer-authorized Profile image read, Prof
       명시적 field retry와 save retry Ready ID 재사용을 검증한다.
 - [x] 2.7 dirty route/Web/Android back confirmation, saving navigation 차단과 성공 guard 해제→Relay normalize→
       relativeHandle Profile replace를 구현하고 route test를 추가한다.
-- [x] 2.8 core·API·app·Web 필수 검증을 통과하고 실제 Web QA 증거와 iOS·Android 실제 기기 QA의 명시적 제외를
+- [x] 2.8 core·API·app·Web 필수 검증을 통과하고 실제 Web QA 증거와 iOS·Android 실제 기기 QA의 미실행 상태를
       구분해 PROD-492 PR에 권한·Media·Relay·navigation 증거와 Native 출시 gate를 기록한다.
 
 ## 3. PROD-613 post-commit 응답·Relay·navigation 회귀 수정

--- a/openspec/changes/add-production-sentry-error-collection/decisions.md
+++ b/openspec/changes/add-production-sentry-error-collection/decisions.md
@@ -4,17 +4,21 @@
 
 ## Decision Records
 
-### Android·iOS는 Web 관측 조합에서 제외한다
+### Android·iOS 관측은 현재 Web slice와 별도 release gate로 둔다
 
 - Decision Date: 2026-07-27
 - Decision Class: Derived Contract
 - Authority / Provenance: PROD-477, PROD-483, PROD-493
 - Status: Active
 - Context / Problem: 공용 Expo source에 Web 수집을 추가하면 native runtime에도 같은 import와 초기화가 도달할 수 있다.
-- Decision Outcome: Web platform entry만 Sentry browser client를 import·초기화하고 generic 오류 reporter context를 제공하며 Android·iOS에는 Sentry 관측 구현을 추가하지 않는다.
+- Decision Outcome: 현재 Web 출시·검증 slice에서는 Web platform entry만 Sentry browser client를 import·초기화하고
+  generic 오류 reporter context를 제공한다. Android·iOS native runtime 관측과 debug symbol은 PROD-483에서 별도로
+  결정·검증하며, 이 change는 Native entry의 기존 동작을 유지한다.
 - Alternatives Considered: 공용 `@sentry/react-native` 초기화는 Backlog인 PROD-483의 SDK·native crash·debug symbol 범위를 선행하므로 선택하지 않는다.
-- Consequences: 공용 오류 경계의 UI·retry 구현은 공유하지만 Sentry capture callback은 Web entry만 소유한다.
-- Confirmation / Follow-up: Web bundle에는 SDK가 포함되고 native bundle에는 Sentry 관측 module import가 없는지 검증한다.
+- Consequences: 공용 오류 경계의 UI·retry 구현은 공유하지만 현재 Sentry capture callback은 Web entry만 소유한다.
+  PROD-483에서 Native 관측을 도입할 때 같은 경계를 재검토할 수 있다.
+- Confirmation / Follow-up: Web bundle에는 SDK가 포함되고 Native bundle에는 이번 Web slice의 Sentry 관측 module
+  import가 없는지 검증한다. 이 결과를 Native 지원 완료 또는 영구 비적용의 증거로 해석하지 않는다.
 
 ### SDK event를 beforeSend 정제 없이 전달한다
 

--- a/openspec/changes/add-production-sentry-error-collection/design.md
+++ b/openspec/changes/add-production-sentry-error-collection/design.md
@@ -16,7 +16,8 @@ API와 Web BFF는 Hono/Node ESM 애플리케이션이며 TypeScript source를 `t
 
 **Non-Goals:**
 
-- Android·iOS SDK, native crash 수집과 debug symbol
+- 이번 변경에서 Android·iOS SDK, native crash 수집과 debug symbol을 활성화하지 않는다. Native 지원·검증은
+  PROD-483에서 별도 결정·검증한다.
 - tracing, Session Replay, 전면 로그 수집, 사용자 식별
 - 예상 도메인 오류 전송과 사용자 오류 UI·event ID 변경
 - Sentry 조직·프로젝트·알림 rule 자체를 저장소에서 자동 생성하는 provisioning
@@ -27,7 +28,8 @@ API와 Web BFF는 Hono/Node ESM 애플리케이션이며 TypeScript source를 `t
 
 - API GraphQL 오류는 Yoga가 응답으로 소비하므로 Hono `onError`만 연결하면 resolver unexpected 오류가 누락된다. 반대로 두 경계에서 무조건 capture하면 같은 오류가 중복될 수 있다.
 - `NODE_ENV=production`은 API unit test에서도 사용하므로 활성화 조건으로 사용할 수 없다. 로컬·테스트에는 배포 DSN·환경·release를 기본 주입하지 않아야 한다.
-- `apps/app`의 공용 source에 Web SDK를 직접 import하면 PROD-483보다 먼저 native bundle과 runtime을 바꾼다. platform module 경계가 필요하다.
+- `apps/app`의 공용 source에 Web SDK를 직접 import하면 PROD-483보다 먼저 native bundle과 runtime을 바꾼다. 현재
+  Web slice에서는 platform module 경계를 사용해 Native entry를 유지하고, Native 관측의 향후 지원 가능성은 닫지 않는다.
 - Expo Web source map을 그대로 정적 root에 복사하면 원본 source가 공개된다. 업로드는 gzip과 runtime image 복사보다 먼저 끝나야 한다.
 - 서버는 TypeScript source를 `tsx`로 직접 실행한다. 서버 JavaScript artifact와 source map을 만들기 위한 build/runtime 전환은 오류 event 수집에 필수적이지 않으므로 PROD-516으로 연기한다.
 
@@ -35,7 +37,7 @@ API와 Web BFF는 Hono/Node ESM 애플리케이션이며 TypeScript source를 `t
 
 - API와 BFF는 작은 공용 server 관측 모듈을 공유하지 말고 각 앱이 같은 최소 설정을 소유한다. Sentry SDK는 DSN, environment와 release가 모두 있으면 활성화한다.
 - API GraphQL plugin은 Kosmo/validation 오류와 명시적으로 던진 `GraphQLError`를 capture하지 않고, plain `Error`와 non-null field 위반 같은 unexpected execution 원인만 capture한다. GraphQL 밖 API 오류와 Web BFF unexpected 오류는 각 Hono `onError`가 capture한다.
-- Web platform entry가 router와 애플리케이션 module보다 먼저 browser SDK를 초기화하고 generic 오류 reporter context를 제공한다. `react-error-boundary`로 구성한 단일 GraphQL 경계가 이 reporter를 상속하며 내부 route·session 경계의 `onError`도 같은 reporter로 capture한다. Android·iOS entry는 Sentry 관측 module을 import하지 않는다.
+- Web platform entry가 router와 애플리케이션 module보다 먼저 browser SDK를 초기화하고 generic 오류 reporter context를 제공한다. `react-error-boundary`로 구성한 단일 GraphQL 경계가 이 reporter를 상속하며 내부 route·session 경계의 `onError`도 같은 reporter로 capture한다. 현재 Web slice에서 Android·iOS entry는 Sentry 관측 module을 import하지 않고 기존 동작을 유지하며, Native 관측은 PROD-483의 별도 release gate로 검증한다.
 - `beforeSend` event processor를 두지 않고 SDK event 전체를 전달한다. environment/release/runtime metadata는 유지하고 자동 breadcrumb와 Web session tracking은 전부 비활성화한다.
 - Docker build는 Expo Web export에 external source map을 요청한다. Sentry CLI의 debug ID inject와 upload를 업로드 token BuildKit secret으로 수행한 뒤 Web map과 sourceMappingURL을 제거한다. API와 Web BFF는 기존 TypeScript source와 `tsx` runtime entry를 유지한다.
 - API, Web BFF와 Web browser는 Sentry project 하나를 공유하고 `runtime` tag로 구분한다. GitHub Actions는 공식 Vault Action과 branch/dev·SemVer tag/prod role을 사용해 각각 Vault의 `secret/kubernetes/kosmo/dev|prod`에서 `EXPO_PUBLIC_SENTRY_DSN`을 읽는다. 공개 DSN과 GitHub repository variables의 조직·project slug는 build arg, repository secret의 upload token만 BuildKit secret으로 전달한다. API와 Web BFF는 Vault Secrets Operator가 환경별 객체를 변환한 기존 `env` Kubernetes Secret에서 같은 `EXPO_PUBLIC_SENTRY_DSN`을 읽는다.

--- a/openspec/changes/add-production-sentry-error-collection/proposal.md
+++ b/openspec/changes/add-production-sentry-error-collection/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Kosmo의 API, Web BFF, Web 앱은 프로덕션 처리되지 않은 예외를 중앙에서 조사할 수 없어 릴리스별 회귀와 원인을 stack trace 기준으로 추적할 수 없다. 7월 29일 서버·Web 배포 범위에 Sentry 오류 수집을 연결하고 Web 원본 소스 symbolication을 제공하되, 서버 source map과 Android·iOS 범위는 후속 Backlog로 남긴다.
+Kosmo의 API, Web BFF, Web 앱은 프로덕션 처리되지 않은 예외를 중앙에서 조사할 수 없어 릴리스별 회귀와 원인을 stack trace 기준으로 추적할 수 없다. 7월 29일 서버·Web 배포 범위에 Sentry 오류 수집을 연결하고 Web 원본 소스 symbolication을 제공한다. 현재 Native runtime 관측과 실기기 검증은 이 Web 출시·검증 범위에 포함하지 않으며, 관련 결정·구현은 후속 PROD-483에서 별도로 다룬다.
 
 ## What Changes
 
@@ -10,7 +10,7 @@ Kosmo의 API, Web BFF, Web 앱은 프로덕션 처리되지 않은 예외를 중
 - Sentry SDK가 만든 event와 exception은 `beforeSend`로 정제하지 않고 그대로 전송하며 자동 breadcrumb만 비활성화한다.
 - 로컬 개발과 테스트에는 배포 DSN·환경·release를 기본 주입하지 않아 외부 전송하지 않는다.
 - DSN과 source map 업로드 자격 증명을 Vault·GitHub 배포 설정으로 분리하고 운영 검증·triage 절차를 문서화한다.
-- Android·iOS native runtime과 debug symbol 업로드는 Backlog인 PROD-483에 남긴다.
+- Android·iOS native runtime과 debug symbol 업로드는 현재 변경의 Web 출시·검증에 포함하지 않으며, 후속 PROD-483에서 별도로 결정·검증한다.
 - API·Web BFF의 JavaScript artifact와 TypeScript source map은 Backlog인 PROD-516에 남기고 기존 `tsx` 실행을 유지한다.
 
 ## Authority / Provenance

--- a/openspec/changes/add-production-sentry-error-collection/tasks.md
+++ b/openspec/changes/add-production-sentry-error-collection/tasks.md
@@ -39,17 +39,19 @@
 
 **Guardrails**
 
-- Android·iOS platform에서는 Sentry SDK를 초기화하거나 native 범위를 선행하지 않는다.
+- 현재 Web slice에서는 Android·iOS platform의 Sentry SDK를 초기화하지 않고 Native 범위를 선행하지 않는다.
+  Native 관측·debug symbol은 PROD-483의 별도 release gate에서 결정·검증한다.
 - Sentry SDK event는 `beforeSend` 정제 없이 그대로 전달하고 console·UI·network breadcrumb만 제거한다.
 - 업로드 token은 client bundle에 포함하지 않고 local/test는 기본 비전송한다.
 - 기존 `GraphQLErrorBoundary`의 오류 화면·문구·재시도 행동을 변경하지 않는다.
 
 **Verification**
 
-- Web 전용 초기화와 native 관측 제외, event 전달 설정, React boundary capture와 기존 fallback/retry를 단위·Storybook 또는 관련 UI test로 검증한다.
+- Web 전용 초기화와 현재 Native entry의 비변경 경계, event 전달 설정, React boundary capture와 기존 fallback/retry를
+  단위·Storybook 또는 관련 UI test로 검증한다. Native runtime 관측 완료를 주장하지 않는다.
 - Relay, TypeScript, Expo Web export와 Web source map 정적 검증을 통과시킨다.
 
-- [x] 2.1 Web-only Sentry 초기화·event 전달과 native 관측 제외 경계를 구현하고 배포 metadata 설정 테스트를 추가한다.
+- [x] 2.1 Web Sentry 초기화·event 전달과 현재 Native entry 비변경 경계를 구현하고 배포 metadata 설정 테스트를 추가한다.
 - [x] 2.2 공용 React 오류 경계의 Web capture를 기존 fallback·retry 동작에 연결하고 중복 없는 capture를 검증한다.
 - [x] 2.3 Expo Web build가 외부 source map을 생성하고 업로드 뒤 제공 asset에서 map과 참조를 제거하도록 정렬한다.
 
@@ -69,7 +71,7 @@ API, Web BFF와 Web browser가 동일 커밋 release와 일관된 환경/runtime
 
 - source map 업로드 token은 BuildKit secret으로만 소비하고 저장소·로그·image·Web asset에 남기지 않는다.
 - 환경별 Vault dev/prod 객체의 `EXPO_PUBLIC_SENTRY_DSN`을 API, Web BFF와 Web build가 공유한다. 공식 Vault Action이 DSN을 조회하고 build 전용 organization/project slug와 upload token은 각각 GitHub repository variables/secret에서 관리한다. 공개 설정은 build arg, token만 BuildKit secret으로 전달하고 API와 Web BFF는 기존 환경 `env` Secret에서 같은 DSN 변수를 읽는다. Build role이 대응 환경 Vault 객체 전체를 읽는 권한 확대는 사용자 결정으로 수용한다.
-- Android·iOS PROD-483 범위는 통합 완료 조건에 포함하지 않는다.
+- Android·iOS PROD-483의 Native 관측·debug symbol은 이 Web 통합 완료 조건에 포함하지 않으며, 별도 release gate로 남긴다.
 - 실제 event, release, Web symbolication, event 전달 결과와 알림 전달을 확인하기 전에는 부모 통합 검증과 OpenSpec archive를 완료하지 않는다.
 
 **Verification**

--- a/openspec/changes/add-web-openpanel-product-analytics/decisions.md
+++ b/openspec/changes/add-web-openpanel-product-analytics/decisions.md
@@ -4,17 +4,21 @@
 
 ## Decision Records
 
-### Web 전용 OpenPanel 도입과 후속 범위 분리
+### Web OpenPanel 도입과 Native 후속 범위 분리
 
 - Decision Date: 2026-07-29
 - Decision Class: Derived Contract
 - Authority / Provenance: Linear `PROD-469`, `PROD-537`, `PROD-539`
 - Status: Active
 - Context / Problem: 첫 분석 도입에 Web과 native, 현재 핵심 행동과 추가 소셜 행동을 모두 포함하면 독립 배포 가능한 범위가 섞인다.
-- Decision Outcome: PROD-469는 Web만 구현한다. Android·iOS는 PROD-537, 재게시·반응·북마크는 PROD-539로 분리한다.
+- Decision Outcome: PROD-469는 현재 Web 출시·검증 범위의 OpenPanel만 구현한다. Android·iOS 분석 지원·검증은
+  PROD-537에서 별도로 결정하고, 재게시·반응·북마크는 PROD-539로 분리한다. 이 분리는 현재 delivery 경계를
+  설명하며 Native의 영구 비적용을 결정하지 않는다.
 - Alternatives Considered: 모든 플랫폼과 이벤트를 한 번에 구현하는 방법은 배포·검증 경계가 커져 제외했다.
-- Consequences: 이번 변경의 공통 import는 native에서 no-op이어야 하며, 후속 이슈가 현재 변경의 완료를 막지 않는다.
-- Confirmation / Follow-up: native bundle에 OpenPanel client가 생성되지 않는지 확인한다.
+- Consequences: 이번 변경의 공통 import는 Native에서 no-op이어야 하며, 후속 이슈가 현재 Web 변경의 완료를 막지
+  않는다. PROD-537은 Native 지원이 필요할 때 별도 결정·검증을 소유한다.
+- Confirmation / Follow-up: Native bundle에 이번 Web slice의 OpenPanel client가 생성되지 않는지 확인하고, 이를
+  Native 지원 완료 또는 영구 비적용의 증거로 해석하지 않는다.
 
 ### Client ID 존재 여부를 유일한 활성화 조건으로 사용
 

--- a/openspec/changes/add-web-openpanel-product-analytics/design.md
+++ b/openspec/changes/add-web-openpanel-product-analytics/design.md
@@ -16,7 +16,8 @@ OpenPanel Web SDK의 자동 화면·외부 링크·속성 추적은 브라우저
 
 **Non-Goals:**
 
-- Android·iOS 분석 SDK 도입
+- 이번 Web 분석 slice에서 Android·iOS 분석 SDK를 도입하지 않는다. Native 분석 지원·검증은 PROD-537에서
+  별도로 결정한다.
 - 재게시·반응·북마크 이벤트 계측
 - 사용자 설정 기반 분석 opt-out UI
 - OpenPanel Account 데이터 삭제 자동화
@@ -33,7 +34,11 @@ OpenPanel Web SDK의 자동 화면·외부 링크·속성 추적은 브라우저
 
 ### Recommended Approach
 
-플랫폼별 모듈 해석을 사용해 Web 구현은 `@openpanel/web` singleton을 지연 생성하고 native 구현은 동일 API의 no-op으로 둔다. 공통 event helper가 OpenPanel의 event name과 선택적 properties를 그대로 전달하고, 모든 SDK 호출은 오류를 흡수하는 fire-and-forget 경계 뒤에 둔다. 허용된 이벤트와 속성은 실제 성공 경계의 호출부와 payload test로 유지한다.
+플랫폼별 모듈 해석을 사용해 현재 Web 구현은 `@openpanel/web` singleton을 지연 생성하고 Native 구현은 동일 API의
+no-op으로 둔다. 이는 Web SDK가 Native bundle에 도달하지 않게 하는 현재 배포·검증 경계이며, Native 분석 지원을
+영구적으로 막는 계약이 아니다. 공통 event helper가 OpenPanel의 event name과 선택적 properties를 그대로 전달하고,
+모든 SDK 호출은 오류를 흡수하는 fire-and-forget 경계 뒤에 둔다. 허용된 이벤트와 속성은 실제 성공 경계의 호출부와
+payload test로 유지한다.
 
 App provider가 Session query 경계 밖에서 anonymous client를 초기화하여 guest·Session error 화면에서도 자동 수집과 replay를 유지한다. Session 내부의 bridge는 guest에서 이전 identity를 clear하고, valid Session에서 Account ID를 identify한다. 명시적 로그아웃 경계도 서버 로그아웃과 actor reset이 완료된 뒤 identity를 clear한다. Profile·Post·Follow mutation과 검색 UI는 기존 성공 callback에서만 event helper를 호출한다.
 

--- a/openspec/changes/add-web-openpanel-product-analytics/tasks.md
+++ b/openspec/changes/add-web-openpanel-product-analytics/tasks.md
@@ -10,14 +10,16 @@ Client ID가 있는 Kosmo Web은 OpenPanel 자동 수집과 10% replay를 시작
 
 **Guardrails**
 
-- Client ID가 없거나 native인 경우 client와 분석 전송을 만들지 않고 Web SDK를 native bundle에 포함하지 않는다.
+- Client ID가 없거나 현재 Native runtime인 경우 client와 분석 전송을 만들지 않는다. Web SDK는 Native bundle에
+  포함하지 않으며, Native 분석 지원·검증은 PROD-537의 별도 gate에서 결정한다.
 - Account의 opaque ID만 identity로 사용한다.
 - 모든 입력값과 canonical Post Content를 replay에서 마스킹한다.
 - 분석 실패는 인증·렌더링·navigation을 실패시키지 않는다.
 
 **Verification**
 
-- Client ID 유무, guest 초기화, identify·clear, native no-op, replay 설정과 Post Content mask를 unit test와 typecheck로 검증한다.
+- Client ID 유무, guest 초기화, identify·clear, 현재 Native no-op 경계, replay 설정과 Post Content mask를 unit test와
+  typecheck로 검증한다. 이 결과를 Native 분석 runtime 완료로 일반화하지 않는다.
 
 - [x] 1.1 Web 전용 OpenPanel dependency와 Client ID 기반 초기화를 구현한다.
 - [x] 1.2 Session의 Account identify와 로그아웃 clear를 구현한다.
@@ -89,7 +91,8 @@ Web의 Profile 생성·선택, Post 생성, Follow와 검색 흐름이 실제 �
 
 **Guardrails**
 
-- Android·iOS와 재게시·반응·북마크 구현을 현재 변경에 포함하지 않는다.
+- 현재 Web 변경의 deliverable·verification에는 Android·iOS 분석 구현과 재게시·반응·북마크 계측을 포함하지 않는다.
+  Native 분석 지원·검증은 PROD-537의 별도 release gate로 남긴다.
 - 실제 production Client ID나 인증 정보를 repository에 저장하지 않는다.
 
 **Verification**


### PR DESCRIPTION
## 무엇을 변경했는지

- OpenSpec 워크플로에 플랫폼 지원·검증 상태와 영구 제품 계약을 분리하는 작성 원칙을 추가했습니다.
- Profile Edit의 Native 실제 기기 QA를 영구 제외가 아니라 현재 미실행 상태와 후속 출시 gate로 정정했습니다.
- Sentry와 OpenPanel의 Android·iOS 범위를 현재 Web delivery·검증 범위와 후속 이슈(PROD-483, PROD-537)로 표현하고, Native 영구 비적용으로 해석하지 않도록 정렬했습니다.
- Web hover나 platform-specific geometry처럼 실제 입력·표현 모델 차이에 근거한 플랫폼 한정 계약은 유지했습니다.

## 왜 변경했는지

현재 Native runtime을 지원·검증하지 않는다는 운영 상태가 일부 OpenSpec에서 Native에는 적용하지 않는다는 영구 제품 계약처럼 표현되고 있었습니다. 이 상태를 규범적 비적용으로 고정하면 향후 Native 지원 시 불필요한 계약 변경이 필요하고, 현재 Web 검증 결과와 미래 제품 범위가 혼동됩니다.

## 이번 PR의 주요 결정

### 지원·검증 상태와 제품 계약을 분리

- 결정자: 사용자
- 선택: Native 미지원·미검증은 현재 출시 시점과 증거 범위로 기록하고, 영구 비적용은 canonical domain/design 또는 Linear authority가 명시한 경우에만 normative requirement/decision으로 기록합니다.
- 고려한 대안: 현재 Native를 지원하지 않는다는 이유만으로 각 change의 Non-Goal, Guardrail, 완료 조건에 Native 비적용을 고정하는 방식.
- 이유: 현재 운영 상태를 미래 제품 계약으로 과도하게 일반화하지 않으면서도, 실행하지 않은 Native 검증을 완료로 주장하지 않기 위해서입니다.
- 감수한 결과: Native 지원을 시작할 때 후속 owner와 release gate에서 실제 구현·runtime 증거를 별도로 확보해야 합니다.
- 관련 근거: memory/issue-openspec-workflow.md와 이번 PR에서 정렬한 active OpenSpec artifacts.

Linear 이슈 없이 PR을 생성하라는 사용자 지시에 따라 별도 이슈는 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- openspec validate --all --strict (75 passed, 0 failed)
- git diff --check
- commit hook의 eslint --fix와 prettier --write 통과

## 아직 어떤 문제가 남았는지

이번 PR은 공통 작성 원칙과 명백한 active 사례(Profile Edit, Sentry, OpenPanel)를 정정합니다. 기존 archived change를 일괄 rewrite하지 않으며, 앞으로 관련 OpenSpec을 수정할 때 새 원칙에 따라 정렬합니다.