### PR TITLE
프로필 헤더 이미지의 3:1 비율을 유지한다

### DIFF
--- a/apps/app/src/components/profile/ProfileHero.test.ts
+++ b/apps/app/src/components/profile/ProfileHero.test.ts
@@ -98,6 +98,33 @@ const baseProfile: ProfileData = {
   tags: [],
 };
 
+const findCoverStyle = () => {
+  const cover = renderer!.root.find(
+    (node) =>
+      (node.type as unknown) === 'View' &&
+      Array.isArray(node.props.style) &&
+      node.props.style[0]?.width === '100%',
+  );
+  return cover.props.style[0];
+};
+
+describe('ProfileHero cover geometry', () => {
+  it('data/no-header branch uses the shared 3:1 cover geometry', async () => {
+    await renderProfile(baseProfile);
+
+    assert.deepEqual(findCoverStyle(), { aspectRatio: 3, width: '100%' });
+  });
+
+  it('loading branch uses the shared 3:1 cover geometry', async () => {
+    await act(async () => {
+      renderer = create(createElement(ProfileHero, { loading: true }));
+    });
+    assert.ok(renderer);
+
+    assert.deepEqual(findCoverStyle(), { aspectRatio: 3, width: '100%' });
+  });
+});
+
 describe('ProfileHero media presentation', () => {
   it('header와 avatar URL을 각각 cover 이미지로 렌더한다', async () => {
     await renderProfile({

--- a/apps/app/src/components/profile/ProfileHero.tsx
+++ b/apps/app/src/components/profile/ProfileHero.tsx
@@ -137,7 +137,7 @@ export function ProfileHero({ action, loading = false, profile = null }: Profile
 
 const styles = StyleSheet.create({
   root: { marginBottom: spacing.xl },
-  cover: { height: 104, width: '100%' },
+  cover: { aspectRatio: 3, width: '100%' },
   coverImage: { height: '100%', width: '100%' },
   body: { paddingHorizontal: spacing.lg },
   avatarRow: { alignItems: 'flex-start', flexDirection: 'row', justifyContent: 'space-between' },

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,6 +20,7 @@ KOSMO의 UI/프로덕트 디자인 결정을 기록하고 공유하는 문서 �
 - [media-upload-errors.md](./media-upload-errors.md) — Post Composer·Profile 편집의 공통 이미지 업로드 오류 분류와 복구 안내
 - [reactions.md](./reactions.md) — Reaction Quick Picker, 요약 token toggle과 Profile 목록의 형태·상태·대상 Post 계약
 - [profile-edit.md](./profile-edit.md) — Local Profile 편집 화면의 필드, 상태와 route 연결 경계
+- [profile-hero.md](./profile-hero.md) — 공개 Profile Hero의 header 이미지 비율, 상태와 검증 범위
 - [profile-tags.md](./profile-tags.md) — Profile Tag 편집·공개 표시의 플랫폼 공통 계약
 - [hashtag-related-profiles.md](./hashtag-related-profiles.md) — Hashtag 관련 Profile 목록 탐색의 결과·상태 계약
 

--- a/docs/design/profile-edit.md
+++ b/docs/design/profile-edit.md
@@ -114,7 +114,7 @@
 - 공개 `Profile.avatar`와 `Profile.header`는 해당 Profile 조회 정책을 통과한 viewer에게 Profile 관계를 통해
   Media identity와 표시 URL을 제공한다. 일반 Media Node의 owner-only loader 정책은 넓히지 않는다. 초기 query와
   update payload는 같은 Media `id`와 표시 field를 선택해 Relay가 같은 record를 정규화하며 `ProfileHero`가 실제
-  avatar/header를 표시한다.
+  avatar/header를 표시한다. 공개 header의 비율과 crop은 [공개 Profile Hero 디자인](./profile-hero.md)을 따른다.
 
 ### Upload, 실패 복구와 navigation
 

--- a/docs/design/profile-hero.md
+++ b/docs/design/profile-hero.md
@@ -1,0 +1,25 @@
+# 공개 Profile Hero
+
+## 목적
+
+공개 Profile 화면의 header 이미지, avatar와 action이 Web·Android·iOS의 지원 폭에서 같은 정보 구조와
+geometry를 유지하도록 한다. 이 문서는 Profile 편집 화면의 header preview가 아니라 공개 `ProfileHero`의
+표시 계약을 다룬다.
+
+## Header 이미지 geometry
+
+- header 이미지 영역은 모든 지원 폭에서 가로:세로 `3:1`을 유지한다. 너비가 `W`이면 높이는 `W / 3`이며,
+  `600px` surface에서는 `600×200`, `390px` mobile에서는 `390×130`이다.
+- Profile 데이터가 로딩 중이거나 header 이미지가 없는 상태도 같은 `3:1` 영역을 유지한다. 상태에 따라 고정
+  높이로 대체하거나 영역을 접지 않는다.
+- 원본 이미지 비율이 다르면 `3:1` 경계 안에서 중앙 기준 cover crop으로 표시한다.
+- avatar overlap과 follow 등 profile action은 header 이미지 영역 밖의 hero layout이 소유한다. 이 요소의
+  배치나 높이는 header 이미지의 `3:1` 계산에 포함하지 않는다.
+
+## 출시와 검증 범위
+
+- 공용 React Native 구현은 Web·Android·iOS에 위 geometry 계약을 적용한다.
+- 현재 PR readiness의 실제 runtime QA 범위는 Web이다. iOS·Android 실제 기기·simulator runtime QA는 이번
+  검증 범위에서 제외하고 Native 출시 gate에서 별도로 수행한다.
+- Web 자동화나 공용 source·단위 테스트 결과를 Native runtime 완료 증거로 사용하지 않는다. Native 출시
+  전에는 실제 환경에서 비율, 중앙 cover crop, avatar overlap과 profile action 배치를 다시 검증한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- 공개 `ProfileHero` 헤더의 고정 104px 높이를 3:1 `aspectRatio`로 변경했습니다.
- 데이터 및 로딩 상태가 동일한 헤더 geometry를 사용하는 회귀 테스트를 추가했습니다.
- 기존 중앙 `cover` crop과 avatar/action 배치를 유지했습니다.
- 공개 Profile Hero의 3:1 geometry와 플랫폼별 검증 경계를 canonical 디자인 문서에 명시했습니다.

## 왜 변경했는지

고정 높이는 화면 너비에 따라 헤더 이미지의 3:1 비율을 깨뜨렸습니다.  
[PROD-615](https://linear.app/byulmaru/issue/PROD-615/프로필-상세-페이지-헤더-이미지의-31-비율을-유지한다)에 정의된 대로 너비에 비례해 높이가 결정되도록 수정합니다.

## 이번 PR의 주요 결정

### 별도 OpenSpec 없이 Linear의 좁은 버그 계약을 직접 적용

- 결정자: PR 작성자
- 선택: `ProfileHero`의 공유 cover 스타일과 가장 가까운 단위 테스트만 변경
- 고려한 대안: 별도 OpenSpec change 생성
- 이유: Linear에 3:1 비율, 중앙 crop, 상태별 동일 geometry와 제외 범위가 이미 확정되어 있고 구현이 단일 스타일 변경으로 닫힘
- 감수한 결과: 관련 동작 범위가 확장되면 OpenSpec 필요성을 다시 판단해야 함
- 관련 근거: PROD-615, `docs/design/profile-hero.md`

### Native runtime QA를 Native 출시 gate로 분리

- 결정자: PR 작성자
- 선택: 이번 PR readiness의 실제 runtime QA는 Web을 대상으로 하고, Native 실제 기기·simulator QA는 Native 출시 gate에서 별도로 수행
- 고려한 대안: Native runtime QA가 끝날 때까지 Draft 유지
- 이유: 공용 React Native 구현과 회귀 테스트는 유지하되 이번 PR의 검증 범위를 현재 확인 가능한 Web runtime으로 한정
- 감수한 결과: 이번 PR은 Native runtime 완료 증거를 제공하지 않으며 Native 출시 전 실제 환경 검증이 필요함
- 관련 근거: PROD-615, `docs/design/profile-hero.md`

## 어떻게 확인할 수 있는지

- `ProfileHero.test.ts`: 6/6 통과
- `@kosmo/app test:unit`: 200/200 통과
- Relay compiler `--noWatchman`: 통과
- TypeScript `--noEmit`: 통과
- Web 런타임: 390×130, 600×200 확인
- Web 중앙 cover crop, 로딩 상태 비율, avatar/action 위치 및 콘솔 오류 없음 확인
- 문서 Prettier와 `git diff --check`: 통과

표준 `@kosmo/app check`는 샌드박스의 Watchman 권한 오류로 완료되지 않았으며, Relay와 TypeScript를 각각 실행해 통과했습니다.
Native 실제 기기·simulator runtime QA는 이번 PR의 필수 검증에서 제외했으며 Native 출시 gate에서 별도로 수행합니다.

## 아직 어떤 문제가 남았는지

없음. 단, 이 PR은 Native runtime 완료를 증명하지 않습니다.
