### PR TITLE
Web trusted ingress Post SQL에 명시적 DB handle을 전달한다

### DIFF
--- a/apps/api/src/graphql/resolvers/profile/query/by-handle.ts
+++ b/apps/api/src/graphql/resolvers/profile/query/by-handle.ts
@@ -1,4 +1,4 @@
-import { first, Instances, Profiles } from '@kosmo/core/db';
+import { db, first, Instances, Profiles } from '@kosmo/core/db';
 import { InstanceKind, ProfileState } from '@kosmo/core/enums';
 import { ConflictError, NotFoundError } from '@kosmo/core/error';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
@@ -118,7 +118,7 @@ builder.queryField('searchProfiles', (t) =>
         if (isExplicitRemoteHandle(args.query, parsed)) {
           try {
             const profile = await findOrMaterializeRemoteProfileActor({
-              context: federation.createContext(new URL(localInstance.canonicalOrigin), undefined),
+              context: federation.createContext(new URL(localInstance.canonicalOrigin), { db }),
               handle: `${parsed.handle}@${parsed.domain}`,
               scheduleRefresh: () => undefined,
             });

--- a/apps/api/tests/integration/graphql/post.test.ts
+++ b/apps/api/tests/integration/graphql/post.test.ts
@@ -513,6 +513,7 @@ describe('Post Reply GraphQL 경계', () => {
         getActorUri: (identifier) => new URL(`/ap/actor/${identifier}`, publicOrigin),
       },
       storedPost.id,
+      db,
     );
     assert.ok(projection);
     assert.equal(projection.object.content?.toString(), '<p>통합 검증 본문</p>');

--- a/apps/api/tests/integration/graphql/profile.test.ts
+++ b/apps/api/tests/integration/graphql/profile.test.ts
@@ -2884,7 +2884,9 @@ describe('GraphQL remote profile boundary', () => {
     });
     try {
       await handleInboundDelete(
-        { documentLoader: fetchMock } as unknown as Parameters<typeof handleInboundDelete>[0],
+        { data: { db }, documentLoader: fetchMock } as unknown as Parameters<
+          typeof handleInboundDelete
+        >[0],
         new Delete({ actor: new URL(author.actorUri), object: new URL(objectUri) }),
       );
 
@@ -3941,7 +3943,7 @@ const materializeRemotePost = async ({
   });
 
   await handleInboundCreate(
-    { documentLoader, parseUri: () => null } as unknown as Parameters<
+    { data: { db }, documentLoader, parseUri: () => null } as unknown as Parameters<
       typeof handleInboundCreate
     >[0],
     new Create({ actor: new URL(actorUri), object: note }),

--- a/apps/fedify-consumer/src/index.ts
+++ b/apps/fedify-consumer/src/index.ts
@@ -1,6 +1,6 @@
 import { once } from 'node:events';
 import { createServer } from 'node:http';
-import { pg } from '@kosmo/core/db';
+import { db, pg } from '@kosmo/core/db';
 import { closeFedifyQueue, federation } from '@kosmo/fedify';
 import type { Server } from 'node:http';
 
@@ -67,7 +67,7 @@ async function run(): Promise<void> {
       return;
     }
 
-    const queueRun = federation.startQueue(undefined, { signal: abortController.signal });
+    const queueRun = federation.startQueue({ db }, { signal: abortController.signal });
     state = 'ready';
     await queueRun;
   } catch (error) {

--- a/apps/web/src/server/app.test.ts
+++ b/apps/web/src/server/app.test.ts
@@ -6,6 +6,7 @@ import { gunzipSync, gzipSync } from 'node:zlib';
 import { parse } from 'hono/utils/cookie';
 import { Configuration, enableNonRepudiationChecks } from 'openid-client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { DatabaseOwner } from '@kosmo/core/db';
 import type { federation } from '@kosmo/fedify';
 import type { Hono } from 'hono';
 import type {
@@ -17,6 +18,8 @@ const {
   authorizationCodeGrant,
   captureNotificationEffectError,
   captureUnexpectedError,
+  closeDatabase,
+  createDatabaseOwner,
   createSession,
   discovery,
   federationFetch,
@@ -27,6 +30,8 @@ const {
   authorizationCodeGrant: vi.fn<typeof oidcAuthorizationCodeGrant>(),
   captureNotificationEffectError: vi.fn(),
   captureUnexpectedError: vi.fn<(cause: unknown) => void>(),
+  closeDatabase: vi.fn<DatabaseOwner['close']>(),
+  createDatabaseOwner: vi.fn<() => DatabaseOwner>(),
   createSession:
     vi.fn<(identity: { displayName: string; oidcSubject: string }) => Promise<string>>(),
   discovery: vi.fn<typeof oidcDiscovery>(),
@@ -50,6 +55,8 @@ vi.mock('@kosmo/core/services', () => ({
   revokeCurrentSession: revokeSession,
   setNotificationEffectErrorReporter,
 }));
+
+vi.mock('@kosmo/core/db', () => ({ createDatabaseOwner }));
 
 vi.mock('@kosmo/fedify', () => ({
   federation: { fetch: federationFetch },
@@ -111,6 +118,11 @@ beforeEach(() => {
   );
   createSession.mockResolvedValue('kosmo-session-token');
   revokeSession.mockResolvedValue({ status: 'REVOKED' });
+  closeDatabase.mockResolvedValue(undefined);
+  createDatabaseOwner.mockReturnValue({
+    close: closeDatabase,
+    db: { requestDatabase: true } as unknown as DatabaseOwner['db'],
+  });
   federationFetch.mockImplementation(async (request, options) => {
     if (!options.onNotFound) {
       throw new Error('Missing federation fallback');
@@ -449,6 +461,50 @@ describe('GraphQL proxy', () => {
 });
 
 describe('runtime routing', () => {
+  test('supplies a fresh owner database to federation and closes it after the response', async () => {
+    let requestId = 0;
+    createDatabaseOwner.mockImplementation(() => ({
+      close: closeDatabase,
+      db: { requestId: ++requestId } as unknown as DatabaseOwner['db'],
+    }));
+    federationFetch.mockImplementation(async () => new Response('accepted', { status: 202 }));
+
+    const firstResponse = await app.request('/inbox', { method: 'POST' });
+    const secondResponse = await app.request('/inbox', { method: 'POST' });
+    const firstOwner = createDatabaseOwner.mock.results[0]?.value;
+    const secondOwner = createDatabaseOwner.mock.results[1]?.value;
+
+    expect(firstResponse.status).toBe(202);
+    expect(secondResponse.status).toBe(202);
+    expect(createDatabaseOwner).toHaveBeenCalledTimes(2);
+    expect(createDatabaseOwner).toHaveBeenNthCalledWith(1, process.env.DATABASE_URL);
+    expect(createDatabaseOwner).toHaveBeenNthCalledWith(2, process.env.DATABASE_URL);
+    expect(firstOwner?.db).not.toBe(secondOwner?.db);
+    expect(federationFetch.mock.calls[0]?.[1].contextData).toEqual({ db: firstOwner?.db });
+    expect(federationFetch.mock.calls[1]?.[1].contextData).toEqual({ db: secondOwner?.db });
+    expect(closeDatabase).toHaveBeenCalledTimes(2);
+    expect(closeDatabase).toHaveBeenNthCalledWith(1);
+    expect(closeDatabase).toHaveBeenNthCalledWith(2);
+    expect(federationFetch.mock.invocationCallOrder[0]).toBeLessThan(
+      closeDatabase.mock.invocationCallOrder[0]!,
+    );
+    expect(federationFetch.mock.invocationCallOrder[1]).toBeLessThan(
+      closeDatabase.mock.invocationCallOrder[1]!,
+    );
+  });
+
+  test('force-closes the owner while preserving a federation failure', async () => {
+    const failure = new Error('federation failed');
+    federationFetch.mockRejectedValueOnce(failure);
+
+    const response = await app.request('/inbox', { method: 'POST' });
+
+    expect(response.status).toBe(500);
+    expect(closeDatabase).toHaveBeenCalledOnce();
+    expect(closeDatabase).toHaveBeenCalledWith({ force: true });
+    expect(captureUnexpectedError).toHaveBeenCalledWith(failure);
+  });
+
   test('serves health, assets, and SPA deep links', async () => {
     const health = await app.request('/health', {
       headers: { 'sec-fetch-mode': 'navigate' },
@@ -608,12 +664,19 @@ describe('runtime routing', () => {
   });
 
   test('falls through when federation declines the requested representation', async () => {
+    const events: string[] = [];
     federationFetch.mockImplementation(async (request, options) => {
       if (!options.onNotAcceptable) {
         throw new Error('Missing federation representation fallback');
       }
 
-      return options.onNotAcceptable(request);
+      events.push('federation:start');
+      const response = await options.onNotAcceptable(request);
+      events.push('federation:end');
+      return response;
+    });
+    closeDatabase.mockImplementation(async () => {
+      events.push('database:close');
     });
 
     const response = await app.request('/@alice/post-id', {
@@ -622,6 +685,9 @@ describe('runtime routing', () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe('<html>expo app</html>');
+    expect(events).toEqual(['federation:start', 'federation:end', 'database:close']);
+    expect(closeDatabase).toHaveBeenCalledOnce();
+    expect(closeDatabase).toHaveBeenCalledWith();
   });
 
   test('preserves a federation 406 when no BFF route accepts the request', async () => {

--- a/apps/web/src/server/app.test.ts
+++ b/apps/web/src/server/app.test.ts
@@ -477,8 +477,8 @@ describe('runtime routing', () => {
     expect(firstResponse.status).toBe(202);
     expect(secondResponse.status).toBe(202);
     expect(createDatabaseOwner).toHaveBeenCalledTimes(2);
-    expect(createDatabaseOwner).toHaveBeenNthCalledWith(1, process.env.DATABASE_URL);
-    expect(createDatabaseOwner).toHaveBeenNthCalledWith(2, process.env.DATABASE_URL);
+    expect(createDatabaseOwner).toHaveBeenNthCalledWith(1);
+    expect(createDatabaseOwner).toHaveBeenNthCalledWith(2);
     expect(firstOwner?.db).not.toBe(secondOwner?.db);
     expect(federationFetch.mock.calls[0]?.[1].contextData).toEqual({ db: firstOwner?.db });
     expect(federationFetch.mock.calls[1]?.[1].contextData).toEqual({ db: secondOwner?.db });

--- a/apps/web/src/server/app.ts
+++ b/apps/web/src/server/app.ts
@@ -1,3 +1,4 @@
+import { createDatabaseOwner } from '@kosmo/core/db';
 import { setNotificationEffectErrorReporter } from '@kosmo/core/services';
 import { federation, setInboundObservabilityReporter } from '@kosmo/fedify';
 import { Hono } from 'hono';
@@ -17,6 +18,7 @@ const app = new Hono();
 setNotificationEffectErrorReporter(captureNotificationEffectError);
 
 app.use('*', async (c, next) => {
+  const database = createDatabaseOwner(process.env.DATABASE_URL!);
   const fallThrough = async () => {
     await next();
     return new Response(c.res.body, c.res);
@@ -33,12 +35,24 @@ app.use('*', async (c, next) => {
     });
   };
 
-  const response = await federation.fetch(c.req.raw, {
-    contextData: undefined,
-    onNotAcceptable: fallThroughNotAcceptable,
-    onNotFound: fallThrough,
-    onUnauthorized: fallThrough,
-  });
+  let response: Response;
+  try {
+    response = await federation.fetch(c.req.raw, {
+      contextData: { db: database.db },
+      onNotAcceptable: fallThroughNotAcceptable,
+      onNotFound: fallThrough,
+      onUnauthorized: fallThrough,
+    });
+  } catch (error) {
+    try {
+      await database.close({ force: true });
+    } catch {
+      // Preserve the federation or downstream route error as the response cause.
+    }
+    throw error;
+  }
+
+  await database.close();
 
   c.res = response;
   return c.res;

--- a/apps/web/src/server/app.ts
+++ b/apps/web/src/server/app.ts
@@ -18,7 +18,7 @@ const app = new Hono();
 setNotificationEffectErrorReporter(captureNotificationEffectError);
 
 app.use('*', async (c, next) => {
-  const database = createDatabaseOwner(process.env.DATABASE_URL!);
+  const database = createDatabaseOwner();
   const fallThrough = async () => {
     await next();
     return new Response(c.res.body, c.res);

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/.openspec.yaml
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-11

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/decisions.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/decisions.md
@@ -1,0 +1,50 @@
+## Context
+
+이 기록은 PROD-710의 Web trusted federation ingress Post/PostContent SQL 실행 경계와 최초 owner connection 유지 계약을 반영한다. canonical Post/ActivityPub 결과는 유지하고 credential principal 전환은 PROD-715에 남긴다.
+
+## Decision Records
+
+### 실제 Post SQL과 함께 최소 explicit handle seam을 도입한다
+
+- Decision Date: 2026-08-11
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, Linear `PROD-710`
+- Status: Active
+- Context / Problem: 미래 consumer 없이 범용 실행 경계만 추가하면 독립 capability의 완료 증거가 없지만, 전역 DB를 사용하는 현재 production ingress SQL은 후속 credential 전환과 callsite 변경을 결합한다.
+- Decision Outcome: Web trusted federation ingress의 실제 Post/PostContent SQL callsite 이전과 그에 필요한 최소 `DatabaseHandle`/context/lifetime seam을 하나의 change에서 구현한다.
+- Alternatives Considered: 범용 system context를 먼저 추가하는 방안은 실제 consumer 없는 YAGNI이며, credential 전환과 함께 구현하는 방안은 rollback과 principal 변경을 결합하므로 채택하지 않았다.
+- Consequences: Post와 무관한 Fedify SQL, Temporal domain activity와 credential source는 이 seam의 범위가 아니다.
+- Integration Constraint: 공유 federation을 사용하는 PROD-448 queue consumer는 변경하지 않고 기존 전역 owner fallback을 유지한다. Web trusted ingress만 명시적 request database와 cleanup lifetime을 소유한다.
+- Confirmation / Follow-up: production Post/PostContent import/callsite inventory와 explicit handle 회귀 테스트로 확인한다.
+
+### 최초 handle source는 기존 owner DATABASE_URL을 사용한다
+
+- Decision Date: 2026-08-11
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-710`
+- Status: Active
+- Context / Problem: execution boundary와 database principal을 동시에 바꾸면 SQL 회귀와 권한/credential 문제를 분리해 rollback할 수 없다.
+- Decision Outcome: PROD-710의 request database는 기존 `DATABASE_URL` owner source로 만들고 principal 전환을 주장하지 않는다. PROD-715가 이후 같은 생성 seam의 source만 `WORKER_DATABASE_*`로 교체한다.
+- Alternatives Considered: 지금 Worker credential을 읽는 방안은 PROD-715를 선점하고, 전역 pool을 그대로 context에 넣는 방안은 명시적 connection lifetime과 cleanup 완료 기준을 만족하지 않으므로 채택하지 않았다.
+- Consequences: 이번 change는 role, Secret, GRANT, Helm이나 production cutover를 포함하지 않으며 DB 결과는 기존 owner 권한으로 유지된다.
+- Confirmation / Follow-up: 테스트에서 기본 source가 `DATABASE_URL`인지 확인하고 PR에 principal 미전환을 명시한다.
+
+### Action transaction과 request database lifetime을 분리한다
+
+- Decision Date: 2026-08-11
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, Linear `PROD-710`
+- Status: Active
+- Context / Problem: Post action은 caller-owned transaction에 합류해야 하지만 post-commit SQL과 request cleanup은 transaction commit 이후까지 살아 있는 `Database`가 필요하다.
+- Decision Outcome: core action 입력은 `DatabaseHandle = Database | Transaction`을 유지하고, inbound outer transaction 안에서는 같은 `Transaction`을 lookup/direct SQL/action에 전달한다. post-commit callback은 outer commit 뒤 request `Database`로 실행하며 Web은 전체 federation request가 끝난 뒤 해당 database를 닫는다.
+- Alternatives Considered: transaction을 post-commit callback이나 Web context lifetime 밖으로 전달하는 방안은 commit 이후 유효하지 않고, core action이 별도 전역 transaction을 열게 두는 방안은 원자성과 principal 경계를 분리하므로 채택하지 않았다.
+- Consequences: 테스트는 success/rollback/savepoint뿐 아니라 post-commit ordering과 success/error close를 검증해야 한다.
+- Confirmation / Follow-up: DB-backed Fedify 테스트와 Web adapter 단위 테스트로 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/decisions.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/decisions.md
@@ -14,7 +14,7 @@
 - Decision Outcome: Web trusted federation ingress의 실제 Post/PostContent SQL callsite 이전과 그에 필요한 최소 `DatabaseHandle`/context/lifetime seam을 하나의 change에서 구현한다.
 - Alternatives Considered: 범용 system context를 먼저 추가하는 방안은 실제 consumer 없는 YAGNI이며, credential 전환과 함께 구현하는 방안은 rollback과 principal 변경을 결합하므로 채택하지 않았다.
 - Consequences: Post와 무관한 Fedify SQL, Temporal domain activity와 credential source는 이 seam의 범위가 아니다.
-- Integration Constraint: 공유 federation을 사용하는 PROD-448 queue consumer는 변경하지 않고 기존 전역 owner fallback을 유지한다. Web trusted ingress만 명시적 request database와 cleanup lifetime을 소유한다.
+- Integration Constraint: 공유 federation에는 database context를 항상 명시한다. PROD-448 queue consumer는 기존 전역 owner `db`를 명시적으로 전달할 뿐 queue credential, SQL과 lifetime은 변경하지 않으며 Web trusted ingress만 request database와 cleanup lifetime을 소유한다.
 - Confirmation / Follow-up: production Post/PostContent import/callsite inventory와 explicit handle 회귀 테스트로 확인한다.
 
 ### 최초 handle source는 기존 owner DATABASE_URL을 사용한다

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/design.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/design.md
@@ -24,30 +24,30 @@ PROD-710은 실제 Web trusted ingress callsite와 함께 최소 실행 경계�
 
 ### Current Constraints
 
-- 하나의 production federation instance가 Web inbound, process 내부 outbound context 생성과 PROD-448 queue consumer에 함께 쓰인다. Web은 명시적인 data를 제공하되 이 change에서 제외된 queue consumer의 기존 `undefined` context는 전역 owner fallback으로 유지해야 한다.
+- 하나의 production federation instance가 Web inbound, process 내부 outbound context 생성과 PROD-448 queue consumer에 함께 쓰인다. 공유 federation의 context는 항상 database를 명시적으로 받아야 하므로 Web은 request owner를, 제외된 outbound/API/queue caller는 기존 전역 owner `db`를 명시한다. 이 adapter plumbing은 해당 caller의 credential, SQL 또는 lifetime을 바꾸지 않는다.
 - `createPost`, `deletePost`, `repostPost`는 transaction을 내부에서 열 수 있고 일부 action은 post-commit callback을 반환한다. caller transaction을 전달하면 callback은 outer commit 뒤 실행해야 하며 transaction을 post-commit lifetime으로 넘겨서는 안 된다.
 - `activitypub-post-uri.ts`와 inbound handler의 direct Post mapping SQL이 전역 `db`를 사용하면 core action만 handle로 바꿔도 요청 경계 밖 SQL이 남는다.
 - Web middleware는 federation 응답뿐 아니라 onNotFound/onUnauthorized fallthrough까지 await한 뒤 Hono 응답을 확정하므로, database close는 전체 `federation.fetch()` 호출을 감싸야 한다.
 
 ### Recommended Approach
 
-- core DB module에 URL로 단일-client `Database`와 idempotent `close()`를 소유하는 일반 request-lifetime factory를 두고 GraphQL operation factory도 같은 primitive를 조합한다.
-- Fedify package 내부 context data에 선택적인 `db: Database`를 두고 production federation listener/dispatcher는 단일 adapter로 database를 선택한다. Web은 항상 명시적 request database를 전달하고, PROD-448 queue consumer처럼 이 change에서 제외된 caller만 기존 전역 owner fallback을 유지한다.
-- Post/PostContent 관련 helper와 URI lookup은 `DatabaseHandle`을 명시적으로 받고 `getDatabaseConnection(handle)`을 사용한다. core action에는 같은 handle을 전달한다.
+- core DB module의 private primitive가 URL로 단일-client `Database`와 idempotent `close()`를 만들고, 공개 request-lifetime factory가 기존 owner `DATABASE_URL` source 선택까지 소유한다. GraphQL operation factory는 별도 `OPERATION_DATABASE_URL` 선택을 유지하면서 같은 private primitive를 조합한다.
+- Fedify package 내부 context data에 필수 `db: Database`를 두고 production federation listener/dispatcher는 `context.data.db`를 직접 사용한다. Web은 request database를 전달하고 제외된 outbound/API/queue caller도 기존 전역 owner `db`를 명시해 누락 fallback을 만들지 않는다.
+- Post/PostContent 관련 helper와 URI lookup은 필수 `DatabaseHandle`을 받고 전달된 handle을 직접 사용한다. core action에는 같은 handle을 전달한다.
 - inbound handler가 outer transaction을 소유하는 경우 lookup, direct mapping SQL과 core action을 같은 transaction에 합류시키고, 반환된 post-commit callback은 transaction 성공 뒤 request `Database`로 실행한다.
 - Web test는 injected factory 또는 adapter seam으로 success/error 모두 close를 검증하고 Fedify DB-backed tests는 explicit transaction composition과 rollback을 검증한다.
 
 ### Allowed Alternatives
 
 - public Web adapter 대신 `federation.fetch()`에 context data를 직접 전달할 수 있다. 단, Web만 context shape를 만들고 모든 성공·오류·fallthrough 경로의 close를 소유하며 package-internal 타입이 불필요하게 공개되지 않아야 한다.
-- 별도 request factory 없이 기존 single-client factory를 일반화해 재사용할 수 있다. 단, GraphQL의 `OPERATION_DATABASE_URL` 선택과 Web의 owner `DATABASE_URL` 선택은 각각 호출 경계에서 명시되어야 한다.
+- 별도 request factory 없이 기존 single-client primitive를 내부에서 재사용할 수 있다. 단, GraphQL의 `OPERATION_DATABASE_URL`과 trusted ingress의 owner `DATABASE_URL` 선택은 각각의 공개 DB factory가 소유해야 하며 Web 호출부가 raw URL을 전달해서는 안 된다.
 
 ### Known Traps
 
 - `WORKER_DATABASE_*`를 지금 읽거나 fallback source로 추가하면 PROD-715 credential 전환을 선점한다.
 - core action에만 handle을 전달하고 URI lookup/direct mapping SQL을 전역 `db`에 남기면 transaction과 principal이 갈라진다.
 - transaction 자체를 post-commit callback에 전달하면 commit 이후 lifetime과 충돌한다.
-- Web trusted ingress가 `undefined` context로 돌아가면 명시적 request lifetime을 우회하므로 허용하지 않는다. 다만 PROD-448 queue consumer의 기존 `undefined` context는 독립 scope를 유지하기 위해 adapter의 legacy fallback을 사용한다.
+- production federation이 `undefined` context를 허용하거나 누락 handle을 전역 `db`로 대체하면 명시적 request lifetime을 우회하므로 허용하지 않는다. 제외된 caller도 기존 전역 owner를 사용한다는 선택을 context에 명시한다.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/design.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`packages/core`에는 `DatabaseHandle = Database | Transaction`과 `getDatabaseConnection(handle)`이 이미 존재하고 Post service 일부도 선택적 handle을 받는다. 그러나 `packages/fedify`의 production federation은 `Federation<void>`이며, Web의 `federation.fetch()`는 `contextData: undefined`를 전달한다. 따라서 inbound Note 생성·삭제·Announce 및 URI lookup의 Post SQL은 전역 `db`를 선택하고 Web 요청의 database lifetime과 분리되어 있다.
+
+PROD-710은 실제 Web trusted ingress callsite와 함께 최소 실행 경계를 도입한다. 최초 source는 기존 owner `DATABASE_URL`이고 PROD-715가 이후 같은 생성 seam의 source만 Worker SCRAM credential로 바꾼다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Web federation 요청마다 명시적인 owner database와 close lifetime을 만든다.
+- Fedify context가 database handle을 내부 listener/dispatcher에 전달한다.
+- inbound Post/PostContent lookup과 core action을 같은 handle에 결속한다.
+- transaction, savepoint, post-commit, 오류와 cleanup 동작을 회귀 테스트로 고정한다.
+
+**Non-Goals:**
+
+- database principal 또는 credential source 전환.
+- role, VaultStaticSecret, Secret, object GRANT, Helm selector나 production apply.
+- GraphQL operation database/RLS, Temporal Workflow/Activity, Fedify MessageQueue.
+- Post와 무관한 모든 Fedify/Profile SQL의 일괄 이전.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- 하나의 production federation instance가 Web inbound, process 내부 outbound context 생성과 PROD-448 queue consumer에 함께 쓰인다. Web은 명시적인 data를 제공하되 이 change에서 제외된 queue consumer의 기존 `undefined` context는 전역 owner fallback으로 유지해야 한다.
+- `createPost`, `deletePost`, `repostPost`는 transaction을 내부에서 열 수 있고 일부 action은 post-commit callback을 반환한다. caller transaction을 전달하면 callback은 outer commit 뒤 실행해야 하며 transaction을 post-commit lifetime으로 넘겨서는 안 된다.
+- `activitypub-post-uri.ts`와 inbound handler의 direct Post mapping SQL이 전역 `db`를 사용하면 core action만 handle로 바꿔도 요청 경계 밖 SQL이 남는다.
+- Web middleware는 federation 응답뿐 아니라 onNotFound/onUnauthorized fallthrough까지 await한 뒤 Hono 응답을 확정하므로, database close는 전체 `federation.fetch()` 호출을 감싸야 한다.
+
+### Recommended Approach
+
+- core DB module에 URL로 단일-client `Database`와 idempotent `close()`를 소유하는 일반 request-lifetime factory를 두고 GraphQL operation factory도 같은 primitive를 조합한다.
+- Fedify package 내부 context data에 선택적인 `db: Database`를 두고 production federation listener/dispatcher는 단일 adapter로 database를 선택한다. Web은 항상 명시적 request database를 전달하고, PROD-448 queue consumer처럼 이 change에서 제외된 caller만 기존 전역 owner fallback을 유지한다.
+- Post/PostContent 관련 helper와 URI lookup은 `DatabaseHandle`을 명시적으로 받고 `getDatabaseConnection(handle)`을 사용한다. core action에는 같은 handle을 전달한다.
+- inbound handler가 outer transaction을 소유하는 경우 lookup, direct mapping SQL과 core action을 같은 transaction에 합류시키고, 반환된 post-commit callback은 transaction 성공 뒤 request `Database`로 실행한다.
+- Web test는 injected factory 또는 adapter seam으로 success/error 모두 close를 검증하고 Fedify DB-backed tests는 explicit transaction composition과 rollback을 검증한다.
+
+### Allowed Alternatives
+
+- public Web adapter 대신 `federation.fetch()`에 context data를 직접 전달할 수 있다. 단, Web만 context shape를 만들고 모든 성공·오류·fallthrough 경로의 close를 소유하며 package-internal 타입이 불필요하게 공개되지 않아야 한다.
+- 별도 request factory 없이 기존 single-client factory를 일반화해 재사용할 수 있다. 단, GraphQL의 `OPERATION_DATABASE_URL` 선택과 Web의 owner `DATABASE_URL` 선택은 각각 호출 경계에서 명시되어야 한다.
+
+### Known Traps
+
+- `WORKER_DATABASE_*`를 지금 읽거나 fallback source로 추가하면 PROD-715 credential 전환을 선점한다.
+- core action에만 handle을 전달하고 URI lookup/direct mapping SQL을 전역 `db`에 남기면 transaction과 principal이 갈라진다.
+- transaction 자체를 post-commit callback에 전달하면 commit 이후 lifetime과 충돌한다.
+- Web trusted ingress가 `undefined` context로 돌아가면 명시적 request lifetime을 우회하므로 허용하지 않는다. 다만 PROD-448 queue consumer의 기존 `undefined` context는 독립 scope를 유지하기 위해 adapter의 legacy fallback을 사용한다.
+
+## Risks / Trade-offs
+
+- [요청마다 single PostgreSQL client를 열고 닫아 connection churn이 늘어난다] → 현재 명시적 lifetime과 후속 Pooler cutover seam을 우선하고, max=1과 idempotent close를 유지한다.
+- [Post SQL 일부가 inventory에서 누락될 수 있다] → production non-test import와 `Posts`/`PostContents`/`ActivityPubPosts`, Post service call을 함께 검색하고 explicit-handle 회귀 테스트를 둔다.
+- [Fedify context 변경이 outbound delivery를 깨뜨릴 수 있다] → inbound adapter와 outbound context 생성 경계를 분리하거나 outbound에 안전한 명시적 context data를 제공하고 package 전체 typecheck/tests를 실행한다.
+
+## Migration Plan
+
+1. DB owner와 Fedify context/adapter를 additive하게 추가한다.
+2. Web ingress와 Post/PostContent callsite를 같은 change에서 explicit handle로 연결한다.
+3. 기존 owner `DATABASE_URL`에서 로컬/CI 회귀 테스트와 전체 관련 package 검증을 수행한다.
+4. 코드만 독립 배포할 수 있으나 이번 작업에서 production sync/apply/cutover는 하지 않는다.
+5. rollback은 이 코드 change를 되돌려 기존 전역 owner pool 경로로 복귀한다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/proposal.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Web trusted federation ingress의 Post/PostContent SQL은 현재 전역 owner database connection을 암묵적으로 사용해, 후속 Worker credential 전환이 SQL 호출부 변경과 결합된다. 실제 inbound ActivityPub 경로에 최소한의 명시적 database execution 경계를 도입해 현재 owner 동작을 유지하면서 credential source만 독립적으로 교체할 수 있게 한다.
+
+## What Changes
+
+- Web trusted federation ingress가 요청마다 현재 owner `DATABASE_URL` connection을 명시적 database handle로 전달한다.
+- inbound ActivityPub의 Post/PostContent core service와 직접 SQL 호출부가 전달받은 handle 안에서 transaction과 savepoint 의미를 유지한다.
+- 요청 실행과 connection lifetime을 함께 관리하고 성공, 오류와 rollback 뒤 resource cleanup을 검증한다.
+- API/Web BFF 기본 database connection, GraphQL operation session, SQL 결과와 post-commit 동작은 변경하지 않는다.
+- Worker role, Vault/Secret/GRANT/Helm credential selector, Temporal Workflow/Activity, Fedify MessageQueue와 production cutover는 변경하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- Linear Contract: `PROD-710`
+- Linear Implementations: `PROD-710`
+
+## Capabilities
+
+### New Capabilities
+
+- `trusted-federation-post-db-execution`: Web trusted federation ingress의 Post/PostContent SQL과 connection lifetime을 명시적 database handle에 결속하는 계약.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `packages/core`: Post 계열 service가 선택한 `DatabaseHandle`을 사용하도록 명시적 입력을 확장한다.
+- `packages/fedify`: inbound dispatcher/listener context와 Post/PostContent SQL callsite가 같은 handle을 전달받는다.
+- `apps/web`: federation ingress 요청에서 현재 owner database connection의 lifetime을 열고 닫는다.
+- 외부 ActivityPub/GraphQL API, database schema, runtime credential과 배포 설정에는 변화가 없다.

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/specs/trusted-federation-post-db-execution/spec.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/specs/trusted-federation-post-db-execution/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Trusted ingress Post SQL은 명시적 database handle을 사용한다
+
+**Authority / Provenance**: `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, Linear `PROD-710`
+
+MUST: Web trusted federation ingress가 inbound ActivityPub 요청으로 Post 또는 Post Content를 조회·생성·변경할 때 해당 요청에 명시적으로 전달된 `DatabaseHandle`로 SQL을 실행한다. 이전된 호출부는 전역 database singleton을 직접 선택해서는 안 된다.
+
+#### Scenario: Remote Note 수신
+
+- **WHEN** Web trusted federation ingress가 유효한 remote `Create(Note)`를 처리한다
+- **THEN** Post, Post Content와 연관된 SQL은 ingress가 전달한 database handle 안에서 실행된다
+
+#### Scenario: Remote Post 삭제
+
+- **WHEN** Web trusted federation ingress가 저장된 remote Post에 대한 유효한 `Delete(Note)`를 처리한다
+- **THEN** Post 조회와 Tombstone 전이는 같은 명시적 database handle 안에서 실행된다
+
+### Requirement: Inbound transaction composition과 결과를 보존한다
+
+**Authority / Provenance**: `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`, Linear `PROD-710`
+
+MUST: Post core service는 `Database` 또는 caller가 소유한 `Transaction`을 입력받아 기존 transaction과 savepoint 의미를 보존한다. handle 이전은 ActivityPub 처리 결과, 원자성, 오류와 post-commit 시점을 바꾸어서는 안 된다.
+
+#### Scenario: Caller-owned transaction 성공
+
+- **WHEN** inbound handler가 전달받은 transaction 안에서 Post와 Post Content를 성공적으로 저장한다
+- **THEN** 모든 SQL은 해당 transaction에 합류하고 outer transaction commit 뒤에만 결과가 확정된다
+
+#### Scenario: Inbound 처리 실패
+
+- **WHEN** Post/PostContent 처리 중 오류가 발생한다
+- **THEN** 해당 요청의 변경은 기존 원자성 계약에 따라 rollback되고 부분 저장이 남지 않는다
+
+### Requirement: 최초 배포는 owner principal과 외부 계약을 유지한다
+
+**Authority / Provenance**: `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, Linear `PROD-710`
+
+MUST: 최초 배포의 Web trusted federation ingress는 기존 `DATABASE_URL` owner connection을 명시적 handle source로 사용한다. API/Web BFF 기본 connection, GraphQL operation database, role·credential·GRANT·schema와 ActivityPub 응답 계약을 변경해서는 안 된다.
+
+#### Scenario: 기존 owner source로 실행
+
+- **WHEN** PROD-710 구현만 배포되어 inbound federation 요청을 처리한다
+- **THEN** 명시적 handle의 PostgreSQL principal은 기존 owner connection과 같고 principal 전환은 발생하지 않는다
+
+#### Scenario: 후속 credential source 교체
+
+- **WHEN** 후속 PROD-715가 승인된 Worker credential source를 연결한다
+- **THEN** Post/PostContent SQL callsite를 다시 변경하지 않고 ingress handle 생성 경계의 source만 교체할 수 있다
+
+### Requirement: Request database lifetime을 항상 정리한다
+
+**Authority / Provenance**: Linear `PROD-710`
+
+MUST: Web trusted federation ingress는 각 요청의 명시적 database connection lifetime을 소유하고 정상 완료, handler 오류와 transaction rollback 뒤에 항상 connection resource를 정리한다.
+
+#### Scenario: 정상 요청 cleanup
+
+- **WHEN** inbound ActivityPub 요청이 성공적으로 완료된다
+- **THEN** 요청에 사용된 database connection은 응답 완료 전에 정리된다
+
+#### Scenario: 실패 요청 cleanup
+
+- **WHEN** inbound ActivityPub handler 또는 transaction이 오류로 종료된다
+- **THEN** 요청에 사용된 database connection은 오류를 보존한 채 정리된다

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/specs/trusted-federation-post-db-execution/spec.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/specs/trusted-federation-post-db-execution/spec.md
@@ -4,7 +4,7 @@
 
 **Authority / Provenance**: `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, Linear `PROD-710`
 
-MUST: Web trusted federation ingress가 inbound ActivityPub 요청으로 Post 또는 Post Content를 조회·생성·변경할 때 해당 요청에 명시적으로 전달된 `DatabaseHandle`로 SQL을 실행한다. 이전된 호출부는 전역 database singleton을 직접 선택해서는 안 된다.
+MUST: Web trusted federation ingress가 inbound ActivityPub 요청으로 Post 또는 Post Content를 조회·생성·변경할 때 해당 요청에 명시적으로 전달된 `DatabaseHandle`로 SQL을 실행한다. 이전된 호출부는 전역 database singleton을 직접 선택하거나 handle 누락을 전역 database로 대체해서는 안 된다.
 
 #### Scenario: Remote Note 수신
 

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/tasks.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/tasks.md
@@ -1,0 +1,32 @@
+## 1. PROD-710 Web trusted ingress Post DB execution boundary
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/post-content.md`
+- `docs/domain/decisions/0017-activitypub-local-post-note.md`
+- Linear `PROD-710`
+
+**Deliverable**
+
+Web trusted federation ingress의 Post/PostContent SQL이 요청에서 전달된 명시적 database handle을 사용하고, 최초 배포의 기존 owner 결과와 transaction/post-commit 동작을 유지하며 요청 종료 시 connection resource를 정리한다.
+
+**Guardrails**
+
+- 최초 handle source는 기존 `DATABASE_URL` owner connection이다.
+- API/Web BFF 기본 DB, GraphQL operation DB/RLS, role·Vault·Secret·GRANT·Helm credential selector를 바꾸지 않는다.
+- Temporal Workflow/Activity, Fedify MessageQueue와 production sync/apply/cutover를 포함하지 않는다.
+- caller-owned transaction은 Post SQL과 core action에 그대로 합류하고 post-commit에는 transaction을 전달하지 않는다.
+
+**Verification**
+
+- production callsite inventory에서 inbound Post/PostContent 전역 singleton 직접 참조가 남지 않았는지 확인한다.
+- DB-backed inbound ActivityPub 테스트로 create/delete/announce 결과, transaction commit/rollback과 post-commit 순서를 확인한다.
+- Web request 테스트로 success/error/fallthrough connection cleanup과 기존 federation 응답을 확인한다.
+- Core/Fedify/Web typecheck, lint, tests, Prettier, OpenSpec strict validation과 `git diff --check`를 통과시킨다.
+
+- [x] 1.1 Web federation entry부터 inbound Post/PostContent SQL과 core action까지 production callsite를 인벤토리하고 이전 범위를 확정한다.
+- [x] 1.2 기존 owner `DATABASE_URL`로 request database handle과 idempotent cleanup lifetime을 제공한다.
+- [x] 1.3 Fedify context와 inbound Post/PostContent helper·direct SQL·core action이 같은 명시적 handle을 사용하게 한다.
+- [x] 1.4 transaction composition, rollback, post-commit ordering과 success/error cleanup 회귀 테스트를 추가한다.
+- [x] 1.5 관련 Core/Fedify/Web 검증과 repository formatting/OpenSpec strict validation을 완료한다.

--- a/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/tasks.md
+++ b/openspec/changes/route-trusted-ingress-post-sql-through-explicit-db-handle/tasks.md
@@ -30,3 +30,5 @@ Web trusted federation ingress의 Post/PostContent SQL이 요청에서 전달된
 - [x] 1.3 Fedify context와 inbound Post/PostContent helper·direct SQL·core action이 같은 명시적 handle을 사용하게 한다.
 - [x] 1.4 transaction composition, rollback, post-commit ordering과 success/error cleanup 회귀 테스트를 추가한다.
 - [x] 1.5 관련 Core/Fedify/Web 검증과 repository formatting/OpenSpec strict validation을 완료한다.
+- [x] 1.6 request database factory가 `DATABASE_URL` source 선택을 소유하고 Web 호출부는 raw URL을 전달하지 않도록 경계를 수정한다.
+- [x] 1.7 Fedify context와 이전된 Post helper에서 누락 handle의 전역 database fallback을 제거하고 모든 shared federation caller가 database 선택을 명시하게 한다.

--- a/packages/core/db/index.test.ts
+++ b/packages/core/db/index.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import { mock, test } from 'node:test';
-import { createOperationDatabase, db } from './index';
+import { createDatabaseOwner, createOperationDatabase, db } from './index';
 
-type OperationClient = {
+type OwnedClient = {
   options: {
     host: string[];
     max: number;
@@ -11,8 +11,8 @@ type OperationClient = {
   end: (options?: { timeout?: number }) => Promise<void>;
 };
 
-const getClient = (owner: ReturnType<typeof createOperationDatabase>) =>
-  (owner.db as unknown as { _: { session: { client: OperationClient } } })._.session.client;
+const getClient = (owner: ReturnType<typeof createDatabaseOwner>) =>
+  (owner.db as unknown as { _: { session: { client: OwnedClient } } })._.session.client;
 
 test('keeps operation client bounded and isolated from direct startup parameters', async () => {
   const owner = createOperationDatabase('postgres://127.0.0.1:1/kosmo_test');
@@ -37,6 +37,33 @@ test('keeps operation client bounded and isolated from direct startup parameters
   await firstForceClose;
   assert.deepEqual(forceEnd.mock.calls[0]?.arguments, [{ timeout: 0 }]);
   assert.equal(forceEnd.mock.calls.length, 1);
+});
+
+test('creates a bounded owner from the direct database endpoint by default', async () => {
+  const previousOperationUrl = process.env.OPERATION_DATABASE_URL;
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+
+  try {
+    process.env.DATABASE_URL = 'postgres://kosmo@direct.example:5432/kosmo';
+    process.env.OPERATION_DATABASE_URL = 'postgres://kosmo@operation.example:5432/kosmo';
+
+    const owner = createDatabaseOwner();
+    assert.deepEqual(getClient(owner).options.host, ['direct.example']);
+    assert.equal(getClient(owner).options.max, 1);
+    assert.equal(getClient(owner).options.connect_timeout, 5);
+    await owner.close();
+  } finally {
+    if (previousOperationUrl === undefined) {
+      delete process.env.OPERATION_DATABASE_URL;
+    } else {
+      process.env.OPERATION_DATABASE_URL = previousOperationUrl;
+    }
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+  }
 });
 
 test('prefers the operation endpoint and falls back to the direct endpoint', async () => {

--- a/packages/core/db/index.ts
+++ b/packages/core/db/index.ts
@@ -38,7 +38,7 @@ export type DatabaseOwner = {
 
 export type OperationDatabaseOwner = DatabaseOwner;
 
-export const createDatabaseOwner = (databaseUrl = process.env.DATABASE_URL!): DatabaseOwner => {
+const createOwnedDatabase = (databaseUrl: string): DatabaseOwner => {
   const client = postgres(databaseUrl, {
     ...postgresConnectionOptions,
     connect_timeout: 5,
@@ -52,6 +52,9 @@ export const createDatabaseOwner = (databaseUrl = process.env.DATABASE_URL!): Da
     close: (options) => (closeTask ??= options?.force ? client.end({ timeout: 0 }) : client.end()),
   };
 };
+
+export const createDatabaseOwner = (): DatabaseOwner =>
+  createOwnedDatabase(process.env.DATABASE_URL!);
 
 /**
  * Create the database handle owned by one GraphQL Query or Mutation.

--- a/packages/core/db/index.ts
+++ b/packages/core/db/index.ts
@@ -31,9 +31,26 @@ export type Database = typeof db;
 export type Transaction = Parameters<Parameters<Database['transaction']>[0]>[0];
 export type DatabaseHandle = Database | Transaction;
 
-export type OperationDatabaseOwner = {
+export type DatabaseOwner = {
   db: Database;
   close: (options?: { force?: boolean }) => Promise<void>;
+};
+
+export type OperationDatabaseOwner = DatabaseOwner;
+
+export const createDatabaseOwner = (databaseUrl = process.env.DATABASE_URL!): DatabaseOwner => {
+  const client = postgres(databaseUrl, {
+    ...postgresConnectionOptions,
+    connect_timeout: 5,
+    max: 1,
+  });
+  const ownedDb = drizzle({ client, schema });
+  let closeTask: Promise<void> | undefined;
+
+  return {
+    db: ownedDb,
+    close: (options) => (closeTask ??= options?.force ? client.end({ timeout: 0 }) : client.end()),
+  };
 };
 
 /**

--- a/packages/core/services/activitypub-reaction.ts
+++ b/packages/core/services/activitypub-reaction.ts
@@ -14,7 +14,8 @@ import {
 import { InstanceKind, InstanceState, PostState, PostVisibility, ProfileState } from '../enums';
 import { reactionTypeSchema } from '../validation';
 import { addReaction, deleteReaction } from './reaction';
-import type { Transaction } from '../db';
+import type { Database, Transaction } from '../db';
+import type { PostCommit } from './post-commit';
 
 type MaterializeInboundReactionInput = {
   readonly activityUri: string;
@@ -160,6 +161,7 @@ const isSameReaction = (
 
 export const materializeInboundReaction = async (
   input: MaterializeInboundReactionInput,
+  database: Database = db,
 ): Promise<MaterializeInboundReactionResult> => {
   const parsedType = reactionTypeSchema.safeParse(input.type);
   if (
@@ -172,10 +174,10 @@ export const materializeInboundReaction = async (
   }
 
   let result: Exclude<MaterializeInboundReactionResult, { kind: 'REJECTED' }> & {
-    readonly postCommit: () => Promise<void>;
+    readonly postCommit: PostCommit;
   };
   try {
-    result = await db.transaction(async (tx) => {
+    result = await database.transaction(async (tx) => {
       const actor = await tx
         .select({ profileId: Profiles.id })
         .from(ActivityPubActors)
@@ -255,25 +257,28 @@ export const materializeInboundReaction = async (
     throw error;
   }
 
-  await result.postCommit();
+  await result.postCommit(database);
 
   return { kind: result.kind, reaction: result.reaction };
 };
 
-export const undoInboundReaction = async ({
-  activityUri,
-  actorUri,
-  onPostCommitError,
-}: {
-  readonly activityUri: string;
-  readonly actorUri: string;
-  readonly onPostCommitError?: (error: unknown) => void | Promise<void>;
-}): Promise<{ readonly reactionId: string | null }> => {
+export const undoInboundReaction = async (
+  {
+    activityUri,
+    actorUri,
+    onPostCommitError,
+  }: {
+    readonly activityUri: string;
+    readonly actorUri: string;
+    readonly onPostCommitError?: (error: unknown) => void | Promise<void>;
+  },
+  database: Database = db,
+): Promise<{ readonly reactionId: string | null }> => {
   if (!isHttpUri(activityUri) || !isHttpUri(actorUri)) {
     return { reactionId: null };
   }
 
-  const deleted = await db.transaction(async (tx) => {
+  const deleted = await database.transaction(async (tx) => {
     const mapped = await tx
       .select({ reaction: Reactions })
       .from(ActivityPubReactions)
@@ -311,7 +316,7 @@ export const undoInboundReaction = async ({
     return deleted;
   });
 
-  await deleted?.postCommit();
+  await deleted?.postCommit(database);
 
   return { reactionId: deleted?.reaction?.id ?? null };
 };

--- a/packages/fedify/src/activitypub-post-uri.ts
+++ b/packages/fedify/src/activitypub-post-uri.ts
@@ -1,20 +1,31 @@
 import { Note } from '@fedify/vocab';
-import { ActivityPubPosts, db, first, Instances, Posts, Profiles } from '@kosmo/core/db';
+import {
+  ActivityPubPosts,
+  first,
+  getDatabaseConnection,
+  Instances,
+  Posts,
+  Profiles,
+} from '@kosmo/core/db';
 import { InstanceKind } from '@kosmo/core/enums';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import type { Context } from '@fedify/fedify';
+import type { DatabaseHandle } from '@kosmo/core/db';
 
 const postIdSchema = z.uuid().refine((value) => value === value.toLowerCase());
 
 export const isCanonicalPostId = (value: string): boolean => postIdSchema.safeParse(value).success;
 
-export const resolveActivityPubPostUri = async (postId: string): Promise<URL | undefined> => {
+export const resolveActivityPubPostUri = async (
+  postId: string,
+  handle?: DatabaseHandle,
+): Promise<URL | undefined> => {
   if (!isCanonicalPostId(postId)) {
     return undefined;
   }
 
-  const row = await db
+  const row = await getDatabaseConnection(handle)
     .select({
       instanceCanonicalOrigin: Instances.canonicalOrigin,
       instanceKind: Instances.kind,
@@ -43,6 +54,7 @@ export const resolveActivityPubPostUri = async (postId: string): Promise<URL | u
 export const findPostByActivityPubUri = async (
   context: Pick<Context<unknown>, 'canonicalOrigin' | 'parseUri'>,
   uri: URL,
+  handle?: DatabaseHandle,
 ): Promise<string | undefined> => {
   if (uri.protocol !== 'http:' && uri.protocol !== 'https:') {
     return undefined;
@@ -59,7 +71,7 @@ export const findPostByActivityPubUri = async (
       return undefined;
     }
 
-    return db
+    return getDatabaseConnection(handle)
       .select({ id: Posts.id })
       .from(Posts)
       .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
@@ -76,7 +88,7 @@ export const findPostByActivityPubUri = async (
       .then((post) => post?.id);
   }
 
-  const remotePost = await db
+  const remotePost = await getDatabaseConnection(handle)
     .select({ id: Posts.id })
     .from(ActivityPubPosts)
     .innerJoin(Posts, eq(Posts.id, ActivityPubPosts.postId))

--- a/packages/fedify/src/activitypub-post-uri.ts
+++ b/packages/fedify/src/activitypub-post-uri.ts
@@ -1,12 +1,5 @@
 import { Note } from '@fedify/vocab';
-import {
-  ActivityPubPosts,
-  first,
-  getDatabaseConnection,
-  Instances,
-  Posts,
-  Profiles,
-} from '@kosmo/core/db';
+import { ActivityPubPosts, first, Instances, Posts, Profiles } from '@kosmo/core/db';
 import { InstanceKind } from '@kosmo/core/enums';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
@@ -19,13 +12,13 @@ export const isCanonicalPostId = (value: string): boolean => postIdSchema.safePa
 
 export const resolveActivityPubPostUri = async (
   postId: string,
-  handle?: DatabaseHandle,
+  handle: DatabaseHandle,
 ): Promise<URL | undefined> => {
   if (!isCanonicalPostId(postId)) {
     return undefined;
   }
 
-  const row = await getDatabaseConnection(handle)
+  const row = await handle
     .select({
       instanceCanonicalOrigin: Instances.canonicalOrigin,
       instanceKind: Instances.kind,
@@ -54,7 +47,7 @@ export const resolveActivityPubPostUri = async (
 export const findPostByActivityPubUri = async (
   context: Pick<Context<unknown>, 'canonicalOrigin' | 'parseUri'>,
   uri: URL,
-  handle?: DatabaseHandle,
+  handle: DatabaseHandle,
 ): Promise<string | undefined> => {
   if (uri.protocol !== 'http:' && uri.protocol !== 'https:') {
     return undefined;
@@ -71,7 +64,7 @@ export const findPostByActivityPubUri = async (
       return undefined;
     }
 
-    return getDatabaseConnection(handle)
+    return handle
       .select({ id: Posts.id })
       .from(Posts)
       .innerJoin(Profiles, eq(Profiles.id, Posts.profileId))
@@ -88,7 +81,7 @@ export const findPostByActivityPubUri = async (
       .then((post) => post?.id);
   }
 
-  const remotePost = await getDatabaseConnection(handle)
+  const remotePost = await handle
     .select({ id: Posts.id })
     .from(ActivityPubPosts)
     .innerJoin(Posts, eq(Posts.id, ActivityPubPosts.postId))

--- a/packages/fedify/src/federation.ts
+++ b/packages/fedify/src/federation.ts
@@ -44,10 +44,11 @@ import { createLocalProfilePerson } from './local-profile-person';
 import { fedifyQueue } from './queue';
 import { resolveLocalActorIdentifierByHandle } from './webfinger';
 import type { Context, Federation } from '@fedify/fedify';
+import type { FedifyContextData } from './fedify-context';
 
 const federationOrigin = process.env.PUBLIC_ORIGIN;
 
-export const federation: Federation<void> = createFederation<void>({
+export const federation: Federation<FedifyContextData> = createFederation<FedifyContextData>({
   allowPrivateAddress: false,
   kv: new MemoryKvStore(),
   ...(fedifyQueue
@@ -104,7 +105,7 @@ federation
   });
 
 const findActiveLocalProfile = async (
-  context: Pick<Context<void>, 'canonicalOrigin' | 'host'>,
+  context: Pick<Context<FedifyContextData>, 'canonicalOrigin' | 'host'>,
   profileId: string,
 ) => {
   // Multiple Local Instances are valid domain state. This runtime currently serves only its

--- a/packages/fedify/src/fedify-context.ts
+++ b/packages/fedify/src/fedify-context.ts
@@ -1,0 +1,10 @@
+import { db } from '@kosmo/core/db';
+import type { Database } from '@kosmo/core/db';
+
+export type FedifyContextData = { readonly db: Database } | undefined;
+
+export const createFedifyContextData = (
+  database: Database = db,
+): NonNullable<FedifyContextData> => ({ db: database });
+
+export const getFedifyDatabase = (data: FedifyContextData): Database => data?.db ?? db;

--- a/packages/fedify/src/fedify-context.ts
+++ b/packages/fedify/src/fedify-context.ts
@@ -1,10 +1,7 @@
-import { db } from '@kosmo/core/db';
 import type { Database } from '@kosmo/core/db';
 
-export type FedifyContextData = { readonly db: Database } | undefined;
+export type FedifyContextData = { readonly db: Database };
 
-export const createFedifyContextData = (
-  database: Database = db,
-): NonNullable<FedifyContextData> => ({ db: database });
-
-export const getFedifyDatabase = (data: FedifyContextData): Database => data?.db ?? db;
+export const createFedifyContextData = (database: Database): FedifyContextData => ({
+  db: database,
+});

--- a/packages/fedify/src/follow-delivery.test.ts
+++ b/packages/fedify/src/follow-delivery.test.ts
@@ -4,6 +4,7 @@ import { Accept, Follow, Person } from '@fedify/vocab';
 import { sendAcceptFollowActivity } from './follow-delivery';
 import type { Context } from '@fedify/fedify';
 import type { Activity, Recipient } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 const canonicalOrigin = 'https://kos.moe';
 const senderProfileId = '019f6f67-1111-7777-8888-123456789abc';
@@ -72,7 +73,7 @@ const createContextFixture = () => {
     ) => {
       calls.push({ activity, options, recipient, sender });
     },
-  } as Pick<Context<void>, 'canonicalOrigin' | 'getActorUri' | 'sendActivity'>;
+  } as Pick<Context<FedifyContextData>, 'canonicalOrigin' | 'getActorUri' | 'sendActivity'>;
 
   return { calls, context };
 };

--- a/packages/fedify/src/follow-delivery.ts
+++ b/packages/fedify/src/follow-delivery.ts
@@ -1,9 +1,10 @@
 import { Accept } from '@fedify/vocab';
 import type { Context } from '@fedify/fedify';
 import type { Follow, Recipient } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 type FollowDeliveryContext = Pick<
-  Context<void>,
+  Context<FedifyContextData>,
   'canonicalOrigin' | 'getActorUri' | 'sendActivity'
 >;
 

--- a/packages/fedify/src/inbound-accept-follow.ts
+++ b/packages/fedify/src/inbound-accept-follow.ts
@@ -7,6 +7,7 @@ import { resolveInboundLocalRecipient } from './inbound-local-recipient';
 import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Follow } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 export const handleInboundAcceptFollow = async ({
   context,
@@ -16,7 +17,7 @@ export const handleInboundAcceptFollow = async ({
   acceptProfileFollowRequest: acceptFollowRequest = acceptProfileFollowRequest,
 }: {
   readonly acceptProfileFollowRequest?: typeof acceptProfileFollowRequest;
-  context: InboxContext<void>;
+  context: InboxContext<FedifyContextData>;
   follow: Follow;
   followeeActorUri: URL;
   followeeProfileId: string;

--- a/packages/fedify/src/inbound-accept-reject.test.ts
+++ b/packages/fedify/src/inbound-accept-reject.test.ts
@@ -12,7 +12,7 @@ import {
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
 import { eq, ne } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
@@ -33,6 +33,7 @@ const remoteActorUri = new URL('https://remote.example/users/alice');
 
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let db: typeof CoreDb.db;
+const createFedifyContextData = () => createFedifyContextDataWithDatabase(db);
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
 let Notifications: typeof CoreDb.Notifications;

--- a/packages/fedify/src/inbound-accept-reject.test.ts
+++ b/packages/fedify/src/inbound-accept-reject.test.ts
@@ -12,12 +12,14 @@ import {
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
 import { eq, ne } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as CoreServices from '@kosmo/core/services';
 import type { federation as productionFederation } from './federation';
+import type { FedifyContextData } from './fedify-context';
 import type * as InboundAccept from './inbound-accept';
 import type * as InboundAcceptFollow from './inbound-accept-follow';
 import type * as InboundReject from './inbound-reject';
@@ -96,7 +98,7 @@ describe('inbound Accept and Reject', () => {
       loadedUrls.push(url);
       const response = await federation.fetch(
         new Request(url, { headers: { Accept: 'application/activity+json' } }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
       if (!response.ok) {
         throw new Error(`Follow document returned ${response.status}: ${url}`);
@@ -113,7 +115,7 @@ describe('inbound Accept and Reject', () => {
       new Request(`${publicOrigin}/ap/follow/${fixture.projection.id}`, {
         headers: { Accept: 'application/activity+json' },
       }),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
     assert.equal(followResponse.status, 200, await followResponse.text());
 
@@ -130,21 +132,21 @@ describe('inbound Accept and Reject', () => {
       new Request(`${publicOrigin}/ap/follow/${established.id}`, {
         headers: { Accept: 'application/activity+json' },
       }),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
     assert.equal(establishedFollowResponse.status, 200);
     const consumedRequestResponse = await federation.fetch(
       new Request(`${publicOrigin}/ap/follow/${fixture.projection.id}`, {
         headers: { Accept: 'application/activity+json' },
       }),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
     assert.equal(consumedRequestResponse.status, 404);
     const unknownResponse = await federation.fetch(
       new Request(`${publicOrigin}/ap/follow/${crypto.randomUUID()}`, {
         headers: { Accept: 'application/activity+json' },
       }),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
     assert.equal(unknownResponse.status, 404);
   });
@@ -156,7 +158,7 @@ describe('inbound Accept and Reject', () => {
         new Request(`${publicOrigin}/ap/follow/${id}`, {
           headers: { Accept: 'application/activity+json' },
         }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
 
     assert.equal((await fetchFollow(fixture.projection.id.toUpperCase())).status, 404);
@@ -920,13 +922,14 @@ const createContext = (
   documentLoader: DocumentLoader = async (url) => {
     throw new Error(`Unexpected document URL: ${url}`);
   },
-): InboxContext<void> =>
+): InboxContext<FedifyContextData> =>
   ({
     canonicalOrigin: publicOrigin,
+    data: createFedifyContextData(),
     documentLoader,
     getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
     recipient,
-  }) as unknown as InboxContext<void>;
+  }) as unknown as InboxContext<FedifyContextData>;
 
 const readCounts = async ({
   localProfile,

--- a/packages/fedify/src/inbound-accept.ts
+++ b/packages/fedify/src/inbound-accept.ts
@@ -10,9 +10,10 @@ import {
 import { findUsableStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Accept } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 export const handleInboundAccept = async (
-  context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   accept: Accept,
 ): Promise<void> => {
   const actorUri = accept.actorId;

--- a/packages/fedify/src/inbound-announce.test.ts
+++ b/packages/fedify/src/inbound-announce.test.ts
@@ -18,11 +18,13 @@ import {
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { createPost } from '@kosmo/core/services';
 import { and, eq, ne, sql } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as FederationModule from './federation';
+import type { FedifyContextData } from './fedify-context';
 import type { handleInboundAnnounce as HandleInboundAnnounce } from './inbound-announce';
 import type { handleInboundUndo as HandleInboundUndo } from './inbound-follow';
 
@@ -36,6 +38,7 @@ const receivedAt = Temporal.Instant.from('2026-07-27T00:00:00Z');
 
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
+let createDatabaseOwner: typeof CoreDb.createDatabaseOwner;
 let db: typeof CoreDb.db;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
@@ -56,6 +59,7 @@ describe('inbound Announce materialization', () => {
     ({
       ActivityPubActors,
       ActivityPubPosts,
+      createDatabaseOwner,
       db,
       firstOrThrow,
       Instances,
@@ -102,6 +106,24 @@ describe('inbound Announce materialization', () => {
     assert.equal(repost.visibility, PostVisibility.UNLISTED);
     assert.equal(repost.state, PostState.ACTIVE);
     assert.equal(mapping.receivedAt.toString(), receivedAt.toString());
+  });
+
+  test('uses the database owner supplied by the trusted ingress context', async () => {
+    await createRemoteActor(actorUri);
+    await createRemoteSource();
+    const owner = createDatabaseOwner(databaseUrl);
+    const transaction = mock.method(owner.db, 'transaction');
+
+    try {
+      await handleInboundAnnounce(
+        context(owner.db),
+        announce('explicit-owner', sourceUri),
+        receivedAt,
+      );
+      assert.equal(transaction.mock.callCount(), 1);
+    } finally {
+      await owner.close();
+    }
   });
 
   test('accepts an exact canonical local Note URI without an ActivityPub mapping', async () => {
@@ -352,9 +374,11 @@ describe('inbound Announce materialization', () => {
     try {
       const [personal, shared] = await Promise.all([
         federation.fetch(await createSignedRequest(`/ap/actor/${localProfileId}/inbox`), {
-          contextData: undefined,
+          contextData: createFedifyContextData(),
         }),
-        federation.fetch(await createSignedRequest('/inbox'), { contextData: undefined }),
+        federation.fetch(await createSignedRequest('/inbox'), {
+          contextData: createFedifyContextData(),
+        }),
       ]);
 
       assert.equal(personal.status, 202, await personal.text());
@@ -518,15 +542,18 @@ describe('inbound Announce materialization', () => {
   });
 });
 
-const context = () =>
+const context = (database: CoreDb.Database = db) =>
   ({
     canonicalOrigin: publicOrigin,
+    data: createFedifyContextData(database),
     documentLoader: async (url: string) => {
       throw new Error(`Unexpected document URL: ${url}`);
     },
     parseUri: (uri: URL | null) =>
-      federation.createContext(new URL(publicOrigin), undefined).parseUri(uri),
-  }) as unknown as InboxContext<void>;
+      federation
+        .createContext(new URL(publicOrigin), createFedifyContextData(database))
+        .parseUri(uri),
+  }) as unknown as InboxContext<FedifyContextData>;
 
 const announce = (id: string, object: URL) =>
   new Announce({

--- a/packages/fedify/src/inbound-announce.test.ts
+++ b/packages/fedify/src/inbound-announce.test.ts
@@ -18,7 +18,7 @@ import {
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { createPost } from '@kosmo/core/services';
 import { and, eq, ne, sql } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
@@ -40,6 +40,8 @@ let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
 let createDatabaseOwner: typeof CoreDb.createDatabaseOwner;
 let db: typeof CoreDb.db;
+const createFedifyContextData = (database: typeof CoreDb.db = db) =>
+  createFedifyContextDataWithDatabase(database);
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
 let Notifications: typeof CoreDb.Notifications;
@@ -111,7 +113,7 @@ describe('inbound Announce materialization', () => {
   test('uses the database owner supplied by the trusted ingress context', async () => {
     await createRemoteActor(actorUri);
     await createRemoteSource();
-    const owner = createDatabaseOwner(databaseUrl);
+    const owner = createDatabaseOwner();
     const transaction = mock.method(owner.db, 'transaction');
 
     try {

--- a/packages/fedify/src/inbound-announce.ts
+++ b/packages/fedify/src/inbound-announce.ts
@@ -7,7 +7,6 @@ import { repostPost } from '@kosmo/core/services';
 import { eq, or } from 'drizzle-orm';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import { getFedifyDatabase } from './fedify-context';
 import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
 import { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
@@ -100,7 +99,7 @@ export const handleInboundAnnounce = async (
   announce: Announce,
   receivedAt: Temporal.Instant = Temporal.Now.instant(),
 ): Promise<void> => {
-  const database = getFedifyDatabase(context.data);
+  const database = context.data.db;
   const activityUri = announce.id;
   const actorHref = uniqueHref(announce.actorIds);
   const objectHref = uniqueHref(announce.objectIds);

--- a/packages/fedify/src/inbound-announce.ts
+++ b/packages/fedify/src/inbound-announce.ts
@@ -1,17 +1,19 @@
 import '@kosmo/core/polyfill';
 
-import { ActivityPubPosts, db, first, isUniqueViolation, Posts } from '@kosmo/core/db';
+import { ActivityPubPosts, first, isUniqueViolation, Posts } from '@kosmo/core/db';
 import { InstanceState, PostState } from '@kosmo/core/enums';
 import { NotFoundError, PermissionDeniedError, ValidationError } from '@kosmo/core/error';
 import { repostPost } from '@kosmo/core/services';
 import { eq, or } from 'drizzle-orm';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import { getFedifyDatabase } from './fedify-context';
 import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
 import { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Announce } from '@fedify/vocab';
 import type { Transaction } from '@kosmo/core/db';
+import type { FedifyContextData } from './fedify-context';
 
 const isExpectedRepostRejection = (error: unknown): boolean =>
   error instanceof NotFoundError ||
@@ -94,10 +96,11 @@ const saveCurrentAnnounce = async (
 };
 
 export const handleInboundAnnounce = async (
-  context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   announce: Announce,
   receivedAt: Temporal.Instant = Temporal.Now.instant(),
 ): Promise<void> => {
+  const database = getFedifyDatabase(context.data);
   const activityUri = announce.id;
   const actorHref = uniqueHref(announce.actorIds);
   const objectHref = uniqueHref(announce.objectIds);
@@ -143,7 +146,7 @@ export const handleInboundAnnounce = async (
     return;
   }
 
-  const sourcePostId = await findPostByActivityPubUri(context, objectUri);
+  const sourcePostId = await findPostByActivityPubUri(context, objectUri, database);
   if (!sourcePostId) {
     observeInboundNoop({
       activityType: 'Announce',
@@ -158,7 +161,7 @@ export const handleInboundAnnounce = async (
 
   let materialized: Awaited<ReturnType<typeof repostPost>>;
   try {
-    materialized = await db.transaction(async (tx) => {
+    materialized = await database.transaction(async (tx) => {
       let result = await repostPost(
         {
           actorProfileId: storedActor.profile.id,
@@ -209,5 +212,5 @@ export const handleInboundAnnounce = async (
     throw error;
   }
 
-  await materialized.postCommit();
+  await materialized.postCommit(database);
 };

--- a/packages/fedify/src/inbound-create-note.ts
+++ b/packages/fedify/src/inbound-create-note.ts
@@ -10,6 +10,7 @@ import { createPost } from '@kosmo/core/services';
 import { and, eq } from 'drizzle-orm';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import { getFedifyDatabase } from './fedify-context';
 import {
   observeInbound,
   observeInboundNoop,
@@ -17,6 +18,7 @@ import {
 } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Note } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 import type { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 
 type StoredRemoteProfileActor = NonNullable<
@@ -83,9 +85,10 @@ export const projectRemoteNoteMedia = async (note: Note) => {
 };
 
 const resolveReplyParentId = async (
-  context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   note: Note,
 ): Promise<string | undefined> => {
+  const database = getFedifyDatabase(context.data);
   const replyTargetHref = uniqueHref(note.replyTargetIds);
   if (!replyTargetHref) {
     return undefined;
@@ -96,7 +99,7 @@ const resolveReplyParentId = async (
     return undefined;
   }
 
-  return findPostByActivityPubUri(context, replyTarget);
+  return findPostByActivityPubUri(context, replyTarget, database);
 };
 
 const hasEstablishedFollower = async ({
@@ -137,12 +140,13 @@ export const handleInboundCreateNote = async ({
   receivedAt,
 }: {
   actorUri: string;
-  context: InboxContext<void>;
+  context: InboxContext<FedifyContextData>;
   note: Note;
   objectUri: string;
   storedActor: StoredRemoteProfileActor;
   receivedAt: Temporal.Instant;
 }): Promise<void> => {
+  const database = getFedifyDatabase(context.data);
   if (note.id?.href !== objectUri) {
     observeInboundRejected({
       activityType: 'Create',
@@ -265,7 +269,7 @@ export const handleInboundCreateNote = async ({
     });
 
   try {
-    const result = await createPost(replyParentId ? { ...input, replyParentId } : input);
+    const result = await createPost(replyParentId ? { ...input, replyParentId } : input, database);
     if (!result.created) {
       observeDuplicateCreate();
     }
@@ -299,7 +303,7 @@ export const handleInboundCreateNote = async ({
       phase: 'projection',
       reasonCode: 'reply_parent_missing_fallback',
     });
-    const result = await createPost(input);
+    const result = await createPost(input, database);
     if (!result.created) {
       observeDuplicateCreate();
     }

--- a/packages/fedify/src/inbound-create-note.ts
+++ b/packages/fedify/src/inbound-create-note.ts
@@ -10,7 +10,6 @@ import { createPost } from '@kosmo/core/services';
 import { and, eq } from 'drizzle-orm';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import { getFedifyDatabase } from './fedify-context';
 import {
   observeInbound,
   observeInboundNoop,
@@ -88,7 +87,7 @@ const resolveReplyParentId = async (
   context: InboxContext<FedifyContextData>,
   note: Note,
 ): Promise<string | undefined> => {
-  const database = getFedifyDatabase(context.data);
+  const database = context.data.db;
   const replyTargetHref = uniqueHref(note.replyTargetIds);
   if (!replyTargetHref) {
     return undefined;
@@ -146,7 +145,7 @@ export const handleInboundCreateNote = async ({
   storedActor: StoredRemoteProfileActor;
   receivedAt: Temporal.Instant;
 }): Promise<void> => {
-  const database = getFedifyDatabase(context.data);
+  const database = context.data.db;
   if (note.id?.href !== objectUri) {
     observeInboundRejected({
       activityType: 'Create',

--- a/packages/fedify/src/inbound-create.test.ts
+++ b/packages/fedify/src/inbound-create.test.ts
@@ -35,7 +35,7 @@ import {
   postContentDocumentToText,
 } from '@kosmo/core/post-content/server';
 import { eq, ne, sql } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
@@ -59,6 +59,7 @@ const uriContext = uriFederation.createContext(new URL(publicOrigin), undefined)
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
 let db: typeof CoreDb.db;
+const createFedifyContextData = () => createFedifyContextDataWithDatabase(db);
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
 let Media: typeof CoreDb.Media;
@@ -885,6 +886,7 @@ describe('inbound Create dispatch', () => {
       await findPostByActivityPubUri(
         createContext(),
         new URL(`/ap/note/${previousPost.post.id}`, publicOrigin),
+        db,
       ),
       undefined,
     );
@@ -898,6 +900,7 @@ describe('inbound Create dispatch', () => {
               .parseUri(uri),
         },
         new URL(`/ap/note/${previousPost.post.id}`, previousInstance.canonicalOrigin!),
+        db,
       ),
       previousPost.post.id,
     );
@@ -982,7 +985,7 @@ describe('inbound Create dispatch', () => {
       uri: contentlessParentUri.href,
     });
     assert.equal(
-      await findPostByActivityPubUri(createContext(), contentlessParentUri),
+      await findPostByActivityPubUri(createContext(), contentlessParentUri, db),
       contentlessParent.id,
     );
     const existingPostCount = await db.$count(Posts);

--- a/packages/fedify/src/inbound-create.test.ts
+++ b/packages/fedify/src/inbound-create.test.ts
@@ -35,12 +35,14 @@ import {
   postContentDocumentToText,
 } from '@kosmo/core/post-content/server';
 import { eq, ne, sql } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as CoreServices from '@kosmo/core/services';
 import type { findPostByActivityPubUri as findPostByActivityPubUriType } from './activitypub-post-uri';
+import type { FedifyContextData } from './fedify-context';
 import type { handleInboundCreate as handleInboundCreateType } from './inbound-create';
 
 const publicOrigin = 'http://127.0.0.1:4173';
@@ -1154,7 +1156,7 @@ describe('inbound Create dispatch', () => {
         undefined,
         audience,
       ),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
     const sharedResponse = await fixture.federation.fetch(
       await fixture.createSignedCreateRequest(
@@ -1164,7 +1166,7 @@ describe('inbound Create dispatch', () => {
         undefined,
         audience,
       ),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
 
     assert.equal(personalResponse.status, 202, await personalResponse.text());
@@ -1193,7 +1195,7 @@ describe('inbound Create dispatch', () => {
           objectUri,
           new URL('https://remote.example/activities/create-concurrent-personal'),
         ),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       ),
       fixture.federation.fetch(
         await fixture.createSignedCreateRequest(
@@ -1201,7 +1203,7 @@ describe('inbound Create dispatch', () => {
           objectUri,
           new URL('https://remote.example/activities/create-concurrent-shared'),
         ),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       ),
     ]);
 
@@ -1232,11 +1234,11 @@ describe('inbound Create dispatch', () => {
           new URL('https://remote.example/activities/create-reply-personal'),
           parentUri,
         ),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       ),
       fixture.federation.fetch(
         await fixture.createSignedCreateRequest('/inbox', replyUri, null, parentUri),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       ),
     ]);
 
@@ -1469,10 +1471,11 @@ const createContext = (
 ) =>
   ({
     canonicalOrigin: publicOrigin,
+    data: createFedifyContextData(),
     documentLoader,
     parseUri: (uri: URL | null) => uriContext.parseUri(uri),
     recipient,
-  }) as unknown as InboxContext<void>;
+  }) as unknown as InboxContext<FedifyContextData>;
 
 const createRemoteCreate = ({ objectUri, replyTarget }: { objectUri: URL; replyTarget?: URL }) =>
   new Create({
@@ -1588,7 +1591,7 @@ const createInboxFixture = async () => {
     return { contextUrl: null, document, documentUrl: url };
   };
   const contextLoader = getDocumentLoader();
-  const federation = createFederation<void>({
+  const federation = createFederation<FedifyContextData>({
     authenticatedDocumentLoaderFactory: () => documentLoader,
     contextLoaderFactory: () => contextLoader,
     documentLoaderFactory: () => documentLoader,

--- a/packages/fedify/src/inbound-create.ts
+++ b/packages/fedify/src/inbound-create.ts
@@ -12,9 +12,10 @@ import {
 import { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Create } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 export const handleInboundCreate = async (
-  context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   create: Create,
   receivedAt: Temporal.Instant = Temporal.Now.instant(),
 ): Promise<void> => {

--- a/packages/fedify/src/inbound-delete.test.ts
+++ b/packages/fedify/src/inbound-delete.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { eq, ne } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
@@ -46,6 +46,7 @@ const receivedAt = Temporal.Instant.from('2026-07-30T00:00:00Z');
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
 let db: typeof CoreDb.db;
+const createFedifyContextData = () => createFedifyContextDataWithDatabase(db);
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
 let pg: typeof CoreDb.pg;

--- a/packages/fedify/src/inbound-delete.test.ts
+++ b/packages/fedify/src/inbound-delete.test.ts
@@ -29,11 +29,13 @@ import {
 } from '@kosmo/core/enums';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { eq, ne } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as CoreServices from '@kosmo/core/services';
+import type { FedifyContextData } from './fedify-context';
 import type { handleInboundCreate as handleInboundCreateType } from './inbound-create';
 import type { handleInboundDelete as handleInboundDeleteType } from './inbound-delete';
 
@@ -462,11 +464,11 @@ describe('inbound Delete dispatch', () => {
 
     const personalResponse = await fixture.federation.fetch(
       await fixture.createSignedDeleteRequest('/ap/actor/local/inbox', personalUri),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
     const sharedResponse = await fixture.federation.fetch(
       await fixture.createSignedDeleteRequest('/inbox', sharedUri),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
 
     assert.equal(personalResponse.status, 202, await personalResponse.text());
@@ -480,7 +482,11 @@ const createContext = (
   documentLoader = async (url: string) => {
     throw new Error(`Unexpected document URL: ${url}`);
   },
-) => ({ documentLoader }) as unknown as InboxContext<void>;
+) =>
+  ({
+    data: createFedifyContextData(),
+    documentLoader,
+  }) as unknown as InboxContext<FedifyContextData>;
 
 const createStoredRemoteActor = async (
   actorUri: URL,
@@ -598,7 +604,7 @@ const createInboxFixture = async (actorUri: URL) => {
     return { contextUrl: null, document, documentUrl: url };
   };
   const contextLoader = getDocumentLoader();
-  const federation = createFederation<void>({
+  const federation = createFederation<FedifyContextData>({
     authenticatedDocumentLoaderFactory: () => documentLoader,
     contextLoaderFactory: () => contextLoader,
     documentLoaderFactory: () => documentLoader,

--- a/packages/fedify/src/inbound-delete.ts
+++ b/packages/fedify/src/inbound-delete.ts
@@ -4,7 +4,6 @@ import { Tombstone } from '@fedify/vocab';
 import {
   ActivityPubActors,
   ActivityPubPosts,
-  db,
   first,
   Instances,
   Posts,
@@ -14,6 +13,7 @@ import { InstanceKind } from '@kosmo/core/enums';
 import { deletePost } from '@kosmo/core/services';
 import { and, eq, isNotNull } from 'drizzle-orm';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import { getFedifyDatabase } from './fedify-context';
 import {
   observeInboundExternalFailure,
   observeInboundNoop,
@@ -21,15 +21,17 @@ import {
 } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Delete } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 const noNetworkDocumentLoader = async (url: string) => {
   throw new Error(`Network lookup is disabled for inbound Delete: ${url}`);
 };
 
 export const handleInboundDelete = async (
-  _context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   activity: Delete,
 ): Promise<void> => {
+  const database = getFedifyDatabase(context.data);
   const actorHref = uniqueHref(activity.actorIds);
   const objectHref = uniqueHref(activity.objectIds);
   const actorUri = actorHref ? new URL(actorHref) : null;
@@ -77,7 +79,7 @@ export const handleInboundDelete = async (
     return;
   }
 
-  const result = await db.transaction(async (tx) => {
+  const result = await database.transaction(async (tx) => {
     const row = await tx
       .select({
         actorUri: ActivityPubActors.uri,
@@ -117,5 +119,5 @@ export const handleInboundDelete = async (
     return deleted;
   });
 
-  await result?.postCommit();
+  await result?.postCommit(database);
 };

--- a/packages/fedify/src/inbound-delete.ts
+++ b/packages/fedify/src/inbound-delete.ts
@@ -13,7 +13,6 @@ import { InstanceKind } from '@kosmo/core/enums';
 import { deletePost } from '@kosmo/core/services';
 import { and, eq, isNotNull } from 'drizzle-orm';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import { getFedifyDatabase } from './fedify-context';
 import {
   observeInboundExternalFailure,
   observeInboundNoop,
@@ -31,7 +30,7 @@ export const handleInboundDelete = async (
   context: InboxContext<FedifyContextData>,
   activity: Delete,
 ): Promise<void> => {
-  const database = getFedifyDatabase(context.data);
+  const database = context.data.db;
   const actorHref = uniqueHref(activity.actorIds);
   const objectHref = uniqueHref(activity.objectIds);
   const actorUri = actorHref ? new URL(actorHref) : null;

--- a/packages/fedify/src/inbound-follow.test.ts
+++ b/packages/fedify/src/inbound-follow.test.ts
@@ -12,12 +12,14 @@ import {
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
 import { eq, ne, sql } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as CoreServices from '@kosmo/core/services';
 import type * as FederationModule from './federation';
+import type { FedifyContextData } from './fedify-context';
 import type * as InboundFollow from './inbound-follow';
 
 const publicOrigin = 'http://127.0.0.1:4173';
@@ -184,7 +186,7 @@ describe('inbound Follow and Undo', () => {
         object: localActorUri,
       });
       const followResponse = await federation.fetch(await createSignedRequest(follow), {
-        contextData: undefined,
+        contextData: createFedifyContextData(),
       });
       assert.equal(followResponse.status, 202, await followResponse.text());
 
@@ -208,7 +210,7 @@ describe('inbound Follow and Undo', () => {
             object: new Follow({ actor: remoteActorUri, object: localActorUri }),
           }),
         ),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
       assert.equal(undoResponse.status, 202, await undoResponse.text());
       assert.equal((await db.select().from(ProfileFollows)).length, 0);
@@ -240,7 +242,7 @@ describe('inbound Follow and Undo', () => {
           headers: { 'content-type': 'application/activity+json' },
           method: 'POST',
         }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
 
       assert.equal(response.status, 400, await response.text());
@@ -915,12 +917,13 @@ const createContext = ({
   lookupWebFinger?: ReturnType<typeof mock.fn>;
   recipient: string | null;
   sendActivity?: ReturnType<typeof mock.fn>;
-}): InboxContext<void> =>
+}): InboxContext<FedifyContextData> =>
   ({
     canonicalOrigin: publicOrigin,
+    data: createFedifyContextData(),
     getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
     lookupObject,
     lookupWebFinger,
     recipient,
     sendActivity,
-  }) as unknown as InboxContext<void>;
+  }) as unknown as InboxContext<FedifyContextData>;

--- a/packages/fedify/src/inbound-follow.test.ts
+++ b/packages/fedify/src/inbound-follow.test.ts
@@ -12,7 +12,7 @@ import {
   ProfileFollowPolicy,
 } from '@kosmo/core/enums';
 import { eq, ne, sql } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
@@ -30,6 +30,7 @@ const remoteActorUri = new URL('https://remote.example/users/alice');
 
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let db: typeof CoreDb.db;
+const createFedifyContextData = () => createFedifyContextDataWithDatabase(db);
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;
 let Notifications: typeof CoreDb.Notifications;

--- a/packages/fedify/src/inbound-follow.ts
+++ b/packages/fedify/src/inbound-follow.ts
@@ -4,7 +4,6 @@ import { EmojiReact, Follow, Like } from '@fedify/vocab';
 import {
   ActivityPubActors,
   ActivityPubPosts,
-  db,
   first,
   Instances,
   Posts,
@@ -20,6 +19,7 @@ import {
 } from '@kosmo/core/services';
 import { and, eq, isNotNull, isNull } from 'drizzle-orm';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import { getFedifyDatabase } from './fedify-context';
 import { sendAcceptFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
 import {
@@ -35,6 +35,7 @@ import {
 } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Recipient, Undo } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 const getNow = () => Temporal.Now.instant();
 
@@ -56,7 +57,7 @@ const toRecipient = (actor: typeof ActivityPubActors.$inferSelect): Recipient | 
 };
 
 export const handleInboundFollow = async (
-  context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   follow: Follow,
   now: Temporal.Instant = getNow(),
 ): Promise<void> => {
@@ -188,10 +189,12 @@ const noNetworkDocumentLoader = async (url: string) => {
 type UndoAnnounceResult = 'deleted' | 'ignored' | null;
 
 const handleInboundUndoAnnounce = async (
+  context: InboxContext<FedifyContextData>,
   activityUri: URL,
   actorUri: URL,
 ): Promise<UndoAnnounceResult> => {
-  const result = await db.transaction(async (tx) => {
+  const database = getFedifyDatabase(context.data);
+  const result = await database.transaction(async (tx) => {
     const row = await tx
       .select({
         actorUri: ActivityPubActors.uri,
@@ -244,13 +247,17 @@ const handleInboundUndoAnnounce = async (
   });
 
   if (result?.outcome === 'deleted') {
-    await result.postCommit();
+    await result.postCommit(database);
   }
 
   return result?.outcome ?? null;
 };
 
-export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo): Promise<void> => {
+export const handleInboundUndo = async (
+  context: InboxContext<FedifyContextData>,
+  undo: Undo,
+): Promise<void> => {
+  const database = getFedifyDatabase(context.data);
   const actorHref = uniqueHref(undo.actorIds);
   const actorUri = actorHref ? new URL(actorHref) : null;
   if (!isHttpUri(actorUri)) {
@@ -287,7 +294,7 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   }
 
   if (objectUri) {
-    const announceResult = await handleInboundUndoAnnounce(objectUri, actorUri);
+    const announceResult = await handleInboundUndoAnnounce(context, objectUri, actorUri);
     if (announceResult === 'deleted') {
       return;
     }
@@ -436,21 +443,24 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     return;
   }
 
-  const result = await undoInboundReaction({
-    activityUri: activityUri.href,
-    actorUri: actorUri.href,
-    onPostCommitError: (error) =>
-      observeInbound({
-        activityType: 'Undo',
-        actorOrigin: actorUri.origin,
-        error,
-        handler: 'undo',
-        objectOrigin: activityUri.origin,
-        outcome: 'internal_failure',
-        phase: 'effect',
-        reasonCode: 'reaction_undo_notification_effect_failed',
-      }),
-  });
+  const result = await undoInboundReaction(
+    {
+      activityUri: activityUri.href,
+      actorUri: actorUri.href,
+      onPostCommitError: (error) =>
+        observeInbound({
+          activityType: 'Undo',
+          actorOrigin: actorUri.origin,
+          error,
+          handler: 'undo',
+          objectOrigin: activityUri.origin,
+          outcome: 'internal_failure',
+          phase: 'effect',
+          reasonCode: 'reaction_undo_notification_effect_failed',
+        }),
+    },
+    database,
+  );
   if (result.reactionId === null) {
     observeInboundNoop({
       activityType: 'Undo',

--- a/packages/fedify/src/inbound-follow.ts
+++ b/packages/fedify/src/inbound-follow.ts
@@ -19,7 +19,6 @@ import {
 } from '@kosmo/core/services';
 import { and, eq, isNotNull, isNull } from 'drizzle-orm';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import { getFedifyDatabase } from './fedify-context';
 import { sendAcceptFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
 import {
@@ -193,7 +192,7 @@ const handleInboundUndoAnnounce = async (
   activityUri: URL,
   actorUri: URL,
 ): Promise<UndoAnnounceResult> => {
-  const database = getFedifyDatabase(context.data);
+  const database = context.data.db;
   const result = await database.transaction(async (tx) => {
     const row = await tx
       .select({
@@ -257,7 +256,7 @@ export const handleInboundUndo = async (
   context: InboxContext<FedifyContextData>,
   undo: Undo,
 ): Promise<void> => {
-  const database = getFedifyDatabase(context.data);
+  const database = context.data.db;
   const actorHref = uniqueHref(undo.actorIds);
   const actorUri = actorHref ? new URL(actorHref) : null;
   if (!isHttpUri(actorUri)) {

--- a/packages/fedify/src/inbound-local-recipient.ts
+++ b/packages/fedify/src/inbound-local-recipient.ts
@@ -2,9 +2,10 @@ import { ActivityPubActors, db, first, Instances, Profiles } from '@kosmo/core/d
 import { InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
 import { and, eq } from 'drizzle-orm';
 import type { InboxContext } from '@fedify/fedify';
+import type { FedifyContextData } from './fedify-context';
 
 export const resolveInboundLocalRecipient = async (
-  context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   actorUri: URL,
 ): Promise<typeof Profiles.$inferSelect | undefined> => {
   if (context.recipient !== null && context.getActorUri(context.recipient).href !== actorUri.href) {

--- a/packages/fedify/src/inbound-reaction.test.ts
+++ b/packages/fedify/src/inbound-reaction.test.ts
@@ -25,9 +25,11 @@ import {
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { createPost } from '@kosmo/core/services';
 import { and, eq } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import { handleInboundUndo } from './inbound-follow';
 import { handleInboundReaction } from './inbound-reaction';
 import type { InboxContext } from '@fedify/fedify';
+import type { FedifyContextData } from './fedify-context';
 
 after(async () => {
   await pg.end();
@@ -89,8 +91,8 @@ const createLocalTarget = async () => {
   };
 };
 
-const createContext = (recipient: string | null): InboxContext<void> =>
-  ({ recipient }) as unknown as InboxContext<void>;
+const createContext = (recipient: string | null): InboxContext<FedifyContextData> =>
+  ({ data: createFedifyContextData(), recipient }) as unknown as InboxContext<FedifyContextData>;
 
 const readReaction = (profileId: string, postId: string) =>
   db

--- a/packages/fedify/src/inbound-reaction.test.ts
+++ b/packages/fedify/src/inbound-reaction.test.ts
@@ -92,7 +92,7 @@ const createLocalTarget = async () => {
 };
 
 const createContext = (recipient: string | null): InboxContext<FedifyContextData> =>
-  ({ data: createFedifyContextData(), recipient }) as unknown as InboxContext<FedifyContextData>;
+  ({ data: createFedifyContextData(db), recipient }) as unknown as InboxContext<FedifyContextData>;
 
 const readReaction = (profileId: string, postId: string) =>
   db

--- a/packages/fedify/src/inbound-reaction.ts
+++ b/packages/fedify/src/inbound-reaction.ts
@@ -4,6 +4,7 @@ import { Like } from '@fedify/vocab';
 import { materializeInboundReaction } from '@kosmo/core/services';
 import { reactionTypeSchema } from '@kosmo/core/validation';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
+import { getFedifyDatabase } from './fedify-context';
 import {
   observeInbound,
   observeInboundNoop,
@@ -11,6 +12,7 @@ import {
 } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { EmojiReact } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 const fallbackReactionType = '❤️';
 
@@ -22,9 +24,10 @@ const toReactionType = (activity: Like | EmojiReact): string => {
 };
 
 export const handleInboundReaction = async (
-  _context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   activity: Like | EmojiReact,
 ): Promise<void> => {
+  const database = getFedifyDatabase(context.data);
   const activityUri = activity.id;
   const actorUri = uniqueHref(activity.actorIds);
   const objectUri = uniqueHref(activity.objectIds);
@@ -38,23 +41,26 @@ export const handleInboundReaction = async (
     return;
   }
 
-  const result = await materializeInboundReaction({
-    activityUri: activityUri.href,
-    actorUri,
-    objectUri,
-    onPostCommitError: (error) =>
-      observeInbound({
-        activityType: activity instanceof Like ? 'Like' : 'EmojiReact',
-        actorOrigin: actorUri,
-        error,
-        handler: 'reaction',
-        objectOrigin: objectUri,
-        outcome: 'internal_failure',
-        phase: 'effect',
-        reasonCode: 'reaction_notification_effect_failed',
-      }),
-    type: toReactionType(activity),
-  });
+  const result = await materializeInboundReaction(
+    {
+      activityUri: activityUri.href,
+      actorUri,
+      objectUri,
+      onPostCommitError: (error) =>
+        observeInbound({
+          activityType: activity instanceof Like ? 'Like' : 'EmojiReact',
+          actorOrigin: actorUri,
+          error,
+          handler: 'reaction',
+          objectOrigin: objectUri,
+          outcome: 'internal_failure',
+          phase: 'effect',
+          reasonCode: 'reaction_notification_effect_failed',
+        }),
+      type: toReactionType(activity),
+    },
+    database,
+  );
   const activityType = activity instanceof Like ? 'Like' : 'EmojiReact';
   if (result.kind === 'REJECTED') {
     observeInboundRejected({

--- a/packages/fedify/src/inbound-reaction.ts
+++ b/packages/fedify/src/inbound-reaction.ts
@@ -4,7 +4,6 @@ import { Like } from '@fedify/vocab';
 import { materializeInboundReaction } from '@kosmo/core/services';
 import { reactionTypeSchema } from '@kosmo/core/validation';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import { getFedifyDatabase } from './fedify-context';
 import {
   observeInbound,
   observeInboundNoop,
@@ -27,7 +26,7 @@ export const handleInboundReaction = async (
   context: InboxContext<FedifyContextData>,
   activity: Like | EmojiReact,
 ): Promise<void> => {
-  const database = getFedifyDatabase(context.data);
+  const database = context.data.db;
   const activityUri = activity.id;
   const actorUri = uniqueHref(activity.actorIds);
   const objectUri = uniqueHref(activity.objectIds);

--- a/packages/fedify/src/inbound-reject-follow.ts
+++ b/packages/fedify/src/inbound-reject-follow.ts
@@ -13,6 +13,7 @@ import {
 } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Follow } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 export const handleInboundRejectFollow = async ({
   context,
@@ -20,7 +21,7 @@ export const handleInboundRejectFollow = async ({
   followeeActorUri,
   followeeProfileId,
 }: {
-  context: InboxContext<void>;
+  context: InboxContext<FedifyContextData>;
   follow: Follow;
   followeeActorUri: URL;
   followeeProfileId: string;

--- a/packages/fedify/src/inbound-reject.ts
+++ b/packages/fedify/src/inbound-reject.ts
@@ -12,9 +12,10 @@ import { handleInboundRejectFollow } from './inbound-reject-follow';
 import { findUsableStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Reject } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 export const handleInboundReject = async (
-  context: InboxContext<void>,
+  context: InboxContext<FedifyContextData>,
   reject: Reject,
 ): Promise<void> => {
   const actorUri = reject.actorId;

--- a/packages/fedify/src/inbound-update.test.ts
+++ b/packages/fedify/src/inbound-update.test.ts
@@ -11,11 +11,13 @@ import {
   ProfileMediaKind,
 } from '@kosmo/core/enums';
 import { and, eq, inArray } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as CoreServices from '@kosmo/core/services';
+import type { FedifyContextData } from './fedify-context';
 import type { handleInboundAccept as HandleInboundAccept } from './inbound-accept';
 import type { handleInboundUpdate as HandleInboundUpdate } from './inbound-update';
 
@@ -362,13 +364,14 @@ const createContext = (
   documentLoader: DocumentLoader = async (url) => {
     throw new Error(`Unexpected document load: ${url}`);
   },
-): InboxContext<void> =>
+): InboxContext<FedifyContextData> =>
   ({
     canonicalOrigin: publicOrigin,
+    data: createFedifyContextData(),
     documentLoader,
     getActorUri: (identifier: string) => new URL(`/ap/actor/${identifier}`, publicOrigin),
     recipient,
-  }) as unknown as InboxContext<void>;
+  }) as unknown as InboxContext<FedifyContextData>;
 
 const createRemoteActor = async (followPolicy: ProfileFollowPolicy) => {
   const instance = await db

--- a/packages/fedify/src/inbound-update.test.ts
+++ b/packages/fedify/src/inbound-update.test.ts
@@ -11,7 +11,7 @@ import {
   ProfileMediaKind,
 } from '@kosmo/core/enums';
 import { and, eq, inArray } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import { setInboundObservabilityReporter } from './inbound-observability';
 import type { DocumentLoader, InboxContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
@@ -29,6 +29,7 @@ const secondLocalProfileId = '019f7abc-2222-7777-8888-123456789abc';
 
 let ActivityPubActors: typeof CoreDb.ActivityPubActors;
 let db: typeof CoreDb.db;
+const createFedifyContextData = () => createFedifyContextDataWithDatabase(db);
 let first: typeof CoreDb.first;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Instances: typeof CoreDb.Instances;

--- a/packages/fedify/src/inbound-update.ts
+++ b/packages/fedify/src/inbound-update.ts
@@ -15,13 +15,14 @@ import {
 } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Object as ActivityPubObject, Update } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 const noNetworkDocumentLoader = async (url: string) => {
   throw new Error(`Network lookup is disabled for inbound Update: ${url}`);
 };
 
 export const handleInboundUpdate = async (
-  _context: InboxContext<void>,
+  _context: InboxContext<FedifyContextData>,
   update: Update,
   receivedAt: Temporal.Instant = Temporal.Now.instant(),
 ): Promise<void> => {

--- a/packages/fedify/src/local-post-delivery.ts
+++ b/packages/fedify/src/local-post-delivery.ts
@@ -58,7 +58,7 @@ export const sendLocalPostCreate = async (postId: string): Promise<void> => {
   const context = localOutboundFederation.createContext(new URL(source.canonicalOrigin), {
     localInstanceId: source.localInstanceId,
   });
-  const projection = await projectLocalPostNote(context, postId);
+  const projection = await projectLocalPostNote(context, postId, db);
   if (!projection) {
     return;
   }

--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -32,10 +32,12 @@ import {
   ProfileState,
 } from '@kosmo/core/enums';
 import { eq, inArray } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import type { RequestContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as PostUriModule from './activitypub-post-uri';
+import type { FedifyContextData } from './fedify-context';
 import type * as LocalPostNoteModule from './local-post-note';
 import type * as LocalPostReactionCollectionModule from './local-post-reaction-collection';
 
@@ -380,7 +382,7 @@ describe('ActivityPub Local Post Note', () => {
     });
     const allowedRequest = await signedFixture.createRequest(followersPost.id);
     const allowed = await signedFixture.federation.fetch(allowedRequest, {
-      contextData: undefined,
+      contextData: createFedifyContextData(),
       onUnauthorized: () => new Response('Not found', { status: 404 }),
     });
     assert.equal(allowed.status, 200);
@@ -404,7 +406,7 @@ describe('ActivityPub Local Post Note', () => {
         headers: { accept: 'application/activity+json' },
       }),
       {
-        contextData: undefined,
+        contextData: createFedifyContextData(),
         onUnauthorized: () => new Response('Not found', { status: 404 }),
       },
     );
@@ -414,10 +416,13 @@ describe('ActivityPub Local Post Note', () => {
   test('allows the local Author identity without requiring a Follow row', async () => {
     const author = await createProfile({ kind: InstanceKind.LOCAL });
     const followersPost = await createPost(author.id, { visibility: PostVisibility.FOLLOWERS });
-    const context = Object.assign(Object.create(createContext()) as RequestContext<void>, {
-      getSignedKeyOwner: async () =>
-        new Person({ id: new URL(`/ap/actor/${author.id}`, publicOrigin) }),
-    });
+    const context = Object.assign(
+      Object.create(createContext()) as RequestContext<FedifyContextData>,
+      {
+        getSignedKeyOwner: async () =>
+          new Person({ id: new URL(`/ap/actor/${author.id}`, publicOrigin) }),
+      },
+    );
 
     assert.equal(await authorizeLocalPostNote(context, { id: followersPost.id }), true);
   });
@@ -744,7 +749,7 @@ describe('ActivityPub Local Post Note', () => {
           headers: { accept: 'application/activity+json' },
         }),
         {
-          contextData: undefined,
+          contextData: createFedifyContextData(),
           onNotFound: () => new Response('Not found', { status: 404 }),
           onUnauthorized: () => new Response('Not found', { status: 404 }),
         },
@@ -799,20 +804,26 @@ describe('ActivityPub Local Post Note', () => {
   });
 });
 
-const createContext = (): RequestContext<void> => {
-  const federation = createFederation<void>({ kv: new MemoryKvStore(), origin: publicOrigin });
+const createContext = (): RequestContext<FedifyContextData> => {
+  const federation = createFederation<FedifyContextData>({
+    kv: new MemoryKvStore(),
+    origin: publicOrigin,
+  });
   federation.setActorDispatcher(
     '/ap/actor/{identifier}',
     (context, identifier) => new Person({ id: context.getActorUri(identifier) }),
   );
   return federation.createContext(
     new Request(`${publicOrigin}/ap/note/00000000-0000-8000-8000-000000000001`),
-    undefined,
+    createFedifyContextData(),
   );
 };
 
 const createUnsignedCollectionFederation = () => {
-  const federation = createFederation<void>({ kv: new MemoryKvStore(), origin: publicOrigin });
+  const federation = createFederation<FedifyContextData>({
+    kv: new MemoryKvStore(),
+    origin: publicOrigin,
+  });
   federation.setActorDispatcher(
     '/ap/actor/{identifier}',
     (context, identifier) => new Person({ id: context.getActorUri(identifier) }),
@@ -847,7 +858,7 @@ const createSignedFederation = async () => {
     document: documents.get(url),
     documentUrl: url,
   });
-  const federation = createFederation<void>({
+  const federation = createFederation<FedifyContextData>({
     authenticatedDocumentLoaderFactory: () => documentLoader,
     contextLoaderFactory: getDocumentLoader,
     documentLoaderFactory: () => documentLoader,
@@ -883,7 +894,7 @@ const createSignedFederation = async () => {
   const fetch = async (postId: string) => {
     const request = await createRequest(postId);
     return federation.fetch(request, {
-      contextData: undefined,
+      contextData: createFedifyContextData(),
       onUnauthorized: () => new Response('Not found', { status: 404 }),
     });
   };
@@ -896,7 +907,7 @@ const createSignedFederation = async () => {
       remoteKeyUri,
     );
     return federation.fetch(request, {
-      contextData: undefined,
+      contextData: createFedifyContextData(),
       onUnauthorized: () => new Response('Not found', { status: 404 }),
       onNotFound: () => new Response('Not found', { status: 404 }),
     });

--- a/packages/fedify/src/local-post-note.test.ts
+++ b/packages/fedify/src/local-post-note.test.ts
@@ -32,7 +32,7 @@ import {
   ProfileState,
 } from '@kosmo/core/enums';
 import { eq, inArray } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import type { RequestContext } from '@fedify/fedify';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
@@ -52,6 +52,7 @@ let Accounts: typeof CoreDb.Accounts;
 let ActivityPubPosts: typeof CoreDb.ActivityPubPosts;
 let authorizeLocalPostNote: typeof LocalPostNoteModule.authorizeLocalPostNote;
 let db: typeof CoreDb.db;
+const createFedifyContextData = () => createFedifyContextDataWithDatabase(db);
 let dispatchLocalPostNote: typeof LocalPostNoteModule.dispatchLocalPostNote;
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let isCanonicalPostId: typeof PostUriModule.isCanonicalPostId;
@@ -139,7 +140,7 @@ describe('ActivityPub Local Post Note', () => {
       .where(eq(Instances.id, localInstanceId));
     try {
       assert.equal(
-        (await resolveActivityPubPostUri(localPost.id))?.href,
+        (await resolveActivityPubPostUri(localPost.id, db))?.href,
         `${storedCanonicalOrigin}/ap/note/${localPost.id}`,
       );
     } finally {
@@ -148,8 +149,8 @@ describe('ActivityPub Local Post Note', () => {
         .set({ canonicalOrigin: publicOrigin })
         .where(eq(Instances.id, localInstanceId));
     }
-    assert.equal((await resolveActivityPubPostUri(remotePost.id))?.href, remoteUri.href);
-    assert.equal(await resolveActivityPubPostUri(unmappedRemotePost.id), undefined);
+    assert.equal((await resolveActivityPubPostUri(remotePost.id, db))?.href, remoteUri.href);
+    assert.equal(await resolveActivityPubPostUri(unmappedRemotePost.id, db), undefined);
     assert.equal((await db.select().from(ActivityPubPosts)).length, 1);
   });
 

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -5,6 +5,7 @@ import {
   ActivityPubActors,
   db,
   first,
+  getDatabaseConnection,
   Instances,
   Media,
   PostContents,
@@ -27,8 +28,11 @@ import { postContentDocumentToHtml } from '@kosmo/core/post-content/server';
 import { and, eq, inArray, ne } from 'drizzle-orm';
 import { escapeText } from 'entities/escape';
 import { isCanonicalPostId, resolveActivityPubPostUri } from './activitypub-post-uri';
+import { getFedifyDatabase } from './fedify-context';
 import type { Context, RequestContext } from '@fedify/fedify';
+import type { DatabaseHandle } from '@kosmo/core/db';
 import type { PostContentDocumentV1 } from '@kosmo/core/post-content';
+import type { FedifyContextData } from './fedify-context';
 
 type LocalPostNote = {
   readonly authorHandle: string;
@@ -48,14 +52,18 @@ type LocalPostNoteProjection = LocalPostNote & {
   readonly object: Note;
 };
 
-type LocalPostNoteContext = Pick<Context<void>, 'canonicalOrigin' | 'getActorUri'>;
+type LocalPostNoteContext = Pick<Context<unknown>, 'canonicalOrigin' | 'getActorUri'>;
 
-const loadLocalPostNoteRow = async (context: LocalPostNoteContext, postId: string) => {
+const loadLocalPostNoteRow = async (
+  context: LocalPostNoteContext,
+  postId: string,
+  handle?: DatabaseHandle,
+) => {
   if (!isCanonicalPostId(postId)) {
     return null;
   }
 
-  const row = await db
+  const row = await getDatabaseConnection(handle)
     .select({
       contentDocument: PostContents.document,
       instanceCanonicalOrigin: Instances.canonicalOrigin,
@@ -89,8 +97,9 @@ const loadLocalPostNoteRow = async (context: LocalPostNoteContext, postId: strin
 export const loadLocalPostNote = async (
   context: LocalPostNoteContext,
   postId: string,
+  handle?: DatabaseHandle,
 ): Promise<LocalPostNote | null> => {
-  const row = await loadLocalPostNoteRow(context, postId);
+  const row = await loadLocalPostNoteRow(context, postId, handle);
   if (!row) {
     return null;
   }
@@ -200,10 +209,10 @@ const isEstablishedFollower = async (actorUri: URL, authorProfileId: string): Pr
     .then(Boolean);
 
 export const authorizeLocalPostNote = async (
-  context: RequestContext<void>,
+  context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<boolean> => {
-  const row = await loadLocalPostNoteRow(context, id);
+  const row = await loadLocalPostNoteRow(context, id, getFedifyDatabase(context.data));
   if (!row) {
     return false;
   }
@@ -223,17 +232,18 @@ export const authorizeLocalPostNote = async (
 };
 
 export const dispatchLocalPostNote = async (
-  context: RequestContext<void>,
+  context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<Note | null> => {
-  return (await projectLocalPostNote(context, id))?.object ?? null;
+  return (await projectLocalPostNote(context, id, getFedifyDatabase(context.data)))?.object ?? null;
 };
 
 export const projectLocalPostNote = async (
   context: LocalPostNoteContext,
   postId: string,
+  handle?: DatabaseHandle,
 ): Promise<LocalPostNoteProjection | null> => {
-  const note = await loadLocalPostNote(context, postId);
+  const note = await loadLocalPostNote(context, postId, handle);
   if (!note) {
     return null;
   }
@@ -241,7 +251,7 @@ export const projectLocalPostNote = async (
   const authorUri = context.getActorUri(note.authorProfileId);
   const followersUri = getFollowersUri(context, note.authorProfileId);
   const replyTarget = note.replyParentId
-    ? await resolveActivityPubPostUri(note.replyParentId)
+    ? await resolveActivityPubPostUri(note.replyParentId, handle)
     : undefined;
   const to = note.visibility === PostVisibility.PUBLIC ? PUBLIC_COLLECTION : followersUri;
   const cc =

--- a/packages/fedify/src/local-post-note.ts
+++ b/packages/fedify/src/local-post-note.ts
@@ -5,7 +5,6 @@ import {
   ActivityPubActors,
   db,
   first,
-  getDatabaseConnection,
   Instances,
   Media,
   PostContents,
@@ -28,7 +27,6 @@ import { postContentDocumentToHtml } from '@kosmo/core/post-content/server';
 import { and, eq, inArray, ne } from 'drizzle-orm';
 import { escapeText } from 'entities/escape';
 import { isCanonicalPostId, resolveActivityPubPostUri } from './activitypub-post-uri';
-import { getFedifyDatabase } from './fedify-context';
 import type { Context, RequestContext } from '@fedify/fedify';
 import type { DatabaseHandle } from '@kosmo/core/db';
 import type { PostContentDocumentV1 } from '@kosmo/core/post-content';
@@ -57,13 +55,13 @@ type LocalPostNoteContext = Pick<Context<unknown>, 'canonicalOrigin' | 'getActor
 const loadLocalPostNoteRow = async (
   context: LocalPostNoteContext,
   postId: string,
-  handle?: DatabaseHandle,
+  handle: DatabaseHandle,
 ) => {
   if (!isCanonicalPostId(postId)) {
     return null;
   }
 
-  const row = await getDatabaseConnection(handle)
+  const row = await handle
     .select({
       contentDocument: PostContents.document,
       instanceCanonicalOrigin: Instances.canonicalOrigin,
@@ -97,7 +95,7 @@ const loadLocalPostNoteRow = async (
 export const loadLocalPostNote = async (
   context: LocalPostNoteContext,
   postId: string,
-  handle?: DatabaseHandle,
+  handle: DatabaseHandle,
 ): Promise<LocalPostNote | null> => {
   const row = await loadLocalPostNoteRow(context, postId, handle);
   if (!row) {
@@ -212,7 +210,7 @@ export const authorizeLocalPostNote = async (
   context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<boolean> => {
-  const row = await loadLocalPostNoteRow(context, id, getFedifyDatabase(context.data));
+  const row = await loadLocalPostNoteRow(context, id, context.data.db);
   if (!row) {
     return false;
   }
@@ -235,13 +233,13 @@ export const dispatchLocalPostNote = async (
   context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<Note | null> => {
-  return (await projectLocalPostNote(context, id, getFedifyDatabase(context.data)))?.object ?? null;
+  return (await projectLocalPostNote(context, id, context.data.db))?.object ?? null;
 };
 
 export const projectLocalPostNote = async (
   context: LocalPostNoteContext,
   postId: string,
-  handle?: DatabaseHandle,
+  handle: DatabaseHandle,
 ): Promise<LocalPostNoteProjection | null> => {
   const note = await loadLocalPostNote(context, postId, handle);
   if (!note) {

--- a/packages/fedify/src/local-post-reaction-collection.ts
+++ b/packages/fedify/src/local-post-reaction-collection.ts
@@ -14,7 +14,6 @@ import { InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
 import { reactionTypes, reactionTypeSchema } from '@kosmo/core/validation';
 import { and, count, desc, eq, inArray, isNotNull, lt, ne, or, sql } from 'drizzle-orm';
 import { isCanonicalPostId } from './activitypub-post-uri';
-import { getFedifyDatabase } from './fedify-context';
 import { loadLocalPostNote } from './local-post-note';
 import type { PageItems, RequestContext } from '@fedify/fedify';
 import type { SQLWrapper } from 'drizzle-orm';
@@ -206,7 +205,7 @@ export const dispatchLocalPostEmojiReactions = async (
   { id }: { id: string },
   rawCursor: string | null,
 ): Promise<PageItems<Like | EmojiReact> | null> => {
-  const note = await loadLocalPostNote(context, id, getFedifyDatabase(context.data));
+  const note = await loadLocalPostNote(context, id, context.data.db);
   const cursor = parseCursor(rawCursor);
   if (!note || !cursor) {
     return null;
@@ -286,7 +285,7 @@ export const countLocalPostEmojiReactions = async (
   context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<number | null> => {
-  const note = await loadLocalPostNote(context, id, getFedifyDatabase(context.data));
+  const note = await loadLocalPostNote(context, id, context.data.db);
   if (!note) {
     return null;
   }
@@ -306,4 +305,4 @@ export const firstLocalPostEmojiReactionsCursor = async (
   context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<string | null> =>
-  (await loadLocalPostNote(context, id, getFedifyDatabase(context.data))) ? FIRST_CURSOR : null;
+  (await loadLocalPostNote(context, id, context.data.db)) ? FIRST_CURSOR : null;

--- a/packages/fedify/src/local-post-reaction-collection.ts
+++ b/packages/fedify/src/local-post-reaction-collection.ts
@@ -14,9 +14,11 @@ import { InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
 import { reactionTypes, reactionTypeSchema } from '@kosmo/core/validation';
 import { and, count, desc, eq, inArray, isNotNull, lt, ne, or, sql } from 'drizzle-orm';
 import { isCanonicalPostId } from './activitypub-post-uri';
+import { getFedifyDatabase } from './fedify-context';
 import { loadLocalPostNote } from './local-post-note';
 import type { PageItems, RequestContext } from '@fedify/fedify';
 import type { SQLWrapper } from 'drizzle-orm';
+import type { FedifyContextData } from './fedify-context';
 
 const PAGE_SIZE = 50;
 const FIRST_CURSOR = 'v1:first';
@@ -200,11 +202,11 @@ const projectReaction = (
 };
 
 export const dispatchLocalPostEmojiReactions = async (
-  context: RequestContext<void>,
+  context: RequestContext<FedifyContextData>,
   { id }: { id: string },
   rawCursor: string | null,
 ): Promise<PageItems<Like | EmojiReact> | null> => {
-  const note = await loadLocalPostNote(context, id);
+  const note = await loadLocalPostNote(context, id, getFedifyDatabase(context.data));
   const cursor = parseCursor(rawCursor);
   if (!note || !cursor) {
     return null;
@@ -281,10 +283,10 @@ export const dispatchLocalPostEmojiReactions = async (
 };
 
 export const countLocalPostEmojiReactions = async (
-  context: RequestContext<void>,
+  context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<number | null> => {
-  const note = await loadLocalPostNote(context, id);
+  const note = await loadLocalPostNote(context, id, getFedifyDatabase(context.data));
   if (!note) {
     return null;
   }
@@ -301,6 +303,7 @@ export const countLocalPostEmojiReactions = async (
 };
 
 export const firstLocalPostEmojiReactionsCursor = async (
-  context: RequestContext<void>,
+  context: RequestContext<FedifyContextData>,
   { id }: { id: string },
-): Promise<string | null> => ((await loadLocalPostNote(context, id)) ? FIRST_CURSOR : null);
+): Promise<string | null> =>
+  (await loadLocalPostNote(context, id, getFedifyDatabase(context.data))) ? FIRST_CURSOR : null;

--- a/packages/fedify/src/local-profile-follow.ts
+++ b/packages/fedify/src/local-profile-follow.ts
@@ -16,6 +16,7 @@ import { z } from 'zod';
 import { isHttpUri } from './activitypub-uri';
 import { getFollowActivityUri } from './follow-delivery';
 import type { RequestContext } from '@fedify/fedify';
+import type { FedifyContextData } from './fedify-context';
 
 const FollowerProfiles = alias(Profiles, 'outbound_follow_follower_profile');
 const FollowerInstances = alias(Instances, 'outbound_follow_follower_instance');
@@ -29,7 +30,7 @@ const followIdSchema = z.uuid().refine((value) => value === value.toLowerCase())
 type FollowProjectionTable = typeof ProfileFollowRequests | typeof ProfileFollows;
 
 const loadOutboundFollow = async (
-  context: RequestContext<void>,
+  context: RequestContext<FedifyContextData>,
   table: FollowProjectionTable,
   id: string,
 ) =>
@@ -64,7 +65,7 @@ const loadOutboundFollow = async (
     .then(first);
 
 export const dispatchLocalProfileFollow = async (
-  context: RequestContext<void>,
+  context: RequestContext<FedifyContextData>,
   { id }: { id: string },
 ): Promise<Follow | null> => {
   if (

--- a/packages/fedify/src/profile-follow-delivery.ts
+++ b/packages/fedify/src/profile-follow-delivery.ts
@@ -1,9 +1,11 @@
 import { Follow, Undo } from '@fedify/vocab';
+import { db } from '@kosmo/core/db';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { federation } from './federation';
 import { getFollowActivityUri, getFollowOrderingKey } from './follow-delivery';
 import type { Context } from '@fedify/fedify';
 import type { Recipient } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 type RemoteProfileFollowActor = {
   inboxUri: string | null;
@@ -25,9 +27,9 @@ type ProfileFollowRecipient = Recipient & {
   inboxId: URL;
 };
 
-const createFederationContext = async (): Promise<Context<void>> => {
+const createFederationContext = async (): Promise<Context<FedifyContextData>> => {
   const localInstance = await resolveConfiguredLocalInstance();
-  return federation.createContext(new URL(localInstance.canonicalOrigin), undefined);
+  return federation.createContext(new URL(localInstance.canonicalOrigin), { db });
 };
 
 const toProfileFollowRecipient = (actor: RemoteProfileFollowActor): ProfileFollowRecipient => {

--- a/packages/fedify/src/reaction-delivery.ts
+++ b/packages/fedify/src/reaction-delivery.ts
@@ -183,7 +183,7 @@ export const sendReaction = async (reaction: OutboundReaction): Promise<void> =>
     return;
   }
 
-  const context = federation.createContext(new URL(projection.canonicalOrigin), undefined);
+  const context = federation.createContext(new URL(projection.canonicalOrigin), { db });
   const activity = createReactionActivity(projection);
   const orderingKey = getReactionActivityUri(projection.canonicalOrigin, reaction.id).href;
   await context.sendActivity(projection.senderKeys, projection.recipient, activity, {
@@ -198,7 +198,7 @@ export const sendReactionUndo = async (reaction: OutboundReaction): Promise<void
     return;
   }
 
-  const context = federation.createContext(new URL(projection.canonicalOrigin), undefined);
+  const context = federation.createContext(new URL(projection.canonicalOrigin), { db });
   const originalActivity = createReactionActivity(projection);
   if (!originalActivity.id) {
     throw new TypeError('ActivityPub Reaction must have an ID.');

--- a/packages/fedify/src/remote-actor-materialization.test.ts
+++ b/packages/fedify/src/remote-actor-materialization.test.ts
@@ -18,6 +18,7 @@ import type { Context } from '@fedify/fedify';
 import type { Object as ActivityPubObject } from '@fedify/vocab';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
+import type { FedifyContextData } from './fedify-context';
 import type * as Materialization from './remote-actor-materialization';
 
 const publicOrigin = 'http://127.0.0.1:4173';
@@ -1284,14 +1285,14 @@ const mockWebFinger = (descriptor: { subject: string }) =>
 const createLookupContext = (
   implementation: (
     identifier: string | URL,
-    options?: NonNullable<Parameters<Context<void>['lookupObject']>[1]>,
+    options?: NonNullable<Parameters<Context<FedifyContextData>['lookupObject']>[1]>,
   ) => Promise<ActivityPubObject | null>,
 ) => {
   const lookupObject = mock.fn(implementation);
 
   return {
     context: {
-      lookupObject: lookupObject as unknown as Context<void>['lookupObject'],
+      lookupObject: lookupObject as unknown as Context<FedifyContextData>['lookupObject'],
     },
     lookupObject,
   };

--- a/packages/fedify/src/remote-actor-materialization.ts
+++ b/packages/fedify/src/remote-actor-materialization.ts
@@ -35,6 +35,7 @@ import {
 import { and, eq, getColumns, inArray, ne } from 'drizzle-orm';
 import type { Context } from '@fedify/fedify';
 import type { Actor, Image, LanguageString, Object as ActivityPubObject } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 const remoteActorRefreshTtl = Temporal.Duration.from({ hours: 7 * 24 });
 
@@ -45,7 +46,7 @@ export class RemoteActorMaterializationError extends Error {
   }
 }
 
-type RemoteActorLookupContext = Pick<Context<void>, 'lookupObject'>;
+type RemoteActorLookupContext = Pick<Context<FedifyContextData>, 'lookupObject'>;
 
 type RemoteActorMaterializationOptions = {
   context: RemoteActorLookupContext;

--- a/packages/fedify/src/repost-delivery.ts
+++ b/packages/fedify/src/repost-delivery.ts
@@ -122,7 +122,7 @@ const loadRepostProjection = async (
     }
   }
 
-  const objectUri = await resolveActivityPubPostUri(row.repost.repostSourceId);
+  const objectUri = await resolveActivityPubPostUri(row.repost.repostSourceId, db);
   if (!objectUri) {
     return undefined;
   }

--- a/packages/fedify/src/repost-delivery.ts
+++ b/packages/fedify/src/repost-delivery.ts
@@ -24,6 +24,7 @@ import { resolveActivityPubPostUri } from './activitypub-post-uri';
 import { federation } from './federation';
 import type { Context } from '@fedify/fedify';
 import type { Recipient } from '@fedify/vocab';
+import type { FedifyContextData } from './fedify-context';
 
 const FollowerProfiles = alias(Profiles, 'repost_delivery_follower_profile');
 const FollowerInstances = alias(Instances, 'repost_delivery_follower_instance');
@@ -55,7 +56,7 @@ const getFollowersUri = (actorUri: URL): URL =>
   new URL(`${actorUri.pathname.replace(/\/$/, '')}/followers`, actorUri);
 
 const loadRepostProjection = async (
-  context: Context<void>,
+  context: Context<FedifyContextData>,
   repostId: string,
   kind: RepostDeliveryKind,
 ): Promise<RepostProjection | undefined> => {
@@ -192,7 +193,7 @@ const createAnnounce = (projection: RepostProjection): Announce =>
 
 const sendRepostActivity = async (repostId: string, kind: RepostDeliveryKind): Promise<void> => {
   const localInstance = await resolveConfiguredLocalInstance();
-  const context = federation.createContext(new URL(localInstance.canonicalOrigin), undefined);
+  const context = federation.createContext(new URL(localInstance.canonicalOrigin), { db });
   const projection = await loadRepostProjection(context, repostId, kind);
   if (!projection) {
     return;

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@kosmo/core/enums';
 import { normalizeHandle } from '@kosmo/core/utils';
 import { and, eq } from 'drizzle-orm';
-import { createFedifyContextData } from './fedify-context';
+import { createFedifyContextData as createFedifyContextDataWithDatabase } from './fedify-context';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as FederationModule from './federation';
@@ -22,6 +22,7 @@ const publicOrigin = 'http://127.0.0.1:4173';
 const databaseUrl = process.env.DATABASE_URL ?? 'postgres://kosmo:kosmo@localhost:54329/kosmo_test';
 
 let db: typeof CoreDb.db;
+const createFedifyContextData = () => createFedifyContextDataWithDatabase(db);
 let firstOrThrow: typeof CoreDb.firstOrThrow;
 let Accounts: typeof CoreDb.Accounts;
 let ActivityPubActorKeys: typeof CoreDb.ActivityPubActorKeys;

--- a/packages/fedify/src/webfinger.test.ts
+++ b/packages/fedify/src/webfinger.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@kosmo/core/enums';
 import { normalizeHandle } from '@kosmo/core/utils';
 import { and, eq } from 'drizzle-orm';
+import { createFedifyContextData } from './fedify-context';
 import type * as CoreDb from '@kosmo/core/db';
 import type * as CoreSeed from '@kosmo/core/db/seed';
 import type * as FederationModule from './federation';
@@ -114,7 +115,7 @@ describe('WebFinger local profile handle mapping', () => {
           'acct:alice@127.0.0.1:4173',
         )}`,
       ),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
 
     assert.equal(response.status, 200);
@@ -149,7 +150,7 @@ describe('WebFinger local profile handle mapping', () => {
 
     const response = await federation.fetch(
       new Request(`${publicOrigin}/.well-known/webfinger?resource=${encodeURIComponent(actorUri)}`),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
 
     assert.equal(response.status, 200);
@@ -175,7 +176,7 @@ describe('WebFinger local profile handle mapping', () => {
     for (const query of ['', '?resource=not-a-url']) {
       const response = await federation.fetch(
         new Request(`${publicOrigin}/.well-known/webfinger${query}`),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
 
       assert.equal(response.status, 400);
@@ -188,7 +189,7 @@ describe('WebFinger local profile handle mapping', () => {
         new Request(
           `${publicOrigin}/.well-known/webfinger?resource=${encodeURIComponent(resource)}`,
         ),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
 
       assert.equal(response.status, 404);
@@ -206,7 +207,7 @@ describe('WebFinger local profile handle mapping', () => {
         new Request(
           `http://preview.example/.well-known/webfinger?resource=${encodeURIComponent(resource)}`,
         ),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
 
       assert.equal(response.status, 404);
@@ -238,7 +239,7 @@ describe('WebFinger local profile handle mapping', () => {
         new Request(`${publicOrigin}/ap/actor/${profile.id}`, {
           headers: { accept: 'application/activity+json' },
         }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
     const response = await requestActor();
     const actor = (await response.json()) as {
@@ -312,7 +313,7 @@ describe('WebFinger local profile handle mapping', () => {
         new Request(`${publicOrigin}/ap/actor/${profile.id}`, {
           headers: { accept: 'application/activity+json' },
         }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
 
       assert.equal(response.status, 200);
@@ -395,7 +396,7 @@ describe('WebFinger local profile handle mapping', () => {
       const collectionUri = `${publicOrigin}/ap/actor/${profile.id}/${collection}`;
       const response = await federation.fetch(
         new Request(collectionUri, { headers: { accept: 'application/activity+json' } }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
       const json = (await response.json()) as {
         first?: string;
@@ -419,7 +420,7 @@ describe('WebFinger local profile handle mapping', () => {
         new Request(`${collectionUri}?cursor=arbitrary`, {
           headers: { accept: 'application/activity+json' },
         }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
       assert.equal(pageResponse.status, 404);
 
@@ -427,7 +428,7 @@ describe('WebFinger local profile handle mapping', () => {
         new Request(collectionUri.replace(publicOrigin, 'https://alternate.example'), {
           headers: { accept: 'application/activity+json' },
         }),
-        { contextData: undefined },
+        { contextData: createFedifyContextData() },
       );
       assert.equal(alternateHostResponse.status, 404);
     }
@@ -461,7 +462,7 @@ describe('WebFinger local profile handle mapping', () => {
           new Request(`${publicOrigin}/ap/actor/${profileId}/${collection}`, {
             headers: { accept: 'application/activity+json' },
           }),
-          { contextData: undefined },
+          { contextData: createFedifyContextData() },
         );
 
         assert.equal(response.status, 404);
@@ -477,7 +478,7 @@ describe('WebFinger local profile handle mapping', () => {
       new Request(`${publicOrigin}/ap/actor/019f6f67-1111-7777-8888-123456789abc`, {
         headers: { accept: 'application/activity+json' },
       }),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
 
     assert.equal(response.status, 404);
@@ -493,7 +494,7 @@ describe('WebFinger local profile handle mapping', () => {
       new Request(`${publicOrigin}/ap/actor/${profile.id.toUpperCase()}`, {
         headers: { accept: 'application/activity+json' },
       }),
-      { contextData: undefined },
+      { contextData: createFedifyContextData() },
     );
 
     assert.equal(response.status, 404);


### PR DESCRIPTION
## 변경 사항

- Core DB factory가 기존 owner `DATABASE_URL` source 선택과 single-client lifetime을 함께 소유하며, Web 호출부는 raw database URL을 전달하지 않습니다.
- Web trusted federation ingress 요청마다 request owner를 만들고 Fedify context에 명시적으로 전달한 뒤 success/error/fallthrough 전체 수명 뒤에 정리합니다.
- `FedifyContextData`와 이전된 Post/PostContent URI·projection helper는 database를 필수로 요구하고, 누락 handle을 전역 `db`로 대체하는 fallback을 제공하지 않습니다.
- inbound Create/Delete/Announce/Undo/Reaction의 Post/PostContent SQL과 core action이 전달된 database handle을 사용하며 caller transaction, rollback, post-commit 시점을 유지합니다.
- 공유 federation을 사용하는 기존 outbound/API/queue caller는 기존 전역 owner `db` 선택을 context에 명시합니다. 해당 caller의 credential, SQL과 lifetime은 변경하지 않습니다.
- GraphQL의 `OPERATION_DATABASE_URL` 선택은 유지하면서 공통 private single-client primitive만 재사용합니다.

## 범위 경계

- database principal은 전환하지 않았습니다. `WORKER_DATABASE_*` 전환은 PROD-715에 남아 있습니다.
- role, Vault, Secret, GRANT, Helm credential selector, Temporal Workflow/Activity, GraphQL/API RLS와 Fedify MessageQueue credential/runtime lifecycle은 변경하지 않았습니다.
- production sync/apply/cutover는 수행하지 않았습니다.

## 검증

- `pnpm test:fedify` — Fedify 228개 및 fedify-consumer 1개 통과
- API integration — 228개 통과, 1개 skip, 실패 0개
- `pnpm --filter @kosmo/core test` — Core unit/migration/service 전체 통과, service 177개 통과
- Web server focused unit — 33개 통과
- Fedify/API/Web/fedify-consumer TypeScript typecheck 통과
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- `openspec validate route-trusted-ingress-post-sql-through-explicit-db-handle --strict`
- `git diff --check`
- 최신 `origin/main` `3af2f8e5` 위로 rebase했으며 #580을 포함합니다.
- GitHub CI — #571을 포함한 최신 `origin/main` 리베이스 후 Lint, Semgrep, API, App, Core, Fedify, Root, Web, Worker 및 집계 Test 전체 통과

## OpenSpec

- `route-trusted-ingress-post-sql-through-explicit-db-handle`의 구현 task 7개를 완료했습니다.
- PR readiness와 OpenSpec archive는 분리하며, 이 PR에서는 change를 archive하지 않습니다.
