### PR TITLE
런타임 이미지의 undici High 취약점을 제거한다

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6514,8 +6514,8 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -11734,7 +11734,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -13559,7 +13559,7 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `@kosmo/core`의 `jsdom 29.1.1` 전이 의존성 `undici`를 `7.28.0`에서 보안 패치 버전 `7.29.0`으로 갱신했습니다.
- package manifest, Node 런타임, Dockerfile, pnpm override는 변경하지 않았습니다.

## 왜 변경했는지

[Trivy Scan 30976044345](https://github.com/byulmaru/kosmo/actions/runs/30976044345)이 런타임 이미지에서 High 취약점 [CVE-2026-13697 / GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272)을 탐지했습니다. `jsdom`이 허용하는 기존 `undici` 7.x 범위 안에서 수정 버전을 선택해 취약한 패키지가 다음 런타임 이미지에 포함되지 않게 합니다.

## 이번 PR의 주요 결정

### 전이 의존성의 패치 버전만 갱신

- 결정자: @robin-maki
- 선택: `pnpm-lock.yaml`에서 `undici 7.29.0`을 해소합니다.
- 고려한 대안: `jsdom 30` 메이저 업그레이드, Node 베이스 변경, 직접 의존성 추가, 영구 pnpm override
- 이유: `jsdom 29.1.1`의 `undici ^7.25.0` 계약 안에서 공식 수정 버전을 적용할 수 있어 가장 작은 변경으로 취약점을 제거할 수 있습니다.
- 감수한 결과: 실제 제거 증거는 이 PR의 새 런타임 이미지가 빌드된 뒤 Trivy 재검사로 확정됩니다.
- 관련 근거: [PROD-694](https://linear.app/byulmaru/issue/PROD-694/trivy가-탐지한-undici-cve-2026-13697을-패치한다), [GitHub Advisory](https://github.com/advisories/GHSA-4cwx-7wf7-3272)

## 어떻게 확인할 수 있는지

- `CI=true pnpm --filter @kosmo/core test:unit` — 51 tests passed
- `pnpm lint:prettier` — passed
- `git diff --check` — passed
- pnpm supply-chain policy verification — passed

## 아직 어떤 문제가 남았는지

- 병합 후 새 런타임 이미지 digest를 대상으로 Trivy를 다시 실행해 `CVE-2026-13697` 미검출을 확인해야 합니다.