### PR TITLE
full Web에서 현재 배포 버전을 확인할 수 있게 한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -101,6 +101,7 @@ jobs:
           build-args: |
             EXPO_PUBLIC_ENVIRONMENT=${{ env.ENVIRONMENT }}
             EXPO_PUBLIC_OPENPANEL_CLIENT_ID=${{ startsWith(github.ref, 'refs/tags/') && vars.EXPO_PUBLIC_OPENPANEL_CLIENT_ID || '' }}
+            EXPO_PUBLIC_RELEASE_TAG=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
             EXPO_PUBLIC_SENTRY_DSN=${{ steps.sentry.outputs.EXPO_PUBLIC_SENTRY_DSN }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}
             SENTRY_PROJECT=${{ vars.SENTRY_PROJECT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,6 @@ COPY scripts ./scripts
 
 RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN,required=false \
   pnpm build:sentry-artifacts
-RUN test -z "$EXPO_PUBLIC_RELEASE_TAG" \
-  || grep -R -F -q -- "$EXPO_PUBLIC_RELEASE_TAG" apps/app/dist
 RUN find apps/app/dist -type f \( \
       -name '*.css' -o -name '*.html' -o -name '*.js' -o -name '*.json' \
       -o -name '*.mjs' -o -name '*.svg' -o -name '*.ttf' -o -name '*.wasm' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ FROM deps AS app-build
 
 ARG EXPO_PUBLIC_ENVIRONMENT
 ARG EXPO_PUBLIC_OPENPANEL_CLIENT_ID
+ARG EXPO_PUBLIC_RELEASE_TAG
 ARG EXPO_PUBLIC_SENTRY_DSN
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT
@@ -47,6 +48,7 @@ ARG SENTRY_UPLOAD_REQUIRED=0
 
 ENV EXPO_PUBLIC_ENVIRONMENT=$EXPO_PUBLIC_ENVIRONMENT
 ENV EXPO_PUBLIC_OPENPANEL_CLIENT_ID=$EXPO_PUBLIC_OPENPANEL_CLIENT_ID
+ENV EXPO_PUBLIC_RELEASE_TAG=$EXPO_PUBLIC_RELEASE_TAG
 ENV EXPO_PUBLIC_SENTRY_RELEASE=$SENTRY_RELEASE
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 ENV SENTRY_UPLOAD_REQUIRED=$SENTRY_UPLOAD_REQUIRED
@@ -58,6 +60,8 @@ COPY scripts ./scripts
 
 RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN,required=false \
   pnpm build:sentry-artifacts
+RUN test -z "$EXPO_PUBLIC_RELEASE_TAG" \
+  || grep -R -F -q -- "$EXPO_PUBLIC_RELEASE_TAG" apps/app/dist
 RUN find apps/app/dist -type f \( \
       -name '*.css' -o -name '*.html' -o -name '*.js' -o -name '*.json' \
       -o -name '*.mjs' -o -name '*.svg' -o -name '*.ttf' -o -name '*.wasm' \

--- a/apps/app/.storybook/preview.tsx
+++ b/apps/app/.storybook/preview.tsx
@@ -14,6 +14,7 @@ import type { Preview } from '@storybook/react-vite';
 
 sb.mock(import('../src/analytics/client.web.ts'), { spy: true });
 sb.mock(import('../src/auth/webLogin.ts'), { spy: true });
+sb.mock(import('../src/buildVersion.ts'), { spy: true });
 
 const preview: Preview = {
   decorators: [

--- a/apps/app/src/buildVersion.test.ts
+++ b/apps/app/src/buildVersion.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getBuildVersionLabel } from './buildVersion';
+
+test('production release tag를 표시값으로 그대로 사용한다', () => {
+  assert.equal(getBuildVersionLabel('v0.1.1'), 'v0.1.1');
+});
+
+test('release tag가 없으면 개발 빌드라고 표시한다', () => {
+  assert.equal(getBuildVersionLabel(undefined), '개발 빌드');
+  assert.equal(getBuildVersionLabel(''), '개발 빌드');
+});

--- a/apps/app/src/buildVersion.ts
+++ b/apps/app/src/buildVersion.ts
@@ -1,0 +1,5 @@
+export function getBuildVersionLabel(releaseTag: string | undefined): string {
+  return releaseTag || '개발 빌드';
+}
+
+export const buildVersionLabel = getBuildVersionLabel(process.env.EXPO_PUBLIC_RELEASE_TAG);

--- a/apps/app/src/buildVersion.ts
+++ b/apps/app/src/buildVersion.ts
@@ -1,5 +1,3 @@
 export function getBuildVersionLabel(releaseTag: string | undefined): string {
   return releaseTag || '개발 빌드';
 }
-
-export const buildVersionLabel = getBuildVersionLabel(process.env.EXPO_PUBLIC_RELEASE_TAG);

--- a/apps/app/src/components/shell/RightRail.tsx
+++ b/apps/app/src/components/shell/RightRail.tsx
@@ -5,6 +5,7 @@ import { PostComposer } from '@/components/post/PostComposer';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';
 import { GuardedLink } from './GuardedLink';
+import type { TextStyle } from 'react-native';
 import type { RightRail_profile$key } from './__generated__/RightRail_profile.graphql';
 
 const RightRailFragment = graphql`
@@ -18,7 +19,9 @@ export function RightRail({ profile: profileKey }: { profile: RightRail_profile$
   return <PostComposer profile={profile} />;
 }
 
-export function RightRailFooter() {
+export function RightRailFooter({
+  versionLabel = buildVersionLabel,
+}: { versionLabel?: string } = {}) {
   const theme = useTheme();
 
   return (
@@ -35,8 +38,8 @@ export function RightRailFooter() {
       <Text aria-hidden style={[styles.footerText, { color: theme.textSecondary }]}>
         ·
       </Text>
-      <Text style={[styles.footerText, { color: theme.textSecondary }]}>
-        버전: {buildVersionLabel}
+      <Text style={[styles.footerText, styles.versionText, { color: theme.textSecondary }]}>
+        버전: {versionLabel}
       </Text>
     </View>
   );
@@ -46,6 +49,7 @@ const styles = StyleSheet.create({
   footer: {
     alignItems: 'center',
     flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: spacing.xs,
     marginBottom: spacing.sm,
     marginTop: 'auto',
@@ -56,4 +60,10 @@ const styles = StyleSheet.create({
     minHeight: 32,
   },
   footerText: { fontFamily: 'SUIT', ...typography.xsm },
+  versionText: {
+    flexShrink: 1,
+    maxWidth: '100%',
+    minWidth: 0,
+    wordBreak: 'break-all',
+  } as TextStyle & { wordBreak: 'break-all' },
 });

--- a/apps/app/src/components/shell/RightRail.tsx
+++ b/apps/app/src/components/shell/RightRail.tsx
@@ -1,5 +1,6 @@
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
+import { buildVersionLabel } from '@/buildVersion';
 import { PostComposer } from '@/components/post/PostComposer';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';
@@ -17,29 +18,42 @@ export function RightRail({ profile: profileKey }: { profile: RightRail_profile$
   return <PostComposer profile={profile} />;
 }
 
-export function RightRailPrivacyLink() {
+export function RightRailFooter() {
   const theme = useTheme();
 
   return (
-    <GuardedLink href="/privacy">
-      <Pressable
-        accessibilityLabel="개인정보 처리방침"
-        accessibilityRole="link"
-        style={styles.privacyLink}
-      >
-        <Text style={[styles.privacyLabel, { color: theme.textSecondary }]}>개인정보 처리방침</Text>
-      </Pressable>
-    </GuardedLink>
+    <View style={styles.footer}>
+      <GuardedLink href="/privacy">
+        <Pressable
+          accessibilityLabel="개인정보 처리방침"
+          accessibilityRole="link"
+          style={styles.privacyLink}
+        >
+          <Text style={[styles.footerText, { color: theme.textSecondary }]}>개인정보 처리방침</Text>
+        </Pressable>
+      </GuardedLink>
+      <Text aria-hidden style={[styles.footerText, { color: theme.textSecondary }]}>
+        ·
+      </Text>
+      <Text style={[styles.footerText, { color: theme.textSecondary }]}>
+        버전: {buildVersionLabel}
+      </Text>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  privacyLink: {
-    alignSelf: 'flex-start',
-    justifyContent: 'center',
+  footer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
     marginTop: 'auto',
     minHeight: 32,
-    marginBottom: spacing.sm,
   },
-  privacyLabel: { fontFamily: 'SUIT', ...typography.xsm },
+  privacyLink: {
+    justifyContent: 'center',
+    minHeight: 32,
+  },
+  footerText: { fontFamily: 'SUIT', ...typography.xsm },
 });

--- a/apps/app/src/components/shell/RightRail.tsx
+++ b/apps/app/src/components/shell/RightRail.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
-import { buildVersionLabel } from '@/buildVersion';
+import { getBuildVersionLabel } from '@/buildVersion';
 import { PostComposer } from '@/components/post/PostComposer';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing, typography } from '@/theme/tokens';
@@ -19,9 +19,7 @@ export function RightRail({ profile: profileKey }: { profile: RightRail_profile$
   return <PostComposer profile={profile} />;
 }
 
-export function RightRailFooter({
-  versionLabel = buildVersionLabel,
-}: { versionLabel?: string } = {}) {
+export function RightRailFooter() {
   const theme = useTheme();
 
   return (
@@ -39,7 +37,7 @@ export function RightRailFooter({
         ·
       </Text>
       <Text style={[styles.footerText, styles.versionText, { color: theme.textSecondary }]}>
-        버전: {versionLabel}
+        버전: {getBuildVersionLabel(process.env.EXPO_PUBLIC_RELEASE_TAG)}
       </Text>
     </View>
   );

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -27,7 +27,7 @@ import {
   PrimaryNavigationScrollProvider,
   PrimaryNavigationScrollReset,
 } from './PrimaryNavigationScrollContext';
-import { RightRail, RightRailPrivacyLink } from './RightRail';
+import { RightRail, RightRailFooter } from './RightRail';
 import { ShellChromeProvider } from './ShellChromeContext';
 import {
   getShellRoutePresentation,
@@ -330,7 +330,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
             ]}
           >
             {profile ? <RightRail profile={profile} /> : null}
-            <RightRailPrivacyLink />
+            <RightRailFooter />
           </View>
         ) : null}
 

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -22,6 +22,7 @@ import { spacing } from '@/theme/tokens';
 import { profile, shellQuery } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ViewStyle } from 'react-native';
 import type { GuardedNavigationAction } from '@/components/shell/NavigationGuardContext';
 import type { ShellStoriesQuery as ShellStoriesQueryType } from './__generated__/ShellStoriesQuery.graphql';
 
@@ -1365,6 +1366,9 @@ const universalParameters = {
   router: { pathname: '/home', slotLabel: '홈 타임라인' },
 };
 
+const longReleaseTag =
+  'v20260810releaseaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
 function UniversalShellStory() {
   return (
     <SessionProvider>
@@ -2247,6 +2251,7 @@ export const UniversalFull: Story = {
     const versionLabel = canvas.getByText('버전: 개발 빌드');
     const rightRailRect = rightRail?.getBoundingClientRect();
     const privacyLinkRect = privacyLink.getBoundingClientRect();
+    const versionLabelRect = versionLabel.getBoundingClientRect();
 
     expect(leftRail).not.toBeNull();
     expect(leftRail?.getBoundingClientRect().height).toBeLessThanOrEqual(view?.innerHeight ?? 0);
@@ -2257,11 +2262,46 @@ export const UniversalFull: Story = {
     expect(rightRail?.scrollWidth ?? 1).toBeLessThanOrEqual(rightRail?.clientWidth ?? 0);
     expect(privacyLink).toHaveAttribute('href', '/privacy');
     expect(versionLabel).toBeVisible();
+    expect(versionLabelRect.top).toBeGreaterThanOrEqual(privacyLinkRect.top);
+    expect(versionLabelRect.bottom).toBeLessThanOrEqual(privacyLinkRect.bottom);
     expect((rightRailRect?.bottom ?? 0) - privacyLinkRect.bottom).toBeLessThanOrEqual(spacing.sm);
   },
   render: () => (
     <View style={{ height: 1800 }}>
       <UniversalShellStory />
+    </View>
+  ),
+};
+
+export const RightRailFooterLongReleaseTag: Story = {
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const surface = canvas.getByTestId('long-tag-footer-surface');
+    const footer = surface.firstElementChild;
+    const label = canvas.getByText(`버전: ${longReleaseTag}`, { exact: true });
+    const surfaceRect = surface.getBoundingClientRect();
+    const footerRect = footer?.getBoundingClientRect();
+    const labelRect = label.getBoundingClientRect();
+
+    expect(footer).not.toBeNull();
+    expect(label).toBeVisible();
+    expect(surface.scrollWidth).toBe(surface.clientWidth);
+    expect(labelRect.right).toBeLessThanOrEqual(footerRect?.right ?? 0);
+    expect(labelRect.bottom).toBeLessThanOrEqual(surfaceRect.bottom);
+  },
+  render: () => (
+    <View
+      style={
+        {
+          height: 160,
+          overflowX: 'hidden',
+          paddingLeft: spacing.xl,
+          width: 350,
+        } as ViewStyle
+      }
+      testID="long-tag-footer-surface"
+    >
+      <RightRailFooter versionLabel={longReleaseTag} />
     </View>
   ),
 };

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -13,7 +13,7 @@ import {
   useNavigationGuard,
 } from '@/components/shell/NavigationGuardContext';
 import { ProfileSwitcher } from '@/components/shell/ProfileSwitcher';
-import { RightRail, RightRailPrivacyLink } from '@/components/shell/RightRail';
+import { RightRail, RightRailFooter } from '@/components/shell/RightRail';
 import { SidebarNavigation } from '@/components/shell/SidebarNavigation';
 import { UniversalShell } from '@/components/shell/UniversalShell';
 import { useRelayActor } from '@/relay/RelayActorProvider';
@@ -186,7 +186,7 @@ function NavigationCatalog() {
       <Section title="Right rail">
         <View style={{ height: 560, padding: spacing.lg, width: 320 }}>
           <RightRail profile={data.profile} />
-          <RightRailPrivacyLink />
+          <RightRailFooter />
         </View>
       </Section>
     </Catalog>
@@ -2244,6 +2244,7 @@ export const UniversalFull: Story = {
     const rightRail = canvas.getByLabelText('새 게시글 작성').parentElement;
     const rightRailStyle = rightRail ? view?.getComputedStyle(rightRail) : undefined;
     const privacyLink = canvas.getByRole('link', { name: '개인정보 처리방침' });
+    const versionLabel = canvas.getByText('버전: 개발 빌드');
     const rightRailRect = rightRail?.getBoundingClientRect();
     const privacyLinkRect = privacyLink.getBoundingClientRect();
 
@@ -2255,6 +2256,7 @@ export const UniversalFull: Story = {
     expect(rightRailStyle?.overflowY).toBe('auto');
     expect(rightRail?.scrollWidth ?? 1).toBeLessThanOrEqual(rightRail?.clientWidth ?? 0);
     expect(privacyLink).toHaveAttribute('href', '/privacy');
+    expect(versionLabel).toBeVisible();
     expect((rightRailRect?.bottom ?? 0) - privacyLinkRect.bottom).toBeLessThanOrEqual(spacing.sm);
   },
   render: () => (

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -4,6 +4,7 @@ import { graphql, useLazyLoadQuery, useRelayEnvironment } from 'react-relay';
 import { commitLocalUpdate } from 'relay-runtime';
 import { expect, fireEvent, mocked, userEvent, waitFor, within } from 'storybook/test';
 import { trackAnalytics } from '@/analytics/client';
+import { getBuildVersionLabel } from '@/buildVersion';
 import { FollowButton } from '@/components/profile/FollowButton';
 import { ProfileEditDiscardDialog } from '@/components/profile/ProfileEditDiscardDialog';
 import { ProfileHero } from '@/components/profile/ProfileHero';
@@ -2274,6 +2275,9 @@ export const UniversalFull: Story = {
 };
 
 export const RightRailFooterLongReleaseTag: Story = {
+  beforeEach: () => {
+    mocked(getBuildVersionLabel).mockReturnValue(longReleaseTag);
+  },
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const surface = canvas.getByTestId('long-tag-footer-surface');
@@ -2301,7 +2305,7 @@ export const RightRailFooterLongReleaseTag: Story = {
       }
       testID="long-tag-footer-surface"
     >
-      <RightRailFooter versionLabel={longReleaseTag} />
+      <RightRailFooter />
     </View>
   ),
 };

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -54,7 +54,7 @@ Settings master pane은 약 `320px`, detail pane은 남은 폭을 사용한다. 
   개인정보 처리방침만 링크이고 버전은 정적 텍스트다. production Web build는 build를 시작한 Git tag를
   정규화하거나 접두어를 추가하지 않고 그대로 표시하며, tag가 없는 로컬·브랜치 build는 `버전: 개발 빌드`를
   표시한다. 선택한 Profile이 없어 컴포저가 표시되지 않아도 footer는 유지하며, 기존 위치보다 viewport 하단에
-  가깝게 배치한다.
+  가깝게 배치한다. 긴 공백 없는 Git tag도 footer 폭 안에서 줄바꿈해 전체 표시한다.
 - `compact`~`full`: 좁은 아이콘 레일의 공간과 navigation 위계를 보존하기 위해 개인정보 처리방침 진입점을
   포함한 footer를 표시하지 않는다.
 - `< compact` mobile Web과 Android/iOS: mobile drawer에 개인정보 처리방침 진입점을 표시하지 않는다.

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -50,10 +50,13 @@ Settings master pane은 약 `320px`, detail pane은 남은 폭을 사용한다. 
 공개 `/privacy` route와 비로그인 landing의 링크는 유지한다. 인증 후 셸에서는 generic `/menu`를 법적 고지의
 영구 위치로 사용하지 않고 full Web 우측 레일에만 보조 진입점을 둔다.
 
-- `≥ full`: 우측 레일 최하단에 `textSecondary` 색의 `개인정보 처리방침` 텍스트 링크를 둔다. 선택한 Profile이
-  없어 컴포저가 표시되지 않아도 링크는 유지하며, 기존 위치보다 viewport 하단에 가깝게 배치한다.
+- `≥ full`: 우측 레일 최하단에 `textSecondary` 색의 `개인정보 처리방침 · 버전: <Git tag>` footer를 둔다.
+  개인정보 처리방침만 링크이고 버전은 정적 텍스트다. production Web build는 build를 시작한 Git tag를
+  정규화하거나 접두어를 추가하지 않고 그대로 표시하며, tag가 없는 로컬·브랜치 build는 `버전: 개발 빌드`를
+  표시한다. 선택한 Profile이 없어 컴포저가 표시되지 않아도 footer는 유지하며, 기존 위치보다 viewport 하단에
+  가깝게 배치한다.
 - `compact`~`full`: 좁은 아이콘 레일의 공간과 navigation 위계를 보존하기 위해 개인정보 처리방침 진입점을
-  표시하지 않는다.
+  포함한 footer를 표시하지 않는다.
 - `< compact` mobile Web과 Android/iOS: mobile drawer에 개인정보 처리방침 진입점을 표시하지 않는다.
 - 가입·로그인 온보딩 안의 추가 개인정보 처리방침 진입점은 후속 범위에서 결정한다. 현재 범위에서는 공개
   route와 landing 링크, full Web 보조 진입점만 유지하며 준비되지 않은 팔로워 요청 또는 generic menu


### PR DESCRIPTION
## 무엇을 변경했는지

- full Web RightRail footer에 `개인정보 처리방침 · 버전: <Git tag>`를 표시합니다.
- 긴 Git tag도 RightRail 폭 안에서 줄바꿈해 전체 표시합니다.
- release tag가 없으면 `버전: 개발 빌드`를 표시합니다.
- tag 기반 Docker build가 `EXPO_PUBLIC_RELEASE_TAG`를 Web bundle에 전달합니다.
- tag 결정은 unit test, footer 표시는 Storybook에서 각각 검증합니다.
- full Web 전용 배치와 compact·mobile·Native 제외 범위를 디자인 문서에 반영했습니다.

## 왜 변경했는지

PROD-631에 따라 사용자가 개발자 도구 없이 배포된 Web release의 Git tag를 확인할 수 있게 합니다.

## 이번 PR의 주요 결정

### full Web footer에 정적 텍스트로만 표시

- 결정자: @yeeun-uwu
- 선택: 기존 개인정보 처리방침 링크 옆에 클릭 없는 버전 텍스트를 표시합니다.
- 고려한 대안: Settings 항목과 modal, compact·mobile·Native 공통 표시
- 이유: 기존 surface를 재사용하는 가장 작은 변경으로 필요한 Web 결과를 제공합니다.
- 감수한 결과: compact·mobile Web과 Android·iOS에서는 버전을 표시하지 않습니다.
- 관련 근거: https://linear.app/byulmaru/issue/PROD-631

## 어떻게 확인할 수 있는지

- App unit test: 303개 통과
- Storybook browser test: 344개 통과
- Relay compiler(`--noWatchman`) 및 TypeScript 검사 통과
- Storybook production build 통과
- ESLint, Prettier, `git diff --check` 통과

## 아직 어떤 문제가 남았는지

- 실제 tag-triggered GitHub Docker workflow와 배포된 브라우저 표시는 CI·배포 후 확인해야 합니다.
- compact·mobile Web과 Android·iOS는 의도적으로 제외했습니다.