### PR TITLE
Temporal SDK의 quinn-proto High 취약 의존성을 제거한다

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,7 +9,7 @@
     "test": "pnpm build && node --import tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
-    "@temporalio/worker": "^1.21.1",
+    "@temporalio/worker": "^1.22.0",
     "tsx": "^4.22.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,8 +370,8 @@ importers:
   apps/worker:
     dependencies:
       '@temporalio/worker':
-        specifier: ^1.21.1
-        version: 1.21.1(tslib@2.8.1)
+        specifier: ^1.22.0
+        version: 1.22.0(tslib@2.8.1)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -3107,36 +3107,36 @@ packages:
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
-  '@temporalio/activity@1.21.1':
-    resolution: {integrity: sha512-UjA1d4ugL3pRXElwnggtVAMe3lppUPzYpBPmpDLTXfOtxEXPTK1x+8OC2jrZY7qmvpHkOdoo86S+UYFzJkMk/A==}
+  '@temporalio/activity@1.22.0':
+    resolution: {integrity: sha512-hrPeELIMloFWVrwmDfG1lh3uFNkaYp1ZHpcpWmJniTeSyxqCqLdil4lBOv11FByb6HeKxE6rsvOOUohulyVhRg==}
     engines: {node: '>= 20.3.0'}
 
-  '@temporalio/client@1.21.1':
-    resolution: {integrity: sha512-rdZAh20wzI5i/SyS46Nv9mE6t2KkS9DTrB57HEMLsq6eqm58Nc6la0WQKJGsUNkmN98KKirByidZ5D/ik3kiQw==}
+  '@temporalio/client@1.22.0':
+    resolution: {integrity: sha512-b02ty0uDly6/ZRKlbavs5GjXVTry/GB4tkq0v1NH4H7x+nTo/OK0u5Ms8Nni8D+aar3xff9lzIpXNwu/Dp3P3w==}
     engines: {node: '>= 20.3.0'}
 
-  '@temporalio/common@1.21.1':
-    resolution: {integrity: sha512-8Pis59xYLrGu6GfkkWvrYWkSPEvo8lBBILsR6gBHGbymNlEc0ynylRXqPmRjwuLfYS7jHzxqjjO7cvXJQ/z2Fg==}
+  '@temporalio/common@1.22.0':
+    resolution: {integrity: sha512-1NpQpo/y6XU1ULbo/bXgBEhl6qQnOeB79NrsSJdjI38/hfXPom2IYGJcIxOFfsQICQ0zePEKzB9Yyo31KNpIxA==}
     engines: {node: '>= 20.3.0'}
 
-  '@temporalio/core-bridge@1.21.1':
-    resolution: {integrity: sha512-gCy/6TFhcFAjFPRN1DeHSwAnXU380Jn/y6yG2dkSV+rYK0JRl66SE2NvdcAjzhoPO/twHEaHklbppojH0cUpUw==}
+  '@temporalio/core-bridge@1.22.0':
+    resolution: {integrity: sha512-mJ5agqtfW+GBPYl+ivYLrBpKJ3oFOw8ogcoizNrxYCzwJeprGFiEgHDb/jzyvECR4HAy5s9zQFJYNyTruXXFMw==}
     engines: {node: '>= 20.3.0'}
 
-  '@temporalio/nexus@1.21.1':
-    resolution: {integrity: sha512-CIAoTt/WpSE0bn1mE9q5O6hU76q97W349e0FSrUuwQAYDXBy7jzFM6ZzYmm7S5Uk2tC1xrRCAjUGg1lMnHQppw==}
+  '@temporalio/nexus@1.22.0':
+    resolution: {integrity: sha512-4S1ZZdSNjrO9IUyhWxweIidvNn1X/ihEl+P2fOn/Ky38YRx9G+8wtV6g6lqG8zUrtEv//uqFw+HsRMziE2y4tg==}
     engines: {node: '>= 20.3.0'}
 
-  '@temporalio/proto@1.21.1':
-    resolution: {integrity: sha512-eSHGrZ6CxbtjrAzxiMgKrWeDiBlWk6/JkIqsB1hrkPB6TQXC67Az8v0BL0Fj3ur8ktQZbaacON/xCDjTsvJyGw==}
+  '@temporalio/proto@1.22.0':
+    resolution: {integrity: sha512-X7NVa0Z6HK3l9irZR48FKwZ9w9YXetCdF2z2KCIRr0W7Kul64Wt9o5hwvSXShAtrZuCEEHH8WO/ffHTXxJieLg==}
     engines: {node: '>= 20.3.0'}
 
-  '@temporalio/worker@1.21.1':
-    resolution: {integrity: sha512-ccXus6+w317tL+NsJXEYWpHFxcy0VDPfstmBzej0yZrkzWNvAkaWVGQbguKoLToDM8+DMaqklx1dX4gJnknR1g==}
+  '@temporalio/worker@1.22.0':
+    resolution: {integrity: sha512-axRHhUsovFlqDtXZxUnhRLV7WmC6qOMUCij13lw4glT5yRH62k8wIZqcT3naEfvLSzoDxjt2xM7me3VvTRSaow==}
     engines: {node: '>= 20.3.0'}
 
-  '@temporalio/workflow@1.21.1':
-    resolution: {integrity: sha512-Tsoe9RnB0mL75DGVo3wJJrgTl+QnHYUysPjqRkzQdzgeKravN8RxE0HCfS3cYRZej3eEVwoDftgbo7/KR0NXWQ==}
+  '@temporalio/workflow@1.22.0':
+    resolution: {integrity: sha512-31Ax529+TvfH2RCexOhiCyM3lARJJoVzrnRUS1gX+jl+mka+pRRnEUx4B572mZz0oOlCCxbiztHZF72wwwWZDA==}
     engines: {node: '>= 20.3.0'}
 
   '@testing-library/dom@10.4.1':
@@ -10167,58 +10167,58 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@temporalio/activity@1.21.1':
+  '@temporalio/activity@1.22.0':
     dependencies:
-      '@temporalio/client': 1.21.1
-      '@temporalio/common': 1.21.1
+      '@temporalio/client': 1.22.0
+      '@temporalio/common': 1.22.0
 
-  '@temporalio/client@1.21.1':
+  '@temporalio/client@1.22.0':
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@temporalio/common': 1.21.1
-      '@temporalio/proto': 1.21.1
+      '@temporalio/common': 1.22.0
+      '@temporalio/proto': 1.22.0
       abort-controller: 3.0.0
       long: 5.3.2
       nexus-rpc: 0.0.2
       uuid: 11.1.1
 
-  '@temporalio/common@1.21.1':
+  '@temporalio/common@1.22.0':
     dependencies:
-      '@temporalio/proto': 1.21.1
+      '@temporalio/proto': 1.22.0
       long: 5.3.2
       ms: 3.0.0-canary.1
       nexus-rpc: 0.0.2
       proto3-json-serializer: 2.0.2
 
-  '@temporalio/core-bridge@1.21.1':
+  '@temporalio/core-bridge@1.22.0':
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@temporalio/common': 1.21.1
+      '@temporalio/common': 1.22.0
 
-  '@temporalio/nexus@1.21.1':
+  '@temporalio/nexus@1.22.0':
     dependencies:
-      '@temporalio/client': 1.21.1
-      '@temporalio/common': 1.21.1
-      '@temporalio/proto': 1.21.1
+      '@temporalio/client': 1.22.0
+      '@temporalio/common': 1.22.0
+      '@temporalio/proto': 1.22.0
       long: 5.3.2
       nexus-rpc: 0.0.2
 
-  '@temporalio/proto@1.21.1':
+  '@temporalio/proto@1.22.0':
     dependencies:
       long: 5.3.2
       protobufjs: 7.6.5
 
-  '@temporalio/worker@1.21.1(tslib@2.8.1)':
+  '@temporalio/worker@1.22.0(tslib@2.8.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@swc/core': 1.15.47
-      '@temporalio/activity': 1.21.1
-      '@temporalio/client': 1.21.1
-      '@temporalio/common': 1.21.1
-      '@temporalio/core-bridge': 1.21.1
-      '@temporalio/nexus': 1.21.1
-      '@temporalio/proto': 1.21.1
-      '@temporalio/workflow': 1.21.1
+      '@temporalio/activity': 1.22.0
+      '@temporalio/client': 1.22.0
+      '@temporalio/common': 1.22.0
+      '@temporalio/core-bridge': 1.22.0
+      '@temporalio/nexus': 1.22.0
+      '@temporalio/proto': 1.22.0
+      '@temporalio/workflow': 1.22.0
       heap-js: 2.7.1
       memfs: 4.64.0(tslib@2.8.1)
       nexus-rpc: 0.0.2
@@ -10246,10 +10246,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@temporalio/workflow@1.21.1':
+  '@temporalio/workflow@1.22.0':
     dependencies:
-      '@temporalio/common': 1.21.1
-      '@temporalio/proto': 1.21.1
+      '@temporalio/common': 1.22.0
+      '@temporalio/proto': 1.22.0
       nexus-rpc: 0.0.2
 
   '@testing-library/dom@10.4.1':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,11 +21,6 @@ allowBuilds:
   protobufjs: false
   unrs-resolver: true
 minimumReleaseAgeExclude:
-  # Security fixes GHSA-rgw5-rvv9-x895 for brace-expansion were published
-  # 2026-07-30; exempt only the patched versions while the seven-day gate matures.
-  - brace-expansion@1.1.18
-  - brace-expansion@5.0.9
-  - hono@4.12.34
   # Temporal 1.22.0 clears GHSA-4w2j-m93h-cj5j from the bundled Rust lockfile.
   - '@temporalio/activity@1.22.0'
   - '@temporalio/client@1.22.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,15 @@ minimumReleaseAgeExclude:
   - brace-expansion@1.1.18
   - brace-expansion@5.0.9
   - hono@4.12.34
+  # Temporal 1.22.0 clears GHSA-4w2j-m93h-cj5j from the bundled Rust lockfile.
+  - '@temporalio/activity@1.22.0'
+  - '@temporalio/client@1.22.0'
+  - '@temporalio/common@1.22.0'
+  - '@temporalio/core-bridge@1.22.0'
+  - '@temporalio/nexus@1.22.0'
+  - '@temporalio/proto@1.22.0'
+  - '@temporalio/worker@1.22.0'
+  - '@temporalio/workflow@1.22.0'
 overrides:
   '@opentelemetry/sdk-metrics@<2.8.0': ^2.8.0
   # Expo Router exposes broad native peers; align every peer snapshot with SDK 56 / RN 0.85.


### PR DESCRIPTION
## 무엇을 변경했는지

- `@temporalio/worker`와 함께 설치되는 Temporal 패키지군을 1.22.0으로 갱신했습니다.
- 7일 성숙도 정책에서 이번 보안 패치에 필요한 정확한 `package@1.22.0` 8개만 예외 처리했습니다.
- 이미 7일이 지난 `brace-expansion@1.1.18`, `brace-expansion@5.0.9`, `hono@4.12.34` 예외를 제거했습니다.
- 배포 이미지에 포함되는 `@temporalio/core-bridge`의 Rust lockfile이 `quinn-proto 0.11.15`를 사용하도록 했습니다.

## 왜 변경했는지

[Trivy 이미지 검사](https://github.com/byulmaru/kosmo/actions/runs/31364114863)에서 [GHSA-4w2j-m93h-cj5j](https://github.com/advisories/GHSA-4w2j-m93h-cj5j)가 HIGH로 검출됐습니다.

현재 Kosmo의 기본 배포에서는 Worker가 비활성화되어 있고 정상 Temporal 연결도 QUIC/HTTP3 경로를 사용하지 않아 런타임 악용 가능성은 낮습니다. 다만 취약한 컴포넌트와 lockfile이 이미지에 실제 포함되어 반복 경보가 발생하므로, 수정 릴리스가 나온 지금 제거합니다.

## 이번 PR의 주요 결정

### 패치 릴리스를 즉시 허용

- 결정자: @robin-maki
- 선택: Temporal 1.22.0 패키지군 8개에 정확한 버전의 성숙도 예외를 추가합니다.
- 대안:
  - 7일 성숙 기간이 끝날 때까지 기다립니다.
  - Trivy ignore를 추가하거나 이미지에서 중첩 Cargo.lock만 제거합니다.
- 이유: 수정 릴리스가 존재하는 상황에서 경보를 미루거나 숨기지 않고, 잊히기 전에 취약 의존성을 제거하기 위해서입니다.
- 결과: 7일 이전의 Temporal 1.22.0을 사용하지만, 예외를 정확한 버전으로 제한하고 Worker 테스트·ARM64 이미지 빌드·완성 이미지 Trivy 검사로 검증했습니다.
- 관련 이슈: [PROD-739](https://linear.app/byulmaru/issue/PROD-739/temporal-sdk의-quinn-proto-high-취약-의존성을-제거한다)

이 변경은 기존 런타임 계약을 바꾸지 않는 의존성 보안 업데이트이므로 별도 OpenSpec은 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- `CI=true pnpm --store-dir /Users/jiyu/Library/pnpm/store/v11 install --frozen-lockfile`
- `pnpm --filter @kosmo/worker test` — 4/4 통과
- `pnpm lint:syncpack`
- 예외 제거 상태의 frozen install 및 공급망 정책 검사 — 1,435개 entry 통과
- 변경 파일 Prettier 검사
- `pnpm lint:eslint`
- `docker build --platform linux/arm64 --tag kosmo:prod-739 .`
- 완성 이미지 archive를 Trivy 0.70.0으로 검사 — CRITICAL 0, HIGH 0, GHSA 검출 0

## 아직 어떤 문제가 남았는지

- 이 PR HEAD의 GitHub Actions 결과는 PR 생성 후 확인합니다.
- 실제 Temporal Server E2E는 현재 Worker가 비활성화·미등록 상태라 이 PR 범위에 포함하지 않았습니다.