### PR TITLE
Kosmo 배포 전에 Temporal namespace를 준비한다

### DIFF
--- a/apps/helm/templates/_helpers.tpl
+++ b/apps/helm/templates/_helpers.tpl
@@ -86,3 +86,26 @@ password
 {{- printf "%s:%s" .Values.image .Values.version -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "kosmo.temporalAdminToolsImageRef" -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" .Values.temporal.adminTools.digest) -}}
+{{- fail "temporal.adminTools.digest must be a sha256 digest" -}}
+{{- end -}}
+{{- printf "%s@%s" .Values.temporal.adminTools.image .Values.temporal.adminTools.digest -}}
+{{- end -}}
+
+{{- define "kosmo.temporalNamespaceName" -}}
+{{- $name := get .Values.temporal.namespace.names .Values.env | default "" -}}
+{{- if not $name -}}
+{{- fail (printf "temporal.namespace.names.%s is required" .Values.env) -}}
+{{- end -}}
+{{- $name -}}
+{{- end -}}
+
+{{- define "kosmo.temporalNamespaceRetention" -}}
+{{- $retention := get .Values.temporal.namespace.retentions .Values.env | default "" -}}
+{{- if not $retention -}}
+{{- fail (printf "temporal.namespace.retentions.%s is required" .Values.env) -}}
+{{- end -}}
+{{- $retention -}}
+{{- end -}}

--- a/apps/helm/templates/temporal-namespace-job.yaml
+++ b/apps/helm/templates/temporal-namespace-job.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-temporal-namespace" .Release.Name | trunc 63 | trimSuffix "-" }}
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: temporal-namespace
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.version | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  activeDeadlineSeconds: 300
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: temporal-namespace
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: temporal-namespace
+          image: {{ include "kosmo.temporalAdminToolsImageRef" . | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              if temporal operator namespace create \
+                --address "${TEMPORAL_ADDRESS}" \
+                --tls=false \
+                --disable-config-env \
+                --disable-config-file \
+                --client-connect-timeout 10s \
+                --command-timeout 20s \
+                --namespace "${TEMPORAL_NAMESPACE}" \
+                --email "${TEMPORAL_NAMESPACE_OWNER_EMAIL}" \
+                --retention "${TEMPORAL_NAMESPACE_RETENTION}"; then
+                echo "Created Temporal namespace ${TEMPORAL_NAMESPACE}."
+                exit 0
+              fi
+
+              echo "Temporal namespace create did not succeed; reconciling the existing namespace."
+              temporal operator namespace update \
+                --address "${TEMPORAL_ADDRESS}" \
+                --tls=false \
+                --disable-config-env \
+                --disable-config-file \
+                --client-connect-timeout 10s \
+                --command-timeout 20s \
+                --namespace "${TEMPORAL_NAMESPACE}" \
+                --email "${TEMPORAL_NAMESPACE_OWNER_EMAIL}" \
+                --retention "${TEMPORAL_NAMESPACE_RETENTION}"
+              echo "Reconciled Temporal namespace ${TEMPORAL_NAMESPACE}."
+          env:
+            - name: TEMPORAL_ADDRESS
+              value: {{ .Values.temporal.frontendAddress | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ include "kosmo.temporalNamespaceName" . | quote }}
+            - name: TEMPORAL_NAMESPACE_OWNER_EMAIL
+              value: {{ .Values.temporal.namespace.ownerEmail | quote }}
+            - name: TEMPORAL_NAMESPACE_RETENTION
+              value: {{ include "kosmo.temporalNamespaceRetention" . | quote }}
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -10,6 +10,19 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
 migration:
   enabled: false
+temporal:
+  frontendAddress: temporal-frontend.temporal.svc.cluster.local:7233
+  adminTools:
+    image: temporalio/admin-tools
+    digest: sha256:dbc5fcd6ee8f0f4d808bf765af9a87dea9d8a283abfdcfbd2fc148496ba66107
+  namespace:
+    ownerEmail: dev@byulmaru.co
+    names:
+      dev: kosmo-dev
+      prod: kosmo-prod
+    retentions:
+      dev: 3d
+      prod: 30d
 postgres:
   credentials:
     api:

--- a/openspec/changes/provision-temporal-logical-namespaces/.openspec.yaml
+++ b/openspec/changes/provision-temporal-logical-namespaces/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-08

--- a/openspec/changes/provision-temporal-logical-namespaces/decisions.md
+++ b/openspec/changes/provision-temporal-logical-namespaces/decisions.md
@@ -1,0 +1,124 @@
+## Context
+
+이 기록은 PROD-719 Issue Gate에서 확정한 namespace provisioning 책임, 환경별 값, provider, Terraform runner 접속 경계와 PROD-730 분리를 반영한다. 제품 도메인 동작을 추가하지 않고 self-hosted Temporal의 application-owned desired state를 구현하는 선택만 기록한다.
+
+## Decision Records
+
+### Application Terraform이 logical namespace를 소유한다 (Superseded)
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `PROD-695`, `PROD-719`, `PROD-730`
+- Status: Superseded
+- Context / Problem: Temporal Server platform resource와 application namespace·Worker runtime의 생명주기를 구분해야 한다.
+- Decision Outcome: Shared Temporal Server는 PROD-695 platform 경계에 남기고, `kosmo-dev`와 `kosmo-prod` logical namespace는 Kosmo application Terraform이 소유한다. Worker runtime은 PROD-730이 별도로 소유한다.
+- Alternatives Considered: Platform Terraform이 application namespace까지 소유하는 방식은 application retention과 rollout 책임을 platform 변경에 결합해 제외했다. Argo CD hook은 지속적인 desired-state 수렴을 제공하지 않아 제외했다.
+- Consequences: `apps/terraform`은 namespace resource를 가지지만 Helm이나 Worker package는 이 change에서 바뀌지 않는다.
+- Confirmation / Follow-up: PROD-719 apply/no-op 검증 뒤 PROD-730 blocker를 해제한다.
+
+### self-hosted namespace provider를 정확히 고정한다 (Superseded)
+
+- Decision Date: 2026-08-08
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-719`
+- Status: Superseded
+- Context / Problem: 공식 Temporal Cloud provider는 self-hosted frontend namespace를 관리하지 않으며 provider 변화가 namespace lifecycle에 직접 영향을 준다.
+- Decision Outcome: `platacard/temporal` provider `0.19.0`을 exact version으로 고정한다.
+- Alternatives Considered: `temporalio/temporalcloud`는 대상이 달라 제외했다. CLI 명령을 Terraform/Argo hook에서 실행하는 방식은 선언적 resource와 drift를 제공하지 않아 제외했다. 새 provider 개발은 현재 범위에 비해 과도해 제외했다.
+- Consequences: Third-party provider의 호환성과 공급망을 dev에서 먼저 검증하고 dependency lock을 리뷰해야 한다.
+- Confirmation / Follow-up: `terraform init`, `validate`, dev plan/apply/read와 subsequent no-op plan으로 확인한다.
+
+### 환경별 namespace 값과 owner를 고정한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `PROD-719`
+- Status: Active
+- Context / Problem: Worker history 보존과 운영 소유권을 환경별로 명확히 해야 한다.
+- Decision Outcome: `kosmo-dev` retention은 3일, `kosmo-prod`는 30일로 두고 두 namespace의 owner email은 `dev@byulmaru.co`로 통일한다.
+- Alternatives Considered: `platform@byulmaru.co`와 환경별 owner 분리는 선택하지 않았다. retention을 Temporal CLI 기본값에 맡기는 방식은 drift 검토가 불가능해 제외했다.
+- Consequences: retention과 owner 변경은 Helm values와 rendered Job diff에서 환경별로 명시되며 reviewed change가 된다.
+- Confirmation / Follow-up: Argo CD sync 뒤 live namespace describe 결과와 선언을 비교한다.
+
+### Provisioning 접속과 runtime 인가를 분리한다 (Superseded)
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `PROD-719`, `PROD-704`
+- Status: Superseded
+- Context / Problem: Terraform이 namespace를 관리하려면 frontend gRPC 접속과 관리자 인증이 필요하지만 Worker의 dev/prod namespace 접근 인가 정책과는 책임이 다르다.
+- Decision Outcome: Terraform runner의 최소 private network 경로와 namespace 관리자 credential 주입은 PROD-719가 소유한다. Worker runtime의 namespace 인증·인가는 PROD-704에 남긴다.
+- Alternatives Considered: 접속 선행 이슈를 새로 만드는 방식과 PROD-704에 provisioning 전체를 위임하는 방식은 namespace apply 결과를 불필요하게 분리하므로 선택하지 않았다.
+- Consequences: 719 구현은 application repository 밖의 network/credential 설정 변경이 필요할 수 있지만 runtime authorization 정책을 확장해서는 안 된다.
+- Confirmation / Follow-up: 실제 plan/apply runner에서 DNS·TCP·TLS/auth preflight와 namespace read를 검증한다.
+
+### Namespace lifecycle은 Terraform만 소유하고 일반 삭제를 차단한다 (Superseded)
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `PROD-719`
+- Status: Superseded
+- Context / Problem: Namespace lifecycle을 여러 도구가 함께 소유하면 desired state와 실제 상태가 갈라지고 일반 destroy가 영속 History를 제거할 수 있다.
+- Decision Outcome: Namespace 생성과 owner·retention 변경은 application Terraform만 소유한다. Namespace resource에는 lifecycle 삭제 보호를 적용한다.
+- Alternatives Considered: Temporal CLI와 Argo CD hook을 함께 사용하는 방식은 중복 소유권을 만들므로 제외했다.
+- Consequences: Terraform 밖에서 namespace를 생성·갱신하지 않으며 의도적인 namespace 폐기는 별도 운영 결정과 보호 해제 없이는 실행할 수 없다.
+- Confirmation / Follow-up: plan/apply 외 생성·변경 경로가 없는지 검토하고 destroy 계획이 보호에 의해 실패하는지 검증한다.
+
+### In-cluster PreSync Job이 namespace provisioning을 소유한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `PROD-695`, `PROD-719`, 2026-08-08 사용자 결정
+- Status: Active
+- Context / Problem: Third-party Terraform provider는 외부 Mac runner에서 ClusterIP frontend에 도달하기 위해 Tailscale endpoint, EKS port-forward 또는 별도 runner 기반까지 요구했다.
+- Decision Outcome: Terraform 관리를 포기하고 각 Kosmo 환경 내부의 Argo CD PreSync Job이 자신의 logical namespace를 생성·갱신한다.
+- Alternatives Considered: Tailnet-only frontend는 낮은 사용 빈도에 비해 영구 endpoint가 과도해 제외했다. EKS API port-forward는 별도 access/RBAC와 tunnel lifecycle이 필요해 제외했다. 전용 in-cluster runner는 가장 큰 새 기반이라 제외했다. 수동 1회 생성과 Worker startup bootstrap은 각각 drift와 책임 결합 때문에 제외했다.
+- Consequences: Namespace 준비는 application sync의 선행 조건이 되고 Temporal 장애 시 해당 sync가 실패한다. Application Terraform과 외부 접속 경계는 변경하지 않는다.
+- Confirmation / Follow-up: dev/prod Helm render와 live PreSync create/re-run/drift/failure cases로 확인한다.
+
+### Platform과 같은 admin-tools image digest를 사용한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-695`, `PROD-719`
+- Status: Active
+- Context / Problem: Floating CLI image는 server 호환성과 target architecture를 배포마다 바꿀 수 있다.
+- Decision Outcome: Platform과 같은 `temporalio/admin-tools:1.31.2`의 multi-architecture digest `sha256:dbc5fcd6ee8f0f4d808bf765af9a87dea9d8a283abfdcfbd2fc148496ba66107`를 Job image로 사용한다.
+- Alternatives Considered: Tag-only reference와 latest는 공급망 재현성이 낮아 제외했다. Kosmo runtime image에 Temporal CLI를 추가하면 Worker/API와 bootstrap dependency가 결합되어 제외했다.
+- Consequences: amd64와 arm64에서 같은 image index를 사용하며 image 갱신은 명시적 reviewed change가 된다.
+- Confirmation / Follow-up: OCI manifest의 amd64/arm64 항목과 실제 image의 create/update `--email`·`--retention` flags를 확인했다.
+
+### Create 후 update fallback으로 최종 상태를 검증한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-719`
+- Status: Active
+- Context / Problem: Namespace 최초 생성과 기존 namespace 수렴을 멱등 처리하면서 CLI error text에 의존하지 않아야 한다.
+- Decision Outcome: Job은 create를 먼저 실행하고 성공하면 종료한다. Create가 성공하지 않으면 동일 owner·retention으로 update를 실행하며 update도 실패하면 Job을 실패시킨다. Namespace delete 명령은 포함하지 않는다.
+- Alternatives Considered: Describe error text를 파싱해 not-found를 구분하는 방식은 CLI 출력 결합이 커 제외했다. `create || true`는 실제 연결 실패를 숨겨 제외했다.
+- Consequences: 기존 namespace 재실행 시 create의 already-exists 출력이 남을 수 있지만 update 성공으로 desired state를 검증한다. Connection 실패는 create와 update 모두 실패해 PreSync를 차단한다.
+- Confirmation / Follow-up: create, existing, drift와 unreachable endpoint cases를 고정 image로 검증한다.
+
+### 현재 무인증 frontend 경계를 유지한다
+
+- Decision Date: 2026-08-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `PROD-695`, `PROD-704`, `PROD-719`
+- Status: Active
+- Context / Problem: 현재 frontend는 dev/prod를 같은 trust boundary로 수용하며 인증·인가는 아직 구현되지 않았다.
+- Decision Outcome: PreSync Job은 cluster-internal address와 `--tls=false`를 명시해 현재 runtime에 연결한다. 외부 endpoint를 추가하지 않고 인증 전환은 PROD-704가 소유한다.
+- Alternatives Considered: PROD-704 완료까지 namespace provisioning을 차단하거나 719에서 인증을 구현하는 방식은 현재 rollout을 지연하거나 책임을 중복시켜 제외했다.
+- Consequences: Job은 해당 Kubernetes namespace의 NetworkPolicy 경계에 의존한다. PROD-704 구현 시 CLI client 설정을 함께 전환해야 한다.
+- Confirmation / Follow-up: 각 환경 내부 Job의 frontend 연결과 외부 노출 부재를 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- `Application Terraform이 logical namespace를 소유한다`는 `In-cluster PreSync Job이 namespace provisioning을 소유한다`로 대체됐다. Third-party provider를 쓰기 위한 외부 접속 우회가 결과에 비해 과도했기 때문이다.
+- `self-hosted namespace provider를 정확히 고정한다`는 provider 미도입과 고정 admin-tools image 결정으로 대체됐다.
+- `Provisioning 접속과 runtime 인가를 분리한다`의 외부 Terraform 접속 책임은 제거됐고, 현재 runtime 인증 경계는 in-cluster Job 결정에 반영됐다.
+- `Namespace lifecycle은 Terraform만 소유하고 일반 삭제를 차단한다`는 PreSync create/update와 namespace delete 제외 계약으로 대체됐다.

--- a/openspec/changes/provision-temporal-logical-namespaces/design.md
+++ b/openspec/changes/provision-temporal-logical-namespaces/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Temporal Server는 PROD-695가 EKS의 `temporal` Kubernetes namespace에 배포했으며 SDK frontend는 `temporal-frontend.temporal.svc.cluster.local:7233` ClusterIP로만 제공한다. `kosmo-dev`와 `kosmo-prod` workload의 TCP 7233 접근은 허용되어 있지만 외부 Terraform runner는 cluster DNS와 ClusterIP를 직접 사용할 수 없다.
+
+`apps/helm`에는 이미 database migration을 위한 Argo CD PreSync Job 패턴이 있다. 반면 `apps/terraform`에는 Temporal provider가 없고 Terraform workflow는 외부 Mac runner에서 실행된다. Namespace 두 개를 위해 third-party provider와 별도 Tailscale/EKS 접속 경로를 추가하지 않고, 환경 내부의 Temporal CLI Job을 재사용하는 편이 현재 운영 경계에 맞다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- dev/prod namespace name, owner와 retention을 환경별 Helm desired input으로 둔다.
+- in-cluster PreSync Job이 namespace를 멱등 생성·갱신한다.
+- provisioning 실패가 후속 workload sync를 차단한다.
+- Worker runtime과 독립적으로 배포·검증한다.
+
+**Non-Goals:**
+
+- Application Terraform provider/resource/state를 추가하지 않는다.
+- Temporal frontend를 Tailscale 또는 public endpoint로 노출하지 않는다.
+- 외부 runner EKS access·port-forward 또는 전용 runner를 추가하지 않는다.
+- Temporal Server, Worker package, task queue 또는 business Workflow를 변경하지 않는다.
+- Namespace 삭제와 폐기 workflow를 구현하지 않는다.
+- dev/prod namespace authorization을 구현하지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- 현재 Temporal frontend는 PROD-695에서 인증 없는 동일 trust boundary로 운영하며 인증·인가는 PROD-704로 유예했다.
+- Namespace Job은 `kosmo-dev`와 `kosmo-prod` 안에서 실행해야 기존 NetworkPolicy의 frontend 접근 계약을 따른다.
+- Argo CD PreSync hook 실패는 해당 application의 나머지 sync를 차단하므로 Job은 빠르고 bounded하게 종료해야 한다.
+- Namespace create와 update는 서로 다른 Temporal CLI 명령이며, create의 already-exists 결과와 실제 연결 실패를 최종 성공 여부에서 구분해야 한다.
+- Job image는 target CPU architecture에서 실행되고 배포된 Temporal Server와 호환되는 Temporal CLI를 포함해야 한다.
+
+### Recommended Approach
+
+환경별 Helm values에 namespace name, owner email, retention을 선언하고 같은 template에서 PreSync Job을 render한다. Job image는 platform과 같은 `temporalio/admin-tools:1.31.2`의 multi-architecture digest `sha256:dbc5fcd6ee8f0f4d808bf765af9a87dea9d8a283abfdcfbd2fc148496ba66107`로 고정한다.
+
+Job script는 선언값으로 namespace create를 먼저 시도한다. Create가 성공하면 종료하고, already-exists를 포함해 create가 성공하지 않으면 같은 owner·retention으로 update를 실행해 최종 상태를 검증한다. Connection/auth 오류라면 create와 update가 모두 실패하므로 Job도 실패한다. Update 성공 없이 create 오류를 삼키지 않는다. 모든 명령은 명시적 frontend address, `--tls=false`, namespace, email, retention과 command timeout을 전달한다.
+
+Hook은 database migration과 구분되는 name/label을 사용하고 PreSync 단계에서 실행한다. 실패한 Job log는 조사할 수 있어야 하며 active deadline, retry/backoff와 Pod security context/resource request를 명시한다. Namespace delete 명령은 image command와 script에 포함하지 않는다.
+
+### Allowed Alternatives
+
+- Create/update fallback과 같은 실패 전파를 보존한다면 작은 repository-owned command로 감쌀 수 있다.
+- 성공한 hook의 보존 기간과 재생성 정책은 기존 Helm 운영 관례에 맞출 수 있다. 실패한 실행의 log는 반드시 남아야 한다.
+
+### Known Traps
+
+- `create || true` 또는 `update || true`로 실제 연결·권한·CLI 실패를 성공 처리하는 것.
+- latest/floating CLI image를 사용해 server/CLI 호환성을 배포마다 바꾸는 것.
+- Terraform provider, Tailscale frontend 또는 외부 port-forward 경로를 다시 추가하는 것.
+- Namespace bootstrap을 Worker process startup에 넣어 관리자 책임과 Worker lifecycle을 결합하는 것.
+- Helm release 삭제에 맞춰 Temporal namespace를 삭제하는 것.
+
+## Risks / Trade-offs
+
+- [Temporal 장애가 전체 application sync를 차단함] → Job timeout/backoff를 제한하고 실패 log를 보존한다. 이는 namespace 준비 전 workload를 진행하지 않는 선택의 의도된 결과다.
+- [CLI 동작이 image version에 따라 달라질 수 있음] → multi-architecture image digest를 고정하고 create/existing/drift/connection-failure cases를 실제 CLI로 검증한다.
+- [인증 없는 frontend에서 Job이 namespace 관리자 명령을 실행함] → 현재 PROD-695의 동일 trust boundary만 사용하고 외부 endpoint를 추가하지 않는다. PROD-704 도입 시 Job client 설정을 함께 전환한다.
+- [PreSync Job이 매 sync마다 update를 호출함] → 동일 값 update가 안전한지 검증하고, 필요하면 machine-readable describe 결과로 실제 drift가 있을 때만 update한다.
+
+## Migration Plan
+
+1. 환경별 values와 PreSync Job을 추가하고 dev/prod Helm render를 검증한다.
+2. 고정 CLI image에서 namespace create, existing, drift와 connection-failure 동작을 검증한다.
+3. dev sync로 `kosmo-dev`를 생성하고 재동기화와 retention drift 수렴을 확인한다.
+4. dev 증거 뒤 prod sync로 `kosmo-prod`를 생성하고 재동기화와 retention drift 수렴을 확인한다.
+5. 문제가 생기면 Job template/values를 되돌리되 생성된 Temporal namespace는 삭제하지 않는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/provision-temporal-logical-namespaces/proposal.md
+++ b/openspec/changes/provision-temporal-logical-namespaces/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+PROD-695로 self-hosted Temporal Server는 준비됐지만 Kosmo가 사용할 logical namespace와 History retention은 아직 Worker rollout 전에 생성·검증되지 않는다. 외부 Terraform runner에서 ClusterIP frontend에 접근하기 위해 third-party provider나 별도 접속 경로를 추가하지 않고, 각 애플리케이션 환경 내부에서 작은 bootstrap Job으로 수렴시킨다.
+
+## What Changes
+
+- 각 Kosmo 환경의 Argo CD sync가 Temporal namespace provisioning PreSync Job을 실행한다.
+- Job은 cluster-internal frontend에 연결해 namespace가 없으면 생성하고, 있으면 owner email과 retention을 선언값으로 갱신한다.
+- `kosmo-dev`는 3일, `kosmo-prod`는 30일 retention과 공통 owner `dev@byulmaru.co`를 사용한다.
+- frontend 연결 또는 CLI 실행이 실패하면 PreSync가 실패하고 후속 workload sync를 차단한다.
+- Namespace 삭제는 수행하지 않는다.
+- Terraform provider/resource, Tailscale frontend endpoint와 외부 runner port-forward는 도입하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: 적용되는 `docs/domain` 또는 `docs/design` 문서 없음. application-owned logical namespace와 platform-owned Temporal Server 경계는 Linear 계약으로 확정한다.
+- Linear Contract: [PROD-719](https://linear.app/byulmaru/issue/PROD-719/kosmo-temporal-logical-namespace를-presync에서-프로비저닝한다)
+- Linear Implementations: PROD-719. 후속 Worker runtime은 [PROD-730](https://linear.app/byulmaru/issue/PROD-730/kosmo-temporal-worker-runtime을-구현배포한다)가 소유한다.
+
+## Capabilities
+
+### New Capabilities
+
+- `temporal-namespace-provisioning`: 환경별 Argo CD PreSync Job이 cluster-internal Temporal namespace의 생성과 owner·retention 수렴을 수행한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/helm`에 환경별 Temporal namespace 설정과 PreSync Job이 추가된다.
+- Temporal CLI를 제공하는 고정된 호환 image가 runtime dependency로 추가된다.
+- API, Web, application Terraform, Temporal Worker SDK와 business Workflow에는 변경이 없다.

--- a/openspec/changes/provision-temporal-logical-namespaces/specs/temporal-namespace-provisioning/spec.md
+++ b/openspec/changes/provision-temporal-logical-namespaces/specs/temporal-namespace-provisioning/spec.md
@@ -47,7 +47,7 @@
 
 ### Requirement: PreSync 실패 경계
 
-**Authority / Provenance:** `PROD-719`. Frontend 연결, namespace describe/create/update 또는 CLI 실행이 실패하면 Job은 실패해야 하고(MUST), Argo CD는 후속 workload sync를 진행해서는 안 된다(MUST NOT). Job은 bounded timeout과 retry 경계를 가져야 한다(MUST).
+**Authority / Provenance:** `PROD-719`. Frontend 연결이 실패하거나 namespace create와 fallback update가 모두 실패해 최종 수렴하지 못하면 Job은 실패해야 하고(MUST), Argo CD는 후속 workload sync를 진행해서는 안 된다(MUST NOT). Job은 bounded timeout과 retry 경계를 가져야 한다(MUST).
 
 #### Scenario: Frontend 연결 실패
 
@@ -55,9 +55,9 @@
 - **THEN** Job은 제한된 시간 안에 실패한다
 - **AND** 후속 workload sync는 진행되지 않는다
 
-#### Scenario: Namespace 명령 실패
+#### Scenario: Namespace 최종 수렴 실패
 
-- **WHEN** namespace create 또는 update 명령이 성공하지 못한다
+- **WHEN** namespace create가 성공하지 못하고 fallback update도 성공하지 못한다
 - **THEN** Job은 성공으로 가장하지 않고 실패한다
 - **AND** 실패 원인을 Job log에서 확인할 수 있다
 

--- a/openspec/changes/provision-temporal-logical-namespaces/specs/temporal-namespace-provisioning/spec.md
+++ b/openspec/changes/provision-temporal-logical-namespaces/specs/temporal-namespace-provisioning/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: 환경별 Temporal namespace desired state
+
+**Authority / Provenance:** `PROD-695`, `PROD-719`. Kosmo는 self-hosted Temporal에 `kosmo-dev`와 `kosmo-prod` logical namespace를 준비해야 한다(MUST). `kosmo-dev`의 Workflow History retention은 3일, `kosmo-prod`는 30일이어야 하며(SHALL), 두 namespace의 owner email은 `dev@byulmaru.co`여야 한다(SHALL).
+
+#### Scenario: dev namespace 선언
+
+- **WHEN** dev Helm chart를 render한다
+- **THEN** namespace name은 `kosmo-dev`이고 retention은 3일이다
+- **AND** owner email은 `dev@byulmaru.co`이다
+
+#### Scenario: prod namespace 선언
+
+- **WHEN** prod Helm chart를 render한다
+- **THEN** namespace name은 `kosmo-prod`이고 retention은 30일이다
+- **AND** owner email은 `dev@byulmaru.co`이다
+
+### Requirement: In-cluster PreSync provisioning
+
+**Authority / Provenance:** `PROD-695`, `PROD-719`. 각 환경은 자신의 Kubernetes namespace에서 Argo CD PreSync Job을 실행해 `temporal-frontend.temporal.svc.cluster.local:7233`에 연결해야 한다(MUST). 이 provisioning을 위해 Terraform provider/resource, Tailscale frontend endpoint, 외부 runner port-forward 또는 전용 runner를 추가해서는 안 된다(MUST NOT).
+
+#### Scenario: Cluster-internal 연결
+
+- **WHEN** Argo CD가 Kosmo environment를 sync한다
+- **THEN** PreSync Job이 cluster-internal frontend address로 Temporal CLI를 실행한다
+- **AND** 외부 ingress나 Terraform runner를 경유하지 않는다
+
+### Requirement: 멱등 create/update 수렴
+
+**Authority / Provenance:** `PROD-719`. PreSync Job은 대상 namespace가 없으면 선언된 name·owner·retention으로 생성해야 하고(MUST), 이미 있으면 owner와 retention을 선언값으로 갱신해야 한다(MUST). 같은 선언으로 반복 실행해도 성공해야 한다(MUST).
+
+#### Scenario: Namespace 최초 생성
+
+- **WHEN** 대상 Temporal namespace가 존재하지 않는다
+- **THEN** Job은 선언된 name·owner·retention으로 namespace를 생성한다
+
+#### Scenario: 동일 선언 재실행
+
+- **WHEN** 대상 namespace의 owner와 retention이 이미 선언과 일치한다
+- **THEN** Job은 성공하고 namespace 값을 유지한다
+
+#### Scenario: Owner 또는 retention drift
+
+- **WHEN** 대상 namespace의 owner 또는 retention이 선언과 다르다
+- **THEN** Job은 두 값을 선언된 상태로 갱신한다
+
+### Requirement: PreSync 실패 경계
+
+**Authority / Provenance:** `PROD-719`. Frontend 연결, namespace describe/create/update 또는 CLI 실행이 실패하면 Job은 실패해야 하고(MUST), Argo CD는 후속 workload sync를 진행해서는 안 된다(MUST NOT). Job은 bounded timeout과 retry 경계를 가져야 한다(MUST).
+
+#### Scenario: Frontend 연결 실패
+
+- **WHEN** Job이 Temporal frontend에 연결할 수 없다
+- **THEN** Job은 제한된 시간 안에 실패한다
+- **AND** 후속 workload sync는 진행되지 않는다
+
+#### Scenario: Namespace 명령 실패
+
+- **WHEN** namespace create 또는 update 명령이 성공하지 못한다
+- **THEN** Job은 성공으로 가장하지 않고 실패한다
+- **AND** 실패 원인을 Job log에서 확인할 수 있다
+
+### Requirement: Namespace 삭제 제외
+
+**Authority / Provenance:** `PROD-719`. Provisioning Job은 Temporal namespace 삭제를 수행하거나 자동 폐기 경로를 제공해서는 안 된다(MUST NOT).
+
+#### Scenario: Helm release 제거 또는 재동기화
+
+- **WHEN** Helm release가 제거되거나 chart가 다시 sync된다
+- **THEN** provisioning 경로는 기존 Temporal namespace를 삭제하지 않는다
+
+### Requirement: Worker runtime과 분리된 readiness 경계
+
+**Authority / Provenance:** `PROD-719`, `PROD-730`. Namespace provisioning은 Temporal Worker 코드와 business Workflow 없이 독립적으로 render·sync·검증할 수 있어야 한다(MUST). PROD-730 Worker runtime은 대상 환경의 PreSync provisioning이 성공한 뒤에만 rollout해야 한다(MUST).
+
+#### Scenario: Namespace provisioning 단독 배포
+
+- **WHEN** Worker runtime이 아직 구현 또는 배포되지 않았다
+- **THEN** PreSync Job은 독립적으로 namespace를 생성·갱신하고 완료된다
+
+#### Scenario: Worker 선행 조건
+
+- **WHEN** 대상 환경의 namespace provisioning이 실패한다
+- **THEN** Worker runtime rollout은 시작되지 않는다

--- a/openspec/changes/provision-temporal-logical-namespaces/tasks.md
+++ b/openspec/changes/provision-temporal-logical-namespaces/tasks.md
@@ -1,0 +1,108 @@
+## 1. PROD-719 Helm namespace provisioning
+
+**Authority / Provenance**
+
+- `PROD-695`
+- `PROD-719`
+
+**Deliverable**
+
+Dev/prod Helm render에 환경별 Temporal namespace name, owner, retention과 고정 CLI image를 사용하는 독립 PreSync Job이 나타난다.
+
+**Guardrails**
+
+- `kosmo-dev`는 3일, `kosmo-prod`는 30일 retention을 사용한다.
+- 두 namespace의 owner email은 `dev@byulmaru.co`이다.
+- Job은 `temporalio/admin-tools:1.31.2`의 검증된 multi-architecture digest를 사용한다.
+- Job은 cluster-internal frontend와 `--tls=false`를 명시한다.
+- Terraform provider/resource, Tailscale endpoint, 외부 port-forward와 Worker runtime을 포함하지 않는다.
+
+**Verification**
+
+- Dev/prod Helm render에서 환경별 값, hook annotation, image digest, address와 timeout을 검토한다.
+- Helm template과 repository formatting 검증을 통과한다.
+- Render 결과에 Terraform/Tailscale/Worker resource가 추가되지 않았는지 확인한다.
+
+- [x] 1.1 환경별 namespace name·owner·retention과 고정 CLI image values를 추가한다.
+- [x] 1.2 Bounded timeout/backoff와 안전한 Pod security context를 가진 PreSync Job을 구현한다.
+- [x] 1.3 Dev/prod Helm render와 정적 검증을 통과시킨다.
+
+## 2. PROD-719 멱등 create/update와 실패 전파
+
+**Authority / Provenance**
+
+- `PROD-719`
+
+**Deliverable**
+
+PreSync Job이 namespace 최초 생성과 기존 owner·retention 수렴을 멱등 수행하고, 최종 create/update 실패를 Argo CD sync 실패로 전달한다.
+
+**Guardrails**
+
+- Create 성공 또는 update 성공 없이 Job을 성공 처리하지 않는다.
+- CLI error text 파싱에 namespace 존재 판정을 결합하지 않는다.
+- Namespace delete 명령이나 자동 폐기 경로를 포함하지 않는다.
+- Failed Job의 원인을 log에서 확인할 수 있어야 한다.
+
+**Verification**
+
+- 고정 image가 linux/amd64·linux/arm64와 create/update `--email`·`--retention` flags를 제공하는지 확인한다.
+- Create 성공, already-exists 후 update 성공, drift update와 unreachable endpoint 실패를 검증한다.
+- Rendered command에 namespace delete와 오류 무시 경계가 없는지 확인한다.
+
+- [x] 2.1 고정 CLI image의 architecture와 필요한 namespace flags를 검증한다.
+- [x] 2.2 Create 성공과 create 실패 후 update 성공 경로를 검증한다.
+- [x] 2.3 Create와 update가 모두 실패할 때 Job이 실패하는지 검증한다.
+- [x] 2.4 Namespace delete와 오류 무시 경계가 없음을 검증한다.
+
+## 3. PROD-719 Live dev/prod sync
+
+**Authority / Provenance**
+
+- `PROD-695`
+- `PROD-719`
+
+**Deliverable**
+
+실제 dev/prod Argo CD sync가 각 Temporal namespace를 선언값으로 수렴시키고 재동기화에도 성공한다.
+
+**Guardrails**
+
+- Prod sync는 dev create·rerun·drift·failure 검증 뒤에 수행한다.
+- Rollback은 생성된 Temporal namespace를 삭제하지 않는다.
+- Provisioning 실패 시 후속 workload sync를 진행하지 않는다.
+
+**Verification**
+
+- Dev create, rerun, retention drift update와 unreachable frontend 실패를 확인한다.
+- Dev 증거 뒤 prod create, rerun과 retention drift update를 확인한다.
+- Job 상태·log와 Argo CD sync gate를 확인한다.
+
+- [ ] 3.1 Dev sync에서 `kosmo-dev` create·rerun·drift·failure gate를 검증한다.
+- [ ] 3.2 Prod sync에서 `kosmo-prod` create·rerun·drift를 검증한다.
+- [ ] 3.3 Job 관측과 비파괴 rollback 절차를 검증·문서화한다.
+
+## 4. PROD-719 완료 정합성 및 archive
+
+**Authority / Provenance**
+
+- `PROD-719`
+
+**Deliverable**
+
+PROD-719의 구현·운영 검증 증거와 OpenSpec delta가 일치하고, PROD-730이 namespace readiness를 선행 조건으로 사용할 수 있다.
+
+**Guardrails**
+
+- Worker runtime 구현이나 downstream Workflow 구현을 완료 증거로 요구하지 않는다.
+- Live dev/prod 수렴 전에는 change를 archive하거나 PROD-730 blocker를 해제하지 않는다.
+
+**Verification**
+
+- 모든 task와 PROD-719 완료 조건을 구현·CI·live evidence에 대조한다.
+- Delta spec 동기화와 strict validation을 확인한다.
+- PROD-730 blocker 해제 가능 여부를 검토한다.
+
+- [ ] 4.1 구현·CI·live evidence를 PROD-719와 각 requirement에 연결해 최종 검토한다.
+- [x] 4.2 OpenSpec strict validation과 delta spec 정합성을 확인한다.
+- [ ] 4.3 전체 scope가 완료된 경우 canonical spec을 동기화하고 change를 archive한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- `kosmo-dev`와 `kosmo-prod`의 Temporal logical namespace 이름, owner email, History retention을 Helm values에 선언했습니다.
- 각 애플리케이션 환경 내부에서 실행되는 Argo CD PreSync Job을 추가했습니다.
- Job은 고정된 `temporalio/admin-tools:1.31.2` multi-architecture digest로 namespace를 생성하고, 이미 존재하면 owner와 retention을 갱신합니다.
- Helm helper가 잘못된 환경이나 image digest를 render 단계에서 거부하도록 했습니다.
- PROD-719의 계약, 결정, 검증 및 live rollout gate를 OpenSpec change로 기록했습니다.

## 왜 변경했는지

PROD-695로 Temporal Server는 준비됐지만 Kosmo Worker가 사용할 logical namespace는 아직 배포 전에 보장되지 않습니다. 외부 Terraform runner가 ClusterIP frontend에 접근하도록 third-party provider와 Tailscale 또는 port-forward 기반을 추가하는 대신, 이미 cluster network 안에 있는 애플리케이션 sync가 namespace를 준비하도록 해 운영 기반을 작게 유지합니다.

## 이번 PR의 주요 결정

### Namespace provisioning은 in-cluster PreSync가 소유한다

- 결정자: @robin-maki
- 선택: 각 Kosmo 환경의 Argo CD PreSync Job이 cluster-internal Temporal frontend에 연결해 namespace를 생성·갱신합니다.
- 고려한 대안: Third-party Terraform provider, Tailnet-only frontend, EKS port-forward, 전용 in-cluster runner, 수동 1회 생성, Worker startup bootstrap.
- 이유: namespace 두 개를 위해 외부 접속 경계와 별도 기반을 늘리지 않고 application sync 안에서 독립적으로 검증할 수 있습니다.
- 감수한 결과: Temporal 장애가 있으면 PreSync가 실패해 해당 application sync도 중단됩니다.
- 관련 근거: [PROD-719](https://linear.app/byulmaru/issue/PROD-719/kosmo-temporal-logical-namespace를-presync에서-프로비저닝한다), [`decisions.md`](openspec/changes/provision-temporal-logical-namespaces/decisions.md)

### Create 후 update fallback으로 수렴한다

- 결정자: @robin-maki
- 선택: create 성공 시 종료하고, create가 성공하지 않으면 동일한 owner·retention으로 update하며 update도 실패하면 Job을 실패시킵니다.
- 고려한 대안: CLI error text로 already-exists를 판별하는 방식, `create || true`로 오류를 무시하는 방식.
- 이유: 출력 문자열에 결합하지 않으면서 최초 생성과 재실행·drift 수렴을 같은 경로로 처리합니다.
- 감수한 결과: 기존 namespace의 재실행 로그에는 create 실패와 후속 update 성공이 함께 남습니다.
- 관련 근거: [`decisions.md`](openspec/changes/provision-temporal-logical-namespaces/decisions.md)

### 현재 cluster-internal 무인증 경계를 유지한다

- 결정자: @robin-maki
- 선택: PROD-695의 현재 경계에 맞춰 내부 frontend와 `--tls=false`를 명시하고 외부 endpoint는 추가하지 않습니다.
- 고려한 대안: PROD-704 인증 구현을 이번 PR에 포함하거나 namespace provisioning을 그때까지 차단하는 방식.
- 이유: namespace provisioning과 Worker runtime 인증·인가의 책임을 분리합니다.
- 감수한 결과: PROD-704에서 인증 경계가 바뀌면 이 CLI client 설정도 함께 전환해야 합니다.
- 관련 근거: [PROD-704](https://linear.app/byulmaru/issue/PROD-704), [`decisions.md`](openspec/changes/provision-temporal-logical-namespaces/decisions.md)

## 어떻게 확인할 수 있는지

- `helm lint` dev/prod
- `helm template` dev/prod: `kosmo-dev` 3d, `kosmo-prod` 30d, owner와 digest 확인
- 잘못된 environment와 admin-tools digest가 render 실패하는지 확인
- rendered shell을 fake Temporal CLI로 실행해 create 성공, create 실패 후 update 성공, create/update 동시 실패(exit 1) 확인
- 고정 image를 read-only root filesystem, UID 1000, capability drop 조건으로 실행해 namespace flags 확인
- `pnpm lint:prettier`
- `pnpm exec openspec validate provision-temporal-logical-namespaces --strict`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- 실제 dev Argo CD sync에서 create·rerun·drift·failure gate를 확인해야 합니다.
- dev 증거 뒤 prod create·rerun·drift를 확인해야 합니다.
- Live 검증 전에는 OpenSpec을 archive하거나 PROD-730 blocker를 해제하지 않습니다.

Linear: [PROD-719](https://linear.app/byulmaru/issue/PROD-719/kosmo-temporal-logical-namespace를-presync에서-프로비저닝한다)
