### PR TITLE
화면 셸과 연속 피드가 같은 semantic plane을 사용하게 한다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/compose.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/compose.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { Skeleton } from '@/components/ui/StateView';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
 import type { ComposePageQuery } from './__generated__/ComposePageQuery.graphql';
 
 const ComposeQuery = graphql`
@@ -83,14 +83,9 @@ function ComposeContent({ fetchKey, onGoHome }: { fetchKey: string; onGoHome: ()
 }
 
 function ComposeLoading() {
-  const theme = useTheme();
-
   return (
     <>
-      <View
-        accessibilityElementsHidden
-        style={[styles.loadingCard, { backgroundColor: theme.card, borderColor: theme.border }]}
-      >
+      <View accessibilityElementsHidden style={styles.loadingCard}>
         <Skeleton height={20} width={144} />
         <Skeleton height={160} />
         <View style={styles.loadingAction}>
@@ -118,12 +113,11 @@ function ComposeStateCard({
   const theme = useTheme();
 
   return (
-    <View
-      accessibilityRole={alert ? 'alert' : undefined}
-      style={[styles.stateCard, { backgroundColor: theme.card, borderColor: theme.border }]}
-    >
-      <Text style={[styles.stateTitle, { color: theme.text }]}>{title}</Text>
-      <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>{description}</Text>
+    <View accessibilityRole={alert ? 'alert' : undefined} style={styles.stateCard}>
+      <Text style={[styles.stateTitle, { color: theme.foregroundPrimary }]}>{title}</Text>
+      <Text style={[styles.stateDescription, { color: theme.foregroundSecondary }]}>
+        {description}
+      </Text>
       <View style={styles.stateAction}>
         <Button onPress={onAction} tone="secondary">
           {alert ? '다시 시도' : '홈으로 이동'}
@@ -148,15 +142,11 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   loadingCard: {
-    borderRadius: radii.sm,
-    borderWidth: 1,
     gap: spacing.md,
     padding: spacing.lg,
   },
   loadingAction: { alignItems: 'flex-end' },
   stateCard: {
-    borderRadius: radii.sm,
-    borderWidth: 1,
     padding: 20,
   },
   stateTitle: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },

--- a/apps/app/src/components/PageHeader.test.ts
+++ b/apps/app/src/components/PageHeader.test.ts
@@ -20,6 +20,7 @@ mockModule(new URL('../theme/ThemeProvider.tsx', import.meta.url), {
     backgroundCanvas: '#f7f7f8',
     border: '#dddddd',
     borderSubtle: '#ececf0',
+    foregroundPrimary: '#1a1a1a',
     text: '#111111',
   }),
 });
@@ -77,6 +78,7 @@ test('text variant exposes one visible heading in a 64px page bar', () => {
   assert.equal((header.props.style as Array<{ minHeight?: number }>)[0]?.minHeight, 64);
   assert.equal(headings.length, 1);
   assert.equal(headings[0]?.props.children, '알림');
+  assert.equal((headings[0]?.props.style as Array<Record<string, unknown>>)[1]?.color, '#1a1a1a');
 });
 
 test('page bar stays on the route canvas and uses only a subtle boundary', () => {

--- a/apps/app/src/components/PageHeader.tsx
+++ b/apps/app/src/components/PageHeader.tsx
@@ -51,7 +51,10 @@ export function PageHeader(props: PageHeaderProps) {
       ) : (
         <>
           {props.leading ? <View style={styles.leading}>{props.leading}</View> : null}
-          <Text accessibilityRole="header" style={[styles.title, { color: theme.text }]}>
+          <Text
+            accessibilityRole="header"
+            style={[styles.title, { color: theme.foregroundPrimary }]}
+          >
             {props.title}
           </Text>
           {props.trailing ? <View style={styles.trailing}>{props.trailing}</View> : null}

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -194,7 +194,7 @@ export function PostListItem({
   const cardStyle = [
     styles.card,
     showDivider && styles.cardDivider,
-    showDivider && { borderColor: theme.divider },
+    showDivider && { borderColor: theme.borderSubtle },
   ];
   const replyAttribution =
     showReplyAttribution && post.replyParent ? (

--- a/apps/app/src/components/post/PostSourcePresentationView.tsx
+++ b/apps/app/src/components/post/PostSourcePresentationView.tsx
@@ -90,7 +90,10 @@ export function PostSourcePresentationView({
         accessibilityLabel={`${post.profile.displayName}의 게시글 보기`}
         href={postDetailHref}
       >
-        <Text style={[styles.timestamp, { color: theme.textSecondary }]} testID="post-timestamp">
+        <Text
+          style={[styles.timestamp, { color: theme.foregroundSecondary }]}
+          testID="post-timestamp"
+        >
           {formatTimelineTimestamp(post.createdAt)}
         </Text>
       </PresentationLink>
@@ -163,12 +166,12 @@ export function PostSourcePreview({
         </View>
         {interactive ? (
           <PresentationLink accessibilityLabel="원문 게시글 보기" href={sourcePostHref}>
-            <Text style={[styles.timestamp, { color: theme.textSecondary }]}>
+            <Text style={[styles.timestamp, { color: theme.foregroundSecondary }]}>
               {formatTimelineTimestamp(source.createdAt)}
             </Text>
           </PresentationLink>
         ) : (
-          <Text style={[styles.timestamp, { color: theme.textSecondary }]}>
+          <Text style={[styles.timestamp, { color: theme.foregroundSecondary }]}>
             {formatTimelineTimestamp(source.createdAt)}
           </Text>
         )}
@@ -198,7 +201,11 @@ export function PostSourcePreview({
 
   return (
     <View
-      style={[styles.preview, style, { borderColor: theme.border }]}
+      style={[
+        styles.preview,
+        style,
+        { backgroundColor: theme.backgroundSurface, borderColor: theme.borderDefault },
+      ]}
       testID="source-post-preview"
     >
       {content}
@@ -278,10 +285,10 @@ function Author({ profile, showAvatar }: { profile: PresentationProfile; showAva
         />
       ) : null}
       <View style={styles.authorText}>
-        <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
+        <Text numberOfLines={1} style={[styles.displayName, { color: theme.foregroundPrimary }]}>
           {profile.displayName}
         </Text>
-        <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
+        <Text numberOfLines={1} style={[styles.handle, { color: theme.foregroundSecondary }]}>
           {profile.relativeHandle}
         </Text>
       </View>

--- a/apps/app/src/components/post/PostThreadLayout.tsx
+++ b/apps/app/src/components/post/PostThreadLayout.tsx
@@ -51,7 +51,7 @@ export function PostThreadLayout<TPost>({
             key={item.id}
             aria-current={role === 'current' ? true : undefined}
             role={role === 'current' ? 'article' : undefined}
-            style={[styles.row, role === 'current' && { backgroundColor: theme.card }]}
+            style={styles.row}
             testID={
               role === 'current' ? `post-thread-current-${item.id}` : `post-thread-item-${item.id}`
             }
@@ -79,7 +79,7 @@ export function PostThreadLayout<TPost>({
             )}
             {index < rows.length - 1 ? (
               <View
-                style={[styles.divider, { backgroundColor: theme.divider }]}
+                style={[styles.divider, { backgroundColor: theme.borderSubtle }]}
                 testID={`post-thread-divider-${item.id}`}
               />
             ) : null}

--- a/apps/app/src/components/shell/BottomTabBar.tsx
+++ b/apps/app/src/components/shell/BottomTabBar.tsx
@@ -62,7 +62,11 @@ export function BottomTabBar({
       role="navigation"
       style={[
         styles.root,
-        { backgroundColor: theme.card, borderColor: theme.border, paddingBottom: insets.bottom },
+        {
+          backgroundColor: theme.backgroundCanvas,
+          borderColor: theme.borderSubtle,
+          paddingBottom: insets.bottom,
+        },
       ]}
     >
       {tabs.map((tab) => {
@@ -81,7 +85,7 @@ export function BottomTabBar({
             style={StyleSheet.flatten([
               styles.item,
               {
-                backgroundColor: active ? theme.primary : 'transparent',
+                backgroundColor: active ? theme.stateSelectedSurface : 'transparent',
                 opacity: tab.href ? 1 : 0.45,
               },
             ])}
@@ -98,7 +102,7 @@ export function BottomTabBar({
                 ) : tab.Icon ? (
                   <View style={styles.iconWithBadge}>
                     <tab.Icon
-                      color={active ? theme.text : theme.textSecondary}
+                      color={active ? theme.foregroundPrimary : theme.foregroundSecondary}
                       size={24}
                       strokeWidth={2}
                       style={pressed && styles.pressedContent}
@@ -112,7 +116,9 @@ export function BottomTabBar({
                   style={[
                     styles.label,
                     pressed && styles.pressedContent,
-                    { color: active ? theme.text : theme.textSecondary },
+                    {
+                      color: active ? theme.foregroundPrimary : theme.foregroundSecondary,
+                    },
                   ]}
                 >
                   {tab.label}

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -109,7 +109,9 @@ export function SidebarNavigation({
       style={[
         styles.root,
         compact ? styles.compactRoot : styles.fullRoot,
-        { backgroundColor: theme.card },
+        {
+          backgroundColor: surface === 'drawer' ? theme.backgroundElevated : theme.backgroundCanvas,
+        },
       ]}
     >
       <ProfileSwitcher
@@ -128,7 +130,7 @@ export function SidebarNavigation({
         style={[
           styles.navigationArea,
           compact && styles.compactNavigationArea,
-          { borderColor: theme.border },
+          { borderColor: theme.borderSubtle },
         ]}
         testID={surface === 'drawer' ? 'mobile-sidebar-scroll' : undefined}
       >
@@ -150,7 +152,7 @@ export function SidebarNavigation({
                   styles.item,
                   compact && styles.compactItem,
                   {
-                    backgroundColor: active ? theme.surface : 'transparent',
+                    backgroundColor: active ? theme.stateSelectedSurface : 'transparent',
                     opacity: href ? 1 : 0.5,
                   },
                 ])}
@@ -159,7 +161,7 @@ export function SidebarNavigation({
                   <>
                     <View style={styles.iconWithBadge}>
                       <item.Icon
-                        color={theme.text}
+                        color={theme.foregroundPrimary}
                         size={20}
                         strokeWidth={2}
                         style={pressed && styles.pressedContent}
@@ -174,7 +176,7 @@ export function SidebarNavigation({
                           styles.itemLabel,
                           active && styles.activeItemLabel,
                           pressed && styles.pressedContent,
-                          { color: theme.text },
+                          { color: theme.foregroundPrimary },
                         ]}
                       >
                         {item.label}
@@ -201,13 +203,13 @@ export function SidebarNavigation({
                 style={StyleSheet.flatten([
                   styles.compose,
                   compact && styles.compactCompose,
-                  { backgroundColor: theme.primary },
+                  { backgroundColor: theme.actionPrimaryBase },
                 ])}
               >
                 {({ pressed }) => (
                   <>
                     <PenLine
-                      color="#111111"
+                      color={theme.actionPrimaryOnBase}
                       size={20}
                       strokeWidth={2}
                       style={pressed && styles.pressedContent}
@@ -220,7 +222,11 @@ export function SidebarNavigation({
         </View>
 
         <View
-          style={[styles.footer, compact && styles.compactFooter, { borderColor: theme.border }]}
+          style={[
+            styles.footer,
+            compact && styles.compactFooter,
+            { borderColor: theme.borderSubtle },
+          ]}
         >
           {data.currentSession ? (
             feedbackUsesOverlay ? (
@@ -234,9 +240,15 @@ export function SidebarNavigation({
                   styles.feedbackFooterItem,
                 ])}
               >
-                <Mail color={theme.textSecondary} size={20} strokeWidth={2} />
+                <Mail color={theme.foregroundSecondary} size={20} strokeWidth={2} />
                 {!compact ? (
-                  <Text style={[styles.footerLabel, styles.footerLabelGrow, { color: theme.text }]}>
+                  <Text
+                    style={[
+                      styles.footerLabel,
+                      styles.footerLabelGrow,
+                      { color: theme.foregroundPrimary },
+                    ]}
+                  >
                     피드백 보내기
                   </Text>
                 ) : null}
@@ -253,12 +265,12 @@ export function SidebarNavigation({
                     compact && styles.compactItem,
                     styles.feedbackFooterItem,
                     {
-                      backgroundColor: feedbackActive ? theme.surface : 'transparent',
+                      backgroundColor: feedbackActive ? theme.stateSelectedSurface : 'transparent',
                     },
                   ])}
                 >
                   <Mail
-                    color={feedbackActive ? theme.text : theme.textSecondary}
+                    color={feedbackActive ? theme.foregroundPrimary : theme.foregroundSecondary}
                     size={20}
                     strokeWidth={2}
                   />
@@ -268,7 +280,7 @@ export function SidebarNavigation({
                         styles.footerLabel,
                         styles.footerLabelGrow,
                         feedbackActive && styles.activeItemLabel,
-                        { color: theme.text },
+                        { color: theme.foregroundPrimary },
                       ]}
                     >
                       피드백 보내기

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -22,7 +22,7 @@ import { RouteBoundary } from '@/components/RouteBoundary';
 import { Splash } from '@/components/Splash';
 import { IconButton } from '@/components/ui/IconButton';
 import { useRelayActor } from '@/relay/RelayActorProvider';
-import { useTheme } from '@/theme/ThemeProvider';
+import { useElevation, useTheme } from '@/theme/ThemeProvider';
 import { spacing } from '@/theme/tokens';
 import { returnToSettingsRoot } from '../settings/settingsNavigation';
 import { BottomTabBar } from './BottomTabBar';
@@ -113,6 +113,7 @@ export function UniversalShell() {
 
 function UniversalShellContent({ revision }: { revision: number }) {
   const theme = useTheme();
+  const elevation = useElevation();
   const insets = useSafeAreaInsets();
   const pathname = usePathname();
   const routeSegments = useSegments();
@@ -221,7 +222,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
       targetSize={44}
       visualSize={44}
     >
-      <Menu color={theme.text} size={24} strokeWidth={2} />
+      <Menu color={theme.foregroundPrimary} size={24} strokeWidth={2} />
     </IconButton>
   );
   const backButton = (
@@ -232,7 +233,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
       targetSize={44}
       visualSize={44}
     >
-      <ChevronLeftIcon color={theme.text} size={20} />
+      <ChevronLeftIcon color={theme.foregroundPrimary} size={20} />
     </IconButton>
   );
 
@@ -253,7 +254,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
           styles.root,
           web ? styles.webRoot : styles.nativeRoot,
           feedbackOverlayVisible ? styles.backgroundBlocked : null,
-          { backgroundColor: theme.background },
+          { backgroundColor: theme.backgroundCanvas },
         ]}
         testID="universal-shell-root"
       >
@@ -263,7 +264,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
               styles.sidebar,
               web && webStickyRail,
               switcherOpen && styles.sidebarWithOverlay,
-              { borderColor: theme.border, width: full ? 320 : 80 },
+              { borderColor: theme.borderSubtle, width: full ? 320 : 80 },
             ]}
           >
             <SidebarNavigation
@@ -282,7 +283,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
             web && webDocumentColumn,
             settingsWorkspace && styles.settingsCenter,
             showRightRail && styles.centerWithRightRail,
-            { borderColor: theme.border },
+            { borderColor: theme.borderSubtle },
           ]}
         >
           {mobile && !routeOwnsMobileHeader ? (
@@ -291,7 +292,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
                 styles.mobileChrome,
                 web && webStickyHeader,
                 {
-                  backgroundColor: theme.background,
+                  backgroundColor: theme.backgroundCanvas,
                   paddingTop: web ? 0 : insets.top,
                 },
               ]}
@@ -307,7 +308,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
                   }
                 />
               ) : (
-                <View style={[styles.mobileHeader, { borderColor: theme.border }]}>
+                <View style={[styles.mobileHeader, { borderColor: theme.borderSubtle }]}>
                   {menuButton}
                 </View>
               )}
@@ -335,7 +336,7 @@ function UniversalShellContent({ revision }: { revision: number }) {
               styles.rightRail,
               web && webStickyRail,
               web && webRightRailOverflow,
-              { borderColor: theme.border },
+              { borderColor: theme.borderSubtle },
             ]}
           >
             {profile ? <RightRail profile={profile} /> : null}
@@ -351,10 +352,14 @@ function UniversalShellContent({ revision }: { revision: number }) {
           transparent
           visible={drawerOpen}
         >
-          <View style={styles.drawerBackdrop}>
+          <View style={[styles.drawerBackdrop, { backgroundColor: theme.overlayScrim }]}>
             <View
               nativeID="mobile-sidebar"
-              style={[styles.drawer, { backgroundColor: theme.card }]}
+              style={[
+                styles.drawer,
+                elevation.overlay,
+                { backgroundColor: theme.backgroundElevated },
+              ]}
             >
               <SidebarNavigation
                 onFeedbackOpen={openFeedbackOverlay}
@@ -424,7 +429,6 @@ const styles = StyleSheet.create({
     width: 44,
   },
   drawerBackdrop: {
-    backgroundColor: 'rgba(0,0,0,0.35)',
     flex: 1,
     flexDirection: 'row',
     minHeight: 0,
@@ -432,7 +436,6 @@ const styles = StyleSheet.create({
   drawer: {
     borderBottomRightRadius: 16,
     borderTopRightRadius: 16,
-    boxShadow: '4px 0 4px rgba(0, 0, 0, 0.4)',
     height: '100%',
     maxWidth: '85%',
     minHeight: 0,

--- a/apps/app/src/stories/Compose.stories.tsx
+++ b/apps/app/src/stories/Compose.stories.tsx
@@ -52,7 +52,15 @@ export const ProfileRequiredCompact: Story = {
       },
     },
   },
-  play: ({ canvasElement }) => expectComposeHeader(canvasElement),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const stateTitle = await canvas.findByText('프로필이 필요해요');
+    const stateCard = stateTitle.parentElement;
+    expect(stateCard).not.toBeNull();
+    expect(window.getComputedStyle(stateCard!).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(window.getComputedStyle(stateCard!).borderTopWidth).toBe('0px');
+    expectComposeHeader(canvasElement);
+  },
 };
 
 export const LoadingFull: Story = {
@@ -68,7 +76,12 @@ export const LoadingFull: Story = {
     },
   },
   play: ({ canvasElement }) => {
-    expect(within(canvasElement).getByRole('status')).toBeInTheDocument();
+    const status = within(canvasElement).getByRole('status');
+    const loadingHost = status.previousElementSibling;
+    expect(status).toBeInTheDocument();
+    expect(loadingHost).not.toBeNull();
+    expect(window.getComputedStyle(loadingHost!).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(window.getComputedStyle(loadingHost!).borderTopWidth).toBe('0px');
     expectComposeHeader(canvasElement);
   },
 };

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -4537,6 +4537,8 @@ export const LinkedSourceQuote: Story = {
     Linking.openURL = openURL;
 
     try {
+      expect(window.getComputedStyle(sourcePreview).backgroundColor).toBe('rgb(248, 248, 250)');
+      expect(window.getComputedStyle(sourcePreview).borderColor).toBe('rgb(223, 223, 229)');
       expect(canvasElement.querySelector('[role="link"] [role="link"]')).toBeNull();
       await userEvent.click(
         within(postBody).getByLabelText('안전한 외부 링크, https://example.com/path'),
@@ -4650,9 +4652,10 @@ export const ReplyThreadPresentation: Story = {
       for (const connector of within(row).queryAllByTestId(/^post-thread-connector-/)) {
         expect(connector.getBoundingClientRect().right).toBeLessThan(dividerBounds.left);
       }
-      expect(window.getComputedStyle(divider).backgroundColor).toBe('rgb(242, 242, 242)');
+      expect(window.getComputedStyle(divider).backgroundColor).toBe('rgb(236, 236, 240)');
     });
     const currentRow = canvas.getByTestId('post-thread-current-thread-current');
+    expect(window.getComputedStyle(currentRow).backgroundColor).toBe('rgba(0, 0, 0, 0)');
     expect(window.getComputedStyle(currentRow).borderTopWidth).toBe('0px');
     expect(window.getComputedStyle(currentRow).borderBottomWidth).toBe('0px');
     for (const rowId of [

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -3318,7 +3318,7 @@ export const ProductionRepostQuoteListIntegration: Story = {
       expect(actionBarSlotStyle.paddingTop).toBe('0px');
       expect(actionBarSlotStyle.paddingBottom).toBe('4px');
       expect(cardBounds.bottom - borderBottomWidth - actionBarBounds.bottom).toBeCloseTo(4, 0);
-      expect(getComputedStyle(card).borderBottomColor).toBe('rgb(242, 242, 242)');
+      expect(getComputedStyle(card).borderBottomColor).toBe('rgb(236, 236, 240)');
     }
     for (const actionBar of [ordinaryActionBar, quoteActionBar, pureRepostActionBar]) {
       expect(

--- a/apps/app/src/stories/Posts.stories.tsx
+++ b/apps/app/src/stories/Posts.stories.tsx
@@ -4537,7 +4537,7 @@ export const LinkedSourceQuote: Story = {
     Linking.openURL = openURL;
 
     try {
-      expect(window.getComputedStyle(sourcePreview).backgroundColor).toBe('rgb(248, 248, 250)');
+      expect(window.getComputedStyle(sourcePreview).backgroundColor).toBe('rgb(250, 250, 251)');
       expect(window.getComputedStyle(sourcePreview).borderColor).toBe('rgb(223, 223, 229)');
       expect(canvasElement.querySelector('[role="link"] [role="link"]')).toBeNull();
       await userEvent.click(

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -316,6 +316,7 @@ export const SharedNavigation: Story = {
     const activeProfile = canvas.getByLabelText('활성 프로필');
     const navigation = canvas.getByRole('navigation', { name: '주요 메뉴' });
     const bookmarks = canvas.getByRole('link', { name: '북마크' });
+    const search = canvas.getByRole('link', { name: '검색' });
     const profile = canvas.getByRole('link', { name: '프로필' });
     const profileEdit = within(activeProfile).getByRole('link', { name: '프로필 편집' });
     const profileEditVisual = within(profileEdit).getByTestId('profile-edit-action-visual');
@@ -323,6 +324,7 @@ export const SharedNavigation: Story = {
     const activeProfileRect = activeProfile.getBoundingClientRect();
     const profileEditRect = profileEdit.getBoundingClientRect();
     expect(bookmarks).toHaveAttribute('href', '/bookmarks');
+    expect(window.getComputedStyle(search).backgroundColor).toBe('rgb(255, 249, 230)');
     expect(profile).toHaveAttribute('href', '/@selected');
     expect(profileEdit).toHaveAttribute('href', '/profile-edit');
     expect(within(profileEdit).getByText('편집', { exact: true })).toBeVisible();
@@ -363,7 +365,10 @@ export const SharedNavigation: Story = {
 export const BottomNavigation: Story = {
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const navigation = canvas.getByRole('navigation', { name: '주요 메뉴' });
     const avatar = canvas.getByLabelText(`${selectedProfile.displayName} 프로필 이미지`);
+    expect(window.getComputedStyle(navigation).backgroundColor).toBe('rgb(247, 247, 248)');
+    expect(window.getComputedStyle(navigation).borderTopColor).toBe('rgb(236, 236, 240)');
     expect(canvas.getByRole('link', { name: '글쓰기' })).toHaveAttribute('href', '/compose');
     expect(avatar.querySelector('img')).toHaveAttribute('src', selectedAvatarUrl);
     expect(canvas.queryByRole('link', { name: '팔로워 요청' })).not.toBeInTheDocument();
@@ -436,7 +441,7 @@ export const FeedbackNavigationCurrentState: Story = {
     const logoutLabel = within(logout).getByText('로그아웃');
     expect(link).toHaveAttribute('href', '/feedback');
     expect(link).toHaveAttribute('aria-current', 'page');
-    expect(link).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
+    expect(link).toHaveStyle({ backgroundColor: 'rgb(255, 249, 230)' });
     expect(link.nextElementSibling).toContainElement(logout);
     expect(link.parentElement).toHaveStyle({ borderTopWidth: '1px' });
     expect(feedbackLabel).toHaveStyle({ fontSize: '14px', lineHeight: '21px' });
@@ -490,7 +495,7 @@ export const FollowRequestsNavigationCurrentState: Story = {
     const link = canvas.getByRole('link', { name: '팔로워 요청' });
     expect(link).toHaveAttribute('href', '/follow-requests');
     expect(link).toHaveAttribute('aria-current', 'page');
-    expect(link).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
+    expect(link).toHaveStyle({ backgroundColor: 'rgb(255, 249, 230)' });
   },
   render: () => <FeedbackNavigationFullStory />,
 };
@@ -503,7 +508,7 @@ export const FeedbackNavigationCompactCurrentState: Story = {
     const logout = canvas.getByRole('button', { name: '로그아웃' });
     expect(link).toHaveAttribute('href', '/feedback');
     expect(link).toHaveAttribute('aria-current', 'page');
-    expect(link).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
+    expect(link).toHaveStyle({ backgroundColor: 'rgb(255, 249, 230)' });
     expect(link.nextElementSibling).toContainElement(logout);
     expect(link.parentElement).toHaveStyle({ borderTopWidth: '0px' });
   },
@@ -521,7 +526,7 @@ export const FeedbackNavigationDrawerCurrentState: Story = {
     const logout = canvas.getByRole('button', { name: '로그아웃' });
     expect(link).toHaveAttribute('href', '/feedback');
     expect(link).toHaveAttribute('aria-current', 'page');
-    expect(link).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
+    expect(link).toHaveStyle({ backgroundColor: 'rgb(255, 249, 230)' });
     expect(link.nextElementSibling).toContainElement(logout);
     expect(link.parentElement).toHaveStyle({ borderTopWidth: '1px' });
     expect(canvas.queryByRole('link', { name: '글쓰기' })).not.toBeInTheDocument();
@@ -1446,6 +1451,7 @@ export const UniversalMobile: Story = {
   parameters: universalParameters,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const shellRoot = canvas.getByTestId('universal-shell-root');
     const homeHeading = canvas.getByRole('heading', { name: '홈' });
     const menuButton = canvas.getByRole('button', { name: '메뉴 열기' });
     const homeHeader = homeHeading.parentElement?.parentElement;
@@ -1455,6 +1461,7 @@ export const UniversalMobile: Story = {
     );
 
     expect(homeHeader).not.toBeNull();
+    expect(window.getComputedStyle(shellRoot).backgroundColor).toBe('rgb(247, 247, 248)');
     expect(homeHeader).toContainElement(menuButton);
     expect(brandMark).not.toBeNull();
     expect(trailingSlot).not.toBeNull();
@@ -1476,6 +1483,9 @@ export const UniversalMobile: Story = {
     const ownerDocument = canvasElement.ownerDocument;
     const page = within(ownerDocument.body);
     const drawer = await page.findByRole('navigation', { name: '주요 메뉴' });
+    const drawerSurface = ownerDocument.getElementById('mobile-sidebar');
+    const drawerBackdrop = drawerSurface?.parentElement;
+    const drawerNavigationSurface = page.getByTestId('mobile-sidebar-scroll').parentElement;
     const profileTrigger = page.getByRole('button', { name: '프로필 목록' });
     const triggerName = within(profileTrigger).getByText('코스모 작가');
     const profileHandle = page.getByLabelText('활성 프로필 핸들');
@@ -1486,6 +1496,15 @@ export const UniversalMobile: Story = {
     const handleRect = profileHandle.getBoundingClientRect();
     const iconRect = triggerIcon.getBoundingClientRect();
 
+    expect(drawerSurface).not.toBeNull();
+    expect(drawerBackdrop).not.toBeNull();
+    expect(drawerNavigationSurface).not.toBeNull();
+    expect(window.getComputedStyle(drawerSurface!).backgroundColor).toBe('rgb(250, 250, 251)');
+    expect(window.getComputedStyle(drawerNavigationSurface!).backgroundColor).toBe(
+      'rgb(250, 250, 251)',
+    );
+    expect(window.getComputedStyle(drawerSurface!).boxShadow).toContain('rgba(0, 0, 0, 0.1)');
+    expect(window.getComputedStyle(drawerBackdrop!).backgroundColor).toBe('rgba(0, 0, 0, 0.45)');
     expect(within(drawer).getByRole('link', { name: '북마크' })).toHaveAttribute(
       'href',
       '/bookmarks',

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -367,7 +367,7 @@ export const BottomNavigation: Story = {
     const canvas = within(canvasElement);
     const navigation = canvas.getByRole('navigation', { name: '주요 메뉴' });
     const avatar = canvas.getByLabelText(`${selectedProfile.displayName} 프로필 이미지`);
-    expect(window.getComputedStyle(navigation).backgroundColor).toBe('rgb(247, 247, 248)');
+    expect(window.getComputedStyle(navigation).backgroundColor).toBe('rgb(255, 255, 255)');
     expect(window.getComputedStyle(navigation).borderTopColor).toBe('rgb(236, 236, 240)');
     expect(canvas.getByRole('link', { name: '글쓰기' })).toHaveAttribute('href', '/compose');
     expect(avatar.querySelector('img')).toHaveAttribute('src', selectedAvatarUrl);
@@ -1461,7 +1461,7 @@ export const UniversalMobile: Story = {
     );
 
     expect(homeHeader).not.toBeNull();
-    expect(window.getComputedStyle(shellRoot).backgroundColor).toBe('rgb(247, 247, 248)');
+    expect(window.getComputedStyle(shellRoot).backgroundColor).toBe('rgb(255, 255, 255)');
     expect(homeHeader).toContainElement(menuButton);
     expect(brandMark).not.toBeNull();
     expect(trailingSlot).not.toBeNull();
@@ -1499,9 +1499,9 @@ export const UniversalMobile: Story = {
     expect(drawerSurface).not.toBeNull();
     expect(drawerBackdrop).not.toBeNull();
     expect(drawerNavigationSurface).not.toBeNull();
-    expect(window.getComputedStyle(drawerSurface!).backgroundColor).toBe('rgb(250, 250, 251)');
+    expect(window.getComputedStyle(drawerSurface!).backgroundColor).toBe('rgb(255, 255, 255)');
     expect(window.getComputedStyle(drawerNavigationSurface!).backgroundColor).toBe(
-      'rgb(250, 250, 251)',
+      'rgb(255, 255, 255)',
     );
     expect(window.getComputedStyle(drawerSurface!).boxShadow).toContain('rgba(0, 0, 0, 0.1)');
     expect(window.getComputedStyle(drawerBackdrop!).backgroundColor).toBe('rgba(0, 0, 0, 0.45)');

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -124,7 +124,7 @@ Focus와 Selected를 서로 대체하지 않는다. 두 상태가 동시에 존�
 | Success Green / White           |  `5.43:1` |
 | Warning Tangerine / Ink         |  `6.09:1` |
 | Danger Red / White              |  `6.57:1` |
-| Link Light / Surface            |  `5.93:1` |
+| Link Light / Surface            |  `6.03:1` |
 | Link Dark / Canvas              |  `8.89:1` |
 | Light Muted / Canvas            |  `4.83:1` |
 | Dark Muted / Elevated           |  `4.92:1` |
@@ -134,7 +134,7 @@ Focus와 Selected를 서로 대체하지 않는다. 두 상태가 동시에 존�
 | Light Selected Border / Surface |  `3.24:1` |
 | Light Info Border / Subtle      |  `3.24:1` |
 | Light Warning Border / Subtle   |  `3.25:1` |
-| Light Warning Border / Surface  |  `3.37:1` |
+| Light Warning Border / Surface  |  `3.42:1` |
 
 ## Component usage mapping
 

--- a/docs/design/post-thread.md
+++ b/docs/design/post-thread.md
@@ -6,7 +6,7 @@ Post 상세 thread는 API가 제공한 조상·현재·하위 Post 순서와 직
 
 - `PROD-422`: production Reply thread data·route integration
 - `PROD-593`: thread row 구분선 정리
-- `docs/design/colors.md`: 저강도 콘텐츠 행 경계의 `divider` token
+- `docs/design/colors.md`: 저강도 콘텐츠 행 경계의 `border/subtle` semantic token
 - 2026-07-31 Web 수동 시각 확인
 
 ## 렌더링과 소유권
@@ -22,10 +22,10 @@ Post 상세 thread는 API가 제공한 조상·현재·하위 Post 순서와 직
 ## Row boundary
 
 - N개 thread row 사이에 N-1개의 구분선을 표시한다. 마지막 행과 단일 행에는 구분선을 표시하지 않는다.
-- 구분선은 `theme.divider` 색상의 1px 선이며 왼쪽 64px, 오른쪽 8px inset을 사용한다.
+- 구분선은 `theme.borderSubtle` 색상의 1px 선이며 왼쪽 64px, 오른쪽 8px inset을 사용한다.
 - 왼쪽 64px은 현재 상세 Post의 본문 열에 맞춘 값이다. 목록형 Post 본문이 시작하는 68px과 완전히 정렬하는 것은 목표가 아니다.
 - thread 안의 `PostListItem`은 자체 row divider를 끄고 `PostThreadLayout`의 구분선만 사용한다. Home·Profile·Bookmark 등 thread 밖 목록의 기본 divider는 유지한다.
-- Home timeline과는 `divider` token과 1px 시각 무게만 공유하며 geometry는 thread 관계 표현에 맞게 독립적으로 유지한다.
+- Home timeline과는 `border/subtle` token과 1px 시각 무게만 공유하며 geometry는 thread 관계 표현에 맞게 독립적으로 유지한다.
 
 ## Connector
 
@@ -35,7 +35,7 @@ Post 상세 thread는 API가 제공한 조상·현재·하위 Post 순서와 직
 
 ## 검증과 rollout
 
-- Storybook에서 N-1 구분선, 마지막·단일 행 예외, 1px `theme.divider`, 64px/8px inset, 현재 상세 본문 열 정렬, connector 비중첩, thread 내부 중복 border 제거와 thread 밖 기본 divider 유지를 검증한다.
+- Storybook에서 N-1 구분선, 마지막·단일 행 예외, 1px `theme.borderSubtle`, 64px/8px inset, 현재 상세 본문 열 정렬, connector 비중첩, thread 내부 중복 border 제거와 thread 밖 기본 divider 유지를 검증한다.
 - Reply 대상 attribution이 일반 목록에서는 유지되지만 상세 thread의 조상·현재·하위 모든 행에서는
   표시되지 않는지 검증한다.
 - Web Light 화면에서 구분선 x=64, connector x=32~34, 오른쪽 inset 8px과 비중첩을 확인했다.


### PR DESCRIPTION
## 무엇을 변경했는지

- `UniversalShell`, `SidebarNavigation`, `BottomTabBar`, `PageHeader`를 `background/canvas`, `border/subtle`, semantic foreground·selected state에 맞췄습니다.
- 모바일 드로어는 `background/elevated`, 표준 scrim, `elevation/overlay`를 사용하도록 정리했습니다.
- 연속 thread의 현재 post row는 별도 fill 없이 canvas를 상속하고, divider는 `border/subtle`을 사용합니다.
- 인용·원문 preview는 `background/surface + border/default`로 경계를 명시했습니다.
- Compose loading/profile-required/error host는 별도 card fill·border 없이 route canvas를 상속합니다.
- 위 역할이 다시 legacy `card/surface`로 돌아가지 않도록 가장 가까운 단위·Storybook 검사를 보강했습니다.

## 왜 변경했는지

DSN-19에서 semantic token과 공용 primitive가 도입됐지만 route·shell·domain 소비처에는 legacy `background/card/surface/border`가 남아 있었습니다. 그 결과 연속 피드와 공통 header가 별도 surface처럼 보이거나, route 상태가 독립 card처럼 보이는 문제가 있었습니다.

DSN-21의 소비처 이관 범위에서 화면 바탕과 연속 피드를 하나의 canvas로 정렬하고, 실제로 독립된 drawer와 내부 preview만 elevated/surface 역할을 갖도록 수정했습니다.

## 이번 PR의 주요 결정

### 연속 피드와 공통 chrome의 plane

- 결정자: @yeeun-uwu
- 선택: route body·공통 header·연속 feed는 `background/canvas`, post row와 route state host는 no-fill/inherit로 둡니다.
- 고려한 대안: post row와 route state마다 `background/surface`를 반복 적용합니다.
- 이유: 연속 콘텐츠를 독립 카드의 반복으로 보이게 하지 않고 화면 전체를 하나의 평면으로 읽히게 하기 위해서입니다.
- 감수한 결과: row 구분은 fill 차이가 아니라 `border/subtle`과 콘텐츠 구조에 의존합니다.
- 관련 근거: [`docs/design/colors.md`](https://github.com/byulmaru/kosmo/blob/main/docs/design/colors.md), [`docs/design/foundations.md`](https://github.com/byulmaru/kosmo/blob/main/docs/design/foundations.md), [DSN-21](https://linear.app/byulmaru/issue/DSN-21/kosmo-화면-상태셸반응형-디자인-규칙-프로덕션-반영)

### 독립 surface의 구분

- 결정자: @yeeun-uwu
- 선택: drawer는 elevated, 인용·원문 preview는 surface로 유지합니다.
- 고려한 대안: shell과 preview까지 모두 canvas로 평탄화합니다.
- 이유: 화면 위에 올라오는 overlay와 콘텐츠 내부의 bounded preview에는 위치·경계 단서가 필요하기 때문입니다.
- 감수한 결과: 같은 밝은 계열 색이라도 semantic 역할과 elevation을 함께 검증해야 합니다.

## 어떻게 확인할 수 있는지

검증 결과:

- `pnpm exec relay-compiler --noWatchman`
- `pnpm exec tsc --noEmit --pretty false`
- 전체 unit test 통과
- Storybook 360/360 통과
- 변경 Story 162/162 통과(rebase 후 재검증)
- Storybook 정적 빌드 통과
- Web export 통과
- `git diff --check` 통과

## 아직 어떤 문제가 남았는지

- pagination, inline StateView/Skeleton, raw overlay consumer, NavigationLink/Tabs/RadioGroup/Button/identity 이관은 연결된 Product 이슈가 소유합니다.
- iOS/Android 실제 runtime의 색상·drawer elevation·safe area는 이번 PR에서 확인하지 않았습니다.
- Figma Components/Screens의 semantic variable 재바인딩과 최종 시각 대조는 DSN-13에서 진행합니다.
- 프로덕션 앱의 기본 theme는 계속 Light이며, 전역 Dark 활성화는 이 PR에서 하지 않습니다.
