### PR TITLE
Reply 알림 생성을 Temporal Workflow로 전환한다

### DIFF
--- a/apps/api/src/graphql/resolvers/post/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.ts
@@ -64,7 +64,7 @@ builder.mutationField('createPost', (t) =>
       const media = input.media ?? [];
       const contentWarning = normalizePostContentPlainText(input.contentWarning ?? '');
 
-      const { post } = await createPost(
+      const result = await createPost(
         {
           accountId: ctx.session.accountId,
           document: postContentDocumentFromTextAndMedia(
@@ -86,8 +86,9 @@ builder.mutationField('createPost', (t) =>
         },
         ctx.db,
       );
+      await result.postCommit(ctx.db);
 
-      return { post };
+      return { post: result.post };
     },
   }),
 );

--- a/apps/api/tests/integration/graphql/notification.test.ts
+++ b/apps/api/tests/integration/graphql/notification.test.ts
@@ -14,7 +14,11 @@ import {
   SessionState,
 } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
-import { cancelProfileFollowRequest, followProfile } from '@kosmo/core/services';
+import {
+  cancelProfileFollowRequest,
+  createReplyNotification,
+  followProfile,
+} from '@kosmo/core/services';
 import { normalizeHandle } from '@kosmo/core/utils';
 import { and, eq, ne, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
@@ -638,7 +642,7 @@ describe('Notification GraphQL Node boundary', () => {
     );
   });
 
-  test('creates Reply Notifications after commit, suppresses self/invisible sources, and isolates insert failure', async () => {
+  test('keeps Reply Workflow projection post-commit, suppresses self/invisible sources, and isolates insert failure', async () => {
     const author = await createAuthenticatedSession();
     const recipient = await createProfile('reply-create-recipient');
     const parent = await createContentPost(recipient.id);
@@ -649,6 +653,14 @@ describe('Notification GraphQL Node boundary', () => {
       .from(Posts)
       .where(eq(Posts.replyParentId, parent.id))
       .then(firstOrThrow);
+    assert.equal(
+      await db.$count(
+        Notifications,
+        and(eq(Notifications.kind, NotificationKind.REPLY), eq(Notifications.sourceId, reply.id)),
+      ),
+      0,
+    );
+    await createReplyNotification(reply.id);
     assert.equal(
       await db.$count(
         Notifications,
@@ -669,6 +681,12 @@ describe('Notification GraphQL Node boundary', () => {
     try {
       const failureParent = await createContentPost(recipient.id);
       assertNoGraphQLErrors(await requestCreateReply(failureParent.id, author.token));
+      const failureReply = await db
+        .select()
+        .from(Posts)
+        .where(eq(Posts.replyParentId, failureParent.id))
+        .then(firstOrThrow);
+      await assert.rejects(createReplyNotification(failureReply.id));
       assert.equal(await db.$count(Posts, eq(Posts.replyParentId, failureParent.id)), 1);
     } finally {
       await pg.unsafe(
@@ -686,6 +704,12 @@ describe('Notification GraphQL Node boundary', () => {
     assertNoGraphQLErrors(created);
     const replyId = created.data?.createPost.post.id;
     assert.ok(replyId);
+    const storedReply = await db
+      .select()
+      .from(Posts)
+      .where(eq(Posts.replyParentId, parent.id))
+      .then(firstOrThrow);
+    await createReplyNotification(storedReply.id);
 
     const thread = await requestReplyDescendants(parent.id, parentAuthor.token);
     assertNoGraphQLErrors(thread);
@@ -730,6 +754,7 @@ describe('Notification GraphQL Node boundary', () => {
       .from(Posts)
       .where(eq(Posts.replyParentId, parent.id))
       .then(firstOrThrow);
+    await createReplyNotification(visible.id);
     const hiddenAuthor = await createAuthenticatedSession();
     assertNoGraphQLErrors(await requestCreateReply(parent.id, hiddenAuthor.token));
     const hidden = await db
@@ -737,6 +762,7 @@ describe('Notification GraphQL Node boundary', () => {
       .from(Posts)
       .where(and(eq(Posts.replyParentId, parent.id), ne(Posts.id, visible.id)))
       .then(firstOrThrow);
+    await createReplyNotification(hidden.id);
     const visibleNotification = await db
       .select()
       .from(Notifications)
@@ -785,6 +811,7 @@ describe('Notification GraphQL Node boundary', () => {
       .from(Posts)
       .where(eq(Posts.replyParentId, parent.id))
       .then(firstOrThrow);
+    await createReplyNotification(reply.id);
     const notification = await db
       .select()
       .from(Notifications)

--- a/apps/helm/templates/api/rollout.yaml
+++ b/apps/helm/templates/api/rollout.yaml
@@ -52,6 +52,10 @@ spec:
           env:
             - name: ENVIRONMENT
               value: {{ .Values.env | quote }}
+            - name: TEMPORAL_ADDRESS
+              value: {{ .Values.temporal.frontendAddress | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ include "kosmo.temporalNamespaceName" . | quote }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:

--- a/apps/helm/templates/vaultstaticsecret.yaml
+++ b/apps/helm/templates/vaultstaticsecret.yaml
@@ -54,6 +54,10 @@ spec:
       name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
     - kind: "Deployment"
       name: {{ printf "%s-fedify-consumer" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
+    {{- if .Values.worker.enabled }}
+    - kind: "Deployment"
+      name: {{ printf "%s-worker" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
+    {{- end }}
   {{- end }}
 {{- if eq .Values.env "prod" }}
 ---

--- a/apps/helm/templates/web/rollout.yaml
+++ b/apps/helm/templates/web/rollout.yaml
@@ -52,6 +52,10 @@ spec:
           env:
             - name: ENVIRONMENT
               value: {{ .Values.env | quote }}
+            - name: TEMPORAL_ADDRESS
+              value: {{ .Values.temporal.frontendAddress | quote }}
+            - name: TEMPORAL_NAMESPACE
+              value: {{ include "kosmo.temporalNamespaceName" . | quote }}
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -5,7 +5,7 @@ version: main
 workloads:
   enabled: true
 worker:
-  enabled: false
+  enabled: true
   replicas:
     dev: 1
     prod: 2

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,7 +9,9 @@
     "test": "pnpm build && node --import tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
+    "@kosmo/core": "workspace:*",
     "@temporalio/worker": "^1.22.0",
+    "@temporalio/workflow": "^1.22.0",
     "tsx": "^4.22.4"
   }
 }

--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -1,0 +1,22 @@
+import { NotFoundError } from '@kosmo/core/error';
+import { createReplyNotification } from '@kosmo/core/services';
+
+/**
+ * Materialize the Reply Notification projection for a committed Reply.
+ *
+ * The source is deliberately the only durable input. The core service reads
+ * the current Reply, Parent and Profile state on every attempt, so replay and
+ * concurrent execution keep the existing visibility and uniqueness policy.
+ * A source that is no longer available is an expected terminal no-op; every
+ * other error is rethrown so Temporal can apply its Activity retry policy.
+ */
+export const createReplyNotificationActivity = async (replyId: string): Promise<void> => {
+  try {
+    await createReplyNotification(replyId);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return;
+    }
+    throw error;
+  }
+};

--- a/apps/worker/src/index.test.ts
+++ b/apps/worker/src/index.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { KOSMO_TASK_QUEUE } from '@kosmo/core/services';
+import { createReplyNotificationActivity } from './activities';
+import { registration } from './index';
+
+test('Reply business capability는 kosmo task queue에 등록된다', () => {
+  assert.equal(KOSMO_TASK_QUEUE, 'kosmo');
+  assert.equal(registration.taskQueue, KOSMO_TASK_QUEUE);
+  assert.equal(
+    (registration.activities as { createReplyNotificationActivity?: unknown })
+      .createReplyNotificationActivity,
+    createReplyNotificationActivity,
+  );
+  assert.equal(registration.workflowsPath, new URL('./workflows.ts', import.meta.url).pathname);
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,12 +1,19 @@
+import { KOSMO_TASK_QUEUE } from '@kosmo/core/services';
+import { createReplyNotificationActivity } from './activities';
 import { runWorker } from './worker';
 import type { WorkerRegistration } from './worker';
 
-// The first business capability will replace this empty registration.
-const registration: WorkerRegistration | undefined = undefined;
+export const registration: WorkerRegistration = {
+  activities: { createReplyNotificationActivity },
+  taskQueue: KOSMO_TASK_QUEUE,
+  workflowsPath: new URL('./workflows.ts', import.meta.url).pathname,
+};
 
-try {
-  await runWorker(registration);
-} catch (error) {
-  console.error(error instanceof Error ? error.message : error);
-  process.exitCode = 1;
+if (import.meta.main) {
+  try {
+    await runWorker(registration);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
 }

--- a/apps/worker/src/workflows.ts
+++ b/apps/worker/src/workflows.ts
@@ -1,0 +1,16 @@
+import { proxyActivities } from '@temporalio/workflow';
+import type * as activities from './activities';
+
+const { createReplyNotificationActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+});
+
+/**
+ * Durable Reply Notification lifecycle.
+ *
+ * Keep this function deterministic: all database access belongs to the
+ * Activity, and the Workflow carries only the committed Reply identity.
+ */
+export async function replyNotificationWorkflow(replyId: string): Promise<void> {
+  await createReplyNotificationActivity(replyId);
+}

--- a/openspec/changes/create-reply-notifications-with-temporal/.openspec.yaml
+++ b/openspec/changes/create-reply-notifications-with-temporal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-10

--- a/openspec/changes/create-reply-notifications-with-temporal/decisions.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/decisions.md
@@ -1,0 +1,168 @@
+## Context
+
+이 기록은 Reply Notification을 transaction savepoint에서 Temporal Workflow로 전환하는 PROD-722 계약과,
+`docs/domain`의 Reply/Notification 관계, core commit 경계, 기존 Temporal Worker foundation을 구현 가능한
+선택으로 정리한다. 2026-08-10 사용자 논의에서 start 대기 방식, task queue 범위, rollout과 cutover 방식을
+확정했다.
+
+## Decision Records
+
+### Reply commit 뒤 direct Workflow start를 사용한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/architecture/core-services.md`, `docs/domain/objects/post.md`, `PROD-722`
+- Status: Active
+- Context / Problem: Reply transaction과 Notification 실행을 분리하면서 어느 시점부터 durable recovery가
+  시작되는지 정해야 한다.
+- Decision Outcome: 실제 Reply commit 뒤 core lifecycle이 stable ID로 Workflow start를 직접 시도한다.
+  transaction과 함께 기록하는 intent/outbox 및 relay는 만들지 않으며, Temporal이 start를 수락한 뒤부터만
+  history·Activity retry·Worker restart 복구를 보장한다.
+- Alternatives Considered: transactional intent/outbox와 relay는 PROD-722의 명시적 제외 범위다. commit 전
+  enqueue는 rollback된 Reply의 Workflow를 만들 수 있어 제외한다.
+- Consequences: commit과 start 요청 사이 process 종료 누락을 수용한다. source 성공은 start·Activity 실패로
+  rollback되지 않는다.
+- Confirmation / Follow-up: rollback·duplicate·commit→start fault test와 dev accepted Workflow 실행으로 경계를
+  검증한다.
+
+### core-owned post-commit effect를 caller가 commit 뒤 실행한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, `PROD-722`
+- Status: Active
+- Context / Problem: `createPost`가 caller-owned transaction에 참여할 수 있어 함수 내부 start는 outer commit보다
+  먼저 실행될 수 있다.
+- Decision Outcome: core action이 stable Reply identity를 캡처한 once-only post-commit effect를 반환하고,
+  Local GraphQL과 ActivityPub production caller가 자신의 commit 경계 뒤 이를 실행한다. transaction 인자나
+  origin으로 lifecycle을 생략하지 않는다.
+- Alternatives Considered: core 함수 내부 즉시 start는 outer transaction 안전성을 깨뜨린다. caller가 Workflow
+  identity와 start policy를 직접 조립하면 공통 lifecycle 책임이 entrypoint에 중복된다.
+- Consequences: 모든 production caller가 effect 실행 책임을 가져야 한다. 새 caller는 같은 commit 계약을 따라야
+  한다.
+- Confirmation / Follow-up: outer rollback에는 start가 없고, commit 전에는 start되지 않으며, 두 production
+  caller가 effect를 호출하는 테스트를 둔다.
+
+### Workflow start 승인 또는 실패까지 await하고 실패를 격리한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, `PROD-722`
+- Status: Active
+- Context / Problem: fire-and-forget은 process 종료와 Promise rejection을 관측하지 못하고, start 실패를 호출
+  실패로 노출하면 이미 commit된 Post와 외부 결과가 어긋난다.
+- Decision Outcome: post-commit effect는 Workflow start 승인 또는 실패까지 await한다. start 실패는 observer와
+  구조화 로그에 기록하지만 Reply·GraphQL·ActivityPub 성공은 유지한다. Workflow/Activity 완료는 기다리지 않는다.
+- Alternatives Considered: 백그라운드 호출은 보장과 관측을 더 약화한다. start 오류를 caller 실패로 노출하는
+  방식은 committed state를 되돌릴 수 없어 제외한다.
+- Consequences: Temporal frontend latency가 Reply 처리 시간에 start RPC만큼 추가될 수 있다.
+- Confirmation / Follow-up: start 실패 시 committed Reply와 성공 결과가 유지되고 오류가 관측되는 테스트를 둔다.
+
+### 모든 환경에서 Reply는 Workflow-only 경로를 사용한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/notification.md`, `PROD-722`
+- Status: Active
+- Context / Problem: dev만 먼저 live 검증하되 source 코드에 환경 분기나 장기 dual-write를 남길지 결정해야 한다.
+- Decision Outcome: capability flag, 환경 이름 분기와 dual-write 없이 기존 Reply Notification savepoint를 제거하고
+  모든 runtime에서 Workflow-only 경로를 사용한다.
+- Alternatives Considered: capability flag는 안전한 단계 전환이 가능하지만 사용자가 환경별 코드 경계를 원하지
+  않았다. 항상 dual-write는 migration 이후에도 savepoint 책임을 유지해 전환 완료를 증명하지 못한다.
+- Consequences: 이 image를 production에 release할 때는 같은 release에서 namespace PreSync와 활성 Worker가 먼저
+  준비되어야 한다. Worker 없는 production에 image만 배포하면 Reply Notification이 누락된다.
+- Confirmation / Follow-up: dev에서 Workflow-only 생성을 검증한다. production 실제 release는 별도 명시적 승인
+  전에는 수행하지 않는다.
+
+### 단일 Kosmo 공통 task queue를 사용한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, `PROD-722`, `PROD-730`
+- Status: Active
+- Context / Problem: 첫 business Workflow가 이후 Notification과 Fedify capability가 사용할 Worker registration
+  topology를 열어야 한다.
+- Decision Outcome: Reply Workflow/Activity를 `kosmo` 공통 task queue에 등록한다. capability별 Workflow와
+  Activity 코드는 분리하되 현재 Worker Deployment와 polling queue는 하나로 유지한다.
+- Alternatives Considered: Notification 전용 또는 kind별 queue는 현재 단일 Worker foundation에 Deployment와
+  registration을 추가하고 실제 독립 scaling 요구 없이 운영 복잡도를 늘린다.
+- Consequences: 후속 PROD-723/720/725와 PROD-448은 같은 registration seam을 확장할 수 있다. 실제 부하·권한
+  격리가 필요해지면 별도 runtime topology 결정이 필요하다.
+- Confirmation / Follow-up: Worker가 `kosmo` queue에서 Reply Workflow를 poll하고 다른 queue를 만들지 않는지
+  package와 live dev에서 검증한다.
+
+### Reply identity 하나에 Workflow history 하나를 유지한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/notification.md`, `PROD-722`
+- Status: Active
+- Context / Problem: concurrent 또는 ambiguous start 재시도가 같은 Reply에 여러 Workflow run을 만들지 않게 해야
+  한다.
+- Decision Outcome: Workflow ID를 source Reply ID에서 결정적으로 파생하고, 실행 중 동일 ID start는 existing run을
+  사용하며 완료된 ID의 새 run은 거부한다.
+- Alternatives Considered: 매 start마다 새 Workflow ID를 만들거나 완료 뒤 ID 재사용을 허용하면 DB unique row는
+  중복을 막더라도 실행 이력과 Activity 시도가 분산된다.
+- Consequences: 같은 Reply lifecycle은 하나의 history로 추적된다. 동일 start 요청은 성공과 동등하게 처리할 수
+  있다.
+- Confirmation / Follow-up: concurrent start와 완료 후 duplicate start가 새 Notification이나 새 Workflow
+  lifecycle을 만들지 않는지 검증한다.
+
+### dev live 검증을 change 완료 증거로 사용하고 production release는 분리한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-722`, `PROD-730`
+- Status: Active
+- Context / Problem: 첫 business capability는 실제 RUNNING/readiness와 task drain을 검증해야 하지만 production
+  적용은 별도 운영 승인이 필요하다.
+- Decision Outcome: 환경 중립 Worker code와 chart를 구현하고 main merge 뒤 dev에서 actual Workflow,
+  readiness, transient DB retry와 Worker restart를 검증한다. production 실제 sync/release는 PROD-722 완료 gate로
+  요구하지 않는다.
+- Alternatives Considered: 코드 검증만으로 끝내면 PROD-722와 PROD-730이 요구한 accepted Workflow/Worker restart
+  증거가 없다. production까지 자동 배포하는 방식은 현재 권한 범위를 넘는다.
+- Consequences: production 미배포는 change 미완료가 아니지만, production release 전제는 운영자가 별도로 확인해야
+  한다.
+- Confirmation / Follow-up: dev live evidence와 production 미변경 상태를 completion 기록에 함께 남긴다.
+
+### Activity retry는 Temporal 기본 정책을 따른다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/notification.md`, `PROD-722`
+- Status: Active
+- Context / Problem: accepted Workflow의 transient DB 실패를 몇 회 또는 얼마 동안 재시도할지 상위 계약이
+  수치로 정하지 않았다.
+- Decision Outcome: Activity attempt timeout은 명시하되 retry 횟수·backoff를 별도로 덮지 않고 Temporal 기본
+  Activity retry policy를 사용한다.
+- Alternatives Considered: 10회 제한은 transient 장애가 더 길면 자동 수렴을 중단하고 근거 없는 수동 복구
+  경계를 만든다. 24시간 제한도 허용 지연과 복구 owner가 없어 채택하지 않았다.
+- Consequences: retry는 기본 정책에 따라 장시간 계속될 수 있다. 이후 명시 정책을 추가해도 새로 schedule되는
+  Activity부터 적용되고 이미 history에 기록된 Activity 정책을 소급 변경하지 않는다.
+- Confirmation / Follow-up: retry options를 임의로 고정하지 않았는지와 transient 실패 뒤 재시도를 검증하고,
+  dev 관측 결과에서 bounded policy 필요성을 재평가한다.
+
+### Workflow start RPC는 별도 deadline 없이 SDK 기본을 따른다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, `PROD-722`
+- Status: Active
+- Context / Problem: Reply 요청은 Workflow start 승인 또는 실패까지 기다리지만, 연결 뒤 start RPC에 별도
+  deadline을 둘지는 상위 계약이 정하지 않았다.
+- Decision Outcome: `workflow.start()`에 application deadline을 추가하지 않고 Temporal SDK 기본 RPC 동작을
+  사용한다.
+- Alternatives Considered: 10초 deadline은 초기 connection timeout과 일치하고, 30초 deadline은 일시 지연을
+  더 허용하지만 둘 다 근거 없는 application latency·failure 경계를 새로 만든다.
+- Consequences: Temporal frontend가 연결된 뒤 start RPC 응답을 멈추면 GraphQL 또는 ActivityPub 요청이 장시간
+  대기할 수 있다. 명시적인 timeout 오류 격리는 SDK가 오류를 반환한 경우에만 적용된다.
+- Confirmation / Follow-up: dev 관측에서 start 지연이 실제 request budget 문제가 되면 별도 timeout 정책을
+  결정하고 새 요청부터 application deadline을 적용한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/create-reply-notifications-with-temporal/design.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/design.md
@@ -1,0 +1,120 @@
+## Context
+
+`createPost`는 Local과 ActivityPub Post materialization을 공통 처리한다. 현재 Reply이면 같은 transaction 안에서
+`createReplyNotification`을 savepoint로 호출하고 오류를 삼키므로 source commit과 함께 보이거나 함께
+rollback되지만, commit 뒤 재시도 가능한 실행 이력은 없다. GraphQL caller는 `ctx.db`를 전달하고 ActivityPub
+inbound caller는 shared DB를 사용한다. 테스트에는 caller-owned transaction 참여 경계가 이미 존재한다.
+
+`apps/worker`는 Temporal connection, health/readiness와 SIGTERM lifecycle을 제공하지만 business registration이
+없어 fail-fast한다. Helm Worker component도 business capability가 없어 기본 비활성이다. PROD-722는 이 foundation을 사용하는 첫 business
+capability이며, 사용자가 선택한 계약은 환경별 코드 분기 없이 Workflow-only로 전환하고 단일 Kosmo 공통 task
+queue를 사용하는 것이다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 실제 Reply commit 뒤에만 stable Workflow start effect를 실행한다.
+- 기존 Reply Notification persistence policy를 Activity에서 재사용해 replay-safe하게 수렴한다.
+- Local GraphQL과 ActivityPub inbound가 같은 core lifecycle을 사용한다.
+- 첫 Worker registration과 dev live lifecycle/retry/restart 증거를 완성한다.
+- 다른 Notification kind가 같은 task queue와 Worker registration에 독립적으로 추가될 최소 seam을 제공한다.
+
+**Non-Goals:**
+
+- transaction과 Workflow start를 원자화하거나 누락을 relay하는 outbox
+- 다른 Notification kind 또는 ActivityPub outbound delivery 전환
+- Notification read model, GraphQL/UI, unavailable cleanup 변경
+- production 실제 배포와 운영 승인
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `createPost` 내부에서 Workflow를 즉시 시작하면 caller-owned outer transaction의 commit 전에 side effect가
+  실행될 수 있다. 반대로 transaction 인자 존재 여부로 lifecycle을 생략하거나 내부/외부 실행을 분기하면 같은
+  Reply가 caller에 따라 다른 계약을 갖게 된다.
+- ActivityPub duplicate Create는 `{ created: false }`로 끝나므로 Workflow effect를 만들면 안 된다.
+- `createReplyNotification`은 unique constraint와 `onConflictDoNothing`으로 replay-safe하지만, source가 없거나
+  Reply가 아니면 `NotFoundError`를 던진다. Temporal Activity는 terminal source 부재와 transient DB 실패를
+  구분해야 한다.
+- Workflow 모듈은 deterministic sandbox에서 실행되므로 core DB service나 Node/Temporal client 모듈을 직접
+  import하면 안 된다. DB 호출은 Worker Activity에 남겨야 한다.
+- API와 ActivityPub ingress가 모두 Workflow start를 수행하므로 두 runtime에 Temporal address와 namespace가
+  필요하다.
+- 같은 image/chart가 이후 production release에도 사용된다. 항상 Workflow-only이므로 production release는
+  namespace provisioning과 활성 Worker를 함께 포함해야 하며, 이 선행조건 없이 image만 배포하면 Reply
+  Notification이 누락된다.
+
+### Recommended Approach
+
+`createPost`의 실제 create 결과에 `oncePostCommit`으로 보호한 core-owned effect를 포함한다. Reply가 아니면
+no-op, Reply이면 stable source ID로 start하는 effect다. GraphQL과 ActivityPub production caller는 자신의
+commit 경계 뒤에 이를 await한다. 기존 Local Post Fedify delivery는 PROD-722의 transport 범위가 아니므로 이
+change에서 재설계하지 않는다.
+
+core에는 Temporal connection/client를 필요할 때 생성하고 재사용하는 작은 start seam을 둔다. 실패한 connection
+promise는 다음 호출이 다시 연결을 시도할 수 있게 폐기한다. Workflow ID는 Reply source ID에서 결정적으로
+파생하고, 실행 중 같은 ID에는 existing run을 사용하며 완료된 ID 재사용은 거부해 하나의 Reply lifecycle에
+하나의 Workflow history만 둔다. start 호출자는 start 승인 또는 실패까지 await하지만 오류를 기존 observer와
+구조화 로그로 격리한다.
+
+Worker Workflow는 source Reply ID 하나만 받고, bounded Activity attempt timeout과 Temporal 기본 retry policy로 Reply Notification
+Activity 하나를 호출한다. Activity는 기존 `createReplyNotification`을 재사용하고 source 부재를 나타내는
+`NotFoundError`만 terminal no-op으로 변환한다. 다른 DB·runtime 오류는 그대로 throw해 Temporal retry에 맡긴다.
+Worker entrypoint는 Workflow bundle/path와 Activity를 `kosmo` task queue에 등록한다.
+
+환경 중립 Helm component의 기본값을 활성화하고 API, Web, Worker에 같은 Temporal address/namespace를 전달한다. main
+merge 뒤 자동 dev sync에서 namespace PreSync 후 Worker가 올라오게 하고, 실제 Workflow 실행·readiness·DB 오류
+retry·Worker restart를 검증한다. production은 별도 release 승인이 있기 전에는 현재 배포를 바꾸지 않는다.
+
+### Allowed Alternatives
+
+- core가 만든 post-commit descriptor를 caller가 실행하는 대신 transaction abstraction이 after-commit hook을
+  제공할 수 있다. 단, 모든 Local/ActivityPub caller와 caller-owned transaction에서 commit 뒤 실행이 증명되고
+  test-only generic port를 만들지 않아야 한다.
+- Temporal client connection을 runtime entrypoint가 주입할 수 있다. 단, core public action이 API/Web 전용
+  타입에 의존하지 않고 두 production caller가 같은 lifecycle을 유지해야 한다.
+
+### Known Traps
+
+- `handle` 또는 `origin`에 따라 Reply Workflow를 생략하지 않는다.
+- `void client.workflow.start(...)` fire-and-forget으로 start 실패 관측과 process lifecycle을 잃지 않는다.
+- Workflow 코드에서 core DB service를 import하거나 Activity 함수 자체를 Workflow bundle에 포함하지 않는다.
+- `NotFoundError` 이외의 DB 오류를 terminal no-op으로 삼켜 retry를 막지 않는다.
+- dev 검증을 위해 smoke Workflow, 별도 test task queue 또는 두 번째 Worker abstraction을 만들지 않는다.
+- production release 전제와 PROD-722 코드 완료를 혼동해 자동 production sync를 수행하지 않는다.
+
+## Risks / Trade-offs
+
+- [Reply commit 뒤 start 전 process 종료 시 Notification 누락] → 계약상 수용하고 fault test와 운영 기록에서
+  durable 보장 시작점을 Temporal의 start 수락 이후로 명시한다.
+- [Temporal frontend 지연이 Reply 요청 시간을 늘림] → start만 await하고 Workflow/Activity 결과는 기다리지
+  않으며 client connection을 재사용한다. start RPC에는 별도 application deadline을 두지 않으므로 SDK가 오류를
+  반환하지 않는 stall은 장시간 요청 대기로 이어질 수 있다.
+- [항상 Workflow-only image가 Worker 없는 production에 배포됨] → production release 승인 시 namespace PreSync와
+  Worker 활성화를 같은 chart release에서 요구하고, 이 change 자체는 production sync를 수행하지 않는다.
+- [단일 Kosmo queue의 향후 noisy-neighbor] → 현재는 하나의 Worker deployment로 단순화하고 capability별
+  Workflow/Activity와 retry 설정을 분리한다. 실제 독립 scaling 요구가 생기면 별도 runtime topology issue로
+  task queue를 분리한다.
+- [Activity replay 중 source 상태 변경] → 매 실행 시 source와 visibility를 다시 조회해 Notification 또는 no-op의
+  현재 유효 결과로 수렴한다.
+- [기본 retry가 장시간 계속됨] → 이번 capability는 Temporal 기본 정책을 따르고 retry 횟수 제한을 임의로
+  추가하지 않는다. 실제 failure 관측 뒤 공통 Activity policy가 필요하면 새로 schedule되는 Activity에 명시적
+  retry 또는 schedule-to-close 제한을 적용한다.
+
+## Migration Plan
+
+1. core post-commit start seam과 Reply Workflow/Activity를 추가하고 기존 savepoint 호출을 제거한다.
+2. Local GraphQL과 ActivityPub caller가 실제 create 결과의 post-commit effect를 commit 뒤 await하도록 전환한다.
+3. Worker에 `kosmo` task queue business registration을 추가하고 Helm Worker 기본값을 환경 중립적으로 활성화한다.
+4. unit/integration test와 dev render를 검증한 뒤 main에 merge한다.
+5. 자동 dev sync에서 namespace PreSync, Worker readiness, 실제 Reply Workflow, transient DB retry와 Worker restart
+   복구를 검증한다. production은 변경하지 않는다.
+6. rollback은 application/chart commit을 revert해 Worker registration/start 호출을 제거하고 기존 transaction
+   savepoint 생성을 복원한다. 이미 accepted된 Workflow는 멱등 Activity로 완료되거나 Worker가 사라진 동안
+   Temporal history에 남는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/create-reply-notifications-with-temporal/proposal.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Reply Notification 생성은 현재 Reply Post transaction 안의 Best Effort savepoint에 머물러 있어, 일시적인
+데이터베이스 실패를 source Post와 분리해 재시도하거나 Worker 재시작 뒤 이어갈 실행 이력이 없다. PROD-719와
+PROD-730이 Temporal namespace와 Worker runtime 기반을 준비했으므로, 가장 작은 create-only Notification
+lifecycle인 Reply를 첫 business Workflow로 전환한다.
+
+## What Changes
+
+- 실제 Reply Post가 commit된 뒤 stable Reply identity로 Temporal Workflow start를 시도한다.
+- Workflow는 Reply source를 다시 조회하는 Activity를 실행하고 기존 recipient, self suppression, visibility와
+  unique 계약을 그대로 적용해 REPLY Notification을 멱등 생성한다.
+- Reply Notification의 transaction savepoint 생성 경로를 제거하고 Local GraphQL과 ActivityPub inbound가 같은
+  post-commit Workflow start 경계를 사용한다.
+- start 요청과 Activity 실패는 이미 commit된 Post 결과에서 격리한다. commit 뒤 start 요청 전 프로세스 종료로
+  생기는 누락은 명시적으로 수용한다.
+- Kosmo 공통 task queue에 첫 business Workflow와 Activity를 등록하고 dev에서 Worker를 활성화해 readiness,
+  Activity retry와 Worker restart 복구를 검증한다. production 실제 배포는 이 change의 완료 gate가 아니다.
+- transactional intent/outbox/relay, 다른 Notification kind, ActivityPub transport와 Notification API/UI는 변경하지
+  않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/domain/objects/notification.md`,
+  `docs/architecture/core-services.md`
+- Linear Contract: `PROD-722`
+- Linear Implementations: `PROD-722`
+
+## Capabilities
+
+### New Capabilities
+
+- `temporal-reply-notification`: committed Reply에서 stable Workflow를 시작하고 REPLY Notification 생성에
+  수렴하는 durable execution 경계
+
+### Modified Capabilities
+
+- `notification`: Reply Notification 생성 시점을 transaction savepoint Best Effort에서 post-commit Temporal
+  Workflow로 변경
+- `temporal-worker-runtime-foundation`: 첫 business registration이 생긴 뒤 환경 중립 Worker component를 기본
+  활성 상태로 전환하고 기존 replica·health·credential 계약을 유지
+
+## Impact
+
+- `packages/core/services`: Reply 생성 결과와 post-commit Workflow start, 기존 savepoint 제거
+- `apps/worker`: Reply Workflow/Activity 등록과 core Notification service 실행
+- `apps/api`, `packages/fedify`: Local·ActivityPub Reply materialization 뒤 공통 post-commit effect 실행
+- `apps/helm`, `apps/terraform`, 배포 workflow: 환경 중립 Worker manifest를 사용한 dev 활성화와 restart 처리
+- workspace dependencies와 lockfile: Temporal client/workflow 및 Worker의 core dependency
+- 외부 GraphQL schema, Notification read model과 ActivityPub vocabulary에는 변경 없음

--- a/openspec/changes/create-reply-notifications-with-temporal/specs/notification/spec.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/specs/notification/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: Reply Notification source correlation
+
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/domain/objects/post.md`, `PROD-426`, `PROD-507`, `PROD-722` 시스템은 origin과 application entrypoint에 관계없이 다른 Profile의 Post에 새 Reply가 실제 commit되면 결과 Reply를 source로 하는 Profile-scoped Reply Notification Workflow를 공통 post-commit lifecycle에서 시작해야 한다(MUST).
+
+#### Scenario: 다른 Profile의 Post에 Reply
+
+- **WHEN** 새 Reply transaction이 commit되고 Reply Author와 Parent Author가 다르며 Recipient가 결과 Reply와 Reply Author를 조회할 수 있다
+- **THEN** 시스템은 결과 Reply를 Related Post와 source로, Reply Author를 Related Profile로, Parent Author를 Recipient로 하는 Unread Reply Notification 생성 Workflow를 시작한다
+- **AND** 이름, handle, Profile 또는 Post snapshot을 kind data에 저장하지 않는다
+
+#### Scenario: ActivityPub 원격 Reply
+
+- **WHEN** 새 ActivityPub 원격 Reply가 Local Parent를 참조해 commit된다
+- **THEN** 공통 core Post 생성 lifecycle은 Local Parent Author를 Recipient, 원격 Reply Author를 Related Profile, 결과 Reply를 source와 Related Post로 하는 Notification을 정확히 하나 생성하는 Workflow를 시작한다
+- **AND** Fedify adapter는 Notification side effect를 직접 호출하지 않는다
+
+#### Scenario: duplicate 또는 concurrent ActivityPub Create
+
+- **WHEN** ActivityPub object URI가 이미 저장되어 duplicate 또는 concurrent Create가 no-op이 된다
+- **THEN** 시스템은 Reply Notification Workflow를 다시 시작하지 않는다
+- **AND** 과거에 누락된 Notification을 backfill하지 않는다
+
+#### Scenario: self-reply
+
+- **WHEN** Reply Author와 Parent Author가 같다
+- **THEN** 시스템은 Reply 생성 결과를 유지한다
+- **AND** Workflow Activity는 Reply Notification을 생성하지 않는다
+
+#### Scenario: Recipient에게 결과가 보이지 않음
+
+- **WHEN** Parent Author Profile이 결과 Reply 또는 Reply Author Profile을 조회할 수 없다
+- **THEN** Workflow Activity는 Reply Notification을 생성하지 않는다
+
+#### Scenario: 동일 source 재처리
+
+- **WHEN** 같은 결과 Reply source의 Notification 저장 경계가 중복 또는 동시 호출된다
+- **THEN** 같은 Recipient, Reply kind와 source ID의 Notification은 하나만 존재한다
+- **AND** 재처리는 기존 item을 나타내는 성공 또는 동등한 멱등 no-op으로 끝난다
+
+### Requirement: Reply Notification 실패 격리
+
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/architecture/core-services.md`, `PROD-426`, `PROD-507`, `PROD-722` Reply Notification Workflow start 또는 Activity 실패는 Reply transaction, GraphQL 성공 또는 ActivityPub 수신 성공을 rollback하거나 실패로 바꾸어서는 안 된다(MUST NOT). Temporal이 start를 수락한 뒤의 transient Activity
+실패는 retry해야 하며(MUST), commit 뒤 start 요청 전 프로세스 종료에 따른 누락은 수용해야 한다(MUST).
+
+#### Scenario: Notification Activity 저장 실패
+
+- **WHEN** accepted Reply Notification Workflow의 Activity가 transient 저장 오류로 실패한다
+- **THEN** 시스템은 Reply와 Reply 생성 성공 결과를 유지한다
+- **AND** Temporal은 Activity retry 정책에 따라 Notification 생성을 재시도한다
+
+#### Scenario: caller-owned outer transaction
+
+- **WHEN** 공통 Post 생성 action이 caller-owned transaction에 참여해 새 Reply를 만든다
+- **THEN** Reply Notification Workflow start는 outer transaction이 실제 commit되기 전에 실행되지 않는다
+- **AND** outer transaction이 rollback되면 Reply, Notification과 Workflow를 모두 남기지 않는다
+
+#### Scenario: start가 수락되기 전 누락
+
+- **WHEN** Reply가 commit된 뒤 Workflow start 요청 전에 process가 종료된다
+- **THEN** Reply는 유지되고 Reply Notification은 누락될 수 있다
+- **AND** transactional intent, outbox, relay 또는 backfill로 누락을 자동 복구하지 않는다

--- a/openspec/changes/create-reply-notifications-with-temporal/specs/temporal-reply-notification/spec.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/specs/temporal-reply-notification/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: committed Reply의 stable Workflow start
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/notification.md`, `docs/architecture/core-services.md`, `PROD-722` 시스템은 origin과 application entrypoint에 관계없이 실제 Reply Post가 commit된 뒤 source Reply identity에서 파생한 stable Workflow ID로 Reply Notification Workflow start를 시도해야 한다(MUST). Workflow start 요청은
+commit 전에는 실행해서는 안 되며(MUST NOT), rollback되거나 duplicate materialization으로 새 Reply가 생성되지
+않으면 실행해서는 안 된다(MUST NOT).
+
+#### Scenario: Local Reply commit
+
+- **WHEN** Local GraphQL action이 새 Reply를 commit한다
+- **THEN** 공통 core lifecycle은 source Reply identity의 stable Workflow ID로 Workflow start를 시도한다
+- **AND** start 요청은 Reply transaction commit 뒤에 실행된다
+
+#### Scenario: ActivityPub Reply commit
+
+- **WHEN** ActivityPub inbound Create가 Local Parent를 참조하는 새 Reply를 commit한다
+- **THEN** Local과 같은 공통 core lifecycle이 source Reply identity의 stable Workflow ID로 Workflow start를 시도한다
+- **AND** Fedify adapter는 Reply Notification을 직접 생성하지 않는다
+
+#### Scenario: rollback 또는 duplicate materialization
+
+- **WHEN** Reply transaction이 rollback되거나 ActivityPub object URI duplicate가 no-op으로 끝난다
+- **THEN** 시스템은 해당 처리에서 Reply Notification Workflow start를 시도하지 않는다
+
+#### Scenario: caller-owned transaction
+
+- **WHEN** 공통 Post 생성 action이 caller-owned transaction에 참여해 새 Reply를 만든다
+- **THEN** Workflow start effect는 outer transaction이 실제 commit된 뒤에만 호출된다
+- **AND** outer transaction이 rollback되면 Workflow start를 호출하지 않는다
+
+### Requirement: Reply Notification Activity의 멱등 수렴
+
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/domain/objects/post.md`, `PROD-722` Reply Notification Workflow는 source Reply ID만으로 Activity를 실행해 현재 source와 visibility를 다시 조회하고, 기존 Reply Notification recipient·Related Post·Related Profile·self suppression·local recipient·unique 계약에 수렴해야 한다(MUST). transient 데이터베이스 실패는 Activity 실패로 유지해 재시도해야 하며(MUST), source가
+존재하지 않거나 더 이상 유효한 Reply Notification을 만들 수 없으면 안전한 terminal no-op으로 끝나야 한다(MUST).
+
+#### Scenario: 유효한 Reply source
+
+- **WHEN** Activity가 다른 Local Profile의 visible Parent에 작성된 유효한 Reply source를 조회한다
+- **THEN** 결과 Reply를 source와 Related Post로, Reply Author를 Related Profile로, Parent Author를 Recipient로 하는 Unread Reply Notification을 생성한다
+- **AND** 이름, handle, Profile 또는 Post snapshot을 kind data에 저장하지 않는다
+
+#### Scenario: self reply 또는 조회 불가 source
+
+- **WHEN** Reply Author가 Parent Author와 같거나 Recipient가 결과 Reply 또는 Reply Author를 조회할 수 없다
+- **THEN** Activity는 Reply Notification을 생성하지 않고 성공한 no-op으로 끝난다
+
+#### Scenario: source가 더 이상 유효하지 않음
+
+- **WHEN** Activity가 source 삭제·관계 제거 등으로 Reply Notification 필수 source를 조회할 수 없다
+- **THEN** Workflow는 Notification을 만들지 않고 terminal no-op으로 수렴한다
+
+#### Scenario: 동일 source replay
+
+- **WHEN** 같은 source Reply의 Workflow 또는 Activity가 재실행되거나 동시에 처리된다
+- **THEN** 같은 Recipient, Reply kind와 source ID의 Notification은 하나만 존재한다
+- **AND** 재처리는 기존 item을 나타내는 성공 또는 동등한 멱등 no-op으로 끝난다
+
+#### Scenario: transient 데이터베이스 실패
+
+- **WHEN** 유효한 Reply를 처리하는 Activity가 일시적인 데이터베이스 오류로 실패한다
+- **THEN** Temporal은 구성된 Activity retry 정책에 따라 같은 source Reply 처리를 재시도한다
+- **AND** 재시도 성공 뒤 하나의 Reply Notification에 수렴한다
+
+### Requirement: accepted Workflow의 durable 실행과 실패 격리
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-722` Reply commit 뒤 Workflow start 요청은 완료를 기다려야 하지만(MUST), start 또는 Activity 실패가 이미 commit된 Post 결과나 GraphQL·ActivityPub 처리 성공을 rollback하거나 실패로 바꾸어서는 안 된다(MUST NOT). Temporal이
+start를 수락한 Workflow는 history와 Activity retry를 사용해 Worker 재시작 뒤 같은 identity로 재개해야 한다(MUST).
+시스템은 Reply transaction과 원자적인 intent/outbox/relay를 만들지 않아야 한다(MUST NOT).
+
+#### Scenario: Workflow start 실패
+
+- **WHEN** Reply가 commit된 뒤 Workflow start 요청이 실패하거나 timeout된다
+- **THEN** 시스템은 실패를 관측 가능하게 기록하고 Reply와 호출 성공 결과를 유지한다
+- **AND** transaction과 원자적인 intent 또는 relay가 없으므로 자동 복구를 보장하지 않는다
+
+#### Scenario: commit과 start 사이 프로세스 종료
+
+- **WHEN** Reply commit 뒤 Workflow start 요청 전에 process가 종료된다
+- **THEN** Reply는 유지되고 Reply Notification은 누락될 수 있다
+- **AND** 시스템은 이 구간을 durable delivery로 표현하지 않는다
+
+#### Scenario: accepted Workflow 처리 중 Worker 재시작
+
+- **WHEN** Temporal이 Workflow start를 수락한 뒤 Activity 완료 전에 Worker가 재시작된다
+- **THEN** 같은 Workflow identity와 history에서 처리를 재개한다
+- **AND** 최종 저장 결과는 하나의 Reply Notification 또는 source가 유효하지 않은 no-op에 수렴한다

--- a/openspec/changes/create-reply-notifications-with-temporal/specs/temporal-worker-runtime-foundation/spec.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/specs/temporal-worker-runtime-foundation/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: 기본 활성 Business Worker Helm component
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-722`, `PROD-730` Kosmo Helm chart는 실제 Reply Workflow/Activity와 `kosmo` task queue가 등록된 Worker Deployment와 전용 ServiceAccount를 기본 활성 상태로 제공해야 한다(MUST). dev는 1개, prod는 2개의 replica를 기본값으로
+render하고, 공통 runtime image의 Worker command, HTTP liveness/readiness probe, 환경별 Temporal
+endpoint·namespace를 전달해야 한다(MUST). component는 명시적 override로 비활성화할 수 있어야 한다(MUST).
+
+#### Scenario: dev 기본 Helm render
+
+- **WHEN** dev chart를 Worker override 없이 render한다
+- **THEN** 1개 replica, Worker command, HTTP probes와 dev Temporal endpoint·namespace를 가진 Deployment와 ServiceAccount가 render된다
+
+#### Scenario: prod 기본 Helm render
+
+- **WHEN** prod chart를 Worker override 없이 render한다
+- **THEN** 2개 replica, Worker command, HTTP probes와 prod Temporal endpoint·namespace를 가진 Deployment와 ServiceAccount가 render된다
+
+#### Scenario: Worker component rollback override
+
+- **WHEN** 운영자가 Worker component를 명시적으로 비활성화해 chart를 render한다
+- **THEN** Worker Deployment와 ServiceAccount가 생성되지 않는다
+
+## REMOVED Requirements
+
+### Requirement: 기본 비활성 Worker Helm component
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-722`, `PROD-730`
+
+**Reason**: foundation 단계에는 business registration이 없어 Worker를 기본 비활성으로 유지했지만,
+PROD-722가 실제 Reply Workflow/Activity와 task queue를 등록하므로 기본 비활성 전제가 더 이상 성립하지 않는다.
+
+**Migration**: 기존 dev/prod replica, command, probe와 Temporal namespace 입력을 유지한 환경 중립 Business Worker
+component를 기본 활성화한다. 긴급 rollback은 기존 `worker.enabled` override를 false로 설정한다.

--- a/openspec/changes/create-reply-notifications-with-temporal/tasks.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/tasks.md
@@ -116,7 +116,7 @@ dev에서 Workflow-only Reply Notification과 Worker lifecycle의 실제 복구 
 - production workload와 namespace가 이 작업으로 sync되지 않았음을 확인한다.
 - OpenSpec strict validation, 관련 workspace checks와 hosted CI를 통과시킨다.
 
-- [ ] 4.1 구현 diff와 OpenSpec을 strict validation하고 관련 전체 test/lint/render를 통과시킨다.
+- [x] 4.1 구현 diff와 OpenSpec을 strict validation하고 관련 전체 test/lint/render를 통과시킨다.
 - [ ] 4.2 main dev rollout에서 Worker readiness와 실제 Reply Notification Workflow 성공을 검증한다.
 - [ ] 4.3 accepted Workflow의 transient Activity 실패 retry와 Worker restart 복구를 dev에서 검증한다.
 - [ ] 4.4 production 미변경과 보장 경계 증거를 Linear/PR에 기록하고 전체 change가 완료되면 canonical spec을 동기화해 archive한다.

--- a/openspec/changes/create-reply-notifications-with-temporal/tasks.md
+++ b/openspec/changes/create-reply-notifications-with-temporal/tasks.md
@@ -1,0 +1,122 @@
+## 1. PROD-722 Reply commit과 Workflow start 경계
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/notification.md`
+- `docs/architecture/core-services.md`
+- `PROD-722`
+
+**Deliverable**
+
+Local과 ActivityPub의 실제 Reply commit 뒤 stable identity로 같은 Reply Notification Workflow start를 시도하고,
+rollback·duplicate·start 실패는 committed Post 결과와 올바르게 격리된다.
+
+**Guardrails**
+
+- transaction과 start 사이 누락은 수용하며 intent/outbox/relay를 만들지 않는다.
+- transaction 인자 또는 origin으로 Reply lifecycle을 생략하지 않는다.
+- start 승인 또는 실패까지 await하되 Post·GraphQL·ActivityPub 성공을 되돌리지 않는다.
+- 다른 ActivityPub delivery lifecycle을 이 task에서 재설계하지 않는다.
+
+**Verification**
+
+- Local/AP 실제 create, duplicate, self reply, outer commit/rollback과 start failure를 core·entrypoint test로 검증한다.
+- commit 전 start 없음과 같은 Reply identity의 stable ID를 검증한다.
+
+- [x] 1.1 core Post 생성 결과에 commit 뒤 한 번만 실행되는 Reply Workflow start effect를 제공한다.
+- [x] 1.2 Local GraphQL과 ActivityPub production caller가 실제 create의 effect를 commit 뒤 await하도록 전환한다.
+- [x] 1.3 기존 Reply Notification transaction savepoint 경로를 제거하고 start 실패 관측을 유지한다.
+- [x] 1.4 commit·rollback·duplicate·origin·start 실패 경계의 자동화 검증을 추가하고 통과시킨다.
+
+## 2. PROD-722 Reply Workflow와 Activity 수렴
+
+**Authority / Provenance**
+
+- `docs/domain/objects/notification.md`
+- `docs/domain/objects/post.md`
+- `PROD-722`
+
+**Deliverable**
+
+accepted Reply Workflow가 source를 다시 조회해 하나의 visible REPLY Notification 또는 안전한 no-op으로
+수렴하고, transient DB 실패와 Worker 재시작 뒤 처리를 이어간다.
+
+**Guardrails**
+
+- source Reply ID만 durable input으로 사용하고 Profile/Post snapshot을 저장하지 않는다.
+- 기존 recipient, Related Post/Profile, local recipient, self suppression, visibility와 unique 계약을 유지한다.
+- source 부재만 terminal no-op으로 처리하고 transient DB 오류는 retry 가능한 Activity 실패로 유지한다.
+- Reply identity 하나에는 Workflow history 하나만 유지한다.
+
+**Verification**
+
+- 유효 Reply, self reply, unavailable source, replay·concurrent start와 transient Activity failure를 검증한다.
+- Worker 중단·재시작 뒤 accepted Workflow가 같은 identity로 Notification/no-op에 수렴함을 검증한다.
+
+- [x] 2.1 Reply source를 처리하는 deterministic Workflow와 DB Activity를 구현한다.
+- [x] 2.2 기존 Reply Notification persistence policy를 Activity에서 재사용하고 terminal source 부재와 retryable 오류를 구분한다.
+- [x] 2.3 stable Workflow ID의 running conflict와 completed reuse 정책을 적용한다.
+- [ ] 2.4 Workflow replay, Activity retry, source no-op과 Worker restart 수렴 검증을 추가하고 통과시킨다.
+
+## 3. PROD-722 첫 Business Worker 등록과 배포 경계
+
+**Authority / Provenance**
+
+- `docs/architecture/core-services.md`
+- `PROD-722`
+- `PROD-730`
+
+**Deliverable**
+
+독립 Worker가 `kosmo` task queue에서 Reply Workflow/Activity를 poll하고, 같은 환경 중립 chart가 dev/prod별 기존
+replica·health·credential 계약으로 Worker와 Workflow client runtime 입력을 제공한다.
+
+**Guardrails**
+
+- smoke Workflow, 검증 전용 task queue와 두 번째 Worker runtime을 만들지 않는다.
+- API/Web/Worker는 환경별로 같은 Temporal address와 namespace를 사용한다.
+- Worker component는 기본 활성화하되 명시적 override rollback을 유지한다.
+- production 실제 sync/release를 이 task에서 수행하지 않는다.
+
+**Verification**
+
+- Worker package build/test, workspace dependency·lockfile 정합성과 dev/prod Helm lint/render를 검증한다.
+- 기본 render의 dev 1 replica/prod 2 replica, `kosmo` registration, probes, DB·Temporal 입력과 disable override를 검증한다.
+
+- [x] 3.1 Worker entrypoint에 실제 Reply Workflow/Activity와 `kosmo` task queue를 등록한다.
+- [x] 3.2 API/Web/Worker가 Workflow start와 Activity 실행에 필요한 runtime 입력과 package dependency를 갖추게 한다.
+- [x] 3.3 환경 중립 Worker component를 기본 활성화하고 dev/prod render 및 명시적 disable rollback을 유지한다.
+- [x] 3.4 package build/test, dependency lockfile, Helm lint와 dev/prod render 검증을 통과시킨다.
+
+## 4. PROD-722 dev 통합 검증과 완료
+
+**Authority / Provenance**
+
+- `docs/domain/objects/notification.md`
+- `docs/architecture/core-services.md`
+- `PROD-722`
+- `PROD-730`
+
+**Deliverable**
+
+dev에서 Workflow-only Reply Notification과 Worker lifecycle의 실제 복구 경계를 증명하고 production을 변경하지
+않은 채 PROD-722 change를 완료한다.
+
+**Guardrails**
+
+- dev live evidence와 production release를 분리한다.
+- Temporal start 수락 전 누락과 수락 후 durable recovery를 구분해 기록한다.
+- live 검증을 위해 source Post/Notification 외의 production data나 Argo 소유 resource를 임의 삭제하지 않는다.
+
+**Verification**
+
+- dev에서 Worker RUNNING/readiness, 실제 Local 또는 ActivityPub Reply Workflow, transient DB Activity retry와
+  Worker restart 뒤 수렴을 확인한다.
+- production workload와 namespace가 이 작업으로 sync되지 않았음을 확인한다.
+- OpenSpec strict validation, 관련 workspace checks와 hosted CI를 통과시킨다.
+
+- [ ] 4.1 구현 diff와 OpenSpec을 strict validation하고 관련 전체 test/lint/render를 통과시킨다.
+- [ ] 4.2 main dev rollout에서 Worker readiness와 실제 Reply Notification Workflow 성공을 검증한다.
+- [ ] 4.3 accepted Workflow의 transient Activity 실패 retry와 Worker restart 복구를 dev에서 검증한다.
+- [ ] 4.4 production 미변경과 보장 경계 증거를 Linear/PR에 기록하고 전체 change가 완료되면 canonical spec을 동기화해 archive한다.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@kosmo/fedify": "workspace:*",
+    "@temporalio/client": "^1.21.1",
     "core-js": "^3.49.0",
     "drizzle-orm": "1.0.0-beta.22",
     "jsdom": "^29.1.1",

--- a/packages/core/services/index.ts
+++ b/packages/core/services/index.ts
@@ -1,7 +1,7 @@
 export { materializeInboundReaction, undoInboundReaction } from './activitypub-reaction';
 export { createBookmark, deleteBookmark } from './bookmark';
 export type { NotificationEffectErrorContext } from './notification';
-export { setNotificationEffectErrorReporter } from './notification';
+export { createReplyNotification, setNotificationEffectErrorReporter } from './notification';
 export { createPost, deletePost, repostPost } from './post';
 export { disableProfile } from './profile';
 export { followProfile, removeInboundFollow, unfollowProfile } from './profile-follow';
@@ -16,3 +16,4 @@ export { updateProfile } from './profile-update';
 export { addReaction, deleteReaction } from './reaction';
 export type { RevokeCurrentSessionResult } from './session';
 export { createOidcSession, revokeCurrentSession } from './session';
+export { KOSMO_TASK_QUEUE } from './temporal';

--- a/packages/core/services/post.test.ts
+++ b/packages/core/services/post.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { after, test } from 'node:test';
-import { and, eq, sql } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import {
   Accounts,
   ActivityPubPosts,
@@ -20,7 +20,6 @@ import {
   InstanceState,
   MediaSource,
   MediaState,
-  NotificationKind,
   PostState,
   PostVisibility,
   ProfileFollowPolicy,
@@ -521,7 +520,7 @@ test('createPost는 caller transaction rollback에 Post와 Content를 남기지 
   assert.equal(await db.$count(PostContents), contentCount);
 });
 
-test('caller transaction의 Reply Notification은 outer commit 전에 생성하지 않는다', async () => {
+test('caller transaction의 Reply Workflow effect는 outer commit 뒤에만 실행한다', async () => {
   const author = await createProfile();
   const recipient = await createProfile();
   const parent = await createPost({
@@ -531,10 +530,15 @@ test('caller transaction의 Reply Notification은 outer commit 전에 생성하�
     visibility: PostVisibility.PUBLIC,
   });
   let replyId: string | undefined;
+  let observerCalls = 0;
+  let postCommit: (() => Promise<void>) | undefined;
   await db.transaction(async (tx) => {
     const reply = await createPost(
       {
         document: postContentDocumentFromText('reply'),
+        onPostCommitError: () => {
+          observerCalls += 1;
+        },
         origin: 'LOCAL',
         profileId: author.id,
         replyParentId: parent.post.id,
@@ -543,16 +547,21 @@ test('caller transaction의 Reply Notification은 outer commit 전에 생성하�
       tx,
     );
     replyId = reply.post.id;
+    postCommit = reply.postCommit;
 
-    assert.equal(await tx.$count(Notifications, eq(Notifications.sourceId, reply.post.id)), 1);
+    assert.equal(await tx.$count(Notifications, eq(Notifications.sourceId, reply.post.id)), 0);
     assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, reply.post.id)), 0);
   });
 
   assert.ok(replyId);
-  assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, replyId)), 1);
+  assert.ok(postCommit);
+  await postCommit();
+  await postCommit();
+  assert.equal(observerCalls, 1);
+  assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, replyId)), 0);
 });
 
-test('ActivityPub Reply는 Local Parent Author에게 알림 하나를 만들고 duplicate로 backfill하지 않는다', async () => {
+test('ActivityPub Reply duplicate는 Workflow effect를 새로 만들지 않는다', async () => {
   const author = await createProfile();
   const recipient = await createProfile();
   const parent = await createPost({
@@ -564,6 +573,7 @@ test('ActivityPub Reply는 Local Parent Author에게 알림 하나를 만들고 
   const input = {
     document: postContentDocumentFromText('remote reply'),
     objectUri: `https://remote.example/notes/reply-notification-${author.id}`,
+    onPostCommitError: () => undefined,
     origin: 'ACTIVITYPUB' as const,
     profileId: author.id,
     publishedAt: null,
@@ -577,26 +587,16 @@ test('ActivityPub Reply는 Local Parent Author에게 알림 하나를 만들고 
   assert.ok(created);
   assert.deepEqual(results.map(({ created }) => created).sort(), [false, true]);
   assert.equal(created.created, true);
-  assert.equal(
-    await db.$count(
-      Notifications,
-      and(
-        eq(Notifications.kind, NotificationKind.REPLY),
-        eq(Notifications.recipientProfileId, recipient.id),
-        eq(Notifications.sourceId, created.post.id),
-      ),
-    ),
-    1,
-  );
+  assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, created.post.id)), 0);
 
-  await db.delete(Notifications).where(eq(Notifications.sourceId, created.post.id));
   const duplicate = await createPost(input);
 
   assert.equal(duplicate.created, false);
+  assert.equal('postCommit' in duplicate, false);
   assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, created.post.id)), 0);
 });
 
-test('ActivityPub Reply의 post-commit observer 실패가 Post transaction과 호출을 실패시키지 않는다', async () => {
+test('Reply Workflow start와 observer 실패가 Post transaction과 호출을 실패시키지 않는다', async () => {
   const author = await createProfile();
   const recipient = await createProfile();
   const parent = await createPost({
@@ -608,9 +608,10 @@ test('ActivityPub Reply의 post-commit observer 실패가 Post transaction과 �
   const objectUri = `https://remote.example/notes/reply-observer-failure-${crypto.randomUUID()}`;
   let observerCalls = 0;
 
-  await db.execute(
-    sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_reply_observer_failure CHECK (false) NOT VALID`,
-  );
+  const previousAddress = process.env.TEMPORAL_ADDRESS;
+  const previousNamespace = process.env.TEMPORAL_NAMESPACE;
+  delete process.env.TEMPORAL_ADDRESS;
+  delete process.env.TEMPORAL_NAMESPACE;
   try {
     const result = await createPost({
       document: postContentDocumentFromText('remote reply'),
@@ -628,13 +629,22 @@ test('ActivityPub Reply의 post-commit observer 실패가 Post transaction과 �
     });
 
     assert.equal(result.created, true);
+    assert.equal(observerCalls, 0);
+    await result.postCommit();
     assert.equal(observerCalls, 1);
     assert.equal(result.post.replyParentId, parent.post.id);
     assert.equal(await db.$count(Notifications, eq(Notifications.sourceId, result.post.id)), 0);
   } finally {
-    await db.execute(
-      sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_reply_observer_failure`,
-    );
+    if (previousAddress === undefined) {
+      delete process.env.TEMPORAL_ADDRESS;
+    } else {
+      process.env.TEMPORAL_ADDRESS = previousAddress;
+    }
+    if (previousNamespace === undefined) {
+      delete process.env.TEMPORAL_NAMESPACE;
+    } else {
+      process.env.TEMPORAL_NAMESPACE = previousNamespace;
+    }
   }
 });
 

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -27,13 +27,10 @@ import {
   canonicalizePostContentDocument,
   validateLocalPostContentDocument,
 } from '../post-content/server';
-import {
-  createReplyNotification,
-  createRepostNotification,
-  deleteNotificationBySource,
-} from './notification';
+import { createRepostNotification, deleteNotificationBySource } from './notification';
 import { noPostCommit, oncePostCommit } from './post-commit';
 import { validatePostStructure } from './post-structure';
+import { startReplyNotificationWorkflow } from './temporal';
 import type { DatabaseHandle, Transaction } from '../db';
 import type { PostContentDocumentV1 } from '../post-content';
 import type { PostCommit } from './post-commit';
@@ -76,6 +73,7 @@ type PostOrigin = 'LOCAL' | 'ACTIVITYPUB';
 type CreatedPost = {
   content: typeof PostContents.$inferSelect;
   created: true;
+  postCommit: PostCommit;
   post: typeof Posts.$inferSelect;
 };
 
@@ -389,7 +387,7 @@ export async function createPost(
   input: LocalPostInput | ActivityPubPostInput,
   handle?: DatabaseHandle,
 ): Promise<CreatedPost | DuplicatePost> {
-  let result: CreatedPost;
+  let result: Omit<CreatedPost, 'postCommit'>;
   try {
     result = await getDatabaseConnection(handle).transaction(async (tx) => {
       let document =
@@ -535,28 +533,6 @@ export async function createPost(
         .returning()
         .then(firstOrThrow);
 
-      if (input.replyParentId !== undefined) {
-        await createReplyNotification(linkedPost.id, tx).catch(async (error) => {
-          if (!input.onPostCommitError) {
-            console.error('Reply notification creation failed', {
-              error,
-              postId: linkedPost.id,
-            });
-            return;
-          }
-
-          try {
-            await input.onPostCommitError(error);
-          } catch (observerError) {
-            console.error('Reply notification creation failed', {
-              error,
-              observerError,
-              postId: linkedPost.id,
-            });
-          }
-        });
-      }
-
       return { content, created: true, post: linkedPost };
     });
   } catch (error) {
@@ -579,5 +555,33 @@ export async function createPost(
     }
   }
 
-  return result;
+  return {
+    ...result,
+    postCommit:
+      input.replyParentId === undefined
+        ? noPostCommit
+        : oncePostCommit(async () => {
+            try {
+              await startReplyNotificationWorkflow(result.post.id);
+            } catch (error) {
+              if (!input.onPostCommitError) {
+                console.error('Reply notification Workflow start failed', {
+                  error,
+                  postId: result.post.id,
+                });
+                return;
+              }
+
+              try {
+                await input.onPostCommitError(error);
+              } catch (observerError) {
+                console.error('Reply notification Workflow start failed', {
+                  error,
+                  observerError,
+                  postId: result.post.id,
+                });
+              }
+            }
+          }),
+  };
 }

--- a/packages/core/services/temporal.test.ts
+++ b/packages/core/services/temporal.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  KOSMO_TASK_QUEUE,
+  REPLY_NOTIFICATION_WORKFLOW_TYPE,
+  replyNotificationWorkflowId,
+  replyNotificationWorkflowStartOptions,
+  startReplyNotificationWorkflow,
+} from './temporal';
+
+test('Reply Notification Workflow start는 stable ID와 공통 start policy를 사용한다', () => {
+  const replyId = '00000000-0000-8000-8000-000000000001';
+
+  assert.equal(replyNotificationWorkflowId(replyId), `reply-notification:${replyId}`);
+  assert.deepEqual(replyNotificationWorkflowStartOptions(replyId), {
+    args: [replyId],
+    taskQueue: KOSMO_TASK_QUEUE,
+    workflowId: `reply-notification:${replyId}`,
+    workflowIdConflictPolicy: 'USE_EXISTING',
+    workflowIdReusePolicy: 'REJECT_DUPLICATE',
+  });
+  assert.equal(REPLY_NOTIFICATION_WORKFLOW_TYPE, 'replyNotificationWorkflow');
+  assert.equal(KOSMO_TASK_QUEUE, 'kosmo');
+});
+
+test('Temporal runtime 입력이 없으면 Workflow start를 연결 전에 거부한다', async () => {
+  const previousAddress = process.env.TEMPORAL_ADDRESS;
+  const previousNamespace = process.env.TEMPORAL_NAMESPACE;
+  delete process.env.TEMPORAL_ADDRESS;
+  delete process.env.TEMPORAL_NAMESPACE;
+
+  try {
+    await assert.rejects(
+      startReplyNotificationWorkflow('00000000-0000-8000-8000-000000000002'),
+      /TEMPORAL_ADDRESS is required/,
+    );
+  } finally {
+    if (previousAddress === undefined) {
+      delete process.env.TEMPORAL_ADDRESS;
+    } else {
+      process.env.TEMPORAL_ADDRESS = previousAddress;
+    }
+    if (previousNamespace === undefined) {
+      delete process.env.TEMPORAL_NAMESPACE;
+    } else {
+      process.env.TEMPORAL_NAMESPACE = previousNamespace;
+    }
+  }
+});

--- a/packages/core/services/temporal.ts
+++ b/packages/core/services/temporal.ts
@@ -1,0 +1,49 @@
+import { Client, Connection } from '@temporalio/client';
+
+export const KOSMO_TASK_QUEUE = 'kosmo';
+export const REPLY_NOTIFICATION_WORKFLOW_TYPE = 'replyNotificationWorkflow';
+
+export const replyNotificationWorkflowId = (replyId: string): string =>
+  `reply-notification:${replyId}`;
+
+export const replyNotificationWorkflowStartOptions = (replyId: string) => ({
+  args: [replyId] as [string],
+  taskQueue: KOSMO_TASK_QUEUE,
+  workflowId: replyNotificationWorkflowId(replyId),
+  workflowIdConflictPolicy: 'USE_EXISTING' as const,
+  workflowIdReusePolicy: 'REJECT_DUPLICATE' as const,
+});
+
+let temporalClientPromise: Promise<Client> | undefined;
+
+const connectTemporalClient = async (): Promise<Client> => {
+  const address = process.env.TEMPORAL_ADDRESS?.trim();
+  const namespace = process.env.TEMPORAL_NAMESPACE?.trim();
+  if (!address) {
+    throw new Error('TEMPORAL_ADDRESS is required');
+  }
+  if (!namespace) {
+    throw new Error('TEMPORAL_NAMESPACE is required');
+  }
+
+  const connection = await Connection.connect({ address });
+  return new Client({ connection, namespace });
+};
+
+const getTemporalClient = (): Promise<Client> => {
+  temporalClientPromise ??= connectTemporalClient().catch((error) => {
+    // A failed connection must not poison later post-commit effects. The next
+    // effect will establish a fresh connection and retry the start request.
+    temporalClientPromise = undefined;
+    throw error;
+  });
+  return temporalClientPromise;
+};
+
+export const startReplyNotificationWorkflow = async (replyId: string): Promise<void> => {
+  const client = await getTemporalClient();
+  await client.workflow.start(
+    REPLY_NOTIFICATION_WORKFLOW_TYPE,
+    replyNotificationWorkflowStartOptions(replyId),
+  );
+};

--- a/packages/fedify/src/inbound-create-note.ts
+++ b/packages/fedify/src/inbound-create-note.ts
@@ -244,7 +244,7 @@ export const handleInboundCreateNote = async ({
         objectOrigin: objectUri,
         outcome: 'internal_failure',
         phase: 'effect',
-        reasonCode: 'reply_notification_effect_failed',
+        reasonCode: 'reply_notification_workflow_start_failed',
       }),
     objectUri,
     origin: 'ACTIVITYPUB',
@@ -268,6 +268,8 @@ export const handleInboundCreateNote = async ({
     const result = await createPost(replyParentId ? { ...input, replyParentId } : input);
     if (!result.created) {
       observeDuplicateCreate();
+    } else {
+      await result.postCommit();
     }
   } catch (error) {
     if (error instanceof ValidationError && error.field === 'media') {
@@ -302,6 +304,8 @@ export const handleInboundCreateNote = async ({
     const result = await createPost(input);
     if (!result.created) {
       observeDuplicateCreate();
+    } else {
+      await result.postCommit();
     }
   }
 };

--- a/packages/fedify/src/inbound-create.test.ts
+++ b/packages/fedify/src/inbound-create.test.ts
@@ -24,7 +24,6 @@ import {
   ActivityPubActorType,
   InstanceKind,
   InstanceState,
-  NotificationKind,
   PostState,
   PostVisibility,
   ProfileFollowPolicy,
@@ -34,7 +33,7 @@ import {
   postContentDocumentFromText,
   postContentDocumentToText,
 } from '@kosmo/core/post-content/server';
-import { eq, ne, sql } from 'drizzle-orm';
+import { eq, ne } from 'drizzle-orm';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
@@ -70,11 +69,17 @@ let createPost: typeof CoreServices.createPost;
 let findPostByActivityPubUri: typeof findPostByActivityPubUriType;
 let handleInboundCreate: typeof handleInboundCreateType;
 let localInstanceId: string;
+let temporalAddress: string | undefined;
+let temporalNamespace: string | undefined;
 
 describe('inbound Create dispatch', () => {
   before(async () => {
     process.env.DATABASE_URL = databaseUrl;
     process.env.PUBLIC_ORIGIN = publicOrigin;
+    temporalAddress = process.env.TEMPORAL_ADDRESS;
+    temporalNamespace = process.env.TEMPORAL_NAMESPACE;
+    delete process.env.TEMPORAL_ADDRESS;
+    delete process.env.TEMPORAL_NAMESPACE;
     ({
       ActivityPubActors,
       ActivityPubPosts,
@@ -114,6 +119,16 @@ describe('inbound Create dispatch', () => {
     await db.delete(Posts);
     await db.delete(Media);
     await pg.end();
+    if (temporalAddress === undefined) {
+      delete process.env.TEMPORAL_ADDRESS;
+    } else {
+      process.env.TEMPORAL_ADDRESS = temporalAddress;
+    }
+    if (temporalNamespace === undefined) {
+      delete process.env.TEMPORAL_NAMESPACE;
+    } else {
+      process.env.TEMPORAL_NAMESPACE = temporalNamespace;
+    }
   });
 
   test('materializes a hydrated Note without persisting the activity id', async () => {
@@ -830,22 +845,12 @@ describe('inbound Create dispatch', () => {
       localParent.post.id,
     );
     assert.equal((await getMaterializedPost(remoteReplyUri)).post.profileId, remoteProfile.id);
-    const localParentReply = await getMaterializedPost(localReplyUri);
-    assert.deepEqual(
+    assert.equal(
       await db
-        .select({
-          kind: Notifications.kind,
-          recipientProfileId: Notifications.recipientProfileId,
-          sourceId: Notifications.sourceId,
-        })
-        .from(Notifications),
-      [
-        {
-          kind: NotificationKind.REPLY,
-          recipientProfileId: localProfile.id,
-          sourceId: localParentReply.post.id,
-        },
-      ],
+        .select()
+        .from(Notifications)
+        .then((rows) => rows.length),
+      0,
     );
   });
 
@@ -901,7 +906,7 @@ describe('inbound Create dispatch', () => {
     );
   });
 
-  test('keeps an inbound Reply committed when Notification creation fails', async () => {
+  test('keeps an inbound Reply committed when Workflow start fails', async () => {
     await createStoredRemoteActor();
     const localProfile = await db
       .insert(Profiles)
@@ -922,9 +927,6 @@ describe('inbound Create dispatch', () => {
       visibility: PostVisibility.PUBLIC,
     });
     const replyUri = new URL('https://remote.example/notes/notification-failure-reply');
-    await db.execute(
-      sql`ALTER TABLE ${Notifications} ADD CONSTRAINT notification_inbound_reply_create_failure CHECK (false) NOT VALID`,
-    );
     const captures: { context: { tags: Record<string, string> }; error: unknown }[] = [];
     const restoreReporter = setInboundObservabilityReporter({
       captureException: (error, context) => captures.push({ context, error }),
@@ -942,15 +944,12 @@ describe('inbound Create dispatch', () => {
       );
     } finally {
       restoreReporter();
-      await db.execute(
-        sql`ALTER TABLE ${Notifications} DROP CONSTRAINT notification_inbound_reply_create_failure`,
-      );
     }
 
     assert.equal((await getMaterializedPost(replyUri)).post.replyParentId, parent.post.id);
     assert.equal((await db.select().from(Notifications)).length, 0);
     assert.equal(captures.length, 1);
-    assert.equal(captures[0]?.context.tags.reason_code, 'reply_notification_effect_failed');
+    assert.equal(captures[0]?.context.tags.reason_code, 'reply_notification_workflow_start_failed');
     assert.ok(captures[0]?.error instanceof Error);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,9 +381,15 @@ importers:
 
   apps/worker:
     dependencies:
+      '@kosmo/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@temporalio/worker':
         specifier: ^1.22.0
         version: 1.22.0(tslib@2.8.1)
+      '@temporalio/workflow':
+        specifier: ^1.22.0
+        version: 1.22.0
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -393,6 +399,9 @@ importers:
       '@kosmo/fedify':
         specifier: workspace:*
         version: link:../fedify
+      '@temporalio/client':
+        specifier: ^1.21.1
+        version: 1.22.0
       core-js:
         specifier: ^3.49.0
         version: 3.49.0


### PR DESCRIPTION
## 무엇을 변경했는지

- 실제 Reply Post가 commit된 뒤 stable Reply ID로 `replyNotificationWorkflow` start를 시도하도록 core lifecycle을 전환했습니다.
- Local GraphQL과 ActivityPub inbound caller가 같은 one-shot `postCommit` effect를 await하고, 기존 transaction savepoint Reply Notification 생성을 제거했습니다.
- Worker에 deterministic Reply Workflow와 DB Activity를 등록했습니다. Activity는 기존 Notification persistence policy를 재사용하고 source 부재만 terminal no-op으로 처리합니다.
- API/Web/Worker에 같은 Temporal endpoint·namespace를 전달하고, `kosmo` task queue의 Worker를 기본 활성화했습니다. 명시적 `worker.enabled=false` rollback과 dev mutable-image restart도 유지합니다.
- 변경 계약과 남은 dev live gate를 `create-reply-notifications-with-temporal` OpenSpec change로 기록했습니다.

## 왜 변경했는지

Reply Notification은 source Post transaction의 savepoint에서 Best Effort로 생성되어, Notification DB 오류를 source 성공과 분리해 재시도하거나 Worker 재시작 뒤 이어갈 실행 이력이 없었습니다. [PROD-722](https://linear.app/byulmaru/issue/PROD-722/reply-notification-lifecycle을-temporal-workflow로-전환한다)는 Reply를 첫 business Temporal Workflow로 전환하되, Post 성공과 Notification 실패를 분리하고 Local/AP가 같은 lifecycle을 사용하도록 요구합니다.

## 이번 PR의 주요 결정

결정자는 @robin-maki이며, 상세 기록은 [OpenSpec decisions](https://github.com/byulmaru/kosmo/blob/prod-722/openspec/changes/create-reply-notifications-with-temporal/decisions.md)에 있습니다.

### commit 뒤 직접 Workflow start

- 선택: transactional intent/outbox/relay 없이 commit 뒤 stable ID로 직접 start하고 승인 또는 실패까지 await합니다.
- 고려한 대안: transaction과 원자적인 intent/relay, fire-and-forget start.
- 이유: PROD-718/721을 취소한 현재 Linear 계약과 source 성공 격리 경계를 그대로 적용합니다.
- 감수한 결과: commit 뒤 start 요청 전 process 종료에 따른 Notification 누락은 복구하지 않습니다.

### Workflow-only와 단일 `kosmo` task queue

- 선택: 환경별 코드 분기나 dual-write 없이 기존 savepoint를 제거하고 하나의 Worker/task queue를 사용합니다.
- 고려한 대안: dev-only capability flag, Notification/kind별 queue.
- 이유: 첫 capability에 필요한 runtime만 열고 이후 capability가 같은 registration seam을 확장하게 합니다.
- 감수한 결과: 향후 production release는 namespace provisioning과 Worker를 함께 포함해야 하며, 이 PR에서는 production을 배포하지 않습니다.

### Temporal 기본 정책 사용

- 선택: Activity retry 횟수·backoff와 `workflow.start()` application deadline을 별도로 덮지 않습니다.
- 고려한 대안: Activity 10회/24시간 제한, start RPC 10초/30초 deadline.
- 이유: 현재 상위 계약에 근거 있는 수치가 없어 SDK 기본을 유지합니다.
- 감수한 결과: Activity retry가 장시간 계속될 수 있고, 연결 뒤 start RPC stall은 GraphQL/AP 요청의 장시간 대기로 이어질 수 있습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/core test:services:database` — 179 pass
- `pnpm --filter @kosmo/api test:integration` — 226 pass, 1 skip
- `pnpm test:fedify` — pass
- `pnpm --filter @kosmo/worker test` — 5 pass
- Temporal Workflow bundle 생성 — 1.48 MB, compile 성공
- `pnpm lint:eslint`, `pnpm lint:prettier`, `pnpm lint:syncpack` — pass
- `actionlint .github/workflows/deploy-dev.yml` — pass
- dev/prod `helm lint`·Worker/API/Web render 및 `worker.enabled=false` render — pass
- `pnpm exec openspec validate create-reply-notifications-with-temporal --strict` — valid

## 아직 어떤 문제가 남았는지

- OpenSpec은 12/16입니다. 구현 diff의 hosted CI까지 통과해 4.1을 닫았습니다.
- main merge 뒤 dev에서 실제 accepted Workflow, transient Activity retry, Worker restart 복구와 readiness를 검증해야 합니다(2.4, 4.2, 4.3).
- dev 증거와 production 미변경 상태를 기록한 뒤 canonical spec을 동기화하고 change를 archive합니다(4.4).
- production sync/release는 이 PR에서 수행하지 않았고 별도 운영 승인 대상입니다.
