### PR TITLE
Web navigation scroll E2E가 runner 타이밍에 흔들리지 않게 한다

### DIFF
--- a/apps/web/e2e/navigation-scroll.e2e.ts
+++ b/apps/web/e2e/navigation-scroll.e2e.ts
@@ -252,11 +252,8 @@ test('search query-only 이동은 document scroll과 입력 focus를 보존하�
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   await page.mouse.wheel(0, -120);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(offsetBeforeWheel);
-  const offsetAfterWheel = await page.evaluate(() => window.scrollY);
   await waitAnimationFrames(page);
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(offsetAfterWheel);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeLessThan(offsetBeforeWheel);
-  expect(offsetAfterWheel).toBeLessThan(offsetBeforeWheel);
   await expect(input).toBeFocused();
 
   await page.getByRole('link', { name: '뒤로', exact: true }).click();


### PR DESCRIPTION
## 무엇을 변경했는지

- Web navigation E2E에서 wheel 직후의 transient scroll 좌표를 저장하지 않도록 했습니다.
- 4 animation frame 뒤에도 해당 중간 좌표와 정확히 같아야 한다는 assertion을 제거했습니다.
- 사용자 wheel 입력 뒤 이전 위치보다 위로 이동하고, 추가 frame 뒤에도 query 복원 로직이 되돌리지 않으며, 검색 입력 focus가 유지되는 관찰 가능한 계약은 그대로 검증합니다.

## 왜 변경했는지

최근 GitHub Actions에서 서로 무관한 여러 PR의 Web suite가 같은 `navigation-scroll.e2e.ts` assertion으로 반복 실패했습니다. wheel scroll이 아직 진행 중일 때 저장된 `169`를 고정한 뒤 이후 좌표 `49`와 exact equality를 비교해 CI runner 타이밍에 따라 실패했습니다.

대표 실패: https://github.com/byulmaru/kosmo/actions/runs/30965633453

## 이번 PR의 주요 결정

없음. 제품 동작이나 navigation 계약은 바꾸지 않고, transient 좌표에 결합된 중복 assertion만 제거했습니다. 별도 Linear 이슈나 OpenSpec은 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm exec prettier --check apps/web/e2e/navigation-scroll.e2e.ts`
- `pnpm exec eslint --max-warnings 0 apps/web/e2e/navigation-scroll.e2e.ts`
- `navigation-scroll.e2e.ts` 전체 4개 테스트 통과
- 대상 search query-only 테스트 `--repeat-each=20`: 20/20 통과
- `git diff --check`

## 아직 어떤 문제가 남았는지

없음.