### PR TITLE
프로덕션 버튼 역할 컨트롤을 공용 컴포넌트로 이관한다

### DIFF
--- a/apps/app/src/components/post/PostContentRenderer.test.ts
+++ b/apps/app/src/components/post/PostContentRenderer.test.ts
@@ -34,6 +34,7 @@ mockModule(new URL('../../theme/ThemeProvider.tsx', import.meta.url), {
     text: '#111',
     textSecondary: '#777',
   }),
+  useReducedMotion: () => true,
 });
 mockModule(new URL('./PostMediaGallery.tsx', import.meta.url), {
   PostMediaGallery: (props: Record<string, unknown>) => createElement('PostMediaGallery', props),
@@ -52,11 +53,13 @@ type RendererProps = {
 
 let PostContentRenderer: ComponentType<RendererProps>;
 let PostContentWarningRevealProvider: ComponentType<{ children?: ReactNode }>;
+let Button: ComponentType<Record<string, unknown>>;
 let renderer: ReactTestRenderer | null = null;
 
 before(async () => {
   ({ PostContentRenderer } = await import('./PostContentRenderer'));
   ({ PostContentWarningRevealProvider } = await import('./PostContentWarningRevealContext'));
+  ({ Button } = await import('@/components/ui/Button'));
 });
 
 afterEach(async () => {
@@ -68,6 +71,31 @@ afterEach(async () => {
 });
 
 describe('PostContentRenderer', () => {
+  it('content warning reveal uses Button and forwards expanded state', async () => {
+    await render({
+      bodyText: '원문 본문',
+      contentWarning: '민감한 내용',
+      document: null,
+      media: [],
+      postId: 'post-warning-button',
+    });
+
+    assert.deepEqual(
+      renderer?.root.findAllByType(Button).map(({ props }) => ({
+        accessibilityLabel: props.accessibilityLabel,
+        accessibilityState: props.accessibilityState,
+        ariaExpanded: props['aria-expanded'],
+      })),
+      [
+        {
+          accessibilityLabel: '내용 보기',
+          accessibilityState: { expanded: false },
+          ariaExpanded: false,
+        },
+      ],
+    );
+  });
+
   it('Gallery에는 viewer open callback만 전달한다', async () => {
     const onMediaOpen = () => undefined;
     await render({

--- a/apps/app/src/components/post/PostContentRenderer.tsx
+++ b/apps/app/src/components/post/PostContentRenderer.tsx
@@ -2,6 +2,7 @@ import { isPostContentDocumentV1 } from '@kosmo/core/post-content';
 import { Fragment } from 'react';
 import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { match } from 'ts-pattern';
+import { Button } from '@/components/ui/Button';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
 import { usePostContentWarningReveal } from './PostContentWarningRevealContext';
@@ -104,25 +105,19 @@ export function PostContentRenderer({
         >
           <Text style={[styles.warningLabel, { color: theme.text }]}>내용 경고</Text>
           <Text style={[styles.warningText, { color: theme.textSecondary }]}>{contentWarning}</Text>
-          <Pressable
+          <Button
             accessibilityLabel={revealed ? '내용 다시 가리기' : '내용 보기'}
-            accessibilityRole="button"
             accessibilityState={{ expanded: revealed }}
             aria-expanded={revealed}
             onPress={(event) => {
               event.stopPropagation();
               toggle();
             }}
-            style={({ pressed }) => [
-              styles.warningButton,
-              { backgroundColor: pressed ? theme.primaryHover : theme.primary },
-            ]}
+            style={styles.warningButton}
             testID="post-content-warning-toggle"
           >
-            <Text style={[styles.warningButtonText, { color: theme.text }]}>
-              {revealed ? '다시 가리기' : '내용 보기'}
-            </Text>
-          </Pressable>
+            {revealed ? '다시 가리기' : '내용 보기'}
+          </Button>
         </View>
       ) : null}
       {bodyContent}
@@ -217,12 +212,8 @@ const styles = StyleSheet.create({
   warningLabel: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
   warningText: { fontFamily: 'SUIT', ...typography.sm },
   warningButton: {
-    alignItems: 'center',
-    borderRadius: radii.full,
-    justifyContent: 'center',
     marginTop: spacing.xs,
     minHeight: Platform.OS === 'android' ? 48 : 44,
-    paddingHorizontal: spacing.lg,
+    minWidth: 0,
   },
-  warningButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
 });

--- a/apps/app/src/components/post/PostMediaGallery.test.ts
+++ b/apps/app/src/components/post/PostMediaGallery.test.ts
@@ -29,10 +29,12 @@ let PostMediaGallery: ComponentType<{
   onMediaOpen?: (index: number) => void;
   sensitive: boolean;
 }>;
+let Button: ComponentType<Record<string, unknown>>;
 let renderer: ReactTestRenderer | null = null;
 
 before(async () => {
   ({ PostMediaGallery } = await import('./PostMediaGallery'));
+  ({ Button } = await import('@/components/ui/Button'));
 });
 
 afterEach(async () => {
@@ -43,6 +45,25 @@ afterEach(async () => {
 });
 
 describe('PostMediaGallery', () => {
+  it('sensitive media reveal uses Button and forwards expanded state', async () => {
+    await render({ media: [media(1, null)], sensitive: true });
+
+    assert.deepEqual(
+      renderer?.root.findAllByType(Button).map(({ props }) => ({
+        accessibilityLabel: props.accessibilityLabel,
+        accessibilityState: props.accessibilityState,
+        ariaExpanded: props['aria-expanded'],
+      })),
+      [
+        {
+          accessibilityLabel: '민감한 이미지 표시',
+          accessibilityState: { expanded: false },
+          ariaExpanded: false,
+        },
+      ],
+    );
+  });
+
   it('개수별 surface와 tile geometry를 document 순서대로 구성한다', async () => {
     for (const count of [1, 2, 3, 4]) {
       await render({
@@ -225,13 +246,13 @@ describe('PostMediaGallery', () => {
 
     assert.equal(rendered('PostMediaImage').length, 0);
     const reveal = pressable('민감한 이미지 표시');
-    assert.deepEqual(reveal.props.accessibilityState, { expanded: false });
+    assert.equal(reveal.props.accessibilityState.expanded, false);
 
     await act(async () => reveal.props.onPress());
     assert.equal(rendered('PostMediaImage').length, 2);
     const hide = pressable('민감한 이미지 다시 가리기');
     assert.equal(hide, reveal);
-    assert.deepEqual(hide.props.accessibilityState, { expanded: true });
+    assert.equal(hide.props.accessibilityState.expanded, true);
 
     await act(async () => hide.props.onPress());
     assert.equal(rendered('PostMediaImage').length, 0);

--- a/apps/app/src/components/post/PostMediaGallery.tsx
+++ b/apps/app/src/components/post/PostMediaGallery.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { Button } from '@/components/ui/Button';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
 import { PostMediaImage } from './PostMediaImage';
@@ -177,24 +178,16 @@ function MediaVisibilityButton({
   readonly expanded: boolean;
   readonly onPress: () => void;
 }) {
-  const theme = useTheme();
-
   return (
-    <Pressable
+    <Button
       aria-expanded={expanded}
       accessibilityLabel={expanded ? '민감한 이미지 다시 가리기' : '민감한 이미지 표시'}
-      accessibilityRole="button"
       accessibilityState={{ expanded }}
       onPress={onPress}
-      style={({ pressed }) => [
-        styles.visibilityButton,
-        { backgroundColor: pressed ? theme.primaryHover : theme.primary },
-      ]}
+      style={styles.visibilityButton}
     >
-      <Text style={[styles.visibilityButtonText, { color: theme.text }]}>
-        {expanded ? '다시 가리기' : '이미지 표시'}
-      </Text>
-    </Pressable>
+      {expanded ? '다시 가리기' : '이미지 표시'}
+    </Button>
   );
 }
 
@@ -249,13 +242,8 @@ const styles = StyleSheet.create({
   },
   unavailableText: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
   visibilityButton: {
-    alignItems: 'center',
-    borderRadius: radii.full,
-    justifyContent: 'center',
     marginTop: spacing.xs,
     minHeight: 48,
     minWidth: 120,
-    paddingHorizontal: spacing.lg,
   },
-  visibilityButtonText: { fontFamily: 'SUIT', fontWeight: '700', ...typography.sm },
 });

--- a/apps/app/src/components/post/PostMediaViewer.test.ts
+++ b/apps/app/src/components/post/PostMediaViewer.test.ts
@@ -17,6 +17,19 @@ let keydownListener: ((event: KeyboardEvent) => void) | null = null;
 let closeFocused = 0;
 const viewerKeyTarget = { tagName: 'DIV' };
 const childOverlayKeyTarget = { tagName: 'DIV' };
+type PressableMockState = { pressed: boolean };
+type PressableMockProps = Record<string, unknown> & {
+  children?: ReactNode | ((state: PressableMockState) => ReactNode);
+  style?: unknown | ((state: PressableMockState) => unknown);
+};
+const Pressable = ({ children, style, ...props }: PressableMockProps) => {
+  const state = { pressed: false };
+  return createElement(
+    'Pressable',
+    { ...props, style: typeof style === 'function' ? style(state) : style },
+    typeof children === 'function' ? children(state) : children,
+  );
+};
 
 Object.assign(globalThis, {
   addEventListener: (type: string, listener: (event: KeyboardEvent) => void) => {
@@ -46,7 +59,7 @@ mock.module('react-native', {
       },
     },
     Platform: platform,
-    Pressable: 'Pressable',
+    Pressable,
     ScrollView: 'ScrollView',
     StyleSheet: { create: <T>(styles: T) => styles },
     Text: 'Text',
@@ -98,10 +111,14 @@ type ViewerProps = {
 };
 
 let PostMediaViewer: ComponentType<ViewerProps>;
+let IconButton: ComponentType<Record<string, unknown>>;
 let renderer: ReactTestRenderer | null = null;
 
 before(async () => {
-  const module = await import('./PostMediaViewer');
+  const [module, iconButtonModule] = await Promise.all([
+    import('./PostMediaViewer'),
+    import('@/components/ui/IconButton'),
+  ]);
   PostMediaViewer = (props) =>
     createElement(
       module.PostMediaViewer,
@@ -117,6 +134,7 @@ before(async () => {
         wideDetail: props.wideDetail,
       }),
     );
+  IconButton = iconButtonModule.IconButton as ComponentType<Record<string, unknown>>;
 });
 
 afterEach(async () => {
@@ -133,6 +151,47 @@ afterEach(async () => {
 });
 
 describe('PostMediaViewer', () => {
+  it('viewer controls use the shared 48px IconButton contract', async () => {
+    await render({ selectedIndex: 0 });
+
+    assert.deepEqual(
+      renderer?.root.findAllByType(IconButton).map(({ props }) => ({
+        accessibilityLabel: props.accessibilityLabel,
+        accessibilityState: props.accessibilityState,
+        controlRef: props.controlRef != null,
+        disabled: props.disabled,
+        targetSize: props.targetSize,
+        visualSize: props.visualSize,
+      })),
+      [
+        {
+          accessibilityLabel: '이미지 뷰어 닫기',
+          accessibilityState: undefined,
+          controlRef: true,
+          disabled: undefined,
+          targetSize: 48,
+          visualSize: 48,
+        },
+        {
+          accessibilityLabel: '이전 이미지',
+          accessibilityState: { disabled: true },
+          controlRef: false,
+          disabled: true,
+          targetSize: 48,
+          visualSize: 48,
+        },
+        {
+          accessibilityLabel: '다음 이미지',
+          accessibilityState: { disabled: false },
+          controlRef: false,
+          disabled: false,
+          targetSize: 48,
+          visualSize: 48,
+        },
+      ],
+    );
+  });
+
   it('같은 Post fragment의 Content·Media·Profile 표시 데이터를 사용한다', async () => {
     await render();
 

--- a/apps/app/src/components/post/PostMediaViewer.tsx
+++ b/apps/app/src/components/post/PostMediaViewer.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { Avatar } from '@/components/ui/Avatar';
+import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
 import { breakpoints, radii, spacing, typography } from '@/theme/tokens';
 import { focusPostMediaViewerTarget } from './postMediaViewerSession';
@@ -233,18 +234,19 @@ export function PostMediaViewer({
           testID="post-media-viewer-dialog"
         >
           <View style={styles.chrome}>
-            <Pressable
+            <IconButton
               accessibilityLabel="이미지 뷰어 닫기"
-              accessibilityRole="button"
               onPress={requestClose}
-              ref={closeRef}
+              controlRef={closeRef}
               style={({ pressed }) => [styles.iconButton, { opacity: pressed ? 0.7 : 1 }]}
+              targetSize={48}
               testID="post-media-viewer-close"
+              visualSize={48}
             >
               <Text aria-hidden style={styles.closeIcon}>
                 ×
               </Text>
-            </Pressable>
+            </IconButton>
             {position && position.total > 1 ? (
               <Text aria-hidden style={styles.counter} testID="post-media-viewer-counter">
                 {position.current} / {position.total}
@@ -663,9 +665,8 @@ function NavigationButton({
 }) {
   const label = direction === 'previous' ? '이전 이미지' : '다음 이미지';
   return (
-    <Pressable
+    <IconButton
       accessibilityLabel={label}
-      accessibilityRole="button"
       accessibilityState={{ disabled }}
       disabled={disabled}
       onPress={onPress}
@@ -674,11 +675,13 @@ function NavigationButton({
         direction === 'previous' ? styles.previousButton : styles.nextButton,
         { opacity: disabled ? 0.3 : pressed ? 0.7 : 1 },
       ]}
+      targetSize={48}
+      visualSize={48}
     >
       <Text aria-hidden style={styles.navigationIcon}>
         {direction === 'previous' ? '‹' : '›'}
       </Text>
-    </Pressable>
+    </IconButton>
   );
 }
 


### PR DESCRIPTION
## 무엇을 변경했는지

- PostMediaViewer의 닫기·이전·다음 raw Pressable을 공용 IconButton으로 이관했습니다.
- 기존 focus 복귀, keyboard·swipe 탐색, disabled·pressed 상태와 48×48 visual/target geometry를 유지했습니다.
- PostContentRenderer의 Content Warning 공개 control과 PostMediaGallery의 Sensitive Media 공개 control을 공용 Button으로 이관했습니다.
- 기존 expanded state, event propagation, 공개·다시 가리기 흐름과 Media 미mount·geometry를 유지했습니다.
- 세 소비처의 공용 primitive 사용과 상태 전달을 기존 component test에 최소 보강했습니다.

## 왜 변경했는지

DSN-19에서 확정된 공용 Button·IconButton 계약을 Product 소비처에 적용하면서 Viewer와 reveal surface의 기존 접근성·상호작용·Media geometry를 유지하기 위함입니다.

## 이번 PR의 주요 결정

### Viewer glyph와 48×48 geometry를 유지합니다

- 결정자: @yeeun-uwu
- 선택: 기존 `×`, `‹`, `›` glyph와 48×48 visual/target geometry를 유지한 채 공용 IconButton을 사용합니다.
- 고려한 대안: lucide icon으로 함께 교체
- 이유: 이번 범위는 공용 primitive 이관이며 glyph 교체에 따른 시각적 변화는 승인 범위가 아닙니다.
- 감수한 결과: Viewer glyph는 기존 text 표현을 계속 사용합니다.
- 관련 근거: PROD-749, DSN-19, `docs/design/accessibility.md`, `docs/design/post-media-viewer.md`

### reveal control은 공용 Button의 semantic 표현을 사용합니다

- 결정자: @yeeun-uwu
- 선택: 기존 Button의 semantic typography·color·pressed feedback을 사용하고 surface별 margin과 플랫폼 target 높이만 유지합니다.
- 고려한 대안: 기존 pill의 legacy color·text style을 Button 위에 다시 덮기
- 이유: 공용 primitive 이관 목적을 유지하면서 Media geometry와 플랫폼 target 계약을 보존할 수 있습니다.
- 감수한 결과: reveal label은 공용 Button의 시각 계약으로 정렬됩니다.
- 관련 근거: PROD-749, DSN-19, `docs/design/accessibility.md`, `docs/design/foundations.md`

### 새 Button abstraction을 만들지 않습니다

- 결정자: @yeeun-uwu
- 선택: 기존 Button·IconButton만 재사용하고 surface-specific geometry와 상태만 caller에서 유지합니다.
- 고려한 대안: Viewer 또는 reveal control 전용 공용 wrapper 추가
- 이유: PROD-749의 제외 범위이며 기존 공용 primitive로 필요한 계약을 충족할 수 있습니다.
- 감수한 결과: 도메인별 state와 event handler는 기존 Post 컴포넌트에 남습니다.
- 관련 근거: PROD-749, DSN-19

## 어떻게 확인할 수 있는지

- 관련 Post component test 3개: 34/34 통과
- Relay compiler `--noWatchman`: 통과
- TypeScript `--noEmit`: 통과
- 앱 unit test: 327/327 통과
- Storybook build: 통과
- Storybook test: 24 files, 360/360 통과
- OpenSpec `validate --all --strict`: 95/95 통과
- Web Storybook 수동 확인:
  - Viewer 닫기·이전·다음 48×48
  - ArrowRight/ArrowLeft 이동과 양끝 disabled
  - 닫기 후 원래 Media trigger로 focus 복귀
  - Content Warning 44px, Sensitive Media 48px 및 expanded 토글
- 독립 구현 리뷰 2회(저장소 지침 없는 diff-only, 저장소 지침·canonical 계약 적용): 최종 지적 사항 없음
- DSN-19 squash merge 후 range-diff: 두 PROD-749 커밋의 patch 동일

`pnpm --filter @kosmo/app test` 단일 명령은 sandbox의 Watchman chmod 제한으로 시작하지 못해, 동일 구성 단계를 Relay `--noWatchman`과 나머지 subcommand로 각각 실행했습니다.

## 아직 어떤 문제가 남았는지

- iOS VoiceOver·Android TalkBack 및 실제 Native touch target 실기기 검증은 수행하지 않았습니다.

Stack: main -> PROD-749
