### PR TITLE
Profile edit E2E의 DB reset deadlock을 방지한다

### DIFF
--- a/apps/web/e2e/profile-edit.e2e.ts
+++ b/apps/web/e2e/profile-edit.e2e.ts
@@ -5,7 +5,12 @@ import {
   setE2ESessionCookie,
 } from './db-fixtures';
 import { expect, test } from './fixtures';
-import { isGraphQLOperation, readGraphQLOperation, toGlobalId } from './graphql';
+import {
+  isGraphQLOperation,
+  readGraphQLOperation,
+  toGlobalId,
+  waitForGraphQLOperation,
+} from './graphql';
 import type { Page } from '@playwright/test';
 
 test.beforeEach(async () => {
@@ -28,6 +33,7 @@ test('text-only 저장은 Ready avatar/header payload를 끝내고 Profile로 re
       new URL(response.url()).pathname === '/graphql' &&
       isGraphQLOperation(response.request().postData(), 'ProfileEditRouteUpdateProfileMutation'),
   );
+  const profileRoutePromise = waitForProfileRoute(page);
 
   await page.getByRole('button', { name: '저장', exact: true }).click();
   const response = await responsePromise;
@@ -53,6 +59,7 @@ test('text-only 저장은 Ready avatar/header payload를 끝내고 Profile로 re
     relativeHandle: '@prod613-text',
   });
   await expect(page).toHaveURL(/\/@prod613-text$/);
+  await profileRoutePromise;
   await expect(page.getByRole('button', { name: '저장', exact: true })).toHaveCount(0);
 });
 
@@ -123,6 +130,7 @@ test('Ready avatar/header ID 저장도 응답 결과와 최종 Profile route를 
       new URL(response.url()).pathname === '/graphql' &&
       isGraphQLOperation(response.request().postData(), 'ProfileEditRouteUpdateProfileMutation'),
   );
+  const profileRoutePromise = waitForProfileRoute(page);
   await page.getByRole('textbox', { name: '소개' }).fill('PROD-613 Ready Media boundary');
   await page.getByRole('button', { name: '저장', exact: true }).click();
   const responseBody = (await (await responsePromise).json()) as {
@@ -134,6 +142,7 @@ test('Ready avatar/header ID 저장도 응답 결과와 최종 Profile route를 
   expect(updateVariables).toMatchObject({ input: { avatarId, headerId } });
   expect(responseBody.data?.updateProfile?.profile?.relativeHandle).toBe('@prod613-ready-media');
   await expect(page).toHaveURL(/\/@prod613-ready-media$/);
+  await profileRoutePromise;
 });
 
 test('프로필 태그는 같은 저장으로 서버에 반영되고 공개 프로필의 관계 목록 link로 표시된다', async ({
@@ -163,6 +172,7 @@ test('프로필 태그는 같은 저장으로 서버에 반영되고 공개 프�
       new URL(response.url()).pathname === '/graphql' &&
       isGraphQLOperation(response.request().postData(), 'ProfileEditRouteUpdateProfileMutation'),
   );
+  const profileRoutePromise = waitForProfileRoute(page);
   await page.getByRole('button', { name: '저장', exact: true }).click();
   const body = (await (await responsePromise).json()) as {
     data?: {
@@ -190,9 +200,12 @@ test('프로필 태그는 같은 저장으로 서버에 반영되고 공개 프�
     ]),
   );
   await expect(page).toHaveURL(/\/@prod527-tags$/);
+  await profileRoutePromise;
 
   // Relay cache만이 아니라 저장된 서버 상태를 다시 조회한다.
+  const reloadedProfileRoutePromise = waitForProfileRoute(page);
   await page.reload();
+  await reloadedProfileRoutePromise;
   await expect(page.getByText('#FirstWrite', { exact: true })).toBeVisible();
   await expect(page.getByText('#길게표시되는프로필태그', { exact: true })).toBeVisible();
 
@@ -228,6 +241,19 @@ async function selectReplacement(page: Page, triggerName: string, fileName: stri
     mimeType: 'image/webp',
     name: fileName,
   });
+}
+
+async function waitForProfileRoute(page: Page) {
+  const responses = await Promise.all([
+    waitForGraphQLOperation(page, 'ProfileLayoutQuery'),
+    waitForGraphQLOperation(page, 'ProfilePostListPageQuery'),
+  ]);
+
+  for (const response of responses) {
+    const body = (await response.json()) as { errors?: unknown[] };
+    expect(response.ok(), JSON.stringify(body, null, 2)).toBe(true);
+    expect(body.errors, JSON.stringify(body, null, 2)).toBeUndefined();
+  }
 }
 
 async function addProfileTag(page: Page, tag: string) {


### PR DESCRIPTION
## 무엇을 변경했는지

- Profile edit 저장 뒤 공개 Profile route가 시작하는 `ProfileLayoutQuery`와 `ProfilePostListPageQuery` 응답을 E2E 종료 전에 모두 기다립니다.
- redirect와 reload 뒤의 route query가 HTTP 성공 및 GraphQL error 없음으로 끝났는지 확인합니다.

## 왜 변경했는지

- [PROD-755](https://linear.app/byulmaru/issue/PROD-755/profile-edit-web-e2e의-postgresql-deadlock-flake를-제거한다)
- merge queue 최초 실행에서 다음 테스트의 DB reset이 PostgreSQL deadlock으로 실패했습니다. 저장 테스트는 URL 전환만 확인하고 끝났지만 공개 Profile route의 두 Relay query는 `store-and-network`로 별도 요청을 시작하므로, 이전 테스트의 API DB session이 다음 `TRUNCATE ... CASCADE`와 겹칠 수 있었습니다.
- 제품 Profile update transaction에 retry를 추가하지 않고 테스트가 시작한 서버 작업의 완료를 fixture 격리 경계 안에서 보장합니다.

## 이번 PR의 주요 결정

없음. Linear 이슈가 정한 무조건 retry·skip 금지와 fixture/isolation 우선 조사 범위를 그대로 적용했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web test`
  - TypeScript 검사 통과
  - Web 단위 테스트 35개 통과
  - Web E2E 102개 통과
- `pnpm --filter @kosmo/web test:e2e profile-edit.e2e.ts --repeat-each=5 --reporter=dot`
  - 최종 변경 기준 profile edit E2E 15개 통과
- 자체 correctness 리뷰 및 단순화 리뷰에서 확인된 finding 없음

## 아직 어떤 문제가 남았는지

없음.
