### PR TITLE
dev Fedify queue 데이터베이스를 안전하게 준비한다

### DIFF
--- a/apps/helm/templates/postgres-runtime-roles.yaml
+++ b/apps/helm/templates/postgres-runtime-roles.yaml
@@ -1,4 +1,7 @@
 {{- $releaseName := .Release.Name | trunc 47 | trimSuffix "-" }}
+{{- if and .Values.fedify.queueDatabase.enabled (ne .Values.env "dev") }}
+{{- fail "fedify.queueDatabase.enabled is currently supported only when env=dev" }}
+{{- end }}
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: DatabaseRole
@@ -27,6 +30,69 @@ spec:
   clientCertificate:
     enabled: true
   databaseRoleReclaimPolicy: retain
+{{- if and (eq .Values.env "dev") .Values.fedify.queueDatabase.enabled }}
+{{- $queue := .Values.postgres.credentials.fedifyQueue | default dict }}
+{{- $passwordSecret := $queue.passwordSecret | default dict }}
+{{- $passwordSecretName := $passwordSecret.name | default "" | toString }}
+{{- $passwordSecretKey := $passwordSecret.key | default "" | toString }}
+{{- $databaseUrl := $queue.databaseUrl | default "" | toString }}
+{{- if not $passwordSecretName }}
+{{- fail "postgres.credentials.fedifyQueue.passwordSecret.name is required when fedify.queueDatabase.enabled is true" }}
+{{- end }}
+{{- if ne $passwordSecretKey "password" }}
+{{- fail "postgres.credentials.fedifyQueue.passwordSecret.key must be password when fedify.queueDatabase.enabled is true" }}
+{{- end }}
+{{- if not $databaseUrl }}
+{{- fail "postgres.credentials.fedifyQueue.databaseUrl is required when fedify.queueDatabase.enabled is true" }}
+{{- end }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: DatabaseRole
+metadata:
+  name: {{ printf "%s-postgres-fedify-queue" $releaseName }}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
+    argocd.argoproj.io/sync-wave: "-2"
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: postgres-fedify-queue
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  cluster:
+    name: {{ include "kosmo.postgresName" . }}
+  name: kosmo_fedify_queue
+  login: true
+  inherit: true
+  superuser: false
+  createdb: false
+  createrole: false
+  replication: false
+  bypassrls: false
+  inRoles: []
+  passwordSecret:
+    name: {{ $passwordSecretName | quote }}
+  databaseRoleReclaimPolicy: retain
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: {{ printf "%s-postgres-fedify-queue-database" $releaseName | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: postgres-fedify-queue-database
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  cluster:
+    name: {{ include "kosmo.postgresName" . }}
+  name: kosmo_fedify_queue
+  owner: kosmo_fedify_queue
+  databaseReclaimPolicy: retain
+{{- end }}
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: DatabaseRole

--- a/apps/helm/templates/postgres-runtime-roles.yaml
+++ b/apps/helm/templates/postgres-runtime-roles.yaml
@@ -1,4 +1,8 @@
 {{- $releaseName := .Release.Name | trunc 47 | trimSuffix "-" }}
+{{- $queueWorkloadEnabled := or .Values.fedify.producer.enabled .Values.fedify.consumer.enabled }}
+{{- if and (eq .Values.env "dev") $queueWorkloadEnabled (not .Values.fedify.queueDatabase.enabled) }}
+{{- fail "fedify.queueDatabase.enabled must be true when a dev Fedify queue workload is enabled" }}
+{{- end }}
 {{- if and .Values.fedify.queueDatabase.enabled (ne .Values.env "dev") }}
 {{- fail "fedify.queueDatabase.enabled is currently supported only when env=dev" }}
 {{- end }}
@@ -44,6 +48,10 @@ spec:
 {{- end }}
 {{- if not $databaseUrl }}
 {{- fail "postgres.credentials.fedifyQueue.databaseUrl is required when fedify.queueDatabase.enabled is true" }}
+{{- end }}
+{{- $queueUrlPattern := printf "^postgres(ql)?://kosmo_fedify_queue:[^@]+@%s:5432/kosmo_fedify_queue(?:\\?.*)?$" (include "kosmo.postgresPoolerName" .) }}
+{{- if not (regexMatch $queueUrlPattern $databaseUrl) }}
+{{- fail (printf "postgres.credentials.fedifyQueue.databaseUrl must target kosmo_fedify_queue through %s:5432" (include "kosmo.postgresPoolerName" .)) }}
 {{- end }}
 ---
 apiVersion: postgresql.cnpg.io/v1

--- a/apps/helm/templates/vaultstaticsecret.yaml
+++ b/apps/helm/templates/vaultstaticsecret.yaml
@@ -83,3 +83,49 @@ spec:
         - "^username$"
         - "^password$"
 {{- end }}
+{{ if and (eq .Values.env "dev") .Values.fedify.queueDatabase.enabled }}
+{{- $queue := .Values.postgres.credentials.fedifyQueue -}}
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: "fedify-queue-database"
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
+    argocd.argoproj.io/sync-wave: "-3"
+  labels:
+    helm.sh/chart: {{ include "kosmo.chart" . }}
+    app.kubernetes.io/name: fedify-queue-database
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  vaultAuthRef: "vso-kubernetes-sync"
+  mount: "secret"
+  type: "kv-v2"
+  path: "kubernetes/kosmo/dev/fedify-queue"
+  refreshAfter: "5m"
+  destination:
+    name: {{ $queue.passwordSecret.name | quote }}
+    create: true
+    overwrite: true
+    type: "kubernetes.io/basic-auth"
+    labels:
+      cnpg.io/reload: "true"
+    transformation:
+      includes:
+        - "^username$"
+        - "^password$"
+  {{- if or (and .Values.workloads.enabled .Values.fedify.producer.enabled) .Values.fedify.consumer.enabled }}
+  rolloutRestartTargets:
+    {{- if and .Values.workloads.enabled .Values.fedify.producer.enabled }}
+    - kind: "argo.Rollout"
+      name: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
+    - kind: "argo.Rollout"
+      name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
+    {{- end }}
+    {{- if .Values.fedify.consumer.enabled }}
+    - kind: "Deployment"
+      name: {{ printf "%s-fedify-consumer" .Release.Name | trunc 63 | trimSuffix "-" | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/apps/helm/values.yaml
+++ b/apps/helm/values.yaml
@@ -25,6 +25,8 @@ autoscaling:
 migration:
   enabled: false
 fedify:
+  queueDatabase:
+    enabled: false
   producer:
     enabled: false
   consumer:

--- a/openspec/changes/configure-fedify-postgres-message-queue-runtime/decisions.md
+++ b/openspec/changes/configure-fedify-postgres-message-queue-runtime/decisions.md
@@ -88,6 +88,18 @@
 - Consequences: credential values가 존재해도 Helm flag가 꺼져 있으면 runtime에 주입되지 않아 기존 direct mode를 유지한다. enabled Helm render는 완전한 Secret selector를 요구하고, queue가 구성된 runtime은 실패를 direct/owner connection으로 우회하지 않는다.
 - Confirmation / Follow-up: default, producer, consumer와 incomplete credential은 구현 시점의 일회성 Helm lint/template inspection으로 확인하고, 실제 adapter enqueue/listen smoke test로 activation과 rollback을 검증한다. 이 변경만을 위한 상시 render harness는 저장소에 추가하지 않는다.
 
+### Dev queue는 같은 cluster의 별도 database와 전용 credential을 사용한다
+
+- Decision Date: 2026-08-11
+- Decision Class: Implementation Choice
+- Authority / Provenance: PROD-448 사용자 승인과 갱신된 Linear 본문·dev-live 댓글
+- Status: Active
+- Context / Problem: official `PostgresMessageQueue` adapter는 table name만 받고 schema option을 제공하지 않으며 첫 enqueue/listen에서 unqualified table/index DDL을 실행한다. domain database 안의 별도 schema를 사용하려면 `search_path`와 권한 helper를 추가해야 해 adapter 사용보다 배포 구조가 복잡해진다.
+- Decision Outcome: dev queue transport는 기존 CloudNativePG cluster 안의 별도 PostgreSQL database `kosmo_fedify_queue`와 전용 login/Secret을 사용한다. dev credential은 기존 VSO convention에 따라 `kubernetes/kosmo/dev/fedify-queue` Vault path의 `username`/`password`를 `kubernetes.io/basic-auth` Secret으로 동기화한다. API/Web/consumer의 `FEDIFY_QUEUE_DATABASE_*`만 이 database를 가리키며 `DATABASE_URL`, `OPERATION_DATABASE_URL` 또는 `WORKER_DATABASE_*`로 fallback하지 않는다. adapter가 queue database 안의 table/index implicit DDL을 소유하고 custom schema, `search_path` helper, Drizzle migration 또는 one-shot queue DDL command를 추가하지 않는다.
+- Alternatives Considered: domain `kosmo` database의 `public` schema 사용, domain database 안의 별도 schema와 role-level/URL `search_path`, 별도 PostgreSQL cluster.
+- Consequences: 같은 cluster이므로 물리 장애 격리는 늘지 않지만 namespace, credential과 DDL 범위가 분리된다. consumer는 queue database connection과 trusted domain listener connection 두 개를 유지한다. queue database/login/Secret 생성은 dev에서만 먼저 수행하고 production 준비·활성화는 별도 승인을 유지한다.
+- Confirmation / Follow-up: Helm/CloudNativePG render에서 database·role·Secret과 queue URL target을 확인하고, dev에서 adapter implicit initialization, producer/consumer handoff와 dequeue 전 restart persistence를 검증한다.
+
 ### Production queue database 준비와 runtime 활성화는 별도 승인한다
 
 - Decision Date: 2026-08-10
@@ -96,7 +108,7 @@
 - Status: Active
 - Context / Problem: code/PR completion과 실제 database schema mutation, consumer rollout, producer cutover는 위험과 증거가 서로 다르다.
 - Decision Outcome: 구현과 nonproduction 검증은 production mutation 없이 완료한다. production queue database·credential 준비, consumer 최초 activation과 adapter implicit initialization, producer queue 활성화는 각 정확한 대상과 현재 evidence를 제시하고 별도 사용자 승인을 받은 작업만 수행한다. 별도 custom schema migration/one-shot DDL command는 만들지 않는다.
-- Alternatives Considered: domain database 안에 custom schema bootstrap 추가, adapter initialization과 별도 DDL command 중복, dev 검증을 production 완료로 일반화.
+- Alternatives Considered: domain database 안에 custom schema bootstrap 추가, adapter initialization과 별도 DDL command 중복, dev database 선택을 production apply 승인으로 일반화.
 - Consequences: PR Ready 상태가 dev live 또는 production 활성화를 뜻하지 않는다. rollback에서도 queue purge/table drop은 별도 파괴적 승인 없이는 실행하지 않는다.
 - Confirmation / Follow-up: PR 본문과 완료 보고에서 local/CI, dev live, production apply/cutover 증거를 분리한다.
 

--- a/openspec/changes/configure-fedify-postgres-message-queue-runtime/design.md
+++ b/openspec/changes/configure-fedify-postgres-message-queue-runtime/design.md
@@ -37,6 +37,7 @@ Domain effects Workflow는 이 change와 병렬로 기존 Fedify delivery Activi
 - 취소된 PROD-706 branch도 `federation.ts`를 수정했지만 merge 대상이 아니다. 그 branch를 cherry-pick하거나 generic execution-context seam을 PROD-448에서 재구현하면 취소 결정을 우회한다.
 - `PostgresMessageQueue`와 consumer parallelism은 PostgreSQL connection을 사용한다. connection pool을 API/Web 기본 DB pool과 무비판적으로 공유하면 queue backlog 때 connection starvation이 생길 수 있다.
 - `PostgresMessageQueue`는 첫 `enqueue()`/`listen()`에서 `CREATE TABLE`, `ALTER TABLE`, `CREATE INDEX IF NOT EXISTS`를 실행한다. 별도 one-shot schema command를 중복 구현하지 않고, production에서는 queue 전용 database/credential 준비와 최초 mode 활성화를 함께 명시적으로 승인해야 한다.
+- dev queue transport는 기존 CloudNativePG cluster 안의 별도 `kosmo_fedify_queue` database와 전용 login/Secret을 사용한다. adapter는 schema option을 제공하지 않으므로 domain database 안의 custom schema, `search_path` helper 또는 adapter table migration을 만들지 않는다.
 - 기존 test DB wrapper는 `DATABASE_URL`만 격리 DB로 바꾼다. queue 통합 테스트는 별도 transport URL을 같은 격리 DB로 명시해 owner/API DB fallback 부재를 검증해야 한다.
 
 ### Recommended Approach
@@ -46,7 +47,7 @@ Domain effects Workflow는 이 change와 병렬로 기존 Fedify delivery Activi
 3. producer federation은 `manuallyStartQueue: true`로 구성해 Web/API process가 queue를 소비하지 않게 한다. API/Web producer와 consumer의 queue transport connection은 API domain DB 및 trusted Worker execution DB와 분리하고, API에 Worker credential을 주입하지 않는다. `apps/fedify-consumer`는 같은 federation의 `startQueue()`만 실행하고 public HTTP listener나 Temporal Worker를 시작하지 않는다.
 4. consumer process는 작은 probe server 또는 동등한 platform-native probe 경계를 둔다. SIGTERM/SIGINT에서는 readiness를 내린 뒤 AbortController로 Fedify listener를 중단하고 queue용 PostgreSQL client를 정리한다.
 5. 장기 실행 process와 probe/signal lifecycle은 `apps/fedify-consumer`가 소유한다. 공통 image에 이 app을 실행하는 별도 `fedify-queue` command를 추가하고 Helm에 Web/Temporal Worker와 독립된 기본 비활성 Fedify consumer Deployment를 둔다. Service/Ingress는 만들지 않고 replica/resource/probe/Fedify credential을 별도로 render한다.
-6. exact adapter의 implicit `initialize()`가 queue connection 대상 database 안의 기본 table/index를 소유하게 하고 Drizzle domain migration, custom DDL 또는 transport ledger를 만들지 않는다. dev/test에서는 격리 DB에서 초기화를 검증한다. production isolation이 필요하면 custom schema보다 별도 queue database/credential을 우선하고, 그 database 준비와 최초 producer/consumer 활성화는 별도 승인한다.
+6. exact adapter의 implicit `initialize()`가 queue connection 대상 database 안의 기본 table/index를 소유하게 하고 Drizzle domain migration, custom DDL 또는 transport ledger를 만들지 않는다. dev는 기존 CloudNativePG cluster 안에 별도 `kosmo_fedify_queue` database와 전용 login/Secret을 준비하고, test는 격리 DB에서 초기화를 검증한다. production도 custom schema보다 별도 queue database/credential을 사용하되, 그 database 준비와 최초 producer/consumer 활성화는 별도 승인한다.
 7. 기존 activity별 delivery 테스트는 identity/audience와 이미 존재하는 Fedify ordering option을 보존하는지만 검증한다. 새 integration test는 실제 PostgreSQL queue가 수락한 message를 consumer가 연결되기 전에 producer connection을 닫아도 새 connection에서 소비하는지만 검증한다. dequeue 뒤 handler process crash redelivery, protocol-level idempotency나 새로운 ordering contract를 이 change의 검증 대상으로 확장하지 않는다.
 8. Helm producer/consumer flag가 default-off 활성화와 queue credential 주입을 제어한다. package-level runtime mode, custom config parser와 startup `getDepth()` probe를 추가하지 않고 official adapter의 enqueue/listen lazy initialization과 오류를 그대로 사용한다.
 
@@ -73,7 +74,7 @@ Domain effects Workflow는 이 change와 병렬로 기존 Fedify delivery Activi
 - [dequeue 뒤 handler 완료 전 process crash에서 message가 유실될 수 있음] → official adapter의 현재 보장 수준으로 명시해 수용하고 custom ack/requeue/relay를 추가하지 않는다. 통합 테스트는 dequeue 전 queued persistence만 증명한다.
 - [분리 consumer 도입 시 Web과 worker registration drift] → 같은 production registration factory와 동일한 configuration contract를 사용하고 producer/consumer compatibility test를 둔다.
 - [PostgreSQL connection starvation] → queue 전용 pool과 보수적 concurrency를 기본으로 하고, parallelism을 늘릴 때 pool headroom과 backlog drain을 함께 검증한다.
-- [implicit adapter DDL이 의도하지 않은 database를 변경] → queue transport URL을 domain database와 분리하고 production queue database/credential 준비 및 최초 activation을 하나의 명시적 승인 대상으로 제시한다.
+- [implicit adapter DDL이 의도하지 않은 database를 변경] → dev에서는 별도 `kosmo_fedify_queue` database와 전용 login/Secret으로 범위를 격리하고, production queue database/credential 준비 및 최초 activation은 하나의 명시적 승인 대상으로 제시한다.
 - [비동기 handoff로 기존 테스트와 운영자가 remote delivery 성공을 과대 해석] → queue handoff 성공과 remote delivery 성공을 테스트와 보고 문구에서 분리한다.
 - [기존 domain idempotency가 모든 duplicate timing을 견디지 못할 수 있음] → activity별 integration test로 검증하고 transport change가 domain transition을 새로 소유하지 않게 한다.
 - [Fedify MessageQueue 전환이 기존 ordering option 또는 shared inbox recipient 병합을 손실할 수 있음] → 기존 callsite option과 fan-out 결과를 검증하되, PROD-448에서 KV/custom dedupe나 신규 ordering key를 추가하지 않는다.
@@ -85,7 +86,7 @@ Domain effects Workflow는 이 change와 병렬로 기존 Fedify delivery Activi
 2. dependency, queue construction, producer/consumer 분리, entrypoint, probes와 격리 PostgreSQL 통합 테스트를 구현한다.
 3. local/CI에서 adapter implicit initialization, dequeue 전 queued persistence, 기존 ordering option 보존, shared inbox recipient 병합, retry/failure, graceful shutdown과 Helm default/opt-in render를 검증한다.
 4. 구현 PR은 production mutation이나 domain Workflow 완료 없이 Ready로 만들고 PR completion evidence와 미실행 dev live/production verification을 구분한다. 이 시점에도 direct mode를 사용하는 Activity는 기존 delivery request 실패를 Temporal retry 경계에 남길 수 있다.
-5. 별도 승인을 받은 경우에만 dev queue mode를 활성화해 adapter initialization, consumer rollout과 live enqueue/consume/restart를 검증한다.
+5. 승인된 dev 범위에서 기존 CloudNativePG cluster에 별도 `kosmo_fedify_queue` database와 전용 login/Secret을 준비한 뒤 queue mode를 활성화해 adapter initialization, consumer rollout과 live enqueue/consume/restart를 검증한다.
 6. production은 다시 queue database/credential과 backlog 상태를 확인하고, 별도 승인된 queue database 준비 → consumer 최초 activation/implicit initialization → producer queue cutover 순서로 진행한다. producer cutover 뒤 Activity 성공은 queue 수락이며 remote HTTP retry/order는 Fedify만 소유한다. 각 단계는 이전 direct path 또는 disabled consumer로 rollback 가능해야 한다.
 7. rollback 시 새 producer enqueue를 먼저 중단하고 queue backlog의 처리/보존 결정을 명시한 뒤 consumer를 내린다. queue table 삭제나 purge는 별도 파괴적 승인 없이는 수행하지 않는다.
 

--- a/openspec/changes/configure-fedify-postgres-message-queue-runtime/proposal.md
+++ b/openspec/changes/configure-fedify-postgres-message-queue-runtime/proposal.md
@@ -8,7 +8,7 @@
 - Web ingress는 검증 가능한 ActivityPub 요청을 queue가 수락하면 remote sender에게 응답하고, domain materialization은 Fedify queue consumer에서 실행한다.
 - outbound 호출자는 activity와 명시적 actor identity, audience를 Fedify에 넘기고 queue handoff 수락까지만 기다린다. 기존 callsite가 이미 정의한 ordering option은 그대로 전달하며, remote HTTP delivery, retry, 기존 ordering option 실행과 shared inbox recipient 병합 정책은 Fedify가 소유한다.
 - Web/API 요청 처리와 독립적으로 배포·확장·재시작할 수 있는 Fedify queue consumer runtime, health/readiness와 graceful shutdown 경계를 제공한다.
-- queue runtime은 명시적으로 활성화될 때 공식 adapter가 connection 대상 database 안의 queue table/index를 implicit하게 초기화하게 한다. queue connection은 domain/API DB 및 Worker execution credential과 분리하고, 실제 production queue database·credential 준비와 최초 활성화는 별도 승인·변경에 남긴다.
+- queue runtime은 명시적으로 활성화될 때 공식 adapter가 connection 대상 database 안의 queue table/index를 implicit하게 초기화하게 한다. dev는 기존 CloudNativePG cluster 안의 별도 `kosmo_fedify_queue` database와 전용 login/Secret을 사용하고, queue connection은 domain/API DB 및 Worker execution credential과 분리한다. 실제 production queue database·credential 준비와 최초 활성화는 별도 승인·변경에 남긴다.
 - queue가 수락하고 아직 dequeue하지 않은 message의 process restart 영속성만 보장한다. dequeue 뒤 handler 완료 전 process crash 재전달을 보강하는 custom ack, lease, requeue 또는 relay는 추가하지 않는다.
 - Temporal task queue, domain state transition, Notification, domain Workflow/Workflow ID, transactional Workflow intent/outbox/relay는 추가하거나 변경하지 않는다.
 - 전환 전에는 domain effects Workflow가 기존 Fedify delivery Activity를 호출하고 Temporal Activity가 delivery request 실패를 재시도할 수 있다. PROD-448 queue producer를 활성화한 뒤에는 queue handoff 수락이 그 Activity의 성공 경계가 되며, 이후 remote HTTP retry와 기존 ordering option 실행은 Fedify만 소유한다. 이 전환은 domain Workflow 구현을 선행 조건으로 만들지 않는다.
@@ -43,5 +43,6 @@
 - `@fedify/postgres` production dependency와 adapter-managed `fedify_message_v2` table/index가 queue connection 대상 PostgreSQL database에 추가된다.
 - `packages/fedify` federation construction과 inbound/outbound context 생성이 영향을 받고, 장기 실행 queue lifecycle은 `apps/fedify-consumer`가 소유한다.
 - 공통 runtime image에 `apps/fedify-consumer`가 추가되고 Helm에 기본 비활성 또는 별도 opt-in consumer Deployment, probe, resource/replica 설정과 Fedify DB credential 입력이 추가된다.
+- dev Helm에는 default-off `kosmo_fedify_queue` Database/DatabaseRole과 VSO basic-auth Secret 동기화가 추가되며 실제 Vault value와 workload activation 전에는 database를 생성하지 않는다.
 - 기존 Web ingress, API/Core의 Fedify 호출 경계와 ActivityPub 통합 테스트는 queue handoff 기준으로 갱신된다. API가 outbound producer인 동안 API runtime에도 API domain DB와 분리된 Fedify queue credential 입력이 필요하다.
-- 취소된 PROD-706/PR #543 코드를 cherry-pick하거나 재구현하지 않는다. queue consumer의 domain listener는 현재 main의 trusted ingress DB 동작을 보존하며, 별도 runtime role·credential cutover는 제외한다. production values 변경, Argo CD sync, Helm apply와 DB production apply는 이 change의 자동 실행 범위가 아니다.
+- 취소된 PROD-706/PR #543 코드를 cherry-pick하거나 재구현하지 않는다. queue consumer의 domain listener는 현재 main의 trusted ingress DB 동작을 보존하며, API/Worker runtime role·credential cutover는 제외한다. production values 변경, Argo CD sync, Helm apply와 DB production apply는 이 change의 자동 실행 범위가 아니다.

--- a/openspec/changes/configure-fedify-postgres-message-queue-runtime/specs/fedify-postgres-message-queue-runtime/spec.md
+++ b/openspec/changes/configure-fedify-postgres-message-queue-runtime/specs/fedify-postgres-message-queue-runtime/spec.md
@@ -164,6 +164,7 @@
 - **THEN** 기존 CloudNativePG cluster 안의 별도 `kosmo_fedify_queue` database와 전용 login/Secret을 사용한다
 - **AND** official adapter가 해당 database 안의 queue table/index implicit DDL을 소유하며 domain database schema, `search_path` helper 또는 custom queue migration을 추가하지 않는다
 - **AND** queue connection은 API/domain DB와 Worker trusted execution credential을 재사용하거나 fallback하지 않는다
+- **AND** dev producer 또는 consumer를 활성화하면서 queue database 준비 flag를 끄거나 전용 role·PgBouncer·database가 아닌 URL을 지정하면 Helm render에 실패한다
 
 #### Scenario: 구현 PR 완료
 

--- a/openspec/changes/configure-fedify-postgres-message-queue-runtime/specs/fedify-postgres-message-queue-runtime/spec.md
+++ b/openspec/changes/configure-fedify-postgres-message-queue-runtime/specs/fedify-postgres-message-queue-runtime/spec.md
@@ -158,6 +158,13 @@
 - **THEN** Helm은 완전한 Fedify queue credential을 runtime에 주입하고 official adapter가 첫 enqueue에서 connection 대상 database의 queue table/index를 idempotent하게 초기화하게 한다
 - **AND** enabled Helm 상태의 누락·부분 selector는 render에 실패하며 adapter 오류는 direct delivery나 owner/API DB fallback으로 우회하지 않는다
 
+#### Scenario: dev queue database 격리
+
+- **WHEN** dev Fedify queue producer와 consumer를 활성화할 준비를 한다
+- **THEN** 기존 CloudNativePG cluster 안의 별도 `kosmo_fedify_queue` database와 전용 login/Secret을 사용한다
+- **AND** official adapter가 해당 database 안의 queue table/index implicit DDL을 소유하며 domain database schema, `search_path` helper 또는 custom queue migration을 추가하지 않는다
+- **AND** queue connection은 API/domain DB와 Worker trusted execution credential을 재사용하거나 fallback하지 않는다
+
 #### Scenario: 구현 PR 완료
 
 - **WHEN** 코드, chart, 격리 database의 adapter initialization과 비production 검증이 완료되어 PR이 review-ready 상태가 된다

--- a/openspec/changes/configure-fedify-postgres-message-queue-runtime/tasks.md
+++ b/openspec/changes/configure-fedify-postgres-message-queue-runtime/tasks.md
@@ -194,9 +194,10 @@ PR completion과 별도로 dev 환경에서 실제 Fedify queue producer/consume
 
 **Verification**
 
-- dev의 현재 schema/credential/deployment 상태를 먼저 읽고, 실제 inbound/outbound canary handoff, queue depth 변화, consumer restart 뒤 처리와 Web/consumer 독립 rollout을 관측한다.
+- dev의 현재 database/credential/deployment 상태를 먼저 읽고, 기존 CloudNativePG cluster 안의 별도 `kosmo_fedify_queue` database와 전용 login/Secret이 domain/Worker credential fallback 없이 준비됐는지 확인한다.
+- 실제 inbound/outbound canary handoff, queue depth 변화, consumer restart 뒤 처리와 Web/consumer 독립 rollout을 관측한다. adapter implicit DDL 외 custom schema/search-path helper 또는 queue migration을 추가하지 않는다.
 - dev 미실행이면 미실행 사유와 PR completion evidence만 명확히 보고한다.
 
-- [ ] 7.1 dev 현재 상태와 안전한 canary/rollback 대상을 확인하고 live verification 범위를 기록한다.
+- [x] 7.1 dev 현재 상태와 안전한 canary/rollback 대상을 확인하고 live verification 범위를 기록한다.
 - [ ] 7.2 dev에서 producer handoff, consumer 처리, queue depth와 dequeue 전 queued-message persistence를 검증한다.
 - [ ] 7.3 dev live 결과와 남은 production apply/cutover gate를 Linear와 PR에 구분해 기록한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- dev 전용 `fedify.queueDatabase.enabled` opt-in을 추가했습니다.
- 기존 CloudNativePG cluster 안에 `kosmo_fedify_queue` 전용 `DatabaseRole`과 `Database`를 선언했습니다.
- `kubernetes/kosmo/dev/fedify-queue`의 `username`/`password`를 VSO가 `kubernetes.io/basic-auth` Secret으로 동기화하게 했습니다.
- VSO Secret → DatabaseRole → Database 순서로 적용하고 모든 DB/role 리소스는 retain 및 `Prune=confirm`으로 보호했습니다.
- PROD-448 OpenSpec에 별도 database 결정과 dev-live 7.1 evidence를 반영했습니다.

## 왜 변경했는지

PR #566은 Fedify official PostgreSQL MessageQueue runtime을 default-off로 제공했지만 dev에는 queue 전용 database, login, Secret이 없어 live handoff를 활성화할 수 없었습니다. queue DDL을 domain DB나 Worker credential에 섞지 않고 dev canary를 단계적으로 준비하기 위한 후속 변경입니다.

Linear: https://linear.app/byulmaru/issue/PROD-448/fedify-postgresql-messagequeue-runtime을-구성한다

## 이번 PR의 주요 결정

### 같은 cluster의 별도 database를 사용한다

- 결정자: @robin-maki
- 선택: 기존 CNPG cluster 안의 `kosmo_fedify_queue` database와 동명의 전용 owner login/Secret
- 고려한 대안: domain `kosmo` DB의 `public` schema, 별도 schema와 `search_path`, 별도 PostgreSQL cluster
- 이유: `PostgresMessageQueue`가 schema option 없이 unqualified implicit DDL을 수행하므로 별도 schema는 별도 helper와 권한 규칙을 요구합니다. 별도 database는 adapter를 그대로 사용하면서 DDL namespace와 credential을 분리합니다.
- 감수한 결과: 같은 cluster를 사용하므로 물리 장애 격리는 늘지 않습니다. consumer는 queue connection과 trusted domain listener connection을 별도로 유지합니다.
- 관련 근거: `openspec/changes/configure-fedify-postgres-message-queue-runtime/decisions.md`

### database 준비와 workload 활성화를 분리한다

- 결정자: @robin-maki
- 선택: queue database provisioning, consumer, producer를 각각 default-off로 두고 순서대로 활성화
- 고려한 대안: credential 존재만으로 자동 생성·활성화, producer/consumer와 database 동시 활성화
- 이유: Secret/DDL 준비 실패가 기존 Web/API runtime에 영향을 주지 않게 하고 rollback 시 queue database나 message를 제거하지 않기 위함입니다.
- 감수한 결과: dev live verification에는 별도의 Vault value 준비와 후속 Argo values 변경이 필요합니다.
- 관련 근거: `openspec/changes/configure-fedify-postgres-message-queue-runtime/specs/fedify-postgres-message-queue-runtime/spec.md`

## 어떻게 확인할 수 있는지

- dev/prod 기본값 Helm lint 통과
- dev database-only opt-in Helm lint/template 통과
- dev database + producer + consumer 전체 opt-in Helm lint/template 통과
- prod에서 `fedify.queueDatabase.enabled=true` 지정 시 명시적 실패 확인
- VSO basic-auth Secret, CNPG role/database와 Argo sync wave 렌더 확인
- Prettier, lint-staged, `git diff --check` 통과
- `openspec validate configure-fedify-postgres-message-queue-runtime --strict` 통과

## 아직 어떤 문제가 남았는지

- 현재 변경은 default-off이며 dev sync/apply를 수행하지 않았습니다.
- Vault/Tailscale DNS가 로컬에서 해석되지 않아 dev Vault path의 실제 credential 생성은 아직 수행하지 않았습니다.
- merge 뒤 dev Secret → database/role → consumer → producer 순서로 활성화하고 실제 handoff, queue depth와 dequeue 전 restart persistence를 검증해야 합니다.
- production database/credential 생성, apply, rollout과 cutover는 별도 사용자 승인 전 수행하지 않습니다.
