### PR TITLE
자동 pagination lifecycle을 공통화한다

### DIFF
--- a/apps/app/src/components/follow-request/FollowRequestList.tsx
+++ b/apps/app/src/components/follow-request/FollowRequestList.tsx
@@ -1,19 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 import { ConnectionHandler } from 'relay-runtime';
 import { PageHeader } from '@/components/PageHeader';
-import {
-  createNativeScrollHandlers,
-  isScrollNearEnd,
-  resumeNativePagination,
-} from '@/components/pagination/nativeScrollPagination';
+import { useAutomaticPagination } from '@/components/pagination/useAutomaticPagination';
 import { Button } from '@/components/ui/Button';
 import { Skeleton } from '@/components/ui/StateView';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
 import { FollowRequestListItem } from './FollowRequestListItem';
-import type { ScrollMetrics } from '@/components/pagination/nativeScrollPagination';
 import type { FollowRequestList_profile$key } from './__generated__/FollowRequestList_profile.graphql';
 import type { FollowRequestListNextPageQuery } from './__generated__/FollowRequestListNextPageQuery.graphql';
 
@@ -51,90 +45,13 @@ export function FollowRequestList({ profile }: FollowRequestListProps) {
     pagination.data.id,
     'FollowRequestList_incomingProfileFollowRequests',
   );
-  const [loadError, setLoadError] = useState(false);
-  const [nativePageRevision, setNativePageRevision] = useState(0);
-  const handledNativePageRevisionRef = useRef(0);
-  const requestInFlightRef = useRef(false);
-  const pageErrorRef = useRef(false);
-  const loadNextPage = useCallback(() => {
-    if (!pagination.hasNext || pagination.isLoadingNext || requestInFlightRef.current) {
-      return;
-    }
-
-    requestInFlightRef.current = true;
-    pageErrorRef.current = false;
-    setLoadError(false);
-    pagination.loadNext(20, {
-      onComplete: (error) => {
-        pageErrorRef.current = Boolean(error);
-        setLoadError(Boolean(error));
-        if (error) {
-          requestInFlightRef.current = false;
-          return;
-        }
-
-        setTimeout(() => {
-          if (Platform.OS === 'web') {
-            requestInFlightRef.current = false;
-          } else {
-            setNativePageRevision((revision) => revision + 1);
-          }
-        }, 0);
-      },
-    });
-  }, [pagination.hasNext, pagination.isLoadingNext, pagination.loadNext]);
-  const maybeLoadNextPage = useCallback(
-    (metrics: ScrollMetrics) => {
-      if (!pageErrorRef.current && !loadError && isScrollNearEnd(metrics)) {
-        loadNextPage();
-      }
-    },
-    [loadError, loadNextPage],
-  );
-  const nativeMetricsRef = useRef<ScrollMetrics>({
-    contentLength: 0,
-    offset: 0,
-    viewportLength: 0,
+  const { loadError, loadNextPage, nativeScrollProps } = useAutomaticPagination({
+    hasNext: pagination.hasNext,
+    isLoadingNext: pagination.isLoadingNext,
+    itemCount: edges.length,
+    loadNext: pagination.loadNext,
+    pageSize: 20,
   });
-  const nativeScrollProps = useMemo(
-    () => createNativeScrollHandlers(nativeMetricsRef, maybeLoadNextPage),
-    [maybeLoadNextPage],
-  );
-
-  useEffect(() => {
-    if (
-      Platform.OS === 'web' ||
-      nativePageRevision === 0 ||
-      pagination.isLoadingNext ||
-      handledNativePageRevisionRef.current === nativePageRevision
-    ) {
-      return;
-    }
-
-    handledNativePageRevisionRef.current = nativePageRevision;
-    resumeNativePagination(requestInFlightRef, nativeMetricsRef, maybeLoadNextPage);
-  }, [maybeLoadNextPage, nativePageRevision, pagination.isLoadingNext]);
-
-  useEffect(() => {
-    if (Platform.OS !== 'web') {
-      return;
-    }
-
-    const check = () =>
-      maybeLoadNextPage({
-        contentLength: document.documentElement.scrollHeight,
-        offset: window.scrollY,
-        viewportLength: window.innerHeight,
-      });
-    const frame = window.requestAnimationFrame(check);
-    window.addEventListener('scroll', check, { passive: true });
-    window.addEventListener('resize', check);
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.removeEventListener('scroll', check);
-      window.removeEventListener('resize', check);
-    };
-  }, [edges.length, maybeLoadNextPage]);
 
   if (!connection) {
     throw new Error('Selected Profile incoming follow request connection is unavailable.');

--- a/apps/app/src/components/pagination/useAutomaticPagination.test.ts
+++ b/apps/app/src/components/pagination/useAutomaticPagination.test.ts
@@ -200,6 +200,37 @@ describe('useAutomaticPagination', () => {
     assert.equal(loadRequests.length, 3, '마지막 page에서는 추가 요청하지 않는다');
   });
 
+  it('Web itemCount RAF가 먼저 실행돼도 성공 page 뒤 다시 측정한다', async () => {
+    await renderHook(options());
+    await runAnimationFrame();
+    assert.equal(loadRequests.length, 1);
+
+    await updateHook(options({ isLoadingNext: true, itemCount: 20 }));
+    const request = loadRequests[0];
+    assert.ok(request);
+    const scheduledTimers: Array<() => void> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((callback: () => void) => {
+      scheduledTimers.push(callback);
+      return 1;
+    }) as typeof setTimeout;
+
+    try {
+      await act(async () => request.onComplete(null));
+      await updateHook(options({ isLoadingNext: false, itemCount: 40 }));
+      await runAnimationFrame();
+      assert.equal(loadRequests.length, 1, 'guard 해제 전 itemCount RAF는 요청하지 않는다');
+
+      const completeSuccess = scheduledTimers.shift();
+      assert.ok(completeSuccess);
+      await act(async () => completeSuccess());
+      await runAnimationFrame();
+      assert.equal(loadRequests.length, 2, 'guard 해제 뒤 성공 lifecycle이 다시 측정한다');
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
   it('Web page 실패는 자동 재시도를 막고 수동 재시도만 허용한다', async () => {
     await renderHook(options());
     await runAnimationFrame();

--- a/apps/app/src/components/pagination/useAutomaticPagination.test.ts
+++ b/apps/app/src/components/pagination/useAutomaticPagination.test.ts
@@ -1,0 +1,266 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import type { createNativeScrollHandlers } from './nativeScrollPagination';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type HookOptions = {
+  hasNext: boolean;
+  isLoadingNext: boolean;
+  itemCount: number;
+  loadNext: (count: number, options: { onComplete: (error: Error | null) => void }) => void;
+  pageSize: number;
+};
+
+type HookResult = {
+  loadError: boolean;
+  loadNextPage: () => void;
+  nativeScrollProps: ReturnType<typeof createNativeScrollHandlers>;
+};
+
+const platform = { OS: 'web' };
+const listeners = new Map<string, Set<EventListener>>();
+const animationFrames = new Map<number, FrameRequestCallback>();
+const loadRequests: Array<{
+  count: number;
+  onComplete: (error: Error | null) => void;
+}> = [];
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+let nextAnimationFrame = 0;
+let renderer: ReactTestRenderer | null = null;
+let current: HookResult | undefined;
+
+const windowFixture = {
+  requestAnimationFrame: (callback: FrameRequestCallback) => {
+    const id = ++nextAnimationFrame;
+    animationFrames.set(id, callback);
+    return id;
+  },
+  cancelAnimationFrame: (id: number) => {
+    animationFrames.delete(id);
+  },
+  addEventListener: (type: string, listener: EventListener) => {
+    const typeListeners = listeners.get(type) ?? new Set<EventListener>();
+    typeListeners.add(listener);
+    listeners.set(type, typeListeners);
+  },
+  removeEventListener: (type: string, listener: EventListener) => {
+    listeners.get(type)?.delete(listener);
+  },
+  scrollY: 0,
+  innerHeight: 800,
+};
+const documentFixture = { documentElement: { scrollHeight: 1200 } };
+
+const mockModule = (specifier: string | URL, exports: object) =>
+  mock.module(specifier, {
+    exports,
+  } as unknown as Parameters<typeof mock.module>[1]);
+
+mockModule('react-native', { Platform: platform });
+
+let useAutomaticPagination: (options: HookOptions) => HookResult;
+
+before(async () => {
+  ({ useAutomaticPagination } = await import('./useAutomaticPagination'));
+});
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: windowFixture,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    writable: true,
+    value: documentFixture,
+  });
+});
+
+const restoreGlobal = (name: 'window' | 'document', descriptor?: PropertyDescriptor) => {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete (globalThis as Record<string, unknown>)[name];
+  }
+};
+
+afterEach(async () => {
+  await act(async () => renderer?.unmount());
+  renderer = null;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  current = undefined;
+  platform.OS = 'web';
+  windowFixture.scrollY = 0;
+  windowFixture.innerHeight = 800;
+  documentFixture.documentElement.scrollHeight = 1200;
+  listeners.clear();
+  animationFrames.clear();
+  loadRequests.length = 0;
+  nextAnimationFrame = 0;
+  restoreGlobal('window', originalWindowDescriptor);
+  restoreGlobal('document', originalDocumentDescriptor);
+});
+
+function HookProbe(options: HookOptions) {
+  current = useAutomaticPagination(options);
+  return null;
+}
+
+const loadNext = (count: number, options: { onComplete: (error: Error | null) => void }) => {
+  loadRequests.push({ count, onComplete: options.onComplete });
+};
+
+function options(overrides: Partial<Omit<HookOptions, 'loadNext' | 'pageSize'>> = {}): HookOptions {
+  return {
+    hasNext: true,
+    isLoadingNext: false,
+    itemCount: 20,
+    loadNext,
+    pageSize: 20,
+    ...overrides,
+  };
+}
+
+async function renderHook(nextOptions: HookOptions) {
+  await act(async () => {
+    renderer = create(createElement(HookProbe, nextOptions));
+  });
+  assert.ok(current);
+}
+
+async function updateHook(nextOptions: HookOptions) {
+  assert.ok(renderer);
+  await act(async () => {
+    renderer?.update(createElement(HookProbe, nextOptions));
+  });
+  assert.ok(current);
+}
+
+function currentResult() {
+  assert.ok(current);
+  return current;
+}
+
+async function runAnimationFrame() {
+  const callbacks = [...animationFrames.values()];
+  animationFrames.clear();
+  await act(async () => {
+    callbacks.forEach((callback) => callback(0));
+  });
+}
+
+async function dispatchWindowEvent(type: string) {
+  const typeListeners = [...(listeners.get(type) ?? [])];
+  await act(async () => {
+    typeListeners.forEach((listener) => listener(new Event(type)));
+  });
+}
+
+async function completeRequest(index: number, error: Error | null) {
+  const request = loadRequests[index];
+  assert.ok(request);
+  await act(async () => {
+    request.onComplete(error);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe('useAutomaticPagination', () => {
+  it('Web near-end에서 한 번 요청하고 짧은 성공 page 뒤 다시 측정한다', async () => {
+    await renderHook(options());
+    await runAnimationFrame();
+    assert.equal(loadRequests.length, 1);
+
+    await dispatchWindowEvent('scroll');
+    await dispatchWindowEvent('resize');
+    assert.equal(loadRequests.length, 1, 'in-flight request는 중복 실행하지 않는다');
+
+    await updateHook(options({ isLoadingNext: true, itemCount: 20 }));
+    await completeRequest(0, null);
+    await updateHook(options({ isLoadingNext: false, itemCount: 40 }));
+    await runAnimationFrame();
+    assert.equal(loadRequests.length, 2, '짧은 성공 page 뒤 near-end를 다시 측정한다');
+
+    await updateHook(options({ isLoadingNext: true, itemCount: 40 }));
+    await completeRequest(1, null);
+    await updateHook(options({ isLoadingNext: false, itemCount: 60 }));
+    await runAnimationFrame();
+    assert.equal(loadRequests.length, 3, '연속된 두 번째 짧은 page도 다시 측정한다');
+
+    await updateHook(options({ isLoadingNext: true, itemCount: 60 }));
+    await completeRequest(2, null);
+    await updateHook(options({ hasNext: false, isLoadingNext: false, itemCount: 65 }));
+    await runAnimationFrame();
+    assert.equal(loadRequests.length, 3, '마지막 page에서는 추가 요청하지 않는다');
+  });
+
+  it('Web page 실패는 자동 재시도를 막고 수동 재시도만 허용한다', async () => {
+    await renderHook(options());
+    await runAnimationFrame();
+    assert.equal(loadRequests.length, 1);
+
+    await completeRequest(0, new Error('next page failed'));
+    assert.equal(currentResult().loadError, true);
+
+    await dispatchWindowEvent('scroll');
+    assert.equal(loadRequests.length, 1, '실패 뒤 자동 요청을 반복하지 않는다');
+
+    await act(async () => currentResult().loadNextPage());
+    assert.equal(loadRequests.length, 2, '수동 재시도는 같은 page를 다시 요청한다');
+    assert.equal(currentResult().loadError, false);
+  });
+
+  it('Native metric으로 요청하고 Relay loading 뒤 저장된 metric을 다시 측정한다', async () => {
+    platform.OS = 'ios';
+    await renderHook(options());
+
+    await act(async () => {
+      currentResult().nativeScrollProps.onLayout({
+        nativeEvent: { layout: { height: 800 } },
+      });
+      currentResult().nativeScrollProps.onContentSizeChange(0, 1200);
+    });
+    assert.equal(loadRequests.length, 1);
+
+    await act(async () => {
+      currentResult().nativeScrollProps.onScroll({
+        nativeEvent: {
+          contentOffset: { y: 400 },
+          contentSize: { height: 1200 },
+          layoutMeasurement: { height: 800 },
+        },
+      });
+    });
+    assert.equal(loadRequests.length, 1, 'Native in-flight guard를 유지한다');
+
+    await updateHook(options({ isLoadingNext: true, itemCount: 20 }));
+    await completeRequest(0, null);
+    assert.equal(loadRequests.length, 1, 'Relay loading 중에는 성공 재측정을 보류한다');
+
+    await updateHook(options({ isLoadingNext: false, itemCount: 40 }));
+    assert.equal(loadRequests.length, 2, '성공 뒤 저장된 Native metric을 다시 측정한다');
+  });
+
+  it('Web listener와 pending RAF를 unmount 때 정리한다', async () => {
+    await renderHook(options());
+    assert.equal(listeners.get('scroll')?.size, 1);
+    assert.equal(listeners.get('resize')?.size, 1);
+    assert.equal(animationFrames.size, 1);
+
+    const requestsBeforeUnmount = loadRequests.length;
+    await act(async () => renderer?.unmount());
+    renderer = null;
+    assert.equal(listeners.get('scroll')?.size ?? 0, 0);
+    assert.equal(listeners.get('resize')?.size ?? 0, 0);
+    assert.equal(animationFrames.size, 0);
+
+    await dispatchWindowEvent('scroll');
+    assert.equal(loadRequests.length, requestsBeforeUnmount);
+  });
+});

--- a/apps/app/src/components/pagination/useAutomaticPagination.ts
+++ b/apps/app/src/components/pagination/useAutomaticPagination.ts
@@ -38,6 +38,7 @@ export function useAutomaticPagination({
   const handledNativePageRevisionRef = useRef(0);
   const requestInFlightRef = useRef(false);
   const pageErrorRef = useRef(false);
+  const webNearEndCheckRef = useRef<(() => void) | null>(null);
   const nativeMetricsRef = useRef<ScrollMetrics>({
     contentLength: 0,
     offset: 0,
@@ -62,7 +63,10 @@ export function useAutomaticPagination({
         }
         setTimeout(() => {
           if (Platform.OS === 'web') {
-            requestInFlightRef.current = false;
+            window.requestAnimationFrame(() => {
+              requestInFlightRef.current = false;
+              webNearEndCheckRef.current?.();
+            });
           } else {
             setNativePageRevision((revision) => revision + 1);
           }
@@ -108,10 +112,14 @@ export function useAutomaticPagination({
         offset: window.scrollY,
         viewportLength: window.innerHeight,
       });
+    webNearEndCheckRef.current = check;
     const frame = window.requestAnimationFrame(check);
     window.addEventListener('scroll', check, { passive: true });
     window.addEventListener('resize', check);
     return () => {
+      if (webNearEndCheckRef.current === check) {
+        webNearEndCheckRef.current = null;
+      }
       window.cancelAnimationFrame(frame);
       window.removeEventListener('scroll', check);
       window.removeEventListener('resize', check);

--- a/apps/app/src/components/pagination/useAutomaticPagination.ts
+++ b/apps/app/src/components/pagination/useAutomaticPagination.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Platform } from 'react-native';
+import {
+  createNativeScrollHandlers,
+  isScrollNearEnd,
+  resumeNativePagination,
+} from './nativeScrollPagination';
+import type { ScrollMetrics } from './nativeScrollPagination';
+
+export type LoadNext = (
+  count: number,
+  options: { onComplete: (error: Error | null) => void },
+) => void;
+
+export type UseAutomaticPaginationOptions = {
+  hasNext: boolean;
+  isLoadingNext: boolean;
+  itemCount: number;
+  loadNext: LoadNext;
+  pageSize: number;
+};
+
+export type UseAutomaticPaginationResult = {
+  loadError: boolean;
+  loadNextPage: () => void;
+  nativeScrollProps: ReturnType<typeof createNativeScrollHandlers>;
+};
+
+export function useAutomaticPagination({
+  hasNext,
+  isLoadingNext,
+  itemCount,
+  loadNext,
+  pageSize,
+}: UseAutomaticPaginationOptions): UseAutomaticPaginationResult {
+  const [loadError, setLoadError] = useState(false);
+  const [nativePageRevision, setNativePageRevision] = useState(0);
+  const handledNativePageRevisionRef = useRef(0);
+  const requestInFlightRef = useRef(false);
+  const pageErrorRef = useRef(false);
+  const nativeMetricsRef = useRef<ScrollMetrics>({
+    contentLength: 0,
+    offset: 0,
+    viewportLength: 0,
+  });
+
+  const loadNextPage = useCallback(() => {
+    if (!hasNext || isLoadingNext || requestInFlightRef.current) {
+      return;
+    }
+
+    requestInFlightRef.current = true;
+    pageErrorRef.current = false;
+    setLoadError(false);
+    loadNext(pageSize, {
+      onComplete: (error) => {
+        pageErrorRef.current = Boolean(error);
+        setLoadError(Boolean(error));
+        if (error) {
+          requestInFlightRef.current = false;
+          return;
+        }
+        setTimeout(() => {
+          if (Platform.OS === 'web') {
+            requestInFlightRef.current = false;
+          } else {
+            setNativePageRevision((revision) => revision + 1);
+          }
+        }, 0);
+      },
+    });
+  }, [hasNext, isLoadingNext, loadNext, pageSize]);
+
+  const maybeLoadNextPage = useCallback(
+    (metrics: ScrollMetrics) => {
+      if (!pageErrorRef.current && !loadError && isScrollNearEnd(metrics)) {
+        loadNextPage();
+      }
+    },
+    [loadError, loadNextPage],
+  );
+
+  const nativeScrollProps = useMemo(
+    () => createNativeScrollHandlers(nativeMetricsRef, maybeLoadNextPage),
+    [maybeLoadNextPage],
+  );
+
+  useEffect(() => {
+    if (
+      Platform.OS === 'web' ||
+      nativePageRevision === 0 ||
+      isLoadingNext ||
+      handledNativePageRevisionRef.current === nativePageRevision
+    ) {
+      return;
+    }
+    handledNativePageRevisionRef.current = nativePageRevision;
+    resumeNativePagination(requestInFlightRef, nativeMetricsRef, maybeLoadNextPage);
+  }, [isLoadingNext, maybeLoadNextPage, nativePageRevision]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') {
+      return;
+    }
+    const check = () =>
+      maybeLoadNextPage({
+        contentLength: document.documentElement.scrollHeight,
+        offset: window.scrollY,
+        viewportLength: window.innerHeight,
+      });
+    const frame = window.requestAnimationFrame(check);
+    window.addEventListener('scroll', check, { passive: true });
+    window.addEventListener('resize', check);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', check);
+      window.removeEventListener('resize', check);
+    };
+  }, [itemCount, maybeLoadNextPage]);
+
+  return { loadError, loadNextPage, nativeScrollProps };
+}

--- a/apps/app/src/components/post/PostDetailThread.tsx
+++ b/apps/app/src/components/post/PostDetailThread.tsx
@@ -1,11 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
-import {
-  createNativeScrollHandlers,
-  isScrollNearEnd,
-  resumeNativePagination,
-} from '@/components/pagination/nativeScrollPagination';
+import { useAutomaticPagination } from '@/components/pagination/useAutomaticPagination';
 import { PostActionAuthenticationProvider } from '@/components/post/PostActionAuthentication';
 import { PostLayout } from '@/components/post/PostLayout';
 import { PostListItem } from '@/components/post/PostListItem';
@@ -16,7 +11,6 @@ import { getWebMobileShellHeaderStickyOffset } from '../shell/shellLayout';
 import { PostThreadLayout } from './PostThreadLayout';
 import type { PropsWithChildren, ReactNode } from 'react';
 import type { ScrollViewProps } from 'react-native';
-import type { ScrollMetrics } from '@/components/pagination/nativeScrollPagination';
 import type { PostDetailThread_post$key } from './__generated__/PostDetailThread_post.graphql';
 import type { PostDetailThreadNextPageQuery } from './__generated__/PostDetailThreadNextPageQuery.graphql';
 import type { PostLayout_post$key } from './__generated__/PostLayout_post.graphql';
@@ -136,86 +130,13 @@ function PostDetailThreadContent({
     PostDetailThreadNextPageQuery,
     PostDetailThread_post$key
   >(PostDetailThreadFragment, postKey);
-  const [loadError, setLoadError] = useState(false);
-  const [nativePageRevision, setNativePageRevision] = useState(0);
-  const handledNativePageRevisionRef = useRef(0);
-  const requestInFlightRef = useRef(false);
-  const pageErrorRef = useRef(false);
-  const loadNextPage = useCallback(() => {
-    if (!hasNext || isLoadingNext || requestInFlightRef.current) {
-      return;
-    }
-    requestInFlightRef.current = true;
-    pageErrorRef.current = false;
-    setLoadError(false);
-    loadNext(20, {
-      onComplete: (error) => {
-        pageErrorRef.current = Boolean(error);
-        setLoadError(Boolean(error));
-        if (error) {
-          requestInFlightRef.current = false;
-        } else {
-          setTimeout(() => {
-            if (Platform.OS === 'web') {
-              requestInFlightRef.current = false;
-            } else {
-              setNativePageRevision((revision) => revision + 1);
-            }
-          }, 0);
-        }
-      },
-    });
-  }, [hasNext, isLoadingNext, loadNext]);
-  const maybeLoadNextPage = useCallback(
-    (metrics: ScrollMetrics) => {
-      if (!pageErrorRef.current && !loadError && isScrollNearEnd(metrics)) {
-        loadNextPage();
-      }
-    },
-    [loadError, loadNextPage],
-  );
-  const nativeMetricsRef = useRef<ScrollMetrics>({
-    contentLength: 0,
-    offset: 0,
-    viewportLength: 0,
+  const { loadError, loadNextPage, nativeScrollProps } = useAutomaticPagination({
+    hasNext,
+    isLoadingNext,
+    itemCount: data.replyDescendants.edges.length,
+    loadNext,
+    pageSize: 20,
   });
-  const nativeScrollProps = useMemo(
-    () => createNativeScrollHandlers(nativeMetricsRef, maybeLoadNextPage),
-    [maybeLoadNextPage],
-  );
-
-  useEffect(() => {
-    if (
-      Platform.OS === 'web' ||
-      nativePageRevision === 0 ||
-      isLoadingNext ||
-      handledNativePageRevisionRef.current === nativePageRevision
-    ) {
-      return;
-    }
-    handledNativePageRevisionRef.current = nativePageRevision;
-    resumeNativePagination(requestInFlightRef, nativeMetricsRef, maybeLoadNextPage);
-  }, [isLoadingNext, maybeLoadNextPage, nativePageRevision]);
-
-  useEffect(() => {
-    if (Platform.OS !== 'web') {
-      return;
-    }
-    const check = () =>
-      maybeLoadNextPage({
-        contentLength: document.documentElement.scrollHeight,
-        offset: window.scrollY,
-        viewportLength: window.innerHeight,
-      });
-    const frame = window.requestAnimationFrame(check);
-    window.addEventListener('scroll', check, { passive: true });
-    window.addEventListener('resize', check);
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.removeEventListener('scroll', check);
-      window.removeEventListener('resize', check);
-    };
-  }, [data.replyDescendants.edges.length, maybeLoadNextPage]);
   const ancestors = data.replyAncestors
     .filter((post) => post != null)
     .reverse()


### PR DESCRIPTION
## 무엇을 변경했나요

- Web·Native 자동 pagination lifecycle을 담당하는 `useAutomaticPagination` 공통 hook을 추가했습니다.
- `FollowRequestList`와 `PostDetailThread`의 중복된 요청 guard, near-end 측정, 성공 후 재측정과 실패·재시도 lifecycle을 공통 hook으로 전환했습니다.
- Web 연속 short page, 마지막 page, 중복 요청 방지, 실패 후 수동 재시도, Native loading 전환과 listener·RAF 정리를 직접 검증하는 unit test를 추가했습니다.
- 기존 Relay fragment·connection key·page size 20과 목록별 loading/error/retry UI는 유지했습니다.

## 왜 변경했나요

`FollowRequestList`와 `PostDetailThread`가 같은 Web·Native 자동 pagination lifecycle을 각각 구현하고 있었습니다.

후속 [PROD-646](https://linear.app/byulmaru/issue/PROD-646/home과-profile-게시글-목록에-커서-기반-무한-스크롤을-제공한다)에서 Home·Profile까지 자동 pagination을 적용하기 전에, 기존 동작을 보존하면서 feature-neutral 공통 경계를 마련했습니다.

## 이번 PR의 주요 결정

### Web·Native lifecycle을 universal hook으로 통합

- 결정자: @yeeun-uwu
- 선택: 플랫폼별 파일로 나누지 않고 `Platform.OS` guard를 사용하는 universal hook 한 곳에서 공통 lifecycle을 관리합니다.
- 고려한 대안: 공통 core와 Web·Native adapter 분리, headless lifecycle hook과 소비자별 trigger 조립
- 이유: 두 소비자의 lifecycle이 실질적으로 같고, 기존 앱에도 guarded DOM effect 관례가 있어 가장 작은 변경으로 production boundary를 단일화할 수 있습니다.
- 감수한 결과: universal 파일에 Web DOM 측정 코드가 포함됩니다. Native 경계는 platform guard와 source/unit 검증으로 보호하지만 실제 Native runtime QA는 별도로 남습니다.
- 관련 근거: [PROD-662](https://linear.app/byulmaru/issue/PROD-662/자동-pagination-lifecycle을-공통화한다)

## 어떻게 확인할 수 있나요

```bash
pnpm --filter @kosmo/app test
```

- Relay compiler와 TypeScript 검사를 통과했습니다.
- app Node unit suite를 통과했습니다.
- 새 공통 hook과 기존 Native helper 집중 검증 8개를 통과했습니다.
- Storybook static build와 browser interaction 23 files, 319 tests를 통과했습니다.
- 원격 CI의 Test·Lint·Semgrep을 모두 통과했습니다.
- 독립 whole-branch 리뷰에서 Critical, Important, Minor finding이 없었습니다.
- 실제 iOS/Android runtime QA는 실행하지 않았습니다.

## 아직 어떤 문제가 남았나요

- 실제 iOS/Android 기기에서 ScrollView event 순서와 연속 short-page 동작은 확인하지 않았습니다.
- Home·Profile 무한 스크롤 통합과 OpenSpec 완료·archive는 PROD-646 범위입니다.