### PR TITLE
디자인 문서의 코드 오너를 yeeun-uwu로 단일화한다

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @robin-maki
 
 # Design decisions and app presentation
-/docs/design/ @robin-maki @yeeun-uwu
+/docs/design/ @yeeun-uwu
 /apps/app/.storybook/ @robin-maki @yeeun-uwu
 /apps/app/src/app/ @robin-maki @yeeun-uwu
 /apps/app/src/components/ @robin-maki @yeeun-uwu


### PR DESCRIPTION
## 무엇을 변경했는지

- `/docs/design/` 아래 문서의 코드 오너에서 `@robin-maki`를 제거했습니다.
- 해당 범위의 유일한 코드 오너로 `@yeeun-uwu`를 지정했습니다.
- Storybook과 앱 UI 경로의 기존 공동 코드 오너 규칙은 변경하지 않았습니다.

## 왜 변경했는지

디자인 문서의 리뷰 책임을 `@yeeun-uwu`에게 단일하게 부여하려는 요청을 반영합니다.

## 이번 PR의 주요 결정

### 디자인 문서 단독 소유권

- 결정자: @robin-maki
- 선택: `/docs/design/`의 코드 오너를 `@yeeun-uwu` 한 명으로 지정
- 고려한 대안: 기존 `@robin-maki`, `@yeeun-uwu` 공동 소유 유지
- 이유: 디자인 문서의 코드 오너 리뷰 책임을 단일화하라는 요청을 그대로 적용
- 감수한 결과: 코드 오너 승인이 필요한 경우 `@yeeun-uwu`의 리뷰 가능 여부에 의존함

## 어떻게 확인할 수 있는지

- `git diff --check origin/main...HEAD`
- 커밋 훅에서 `eslint --fix --no-warn-ignored`, `prettier --write --ignore-unknown` 통과
- CODEOWNERS 외 파일이 변경되지 않았는지 diff 확인

## 아직 어떤 문제가 남았는지

없음.