### PR TITLE
수정 가능한 취약 전이 의존성을 최신 패치로 갱신한다

### DIFF
--- a/apps/app/Gemfile.lock
+++ b/apps/app/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.21.0)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
@@ -313,7 +313,7 @@ CHECKSUMS
   http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.21.0) sha256=8de199e53f93450414b9fd49811012a73f3e3265b60468c7274d1cacebde1969
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5257,12 +5257,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsbi@4.3.2:
@@ -5716,12 +5716,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8200,7 +8196,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8609,7 +8605,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@fastify/busboy@3.2.0': {}
 
@@ -11218,7 +11214,7 @@ snapshots:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       parse-json: 4.0.0
 
   cosmiconfig@6.0.0:
@@ -11957,7 +11953,7 @@ snapshots:
       expo-symbols: 56.0.6(expo-font@56.0.7)(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       query-string: 7.1.3
       react: 19.2.3
       react-fast-compare: 3.2.2
@@ -12603,12 +12599,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13116,9 +13112,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.12: {}
-
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -13426,7 +13420,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `js-yaml` 3.15.0/4.3.0을 3.15.1/4.3.1로 갱신했습니다.
- `nanoid` 3.3.12/3.3.16을 3.3.17로 통합했습니다.
- Fastlane 전이 의존성인 Ruby `json` 2.21.0을 2.21.2로 갱신했습니다.
- 부모 패키지, package.json, pnpm override는 변경하지 않았습니다.

## 왜 변경했는지

현재 lockfile에서 수정 버전이 배포되어 있고 기존 부모 SemVer 범위 안에서 해소할 수 있는 Dependabot 경보를 제거합니다. 이 변경으로 npm High 경보 4건과 Ruby Low 경보 1건을 제거합니다.

## 이번 PR의 주요 결정

### 배포된 안전 버전이 있는 의존성만 갱신한다

- 결정자: @robin-maki
- 선택: `js-yaml`, `nanoid`, Ruby `json`만 기존 부모 범위 안에서 갱신하고 `image-size`는 제외합니다.
- 고려한 대안: `image-size`를 현재 최신 2.0.2로 override하거나 아직 배포되지 않은 2.0.3을 지정하는 방법을 검토했습니다.
- 이유: `image-size <=2.0.2` 전체가 취약 범위이고 수정 버전 2.0.3은 npm에 아직 배포되지 않아 유효한 안전 버전이 없습니다.
- 감수한 결과: 전체 및 production `pnpm audit`에 `image-size@1.2.1` High 경보 2건이 남습니다.

## 어떻게 확인할 수 있는지

- `CI=true pnpm install --frozen-lockfile`
- `pnpm lint:syncpack`
- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app export:web`
- Ruby 3.4.10 / Bundler 4.0.15에서 `bundle lock --update json` 및 `bundle check`
- `git diff --check`
- `pnpm audit --json`: High 2, Critical 0
- `pnpm audit --prod --json`: High 2, Critical 0

## 아직 어떤 문제가 남았는지

`image-size@1.2.1`의 ICNS 및 JXL/HEIF 무한 루프 High 경보 2건이 남습니다. 수정 버전 2.0.3이 배포된 뒤 Metro 호환성을 검증해 후속 처리해야 합니다.