### PR TITLE
KOSMO 워크트리에서 CodeGraph 기준선을 안전하게 공유한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@
   `main` checkout. If that checkout has `.codegraph/codegraph.db`, pass its absolute path as
   CodeGraph's `projectPath` and use its graph only as a read-only structural baseline. Do not
   hard-code a machine-specific checkout path in repository files.
+- Before using the shared baseline, run `codegraph status <main-checkout-path>` to verify that the
+  index is up to date. If freshness cannot be verified or CodeGraph reports a pending or stale
+  state, treat the entire baseline as stale and use current-worktree reads and targeted searches.
 - Before relying on the baseline graph, collect paths that differ between the baseline checkout
   and the current worktree, plus staged, unstaged, and untracked paths in both checkouts. Treat
   CodeGraph results for those paths, and relationships that cross them, as hints only; verify the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,24 @@
 - Use the Question tool when asking the user to decide between implementation options or unresolved requirements.
 - Do not add a `Co-authored-by` trailer for the agent in commits or PR descriptions. The author of record is the human running the agent; agent attribution belongs in the PR body or Linear, not in the git trailer.
 
+## CodeGraph In Linked Worktrees
+
+- For this repository, consider CodeGraph initialized only when the current worktree contains
+  `.codegraph/codegraph.db`. A `.codegraph/` directory containing only `.gitignore` is not an
+  initialized index. This rule overrides broader instructions that check only for the directory.
+- Do not run `codegraph init` in a linked worktree without user approval.
+- When the current worktree has no local index, use `git worktree list --porcelain` to find the
+  `main` checkout. If that checkout has `.codegraph/codegraph.db`, pass its absolute path as
+  CodeGraph's `projectPath` and use its graph only as a read-only structural baseline. Do not
+  hard-code a machine-specific checkout path in repository files.
+- Before relying on the baseline graph, collect paths that differ between the baseline checkout
+  and the current worktree, plus staged, unstaged, and untracked paths in both checkouts. Treat
+  CodeGraph results for those paths, and relationships that cross them, as hints only; verify the
+  current worktree with direct reads and targeted searches.
+- If graph-shaping configuration differs or the task makes broad structural changes, state that
+  the shared baseline is not branch-exact and ask whether to initialize CodeGraph in the current
+  worktree. Otherwise, do not create a worktree-local index by default.
+
 ## Review Guidelines
 
 - Write review comments and review summaries in Korean.


### PR DESCRIPTION
## 무엇을 변경했나요

- `AGENTS.md`에 linked worktree의 CodeGraph 운영 규칙을 추가했습니다.
- 현재 워크트리에 `.codegraph/codegraph.db`가 있을 때만 로컬 인덱스가 초기화된 것으로 판단합니다.
- 로컬 인덱스가 없으면 `main` 체크아웃의 인덱스를 읽기 전용 구조 기준선으로 사용합니다.
- 두 체크아웃 사이에서 다르거나 staged·unstaged·untracked 상태인 파일과 해당 파일을 통과하는 관계는 현재 워크트리에서 직접 재검증하도록 했습니다.
- 광범위한 구조 변경이나 그래프 해석 설정 변경 때만 워크트리 로컬 인덱스 생성 여부를 사용자에게 확인합니다.

## 왜 변경했나요

PR #519를 통해 `.codegraph/.gitignore`가 추적되면서 모든 워크트리에 `.codegraph/` 디렉터리는 존재하지만, 실제 데이터베이스는 워크트리별로 공유되지 않습니다.

기존의 디렉터리 존재 여부만 확인하는 규칙은 빈 `.codegraph/`를 초기화된 인덱스로 오인할 수 있었습니다. 반대로 모든 워크트리를 각각 초기화하면 동일 저장소의 로컬 그래프 데이터와 초기화 비용이 반복됩니다.

메인 체크아웃의 인덱스는 공통 구조 탐색에 재사용하면서, 브랜치별 변경은 현재 워크트리에서 검증하도록 경계를 명확히 했습니다.

## 이번 PR의 주요 결정

### 메인 체크아웃 인덱스를 구조 기준선으로 사용한다

- 결정자: @yeeun-uwu
- 선택: 워크트리 로컬 인덱스가 없으면 `main` 체크아웃의 CodeGraph 인덱스를 읽기 전용 구조 기준선으로 사용하고, 서로 다른 파일과 해당 파일을 통과하는 관계는 현재 워크트리에서 직접 검증합니다.
- 고려한 대안: 모든 워크트리에서 CodeGraph를 각각 초기화하거나, 워크트리에서는 CodeGraph를 전혀 사용하지 않는 방식
- 이유: 중복된 인덱스 저장 공간과 초기화 비용을 피하면서도 공통 코드 구조 탐색의 이점을 유지할 수 있기 때문입니다.
- 감수한 결과: 공용 인덱스는 변경된 브랜치의 정확한 그래프가 아니므로 변경 파일과 관련 관계에 대한 별도 검증이 필요합니다.
- 관련 근거: https://github.com/byulmaru/kosmo/pull/519

## 어떻게 확인할 수 있나요

- `pnpm exec prettier --check AGENTS.md`
- `git diff origin/main...HEAD --check`
- 커밋 훅의 ESLint 및 Prettier 실행 완료
- 독립 구현 리뷰에서 finding 없음
- 저장소 작업 지침만 변경하므로 애플리케이션 테스트는 실행하지 않았습니다.

## 아직 어떤 문제가 남았나요

- 공용 기준선은 브랜치별 변경을 정확히 반영하지 않으므로, 규칙에 명시한 현재 워크트리 직접 검증이 계속 필요합니다.
- 실제 제품 동작이나 배포에는 영향이 없습니다.