### PR TITLE
프로필 identity 표시를 ProfileNameBlock으로 수렴한다

### DIFF
--- a/apps/app/src/components/follow-request/FollowRequestListItem.tsx
+++ b/apps/app/src/components/follow-request/FollowRequestListItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment, useMutation } from 'react-relay';
+import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
 import { NavigationLink } from '@/components/shell/NavigationLink';
 import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
@@ -32,6 +33,7 @@ const followRequestListItemFragment = graphql`
       displayName
       handle
       relativeHandle
+      ...ProfileNameBlock_profile
     }
   }
 `;
@@ -150,14 +152,7 @@ export function FollowRequestListItem({ connectionId, request }: FollowRequestLi
               style={styles.profile}
             >
               <Avatar imageUri={follower.avatar?.url} label={name} size={40} />
-              <View style={styles.copy}>
-                <Text numberOfLines={1} style={[styles.name, { color: theme.text }]}>
-                  {name}
-                </Text>
-                <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
-                  {follower.relativeHandle}
-                </Text>
-              </View>
+              <ProfileNameBlock profile={follower} style={styles.copy} />
             </Pressable>
           </NavigationLink>
         ) : (
@@ -253,7 +248,6 @@ const styles = StyleSheet.create({
   },
   copy: { flex: 1, minWidth: 0 },
   name: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
-  handle: { fontFamily: 'SUIT', ...typography.xsm },
   actions: { flexDirection: 'row', flexShrink: 0, gap: spacing.sm },
   action: {
     minHeight: actionMinHeight,

--- a/apps/app/src/components/post/PostLayout.tsx
+++ b/apps/app/src/components/post/PostLayout.tsx
@@ -19,7 +19,6 @@ import type { PostLayout_post$key } from './__generated__/PostLayout_post.graphq
 import type { PostActionBarProps } from './PostActionBar';
 import type { PostContentWarningPresentation } from './PostContentRenderer';
 import type { PostMediaOpenHandler } from './PostMediaImage';
-import type { SourcePostPresentationData } from './PostSourcePresentationView';
 
 const PostLayoutFragment = graphql`
   fragment PostLayout_post on Post {
@@ -74,6 +73,7 @@ const PostLayoutFragment = graphql`
         handle
         relativeHandle
       }
+      ...PostSourcePreview_source
       ...PostActionSurface_post @alias(as: "actionSurface")
     }
     ...PostBody_post
@@ -143,33 +143,6 @@ export function PostLayout({
         ),
       }
     : undefined;
-  const presentationSource: SourcePostPresentationData | null = source
-    ? {
-        content: source.content
-          ? {
-              bodyText: source.content.bodyText,
-              contentWarning: source.content.contentWarning,
-              document: source.content.document,
-              media:
-                source.content.media?.map(({ altText, id, url }) => ({
-                  altText: altText ?? null,
-                  id,
-                  url: url ?? null,
-                })) ?? null,
-              postId: source.id,
-            }
-          : null,
-        createdAt: source.createdAt,
-        id: source.id,
-        profile: {
-          displayName: source.profile.displayName,
-          handle: source.profile.handle,
-          relativeHandle: source.profile.relativeHandle,
-          avatar: source.profile.avatar,
-        },
-      }
-    : null;
-
   return (
     <View style={styles.root}>
       <Link asChild href={profileHref}>
@@ -199,9 +172,7 @@ export function PostLayout({
             post={post}
             size="lg"
           />
-          {presentationSource ? (
-            <PostSourcePreview source={presentationSource} style={styles.source} />
-          ) : null}
+          {source ? <PostSourcePreview source={source} style={styles.source} /> : null}
           <Text style={[styles.meta, { color: theme.textSecondary }]}>
             {formatPostDate(post.createdAt)} ·{' '}
             {visibilityLabels[post.visibility] ?? post.visibility}

--- a/apps/app/src/components/post/PostLayout.tsx
+++ b/apps/app/src/components/post/PostLayout.tsx
@@ -52,27 +52,6 @@ const PostLayoutFragment = graphql`
     ...ReplyComposerSurface_parent @alias(as: "replySurface")
     ...PostActionSurface_post @alias(as: "actionSurface")
     repostSource {
-      id
-      createdAt
-      content {
-        bodyText
-        contentWarning
-        document
-        media {
-          id
-          altText
-          url
-        }
-      }
-      profile {
-        avatar {
-          id
-          url
-        }
-        displayName
-        handle
-        relativeHandle
-      }
       ...PostSourcePreview_source
       ...PostActionSurface_post @alias(as: "actionSurface")
     }

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -87,27 +87,6 @@ const PostListItemFragment = graphql`
     ...PostActionSurface_post @alias(as: "actionSurface")
     ...PostSourcePresentationView_post
     repostSource {
-      id
-      createdAt
-      content {
-        bodyText
-        contentWarning
-        document
-        media {
-          id
-          altText
-          url
-        }
-      }
-      profile {
-        avatar {
-          id
-          url
-        }
-        displayName
-        handle
-        relativeHandle
-      }
       ...PostListRow_post
     }
     ...PostListRow_post

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -21,7 +21,6 @@ import type { PostListItem_post$key } from './__generated__/PostListItem_post.gr
 import type { PostListRow_post$key } from './__generated__/PostListRow_post.graphql';
 import type { PostActionBarProps } from './PostActionBar';
 import type { PostMediaOpenHandler } from './PostMediaImage';
-import type { PostSourcePresentationData } from './PostSourcePresentationView';
 
 const PostListRowFragment = graphql`
   fragment PostListRow_post on Post {
@@ -86,6 +85,7 @@ const PostListItemFragment = graphql`
     }
     ...ReplyComposerSurface_parent @alias(as: "replySurface")
     ...PostActionSurface_post @alias(as: "actionSurface")
+    ...PostSourcePresentationView_post
     repostSource {
       id
       createdAt
@@ -172,13 +172,6 @@ export function PostListItem({
     ) : (
       replySurface
     );
-  const quoteContent = post.content;
-  const quoteMedia =
-    quoteContent?.media?.map(({ altText, id, url }) => ({
-      altText: altText ?? null,
-      id,
-      url: url ?? null,
-    })) ?? null;
   const handleQuoteMediaOpen = useCallback<PostMediaOpenHandler>(
     (selectedIndex, originControl) => {
       openViewer({
@@ -271,49 +264,6 @@ export function PostListItem({
     );
   }
 
-  const presentationPost: PostSourcePresentationData = {
-    content: {
-      bodyText: post.content.bodyText,
-      contentWarning: post.content.contentWarning,
-      document: post.content.document,
-      media: quoteMedia,
-      postId: post.id,
-    },
-    createdAt: post.createdAt,
-    id: post.id,
-    profile: {
-      displayName: post.profile.displayName,
-      handle: post.profile.handle,
-      relativeHandle: post.profile.relativeHandle,
-      avatar: post.profile.avatar,
-    },
-    replyParent: post.replyParent ? { id: post.replyParent.id } : null,
-    repostSource: {
-      content: source.content
-        ? {
-            bodyText: source.content.bodyText,
-            contentWarning: source.content.contentWarning,
-            document: source.content.document,
-            media:
-              source.content.media?.map(({ altText, id, url }) => ({
-                altText: altText ?? null,
-                id,
-                url: url ?? null,
-              })) ?? null,
-            postId: source.id,
-          }
-        : null,
-      createdAt: source.createdAt,
-      id: source.id,
-      profile: {
-        displayName: source.profile.displayName,
-        handle: source.profile.handle,
-        relativeHandle: source.profile.relativeHandle,
-        avatar: source.profile.avatar,
-      },
-    },
-  };
-
   return renderWithReplySurface(
     <View style={cardStyle}>
       {replyAttribution}
@@ -338,7 +288,7 @@ export function PostListItem({
         <View style={styles.sourcePresentation}>
           <PostSourcePresentationView
             onMediaOpen={handleQuoteMediaOpen}
-            post={presentationPost}
+            post={post}
             showPostAvatar={false}
             sourcePreviewStyle={styles.quoteSourcePreview}
           />

--- a/apps/app/src/components/post/PostMediaViewer.test.ts
+++ b/apps/app/src/components/post/PostMediaViewer.test.ts
@@ -83,6 +83,18 @@ mock.module('lucide-react-native', {
   },
 } as unknown as Parameters<typeof mock.module>[1]);
 
+mock.module('@/components/profile/ProfileNameBlock', {
+  exports: {
+    ProfileNameBlock: ({ profile }: { profile: { displayName: string; relativeHandle: string } }) =>
+      createElement(
+        'ProfileNameBlock',
+        null,
+        createElement('Text', null, profile.displayName),
+        createElement('Text', null, profile.relativeHandle),
+      ),
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+
 mock.module('@/components/ui/Avatar', {
   exports: { Avatar: (props: Record<string, unknown>) => createElement('Avatar', props) },
 } as unknown as Parameters<typeof mock.module>[1]);

--- a/apps/app/src/components/post/PostMediaViewer.tsx
+++ b/apps/app/src/components/post/PostMediaViewer.tsx
@@ -20,6 +20,7 @@ import {
   View,
 } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
+import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
 import { Avatar } from '@/components/ui/Avatar';
 import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -47,6 +48,7 @@ const PostMediaViewerFragment = graphql`
       }
       displayName
       relativeHandle
+      ...ProfileNameBlock_profile
     }
   }
 `;
@@ -291,11 +293,6 @@ export function PostMediaViewerContent({ actionBar, post: postKey, wideDetail }:
     ? `${currentMedia.id}:${currentMedia.url ?? ''}`
     : undefined;
   const bodyText = content?.bodyText ?? '';
-  const profile = {
-    avatarUrl: post.profile.avatar?.url ?? null,
-    displayName: post.profile.displayName,
-    relativeHandle: post.profile.relativeHandle,
-  };
   const theme = useTheme();
   const { height, width } = useWindowDimensions();
   const wide = Platform.OS === 'web' && width >= breakpoints.compact;
@@ -526,18 +523,11 @@ export function PostMediaViewerContent({ actionBar, post: postKey, wideDetail }:
         >
           <View style={styles.author}>
             <Avatar
-              imageUri={profile.avatarUrl}
-              label={profile.displayName || profile.relativeHandle}
+              imageUri={post.profile.avatar?.url}
+              label={post.profile.displayName || post.profile.relativeHandle}
               size={40}
             />
-            <View style={styles.authorText}>
-              <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
-                {profile.displayName}
-              </Text>
-              <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
-                {profile.relativeHandle}
-              </Text>
-            </View>
+            <ProfileNameBlock profile={post.profile} />
           </View>
 
           <View style={styles.bodyRegion} testID="post-media-viewer-body-region">
@@ -796,9 +786,6 @@ const styles = StyleSheet.create({
   },
   wideDetail: { flex: 0, minHeight: 0 },
   author: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm },
-  authorText: { flex: 1, minWidth: 0 },
-  displayName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
-  handle: { fontFamily: 'SUIT', ...typography.sm },
   bodyRegion: { flexShrink: 1, minHeight: 0, position: 'relative' },
   bodyMeasure: { left: 0, opacity: 0, position: 'absolute', right: 0, top: 0 },
   bodyText: { fontFamily: 'Pretendard', ...typography.md },

--- a/apps/app/src/components/post/PostSourcePresentationView.tsx
+++ b/apps/app/src/components/post/PostSourcePresentationView.tsx
@@ -1,5 +1,6 @@
 import { Link, useRouter } from 'expo-router';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { ProfileNameBlockView } from '@/components/profile/ProfileNameBlock';
 import { Avatar } from '@/components/ui/Avatar';
 import { formatTimelineTimestamp } from '@/lib/date';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -273,8 +274,6 @@ function PostBodyPressTarget({
 }
 
 function Author({ profile, showAvatar }: { profile: PresentationProfile; showAvatar: boolean }) {
-  const theme = useTheme();
-
   return (
     <View style={styles.author}>
       {showAvatar ? (
@@ -284,14 +283,11 @@ function Author({ profile, showAvatar }: { profile: PresentationProfile; showAva
           size={40}
         />
       ) : null}
-      <View style={styles.authorText}>
-        <Text numberOfLines={1} style={[styles.displayName, { color: theme.foregroundPrimary }]}>
-          {profile.displayName}
-        </Text>
-        <Text numberOfLines={1} style={[styles.handle, { color: theme.foregroundSecondary }]}>
-          {profile.relativeHandle}
-        </Text>
-      </View>
+      <ProfileNameBlockView
+        displayName={profile.displayName}
+        relativeHandle={profile.relativeHandle}
+        style={styles.authorText}
+      />
     </View>
   );
 }
@@ -306,8 +302,6 @@ const styles = StyleSheet.create({
     minWidth: 0,
   },
   authorText: { flex: 1, minWidth: 0 },
-  displayName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
-  handle: { flexShrink: 1, fontFamily: 'SUIT', ...typography.xsm },
   authorHeader: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm, minWidth: 0 },
   authorSlot: { flex: 1, minWidth: 0 },
   timestamp: { fontFamily: 'SUIT', minHeight: 44, minWidth: 44, paddingTop: 12, ...typography.xsm },

--- a/apps/app/src/components/post/PostSourcePresentationView.tsx
+++ b/apps/app/src/components/post/PostSourcePresentationView.tsx
@@ -1,6 +1,7 @@
 import { Link, useRouter } from 'expo-router';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { ProfileNameBlockView } from '@/components/profile/ProfileNameBlock';
+import { graphql, useFragment } from 'react-relay';
+import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
 import { Avatar } from '@/components/ui/Avatar';
 import { formatTimelineTimestamp } from '@/lib/date';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -9,9 +10,12 @@ import { PostContentRenderer } from './PostContentRenderer';
 import type { Href } from 'expo-router';
 import type { ReactNode } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
+import type { ProfileNameBlock_profile$key } from '@/components/profile/__generated__/ProfileNameBlock_profile.graphql';
+import type { PostSourcePresentationView_post$key } from './__generated__/PostSourcePresentationView_post.graphql';
+import type { PostSourcePreview_source$key } from './__generated__/PostSourcePreview_source.graphql';
 import type { PostMediaItem, PostMediaOpenHandler } from './PostMediaImage';
 
-export type PresentationProfile = {
+type AuthorProfile = ProfileNameBlock_profile$key & {
   readonly avatar:
     | {
         readonly id: string;
@@ -21,36 +25,85 @@ export type PresentationProfile = {
     | undefined;
   readonly displayName: string;
   readonly handle: string;
-  readonly relativeHandle: string;
 };
 
-export type PresentationContent = {
+type PresentationContent = {
   readonly bodyText: string;
   readonly contentWarning: string | null | undefined;
   readonly document: unknown;
-  readonly media: ReadonlyArray<PostMediaItem> | null;
-  readonly postId: string;
+  readonly media:
+    | ReadonlyArray<{
+        readonly altText: string | null | undefined;
+        readonly id: string;
+        readonly url: string | null | undefined;
+      }>
+    | null
+    | undefined;
 };
 
-export type SourcePostPresentationData = {
-  readonly content: PresentationContent | null;
-  readonly createdAt: string;
-  readonly id: string;
-  readonly profile: PresentationProfile;
-};
+const PostSourcePreviewFragment = graphql`
+  fragment PostSourcePreview_source on Post {
+    id
+    createdAt
+    content {
+      bodyText
+      contentWarning
+      document
+      media {
+        id
+        altText
+        url
+      }
+    }
+    profile {
+      avatar {
+        id
+        url
+      }
+      displayName
+      handle
+      relativeHandle
+      ...ProfileNameBlock_profile
+    }
+  }
+`;
 
-export type PostSourcePresentationData = {
-  readonly content: PresentationContent | null;
-  readonly createdAt: string;
-  readonly id: string;
-  readonly profile: PresentationProfile;
-  readonly replyParent: { readonly id: string } | null;
-  readonly repostSource: SourcePostPresentationData | null;
-};
+const PostSourcePresentationViewFragment = graphql`
+  fragment PostSourcePresentationView_post on Post {
+    id
+    createdAt
+    content {
+      bodyText
+      contentWarning
+      document
+      media {
+        id
+        altText
+        url
+      }
+    }
+    profile {
+      avatar {
+        id
+        url
+      }
+      displayName
+      handle
+      relativeHandle
+      ...ProfileNameBlock_profile
+    }
+    repostSource {
+      ...PostSourcePreview_source
+    }
+  }
+`;
 
 type PresentationKind = 'invalid' | 'ordinary' | 'quote';
 
-function presentationKind(post: PostSourcePresentationData): PresentationKind {
+function presentationKind(post: {
+  readonly content: PresentationContent | null | undefined;
+  readonly repostSource: PostSourcePreview_source$key | null | undefined;
+}): PresentationKind {
   if (!post.repostSource) {
     return post.content ? 'ordinary' : 'invalid';
   }
@@ -59,16 +112,17 @@ function presentationKind(post: PostSourcePresentationData): PresentationKind {
 
 export function PostSourcePresentationView({
   onMediaOpen,
-  post,
+  post: postKey,
   showPostAvatar = true,
   sourcePreviewStyle,
 }: {
   onMediaOpen?: PostMediaOpenHandler;
-  post: PostSourcePresentationData;
+  post: PostSourcePresentationView_post$key;
   showPostAvatar?: boolean;
   sourcePreviewStyle?: StyleProp<ViewStyle>;
 }): ReactNode {
   const theme = useTheme();
+  const post = useFragment(PostSourcePresentationViewFragment, postKey);
   const kind = presentationKind(post);
 
   if (kind === 'invalid') {
@@ -113,6 +167,7 @@ export function PostSourcePresentationView({
           content={post.content}
           href={postDetailHref}
           onMediaOpen={onMediaOpen}
+          postId={post.id}
           testID="post-body"
         />
       </View>
@@ -131,6 +186,7 @@ export function PostSourcePresentationView({
         content={post.content}
         href={postDetailHref}
         onMediaOpen={onMediaOpen}
+        postId={post.id}
         testID="post-body"
       />
       <PostSourcePreview source={source} style={sourcePreviewStyle} />
@@ -140,14 +196,15 @@ export function PostSourcePresentationView({
 
 export function PostSourcePreview({
   interactive = true,
-  source,
+  source: sourceKey,
   style,
 }: {
   interactive?: boolean;
-  source: SourcePostPresentationData;
+  source: PostSourcePreview_source$key;
   style?: StyleProp<ViewStyle>;
 }): ReactNode {
   const theme = useTheme();
+  const source = useFragment(PostSourcePreviewFragment, sourceKey);
   const sourceProfileHref = `/${source.profile.relativeHandle}` as Href;
   const sourcePostHref = `/${source.profile.relativeHandle}/${source.id}` as Href;
   const content = (
@@ -181,6 +238,7 @@ export function PostSourcePreview({
         <PostBodyPressTarget
           content={source.content}
           href={sourcePostHref}
+          postId={source.id}
           style={styles.sourceBody}
           testID="source-post-body"
         />
@@ -191,8 +249,8 @@ export function PostSourcePreview({
             contentWarning={source.content.contentWarning}
             document={source.content.document}
             interactive={false}
-            media={source.content.media ?? null}
-            postId={source.content.postId}
+            media={presentationMedia(source.content.media)}
+            postId={source.id}
             size="md"
           />
         </View>
@@ -240,12 +298,14 @@ function PostBodyPressTarget({
   content,
   href,
   onMediaOpen,
+  postId,
   style,
   testID,
 }: {
   content: PresentationContent;
   href: Href;
   onMediaOpen?: PostMediaOpenHandler;
+  postId: string;
   style?: StyleProp<ViewStyle>;
   testID: string;
 }) {
@@ -264,16 +324,28 @@ function PostBodyPressTarget({
         bodyText={content.bodyText}
         contentWarning={content.contentWarning}
         document={content.document}
-        media={content.media}
+        media={presentationMedia(content.media)}
         onMediaOpen={onMediaOpen}
-        postId={content.postId}
+        postId={postId}
         size="md"
       />
     </Pressable>
   );
 }
 
-function Author({ profile, showAvatar }: { profile: PresentationProfile; showAvatar: boolean }) {
+function presentationMedia(
+  media: PresentationContent['media'],
+): ReadonlyArray<PostMediaItem> | null {
+  return (
+    media?.map(({ altText, id, url }) => ({
+      altText: altText ?? null,
+      id,
+      url: url ?? null,
+    })) ?? null
+  );
+}
+
+function Author({ profile, showAvatar }: { profile: AuthorProfile; showAvatar: boolean }) {
   return (
     <View style={styles.author}>
       {showAvatar ? (
@@ -283,11 +355,7 @@ function Author({ profile, showAvatar }: { profile: PresentationProfile; showAva
           size={40}
         />
       ) : null}
-      <ProfileNameBlockView
-        displayName={profile.displayName}
-        relativeHandle={profile.relativeHandle}
-        style={styles.authorText}
-      />
+      <ProfileNameBlock profile={profile} style={styles.authorText} />
     </View>
   );
 }

--- a/apps/app/src/components/post/ReplyComposerSurface.tsx
+++ b/apps/app/src/components/post/ReplyComposerSurface.tsx
@@ -34,7 +34,6 @@ import type { TextInput, View as NativeView } from 'react-native';
 import type { ReplyComposerSurface_parent$key } from './__generated__/ReplyComposerSurface_parent.graphql';
 import type { ReplyComposerSurface_profile$key } from './__generated__/ReplyComposerSurface_profile.graphql';
 import type { PostComposerCreatedPost } from './PostComposer';
-import type { SourcePostPresentationData } from './PostSourcePresentationView';
 
 const ReplyComposerSurfaceParentFragment = graphql`
   fragment ReplyComposerSurface_parent on Post {
@@ -54,27 +53,7 @@ const ReplyComposerSurfaceParentFragment = graphql`
       ...ProfileNameBlock_profile
     }
     repostSource {
-      id
-      createdAt
-      content {
-        bodyText
-        contentWarning
-        document
-        media {
-          id
-          altText
-          url
-        }
-      }
-      profile {
-        displayName
-        handle
-        relativeHandle
-        avatar {
-          id
-          url
-        }
-      }
+      ...PostSourcePreview_source
     }
     ...PostBody_post
   }
@@ -373,27 +352,6 @@ function ReplyComposerSurfaceContents({
     );
   }
 
-  const source: SourcePostPresentationData | null = parent.repostSource
-    ? {
-        content: parent.repostSource.content
-          ? {
-              postId: parent.repostSource.id,
-              bodyText: parent.repostSource.content.bodyText,
-              contentWarning: parent.repostSource.content.contentWarning,
-              document: parent.repostSource.content.document,
-              media:
-                parent.repostSource.content.media?.map(({ altText, id, url }) => ({
-                  altText: altText ?? null,
-                  id,
-                  url: url ?? null,
-                })) ?? null,
-            }
-          : null,
-        createdAt: parent.repostSource.createdAt,
-        id: parent.repostSource.id,
-        profile: parent.repostSource.profile,
-      }
-    : null;
   const closeControlSize = Platform.OS === 'ios' ? 44 : Platform.OS === 'android' ? 48 : 36;
 
   return (
@@ -483,10 +441,10 @@ function ReplyComposerSurfaceContents({
                           </Text>
                         </View>
                         <PostBody interactive={false} post={parent} />
-                        {source ? (
+                        {parent.repostSource ? (
                           <PostSourcePreview
                             interactive={false}
-                            source={source}
+                            source={parent.repostSource}
                             style={styles.source}
                           />
                         ) : null}

--- a/apps/app/src/components/profile/ProfileDefaultPostVisibilityControl.tsx
+++ b/apps/app/src/components/profile/ProfileDefaultPostVisibilityControl.tsx
@@ -2,6 +2,7 @@ import { PostVisibility } from '@kosmo/core/enums';
 import { useCallback, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment, useMutation, useRelayEnvironment } from 'react-relay';
+import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
 import { Button } from '@/components/ui/Button';
 import { useRelayEnvironmentGeneration } from '@/relay/RelayEnvironmentBoundary';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -29,6 +30,7 @@ const ProfileFragment = graphql`
     id
     displayName
     relativeHandle
+    ...ProfileNameBlock_profile
     private {
       defaultPostVisibility
     }
@@ -165,10 +167,7 @@ function ProfileDefaultPostVisibilityControlContents({
         </Text>
       ) : null}
       <View accessibilityLabel={`현재 Profile ${profile.displayName} ${profile.relativeHandle}`}>
-        <Text style={[styles.target, { color: theme.text }]}>{profile.displayName}</Text>
-        <Text style={[styles.targetHandle, { color: theme.textSecondary }]}>
-          {profile.relativeHandle}
-        </Text>
+        <ProfileNameBlock profile={profile} />
       </View>
       <View accessibilityLabel={label} accessibilityRole="radiogroup" style={styles.options}>
         {options.map((option) => {
@@ -252,8 +251,6 @@ function ProfileDefaultPostVisibilityControlContents({
 const styles = StyleSheet.create({
   root: { borderRadius: radii.md, borderWidth: 1, gap: spacing.md, padding: spacing.lg },
   title: { fontFamily: 'SUIT', fontWeight: '700', ...typography.lg },
-  target: { fontFamily: 'SUIT', ...typography.sm },
-  targetHandle: { fontFamily: 'SUIT', ...typography.xsm },
   options: { gap: spacing.sm },
   option: {
     alignItems: 'center',

--- a/apps/app/src/components/profile/ProfileDefaultPostVisibilityControl.tsx
+++ b/apps/app/src/components/profile/ProfileDefaultPostVisibilityControl.tsx
@@ -167,7 +167,7 @@ function ProfileDefaultPostVisibilityControlContents({
         </Text>
       ) : null}
       <View accessibilityLabel={`현재 Profile ${profile.displayName} ${profile.relativeHandle}`}>
-        <ProfileNameBlock profile={profile} />
+        <ProfileNameBlock profile={profile} style={styles.target} />
       </View>
       <View accessibilityLabel={label} accessibilityRole="radiogroup" style={styles.options}>
         {options.map((option) => {
@@ -251,6 +251,7 @@ function ProfileDefaultPostVisibilityControlContents({
 const styles = StyleSheet.create({
   root: { borderRadius: radii.md, borderWidth: 1, gap: spacing.md, padding: spacing.lg },
   title: { fontFamily: 'SUIT', fontWeight: '700', ...typography.lg },
+  target: { paddingVertical: spacing.xs },
   options: { gap: spacing.sm },
   option: {
     alignItems: 'center',

--- a/apps/app/src/components/profile/ProfileNameBlock.test.ts
+++ b/apps/app/src/components/profile/ProfileNameBlock.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, mock, test } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import type { ProfileNameBlockView as ProfileNameBlockViewExport } from './ProfileNameBlock';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockModule = (specifier: string | URL, exports: object) =>
+  mock.module(specifier, {
+    exports,
+  } as unknown as Parameters<typeof mock.module>[1]);
+
+mockModule('expo-router', { Link: 'Link' });
+mockModule('react-native', {
+  Pressable: 'Pressable',
+  StyleSheet: { create: <T>(styles: T) => styles },
+  Text: 'Text',
+  View: 'View',
+});
+mockModule('react-relay', { graphql: () => ({}), useFragment: () => undefined });
+mockModule('@/theme/ThemeProvider', {
+  useTheme: () => ({ text: '#111111', textSecondary: '#666666' }),
+});
+mockModule('@/theme/tokens', {
+  radii: { md: 8 },
+  typography: { md: { fontSize: 16, lineHeight: 24 }, sm: { fontSize: 14, lineHeight: 20 } },
+});
+
+let ProfileNameBlockView: typeof ProfileNameBlockViewExport;
+let renderer: ReactTestRenderer | null = null;
+
+before(async () => {
+  ({ ProfileNameBlockView } = await import('./ProfileNameBlock'));
+});
+
+afterEach(async () => {
+  if (renderer) {
+    await act(async () => renderer?.unmount());
+    renderer = null;
+  }
+  mock.restoreAll();
+});
+
+test('ProfileNameBlockView truncates long display names and handles to one line', async () => {
+  assert.ok(ProfileNameBlockView);
+  await act(async () => {
+    renderer = create(
+      createElement(ProfileNameBlockView, {
+        displayName: '아주 긴 표시 이름이 한 줄을 넘을 수 있습니다',
+        relativeHandle: '@very-long-relative-handle-that-must-stay-on-one-line',
+      }),
+    );
+  });
+
+  assert.ok(renderer);
+  const textNodes = renderer.root.findAll((node) => (node.type as unknown) === 'Text');
+  assert.deepEqual(
+    textNodes.map((node) => ({
+      numberOfLines: node.props.numberOfLines,
+      value: node.children.join(''),
+    })),
+    [
+      {
+        numberOfLines: 1,
+        value: '아주 긴 표시 이름이 한 줄을 넘을 수 있습니다',
+      },
+      {
+        numberOfLines: 1,
+        value: '@very-long-relative-handle-that-must-stay-on-one-line',
+      },
+    ],
+  );
+});

--- a/apps/app/src/components/profile/ProfileNameBlock.test.ts
+++ b/apps/app/src/components/profile/ProfileNameBlock.test.ts
@@ -3,7 +3,7 @@ import { afterEach, before, mock, test } from 'node:test';
 import { createElement } from 'react';
 import { act, create } from 'react-test-renderer';
 import type { ReactTestRenderer } from 'react-test-renderer';
-import type { ProfileNameBlockView as ProfileNameBlockViewExport } from './ProfileNameBlock';
+import type { ProfileNameBlock as ProfileNameBlockExport } from './ProfileNameBlock';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -19,7 +19,13 @@ mockModule('react-native', {
   Text: 'Text',
   View: 'View',
 });
-mockModule('react-relay', { graphql: () => ({}), useFragment: () => undefined });
+mockModule('react-relay', {
+  graphql: () => ({}),
+  useFragment: () => ({
+    displayName: '아주 긴 표시 이름이 한 줄을 넘을 수 있습니다',
+    relativeHandle: '@very-long-relative-handle-that-must-stay-on-one-line',
+  }),
+});
 mockModule('@/theme/ThemeProvider', {
   useTheme: () => ({ text: '#111111', textSecondary: '#666666' }),
 });
@@ -28,11 +34,11 @@ mockModule('@/theme/tokens', {
   typography: { md: { fontSize: 16, lineHeight: 24 }, sm: { fontSize: 14, lineHeight: 20 } },
 });
 
-let ProfileNameBlockView: typeof ProfileNameBlockViewExport;
+let ProfileNameBlock: typeof ProfileNameBlockExport;
 let renderer: ReactTestRenderer | null = null;
 
 before(async () => {
-  ({ ProfileNameBlockView } = await import('./ProfileNameBlock'));
+  ({ ProfileNameBlock } = await import('./ProfileNameBlock'));
 });
 
 afterEach(async () => {
@@ -43,15 +49,10 @@ afterEach(async () => {
   mock.restoreAll();
 });
 
-test('ProfileNameBlockView truncates long display names and handles to one line', async () => {
-  assert.ok(ProfileNameBlockView);
+test('ProfileNameBlock truncates long display names and handles to one line', async () => {
+  assert.ok(ProfileNameBlock);
   await act(async () => {
-    renderer = create(
-      createElement(ProfileNameBlockView, {
-        displayName: '아주 긴 표시 이름이 한 줄을 넘을 수 있습니다',
-        relativeHandle: '@very-long-relative-handle-that-must-stay-on-one-line',
-      }),
-    );
+    renderer = create(createElement(ProfileNameBlock, { profile: {} as never }));
   });
 
   assert.ok(renderer);

--- a/apps/app/src/components/profile/ProfileNameBlock.tsx
+++ b/apps/app/src/components/profile/ProfileNameBlock.tsx
@@ -51,11 +51,7 @@ export function ProfileNameBlock({ href, profile, style }: ProfileNameBlockProps
   );
 }
 
-export function ProfileNameBlockView({
-  displayName,
-  relativeHandle,
-  style,
-}: ProfileNameBlockViewProps) {
+function ProfileNameBlockView({ displayName, relativeHandle, style }: ProfileNameBlockViewProps) {
   const theme = useTheme();
 
   return (

--- a/apps/app/src/components/profile/ProfileNameBlock.tsx
+++ b/apps/app/src/components/profile/ProfileNameBlock.tsx
@@ -13,6 +13,12 @@ type ProfileNameBlockProps = {
   style?: StyleProp<ViewStyle>;
 };
 
+type ProfileNameBlockViewProps = {
+  displayName: string;
+  relativeHandle: string;
+  style?: StyleProp<ViewStyle>;
+};
+
 const profileNameBlockFragment = graphql`
   fragment ProfileNameBlock_profile on Profile {
     displayName
@@ -21,30 +27,47 @@ const profileNameBlockFragment = graphql`
 `;
 
 export function ProfileNameBlock({ href, profile, style }: ProfileNameBlockProps) {
-  const theme = useTheme();
   const data = useFragment(profileNameBlockFragment, profile);
-  const content = (
-    <>
-      <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
-        {data.displayName}
-      </Text>
-      <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
-        {data.relativeHandle}
-      </Text>
-    </>
-  );
 
   if (href) {
     return (
       <NavigationLink href={href}>
         <Pressable accessibilityRole="link" style={StyleSheet.flatten([styles.root, style])}>
-          {content}
+          <ProfileNameBlockView
+            displayName={data.displayName}
+            relativeHandle={data.relativeHandle}
+          />
         </Pressable>
       </NavigationLink>
     );
   }
 
-  return <View style={[styles.root, style]}>{content}</View>;
+  return (
+    <ProfileNameBlockView
+      displayName={data.displayName}
+      relativeHandle={data.relativeHandle}
+      style={style}
+    />
+  );
+}
+
+export function ProfileNameBlockView({
+  displayName,
+  relativeHandle,
+  style,
+}: ProfileNameBlockViewProps) {
+  const theme = useTheme();
+
+  return (
+    <View style={[styles.root, style]}>
+      <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
+        {displayName}
+      </Text>
+      <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
+        {relativeHandle}
+      </Text>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/apps/app/src/components/profile/ProfileNameBlock.tsx
+++ b/apps/app/src/components/profile/ProfileNameBlock.tsx
@@ -13,12 +13,6 @@ type ProfileNameBlockProps = {
   style?: StyleProp<ViewStyle>;
 };
 
-type ProfileNameBlockViewProps = {
-  displayName: string;
-  relativeHandle: string;
-  style?: StyleProp<ViewStyle>;
-};
-
 const profileNameBlockFragment = graphql`
   fragment ProfileNameBlock_profile on Profile {
     displayName
@@ -27,43 +21,30 @@ const profileNameBlockFragment = graphql`
 `;
 
 export function ProfileNameBlock({ href, profile, style }: ProfileNameBlockProps) {
+  const theme = useTheme();
   const data = useFragment(profileNameBlockFragment, profile);
+  const content = (
+    <>
+      <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
+        {data.displayName}
+      </Text>
+      <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
+        {data.relativeHandle}
+      </Text>
+    </>
+  );
 
   if (href) {
     return (
       <NavigationLink href={href}>
         <Pressable accessibilityRole="link" style={StyleSheet.flatten([styles.root, style])}>
-          <ProfileNameBlockView
-            displayName={data.displayName}
-            relativeHandle={data.relativeHandle}
-          />
+          {content}
         </Pressable>
       </NavigationLink>
     );
   }
 
-  return (
-    <ProfileNameBlockView
-      displayName={data.displayName}
-      relativeHandle={data.relativeHandle}
-      style={style}
-    />
-  );
-}
-
-function ProfileNameBlockView({ displayName, relativeHandle, style }: ProfileNameBlockViewProps) {
-  const theme = useTheme();
-
-  return (
-    <View style={[styles.root, style]}>
-      <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
-        {displayName}
-      </Text>
-      <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
-        {relativeHandle}
-      </Text>
-    </View>
-  );
+  return <View style={[styles.root, style]}>{content}</View>;
 }
 
 const styles = StyleSheet.create({

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -60,7 +60,6 @@ const ProfileSwitcherFragment = graphql`
           id
           url
         }
-        ...ProfileNameBlock_profile
       }
     }
     me {

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import { graphql, useFragment, useMutation } from 'react-relay';
 import { trackAnalytics } from '@/analytics/client';
+import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
 import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
 import { useRelayActor } from '@/relay/RelayActorProvider';
@@ -59,6 +60,7 @@ const ProfileSwitcherFragment = graphql`
           id
           url
         }
+        ...ProfileNameBlock_profile
       }
     }
     me {
@@ -73,6 +75,7 @@ const ProfileSwitcherFragment = graphql`
           id
           url
         }
+        ...ProfileNameBlock_profile
       }
     }
   }
@@ -357,6 +360,7 @@ export function ProfileSwitcher({
         role={Platform.OS === 'web' && !redesignedWeb ? ('menuitemradio' as 'radio') : undefined}
         style={({ pressed }) => [
           styles.profile,
+          !selected ? styles.unselectedProfile : undefined,
           {
             backgroundColor: selected || pressed ? theme.surface : 'transparent',
             opacity: busy ? 0.5 : 1,
@@ -373,14 +377,7 @@ export function ProfileSwitcher({
             <UnreadDot style={styles.profileUnreadDot} testID="profile-switcher-unread-dot" />
           ) : null}
         </View>
-        <View style={styles.profileLabel}>
-          <Text numberOfLines={1} style={[styles.profileName, { color: theme.text }]}>
-            {profile.displayName}
-          </Text>
-          <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
-            {profile.relativeHandle}
-          </Text>
-        </View>
+        <ProfileNameBlock profile={profile} style={styles.profileLabel} />
         {selected ? <CheckIcon color={theme.text} size={16} /> : null}
       </Pressable>
     );
@@ -781,8 +778,6 @@ const styles = StyleSheet.create({
   profileList: { flexShrink: 1, minHeight: 0 },
   profileListContent: { gap: 2 },
   pickerFooter: { flexShrink: 0 },
-  profileName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
-  handle: { fontFamily: 'SUIT', ...typography.xsm },
   backdrop: {
     alignItems: 'center',
     backgroundColor: 'rgba(0,0,0,0.4)',
@@ -798,6 +793,7 @@ const styles = StyleSheet.create({
     gap: 10,
     padding: spacing.sm,
   },
+  unselectedProfile: { paddingVertical: spacing.xs },
   profileAvatar: { position: 'relative' },
   profileUnreadDot: {
     height: 12,

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -59,7 +59,6 @@ import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { GraphQLResponse, RequestParameters, Variables } from 'relay-runtime';
 import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
-import type { PostSourcePresentationData } from '@/components/post/PostSourcePresentationView';
 import type { PostDeletionListEdgeSafetyQuery as PostDeletionListEdgeSafetyQueryType } from './__generated__/PostDeletionListEdgeSafetyQuery.graphql';
 import type { PostDetailThreadIdentityStoryQuery } from './__generated__/PostDetailThreadIdentityStoryQuery.graphql';
 import type { PostsStoriesQuery as PostsStoriesQueryType } from './__generated__/PostsStoriesQuery.graphql';
@@ -365,6 +364,20 @@ const sourceAuthor = profile({
   handle: 'source@remote.example',
   id: 'profile-repost-source',
   relativeHandle: '@source@remote.example',
+});
+const contentWarningSourcePreviewPost = post({
+  bodyText: '가림 해제 뒤 표시되는 원문 프리뷰 본문입니다.',
+  contentWarning: '원문 프리뷰 경고',
+  id: 'content-warning-source-preview-post',
+  media: [
+    {
+      __typename: 'Media',
+      altText: '가림 해제 뒤 표시되는 원문 프리뷰 이미지',
+      id: 'content-warning-source-preview-media',
+      url: postMediaImageUri,
+    },
+  ],
+  profile: sourceAuthor,
 });
 const replyTargetProfile = profile({
   displayName: 'Reply 대상 작성자',
@@ -827,6 +840,7 @@ const storyPosts = [
   mediaTextPost,
   mediaOnlyPost,
   contentWarningPost,
+  contentWarningSourcePreviewPost,
   sensitiveTwoMediaPost,
   threeMediaPost,
   fourMediaPost,
@@ -938,6 +952,8 @@ const PostsStoriesQuery = graphql`
         ...PostLayout_post @alias(as: "layout")
         ...PostListItem_post @alias(as: "listItem")
         ...PostMediaViewer_post @alias(as: "viewer")
+        ...PostSourcePresentationView_post @alias(as: "sourcePresentation")
+        ...PostSourcePreview_source @alias(as: "sourcePreview")
         ...ReplyComposerSurface_parent @alias(as: "replySurface")
       }
     }
@@ -1075,52 +1091,6 @@ function requirePostById(posts: ReadonlyArray<PostNode>, id: string): PostNode {
     throw new Error(`Missing post fixture ${id}.`);
   }
   return result;
-}
-
-function toPostSourcePresentationData(post: StoryPost): PostSourcePresentationData {
-  const repostSource = post.repostSource ?? null;
-
-  return {
-    content: post.content
-      ? {
-          bodyText: post.content.bodyText,
-          contentWarning: post.content.contentWarning,
-          document: post.content.document,
-          media:
-            post.content.media?.map(({ altText, id, url }) => ({
-              altText,
-              id,
-              url,
-            })) ?? null,
-          postId: post.id,
-        }
-      : null,
-    createdAt: post.createdAt,
-    id: post.id,
-    profile: post.profile,
-    replyParent: post.replyParent ?? null,
-    repostSource: repostSource
-      ? {
-          content: repostSource.content
-            ? {
-                bodyText: repostSource.content.bodyText,
-                contentWarning: repostSource.content.contentWarning,
-                document: repostSource.content.document,
-                media:
-                  repostSource.content.media?.map(({ altText, id, url }) => ({
-                    altText,
-                    id,
-                    url,
-                  })) ?? null,
-                postId: repostSource.id,
-              }
-            : null,
-          createdAt: repostSource.createdAt,
-          id: repostSource.id,
-          profile: repostSource.profile,
-        }
-      : null,
-  };
 }
 
 function PostCatalog(_args: PostsStoryArgs) {
@@ -1851,12 +1821,14 @@ function ProductionPostActionSessionBoundaryStory({
 }
 
 function RepostQuotePresentationStory({ postId }: { postId: string }) {
-  const post = requireStoryPostById(storyPosts, postId);
+  const post = requirePostById(usePostsStoryData().posts, postId);
 
   return (
     <Catalog>
       <StoryPathname testID="presentation-story-pathname" />
-      <PostSourcePresentationView post={toPostSourcePresentationData(post)} />
+      <PostSourcePresentationView
+        post={requireFragment(post.sourcePresentation, 'Post Source presentation')}
+      />
     </Catalog>
   );
 }
@@ -1890,27 +1862,12 @@ function ContentWarningRevealStory() {
 }
 
 function ContentWarningSourcePreviewStory() {
+  const source = requirePostById(usePostsStoryData().posts, contentWarningSourcePreviewPost.id);
+
   return (
     <Catalog>
       <PostSourcePreview
-        source={{
-          content: {
-            bodyText: '가림 해제 뒤 표시되는 원문 프리뷰 본문입니다.',
-            contentWarning: '원문 프리뷰 경고',
-            document: null,
-            media: [
-              {
-                altText: '가림 해제 뒤 표시되는 원문 프리뷰 이미지',
-                id: 'content-warning-source-preview-media',
-                url: postMediaImageUri,
-              },
-            ],
-            postId: 'content-warning-source-preview-post',
-          },
-          createdAt: '2026-08-04T00:00:00.000Z',
-          id: 'content-warning-source-preview-post',
-          profile: sourceAuthor,
-        }}
+        source={requireFragment(source.sourcePreview, 'Content Warning Source preview')}
       />
     </Catalog>
   );


### PR DESCRIPTION
## 무엇을 변경했는지

- PostMediaViewer, ProfileSwitcher, ProfileDefaultPostVisibilityControl, FollowRequestListItem에 `ProfileNameBlock_profile` fragment spread를 추가하고 `ProfileNameBlock`을 직접 사용했습니다.
- `PostSourcePresentationView`와 `PostSourcePreview`가 필요한 Post fragment를 소유하고, PostListItem·PostLayout·ReplyComposerSurface가 fragment ref를 그대로 전달하도록 정리했습니다.
- 프로덕션과 Storybook의 수동 Post/Profile scalar projection을 제거하고 `ProfileNameBlockView`를 비공개 구현으로 제한했습니다.
- ProfileSwitcher의 선택·읽지 않음·생성 lifecycle은 유지하면서 미선택 행 높이 52px를 보존했습니다.
- 긴 이름과 핸들의 한 줄 말줄임 회귀 테스트를 공용 `ProfileNameBlock` 경계에서 검증하도록 갱신했습니다.

## 왜 변경했는지

각 소비처가 이름·핸들 typography와 말줄임을 직접 정의하던 중복을 제거하고, 프로필 identity 표현과 Relay 데이터 소유권을 공용 `ProfileNameBlock` 계약으로 수렴하기 위함입니다.

## 이번 PR의 주요 결정

### Identity-only 영역은 ProfileNameBlock fragment 경계를 사용합니다

- 결정자: @yeeun-uwu
- 선택: identity-only 영역은 `ProfileNameBlock`을 직접 사용하고, Post source presentation은 자체 fragment를 소유해 부모로부터 fragment ref를 전달받습니다.
- 고려한 대안: `ProfileListItem`을 각 소비처에 사용하거나 Post source에 scalar presentation API를 유지
- 이유: `ProfileListItem`은 bio, FollowButton, 전체 row 동작까지 소유해 이번 범위를 확장하며, 별도 scalar API는 Relay-backed identity 필드를 다시 복사하게 만듭니다.
- 감수한 결과: Post source의 부모 fragment가 child fragment를 spread해야 하며, nullable Media scalar 정규화는 실제 소비자인 Post source component가 소유합니다.
- 관련 근거: PROD-746, DSN-19, #574, #575 review thread

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app exec relay-compiler --noWatchman`
- `pnpm --filter @kosmo/app exec tsc --noEmit`
- 변경 파일 ESLint·Prettier·`git diff --check` 통과
- `pnpm --filter @kosmo/app test:unit` — 326/326 통과
- `pnpm --filter @kosmo/app test:storybook` — 24 files, 360/360 통과
- Web Storybook에서 ProfileSwitcher 행 높이 52px와 좁은 폭의 이름·핸들 말줄임 확인

## 아직 어떤 문제가 남았는지

- 실제 iOS/Android runtime의 행 높이와 말줄임은 확인하지 않았습니다.

Stack: main → PROD-746
