### PR TITLE
PostgreSQL session pool을 기존 연결과 독립적으로 준비한다

### DIFF
--- a/apps/helm/templates/_helpers.tpl
+++ b/apps/helm/templates/_helpers.tpl
@@ -7,7 +7,7 @@
 {{- end -}}
 
 {{- define "kosmo.postgresPoolerName" -}}
-{{- printf "%s-pooler-rw" (include "kosmo.postgresName" .) | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-pooler-rw" (include "kosmo.postgresName" . | trunc 53 | trimSuffix "-") -}}
 {{- end -}}
 
 {{- define "kosmo.postgresTailscaleName" -}}

--- a/apps/helm/templates/_helpers.tpl
+++ b/apps/helm/templates/_helpers.tpl
@@ -6,6 +6,10 @@
 {{- printf "%s-postgres" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kosmo.postgresPoolerName" -}}
+{{- printf "%s-pooler-rw" (include "kosmo.postgresName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "kosmo.postgresTailscaleName" -}}
 {{- printf "%s-postgres-ts" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/apps/helm/templates/postgres-pooler.yaml
+++ b/apps/helm/templates/postgres-pooler.yaml
@@ -1,0 +1,26 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: {{ include "kosmo.postgresPoolerName" . }}
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: postgres-pooler
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  cluster:
+    name: {{ include "kosmo.postgresName" . }}
+  instances: {{ ternary .Values.postgres.pooler.replicas.prod .Values.postgres.pooler.replicas.dev (eq .Values.env "prod") }}
+  type: rw
+  pgbouncer:
+    poolMode: session
+    parameters:
+      max_client_conn: {{ .Values.postgres.pooler.maxClientConnections | quote }}
+      default_pool_size: {{ .Values.postgres.pooler.defaultPoolSize | quote }}
+      server_reset_query: "DISCARD ALL"
+  template:
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+{{ toYaml .Values.postgres.pooler.resources | indent 12 }}

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -29,3 +29,16 @@ postgres:
     limits:
       cpu: 250m
       memory: 1Gi
+  pooler:
+    replicas:
+      dev: 1
+      prod: 3
+    maxClientConnections: 1000
+    defaultPoolSize: 10
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -37,8 +37,8 @@ postgres:
     defaultPoolSize: 10
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 25m
+        memory: 64Mi
       limits:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 250m
+        memory: 128Mi

--- a/docs/operations/postgres-session-pool.md
+++ b/docs/operations/postgres-session-pool.md
@@ -128,7 +128,7 @@ printf '%s\n' "$FIRST_STATUS"
 psql -qXAt --set first_backend_pid="$FIRST_BACKEND_PID" <<'SQL'
 SELECT CASE
   WHEN pg_backend_pid() = :'first_backend_pid'::integer
-    AND current_setting('kosmo.prod_728_probe', true) IS NULL
+    AND NULLIF(current_setting('kosmo.prod_728_probe', true), '') IS NULL
   THEN 'reset-ok'
   WHEN pg_backend_pid() <> :'first_backend_pid'::integer
   THEN 'reset-not-proven-different-backend'

--- a/docs/operations/postgres-session-pool.md
+++ b/docs/operations/postgres-session-pool.md
@@ -1,0 +1,166 @@
+# PostgreSQL PgBouncer session pool 운영
+
+## 운영 경계
+
+이 문서는 CloudNativePG가 생성한 read-write PgBouncer Pooler를 기존 PostgreSQL Cluster 옆에 배포하고 확인하는 절차를 정의한다.
+
+- Pooler 이름은 `<release>-postgres-pooler-rw`이고 Cluster 이름은 `<release>-postgres`이다.
+- Pooler Service의 기본 client port는 `5432`이며, 기존 `<release>-postgres-rw` Service와 별개다.
+- API/Web과 migration workload는 계속 `<release>-postgres-rw`와 기존 Secret을 사용한다. 이 문서의 검증 명령은 workload의 `DATABASE_URL` 또는 credential을 변경하지 않는다.
+- CloudNativePG operator와 `Pooler` CRD가 대상 namespace에 먼저 설치되어 있어야 한다.
+- 명령 출력에는 Secret 값, connection string, database row를 남기지 않는다. 검증 결과는 readiness, metric 이름과 비민감한 성공/실패만 기록한다.
+
+## Render와 admission 확인
+
+지원되는 환경별로 Pooler가 기존 Cluster를 참조하고, direct endpoint가 유지되는지 확인한다. Production render에는 실제 release digest를 사용한다.
+
+```sh
+helm template kosmo apps/helm \
+  --namespace kosmo-dev \
+  --set env=dev \
+  | rg -n 'kind: (Cluster|Pooler)|name: kosmo-postgres(-pooler-rw)?|poolMode:|server_reset_query|max_client_conn|default_pool_size|instances:'
+
+helm template kosmo apps/helm \
+  --namespace kosmo-prod \
+  --set env=prod \
+  --set imageDigest=sha256:0000000000000000000000000000000000000000000000000000000000000000 \
+  --set workloads.enabled=false \
+  | rg -n 'kind: (Cluster|Pooler)|name: kosmo-postgres(-pooler-rw)?|poolMode:|server_reset_query|max_client_conn|default_pool_size|instances:'
+```
+
+정적 결과에는 dev Pooler `instances: 1`, prod Pooler `instances: 3`, `type: rw`, `poolMode: session`, `server_reset_query: DISCARD ALL`, `max_client_conn: "1000"`, `default_pool_size: "10"`과 `pgbouncer` container의 resource request/limit가 나타나야 한다. API/Web workload를 렌더링하는 환경에서는 `DATABASE_URL`의 host가 계속 `<release>-postgres-rw`인지 확인한다.
+
+CRD가 설치된 대상 cluster에서는 실제 변경 없이 server-side admission도 확인한다.
+
+```sh
+helm template kosmo apps/helm \
+  --namespace kosmo-prod \
+  --set env=prod \
+  --set imageDigest=sha256:0000000000000000000000000000000000000000000000000000000000000000 \
+  --set workloads.enabled=false \
+  | kubectl apply --server-side --dry-run=server -f -
+```
+
+## Pooler와 Service readiness
+
+`POOLER`는 `<release>-postgres-pooler-rw`로, `NAMESPACE`는 배포 namespace로 설정한다. Pooler가 소유한 Deployment와 Pod가 Ready이고 Service에 endpoint가 생긴 뒤에만 연결 검증을 진행한다.
+
+```sh
+NAMESPACE=kosmo-prod
+POOLER=kosmo-postgres-pooler-rw
+
+kubectl get pooler "$POOLER" -n "$NAMESPACE" -o wide
+kubectl describe pooler "$POOLER" -n "$NAMESPACE"
+kubectl wait --for=condition=Available \
+  "deployment/$POOLER" -n "$NAMESPACE" --timeout=5m
+kubectl wait --for=condition=Ready \
+  pod -l cnpg.io/poolerName="$POOLER" -n "$NAMESPACE" --timeout=5m
+kubectl get service "$POOLER" -n "$NAMESPACE" -o wide
+kubectl get endpointslice -n "$NAMESPACE" \
+  -l "kubernetes.io/service-name=$POOLER" -o wide
+```
+
+Service port `5432`와 metrics port `9127`을 혼동하지 않는다. Pooler Service에 metrics port를 추가하지 않고, PgBouncer Pod의 exporter를 직접 확인한다.
+
+```sh
+POD="$(kubectl get pod -n "$NAMESPACE" \
+  -l cnpg.io/poolerName="$POOLER" \
+  -o jsonpath='{.items[0].metadata.name}')"
+kubectl port-forward -n "$NAMESPACE" "pod/$POD" 19127:9127
+```
+
+다른 터미널에서 다음 지표가 응답에 포함되는지만 확인한다. 실제 database/user label 값이나 credential은 기록하지 않는다.
+
+```sh
+curl --fail --silent http://127.0.0.1:19127/metrics \
+  | rg 'cnpg_pgbouncer_(pools_pool_mode|pools_cl_active|pools_cl_waiting|pools_sv_active|pools_sv_idle|pools_maxwait)'
+```
+
+`pools_pool_mode` 값은 PgBouncer session mode인 `1`이어야 한다. `cl_waiting`, `sv_active`, `sv_idle`, `maxwait`는 부하와 pool 크기를 판단하는 관찰값이다.
+
+## Session affinity와 reset 검증
+
+검증용으로 한 Pooler Pod에만 port-forward한다. Cluster의 기존 `<cluster>-app` Secret에서 username/password를 shell 변수로만 읽고 출력하지 않는다.
+
+Terminal 1에서 한 Pooler Pod에 port-forward한다.
+
+```sh
+NAMESPACE=kosmo-prod
+POOLER=kosmo-postgres-pooler-rw
+POD="$(kubectl get pod -n "$NAMESPACE" \
+  -l cnpg.io/poolerName="$POOLER" \
+  -o jsonpath='{.items[0].metadata.name}')"
+kubectl port-forward -n "$NAMESPACE" "pod/$POD" 15432:5432
+```
+
+Terminal 2에서 Cluster의 기존 `<cluster>-app` Secret을 shell 변수로만 읽고 출력하지 않는다.
+
+```sh
+CLUSTER=kosmo-postgres
+NAMESPACE=kosmo-prod
+PGUSER="$(kubectl get secret "${CLUSTER}-app" -n "$NAMESPACE" \
+  -o jsonpath='{.data.username}' | base64 --decode)"
+PGPASSWORD="$(kubectl get secret "${CLUSTER}-app" -n "$NAMESPACE" \
+  -o jsonpath='{.data.password}' | base64 --decode)"
+export PGUSER PGPASSWORD PGHOST=127.0.0.1 PGPORT=15432 PGDATABASE=kosmo
+```
+
+첫 client는 두 query 사이에 session GUC와 backend identity가 유지되는지 확인한다. 두 번째 client는 첫 client가 닫힌 뒤 같은 backend connection을 재사용했을 때 reset된 상태를 확인한다. backend PID는 shell 변수 안에서 비교에만 사용하고 출력하거나 기록하지 않는다. 출력은 `affinity-ok`/`reset-ok` 같은 비민감한 판정으로만 기록한다.
+
+```sh
+FIRST_CLIENT_RESULT="$(psql -qXAt <<'SQL'
+SELECT pg_backend_pid() AS first_backend_pid \gset
+SET kosmo.prod_728_probe = 'first-client';
+SELECT CASE
+  WHEN pg_backend_pid() = :first_backend_pid
+    AND current_setting('kosmo.prod_728_probe', true) = 'first-client'
+  THEN 'affinity-ok'
+  ELSE 'affinity-failed'
+END;
+SELECT pg_backend_pid();
+SQL
+)"
+
+FIRST_STATUS="$(printf '%s\n' "$FIRST_CLIENT_RESULT" | sed -n '1p')"
+FIRST_BACKEND_PID="$(printf '%s\n' "$FIRST_CLIENT_RESULT" | sed -n '2p')"
+printf '%s\n' "$FIRST_STATUS"
+
+psql -qXAt --set first_backend_pid="$FIRST_BACKEND_PID" <<'SQL'
+SELECT CASE
+  WHEN pg_backend_pid() = :'first_backend_pid'::integer
+    AND current_setting('kosmo.prod_728_probe', true) IS NULL
+  THEN 'reset-ok'
+  WHEN pg_backend_pid() <> :'first_backend_pid'::integer
+  THEN 'reset-not-proven-different-backend'
+  ELSE 'reset-failed'
+END;
+SQL
+```
+
+첫 client는 `affinity-ok`를 출력해야 한다. 첫 client 종료 뒤 두 번째 client가 같은 backend connection에서 `reset-ok`를 출력해야 한다. `reset-not-proven-different-backend`이면 state 유출을 뜻하지는 않지만 reset 증거도 아니므로 같은 Pooler Pod에서 반복해 동일 backend 재사용을 확인한다. `reset-failed`이면 Pooler를 application traffic에 연결하지 않고 PgBouncer Pod 로그, `cnpg_pgbouncer_*` metrics와 rendered parameters를 확인한다.
+
+## Pooler-only rollback
+
+이 Pooler는 Cluster와 workload에서 독립된 리소스다. API/Web가 Pooler Service를 참조하지 않는 것을 먼저 확인한 뒤, 이 변경을 되돌려 Pooler manifest만 빠진 별도 Git commit/release를 배포하고 Argo CD sync가 Pooler를 prune하게 한다. `kubectl delete`로 Helm/Argo CD 소유 리소스를 out-of-band 삭제하지 않는다. Cluster, `<cluster>-rw` Service, 기존 Secret과 API/Web Rollout은 삭제하거나 수정하지 않는다.
+
+```sh
+NAMESPACE=kosmo-prod
+CLUSTER=kosmo-postgres
+POOLER="${CLUSTER}-pooler-rw"
+
+kubectl get pooler "$POOLER" -n "$NAMESPACE"
+kubectl get service "$POOLER" -n "$NAMESPACE"
+kubectl get cluster "$CLUSTER" -n "$NAMESPACE"
+kubectl get service "${CLUSTER}-rw" -n "$NAMESPACE"
+```
+
+Rollback release를 sync한 뒤 Pooler와 그 Service가 제거되고 기존 direct Service와 workload readiness가 그대로 유지되는지 확인한다.
+
+```sh
+kubectl get pooler "$POOLER" -n "$NAMESPACE"
+kubectl get service "$POOLER" -n "$NAMESPACE"
+kubectl get cluster "$CLUSTER" -n "$NAMESPACE"
+kubectl get service "${CLUSTER}-rw" -n "$NAMESPACE"
+```
+
+앞의 두 명령은 `NotFound`, 뒤의 두 명령은 정상 상태여야 한다. Pooler-only rollback 결과와 direct endpoint 불변 여부만 비민감하게 기록한다.

--- a/docs/operations/postgres-session-pool.md
+++ b/docs/operations/postgres-session-pool.md
@@ -141,7 +141,7 @@ SQL
 
 ## Pooler-only rollback
 
-이 Pooler는 Cluster와 workload에서 독립된 리소스다. API/Web가 Pooler Service를 참조하지 않는 것을 먼저 확인한 뒤, 이 변경을 되돌려 Pooler manifest만 빠진 별도 Git commit/release를 배포하고 Argo CD sync가 Pooler를 prune하게 한다. `kubectl delete`로 Helm/Argo CD 소유 리소스를 out-of-band 삭제하지 않는다. Cluster, `<cluster>-rw` Service, 기존 Secret과 API/Web Rollout은 삭제하거나 수정하지 않는다.
+이 Pooler는 Cluster와 workload에서 독립된 리소스다. API/Web가 Pooler Service를 참조하지 않는 것을 먼저 확인한 뒤, 이 변경을 되돌려 Pooler manifest만 빠진 별도 Git commit/release를 배포하고 Argo CD가 Pooler를 prune하게 한다. Dev `kosmo-dev` Application은 automated prune을 사용한다. Production `kosmo-prod` Application은 automated prune을 사용하지 않으므로 revert commit이 `main`에 반영된 뒤 승인된 Argo CD identity로 prune을 명시한 sync를 실행한다. `kubectl delete`로 Helm/Argo CD 소유 리소스를 out-of-band 삭제하지 않는다. Cluster, `<cluster>-rw` Service, 기존 Secret과 API/Web Rollout은 삭제하거나 수정하지 않는다.
 
 ```sh
 NAMESPACE=kosmo-prod
@@ -154,7 +154,15 @@ kubectl get cluster "$CLUSTER" -n "$NAMESPACE"
 kubectl get service "${CLUSTER}-rw" -n "$NAMESPACE"
 ```
 
-Rollback release를 sync한 뒤 Pooler와 그 Service가 제거되고 기존 direct Service와 workload readiness가 그대로 유지되는지 확인한다.
+Production rollback은 Git의 revert commit을 source로 다음과 같이 sync한다. `ROLLBACK_REVISION`은 Pooler manifest가 제거된 `main` commit SHA로 고정한다.
+
+```sh
+ROLLBACK_REVISION=REVERT_COMMIT_SHA
+argocd app sync kosmo-prod --revision "$ROLLBACK_REVISION" --prune
+argocd app wait kosmo-prod --sync --health --timeout 600
+```
+
+Dev는 revert commit이 `main`에 반영되면 automated sync/prune 완료를 기다린다. Rollback sync 뒤 Pooler와 그 Service가 제거되고 기존 direct Service와 workload readiness가 그대로 유지되는지 확인한다.
 
 ```sh
 kubectl get pooler "$POOLER" -n "$NAMESPACE"

--- a/openspec/changes/add-postgres-session-pool/.openspec.yaml
+++ b/openspec/changes/add-postgres-session-pool/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-08

--- a/openspec/changes/add-postgres-session-pool/decisions.md
+++ b/openspec/changes/add-postgres-session-pool/decisions.md
@@ -35,7 +35,7 @@
 - Authority / Provenance: Linear `PROD-728`
 - Status: Active
 - Context / Problem: 이슈는 replica, client/server limit와 resource 기본값을 요구하지만 구체 수치를 고정하지 않는다. 현재 production Cluster는 3 instances이고 dev는 1 instance다.
-- Decision Outcome: dev는 Pooler 1 replica, prod는 3 replicas를 사용한다. 각 replica는 `max_client_conn=1000`, user/database pair별 `default_pool_size=10`을 사용한다. PgBouncer container는 request `100m/128Mi`, limit `500m/512Mi`를 기본값으로 두고 모두 Helm values에서 조정 가능하게 한다.
+- Decision Outcome: dev는 Pooler 1 replica, prod는 3 replicas를 사용한다. 각 replica는 `max_client_conn=1000`, user/database pair별 `default_pool_size=10`을 사용한다. PgBouncer container는 경량 proxy와 exporter의 초기 경계로 request `25m/64Mi`, limit `250m/128Mi`를 기본값으로 두고 모두 Helm values에서 조정 가능하게 한다. CNPG 문서의 더 큰 resource 수치는 구성 방법을 보여 주는 예시이지 workload sizing 권위가 아니므로 그대로 채택하지 않는다. 실제 traffic 활성화 전 dev 사용량과 throttling/OOM을 관찰하고 후속 PROD-726에서 필요할 때 조정한다.
 - Alternatives Considered: 모든 환경 3 replicas는 dev 비용이 불필요해 제외했다. PgBouncer 기본 `default_pool_size=20`은 production 3 replicas에서 pair당 최대 60 backend connection을 만들 수 있어 초기값으로 제외했다. limit 미지정은 이슈의 명시적 capacity 경계를 충족하지 못한다.
 - Consequences: production은 user/database pair마다 최대 30 backend connection을 사용할 수 있고 replica당 최대 1000 client가 연결될 수 있다. 다수 DB user가 생기면 전체 server connection budget을 다시 계산해야 한다.
 - Confirmation / Follow-up: render된 값을 확인하고 live metrics의 active/idle/waiting/max-wait 및 PostgreSQL connection budget으로 후속 values 조정을 판단한다.

--- a/openspec/changes/add-postgres-session-pool/decisions.md
+++ b/openspec/changes/add-postgres-session-pool/decisions.md
@@ -1,0 +1,73 @@
+## Context
+
+이 기록은 Linear PROD-728의 additive PgBouncer session pool 계약, 현재 Kosmo Helm의 CloudNativePG workload 소유권, 공식 CloudNativePG 1.30 Pooler와 PgBouncer session reset 동작을 반영한다. 제품 도메인·디자인 요구사항은 변경하지 않는다.
+
+## Decision Records
+
+### Kosmo Helm이 namespaced Pooler를 소유한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-728`; 운영 맥락 `docs/operations/production-migrations.md`, `docs/operations/postgres-backup.md`
+- Status: Active
+- Context / Problem: CloudNativePG operator는 platform repository가 제공하지만 기존 application Cluster와 관련 namespaced 리소스는 Kosmo Helm이 선언한다.
+- Decision Outcome: 기존 Kosmo Cluster를 가리키는 `Pooler`는 `apps/helm`에 추가하고 cluster-wide operator/CRD 설치는 변경하지 않는다.
+- Alternatives Considered: `byulmaru/kubernetes`에서 Pooler까지 선언하면 application release의 Cluster 이름·namespace·rollback 소유권이 platform state로 분리되므로 제외했다.
+- Consequences: operator/CRD가 준비되지 않은 환경은 배포 선행조건으로 확인하며, Pooler의 application lifecycle은 Kosmo release가 소유한다.
+- Confirmation / Follow-up: Helm render와 server-side dry-run에서 CRD 인식 및 Cluster 참조를 확인한다.
+
+### 별도 read-write session Pooler와 명시적 DISCARD ALL
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-728`
+- Status: Active
+- Context / Problem: 후속 operation connection은 client 수명 동안 backend session과 actor state가 유지되고 client 반환 뒤 state가 완전히 제거되는 access layer가 필요하다.
+- Decision Outcome: 기존 Cluster와 다른 이름의 `type: rw` Pooler를 `poolMode: session`으로 선언하고 `server_reset_query: DISCARD ALL`을 명시한다. `server_reset_query_always`는 설정하지 않는다.
+- Alternatives Considered: transaction pooling은 session GUC를 보존하지 못해 제외했다. reset 기본값에만 의존하거나 `DEALLOCATE ALL`로 약화하면 actor state 격리를 manifest에서 보장하지 못해 제외했다.
+- Consequences: client 연결 동안 backend connection이 점유되고 반환 때 prepared statement와 session cache도 제거된다.
+- Confirmation / Follow-up: live 두-client GUC reset과 한 client 내 backend identity 유지로 검증한다.
+
+### 환경별 replica와 초기 connection budget
+
+- Decision Date: 2026-08-08
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-728`
+- Status: Active
+- Context / Problem: 이슈는 replica, client/server limit와 resource 기본값을 요구하지만 구체 수치를 고정하지 않는다. 현재 production Cluster는 3 instances이고 dev는 1 instance다.
+- Decision Outcome: dev는 Pooler 1 replica, prod는 3 replicas를 사용한다. 각 replica는 `max_client_conn=1000`, user/database pair별 `default_pool_size=10`을 사용한다. PgBouncer container는 request `100m/128Mi`, limit `500m/512Mi`를 기본값으로 두고 모두 Helm values에서 조정 가능하게 한다.
+- Alternatives Considered: 모든 환경 3 replicas는 dev 비용이 불필요해 제외했다. PgBouncer 기본 `default_pool_size=20`은 production 3 replicas에서 pair당 최대 60 backend connection을 만들 수 있어 초기값으로 제외했다. limit 미지정은 이슈의 명시적 capacity 경계를 충족하지 못한다.
+- Consequences: production은 user/database pair마다 최대 30 backend connection을 사용할 수 있고 replica당 최대 1000 client가 연결될 수 있다. 다수 DB user가 생기면 전체 server connection budget을 다시 계산해야 한다.
+- Confirmation / Follow-up: render된 값을 확인하고 live metrics의 active/idle/waiting/max-wait 및 PostgreSQL connection budget으로 후속 values 조정을 판단한다.
+
+### CloudNativePG 기본 readiness와 exporter를 소비한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-728`
+- Status: Active
+- Context / Problem: Pooler readiness와 pool 사용 metrics를 관찰해야 하지만 platform monitoring 리소스와 중복 선언하면 소유권이 섞인다.
+- Decision Outcome: CloudNativePG가 생성·관리하는 Pooler Deployment/Pod/Service readiness와 PgBouncer exporter의 `cnpg_pgbouncer_*` metrics를 사용한다. 이 변경에서 별도 ServiceMonitor/PodMonitor나 custom Service port를 만들지 않는다.
+- Alternatives Considered: application chart가 PodMonitor를 추가하면 현재 platform Prometheus discovery 정책과 중복될 수 있고, Pooler Service에 9127을 노출할 필요도 없어 제외했다.
+- Consequences: metrics 수집 여부는 기존 platform discovery가 담당하고, 수집 전 검증은 exporter Pod의 9127 port를 직접 확인한다.
+- Confirmation / Follow-up: Pooler/Deployment/Pod/Service 상태와 exporter metrics에 pool mode, client waiting, server active/idle, max wait가 나타나는지 확인한다.
+
+### 기존 workload 연결을 불변으로 유지한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-728`, `PROD-708`, `PROD-726`, `PROD-716`
+- Status: Active
+- Context / Problem: Pooler 기반과 실제 GraphQL operation session/credential 전환은 독립 배포·rollback 단위다.
+- Decision Outcome: 기존 database URL helper, API/Web Rollout env와 Secret 참조는 변경하지 않는다. Pooler Service는 이번 변경에서 어떤 workload도 소비하지 않으며 Pooler 리소스만 제거해 rollback한다.
+- Alternatives Considered: API/Web를 동시에 Pooler로 전환하면 전체 DB consumer 정렬과 connection cleanup을 소유한 PROD-726, credential 전환을 소유한 PROD-716 범위를 침범하므로 제외했다.
+- Consequences: 배포 직후 Pooler는 검증 트래픽 외 production application traffic을 받지 않는다. 실제 활성화는 후속 이슈가 소유한다.
+- Confirmation / Follow-up: Pooler 추가 전후 API/Web의 rendered `DATABASE_URL`과 Secret 참조가 동일하고 rollback 뒤 direct workload가 유지되는지 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-postgres-session-pool/design.md
+++ b/openspec/changes/add-postgres-session-pool/design.md
@@ -34,7 +34,7 @@ CloudNativePG `Pooler` CRD는 같은 namespace의 하나의 Cluster와 `rw` 또�
 
 ### Recommended Approach
 
-`postgres.pooler` values 아래에 replica 수, `maxClientConnections`, `defaultPoolSize`와 resources를 둔다. production은 Cluster HA와 맞춰 3 replicas, dev는 1 replica를 렌더링하고, PgBouncer 기본 예시와 현재 예상 부하를 보수적으로 시작하기 위해 replica당 `max_client_conn=1000`, user/database pair당 `default_pool_size=10`을 사용한다. resources는 경량 proxy의 초기 경계로 request `100m/128Mi`, limit `500m/512Mi`를 명시한다.
+`postgres.pooler` values 아래에 replica 수, `maxClientConnections`, `defaultPoolSize`와 resources를 둔다. production은 Cluster HA와 맞춰 3 replicas, dev는 1 replica를 렌더링하고, PgBouncer 기본 예시와 현재 예상 부하를 보수적으로 시작하기 위해 replica당 `max_client_conn=1000`, user/database pair당 `default_pool_size=10`을 사용한다. resources는 경량 proxy와 내장 exporter의 초기 경계로 request `25m/64Mi`, limit `250m/128Mi`를 명시한다. CNPG의 resource override 예시는 sizing 권위로 사용하지 않으며, 실제 traffic을 활성화하는 PROD-726 전에 dev working set과 CPU throttling/OOM을 관찰해 별도 조정한다.
 
 별도 Pooler template은 기존 Cluster 이름을 참조하고 `type: rw`, `poolMode: session`, `server_reset_query: DISCARD ALL`을 선언한다. Pod template에는 PgBouncer container resource만 override하며 CloudNativePG가 Service, readiness와 metrics exporter 구성을 소유하게 둔다. 이름 helper는 `<release>-postgres-pooler-rw`처럼 direct `-rw`와 명확히 구분한다.
 

--- a/openspec/changes/add-postgres-session-pool/design.md
+++ b/openspec/changes/add-postgres-session-pool/design.md
@@ -1,0 +1,72 @@
+## Context
+
+현재 `apps/helm/templates/postgres-cluster.yaml`은 환경별 CloudNativePG Cluster를 선언하고 `_helpers.tpl`의 기본 database URL은 `<release>-postgres-rw` direct Service를 사용한다. CloudNativePG operator와 cluster-wide CRD는 `byulmaru/kubernetes`가 제공하지만, application namespace의 Cluster·Pooler 같은 workload resource는 이 저장소의 Helm chart가 소유한다.
+
+PROD-708은 operation context/DB handle seam만 제공하며 실제 connection을 열지 않는다. PROD-726이 모든 GraphQL DB consumer 정렬 뒤 Pooler endpoint와 session-level actor GUC를 활성화하고, PROD-716은 그 뒤 non-owner credential 전환을 소유한다. 따라서 이번 배포는 사용되지 않는 access layer를 기존 경로 옆에 추가하는 것으로 끝나야 한다.
+
+CloudNativePG `Pooler` CRD는 같은 namespace의 하나의 Cluster와 `rw` 또는 `ro` Service에 결합된다. PgBouncer session mode에서는 client disconnect 때 backend connection이 pool로 반환되고 기본 `server_reset_query`인 `DISCARD ALL`이 실행되지만, reset 계약을 manifest에서 명시해 operator/PgBouncer 기본값 변화에도 의도가 보이게 한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 기존 Cluster 앞에 별도 read-write session Pooler Service를 additive하게 선언한다.
+- client/server capacity, replica, resource와 `DISCARD ALL` reset 경계를 명시한다.
+- 정적 render와 실제 환경에서 readiness, session affinity/reset, PgBouncer pool metrics를 검증할 절차를 제공한다.
+- Pooler만 제거할 수 있는 독립 rollback 경계를 유지한다.
+
+**Non-Goals:**
+
+- API/Web database endpoint 또는 Secret 전환
+- GraphQL operation connection 생성·종료, actor GUC 설정 또는 resolver DB handle 이전
+- PostgreSQL role·grant·RLS policy, database schema 또는 credential 변경
+- transaction pooling, read-only routing 또는 cluster-wide CloudNativePG 설치 변경
+
+## Implementation Guidance
+
+### Current Constraints
+
+- 기본 database URL helper와 API/Web workload는 `<release>-postgres-rw`를 사용하므로 새 Pooler helper를 기존 helper에 연결하면 범위를 침범한다.
+- CloudNativePG Pooler 이름은 같은 namespace의 Cluster 이름과 달라야 하고, Cluster와 같은 namespace에 렌더링돼야 한다.
+- Pooler의 각 replica가 user/database pair별 server pool을 별도로 유지하므로 `default_pool_size`를 replica 수와 곱한 최대 backend connection 소비를 검토해야 한다.
+- PgBouncer는 parameter 값을 검증하지 않으므로 문자열 타입과 지원되는 option 이름을 chart에서 정확히 렌더링해야 한다.
+- 실제 session reset은 manifest만으로 증명되지 않는다. 동일 credential로 첫 client가 custom GUC를 설정·종료한 뒤 다른 client가 값을 관찰하지 못하는 live 검증이 필요하다.
+
+### Recommended Approach
+
+`postgres.pooler` values 아래에 replica 수, `maxClientConnections`, `defaultPoolSize`와 resources를 둔다. production은 Cluster HA와 맞춰 3 replicas, dev는 1 replica를 렌더링하고, PgBouncer 기본 예시와 현재 예상 부하를 보수적으로 시작하기 위해 replica당 `max_client_conn=1000`, user/database pair당 `default_pool_size=10`을 사용한다. resources는 경량 proxy의 초기 경계로 request `100m/128Mi`, limit `500m/512Mi`를 명시한다.
+
+별도 Pooler template은 기존 Cluster 이름을 참조하고 `type: rw`, `poolMode: session`, `server_reset_query: DISCARD ALL`을 선언한다. Pod template에는 PgBouncer container resource만 override하며 CloudNativePG가 Service, readiness와 metrics exporter 구성을 소유하게 둔다. 이름 helper는 `<release>-postgres-pooler-rw`처럼 direct `-rw`와 명확히 구분한다.
+
+운영 문서는 render/admission 확인, Pooler/Deployment/Pod/Service readiness, session affinity와 reset SQL, pool mode/client waiting/server active·idle/max-wait metrics, rollback 뒤 direct endpoint 불변을 한 절차로 기록한다. credential 값이나 database row는 출력하지 않는다.
+
+### Allowed Alternatives
+
+spec과 결정 경계를 유지한다면 초기 capacity/resource 값은 production 관측에 따라 별도 values override로 조정할 수 있다. Pooler 이름도 Cluster와 충돌하지 않고 direct endpoint와 구분되며 후속 PROD-726이 안정적으로 참조할 수 있으면 다른 명명 규칙을 사용할 수 있다.
+
+### Known Traps
+
+- API/Web `DATABASE_URL`을 새 Service로 바꾸거나 기존 helper를 재사용해 endpoint를 조용히 전환하지 않는다.
+- `poolMode: transaction` 또는 `server_reset_query_always`로 session semantics를 바꾸지 않는다.
+- `DISCARD ALL`을 생략하고 현재 PgBouncer 기본값에만 의존하지 않는다.
+- 단일 Pooler replica의 `default_pool_size`만 보고 production 전체 backend connection 상한을 계산하지 않는다.
+- 정적 manifest나 Ready condition만으로 session affinity/reset 완료를 주장하지 않는다.
+
+## Risks / Trade-offs
+
+- [3개 production replica와 pool size 10은 user/database pair마다 최대 30개 backend connection을 유지할 수 있다] → rollout 전 PostgreSQL connection budget을 확인하고 metrics의 active/idle/waiting/max-wait를 근거로 values를 조정한다.
+- [session pooling은 긴 client session 동안 backend connection을 점유해 transaction pooling보다 multiplexing 이득이 작다] → 이 access layer의 목적은 operation 단위 session state이며 PROD-726에서 connection 수명과 동시성 stress를 검증한다.
+- [`DISCARD ALL`은 prepared statement와 cache를 제거해 connection 반환 비용이 생긴다] → actor state 격리를 우선하고 reset을 약화하지 않는다.
+- [사용되지 않는 Pooler도 Pod와 유휴 backend connection 비용을 만든다] → 최소 dev/prod replica/resource 기본값을 사용하고 Pooler 리소스만 독립 rollback할 수 있게 한다.
+
+## Migration Plan
+
+1. Helm lint/render와 가능한 admission dry-run으로 Cluster 참조, Pooler mode/parameters/resources와 기존 workload endpoint 불변을 확인한다.
+2. Pooler만 기존 environment에 sync하고 Pooler, Deployment, Pod와 Service readiness를 확인한다. API/Web는 direct `-rw`를 계속 사용한다.
+3. 비민감 test GUC와 backend identity로 한 client 안의 session affinity 및 client 종료 뒤 reset을 검증한다.
+4. metrics에서 pool mode, active/waiting client, active/idle server와 max wait를 확인한다.
+5. 실패하면 Pooler manifest만 제거한다. 기존 Cluster, `-rw` Service, credentials와 workload를 변경하거나 rollback하지 않는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-postgres-session-pool/proposal.md
+++ b/openspec/changes/add-postgres-session-pool/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+GraphQL operation별 session-level RLS actor context를 후속 전환에서 안전하게 사용할 수 있도록, 현재 direct PostgreSQL 연결과 독립된 PgBouncer session pooling access layer가 먼저 필요하다. PROD-728은 애플리케이션 트래픽이나 credential을 바꾸지 않고 이 기반만 additive하게 준비한다.
+
+## What Changes
+
+- 기존 CloudNativePG Cluster의 read-write Service를 대상으로 하는 별도 `Pooler`와 Service를 선언한다.
+- PgBouncer를 session pooling mode로 고정하고 client 반환 시 `DISCARD ALL`로 backend session state를 초기화한다.
+- client/server connection limit, replica와 resource 기본값을 선언하고 Pooler readiness와 PgBouncer metrics를 관찰할 수 있게 한다.
+- 기존 API/Web `DATABASE_URL`, direct PostgreSQL Service, credential과 GraphQL DB lifecycle은 유지한다.
+- Pooler 리소스만 제거해 기존 workload에 영향 없이 rollback할 수 있는 경계를 문서화하고 검증한다.
+
+## Authority / Provenance
+
+- Canonical: 적용되는 `docs/domain` 또는 `docs/design` 변경 없음. 운영 맥락은 `docs/operations/production-migrations.md`, `docs/operations/postgres-backup.md`를 따른다.
+- Linear Contract: `PROD-728`
+- Linear Implementations: `PROD-728`; 병렬 경계 `PROD-708`; 후속 활성화 `PROD-726`; 제외되는 credential 전환 `PROD-716`
+
+## Capabilities
+
+### New Capabilities
+
+- `postgres-session-pool`: 기존 direct endpoint와 독립된 CloudNativePG PgBouncer session pool의 선언, reset, 관측과 rollback 계약
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/helm`: CloudNativePG `Pooler` template, values와 이름 helper
+- 운영 검증: Pooler/Service readiness, session affinity/reset, Prometheus metrics 확인 절차
+- Kubernetes: 기존 Cluster와 같은 namespace의 additive read-write PgBouncer Deployment/Service
+- API/Web, GraphQL, PostgreSQL role·credential, RLS policy와 기존 direct `-rw` Service에는 변경 없음

--- a/openspec/changes/add-postgres-session-pool/specs/postgres-session-pool/spec.md
+++ b/openspec/changes/add-postgres-session-pool/specs/postgres-session-pool/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Additive read-write session pool
+
+**Authority / Provenance:** Linear `PROD-728`; 이 요구사항을 MUST 준수한다.
+
+시스템은 MUST 기존 CloudNativePG Cluster의 primary read-write 경로를 대상으로 하는 별도 PgBouncer Pooler와 Service를 선언한다. Pooler는 MUST `session` mode를 사용하고 기존 direct PostgreSQL Service를 대체하거나 제거하지 않는다.
+
+#### Scenario: Helm이 별도 session pool을 렌더링한다
+
+- **WHEN** 운영자가 지원되는 환경 값으로 Helm chart를 렌더링한다
+- **THEN** 기존 Cluster를 참조하는 read-write Pooler가 `session` mode와 별도 Service 이름으로 나타난다
+- **THEN** 기존 CloudNativePG Cluster와 direct read-write Service 선언은 유지된다
+
+#### Scenario: Client session 동안 backend session이 유지된다
+
+- **WHEN** client가 Pooler Service에 연결해 같은 session에서 backend process identity와 session state를 연속 조회한다
+- **THEN** client가 연결을 닫을 때까지 같은 backend PostgreSQL session이 사용된다
+
+### Requirement: 반환된 session state 초기화
+
+**Authority / Provenance:** Linear `PROD-728`; 이 요구사항을 MUST 준수한다.
+
+PgBouncer는 MUST client session이 반환한 backend connection을 다른 client에게 제공하기 전에 `DISCARD ALL`로 session state를 초기화한다. 이 reset 경계는 MUST actor GUC를 포함한 이전 client의 session state가 다음 client로 유출되지 않음을 검증할 수 있게 한다.
+
+#### Scenario: 다음 client가 이전 GUC를 관찰하지 못한다
+
+- **WHEN** 첫 client가 session-level test GUC를 설정하고 연결을 종료한 뒤 다른 client가 재사용 가능한 Pooler connection으로 연결한다
+- **THEN** 두 번째 client는 첫 client의 test GUC 값을 관찰하지 못한다
+
+### Requirement: 명시적인 capacity와 availability 기본값
+
+**Authority / Provenance:** Linear `PROD-728`; 이 요구사항을 MUST 준수한다.
+
+Pooler 선언은 MUST PgBouncer의 최대 client connection 수와 user/database pair별 기본 server pool 크기, replica 수와 container resource request/limit를 명시한다. 값은 MUST Helm values에서 검토·조정 가능하고, 비정상 Pooler Pod는 Service readiness에서 제외될 수 있다.
+
+#### Scenario: 기본 capacity와 resource 경계를 렌더링한다
+
+- **WHEN** 별도 override 없이 chart를 렌더링한다
+- **THEN** Pooler에 최대 client 수, 기본 server pool 크기, replica 수와 PgBouncer resource request/limit가 모두 명시된다
+
+### Requirement: readiness와 pool 사용 상태 관찰
+
+**Authority / Provenance:** Linear `PROD-728`; 이 요구사항을 MUST 준수한다.
+
+운영자는 MUST Kubernetes Pooler, Deployment, Pod와 Service 상태에서 access layer readiness를 확인할 수 있다. 운영자는 MUST CloudNativePG가 노출하는 PgBouncer metrics에서 session pool mode, active/waiting client, active/idle server와 최대 대기 시간을 관찰할 수 있다.
+
+#### Scenario: Pooler 상태와 metrics를 확인한다
+
+- **WHEN** Pooler가 배포되고 metrics endpoint가 수집된다
+- **THEN** 운영자는 Pooler/Deployment/Pod/Service readiness와 pool mode, client 대기, server 사용량, 최대 대기 지표를 확인할 수 있다
+
+### Requirement: 애플리케이션 전환과 독립된 배포 및 rollback
+
+**Authority / Provenance:** Linear `PROD-728`, 병렬 경계 `PROD-708`, 후속 활성화 `PROD-726`, 제외 범위 `PROD-716`; 이 요구사항을 MUST 준수한다.
+
+이 변경은 MUST API/Web `DATABASE_URL`, PostgreSQL credential, GraphQL operation connection lifecycle, actor GUC 설정, RLS policy·grant를 변경하지 않는다. 기존 workload는 MUST direct read-write Service를 계속 사용한다. 운영자는 MUST Pooler 리소스만 배포하거나 제거해 애플리케이션 트래픽과 독립적으로 rollout 및 rollback할 수 있다.
+
+#### Scenario: Pooler를 추가해도 workload 연결은 유지된다
+
+- **WHEN** 기존 환경에 Pooler manifest를 추가해 배포한다
+- **THEN** API/Web가 렌더링하는 database endpoint와 Secret 참조는 배포 전과 동일한 direct 경계를 유지한다
+
+#### Scenario: Pooler만 제거한다
+
+- **WHEN** 운영자가 이 변경을 rollback해 Pooler 리소스를 제거한다
+- **THEN** 기존 Cluster, direct read-write Service와 이를 사용하는 API/Web workload는 계속 유지된다

--- a/openspec/changes/add-postgres-session-pool/tasks.md
+++ b/openspec/changes/add-postgres-session-pool/tasks.md
@@ -1,0 +1,32 @@
+## 1. PROD-728 Additive PostgreSQL session pool
+
+**Authority / Provenance**
+
+- Linear `PROD-728`
+- 병렬·후속 경계 Linear `PROD-708`, `PROD-726`, `PROD-716`
+- 운영 맥락 `docs/operations/production-migrations.md`, `docs/operations/postgres-backup.md`
+
+**Deliverable**
+
+기존 CloudNativePG direct endpoint와 workload 연결에 영향 없이 별도 read-write PgBouncer session pool을 배포·관찰·rollback할 수 있다.
+
+**Guardrails**
+
+- Pooler는 session mode와 `DISCARD ALL` reset을 사용하고 기존 Cluster와 다른 이름의 별도 Service를 제공한다.
+- client/server connection limit, 환경별 replica와 container resource request/limit를 명시한다.
+- 기존 API/Web database endpoint·Secret, GraphQL operation lifecycle, actor GUC, RLS/role/grant와 credential을 변경하지 않는다.
+- Pooler만 제거해 기존 direct workload에 영향 없이 rollback할 수 있어야 한다.
+- 별도 monitoring CR이나 metrics Service port를 추측해 추가하지 않고 CloudNativePG readiness와 exporter 경계를 사용한다.
+
+**Verification**
+
+- dev/prod Helm lint와 render에서 Pooler Cluster 참조, `rw`/`session`, reset, limit, replica/resources를 확인한다.
+- render diff에서 기존 Cluster와 API/Web `DATABASE_URL`·Secret 참조가 유지되고 Pooler만 additive한지 확인한다.
+- 지원되는 cluster에서 server-side dry-run 뒤 Pooler/Deployment/Pod/Service readiness를 확인한다.
+- live 두-client test에서 client session 동안 backend identity가 유지되고 첫 client 종료 뒤 test GUC가 다음 client에 남지 않는지 확인한다.
+- exporter metrics에서 pool mode, client waiting, server active/idle와 max wait를 확인한다.
+
+- [x] 1.1 session mode, reset, capacity, replica와 resource 경계를 가진 additive read-write Pooler를 Helm에 구현한다.
+- [x] 1.2 readiness, session affinity/reset, exporter metrics와 Pooler-only rollback 검증 절차를 운영 문서에 추가한다.
+- [x] 1.3 dev/prod lint·render와 OpenSpec strict validation을 통과하고 기존 workload endpoint/credential 불변을 정적으로 검증한다.
+- [ ] 1.4 배포된 환경에서 admission/readiness, session affinity/reset와 exporter metrics를 검증하고 PROD-728에 비민감 근거를 기록한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- 기존 CloudNativePG Cluster를 가리키는 별도 read-write `Pooler`를 추가했습니다.
- PgBouncer를 `session` mode로 고정하고 backend 반환 시 `DISCARD ALL` reset을 명시했습니다.
- dev 1/prod 3 replica, replica당 최대 client 1000, user/database pair별 server pool 10, PgBouncer resource request/limit를 values로 조정 가능하게 선언했습니다.
- Pooler/Service readiness, Pod exporter 9127 metrics, backend session affinity, 동일 backend 재사용 시 GUC reset, GitOps rollback 절차를 운영 문서로 추가했습니다.
- `add-postgres-session-pool` OpenSpec proposal/spec/design/decisions/tasks를 추가하고 구현·정적 검증 task를 완료했습니다.

## 왜 변경했는지

[PROD-728](https://linear.app/byulmaru/issue/PROD-728/cloudnativepg-pgbouncer-session-pool을-additive하게-provision한다)은 후속 GraphQL operation session 전환 전에 기존 direct PostgreSQL 경로와 독립된 PgBouncer access layer를 additive하게 준비합니다. Pooler 기반과 application activation을 분리하면 기존 API/Web 트래픽을 건드리지 않고 session semantics와 reset을 검증하고, 실패 시 Pooler만 되돌릴 수 있습니다.

이 PR은 [PROD-708](https://linear.app/byulmaru/issue/PROD-708/graphql-operation-context와-db-handle-seam을-추가한다)과 병렬 배포 가능합니다. PROD-708의 context/DB handle seam이나 현재 global DB fallback을 변경하지 않습니다.

## 이번 PR의 주요 결정

### session mode와 명시적 DISCARD ALL

- 결정자: @robin-maki
- 선택: 별도 `type: rw` Pooler에 `poolMode: session`과 `server_reset_query: DISCARD ALL`을 명시했습니다.
- 고려한 대안: transaction pooling, PgBouncer 기본 reset에만 의존, `DEALLOCATE ALL`.
- 이유: operation 동안 backend session state를 유지하면서 client 종료 뒤 actor GUC를 포함한 session state를 완전히 제거해야 합니다.
- 감수한 결과: client session 동안 backend connection을 점유하고 반환 때 prepared statement/cache도 제거합니다.
- 관련 근거: PROD-728, `openspec/changes/add-postgres-session-pool/decisions.md`, [CloudNativePG 1.30 Pooler](https://cloudnative-pg.io/docs/1.30/connection_pooling/), [PgBouncer configuration](https://www.pgbouncer.org/config)

### 초기 capacity와 resource 경계

- 결정자: @robin-maki
- 선택: dev 1/prod 3 replicas, `max_client_conn=1000`, `default_pool_size=10`, request `25m/64Mi`, limit `250m/128Mi`를 values 기본값으로 두었습니다.
- 고려한 대안: 모든 환경 3 replicas, PgBouncer 기본 pool size 20, resource/limit 미지정.
- 이유: dev 비용을 줄이고 production HA를 기존 Cluster와 맞추면서 production user/database pair당 초기 backend connection 상한을 30으로 제한합니다. CNPG resource 수치는 구성 예시이지 이 workload의 sizing 권위가 아니므로 경량 PgBouncer와 exporter에 맞는 작은 초기 경계를 사용합니다.
- 감수한 결과: 실제 traffic 전 dev working set과 CPU throttling/OOM을 관찰하고 PROD-726에서 필요하면 metrics를 근거로 values를 조정해야 합니다.
- 관련 근거: PROD-728, `openspec/changes/add-postgres-session-pool/decisions.md`

### activation과 credential 전환 분리

- 결정자: @robin-maki
- 선택: API/Web `DATABASE_URL`과 Secret 참조를 기존 `<release>-postgres-rw` direct 경계에 유지했습니다.
- 고려한 대안: 이 PR에서 Pooler endpoint까지 함께 활성화.
- 이유: 실제 operation connection lifecycle/actor GUC 활성화는 [PROD-726](https://linear.app/byulmaru/issue/PROD-726/모든-graphql-db-consumer-정렬-뒤-operation-db-session을-활성화한다)이 소유하고, [PROD-716](https://linear.app/byulmaru/issue/PROD-716/apiweb-bff를-non-owner-api-rls-credential로-전환한다)의 credential 전환은 이 PR 범위가 아닙니다.
- 감수한 결과: merge 직후 Pooler는 검증 트래픽 외 application traffic을 받지 않습니다.
- 관련 근거: PROD-728, PROD-708, PROD-726, PROD-716, `openspec/changes/add-postgres-session-pool/decisions.md`

## 어떻게 확인할 수 있는지

- Helm 4.2.2 dev/prod lint: 통과
- dev/prod focused render: `Pooler`, Cluster 참조, replicas, `rw`/`session`, reset, capacity/resources 확인
- custom values override render: 통과
- 전체 dev render: API/Web/migration `DATABASE_URL`이 계속 `kosmo-postgres-rw:5432`를 사용하는지 확인
- `openspec validate add-postgres-session-pool --strict`: 통과
- `openspec validate --all --strict`: 86/86 통과
- `git diff --check`: 통과
- exact-head GitHub Actions: Lint, Semgrep, Test aggregate와 Root/Core/Fedify/API/App/Web matrix 통과
- Luna correctness review: confirmed finding 없음
- ponytail review: `Lean already. Ship.` (`net: -0 lines possible`)

## 아직 어떤 문제가 남았는지

- merge 후 지원되는 cluster에서 server-side admission, Pooler/Deployment/Pod/Service readiness, 동일 backend session affinity/reset, `cnpg_pgbouncer_*` exporter metrics를 실제 검증하고 PROD-728에 비민감 근거를 기록해야 합니다.
- 이 live gate까지는 OpenSpec task 1.4를 열어 두며 change를 archive하거나 PROD-728을 완료하지 않습니다.
- PROD-726 전에는 application traffic을 Pooler로 전환하지 않습니다.
- PROD-716 credential 전환은 포함하지 않습니다.

Linear: PROD-728
