### PR TITLE
Home과 Profile 게시글 목록에 무한 스크롤을 제공한다

### DIFF
--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
@@ -1,7 +1,8 @@
 import { Link, Slot, useGlobalSearchParams } from 'expo-router';
 import { useState } from 'react';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { PaginationScrollView } from '@/components/pagination/PaginationScrollView';
 import { FollowButton } from '@/components/profile/FollowButton';
 import { ProfileHero } from '@/components/profile/ProfileHero';
 import { normalizeProfileHandle } from '@/components/profile/route';
@@ -99,7 +100,7 @@ function ProfileRouteContainer({ children }: { children: ReactNode }) {
   return Platform.OS === 'web' ? (
     <View style={styles.webRoot}>{children}</View>
   ) : (
-    <ScrollView style={styles.nativeRoot}>{children}</ScrollView>
+    <PaginationScrollView style={styles.nativeRoot}>{children}</PaginationScrollView>
   );
 }
 

--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/_layout.tsx
@@ -1,4 +1,4 @@
-import { Link, Slot, useGlobalSearchParams } from 'expo-router';
+import { Link, Slot, useGlobalSearchParams, usePathname } from 'expo-router';
 import { useState } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -38,26 +38,40 @@ export default function ProfileLayout() {
     profileHandle?: string | string[];
   }>();
   const handle = normalizeProfileHandle(profileHandle);
+  const pathname = usePathname();
   const { revision } = useRelayActor();
   const [fetchKey, setFetchKey] = useState(0);
+  const paginationOwnerKey = `${revision}:${pathname}`;
 
   return (
     <RouteBoundary
       key={handle}
       loading={
-        <ProfileRouteContainer>
+        <ProfileRouteContainer paginationOwnerKey={paginationOwnerKey}>
           <ProfileHero loading />
         </ProfileRouteContainer>
       }
       onRetry={() => setFetchKey((key) => key + 1)}
       title="프로필을 불러오지 못했어요"
     >
-      <ProfileLayoutContent fetchKey={`${revision}:${fetchKey}`} handle={handle} />
+      <ProfileLayoutContent
+        fetchKey={`${revision}:${fetchKey}`}
+        handle={handle}
+        paginationOwnerKey={paginationOwnerKey}
+      />
     </RouteBoundary>
   );
 }
 
-function ProfileLayoutContent({ fetchKey, handle }: { fetchKey: string; handle: string }) {
+function ProfileLayoutContent({
+  fetchKey,
+  handle,
+  paginationOwnerKey,
+}: {
+  fetchKey: string;
+  handle: string;
+  paginationOwnerKey: string;
+}) {
   const data = useLazyLoadQuery<ProfileLayoutQueryType>(
     ProfileLayoutQuery,
     { handle },
@@ -89,18 +103,26 @@ function ProfileLayoutContent({ fetchKey, handle }: { fetchKey: string; handle: 
   );
 
   return (
-    <ProfileRouteContainer>
+    <ProfileRouteContainer paginationOwnerKey={paginationOwnerKey}>
       <ProfileHero action={action} profile={profile} />
       <Slot />
     </ProfileRouteContainer>
   );
 }
 
-function ProfileRouteContainer({ children }: { children: ReactNode }) {
+function ProfileRouteContainer({
+  children,
+  paginationOwnerKey,
+}: {
+  children: ReactNode;
+  paginationOwnerKey: string;
+}) {
   return Platform.OS === 'web' ? (
     <View style={styles.webRoot}>{children}</View>
   ) : (
-    <PaginationScrollView style={styles.nativeRoot}>{children}</PaginationScrollView>
+    <PaginationScrollView paginationOwnerKey={paginationOwnerKey} style={styles.nativeRoot}>
+      {children}
+    </PaginationScrollView>
   );
 }
 

--- a/apps/app/src/app/(tabs)/(profile)/[profileHandle]/index.tsx
+++ b/apps/app/src/app/(tabs)/(profile)/[profileHandle]/index.tsx
@@ -18,7 +18,7 @@ const ProfilePostListPageQuery = graphql`
     }
     profileByHandle(handle: $handle) {
       id
-      ...PostList_profile
+      ...PostList_profile @arguments(count: 20)
     }
   }
 `;
@@ -39,7 +39,11 @@ export default function ProfilePostListPage() {
       onRetry={() => setFetchKey((key) => key + 1)}
       title="게시글 목록을 불러오지 못했어요"
     >
-      <ProfilePostListPageContent fetchKey={`${revision}:${fetchKey}`} handle={handle} />
+      <ProfilePostListPageContent
+        fetchKey={`${revision}:${fetchKey}`}
+        handle={handle}
+        key={`${revision}:${handle}`}
+      />
     </RouteBoundary>
   );
 }

--- a/apps/app/src/app/(tabs)/(protected)/home.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/home.tsx
@@ -1,8 +1,9 @@
 import { UserRoundPlus } from 'lucide-react-native';
 import { useState } from 'react';
-import { Platform, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import { Platform, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { PageHeader } from '@/components/PageHeader';
+import { PaginationScrollView } from '@/components/pagination/PaginationScrollView';
 import { PostList } from '@/components/post/PostList';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { useShellChrome } from '@/components/shell/ShellChromeContext';
@@ -31,16 +32,7 @@ const HomeQuery = graphql`
         id
       }
     }
-    homeTimeline(first: 20) @connection(key: "PostList_homeTimeline") {
-      edges {
-        cursor
-        node {
-          id
-          ...PostListItem_post
-        }
-      }
-      ...PostList_homeTimeline
-    }
+    ...PostList_home @arguments(count: 20)
   }
 `;
 
@@ -55,7 +47,7 @@ export default function HomeScreen() {
         onRetry={() => setFetchKey((key) => key + 1)}
         title="홈을 불러오지 못했어요"
       >
-        <HomeContent fetchKey={`${revision}:${fetchKey}`} />
+        <HomeContent fetchKey={`${revision}:${fetchKey}`} key={revision} />
       </RouteBoundary>
     </HomeFrame>
   );
@@ -66,10 +58,10 @@ function HomeFrame({ children }: PropsWithChildren) {
   const routeOwnsHeader = getShellLayout(Platform.OS === 'web', width) !== 'mobile';
 
   return (
-    <ScrollView contentContainerStyle={styles.root}>
+    <PaginationScrollView contentContainerStyle={styles.root}>
       {routeOwnsHeader ? <PageHeader accessibilityLabel="홈" variant="brand" /> : null}
       <View style={styles.body}>{children}</View>
-    </ScrollView>
+    </PaginationScrollView>
   );
 }
 
@@ -107,7 +99,7 @@ function HomeContent({ fetchKey }: { fetchKey: string }) {
 
   return (
     <View style={styles.timeline}>
-      <PostList homeTimeline={data.homeTimeline} replyProfile={selectedProfile} />
+      <PostList home={data} replyProfile={selectedProfile} />
     </View>
   );
 }

--- a/apps/app/src/app/(tabs)/(protected)/home.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/home.tsx
@@ -41,7 +41,7 @@ export default function HomeScreen() {
   const [fetchKey, setFetchKey] = useState(0);
 
   return (
-    <HomeFrame>
+    <HomeFrame paginationOwnerKey={`home:${revision}`}>
       <RouteBoundary
         loading={<StateView loading title="홈을 불러오는 중입니다." />}
         onRetry={() => setFetchKey((key) => key + 1)}
@@ -53,12 +53,18 @@ export default function HomeScreen() {
   );
 }
 
-function HomeFrame({ children }: PropsWithChildren) {
+function HomeFrame({
+  children,
+  paginationOwnerKey,
+}: PropsWithChildren<{ paginationOwnerKey: string }>) {
   const { width } = useWindowDimensions();
   const routeOwnsHeader = getShellLayout(Platform.OS === 'web', width) !== 'mobile';
 
   return (
-    <PaginationScrollView contentContainerStyle={styles.root}>
+    <PaginationScrollView
+      contentContainerStyle={styles.root}
+      paginationOwnerKey={paginationOwnerKey}
+    >
       {routeOwnsHeader ? <PageHeader accessibilityLabel="홈" variant="brand" /> : null}
       <View style={styles.body}>{children}</View>
     </PaginationScrollView>

--- a/apps/app/src/components/pagination/PaginationScrollView.test.ts
+++ b/apps/app/src/components/pagination/PaginationScrollView.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, describe, it, mock } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ComponentType, PropsWithChildren } from 'react';
+import type { ReactTestRenderer } from 'react-test-renderer';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type NativeScrollProps = {
+  onContentSizeChange: (width: number, height: number) => void;
+  onLayout: (event: { nativeEvent: { layout: { height: number } } }) => void;
+  onScroll: (event: {
+    nativeEvent: {
+      contentOffset: { y: number };
+      contentSize: { height: number };
+      layoutMeasurement: { height: number };
+    };
+  }) => void;
+  scrollEventThrottle: 16;
+};
+
+let contentHeight = 0;
+let layoutHeight = 0;
+let scrollOffset = 0;
+const handlers: NativeScrollProps = {
+  onContentSizeChange: (_width, height) => {
+    contentHeight = height;
+  },
+  onLayout: (event) => {
+    layoutHeight = event.nativeEvent.layout.height;
+  },
+  onScroll: (event) => {
+    contentHeight = event.nativeEvent.contentSize.height;
+    layoutHeight = event.nativeEvent.layoutMeasurement.height;
+    scrollOffset = event.nativeEvent.contentOffset.y;
+  },
+  scrollEventThrottle: 16,
+};
+let renderer: ReactTestRenderer | null = null;
+
+mock.module('react-native', {
+  exports: {
+    Platform: { OS: 'ios' },
+    ScrollView: 'ScrollView',
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+
+let PaginationScrollView: ComponentType<PropsWithChildren>;
+let usePaginationScrollRegistration: (props: NativeScrollProps) => void;
+
+before(async () => {
+  const module = await import('./PaginationScrollView');
+  PaginationScrollView = module.PaginationScrollView as ComponentType<PropsWithChildren>;
+  usePaginationScrollRegistration = module.usePaginationScrollRegistration;
+});
+
+afterEach(async () => {
+  if (renderer) {
+    await act(async () => renderer?.unmount());
+    renderer = null;
+  }
+});
+
+function RegistrationProbe() {
+  usePaginationScrollRegistration(handlers);
+  return createElement('Content');
+}
+
+function renderOwner(registered: boolean) {
+  return createElement(
+    PaginationScrollView,
+    null,
+    registered ? createElement(RegistrationProbe) : createElement('Content'),
+  );
+}
+
+describe('PaginationScrollView', () => {
+  it('registration 전 초기 metric을 저장해 자식 handler에 전달하고 unmount에서 해제한다', async () => {
+    await act(async () => {
+      renderer = create(renderOwner(false));
+    });
+    assert.ok(renderer);
+
+    let scrollViews = renderer.root.findAll((node) => (node.type as unknown) === 'ScrollView');
+    assert.equal(scrollViews.length, 1);
+    assert.equal(typeof scrollViews[0]?.props.onContentSizeChange, 'function');
+    assert.equal(typeof scrollViews[0]?.props.onLayout, 'function');
+    assert.equal(typeof scrollViews[0]?.props.onScroll, 'function');
+    assert.equal(scrollViews[0]?.props.scrollEventThrottle, 16);
+    scrollViews[0]?.props.onContentSizeChange(320, 480);
+    scrollViews[0]?.props.onLayout({ nativeEvent: { layout: { height: 240 } } });
+    scrollViews[0]?.props.onScroll({
+      nativeEvent: {
+        contentOffset: { y: 16 },
+        contentSize: { height: 480 },
+        layoutMeasurement: { height: 240 },
+      },
+    });
+
+    assert.equal(contentHeight, 0);
+    assert.equal(layoutHeight, 0);
+    assert.equal(scrollOffset, 0);
+
+    await act(async () => {
+      renderer?.update(renderOwner(true));
+    });
+
+    assert.equal(contentHeight, 480);
+    assert.equal(layoutHeight, 240);
+    assert.equal(scrollOffset, 16);
+
+    await act(async () => {
+      renderer?.update(renderOwner(false));
+    });
+
+    scrollViews = renderer.root.findAll((node) => (node.type as unknown) === 'ScrollView');
+    assert.equal(scrollViews.length, 1);
+    scrollViews[0]?.props.onContentSizeChange(320, 960);
+    assert.equal(contentHeight, 480);
+
+    await act(async () => {
+      renderer?.update(renderOwner(true));
+    });
+    assert.equal(contentHeight, 960);
+  });
+});

--- a/apps/app/src/components/pagination/PaginationScrollView.test.ts
+++ b/apps/app/src/components/pagination/PaginationScrollView.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { afterEach, before, describe, it, mock } from 'node:test';
+import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 import { createElement } from 'react';
 import { act, create } from 'react-test-renderer';
 import type { ComponentType, PropsWithChildren } from 'react';
@@ -46,13 +46,21 @@ mock.module('react-native', {
   },
 } as unknown as Parameters<typeof mock.module>[1]);
 
-let PaginationScrollView: ComponentType<PropsWithChildren>;
+let PaginationScrollView: ComponentType<PropsWithChildren<{ paginationOwnerKey: string }>>;
 let usePaginationScrollRegistration: (props: NativeScrollProps) => void;
 
 before(async () => {
   const module = await import('./PaginationScrollView');
-  PaginationScrollView = module.PaginationScrollView as ComponentType<PropsWithChildren>;
+  PaginationScrollView = module.PaginationScrollView as ComponentType<
+    PropsWithChildren<{ paginationOwnerKey: string }>
+  >;
   usePaginationScrollRegistration = module.usePaginationScrollRegistration;
+});
+
+beforeEach(() => {
+  contentHeight = 0;
+  layoutHeight = 0;
+  scrollOffset = 0;
 });
 
 afterEach(async () => {
@@ -67,10 +75,10 @@ function RegistrationProbe() {
   return createElement('Content');
 }
 
-function renderOwner(registered: boolean) {
+function renderOwner(registered: boolean, paginationOwnerKey = 'owner-a') {
   return createElement(
     PaginationScrollView,
-    null,
+    { paginationOwnerKey },
     registered ? createElement(RegistrationProbe) : createElement('Content'),
   );
 }
@@ -123,5 +131,56 @@ describe('PaginationScrollView', () => {
       renderer?.update(renderOwner(true));
     });
     assert.equal(contentHeight, 960);
+  });
+
+  it('owner가 바뀌면 이전 metric을 새 registration에 재생하지 않는다', async () => {
+    await act(async () => {
+      renderer = create(renderOwner(false, 'owner-a'));
+    });
+    assert.ok(renderer);
+
+    let scrollViews = renderer.root.findAll((node) => (node.type as unknown) === 'ScrollView');
+    assert.equal(scrollViews.length, 1);
+    let scrollView = scrollViews[0];
+    assert.ok(scrollView);
+    scrollView.props.onScroll({
+      nativeEvent: {
+        contentOffset: { y: 240 },
+        contentSize: { height: 480 },
+        layoutMeasurement: { height: 240 },
+      },
+    });
+
+    await act(async () => {
+      renderer?.update(renderOwner(false, 'owner-b'));
+      renderer?.update(renderOwner(true, 'owner-b'));
+    });
+
+    assert.equal(contentHeight, 0);
+    assert.equal(layoutHeight, 0);
+    assert.equal(scrollOffset, 0);
+
+    await act(async () => {
+      renderer?.update(renderOwner(false, 'owner-b'));
+    });
+    scrollViews = renderer.root.findAll((node) => (node.type as unknown) === 'ScrollView');
+    assert.equal(scrollViews.length, 1);
+    scrollView = scrollViews[0];
+    assert.ok(scrollView);
+    scrollView.props.onScroll({
+      nativeEvent: {
+        contentOffset: { y: 24 },
+        contentSize: { height: 960 },
+        layoutMeasurement: { height: 320 },
+      },
+    });
+
+    await act(async () => {
+      renderer?.update(renderOwner(true, 'owner-b'));
+    });
+
+    assert.equal(contentHeight, 960);
+    assert.equal(layoutHeight, 320);
+    assert.equal(scrollOffset, 24);
   });
 });

--- a/apps/app/src/components/pagination/PaginationScrollView.tsx
+++ b/apps/app/src/components/pagination/PaginationScrollView.tsx
@@ -1,10 +1,11 @@
-import { createContext, useCallback, useContext, useEffect, useRef } from 'react';
+import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useRef } from 'react';
 import { Platform, ScrollView } from 'react-native';
 import type { ScrollViewProps } from 'react-native';
 import type { UseAutomaticPaginationResult } from './useAutomaticPagination';
 
 type NativeScrollProps = UseAutomaticPaginationResult['nativeScrollProps'];
 type Registration = Readonly<{ id: symbol; props: NativeScrollProps }>;
+type ActiveRegistration = Registration & Readonly<{ ownerKey: string }>;
 type Register = (registration: Registration) => () => void;
 type LatestEvent =
   | Readonly<{
@@ -16,6 +17,11 @@ type LatestEvent =
 
 const PaginationScrollContext = createContext<Register | null>(null);
 
+type PaginationScrollViewProps = ScrollViewProps &
+  Readonly<{
+    paginationOwnerKey: string;
+  }>;
+
 function recordLatestEvent(events: LatestEvent[], event: LatestEvent) {
   const previousIndex = events.findIndex((previous) => previous.type === event.type);
   if (previousIndex >= 0) {
@@ -24,50 +30,75 @@ function recordLatestEvent(events: LatestEvent[], event: LatestEvent) {
   events.push(event);
 }
 
-export function PaginationScrollView({ children, ...props }: ScrollViewProps) {
-  const registrationRef = useRef<Registration | null>(null);
+export function PaginationScrollView({
+  children,
+  paginationOwnerKey,
+  ...props
+}: PaginationScrollViewProps) {
+  const registrationRef = useRef<ActiveRegistration | null>(null);
   const latestEventsRef = useRef<LatestEvent[]>([]);
+  useLayoutEffect(() => {
+    registrationRef.current = null;
+    latestEventsRef.current = [];
+  }, [paginationOwnerKey]);
   const onContentSizeChange = useCallback(
     (...args: Parameters<NativeScrollProps['onContentSizeChange']>) => {
       recordLatestEvent(latestEventsRef.current, { args, type: 'contentSize' });
-      const handler = registrationRef.current?.props.onContentSizeChange;
+      const registration = registrationRef.current;
+      const handler =
+        registration?.ownerKey === paginationOwnerKey
+          ? registration.props.onContentSizeChange
+          : undefined;
       if (handler) {
         handler(...args);
       }
     },
-    [],
+    [paginationOwnerKey],
   );
-  const onLayout = useCallback((...args: Parameters<NativeScrollProps['onLayout']>) => {
-    recordLatestEvent(latestEventsRef.current, { args, type: 'layout' });
-    const handler = registrationRef.current?.props.onLayout;
-    if (handler) {
-      handler(...args);
-    }
-  }, []);
-  const onScroll = useCallback((...args: Parameters<NativeScrollProps['onScroll']>) => {
-    recordLatestEvent(latestEventsRef.current, { args, type: 'scroll' });
-    const handler = registrationRef.current?.props.onScroll;
-    if (handler) {
-      handler(...args);
-    }
-  }, []);
-  const register = useCallback<Register>((registration) => {
-    registrationRef.current = registration;
-    for (const event of latestEventsRef.current) {
-      if (event.type === 'contentSize') {
-        registration.props.onContentSizeChange(...event.args);
-      } else if (event.type === 'layout') {
-        registration.props.onLayout(...event.args);
-      } else {
-        registration.props.onScroll(...event.args);
+  const onLayout = useCallback(
+    (...args: Parameters<NativeScrollProps['onLayout']>) => {
+      recordLatestEvent(latestEventsRef.current, { args, type: 'layout' });
+      const registration = registrationRef.current;
+      const handler =
+        registration?.ownerKey === paginationOwnerKey ? registration.props.onLayout : undefined;
+      if (handler) {
+        handler(...args);
       }
-    }
-    return () => {
-      if (registrationRef.current?.id === registration.id) {
-        registrationRef.current = null;
+    },
+    [paginationOwnerKey],
+  );
+  const onScroll = useCallback(
+    (...args: Parameters<NativeScrollProps['onScroll']>) => {
+      recordLatestEvent(latestEventsRef.current, { args, type: 'scroll' });
+      const registration = registrationRef.current;
+      const handler =
+        registration?.ownerKey === paginationOwnerKey ? registration.props.onScroll : undefined;
+      if (handler) {
+        handler(...args);
       }
-    };
-  }, []);
+    },
+    [paginationOwnerKey],
+  );
+  const register = useCallback<Register>(
+    (registration) => {
+      registrationRef.current = { ...registration, ownerKey: paginationOwnerKey };
+      for (const event of latestEventsRef.current) {
+        if (event.type === 'contentSize') {
+          registration.props.onContentSizeChange(...event.args);
+        } else if (event.type === 'layout') {
+          registration.props.onLayout(...event.args);
+        } else {
+          registration.props.onScroll(...event.args);
+        }
+      }
+      return () => {
+        if (registrationRef.current?.id === registration.id) {
+          registrationRef.current = null;
+        }
+      };
+    },
+    [paginationOwnerKey],
+  );
   const nativeScrollProps =
     Platform.OS === 'web'
       ? {}

--- a/apps/app/src/components/pagination/PaginationScrollView.tsx
+++ b/apps/app/src/components/pagination/PaginationScrollView.tsx
@@ -1,0 +1,96 @@
+import { createContext, useCallback, useContext, useEffect, useRef } from 'react';
+import { Platform, ScrollView } from 'react-native';
+import type { ScrollViewProps } from 'react-native';
+import type { UseAutomaticPaginationResult } from './useAutomaticPagination';
+
+type NativeScrollProps = UseAutomaticPaginationResult['nativeScrollProps'];
+type Registration = Readonly<{ id: symbol; props: NativeScrollProps }>;
+type Register = (registration: Registration) => () => void;
+type LatestEvent =
+  | Readonly<{
+      args: Parameters<NativeScrollProps['onContentSizeChange']>;
+      type: 'contentSize';
+    }>
+  | Readonly<{ args: Parameters<NativeScrollProps['onLayout']>; type: 'layout' }>
+  | Readonly<{ args: Parameters<NativeScrollProps['onScroll']>; type: 'scroll' }>;
+
+const PaginationScrollContext = createContext<Register | null>(null);
+
+function recordLatestEvent(events: LatestEvent[], event: LatestEvent) {
+  const previousIndex = events.findIndex((previous) => previous.type === event.type);
+  if (previousIndex >= 0) {
+    events.splice(previousIndex, 1);
+  }
+  events.push(event);
+}
+
+export function PaginationScrollView({ children, ...props }: ScrollViewProps) {
+  const registrationRef = useRef<Registration | null>(null);
+  const latestEventsRef = useRef<LatestEvent[]>([]);
+  const onContentSizeChange = useCallback(
+    (...args: Parameters<NativeScrollProps['onContentSizeChange']>) => {
+      recordLatestEvent(latestEventsRef.current, { args, type: 'contentSize' });
+      const handler = registrationRef.current?.props.onContentSizeChange;
+      if (handler) {
+        handler(...args);
+      }
+    },
+    [],
+  );
+  const onLayout = useCallback((...args: Parameters<NativeScrollProps['onLayout']>) => {
+    recordLatestEvent(latestEventsRef.current, { args, type: 'layout' });
+    const handler = registrationRef.current?.props.onLayout;
+    if (handler) {
+      handler(...args);
+    }
+  }, []);
+  const onScroll = useCallback((...args: Parameters<NativeScrollProps['onScroll']>) => {
+    recordLatestEvent(latestEventsRef.current, { args, type: 'scroll' });
+    const handler = registrationRef.current?.props.onScroll;
+    if (handler) {
+      handler(...args);
+    }
+  }, []);
+  const register = useCallback<Register>((registration) => {
+    registrationRef.current = registration;
+    for (const event of latestEventsRef.current) {
+      if (event.type === 'contentSize') {
+        registration.props.onContentSizeChange(...event.args);
+      } else if (event.type === 'layout') {
+        registration.props.onLayout(...event.args);
+      } else {
+        registration.props.onScroll(...event.args);
+      }
+    }
+    return () => {
+      if (registrationRef.current?.id === registration.id) {
+        registrationRef.current = null;
+      }
+    };
+  }, []);
+  const nativeScrollProps =
+    Platform.OS === 'web'
+      ? {}
+      : { onContentSizeChange, onLayout, onScroll, scrollEventThrottle: 16 as const };
+
+  return (
+    <PaginationScrollContext.Provider value={register}>
+      <ScrollView {...props} {...nativeScrollProps}>
+        {children}
+      </ScrollView>
+    </PaginationScrollContext.Provider>
+  );
+}
+
+export function usePaginationScrollRegistration(props: NativeScrollProps) {
+  const register = useContext(PaginationScrollContext);
+  const id = useRef(Symbol('pagination-scroll-registration'));
+
+  useEffect(() => {
+    if (!register || Platform.OS === 'web') {
+      return;
+    }
+
+    return register({ id: id.current, props });
+  }, [props, register]);
+}

--- a/apps/app/src/components/post/PostList.tsx
+++ b/apps/app/src/components/post/PostList.tsx
@@ -1,21 +1,29 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { graphql, useFragment } from 'react-relay';
+import { useEffect, useRef } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { graphql, usePaginationFragment } from 'react-relay';
+import { usePaginationScrollRegistration } from '@/components/pagination/PaginationScrollView';
+import { useAutomaticPagination } from '@/components/pagination/useAutomaticPagination';
 import { Button } from '@/components/ui/Button';
 import { Skeleton } from '@/components/ui/StateView';
+import { useToast } from '@/components/ui/ToastProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
 import { PostActionAuthenticationProvider } from './PostActionAuthentication';
 import { PostListItem } from './PostListItem';
 import { PostMediaViewerHostProvider } from './PostMediaViewerHost';
 import { PostReplyCoordinatorProvider } from './PostReplyCoordinator';
-import type { PostList_homeTimeline$key } from './__generated__/PostList_homeTimeline.graphql';
+import type { PostList_home$key } from './__generated__/PostList_home.graphql';
 import type { PostList_profile$key } from './__generated__/PostList_profile.graphql';
+import type { PostListHomeNextPageQuery } from './__generated__/PostListHomeNextPageQuery.graphql';
+import type { PostListProfileNextPageQuery } from './__generated__/PostListProfileNextPageQuery.graphql';
 import type { ReplyComposerSurface_profile$key } from './__generated__/ReplyComposerSurface_profile.graphql';
 
 const PostListProfileFragment = graphql`
-  fragment PostList_profile on Profile {
+  fragment PostList_profile on Profile
+  @argumentDefinitions(count: { type: "Int", defaultValue: 20 }, cursor: { type: "String" })
+  @refetchable(queryName: "PostListProfileNextPageQuery") {
     id
-    posts(first: 20) {
+    posts(first: $count, after: $cursor) @connection(key: "PostList_profile__posts") {
       edges {
         cursor
         node {
@@ -27,13 +35,17 @@ const PostListProfileFragment = graphql`
   }
 `;
 
-const PostListHomeTimelineFragment = graphql`
-  fragment PostList_homeTimeline on PostConnection {
-    edges {
-      cursor
-      node {
-        id
-        ...PostListItem_post
+const PostListHomeFragment = graphql`
+  fragment PostList_home on Query
+  @argumentDefinitions(count: { type: "Int", defaultValue: 20 }, cursor: { type: "String" })
+  @refetchable(queryName: "PostListHomeNextPageQuery") {
+    homeTimeline(first: $count, after: $cursor) @connection(key: "PostList_homeTimeline") {
+      edges {
+        cursor
+        node {
+          id
+          ...PostListItem_post
+        }
       }
     }
   }
@@ -41,7 +53,7 @@ const PostListHomeTimelineFragment = graphql`
 
 type Props = {
   error?: boolean;
-  homeTimeline?: PostList_homeTimeline$key | null;
+  home?: PostList_home$key | null;
   loading?: boolean;
   onRetry?: () => void;
   profile?: PostList_profile$key | null;
@@ -50,20 +62,62 @@ type Props = {
 
 export function PostList({
   error = false,
-  homeTimeline: timelineKey,
+  home: homeKey,
   loading = false,
   onRetry,
   profile: profileKey,
   replyProfile,
 }: Props) {
-  const profile = useFragment(PostListProfileFragment, profileKey ?? null);
-  const timeline = useFragment(PostListHomeTimelineFragment, timelineKey ?? null);
-  const edges = timeline?.edges ?? profile?.posts.edges ?? [];
+  const homePagination = usePaginationFragment<PostListHomeNextPageQuery, PostList_home$key>(
+    PostListHomeFragment,
+    homeKey ?? null,
+  );
+  const profilePagination = usePaginationFragment<
+    PostListProfileNextPageQuery,
+    PostList_profile$key
+  >(PostListProfileFragment, profileKey ?? null);
+  const isHome = homeKey != null;
+  const home = homePagination.data;
+  const profile = profilePagination.data;
+  const connection = isHome ? home?.homeTimeline : profile?.posts;
+  const edges = connection?.edges ?? [];
   // A successful delete can remove the node record before Relay prunes an
   // unhandled connection edge. Treat that stale edge as empty until the next
   // server payload instead of passing a missing fragment ref to PostListItem.
   const visibleEdges = edges.filter((edge) => edge.node != null);
-  const hasData = Boolean(timeline || profile);
+  const hasData = Boolean(home || profile);
+  const hasNext = isHome ? homePagination.hasNext : profilePagination.hasNext;
+  const isLoadingNext = isHome ? homePagination.isLoadingNext : profilePagination.isLoadingNext;
+  const loadNext = isHome ? homePagination.loadNext : profilePagination.loadNext;
+  const { loadError, loadNextPage, nativeScrollProps } = useAutomaticPagination({
+    hasNext,
+    isLoadingNext,
+    itemCount: visibleEdges.length,
+    loadNext,
+    pageSize: 20,
+  });
+  const { showToast } = useToast();
+  const loadErrorToastCleanup = useRef<(() => void) | null>(null);
+  usePaginationScrollRegistration(nativeScrollProps);
+
+  useEffect(() => {
+    if (loadError && !loadErrorToastCleanup.current) {
+      loadErrorToastCleanup.current = showToast('게시글을 더 불러오지 못했어요.', {
+        action: { label: '다시 시도', onPress: loadNextPage },
+      });
+    } else if (!loadError && loadErrorToastCleanup.current) {
+      loadErrorToastCleanup.current();
+      loadErrorToastCleanup.current = null;
+    }
+  }, [loadError, loadNextPage, showToast]);
+
+  useEffect(
+    () => () => {
+      loadErrorToastCleanup.current?.();
+      loadErrorToastCleanup.current = null;
+    },
+    [],
+  );
 
   if (loading && !hasData) {
     return <PostListSkeleton />;
@@ -97,6 +151,14 @@ export function PostList({
             {visibleEdges.map((edge) => (
               <PostListItem key={edge.node.id} post={edge.node} />
             ))}
+            {isLoadingNext ? (
+              <View style={styles.loadingNext}>
+                <ActivityIndicator accessibilityLabel="게시글을 더 불러오는 중" />
+                <Text accessibilityLiveRegion="polite" style={styles.srOnly}>
+                  게시글을 더 불러오는 중입니다.
+                </Text>
+              </View>
+            ) : null}
           </View>
         </PostMediaViewerHostProvider>
       </PostReplyCoordinatorProvider>
@@ -166,6 +228,7 @@ function PostListState({
 }
 
 const styles = StyleSheet.create({
+  loadingNext: { alignItems: 'center', padding: spacing.lg },
   root: { width: '100%' },
   skeletonItem: {
     alignItems: 'flex-start',

--- a/apps/app/src/components/profile/ProfileRoute.test.ts
+++ b/apps/app/src/components/profile/ProfileRoute.test.ts
@@ -55,6 +55,7 @@ mockModule('expo-router', {
       : null,
   useGlobalSearchParams: () => globalParams,
   useLocalSearchParams: () => useContext(LocalParamsContext),
+  usePathname: () => `/profile/${String(globalParams.profileHandle ?? '')}`,
 });
 mockModule('react-native', {
   Platform: { OS: 'web' },

--- a/apps/app/src/components/ui/ToastProvider.tsx
+++ b/apps/app/src/components/ui/ToastProvider.tsx
@@ -9,7 +9,7 @@ import type { ViewStyle } from 'react-native';
 const toastDurationMs = 3000;
 
 type ToastContextValue = Readonly<{
-  showToast: (message: string, options?: ToastOptions) => void;
+  showToast: (message: string, options?: ToastOptions) => () => void;
 }>;
 
 const ToastContext = createContext<ToastContextValue | null>(null);
@@ -29,6 +29,7 @@ type Toast = Readonly<{
 
 export function ToastProvider({ children }: PropsWithChildren): ReactNode {
   const [toast, setToast] = useState<Toast | null>(null);
+  const activeToastId = useRef<number | null>(null);
   const nextToastId = useRef(0);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const theme = useTheme();
@@ -37,24 +38,38 @@ export function ToastProvider({ children }: PropsWithChildren): ReactNode {
   const hasBottomTabBar = Platform.OS !== 'web' || width < breakpoints.compact;
   const bottom = insets.bottom + (hasBottomTabBar ? 56 : 0) + spacing.sm;
 
-  const dismissToast = useCallback(() => {
+  const dismissToast = useCallback((id?: number) => {
+    if (id !== undefined && activeToastId.current !== id) {
+      return;
+    }
     if (timer.current) {
       clearTimeout(timer.current);
       timer.current = null;
     }
+    activeToastId.current = null;
     setToast(null);
   }, []);
 
-  const showToast = useCallback((nextMessage: string, options?: ToastOptions) => {
-    if (timer.current) {
-      clearTimeout(timer.current);
-    }
-    setToast({ action: options?.action, id: nextToastId.current++, message: nextMessage });
-    timer.current = setTimeout(() => {
-      setToast(null);
-      timer.current = null;
-    }, toastDurationMs);
-  }, []);
+  const showToast = useCallback(
+    (nextMessage: string, options?: ToastOptions) => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+      const id = nextToastId.current++;
+      activeToastId.current = id;
+      setToast({ action: options?.action, id, message: nextMessage });
+      timer.current = setTimeout(() => {
+        if (activeToastId.current !== id) {
+          return;
+        }
+        activeToastId.current = null;
+        setToast(null);
+        timer.current = null;
+      }, toastDurationMs);
+      return () => dismissToast(id);
+    },
+    [dismissToast],
+  );
 
   useEffect(
     () => () => {
@@ -83,7 +98,7 @@ export function ToastProvider({ children }: PropsWithChildren): ReactNode {
                 hitSlop={spacing.sm}
                 onPress={() => {
                   const action = toast.action;
-                  dismissToast();
+                  dismissToast(toast.id);
                   action?.onPress();
                 }}
                 style={styles.action}

--- a/apps/app/src/stories/Home.stories.tsx
+++ b/apps/app/src/stories/Home.stories.tsx
@@ -2,9 +2,13 @@ import { expect, spyOn, within } from 'storybook/test';
 import HomeScreen from '@/app/(tabs)/(protected)/home';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+const emptyHomeTimeline = {
+  edges: [],
+  pageInfo: { endCursor: null, hasNextPage: false },
+};
 const selectedProfileData = {
   currentSession: { id: 'home-session', selectedProfile: { id: 'home-profile' } },
-  homeTimeline: { edges: [] },
+  homeTimeline: emptyHomeTimeline,
   me: { id: 'home-account', name: 'home-account', profiles: [{ id: 'home-profile' }] },
 };
 
@@ -53,7 +57,7 @@ export const OnboardingCompact: Story = {
         HomePageQuery: {
           data: {
             currentSession: { id: 'home-session', selectedProfile: null },
-            homeTimeline: { edges: [] },
+            homeTimeline: emptyHomeTimeline,
             me: { id: 'home-account', name: 'home-account', profiles: [] },
           },
         },

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -870,6 +870,58 @@ const homeTimeline = timeline(
     linkedSourceQuote,
   ].map(withReactionViewerState),
 );
+const paginationHomeInitialPost = withReactionViewerState(
+  post({ bodyText: 'Home 첫 page 게시글', id: 'post-pagination-home-initial' }),
+);
+const paginationHomeNextPost = withReactionViewerState(
+  post({ bodyText: 'Home 다음 page 게시글', id: 'post-pagination-home-next' }),
+);
+const paginationHomeCreatedPost = withReactionViewerState(
+  post({ bodyText: 'Home에 새로 작성한 게시글', id: 'post-pagination-home-created' }),
+);
+const paginationProfileInitialPost = withReactionViewerState(
+  post({ bodyText: 'Profile 첫 page 게시글', id: 'post-pagination-profile-initial' }),
+);
+const paginationProfileNextPost = withReactionViewerState(
+  post({ bodyText: 'Profile 다음 page 게시글', id: 'post-pagination-profile-next' }),
+);
+
+function paginatedTimeline(storyPost: StoryPost, hasNextPage: boolean) {
+  const connection = timeline(storyPost);
+  return {
+    ...connection,
+    pageInfo: {
+      ...connection.pageInfo,
+      endCursor: hasNextPage ? storyPost.id : null,
+      hasNextPage,
+      startCursor: storyPost.id,
+    },
+  };
+}
+
+const paginationHomeTimeline = paginatedTimeline(paginationHomeInitialPost, true);
+const paginationProfile = {
+  ...profileWithPosts([paginationProfileInitialPost], { id: 'profile-posts-content' }),
+  posts: paginatedTimeline(paginationProfileInitialPost, true),
+};
+const paginationHomeNextPageResponse = {
+  data: { homeTimeline: paginatedTimeline(paginationHomeNextPost, false) },
+};
+const paginationProfileNextPageResponse = {
+  data: {
+    node: {
+      __typename: 'Profile',
+      id: paginationProfile.id,
+      posts: paginatedTimeline(paginationProfileNextPost, false),
+    },
+  },
+};
+const homeAppendPaginationRequestObserver = fn();
+const profileAppendPaginationRequestObserver = fn();
+const homeRetryPaginationRequestObserver = fn();
+const homeLoadingPaginationRequestObserver = fn();
+const homeIdentityPaginationRequestObserver = fn();
+const homePrependPaginationRequestObserver = fn();
 const deletionHomeTimeline = timeline(withReactionViewerState(shortPost));
 
 const PostsStoriesQuery = graphql`
@@ -919,30 +971,19 @@ const PostsStoriesQuery = graphql`
         ...PostList_profile @alias(as: "postList")
       }
     }
-    homeTimeline(first: 20) @connection(key: "PostList_homeTimeline") {
-      edges {
-        cursor
-        node {
-          id
-          ...PostListItem_post
-        }
-      }
-      ...PostList_homeTimeline
-    }
+    ...PostList_home @arguments(count: 20) @alias(as: "home")
   }
 `;
 
 const PostDeletionListEdgeSafetyQuery = graphql`
   query PostDeletionListEdgeSafetyQuery {
+    ...PostList_home @arguments(count: 1) @alias(as: "home")
     deletionProfile: node(id: "profile-posts-deletion") {
       __typename
       ... on Profile {
         id
         ...PostList_profile @alias(as: "postList")
       }
-    }
-    deletionHomeTimeline: homeTimeline(first: 1) {
-      ...PostList_homeTimeline
     }
   }
 `;
@@ -983,7 +1024,7 @@ function usePostsStoryData() {
     data.composerProfile?.__typename !== 'Profile' ||
     data.contentPostsProfile?.__typename !== 'Profile' ||
     data.emptyPostsProfile?.__typename !== 'Profile' ||
-    !data.homeTimeline
+    !data.home
   ) {
     throw new Error('PostsStoriesQuery must return a home timeline fixture.');
   }
@@ -1000,7 +1041,7 @@ function usePostsStoryData() {
     ),
     contentPostsProfile: requireFragment(data.contentPostsProfile.postList, 'content post list'),
     emptyPostsProfile: requireFragment(data.emptyPostsProfile.postList, 'empty post list'),
-    homeTimeline: data.homeTimeline,
+    home: requireFragment(data.home, 'home post list'),
     posts,
   };
 }
@@ -1281,7 +1322,7 @@ function PostListCatalog({ onRetry }: PostsStoryArgs) {
         <PostList profile={data.contentPostsProfile} />
       </Section>
       <Section title="Home timeline content">
-        <PostList homeTimeline={data.homeTimeline} />
+        <PostList home={data.home} />
       </Section>
     </Catalog>
   );
@@ -1294,7 +1335,7 @@ function ProductionRepostQuoteLists() {
     <Catalog>
       <StoryPathname testID="current-story-pathname" />
       <View testID="production-home-reposts">
-        <PostList homeTimeline={data.homeTimeline} />
+        <PostList home={data.home} />
       </View>
       <View testID="production-profile-reposts">
         <PostList profile={data.contentPostsProfile} />
@@ -1303,12 +1344,56 @@ function ProductionRepostQuoteLists() {
   );
 }
 
+function HomePostListPaginationStory() {
+  return <PostList home={usePostsStoryData().home} />;
+}
+
+function ProfilePostListPaginationStory() {
+  return <PostList profile={usePostsStoryData().contentPostsProfile} />;
+}
+
+function HomePostComposerPaginationStory() {
+  const data = usePostsStoryData();
+
+  return (
+    <>
+      <PostComposer profile={data.composerProfile} />
+      <PostList home={data.home} />
+    </>
+  );
+}
+
+function HomePostListPaginationIdentityStory() {
+  const [identity, setIdentity] = useState<'actor-a' | 'actor-b'>('actor-a');
+  const data = usePostsStoryData();
+
+  return (
+    <>
+      <Pressable accessibilityRole="button" onPress={() => setIdentity('actor-b')}>
+        <Text>다른 actor로 전환</Text>
+      </Pressable>
+      {identity === 'actor-a' ? (
+        <PostList home={data.home} key={identity} />
+      ) : (
+        <PostList key={identity} loading />
+      )}
+    </>
+  );
+}
+
+function scrollStoryToEnd(canvasElement: HTMLElement) {
+  const storyWindow = canvasElement.ownerDocument.defaultView!;
+  storyWindow.scrollTo(0, storyWindow.document.documentElement.scrollHeight);
+  storyWindow.dispatchEvent(new Event('scroll'));
+  return storyWindow;
+}
+
 function PostDeletionListEdgeSafety() {
   const data = useLazyLoadQuery<PostDeletionListEdgeSafetyQueryType>(
     PostDeletionListEdgeSafetyQuery,
     {},
   );
-  if (data.deletionProfile?.__typename !== 'Profile' || !data.deletionHomeTimeline) {
+  if (data.deletionProfile?.__typename !== 'Profile' || !data.home) {
     throw new Error('PostDeletionListEdgeSafetyQuery must return both list fixtures.');
   }
 
@@ -1316,7 +1401,7 @@ function PostDeletionListEdgeSafety() {
     <SessionProvider>
       <Catalog>
         <View testID="post-deletion-home-list">
-          <PostList homeTimeline={data.deletionHomeTimeline} />
+          <PostList home={requireFragment(data.home, 'deletion home list')} />
         </View>
         <View testID="post-deletion-profile-list">
           <PostList
@@ -1439,7 +1524,7 @@ function ProductionReactionMutationSurfaces() {
   return (
     <Catalog>
       <View testID="production-home-reposts">
-        <PostList homeTimeline={data.homeTimeline} />
+        <PostList home={data.home} />
       </View>
       <View testID="production-profile-reposts">
         <PostList profile={data.contentPostsProfile} />
@@ -1951,7 +2036,7 @@ function ReplyListSurfaceStory() {
   return (
     <Catalog>
       <StoryPathname testID="reply-success-pathname" />
-      <PostList homeTimeline={data.homeTimeline} replyProfile={data.replyComposerProfile} />
+      <PostList home={data.home} replyProfile={data.replyComposerProfile} />
     </Catalog>
   );
 }
@@ -2676,7 +2761,13 @@ const deletionOwnerSession = shellQuery();
 const deletionOwnerRelayData = {
   ...postsStoryRelayData,
   currentSession: deletionOwnerSession.currentSession,
+  homeTimeline: deletionHomeTimeline,
   me: deletionOwnerSession.me,
+};
+const postListPaginationRelayData = {
+  ...postsStoryRelayData,
+  contentPostsProfile: paginationProfile,
+  homeTimeline: paginationHomeTimeline,
 };
 
 const meta = {
@@ -2961,6 +3052,165 @@ export const ListLoadingErrorEmptyAndContent: Story = {
     await expect(args.onRetry).toHaveBeenCalledTimes(1);
   },
   render: (args) => <PostListCatalog onRetry={args.onRetry} />,
+};
+
+export const HomePostListAutomaticallyLoadsNextPageOnce: Story = {
+  parameters: {
+    relay: {
+      data: postListPaginationRelayData,
+      paginationRequestObserver: homeAppendPaginationRequestObserver,
+      paginationResponses: [paginationHomeNextPageResponse],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const storyWindow = scrollStoryToEnd(canvasElement);
+
+    await expect(canvas.findByText('Home 다음 page 게시글')).resolves.toBeVisible();
+    expect(canvas.getByText('Home 첫 page 게시글')).toBeVisible();
+    expect(homeAppendPaginationRequestObserver).toHaveBeenCalledOnce();
+    expect(homeAppendPaginationRequestObserver).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'PostListHomeNextPageQuery' }),
+      expect.objectContaining({ count: 20, cursor: paginationHomeInitialPost.id }),
+    );
+
+    storyWindow.dispatchEvent(new Event('scroll'));
+    storyWindow.dispatchEvent(new Event('resize'));
+    await waitFor(() => expect(homeAppendPaginationRequestObserver).toHaveBeenCalledOnce());
+    storyWindow.scrollTo(0, 0);
+  },
+  render: () => <HomePostListPaginationStory />,
+};
+
+export const ProfilePostListAutomaticallyLoadsNextPage: Story = {
+  parameters: {
+    relay: {
+      data: postListPaginationRelayData,
+      paginationRequestObserver: profileAppendPaginationRequestObserver,
+      paginationResponses: [paginationProfileNextPageResponse],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const storyWindow = scrollStoryToEnd(canvasElement);
+
+    await expect(canvas.findByText('Profile 다음 page 게시글')).resolves.toBeVisible();
+    expect(canvas.getByText('Profile 첫 page 게시글')).toBeVisible();
+    expect(profileAppendPaginationRequestObserver).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'PostListProfileNextPageQuery' }),
+      expect.objectContaining({ count: 20, cursor: paginationProfileInitialPost.id }),
+    );
+    storyWindow.scrollTo(0, 0);
+  },
+  render: () => <ProfilePostListPaginationStory />,
+};
+
+export const HomePostListPageFailureRequiresManualRetry: Story = {
+  parameters: {
+    relay: {
+      data: postListPaginationRelayData,
+      paginationRequestObserver: homeRetryPaginationRequestObserver,
+      paginationResponses: [{ error: 'Home 다음 page 실패' }, paginationHomeNextPageResponse],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const storyWindow = scrollStoryToEnd(canvasElement);
+
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
+      '게시글을 더 불러오지 못했어요.',
+    );
+    expect(canvas.getByText('Home 첫 page 게시글')).toBeVisible();
+    storyWindow.dispatchEvent(new Event('scroll'));
+    expect(homeRetryPaginationRequestObserver).toHaveBeenCalledOnce();
+
+    await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
+    await expect(canvas.findByText('Home 다음 page 게시글')).resolves.toBeVisible();
+    expect(homeRetryPaginationRequestObserver).toHaveBeenCalledTimes(2);
+    storyWindow.scrollTo(0, 0);
+  },
+  render: () => <HomePostListPaginationStory />,
+};
+
+export const HomePostListPageLoadingPreservesRows: Story = {
+  parameters: {
+    relay: {
+      data: postListPaginationRelayData,
+      paginationLoading: true,
+      paginationRequestObserver: homeLoadingPaginationRequestObserver,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const storyWindow = scrollStoryToEnd(canvasElement);
+
+    const loadingText = await canvas.findByText('게시글을 더 불러오는 중입니다.');
+    expect(loadingText).toHaveAttribute('aria-live', 'polite');
+    expect(canvas.getByText('Home 첫 page 게시글')).toBeVisible();
+    expect(homeLoadingPaginationRequestObserver).toHaveBeenCalledOnce();
+    storyWindow.scrollTo(0, 0);
+  },
+  render: () => <HomePostListPaginationStory />,
+};
+
+export const HomePostListPageFailureClearsOnIdentityChange: Story = {
+  parameters: {
+    relay: {
+      data: postListPaginationRelayData,
+      paginationRequestObserver: homeIdentityPaginationRequestObserver,
+      paginationResponses: [{ error: '이전 actor Home 다음 page 실패' }],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const storyWindow = scrollStoryToEnd(canvasElement);
+
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
+      '게시글을 더 불러오지 못했어요.',
+    );
+    await userEvent.click(canvas.getByRole('button', { name: '다른 actor로 전환' }));
+    await waitFor(() => expect(canvas.queryByRole('alert')).not.toBeInTheDocument());
+    expect(homeIdentityPaginationRequestObserver).toHaveBeenCalledOnce();
+    storyWindow.scrollTo(0, 0);
+  },
+  render: () => <HomePostListPaginationIdentityStory />,
+};
+
+export const HomePostPrependAndPaginationShareConnection: Story = {
+  parameters: {
+    relay: {
+      data: postListPaginationRelayData,
+      mutationResponse: { createPost: { post: paginationHomeCreatedPost } },
+      paginationRequestObserver: homePrependPaginationRequestObserver,
+      paginationResponses: [paginationHomeNextPageResponse],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(
+      canvas.getByRole('textbox', { name: '게시글 본문' }),
+      'Home에 새로 작성한 게시글',
+    );
+    await userEvent.click(canvas.getByRole('button', { name: '게시' }));
+    await expect(canvas.findByText('Home에 새로 작성한 게시글')).resolves.toBeVisible();
+
+    const storyWindow = scrollStoryToEnd(canvasElement);
+    await expect(canvas.findByText('Home 다음 page 게시글')).resolves.toBeVisible();
+
+    expect(canvas.getAllByText('Home에 새로 작성한 게시글')).toHaveLength(1);
+    expect(canvas.getAllByText('Home 첫 page 게시글')).toHaveLength(1);
+    expect(canvas.getAllByText('Home 다음 page 게시글')).toHaveLength(1);
+    const rows = canvas.getAllByRole('article').map((row) => row.textContent ?? '');
+    expect(rows.findIndex((row) => row.includes('Home에 새로 작성한 게시글'))).toBeLessThan(
+      rows.findIndex((row) => row.includes('Home 첫 page 게시글')),
+    );
+    expect(rows.findIndex((row) => row.includes('Home 첫 page 게시글'))).toBeLessThan(
+      rows.findIndex((row) => row.includes('Home 다음 page 게시글')),
+    );
+    expect(homePrependPaginationRequestObserver).toHaveBeenCalledOnce();
+    storyWindow.scrollTo(0, 0);
+  },
+  render: () => <HomePostComposerPaginationStory />,
 };
 
 export const ProductionRepostQuoteListIntegration: Story = {

--- a/apps/app/src/stories/ToastProvider.stories.tsx
+++ b/apps/app/src/stories/ToastProvider.stories.tsx
@@ -1,5 +1,6 @@
+import { useRef } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { ToastProvider, useToast } from '@/components/ui/ToastProvider';
 import { spacing } from '@/theme/tokens';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -24,6 +25,34 @@ function ToastFixture() {
         style={styles.button}
       >
         <Text>취소 실패 표시</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const scopedRetry = fn();
+
+function ScopedToastFixture() {
+  const { showToast } = useToast();
+  const cleanup = useRef<() => void>(() => undefined);
+
+  return (
+    <View style={styles.fixture}>
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => {
+          cleanup.current = showToast('이전 목록 오류', {
+            action: { label: '다시 시도', onPress: scopedRetry },
+          });
+        }}
+      >
+        <Text>목록 오류 표시</Text>
+      </Pressable>
+      <Pressable accessibilityRole="button" onPress={() => showToast('최신 알림')}>
+        <Text>최신 알림 표시</Text>
+      </Pressable>
+      <Pressable accessibilityRole="button" onPress={() => cleanup.current()}>
+        <Text>이전 목록 정리</Text>
       </Pressable>
     </View>
   );
@@ -108,6 +137,30 @@ export const RepeatedMessageRestartsAutoDismiss: Story = {
       timeout: 1500,
     });
     expect(Date.now() - secondShownAt).toBeGreaterThanOrEqual(toastDurationMs - 100);
+  },
+};
+
+export const ScopedCleanupDoesNotDismissNewerToast: Story = {
+  render: () => (
+    <ToastProvider>
+      <ScopedToastFixture />
+    </ToastProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    scopedRetry.mockClear();
+
+    await userEvent.click(canvas.getByRole('button', { name: '목록 오류 표시' }));
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent('이전 목록 오류');
+    await userEvent.click(canvas.getByRole('button', { name: '이전 목록 정리' }));
+    expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: '목록 오류 표시' }));
+    await userEvent.click(canvas.getByRole('button', { name: '최신 알림 표시' }));
+    expect(canvas.getByRole('alert')).toHaveTextContent('최신 알림');
+    await userEvent.click(canvas.getByRole('button', { name: '이전 목록 정리' }));
+    expect(canvas.getByRole('alert')).toHaveTextContent('최신 알림');
+    expect(scopedRetry).not.toHaveBeenCalled();
   },
 };
 

--- a/openspec/changes/add-home-profile-post-infinite-scroll/.openspec.yaml
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-10

--- a/openspec/changes/add-home-profile-post-infinite-scroll/decisions.md
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/decisions.md
@@ -1,0 +1,49 @@
+## Context
+
+이 기록은 PROD-646의 Home/Profile 무한 스크롤 계약, 완료된 PROD-662 공통 lifecycle, PROD-641 Home prepend와 현재 Relay·scroll owner 구조를 반영한다. 제품 동작은 canonical 문서와 최신 Linear 본문에서 파생하고, 구현 선택은 그 범위를 넘지 않는다.
+
+## Decision Records
+
+### Home과 Profile pagination owner를 분리하고 Home connection identity를 유지한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `PROD-641`, `PROD-646`
+- Status: Active
+- Context / Problem: Home은 Query root의 `homeTimeline`을, Profile은 Profile identity의 `posts`를 소비하며 새 Post prepend는 현재 Home managed connection을 대상으로 한다. 두 목록을 같은 owner나 key로 합치거나 Home key를 바꾸면 actor·Profile 격리와 prepend 정합성이 깨진다.
+- Decision Outcome: Home과 Profile은 각자 refetchable Relay pagination owner와 connection identity를 유지한다. Home pagination은 기존 prepend가 사용하는 Home connection identity를 그대로 사용하고, edge·cursor·정렬·중복 제거는 Relay에 맡긴다.
+- Alternatives Considered: 하나의 공용 Post connection, route state의 edge 수동 병합, 새 Home connection key는 owner와 cache lifecycle을 혼합하거나 기존 prepend 대상을 분리하므로 선택하지 않는다.
+- Consequences: 같은 Post item presentation을 공유해도 pagination fragment와 owner는 명시적으로 구분한다. Home prepend 후 next page를 불러오는 회귀를 검증해야 한다.
+- Confirmation / Follow-up: Relay artifact와 집중 검증에서 Home key, Profile identity별 connection, prepend 후 append 순서·중복을 확인한다.
+
+### Relay pagination과 완료된 공통 자동 lifecycle을 조합한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `PROD-646`, `PROD-662`
+- Status: Active
+- Context / Problem: Relay는 connection 누적과 `loadNext`를 소유하고, PROD-662의 공통 hook은 Web·Native near-end, in-flight guard, 성공 후 재측정과 실패 후 수동 retry를 이미 검증했다. Home/Profile에서 둘 중 하나를 다시 구현하면 중복 state와 race가 생긴다.
+- Decision Outcome: 각 surface의 `usePaginationFragment` 결과를 기존 `useAutomaticPagination`에 전달한다. 클라이언트는 cursor나 edge를 합성하지 않고 공통 hook 바깥에 별도 자동 retry·near-end guard를 만들지 않는다.
+- Alternatives Considered: Home/Profile별 lifecycle 복제, route-level cursor state, 범용 paginated-list framework는 완료된 공통 경계를 우회하거나 승인 범위보다 큰 추상화를 추가하므로 선택하지 않는다.
+- Consequences: 공통 hook 자체의 기존 unit 검증은 재사용하고 PROD-646에서는 두 surface의 연결, feedback와 identity reset을 집중 검증한다.
+- Confirmation / Follow-up: `loadNext(20)`, 중복 요청 차단, 짧은 page 재측정, 실패 뒤 manual retry와 마지막 page 종료를 관찰 가능한 결과로 확인한다.
+
+### 기존 scroll owner를 유지하고 Native metric만 좁게 등록한다
+
+- Decision Date: 2026-08-10
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/design/accessibility.md`, `PROD-646`
+- Status: Active
+- Context / Problem: Home frame과 Profile layout이 header·hero를 포함한 실제 Native ScrollView를 소유하지만 pagination data는 하위 Post 목록이 읽는다. 하위 목록에 ScrollView를 새로 만들면 중첩 scroll과 잘못된 near-end metric이 생긴다.
+- Decision Outcome: 기존 Home/Profile scroll owner를 유지하고 Post 목록의 공통 hook이 반환한 Native metric handler만 route 범위의 좁은 registration boundary로 전달한다. Web은 현재 document scroll을 사용한다.
+- Alternatives Considered: 중첩 ScrollView, 앱 전역 scroll registry, Post 목록 View의 scroll event 의존은 기존 layout을 바꾸거나 실제 owner metric을 제공하지 못하므로 선택하지 않는다.
+- Consequences: 작은 owner-child registration seam과 unmount cleanup이 필요하다. 다른 route의 scroll·refresh 동작은 이 seam에 포함하지 않는다.
+- Confirmation / Follow-up: Home/Profile owner에 handler가 연결되고 route/actor 전환 뒤 해제되는지 source test와 실행 가능한 runtime에서 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-home-profile-post-infinite-scroll/design.md
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/design.md
@@ -1,0 +1,78 @@
+## Context
+
+GraphQL의 `homeTimeline`과 `Profile.posts`는 이미 cursor와 `pageInfo`를 제공하는 `PostConnection`이지만, 현재 앱은 두 목록 모두 첫 20개만 렌더한다. Home은 root-scoped `PostList_homeTimeline` Relay connection을 사용하고 새 Post mutation도 같은 connection ID에 prepend한다. Profile 목록은 Profile fragment에서 `posts(first: 20)`만 읽고 pagination owner가 없다.
+
+PROD-662에서 `useAutomaticPagination`이 Web document/container와 Native scroll metric, in-flight guard, 성공 후 재측정, 실패 후 수동 retry lifecycle을 공통화했다. 이 change는 그 lifecycle을 수정하거나 복제하지 않고 Home/Profile Relay pagination과 사용자 feedback를 연결한다.
+
+Home의 ScrollView는 Home frame이, Profile의 Native ScrollView는 Profile layout이 소유한다. 실제 pagination data를 읽는 Post 목록은 그 아래에 있으므로, 내부에 새 ScrollView를 만들면 기존 header·hero·scroll position과 Native metric이 분리된다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Home과 Profile에 서로 독립적인 20개 단위 Relay pagination을 연결한다.
+- 두 surface가 완료된 공통 자동 pagination lifecycle과 기존 feedback·theme component를 재사용한다.
+- 다음-page loading·failure·retry 동안 기존 게시글과 scroll position을 유지한다.
+- Profile handle·actor revision과 Home actor 전환 시 pagination UI state를 격리한다.
+- Home prepend connection identity와 pagination ordering을 유지한다.
+
+**Non-Goals:**
+
+- GraphQL schema·resolver, Post visibility·eligibility·ordering 또는 cursor 정책 변경
+- 공개·추천·Local Timeline과 Subscription runtime 통합
+- Home 재선택 scroll-top·refresh 동작
+- 범용 connection-list framework나 pagination hook 재설계
+- 실제 Android·iOS 기기 검증을 Web 자동화로 대체하는 것
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Home root query와 Profile identity는 같은 Post item을 렌더해도 Relay pagination owner가 다르므로 하나의 connection으로 합칠 수 없다.
+- Profile fragment는 `@argumentDefinitions`, `@refetchable`, `@connection`과 `pageInfo`가 없고 Home source fragment도 compiler가 생성한 metadata를 pagination data로 소비하지 않는다.
+- Home prepend updater는 `PostList_homeTimeline` connection key에 의존하므로 key를 바꾸면 새 Post와 다음 page가 서로 다른 managed connection에 반영된다.
+- 공통 hook의 Native 결과는 실제 ScrollView의 `onLayout`, `onContentSizeChange`, `onScroll`에 연결돼야 한다. Post 목록 내부 View에 붙이거나 중첩 ScrollView를 추가하면 올바른 metric을 얻지 못한다.
+- 다음-page 실패는 초기 query error boundary와 다르다. 기존 edge를 유지한 채 공통 hook의 error 상태와 toast action으로 복구해야 한다.
+
+### Recommended Approach
+
+Home root와 Profile 각각에 refetchable pagination fragment를 두고 `usePaginationFragment`가 해당 connection의 edge, `hasNext`, `isLoadingNext`, `loadNext`를 소유하게 한다. 공통 Post item presentation은 유지하되 surface 선택에 따라 서로 다른 fragment owner를 명시적으로 소비한다.
+
+Post 목록 pagination 경계에서 `useAutomaticPagination`에 현재 edge 수, page size 20과 Relay pagination 결과를 전달한다. Web은 현재 document scroll을 사용하고, Native는 좁은 registration boundary를 통해 hook이 반환한 metric handler를 기존 Home frame/Profile layout ScrollView에 전달한다. registration은 해당 목록이 unmount되면 해제하며 다른 route의 scroll 동작을 소유하지 않는다.
+
+다음 page 요청 중에는 목록 아래에 React Native 기본 spinner와 polite live status를 표시한다. 실패 전환 시 기존 `ToastProvider`에 한 번만 오류 문구와 `다시 시도` action을 전달하고, action은 공통 hook의 수동 retry를 호출한다. 초기 query loading/error/empty presentation은 그대로 유지한다.
+
+actor revision과 Profile handle을 목록 subtree identity에 반영해 owner가 바뀌면 hook의 in-flight/error state와 scroll registration을 함께 remount한다. 이전 Relay Environment에서 늦게 끝난 요청은 새 owner state에 연결하지 않는다.
+
+Relay compiler로 생성 artifact를 갱신하고, Home connection key와 Profile identity argument가 source fragment와 일치하는지 검증한다.
+
+### Allowed Alternatives
+
+- Home/Profile별 얇은 pagination wrapper를 둘 수 있고 하나의 Post 목록 controller에서 nullable owner를 선택할 수도 있다. 어느 방식이든 hooks를 조건부 호출하지 않고 두 connection identity를 분리하며 공통 lifecycle을 복제하지 않아야 한다.
+- Native handler 전달은 route nesting에 맞춘 좁은 context registration 또는 명시적 callback 전달을 사용할 수 있다. 앱 전역 scroll registry로 확장하거나 새 ScrollView를 중첩해서는 안 된다.
+
+### Known Traps
+
+- generated artifact에 `pageInfo`가 있다는 이유로 source fragment가 pagination-ready라고 판단하지 않는다.
+- Home connection key를 바꾸거나 client에서 prepend/append edge를 수동 합성하지 않는다.
+- Web document listener와 Native ScrollView handler를 같은 platform에서 중복 연결하지 않는다.
+- 실패 toast를 render마다 다시 열거나 toast dismiss를 자동 retry 신호로 사용하지 않는다.
+- 첫 page 오류 UI로 다음-page 오류를 대체해 기존 목록을 숨기지 않는다.
+
+## Risks / Trade-offs
+
+- [부모 ScrollView와 자식 pagination owner 사이에 작은 registration seam이 추가됨] → Home/Profile 두 실제 owner로 범위를 제한하고 unmount cleanup과 source test를 둔다.
+- [기존 ToastProvider action은 3초 뒤 닫힘] → 현재 승인된 toast UX와 공용 provider를 유지하고 runtime에서 action·announcement를 확인한다. 지속형 inline retry나 provider API 확장은 별도 제품 결정 없이 추가하지 않는다.
+- [Relay fragment 전환이 Home prepend identity를 깨뜨릴 수 있음] → 기존 connection key를 보존하고 prepend 후 next-page 누적을 집중 검증한다.
+- [Web 자동화가 Native metric을 완전히 증명하지 못함] → 공통 hook의 Native unit test, source mapping과 실제 실행한 runtime QA를 분리해 보고한다.
+
+## Migration Plan
+
+1. OpenSpec strict validation 뒤 client fragment와 scroll registration을 additive하게 구현한다.
+2. Relay artifact를 재생성하고 focused unit·route·Storybook/browser 검증을 수행한다.
+3. Web runtime에서 Home/Profile near-end, spinner, toast retry와 scroll 유지 동작을 확인한다.
+4. 회귀 시 client change를 되돌린다. API·DB migration이나 데이터 backfill은 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-home-profile-post-infinite-scroll/design.md
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/design.md
@@ -40,6 +40,8 @@ Home root와 Profile 각각에 refetchable pagination fragment를 두고 `usePag
 
 Post 목록 pagination 경계에서 `useAutomaticPagination`에 현재 edge 수, page size 20과 Relay pagination 결과를 전달한다. Web은 현재 document scroll을 사용하고, Native는 좁은 registration boundary를 통해 hook이 반환한 metric handler를 기존 Home frame/Profile layout ScrollView에 전달한다. registration은 해당 목록이 unmount되면 해제하며 다른 route의 scroll 동작을 소유하지 않는다.
 
+Native metric buffer는 actor와 현재 route를 함께 나타내는 pagination owner key 안에서만 재생한다. owner key가 바뀌면 이전 registration과 저장 metric을 폐기해, 새 목록이 자기 scroll metric을 내기 전에 이전 route의 near-end 상태로 다음 page를 요청하지 않게 한다.
+
 다음 page 요청 중에는 목록 아래에 React Native 기본 spinner와 polite live status를 표시한다. 실패 전환 시 기존 `ToastProvider`에 한 번만 오류 문구와 `다시 시도` action을 전달하고, action은 공통 hook의 수동 retry를 호출한다. 초기 query loading/error/empty presentation은 그대로 유지한다.
 
 actor revision과 Profile handle을 목록 subtree identity에 반영해 owner가 바뀌면 hook의 in-flight/error state와 scroll registration을 함께 remount한다. 이전 Relay Environment에서 늦게 끝난 요청은 새 owner state에 연결하지 않는다.

--- a/openspec/changes/add-home-profile-post-infinite-scroll/proposal.md
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Home과 Profile 게시글 목록은 서버가 cursor pagination을 제공하는데도 첫 20개만 소비해 이전 게시글을 탐색할 수 없다. 완료된 PROD-662의 공통 Web·Native 자동 pagination lifecycle을 재사용해 두 목록에 같은 무한 스크롤 경험을 제공한다.
+
+## What Changes
+
+- Home과 Profile이 서로 분리된 Relay pagination owner와 connection key로 게시글을 20개씩 누적한다.
+- Web·Native에서 목록 하단 near-end 도달 시 공통 자동 pagination lifecycle로 다음 page를 한 번 요청하고, 짧은 page 성공 뒤 viewport를 다시 측정한다.
+- 다음 page 로딩 중 기존 목록 아래에 spinner를 표시하고, 마지막 page에서는 추가 요청을 중단한다.
+- 다음 page 실패 시 기존 목록을 유지하고 하단 toast의 `다시 시도` action으로만 수동 재시도한다.
+- Profile handle·actor revision 또는 Home actor가 바뀌면 이전 pagination loading·error·page 상태를 재사용하지 않는다.
+- Home의 기존 `PostList_homeTimeline` connection identity를 유지해 새 Post prepend와 다음 page append가 중복이나 순서 역전 없이 함께 동작하게 한다.
+- 공개·추천·Local Timeline, GraphQL schema, Subscription transport, Home 재선택 refresh 동작은 변경하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/design/accessibility.md`
+- Linear Contract: `PROD-646`
+- Linear Implementations: `PROD-646`; 완료된 선행 공통화 `PROD-662`
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `web-app-shell`: Home과 Profile 게시글 목록의 기존 첫-page 표시 계약을 공용 Expo 클라이언트의 Web·Native cursor 무한 스크롤, 다음-page 상태, identity 격리와 Home prepend 정합성 계약으로 확장한다.
+
+## Impact
+
+- `apps/app`의 Home/Profile route, Post 목록 Relay fragment, 부모 scroll owner와 pagination feedback가 영향을 받는다.
+- Relay compiler가 Home/Profile pagination query artifact를 생성한다.
+- 기존 `useAutomaticPagination`, `ToastProvider`, theme token과 Home connection key를 재사용한다.
+- GraphQL schema·resolver, 데이터베이스·migration, 새 dependency와 ActivityPub 동작에는 영향이 없다.

--- a/openspec/changes/add-home-profile-post-infinite-scroll/specs/web-app-shell/spec.md
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/specs/web-app-shell/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: Profile post list data rendering
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `PROD-646` — 게시글 목록 영역은 프로필별 게시글 Relay connection의 첫 게시글 20개를 조회하고 각 edge의 node를 `PostListItem` fragment 계약으로 렌더해야 한다(MUST). 다음 page가 있으면 같은 Profile identity의 connection에서 cursor 이후 게시글을 20개씩 누적해야 하며(MUST), route state에서 edge·cursor·정렬을 합성하거나 다른 Profile의 connection과 병합해서는 안 된다(MUST NOT).
+
+#### Scenario: Post list items display
+
+- **WHEN** 프로필 게시글 목록 query가 첫 게시글 edge를 반환한다
+- **THEN** 시스템은 각 edge의 node를 `PostListItem`으로 렌더한다
+- **AND** 게시글 목록은 프로필 헤더 아래에 표시된다
+
+#### Scenario: Append the next Profile page
+
+- **WHEN** 같은 Profile 게시글 connection에 다음 page가 있고 사용자가 목록 하단 near-end에 도달한다
+- **THEN** 시스템은 현재 cursor 이후 게시글을 최대 20개 요청해 기존 목록 뒤에 누적한다
+- **AND** 기존 edge, 정렬과 현재 scroll position을 유지한다
+
+## ADDED Requirements
+
+### Requirement: Home post list cursor pagination
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `PROD-646` — Home 게시글 목록은 `homeTimeline` Relay connection의 첫 게시글 20개를 표시하고 다음 page가 있으면 같은 Home connection에서 cursor 이후 게시글을 20개씩 누적해야 한다(MUST). Profile 게시글 connection과 Home connection은 서로 다른 owner와 connection identity를 유지해야 한다(MUST).
+
+#### Scenario: Append the next Home page
+
+- **WHEN** Home connection에 다음 page가 있고 사용자가 목록 하단 near-end에 도달한다
+- **THEN** 시스템은 현재 cursor 이후 게시글을 최대 20개 요청해 기존 Home 목록 뒤에 누적한다
+- **AND** Profile 게시글 connection의 edge나 cursor를 읽거나 변경하지 않는다
+
+### Requirement: Automatic post pagination lifecycle
+
+**Authority / Provenance:** `PROD-646`, `PROD-662` — Home과 Profile 게시글 목록은 공통 Web·Native 자동 pagination lifecycle로 near-end, 다음 page 존재 여부와 진행 중 요청을 판정해야 한다(MUST). 같은 page 요청을 중복 실행해서는 안 되며(MUST NOT), 성공 뒤 viewport가 아직 채워지지 않고 다음 page가 있으면 갱신된 목록 크기로 near-end를 다시 측정해야 한다(MUST).
+
+#### Scenario: Load once at the near-end boundary
+
+- **WHEN** 사용자가 Web 또는 Native 게시글 목록의 near-end에 도달하고 다음 page가 있으며 요청이 진행 중이지 않다
+- **THEN** 시스템은 `loadNext(20)`을 한 번 실행한다
+- **AND** 해당 요청이 완료되기 전에는 같은 page 요청을 다시 실행하지 않는다
+
+#### Scenario: Continue across short pages
+
+- **WHEN** 다음 page 요청이 성공했지만 갱신된 목록이 viewport를 채우지 못했고 그 뒤 page가 남아 있다
+- **THEN** 시스템은 갱신된 scroll metric으로 near-end를 다시 확인한다
+- **AND** viewport가 채워지거나 마지막 page에 도달할 때까지 같은 guard를 적용한다
+
+#### Scenario: Stop at the final page
+
+- **WHEN** Relay connection이 다음 page가 없다고 반환한다
+- **THEN** 시스템은 추가 게시글 요청과 다음-page loading 표시를 중단한다
+
+### Requirement: Post pagination feedback and manual recovery
+
+**Authority / Provenance:** `docs/design/accessibility.md`, `PROD-646` — Home과 Profile은 다음 page를 불러오는 동안 기존 게시글 아래에 loading spinner와 보조 기술용 상태 안내를 표시해야 한다(MUST). 다음 page가 실패하면 기존 게시글과 scroll position을 유지하고 하단 toast에 `게시글을 더 불러오지 못했어요.`와 `다시 시도` action을 표시해야 하며(MUST), 사용자가 action을 실행하기 전에는 같은 page를 자동으로 다시 요청해서는 안 된다(MUST NOT).
+
+#### Scenario: Show next-page loading without replacing posts
+
+- **WHEN** 다음 게시글 page 요청이 진행 중이다
+- **THEN** 시스템은 기존 게시글을 유지하고 그 아래에 loading spinner를 표시한다
+- **AND** 보조 기술에 목록을 더 불러오는 상태를 전달한다
+
+#### Scenario: Preserve posts and offer manual retry after failure
+
+- **WHEN** 다음 게시글 page 요청이 실패한다
+- **THEN** 시스템은 기존 게시글과 cursor 위치를 유지하고 loading spinner를 닫는다
+- **AND** 하단 toast에 `게시글을 더 불러오지 못했어요.`와 `다시 시도` action을 표시한다
+- **AND** 사용자가 `다시 시도`를 실행할 때만 같은 다음 page를 다시 요청한다
+
+### Requirement: Post pagination state isolation
+
+**Authority / Provenance:** `PROD-646` — Home과 Profile은 선택 Profile·actor revision·Profile route handle 또는 timeline identity가 바뀌면 이전 owner의 page, loading, error와 retry 상태를 새 목록에 재사용해서는 안 된다(MUST NOT). actor 전환 전에 시작한 다음-page 요청의 늦은 완료는 새 actor 또는 route의 목록과 feedback를 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: Reset Profile pagination on identity change
+
+- **WHEN** Profile route handle 또는 actor revision이 바뀐다
+- **THEN** 시스템은 새 Profile owner의 첫 page와 pagination 상태를 사용한다
+- **AND** 이전 Profile의 edge, cursor, loading, error 또는 retry 상태를 표시하지 않는다
+
+#### Scenario: Reset Home pagination on actor change
+
+- **WHEN** Home의 선택 Profile 또는 actor revision이 바뀐다
+- **THEN** 시스템은 새 actor의 Home connection과 pagination 상태를 사용한다
+- **AND** 이전 actor 요청의 완료가 새 Home 목록이나 feedback를 변경하지 않는다
+
+### Requirement: Home prepend and pagination consistency
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `PROD-641`, `PROD-646` — Home은 새 Post 성공 payload를 현재 Home connection 선두에 반영하는 기존 prepend와 cursor pagination이 같은 managed connection을 사용하게 해야 한다(MUST). prepend된 Post와 다음 page edge가 함께 존재할 때 같은 Post를 중복 표시하거나 최신순 목록 순서를 뒤집어서는 안 된다(MUST NOT).
+
+#### Scenario: Paginate after a Home prepend
+
+- **WHEN** 새 Post가 현재 Home connection 선두에 추가된 뒤 사용자가 다음 page를 불러온다
+- **THEN** 시스템은 prepend된 Post를 유지하고 cursor 이후 edge를 기존 목록 뒤에 누적한다
+- **AND** 같은 Post를 중복 표시하거나 기존 최신순 순서를 뒤집지 않는다

--- a/openspec/changes/add-home-profile-post-infinite-scroll/tasks.md
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/tasks.md
@@ -1,0 +1,35 @@
+## 1. PROD-646 Home과 Profile 게시글 무한 스크롤
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/design/accessibility.md`
+- `PROD-641`
+- `PROD-646`
+- `PROD-662`
+
+**Deliverable**
+
+Home과 Profile 게시글 목록이 서로 독립된 Relay connection에서 게시글을 20개씩 자동으로 누적하고, loading·마지막 page·실패 후 수동 재시도를 기존 목록과 scroll position을 유지한 채 제공한다.
+
+**Guardrails**
+
+- Home과 Profile의 Relay owner·connection identity를 합치지 않는다.
+- Home의 기존 prepend connection identity와 최신순을 유지한다.
+- 완료된 공통 자동 pagination lifecycle을 사용하고 surface별 lifecycle을 복제하지 않는다.
+- 기존 Home과 Profile scroll owner를 유지하고 중첩 ScrollView를 추가하지 않는다.
+- 실패 뒤 자동 재시도를 반복하지 않는다.
+- 공개·추천·Local Timeline, GraphQL schema·resolver, Subscription과 Home 재선택 refresh를 포함하지 않는다.
+
+**Verification**
+
+- Home과 Profile의 cursor, 20개 단위 page 누적, 마지막 page 종료와 identity 격리를 검증한다.
+- loading·실패 toast·수동 retry, Native scroll metric 연결과 Home prepend 순서·중복 방지를 검증한다.
+- 자동화 검증과 실제 Web·Android·iOS runtime 증거를 구분하고 OpenSpec strict validation을 통과시킨다.
+
+- [x] 1.1 Home과 Profile이 독립된 Relay connection에서 다음 20개를 누적하고 마지막 page에서 중단한다.
+- [x] 1.2 Home과 Profile이 실제 scroll owner에서 공통 자동 pagination lifecycle을 사용하고 actor·handle·route 전환 상태를 격리한다.
+- [x] 1.3 다음 page loading과 실패 toast·수동 retry가 기존 게시글과 scroll position을 유지한다.
+- [x] 1.4 Home prepend와 pagination이 최신순을 유지하고 같은 게시글을 중복 표시하지 않는다.
+- [ ] 1.5 실제 Web·Android·iOS runtime에서 near-end, loading, 실패 후 retry와 scroll 유지를 확인한다.
+- [ ] 1.6 전체 계약과 검증이 완료되면 delta spec을 동기화하고 change를 archive한다.

--- a/openspec/changes/add-home-profile-post-infinite-scroll/tasks.md
+++ b/openspec/changes/add-home-profile-post-infinite-scroll/tasks.md
@@ -24,7 +24,7 @@ Home과 Profile 게시글 목록이 서로 독립된 Relay connection에서 게�
 **Verification**
 
 - Home과 Profile의 cursor, 20개 단위 page 누적, 마지막 page 종료와 identity 격리를 검증한다.
-- loading·실패 toast·수동 retry, Native scroll metric 연결과 Home prepend 순서·중복 방지를 검증한다.
+- loading·실패 toast·수동 retry, Native scroll metric 연결·owner 전환 격리와 Home prepend 순서·중복 방지를 검증한다.
 - 자동화 검증과 실제 Web·Android·iOS runtime 증거를 구분하고 OpenSpec strict validation을 통과시킨다.
 
 - [x] 1.1 Home과 Profile이 독립된 Relay connection에서 다음 20개를 누적하고 마지막 page에서 중단한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- Home과 Profile에 서로 독립된 Relay cursor connection을 연결하고 게시글을 20개씩 누적합니다.
- PROD-662의 공통 자동 pagination lifecycle을 Web document scroll과 기존 Native scroll owner에서 사용합니다.
- 다음 page loading spinner, 실패 toast와 수동 재시도, actor·handle·route 전환 상태 정리를 추가했습니다.
- Home prepend와 pagination이 같은 connection에서 최신순과 중복 방지를 유지하도록 검증했습니다.
- `add-home-profile-post-infinite-scroll` OpenSpec을 추가했습니다.

## 왜 변경했는지

PROD-646은 Home과 Profile 게시글 목록에 커서 기반 무한 스크롤을 제공하는 작업입니다. 선행 작업 PROD-662에서 공통화한 Web·Native pagination lifecycle을 소비하면서 각 목록의 Relay identity와 기존 Home prepend 계약을 유지해야 합니다.

## 이번 PR의 주요 결정

새로운 결정은 없습니다. 최신 PROD-646·PROD-662 계약과 OpenSpec 결정을 변경 없이 적용했습니다.

## 어떻게 확인할 수 있는지

- focused 단위·라우트 테스트 12개
- Posts Storybook 100개
- Home Storybook 4개
- ToastProvider Storybook 3개
- App TypeScript 검사
- Relay compiler
- OpenSpec strict validation

## 아직 어떤 문제가 남았는지

- 로컬 Expo Web은 Session GraphQL 요청이 HTTP 502로 실패해 실제 Home/Profile route QA를 완료하지 못했습니다.
- Android·iOS 실기기 runtime QA는 실행하지 않았습니다.
- 실제 runtime 검증 전에는 OpenSpec 완료와 archive를 진행하지 않습니다.