### PR TITLE
CodeGraph 생성 데이터가 Git에 포함되지 않게 한다

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore


### PR DESCRIPTION
## 무엇을 변경했는지

- `.codegraph/.gitignore`를 추가해 CodeGraph 디렉터리의 생성 데이터를 무시합니다.
- `.gitignore` 자체만 예외로 남겨 데이터베이스, WAL/SHM, PID, 소켓, 로그가 커밋 대상에 포함되지 않게 합니다.

## 왜 변경했는지

CodeGraph 데이터와 데몬 런타임 파일은 각 개발 머신에서 생성되는 로컬 산출물입니다. 저장소가 이를 추적하지 않도록 해 거대한 데이터베이스나 실행 중인 데몬 파일이 실수로 커밋되지 않게 합니다.

## 이번 PR의 주요 결정

없음. 이번 변경에는 별도 제품 결정이나 OpenSpec 변경이 없습니다. Linear 이슈가 제공되지 않아 `agent/codegraph-gitignore`라는 좁은 설명형 브랜치를 사용했습니다.

## 어떻게 확인할 수 있는지

- `git diff HEAD^ HEAD --check`
- `git check-ignore -v .codegraph/codegraph.db .codegraph/codegraph.db-wal .codegraph/daemon.log .codegraph/daemon.pid .codegraph/daemon.sock`
- 커밋에는 `.codegraph/.gitignore` 한 파일만 포함됨을 `git show --stat HEAD`로 확인

## 아직 어떤 문제가 남았는지

없음. 현재 로컬 CodeGraph 생성 파일은 계속 무시되며 커밋하지 않았습니다.