### PR TITLE
PVC 용량 부족 대응 절차를 제공한다

### DIFF
--- a/docs/operations/persistent-volume-capacity.md
+++ b/docs/operations/persistent-volume-capacity.md
@@ -1,41 +1,34 @@
 # PersistentVolume 용량 부족 대응
 
-이 문서는 `KubePersistentVolumeFillingUp` 알림을 받은 운영자가 PVC의 용량 위험과
-workload owner를 확인하고, 데이터 보호 경계를 지키면서 용량을 확보한 뒤 복구를
-검증하기 위한 공통 runbook이다. PostgreSQL, Vault, Prometheus와 앞으로 추가될
-PVC 기반 workload에 같은 순서를 적용하되, 애플리케이션별 정책과 선언 소유자의
-절차를 우선한다.
+이 문서는 `KubePersistentVolumeFillingUp` 알림에서 PVC의 용량 위험과 workload
+owner를 확인하고, 데이터 보호 경계를 지키며 용량 확보와 복구를 검증하는 공통
+runbook이다. PostgreSQL, Vault, Prometheus와 앞으로 추가될 PVC workload에 같은
+순서를 적용하되 애플리케이션별 정책과 선언 소유자의 절차를 우선한다.
 
 ## 1. 알림을 확인하고 범위를 고정한다
 
-알림의 다음 필드를 별도 이슈나 대응 기록에 적는다. Secret, credential, database
-row, object 본문과 실제 사용자 데이터는 복사하지 않는다.
+알림의 다음 필드를 별도 이슈나 대응 기록에 적는다. Secret, credential, database row,
+object 본문과 실제 사용자 데이터는 복사하지 않는다.
 
 - `alertname`: `KubePersistentVolumeFillingUp`
 - `namespace`, `persistentvolumeclaim`, `severity`
 - `summary`, `description`
 - 알림이 firing으로 관측된 시각과 확인한 시각
 
-기존 규칙의 의미와 대상 경계를 그대로 사용한다.
+기존 규칙의 의미와 대상 경계를 그대로 사용한다. `critical`은 현재 여유 공간 부족,
+`warning`은 기존 예측 기간 안에 고갈될 추세를 뜻한다. `ReadOnlyMany` 또는
+`excluded_from_alerts=true` PVC를 이 문서가 다시 포함하지 않는다. Alertmanager
+receiver, allowlist, `#monitoring`, Slack 형식, `runbook_url`이나 Slack 링크는
+정의하지 않으며 전달 문제는 [Kubernetes 운영 문서](https://github.com/byulmaru/kubernetes/blob/main/docs/operations.md)의
+소유 범위로 넘긴다.
 
-- `critical`은 현재 여유 공간 부족을 나타낸다.
-- `warning`은 최근 추세로 보아 기존 규칙의 예측 기간 안에 고갈될 위험을 나타낸다.
-- `ReadOnlyMany` PVC와 `excluded_from_alerts=true` 라벨로 제외된 PVC를 이 문서가
-  알림 대상으로 강제로 포함하지 않는다.
-- 이 문서는 Alertmanager receiver, allowlist, `#monitoring`, Slack 메시지 형식,
-  `runbook_url` 또는 Slack runbook 링크를 정의하지 않는다. 알림 전달 자체의 문제는
-  [Kubernetes 운영 문서](https://github.com/byulmaru/kubernetes/blob/main/docs/operations.md)의
-  소유 범위로 넘긴다.
-
-알림이 PostgreSQL이 아닌 PVC에서 시작해도 아래 진단 절차를 동일하게 적용한다.
-알림이 없거나 대상 PVC가 명확하지 않으면 추측으로 다른 PVC를 변경하지 말고 관측
-담당자에게 escalation한다.
+PostgreSQL이 아닌 PVC에도 아래 절차를 적용한다. 알림이 없거나 대상 PVC가
+불명확하면 다른 PVC를 추측해 변경하지 말고 관측 담당자에게 escalation한다.
 
 ## 2. 읽기 전용으로 현재 상태를 진단한다
 
-아래 명령의 꺾쇠 괄호 안 값을 실제 값으로 바꾸되, 명령 자체에 Secret이나 데이터
-출력을 추가하지 않는다. 이 단계에서는 PVC, PV, StorageClass, Pod와 workload를
-변경하지 않는다.
+꺾쇠 괄호 안 값만 실제 값으로 바꾸고 Secret·데이터 출력을 추가하지 않는다. 이
+단계에서는 PVC, PV, StorageClass, Pod와 workload를 변경하지 않는다.
 
 ### PVC, PV와 StorageClass
 
@@ -44,7 +37,7 @@ kubectl get pvc "<pvc>" -n "<namespace>" \
   -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,REQUEST:.spec.resources.requests.storage,BOUND_PV:.spec.volumeName,STATUS_CAPACITY:.status.capacity.storage,STORAGE_CLASS:.spec.storageClassName,ACCESS:.spec.accessModes[*],VOLUME_MODE:.spec.volumeMode'
 
 kubectl get pv "<pv>" \
-  -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,CAPACITY:.spec.capacity.storage,CLAIM:.spec.claimRef.namespace/.spec.claimRef.name,RECLAIM_POLICY:.spec.persistentVolumeReclaimPolicy,CSI_DRIVER:.spec.csi.driver'
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,CAPACITY:.spec.capacity.storage,CLAIM_NAMESPACE:.spec.claimRef.namespace,CLAIM_NAME:.spec.claimRef.name,RECLAIM_POLICY:.spec.persistentVolumeReclaimPolicy,CSI_DRIVER:.spec.csi.driver'
 
 kubectl get storageclass "<storage-class>" \
   -o custom-columns='NAME:.metadata.name,PROVISIONER:.provisioner,ALLOW_EXPANSION:.allowVolumeExpansion,VOLUME_BINDING:.volumeBindingMode'
@@ -55,22 +48,19 @@ kubectl get events -n "<namespace>" \
   -o custom-columns='TIME:.lastTimestamp,TYPE:.type,REASON:.reason,MESSAGE:.message'
 ```
 
-다음 값을 서로 비교해 현재 위험을 고정한다.
+다음 값을 서로 비교해 현재 위험을 고정한다: PVC의 `REQUEST`, `STATUS_CAPACITY`,
+`STATUS`, `ACCESS`; PV의 `CAPACITY`, `PHASE`, reclaim policy, CSI driver; StorageClass의
+`PROVISIONER`, `ALLOW_EXPANSION`; PVC condition, `allocatedResourceStatuses`와
+event의 실패·대기·재시도 상태.
 
-- PVC의 `REQUEST`, `STATUS_CAPACITY`, `STATUS`와 `ACCESS`
-- 연결된 PV의 `CAPACITY`, `PHASE`, reclaim policy와 CSI driver
-- StorageClass의 `PROVISIONER`, `ALLOW_EXPANSION`
-- PVC의 resize condition, `allocatedResourceStatuses`와 event의 실패·대기·재시도
-  상태
-
-`status.capacity`가 비어 있거나 PVC가 `Bound`가 아니거나 event에 resize 실패가
-남아 있으면 확장을 완료로 간주하지 않는다. StorageClass 이름만으로 확장 가능성을
-판정하지 말고 이 incident의 live 값과 실제 provisioner/CSI driver 지원을 확인한다.
+`status.capacity`가 비어 있거나 PVC가 `Bound`가 아니거나 resize 실패 event가 남아
+있으면 확장을 완료로 간주하지 않는다. StorageClass 이름만으로 지원 여부를
+판정하지 말고 incident의 live 값과 실제 provisioner/CSI 지원을 확인한다.
 
 ### 사용량과 증가 추세
 
 Prometheus UI에서 다음 PromQL을 각각 실행한다. 결과에는 namespace, PVC, 관측 시각,
-비민감한 바이트 측정값과 관측 기간만 기록한다. 결과가 없으면 용량이 충분하다고
+비민감한 바이트 측정값과 관측 기간만 기록한다. 결과가 없다고 용량이 충분하다고
 판정하지 말고 kubelet volume metric 수집 상태를 관측 담당자에게 확인한다.
 
 ```promql
@@ -98,14 +88,13 @@ predict_linear(
 )
 ```
 
-`available / capacity`로 현재 여유 비율을 계산하고, 같은 PVC의 최근 표본에서
-available이 감소하는지 확인한다. 위의 예측식은 추세 확인용이며 이 문서가 기존
-alert threshold나 severity를 재정의하는 기준으로 사용하지 않는다.
+`available / capacity`로 여유 비율과 최근 감소 추세를 확인한다. 예측식은 추세
+확인용이며 alert threshold나 severity를 재정의하지 않는다.
 
 ### PVC를 mount한 Pod와 상위 owner
 
-먼저 PVC를 실제로 mount한 Pod를 찾는다. `jq`는 Pod spec에서 PVC 이름만 비교하고
-애플리케이션 payload를 출력하지 않는다.
+먼저 PVC를 실제로 mount한 Pod를 찾는다. `jq`는 PVC 이름만 비교하고 payload를
+출력하지 않는다.
 
 ```sh
 kubectl get pods -n "<namespace>" -o json \
@@ -116,7 +105,7 @@ kubectl get pods -n "<namespace>" -o json \
     '
 ```
 
-각 Pod에서 volume과 mount path를 확인한 뒤 owner reference를 한 단계씩 따라간다.
+각 Pod에서 volume·mount path를 확인하고 owner reference를 한 단계씩 따라간다.
 
 ```sh
 kubectl get pod "<pod>" -n "<namespace>" \
@@ -129,67 +118,55 @@ kubectl get "<owner-kind>" "<owner-name>" -n "<namespace>" \
   -o jsonpath='{range .metadata.ownerReferences[*]}{.apiVersion}{"\t"}{.kind}{"\t"}{.name}{"\tcontroller="}{.controller}{"\n"}{end}'
 ```
 
-ReplicaSet에서 Deployment로, Pod에서 StatefulSet으로 이어지는 것처럼 controller를
-끝까지 추적한다. CNPG, Vault 등 operator가 관리하는 workload라면 최종 operator
-custom resource와 그 resource가 용량을 선언하는 경로까지 확인한다. owner reference가
-없거나 controller가 분명하지 않거나 담당 service owner를 확인할 수 없으면 여기서
-멈춘다. 미확인 관계, 현재 용량 위험과 필요한 담당자를 기록하고 service owner와
-storage 운영 담당자에게 escalation한다.
+ReplicaSet→Deployment, Pod→StatefulSet처럼 controller를 끝까지 추적한다. CNPG,
+Vault 등 operator workload는 최종 custom resource와 용량 선언 경로까지 확인한다.
+owner reference·controller·service owner가 불명확하면 멈추고 미확인 관계, 현재
+위험과 필요한 담당자를 기록해 service owner와 storage 운영 담당자에게 escalation한다.
 
 ## 3. 데이터와 변경 책임을 확인한다
 
-용량을 바꾸거나 데이터를 정리하기 전에 다음을 모두 확인하고 승인자를 기록한다.
+용량을 바꾸거나 데이터를 정리하기 전에 최종 owner resource·service owner, 데이터
+성격과 승인된 retention·backup·export·rebalance 정책, 최근 backup과 복구 경계,
+목표 용량·provider 한도·quota·비용, 가용성 영향과 rollout/restart 계획을 확인하고
+승인자를 기록한다.
 
-1. workload의 최종 owner resource와 담당 service owner
-2. 데이터의 성격, 승인된 retention·backup·export·rebalance 정책
-3. 최근 backup 성공 여부와 복구 경계
-4. 목표 용량, provider 한도 또는 namespace quota와 비용 영향
-5. 확장 중 workload 가용성 영향, rollout/restart 계획과 rollback 불가 범위
+service owner가 승인한 workload 전용 절차와 제거 가능성을 확인한 경우에만 따른다.
+PostgreSQL은 [Production PostgreSQL backup과 복구](./postgres-backup.md)의
+backup·복구 경계를 먼저 확인하고, Vault·Prometheus 등은 각 owner의 절차를 따른다.
 
-서비스 owner가 승인된 workload 전용 정리 절차를 제공하고 해당 데이터가 제거 가능함을
-확인한 경우에만 그 절차를 따른다. PostgreSQL은 [Production PostgreSQL backup과
-복구](./postgres-backup.md)의 backup·복구 경계를 먼저 확인한다. Vault, Prometheus와
-다른 workload는 각 service owner의 전용 retention·backup·export 절차를 따른다.
+보존 정책·삭제 승인, 최근 backup·복구 가능성, workload owner·가용성 영향 또는
+안전한 정리·export·rebalance 절차가 하나라도 없으면 데이터를 건드리지 않는다.
 
-다음 중 하나라도 확인되지 않으면 데이터를 건드리지 않는다.
-
-- 데이터 보존 정책 또는 삭제 승인
-- 최근 backup과 복구 가능성
-- workload owner와 가용성 영향
-- 안전한 정리·export·rebalance 절차
-
-승인된 정리 경로가 없고 용량 위험이 즉시 해소되어야 하면 지원되는 volume 확장 또는
-별도 snapshot/backup/migration 계획을 escalation한다. 이 공통 runbook은 데이터
-내용 삭제, 공통 purge, retention 정책 결정, PVC/PV 교체나 reclaim policy 변경을
-제공하지 않는다.
+승인된 정리 경로가 없고 즉시 해소가 필요하면 지원되는 volume 확장 또는 별도
+snapshot/backup/migration 계획으로 escalation한다. 이 문서는 데이터 삭제·공통
+purge·retention 결정·PVC/PV 교체·reclaim policy 변경을 제공하지 않는다.
 
 ## 4. 지원되는 방법으로 용량을 확장한다
 
 ### 사전 조건
 
-다음 조건을 모두 확인한 뒤에만 확장을 선택한다.
+다음 조건을 모두 확인한 뒤에만 확장을 선택한다: live StorageClass의
+`allowVolumeExpansion=true`, provisioner·CSI driver 지원, 현재 PVC request/status보다
+큰 목표 용량, provider 한도·quota·비용·가용성 승인, 용량 선언 source와 reconcile 방식,
+backup·owner 승인과 필요한 rollout/restart 계획.
 
-- StorageClass의 `allowVolumeExpansion=true`
-- 해당 `provisioner`와 CSI driver가 volume expansion을 지원함
-- 목표 용량이 현재 PVC request와 PV/PVC status capacity보다 큼
-- 목표 용량이 provider 한도와 quota 안에 있으며 비용·가용성 영향이 승인됨
-- workload가 용량을 선언하는 source of truth와 reconcile 방식이 확인됨
-- backup, owner 승인과 필요한 rollout/restart 계획이 준비됨
+StorageClass 또는 CSI 지원 여부가 불명확하거나 expansion을 지원하지 않으면 PVC/PV를
+교체하지 말고 데이터 보호 계획을 포함한 별도 migration 또는 storage 운영 escalation을
+만든다.
 
-StorageClass 또는 CSI 지원 여부를 확인할 수 없거나 expansion을 지원하지 않으면
-PVC/PV를 임의로 교체하지 않는다. 데이터 보호 계획이 포함된 별도 migration 또는
-storage 운영 escalation을 만든다.
+### 선언 source와 기존 PVC를 정합화한다
 
-### 선언 source를 먼저 변경한다
+선언 source는 다음 세 경로를 구분한다.
 
-StatefulSet의 `volumeClaimTemplates`, operator custom resource, Helm/GitOps 선언 등
-상위 resource가 용량을 소유하면 해당 선언 source를 목표 용량으로 변경하고 정상적인
-reconcile을 기다린다. 상위 resource가 다시 PVC request를 덮어쓰는 환경에서 live PVC만
-수정하지 않는다.
+| 선언 source                              | 확장 경로                                                                                                                                                                                                                                                                           |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Operator                                 | 지원된 resize field/reconcile만 사용한다. 경로가 없거나 불명확하면 owner가 direct patch 또는 migration을 별도 승인하며, operator가 덮어쓰는 동안 live PVC를 수정하지 않는다.                                                                                                        |
+| Standalone PVC declaration (Helm/GitOps) | PVC manifest를 직접 소유하면 모든 gate 뒤 declaration을 늘리고 reconcile한 뒤 live PVC 결과를 확인한다.                                                                                                                                                                             |
+| StatefulSet template (Helm/GitOps 포함)  | 기존 object의 `spec.volumeClaimTemplates`는 API가 immutable field로 거부하므로 generic in-place 변경/reconcile하지 않는다. 기존 bound PVC direct patch와 template·미래 replica 정합화는 owner 승인 recreation/migration 계획으로 별도 처리하며 이 runbook은 교체를 실행하지 않는다. |
 
-owner와 선언 source를 확인했으며 해당 PVC가 직접 관리되는 경우에만 다음처럼 기존
-PVC의 request를 더 큰 값으로 변경한다. `<target-size>`는 현재 request/status보다
-큰 승인된 값이어야 한다.
+owner와 선언 source를 확인하고 backup, StorageClass/CSI 지원, 목표 용량·quota,
+service owner 승인과 가용성 gate를 모두 통과한 경우에만 기존 PVC request를 직접
+늘린다. `<target-size>`는 현재 request/status보다 큰 승인된 값이어야 한다.
 
 ```sh
 kubectl patch pvc "<pvc>" -n "<namespace>" \
@@ -197,18 +174,16 @@ kubectl patch pvc "<pvc>" -n "<namespace>" \
   --patch='{"spec":{"resources":{"requests":{"storage":"<target-size>"}}}}'
 ```
 
-Kubernetes가 기존 PV를 resize하도록 PVC request만 변경한다. PV의 capacity를 직접
-편집하거나 PVC request를 줄이지 않는다. 이 runbook에는 자동 증설, PVC/PV 교체,
-reclaim policy 변경과 volume purge 절차가 없다.
+Kubernetes가 기존 PV를 resize하도록 PVC request만 변경한다. PV capacity를 직접
+편집하거나 PVC request를 줄이지 않는다. 자동 증설, PVC/PV 교체, reclaim policy 변경,
+volume purge 절차는 없다.
 
 ### filesystem과 workload 반영
 
 변경 직후 완료 처리하지 말고 PVC condition, allocated resource status와 event를
-반복 확인한다. ReadWrite로 mount된 filesystem은 driver와 filesystem이 online resize를
-지원하면 running Pod에서 반영될 수 있다. 새 Pod가 필요하거나 condition이 restart를
-요구하면 service owner와 가용성 영향을 다시 확인한 뒤 workload가 소유한 방식으로
-통제된 rollout/restart를 수행한다. online expansion이 가능한 경우 불필요한 Pod
-재시작을 고정 절차로 만들지 않는다.
+반복 확인한다. ReadWrite filesystem이 online resize를 지원하면 running Pod에 반영될
+수 있다. 새 Pod가 필요하거나 condition이 restart를 요구할 때만 owner와 가용성 영향을
+다시 확인해 workload 소유 방식으로 통제된 rollout/restart를 수행한다.
 
 filesystem 용량은 mount path를 확인한 뒤 파일 내용이 아닌 filesystem 통계만 읽는다.
 
@@ -217,10 +192,9 @@ kubectl exec -n "<namespace>" "<pod>" -c "<container>" -- \
   df -P -k "<mount-path>"
 ```
 
-operator custom resource가 restart나 failover를 소유하는 경우 generic rollout 명령을
-사용하지 말고 해당 operator의 승인된 절차를 따른다. 확장·restart 중 readiness가
-떨어지거나 event가 반복되면 변경을 완료 처리하지 않고 service owner와 storage 운영
-담당자에게 escalation한다.
+operator custom resource가 restart나 failover를 소유하면 generic rollout 대신 operator
+절차를 따른다. 확장·restart 중 readiness가 떨어지거나 event가 반복되면 완료 처리하지
+않고 service owner와 storage 운영 담당자에게 escalation한다.
 
 ## 5. 복구와 alert 해소를 검증한다
 
@@ -245,14 +219,10 @@ kubectl get "<owner-kind>" "<owner-name>" -n "<namespace>" \
   -o custom-columns='NAME:.metadata.name,READY:.status.readyReplicas,AVAILABLE:.status.availableReplicas,PHASE:.status.phase'
 ```
 
-검증 기준은 다음과 같다.
-
-- PVC가 `Bound`이고 request와 status capacity가 목표 용량으로 수렴한다.
-- resize condition과 allocated resource status에 실패·대기·반복 재시도가 남지 않는다.
-- mount filesystem의 용량과 여유 공간이 증가하고, 예상 증가 추세가 다시 고갈 위험을
-  만들지 않는다.
-- Pod, 상위 workload와 workload별 health/readiness가 정상이다.
-- Prometheus에서 다음 query가 해당 PVC에 firing series를 반환하지 않는다.
+검증 기준은 PVC가 `Bound`이고 request/status capacity가 목표에 수렴하며 resize
+condition·allocated status에 실패·대기·반복 재시도가 없는지, mount filesystem과
+여유 공간·예상 추세 및 Pod·상위 workload health/readiness가 정상인지, Prometheus가
+해당 PVC의 firing series를 반환하지 않는지 확인한다.
 
 ```promql
 ALERTS{
@@ -264,20 +234,16 @@ ALERTS{
 ```
 
 resize가 실패·대기·재시도 중이거나 workload가 Ready가 아니거나 alert가 계속 firing이면
-대응을 완료 처리하지 않는다. 현재 상태, 가용성 영향, 마지막 정상 측정과 escalation
-담당자를 기록한다. Slack resolved notification과 전달 실패 검증은 이 문서의 소유
-범위가 아니며 Kubernetes 저장소의 기존 전달 경계에서 별도로 확인한다.
+완료 처리하지 말고 현재 상태, 가용성 영향, 마지막 정상 측정과 담당자를 기록한다.
+Slack resolved notification과 전달 실패 검증은 Kubernetes 저장소의 기존 경계에서
+별도로 확인한다.
 
 ## 6. 비민감 대응 증거
 
-운영 이슈에는 raw command output 대신 다음 요약만 남긴다.
-
-- alertname, namespace, PVC 이름, severity와 관측 시각
-- request/status capacity, available/capacity 측정값, 관측 기간과 추세 판단
-- PV/StorageClass의 상태, resize condition/event의 reason과 성공·실패 여부
-- 최종 workload owner, service owner, 승인된 조치와 선언 source
-- filesystem 반영, workload readiness/health와 alert가 더 이상 firing이 아닌 시각
-- 실패 시 현재 상태, 가용성 영향과 escalation 대상
+운영 이슈에는 raw command output 대신 alert context(이름·namespace·PVC·severity·시각),
+request/status와 available/capacity·추세, PV/StorageClass·resize condition/event 상태,
+최종 owner·승인 조치·선언 source, filesystem/workload 복구·alert 해소 시각과 실패 시
+현재 상태·영향·escalation 대상만 요약한다.
 
 Secret 값, credential, connection string, database row, object payload, 파일 내용과
 실제 사용자 데이터는 terminal history, CI log, Linear, Slack 또는 commit에 남기지

--- a/docs/operations/persistent-volume-capacity.md
+++ b/docs/operations/persistent-volume-capacity.md
@@ -1,0 +1,290 @@
+# PersistentVolume 용량 부족 대응
+
+이 문서는 `KubePersistentVolumeFillingUp` 알림을 받은 운영자가 PVC의 용량 위험과
+workload owner를 확인하고, 데이터 보호 경계를 지키면서 용량을 확보한 뒤 복구를
+검증하기 위한 공통 runbook이다. PostgreSQL, Vault, Prometheus와 앞으로 추가될
+PVC 기반 workload에 같은 순서를 적용하되, 애플리케이션별 정책과 선언 소유자의
+절차를 우선한다.
+
+## 1. 알림을 확인하고 범위를 고정한다
+
+알림의 다음 필드를 별도 이슈나 대응 기록에 적는다. Secret, credential, database
+row, object 본문과 실제 사용자 데이터는 복사하지 않는다.
+
+- `alertname`: `KubePersistentVolumeFillingUp`
+- `namespace`, `persistentvolumeclaim`, `severity`
+- `summary`, `description`
+- 알림이 firing으로 관측된 시각과 확인한 시각
+
+기존 규칙의 의미와 대상 경계를 그대로 사용한다.
+
+- `critical`은 현재 여유 공간 부족을 나타낸다.
+- `warning`은 최근 추세로 보아 기존 규칙의 예측 기간 안에 고갈될 위험을 나타낸다.
+- `ReadOnlyMany` PVC와 `excluded_from_alerts=true` 라벨로 제외된 PVC를 이 문서가
+  알림 대상으로 강제로 포함하지 않는다.
+- 이 문서는 Alertmanager receiver, allowlist, `#monitoring`, Slack 메시지 형식,
+  `runbook_url` 또는 Slack runbook 링크를 정의하지 않는다. 알림 전달 자체의 문제는
+  [Kubernetes 운영 문서](https://github.com/byulmaru/kubernetes/blob/main/docs/operations.md)의
+  소유 범위로 넘긴다.
+
+알림이 PostgreSQL이 아닌 PVC에서 시작해도 아래 진단 절차를 동일하게 적용한다.
+알림이 없거나 대상 PVC가 명확하지 않으면 추측으로 다른 PVC를 변경하지 말고 관측
+담당자에게 escalation한다.
+
+## 2. 읽기 전용으로 현재 상태를 진단한다
+
+아래 명령의 꺾쇠 괄호 안 값을 실제 값으로 바꾸되, 명령 자체에 Secret이나 데이터
+출력을 추가하지 않는다. 이 단계에서는 PVC, PV, StorageClass, Pod와 workload를
+변경하지 않는다.
+
+### PVC, PV와 StorageClass
+
+```sh
+kubectl get pvc "<pvc>" -n "<namespace>" \
+  -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,REQUEST:.spec.resources.requests.storage,BOUND_PV:.spec.volumeName,STATUS_CAPACITY:.status.capacity.storage,STORAGE_CLASS:.spec.storageClassName,ACCESS:.spec.accessModes[*],VOLUME_MODE:.spec.volumeMode'
+
+kubectl get pv "<pv>" \
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,CAPACITY:.spec.capacity.storage,CLAIM:.spec.claimRef.namespace/.spec.claimRef.name,RECLAIM_POLICY:.spec.persistentVolumeReclaimPolicy,CSI_DRIVER:.spec.csi.driver'
+
+kubectl get storageclass "<storage-class>" \
+  -o custom-columns='NAME:.metadata.name,PROVISIONER:.provisioner,ALLOW_EXPANSION:.allowVolumeExpansion,VOLUME_BINDING:.volumeBindingMode'
+
+kubectl get events -n "<namespace>" \
+  --field-selector='involvedObject.kind=PersistentVolumeClaim,involvedObject.name=<pvc>' \
+  --sort-by=.lastTimestamp \
+  -o custom-columns='TIME:.lastTimestamp,TYPE:.type,REASON:.reason,MESSAGE:.message'
+```
+
+다음 값을 서로 비교해 현재 위험을 고정한다.
+
+- PVC의 `REQUEST`, `STATUS_CAPACITY`, `STATUS`와 `ACCESS`
+- 연결된 PV의 `CAPACITY`, `PHASE`, reclaim policy와 CSI driver
+- StorageClass의 `PROVISIONER`, `ALLOW_EXPANSION`
+- PVC의 resize condition, `allocatedResourceStatuses`와 event의 실패·대기·재시도
+  상태
+
+`status.capacity`가 비어 있거나 PVC가 `Bound`가 아니거나 event에 resize 실패가
+남아 있으면 확장을 완료로 간주하지 않는다. StorageClass 이름만으로 확장 가능성을
+판정하지 말고 이 incident의 live 값과 실제 provisioner/CSI driver 지원을 확인한다.
+
+### 사용량과 증가 추세
+
+Prometheus UI에서 다음 PromQL을 각각 실행한다. 결과에는 namespace, PVC, 관측 시각,
+비민감한 바이트 측정값과 관측 기간만 기록한다. 결과가 없으면 용량이 충분하다고
+판정하지 말고 kubelet volume metric 수집 상태를 관측 담당자에게 확인한다.
+
+```promql
+kubelet_volume_stats_available_bytes{
+  namespace="<namespace>",
+  persistentvolumeclaim="<pvc>"
+}
+
+kubelet_volume_stats_capacity_bytes{
+  namespace="<namespace>",
+  persistentvolumeclaim="<pvc>"
+}
+
+kubelet_volume_stats_used_bytes{
+  namespace="<namespace>",
+  persistentvolumeclaim="<pvc>"
+}
+
+predict_linear(
+  kubelet_volume_stats_available_bytes{
+    namespace="<namespace>",
+    persistentvolumeclaim="<pvc>"
+  }[6h],
+  4 * 24 * 60 * 60
+)
+```
+
+`available / capacity`로 현재 여유 비율을 계산하고, 같은 PVC의 최근 표본에서
+available이 감소하는지 확인한다. 위의 예측식은 추세 확인용이며 이 문서가 기존
+alert threshold나 severity를 재정의하는 기준으로 사용하지 않는다.
+
+### PVC를 mount한 Pod와 상위 owner
+
+먼저 PVC를 실제로 mount한 Pod를 찾는다. `jq`는 Pod spec에서 PVC 이름만 비교하고
+애플리케이션 payload를 출력하지 않는다.
+
+```sh
+kubectl get pods -n "<namespace>" -o json \
+  | jq -r --arg pvc "<pvc>" '
+      .items[]
+      | select(any(.spec.volumes[]?; .persistentVolumeClaim.claimName == $pvc))
+      | .metadata.name
+    '
+```
+
+각 Pod에서 volume과 mount path를 확인한 뒤 owner reference를 한 단계씩 따라간다.
+
+```sh
+kubectl get pod "<pod>" -n "<namespace>" \
+  -o jsonpath='{range .spec.volumes[*]}{.name}{"\t"}{.persistentVolumeClaim.claimName}{"\n"}{end}{range .spec.containers[*]}{.name}{"\t"}{range .volumeMounts[*]}{.name}{"="}{.mountPath}{"\n"}{end}{end}'
+
+kubectl get pod "<pod>" -n "<namespace>" \
+  -o jsonpath='{range .metadata.ownerReferences[*]}{.apiVersion}{"\t"}{.kind}{"\t"}{.name}{"\tcontroller="}{.controller}{"\n"}{end}'
+
+kubectl get "<owner-kind>" "<owner-name>" -n "<namespace>" \
+  -o jsonpath='{range .metadata.ownerReferences[*]}{.apiVersion}{"\t"}{.kind}{"\t"}{.name}{"\tcontroller="}{.controller}{"\n"}{end}'
+```
+
+ReplicaSet에서 Deployment로, Pod에서 StatefulSet으로 이어지는 것처럼 controller를
+끝까지 추적한다. CNPG, Vault 등 operator가 관리하는 workload라면 최종 operator
+custom resource와 그 resource가 용량을 선언하는 경로까지 확인한다. owner reference가
+없거나 controller가 분명하지 않거나 담당 service owner를 확인할 수 없으면 여기서
+멈춘다. 미확인 관계, 현재 용량 위험과 필요한 담당자를 기록하고 service owner와
+storage 운영 담당자에게 escalation한다.
+
+## 3. 데이터와 변경 책임을 확인한다
+
+용량을 바꾸거나 데이터를 정리하기 전에 다음을 모두 확인하고 승인자를 기록한다.
+
+1. workload의 최종 owner resource와 담당 service owner
+2. 데이터의 성격, 승인된 retention·backup·export·rebalance 정책
+3. 최근 backup 성공 여부와 복구 경계
+4. 목표 용량, provider 한도 또는 namespace quota와 비용 영향
+5. 확장 중 workload 가용성 영향, rollout/restart 계획과 rollback 불가 범위
+
+서비스 owner가 승인된 workload 전용 정리 절차를 제공하고 해당 데이터가 제거 가능함을
+확인한 경우에만 그 절차를 따른다. PostgreSQL은 [Production PostgreSQL backup과
+복구](./postgres-backup.md)의 backup·복구 경계를 먼저 확인한다. Vault, Prometheus와
+다른 workload는 각 service owner의 전용 retention·backup·export 절차를 따른다.
+
+다음 중 하나라도 확인되지 않으면 데이터를 건드리지 않는다.
+
+- 데이터 보존 정책 또는 삭제 승인
+- 최근 backup과 복구 가능성
+- workload owner와 가용성 영향
+- 안전한 정리·export·rebalance 절차
+
+승인된 정리 경로가 없고 용량 위험이 즉시 해소되어야 하면 지원되는 volume 확장 또는
+별도 snapshot/backup/migration 계획을 escalation한다. 이 공통 runbook은 데이터
+내용 삭제, 공통 purge, retention 정책 결정, PVC/PV 교체나 reclaim policy 변경을
+제공하지 않는다.
+
+## 4. 지원되는 방법으로 용량을 확장한다
+
+### 사전 조건
+
+다음 조건을 모두 확인한 뒤에만 확장을 선택한다.
+
+- StorageClass의 `allowVolumeExpansion=true`
+- 해당 `provisioner`와 CSI driver가 volume expansion을 지원함
+- 목표 용량이 현재 PVC request와 PV/PVC status capacity보다 큼
+- 목표 용량이 provider 한도와 quota 안에 있으며 비용·가용성 영향이 승인됨
+- workload가 용량을 선언하는 source of truth와 reconcile 방식이 확인됨
+- backup, owner 승인과 필요한 rollout/restart 계획이 준비됨
+
+StorageClass 또는 CSI 지원 여부를 확인할 수 없거나 expansion을 지원하지 않으면
+PVC/PV를 임의로 교체하지 않는다. 데이터 보호 계획이 포함된 별도 migration 또는
+storage 운영 escalation을 만든다.
+
+### 선언 source를 먼저 변경한다
+
+StatefulSet의 `volumeClaimTemplates`, operator custom resource, Helm/GitOps 선언 등
+상위 resource가 용량을 소유하면 해당 선언 source를 목표 용량으로 변경하고 정상적인
+reconcile을 기다린다. 상위 resource가 다시 PVC request를 덮어쓰는 환경에서 live PVC만
+수정하지 않는다.
+
+owner와 선언 source를 확인했으며 해당 PVC가 직접 관리되는 경우에만 다음처럼 기존
+PVC의 request를 더 큰 값으로 변경한다. `<target-size>`는 현재 request/status보다
+큰 승인된 값이어야 한다.
+
+```sh
+kubectl patch pvc "<pvc>" -n "<namespace>" \
+  --type=merge \
+  --patch='{"spec":{"resources":{"requests":{"storage":"<target-size>"}}}}'
+```
+
+Kubernetes가 기존 PV를 resize하도록 PVC request만 변경한다. PV의 capacity를 직접
+편집하거나 PVC request를 줄이지 않는다. 이 runbook에는 자동 증설, PVC/PV 교체,
+reclaim policy 변경과 volume purge 절차가 없다.
+
+### filesystem과 workload 반영
+
+변경 직후 완료 처리하지 말고 PVC condition, allocated resource status와 event를
+반복 확인한다. ReadWrite로 mount된 filesystem은 driver와 filesystem이 online resize를
+지원하면 running Pod에서 반영될 수 있다. 새 Pod가 필요하거나 condition이 restart를
+요구하면 service owner와 가용성 영향을 다시 확인한 뒤 workload가 소유한 방식으로
+통제된 rollout/restart를 수행한다. online expansion이 가능한 경우 불필요한 Pod
+재시작을 고정 절차로 만들지 않는다.
+
+filesystem 용량은 mount path를 확인한 뒤 파일 내용이 아닌 filesystem 통계만 읽는다.
+
+```sh
+kubectl exec -n "<namespace>" "<pod>" -c "<container>" -- \
+  df -P -k "<mount-path>"
+```
+
+operator custom resource가 restart나 failover를 소유하는 경우 generic rollout 명령을
+사용하지 말고 해당 operator의 승인된 절차를 따른다. 확장·restart 중 readiness가
+떨어지거나 event가 반복되면 변경을 완료 처리하지 않고 service owner와 storage 운영
+담당자에게 escalation한다.
+
+## 5. 복구와 alert 해소를 검증한다
+
+다음 순서로 새 상태를 확인하고, 모든 항목이 정상일 때만 완료로 기록한다.
+
+```sh
+kubectl get pvc "<pvc>" -n "<namespace>" \
+  -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,REQUEST:.spec.resources.requests.storage,STATUS_CAPACITY:.status.capacity.storage'
+
+kubectl get pvc "<pvc>" -n "<namespace>" \
+  -o jsonpath='{.status.conditions[*].type}{"\t"}{.status.allocatedResourceStatuses}{"\n"}'
+
+kubectl get events -n "<namespace>" \
+  --field-selector='involvedObject.kind=PersistentVolumeClaim,involvedObject.name=<pvc>' \
+  --sort-by=.lastTimestamp \
+  -o custom-columns='TIME:.lastTimestamp,TYPE:.type,REASON:.reason,MESSAGE:.message'
+
+kubectl get pods -n "<namespace>" \
+  -o custom-columns='NAME:.metadata.name,READY:.status.containerStatuses[*].ready,PHASE:.status.phase'
+
+kubectl get "<owner-kind>" "<owner-name>" -n "<namespace>" \
+  -o custom-columns='NAME:.metadata.name,READY:.status.readyReplicas,AVAILABLE:.status.availableReplicas,PHASE:.status.phase'
+```
+
+검증 기준은 다음과 같다.
+
+- PVC가 `Bound`이고 request와 status capacity가 목표 용량으로 수렴한다.
+- resize condition과 allocated resource status에 실패·대기·반복 재시도가 남지 않는다.
+- mount filesystem의 용량과 여유 공간이 증가하고, 예상 증가 추세가 다시 고갈 위험을
+  만들지 않는다.
+- Pod, 상위 workload와 workload별 health/readiness가 정상이다.
+- Prometheus에서 다음 query가 해당 PVC에 firing series를 반환하지 않는다.
+
+```promql
+ALERTS{
+  alertname="KubePersistentVolumeFillingUp",
+  namespace="<namespace>",
+  persistentvolumeclaim="<pvc>",
+  alertstate="firing"
+}
+```
+
+resize가 실패·대기·재시도 중이거나 workload가 Ready가 아니거나 alert가 계속 firing이면
+대응을 완료 처리하지 않는다. 현재 상태, 가용성 영향, 마지막 정상 측정과 escalation
+담당자를 기록한다. Slack resolved notification과 전달 실패 검증은 이 문서의 소유
+범위가 아니며 Kubernetes 저장소의 기존 전달 경계에서 별도로 확인한다.
+
+## 6. 비민감 대응 증거
+
+운영 이슈에는 raw command output 대신 다음 요약만 남긴다.
+
+- alertname, namespace, PVC 이름, severity와 관측 시각
+- request/status capacity, available/capacity 측정값, 관측 기간과 추세 판단
+- PV/StorageClass의 상태, resize condition/event의 reason과 성공·실패 여부
+- 최종 workload owner, service owner, 승인된 조치와 선언 source
+- filesystem 반영, workload readiness/health와 alert가 더 이상 firing이 아닌 시각
+- 실패 시 현재 상태, 가용성 영향과 escalation 대상
+
+Secret 값, credential, connection string, database row, object payload, 파일 내용과
+실제 사용자 데이터는 terminal history, CI log, Linear, Slack 또는 commit에 남기지
+않는다.
+
+## 참고 자료
+
+- [Kubernetes: Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- [Kubernetes: Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+- [Prometheus Operator: KubePersistentVolumeFillingUp runbook](https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup/)

--- a/openspec/changes/add-persistent-volume-capacity-runbook/.openspec.yaml
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-06

--- a/openspec/changes/add-persistent-volume-capacity-runbook/decisions.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/decisions.md
@@ -10,11 +10,11 @@
 - Decision Class: Derived Contract
 - Authority / Provenance: Linear `PROD-698`
 - Status: Active
-- Context / Problem: 최초 사례는 PostgreSQL이지만 같은 용량 부족 위험이 Vault, Prometheus와 미래의 모든 PVC 기반 workload에 존재하고, Kubernetes 저장소의 Slack message가 안정적인 내부 runbook URL을 필요로 한다.
+- Context / Problem: 최초 사례는 PostgreSQL이지만 같은 용량 부족 위험이 Vault, Prometheus와 미래의 모든 PVC 기반 workload에 존재하므로 특정 workload에 종속되지 않은 공통 대응 절차가 필요하다.
 - Decision Outcome: 모든 대상 PVC에 공통인 runbook을 `docs/operations/persistent-volume-capacity.md`에 추가하고, workload별 차이는 이 문서에서 전용 runbook과 owner 판단으로 연결한다.
-- Alternatives Considered: `docs/operations/postgres-backup.md`에 PostgreSQL 전용 절차만 추가하는 방식은 다른 workload와 Linear가 고정한 공통 URL을 충족하지 않는다. Workload마다 별도 PVC runbook을 먼저 만드는 방식은 현재 존재하지 않는 정책을 중복 작성한다.
-- Consequences: Kubernetes Slack link는 하나의 안정된 Kosmo 경로를 소비할 수 있다. 범용 문서는 애플리케이션별 데이터·복구 결정을 소유하지 않는다.
-- Confirmation / Follow-up: PostgreSQL이 아닌 PVC를 포함한 진입·진단 scenario와 신규 문서 링크를 검증한다.
+- Alternatives Considered: `docs/operations/postgres-backup.md`에 PostgreSQL 전용 절차만 추가하는 방식은 다른 workload의 대응 공백을 남긴다. Workload마다 별도 PVC runbook을 먼저 만드는 방식은 현재 존재하지 않는 정책을 중복 작성한다.
+- Consequences: 운영자는 하나의 범용 PVC 대응 절차를 사용할 수 있지만 Slack 메시지에서 이 문서로 연결되는 계약은 생기지 않는다. 범용 문서는 애플리케이션별 데이터·복구 결정을 소유하지 않는다.
+- Confirmation / Follow-up: PostgreSQL이 아닌 PVC를 포함한 진입·진단 scenario, 신규 문서 경로와 workload별 참고 링크를 검증한다.
 
 ### Kosmo 대응과 Kubernetes 알림 전달의 책임을 분리한다
 
@@ -22,11 +22,11 @@
 - Decision Class: Derived Contract
 - Authority / Provenance: Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`
 - Status: Active
-- Context / Problem: 하나의 `PROD-698` 결과가 두 저장소에 걸치지만 routing과 service 대응을 양쪽 문서에 모두 작성하면 절차가 drift하고, runbook보다 routing PR이 먼저 병합되면 Slack에 깨진 링크가 노출된다.
-- Decision Outcome: Kosmo는 PVC 진단·owner 확인·완화·확장·사후 검증만 문서화하고, Alertmanager receiver·allowlist·Slack message·notification test와 전달 실패 복구는 `byulmaru/kubernetes`가 소유한다. Kosmo runbook PR을 먼저 병합하고 Kubernetes routing PR을 나중에 병합한다.
-- Alternatives Considered: 두 저장소에 end-to-end 절차를 복제하는 방식은 소유권과 업데이트 시점을 불명확하게 한다. Kubernetes PR을 먼저 병합하는 방식은 아직 존재하지 않는 Kosmo URL을 알림에 노출한다.
-- Consequences: 두 PR은 독립 리뷰할 수 있지만 어느 한 PR만으로 `PROD-698`을 완료할 수 없다. 전체 이슈 담당자가 링크 정합성과 firing/resolved 통합 증거를 확인해야 한다.
-- Confirmation / Follow-up: Kosmo 문서에는 Kubernetes 운영 문서로 가는 책임 링크만 두고 routing 명령을 복제하지 않는다. 두 PR의 merge 순서와 최종 link smoke를 확인한다.
+- Context / Problem: 하나의 `PROD-698` 결과가 두 저장소에 걸치지만 routing과 service 대응을 양쪽 문서에 모두 작성하면 절차가 drift한다. 현재 Alertmanager에는 runbook 링크나 custom Slack template 계약이 없으므로 이 이슈에서 새 메시지 계약까지 도입하면 allowlist 추가보다 범위가 커진다.
+- Decision Outcome: Kosmo는 PVC 진단·owner 확인·완화·확장·사후 검증만 문서화한다. `byulmaru/kubernetes`는 기존 receiver, `#monitoring`, `sendResolved=true`와 Slack 메시지 형식을 유지하면서 allowlist·notification test·전달 실패 복구를 소유한다. `runbook_url`, Slack runbook 링크와 custom title/text는 추가하지 않으며 두 PR에 병합 순서 제약을 두지 않는다.
+- Alternatives Considered: 두 저장소에 end-to-end 절차를 복제하는 방식은 소유권과 업데이트 시점을 불명확하게 한다. Slack에 Kosmo runbook 링크를 추가하는 방식은 기존에 없는 공통 메시지 계약을 이 이슈에서 부분적으로 도입하므로 제외한다.
+- Consequences: 두 PR은 독립적으로 리뷰·병합할 수 있지만 어느 한 PR만으로 `PROD-698`을 완료할 수 없다. 전체 이슈 담당자가 runbook 검증과 기존 형식의 firing/resolved·negative routing 증거를 모두 확인해야 한다.
+- Confirmation / Follow-up: Kosmo 문서에 routing·Slack 링크 계약을 복제하지 않는지, Kubernetes diff가 allowlist와 기존 형식의 notification test로 제한되는지 확인한다.
 
 ### 범용 절차는 데이터 정리를 결정하지 않는다
 
@@ -58,10 +58,10 @@
 - Decision Class: Derived Contract
 - Authority / Provenance: Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`
 - Status: Active
-- Context / Problem: PVC request만 변경됐다고 filesystem과 workload가 복구되거나 용량 위험과 Slack alert가 해소됐다고 볼 수 없다. 반대로 실제 data·Secret 원문을 증거에 복사하면 운영 보안 경계를 위반한다.
+- Context / Problem: PVC request만 변경됐다고 filesystem과 workload가 복구되거나 용량 위험과 alert가 해소됐다고 볼 수 없다. 반대로 실제 data·Secret 원문을 증거에 복사하면 운영 보안 경계를 위반한다.
 - Decision Outcome: PVC request/status·resize condition/event, mount filesystem, Pod·상위 workload readiness와 workload별 health, 새 여유 공간·증가 추세를 확인하고 `KubePersistentVolumeFillingUp` resolved를 추적한다. 이슈에는 alert context, 비민감 측정값, 선택한 조치·승인자와 검증 결과만 기록한다.
 - Alternatives Considered: PVC spec 변경 직후 완료하는 방식은 비동기 volume/filesystem resize와 workload 장애를 놓친다. Raw command output 전체를 첨부하는 방식은 credential, Secret 값이나 사용자 데이터 노출 위험이 있다.
-- Consequences: Kosmo PR은 실행 가능한 response 절차를 검증하지만 resolved Slack delivery의 end-to-end 증거는 Kubernetes PR과 전체 `PROD-698` 담당자의 통합 검증을 기다린다.
+- Consequences: Kosmo PR은 실행 가능한 response 절차를 검증하지만 기존 메시지 형식의 resolved Slack delivery 증거는 Kubernetes PR과 전체 `PROD-698` 담당자의 통합 검증을 기다린다.
 - Confirmation / Follow-up: Resize 실패 상태는 완료로 기록하지 않는지, evidence 예시가 namespace·PVC·severity와 비민감 상태만 허용하는지 검토한다.
 
 ## Remaining Decisions

--- a/openspec/changes/add-persistent-volume-capacity-runbook/decisions.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/decisions.md
@@ -1,68 +1,44 @@
 ## Context
 
-이 기록은 `PROD-698`의 전체 PVC alert 결과 중 `byulmaru/kosmo`가 소유하는 범용 대응 runbook slice를 반영한다. 대상 PVC와 alert 의미는 기존 kube-prometheus 규칙을 유지하고, Kosmo는 알림 이후의 진단·owner 판단·안전한 완화·확장·검증을, `byulmaru/kubernetes`는 Alertmanager·Slack 전달과 통합 notification test를 소유한다.
+`PROD-698`의 Kosmo slice는 PVC 진단·owner 판단·안전한 확장·복구 검증을 소유하고,
+`byulmaru/kubernetes` slice는 기존 Alertmanager와 Slack 전달 계약을 소유한다. 이
+기록은 두 경계와 선언 source별 확장 선택만 남긴다.
 
 ## Decision Records
 
-### 범용 PVC 대응 runbook을 독립 경로로 둔다
-
-- Decision Date: 2026-08-06
-- Decision Class: Derived Contract
-- Authority / Provenance: Linear `PROD-698`
-- Status: Active
-- Context / Problem: 최초 사례는 PostgreSQL이지만 같은 용량 부족 위험이 Vault, Prometheus와 미래의 모든 PVC 기반 workload에 존재하므로 특정 workload에 종속되지 않은 공통 대응 절차가 필요하다.
-- Decision Outcome: 모든 대상 PVC에 공통인 runbook을 `docs/operations/persistent-volume-capacity.md`에 추가하고, workload별 차이는 이 문서에서 전용 runbook과 owner 판단으로 연결한다.
-- Alternatives Considered: `docs/operations/postgres-backup.md`에 PostgreSQL 전용 절차만 추가하는 방식은 다른 workload의 대응 공백을 남긴다. Workload마다 별도 PVC runbook을 먼저 만드는 방식은 현재 존재하지 않는 정책을 중복 작성한다.
-- Consequences: 운영자는 하나의 범용 PVC 대응 절차를 사용할 수 있지만 Slack 메시지에서 이 문서로 연결되는 계약은 생기지 않는다. 범용 문서는 애플리케이션별 데이터·복구 결정을 소유하지 않는다.
-- Confirmation / Follow-up: PostgreSQL이 아닌 PVC를 포함한 진입·진단 scenario, 신규 문서 경로와 workload별 참고 링크를 검증한다.
-
-### Kosmo 대응과 Kubernetes 알림 전달의 책임을 분리한다
+### 저장소 책임을 분리한다
 
 - Decision Date: 2026-08-06
 - Decision Class: Derived Contract
 - Authority / Provenance: Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`
 - Status: Active
-- Context / Problem: 하나의 `PROD-698` 결과가 두 저장소에 걸치지만 routing과 service 대응을 양쪽 문서에 모두 작성하면 절차가 drift한다. 현재 Alertmanager에는 runbook 링크나 custom Slack template 계약이 없으므로 이 이슈에서 새 메시지 계약까지 도입하면 allowlist 추가보다 범위가 커진다.
-- Decision Outcome: Kosmo는 PVC 진단·owner 확인·완화·확장·사후 검증만 문서화한다. `byulmaru/kubernetes`는 기존 receiver, `#monitoring`, `sendResolved=true`와 Slack 메시지 형식을 유지하면서 allowlist·notification test·전달 실패 복구를 소유한다. `runbook_url`, Slack runbook 링크와 custom title/text는 추가하지 않으며 두 PR에 병합 순서 제약을 두지 않는다.
-- Alternatives Considered: 두 저장소에 end-to-end 절차를 복제하는 방식은 소유권과 업데이트 시점을 불명확하게 한다. Slack에 Kosmo runbook 링크를 추가하는 방식은 기존에 없는 공통 메시지 계약을 이 이슈에서 부분적으로 도입하므로 제외한다.
-- Consequences: 두 PR은 독립적으로 리뷰·병합할 수 있지만 어느 한 PR만으로 `PROD-698`을 완료할 수 없다. 전체 이슈 담당자가 runbook 검증과 기존 형식의 firing/resolved·negative routing 증거를 모두 확인해야 한다.
-- Confirmation / Follow-up: Kosmo 문서에 routing·Slack 링크 계약을 복제하지 않는지, Kubernetes diff가 allowlist와 기존 형식의 notification test로 제한되는지 확인한다.
+- Decision Outcome: Kosmo runbook은 PVC 사용량·owner 진단, 데이터 보호 gate, workload별
+  완화 연결, 확장과 복구 검증만 제공한다. `byulmaru/kubernetes`는 기존 receiver,
+  `#monitoring`, `sendResolved=true`, Slack 형식과 allowlist·notification test·전달
+  실패 복구를 소유한다. `runbook_url`, Slack 링크·custom title/text와 PR 병합 순서
+  의존성은 추가하지 않는다.
+- Consequences / Confirmation: 두 PR은 독립적으로 revert 가능하지만 `PROD-698`의
+  통합 완료와 archive는 전체 담당자가 양쪽 증거를 확인한 뒤 결정한다.
 
-### 범용 절차는 데이터 정리를 결정하지 않는다
-
-- Decision Date: 2026-08-06
-- Decision Class: Derived Contract
-- Authority / Provenance: `docs/operations/postgres-backup.md`, Linear `PROD-698`
-- Status: Active
-- Context / Problem: 데이터 삭제나 retention 변경은 빠르게 공간을 확보할 수 있지만 workload별 보존·backup·복구 정책을 모르는 범용 문서가 안전하게 결정할 수 없고 잘못된 일반화는 복구 불가능한 데이터 손실을 만든다.
-- Decision Outcome: Runbook은 mutation 전에 read-only 진단으로 workload와 service owner를 식별한다. 데이터 정리·retention·export·rebalance는 승인된 workload별 정책과 owner에게 위임하고, 범용 문서에는 데이터 삭제, PVC/PV 삭제·재생성, reclaim policy 변경 또는 purge 명령을 두지 않는다.
-- Alternatives Considered: 공통 cleanup 명령을 제공하는 방식은 데이터 성격과 backup 상태를 추측한다. 공간이 부족하면 즉시 PVC를 삭제·재생성하는 방식은 현재 Linear 제외 범위이고 데이터 손실·downtime 위험이 크다.
-- Consequences: Owner나 backup을 확인하지 못하면 대응이 escalation에서 멈출 수 있지만, 범용 runbook이 승인되지 않은 파괴 작업을 유도하지 않는다.
-- Confirmation / Follow-up: 구현 리뷰에서 모든 mutation 전에 owner·backup·가용성 gate가 있는지, command 예시에 destructive operation이 없는지 확인한다.
-
-### Expansion은 live 지원과 workload 선언 소유권을 확인한다
+### Expansion은 선언 owner와 live 지원에 맞춘다
 
 - Decision Date: 2026-08-06
 - Decision Class: Implementation Choice
-- Authority / Provenance: Linear `PROD-698`; Kubernetes [`Persistent Volumes — Expanding Persistent Volumes Claims`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims), [`Storage Classes — Volume expansion`](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+- Authority / Provenance: Linear `PROD-698`; Kubernetes [Persistent Volumes —
+  Expanding Persistent Volume Claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims)
+  및 [Storage Classes — Volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/)
 - Status: Active
-- Context / Problem: StorageClass 이름만으로 expansion 지원을 알 수 없고, operator나 Helm/GitOps가 size를 소유하는 workload의 PVC를 직접 편집하면 선언과 live 상태가 어긋날 수 있다. Kubernetes는 PVC request 증가를 통해 기존 PV를 확장하며 PV 직접 편집과 shrink를 지원 경로로 보지 않는다.
-- Decision Outcome: Incident마다 live StorageClass의 `allowVolumeExpansion`, provisioner·CSI 지원, PVC request/status와 condition/event를 확인한다. Workload가 size를 선언하는 상위 resource가 있으면 그 source를 통해 기존 PVC request를 늘리고, 그렇지 않을 때만 PVC request를 직접 늘린다. PV capacity는 직접 편집하지 않고 현재 capacity 아래로 축소하지 않으며, restart는 condition과 workload 특성이 요구할 때만 수행한다.
-- Alternatives Considered: 모든 workload에 `kubectl edit pvc`를 고정하는 방식은 선언 owner를 우회할 수 있다. Standard runbook처럼 mount Pod를 항상 삭제하는 방식은 online expansion에서도 불필요한 중단을 만든다. PV capacity를 먼저 바꾸는 방식은 Kubernetes 자동 resize를 방해한다.
-- Consequences: Runbook에 owner resource와 live capability를 확인하는 조건 분기가 추가된다. 지원 불가·불명인 경우 별도 migration 계획이 필요하며 현재 change는 그 실행 절차를 제공하지 않는다.
-- Confirmation / Follow-up: 서로 다른 owner 유형의 PVC에서 read-only 진단 명령을 smoke하고, online resize·restart 필요·지원 불가 scenario를 문서 검토한다.
-
-### 완료는 workload 복구와 alert resolved까지 확인한다
-
-- Decision Date: 2026-08-06
-- Decision Class: Derived Contract
-- Authority / Provenance: Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`
-- Status: Active
-- Context / Problem: PVC request만 변경됐다고 filesystem과 workload가 복구되거나 용량 위험과 alert가 해소됐다고 볼 수 없다. 반대로 실제 data·Secret 원문을 증거에 복사하면 운영 보안 경계를 위반한다.
-- Decision Outcome: PVC request/status·resize condition/event, mount filesystem, Pod·상위 workload readiness와 workload별 health, 새 여유 공간·증가 추세를 확인하고 `KubePersistentVolumeFillingUp` resolved를 추적한다. 이슈에는 alert context, 비민감 측정값, 선택한 조치·승인자와 검증 결과만 기록한다.
-- Alternatives Considered: PVC spec 변경 직후 완료하는 방식은 비동기 volume/filesystem resize와 workload 장애를 놓친다. Raw command output 전체를 첨부하는 방식은 credential, Secret 값이나 사용자 데이터 노출 위험이 있다.
-- Consequences: Kosmo PR은 실행 가능한 response 절차를 검증하지만 기존 메시지 형식의 resolved Slack delivery 증거는 Kubernetes PR과 전체 `PROD-698` 담당자의 통합 검증을 기다린다.
-- Confirmation / Follow-up: Resize 실패 상태는 완료로 기록하지 않는지, evidence 예시가 namespace·PVC·severity와 비민감 상태만 허용하는지 검토한다.
+- Decision Outcome: Incident마다 live StorageClass의 `allowVolumeExpansion`,
+  provisioner·CSI 지원, 목표 용량과 owner·backup 승인 gate를 확인한다. Operator가
+  지원하는 resize field/reconcile은 그 경로를 사용하고, standalone PVC declaration은
+  gate 뒤 declaration을 늘려 reconcile한다. 기존 StatefulSet object의
+  `spec.volumeClaimTemplates` 변경은 API가 immutable field로 거부하므로 generic
+  in-place reconcile하지 않는다. 기존 bound PVC direct patch와 template·미래 replica
+  정합화는 owner 승인 recreation/migration 계획으로 별도 처리하며 PV 직접 편집과
+  shrink는 사용하지 않는다.
+- Consequences / Confirmation: 지원 여부가 불명확하거나 operator 경로가 없으면
+  migration으로 escalation한다. Resize condition·event와 filesystem/workload 복구를
+  확인하고, 불필요한 restart를 고정하지 않는다.
 
 ## Remaining Decisions
 

--- a/openspec/changes/add-persistent-volume-capacity-runbook/decisions.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/decisions.md
@@ -1,0 +1,73 @@
+## Context
+
+이 기록은 `PROD-698`의 전체 PVC alert 결과 중 `byulmaru/kosmo`가 소유하는 범용 대응 runbook slice를 반영한다. 대상 PVC와 alert 의미는 기존 kube-prometheus 규칙을 유지하고, Kosmo는 알림 이후의 진단·owner 판단·안전한 완화·확장·검증을, `byulmaru/kubernetes`는 Alertmanager·Slack 전달과 통합 notification test를 소유한다.
+
+## Decision Records
+
+### 범용 PVC 대응 runbook을 독립 경로로 둔다
+
+- Decision Date: 2026-08-06
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-698`
+- Status: Active
+- Context / Problem: 최초 사례는 PostgreSQL이지만 같은 용량 부족 위험이 Vault, Prometheus와 미래의 모든 PVC 기반 workload에 존재하고, Kubernetes 저장소의 Slack message가 안정적인 내부 runbook URL을 필요로 한다.
+- Decision Outcome: 모든 대상 PVC에 공통인 runbook을 `docs/operations/persistent-volume-capacity.md`에 추가하고, workload별 차이는 이 문서에서 전용 runbook과 owner 판단으로 연결한다.
+- Alternatives Considered: `docs/operations/postgres-backup.md`에 PostgreSQL 전용 절차만 추가하는 방식은 다른 workload와 Linear가 고정한 공통 URL을 충족하지 않는다. Workload마다 별도 PVC runbook을 먼저 만드는 방식은 현재 존재하지 않는 정책을 중복 작성한다.
+- Consequences: Kubernetes Slack link는 하나의 안정된 Kosmo 경로를 소비할 수 있다. 범용 문서는 애플리케이션별 데이터·복구 결정을 소유하지 않는다.
+- Confirmation / Follow-up: PostgreSQL이 아닌 PVC를 포함한 진입·진단 scenario와 신규 문서 링크를 검증한다.
+
+### Kosmo 대응과 Kubernetes 알림 전달의 책임을 분리한다
+
+- Decision Date: 2026-08-06
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`
+- Status: Active
+- Context / Problem: 하나의 `PROD-698` 결과가 두 저장소에 걸치지만 routing과 service 대응을 양쪽 문서에 모두 작성하면 절차가 drift하고, runbook보다 routing PR이 먼저 병합되면 Slack에 깨진 링크가 노출된다.
+- Decision Outcome: Kosmo는 PVC 진단·owner 확인·완화·확장·사후 검증만 문서화하고, Alertmanager receiver·allowlist·Slack message·notification test와 전달 실패 복구는 `byulmaru/kubernetes`가 소유한다. Kosmo runbook PR을 먼저 병합하고 Kubernetes routing PR을 나중에 병합한다.
+- Alternatives Considered: 두 저장소에 end-to-end 절차를 복제하는 방식은 소유권과 업데이트 시점을 불명확하게 한다. Kubernetes PR을 먼저 병합하는 방식은 아직 존재하지 않는 Kosmo URL을 알림에 노출한다.
+- Consequences: 두 PR은 독립 리뷰할 수 있지만 어느 한 PR만으로 `PROD-698`을 완료할 수 없다. 전체 이슈 담당자가 링크 정합성과 firing/resolved 통합 증거를 확인해야 한다.
+- Confirmation / Follow-up: Kosmo 문서에는 Kubernetes 운영 문서로 가는 책임 링크만 두고 routing 명령을 복제하지 않는다. 두 PR의 merge 순서와 최종 link smoke를 확인한다.
+
+### 범용 절차는 데이터 정리를 결정하지 않는다
+
+- Decision Date: 2026-08-06
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/operations/postgres-backup.md`, Linear `PROD-698`
+- Status: Active
+- Context / Problem: 데이터 삭제나 retention 변경은 빠르게 공간을 확보할 수 있지만 workload별 보존·backup·복구 정책을 모르는 범용 문서가 안전하게 결정할 수 없고 잘못된 일반화는 복구 불가능한 데이터 손실을 만든다.
+- Decision Outcome: Runbook은 mutation 전에 read-only 진단으로 workload와 service owner를 식별한다. 데이터 정리·retention·export·rebalance는 승인된 workload별 정책과 owner에게 위임하고, 범용 문서에는 데이터 삭제, PVC/PV 삭제·재생성, reclaim policy 변경 또는 purge 명령을 두지 않는다.
+- Alternatives Considered: 공통 cleanup 명령을 제공하는 방식은 데이터 성격과 backup 상태를 추측한다. 공간이 부족하면 즉시 PVC를 삭제·재생성하는 방식은 현재 Linear 제외 범위이고 데이터 손실·downtime 위험이 크다.
+- Consequences: Owner나 backup을 확인하지 못하면 대응이 escalation에서 멈출 수 있지만, 범용 runbook이 승인되지 않은 파괴 작업을 유도하지 않는다.
+- Confirmation / Follow-up: 구현 리뷰에서 모든 mutation 전에 owner·backup·가용성 gate가 있는지, command 예시에 destructive operation이 없는지 확인한다.
+
+### Expansion은 live 지원과 workload 선언 소유권을 확인한다
+
+- Decision Date: 2026-08-06
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-698`; Kubernetes [`Persistent Volumes — Expanding Persistent Volumes Claims`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims), [`Storage Classes — Volume expansion`](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+- Status: Active
+- Context / Problem: StorageClass 이름만으로 expansion 지원을 알 수 없고, operator나 Helm/GitOps가 size를 소유하는 workload의 PVC를 직접 편집하면 선언과 live 상태가 어긋날 수 있다. Kubernetes는 PVC request 증가를 통해 기존 PV를 확장하며 PV 직접 편집과 shrink를 지원 경로로 보지 않는다.
+- Decision Outcome: Incident마다 live StorageClass의 `allowVolumeExpansion`, provisioner·CSI 지원, PVC request/status와 condition/event를 확인한다. Workload가 size를 선언하는 상위 resource가 있으면 그 source를 통해 기존 PVC request를 늘리고, 그렇지 않을 때만 PVC request를 직접 늘린다. PV capacity는 직접 편집하지 않고 현재 capacity 아래로 축소하지 않으며, restart는 condition과 workload 특성이 요구할 때만 수행한다.
+- Alternatives Considered: 모든 workload에 `kubectl edit pvc`를 고정하는 방식은 선언 owner를 우회할 수 있다. Standard runbook처럼 mount Pod를 항상 삭제하는 방식은 online expansion에서도 불필요한 중단을 만든다. PV capacity를 먼저 바꾸는 방식은 Kubernetes 자동 resize를 방해한다.
+- Consequences: Runbook에 owner resource와 live capability를 확인하는 조건 분기가 추가된다. 지원 불가·불명인 경우 별도 migration 계획이 필요하며 현재 change는 그 실행 절차를 제공하지 않는다.
+- Confirmation / Follow-up: 서로 다른 owner 유형의 PVC에서 read-only 진단 명령을 smoke하고, online resize·restart 필요·지원 불가 scenario를 문서 검토한다.
+
+### 완료는 workload 복구와 alert resolved까지 확인한다
+
+- Decision Date: 2026-08-06
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`
+- Status: Active
+- Context / Problem: PVC request만 변경됐다고 filesystem과 workload가 복구되거나 용량 위험과 Slack alert가 해소됐다고 볼 수 없다. 반대로 실제 data·Secret 원문을 증거에 복사하면 운영 보안 경계를 위반한다.
+- Decision Outcome: PVC request/status·resize condition/event, mount filesystem, Pod·상위 workload readiness와 workload별 health, 새 여유 공간·증가 추세를 확인하고 `KubePersistentVolumeFillingUp` resolved를 추적한다. 이슈에는 alert context, 비민감 측정값, 선택한 조치·승인자와 검증 결과만 기록한다.
+- Alternatives Considered: PVC spec 변경 직후 완료하는 방식은 비동기 volume/filesystem resize와 workload 장애를 놓친다. Raw command output 전체를 첨부하는 방식은 credential, Secret 값이나 사용자 데이터 노출 위험이 있다.
+- Consequences: Kosmo PR은 실행 가능한 response 절차를 검증하지만 resolved Slack delivery의 end-to-end 증거는 Kubernetes PR과 전체 `PROD-698` 담당자의 통합 검증을 기다린다.
+- Confirmation / Follow-up: Resize 실패 상태는 완료로 기록하지 않는지, evidence 예시가 namespace·PVC·severity와 비민감 상태만 허용하는지 검토한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-persistent-volume-capacity-runbook/design.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/design.md
@@ -1,0 +1,84 @@
+## Context
+
+`PROD-698`은 기존 kube-prometheus-stack의 `KubePersistentVolumeFillingUp` 규칙을 모든 대상 PVC에 유지하면서, 명시적 Alertmanager allowlist를 통해 `#monitoring`으로 전달하고 Kosmo의 내부 대응 runbook으로 연결하는 하나의 운영 결과다. Alertmanager routing, Slack message와 notification test는 `byulmaru/kubernetes`가 소유하고, 이 저장소는 알림 이후의 실제 PVC 진단·완화·확장·복구 검증을 소유한다.
+
+Kosmo에는 PostgreSQL backup·복구 등 workload별 운영 문서는 있지만 PVC 용량 부족에서 시작하는 범용 절차가 없다. PVC는 StatefulSet, operator CR처럼 서로 다른 선언 소유자를 가질 수 있고, 확장 가능 여부도 live StorageClass의 `allowVolumeExpansion`, provisioner와 CSI driver 지원에 달려 있으므로 특정 workload나 현재 cluster 값으로 일반화할 수 없다. Kubernetes 공식 문서는 PVC request 증가, PV 직접 편집 금지, filesystem resize와 실패 재시도 경계를 제공하고, Prometheus Operator 표준 runbook은 사용량 추세·retention·export·rebalance·resize·migration 선택지를 제시한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- warning/critical PVC filling 알림에서 시작해 공통 읽기 전용 진단으로 실제 위험과 owner를 확인한다.
+- 데이터 정리 판단을 workload owner와 전용 보존·backup runbook으로 분리한다.
+- StorageClass·CSI와 workload 선언 경계를 확인한 뒤 지원되는 PVC 확장을 안전하게 수행할 수 있게 한다.
+- PVC/filesystem/workload 상태와 새 여유 공간, 증가 추세와 alert resolved까지 검증한다.
+- `byulmaru/kubernetes` 전달 경로 문서와 책임이 중복되지 않고 비밀·실제 사용자 데이터를 증거에 남기지 않는다.
+
+**Non-Goals:**
+
+- Alertmanager allowlist, Slack message template, firing/resolved 합성 notification test 또는 Terraform 변경
+- `KubePersistentVolumeFillingUp` 표현식·severity·제외 조건 변경
+- 자동·선제 volume 증설, 애플리케이션별 보존 정책 결정 또는 공통 삭제 명령
+- PVC/PV 삭제·재생성, reclaim policy 변경, snapshot restore 또는 volume migration의 실행 절차
+- 전체 storage SLI/SLO, dashboard, quota·inode·node filesystem alert 확대
+
+## Implementation Guidance
+
+### Current Constraints
+
+- 신규 문서 경로는 Linear가 정한 `docs/operations/persistent-volume-capacity.md`이며, Kubernetes 저장소의 Slack runbook 링크가 이 경로를 소비한다. 깨진 링크를 피하려면 Kosmo 문서가 먼저 병합되어야 한다.
+- `docs/operations/postgres-backup.md`는 PostgreSQL의 data protection과 복구를 소유한다. 범용 runbook이 이를 복제하거나 PostgreSQL 데이터 삭제·복구 방식을 새로 정하면 기존 운영 계약과 충돌한다.
+- CNPG, Prometheus, Vault처럼 PVC를 생성·관리하는 상위 resource가 다르다. Pod 하나만 찾아 임의로 삭제하거나 PVC를 직접 편집하는 고정 명령은 선언 source of truth와 가용성 정책을 우회할 수 있다.
+- StorageClass 이름이나 현재 Terraform 선언은 live `allowVolumeExpansion`과 CSI resize 지원의 증거가 아니다. Incident마다 실제 PVC, StorageClass, provisioner, condition과 event를 조회해야 한다.
+- Kubernetes는 PVC 축소를 지원하지 않으며, 과도한 확장 요청은 controller가 계속 재시도할 수 있다. PV capacity를 직접 편집하면 자동 resize가 수행되지 않을 수 있다.
+- 저장소에는 docs/operations 전용 자동 command test가 없다. Markdown formatting·link 정합성, 명령의 읽기 전용 실클러스터 smoke와 사람의 안전 경계 검토를 조합해야 한다.
+
+### Recommended Approach
+
+Runbook을 다음 순서의 하나의 의사결정 흐름으로 작성하는 것을 기본으로 한다.
+
+1. **진입점과 책임:** alertname, namespace, PVC, severity, summary, description을 확인하고 warning/critical의 기존 의미를 그대로 사용한다. Alertmanager·Slack 전달 문제는 `byulmaru/kubernetes/docs/operations.md`로 보낸다.
+2. **읽기 전용 진단:** placeholder를 사용한 `kubectl get/describe`와 Prometheus 조회로 PVC request/status, available/capacity와 최근 추세, PV·StorageClass, condition/event를 확인한다. PVC를 mount한 Pod에서 owner reference를 controller/operator resource까지 추적한다.
+3. **owner와 데이터 경계:** service owner, 데이터의 지속성, 승인된 retention·export·rebalance 절차, backup/restore 상태를 확인한다. PostgreSQL이면 `docs/operations/postgres-backup.md`로 연결하고, 확인되지 않은 데이터 삭제나 purge는 중단한다.
+4. **완화 선택:** 승인된 workload별 정리로 충분하면 그 절차를 사용한다. 그렇지 않으면 live StorageClass와 CSI 지원, 목표 용량, 가용성 영향과 workload의 선언 source를 확인해 expansion을 선택한다. 확장이 불가능하면 범용 문서에서 PVC를 교체하지 않고 별도 migration 계획으로 escalation한다.
+5. **확장:** workload가 용량을 선언하는 상위 resource가 있으면 그 source를 통해 기존 PVC request가 증가하도록 하고, 그렇지 않은 경우에만 기존 PVC request를 직접 늘린다. PV는 직접 편집하지 않고 현재 `status.capacity` 이하로 낮추지 않는다. Restart는 condition과 workload 특성이 요구할 때만 통제된 방식으로 수행한다.
+6. **검증과 증거:** PVC request/status, allocated resize status·condition·event, mount filesystem, Pod/controller readiness와 workload별 health를 확인한다. 새 여유 공간과 추세가 충분하고 alert가 resolved된 뒤 비민감 결과만 기록한다.
+
+명령 예시는 `<namespace>`, `<pvc>`, `<storage-class>`, `<workload>`처럼 명시적인 placeholder를 사용하고, credential이나 Secret 값을 출력하는 command를 포함하지 않는다. 사용량은 `kubelet_volume_stats_available_bytes`와 `kubelet_volume_stats_capacity_bytes`를 같은 namespace/PVC label로 대조하되 기존 alert threshold를 문서에서 다시 정의하지 않는다.
+
+### Allowed Alternatives
+
+- Runbook 안에서 진단·판단·확장·검증을 섹션으로 나누거나, 상단에 동일한 순서를 보존하는 체크리스트를 둘 수 있다.
+- Owner resource 추적과 metric 조회 command는 현재 cluster 도구에 맞는 `kubectl` JSONPath, `jq` 또는 Prometheus UI 쿼리를 사용할 수 있다. 결과가 같은 read-only 사실을 제공하고 placeholder·비밀 비노출 경계를 지켜야 한다.
+- Workload가 공식 operator command나 GitOps 선언으로 size를 관리하면 직접 PVC patch 대신 그 경로를 사용할 수 있다. 최종적으로 기존 PVC request와 실제 volume/filesystem이 커지고 specs의 검증을 만족해야 한다.
+
+### Known Traps
+
+- 표준 Prometheus runbook의 Pod 자동 삭제 예시를 그대로 복사하면 single-replica workload나 operator 관리 workload에 불필요한 중단을 만들 수 있다.
+- StorageClass 이름만 보고 expansion을 지원한다고 가정하거나 PV capacity를 먼저 편집하면 resize를 건너뛰거나 반복 실패 상태를 만들 수 있다.
+- 용량 부족을 즉시 데이터 삭제 문제로 취급하면 승인되지 않은 보존 정책과 데이터 손실을 초래한다.
+- PVC/PV 이름, namespace와 severity는 대응에 필요한 resource context지만, Secret 값·database row·object payload를 함께 출력하거나 Linear/Slack에 복사해서는 안 된다.
+- Kosmo runbook에서 synthetic alert, Slack receiver 또는 Terraform 검증을 다시 설명하면 두 저장소의 운영 문서가 서로 다른 절차로 drift한다.
+
+## Risks / Trade-offs
+
+- [범용 절차가 workload별 복구·가용성 차이를 숨길 수 있음] → 공통 절차는 read-only 진단과 판단 gate까지만 제공하고 mutation은 service owner와 전용 runbook·선언 source에 연결한다.
+- [잘못된 목표 용량은 실패 재시도 또는 비용 증가를 만들고 shrink rollback이 없음] → 현재 용량·추세·provider 한도와 목표를 사전 확인하고 resize condition/event를 완료까지 관찰한다.
+- [Restart가 가용성 또는 모니터링 공백을 만들 수 있음] → online filesystem expansion을 우선 관찰하고 condition이 요구할 때만 owner 승인 아래 workload 방식으로 restart한다.
+- [외부 표준 문서와 cluster 구현이 변할 수 있음] → 공식 문서는 원칙의 근거로 링크하고 실제 지원 여부는 매 incident의 live read-only 조회로 판정한다.
+- [Kosmo 문서와 Kubernetes routing PR의 생명주기가 다름] → Kosmo PR 선병합, Kubernetes PR 후병합, `PROD-698` 담당자의 링크·firing/resolved 통합 검증을 완료 gate로 유지한다.
+
+## Migration Plan
+
+1. Kosmo 브랜치에서 OpenSpec strict validation과 runbook 요구사항을 확정한다.
+2. `docs/operations/persistent-volume-capacity.md`를 추가하고 Markdown formatting, 내부·외부 링크, placeholder와 민감정보 경계를 검증한다.
+3. Tailscale Kubernetes API proxy를 사용한 read-only 명령 smoke로 대상이 다른 PVC에서 진단·owner 추적 명령의 실행 가능성을 확인하되 실제 identifier와 출력 원문은 커밋·Linear에 남기지 않는다.
+4. Kosmo runbook PR을 먼저 병합한다.
+5. `byulmaru/kubernetes`의 별도 `PROD-698` PR이 병합된 runbook URL을 Slack message에 연결하고 positive/negative firing·resolved routing을 검증한다.
+6. 두 저장소의 링크 정합성과 통합 증거를 `PROD-698` 담당자가 확인한다.
+
+이 변경에는 schema나 runtime migration이 없다. Kosmo 문서 rollback이 필요하면 Kubernetes의 소비 링크를 먼저 안전한 기존 fallback으로 되돌린 뒤 문서를 revert하여 깨진 링크를 만들지 않는다.
+
+## Open Questions
+
+없음. Incident별 live StorageClass·CSI 지원, owner, backup과 target size는 구현 전에 고정할 제품 결정이 아니라 runbook이 매번 확인할 운영 입력이다.

--- a/openspec/changes/add-persistent-volume-capacity-runbook/design.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/design.md
@@ -1,84 +1,77 @@
 ## Context
 
-`PROD-698`은 기존 kube-prometheus-stack의 `KubePersistentVolumeFillingUp` 규칙을 모든 대상 PVC에 유지하면서 명시적 Alertmanager allowlist를 통해 `#monitoring`으로 전달하고, 별도로 Kosmo의 내부 대응 runbook을 제공하는 하나의 운영 결과다. 현재 Slack 계약은 receiver, `#monitoring` 채널과 `sendResolved=true`뿐이므로 Alertmanager routing과 기존 메시지 형식의 notification test는 `byulmaru/kubernetes`가 소유하고, 이 저장소는 Slack 링크 없이 실제 PVC 진단·완화·확장·복구 검증을 소유한다.
-
-Kosmo에는 PostgreSQL backup·복구 등 workload별 운영 문서는 있지만 PVC 용량 부족에서 시작하는 범용 절차가 없다. PVC는 StatefulSet, operator CR처럼 서로 다른 선언 소유자를 가질 수 있고, 확장 가능 여부도 live StorageClass의 `allowVolumeExpansion`, provisioner와 CSI driver 지원에 달려 있으므로 특정 workload나 현재 cluster 값으로 일반화할 수 없다. Kubernetes 공식 문서는 PVC request 증가, PV 직접 편집 금지, filesystem resize와 실패 재시도 경계를 제공하고, Prometheus Operator 표준 runbook은 사용량 추세·retention·export·rebalance·resize·migration 선택지를 제시한다.
+`PROD-698`은 기존 `KubePersistentVolumeFillingUp`와 Alertmanager 전달을 유지하면서
+Kosmo에 PVC 대응 runbook을 추가한다. Alertmanager routing·Slack 메시지·notification
+test는 `byulmaru/kubernetes`, PVC 진단·owner 판단·확장·복구 검증은 이 저장소가
+소유한다. 선언 owner는 operator CR, StatefulSet, Helm/GitOps로 다르므로 live
+`allowVolumeExpansion`, provisioner·CSI, condition·event와 owner 절차를 확인하며,
+PostgreSQL data protection은 `docs/operations/postgres-backup.md`를 따른다.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- warning/critical PVC filling 알림에서 시작해 공통 읽기 전용 진단으로 실제 위험과 owner를 확인한다.
-- 데이터 정리 판단을 workload owner와 전용 보존·backup runbook으로 분리한다.
-- StorageClass·CSI와 workload 선언 경계를 확인한 뒤 지원되는 PVC 확장을 안전하게 수행할 수 있게 한다.
-- PVC/filesystem/workload 상태와 새 여유 공간, 증가 추세와 alert resolved까지 검증한다.
-- `byulmaru/kubernetes` 전달 경로 문서와 책임이 중복되지 않고 비밀·실제 사용자 데이터를 증거에 남기지 않는다.
+- 모든 대상 PVC에 warning/critical 진입, read-only 상태·추세·owner 진단, 안전 gate,
+  owner 승인 아래 확장과 filesystem/workload/alert 복구 검증을 제공한다.
+- 비밀·사용자 데이터 증거를 막고 Kubernetes 전달 문서와 책임을 중복하지 않는다.
 
 **Non-Goals:**
 
-- Alertmanager allowlist, `runbook_url` annotation, Slack runbook 링크·custom title/text, firing/resolved 합성 notification test 또는 Terraform 변경
-- `KubePersistentVolumeFillingUp` 표현식·severity·제외 조건 변경
-- 자동·선제 volume 증설, 애플리케이션별 보존 정책 결정 또는 공통 삭제 명령
-- PVC/PV 삭제·재생성, reclaim policy 변경, snapshot restore 또는 volume migration의 실행 절차
-- 전체 storage SLI/SLO, dashboard, quota·inode·node filesystem alert 확대
+- Alertmanager allowlist, Slack 링크/template, `runbook_url`, notification test,
+  Terraform 변경, alert 표현식·severity·제외 조건 변경
+- 자동 증설, 공통 삭제·retention 정책, PVC/PV 교체·reclaim 변경, snapshot restore·
+  migration 실행 절차와 storage SLI/SLO 확대
 
 ## Implementation Guidance
 
 ### Current Constraints
 
-- 신규 문서 경로는 Linear가 정한 `docs/operations/persistent-volume-capacity.md`다. 현재 Slack 메시지는 이 경로를 소비하지 않으며 두 저장소 PR 사이에 runbook 링크나 병합 순서 의존성이 없다.
-- `docs/operations/postgres-backup.md`는 PostgreSQL의 data protection과 복구를 소유한다. 범용 runbook이 이를 복제하거나 PostgreSQL 데이터 삭제·복구 방식을 새로 정하면 기존 운영 계약과 충돌한다.
-- CNPG, Prometheus, Vault처럼 PVC를 생성·관리하는 상위 resource가 다르다. Pod 하나만 찾아 임의로 삭제하거나 PVC를 직접 편집하는 고정 명령은 선언 source of truth와 가용성 정책을 우회할 수 있다.
-- StorageClass 이름이나 현재 Terraform 선언은 live `allowVolumeExpansion`과 CSI resize 지원의 증거가 아니다. Incident마다 실제 PVC, StorageClass, provisioner, condition과 event를 조회해야 한다.
-- Kubernetes는 PVC 축소를 지원하지 않으며, 과도한 확장 요청은 controller가 계속 재시도할 수 있다. PV capacity를 직접 편집하면 자동 resize가 수행되지 않을 수 있다.
-- 저장소에는 docs/operations 전용 자동 command test가 없다. Markdown formatting·link 정합성, 명령의 읽기 전용 실클러스터 smoke와 사람의 안전 경계 검토를 조합해야 한다.
+- 문서 경로는 `docs/operations/persistent-volume-capacity.md`이며 전달 실패는
+  `byulmaru/kubernetes/docs/operations.md` 소유다. 두 PR은 링크나 병합 순서에 의존하지
+  않는다.
+- Operator는 지원된 resize field/reconcile이 있을 때만 그 경로를 사용한다. Helm/GitOps가
+  standalone PVC declaration을 직접 소유하면 gate 뒤 declaration을 늘려 reconcile한다.
+  StatefulSet template(Helm/GitOps 포함)의 기존 object `spec.volumeClaimTemplates`는
+  API가 immutable field로 거부하므로 generic in-place 변경/reconcile하지 않는다. 기존
+  bound PVC direct patch와 template·미래 replica 정합화는 owner 승인 recreation/migration
+  계획으로 별도 처리한다.
+- live StorageClass·provisioner·CSI 지원이 불명확하면 PVC/PV를 교체하지 않고 migration
+  계획으로 escalation한다. PV 직접 편집과 PVC shrink는 허용하지 않는다.
+- docs/operations 전용 자동 command test는 없으므로 formatting·link 검토와 서로 다른
+  owner 유형의 read-only smoke를 조합한다. smoke 결과에는 실제 identifier/raw output을
+  남기지 않는다.
 
 ### Recommended Approach
 
-Runbook을 다음 순서의 하나의 의사결정 흐름으로 작성하는 것을 기본으로 한다.
+1. Alert context와 기존 warning/critical·제외 경계를 확인하고 전달 문제는 Kubernetes
+   문서로 넘긴다.
+2. PVC/PV/StorageClass, metrics·trend, mount Pod와 controller/operator owner를 읽기
+   전용으로 조회한다. owner·backup·가용성·목표 용량 gate가 없으면 mutation하지 않는다.
+3. 승인된 workload 정리 경로가 없으면 선언 owner별 expansion 경로를 선택한다. Operator는
+   지원 field/reconcile, standalone PVC declaration은 declaration 증가·reconcile을 사용하고,
+   StatefulSet template은 generic 변경/reconcile하지 않는다. 기존 bound PVC direct patch는
+   모든 gate 뒤에만 수행하고 template 정합화는 owner 승인 별도 계획으로 둔다.
+4. condition/event, filesystem, workload health/readiness, 여유 추세와
+   `KubePersistentVolumeFillingUp` resolved를 확인하고 비민감 요약만 기록한다.
 
-1. **진입점과 책임:** alertname, namespace, PVC, severity, summary, description을 확인하고 warning/critical의 기존 의미를 그대로 사용한다. Alertmanager·Slack 전달 문제는 `byulmaru/kubernetes/docs/operations.md`로 보낸다.
-2. **읽기 전용 진단:** placeholder를 사용한 `kubectl get/describe`와 Prometheus 조회로 PVC request/status, available/capacity와 최근 추세, PV·StorageClass, condition/event를 확인한다. PVC를 mount한 Pod에서 owner reference를 controller/operator resource까지 추적한다.
-3. **owner와 데이터 경계:** service owner, 데이터의 지속성, 승인된 retention·export·rebalance 절차, backup/restore 상태를 확인한다. PostgreSQL이면 `docs/operations/postgres-backup.md`로 연결하고, 확인되지 않은 데이터 삭제나 purge는 중단한다.
-4. **완화 선택:** 승인된 workload별 정리로 충분하면 그 절차를 사용한다. 그렇지 않으면 live StorageClass와 CSI 지원, 목표 용량, 가용성 영향과 workload의 선언 source를 확인해 expansion을 선택한다. 확장이 불가능하면 범용 문서에서 PVC를 교체하지 않고 별도 migration 계획으로 escalation한다.
-5. **확장:** workload가 용량을 선언하는 상위 resource가 있으면 그 source를 통해 기존 PVC request가 증가하도록 하고, 그렇지 않은 경우에만 기존 PVC request를 직접 늘린다. PV는 직접 편집하지 않고 현재 `status.capacity` 이하로 낮추지 않는다. Restart는 condition과 workload 특성이 요구할 때만 통제된 방식으로 수행한다.
-6. **검증과 증거:** PVC request/status, allocated resize status·condition·event, mount filesystem, Pod/controller readiness와 workload별 health를 확인한다. 새 여유 공간과 추세가 충분하고 alert가 resolved된 뒤 비민감 결과만 기록한다.
-
-명령 예시는 `<namespace>`, `<pvc>`, `<storage-class>`, `<workload>`처럼 명시적인 placeholder를 사용하고, credential이나 Secret 값을 출력하는 command를 포함하지 않는다. 사용량은 `kubelet_volume_stats_available_bytes`와 `kubelet_volume_stats_capacity_bytes`를 같은 namespace/PVC label로 대조하되 기존 alert threshold를 문서에서 다시 정의하지 않는다.
-
-### Allowed Alternatives
-
-- Runbook 안에서 진단·판단·확장·검증을 섹션으로 나누거나, 상단에 동일한 순서를 보존하는 체크리스트를 둘 수 있다.
-- Owner resource 추적과 metric 조회 command는 현재 cluster 도구에 맞는 `kubectl` JSONPath, `jq` 또는 Prometheus UI 쿼리를 사용할 수 있다. 결과가 같은 read-only 사실을 제공하고 placeholder·비밀 비노출 경계를 지켜야 한다.
-- Workload가 공식 operator command나 GitOps 선언으로 size를 관리하면 직접 PVC patch 대신 그 경로를 사용할 수 있다. 최종적으로 기존 PVC request와 실제 volume/filesystem이 커지고 specs의 검증을 만족해야 한다.
-
-### Known Traps
-
-- 표준 Prometheus runbook의 Pod 자동 삭제 예시를 그대로 복사하면 single-replica workload나 operator 관리 workload에 불필요한 중단을 만들 수 있다.
-- StorageClass 이름만 보고 expansion을 지원한다고 가정하거나 PV capacity를 먼저 편집하면 resize를 건너뛰거나 반복 실패 상태를 만들 수 있다.
-- 용량 부족을 즉시 데이터 삭제 문제로 취급하면 승인되지 않은 보존 정책과 데이터 손실을 초래한다.
-- PVC/PV 이름, namespace와 severity는 대응에 필요한 resource context지만, Secret 값·database row·object payload를 함께 출력하거나 Linear/Slack에 복사해서는 안 된다.
-- Kosmo runbook에서 synthetic alert, Slack receiver 또는 Terraform 검증을 다시 설명하면 두 저장소의 운영 문서가 서로 다른 절차로 drift한다.
+명령에는 `<namespace>`, `<pvc>`, `<owner-kind>` 같은 placeholder만 사용하고 Secret,
+credential, payload 또는 파일 내용을 출력하지 않는다. 공식 Kubernetes·Prometheus
+문서는 원칙의 근거로만 링크하며 실제 지원 여부는 매 incident의 live 값으로 판정한다.
 
 ## Risks / Trade-offs
 
-- [범용 절차가 workload별 복구·가용성 차이를 숨길 수 있음] → 공통 절차는 read-only 진단과 판단 gate까지만 제공하고 mutation은 service owner와 전용 runbook·선언 source에 연결한다.
-- [잘못된 목표 용량은 실패 재시도 또는 비용 증가를 만들고 shrink rollback이 없음] → 현재 용량·추세·provider 한도와 목표를 사전 확인하고 resize condition/event를 완료까지 관찰한다.
-- [Restart가 가용성 또는 모니터링 공백을 만들 수 있음] → online filesystem expansion을 우선 관찰하고 condition이 요구할 때만 owner 승인 아래 workload 방식으로 restart한다.
-- [외부 표준 문서와 cluster 구현이 변할 수 있음] → 공식 문서는 원칙의 근거로 링크하고 실제 지원 여부는 매 incident의 live read-only 조회로 판정한다.
-- [Kosmo 문서와 Kubernetes routing PR의 생명주기가 다름] → 두 PR은 독립적으로 리뷰·병합하되 `PROD-698` 담당자가 runbook 실행 가능성과 기존 형식의 firing/resolved·negative routing 증거를 모두 확인해야 이슈를 완료한다.
+- 공통 문서가 workload 차이를 숨길 수 있으므로 mutation은 owner·전용 runbook·선언
+  source에 위임한다.
+- 확장은 shrink rollback이 없고 비용·재시도 위험이 있으므로 목표·quota·condition/event를
+  완료까지 확인한다.
+- online resize를 우선하고 restart는 condition과 owner 절차가 요구할 때만 수행한다.
+- Kosmo와 Kubernetes 결과는 각각 독립적으로 검토·revert할 수 있으며 전체 이슈 완료는
+  양쪽 firing/resolved·negative routing 증거를 통합 확인한 뒤 결정한다.
 
 ## Migration Plan
 
-1. Kosmo 브랜치에서 OpenSpec strict validation과 runbook 요구사항을 확정한다.
-2. `docs/operations/persistent-volume-capacity.md`를 추가하고 Markdown formatting, 내부·외부 링크, placeholder와 민감정보 경계를 검증한다.
-3. Tailscale Kubernetes API proxy를 사용한 read-only 명령 smoke로 대상이 다른 PVC에서 진단·owner 추적 명령의 실행 가능성을 확인하되 실제 identifier와 출력 원문은 커밋·Linear에 남기지 않는다.
-4. Kosmo runbook PR과 `byulmaru/kubernetes`의 별도 `PROD-698` PR을 순서 제약 없이 독립적으로 리뷰·병합한다.
-5. Kubernetes PR은 `KubePersistentVolumeFillingUp`만 기존 allowlist에 추가하고 receiver, `#monitoring`, `sendResolved=true`와 Slack 메시지 형식을 유지한 채 positive/negative firing·resolved routing을 검증한다.
-6. 두 저장소의 결과와 통합 증거를 `PROD-698` 담당자가 확인한다.
-
-이 변경에는 schema나 runtime migration이 없다. Kosmo 문서와 Kubernetes allowlist는 링크 계약을 공유하지 않으므로 각 저장소에서 독립적으로 revert할 수 있다.
+없음. 문서 PR은 독립적으로 revert 가능하다.
 
 ## Open Questions
 
-없음. Incident별 live StorageClass·CSI 지원, owner, backup과 target size는 구현 전에 고정할 제품 결정이 아니라 runbook이 매번 확인할 운영 입력이다.
+없음. Incident별 live StorageClass·CSI 지원, owner, backup과 target size는 runbook이 매번 확인한다.

--- a/openspec/changes/add-persistent-volume-capacity-runbook/design.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-`PROD-698`은 기존 kube-prometheus-stack의 `KubePersistentVolumeFillingUp` 규칙을 모든 대상 PVC에 유지하면서, 명시적 Alertmanager allowlist를 통해 `#monitoring`으로 전달하고 Kosmo의 내부 대응 runbook으로 연결하는 하나의 운영 결과다. Alertmanager routing, Slack message와 notification test는 `byulmaru/kubernetes`가 소유하고, 이 저장소는 알림 이후의 실제 PVC 진단·완화·확장·복구 검증을 소유한다.
+`PROD-698`은 기존 kube-prometheus-stack의 `KubePersistentVolumeFillingUp` 규칙을 모든 대상 PVC에 유지하면서 명시적 Alertmanager allowlist를 통해 `#monitoring`으로 전달하고, 별도로 Kosmo의 내부 대응 runbook을 제공하는 하나의 운영 결과다. 현재 Slack 계약은 receiver, `#monitoring` 채널과 `sendResolved=true`뿐이므로 Alertmanager routing과 기존 메시지 형식의 notification test는 `byulmaru/kubernetes`가 소유하고, 이 저장소는 Slack 링크 없이 실제 PVC 진단·완화·확장·복구 검증을 소유한다.
 
 Kosmo에는 PostgreSQL backup·복구 등 workload별 운영 문서는 있지만 PVC 용량 부족에서 시작하는 범용 절차가 없다. PVC는 StatefulSet, operator CR처럼 서로 다른 선언 소유자를 가질 수 있고, 확장 가능 여부도 live StorageClass의 `allowVolumeExpansion`, provisioner와 CSI driver 지원에 달려 있으므로 특정 workload나 현재 cluster 값으로 일반화할 수 없다. Kubernetes 공식 문서는 PVC request 증가, PV 직접 편집 금지, filesystem resize와 실패 재시도 경계를 제공하고, Prometheus Operator 표준 runbook은 사용량 추세·retention·export·rebalance·resize·migration 선택지를 제시한다.
 
@@ -16,7 +16,7 @@ Kosmo에는 PostgreSQL backup·복구 등 workload별 운영 문서는 있지만
 
 **Non-Goals:**
 
-- Alertmanager allowlist, Slack message template, firing/resolved 합성 notification test 또는 Terraform 변경
+- Alertmanager allowlist, `runbook_url` annotation, Slack runbook 링크·custom title/text, firing/resolved 합성 notification test 또는 Terraform 변경
 - `KubePersistentVolumeFillingUp` 표현식·severity·제외 조건 변경
 - 자동·선제 volume 증설, 애플리케이션별 보존 정책 결정 또는 공통 삭제 명령
 - PVC/PV 삭제·재생성, reclaim policy 변경, snapshot restore 또는 volume migration의 실행 절차
@@ -26,7 +26,7 @@ Kosmo에는 PostgreSQL backup·복구 등 workload별 운영 문서는 있지만
 
 ### Current Constraints
 
-- 신규 문서 경로는 Linear가 정한 `docs/operations/persistent-volume-capacity.md`이며, Kubernetes 저장소의 Slack runbook 링크가 이 경로를 소비한다. 깨진 링크를 피하려면 Kosmo 문서가 먼저 병합되어야 한다.
+- 신규 문서 경로는 Linear가 정한 `docs/operations/persistent-volume-capacity.md`다. 현재 Slack 메시지는 이 경로를 소비하지 않으며 두 저장소 PR 사이에 runbook 링크나 병합 순서 의존성이 없다.
 - `docs/operations/postgres-backup.md`는 PostgreSQL의 data protection과 복구를 소유한다. 범용 runbook이 이를 복제하거나 PostgreSQL 데이터 삭제·복구 방식을 새로 정하면 기존 운영 계약과 충돌한다.
 - CNPG, Prometheus, Vault처럼 PVC를 생성·관리하는 상위 resource가 다르다. Pod 하나만 찾아 임의로 삭제하거나 PVC를 직접 편집하는 고정 명령은 선언 source of truth와 가용성 정책을 우회할 수 있다.
 - StorageClass 이름이나 현재 Terraform 선언은 live `allowVolumeExpansion`과 CSI resize 지원의 증거가 아니다. Incident마다 실제 PVC, StorageClass, provisioner, condition과 event를 조회해야 한다.
@@ -66,18 +66,18 @@ Runbook을 다음 순서의 하나의 의사결정 흐름으로 작성하는 것
 - [잘못된 목표 용량은 실패 재시도 또는 비용 증가를 만들고 shrink rollback이 없음] → 현재 용량·추세·provider 한도와 목표를 사전 확인하고 resize condition/event를 완료까지 관찰한다.
 - [Restart가 가용성 또는 모니터링 공백을 만들 수 있음] → online filesystem expansion을 우선 관찰하고 condition이 요구할 때만 owner 승인 아래 workload 방식으로 restart한다.
 - [외부 표준 문서와 cluster 구현이 변할 수 있음] → 공식 문서는 원칙의 근거로 링크하고 실제 지원 여부는 매 incident의 live read-only 조회로 판정한다.
-- [Kosmo 문서와 Kubernetes routing PR의 생명주기가 다름] → Kosmo PR 선병합, Kubernetes PR 후병합, `PROD-698` 담당자의 링크·firing/resolved 통합 검증을 완료 gate로 유지한다.
+- [Kosmo 문서와 Kubernetes routing PR의 생명주기가 다름] → 두 PR은 독립적으로 리뷰·병합하되 `PROD-698` 담당자가 runbook 실행 가능성과 기존 형식의 firing/resolved·negative routing 증거를 모두 확인해야 이슈를 완료한다.
 
 ## Migration Plan
 
 1. Kosmo 브랜치에서 OpenSpec strict validation과 runbook 요구사항을 확정한다.
 2. `docs/operations/persistent-volume-capacity.md`를 추가하고 Markdown formatting, 내부·외부 링크, placeholder와 민감정보 경계를 검증한다.
 3. Tailscale Kubernetes API proxy를 사용한 read-only 명령 smoke로 대상이 다른 PVC에서 진단·owner 추적 명령의 실행 가능성을 확인하되 실제 identifier와 출력 원문은 커밋·Linear에 남기지 않는다.
-4. Kosmo runbook PR을 먼저 병합한다.
-5. `byulmaru/kubernetes`의 별도 `PROD-698` PR이 병합된 runbook URL을 Slack message에 연결하고 positive/negative firing·resolved routing을 검증한다.
-6. 두 저장소의 링크 정합성과 통합 증거를 `PROD-698` 담당자가 확인한다.
+4. Kosmo runbook PR과 `byulmaru/kubernetes`의 별도 `PROD-698` PR을 순서 제약 없이 독립적으로 리뷰·병합한다.
+5. Kubernetes PR은 `KubePersistentVolumeFillingUp`만 기존 allowlist에 추가하고 receiver, `#monitoring`, `sendResolved=true`와 Slack 메시지 형식을 유지한 채 positive/negative firing·resolved routing을 검증한다.
+6. 두 저장소의 결과와 통합 증거를 `PROD-698` 담당자가 확인한다.
 
-이 변경에는 schema나 runtime migration이 없다. Kosmo 문서 rollback이 필요하면 Kubernetes의 소비 링크를 먼저 안전한 기존 fallback으로 되돌린 뒤 문서를 revert하여 깨진 링크를 만들지 않는다.
+이 변경에는 schema나 runtime migration이 없다. Kosmo 문서와 Kubernetes allowlist는 링크 계약을 공유하지 않으므로 각 저장소에서 독립적으로 revert할 수 있다.
 
 ## Open Questions
 

--- a/openspec/changes/add-persistent-volume-capacity-runbook/proposal.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/proposal.md
@@ -8,7 +8,7 @@
 - namespace와 PVC에서 사용량·증가 추세, 연결된 PV·Pod·상위 workload와 service owner를 확인하는 진단 순서를 정의한다.
 - 애플리케이션별 데이터 정리·보존 변경은 owner가 판단하도록 경계를 두고, StorageClass와 CSI의 확장 지원을 확인한 뒤 PVC 요청 용량만 늘리는 안전한 확장 절차를 정의한다.
 - 확장 상태, filesystem 반영, workload readiness와 용량 여유를 확인하고 alert가 resolved되는지 추적하는 사후 검증을 정의한다.
-- 기존 PostgreSQL backup runbook과 workload별 추가 runbook을 연결하되, 자동 증설·애플리케이션별 보존 정책 결정·PVC/PV 삭제나 migration 절차·Alertmanager routing은 현재 Kosmo slice에서 제외한다.
+- 기존 PostgreSQL backup runbook과 workload별 추가 runbook을 연결하되, 자동 증설·애플리케이션별 보존 정책 결정·PVC/PV 삭제나 migration 절차·Alertmanager routing과 Slack runbook 링크 계약은 현재 Kosmo slice에서 제외한다.
 
 ## Authority / Provenance
 
@@ -30,5 +30,5 @@
 
 - `docs/operations/persistent-volume-capacity.md`: 모든 쓰기 가능한 대상 PVC에 공통으로 적용할 신규 runbook
 - `docs/operations/postgres-backup.md`: 변경하지 않고 PostgreSQL 데이터 보호·복구 절차의 참조 대상으로 사용
-- `byulmaru/kubernetes`: 별도 `PROD-698` PR이 Alertmanager allowlist, Slack runbook 링크와 firing/resolved 통합 검증을 소유하며, 깨진 링크를 피하기 위해 Kosmo runbook PR이 먼저 병합되어야 함
+- `byulmaru/kubernetes`: 별도 `PROD-698` PR이 기존 Alertmanager receiver 계약을 유지하면서 `KubePersistentVolumeFillingUp` allowlist와 기존 Slack 메시지 형식의 firing/resolved 통합 검증을 소유함. `runbook_url`, runbook 링크 출력과 custom title/text는 추가하지 않음
 - 애플리케이션 코드, API, database schema, package dependency 변경 없음

--- a/openspec/changes/add-persistent-volume-capacity-runbook/proposal.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`PROD-698`은 모든 대상 PVC의 용량 부족 알림을 기존 `#monitoring` 경로로 전달하지만, Kosmo 저장소에는 알림을 받은 운영자가 사용량 원인과 소유 workload를 식별하고 데이터 손실 없이 용량을 확보할 범용 대응 절차가 없다. PostgreSQL, Vault, Prometheus와 미래의 PVC 기반 workload에 같은 안전 경계를 적용할 수 있는 내부 runbook이 필요하다.
+
+## What Changes
+
+- `docs/operations/persistent-volume-capacity.md`에 `KubePersistentVolumeFillingUp` 알림에서 시작하는 범용 PVC 용량 대응 runbook을 추가한다.
+- namespace와 PVC에서 사용량·증가 추세, 연결된 PV·Pod·상위 workload와 service owner를 확인하는 진단 순서를 정의한다.
+- 애플리케이션별 데이터 정리·보존 변경은 owner가 판단하도록 경계를 두고, StorageClass와 CSI의 확장 지원을 확인한 뒤 PVC 요청 용량만 늘리는 안전한 확장 절차를 정의한다.
+- 확장 상태, filesystem 반영, workload readiness와 용량 여유를 확인하고 alert가 resolved되는지 추적하는 사후 검증을 정의한다.
+- 기존 PostgreSQL backup runbook과 workload별 추가 runbook을 연결하되, 자동 증설·애플리케이션별 보존 정책 결정·PVC/PV 삭제나 migration 절차·Alertmanager routing은 현재 Kosmo slice에서 제외한다.
+
+## Authority / Provenance
+
+- Canonical: 적용되는 `docs/domain`·`docs/design` 문서 없음. 운영 절차 권위는 `docs/operations/`이며 기존 데이터 보호 경계는 `docs/operations/postgres-backup.md`를 따른다.
+- Linear Contract: `PROD-698`
+- Linear Implementations: `PROD-698`의 `byulmaru/kosmo` runbook slice. 별도 Sub Issue 없음.
+
+## Capabilities
+
+### New Capabilities
+
+- `persistent-volume-capacity-response`: PVC 용량 부족 알림을 안전한 진단, owner 판단, 지원되는 volume 확장과 완료 검증으로 연결하는 내부 운영 절차
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `docs/operations/persistent-volume-capacity.md`: 모든 쓰기 가능한 대상 PVC에 공통으로 적용할 신규 runbook
+- `docs/operations/postgres-backup.md`: 변경하지 않고 PostgreSQL 데이터 보호·복구 절차의 참조 대상으로 사용
+- `byulmaru/kubernetes`: 별도 `PROD-698` PR이 Alertmanager allowlist, Slack runbook 링크와 firing/resolved 통합 검증을 소유하며, 깨진 링크를 피하기 위해 Kosmo runbook PR이 먼저 병합되어야 함
+- 애플리케이션 코드, API, database schema, package dependency 변경 없음

--- a/openspec/changes/add-persistent-volume-capacity-runbook/specs/persistent-volume-capacity-response/spec.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/specs/persistent-volume-capacity-response/spec.md
@@ -77,12 +77,12 @@
 
 ### Requirement: 저장소 책임 분리와 비민감 대응 증거
 
-**Authority / Provenance:** `docs/operations/postgres-backup.md`, Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`. Kosmo runbook은 PVC 사용량 진단, owner 확인, 안전한 완화·확장과 후속 검증만 MUST 소유하며, Alertmanager receiver·allowlist·Slack notification test와 전달 실패 복구 절차를 MUST NOT 복제한다. PostgreSQL처럼 기존 workload별 runbook이 있으면 MUST 연결하고, 대응 증거에는 alert context, 비민감 측정값, 선택한 조치, 승인자와 검증 결과만 MUST 남긴다. Credential·Secret 값·database row·object 내용 또는 기타 실제 사용자 데이터는 command output, Linear, CI log나 Slack payload에 MUST NOT 복사한다.
+**Authority / Provenance:** `docs/operations/postgres-backup.md`, Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`. Kosmo runbook은 PVC 사용량 진단, owner 확인, 안전한 완화·확장과 후속 검증만 MUST 소유하며, Alertmanager receiver·allowlist·`runbook_url` annotation·Slack runbook 링크나 custom title/text·notification test와 전달 실패 복구 절차를 MUST NOT 포함하거나 요구한다. PostgreSQL처럼 기존 workload별 runbook이 있으면 MUST 연결하고, 대응 증거에는 alert context, 비민감 측정값, 선택한 조치, 승인자와 검증 결과만 MUST 남긴다. Credential·Secret 값·database row·object 내용 또는 기타 실제 사용자 데이터는 command output, Linear, CI log나 Slack payload에 MUST NOT 복사한다.
 
-#### Scenario: 전달 경로 자체가 실패함
+#### Scenario: 기존 Slack 계약과 독립된 runbook
 
-- **WHEN** PVC 대응 중 Alertmanager routing, Slack delivery 또는 resolved notification 전달 실패를 진단해야 한다
-- **THEN** 운영자는 `byulmaru/kubernetes/docs/operations.md`의 전달 경로 절차로 이동하고 Kosmo runbook에 중복된 routing 절차를 추가하지 않는다
+- **WHEN** 운영자가 Kosmo의 PVC 대응 runbook을 작성하거나 사용한다
+- **THEN** runbook은 Alertmanager routing이나 Slack 링크·메시지 template을 정의하지 않고 PVC 장애 대응 절차만 제공한다
 
 #### Scenario: 대응 증거를 남김
 

--- a/openspec/changes/add-persistent-volume-capacity-runbook/specs/persistent-volume-capacity-response/spec.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/specs/persistent-volume-capacity-response/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: 모든 대상 PVC에 공통인 알림 진입점
+
+**Authority / Provenance:** 적용되는 `docs/domain`·`docs/design` 문서 없음; Linear `PROD-698`. 내부 PVC 용량 대응 runbook은 namespace나 애플리케이션 종류와 무관하게 기존 `KubePersistentVolumeFillingUp` 규칙의 모든 대상 PVC에 MUST 같은 기본 절차를 제공한다. Runbook은 알림의 namespace, PVC, severity, summary와 description을 MUST 대응 시작 정보로 사용하며, 기존 규칙의 warning/critical 의미와 `ReadOnlyMany`·`excluded_from_alerts=true` 제외 조건을 MUST NOT 재정의한다.
+
+#### Scenario: 비-PostgreSQL PVC 알림에서 진입
+
+- **WHEN** 운영자가 PostgreSQL이 아닌 쓰기 가능한 PVC의 `KubePersistentVolumeFillingUp` 알림에서 namespace, PVC, severity, summary와 description을 확인한다
+- **THEN** runbook은 특정 애플리케이션을 전제하지 않는 동일한 진단 절차로 안내한다
+
+#### Scenario: 기존 alert 대상 경계 유지
+
+- **WHEN** PVC가 `ReadOnlyMany`이거나 `excluded_from_alerts=true`로 기존 규칙에서 제외되어 있다
+- **THEN** runbook은 해당 PVC를 현재 알림 대상에 강제로 포함하거나 기존 규칙의 제외 조건을 변경하도록 안내하지 않는다
+
+### Requirement: 읽기 전용 진단과 workload owner 식별
+
+**Authority / Provenance:** 적용되는 `docs/domain`·`docs/design` 문서 없음; Linear `PROD-698`. Runbook은 변경 작업보다 먼저 PVC의 요청·현재 용량과 상태, 최근 사용량·여유 공간·증가 추세, 연결된 PV와 StorageClass, mount한 Pod, 상위 workload owner와 Kubernetes event를 MUST 읽기 전용으로 확인한다. Pod의 owner reference를 실제 변경을 소유한 controller 또는 operator resource까지 MUST 추적하고 담당 service owner를 식별하며, owner와 데이터 성격을 확인하지 못한 상태에서는 데이터 정리·보존 변경·volume 변경을 MUST NOT 시작한다.
+
+#### Scenario: owner가 식별되는 정상 진단
+
+- **WHEN** namespace와 PVC에서 mount Pod와 상위 workload resource를 추적할 수 있다
+- **THEN** 운영자는 현재 용량·사용량·증가 추세·PVC/PV 상태와 event를 함께 기록하고 변경 책임을 가진 service owner를 확인한다
+
+#### Scenario: owner를 식별할 수 없음
+
+- **WHEN** PVC를 mount한 Pod, 상위 workload 또는 담당 service owner를 확정할 수 없다
+- **THEN** 운영자는 mutation을 중단하고 확인하지 못한 관계와 현재 용량 위험을 운영 담당자에게 escalation한다
+
+### Requirement: 애플리케이션별 데이터 정리의 안전 경계
+
+**Authority / Provenance:** `docs/operations/postgres-backup.md`, Linear `PROD-698`. Runbook은 보존 기간 변경, 오래된 데이터 삭제, export와 rebalance 같은 애플리케이션 수준 완화를 해당 workload의 승인된 정책·전용 runbook과 service owner 판단으로 MUST 분리한다. 범용 절차는 데이터 내용 삭제, PVC/PV 삭제·재생성, reclaim policy 변경 또는 volume purge 명령을 MUST NOT 제공하며, 승인된 정리 경로가 없고 데이터가 필요하면 지원되는 volume 확장 또는 별도 migration 계획으로 MUST escalation한다.
+
+#### Scenario: 승인된 정리 절차가 있음
+
+- **WHEN** service owner가 workload 전용 runbook과 보존 정책에 따라 제거 가능한 데이터를 확인한다
+- **THEN** 운영자는 해당 전용 절차와 백업·복구 경계를 따라 정리하고 범용 runbook에는 데이터별 삭제 방식을 새로 결정하지 않는다
+
+#### Scenario: 정리 가능 여부가 불명확함
+
+- **WHEN** 데이터 보존 정책, 백업 상태 또는 삭제 승인 중 하나라도 확인되지 않는다
+- **THEN** 운영자는 데이터를 삭제하지 않고 volume 확장 가능성을 확인하거나 migration을 별도 계획하도록 escalation한다
+
+### Requirement: 지원 여부를 확인한 PVC 확장
+
+**Authority / Provenance:** 적용되는 `docs/domain`·`docs/design` 문서 없음; Linear `PROD-698`. Runbook은 PVC 확장 전에 해당 StorageClass의 `allowVolumeExpansion`, provisioner·CSI driver의 확장 지원, 현재 PVC 요청·상태 용량, workload가 소유한 선언 경로, backup·가용성 영향과 목표 용량을 MUST 확인한다. 지원되는 경우 기존 PVC의 요청 용량을 현재 용량보다 큰 값으로 MUST 변경하며, PV 용량을 직접 편집하거나 PVC를 축소하는 작업은 MUST NOT 안내한다. Filesystem 반영에 rollout 또는 restart가 필요한지는 PVC condition과 workload 특성으로 MUST 판단하고, 불필요한 restart를 고정 절차로 MUST NOT 요구한다.
+
+#### Scenario: 온라인 확장을 지원함
+
+- **WHEN** StorageClass와 CSI driver가 expansion을 지원하고 in-use filesystem이 온라인 확장을 완료한다
+- **THEN** 운영자는 기존 PVC의 요청 용량만 늘리고 workload를 불필요하게 restart하지 않는다
+
+#### Scenario: filesystem 반영에 restart가 필요함
+
+- **WHEN** volume 확장 뒤 PVC condition 또는 workload 상태가 filesystem resize를 완료하기 위한 rollout이나 restart를 요구한다
+- **THEN** 운영자는 service owner와 가용성 영향을 확인한 뒤 workload 소유 방식에 맞는 통제된 restart를 수행한다
+
+#### Scenario: 확장을 지원하지 않음
+
+- **WHEN** StorageClass 또는 CSI driver가 확장을 지원하지 않거나 지원 여부를 확인할 수 없다
+- **THEN** 운영자는 PVC나 PV를 임의로 교체하지 않고 snapshot·backup·migration이 포함된 workload별 후속 계획으로 escalation한다
+
+### Requirement: 확장 완료와 alert 해소 검증
+
+**Authority / Provenance:** 적용되는 `docs/domain`·`docs/design` 문서 없음; Linear `PROD-698`. Runbook은 변경 뒤 PVC의 요청·상태 용량, resize condition과 event, mount된 filesystem 용량, Pod와 상위 workload readiness, workload별 health, 새 여유 공간과 증가 추세를 MUST 검증한다. 현재 용량 부족 상태가 해소된 뒤 `KubePersistentVolumeFillingUp`이 resolved되는지 MUST 확인하며, resize가 실패하거나 반복 재시도되는 동안에는 완료로 MUST NOT 기록한다.
+
+#### Scenario: 용량 확보와 정상 복구
+
+- **WHEN** PVC와 filesystem 확장이 완료되고 workload readiness와 workload별 health가 정상이다
+- **THEN** 운영자는 확보된 여유 공간과 예상 증가 추세를 확인하고 alert의 resolved 상태까지 완료 증거로 기록한다
+
+#### Scenario: resize가 완료되지 않음
+
+- **WHEN** PVC condition이나 event에 resize 실패·대기 상태가 남거나 workload가 Ready로 복구되지 않는다
+- **THEN** 운영자는 대응을 완료 처리하지 않고 현재 상태와 가용성 영향을 기록해 service owner와 storage 운영 담당자에게 escalation한다
+
+### Requirement: 저장소 책임 분리와 비민감 대응 증거
+
+**Authority / Provenance:** `docs/operations/postgres-backup.md`, Linear `PROD-698`, 관련 운영 알림 계약 `PROD-530`. Kosmo runbook은 PVC 사용량 진단, owner 확인, 안전한 완화·확장과 후속 검증만 MUST 소유하며, Alertmanager receiver·allowlist·Slack notification test와 전달 실패 복구 절차를 MUST NOT 복제한다. PostgreSQL처럼 기존 workload별 runbook이 있으면 MUST 연결하고, 대응 증거에는 alert context, 비민감 측정값, 선택한 조치, 승인자와 검증 결과만 MUST 남긴다. Credential·Secret 값·database row·object 내용 또는 기타 실제 사용자 데이터는 command output, Linear, CI log나 Slack payload에 MUST NOT 복사한다.
+
+#### Scenario: 전달 경로 자체가 실패함
+
+- **WHEN** PVC 대응 중 Alertmanager routing, Slack delivery 또는 resolved notification 전달 실패를 진단해야 한다
+- **THEN** 운영자는 `byulmaru/kubernetes/docs/operations.md`의 전달 경로 절차로 이동하고 Kosmo runbook에 중복된 routing 절차를 추가하지 않는다
+
+#### Scenario: 대응 증거를 남김
+
+- **WHEN** 운영자가 진단, owner 승인, 용량 변경과 복구 결과를 이슈에 기록한다
+- **THEN** 기록에는 namespace·PVC·severity와 비민감 상태·측정값만 포함되고 credential, Secret 값과 실제 사용자 데이터는 포함되지 않는다

--- a/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
@@ -63,4 +63,4 @@ Runbook의 read-only 진단 명령과 내부·외부 참고 링크·안전 gate�
 - [x] 2.2 서로 다른 owner 유형의 PVC 두 개 이상에서 read-only 진단·owner 추적 명령을 실행하고 비민감 성공·실패 증거만 기록한다.
 - [x] 2.3 모든 requirement scenario를 runbook section에 대조하고 expansion·restart·실패·escalation 분기가 누락되지 않았는지 검토한다.
 - [x] 2.4 OpenSpec strict validation을 통과하고 runbook 구현과 delta spec의 정합성을 확인한다.
-- [ ] 2.5 Kosmo runbook과 Kubernetes allowlist의 독립 범위, 기존 receiver·메시지 형식 유지, 통합·archive owner와 남은 검증을 `PROD-698`에 handoff한다.
+- [x] 2.5 Kosmo runbook과 Kubernetes allowlist의 독립 범위, 기존 receiver·메시지 형식 유지, 통합·archive owner와 남은 검증을 `PROD-698`에 handoff한다.

--- a/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
@@ -16,7 +16,7 @@
 - Mutation 전에 read-only 진단, service owner, 데이터 성격, backup·가용성 영향을 확인한다.
 - 범용 문서에서 애플리케이션별 보존 정책을 결정하거나 데이터 삭제, PVC/PV 삭제·재생성, reclaim policy 변경, purge, 자동 증설을 안내하지 않는다.
 - Expansion은 live StorageClass·CSI 지원과 workload 선언 owner를 확인하고 기존 PVC request를 증가시키며, PV를 직접 편집하거나 PVC를 축소하지 않는다.
-- Restart는 condition과 workload 특성이 요구할 때만 수행하고, routing·Slack notification test는 `byulmaru/kubernetes` 운영 문서에 남긴다.
+- Restart는 condition과 workload 특성이 요구할 때만 수행하고, routing·Slack notification test는 `byulmaru/kubernetes` 운영 문서에 남긴다. Kosmo runbook에는 `runbook_url`, Slack 링크나 custom title/text 계약을 추가하지 않는다.
 - Credential, Secret 값, database row·object 내용과 실제 사용자 데이터를 command output, 문서 예시나 협업 시스템에 노출하지 않는다.
 
 **Verification**
@@ -41,13 +41,13 @@
 
 **Deliverable**
 
-Runbook의 read-only 진단 명령과 링크·안전 gate가 현재 cluster에서 실행 가능하고 리뷰 가능한 증거를 가지며, 먼저 병합된 Kosmo 문서 URL을 Kubernetes routing slice가 안전하게 소비할 수 있다.
+Runbook의 read-only 진단 명령과 내부·외부 참고 링크·안전 gate가 현재 cluster에서 실행 가능하고 리뷰 가능한 증거를 가진다. Kubernetes routing slice는 Kosmo 문서 URL을 소비하지 않고 기존 Alertmanager receiver와 Slack 메시지 형식을 유지한 채 allowlist와 firing/resolved 검증을 소유한다.
 
 **Guardrails**
 
 - Live 검증에서는 read-only 진단만 실행하고 incident 없는 PVC에 size·data·workload mutation을 만들지 않는다.
 - 실제 identifier와 raw output을 commit, CI log, Linear 또는 Slack에 복사하지 않고 성공 여부와 비민감 측정 범위만 기록한다.
-- Kosmo runbook PR을 Kubernetes routing PR보다 먼저 병합한다.
+- 두 PR 사이에 runbook 링크나 병합 순서 의존성을 만들지 않는다.
 - OpenSpec archive owner는 `PROD-698` assignee이며, Kosmo runbook 구현·검증·delta spec 동기화와 strict validation이 모두 끝난 뒤에만 이 change를 archive한다.
 - Cross-repository integration과 Linear 완료 owner는 `PROD-698` assignee이며, 두 PR과 firing/resolved·negative routing 증거가 모두 확인되기 전에는 이슈를 완료하지 않는다.
 
@@ -57,10 +57,10 @@ Runbook의 read-only 진단 명령과 링크·안전 gate가 현재 cluster에�
 - 신규 문서의 local Markdown link와 Prometheus Operator·Kubernetes 공식 문서 URL 확인
 - 서로 다른 owner 유형의 PVC 두 개 이상(그중 하나는 비-PostgreSQL)에서 진단·owner 추적 command의 read-only smoke와 redacted 결과
 - `openspec validate add-persistent-volume-capacity-runbook --strict`
-- Kosmo 병합 URL, Kubernetes 후속 dependency와 남은 통합 검증을 `PROD-698` handoff에서 확인
+- Kosmo runbook과 Kubernetes allowlist의 독립 범위, 기존 메시지 형식 유지와 남은 통합 검증을 `PROD-698` handoff에서 확인
 
 - [ ] 2.1 Markdown formatting, local/external link, placeholder, destructive command와 민감정보 노출 경계를 정적 검토한다.
 - [ ] 2.2 서로 다른 owner 유형의 PVC 두 개 이상에서 read-only 진단·owner 추적 명령을 실행하고 비민감 성공·실패 증거만 기록한다.
 - [ ] 2.3 모든 requirement scenario를 runbook section에 대조하고 expansion·restart·실패·escalation 분기가 누락되지 않았는지 검토한다.
 - [ ] 2.4 OpenSpec strict validation을 통과하고 runbook 구현과 delta spec의 정합성을 확인한다.
-- [ ] 2.5 Kosmo 문서의 안정된 병합 URL, Kubernetes PR의 후속 dependency, 통합·archive owner와 남은 검증을 `PROD-698`에 handoff한다.
+- [ ] 2.5 Kosmo runbook과 Kubernetes allowlist의 독립 범위, 기존 receiver·메시지 형식 유지, 통합·archive owner와 남은 검증을 `PROD-698`에 handoff한다.

--- a/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
@@ -25,11 +25,11 @@
 - 모든 command가 명시적 placeholder를 사용하고 destructive operation이나 Secret/data 출력 경로가 없는지 검토한다.
 - 내부 workload runbook과 Kubernetes 전달 경로 문서 링크의 목적과 소유권이 중복되지 않는지 확인한다.
 
-- [ ] 1.1 Alert 필드, 적용 대상과 Kosmo/Kubernetes 책임 경계를 설명하는 runbook 진입부를 작성한다.
-- [ ] 1.2 PVC request/status, 사용량·여유 공간·증가 추세, PV·StorageClass, mount Pod·상위 workload owner와 event를 확인하는 read-only 진단 절차를 작성한다.
-- [ ] 1.3 Service owner와 workload별 retention·backup·export·rebalance 절차로 연결하고, 확인되지 않은 데이터 정리와 파괴 작업을 중단하는 판단 경계를 작성한다.
-- [ ] 1.4 Live expansion 지원, workload 선언 owner와 목표 용량을 확인한 뒤 PVC request를 늘리고 필요한 경우에만 통제된 restart를 수행하는 절차를 작성한다.
-- [ ] 1.5 PVC/filesystem/workload 복구, 새 여유 공간·추세와 alert resolved를 확인하고 비민감 증거만 남기는 완료 절차를 작성한다.
+- [x] 1.1 Alert 필드, 적용 대상과 Kosmo/Kubernetes 책임 경계를 설명하는 runbook 진입부를 작성한다.
+- [x] 1.2 PVC request/status, 사용량·여유 공간·증가 추세, PV·StorageClass, mount Pod·상위 workload owner와 event를 확인하는 read-only 진단 절차를 작성한다.
+- [x] 1.3 Service owner와 workload별 retention·backup·export·rebalance 절차로 연결하고, 확인되지 않은 데이터 정리와 파괴 작업을 중단하는 판단 경계를 작성한다.
+- [x] 1.4 Live expansion 지원, workload 선언 owner와 목표 용량을 확인한 뒤 PVC request를 늘리고 필요한 경우에만 통제된 restart를 수행하는 절차를 작성한다.
+- [x] 1.5 PVC/filesystem/workload 복구, 새 여유 공간·추세와 alert resolved를 확인하고 비민감 증거만 남기는 완료 절차를 작성한다.
 
 ## 2. PROD-698 실행 가능성 검증과 교차 저장소 handoff
 
@@ -59,8 +59,8 @@ Runbook의 read-only 진단 명령과 내부·외부 참고 링크·안전 gate�
 - `openspec validate add-persistent-volume-capacity-runbook --strict`
 - Kosmo runbook과 Kubernetes allowlist의 독립 범위, 기존 메시지 형식 유지와 남은 통합 검증을 `PROD-698` handoff에서 확인
 
-- [ ] 2.1 Markdown formatting, local/external link, placeholder, destructive command와 민감정보 노출 경계를 정적 검토한다.
-- [ ] 2.2 서로 다른 owner 유형의 PVC 두 개 이상에서 read-only 진단·owner 추적 명령을 실행하고 비민감 성공·실패 증거만 기록한다.
-- [ ] 2.3 모든 requirement scenario를 runbook section에 대조하고 expansion·restart·실패·escalation 분기가 누락되지 않았는지 검토한다.
-- [ ] 2.4 OpenSpec strict validation을 통과하고 runbook 구현과 delta spec의 정합성을 확인한다.
+- [x] 2.1 Markdown formatting, local/external link, placeholder, destructive command와 민감정보 노출 경계를 정적 검토한다.
+- [x] 2.2 서로 다른 owner 유형의 PVC 두 개 이상에서 read-only 진단·owner 추적 명령을 실행하고 비민감 성공·실패 증거만 기록한다.
+- [x] 2.3 모든 requirement scenario를 runbook section에 대조하고 expansion·restart·실패·escalation 분기가 누락되지 않았는지 검토한다.
+- [x] 2.4 OpenSpec strict validation을 통과하고 runbook 구현과 delta spec의 정합성을 확인한다.
 - [ ] 2.5 Kosmo runbook과 Kubernetes allowlist의 독립 범위, 기존 receiver·메시지 형식 유지, 통합·archive owner와 남은 검증을 `PROD-698`에 handoff한다.

--- a/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
+++ b/openspec/changes/add-persistent-volume-capacity-runbook/tasks.md
@@ -1,0 +1,66 @@
+## 1. PROD-698 범용 PVC 용량 대응 runbook
+
+**Authority / Provenance**
+
+- 적용되는 `docs/domain`·`docs/design` 문서 없음
+- `docs/operations/postgres-backup.md`
+- Linear `PROD-698`
+
+**Deliverable**
+
+운영자가 namespace나 애플리케이션 종류와 무관하게 `KubePersistentVolumeFillingUp` 알림에서 시작해 PVC 용량과 추세, 상위 workload와 owner를 진단하고, 데이터 안전 경계를 지키며 지원되는 확장과 복구 검증까지 수행할 수 있는 `docs/operations/persistent-volume-capacity.md`를 제공한다.
+
+**Guardrails**
+
+- 기존 warning/critical 의미와 `ReadOnlyMany`·`excluded_from_alerts=true` 제외 조건을 변경하지 않는다.
+- Mutation 전에 read-only 진단, service owner, 데이터 성격, backup·가용성 영향을 확인한다.
+- 범용 문서에서 애플리케이션별 보존 정책을 결정하거나 데이터 삭제, PVC/PV 삭제·재생성, reclaim policy 변경, purge, 자동 증설을 안내하지 않는다.
+- Expansion은 live StorageClass·CSI 지원과 workload 선언 owner를 확인하고 기존 PVC request를 증가시키며, PV를 직접 편집하거나 PVC를 축소하지 않는다.
+- Restart는 condition과 workload 특성이 요구할 때만 수행하고, routing·Slack notification test는 `byulmaru/kubernetes` 운영 문서에 남긴다.
+- Credential, Secret 값, database row·object 내용과 실제 사용자 데이터를 command output, 문서 예시나 협업 시스템에 노출하지 않는다.
+
+**Verification**
+
+- PostgreSQL이 아닌 PVC 진입, owner 미확인, 승인된 정리 경로, expansion 지원·미지원, online resize·restart 필요, resize 실패와 비민감 증거 scenario를 문서에서 재현한다.
+- 모든 command가 명시적 placeholder를 사용하고 destructive operation이나 Secret/data 출력 경로가 없는지 검토한다.
+- 내부 workload runbook과 Kubernetes 전달 경로 문서 링크의 목적과 소유권이 중복되지 않는지 확인한다.
+
+- [ ] 1.1 Alert 필드, 적용 대상과 Kosmo/Kubernetes 책임 경계를 설명하는 runbook 진입부를 작성한다.
+- [ ] 1.2 PVC request/status, 사용량·여유 공간·증가 추세, PV·StorageClass, mount Pod·상위 workload owner와 event를 확인하는 read-only 진단 절차를 작성한다.
+- [ ] 1.3 Service owner와 workload별 retention·backup·export·rebalance 절차로 연결하고, 확인되지 않은 데이터 정리와 파괴 작업을 중단하는 판단 경계를 작성한다.
+- [ ] 1.4 Live expansion 지원, workload 선언 owner와 목표 용량을 확인한 뒤 PVC request를 늘리고 필요한 경우에만 통제된 restart를 수행하는 절차를 작성한다.
+- [ ] 1.5 PVC/filesystem/workload 복구, 새 여유 공간·추세와 alert resolved를 확인하고 비민감 증거만 남기는 완료 절차를 작성한다.
+
+## 2. PROD-698 실행 가능성 검증과 교차 저장소 handoff
+
+**Authority / Provenance**
+
+- `docs/operations/postgres-backup.md`
+- Linear `PROD-698`
+- 관련 운영 알림 계약 `PROD-530`
+
+**Deliverable**
+
+Runbook의 read-only 진단 명령과 링크·안전 gate가 현재 cluster에서 실행 가능하고 리뷰 가능한 증거를 가지며, 먼저 병합된 Kosmo 문서 URL을 Kubernetes routing slice가 안전하게 소비할 수 있다.
+
+**Guardrails**
+
+- Live 검증에서는 read-only 진단만 실행하고 incident 없는 PVC에 size·data·workload mutation을 만들지 않는다.
+- 실제 identifier와 raw output을 commit, CI log, Linear 또는 Slack에 복사하지 않고 성공 여부와 비민감 측정 범위만 기록한다.
+- Kosmo runbook PR을 Kubernetes routing PR보다 먼저 병합한다.
+- OpenSpec archive owner는 `PROD-698` assignee이며, Kosmo runbook 구현·검증·delta spec 동기화와 strict validation이 모두 끝난 뒤에만 이 change를 archive한다.
+- Cross-repository integration과 Linear 완료 owner는 `PROD-698` assignee이며, 두 PR과 firing/resolved·negative routing 증거가 모두 확인되기 전에는 이슈를 완료하지 않는다.
+
+**Verification**
+
+- `pnpm lint:prettier`
+- 신규 문서의 local Markdown link와 Prometheus Operator·Kubernetes 공식 문서 URL 확인
+- 서로 다른 owner 유형의 PVC 두 개 이상(그중 하나는 비-PostgreSQL)에서 진단·owner 추적 command의 read-only smoke와 redacted 결과
+- `openspec validate add-persistent-volume-capacity-runbook --strict`
+- Kosmo 병합 URL, Kubernetes 후속 dependency와 남은 통합 검증을 `PROD-698` handoff에서 확인
+
+- [ ] 2.1 Markdown formatting, local/external link, placeholder, destructive command와 민감정보 노출 경계를 정적 검토한다.
+- [ ] 2.2 서로 다른 owner 유형의 PVC 두 개 이상에서 read-only 진단·owner 추적 명령을 실행하고 비민감 성공·실패 증거만 기록한다.
+- [ ] 2.3 모든 requirement scenario를 runbook section에 대조하고 expansion·restart·실패·escalation 분기가 누락되지 않았는지 검토한다.
+- [ ] 2.4 OpenSpec strict validation을 통과하고 runbook 구현과 delta spec의 정합성을 확인한다.
+- [ ] 2.5 Kosmo 문서의 안정된 병합 URL, Kubernetes PR의 후속 dependency, 통합·archive owner와 남은 검증을 `PROD-698`에 handoff한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- 모든 대상 PVC의 `KubePersistentVolumeFillingUp` 알림에서 시작하는 범용 용량 대응 runbook을 추가했습니다.
- PVC/PV/StorageClass, 사용량·추세, mount Pod와 최종 workload owner를 읽기 전용으로 진단하는 절차를 정리했습니다.
- Operator의 지원된 resize 경로, standalone PVC 선언, immutable StatefulSet template을 구분해 기존 PVC 확장과 선언 정합화 경계를 명시했습니다.
- 데이터 보호·service owner 승인, filesystem/workload 복구와 alert 해소 검증 경계를 명시했습니다.
- OpenSpec proposal/design/decisions/spec/tasks를 구현 결과와 동기화하고 반복 계약을 줄였습니다.

## 왜 변경했는지

PostgreSQL에서 처음 발견된 PVC 용량 위험을 Vault, Prometheus와 미래의 PVC 기반 workload에도 적용 가능한 공통 대응 절차로 제공하기 위해서입니다. Alertmanager allowlist와 Slack 메시지 계약은 이 저장소의 범위에 포함하지 않습니다.

## 이번 PR의 주요 결정

없음. Linear `PROD-698`과 OpenSpec의 기존 결정을 변경 없이 적용했습니다. Kubernetes 저장소의 allowlist·Slack firing/resolved 검증은 별도 `PROD-698` PR이 소유합니다.

## 어떻게 확인할 수 있는지

- `openspec validate add-persistent-volume-capacity-runbook --strict`
- 변경 파일 대상 Prettier 검사
- `git diff --check origin/main...HEAD`
- 내부 문서 링크·placeholder·파괴적 명령 및 민감정보 경계 정적 검사
- 서로 다른 최종 owner 유형 2개(`Cluster`, `Prometheus`; 비-PostgreSQL 포함)에서 PVC/PV/StorageClass/event, mount Pod와 최종 owner chain read-only smoke
- smoke 대상 PVC의 `available`, `capacity`, `used` volume metric query
- 전체 `pnpm lint:prettier`: 기존 변경과 무관한 `apps/app/expo-env.d.ts` 포맷 경고로 실패

실제 resource identifier, raw output, Secret 또는 사용자 데이터는 검증 기록에 남기지 않았습니다.

## 아직 어떤 문제가 남아있는지

- Prometheus → Alertmanager → Slack firing/resolved·negative routing 통합 검증은 Kubernetes PR과 `PROD-698` 통합 담당자가 수행해야 합니다.
- 전체 lint의 기존 `apps/app/expo-env.d.ts` 포맷 경고는 본 PR 범위 밖입니다.

Linear: PROD-698