### PR TITLE
KOSMO 프로덕션 모션·reduced-motion 계약을 확정한다

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,6 +8,7 @@ KOSMO의 UI/프로덕트 디자인 결정을 기록하고 공유하는 문서 �
 - [accessibility.md](./accessibility.md) — Web·Android·iOS 접근성 목표, target과 검증 기준
 - [colors.md](./colors.md) — 컬러 토큰 정책
 - [foundations.md](./foundations.md) — typography, spacing, radius, border, elevation, icon, density와 UI 일관성 Inventory
+- [motion.md](./motion.md) — duration, easing, component motion과 OS reduced-motion 대체 규칙
 - [logo.md](./logo.md) — 확정 로고 자산, clear space와 플랫폼별 소비처
 - [page-header.md](./page-header.md) — 주요 화면 공용 헤더의 variant, 높이와 소유권
 - [settings.md](./settings.md) — 인증 설정 route, Account/Profile 정보 구조와 공통 상태 계약

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -62,6 +62,8 @@ CSS px, pt, dp는 서로 다른 플랫폼 단위다. 저장소의 공통 목표�
 ### 5. 시간과 motion
 
 - 자동으로 시작되고 5초를 넘으며 다른 content와 병렬로 표시되는 moving·blinking·scrolling information은 Level A인 [SC 2.2.2 Pause, Stop, Hide](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html)에 따라 일시정지·중지·숨김 수단을 제공해야 한다. 자동으로 시작되고 다른 content와 병렬로 표시되는 auto-updating information은 같은 수단이나 갱신 빈도 제어를 제공해야 한다. 해당 움직임·갱신이 essential이면 공식 예외를 적용한다.
+- KOSMO의 duration, easing과 component별 대체 규칙은 [motion.md](./motion.md)를 따른다. 프로덕션 계약은 OS reduced-motion 설정만 입력으로 사용하며, 구현 전환은 DSN-19가 소유한다. slide·scale·ripple·rotation loop를 제거하되 focus, loading, success, error, selected와 announcement 의미는 유지한다.
+- reduced-motion loading은 회전 spinner를 정지 화면으로 남기지 않는다. spinner를 숨기고 정적 `···`와 loading 문구로 대체한다.
 
 ### 6. Visual geometry와 interactive target
 

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -8,12 +8,12 @@ KOSMO 디자인 작업은 Figma의 `KOSMO` 파일에서 한다.
 
 | 페이지                                         | 용도                                                                                                                    |
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `01 Foundations`                               | 프로덕션 Foundations — Color System, Typography, Brand & Logo와 Component Usage Mapping                                 |
+| `01 Foundations`                               | 프로덕션 Foundations — Color System, Typography, Brand & Logo, Motion과 Component Usage Mapping                         |
 | `02 Components`                                | 컴포넌트 라이브러리. 도메인별 섹션으로 구성 (아래 참고)                                                                 |
 | `03 Patterns`                                  | (예약, 비어 있음)                                                                                                       |
 | `04 Screens - Mobile`                          | 모바일 화면 디자인. Screen Inventory 프레임에서 화면별 상태(완료 / 마이그레이션 필요 / 신규 필요)를 추적한다            |
 | `05 Screens - Web`                             | 웹 화면 디자인. 화면마다 1440 / 1024 두 breakpoint 프레임으로 구성하고, Web Screen Inventory 프레임에서 상태를 추적한다 |
-| `06 Prototypes / Flows`                        | (예약, 비어 있음)                                                                                                       |
+| `06 Prototypes / Flows`                        | 승인된 interaction·motion의 재생 가능한 대표 timeline과 제품 flow                                                       |
 | `07 Archive`                                   | 구 와이어프레임 보관. 새 디자인의 마이그레이션 원본으로만 참조한다                                                      |
 | `99 Archive — Foundations Legacy · 2026-08-10` | 기존 Foundation 프레임과 variable 원본. 새 작업에 사용하지 않고 이관 근거로만 보존한다                                  |
 
@@ -24,12 +24,15 @@ KOSMO 디자인 작업은 Figma의 `KOSMO` 파일에서 한다.
 - [`01 Color System · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1661-254) — primitive, semantic Light/Dark, feedback, state, contrast와 migration 계약
 - [`02 Typography & Layout · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1659-255) — typography, font mode, spacing, radius, border, elevation, icon과 density/rhythm 계약. 상세 사용 규칙은 [foundations.md](./foundations.md)를 따른다.
 - `03 Brand & Logo · Production` — 로고 규칙, 플랫폼 자산과 Default Avatar
+- [`04 Motion · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1772-890) — duration, easing, interaction·overlay·loading과 OS reduced-motion 계약. 상세 규칙은 [motion.md](./motion.md)를 따른다.
 - [`08 Component Usage Mapping`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1684-254) — 실제 화면과 공용 컴포넌트의 Legacy → Production color 적용표
 
 Active color variable collection은 다음 두 개다.
 
 - `KOSMO Primitive Color` — 실제 값과 alpha. UI에서 직접 사용하지 않는다.
 - `KOSMO Semantic Color` — Light/Dark mode와 Web/Android/iOS code syntax. 새 디자인은 이 컬렉션만 사용한다.
+
+Active motion variable collection은 `KOSMO Motion`이다. duration과 `standard`·`enter`·`exit`·`linear` easing의 Web/Android/iOS code syntax를 제공하며, 재생 가능한 대표 계약은 [`KOSMO Motion Playground · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1774-880)의 Figma Motion timeline에서 확인한다. 화면 간 이동용 Prototype reaction·flow와 motion timeline을 같은 증거로 취급하지 않는다. 기존 Components/Screens의 최종 적용은 DSN-13에서 구현 evidence와 함께 동기화한다.
 
 `[Legacy] Color`, `[Legacy] Foundation`, `[Legacy] Brand`, `[Legacy] 컬렉션 1`은 기존 binding 보존용이다. 새 binding을 추가하지 않으며 DSN-13에서 Components/Screens를 active collection으로 이관한다. 자세한 색상 값과 역할은 [colors.md](./colors.md)를 따른다.
 
@@ -66,6 +69,7 @@ Active color variable collection은 다음 두 개다.
 - 새 화면/컴포넌트는 `02 Components`의 기존 컴포넌트와 Foundation 변수(디자인 토큰)를 사용해 만든다.
 - 색상은 `KOSMO Semantic Color`를 사용한다. `KOSMO Primitive Color`, `[Legacy] Color`와 raw hex를 UI에 직접 연결하지 않는다.
 - 새 semantic 역할이 필요하면 먼저 [colors.md](./colors.md)와 `08 Component Usage Mapping`을 갱신하고 Light/Dark 값, foreground pair와 consumer를 함께 정의한다.
+- motion은 `KOSMO Motion`과 [motion.md](./motion.md)의 semantic 역할을 사용한다. raw duration·easing이나 reduced-motion 대체가 없는 animation을 새로 추가하지 않는다.
 - **폰트 크기, 폰트 weight 등 스타일 값은 반드시 존재하는 변수에 연결한다.** 필요한 변수가 없다면 임의로 추가하거나 raw 값을 쓰지 말고, 디자인 오너에게 확인을 받은 뒤 변수를 추가/변경한다.
 - 외부 라이브러리(SDS, Ant Design, Material Design 3 등)의 컴포넌트와 토큰은 사용하지 않는다. 외부 라이브러리 토큰은 KOSMO 브랜드 토큰으로 통합 완료됐다 (2026-05).
 - 와이어프레임이 필요할 때 별도 와이어 키트를 만들지 않는다. "디테일을 줄인 실제 디자인"으로 — `02 Components`를 그대로 쓰되 모노톤 + `primary` 액센트, 회색 placeholder로 표현한다.

--- a/docs/design/foundations.md
+++ b/docs/design/foundations.md
@@ -97,7 +97,7 @@ Fullscreen media와 제품 고유 shadow는 일괄 치환하지 않고 아래 In
 ## 후속 작업 경계
 
 - DSN-14: 이 문서와 Figma Foundation 계약을 정본으로 고정한다.
-- DSN-18: motion, transition, easing, reduced-motion 계약을 별도로 확정한다.
+- DSN-18: [motion.md](./motion.md)의 motion, transition, easing, reduced-motion 계약을 정본으로 고정한다.
 - DSN-19: shared token, theme, elevation/icon foundation과 공용 primitive를 구현한다.
 - DSN-21 또는 연결된 Product 이슈: route, shell, domain consumer와 상태를 이관·검증한다.
 - DSN-13: 선행 구현 후 Components/Screens를 최종 재바인딩하고 evidence를 남긴다.

--- a/docs/design/motion.md
+++ b/docs/design/motion.md
@@ -1,0 +1,85 @@
+# Motion·transition·reduced-motion 규칙
+
+이 문서는 DSN-18에서 확정한 KOSMO의 motion 계약이다. 시각 정본은 Figma [`04 Motion · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1772-890), 재생 가능한 대표 예시는 [`KOSMO Motion Playground · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1774-880)이다.
+
+finite transition, 반복 loading cycle, toast 체류시간과 focus scheduling은 서로 다른 개념으로 관리한다. 하나의 duration을 모든 motion에 재사용하지 않는다.
+
+## Motion token
+
+Figma의 active collection은 `KOSMO Motion`이며 단일 `Value` mode를 사용한다. duration 값의 단위는 ms다.
+
+| Token                           |                 값 | 역할                                  |
+| ------------------------------- | -----------------: | ------------------------------------- |
+| `motion/duration/instant`       |                0ms | 애니메이션 없는 즉시 상태 전환        |
+| `motion/duration/fast`          |              120ms | hover·pressed·짧은 exit               |
+| `motion/duration/standard`      |              200ms | selected·toast·일반 상태 전환         |
+| `motion/duration/emphasized`    |              360ms | modal·drawer의 공간 변화가 있는 enter |
+| `motion/duration/reaction`      |              300ms | like·reaction의 유한한 확인 피드백    |
+| `motion/duration/loading-cycle` |              800ms | indeterminate spinner 한 바퀴         |
+| `motion/easing/standard`        | `.17, .73, .14, 1` | 일반 상태 전환                        |
+| `motion/easing/enter`           |    `.16, 1, .3, 1` | 빠르게 나타나 안정적으로 정착         |
+| `motion/easing/exit`            |      `.4, 0, 1, 1` | 주의를 끌지 않고 빠르게 퇴장          |
+| `motion/easing/linear`          |           `linear` | indeterminate spinner의 일정한 회전   |
+
+`motion/duration/loading-cycle`은 finite transition에 사용하지 않는다. Toast의 기본 체류시간 `3000ms`도 motion token이 아니라 제품 lifecycle 값이다.
+
+## Component 사용표
+
+| 역할               | Duration                 | Easing     | 표현                                    |
+| ------------------ | ------------------------ | ---------- | --------------------------------------- |
+| Hover·Pressed      | `fast` 120ms             | standard   | color·opacity, 필요한 경우 scale `0.98` |
+| Selected           | `standard` 200ms         | standard   | indicator 위치, surface·border·color    |
+| Modal·Drawer enter | `emphasized` 360ms       | enter      | scrim fade와 짧은 position·opacity 변화 |
+| Modal·Drawer exit  | `standard` 200ms         | exit       | position·opacity를 함께 정리            |
+| Toast              | enter 200ms / exit 120ms | enter/exit | translate·opacity, 체류시간은 별도      |
+| Reaction           | `reaction` 300ms         | standard   | 유한한 scale·color 확인 피드백          |
+| Spinner            | `loading-cycle` 800ms    | linear     | rotation만 반복                         |
+| Skeleton           | `instant` 0ms            | 없음       | 정적 placeholder                        |
+
+상태의 의미와 accessible state는 motion 완료를 기다리지 않고 즉시 갱신한다. focus 이동·복원과 `requestAnimationFrame` scheduling은 시각 transition으로 분류하지 않는다.
+
+## 현행 표현 판정과 이관
+
+DSN-18은 현재 구현을 그대로 정본으로 승인하지 않는다. 아래 판정이 DSN-19·21의 migration 입력이며, 후속 구현은 duration·easing·reduced-motion 동작을 다시 결정하지 않는다.
+
+| 현행 유형      | 현재 source·표현                                                          | 판정      | 목표 계약                                                                              | 후속 소유자                               |
+| -------------- | ------------------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Hover·Pressed  | `Button`, `IconButton`, `PostActionControl`의 즉시 opacity·pressed 상태   | 수정      | 상태 의미는 즉시 반영하고 시각 color·opacity·필요한 scale만 `fast` 120ms + `standard`  | DSN-19 shared primitive, DSN-21 domain    |
+| Modal·Sheet    | `ModalSheet`와 여러 overlay의 React Native `Modal` `fade`                 | 수정·예외 | KOSMO 소유 overlay는 enter 360ms/exit 200ms. iOS·Android system sheet timing은 OS 예외 | DSN-19 shared primitive, DSN-21 call-site |
+| Drawer         | `UniversalShell` mobile drawer의 `animationType="none"`                   | 수정      | scrim과 짧은 position·opacity를 enter 360ms/exit 200ms로 설명                          | DSN-21                                    |
+| Loading        | React Native `ActivityIndicator` 기본 동작과 custom spinner가 혼재        | 유지·수정 | system indicator는 플랫폼 소유로 유지하고 KOSMO custom spinner만 800ms `linear`에 수렴 | DSN-19 shared helper, DSN-21 consumer     |
+| Reaction       | `ReactionPendingSpinner` 820ms linear loop와 즉시 selected·count feedback | 수정      | pending spinner는 800ms `linear`, 유한 reaction feedback은 300ms `standard`            | DSN-19 helper, DSN-21/Product consumer    |
+| Reduced motion | OS setting adapter와 component별 대체 규칙이 아직 중앙화되지 않음         | 수정      | OS setting을 단일 입력으로 사용하고 아래 대체표대로 비필수 이동을 제거                 | DSN-19 adapter, DSN-21/Product consumer   |
+
+## Reduced motion
+
+프로덕션 계약은 Web의 `prefers-reduced-motion`과 Android·iOS의 OS reduced-motion 설정만 입력으로 사용한다. 현재 구현에는 공통 adapter가 없으며 DSN-19가 반영한다. 앱 내부 override는 이번 범위에서 제공하지 않고, 장기 후속은 [PROD-745](https://linear.app/byulmaru/issue/PROD-745/kosmo-앱-내-motion-축소-사용자-설정-지원)가 소유한다.
+
+| 일반 표현                | OS reduced-motion에서의 대체                      |
+| ------------------------ | ------------------------------------------------- |
+| hover·pressed scale      | scale 제거, color·opacity 상태는 즉시 반영        |
+| selected indicator 이동  | 최종 위치·surface·border를 즉시 반영              |
+| modal·drawer slide·scale | 이동 제거, 최종 surface와 scrim을 즉시 표시       |
+| toast translate·fade     | 최종 toast를 즉시 표시·제거, 체류시간은 유지      |
+| reaction scale·ripple    | 즉시 color·count·selected 상태로 대체             |
+| spinner rotation loop    | spinner를 숨기고 정적 `···`와 loading 문구를 표시 |
+| skeleton                 | 정적 placeholder 유지                             |
+
+motion을 제거해도 focus, loading, success, error, selected와 announcement 의미는 제거하지 않는다.
+
+## 플랫폼과 예외
+
+- Web과 KOSMO가 직접 소유한 Native primitive는 위 semantic 역할을 사용한다.
+- iOS system sheet와 Android system bottom sheet처럼 OS presentation API가 소유한 timing·curve는 플랫폼 예외로 유지한다. 임의의 ms 값으로 덮어쓰지 않는다.
+- 위 판정표에 없는 route·shell·domain local motion은 DSN-21/Product가 같은 형식으로 소비처, 목표 token, 플랫폼 예외와 검증 evidence를 기록한다. 새 motion 역할을 임의로 만들지 않는다.
+- 기존 Reaction spinner `820ms`는 `loading-cycle` `800ms`로 수렴한다. 제품 근거 없이 `820ms` 예외를 새로 만들지 않는다.
+- 새 duration·easing을 raw 값으로 추가하지 않는다. spinner는 `motion/easing/linear`를 사용한다. 현재 token으로 표현할 수 없으면 component, platform, reduced-motion 대체와 검증 evidence를 함께 제시해 Design owner 승인을 받는다.
+
+## Figma와 구현 경계
+
+- DSN-18: 이 문서, `KOSMO Motion` variable과 대표 Figma Motion timeline을 정본으로 고정한다.
+- DSN-19: shared motion token, OS preference adapter와 공용 primitive 표현을 구현한다.
+- DSN-21 또는 연결된 Product 이슈: route, shell, domain consumer와 예외를 이관·검증한다.
+- DSN-13: 구현 확정 후 기존 Components/Screens에 같은 계약을 적용하고 최종 Figma evidence를 남긴다.
+
+DSN-18에서는 기존 Components/Screens의 motion을 일괄 재작성하지 않는다. 대표 예시는 Figma Motion의 manual keyframe track과 2.4초 timeline으로 재생하며, 화면 간 이동을 위한 Prototype reaction·flow와는 별개다. 2.4초는 800ms spinner cycle의 정수 배수라 loop 경계에서 멈춤이나 회전 점프가 생기지 않는다. 이 타임라인은 계약을 재생하고 비교하기 위한 canonical example이며 제품 화면 동기화 완료 증거가 아니다.

--- a/docs/design/reactions.md
+++ b/docs/design/reactions.md
@@ -30,7 +30,7 @@ Reaction Quick Picker는 현재 제공된 Reaction option을 빠르게 선택하
 - 투명한 overlay가 option의 네 방향을 0으로 채워 option 전체를 덮는다.
 - Web overlay 가운데에는 배경 track이 없는 16×16px spinner를 표시한다. spinner는 2px 두께의 연결된 180° 호이며, `textSecondary` 색의 짙은 head에서 완전히 투명한 tail까지 자연스럽게 흐려진다.
 - Native spinner와 target geometry는 이번 Web 우선 변경에서 수정하지 않는다.
-- spinner 호는 약 820ms마다 시계 방향으로 한 바퀴를 linear하게 회전한다. 점이나 분리된 spoke를 사용하지 않는다.
+- spinner 호는 `motion/duration/loading-cycle` 800ms마다 시계 방향으로 한 바퀴를 linear하게 회전한다. 점이나 분리된 spoke를 사용하지 않는다.
 - overlay는 emoji 뒤에 렌더되는 sibling의 paint order를 사용하며 별도 `zIndex`를 두지 않는다.
 - pending option만 입력을 막고 다른 Type은 계속 선택할 수 있다.
 - Picker 전체가 disabled이면 비활성 UI를 표시하지 않고 Picker를 렌더링하지 않는다.


### PR DESCRIPTION
## 무엇을 변경했나요

- `KOSMO Motion` Figma Variables에 duration 6종과 easing 4종을 확정했습니다.
- Figma `04 Motion · Production`에 interaction, overlay, loading, reduced-motion 사용 계약을 정리했습니다.
- `KOSMO Motion Playground · Production`에 Pressed, Selected, Modal, Drawer, Toast, Reaction, Spinner의 실제 Motion timeline을 추가했습니다.
- `docs/design/motion.md`에 component별 사용표, 현행 표현 판정, 플랫폼 예외와 후속 소유권을 기록했습니다.
- 접근성·Figma·Foundation 문서에서 motion 정본을 연결했습니다.

## 왜 변경했나요

현재 KOSMO는 중앙 motion token과 reduced-motion 계약이 없고, React Native Modal 기본 동작, 즉시 상태 전환, 820ms Reaction spinner 등이 서로 다른 기준으로 동작합니다.

후속 구현자가 duration, easing, 플랫폼 예외와 reduced-motion 대체를 다시 결정하지 않도록 프로덕션 계약과 재생 가능한 Figma evidence를 먼저 확정합니다.

## 이번 PR의 주요 결정

### 차분하지만 상태 변화가 인지되는 motion을 사용한다

- 결정자: @yeeun-uwu
- 선택: `0 / 120 / 200 / 360 / 300 / 800ms` 역할과 `standard / enter / exit / linear` easing을 사용합니다.
- 고려한 대안: Mastodon처럼 animation을 최소화하거나 Bluesky의 component-local 값을 그대로 사용하는 방식
- 이유: hover·pressed는 빠르게 유지하면서 modal·drawer의 공간 변화는 사용자가 충분히 인지할 수 있어야 합니다.
- 감수한 결과: 모든 motion을 하나의 duration으로 통일하지 않고 역할별 token과 예외를 관리합니다.
- 관련 근거: [`docs/design/motion.md`](docs/design/motion.md), [Linear DSN-18](https://linear.app/byulmaru/issue/DSN-18/kosmo-motiontransitionreduced-motion-디자인-계약-정리), [Figma `04 Motion · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1772-890)

### reduced-motion은 OS 설정만 입력으로 사용한다

- 결정자: @yeeun-uwu
- 선택: slide·scale·ripple·rotation loop를 제거하고 상태·focus·loading·announcement 의미는 즉시 유지합니다. 회전 spinner는 정적 `···`와 loading 문구로 대체합니다.
- 고려한 대안: motion duration만 단축하거나 앱 내부 animation toggle을 이번 범위에 포함하는 방식
- 이유: 움직임을 원하지 않는 사용자의 OS 접근성 설정을 존중하면서 상태 피드백은 보존해야 합니다.
- 감수한 결과: 앱 내부 override는 포함하지 않고 Product 후속 PROD-745로 남깁니다.
- 관련 근거: [`docs/design/motion.md`](docs/design/motion.md), [`docs/design/accessibility.md`](docs/design/accessibility.md), [PROD-745](https://linear.app/byulmaru/issue/PROD-745/kosmo-앱-내-motion-축소-사용자-설정-지원)

### Components와 Screens의 전체 적용은 DSN-13에서 수행한다

- 결정자: @yeeun-uwu
- 선택: DSN-18은 token·계약·대표 Motion timeline까지만 고정합니다.
- 고려한 대안: 기존 Figma Components와 Screens에 이번 PR에서 motion을 일괄 연결하는 방식
- 이유: 현재 화면이 공용 컴포넌트에 완전히 수렴하지 않았고, 구현 확정 전 일괄 적용하면 다시 재작업하게 됩니다.
- 감수한 결과: DSN-19가 shared token·adapter·primitive, DSN-21/Product가 consumer, DSN-13이 최종 Figma 동기화를 담당합니다.
- 관련 근거: [`docs/design/motion.md`](docs/design/motion.md), [`docs/design/figma.md`](docs/design/figma.md), [Linear DSN-18](https://linear.app/byulmaru/issue/DSN-18/kosmo-motiontransitionreduced-motion-디자인-계약-정리)

## 어떻게 확인할 수 있나요

- [Figma `04 Motion · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1772-890)
- [Figma `KOSMO Motion Playground · Production`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1774-880)
  - 2.4초 loop
  - 9개 animated node
  - Spinner `0→360→720→1080°`, 800ms linear 연속 cycle
- `git diff --check`
- Prettier check
- 문서 상대 링크 검사
- Figma 변수·keyframe·timeline live readback
- 독립 계약 리뷰 및 Figma 리뷰: 최종 발견 사항 없음
- MP4 재출력 및 ISO MP4 파일 확인

문서·Figma 계약 이슈이므로 앱 테스트와 Web·Android·iOS runtime QA는 수행하지 않았습니다.

## 아직 어떤 문제가 남았나요

- DSN-19: shared motion token, OS preference adapter와 공용 primitive 구현
- DSN-21 또는 Product: route·shell·domain consumer와 예외 이관
- DSN-13: 구현 확정 후 Components/Screens 최종 동기화
- PROD-745: 장기적인 앱 내부 motion 축소 설정
