### PR TITLE
codebase-memory 로컬 산출물이 커밋되지 않게 한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ apps/app/ios/
 # Figma MCP 등 에이전트 도구가 레포 루트에 떨어뜨리는 임시 산출물(스크린샷 등).
 .tmp-*
 
+# codebase-memory-mcp가 생성하는 로컬 그래프 산출물입니다.
+/.codebase-memory/
+
 # 로컬 Superpowers 설계·계획 문서는 에이전트가 생성한 산출물입니다.
 /docs/superpowers/


### PR DESCRIPTION
## 무엇을 변경했나요

- 루트 `.gitignore`에 `/.codebase-memory/` 규칙을 추가했습니다.
- codebase-memory-mcp가 생성하는 로컬 그래프 산출물을 Git 추적 대상에서 제외했습니다.

## 왜 변경했나요

로컬 코드 지식 그래프 파일이 작업 트리에 나타나거나 실수로 커밋되는 일을 방지하기 위해서입니다.

## 이번 PR의 주요 결정

없음. 제품 동작이나 공개 계약을 변경하지 않는 로컬 도구 산출물 제외 규칙만 추가했습니다.

## 어떻게 확인할 수 있나요

- `git check-ignore -v --no-index .codebase-memory/graph.db.zst`
- `git show --format= --check HEAD`
- 커밋 훅의 ESLint 및 Prettier 실행 완료
- 설정 파일만 변경했으므로 애플리케이션 테스트는 실행하지 않았습니다.

## 아직 어떤 문제가 남았나요

없음.