### PR TITLE
앱 전역 compact icon action을 공통 IconButton으로 통합한다

### DIFF
--- a/apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx
+++ b/apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx
@@ -1,12 +1,13 @@
 import { useLocalSearchParams, usePathname, useRouter, useSegments } from 'expo-router';
 import { ChevronLeftIcon } from 'lucide-react-native';
 import { useEffect, useState } from 'react';
-import { Platform, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { PageHeader } from '@/components/PageHeader';
 import { PostDetailFrame, PostDetailThread } from '@/components/post/PostDetailThread';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { getWebMobileShellHeader } from '@/components/shell/shellLayout';
+import { IconButton } from '@/components/ui/IconButton';
 import { StateView } from '@/components/ui/StateView';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -109,14 +110,15 @@ function PostDetailHeader() {
   return (
     <PageHeader
       leading={
-        <Pressable
+        <IconButton
           accessibilityLabel="뒤로 가기"
-          accessibilityRole="button"
           onPress={() => router.back()}
           style={styles.back}
+          targetSize={44}
+          visualSize={44}
         >
           <ChevronLeftIcon color={theme.text} size={20} />
-        </Pressable>
+        </IconButton>
       }
       title="게시글"
     />

--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -9,6 +9,7 @@ import { ProfileListItem } from '@/components/profile/ProfileListItem';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { usePrimaryNavigationScroll } from '@/components/shell/PrimaryNavigationScrollContext';
 import { Button } from '@/components/ui/Button';
+import { IconButton } from '@/components/ui/IconButton';
 import { StateView } from '@/components/ui/StateView';
 import { addRecentSearch, readRecentSearches, writeRecentSearches } from '@/lib/recentSearches';
 import { useRelayActor } from '@/relay/RelayActorProvider';
@@ -477,15 +478,16 @@ export default function SearchScreen() {
               value={input}
             />
             {input ? (
-              <Pressable
+              <IconButton
                 accessibilityLabel="검색 지우기"
-                accessibilityRole="button"
                 onPress={clearSearch}
                 onPressIn={keepSearchFocused}
                 style={styles.clearButton}
+                targetSize={44}
+                visualSize={44}
               >
                 <X color={theme.textSecondary} size={18} strokeWidth={2} />
-              </Pressable>
+              </IconButton>
             ) : null}
           </View>
         </View>
@@ -520,9 +522,8 @@ export default function SearchScreen() {
                       </Text>
                     </Pressable>
                   </Link>
-                  <Pressable
+                  <IconButton
                     accessibilityLabel={`최근 검색 '${term}' 삭제`}
-                    accessibilityRole="button"
                     onPress={() => {
                       const next = recent.filter((item) => item !== term);
                       setRecent(next);
@@ -531,9 +532,11 @@ export default function SearchScreen() {
                     }}
                     onPressIn={keepSearchFocused}
                     style={styles.deleteButton}
+                    targetSize={44}
+                    visualSize={44}
                   >
                     <X color={theme.textSecondary} size={16} strokeWidth={2} />
-                  </Pressable>
+                  </IconButton>
                 </View>
               ))
             ) : (

--- a/apps/app/src/components/feedback/FeedbackOverlay.tsx
+++ b/apps/app/src/components/feedback/FeedbackOverlay.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Modal,
   Platform,
-  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -11,6 +10,7 @@ import {
   View,
 } from 'react-native';
 import { Button } from '@/components/ui/Button';
+import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
 import { breakpoints, radii, shadow, spacing, typography } from '@/theme/tokens';
 import { FeedbackForm } from './FeedbackForm';
@@ -203,12 +203,11 @@ export function FeedbackOverlay({ fallbackFocusRef, onRequestClose, visible }: P
               <Text accessibilityRole="header" style={[styles.title, { color: theme.text }]}>
                 피드백 보내기
               </Text>
-              <Pressable
+              <IconButton
                 accessibilityLabel="피드백 닫기"
-                accessibilityRole="button"
+                controlRef={closeRef}
                 disabled={formState.submitting}
                 onPress={() => requestClose()}
-                ref={closeRef}
                 style={({ pressed }) => [
                   styles.close,
                   {
@@ -216,9 +215,10 @@ export function FeedbackOverlay({ fallbackFocusRef, onRequestClose, visible }: P
                     opacity: formState.submitting ? 0.45 : 1,
                   },
                 ]}
+                targetSize={36}
               >
                 <XIcon color={theme.text} size={20} strokeWidth={2} />
-              </Pressable>
+              </IconButton>
             </View>
             <ScrollView
               contentContainerStyle={styles.body}

--- a/apps/app/src/components/post/PostComposerMediaControls.tsx
+++ b/apps/app/src/components/post/PostComposerMediaControls.tsx
@@ -18,6 +18,7 @@ import {
   formatImageUploadFailureMessage,
   formatImageUploadRetryLabel,
 } from '@/components/media/imageUploadErrors';
+import { getIconButtonHitSlop, IconButton } from '@/components/ui/IconButton';
 import { TextField } from '@/components/ui/TextField';
 import { useTheme } from '@/theme/ThemeProvider';
 import { colors, radii, spacing, typography } from '@/theme/tokens';
@@ -58,6 +59,10 @@ export const emptyPostComposerMediaValue: PostComposerMediaValue = {
   items: [],
   sensitiveMedia: false,
 };
+
+const mediaActionEffectiveTargetSize = 48;
+const mediaAddVisualSize = 40;
+const mediaRemoveVisualSize = 32;
 
 export function PostComposerMediaControls({
   actions,
@@ -331,15 +336,19 @@ export function PostComposerMediaControls({
         </Text>
       ) : null}
       <View style={styles.footer}>
-        <Pressable
+        <IconButton
           accessibilityLabel={`이미지 추가, ${postComposerMediaLimit - media.length}개 더 선택 가능`}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: disabled || media.length >= postComposerMediaLimit }}
           disabled={disabled || media.length >= postComposerMediaLimit}
-          hitSlop={4}
+          hitSlop={getIconButtonHitSlop(
+            Platform.OS,
+            mediaAddVisualSize,
+            mediaActionEffectiveTargetSize,
+          )}
           onPress={() => void selectMedia()}
-          style={({ pressed }) => [
-            styles.addMedia,
+          style={styles.addMediaTarget}
+          visualSize={mediaAddVisualSize}
+          visualStyle={({ pressed }) => [
+            styles.addMediaVisual,
             {
               backgroundColor: pressed ? theme.surface : 'transparent',
               opacity: disabled || media.length >= postComposerMediaLimit ? 0.45 : 1,
@@ -347,7 +356,7 @@ export function PostComposerMediaControls({
           ]}
         >
           <ImagePlusIcon color={theme.primary} size={24} />
-        </Pressable>
+        </IconButton>
         {actions}
       </View>
     </>
@@ -418,20 +427,24 @@ export function PostComposerMediaItems({
                 )}
               </>
             ) : null}
-            <Pressable
+            <IconButton
               accessibilityLabel={`첨부 이미지 ${index + 1} 제거`}
-              accessibilityRole="button"
-              accessibilityState={{ disabled }}
               disabled={disabled}
-              hitSlop={8}
+              hitSlop={getIconButtonHitSlop(
+                Platform.OS,
+                mediaRemoveVisualSize,
+                mediaActionEffectiveTargetSize,
+              )}
               onPress={() => onRemove(item.key)}
-              style={({ pressed }) => [
-                styles.mediaRemove,
+              style={styles.mediaRemoveTarget}
+              visualSize={mediaRemoveVisualSize}
+              visualStyle={({ pressed }) => [
+                styles.mediaRemoveVisual,
                 { opacity: disabled ? 0.45 : pressed ? 0.75 : 1 },
               ]}
             >
               <XIcon color={colors.light.background} size={18} />
-            </Pressable>
+            </IconButton>
           </View>
           {item.state === 'ready' ? (
             <View style={styles.mediaItemBody}>
@@ -486,13 +499,8 @@ const styles = StyleSheet.create({
     gap: spacing.md,
     justifyContent: 'space-between',
   },
-  addMedia: {
-    alignItems: 'center',
-    borderRadius: radii.sm,
-    height: 40,
-    justifyContent: 'center',
-    width: 40,
-  },
+  addMediaTarget: { height: mediaAddVisualSize, width: mediaAddVisualSize },
+  addMediaVisual: { borderRadius: radii.sm },
   mediaItem: { alignItems: 'flex-start', flexDirection: 'row', gap: spacing.md },
   mediaPreviewContainer: {
     borderRadius: radii.sm,
@@ -504,17 +512,17 @@ const styles = StyleSheet.create({
   mediaPreview: { height: 96, width: 96 },
   mediaOverlayBackdrop: { backgroundColor: colors.light.text, opacity: 0.58 },
   mediaOverlay: { alignItems: 'center', justifyContent: 'center' },
-  mediaRemove: {
-    alignItems: 'center',
-    backgroundColor: colors.light.text,
-    borderRadius: radii.full,
-    height: 32,
-    justifyContent: 'center',
+  mediaRemoveTarget: {
+    height: mediaRemoveVisualSize,
     position: 'absolute',
     right: spacing.xs,
     top: spacing.xs,
-    width: 32,
+    width: mediaRemoveVisualSize,
     zIndex: 1,
+  },
+  mediaRemoveVisual: {
+    backgroundColor: colors.light.text,
+    borderRadius: radii.full,
   },
   mediaItemBody: { flex: 1 },
   sensitiveMedia: {

--- a/apps/app/src/components/post/PostComposerMediaControls.tsx
+++ b/apps/app/src/components/post/PostComposerMediaControls.tsx
@@ -348,11 +348,7 @@ export function PostComposerMediaControls({
         <IconButton
           accessibilityLabel={`이미지 추가, ${postComposerMediaLimit - media.length}개 더 선택 가능`}
           disabled={disabled || media.length >= postComposerMediaLimit}
-          hitSlop={getIconButtonHitSlop(
-            Platform.OS,
-            mediaAddVisualSize,
-            mediaActionEffectiveTargetSize,
-          )}
+          hitSlop={getIconButtonHitSlop(mediaAddVisualSize, mediaActionEffectiveTargetSize)}
           onPress={() => void selectMedia()}
           style={styles.addMediaTarget}
           visualSize={mediaAddVisualSize}

--- a/apps/app/src/components/post/PostComposerMediaControls.tsx
+++ b/apps/app/src/components/post/PostComposerMediaControls.tsx
@@ -441,6 +441,7 @@ export function PostComposerMediaItems({
               disabled={disabled}
               onPress={() => onRemove(item.key)}
               style={styles.mediaRemoveTarget}
+              targetSize={mediaRemoveGeometry.targetSize}
               visualSize={mediaRemoveVisualSize}
               visualStyle={({ pressed }) => [
                 styles.mediaRemoveVisual,

--- a/apps/app/src/components/post/PostComposerMediaControls.tsx
+++ b/apps/app/src/components/post/PostComposerMediaControls.tsx
@@ -18,7 +18,11 @@ import {
   formatImageUploadFailureMessage,
   formatImageUploadRetryLabel,
 } from '@/components/media/imageUploadErrors';
-import { getIconButtonHitSlop, IconButton } from '@/components/ui/IconButton';
+import {
+  getIconButtonHitSlop,
+  getIconButtonOverlayGeometry,
+  IconButton,
+} from '@/components/ui/IconButton';
 import { TextField } from '@/components/ui/TextField';
 import { useTheme } from '@/theme/ThemeProvider';
 import { colors, radii, spacing, typography } from '@/theme/tokens';
@@ -63,6 +67,11 @@ export const emptyPostComposerMediaValue: PostComposerMediaValue = {
 const mediaActionEffectiveTargetSize = 48;
 const mediaAddVisualSize = 40;
 const mediaRemoveVisualSize = 32;
+const mediaRemoveGeometry = getIconButtonOverlayGeometry(
+  Platform.OS,
+  mediaRemoveVisualSize,
+  spacing.xs,
+);
 
 export function PostComposerMediaControls({
   actions,
@@ -430,11 +439,6 @@ export function PostComposerMediaItems({
             <IconButton
               accessibilityLabel={`첨부 이미지 ${index + 1} 제거`}
               disabled={disabled}
-              hitSlop={getIconButtonHitSlop(
-                Platform.OS,
-                mediaRemoveVisualSize,
-                mediaActionEffectiveTargetSize,
-              )}
               onPress={() => onRemove(item.key)}
               style={styles.mediaRemoveTarget}
               visualSize={mediaRemoveVisualSize}
@@ -513,16 +517,19 @@ const styles = StyleSheet.create({
   mediaOverlayBackdrop: { backgroundColor: colors.light.text, opacity: 0.58 },
   mediaOverlay: { alignItems: 'center', justifyContent: 'center' },
   mediaRemoveTarget: {
-    height: mediaRemoveVisualSize,
+    height: mediaRemoveGeometry.targetSize,
     position: 'absolute',
-    right: spacing.xs,
-    top: spacing.xs,
-    width: mediaRemoveVisualSize,
+    right: mediaRemoveGeometry.targetInset,
+    top: mediaRemoveGeometry.targetInset,
+    width: mediaRemoveGeometry.targetSize,
     zIndex: 1,
   },
   mediaRemoveVisual: {
     backgroundColor: colors.light.text,
     borderRadius: radii.full,
+    position: 'absolute',
+    right: mediaRemoveGeometry.visualInset,
+    top: mediaRemoveGeometry.visualInset,
   },
   mediaItemBody: { flex: 1 },
   sensitiveMedia: {

--- a/apps/app/src/components/post/ReplyComposerSurface.tsx
+++ b/apps/app/src/components/post/ReplyComposerSurface.tsx
@@ -17,6 +17,7 @@ import { getDataIDsFromFragment, getFragment } from 'relay-runtime';
 import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
 import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
+import { IconButton } from '@/components/ui/IconButton';
 import { useToast } from '@/components/ui/ToastProvider';
 import { formatTimelineTimestamp } from '@/lib/date';
 import { useRelayEnvironmentGeneration } from '@/relay/RelayEnvironmentBoundary';
@@ -437,24 +438,24 @@ function ReplyComposerSurfaceContents({
                 <Text accessibilityRole="header" style={[styles.title, { color: theme.text }]}>
                   답글 쓰기
                 </Text>
-                <Pressable
+                <IconButton
                   accessibilityLabel="닫기"
-                  accessibilityRole="button"
                   disabled={submitting}
                   hitSlop={4}
                   onPress={() => requestClose()}
-                  style={({ pressed }) => [
+                  style={{ height: closeControlSize, width: closeControlSize }}
+                  targetSize={closeControlSize}
+                  visualSize={closeControlSize}
+                  visualStyle={({ pressed }) => [
                     styles.close,
                     {
                       backgroundColor: pressed ? theme.surface : 'transparent',
-                      height: closeControlSize,
                       opacity: submitting ? 0.45 : 1,
-                      width: closeControlSize,
                     },
                   ]}
                 >
                   <XIcon color={theme.text} size={20} strokeWidth={2} />
-                </Pressable>
+                </IconButton>
               </View>
               <KeyboardAvoidingView
                 behavior={Platform.OS === 'ios' ? 'padding' : undefined}

--- a/apps/app/src/components/profile/ProfileEditImageFields.tsx
+++ b/apps/app/src/components/profile/ProfileEditImageFields.tsx
@@ -5,6 +5,7 @@ import {
   formatImageUploadRetryLabel,
 } from '@/components/media/imageUploadErrors';
 import { ActionMenu } from '@/components/ui/ActionMenu';
+import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
 import { colors, radii, spacing, typography } from '@/theme/tokens';
 import type { Ref } from 'react';
@@ -138,13 +139,13 @@ function ImageEditControl({
     onPress: () => void;
     ref: Ref<View>;
   }) => (
-    <Pressable
+    <IconButton
       accessibilityLabel={accessibilityLabel}
-      accessibilityRole="button"
-      accessibilityState={{ disabled, expanded }}
+      accessibilityState={{ expanded }}
+      controlRef={ref}
       disabled={disabled}
+      feedback="none"
       onPress={onPress}
-      ref={ref}
       style={style}
       testID={testID}
     >
@@ -164,7 +165,7 @@ function ImageEditControl({
           <CameraAffordance disabled={disabled} />
         </>
       )}
-    </Pressable>
+    </IconButton>
   );
 
   if (!draft.previewUri || !onRemove) {

--- a/apps/app/src/components/profile/ProfileEditImageFields.tsx
+++ b/apps/app/src/components/profile/ProfileEditImageFields.tsx
@@ -5,7 +5,6 @@ import {
   formatImageUploadRetryLabel,
 } from '@/components/media/imageUploadErrors';
 import { ActionMenu } from '@/components/ui/ActionMenu';
-import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
 import { colors, radii, spacing, typography } from '@/theme/tokens';
 import type { Ref } from 'react';
@@ -139,13 +138,13 @@ function ImageEditControl({
     onPress: () => void;
     ref: Ref<View>;
   }) => (
-    <IconButton
+    <Pressable
       accessibilityLabel={accessibilityLabel}
-      accessibilityState={{ expanded }}
-      controlRef={ref}
+      accessibilityRole="button"
+      accessibilityState={{ disabled, expanded }}
       disabled={disabled}
-      feedback="none"
       onPress={onPress}
+      ref={ref}
       style={style}
       testID={testID}
     >
@@ -165,7 +164,7 @@ function ImageEditControl({
           <CameraAffordance disabled={disabled} />
         </>
       )}
-    </IconButton>
+    </Pressable>
   );
 
   if (!draft.previewUri || !onRemove) {

--- a/apps/app/src/components/profile/ProfileEditScreen.tsx
+++ b/apps/app/src/components/profile/ProfileEditScreen.tsx
@@ -1,8 +1,9 @@
 import { ArrowLeft } from 'lucide-react-native';
-import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';
 import { Button } from '../ui/Button';
+import { IconButton } from '../ui/IconButton';
 import { ProfileEditForm } from './ProfileEditForm';
 import { canSubmitProfileEdit, validateProfileEditDraft } from './profileEditState';
 import type { ViewStyle } from 'react-native';
@@ -122,19 +123,15 @@ export function ProfileEditScreen({
         ]}
       >
         {onBack ? (
-          <Pressable
+          <IconButton
             accessibilityLabel="프로필 편집 닫기"
-            accessibilityRole="button"
-            accessibilityState={{ disabled: saving }}
             disabled={saving}
             onPress={onBack}
-            style={({ pressed }) => [
-              styles.backAction,
-              { opacity: saving ? 0.45 : pressed ? 0.7 : 1 },
-            ]}
+            style={styles.backAction}
+            targetSize={48}
           >
             <ArrowLeft color={theme.text} size={22} strokeWidth={2} />
-          </Pressable>
+          </IconButton>
         ) : (
           <View style={styles.backAction} />
         )}

--- a/apps/app/src/components/profile/ProfileEditScreen.tsx
+++ b/apps/app/src/components/profile/ProfileEditScreen.tsx
@@ -126,6 +126,7 @@ export function ProfileEditScreen({
           <IconButton
             accessibilityLabel="프로필 편집 닫기"
             disabled={saving}
+            feedback="opacity"
             onPress={onBack}
             style={styles.backAction}
             targetSize={48}

--- a/apps/app/src/components/profile/ProfileHero.test.ts
+++ b/apps/app/src/components/profile/ProfileHero.test.ts
@@ -34,6 +34,7 @@ mockModule('expo-router', {
 });
 mockModule('react-native', {
   Image: 'Image',
+  Platform: { OS: 'web' },
   Pressable: 'Pressable',
   StyleSheet: {
     absoluteFillObject: {},

--- a/apps/app/src/components/profile/ProfileTagChip.tsx
+++ b/apps/app/src/components/profile/ProfileTagChip.tsx
@@ -60,6 +60,7 @@ export function ProfileTagChip(props: ProfileTagChipProps) {
       <IconButton
         accessibilityLabel={`#${name} 제거`}
         disabled={disabled}
+        feedback="opacity"
         onPress={onRemove}
         style={styles.removeTarget}
         testID="profile-tag-remove-button"

--- a/apps/app/src/components/profile/ProfileTagChip.tsx
+++ b/apps/app/src/components/profile/ProfileTagChip.tsx
@@ -1,4 +1,5 @@
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { ICON_BUTTON_TARGET_SIZE, IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
 
@@ -46,34 +47,26 @@ export function ProfileTagChip(props: ProfileTagChipProps) {
   }
 
   const { disabled = false, onRemove } = props;
-  const removeActionTargetSize = Platform.select({ android: 48, ios: 44, web: 32, default: 48 });
-  const removeActionTargetInset = (removeActionTargetSize - PROFILE_TAG_CHIP_VISUAL_SIZE) / 2;
+  const removeActionTargetInset = (ICON_BUTTON_TARGET_SIZE - PROFILE_TAG_CHIP_VISUAL_SIZE) / 2;
 
   return (
     <View
       style={[
         styles.removableRoot,
-        { minHeight: removeActionTargetSize, paddingRight: removeActionTargetInset },
+        { minHeight: ICON_BUTTON_TARGET_SIZE, paddingRight: removeActionTargetInset },
       ]}
     >
       {chip}
-      <Pressable
+      <IconButton
         accessibilityLabel={`#${name} 제거`}
-        accessibilityRole="button"
-        accessibilityState={{ disabled }}
         disabled={disabled}
         onPress={onRemove}
-        style={({ pressed }) => [
-          styles.removeTarget,
-          { height: removeActionTargetSize, width: removeActionTargetSize },
-          { opacity: disabled ? 0.45 : pressed ? 0.7 : 1 },
-        ]}
+        style={styles.removeTarget}
         testID="profile-tag-remove-button"
+        visualSize={PROFILE_TAG_CHIP_VISUAL_SIZE}
       >
-        <View style={styles.removeVisual}>
-          <Text style={[styles.removeLabel, { color: theme.textSecondary }]}>×</Text>
-        </View>
-      </Pressable>
+        <Text style={[styles.removeLabel, { color: theme.textSecondary }]}>×</Text>
+      </IconButton>
     </View>
   );
 }
@@ -100,17 +93,8 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   removeTarget: {
-    alignItems: 'center',
-    justifyContent: 'center',
     position: 'absolute',
     right: 0,
-  },
-  removeVisual: {
-    alignItems: 'center',
-    height: PROFILE_TAG_CHIP_VISUAL_SIZE,
-    justifyContent: 'center',
-    pointerEvents: 'none',
-    width: PROFILE_TAG_CHIP_VISUAL_SIZE,
   },
   removeLabel: {
     fontFamily: 'SUIT',

--- a/apps/app/src/components/profile/ProfileTagChip.tsx
+++ b/apps/app/src/components/profile/ProfileTagChip.tsx
@@ -63,6 +63,7 @@ export function ProfileTagChip(props: ProfileTagChipProps) {
         feedback="opacity"
         onPress={onRemove}
         style={styles.removeTarget}
+        targetSize={ICON_BUTTON_TARGET_SIZE}
         testID="profile-tag-remove-button"
         visualSize={PROFILE_TAG_CHIP_VISUAL_SIZE}
       >

--- a/apps/app/src/components/reaction/ReactionSummary.tsx
+++ b/apps/app/src/components/reaction/ReactionSummary.tsx
@@ -1,4 +1,5 @@
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { IconButton } from '@/components/ui/IconButton';
 import { StateView } from '@/components/ui/StateView';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing } from '@/theme/tokens';
@@ -27,6 +28,8 @@ const copy = {
   errorTitle: '반응을 불러오지 못했어요',
   loadingTitle: '반응 요약을 불러오는 중입니다.',
 } as const;
+
+const moreControlSize = Platform.OS === 'web' ? 32 : 44;
 
 export function ReactionSummary({
   disabled = false,
@@ -110,12 +113,14 @@ export function ReactionSummary({
               );
             })}
             {onMore ? (
-              <Pressable
+              <IconButton
                 accessibilityLabel="반응한 프로필 보기"
-                accessibilityRole="button"
                 onPress={onMore}
-                style={({ pressed }) => [
-                  styles.more,
+                style={styles.moreTarget}
+                targetSize={moreControlSize}
+                visualSize={moreControlSize}
+                visualStyle={({ pressed }) => [
+                  styles.moreVisual,
                   {
                     backgroundColor: theme.card,
                     borderColor: theme.border,
@@ -124,7 +129,7 @@ export function ReactionSummary({
                 ]}
               >
                 <Text style={[styles.moreGlyph, { color: theme.text }]}>…</Text>
-              </Pressable>
+              </IconButton>
             ) : null}
           </ScrollView>
         )
@@ -186,15 +191,14 @@ const styles = StyleSheet.create({
       web: { fontSize: 20, lineHeight: 24 },
     }),
   },
-  more: {
-    alignItems: 'center',
+  moreTarget: {
+    borderRadius: radii.md,
+    height: moreControlSize,
+    width: moreControlSize,
+  },
+  moreVisual: {
     borderRadius: radii.md,
     borderWidth: 1,
-    justifyContent: 'center',
-    ...Platform.select({
-      default: { height: 44, width: 44 },
-      web: { height: 32, width: 32 },
-    }),
   },
   moreGlyph: {
     fontFamily: 'SUIT',

--- a/apps/app/src/components/shell/LogoutControl.tsx
+++ b/apps/app/src/components/shell/LogoutControl.tsx
@@ -1,5 +1,6 @@
 import { LogOut } from 'lucide-react-native';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { IconButton } from '@/components/ui/IconButton';
 import { useLogout } from '@/session/logout';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
@@ -16,28 +17,43 @@ export function LogoutControl({
   const theme = useTheme();
   const { error, logout, pending } = useLogout();
   const { request: requestNavigation } = useNavigationGuard();
+  const handleLogout = () => {
+    if (!requestNavigation(logout)) {
+      logout();
+    }
+  };
+  const icon = pending ? (
+    <ActivityIndicator accessibilityLabel="로그아웃 처리 중" color={theme.textSecondary} />
+  ) : (
+    <LogOut color={theme.textSecondary} size={20} strokeWidth={2} />
+  );
 
   return (
     <View style={[styles.root, compact && styles.compactRoot]}>
-      <Pressable
-        accessibilityLabel="로그아웃"
-        accessibilityRole="button"
-        accessibilityState={{ busy: pending, disabled: pending }}
-        disabled={pending}
-        onPress={() => {
-          if (!requestNavigation(logout)) {
-            logout();
-          }
-        }}
-        style={[styles.control, compact && styles.compactControl, style]}
-      >
-        {pending ? (
-          <ActivityIndicator accessibilityLabel="로그아웃 처리 중" color={theme.textSecondary} />
-        ) : (
-          <LogOut color={theme.textSecondary} size={20} strokeWidth={2} />
-        )}
-        {!compact ? <Text style={[styles.label, { color: theme.text }]}>로그아웃</Text> : null}
-      </Pressable>
+      {compact ? (
+        <IconButton
+          accessibilityLabel="로그아웃"
+          accessibilityState={{ busy: pending }}
+          disabled={pending}
+          onPress={handleLogout}
+          style={[styles.control, styles.compactControl, style]}
+          targetSize={44}
+        >
+          {icon}
+        </IconButton>
+      ) : (
+        <Pressable
+          accessibilityLabel="로그아웃"
+          accessibilityRole="button"
+          accessibilityState={{ busy: pending, disabled: pending }}
+          disabled={pending}
+          onPress={handleLogout}
+          style={[styles.control, style]}
+        >
+          {icon}
+          <Text style={[styles.label, { color: theme.text }]}>로그아웃</Text>
+        </Pressable>
+      )}
       {error ? (
         <Text
           accessibilityLiveRegion="polite"

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -16,6 +16,7 @@ import { FeedbackOverlay } from '@/components/feedback/FeedbackOverlay';
 import { PageHeader } from '@/components/PageHeader';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { Splash } from '@/components/Splash';
+import { IconButton } from '@/components/ui/IconButton';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing } from '@/theme/tokens';
@@ -188,27 +189,30 @@ function UniversalShellContent({ revision }: { revision: number }) {
     setFeedbackOpen(true);
   };
   const menuButton = (
-    <Pressable
+    <IconButton
       aria-controls={drawerOpen ? 'mobile-sidebar' : undefined}
       accessibilityLabel="메뉴 열기"
-      accessibilityRole="button"
       accessibilityState={{ expanded: drawerOpen }}
+      controlRef={menuButtonRef}
+      feedback="opacity"
       onPress={() => setDrawerOpen(true)}
-      ref={menuButtonRef}
-      style={({ pressed }) => [styles.menuButton, { opacity: pressed ? 0.7 : 1 }]}
+      style={styles.menuButton}
+      targetSize={44}
+      visualSize={44}
     >
       <Menu color={theme.text} size={24} strokeWidth={2} />
-    </Pressable>
+    </IconButton>
   );
   const backButton = (
-    <Pressable
+    <IconButton
       accessibilityLabel="뒤로 가기"
-      accessibilityRole="button"
       onPress={() => router.back()}
       style={styles.menuButton}
+      targetSize={44}
+      visualSize={44}
     >
       <ChevronLeftIcon color={theme.text} size={20} />
-    </Pressable>
+    </IconButton>
   );
 
   return (

--- a/apps/app/src/components/ui/IconButton.test.ts
+++ b/apps/app/src/components/ui/IconButton.test.ts
@@ -53,6 +53,13 @@ let getIconButtonOverlayGeometry:
       visualInset: number,
     ) => { targetInset: number; targetSize: number; visualInset: number })
   | undefined;
+let getIconButtonPlatformGeometry:
+  | ((
+      platform: string,
+      targetSize: number,
+      visualSize?: number,
+    ) => { minimumHitSlop: number; minimumTargetSize: number })
+  | undefined;
 let getIconButtonTargetSize: ((platform: string) => number) | undefined;
 
 before(async () => {
@@ -61,6 +68,9 @@ before(async () => {
   getIconButtonHitSlop = module?.getIconButtonHitSlop as typeof getIconButtonHitSlop;
   getIconButtonOverlayGeometry = module?.getIconButtonOverlayGeometry as
     | typeof getIconButtonOverlayGeometry
+    | undefined;
+  getIconButtonPlatformGeometry = module?.getIconButtonPlatformGeometry as
+    | typeof getIconButtonPlatformGeometry
     | undefined;
   getIconButtonTargetSize = module?.getIconButtonTargetSize as
     | ((platform: string) => number)
@@ -134,10 +144,31 @@ test('overlay geometry preserves the visual inset while keeping the platform tar
   });
 });
 
+test('Native target expansion preserves the rendered layout while Web keeps an actual element floor', () => {
+  assert.ok(getIconButtonPlatformGeometry, 'platform geometry resolver must exist');
+  assert.deepEqual(getIconButtonPlatformGeometry('web', 16, 12), {
+    minimumHitSlop: 0,
+    minimumTargetSize: 32,
+  });
+  assert.deepEqual(getIconButtonPlatformGeometry('ios', 40, 40), {
+    minimumHitSlop: 2,
+    minimumTargetSize: 40,
+  });
+  assert.deepEqual(getIconButtonPlatformGeometry('android', 44, 44), {
+    minimumHitSlop: 2,
+    minimumTargetSize: 44,
+  });
+  assert.deepEqual(getIconButtonPlatformGeometry('android', 48, 32), {
+    minimumHitSlop: 0,
+    minimumTargetSize: 48,
+  });
+});
+
 test('caller target and style cannot lower the Web interaction floor', () => {
   const button = renderIconButton({
     accessibilityLabel: '검색 지우기',
     children: '×',
+    hitSlop: -4,
     style: { height: 12, minHeight: 12, minWidth: 12, width: 12 },
     targetSize: 16,
   });
@@ -147,6 +178,7 @@ test('caller target and style cannot lower the Web interaction floor', () => {
 
   assert.equal(targetStyle.minHeight, 32);
   assert.equal(targetStyle.minWidth, 32);
+  assert.equal(button.props.hitSlop, 0);
 });
 
 test('caller can preserve an interaction target larger than the platform floor', () => {

--- a/apps/app/src/components/ui/IconButton.test.ts
+++ b/apps/app/src/components/ui/IconButton.test.ts
@@ -203,6 +203,44 @@ test('Native style-only square preserves its layout and moves the platform defic
   }
 });
 
+test('Native function style uses an explicit stable size for layout and hit slop', () => {
+  for (const [platform, expectedHitSlop] of [
+    ['ios', 2],
+    ['android', 4],
+  ] as const) {
+    mockPlatform.OS = platform;
+    try {
+      const button = renderIconButton({
+        accessibilityLabel: '미디어 추가',
+        children: '+',
+        style: ({ pressed }: { pressed: boolean }) => ({
+          backgroundColor: pressed ? 'gray' : 'white',
+          height: 40,
+          width: 40,
+        }),
+        targetSize: 40,
+      });
+      const targetStyle = flattenStyle(
+        (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: true }),
+      );
+
+      assert.equal(targetStyle.backgroundColor, 'gray');
+      assert.equal(targetStyle.height, 40);
+      assert.equal(targetStyle.width, 40);
+      assert.equal(targetStyle.minHeight, 40);
+      assert.equal(targetStyle.minWidth, 40);
+      assert.deepEqual(button.props.hitSlop, {
+        bottom: expectedHitSlop,
+        left: expectedHitSlop,
+        right: expectedHitSlop,
+        top: expectedHitSlop,
+      });
+    } finally {
+      mockPlatform.OS = 'web';
+    }
+  }
+});
+
 test('caller target and style cannot lower the Web interaction floor', () => {
   const button = renderIconButton({
     accessibilityLabel: '검색 지우기',
@@ -280,6 +318,7 @@ test('button semantics and interaction props are forwarded without losing press 
     hitSlop: 4,
     onPressIn,
     style: ({ pressed }: { pressed: boolean }) => ({ backgroundColor: pressed ? 'gray' : 'white' }),
+    targetSize: 44,
   });
   const disabledStyle = flattenStyle(
     (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: true }),

--- a/apps/app/src/components/ui/IconButton.test.ts
+++ b/apps/app/src/components/ui/IconButton.test.ts
@@ -7,10 +7,15 @@ const mockModule = (specifier: string | URL, exports: object) =>
     exports,
   } as unknown as Parameters<typeof mock.module>[1]);
 
+const mockPlatform: { OS: string } = { OS: 'web' };
+
 mockModule('react-native', {
-  Platform: { OS: 'web' },
+  Platform: mockPlatform,
   Pressable: 'Pressable',
-  StyleSheet: { create: <T>(styles: T) => styles },
+  StyleSheet: {
+    create: <T>(styles: T) => styles,
+    flatten: (style: unknown) => flattenStyle(style),
+  },
   View: 'View',
 });
 
@@ -20,7 +25,7 @@ type TestElementProps = {
   accessibilityState?: { busy?: boolean; disabled?: boolean; expanded?: boolean };
   children?: ReactNode | ((state: { pressed: boolean }) => ReactNode);
   disabled?: boolean;
-  hitSlop?: number;
+  hitSlop?: number | { bottom: number; left: number; right: number; top: number };
   onPressIn?: () => void;
   ref?: unknown;
   style?: unknown;
@@ -63,18 +68,23 @@ let getIconButtonPlatformGeometry:
 let getIconButtonTargetSize: ((platform: string) => number) | undefined;
 
 before(async () => {
-  const module = await import('./IconButton').catch(() => null);
-  IconButton = module?.IconButton as IconButtonComponent | undefined;
-  getIconButtonHitSlop = module?.getIconButtonHitSlop as typeof getIconButtonHitSlop;
-  getIconButtonOverlayGeometry = module?.getIconButtonOverlayGeometry as
-    | typeof getIconButtonOverlayGeometry
-    | undefined;
-  getIconButtonPlatformGeometry = module?.getIconButtonPlatformGeometry as
-    | typeof getIconButtonPlatformGeometry
-    | undefined;
-  getIconButtonTargetSize = module?.getIconButtonTargetSize as
-    | ((platform: string) => number)
-    | undefined;
+  mockPlatform.OS = 'ios';
+  try {
+    const module = await import('./IconButton').catch(() => null);
+    IconButton = module?.IconButton as IconButtonComponent | undefined;
+    getIconButtonHitSlop = module?.getIconButtonHitSlop as typeof getIconButtonHitSlop;
+    getIconButtonOverlayGeometry = module?.getIconButtonOverlayGeometry as
+      | typeof getIconButtonOverlayGeometry
+      | undefined;
+    getIconButtonPlatformGeometry = module?.getIconButtonPlatformGeometry as
+      | typeof getIconButtonPlatformGeometry
+      | undefined;
+    getIconButtonTargetSize = module?.getIconButtonTargetSize as
+      | ((platform: string) => number)
+      | undefined;
+  } finally {
+    mockPlatform.OS = 'web';
+  }
 });
 
 function renderIconButton(props: IconButtonProps) {
@@ -159,6 +169,38 @@ test('Native target expansion preserves the rendered layout while Web keeps an a
     minimumHitSlop: 0,
     minimumTargetSize: 48,
   });
+});
+
+test('Native style-only square preserves its layout and moves the platform deficit into hit slop', () => {
+  for (const [platform, expectedHitSlop] of [
+    ['ios', 2],
+    ['android', 4],
+  ] as const) {
+    mockPlatform.OS = platform;
+    try {
+      const button = renderIconButton({
+        accessibilityLabel: '미디어 추가',
+        children: '+',
+        style: { height: 40, width: 40 },
+      });
+      const targetStyle = flattenStyle(
+        (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: false }),
+      );
+
+      assert.equal(targetStyle.height, 40);
+      assert.equal(targetStyle.width, 40);
+      assert.equal(targetStyle.minHeight, 40);
+      assert.equal(targetStyle.minWidth, 40);
+      assert.deepEqual(button.props.hitSlop, {
+        bottom: expectedHitSlop,
+        left: expectedHitSlop,
+        right: expectedHitSlop,
+        top: expectedHitSlop,
+      });
+    } finally {
+      mockPlatform.OS = 'web';
+    }
+  }
 });
 
 test('caller target and style cannot lower the Web interaction floor', () => {

--- a/apps/app/src/components/ui/IconButton.test.ts
+++ b/apps/app/src/components/ui/IconButton.test.ts
@@ -17,28 +17,41 @@ mockModule('react-native', {
 type TestElementProps = {
   accessibilityLabel?: string;
   accessibilityRole?: string;
-  accessibilityState?: { disabled?: boolean; expanded?: boolean };
+  accessibilityState?: { busy?: boolean; disabled?: boolean; expanded?: boolean };
   children?: ReactNode | ((state: { pressed: boolean }) => ReactNode);
   disabled?: boolean;
+  hitSlop?: number;
+  onPressIn?: () => void;
+  ref?: unknown;
   style?: unknown;
 };
 type TestElement = ReactElement<TestElementProps>;
 type IconButtonProps = {
   accessibilityLabel: string;
-  accessibilityState?: { expanded?: boolean };
-  children: ReactNode;
+  accessibilityState?: { busy?: boolean; expanded?: boolean };
+  children: ReactNode | ((state: { pressed: boolean }) => ReactNode);
+  controlRef?: unknown;
   disabled?: boolean;
+  feedback?: 'none' | 'opacity';
+  hitSlop?: number;
+  onPressIn?: () => void;
+  style?: unknown;
   targetSize?: number;
   visualSize?: number;
+  visualStyle?: unknown;
 };
 type IconButtonComponent = (props: IconButtonProps) => TestElement;
 
 let IconButton: IconButtonComponent | undefined;
+let getIconButtonHitSlop:
+  | ((platform: string, visualSize: number, effectiveTargetSize: number) => number)
+  | undefined;
 let getIconButtonTargetSize: ((platform: string) => number) | undefined;
 
 before(async () => {
   const module = await import('./IconButton').catch(() => null);
   IconButton = module?.IconButton as IconButtonComponent | undefined;
+  getIconButtonHitSlop = module?.getIconButtonHitSlop as typeof getIconButtonHitSlop;
   getIconButtonTargetSize = module?.getIconButtonTargetSize as
     | ((platform: string) => number)
     | undefined;
@@ -82,12 +95,56 @@ test('platform target mapping stays centralized for Web, iOS, and Android', () =
   assert.equal(getIconButtonTargetSize('windows'), 48);
 });
 
+test('hit slop preserves a larger effective region without double-expanding the platform floor', () => {
+  assert.ok(getIconButtonHitSlop, 'hit slop resolver must exist');
+  assert.equal(getIconButtonHitSlop('web', 40, 48), 4);
+  assert.equal(getIconButtonHitSlop('ios', 40, 48), 2);
+  assert.equal(getIconButtonHitSlop('android', 40, 48), 0);
+  assert.equal(getIconButtonHitSlop('web', 32, 48), 8);
+  assert.equal(getIconButtonHitSlop('ios', 32, 48), 2);
+  assert.equal(getIconButtonHitSlop('android', 32, 48), 0);
+});
+
+test('caller target and style cannot lower the Web interaction floor', () => {
+  const button = renderIconButton({
+    accessibilityLabel: '검색 지우기',
+    children: '×',
+    style: { height: 12, minHeight: 12, minWidth: 12, width: 12 },
+    targetSize: 16,
+  });
+  const targetStyle = flattenStyle(
+    (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: false }),
+  );
+
+  assert.equal(targetStyle.minHeight, 32);
+  assert.equal(targetStyle.minWidth, 32);
+});
+
+test('caller can preserve an interaction target larger than the platform floor', () => {
+  const button = renderIconButton({
+    accessibilityLabel: '닫기',
+    children: '×',
+    targetSize: 56,
+  });
+  const targetStyle = flattenStyle(
+    (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: false }),
+  );
+
+  assert.equal(targetStyle.minHeight, 56);
+  assert.equal(targetStyle.minWidth, 56);
+});
+
 test('visual size remains independent from the accessible input target', () => {
   const button = renderIconButton({
     accessibilityLabel: '#공예 제거',
     children: '×',
+    style: { position: 'absolute' },
     targetSize: 44,
     visualSize: 32,
+    visualStyle: ({ pressed }: { pressed: boolean }) => ({
+      backgroundColor: pressed ? 'gray' : 'white',
+      borderWidth: 1,
+    }),
   });
   const targetStyle = flattenStyle(
     (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: false }),
@@ -101,26 +158,67 @@ test('visual size remains independent from the accessible input target', () => {
   assert.equal(button.type, 'Pressable');
   assert.equal(targetStyle.minHeight, 44);
   assert.equal(targetStyle.minWidth, 44);
+  assert.equal(targetStyle.position, 'absolute');
+  assert.equal(targetStyle.backgroundColor, undefined);
   assert.ok(visual);
   const visualStyle = flattenStyle(visual.props.style);
   assert.equal(visualStyle.height, 32);
   assert.equal(visualStyle.width, 32);
+  assert.equal(visualStyle.backgroundColor, 'white');
+  assert.equal(visualStyle.borderWidth, 1);
 });
 
-test('button semantics merge the real disabled state with caller accessibility state', () => {
+test('button semantics and interaction props are forwarded without losing press state', () => {
+  const controlRef = { current: null };
+  const onPressIn = () => undefined;
   const button = renderIconButton({
     accessibilityLabel: '프로필 편집 닫기',
-    accessibilityState: { expanded: true },
-    children: '아이콘',
+    accessibilityState: { busy: true, expanded: true },
+    children: ({ pressed }) => (pressed ? '눌림' : '기본'),
+    controlRef,
     disabled: true,
+    hitSlop: 4,
+    onPressIn,
+    style: ({ pressed }: { pressed: boolean }) => ({ backgroundColor: pressed ? 'gray' : 'white' }),
   });
   const disabledStyle = flattenStyle(
     (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: true }),
   );
+  const pressedChildren =
+    typeof button.props.children === 'function'
+      ? button.props.children({ pressed: true })
+      : button.props.children;
 
   assert.equal(button.props.accessibilityLabel, '프로필 편집 닫기');
   assert.equal(button.props.accessibilityRole, 'button');
   assert.equal(button.props.disabled, true);
-  assert.deepEqual(button.props.accessibilityState, { disabled: true, expanded: true });
-  assert.equal(disabledStyle.opacity, 0.45);
+  assert.deepEqual(button.props.accessibilityState, { busy: true, disabled: true, expanded: true });
+  assert.equal(button.props.hitSlop, 4);
+  assert.equal(button.props.onPressIn, onPressIn);
+  assert.equal(button.props.ref, controlRef);
+  assert.equal(disabledStyle.backgroundColor, 'gray');
+  assert.equal(pressedChildren, '눌림');
+});
+
+test('visual feedback is opt-in and explicit opacity feedback preserves prior states', () => {
+  const defaultButton = renderIconButton({
+    accessibilityLabel: '닫기',
+    children: '×',
+    disabled: true,
+  });
+  const defaultStyle = flattenStyle(
+    (defaultButton.props.style as (state: { pressed: boolean }) => unknown)({ pressed: true }),
+  );
+  const opacityButton = renderIconButton({
+    accessibilityLabel: '닫기',
+    children: '×',
+    disabled: true,
+    feedback: 'opacity',
+  });
+  const opacityStyle = flattenStyle(
+    (opacityButton.props.style as (state: { pressed: boolean }) => unknown)({ pressed: true }),
+  );
+
+  assert.equal(defaultStyle.opacity, undefined);
+  assert.equal(opacityStyle.opacity, 0.45);
 });

--- a/apps/app/src/components/ui/IconButton.test.ts
+++ b/apps/app/src/components/ui/IconButton.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { before, mock, test } from 'node:test';
+import type { ReactElement, ReactNode } from 'react';
+
+const mockModule = (specifier: string | URL, exports: object) =>
+  mock.module(specifier, {
+    exports,
+  } as unknown as Parameters<typeof mock.module>[1]);
+
+mockModule('react-native', {
+  Platform: { OS: 'web' },
+  Pressable: 'Pressable',
+  StyleSheet: { create: <T>(styles: T) => styles },
+  View: 'View',
+});
+
+type TestElementProps = {
+  accessibilityLabel?: string;
+  accessibilityRole?: string;
+  accessibilityState?: { disabled?: boolean; expanded?: boolean };
+  children?: ReactNode | ((state: { pressed: boolean }) => ReactNode);
+  disabled?: boolean;
+  style?: unknown;
+};
+type TestElement = ReactElement<TestElementProps>;
+type IconButtonProps = {
+  accessibilityLabel: string;
+  accessibilityState?: { expanded?: boolean };
+  children: ReactNode;
+  disabled?: boolean;
+  targetSize?: number;
+  visualSize?: number;
+};
+type IconButtonComponent = (props: IconButtonProps) => TestElement;
+
+let IconButton: IconButtonComponent | undefined;
+let getIconButtonTargetSize: ((platform: string) => number) | undefined;
+
+before(async () => {
+  const module = await import('./IconButton').catch(() => null);
+  IconButton = module?.IconButton as IconButtonComponent | undefined;
+  getIconButtonTargetSize = module?.getIconButtonTargetSize as
+    | ((platform: string) => number)
+    | undefined;
+});
+
+function renderIconButton(props: IconButtonProps) {
+  assert.ok(IconButton, 'IconButton component must exist');
+  return IconButton(props);
+}
+
+function findElements(node: ReactNode, type: string): TestElement[] {
+  if (!node || typeof node !== 'object' || !('type' in node)) {
+    return [];
+  }
+
+  const element = node as TestElement;
+  const matches = element.type === type ? [element] : [];
+  const children =
+    typeof element.props.children === 'function'
+      ? []
+      : Array.isArray(element.props.children)
+        ? element.props.children
+        : [element.props.children];
+
+  return [...matches, ...children.flatMap((child) => findElements(child, type))];
+}
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (!Array.isArray(style)) {
+    return typeof style === 'object' && style !== null ? (style as Record<string, unknown>) : {};
+  }
+
+  return Object.assign({}, ...style.flat(Infinity).filter(Boolean));
+}
+
+test('platform target mapping stays centralized for Web, iOS, and Android', () => {
+  assert.ok(getIconButtonTargetSize, 'target size resolver must exist');
+  assert.equal(getIconButtonTargetSize('web'), 32);
+  assert.equal(getIconButtonTargetSize('ios'), 44);
+  assert.equal(getIconButtonTargetSize('android'), 48);
+  assert.equal(getIconButtonTargetSize('windows'), 48);
+});
+
+test('visual size remains independent from the accessible input target', () => {
+  const button = renderIconButton({
+    accessibilityLabel: '#공예 제거',
+    children: '×',
+    targetSize: 44,
+    visualSize: 32,
+  });
+  const targetStyle = flattenStyle(
+    (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: false }),
+  );
+  const renderedChildren =
+    typeof button.props.children === 'function'
+      ? button.props.children({ pressed: false })
+      : button.props.children;
+  const visual = findElements(renderedChildren, 'View')[0];
+
+  assert.equal(button.type, 'Pressable');
+  assert.equal(targetStyle.minHeight, 44);
+  assert.equal(targetStyle.minWidth, 44);
+  assert.ok(visual);
+  const visualStyle = flattenStyle(visual.props.style);
+  assert.equal(visualStyle.height, 32);
+  assert.equal(visualStyle.width, 32);
+});
+
+test('button semantics merge the real disabled state with caller accessibility state', () => {
+  const button = renderIconButton({
+    accessibilityLabel: '프로필 편집 닫기',
+    accessibilityState: { expanded: true },
+    children: '아이콘',
+    disabled: true,
+  });
+  const disabledStyle = flattenStyle(
+    (button.props.style as (state: { pressed: boolean }) => unknown)({ pressed: true }),
+  );
+
+  assert.equal(button.props.accessibilityLabel, '프로필 편집 닫기');
+  assert.equal(button.props.accessibilityRole, 'button');
+  assert.equal(button.props.disabled, true);
+  assert.deepEqual(button.props.accessibilityState, { disabled: true, expanded: true });
+  assert.equal(disabledStyle.opacity, 0.45);
+});

--- a/apps/app/src/components/ui/IconButton.test.ts
+++ b/apps/app/src/components/ui/IconButton.test.ts
@@ -44,7 +44,7 @@ type IconButtonComponent = (props: IconButtonProps) => TestElement;
 
 let IconButton: IconButtonComponent | undefined;
 let getIconButtonHitSlop:
-  | ((platform: string, visualSize: number, effectiveTargetSize: number) => number)
+  | ((renderedTargetSize: number, effectiveTargetSize: number) => number)
   | undefined;
 let getIconButtonOverlayGeometry:
   | ((
@@ -115,14 +115,11 @@ test('platform target mapping stays centralized for Web, iOS, and Android', () =
   assert.equal(getIconButtonTargetSize('windows'), 48);
 });
 
-test('hit slop preserves a larger effective region without double-expanding the platform floor', () => {
+test('hit slop preserves the requested effective region from the rendered layout box', () => {
   assert.ok(getIconButtonHitSlop, 'hit slop resolver must exist');
-  assert.equal(getIconButtonHitSlop('web', 40, 48), 4);
-  assert.equal(getIconButtonHitSlop('ios', 40, 48), 2);
-  assert.equal(getIconButtonHitSlop('android', 40, 48), 0);
-  assert.equal(getIconButtonHitSlop('web', 32, 48), 8);
-  assert.equal(getIconButtonHitSlop('ios', 32, 48), 2);
-  assert.equal(getIconButtonHitSlop('android', 32, 48), 0);
+  assert.equal(getIconButtonHitSlop(40, 48), 4);
+  assert.equal(getIconButtonHitSlop(32, 48), 8);
+  assert.equal(getIconButtonHitSlop(48, 44), 0);
 });
 
 test('overlay geometry preserves the visual inset while keeping the platform target in bounds', () => {

--- a/apps/app/src/components/ui/IconButton.test.ts
+++ b/apps/app/src/components/ui/IconButton.test.ts
@@ -46,12 +46,22 @@ let IconButton: IconButtonComponent | undefined;
 let getIconButtonHitSlop:
   | ((platform: string, visualSize: number, effectiveTargetSize: number) => number)
   | undefined;
+let getIconButtonOverlayGeometry:
+  | ((
+      platform: string,
+      visualSize: number,
+      visualInset: number,
+    ) => { targetInset: number; targetSize: number; visualInset: number })
+  | undefined;
 let getIconButtonTargetSize: ((platform: string) => number) | undefined;
 
 before(async () => {
   const module = await import('./IconButton').catch(() => null);
   IconButton = module?.IconButton as IconButtonComponent | undefined;
   getIconButtonHitSlop = module?.getIconButtonHitSlop as typeof getIconButtonHitSlop;
+  getIconButtonOverlayGeometry = module?.getIconButtonOverlayGeometry as
+    | typeof getIconButtonOverlayGeometry
+    | undefined;
   getIconButtonTargetSize = module?.getIconButtonTargetSize as
     | ((platform: string) => number)
     | undefined;
@@ -103,6 +113,25 @@ test('hit slop preserves a larger effective region without double-expanding the 
   assert.equal(getIconButtonHitSlop('web', 32, 48), 8);
   assert.equal(getIconButtonHitSlop('ios', 32, 48), 2);
   assert.equal(getIconButtonHitSlop('android', 32, 48), 0);
+});
+
+test('overlay geometry preserves the visual inset while keeping the platform target in bounds', () => {
+  assert.ok(getIconButtonOverlayGeometry, 'overlay geometry resolver must exist');
+  assert.deepEqual(getIconButtonOverlayGeometry('web', 32, 4), {
+    targetInset: 4,
+    targetSize: 32,
+    visualInset: 0,
+  });
+  assert.deepEqual(getIconButtonOverlayGeometry('ios', 32, 4), {
+    targetInset: 0,
+    targetSize: 44,
+    visualInset: 4,
+  });
+  assert.deepEqual(getIconButtonOverlayGeometry('android', 32, 4), {
+    targetInset: 0,
+    targetSize: 48,
+    visualInset: 4,
+  });
 });
 
 test('caller target and style cannot lower the Web interaction floor', () => {

--- a/apps/app/src/components/ui/IconButton.tsx
+++ b/apps/app/src/components/ui/IconButton.tsx
@@ -24,6 +24,27 @@ export function getIconButtonHitSlop(
   return Math.max(0, (effectiveTargetSize - renderedTargetSize) / 2);
 }
 
+export function getIconButtonPlatformGeometry(
+  platform: string,
+  targetSize: number,
+  visualSize?: number,
+): { minimumHitSlop: number; minimumTargetSize: number } {
+  const renderedTargetSize = Math.max(0, targetSize, visualSize ?? 0);
+  const platformTargetSize = getIconButtonTargetSize(platform);
+
+  if (platform === 'web') {
+    return {
+      minimumHitSlop: 0,
+      minimumTargetSize: Math.max(platformTargetSize, renderedTargetSize),
+    };
+  }
+
+  return {
+    minimumHitSlop: Math.max(0, (platformTargetSize - renderedTargetSize) / 2),
+    minimumTargetSize: renderedTargetSize,
+  };
+}
+
 export function getIconButtonOverlayGeometry(
   platform: string,
   visualSize: number,
@@ -40,6 +61,26 @@ export function getIconButtonOverlayGeometry(
 }
 
 export const ICON_BUTTON_TARGET_SIZE = getIconButtonTargetSize(Platform.OS);
+
+function mergeHitSlop(
+  hitSlop: PressableProps['hitSlop'],
+  minimumHitSlop: number,
+): PressableProps['hitSlop'] {
+  if (hitSlop == null && minimumHitSlop === 0) {
+    return hitSlop;
+  }
+
+  if (typeof hitSlop === 'number') {
+    return Math.max(hitSlop, minimumHitSlop);
+  }
+
+  return {
+    bottom: Math.max(hitSlop?.bottom ?? 0, minimumHitSlop),
+    left: Math.max(hitSlop?.left ?? 0, minimumHitSlop),
+    right: Math.max(hitSlop?.right ?? 0, minimumHitSlop),
+    top: Math.max(hitSlop?.top ?? 0, minimumHitSlop),
+  };
+}
 
 export type IconButtonProps = Omit<
   PressableProps,
@@ -62,14 +103,20 @@ export function IconButton({
   controlRef,
   disabled = false,
   feedback = 'none',
+  hitSlop,
   style,
-  targetSize = ICON_BUTTON_TARGET_SIZE,
+  targetSize,
   visualSize,
   visualStyle,
   ...props
 }: IconButtonProps): ReactNode {
   const buttonDisabled = disabled === true;
-  const resolvedTargetSize = Math.max(ICON_BUTTON_TARGET_SIZE, targetSize);
+  const requestedTargetSize = targetSize ?? visualSize ?? ICON_BUTTON_TARGET_SIZE;
+  const { minimumHitSlop, minimumTargetSize } = getIconButtonPlatformGeometry(
+    Platform.OS,
+    requestedTargetSize,
+    visualSize,
+  );
 
   return (
     <Pressable
@@ -78,6 +125,7 @@ export function IconButton({
       accessibilityRole="button"
       accessibilityState={{ ...accessibilityState, disabled: buttonDisabled }}
       disabled={buttonDisabled}
+      hitSlop={mergeHitSlop(hitSlop, minimumHitSlop)}
       ref={controlRef}
       style={(state) => [
         styles.target,
@@ -85,7 +133,7 @@ export function IconButton({
           ? { opacity: buttonDisabled ? 0.45 : state.pressed ? 0.7 : 1 }
           : undefined,
         typeof style === 'function' ? style(state) : style,
-        { minHeight: resolvedTargetSize, minWidth: resolvedTargetSize },
+        { minHeight: minimumTargetSize, minWidth: minimumTargetSize },
       ]}
     >
       {(state) => {

--- a/apps/app/src/components/ui/IconButton.tsx
+++ b/apps/app/src/components/ui/IconButton.tsx
@@ -15,12 +15,9 @@ export function getIconButtonTargetSize(platform: string): number {
 }
 
 export function getIconButtonHitSlop(
-  platform: string,
-  visualSize: number,
+  renderedTargetSize: number,
   effectiveTargetSize: number,
 ): number {
-  const renderedTargetSize = Math.max(getIconButtonTargetSize(platform), visualSize);
-
   return Math.max(0, (effectiveTargetSize - renderedTargetSize) / 2);
 }
 

--- a/apps/app/src/components/ui/IconButton.tsx
+++ b/apps/app/src/components/ui/IconButton.tsx
@@ -108,7 +108,17 @@ export function IconButton({
   ...props
 }: IconButtonProps): ReactNode {
   const buttonDisabled = disabled === true;
-  const requestedTargetSize = targetSize ?? visualSize ?? ICON_BUTTON_TARGET_SIZE;
+  const flattenedStyle =
+    targetSize === undefined && visualSize === undefined && typeof style !== 'function'
+      ? StyleSheet.flatten(style)
+      : undefined;
+  const styleSize =
+    typeof flattenedStyle?.width === 'number' &&
+    typeof flattenedStyle.height === 'number' &&
+    flattenedStyle.width === flattenedStyle.height
+      ? Math.max(0, flattenedStyle.width)
+      : undefined;
+  const requestedTargetSize = targetSize ?? visualSize ?? styleSize ?? ICON_BUTTON_TARGET_SIZE;
   const { minimumHitSlop, minimumTargetSize } = getIconButtonPlatformGeometry(
     Platform.OS,
     requestedTargetSize,

--- a/apps/app/src/components/ui/IconButton.tsx
+++ b/apps/app/src/components/ui/IconButton.tsx
@@ -14,6 +14,16 @@ export function getIconButtonTargetSize(platform: string): number {
   return 48;
 }
 
+export function getIconButtonHitSlop(
+  platform: string,
+  visualSize: number,
+  effectiveTargetSize: number,
+): number {
+  const renderedTargetSize = Math.max(getIconButtonTargetSize(platform), visualSize);
+
+  return Math.max(0, (effectiveTargetSize - renderedTargetSize) / 2);
+}
+
 export const ICON_BUTTON_TARGET_SIZE = getIconButtonTargetSize(Platform.OS);
 
 export type IconButtonProps = Omit<
@@ -27,6 +37,7 @@ export type IconButtonProps = Omit<
   style?: PressableProps['style'];
   targetSize?: number;
   visualSize?: number;
+  visualStyle?: PressableProps['style'];
 };
 
 export function IconButton({
@@ -35,13 +46,15 @@ export function IconButton({
   children,
   controlRef,
   disabled = false,
-  feedback = 'opacity',
+  feedback = 'none',
   style,
   targetSize = ICON_BUTTON_TARGET_SIZE,
   visualSize,
+  visualStyle,
   ...props
 }: IconButtonProps): ReactNode {
   const buttonDisabled = disabled === true;
+  const resolvedTargetSize = Math.max(ICON_BUTTON_TARGET_SIZE, targetSize);
 
   return (
     <Pressable
@@ -53,23 +66,27 @@ export function IconButton({
       ref={controlRef}
       style={(state) => [
         styles.target,
-        { minHeight: targetSize, minWidth: targetSize },
         feedback === 'opacity'
           ? { opacity: buttonDisabled ? 0.45 : state.pressed ? 0.7 : 1 }
           : undefined,
         typeof style === 'function' ? style(state) : style,
+        { minHeight: resolvedTargetSize, minWidth: resolvedTargetSize },
       ]}
     >
       {(state) => {
         const content = typeof children === 'function' ? children(state) : children;
 
-        return visualSize === undefined ? (
+        return visualSize === undefined && visualStyle === undefined ? (
           content
         ) : (
           <View
             accessibilityElementsHidden
             importantForAccessibility="no-hide-descendants"
-            style={[styles.visual, { height: visualSize, width: visualSize }]}
+            style={[
+              styles.visual,
+              visualSize === undefined ? undefined : { height: visualSize, width: visualSize },
+              typeof visualStyle === 'function' ? visualStyle(state) : visualStyle,
+            ]}
           >
             {content}
           </View>

--- a/apps/app/src/components/ui/IconButton.tsx
+++ b/apps/app/src/components/ui/IconButton.tsx
@@ -79,6 +79,26 @@ function mergeHitSlop(
   };
 }
 
+type IconButtonFunctionStyle = Extract<PressableProps['style'], (...args: never[]) => unknown>;
+type IconButtonStaticStyle = Exclude<PressableProps['style'], IconButtonFunctionStyle>;
+
+type IconButtonSizeProps =
+  | {
+      style?: IconButtonStaticStyle;
+      targetSize?: number;
+      visualSize?: number;
+    }
+  | {
+      style: IconButtonFunctionStyle;
+      targetSize: number;
+      visualSize?: number;
+    }
+  | {
+      style: IconButtonFunctionStyle;
+      targetSize?: number;
+      visualSize: number;
+    };
+
 export type IconButtonProps = Omit<
   PressableProps,
   'accessibilityLabel' | 'accessibilityRole' | 'children' | 'role' | 'style'
@@ -87,11 +107,8 @@ export type IconButtonProps = Omit<
   children: PressableProps['children'];
   controlRef?: Ref<View>;
   feedback?: 'none' | 'opacity';
-  style?: PressableProps['style'];
-  targetSize?: number;
-  visualSize?: number;
   visualStyle?: PressableProps['style'];
-};
+} & IconButtonSizeProps;
 
 export function IconButton({
   accessibilityLabel,

--- a/apps/app/src/components/ui/IconButton.tsx
+++ b/apps/app/src/components/ui/IconButton.tsx
@@ -1,0 +1,92 @@
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import type { ReactNode, Ref } from 'react';
+import type { PressableProps } from 'react-native';
+
+export function getIconButtonTargetSize(platform: string): number {
+  if (platform === 'web') {
+    return 32;
+  }
+
+  if (platform === 'ios') {
+    return 44;
+  }
+
+  return 48;
+}
+
+export const ICON_BUTTON_TARGET_SIZE = getIconButtonTargetSize(Platform.OS);
+
+export type IconButtonProps = Omit<
+  PressableProps,
+  'accessibilityLabel' | 'accessibilityRole' | 'children' | 'role' | 'style'
+> & {
+  accessibilityLabel: string;
+  children: PressableProps['children'];
+  controlRef?: Ref<View>;
+  feedback?: 'none' | 'opacity';
+  style?: PressableProps['style'];
+  targetSize?: number;
+  visualSize?: number;
+};
+
+export function IconButton({
+  accessibilityLabel,
+  accessibilityState,
+  children,
+  controlRef,
+  disabled = false,
+  feedback = 'opacity',
+  style,
+  targetSize = ICON_BUTTON_TARGET_SIZE,
+  visualSize,
+  ...props
+}: IconButtonProps): ReactNode {
+  const buttonDisabled = disabled === true;
+
+  return (
+    <Pressable
+      {...props}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{ ...accessibilityState, disabled: buttonDisabled }}
+      disabled={buttonDisabled}
+      ref={controlRef}
+      style={(state) => [
+        styles.target,
+        { minHeight: targetSize, minWidth: targetSize },
+        feedback === 'opacity'
+          ? { opacity: buttonDisabled ? 0.45 : state.pressed ? 0.7 : 1 }
+          : undefined,
+        typeof style === 'function' ? style(state) : style,
+      ]}
+    >
+      {(state) => {
+        const content = typeof children === 'function' ? children(state) : children;
+
+        return visualSize === undefined ? (
+          content
+        ) : (
+          <View
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            style={[styles.visual, { height: visualSize, width: visualSize }]}
+          >
+            {content}
+          </View>
+        );
+      }}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  target: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  visual: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    pointerEvents: 'none',
+  },
+});

--- a/apps/app/src/components/ui/IconButton.tsx
+++ b/apps/app/src/components/ui/IconButton.tsx
@@ -24,6 +24,21 @@ export function getIconButtonHitSlop(
   return Math.max(0, (effectiveTargetSize - renderedTargetSize) / 2);
 }
 
+export function getIconButtonOverlayGeometry(
+  platform: string,
+  visualSize: number,
+  visualInset: number,
+): { targetInset: number; targetSize: number; visualInset: number } {
+  const targetSize = Math.max(getIconButtonTargetSize(platform), visualSize);
+  const targetInset = Math.max(0, visualInset - (targetSize - visualSize) / 2);
+
+  return {
+    targetInset,
+    targetSize,
+    visualInset: visualInset - targetInset,
+  };
+}
+
 export const ICON_BUTTON_TARGET_SIZE = getIconButtonTargetSize(Platform.OS);
 
 export type IconButtonProps = Omit<

--- a/apps/app/src/components/ui/IconButton.type-test.tsx
+++ b/apps/app/src/components/ui/IconButton.type-test.tsx
@@ -1,0 +1,45 @@
+import { IconButton } from './IconButton';
+
+export function StaticStyleCanInferItsLayoutSize() {
+  return (
+    <IconButton accessibilityLabel="미디어 추가" style={{ height: 40, width: 40 }}>
+      +
+    </IconButton>
+  );
+}
+
+export function FunctionStyleCanUseTargetSize() {
+  return (
+    <IconButton
+      accessibilityLabel="닫기"
+      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+      targetSize={40}
+    >
+      ×
+    </IconButton>
+  );
+}
+
+export function FunctionStyleCanUseVisualSize() {
+  return (
+    <IconButton
+      accessibilityLabel="닫기"
+      style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+      visualSize={40}
+    >
+      ×
+    </IconButton>
+  );
+}
+
+export function FunctionStyleCannotOmitAStableSize() {
+  return (
+    // @ts-expect-error Function styles require targetSize or visualSize for Native geometry.
+    <IconButton
+      accessibilityLabel="닫기"
+      style={({ pressed }) => ({ height: 40, opacity: pressed ? 0.7 : 1, width: 40 })}
+    >
+      ×
+    </IconButton>
+  );
+}

--- a/apps/app/src/components/ui/ModalSheet.tsx
+++ b/apps/app/src/components/ui/ModalSheet.tsx
@@ -2,6 +2,7 @@ import { XIcon } from 'lucide-react-native';
 import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
+import { IconButton } from './IconButton';
 import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
@@ -34,9 +35,15 @@ export function ModalSheet({ children, onClose, title, visible }: Props) {
             <Text accessibilityRole="header" style={[styles.title, { color: theme.text }]}>
               {title}
             </Text>
-            <Pressable accessibilityLabel="닫기" onPress={onClose} style={styles.close}>
+            <IconButton
+              accessibilityLabel="닫기"
+              onPress={onClose}
+              style={styles.close}
+              targetSize={44}
+              visualSize={44}
+            >
               <XIcon color={theme.text} size={20} />
-            </Pressable>
+            </IconButton>
           </View>
           {children}
         </Pressable>

--- a/apps/app/src/stories/Feedback.stories.tsx
+++ b/apps/app/src/stories/Feedback.stories.tsx
@@ -185,6 +185,9 @@ export const OverlayFocusLifecycle: Story = {
     const dialog = await page.findByRole('dialog', { name: '피드백 보내기' });
     const close = within(dialog).getByRole('button', { name: '피드백 닫기' });
     await waitFor(() => expect(close).toHaveFocus());
+    const closeBounds = close.getBoundingClientRect();
+    expect(closeBounds.width).toBe(36);
+    expect(closeBounds.height).toBe(36);
     expect(ownerDocument.body.style.overflow).toBe('hidden');
     await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
     await waitFor(() =>

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -4669,7 +4669,21 @@ export const ComposerMediaStates: Story = {
     expect(canvas.getByRole('alert')).toHaveTextContent(
       '3번째 이미지 파일이 너무 커요. 16 MiB 이하의 이미지를 선택해 주세요.',
     );
-    expect(canvas.getByRole('button', { name: '첨부 이미지 1 제거' })).toBeVisible();
+    const remove = canvas.getByRole('button', { name: '첨부 이미지 1 제거' });
+    const removeVisual = remove.firstElementChild as HTMLElement | null;
+    const preview = remove.parentElement;
+    const removeBounds = remove.getBoundingClientRect();
+    const removeVisualBounds = removeVisual?.getBoundingClientRect();
+    const previewBounds = preview?.getBoundingClientRect();
+    expect(remove).toBeVisible();
+    expect(removeBounds.width).toBe(32);
+    expect(removeBounds.height).toBe(32);
+    expect(removeVisualBounds?.width).toBe(32);
+    expect(removeVisualBounds?.height).toBe(32);
+    expect(removeBounds.left).toBe(removeVisualBounds?.left);
+    expect(removeBounds.top).toBe(removeVisualBounds?.top);
+    expect(removeBounds.top - (previewBounds?.top ?? 0)).toBe(4);
+    expect((previewBounds?.right ?? 0) - removeBounds.right).toBe(4);
     expect(canvas.getByRole('textbox', { name: '첨부 이미지 2 대체 텍스트' })).toHaveValue(
       '회색 이미지의 대체 텍스트',
     );
@@ -5702,7 +5716,10 @@ export const ReplyModalPresentation: Story = {
     const dialog = await screen.findByRole('dialog', { name: '답글 쓰기' });
 
     expect(within(dialog).getByRole('heading', { name: '답글 쓰기' })).toBeVisible();
-    expect(within(dialog).getByRole('button', { name: '닫기' })).toBeVisible();
+    const close = within(dialog).getByRole('button', { name: '닫기' });
+    expect(close).toBeVisible();
+    expect(close.getBoundingClientRect().width).toBe(36);
+    expect(close.getBoundingClientRect().height).toBe(36);
     expect(within(dialog).getByText('짧은 본문 한 줄.')).toBeVisible();
     const initialBody = within(dialog).getByRole('textbox', { name: '답글 본문' });
     expect(initialBody).toBeVisible();

--- a/apps/app/src/stories/ProfileEdit.stories.tsx
+++ b/apps/app/src/stories/ProfileEdit.stories.tsx
@@ -176,6 +176,9 @@ function expectResponsiveSurface(
   const backAction = canvas
     .getByRole('button', { name: '프로필 편집 닫기' })
     .getBoundingClientRect();
+  const tagRemoveButton = canvas.getByRole('button', { name: '#공예 제거' });
+  const tagRemoveAction = tagRemoveButton.getBoundingClientRect();
+  const tagRemoveLayout = tagRemoveButton.parentElement;
 
   expect(Math.round(surface.width)).toBe(expectedWidth);
   expect(Math.round(header.width)).toBe(expectedWidth);
@@ -184,6 +187,12 @@ function expectResponsiveSurface(
   expect(Math.round(navigationHeader.height)).toBe(48);
   expect(Math.round(backAction.width)).toBe(48);
   expect(Math.round(backAction.height)).toBe(48);
+  expect(Math.round(tagRemoveAction.width)).toBe(32);
+  expect(Math.round(tagRemoveAction.height)).toBe(32);
+  expect(tagRemoveLayout).not.toBeNull();
+  const tagRemoveLayoutRect = tagRemoveLayout?.getBoundingClientRect();
+  expect(tagRemoveAction.left).toBeGreaterThanOrEqual(tagRemoveLayoutRect?.left ?? 0);
+  expect(tagRemoveAction.right).toBeLessThanOrEqual(tagRemoveLayoutRect?.right ?? 0);
   expect(canvas.queryByText(/현재.*유지/)).not.toBeInTheDocument();
 }
 

--- a/apps/app/src/stories/Reactions.stories.tsx
+++ b/apps/app/src/stories/Reactions.stories.tsx
@@ -477,6 +477,9 @@ async function assertReactionViewport(
     ),
   ).toBe(true);
   expect(more.getBoundingClientRect().top).toBe(summaryButtons[0]!.getBoundingClientRect().top);
+  expect(
+    more.getBoundingClientRect().left - summaryButtons.at(-1)!.getBoundingClientRect().right,
+  ).toBe(4);
   expect(picker.scrollWidth).toBeLessThanOrEqual(picker.clientWidth);
   expect(pickerRect.left).toBeGreaterThanOrEqual(canvasRect.left);
   expect(pickerRect.right).toBeLessThanOrEqual(canvasRect.right);

--- a/apps/app/src/stories/Search.stories.tsx
+++ b/apps/app/src/stories/Search.stories.tsx
@@ -180,10 +180,24 @@ export const RecentSearchInteraction: Story = {
     const canvas = within(canvasElement);
     const input = canvas.getByRole('textbox', { name: '검색어' });
     await userEvent.click(input);
+    await userEvent.type(input, '검색');
+    const clear = canvas.getByRole('button', { name: '검색 지우기' });
+    expect(clear.getBoundingClientRect().width).toBe(44);
+    expect(clear.getBoundingClientRect().height).toBe(44);
+    await userEvent.click(clear);
+    await expect(input).toHaveValue('');
+    await expect(input).toHaveFocus();
     await expect(canvas.findByText('별마루')).resolves.toBeVisible();
     await userEvent.tab();
     await expect(canvas.getByRole('link', { name: '별마루' })).toHaveFocus();
-    await userEvent.click(canvas.getByRole('button', { name: "최근 검색 '별마루' 삭제" }));
+    const recentLink = canvas.getByRole('link', { name: '별마루' });
+    const remove = canvas.getByRole('button', { name: "최근 검색 '별마루' 삭제" });
+    expect(remove.getBoundingClientRect().width).toBe(44);
+    expect(remove.getBoundingClientRect().height).toBe(44);
+    expect(recentLink.getBoundingClientRect().right).toBeLessThanOrEqual(
+      remove.getBoundingClientRect().left,
+    );
+    await userEvent.click(remove);
     await expect(canvas.queryByText('별마루')).not.toBeInTheDocument();
     await expect(canvas.findByText('@remote@space.example')).resolves.toBeVisible();
     await expect(input).toHaveFocus();

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -334,6 +334,8 @@ export const CompactSidebar: Story = {
     const feedbackRect = feedback.getBoundingClientRect();
 
     expect(logout).toBeInTheDocument();
+    expect(logoutRect.width).toBe(44);
+    expect(logoutRect.height).toBe(44);
     expect(logout.querySelector('svg')).toHaveAttribute('stroke-width', '2');
     expect(avatarRect.x + avatarRect.width / 2).toBeCloseTo(
       feedbackRect.x + feedbackRect.width / 2,

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -83,7 +83,9 @@ library에 종속하지 않고 icon, glyph, 짧은 기호 문자 또는 loading 
 실제 interactive element가 button role, 필수 accessible name과 현재 상태를 소유한다.
 
 - 최소 interaction target은 Web `32×32 CSS px`, iOS `44×44 pt`, Android `48×48 dp`다. 컴포넌트별로
-  더 큰 target을 사용할 수 있지만 public target override나 caller style로 이 floor를 낮출 수 없다.
+  더 큰 target을 사용할 수 있지만 public target override, caller style 또는 `hitSlop`으로 이 floor를
+  낮출 수 없다. Web은 실제 interactive element가 floor를 소유하고, Native는 기존 layout box를 유지해야 할 때
+  부족분을 공용 `hitSlop`으로 보충할 수 있다.
 - 보이는 glyph·background·control geometry와 interaction target은 분리한다. target을 확대해도 기존 surface의
   glyph 크기, visual box, 배치, 색상, focus 표시와 pressed·disabled feedback을 바꾸지 않는다.
 - Web target은 렌더된 interactive element에서 pointer와 keyboard focus로 검증할 수 있어야 하며, React Native
@@ -91,12 +93,14 @@ library에 종속하지 않고 icon, glyph, 짧은 기호 문자 또는 loading 
   effective input region을 줄이거나 이중 확장하지 않는다.
 - pressed, disabled, pending, busy, expanded 상태와 focus ref, `onPressIn` 같은 event handler는 각 action의
   기존 제품 동작을 유지하도록 전달한다. 공통 컴포넌트가 모든 surface에 하나의 visual feedback을 강제하지 않는다.
-- 확장된 target은 인접한 서로 다른 action과 겹치거나 부모의 clipping으로 잘리지 않아야 한다.
+- Web의 확장된 실제 target은 인접한 서로 다른 action과 겹치거나 부모의 clipping으로 잘리지 않아야 한다.
+  Native `hitSlop` source mapping은 출시 전 실제 기기에서 parent bounds, sibling 우선순위와 focus boundary를
+  별도로 검증한다.
 - 이 계약은 상태 선택·토글 또는 count가 핵심인 control, icon+count action, pill·tab·switch, Link와
   navigation/menu/list row, whole-preview/content action, avatar·label·chevron 같은 compound control 및 텍스트
   `Button`을 공용 `IconButton`으로 바꾸지 않는다.
-- iOS·Android floor mapping은 공용 source와 자동화에서 유지하되, Web 자동화나 runtime 결과를 Native 실제
-  기기·simulator의 touch·focus·assistive technology 검증 완료 증거로 사용하지 않는다.
+- iOS·Android floor mapping과 부족분 계산은 공용 source와 자동화에서 유지하되, Web 자동화나 source 계산을
+  Native 실제 기기·simulator의 touch·focus·assistive technology 검증 완료 증거로 사용하지 않는다.
 
 ### Post Action Bar의 출시 전 임시 예외
 
@@ -109,7 +113,7 @@ Post Action Bar는 현재 Web 우선 출시 범위의 Figma geometry를 먼저 �
 ### 기존 컴포넌트 계약
 
 - Reaction Quick Picker와 Reaction 요약 token은 [reactions.md](./reactions.md)의 Web 32×32 CSS px geometry를 사용한다. 이 값은 SC 2.5.8의 24×24 CSS px minimum을 자체 크기로 충족하며, `apps/app/src/stories/Reactions.stories.tsx`의 Web exact-size assertion도 32×32로 맞춘다.
-- 이번 Web 우선 Reaction 변경은 Native interaction geometry를 수정하지 않는다. 현재 selector·summary의 44 logical unit과 Profile tab의 32 minimum은 iOS Profile tab 44×44pt 및 Android 48×48dp baseline을 모두 충족하는 구현이 아니다. Native 출시 전 iOS target을 최소 44×44pt, Android target을 최소 48×48dp로 복구하고 assistive technology·touch runtime에서 검증한다. Web 검증은 이 출시 gate를 대체하지 않는다.
+- Reaction selector와 icon+count summary token은 Native에서 기존 44 logical unit을 유지하므로 Android 48×48dp baseline을 충족하지 않는다. 공통 `IconButton` 대상인 More만 visual 44를 유지한 채 Android 부족분을 공용 `hitSlop` mapping으로 보충한다. Native 출시 전 selector·summary token과 Profile tab을 포함한 모든 target을 실제 iOS 44pt·Android 48dp touch/focus boundary와 assistive technology에서 검증한다. Web 검증은 이 출시 gate를 대체하지 않는다.
 - 순수 Repost의 `{displayName}님이 재게시함` Profile link는 독립 icon button이 아니라 attribution 문장 전체에 적용된 text link다. Web에서는 SC 2.5.8의 inline target 예외를 사용해 14/20 line box를 유지하며 role, accessible name, keyboard focus와 navigation을 보존한다. Native 출시 전에는 이 링크의 44pt·48dp target, focus boundary와 바로 아래 Source Author link 비중첩을 runtime에서 다시 검증한다.
 - 기존 컴포넌트별 강화 계약은 이 전역 문서만으로 축소하거나 폐기하지 않는다. exact contract를 바꾸려면 해당 컴포넌트의 canonical 디자인 문서와 Linear·OpenSpec·검증을 먼저 정렬한다.
 

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -76,6 +76,28 @@ CSS px, pt, dp는 서로 다른 플랫폼 단위다. 저장소의 공통 목표�
 
 이 문서는 컴포넌트의 플랫폼별 exact contract를 임의로 바꾸지 않는다. 새 컴포넌트는 이 문서의 플랫폼 baseline을 사용하고, 더 큰 target이나 엄격한 검증이 필요하면 컴포넌트 디자인 문서·Linear·OpenSpec에 이유와 exact contract를 기록한다.
 
+### 공통 IconButton
+
+앱 전역의 single-action compact square control은 공통 `IconButton`을 사용한다. 이 컴포넌트는 특정 icon
+library에 종속하지 않고 icon, glyph, 짧은 기호 문자 또는 loading indicator를 content로 받을 수 있으며,
+실제 interactive element가 button role, 필수 accessible name과 현재 상태를 소유한다.
+
+- 최소 interaction target은 Web `32×32 CSS px`, iOS `44×44 pt`, Android `48×48 dp`다. 컴포넌트별로
+  더 큰 target을 사용할 수 있지만 public target override나 caller style로 이 floor를 낮출 수 없다.
+- 보이는 glyph·background·control geometry와 interaction target은 분리한다. target을 확대해도 기존 surface의
+  glyph 크기, visual box, 배치, 색상, focus 표시와 pressed·disabled feedback을 바꾸지 않는다.
+- Web target은 렌더된 interactive element에서 pointer와 keyboard focus로 검증할 수 있어야 하며, React Native
+  `hitSlop`만으로 Web floor 충족을 주장하지 않는다. 기존 `hitSlop` 기반 target을 공용 target으로 옮길 때는
+  effective input region을 줄이거나 이중 확장하지 않는다.
+- pressed, disabled, pending, busy, expanded 상태와 focus ref, `onPressIn` 같은 event handler는 각 action의
+  기존 제품 동작을 유지하도록 전달한다. 공통 컴포넌트가 모든 surface에 하나의 visual feedback을 강제하지 않는다.
+- 확장된 target은 인접한 서로 다른 action과 겹치거나 부모의 clipping으로 잘리지 않아야 한다.
+- 이 계약은 상태 선택·토글 또는 count가 핵심인 control, icon+count action, pill·tab·switch, Link와
+  navigation/menu/list row, whole-preview/content action, avatar·label·chevron 같은 compound control 및 텍스트
+  `Button`을 공용 `IconButton`으로 바꾸지 않는다.
+- iOS·Android floor mapping은 공용 source와 자동화에서 유지하되, Web 자동화나 runtime 결과를 Native 실제
+  기기·simulator의 touch·focus·assistive technology 검증 완료 증거로 사용하지 않는다.
+
 ### Post Action Bar의 출시 전 임시 예외
 
 Post Action Bar는 현재 Web 우선 출시 범위의 Figma geometry를 먼저 맞추기 위해 모든 플랫폼 구현에서 control 높이와 실제 interactive target 높이를 28 logical unit(CSS px·pt·dp)로 통일한다. 이 예외는 [post-action-bar.md](./post-action-bar.md)가 소유하며 다른 toolbar나 icon button의 선례로 일반화하지 않는다.

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -93,6 +93,9 @@ library에 종속하지 않고 icon, glyph, 짧은 기호 문자 또는 loading 
   effective input region을 줄이거나 이중 확장하지 않는다.
 - pressed, disabled, pending, busy, expanded 상태와 focus ref, `onPressIn` 같은 event handler는 각 action의
   기존 제품 동작을 유지하도록 전달한다. 공통 컴포넌트가 모든 surface에 하나의 visual feedback을 강제하지 않는다.
+- Outer `style`이 press state를 받는 함수라면 Native layout과 `hitSlop` 계산에 사용할 안정적인 크기로
+  `targetSize` 또는 `visualSize`를 반드시 제공한다. 정적 square `style`은 width·height가 같을 때만 layout 크기를
+  추론할 수 있으며, 함수형 style callback을 미리 실행해 크기를 추측하지 않는다.
 - Web의 확장된 실제 target은 인접한 서로 다른 action과 겹치거나 부모의 clipping으로 잘리지 않아야 한다.
   Native `hitSlop` source mapping은 출시 전 실제 기기에서 parent bounds, sibling 우선순위와 focus boundary를
   별도로 검증한다.

--- a/docs/design/reactions.md
+++ b/docs/design/reactions.md
@@ -17,7 +17,7 @@ Reaction Quick Picker는 현재 제공된 Reaction option을 빠르게 선택하
 ### 형태
 
 - Web option은 Figma Post Action Bar의 28px 밀도와 함께 사용할 수 있도록 32×32 CSS px의 둥근 사각형으로 정규화하며 radius는 12px이다. emoji는 20px, option 사이 gap과 panel padding은 각각 4px이다. border를 포함한 panel의 전체 높이는 약 42px이다.
-- 이번 Web 우선 변경은 Native interaction geometry를 변경하지 않는다. 현재 selector·summary는 iOS·Android 모두 44 logical unit을 사용하고 Profile tab은 32 minimum을 사용하므로, iOS Profile tab과 Android target은 각각 44×44pt·48×48dp baseline을 아직 충족하지 않는다. Native 출시 전 iOS target을 최소 44×44pt, Android target을 최소 48×48dp로 복구하고 assistive technology·touch runtime에서 검증한다.
+- 이번 Web 우선 변경은 Native selector와 icon+count summary token의 interaction geometry를 변경하지 않는다. 이 control들은 iOS·Android 모두 44 logical unit을 사용하고 Profile tab은 32 minimum을 사용하므로 Android 48×48dp baseline을 아직 충족하지 않는다. 공통 `IconButton` 대상인 summary More는 아래 별도 계약을 사용한다. Native 출시 전 나머지 control도 iOS 44pt·Android 48dp target으로 복구하고 assistive technology·touch runtime에서 검증한다.
 - 바깥 컨테이너는 border가 있는 둥근 직사각형이며 radius는 16px이다.
 - option 자체에는 border를 표시하지 않는다.
 - 선택 여부는 border가 아니라 option 아래에 분리한 배경 layer로만 구분한다.
@@ -63,7 +63,7 @@ Reaction Quick Picker는 현재 제공된 Reaction option을 빠르게 선택하
 - 선택된 token은 Quick Picker와 동일하게 이모지·count와 분리한 `primary` 배경 layer를 70% opacity로 표시하고, pressed 상태에서는 `primaryHover`를 사용한다. 이모지와 count는 100% opacity를 유지한다.
 - 이미 다른 사용자가 남겨 둔 token도 선택한 Profile의 Reaction이 없으면 추가하고, 있으면 삭제한다. mutation이 성공하기 전에는 count나 선택 상태를 바꾸지 않는다.
 - selected Profile이 없으면 token은 보이지만 disabled이며 mutation을 시작하지 않는다.
-- 양수 count Type 뒤에는 radius 12px의 32×32px More button을 둔다. glyph는 16px ellipsis이며 Profile 목록 modal을 연다. More는 selected Profile이 없어도 사용할 수 있다.
+- 양수 count Type 뒤의 More button은 Web visual과 실제 target이 radius 12px의 32×32 CSS px이고, Native visual·layout box는 기존 44 logical unit을 유지한다. iOS는 44pt box 자체로, Android는 공용 `IconButton`이 2dp `hitSlop`을 더해 48dp effective touch target을 source에 표현한다. glyph는 16px ellipsis이며 Profile 목록 modal을 연다. More는 selected Profile이 없어도 사용할 수 있다. Native parent clipping·focus boundary와 assistive technology 결과는 출시 전 실제 runtime에서 검증한다.
 - 가용 너비가 좁으면 token과 More를 줄이거나 여러 줄로 바꾸지 않고 feature-local horizontal `ScrollView` shell에서 같은 한 줄을 유지한다.
 
 ## Reaction Profile 목록

--- a/openspec/changes/add-common-icon-button/.openspec.yaml
+++ b/openspec/changes/add-common-icon-button/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-04

--- a/openspec/changes/add-common-icon-button/decisions.md
+++ b/openspec/changes/add-common-icon-button/decisions.md
@@ -1,0 +1,101 @@
+## Context
+
+이 기록은 PROD-548의 앱 전역 scope, `docs/design/accessibility.md`의 공통 `IconButton` 계약, 현재 production·열린
+PR inventory와 `design.md`의 구현 제약을 반영한다. 구현 전에는 각 Authority를 독립적으로 다시 확인한다.
+
+## Decision Records
+
+### IconButton을 Profile edit와 독립된 cross-surface change로 소유한다
+
+- Decision Date: 2026-08-05
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/accessibility.md`, `docs/design/profile-edit.md`, `PROD-548`
+- Status: Active
+- Context / Problem: 기존 branch는 PROD-548를 `add-local-profile-edit`에 넣고 PROD-490 archive gate와 연결했지만,
+  현재 계약은 shell, post, modal, search, media, reaction, logout과 열린 PR까지 포함한다.
+- Decision Outcome: 공용 component·전역 inventory·cross-surface 검증은 독립 `add-common-icon-button` change가
+  소유한다. `add-local-profile-edit`는 Profile 제품 동작과 PROD-490 통합·archive만 계속 소유한다.
+- Alternatives Considered: `add-local-profile-edit` 확장 — Profile과 무관한 surface의 승인·완료·archive를
+  PROD-490 lifecycle에 결합하므로 선택하지 않았다. 각 surface change에 공용 계약 복제 — 하나의 target
+  primitive가 여러 authority로 갈라지므로 선택하지 않았다.
+- Consequences: Profile header/avatar whole-preview 적용과 기존 task coupling을 되돌리고, 각 surface OpenSpec은
+  제품 동작을 유지한 채 공용 primitive의 소비자만 된다.
+- Confirmation / Follow-up: `add-local-profile-edit` diff에서 PROD-548 section과 archive dependency가 제거됐는지
+  strict validation과 review로 확인한다.
+
+### 플랫폼 floor는 실제 interactive element가 소유한다
+
+- Decision Date: 2026-08-05
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/accessibility.md`, `PROD-548`
+- Status: Active
+- Context / Problem: caller target/style override와 Web에서 입증되지 않은 `hitSlop`만으로는 공용 floor를
+  일관되게 보장할 수 없다.
+- Decision Outcome: 공용 `IconButton`은 Web 32, iOS 44, Android 48 floor와 component-specific larger target을
+  실제 interactive element에 유지한다. Caller target/style은 floor를 낮출 수 없고 Web 완료 증거는 rendered
+  pointer·focus target을 측정한다.
+- Alternatives Considered: 각 caller가 플랫폼 target 계산 — 현재 중복 문제를 유지하므로 선택하지 않았다.
+  `hitSlop`만 사용 — 현재 React Native Web source와 focus bounds에서 floor를 증명하지 못하므로 선택하지 않았다.
+- Consequences: target enforcement는 caller visual style보다 우선하며, 작은 visual control에는 별도 visual
+  layer가 필요하다. 기존 `hitSlop`은 effective region이 줄거나 이중 확장되지 않게 정규화한다.
+- Confirmation / Follow-up: component test에서 smaller target/style override와 larger target을 검증하고 Web
+  runtime에서 bounding box, pointer와 keyboard focus를 확인한다.
+
+### 공용 component는 surface별 visual feedback을 강제하지 않는다
+
+- Decision Date: 2026-08-05
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/accessibility.md`, `PROD-548`
+- Status: Active
+- Context / Problem: 현재 action은 opacity, background, disabled state 또는 별도 feedback 없음 등 서로 다른
+  시각 계약을 가진다.
+- Decision Outcome: 공용 component는 target, button semantics와 state 전달을 중앙화하지만 하나의 opacity나
+  background를 기본 적용하지 않는다. Visible geometry와 feedback은 기존 surface 계약을 그대로 유지한다.
+- Alternatives Considered: 모든 `IconButton`에 opacity feedback 기본 적용 — 기존 시각 동작을 바꾸므로
+  선택하지 않았다. Feedback variant를 모든 caller에 강제 — 필요 없는 공용 API와 migration 변환을 늘리므로
+  선택하지 않았다.
+- Consequences: pressed state를 받는 style/content seam은 유지하되 각 caller가 기존 feedback을 명시한다.
+- Confirmation / Follow-up: surface 회귀 테스트와 Storybook/Web runtime에서 pressed·disabled 시각 결과를
+  전환 전 geometry와 비교한다.
+
+### 열린 PR은 merge 순서에 따라 동적으로 전환을 소유한다
+
+- Decision Date: 2026-08-05
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/accessibility.md`, `PROD-548`
+- Status: Active
+- Context / Problem: PR #486과 #510이 공통 component와 병렬로 진행 중이며 고정 stack은 기존 review와 merge
+  순서를 불필요하게 바꾼다.
+- Decision Outcome: 대상 action이 먼저 production에 들어오면 PROD-548가 rebase 후 흡수한다. 공용 component
+  merge 뒤에도 PR이 열려 있으면 해당 PR이 최신 production을 반영하고 자신의 action을 merge 전에 전환한다.
+- Alternatives Considered: 모든 관련 PR을 PROD-548 위에 stack — base와 review 순서를 바꾸므로 선택하지 않았다.
+  관련 PR이 모두 merge될 때까지 PROD-548 대기 — 공용화가 늦어지고 새 중복이 늘 수 있어 선택하지 않았다.
+- Consequences: #516은 공용 component와 현재 production을 우선 전달하며, 미병합 소비자 branch의 전환은 각
+  PR이 소유할 수 있다. Change archive owner는 마지막 남은 전환·검증 증거를 가진 실제 구현 PR로 결정한다.
+- Confirmation / Follow-up: 각 merge readiness 시점에 GitHub state와 production/open PR inventory를 다시 읽고
+  전환 owner와 남은 task를 PR 본문에 기록한다.
+
+### Native source mapping과 runtime 완료를 분리한다
+
+- Decision Date: 2026-08-05
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/accessibility.md`, `PROD-548`
+- Status: Active
+- Context / Problem: 공용 React Native source는 iOS·Android floor를 표현할 수 있지만 현재 scope는 Native
+  실제 기기·simulator QA를 포함하지 않는다.
+- Decision Outcome: iOS 44와 Android 48 mapping 및 자동화는 이 change에서 유지한다. Web 또는 source-level
+  증거를 Native touch·focus·VoiceOver·TalkBack 완료로 표현하지 않는다.
+- Alternatives Considered: Native runtime을 PROD-548 완료 조건에 포함 — 현재 Linear 제외 범위를 넓히므로
+  선택하지 않았다. Native mapping 제거 — 공용 universal component 계약을 깨므로 선택하지 않았다.
+- Consequences: Native parent clipping, focus bounds와 assistive technology 결과는 출시 gate의 명시적 검증
+  공백으로 남는다.
+- Confirmation / Follow-up: PR과 OpenSpec 완료 보고에 실행한 Web 검증, source mapping과 미실행 Native QA를
+  분리해 기록한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-common-icon-button/decisions.md
+++ b/openspec/changes/add-common-icon-button/decisions.md
@@ -23,7 +23,7 @@ PR inventory와 `design.md`의 구현 제약을 반영한다. 구현 전에는 �
 - Confirmation / Follow-up: `add-local-profile-edit` diff에서 PROD-548 section과 archive dependency가 제거됐는지
   strict validation과 review로 확인한다.
 
-### 플랫폼 floor는 실제 interactive element가 소유한다
+### Web floor는 실제 element가, Native floor는 공용 effective target 계산이 소유한다
 
 - Decision Date: 2026-08-05
 - Decision Class: Derived Contract
@@ -31,15 +31,18 @@ PR inventory와 `design.md`의 구현 제약을 반영한다. 구현 전에는 �
 - Status: Active
 - Context / Problem: caller target/style override와 Web에서 입증되지 않은 `hitSlop`만으로는 공용 floor를
   일관되게 보장할 수 없다.
-- Decision Outcome: 공용 `IconButton`은 Web 32, iOS 44, Android 48 floor와 component-specific larger target을
-  실제 interactive element에 유지한다. Caller target/style은 floor를 낮출 수 없고 Web 완료 증거는 rendered
-  pointer·focus target을 측정한다.
+- Decision Outcome: 공용 `IconButton`은 Web 32 floor와 component-specific larger target을 실제 interactive
+  element에 유지한다. Native는 기존 visual·layout box를 확대하지 않고 iOS 44, Android 48에서 부족한 값을
+  공용 `hitSlop`으로 보충한다. Caller target/style/`hitSlop`은 effective floor를 낮출 수 없고 Web 완료 증거는
+  rendered pointer·focus target을 측정한다.
 - Alternatives Considered: 각 caller가 플랫폼 target 계산 — 현재 중복 문제를 유지하므로 선택하지 않았다.
-  `hitSlop`만 사용 — 현재 React Native Web source와 focus bounds에서 floor를 증명하지 못하므로 선택하지 않았다.
-- Consequences: target enforcement는 caller visual style보다 우선하며, 작은 visual control에는 별도 visual
-  layer가 필요하다. 기존 `hitSlop`은 effective region이 줄거나 이중 확장되지 않게 정규화한다.
-- Confirmation / Follow-up: component test에서 smaller target/style override와 larger target을 검증하고 Web
-  runtime에서 bounding box, pointer와 keyboard focus를 확인한다.
+  모든 플랫폼에서 `hitSlop`만 사용 — 현재 React Native Web source와 focus bounds에서 floor를 증명하지 못하므로
+  선택하지 않았다. 모든 플랫폼에서 실제 box를 확대 — Android에서 기존 44-unit layout과 visual center를
+  이동시키므로 선택하지 않았다.
+- Consequences: Web target enforcement는 caller visual style보다 우선하고, Native `hitSlop`은 effective region이
+  줄거나 기존 expansion과 이중 적용되지 않게 정규화한다. Native focus·clipping은 source 계산만으로 완료하지 않는다.
+- Confirmation / Follow-up: component test에서 Web smaller target/style override와 larger target, Native layout
+  보존·부족분 계산을 검증하고 Web runtime에서 bounding box, pointer와 keyboard focus를 확인한다.
 
 ### 공용 component는 surface별 visual feedback을 강제하지 않는다
 

--- a/openspec/changes/add-common-icon-button/decisions.md
+++ b/openspec/changes/add-common-icon-button/decisions.md
@@ -61,6 +61,25 @@ PR inventory와 `design.md`의 구현 제약을 반영한다. 구현 전에는 �
 - Confirmation / Follow-up: surface 회귀 테스트와 Storybook/Web runtime에서 pressed·disabled 시각 결과를
   전환 전 geometry와 비교한다.
 
+### 함수형 outer style은 안정적인 target 또는 visual size를 요구한다
+
+- Decision Date: 2026-08-06
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/accessibility.md`, `PROD-548`, 2026-08-06 사용자 승인
+- Status: Active
+- Context / Problem: 정적 square style은 width·height를 flatten해 Native layout 크기를 추론할 수 있지만,
+  press state를 받는 함수형 style은 실행 전 안정적인 크기를 알 수 없다. Size prop이 없으면 iOS 44·Android 48
+  default min size가 caller의 40×40 style 뒤에 적용되어 기존 layout box를 확대할 수 있다.
+- Decision Outcome: 함수형 outer `style`은 `targetSize` 또는 `visualSize` 중 하나를 public type에서 필수로
+  제공한다. 정적 square style 추론과 함수형 `visualStyle`·children의 press-state 전달은 유지한다.
+- Alternatives Considered: 별도 `layoutSize` prop 추가 — `targetSize`·`visualSize`와 중복되는 public API를
+  늘리므로 선택하지 않았다. Function style callback을 기본 state로 미리 실행해 크기 추론 — pressed state에 따라
+  layout이 달라질 수 있고 callback 실행 시점을 추가하므로 선택하지 않았다.
+- Consequences: 현재 production의 유일한 함수형 outer style caller는 이미 `targetSize`를 제공해 시각 변경이 없다.
+  새 caller의 누락은 TypeScript에서 차단하며 cast·비TypeScript 호출은 보장 범위 밖이다.
+- Confirmation / Follow-up: type-test에서 함수형 style의 size 누락을 거부하고 `targetSize`·`visualSize` 허용을
+  확인한다. Component test에서 명시적 40 layout이 iOS 2pt·Android 4dp `hitSlop`을 유지하는지 검증한다.
+
 ### 열린 PR은 merge 순서에 따라 동적으로 전환을 소유한다
 
 - Decision Date: 2026-08-05

--- a/openspec/changes/add-common-icon-button/decisions.md
+++ b/openspec/changes/add-common-icon-button/decisions.md
@@ -77,6 +77,8 @@ PR inventory와 `design.md`의 구현 제약을 반영한다. 구현 전에는 �
   PR이 소유할 수 있다. Change archive owner는 마지막 남은 전환·검증 증거를 가진 실제 구현 PR로 결정한다.
 - Confirmation / Follow-up: 각 merge readiness 시점에 GitHub state와 production/open PR inventory를 다시 읽고
   전환 owner와 남은 task를 PR 본문에 기록한다.
+- Current Outcome (2026-08-05): PR #486이 먼저 merge되어 FeedbackOverlay close를 PROD-548 production branch가
+  흡수한다. PR #510의 close·previous·next는 아직 열린 consumer branch가 소유한다.
 
 ### Native source mapping과 runtime 완료를 분리한다
 

--- a/openspec/changes/add-common-icon-button/design.md
+++ b/openspec/changes/add-common-icon-button/design.md
@@ -6,8 +6,9 @@ pressed·disabled 표현을 직접 소유한다. 현재 PROD-548 branch의 `Icon
 opacity feedback을 기본 적용한다. 또한 Profile header/avatar whole-preview를 `IconButton`으로 바꿔 새 scope의
 명시적 제외와 충돌한다.
 
-현재 production에는 서로 다른 visual size, hit region, focus handler, absolute positioning과 상태를 가진 13개
-대상 action이 있다. 열린 PR #486과 #510도 4개 action을 추가한다. React Native 0.85.3의 Native Pressability는
+현재 production에는 서로 다른 visual size, hit region, focus handler, absolute positioning과 상태를 가진 14개
+대상 action이 있다. PR #486의 FeedbackOverlay close는 production에 먼저 들어와 흡수 대상이 됐고, 열린 PR
+#510은 3개 action을 추가한다. React Native 0.85.3의 Native Pressability는
 `hitSlop`으로 responder region을 확장하지만, 현재 React Native Web 0.21.2의 Pressable source에서는 같은 확장
 근거를 확인하지 못했다. 따라서 작은 visual box의 기존 `hitSlop`만 공용 Web floor의 근거로 사용할 수 없다.
 
@@ -44,7 +45,7 @@ OpenSpec이 계속 소유한다. 이 change는 그 제품 동작을 재정의하
 - Profile header/avatar preview는 canonical하게 각각 하나의 whole-image button이지만 compact `IconButton`은 아니다.
 - menu expanded, search `onPressIn`, media disabled·absolute overlay, Reaction more geometry, Logout busy·spinner는
   각 소비자가 보존해야 하는 기존 계약이다.
-- PR #486과 #510의 merge 순서는 PROD-548가 고정하지 않는다.
+- PR #486은 먼저 merge되어 production 흡수 대상이고, PR #510의 merge 순서는 PROD-548가 고정하지 않는다.
 
 ### Recommended Approach
 
@@ -72,9 +73,9 @@ State와 behavior는 Pressable contract를 통해 전달한다. Disabled는 실�
 4. media/reaction/logout action을 전환하고 visual geometry·absolute position·disabled/busy state를 검증한다.
 5. 구현 시작과 merge 직전 production/open PR inventory를 반복한다.
 
-열린 PR에는 승인된 동적 소유 규칙을 사용한다. #486 또는 #510이 먼저 merge되면 PROD-548가 최신 production을
-반영해 흡수한다. 공용 component merge 뒤에도 열린 PR은 최신 production을 반영하고 자신의 대상 action을
-merge 전에 전환한다. 별도 stack이나 PR base 변경을 기본 경로로 만들지 않는다.
+열린 PR에는 승인된 동적 소유 규칙을 사용한다. 먼저 merge된 #486은 PROD-548가 최신 production을 반영해
+흡수하고, 공용 component merge 뒤에도 열려 있는 #510은 최신 production을 반영해 자신의 대상 action을 merge
+전에 전환한다. 별도 stack이나 PR base 변경을 기본 경로로 만들지 않는다.
 
 ### Allowed Alternatives
 
@@ -112,8 +113,9 @@ merge 전에 전환한다. 별도 stack이나 PR base 변경을 기본 경로로
 1. Canonical 접근성 문서와 이 change를 PROD-548 authority에 맞춘다.
 2. `add-local-profile-edit`의 PROD-548 section과 archive dependency를 원래 Profile edit 경계로 되돌린다.
 3. 공용 component와 최소 component test를 수정한 뒤 Profile의 오범위 적용을 제거한다.
-4. 현재 production 대상 13개 action을 위험 묶음별로 전환하고 각 묶음의 회귀 검증을 수행한다.
-5. PR #486/#510 상태를 다시 읽고 동적 소유 규칙에 따라 production 또는 열린 branch의 4개 action을 전환한다.
+4. 현재 production 대상 14개 action을 위험 묶음별로 전환하고 각 묶음의 회귀 검증을 수행한다.
+5. PR #486/#510 상태를 다시 읽고 동적 소유 규칙에 따라 production의 FeedbackOverlay close와 열린 #510
+   branch의 3개 action을 전환한다.
 6. 전체 app 자동화, Storybook build·interaction과 Web runtime을 실행하고 merge 직전 inventory를 기록한다.
 7. 모든 적용 PR의 전환 증거가 준비되면 마지막 완료 증거를 소유한 PR이 이 change를 archive한다.
 

--- a/openspec/changes/add-common-icon-button/design.md
+++ b/openspec/changes/add-common-icon-button/design.md
@@ -64,6 +64,10 @@ State와 behavior는 Pressable contract를 통해 전달한다. Disabled는 실�
 `onPressIn`, `hitSlop`을 포함한 필요한 event·interaction prop은 보존한다. Ref 전달의 구체적인 React API는 현재
 저장소와 React Native type에 맞는 가장 작은 방식을 사용한다.
 
+Outer `style`이 press state를 받는 함수라면 component가 안정적인 layout 크기를 추론할 수 없으므로
+`targetSize` 또는 `visualSize` 중 하나를 public type에서 필수로 요구한다. 정적 square style의 width·height 추론은
+유지하고, 함수 callback을 임의의 state로 미리 실행하거나 별도 `layoutSize` prop을 추가하지 않는다.
+
 전환은 다음 묶음으로 진행한다.
 
 1. 현재 잘못 적용된 Profile header/avatar whole-preview와 관련 Storybook assertion을 기존 `Pressable` 계약으로
@@ -89,6 +93,7 @@ State와 behavior는 Pressable contract를 통해 전달한다. Disabled는 실�
 ### Known Traps
 
 - Web `minWidth`·`minHeight`를 caller style보다 먼저 적용해 floor를 다시 우회하게 만드는 것
+- 함수형 outer style의 크기를 추론하지 못하면서 size prop 없이 플랫폼 default layout을 적용하는 것
 - Native visual·layout box와 공용 `hitSlop`을 동시에 확대해 effective region을 두 번 키우는 것
 - 모든 소비자에 같은 opacity feedback을 기본 적용하는 것
 - icon library나 glyph 종류를 공용 component API에 고정하는 것

--- a/openspec/changes/add-common-icon-button/design.md
+++ b/openspec/changes/add-common-icon-button/design.md
@@ -48,13 +48,14 @@ OpenSpec이 계속 소유한다. 이 change는 그 제품 동작을 재정의하
 
 ### Recommended Approach
 
-공용 component는 requested target과 플랫폼 floor 중 큰 값을 실제 interactive element의 minimum target으로
-계산하고, caller style 뒤에 floor를 적용한다. Visible control은 별도 내부 visual layer에 두어 glyph, background와
-surface별 feedback을 기존 크기로 유지한다. Target positioning과 visual styling을 분리할 수 있는 style seam을
-제공하되, 공용 component는 기본 visual opacity나 background를 강제하지 않는다.
+공용 component는 Web에서 requested target과 32 floor 중 큰 값을 실제 interactive element의 minimum target으로
+계산하고 caller style 뒤에 적용한다. Native에서는 requested visual·layout box를 유지하고 iOS 44, Android 48에
+부족한 절반 값을 공용 `hitSlop` 최소값으로 병합한다. Visible control은 별도 내부 visual layer에 두어 glyph,
+background와 surface별 feedback을 기존 크기로 유지한다. Target positioning과 visual styling을 분리할 수 있는
+style seam을 제공하되, 공용 component는 기본 visual opacity나 background를 강제하지 않는다.
 
-기존 `hitSlop` action은 전환 전 effective region을 먼저 계산한다. 공용 target이 같은 region을 실제 element로
-제공하면 중복 `hitSlop`을 제거하거나 줄이고, 더 큰 기존 target은 requested target으로 유지한다. Web에서는
+기존 `hitSlop` action은 전환 전 effective region을 먼저 계산한다. Web actual target과 Native 공용 부족분이 기존
+expansion과 중복되지 않게 큰 값을 사용하고, 더 큰 기존 target은 requested target으로 유지한다. Web에서는
 rendered bounding box, pointer와 keyboard focus를 함께 확인한다.
 
 State와 behavior는 Pressable contract를 통해 전달한다. Disabled는 실제 `disabled`와 accessibility state를
@@ -77,8 +78,8 @@ merge 전에 전환한다. 별도 stack이나 PR base 변경을 기본 경로로
 
 ### Allowed Alternatives
 
-- Internal visual layer 대신 동등한 wrapper 구조를 사용해도 된다. 단, 실제 interactive element floor, visible
-  geometry, focus와 overlap·clipping requirement를 동일하게 충족해야 한다.
+- Internal visual layer 대신 동등한 wrapper 구조를 사용해도 된다. 단, Web actual floor, Native effective target
+  mapping, visible geometry, focus와 현재 scope의 overlap·clipping requirement를 동일하게 충족해야 한다.
 - Standard ref forwarding 또는 저장소 type과 호환되는 명시적 ref prop을 사용할 수 있다. 소비자 focus 계약과
   public type이 동등해야 한다.
 - Surface별 기존 테스트에 assertion을 추가하거나 공용 Storybook story에서 geometry를 검증할 수 있다. 각
@@ -86,8 +87,8 @@ merge 전에 전환한다. 별도 stack이나 PR base 변경을 기본 경로로
 
 ### Known Traps
 
-- `minWidth`·`minHeight`를 caller style보다 먼저 적용해 floor를 다시 우회하게 만드는 것
-- `hitSlop` 숫자를 그대로 유지하면서 actual target도 확대해 effective region을 두 번 키우는 것
+- Web `minWidth`·`minHeight`를 caller style보다 먼저 적용해 floor를 다시 우회하게 만드는 것
+- Native visual·layout box와 공용 `hitSlop`을 동시에 확대해 effective region을 두 번 키우는 것
 - 모든 소비자에 같은 opacity feedback을 기본 적용하는 것
 - icon library나 glyph 종류를 공용 component API에 고정하는 것
 - Search back Link, Profile preview, media retry, reaction entry나 Post Action Bar를 inventory 숫자만 보고 전환하는 것
@@ -96,8 +97,8 @@ merge 전에 전환한다. 별도 stack이나 PR base 변경을 기본 경로로
 
 ## Risks / Trade-offs
 
-- [실제 target 확대로 layout slot이나 absolute center가 이동할 수 있음] → visual layer와 target style을 분리하고
-  기존 화면 중심 좌표·간격을 Storybook과 Web runtime에서 비교한다.
+- [Web actual target 확대로 layout slot이나 absolute center가 이동할 수 있음] → visual layer와 target style을
+  분리하고 기존 화면 중심 좌표·간격을 Storybook과 Web runtime에서 비교한다. Native는 기존 layout box를 유지한다.
 - [작은 overlay target이 인접 action 또는 부모 bounds와 충돌할 수 있음] → effective region을 계산하고
   overlap·clipping을 surface별로 검증한다.
 - [기존 `hitSlop` 제거가 Native touch behavior를 바꿀 수 있음] → source mapping과 자동화에는 의도를 남기고

--- a/openspec/changes/add-common-icon-button/design.md
+++ b/openspec/changes/add-common-icon-button/design.md
@@ -1,0 +1,124 @@
+## Context
+
+현재 `apps/app`의 compact action은 각 surface가 React Native `Pressable`, target geometry, accessibility state와
+pressed·disabled 표현을 직접 소유한다. 현재 PROD-548 branch의 `IconButton`은 Web 32, iOS 44, 기타 48을
+기본값으로 제공하지만 caller `targetSize`와 뒤에 적용되는 caller style이 floor를 낮출 수 있고, 모든 소비자에
+opacity feedback을 기본 적용한다. 또한 Profile header/avatar whole-preview를 `IconButton`으로 바꿔 새 scope의
+명시적 제외와 충돌한다.
+
+현재 production에는 서로 다른 visual size, hit region, focus handler, absolute positioning과 상태를 가진 13개
+대상 action이 있다. 열린 PR #486과 #510도 4개 action을 추가한다. React Native 0.85.3의 Native Pressability는
+`hitSlop`으로 responder region을 확장하지만, 현재 React Native Web 0.21.2의 Pressable source에서는 같은 확장
+근거를 확인하지 못했다. 따라서 작은 visual box의 기존 `hitSlop`만 공용 Web floor의 근거로 사용할 수 없다.
+
+각 surface의 navigation, search focus, media persistence, modal, reaction과 logout 동작은 기존 component와
+OpenSpec이 계속 소유한다. 이 change는 그 제품 동작을 재정의하지 않고 공용 target primitive 적용만 소유한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- single-action compact square control의 플랫폼 floor와 button semantics를 하나의 공용 primitive에 둔다.
+- visible geometry와 interaction target을 분리하고 기존 위치·색상·feedback·focus·hit region을 보존한다.
+- 현재 production과 열린 PR에서 확인된 모든 대상 action을 누락 없이 전환한다.
+- component 자동화, surface 회귀 검증과 Web runtime 증거를 남기고 Native 검증 경계를 정직하게 기록한다.
+- PROD-548를 Profile edit lifecycle에서 분리해 cross-surface change로 완료한다.
+
+**Non-Goals:**
+
+- 상태형·icon+count·pill·tab·switch, Link·row, whole-preview/content action과 compound control 전환
+- surface별 navigation, persistence, upload, modal, reaction 또는 session 동작 변경
+- 텍스트 `Button` 재설계, 새 icon library나 runtime dependency 도입
+- iOS·Android 실제 기기·simulator runtime QA와 Native 출시 gate 완료
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `IconButton`의 caller style은 target floor 뒤에 적용되므로 현재 floor를 덮을 수 있다.
+- 현재 `feedback="opacity"` 기본값은 pressed feedback이 없거나 background만 바뀌던 surface의 시각 동작을
+  바꿀 수 있다.
+- visual 32·40·44와 기존 `hitSlop`을 그대로 둔 채 Pressable 자체도 48로 키우면 effective input region이
+  이중 확장되거나 인접 target과 겹칠 수 있다.
+- Web은 `hitSlop` 효과가 local installed source에서 입증되지 않았으므로 실제 rendered target을 측정해야 한다.
+- Profile header/avatar preview는 canonical하게 각각 하나의 whole-image button이지만 compact `IconButton`은 아니다.
+- menu expanded, search `onPressIn`, media disabled·absolute overlay, Reaction more geometry, Logout busy·spinner는
+  각 소비자가 보존해야 하는 기존 계약이다.
+- PR #486과 #510의 merge 순서는 PROD-548가 고정하지 않는다.
+
+### Recommended Approach
+
+공용 component는 requested target과 플랫폼 floor 중 큰 값을 실제 interactive element의 minimum target으로
+계산하고, caller style 뒤에 floor를 적용한다. Visible control은 별도 내부 visual layer에 두어 glyph, background와
+surface별 feedback을 기존 크기로 유지한다. Target positioning과 visual styling을 분리할 수 있는 style seam을
+제공하되, 공용 component는 기본 visual opacity나 background를 강제하지 않는다.
+
+기존 `hitSlop` action은 전환 전 effective region을 먼저 계산한다. 공용 target이 같은 region을 실제 element로
+제공하면 중복 `hitSlop`을 제거하거나 줄이고, 더 큰 기존 target은 requested target으로 유지한다. Web에서는
+rendered bounding box, pointer와 keyboard focus를 함께 확인한다.
+
+State와 behavior는 Pressable contract를 통해 전달한다. Disabled는 실제 `disabled`와 accessibility state를
+일치시키고, busy·expanded 등 다른 state를 병합한다. Children과 style은 press state를 받을 수 있고 focus ref,
+`onPressIn`, `hitSlop`을 포함한 필요한 event·interaction prop은 보존한다. Ref 전달의 구체적인 React API는 현재
+저장소와 React Native type에 맞는 가장 작은 방식을 사용한다.
+
+전환은 다음 묶음으로 진행한다.
+
+1. 현재 잘못 적용된 Profile header/avatar whole-preview와 관련 Storybook assertion을 기존 `Pressable` 계약으로
+   되돌리고 Profile back·Tag remove만 유지한다.
+2. 공용 component의 floor·visual separation·state/ref/event contract를 component test로 고정한다.
+3. shell/header/modal/reply/search action을 전환하고 navigation·focus·expanded state를 검증한다.
+4. media/reaction/logout action을 전환하고 visual geometry·absolute position·disabled/busy state를 검증한다.
+5. 구현 시작과 merge 직전 production/open PR inventory를 반복한다.
+
+열린 PR에는 승인된 동적 소유 규칙을 사용한다. #486 또는 #510이 먼저 merge되면 PROD-548가 최신 production을
+반영해 흡수한다. 공용 component merge 뒤에도 열린 PR은 최신 production을 반영하고 자신의 대상 action을
+merge 전에 전환한다. 별도 stack이나 PR base 변경을 기본 경로로 만들지 않는다.
+
+### Allowed Alternatives
+
+- Internal visual layer 대신 동등한 wrapper 구조를 사용해도 된다. 단, 실제 interactive element floor, visible
+  geometry, focus와 overlap·clipping requirement를 동일하게 충족해야 한다.
+- Standard ref forwarding 또는 저장소 type과 호환되는 명시적 ref prop을 사용할 수 있다. 소비자 focus 계약과
+  public type이 동등해야 한다.
+- Surface별 기존 테스트에 assertion을 추가하거나 공용 Storybook story에서 geometry를 검증할 수 있다. 각
+  고위험 제품 동작을 관찰 가능한 결과로 직접 증명해야 한다.
+
+### Known Traps
+
+- `minWidth`·`minHeight`를 caller style보다 먼저 적용해 floor를 다시 우회하게 만드는 것
+- `hitSlop` 숫자를 그대로 유지하면서 actual target도 확대해 effective region을 두 번 키우는 것
+- 모든 소비자에 같은 opacity feedback을 기본 적용하는 것
+- icon library나 glyph 종류를 공용 component API에 고정하는 것
+- Search back Link, Profile preview, media retry, reaction entry나 Post Action Bar를 inventory 숫자만 보고 전환하는 것
+- Web 자동화 결과를 Native target·VoiceOver·TalkBack runtime 증거로 보고하는 것
+- PROD-548 task를 `add-local-profile-edit`의 PROD-490 archive gate에 계속 연결하는 것
+
+## Risks / Trade-offs
+
+- [실제 target 확대로 layout slot이나 absolute center가 이동할 수 있음] → visual layer와 target style을 분리하고
+  기존 화면 중심 좌표·간격을 Storybook과 Web runtime에서 비교한다.
+- [작은 overlay target이 인접 action 또는 부모 bounds와 충돌할 수 있음] → effective region을 계산하고
+  overlap·clipping을 surface별로 검증한다.
+- [기존 `hitSlop` 제거가 Native touch behavior를 바꿀 수 있음] → source mapping과 자동화에는 의도를 남기고
+  실제 Native 결과는 출시 gate의 runtime 검증 공백으로 기록한다.
+- [열린 PR merge 중 새 직접 Pressable이 생길 수 있음] → merge 직전 inventory와 동적 소유 규칙으로 흡수한다.
+- [여러 기존 OpenSpec이 제품 동작을 중복 소유할 수 있음] → 새 change는 공용 primitive와 전환 증거만 소유하고
+  각 surface change의 제품 behavior·archive 책임을 가져오지 않는다.
+
+## Migration Plan
+
+1. Canonical 접근성 문서와 이 change를 PROD-548 authority에 맞춘다.
+2. `add-local-profile-edit`의 PROD-548 section과 archive dependency를 원래 Profile edit 경계로 되돌린다.
+3. 공용 component와 최소 component test를 수정한 뒤 Profile의 오범위 적용을 제거한다.
+4. 현재 production 대상 13개 action을 위험 묶음별로 전환하고 각 묶음의 회귀 검증을 수행한다.
+5. PR #486/#510 상태를 다시 읽고 동적 소유 규칙에 따라 production 또는 열린 branch의 4개 action을 전환한다.
+6. 전체 app 자동화, Storybook build·interaction과 Web runtime을 실행하고 merge 직전 inventory를 기록한다.
+7. 모든 적용 PR의 전환 증거가 준비되면 마지막 완료 증거를 소유한 PR이 이 change를 archive한다.
+
+부분 전환을 rollback해야 하면 해당 surface만 이전 `Pressable` 구현으로 되돌릴 수 있다. 공용 component와 이미
+검증된 소비자는 유지하며, floor를 우회하는 임시 fallback이나 중복 target 계산을 추가하지 않는다.
+
+## Open Questions
+
+없음. PR merge 순서에 따른 전환·archive owner는 위 동적 소유 규칙으로 결정한다.

--- a/openspec/changes/add-common-icon-button/proposal.md
+++ b/openspec/changes/add-common-icon-button/proposal.md
@@ -12,10 +12,10 @@
 - visual geometry와 interaction target을 분리하고 기존 accessible name·state, focus/ref·event handler,
   pressed·disabled feedback, hit region과 absolute positioning을 보존한다.
 - 현재 production의 Profile back·Tag remove, shell menu/back, Post detail back, modal·composer close,
-  search clear/delete, media add/remove, ReactionSummary more와 compact Logout action을 공용 component로 옮긴다.
-- 열린 PR #486의 FeedbackOverlay close와 PR #510의 PostMediaViewer close/previous/next는 merge 순서에 따라
-  먼저 production이 된 action은 이 change가 흡수하고, 아직 열린 PR은 공용 component merge 뒤 자체 branch에서
-  전환한다.
+  search clear/delete, media add/remove, ReactionSummary more, compact Logout과 먼저 merge된 PR #486의
+  FeedbackOverlay close를 공용 component로 옮긴다.
+- 열린 PR #510의 PostMediaViewer close/previous/next는 공용 component merge 뒤 자체 branch에서 전환한다.
+  이후 먼저 production이 되는 대상도 이 change의 동적 소유 규칙에 따라 흡수한다.
 - Profile header/avatar whole-preview에 잘못 적용한 `IconButton`과 Profile edit OpenSpec의 PROD-548 소유를
   제거한다.
 - 상태형·icon+count·pill·tab·switch, Link·row, whole-preview/content action, compound control과 텍스트
@@ -43,8 +43,9 @@
 
 ## Impact
 
-- Universal client: `apps/app` 공용 UI primitive와 현재 production의 13개 compact action
-- Open pull requests: PR #486의 FeedbackOverlay close, PR #510의 PostMediaViewer close/previous/next
+- Universal client: `apps/app` 공용 UI primitive와 현재 production의 14개 compact action
+- Merged consumer: PR #486의 FeedbackOverlay close를 production에서 흡수
+- Open pull request: PR #510의 PostMediaViewer close/previous/next
 - Canonical design: `docs/design/accessibility.md`의 공통 `IconButton` exact contract
 - OpenSpec ownership: `add-local-profile-edit`에서 PROD-548를 분리하고 이 change가 cross-surface 완료 증거를 소유
 - Verification: component tests, 기존 surface 회귀 테스트, Storybook·Web runtime, 구현 시작·merge 직전 inventory

--- a/openspec/changes/add-common-icon-button/proposal.md
+++ b/openspec/changes/add-common-icon-button/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+앱 전역의 single-action compact square control이 production surface마다 `Pressable`과 플랫폼별 target 계산을
+직접 소유해 접근성 floor, 상태 전달과 시각 표현이 서로 달라질 수 있다. Profile edit에서 발견한 문제를 특정
+화면에 한정하지 않고, 현재 production과 열린 PR에서 확인된 action을 공통 계약으로 통합해야 한다.
+
+## What Changes
+
+- icon, glyph, 짧은 기호 문자 또는 loading indicator를 content로 받는 공통 `IconButton`을 제공한다.
+- Web `32×32 CSS px`, iOS `44×44 pt`, Android `48×48 dp` 최소 interaction target을 중앙화하고 public
+  override나 caller style로 floor를 낮추지 못하게 한다.
+- visual geometry와 interaction target을 분리하고 기존 accessible name·state, focus/ref·event handler,
+  pressed·disabled feedback, hit region과 absolute positioning을 보존한다.
+- 현재 production의 Profile back·Tag remove, shell menu/back, Post detail back, modal·composer close,
+  search clear/delete, media add/remove, ReactionSummary more와 compact Logout action을 공용 component로 옮긴다.
+- 열린 PR #486의 FeedbackOverlay close와 PR #510의 PostMediaViewer close/previous/next는 merge 순서에 따라
+  먼저 production이 된 action은 이 change가 흡수하고, 아직 열린 PR은 공용 component merge 뒤 자체 branch에서
+  전환한다.
+- Profile header/avatar whole-preview에 잘못 적용한 `IconButton`과 Profile edit OpenSpec의 PROD-548 소유를
+  제거한다.
+- 상태형·icon+count·pill·tab·switch, Link·row, whole-preview/content action, compound control과 텍스트
+  `Button`은 전환하지 않는다.
+- Web 자동화와 runtime으로 현재 출시 surface를 검증한다. iOS·Android mapping은 공용 source에 유지하되
+  Native 실제 기기·simulator QA 완료로 간주하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/design/accessibility.md` 및 각 적용 surface의 기존 `docs/design` 계약
+- Linear Contract: [PROD-548](https://linear.app/byulmaru/issue/PROD-548)
+- Linear Implementations: `PROD-548`; merge 순서에 따른 소비자 `PROD-594`·`PROD-650`
+- Discovery: `PROD-491`, PR #393
+
+## Capabilities
+
+### New Capabilities
+
+- `common-icon-button`: 앱 전역 single-action compact square control의 content, 플랫폼 target, 접근성 상태,
+  visual 보존, inventory와 검증 계약
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- Universal client: `apps/app` 공용 UI primitive와 현재 production의 13개 compact action
+- Open pull requests: PR #486의 FeedbackOverlay close, PR #510의 PostMediaViewer close/previous/next
+- Canonical design: `docs/design/accessibility.md`의 공통 `IconButton` exact contract
+- OpenSpec ownership: `add-local-profile-edit`에서 PROD-548를 분리하고 이 change가 cross-surface 완료 증거를 소유
+- Verification: component tests, 기존 surface 회귀 테스트, Storybook·Web runtime, 구현 시작·merge 직전 inventory
+- API·GraphQL·database·dependency·제품 navigation/persistence/upload 동작 영향 없음

--- a/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
+++ b/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
@@ -83,7 +83,7 @@
 
 ### Requirement: Production과 열린 PR inventory 전환
 
-**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — PROD-548은 구현 시작과 merge 직전에 production 및 열린 PR inventory를 다시 확인해야 한다(MUST). 현재 production의 Profile back·Tag remove, UniversalShell menu/back, Post detail back, ModalSheet close, ReplyComposer close, search clear/recent-delete, Post Composer media add/remove, ReactionSummary more와 compact Logout action은 공통 `IconButton`을 사용해야 한다(MUST). PR #486의 FeedbackOverlay close와 PR #510의 PostMediaViewer close/previous/next는 merge 순서와 관계없이 최종 production 또는 merge 가능한 branch에 직접 `Pressable` 구현으로 남지 않아야 한다(MUST).
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — PROD-548은 구현 시작과 merge 직전에 production 및 열린 PR inventory를 다시 확인해야 한다(MUST). 현재 production의 Profile back·Tag remove, UniversalShell menu/back, Post detail back, ModalSheet close, ReplyComposer close, FeedbackOverlay close, search clear/recent-delete, Post Composer media add/remove, ReactionSummary more와 compact Logout action은 공통 `IconButton`을 사용해야 한다(MUST). PR #486의 FeedbackOverlay close와 PR #510의 PostMediaViewer close/previous/next는 merge 순서와 관계없이 최종 production 또는 merge 가능한 branch에 직접 `Pressable` 구현으로 남지 않아야 한다(MUST).
 
 #### Scenario: 관련 PR이 공통 component보다 먼저 merge된다
 

--- a/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
+++ b/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
@@ -38,6 +38,11 @@
 - **WHEN** 기존 Native visual·layout box가 iOS 또는 Android floor보다 작다
 - **THEN** 공용 component는 기존 box를 확대해 visual center나 layout slot을 이동시키지 않고 플랫폼별 부족분을 공용 `hitSlop`에 반영한다
 
+#### Scenario: 함수형 target style에 안정적인 크기를 제공한다
+
+- **WHEN** caller가 press state를 받는 함수형 outer `style`을 사용한다
+- **THEN** caller는 `targetSize` 또는 `visualSize`를 제공하고 공용 component는 그 안정적인 크기로 Native layout과 플랫폼별 `hitSlop`을 계산한다
+
 #### Scenario: 기존 hit region을 공용 target으로 옮긴다
 
 - **WHEN** 작은 visual box와 `hitSlop`을 결합해 target을 확장하던 action을 전환한다

--- a/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
+++ b/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
@@ -16,12 +16,12 @@
 
 ### Requirement: 플랫폼 최소 interaction target
 
-**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — 공통 `IconButton`은 Web에서 `32×32 CSS px`, iOS에서 `44×44 pt`, Android에서 `48×48 dp` 이상의 interaction target을 제공해야 한다(MUST). Public target override와 caller style은 해당 플랫폼 floor를 낮출 수 없어야 하며(MUST), component-specific larger target은 유지해야 한다(MUST).
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — 공통 `IconButton`은 Web에서 `32×32 CSS px`, iOS에서 `44×44 pt`, Android에서 `48×48 dp` 이상의 interaction target을 제공해야 한다(MUST). Web floor는 실제 interactive element가 소유해야 하고(MUST), Native는 기존 visual·layout box를 유지해야 할 때 공용 `hitSlop` 계산으로 부족분을 보충할 수 있다(MAY). Public target override, caller style 또는 caller `hitSlop`은 해당 플랫폼의 effective floor를 낮출 수 없어야 하며(MUST), component-specific larger target은 유지해야 한다(MUST).
 
 #### Scenario: caller가 floor보다 작은 값을 요청한다
 
 - **WHEN** caller가 현재 플랫폼 floor보다 작은 target size나 width·height style을 전달한다
-- **THEN** 실제 interactive element는 현재 플랫폼 floor보다 작아지지 않는다
+- **THEN** Web의 실제 interactive element는 floor보다 작아지지 않고 Native의 실제 box와 공용 `hitSlop`을 합친 effective target은 floor보다 작아지지 않는다
 
 #### Scenario: caller가 더 큰 target을 사용한다
 
@@ -33,6 +33,11 @@
 - **WHEN** Web에서 공통 `IconButton`의 pointer와 keyboard focus target을 측정한다
 - **THEN** 렌더된 interactive element가 최소 `32×32 CSS px`를 제공하고 `hitSlop`만으로 floor 충족을 주장하지 않는다
 
+#### Scenario: Native layout을 유지한다
+
+- **WHEN** 기존 Native visual·layout box가 iOS 또는 Android floor보다 작다
+- **THEN** 공용 component는 기존 box를 확대해 visual center나 layout slot을 이동시키지 않고 플랫폼별 부족분을 공용 `hitSlop`에 반영한다
+
 #### Scenario: 기존 hit region을 공용 target으로 옮긴다
 
 - **WHEN** 작은 visual box와 `hitSlop`을 결합해 target을 확장하던 action을 전환한다
@@ -40,7 +45,7 @@
 
 ### Requirement: Visual geometry와 interaction target 분리
 
-**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/page-header.md`, `docs/design/feedback.md`, `docs/design/post-media-gallery.md`, `docs/design/reactions.md`, `docs/design/reply-composer.md`, `docs/design/profile-edit.md`, `docs/design/profile-tags.md`, `PROD-548` — 공통 `IconButton`은 visible glyph·background·control geometry와 interaction target을 독립적으로 표현해야 한다(MUST). 기존 surface의 glyph 크기, visual box, 배치, 색상, focus 표시와 pressed·disabled feedback은 전환 전과 같아야 하며(MUST), 확장 target은 인접 action과 겹치거나 부모 clipping으로 잘리지 않아야 한다(MUST).
+**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/page-header.md`, `docs/design/feedback.md`, `docs/design/post-media-gallery.md`, `docs/design/reactions.md`, `docs/design/reply-composer.md`, `docs/design/profile-edit.md`, `docs/design/profile-tags.md`, `PROD-548` — 공통 `IconButton`은 visible glyph·background·control geometry와 interaction target을 독립적으로 표현해야 한다(MUST). 기존 surface의 glyph 크기, visual box, 배치, 색상, Web focus 표시와 pressed·disabled feedback은 전환 전과 같아야 하며(MUST), Web의 확장된 실제 target은 인접 action과 겹치거나 부모 clipping으로 잘리지 않아야 한다(MUST). Native `hitSlop`의 parent clipping·sibling 우선순위와 focus boundary는 출시 전 runtime에서 검증해야 한다(MUST).
 
 #### Scenario: 작은 visual control을 유지한다
 

--- a/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
+++ b/openspec/changes/add-common-icon-button/specs/common-icon-button/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: 공통 IconButton 적용 경계
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — 앱은 icon, glyph, 짧은 기호 문자 또는 loading indicator를 content로 사용하는 single-action compact square control에 공통 `IconButton`을 사용해야 한다(MUST). 실제 interactive element는 button role, 필수 accessible name과 현재 action의 접근성 상태를 제공해야 한다(MUST).
+
+#### Scenario: 단일 compact action을 렌더링한다
+
+- **WHEN** 화면이 icon, glyph, 짧은 기호 문자 또는 loading indicator로 하나의 action을 제공한다
+- **THEN** action은 공통 `IconButton`을 사용하고 실제 interactive element에 button role과 accessible name을 제공한다
+
+#### Scenario: 다른 의미의 control은 전환하지 않는다
+
+- **WHEN** control이 상태 선택·토글·count, pill·tab·switch, Link·row, whole-preview/content 또는 compound control이다
+- **THEN** 앱은 그 control을 공통 `IconButton` 적용 대상으로 간주하지 않고 기존 semantic owner를 유지한다
+
+### Requirement: 플랫폼 최소 interaction target
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — 공통 `IconButton`은 Web에서 `32×32 CSS px`, iOS에서 `44×44 pt`, Android에서 `48×48 dp` 이상의 interaction target을 제공해야 한다(MUST). Public target override와 caller style은 해당 플랫폼 floor를 낮출 수 없어야 하며(MUST), component-specific larger target은 유지해야 한다(MUST).
+
+#### Scenario: caller가 floor보다 작은 값을 요청한다
+
+- **WHEN** caller가 현재 플랫폼 floor보다 작은 target size나 width·height style을 전달한다
+- **THEN** 실제 interactive element는 현재 플랫폼 floor보다 작아지지 않는다
+
+#### Scenario: caller가 더 큰 target을 사용한다
+
+- **WHEN** 기존 surface가 현재 플랫폼 floor보다 큰 interaction target을 소유한다
+- **THEN** 공통 `IconButton`은 더 큰 target을 유지한다
+
+#### Scenario: Web target을 검증한다
+
+- **WHEN** Web에서 공통 `IconButton`의 pointer와 keyboard focus target을 측정한다
+- **THEN** 렌더된 interactive element가 최소 `32×32 CSS px`를 제공하고 `hitSlop`만으로 floor 충족을 주장하지 않는다
+
+#### Scenario: 기존 hit region을 공용 target으로 옮긴다
+
+- **WHEN** 작은 visual box와 `hitSlop`을 결합해 target을 확장하던 action을 전환한다
+- **THEN** 전환 후 effective input region은 줄어들거나 기존 expansion과 공용 floor가 중복 적용되지 않는다
+
+### Requirement: Visual geometry와 interaction target 분리
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/page-header.md`, `docs/design/feedback.md`, `docs/design/post-media-gallery.md`, `docs/design/reactions.md`, `docs/design/reply-composer.md`, `docs/design/profile-edit.md`, `docs/design/profile-tags.md`, `PROD-548` — 공통 `IconButton`은 visible glyph·background·control geometry와 interaction target을 독립적으로 표현해야 한다(MUST). 기존 surface의 glyph 크기, visual box, 배치, 색상, focus 표시와 pressed·disabled feedback은 전환 전과 같아야 하며(MUST), 확장 target은 인접 action과 겹치거나 부모 clipping으로 잘리지 않아야 한다(MUST).
+
+#### Scenario: 작은 visual control을 유지한다
+
+- **WHEN** visual control이 현재 플랫폼 target보다 작다
+- **THEN** visible geometry와 화면상 중심 위치는 유지되고 interaction target만 플랫폼 floor를 충족한다
+
+#### Scenario: surface별 feedback을 유지한다
+
+- **WHEN** 기존 action이 고유한 pressed background, opacity 또는 disabled 표현을 사용한다
+- **THEN** 공통 `IconButton`은 하나의 전역 feedback을 강제하지 않고 해당 표현을 그대로 유지한다
+
+#### Scenario: 인접 target과 clipping을 검증한다
+
+- **WHEN** expanded target이 row, overlay 또는 absolute-positioned surface에 배치된다
+- **THEN** 서로 다른 action target은 겹치지 않고 부모 bounds에 의해 유효 target이 잘리지 않는다
+
+### Requirement: 상태와 제품 동작 전달
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — 공통 `IconButton`은 disabled, pending, busy, expanded를 포함한 접근성 상태와 focus ref, press state, `onPressIn`을 포함한 event handler를 실제 interactive element에 전달해야 한다(MUST). 전환은 navigation, persistence, upload, modal 또는 session 제품 동작을 바꾸지 않아야 한다(MUST).
+
+#### Scenario: expanded menu action을 전환한다
+
+- **WHEN** menu action이 expanded 상태와 기존 pressed feedback을 전달한다
+- **THEN** 전환 후 같은 상태와 feedback이 실제 button에 유지된다
+
+#### Scenario: focus 보존 handler를 전환한다
+
+- **WHEN** search action이 `onPressIn`으로 입력 focus를 유지한다
+- **THEN** 전환 후 같은 handler 순서와 focus 결과를 유지한다
+
+#### Scenario: pending action을 전환한다
+
+- **WHEN** compact Logout action이 pending 상태에서 spinner, busy와 disabled를 표현한다
+- **THEN** 전환 후 같은 content와 접근성 상태를 제공하고 session 동작을 변경하지 않는다
+
+### Requirement: Production과 열린 PR inventory 전환
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — PROD-548은 구현 시작과 merge 직전에 production 및 열린 PR inventory를 다시 확인해야 한다(MUST). 현재 production의 Profile back·Tag remove, UniversalShell menu/back, Post detail back, ModalSheet close, ReplyComposer close, search clear/recent-delete, Post Composer media add/remove, ReactionSummary more와 compact Logout action은 공통 `IconButton`을 사용해야 한다(MUST). PR #486의 FeedbackOverlay close와 PR #510의 PostMediaViewer close/previous/next는 merge 순서와 관계없이 최종 production 또는 merge 가능한 branch에 직접 `Pressable` 구현으로 남지 않아야 한다(MUST).
+
+#### Scenario: 관련 PR이 공통 component보다 먼저 merge된다
+
+- **WHEN** PR #486 또는 PR #510의 대상 action이 공통 `IconButton`보다 먼저 production branch에 들어온다
+- **THEN** PROD-548 branch는 최신 production을 반영해 해당 action을 같은 change에서 전환한다
+
+#### Scenario: 관련 PR이 공통 component merge 뒤에도 열려 있다
+
+- **WHEN** PR #486 또는 PR #510이 공통 `IconButton` merge 뒤에도 열려 있다
+- **THEN** 해당 PR은 최신 production을 반영하고 자신이 추가한 대상 action을 merge 전에 공통 component로 전환한다
+
+#### Scenario: merge 직전 inventory를 재확인한다
+
+- **WHEN** PROD-548 또는 후속 소비자 PR이 merge readiness를 판단한다
+- **THEN** production과 열린 PR을 다시 검색해 새 대상의 누락, 제외 대상의 잘못된 전환과 직접 플랫폼 target 계산 잔존을 기록한다
+
+### Requirement: 플랫폼별 검증 증거를 구분한다
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-548` — 공통 `IconButton`은 component 자동화와 Web runtime에서 target, semantics, state 전달, visual geometry와 overlap·clipping을 검증해야 한다(MUST). iOS·Android mapping은 공용 source와 자동화에 유지해야 하지만(MUST), 그 결과나 Web runtime을 Native 실제 기기·simulator 검증 완료로 보고해서는 안 된다(MUST NOT).
+
+#### Scenario: Web 완료 증거를 기록한다
+
+- **WHEN** Web component·surface 자동화와 runtime 검증을 완료한다
+- **THEN** 검증한 viewport·입력·focus·geometry와 실행하지 않은 Native runtime 범위를 분리해 기록한다
+
+#### Scenario: Native mapping만 확인한다
+
+- **WHEN** iOS·Android 실제 기기나 simulator를 실행하지 않고 공용 source mapping만 확인한다
+- **THEN** 결과를 source-level mapping 증거로만 기록하고 Native touch·focus·assistive technology 완료로 표현하지 않는다

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -187,19 +187,24 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
 
 - 전체 20개 Storybook 파일의 Chromium interaction 293개를 통과했다. `Posts`, `Reactions`, `Search`, `Shell`
   대상 subset 145개도 별도로 실행했고, Reaction은 320·390·600px viewport에서 More 32×32와 마지막 token 사이
-  4px 간격·컨테이너 overflow를 확인했다.
+  4px 간격·컨테이너 overflow를 확인했다. 최신 `origin/main` 재베이스 뒤 `Posts` 단독 interaction 78개도
+  통과했다.
 - Reply compact viewport에서 close 36×36, Search clear/recent-delete와 compact Logout은 각각 44×44,
   Media remove는 실제 target·visual 32×32와 preview 상·우 4px inset을 확인했다. Search는 pointer click 후
   입력값 초기화·focus 복귀와 recent-delete 뒤 focus 복귀를 함께 확인했다.
 - component test는 Web actual floor·음수 `hitSlop` clamp와 Native layout 보존·플랫폼 부족분 계산을 확인했다.
-- Relay `--noWatchman`, TypeScript, App unit 192개, ESLint, Prettier, syncpack, Storybook production build와 두
+  `targetSize`·`visualSize`가 없는 40×40 static style도 Native layout을 40×40으로 유지하고 iOS 2pt·Android 4dp
+  부족분을 `hitSlop`으로 보충하는 회귀를 추가했다.
+- Relay `--noWatchman`, TypeScript, App unit 206개, ESLint, Prettier, syncpack, Storybook production build와 두
   OpenSpec strict validation을 통과했다.
 - 독립 리뷰 4개를 분리 실행했다. code-only와 production/open-PR 누락 검토는 발견 사항 없이 통과했고,
   repository rules와 docs-to-code 검토의 Android layout·검증 근거·Reaction 문서 지적은 수정 후 재검토를 통과했다.
-- 최신 `origin/main=a6c94c1e` 재베이스 뒤 production의 직접 `Pressable` 65곳과 `IconButton` 13곳, 열린 PR
-  16개의 patch를 다시 검색했다. 새 대상은 없고, 남은 대상은 PR #486 close와 PR #510 close·previous·next
-  4개다. PR #516의 review·comment·review thread는 모두 0개이며 #486은 Open/Ready·CHANGES_REQUESTED,
-  #510은 Open/Draft다.
+- 최신 `origin/main=3fc1d243` 재베이스 뒤 production의 직접 `Pressable` 66곳과 `IconButton` 13곳을 다시
+  검색했다. 새 direct `Pressable` 1곳은 전체 계정 설정 link라 제외 대상이며 새 compact icon action 대상은 없다.
+  열린 PR inventory는 `origin/main=a6c94c1e` 당시 16개 patch를 검색했고, 남은 대상은 PR #486 close와 PR #510
+  close·previous·next 4개였다. 이후 PR #516 재리뷰에서 style-only Native layout 보존 P2 1개와 이를 반영하라는
+  `CHANGES_REQUESTED`가 추가되어 source와 회귀 테스트를 정렬했다. GitHub 답변·resolve·재리뷰 요청은 별도 승인
+  gate로 남는다. #486은 Open/Ready·CHANGES_REQUESTED, #510은 Open/Draft다.
 - iOS·Android 실제 기기·simulator의 touch·focus·VoiceOver·TalkBack은 실행하지 않았고 후속 출시 gate로 남긴다.
 
 - [x] 6.1 구현 시작 inventory에서 포함·제외 대상과 직접 플랫폼 target 계산 baseline을 기록한다.

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -196,11 +196,15 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
   OpenSpec strict validation을 통과했다.
 - 독립 리뷰 4개를 분리 실행했다. code-only와 production/open-PR 누락 검토는 발견 사항 없이 통과했고,
   repository rules와 docs-to-code 검토의 Android layout·검증 근거·Reaction 문서 지적은 수정 후 재검토를 통과했다.
+- 최신 `origin/main=a6c94c1e` 재베이스 뒤 production의 직접 `Pressable` 65곳과 `IconButton` 13곳, 열린 PR
+  16개의 patch를 다시 검색했다. 새 대상은 없고, 남은 대상은 PR #486 close와 PR #510 close·previous·next
+  4개다. PR #516의 review·comment·review thread는 모두 0개이며 #486은 Open/Ready·CHANGES_REQUESTED,
+  #510은 Open/Draft다.
 - iOS·Android 실제 기기·simulator의 touch·focus·VoiceOver·TalkBack은 실행하지 않았고 후속 출시 gate로 남긴다.
 
 - [x] 6.1 구현 시작 inventory에서 포함·제외 대상과 직접 플랫폼 target 계산 baseline을 기록한다.
 - [x] 6.2 App unit·typecheck·lint·Storybook build·Chromium interaction 검증을 완료한다.
 - [x] 6.3 독립 구현 리뷰에서 target floor, visual 무변경, 상태·제품 동작 전달, 누락과 검증 공백을 확인한다.
-- [ ] 6.4 Merge 직전 production/open PR inventory와 review thread를 다시 읽고 새 대상의 누락·잘못된 전환이 없음을 확인한다.
+- [x] 6.4 Merge 직전 production/open PR inventory와 review thread를 다시 읽고 새 대상의 누락·잘못된 전환이 없음을 확인한다.
 - [ ] 6.5 각 적용 PR 본문에 구현·검증·Native 미실행·남은 owner를 동기화한다.
 - [ ] 6.6 모든 task와 cross-PR 완료 증거가 준비되면 실제 마지막 owner가 change를 archive하고 archive 후 validation·Linear 상태를 확인한다.

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -39,7 +39,7 @@
 
 **Guardrails**
 
-- Caller target과 style은 Web 32, iOS 44, Android 48 floor를 낮추지 못한다.
+- Caller target, style과 `hitSlop`은 Web actual 32, iOS effective 44, Android effective 48 floor를 낮추지 못한다.
 - 공용 component는 모든 surface에 하나의 visual feedback을 강제하지 않는다.
 - Profile header/avatar preview와 camera affordance의 단일 whole-image button·비포커스 계약을 바꾸지 않는다.
 - Profile 저장, Media와 navigation 동작을 변경하지 않는다.
@@ -47,8 +47,9 @@
 **Verification**
 
 - 테스트 코드 범위: `apps/app/src/components/ui/IconButton.test.ts`와 기존 Profile story/test의 오범위 assertion 제거.
-- 테스트 필요성: target mapping·floor clamp·caller style override·larger target, visual separation, disabled와 추가
-  accessibility state 병합, press state·ref·event 전달, 기본 visual feedback 무강제를 직접 검증한다.
+- 테스트 필요성: target mapping·Web actual floor clamp·caller style override·larger target, Native layout
+  보존·부족분 계산, visual separation, disabled와 추가 accessibility state 병합, press state·ref·event 전달,
+  기본 visual feedback 무강제를 직접 검증한다.
 - 테스트 제외 범위: 새 fixture·helper·harness, 광범위 snapshot, Profile 제품 동작 coverage 확대와 Native runtime test.
 - 관련 component test, Profile story interaction, TypeScript와 formatter를 통과시킨다.
 
@@ -83,12 +84,13 @@ UniversalShell menu/back, Post detail back, ModalSheet close, ReplyComposer clos
   `Search.stories.tsx`와 `Posts.stories.tsx`에서 직접 관찰할 수 없는 회귀만 가장 가까운 기존 interaction에 보완한다.
 - 테스트 필요성: menu expanded, search focus, reply disabled와 각 action 실행 결과가 전환 전과 같음을 검증한다.
 - 테스트 제외 범위: navigation·modal·search 제품 기능 coverage 확대, 새 Storybook harness와 unrelated snapshot.
-- Web의 compact/full shell, Post detail, modal/reply와 search story/runtime에서 geometry·focus·pressed 결과를 확인한다.
+- Web의 compact/full shell, Post detail, modal/reply와 search Storybook Chromium interaction에서
+  geometry·focus·pressed 결과를 확인한다.
 
 - [x] 3.1 UniversalShell menu/back와 Post detail back을 전환하고 기존 target·expanded·navigation 계약을 유지한다.
 - [x] 3.2 ModalSheet와 ReplyComposer close를 전환하고 기존 target·hit region·disabled·pressed 표현을 유지한다.
 - [x] 3.3 Search clear와 recent-delete를 전환하고 `onPressIn`, persistence와 input refocus 결과를 유지한다.
-- [x] 3.4 관련 기존 자동화와 Web Storybook/runtime을 실행해 visual·focus·제품 동작 무변경을 확인한다.
+- [x] 3.4 관련 기존 자동화와 Web Storybook Chromium interaction에서 target geometry·focus·제품 동작을 확인한다.
 
 ## 4. PROD-548 media·reaction·logout action 전환
 
@@ -117,12 +119,13 @@ visual geometry, effective input region, 상태와 제품 동작을 유지한다
   `Reactions.stories.tsx`, `Shell.stories.tsx`에서 필요한 최소 interaction assertion.
 - 테스트 필요성: media disabled·position, Reaction more geometry, Logout pending content와 busy/disabled를 직접 검증한다.
 - 테스트 제외 범위: upload·reaction·session 제품 coverage 확대, reaction entry·Post Action Bar 변경과 Native runtime test.
-- Web Storybook/runtime에서 media overlay, reaction row와 compact shell visual·pointer·focus 결과를 확인한다.
+- Web Storybook Chromium interaction에서 media overlay, reaction row와 compact shell visual·pointer·focus 결과를
+  확인한다.
 
 - [x] 4.1 Post Composer media add/remove를 전환하고 visual size·absolute position과 기존 effective input region을 유지한다.
 - [x] 4.2 ReactionSummary more만 전환하고 인접 reaction entry·spacing과 Web 32 visual geometry를 유지한다.
 - [x] 4.3 Compact Logout만 전환하고 pending spinner, busy·disabled와 session 결과를 유지한다.
-- [x] 4.4 관련 자동화와 Web Storybook/runtime을 실행해 geometry·state·제품 동작 무변경을 확인한다.
+- [x] 4.4 관련 자동화와 Web Storybook Chromium interaction에서 geometry·state·제품 동작을 확인한다.
 
 ## 5. PROD-594·PROD-650 열린 PR 소비자 조정
 
@@ -177,11 +180,26 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
 **Verification**
 
 - 구현 시작과 merge 직전 `apps/app/src` production 및 열린 PR inventory를 같은 기준으로 반복한다.
-- App unit·typecheck·lint·Storybook build·interaction과 대상 Web runtime을 실행하고 실행하지 못한 검증을 기록한다.
+- App unit·typecheck·lint·Storybook build와 Chromium interaction을 실행하고 실행하지 못한 검증을 기록한다.
 - Canonical·Linear·OpenSpec·구현·PR 본문과 unresolved review thread를 대조하고 archive 전후 strict validation을 확인한다.
 
+**현재 검증 증거 (2026-08-05)**
+
+- 전체 20개 Storybook 파일의 Chromium interaction 293개를 통과했다. `Posts`, `Reactions`, `Search`, `Shell`
+  대상 subset 145개도 별도로 실행했고, Reaction은 320·390·600px viewport에서 More 32×32와 마지막 token 사이
+  4px 간격·컨테이너 overflow를 확인했다.
+- Reply compact viewport에서 close 36×36, Search clear/recent-delete와 compact Logout은 각각 44×44,
+  Media remove는 실제 target·visual 32×32와 preview 상·우 4px inset을 확인했다. Search는 pointer click 후
+  입력값 초기화·focus 복귀와 recent-delete 뒤 focus 복귀를 함께 확인했다.
+- component test는 Web actual floor·음수 `hitSlop` clamp와 Native layout 보존·플랫폼 부족분 계산을 확인했다.
+- Relay `--noWatchman`, TypeScript, App unit 192개, ESLint, Prettier, syncpack, Storybook production build와 두
+  OpenSpec strict validation을 통과했다.
+- 독립 리뷰 4개를 분리 실행했다. code-only와 production/open-PR 누락 검토는 발견 사항 없이 통과했고,
+  repository rules와 docs-to-code 검토의 Android layout·검증 근거·Reaction 문서 지적은 수정 후 재검토를 통과했다.
+- iOS·Android 실제 기기·simulator의 touch·focus·VoiceOver·TalkBack은 실행하지 않았고 후속 출시 gate로 남긴다.
+
 - [x] 6.1 구현 시작 inventory에서 포함·제외 대상과 직접 플랫폼 target 계산 baseline을 기록한다.
-- [x] 6.2 App unit·typecheck·lint·Storybook build·interaction과 대상 Web runtime 검증을 완료한다.
+- [x] 6.2 App unit·typecheck·lint·Storybook build·Chromium interaction 검증을 완료한다.
 - [x] 6.3 독립 구현 리뷰에서 target floor, visual 무변경, 상태·제품 동작 전달, 누락과 검증 공백을 확인한다.
 - [ ] 6.4 Merge 직전 production/open PR inventory와 review thread를 다시 읽고 새 대상의 누락·잘못된 전환이 없음을 확인한다.
 - [ ] 6.5 각 적용 PR 본문에 구현·검증·Native 미실행·남은 owner를 동기화한다.

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -49,7 +49,7 @@
 - 테스트 코드 범위: `apps/app/src/components/ui/IconButton.test.ts`와 기존 Profile story/test의 오범위 assertion 제거.
 - 테스트 필요성: target mapping·Web actual floor clamp·caller style override·larger target, Native layout
   보존·부족분 계산, visual separation, disabled와 추가 accessibility state 병합, press state·ref·event 전달,
-  기본 visual feedback 무강제를 직접 검증한다.
+  함수형 outer style의 안정적인 size prop 요구와 기본 visual feedback 무강제를 직접 검증한다.
 - 테스트 제외 범위: 새 fixture·helper·harness, 광범위 snapshot, Profile 제품 동작 coverage 확대와 Native runtime test.
 - 관련 component test, Profile story interaction, TypeScript와 formatter를 통과시킨다.
 
@@ -195,19 +195,22 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
   입력값 초기화·focus 복귀와 recent-delete 뒤 focus 복귀를 함께 확인했다.
 - component test는 Web actual floor·음수 `hitSlop` clamp와 Native layout 보존·플랫폼 부족분 계산을 확인했다.
   `targetSize`·`visualSize`가 없는 40×40 static style도 Native layout을 40×40으로 유지하고 iOS 2pt·Android 4dp
-  부족분을 `hitSlop`으로 보충하는 회귀를 추가했다.
-- Relay `--noWatchman`, TypeScript, App unit 213개, ESLint, Prettier, syncpack, Storybook production build와 세
+  부족분을 `hitSlop`으로 보충한다. 함수형 outer style은 `targetSize` 또는 `visualSize`를 타입상 요구하고, 명시적
+  40×40 layout에서 iOS 2pt·Android 4dp 부족분을 유지하는 component 회귀 11개를 통과했다.
+- Relay `--noWatchman`, TypeScript, App unit 214개, ESLint, Prettier, syncpack, Storybook production build와 세
   OpenSpec strict validation을 통과했다.
 - 독립 리뷰 4개를 분리 실행했다. code-only와 production/open-PR 누락 검토는 발견 사항 없이 통과했고,
   repository rules와 docs-to-code 검토의 Android layout·검증 근거·Reaction 문서 지적은 수정 후 재검토를 통과했다.
+  함수형 outer style public type 정렬도 별도 독립 구현 재검토에서 발견 사항 없이 통과했다.
 - 최신 `origin/main=664c1642` 재베이스 뒤 production의 직접 `Pressable` 69곳과 `IconButton` 14곳을 다시
   검색했다. PR #486이 먼저 merge되어 FeedbackOverlay close를 공용 component로 흡수했고, 추가된 feedback menu
   row, Content Warning text action과 상태형 visibility radio의 `Pressable`은 제외 대상이다. 열린 PR inventory는
   `origin/main=a6c94c1e` 당시
   16개 patch를 검색했고, 당시 남은 대상은 PR #486 close와 PR #510 close·previous·next 4개였다. 현재 #486은
-  merge·Done이고 #510의 3개 action은 열린 consumer branch에 남는다. 이후 PR #516 재리뷰에서 style-only Native
-  layout 보존 P2 1개와 이를 반영하라는 `CHANGES_REQUESTED`가 추가되어 source와 회귀 테스트를 정렬했다. GitHub
-  답변·resolve와 Codex·robin-maki 재리뷰 요청을 완료했고, 새 review 전까지 기존 decision이 남는다. 최신 main의
+  merge·Done이고 #510의 3개 action은 열린 consumer branch에 남는다. 이후 PR #516 재리뷰에서 static style-only
+  Native layout 보존 P2를 반영하고 답변·resolve와 Codex·robin-maki 재리뷰 요청을 완료했다. 같은 thread의 후속
+  review가 함수형 style-without-size 경로를 다시 열어 public type·source 회귀·canonical·OpenSpec을 정렬했으며,
+  새 답변·resolve·재리뷰 요청은 공개 승인 gate로 남는다. 최신 main의
   Content Warning·reply submitting/discard 흐름, 모바일 Web visibility menu, ProfileSwitcher unread 표시와 Shell
   assertion을 보존했다. PROD-548의 Reply close `IconButton`·geometry assertion 충돌도 양쪽 계약을 모두 보존해
   해소했다.

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -183,11 +183,11 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
 - App unit·typecheck·lint·Storybook build와 Chromium interaction을 실행하고 실행하지 못한 검증을 기록한다.
 - Canonical·Linear·OpenSpec·구현·PR 본문과 unresolved review thread를 대조하고 archive 전후 strict validation을 확인한다.
 
-**현재 검증 증거 (2026-08-05)**
+**현재 검증 증거 (2026-08-06)**
 
-- 전체 21개 Storybook 파일의 Chromium interaction 306개를 통과했다. `Posts`, `Reactions`, `Search`, `Shell`
+- 전체 22개 Storybook 파일의 Chromium interaction 316개를 통과했다. `Posts`, `Reactions`, `Search`, `Shell`
   대상 subset 145개도 별도로 실행했고, Reaction은 320·390·600px viewport에서 More 32×32와 마지막 token 사이
-  4px 간격·컨테이너 overflow를 확인했다. 최신 `origin/main` 재베이스 뒤 `Posts` 단독 interaction 78개도
+  4px 간격·컨테이너 overflow를 확인했다. 최신 `origin/main` 재베이스 뒤 `Posts` 단독 interaction 83개도
   통과했다. `Feedback` 단독 interaction 17개에서는 overlay close 36×36와 focus lifecycle을 확인했고,
   `feedback-overlay` Web E2E 7개에서는 close·focus·dirty·submitting 동작과 viewport geometry를 확인했다.
 - Reply compact viewport에서 close 36×36, Search clear/recent-delete와 compact Logout은 각각 44×44,
@@ -196,17 +196,21 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
 - component test는 Web actual floor·음수 `hitSlop` clamp와 Native layout 보존·플랫폼 부족분 계산을 확인했다.
   `targetSize`·`visualSize`가 없는 40×40 static style도 Native layout을 40×40으로 유지하고 iOS 2pt·Android 4dp
   부족분을 `hitSlop`으로 보충하는 회귀를 추가했다.
-- Relay `--noWatchman`, TypeScript, App unit 206개, ESLint, Prettier, syncpack, Storybook production build와 세
+- Relay `--noWatchman`, TypeScript, App unit 213개, ESLint, Prettier, syncpack, Storybook production build와 세
   OpenSpec strict validation을 통과했다.
 - 독립 리뷰 4개를 분리 실행했다. code-only와 production/open-PR 누락 검토는 발견 사항 없이 통과했고,
   repository rules와 docs-to-code 검토의 Android layout·검증 근거·Reaction 문서 지적은 수정 후 재검토를 통과했다.
-- 최신 `origin/main=0a6b8659` 재베이스 뒤 production의 직접 `Pressable` 67곳과 `IconButton` 14곳을 다시
+- 최신 `origin/main=664c1642` 재베이스 뒤 production의 직접 `Pressable` 69곳과 `IconButton` 14곳을 다시
   검색했다. PR #486이 먼저 merge되어 FeedbackOverlay close를 공용 component로 흡수했고, 추가된 feedback menu
-  row `Pressable`은 compound navigation row라 제외 대상이다. 열린 PR inventory는 `origin/main=a6c94c1e` 당시
+  row, Content Warning text action과 상태형 visibility radio의 `Pressable`은 제외 대상이다. 열린 PR inventory는
+  `origin/main=a6c94c1e` 당시
   16개 patch를 검색했고, 당시 남은 대상은 PR #486 close와 PR #510 close·previous·next 4개였다. 현재 #486은
   merge·Done이고 #510의 3개 action은 열린 consumer branch에 남는다. 이후 PR #516 재리뷰에서 style-only Native
   layout 보존 P2 1개와 이를 반영하라는 `CHANGES_REQUESTED`가 추가되어 source와 회귀 테스트를 정렬했다. GitHub
-  답변·resolve·재리뷰 요청은 별도 승인 gate로 남는다.
+  답변·resolve와 Codex·robin-maki 재리뷰 요청을 완료했고, 새 review 전까지 기존 decision이 남는다. 최신 main의
+  Content Warning·reply submitting/discard 흐름, 모바일 Web visibility menu, ProfileSwitcher unread 표시와 Shell
+  assertion을 보존했다. PROD-548의 Reply close `IconButton`·geometry assertion 충돌도 양쪽 계약을 모두 보존해
+  해소했다.
 - iOS·Android 실제 기기·simulator의 touch·focus·VoiceOver·TalkBack은 실행하지 않았고 후속 출시 gate로 남긴다.
 
 - [x] 6.1 구현 시작 inventory에서 포함·제외 대상과 직접 플랫폼 target 계산 baseline을 기록한다.

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -185,26 +185,28 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
 
 **현재 검증 증거 (2026-08-05)**
 
-- 전체 20개 Storybook 파일의 Chromium interaction 293개를 통과했다. `Posts`, `Reactions`, `Search`, `Shell`
+- 전체 21개 Storybook 파일의 Chromium interaction 306개를 통과했다. `Posts`, `Reactions`, `Search`, `Shell`
   대상 subset 145개도 별도로 실행했고, Reaction은 320·390·600px viewport에서 More 32×32와 마지막 token 사이
   4px 간격·컨테이너 overflow를 확인했다. 최신 `origin/main` 재베이스 뒤 `Posts` 단독 interaction 78개도
-  통과했다.
+  통과했다. `Feedback` 단독 interaction 17개에서는 overlay close 36×36와 focus lifecycle을 확인했고,
+  `feedback-overlay` Web E2E 7개에서는 close·focus·dirty·submitting 동작과 viewport geometry를 확인했다.
 - Reply compact viewport에서 close 36×36, Search clear/recent-delete와 compact Logout은 각각 44×44,
   Media remove는 실제 target·visual 32×32와 preview 상·우 4px inset을 확인했다. Search는 pointer click 후
   입력값 초기화·focus 복귀와 recent-delete 뒤 focus 복귀를 함께 확인했다.
 - component test는 Web actual floor·음수 `hitSlop` clamp와 Native layout 보존·플랫폼 부족분 계산을 확인했다.
   `targetSize`·`visualSize`가 없는 40×40 static style도 Native layout을 40×40으로 유지하고 iOS 2pt·Android 4dp
   부족분을 `hitSlop`으로 보충하는 회귀를 추가했다.
-- Relay `--noWatchman`, TypeScript, App unit 206개, ESLint, Prettier, syncpack, Storybook production build와 두
+- Relay `--noWatchman`, TypeScript, App unit 206개, ESLint, Prettier, syncpack, Storybook production build와 세
   OpenSpec strict validation을 통과했다.
 - 독립 리뷰 4개를 분리 실행했다. code-only와 production/open-PR 누락 검토는 발견 사항 없이 통과했고,
   repository rules와 docs-to-code 검토의 Android layout·검증 근거·Reaction 문서 지적은 수정 후 재검토를 통과했다.
-- 최신 `origin/main=3fc1d243` 재베이스 뒤 production의 직접 `Pressable` 66곳과 `IconButton` 13곳을 다시
-  검색했다. 새 direct `Pressable` 1곳은 전체 계정 설정 link라 제외 대상이며 새 compact icon action 대상은 없다.
-  열린 PR inventory는 `origin/main=a6c94c1e` 당시 16개 patch를 검색했고, 남은 대상은 PR #486 close와 PR #510
-  close·previous·next 4개였다. 이후 PR #516 재리뷰에서 style-only Native layout 보존 P2 1개와 이를 반영하라는
-  `CHANGES_REQUESTED`가 추가되어 source와 회귀 테스트를 정렬했다. GitHub 답변·resolve·재리뷰 요청은 별도 승인
-  gate로 남는다. #486은 Open/Ready·CHANGES_REQUESTED, #510은 Open/Draft다.
+- 최신 `origin/main=0a6b8659` 재베이스 뒤 production의 직접 `Pressable` 67곳과 `IconButton` 14곳을 다시
+  검색했다. PR #486이 먼저 merge되어 FeedbackOverlay close를 공용 component로 흡수했고, 추가된 feedback menu
+  row `Pressable`은 compound navigation row라 제외 대상이다. 열린 PR inventory는 `origin/main=a6c94c1e` 당시
+  16개 patch를 검색했고, 당시 남은 대상은 PR #486 close와 PR #510 close·previous·next 4개였다. 현재 #486은
+  merge·Done이고 #510의 3개 action은 열린 consumer branch에 남는다. 이후 PR #516 재리뷰에서 style-only Native
+  layout 보존 P2 1개와 이를 반영하라는 `CHANGES_REQUESTED`가 추가되어 source와 회귀 테스트를 정렬했다. GitHub
+  답변·resolve·재리뷰 요청은 별도 승인 gate로 남는다.
 - iOS·Android 실제 기기·simulator의 touch·focus·VoiceOver·TalkBack은 실행하지 않았고 후속 출시 gate로 남긴다.
 
 - [x] 6.1 구현 시작 inventory에서 포함·제외 대상과 직접 플랫폼 target 계산 baseline을 기록한다.

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -152,7 +152,7 @@ FeedbackOverlay close와 PostMediaViewer close/previous/next가 merge 순서와 
 - 먼저 production에 들어온 action은 PROD-548 검증에 포함하고, 남아 있는 branch는 자신의 기존 자동화와 Web
   runtime에서 전환 결과를 검증한다.
 
-- [ ] 5.1 PR #486·#510과 production의 최신 상태를 읽고 대상별 전환 owner와 merge 순서를 기록한다.
+- [x] 5.1 PR #486·#510과 production의 최신 상태를 읽고 대상별 전환 owner와 merge 순서를 기록한다.
 - [ ] 5.2 먼저 merge된 action은 PROD-548 branch가 흡수하고, 공용 component 뒤에 남은 PR은 자신의 대상 action을 전환한다.
 - [ ] 5.3 각 소비자 PR의 기존 자동화와 Web runtime에서 close·navigation geometry·focus·제품 동작 무변경을 확인한다.
 
@@ -181,8 +181,8 @@ Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고,
 - Canonical·Linear·OpenSpec·구현·PR 본문과 unresolved review thread를 대조하고 archive 전후 strict validation을 확인한다.
 
 - [x] 6.1 구현 시작 inventory에서 포함·제외 대상과 직접 플랫폼 target 계산 baseline을 기록한다.
-- [ ] 6.2 App unit·typecheck·lint·Storybook build·interaction과 대상 Web runtime 검증을 완료한다.
-- [ ] 6.3 독립 구현 리뷰에서 target floor, visual 무변경, 상태·제품 동작 전달, 누락과 검증 공백을 확인한다.
+- [x] 6.2 App unit·typecheck·lint·Storybook build·interaction과 대상 Web runtime 검증을 완료한다.
+- [x] 6.3 독립 구현 리뷰에서 target floor, visual 무변경, 상태·제품 동작 전달, 누락과 검증 공백을 확인한다.
 - [ ] 6.4 Merge 직전 production/open PR inventory와 review thread를 다시 읽고 새 대상의 누락·잘못된 전환이 없음을 확인한다.
 - [ ] 6.5 각 적용 PR 본문에 구현·검증·Native 미실행·남은 owner를 동기화한다.
 - [ ] 6.6 모든 task와 cross-PR 완료 증거가 준비되면 실제 마지막 owner가 change를 archive하고 archive 후 validation·Linear 상태를 확인한다.

--- a/openspec/changes/add-common-icon-button/tasks.md
+++ b/openspec/changes/add-common-icon-button/tasks.md
@@ -1,0 +1,188 @@
+## 1. PROD-548 authority와 OpenSpec lifecycle 정렬
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/profile-edit.md`
+- `PROD-548`
+
+**Deliverable**
+
+앱 전역 공용 `IconButton` 계약과 구현·검증·archive 책임이 Profile edit lifecycle과 분리되어 추적된다.
+
+**Guardrails**
+
+- `add-local-profile-edit`는 Profile 제품 동작과 PROD-490 통합·archive만 소유한다.
+- 새 change는 각 surface의 navigation, persistence, upload, modal, reaction 또는 session 동작을 재소유하지 않는다.
+
+**Verification**
+
+- Canonical·Linear·두 OpenSpec change의 scope와 task owner를 대조한다.
+- `add-common-icon-button`과 `add-local-profile-edit` strict validation을 통과시킨다.
+
+- [x] 1.1 Canonical 접근성 계약과 `add-common-icon-button` proposal·spec·design·decision·task를 PROD-548에 맞춘다.
+- [x] 1.2 `add-local-profile-edit`에서 PROD-548 section과 PROD-490 archive dependency를 제거하고 두 change를 strict validate한다.
+
+## 2. PROD-548 공용 component 계약과 Profile 적용 경계
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/profile-edit.md`
+- `docs/design/profile-tags.md`
+- `PROD-548`
+
+**Deliverable**
+
+공용 `IconButton`이 플랫폼 floor, button semantics와 state·ref·event 전달을 보장하고 Profile back·Tag remove에서
+기존 visual·제품 동작을 유지한다. Profile header/avatar whole-preview는 기존 content action 계약을 유지한다.
+
+**Guardrails**
+
+- Caller target과 style은 Web 32, iOS 44, Android 48 floor를 낮추지 못한다.
+- 공용 component는 모든 surface에 하나의 visual feedback을 강제하지 않는다.
+- Profile header/avatar preview와 camera affordance의 단일 whole-image button·비포커스 계약을 바꾸지 않는다.
+- Profile 저장, Media와 navigation 동작을 변경하지 않는다.
+
+**Verification**
+
+- 테스트 코드 범위: `apps/app/src/components/ui/IconButton.test.ts`와 기존 Profile story/test의 오범위 assertion 제거.
+- 테스트 필요성: target mapping·floor clamp·caller style override·larger target, visual separation, disabled와 추가
+  accessibility state 병합, press state·ref·event 전달, 기본 visual feedback 무강제를 직접 검증한다.
+- 테스트 제외 범위: 새 fixture·helper·harness, 광범위 snapshot, Profile 제품 동작 coverage 확대와 Native runtime test.
+- 관련 component test, Profile story interaction, TypeScript와 formatter를 통과시킨다.
+
+- [x] 2.1 플랫폼 floor와 public override·state/ref/event·visual separation 회귀를 실패하는 component test로 먼저 고정한다.
+- [x] 2.2 공용 component가 specs와 Active decisions를 만족하도록 수정하고 component test를 통과시킨다.
+- [x] 2.3 Profile header/avatar whole-preview와 관련 story assertion의 오범위 전환을 되돌리고 Profile back·Tag remove만 공용 component로 유지한다.
+- [x] 2.4 Profile 관련 기존 자동화와 Storybook interaction을 실행해 button semantics, geometry와 제품 동작 무변경을 확인한다.
+
+## 3. PROD-548 shell·header·modal·reply·search action 전환
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/page-header.md`
+- `docs/design/reply-composer.md`
+- `PROD-548`
+
+**Deliverable**
+
+UniversalShell menu/back, Post detail back, ModalSheet close, ReplyComposer close와 search clear/recent-delete가 공용
+`IconButton`을 사용하면서 기존 navigation, modal, focus와 시각 결과를 유지한다.
+
+**Guardrails**
+
+- Search back Link와 navigation/menu/list row는 전환하지 않는다.
+- UniversalShell menu expanded state, search `onPressIn` focus 보존, ReplyComposer submitting state를 유지한다.
+- 기존 glyph 크기, target이 더 큰 surface, pressed background·opacity와 배치를 변경하지 않는다.
+
+**Verification**
+
+- 테스트 코드 범위: 공용 component forwarding test를 우선 사용하고, 기존 `Shell.stories.tsx`,
+  `Search.stories.tsx`와 `Posts.stories.tsx`에서 직접 관찰할 수 없는 회귀만 가장 가까운 기존 interaction에 보완한다.
+- 테스트 필요성: menu expanded, search focus, reply disabled와 각 action 실행 결과가 전환 전과 같음을 검증한다.
+- 테스트 제외 범위: navigation·modal·search 제품 기능 coverage 확대, 새 Storybook harness와 unrelated snapshot.
+- Web의 compact/full shell, Post detail, modal/reply와 search story/runtime에서 geometry·focus·pressed 결과를 확인한다.
+
+- [x] 3.1 UniversalShell menu/back와 Post detail back을 전환하고 기존 target·expanded·navigation 계약을 유지한다.
+- [x] 3.2 ModalSheet와 ReplyComposer close를 전환하고 기존 target·hit region·disabled·pressed 표현을 유지한다.
+- [x] 3.3 Search clear와 recent-delete를 전환하고 `onPressIn`, persistence와 input refocus 결과를 유지한다.
+- [x] 3.4 관련 기존 자동화와 Web Storybook/runtime을 실행해 visual·focus·제품 동작 무변경을 확인한다.
+
+## 4. PROD-548 media·reaction·logout action 전환
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/post-media-gallery.md`
+- `docs/design/reactions.md`
+- `PROD-548`
+
+**Deliverable**
+
+Post Composer media add/remove, ReactionSummary more와 compact Logout action이 공용 `IconButton`을 사용하면서 기존
+visual geometry, effective input region, 상태와 제품 동작을 유지한다.
+
+**Guardrails**
+
+- Media preview·retry, reaction entry·selector·icon+count action과 noncompact Logout은 전환하지 않는다.
+- Media add/remove의 기존 effective input region을 줄이거나 공용 target과 기존 `hitSlop`으로 이중 확장하지 않는다.
+- Media remove absolute position, Reaction more의 Web 32/native 44 visual geometry, Logout pending spinner·busy·disabled를 유지한다.
+- Media persistence/upload, reaction modal과 logout session 동작을 변경하지 않는다.
+
+**Verification**
+
+- 테스트 코드 범위: `IconButton.test.ts`의 effective target/state 전달과 기존 `Posts.stories.tsx`,
+  `Reactions.stories.tsx`, `Shell.stories.tsx`에서 필요한 최소 interaction assertion.
+- 테스트 필요성: media disabled·position, Reaction more geometry, Logout pending content와 busy/disabled를 직접 검증한다.
+- 테스트 제외 범위: upload·reaction·session 제품 coverage 확대, reaction entry·Post Action Bar 변경과 Native runtime test.
+- Web Storybook/runtime에서 media overlay, reaction row와 compact shell visual·pointer·focus 결과를 확인한다.
+
+- [x] 4.1 Post Composer media add/remove를 전환하고 visual size·absolute position과 기존 effective input region을 유지한다.
+- [x] 4.2 ReactionSummary more만 전환하고 인접 reaction entry·spacing과 Web 32 visual geometry를 유지한다.
+- [x] 4.3 Compact Logout만 전환하고 pending spinner, busy·disabled와 session 결과를 유지한다.
+- [x] 4.4 관련 자동화와 Web Storybook/runtime을 실행해 geometry·state·제품 동작 무변경을 확인한다.
+
+## 5. PROD-594·PROD-650 열린 PR 소비자 조정
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/feedback.md`
+- `docs/design/post-media-gallery.md`
+- `PROD-548`
+- `PROD-594`
+- `PROD-650`
+
+**Deliverable**
+
+FeedbackOverlay close와 PostMediaViewer close/previous/next가 merge 순서와 관계없이 최종 production 또는 merge
+가능한 branch에서 공용 `IconButton`을 사용한다.
+
+**Guardrails**
+
+- PR #486과 #510의 base·stack·제품 scope를 공용화 때문에 임의로 바꾸지 않는다.
+- Feedback modal과 PostMediaViewer의 close·navigation 제품 동작과 visual geometry를 변경하지 않는다.
+- Retry, reveal과 whole-media content action은 전환하지 않는다.
+
+**Verification**
+
+- 각 조정 시점에 최신 PR head/base/draft/merge 상태와 대상 diff를 다시 읽는다.
+- 먼저 production에 들어온 action은 PROD-548 검증에 포함하고, 남아 있는 branch는 자신의 기존 자동화와 Web
+  runtime에서 전환 결과를 검증한다.
+
+- [ ] 5.1 PR #486·#510과 production의 최신 상태를 읽고 대상별 전환 owner와 merge 순서를 기록한다.
+- [ ] 5.2 먼저 merge된 action은 PROD-548 branch가 흡수하고, 공용 component 뒤에 남은 PR은 자신의 대상 action을 전환한다.
+- [ ] 5.3 각 소비자 PR의 기존 자동화와 Web runtime에서 close·navigation geometry·focus·제품 동작 무변경을 확인한다.
+
+## 6. PROD-548 통합 검증과 OpenSpec archive
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `PROD-548`
+
+**Deliverable**
+
+Production과 열린 PR의 확정 대상이 공용 `IconButton`을 사용하고, Web 완료 증거와 Native 미검증 경계가
+명시된 상태에서 `add-common-icon-button`을 archive한다.
+
+**Guardrails**
+
+- 상태형·count·compound·whole-preview 등 제외 대상을 잘못 전환하지 않는다.
+- Web 결과를 Native 실제 기기·simulator 완료 증거로 사용하지 않는다.
+- 마지막 PR이라는 이유만으로 archive owner를 정하지 않고 실제 남은 전환·통합·정합성 증거를 소유한 PR이 담당한다.
+
+**Verification**
+
+- 구현 시작과 merge 직전 `apps/app/src` production 및 열린 PR inventory를 같은 기준으로 반복한다.
+- App unit·typecheck·lint·Storybook build·interaction과 대상 Web runtime을 실행하고 실행하지 못한 검증을 기록한다.
+- Canonical·Linear·OpenSpec·구현·PR 본문과 unresolved review thread를 대조하고 archive 전후 strict validation을 확인한다.
+
+- [x] 6.1 구현 시작 inventory에서 포함·제외 대상과 직접 플랫폼 target 계산 baseline을 기록한다.
+- [ ] 6.2 App unit·typecheck·lint·Storybook build·interaction과 대상 Web runtime 검증을 완료한다.
+- [ ] 6.3 독립 구현 리뷰에서 target floor, visual 무변경, 상태·제품 동작 전달, 누락과 검증 공백을 확인한다.
+- [ ] 6.4 Merge 직전 production/open PR inventory와 review thread를 다시 읽고 새 대상의 누락·잘못된 전환이 없음을 확인한다.
+- [ ] 6.5 각 적용 PR 본문에 구현·검증·Native 미실행·남은 owner를 동기화한다.
+- [ ] 6.6 모든 task와 cross-PR 완료 증거가 준비되면 실제 마지막 owner가 change를 archive하고 archive 후 validation·Linear 상태를 확인한다.

--- a/openspec/changes/add-local-profile-edit/tasks.md
+++ b/openspec/changes/add-local-profile-edit/tasks.md
@@ -221,43 +221,7 @@ race를 수정한다. 정상 저장은 실제 Profile route commit으로 끝나�
 - [x] 3.5 관련 app·API·BFF·core 필수 검증과 Web dev runtime QA를 완료하고 원인·수정·남은 위험을 기록한 뒤
       PROD-490 통합 검증 담당자에게 evidence를 전달한다.
 
-## 4. PROD-548 공용 IconButton과 Profile edit action 정렬
-
-**Authority / Provenance**
-
-- `docs/design/accessibility.md`
-- `docs/design/profile-edit.md`
-- `docs/design/profile-tags.md`
-- `PROD-548`
-
-**Deliverable**
-
-플랫폼별 최소 입력 target, 접근성 button semantics와 pressed·disabled 상태를 소유하는 React Native 공용
-`IconButton`을 추가하고 Profile edit의 뒤로가기, avatar/header 이미지 편집, Profile Tag 제거 action에 적용한다.
-
-**Guardrails**
-
-- 기존 시각 크기와 배치를 유지하면서 Web `32×32 CSS px`, iOS `44×44 pt`, Android `48×48 dp` 최소 입력
-  target mapping을 공용 구현으로 중앙화한다.
-- header/avatar preview 전체를 각각 하나의 button으로 유지하고 camera affordance를 별도 focus target으로 만들지 않는다.
-- Profile edit의 저장·Media·navigation 동작, 다른 화면의 icon action과 공용 Button 계약을 변경하지 않는다.
-- 현재 완료 조건은 Web component test와 Web runtime 검증이다. iOS·Android mapping은 공용 구현과 자동화로
-  유지하되 실제 기기·simulator runtime QA는 Native 출시 gate에서 수행한다.
-
-**Verification**
-
-- 공용 component test에서 플랫폼별 target mapping, 필수 accessibility label, disabled state와 시각 크기·입력
-  target 분리를 검증한다.
-- Profile edit Storybook에서 뒤로가기와 이미지 편집 preview, Profile Tag 제거 action이 단일 button semantics,
-  기존 geometry, overlap·clipping 없는 배치를 유지하는지 확인한다.
-- app 단위 test, TypeScript, Storybook build·interaction과 Web runtime을 통과하고 Native runtime 미실행을 PR에 기록한다.
-
-- [x] 4.1 공용 `IconButton`을 component test로 정의하고 Profile edit 뒤로가기·이미지 편집·Profile Tag 제거 action을
-      교체해 플랫폼별 target mapping과 기존 single-focus·geometry를 유지한다.
-- [x] 4.2 app 필수 자동화와 Web runtime을 검증하고 독립 구현 리뷰를 통과한 뒤 PROD-548 PR에 증거와 Native 실제
-      기기·simulator runtime QA 제외를 기록한다.
-
-## 5. PROD-490 통합 검증과 OpenSpec archive
+## 4. PROD-490 통합 검증과 OpenSpec archive
 
 **Authority / Provenance**
 
@@ -289,11 +253,11 @@ canonical·Linear·구현·OpenSpec이 일치할 때 `add-local-profile-edit`을
   followPolicy Switch가 enum과 동일 저장 경계로 제공되는지 확인한다.
 - archive 전후 strict validation과 delta spec 동기화를 확인한다.
 
-- [ ] 5.1 PROD-491·492·613·548 완료 조건, PR, 필수 test와 unresolved review thread를 확인한다.
-- [ ] 5.2 Owner 성공과 guest/Member/무관 Account·invalid text/Media·upload/save 실패·post-commit 응답 이상·
+- [ ] 4.1 PROD-491·492·613 완료 조건, PR, 필수 test와 unresolved review thread를 확인한다.
+- [ ] 4.2 Owner 성공과 guest/Member/무관 Account·invalid text/Media·upload/save 실패·post-commit 응답 이상·
       dirty navigation 복구를
       종단 간 검증한다.
-- [ ] 5.3 Profile Tag 저장·공개 표시와 Settings 이전은 제외 범위로 유지하고, 현재 followPolicy 저장 경계·기존
+- [ ] 4.3 Profile Tag 저장·공개 표시와 Settings 이전은 제외 범위로 유지하고, 현재 followPolicy 저장 경계·기존
       Pending Follow Request 불변과 Profile Link 제외 범위·기존 Profile 조회 회귀를 확인한다.
-- [ ] 5.4 canonical·Linear·OpenSpec 정합성과 strict validation을 확인한다.
-- [ ] 5.5 모든 task와 통합 gate 완료 뒤 change를 archive하고 archive 후 validation·Linear 상태를 확인한다.
+- [ ] 4.4 canonical·Linear·OpenSpec 정합성과 strict validation을 확인한다.
+- [ ] 4.5 모든 task와 통합 gate 완료 뒤 change를 archive하고 archive 후 validation·Linear 상태를 확인한다.

--- a/openspec/changes/add-local-profile-edit/tasks.md
+++ b/openspec/changes/add-local-profile-edit/tasks.md
@@ -252,7 +252,7 @@ race를 수정한다. 정상 저장은 실제 Profile route commit으로 끝나�
   기존 geometry, overlap·clipping 없는 배치를 유지하는지 확인한다.
 - app 단위 test, TypeScript, Storybook build·interaction과 Web runtime을 통과하고 Native runtime 미실행을 PR에 기록한다.
 
-- [ ] 4.1 공용 `IconButton`을 component test로 정의하고 Profile edit 뒤로가기·이미지 편집·Profile Tag 제거 action을
+- [x] 4.1 공용 `IconButton`을 component test로 정의하고 Profile edit 뒤로가기·이미지 편집·Profile Tag 제거 action을
       교체해 플랫폼별 target mapping과 기존 single-focus·geometry를 유지한다.
 - [ ] 4.2 app 필수 자동화와 Web runtime을 검증하고 독립 구현 리뷰를 통과한 뒤 PROD-548 PR에 증거와 Native 실제
       기기·simulator runtime QA 제외를 기록한다.

--- a/openspec/changes/add-local-profile-edit/tasks.md
+++ b/openspec/changes/add-local-profile-edit/tasks.md
@@ -221,7 +221,43 @@ race를 수정한다. 정상 저장은 실제 Profile route commit으로 끝나�
 - [x] 3.5 관련 app·API·BFF·core 필수 검증과 Web dev runtime QA를 완료하고 원인·수정·남은 위험을 기록한 뒤
       PROD-490 통합 검증 담당자에게 evidence를 전달한다.
 
-## 4. PROD-490 통합 검증과 OpenSpec archive
+## 4. PROD-548 공용 IconButton과 Profile edit action 정렬
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `docs/design/profile-edit.md`
+- `docs/design/profile-tags.md`
+- `PROD-548`
+
+**Deliverable**
+
+플랫폼별 최소 입력 target, 접근성 button semantics와 pressed·disabled 상태를 소유하는 React Native 공용
+`IconButton`을 추가하고 Profile edit의 뒤로가기, avatar/header 이미지 편집, Profile Tag 제거 action에 적용한다.
+
+**Guardrails**
+
+- 기존 시각 크기와 배치를 유지하면서 Web `32×32 CSS px`, iOS `44×44 pt`, Android `48×48 dp` 최소 입력
+  target mapping을 공용 구현으로 중앙화한다.
+- header/avatar preview 전체를 각각 하나의 button으로 유지하고 camera affordance를 별도 focus target으로 만들지 않는다.
+- Profile edit의 저장·Media·navigation 동작, 다른 화면의 icon action과 공용 Button 계약을 변경하지 않는다.
+- 현재 완료 조건은 Web component test와 Web runtime 검증이다. iOS·Android mapping은 공용 구현과 자동화로
+  유지하되 실제 기기·simulator runtime QA는 Native 출시 gate에서 수행한다.
+
+**Verification**
+
+- 공용 component test에서 플랫폼별 target mapping, 필수 accessibility label, disabled state와 시각 크기·입력
+  target 분리를 검증한다.
+- Profile edit Storybook에서 뒤로가기와 이미지 편집 preview, Profile Tag 제거 action이 단일 button semantics,
+  기존 geometry, overlap·clipping 없는 배치를 유지하는지 확인한다.
+- app 단위 test, TypeScript, Storybook build·interaction과 Web runtime을 통과하고 Native runtime 미실행을 PR에 기록한다.
+
+- [ ] 4.1 공용 `IconButton`을 component test로 정의하고 Profile edit 뒤로가기·이미지 편집·Profile Tag 제거 action을
+      교체해 플랫폼별 target mapping과 기존 single-focus·geometry를 유지한다.
+- [ ] 4.2 app 필수 자동화와 Web runtime을 검증하고 독립 구현 리뷰를 통과한 뒤 PROD-548 PR에 증거와 Native 실제
+      기기·simulator runtime QA 제외를 기록한다.
+
+## 5. PROD-490 통합 검증과 OpenSpec archive
 
 **Authority / Provenance**
 
@@ -253,11 +289,11 @@ canonical·Linear·구현·OpenSpec이 일치할 때 `add-local-profile-edit`을
   followPolicy Switch가 enum과 동일 저장 경계로 제공되는지 확인한다.
 - archive 전후 strict validation과 delta spec 동기화를 확인한다.
 
-- [ ] 4.1 PROD-491·492·613 완료 조건, PR, 필수 test와 unresolved review thread를 확인한다.
-- [ ] 4.2 Owner 성공과 guest/Member/무관 Account·invalid text/Media·upload/save 실패·post-commit 응답 이상·
+- [ ] 5.1 PROD-491·492·613·548 완료 조건, PR, 필수 test와 unresolved review thread를 확인한다.
+- [ ] 5.2 Owner 성공과 guest/Member/무관 Account·invalid text/Media·upload/save 실패·post-commit 응답 이상·
       dirty navigation 복구를
       종단 간 검증한다.
-- [ ] 4.3 Profile Tag 저장·공개 표시와 Settings 이전은 제외 범위로 유지하고, 현재 followPolicy 저장 경계·기존
+- [ ] 5.3 Profile Tag 저장·공개 표시와 Settings 이전은 제외 범위로 유지하고, 현재 followPolicy 저장 경계·기존
       Pending Follow Request 불변과 Profile Link 제외 범위·기존 Profile 조회 회귀를 확인한다.
-- [ ] 4.4 canonical·Linear·OpenSpec 정합성과 strict validation을 확인한다.
-- [ ] 4.5 모든 task와 통합 gate 완료 뒤 change를 archive하고 archive 후 validation·Linear 상태를 확인한다.
+- [ ] 5.4 canonical·Linear·OpenSpec 정합성과 strict validation을 확인한다.
+- [ ] 5.5 모든 task와 통합 gate 완료 뒤 change를 archive하고 archive 후 validation·Linear 상태를 확인한다.

--- a/openspec/changes/add-local-profile-edit/tasks.md
+++ b/openspec/changes/add-local-profile-edit/tasks.md
@@ -254,7 +254,7 @@ race를 수정한다. 정상 저장은 실제 Profile route commit으로 끝나�
 
 - [x] 4.1 공용 `IconButton`을 component test로 정의하고 Profile edit 뒤로가기·이미지 편집·Profile Tag 제거 action을
       교체해 플랫폼별 target mapping과 기존 single-focus·geometry를 유지한다.
-- [ ] 4.2 app 필수 자동화와 Web runtime을 검증하고 독립 구현 리뷰를 통과한 뒤 PROD-548 PR에 증거와 Native 실제
+- [x] 4.2 app 필수 자동화와 Web runtime을 검증하고 독립 구현 리뷰를 통과한 뒤 PROD-548 PR에 증거와 Native 실제
       기기·simulator runtime QA 제외를 기록한다.
 
 ## 5. PROD-490 통합 검증과 OpenSpec archive


### PR DESCRIPTION
## 요약

- 앱 전역의 compact 단일 icon·glyph·짧은 기호 action을 위한 공용 `IconButton`을 추가합니다.
- Web은 실제 interactive element가 최소 32×32 CSS px를 보장하며 caller의 target·style·`hitSlop`으로 우회할 수 없습니다.
- Native는 기존 visual·layout box를 유지하면서 iOS 44pt·Android 48dp에 부족한 영역만 공용 `hitSlop`으로 보충합니다.
- 기존 glyph 크기, 색상, 배치, pressed·disabled 표현과 제품 동작은 변경하지 않습니다.

## 적용 범위

현재 production의 14개 action을 전환했습니다.

- Profile edit back, Profile Tag remove
- UniversalShell menu/back, Post detail back
- ModalSheet close, ReplyComposer close
- FeedbackOverlay close
- Search clear, recent-search delete
- Post Composer media add/remove
- ReactionSummary more
- Compact Logout

상태형·toggle·icon+count·count control, pill·tab·switch, Link·row, whole-preview/content action, retry, compound control, noncompact Logout과 PostActionBar는 제외했습니다.

## 시각·접근성 계약

- Web target과 기존 visual geometry를 분리했습니다.
- 함수형 outer `style`은 `targetSize` 또는 `visualSize` 중 하나를 TypeScript API에서 필수로 요구합니다.
- 정적 square style의 크기 추론은 유지하며 함수형 callback을 미리 실행하거나 별도 `layoutSize` prop은 추가하지 않습니다.
- FeedbackOverlay close의 기존 36×36 geometry, X 20, pressed background, disabled 표현과 focus lifecycle을 유지합니다.
- Media remove는 target·visual 32×32와 preview 상·우 4px inset을 유지합니다.
- Reaction More는 Web 32×32와 인접 token 간격 4px를 유지합니다.
- Search와 compact Logout의 기존 44×44 target을 유지합니다.
- Post Composer media add는 40pt layout과 48pt effective target을 유지합니다.
- `targetSize`·`visualSize`가 없는 static square style도 Native layout을 보존하고 부족분만 `hitSlop`으로 보충합니다.
- 현재 production의 유일한 함수형 outer style caller인 FeedbackOverlay는 기존부터 `targetSize={36}`을 제공하므로 제품 시각 변경이 없습니다.
- Native 실제 기기·simulator의 touch, clipping, focus, VoiceOver·TalkBack 검증은 실행하지 않았으며 별도 출시 gate로 남깁니다.

## 소비자 PR

- 먼저 merge된 PR #486의 FeedbackOverlay close는 이 PR이 production에서 흡수했습니다.
- 열린 PR #510의 PostMediaViewer close/previous/next 3개 action은 공용 component 반영 뒤 해당 branch에서 전환합니다.
- 이를 위해 PR base나 stack은 임의로 변경하지 않습니다.

## 검증

- Relay compiler `--noWatchman`: reader 103 / normalization 65 / operation 111
- IconButton unit 11/11
- App unit 214/214
- TypeScript
- ESLint, Prettier, syncpack
- Storybook production build
- 전체 Storybook Chromium interaction 22 files / 316 tests
- `add-common-icon-button`, `add-web-feedback-overlay`, `add-local-profile-edit` strict validation
- 최신 `origin/main=8147253d` 재베이스 및 12개 커밋 range-diff 동일 확인
- production의 직접 Pressable 69곳, IconButton 14곳 재검색
- PR review P2 반영: 40pt media layout의 기존 48pt effective target 보존
- PR review P2 반영: static style-only 40×40 Native layout 보존
- PR review P2 반영: 함수형 outer style의 안정적인 size를 public API에서 요구
- 독립 구현 재검토 PASS

## 남은 게이트

- PR #510의 close/previous/next 3개 action 전환과 자체 Web 검증
- 적용 소비자 PR 본문 동기화
- 전체 cross-PR scope 완료 후 실제 마지막 owner의 OpenSpec archive
- iOS·Android 실제 기기·simulator 출시 검증

이 PR의 scoped 구현 완료와 OpenSpec 전체 archive는 별도 판단으로 유지합니다.
