### PR TITLE
목록 상태 표현을 공용 StateView와 Skeleton으로 수렴한다

### DIFF
--- a/apps/app/src/components/bookmark/BookmarkList.tsx
+++ b/apps/app/src/components/bookmark/BookmarkList.tsx
@@ -162,6 +162,7 @@ function BookmarkListState({
   return (
     <StateView
       actionLabel={onRetry ? '다시 시도' : undefined}
+      actionStyle={styles.actionButton}
       alert={alert}
       description={description}
       inline

--- a/apps/app/src/components/bookmark/BookmarkList.tsx
+++ b/apps/app/src/components/bookmark/BookmarkList.tsx
@@ -165,7 +165,6 @@ function BookmarkListState({
       actionStyle={styles.actionButton}
       alert={alert}
       description={description}
-      inline
       onAction={onRetry}
       style={styles.state}
       title={title}

--- a/apps/app/src/components/bookmark/BookmarkList.tsx
+++ b/apps/app/src/components/bookmark/BookmarkList.tsx
@@ -5,9 +5,9 @@ import { PostListItem } from '@/components/post/PostListItem';
 import { PostMediaViewerHostProvider } from '@/components/post/PostMediaViewerHost';
 import { PostReplyCoordinatorProvider } from '@/components/post/PostReplyCoordinator';
 import { Button } from '@/components/ui/Button';
-import { Skeleton } from '@/components/ui/StateView';
+import { Skeleton, StateView } from '@/components/ui/StateView';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 import type { ReactNode } from 'react';
 import type { PostListItem_post$key } from '@/components/post/__generated__/PostListItem_post.graphql';
 import type { ReplyComposerSurface_profile$key } from '@/components/post/__generated__/ReplyComposerSurface_profile.graphql';
@@ -121,11 +121,11 @@ function BookmarkListSkeleton() {
       <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
         {[0, 1, 2].map((item) => (
           <View key={item} style={[styles.skeletonItem, { borderColor: theme.border }]}>
-            <View
-              style={[
-                styles.avatarSkeleton,
-                { backgroundColor: theme.surface, borderColor: theme.border },
-              ]}
+            <Skeleton
+              circular
+              height={48}
+              style={[styles.avatarSkeleton, { borderColor: theme.border }]}
+              width={48}
             />
             <View style={styles.skeletonCopy}>
               <View style={styles.skeletonHeader}>
@@ -159,17 +159,16 @@ function BookmarkListState({
   onRetry?: () => void;
   title: string;
 }) {
-  const theme = useTheme();
   return (
-    <View accessibilityRole={alert ? 'alert' : undefined} style={styles.state}>
-      <Text style={[styles.stateTitle, { color: theme.text }]}>{title}</Text>
-      <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>{description}</Text>
-      {onRetry ? (
-        <Button onPress={onRetry} style={styles.actionButton} tone="secondary">
-          다시 시도
-        </Button>
-      ) : null}
-    </View>
+    <StateView
+      actionLabel={onRetry ? '다시 시도' : undefined}
+      alert={alert}
+      description={description}
+      inline
+      onAction={onRetry}
+      style={styles.state}
+      title={title}
+    />
   );
 }
 
@@ -184,13 +183,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.sm,
     paddingTop: spacing.sm,
   },
-  avatarSkeleton: { borderRadius: radii.full, borderWidth: 1, height: 48, width: 48 },
+  avatarSkeleton: { borderWidth: 1 },
   skeletonCopy: { flex: 1, minWidth: 0 },
   skeletonHeader: { gap: spacing.sm },
   skeletonBody: { gap: 10, marginTop: spacing.md },
   state: { alignItems: 'center', gap: spacing.sm, padding: spacing.xxxl },
-  stateTitle: { fontFamily: 'SUIT', fontWeight: '700', textAlign: 'center', ...typography.md },
-  stateDescription: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
   actionButton: { minHeight: 44 },
   pagination: { alignItems: 'center', padding: spacing.lg },
   srOnly: { height: 1, left: 0, overflow: 'hidden', position: 'absolute', top: 0, width: 1 },

--- a/apps/app/src/components/follow-request/FollowRequestList.tsx
+++ b/apps/app/src/components/follow-request/FollowRequestList.tsx
@@ -69,7 +69,6 @@ export function FollowRequestList({ profile }: FollowRequestListProps) {
       ) : (
         <StateView
           description="새 요청이 들어오면 여기에 표시돼요."
-          inline
           style={styles.state}
           title="받은 팔로우 요청이 없어요"
         />
@@ -88,7 +87,6 @@ export function FollowRequestList({ profile }: FollowRequestListProps) {
           actionLabel="다시 시도"
           alert
           description="이미 불러온 요청은 그대로 유지돼요."
-          inline
           onAction={loadNextPage}
           style={[styles.pagination, { borderColor: theme.border }]}
           title="팔로워 요청을 더 불러오지 못했어요"
@@ -137,7 +135,6 @@ export function FollowRequestListState({
           actionLabel={onRetry ? '다시 시도' : undefined}
           alert
           description="잠시 후 다시 시도해주세요."
-          inline
           onAction={onRetry}
           style={styles.state}
           title="팔로워 요청을 불러오지 못했어요"
@@ -145,7 +142,6 @@ export function FollowRequestListState({
       ) : (
         <StateView
           description="팔로워 요청을 보려면 사용할 프로필을 먼저 선택해주세요."
-          inline
           style={styles.state}
           title="프로필이 필요해요"
         />

--- a/apps/app/src/components/follow-request/FollowRequestList.tsx
+++ b/apps/app/src/components/follow-request/FollowRequestList.tsx
@@ -3,10 +3,9 @@ import { graphql, usePaginationFragment } from 'react-relay';
 import { ConnectionHandler } from 'relay-runtime';
 import { PageHeader } from '@/components/PageHeader';
 import { useAutomaticPagination } from '@/components/pagination/useAutomaticPagination';
-import { Button } from '@/components/ui/Button';
-import { Skeleton } from '@/components/ui/StateView';
+import { Skeleton, StateView } from '@/components/ui/StateView';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
 import { FollowRequestListItem } from './FollowRequestListItem';
 import type { FollowRequestList_profile$key } from './__generated__/FollowRequestList_profile.graphql';
 import type { FollowRequestListNextPageQuery } from './__generated__/FollowRequestListNextPageQuery.graphql';
@@ -68,12 +67,12 @@ export function FollowRequestList({ profile }: FollowRequestListProps) {
           <FollowRequestListItem connectionId={connectionId} key={node.id} request={node} />
         ))
       ) : (
-        <View style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>받은 팔로우 요청이 없어요</Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            새 요청이 들어오면 여기에 표시돼요.
-          </Text>
-        </View>
+        <StateView
+          description="새 요청이 들어오면 여기에 표시돼요."
+          inline
+          style={styles.state}
+          title="받은 팔로우 요청이 없어요"
+        />
       )}
       {pagination.isLoadingNext ? (
         <View style={[styles.pagination, { borderColor: theme.border }]}>
@@ -85,17 +84,15 @@ export function FollowRequestList({ profile }: FollowRequestListProps) {
           </Text>
         </View>
       ) : loadError ? (
-        <View accessibilityRole="alert" style={[styles.pagination, { borderColor: theme.border }]}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>
-            팔로워 요청을 더 불러오지 못했어요
-          </Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            이미 불러온 요청은 그대로 유지돼요.
-          </Text>
-          <Button onPress={loadNextPage} style={styles.stateAction} tone="secondary">
-            다시 시도
-          </Button>
-        </View>
+        <StateView
+          actionLabel="다시 시도"
+          alert
+          description="이미 불러온 요청은 그대로 유지돼요."
+          inline
+          onAction={loadNextPage}
+          style={[styles.pagination, { borderColor: theme.border }]}
+          title="팔로워 요청을 더 불러오지 못했어요"
+        />
       ) : null}
     </ScrollView>
   );
@@ -118,11 +115,11 @@ export function FollowRequestListState({
           <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
             {[0, 1, 2].map((item) => (
               <View key={item} style={[styles.skeletonItem, { borderColor: theme.border }]}>
-                <View
-                  style={[
-                    styles.avatarSkeleton,
-                    { backgroundColor: theme.surface, borderColor: theme.border },
-                  ]}
+                <Skeleton
+                  circular
+                  height={40}
+                  style={[styles.avatarSkeleton, { borderColor: theme.border }]}
+                  width={40}
                 />
                 <View style={styles.skeletonCopy}>
                   <Skeleton height={12} width={160} />
@@ -136,26 +133,22 @@ export function FollowRequestListState({
           </Text>
         </>
       ) : state === 'error' ? (
-        <View accessibilityRole="alert" style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>
-            팔로워 요청을 불러오지 못했어요
-          </Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            잠시 후 다시 시도해주세요.
-          </Text>
-          {onRetry ? (
-            <Button onPress={onRetry} style={styles.stateAction} tone="secondary">
-              다시 시도
-            </Button>
-          ) : null}
-        </View>
+        <StateView
+          actionLabel={onRetry ? '다시 시도' : undefined}
+          alert
+          description="잠시 후 다시 시도해주세요."
+          inline
+          onAction={onRetry}
+          style={styles.state}
+          title="팔로워 요청을 불러오지 못했어요"
+        />
       ) : (
-        <View style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>프로필이 필요해요</Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            팔로워 요청을 보려면 사용할 프로필을 먼저 선택해주세요.
-          </Text>
-        </View>
+        <StateView
+          description="팔로워 요청을 보려면 사용할 프로필을 먼저 선택해주세요."
+          inline
+          style={styles.state}
+          title="프로필이 필요해요"
+        />
       )}
     </ScrollView>
   );
@@ -169,9 +162,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.xxxl,
   },
-  stateTitle: { fontFamily: 'SUIT', fontWeight: '700', textAlign: 'center', ...typography.md },
   stateDescription: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
-  stateAction: { marginTop: spacing.md },
   pagination: {
     alignItems: 'center',
     borderTopWidth: 1,
@@ -186,7 +177,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
   },
-  avatarSkeleton: { borderRadius: radii.full, borderWidth: 1, height: 40, width: 40 },
+  avatarSkeleton: { borderWidth: 1 },
   skeletonCopy: { flex: 1, gap: spacing.sm, minWidth: 0 },
   srOnly: {
     height: 1,

--- a/apps/app/src/components/notification/NotificationList.tsx
+++ b/apps/app/src/components/notification/NotificationList.tsx
@@ -13,10 +13,10 @@ import { graphql, useMutation, usePaginationFragment } from 'react-relay';
 import { PageHeader } from '@/components/PageHeader';
 import { getWebMobileShellHeader } from '@/components/shell/shellLayout';
 import { Button } from '@/components/ui/Button';
-import { Skeleton } from '@/components/ui/StateView';
+import { Skeleton, StateView } from '@/components/ui/StateView';
 import { useToast } from '@/components/ui/ToastProvider';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 import {
   FollowRequestNotificationListItem,
   NotificationListItem,
@@ -215,32 +215,38 @@ export function NotificationList({ profile }: NotificationListProps) {
       {notifications.length ? (
         notifications
       ) : (
-        <View style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>아직 알림이 없어요</Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            새로운 팔로우, 팔로우 요청, 답글, 반응 또는 재게시 알림이 생기면 여기에 표시돼요.
-          </Text>
-        </View>
+        <StateView
+          description="새로운 팔로우, 팔로우 요청, 답글, 반응 또는 재게시 알림이 생기면 여기에 표시돼요."
+          inline
+          style={styles.state}
+          title="아직 알림이 없어요"
+        />
       )}
       {pagination.hasNext || loadError ? (
-        <View style={[styles.pagination, { borderColor: theme.border }]}>
-          {loadError ? (
-            <Text accessibilityRole="alert" style={[styles.stateTitle, { color: theme.text }]}>
-              알림을 더 불러오지 못했어요
-            </Text>
-          ) : null}
-          <Button
-            accessibilityState={{
-              busy: pagination.isLoadingNext,
-              disabled: pagination.isLoadingNext,
-            }}
-            disabled={pagination.isLoadingNext}
-            onPress={loadMore}
-            tone="secondary"
-          >
-            {pagination.isLoadingNext ? '불러오는 중' : loadError ? '다시 시도' : '더 불러오기'}
-          </Button>
-        </View>
+        loadError ? (
+          <StateView
+            actionLabel="다시 시도"
+            alert
+            inline
+            onAction={loadMore}
+            style={[styles.pagination, { borderColor: theme.border }]}
+            title="알림을 더 불러오지 못했어요"
+          />
+        ) : (
+          <View style={[styles.pagination, { borderColor: theme.border }]}>
+            <Button
+              accessibilityState={{
+                busy: pagination.isLoadingNext,
+                disabled: pagination.isLoadingNext,
+              }}
+              disabled={pagination.isLoadingNext}
+              onPress={loadMore}
+              tone="secondary"
+            >
+              {pagination.isLoadingNext ? '불러오는 중' : '더 불러오기'}
+            </Button>
+          </View>
+        )
       ) : null}
     </ScrollView>
   );
@@ -263,10 +269,10 @@ export function NotificationListState({
           <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
             {[0, 1, 2].map((item) => (
               <View key={item} style={[styles.skeletonItem, { borderColor: theme.border }]}>
-                <View style={[styles.kindSkeleton, { backgroundColor: theme.surface }]} />
+                <Skeleton circular height={28} width={28} />
                 <View style={styles.skeletonContent}>
                   <View style={styles.skeletonAvatarRow}>
-                    <View style={[styles.avatarSkeleton, { backgroundColor: theme.surface }]} />
+                    <Skeleton circular height={28} width={28} />
                     <Skeleton height={12} width={48} />
                   </View>
                   <View style={styles.skeletonCopy}>
@@ -281,24 +287,22 @@ export function NotificationListState({
           </Text>
         </>
       ) : state === 'error' ? (
-        <View accessibilityRole="alert" style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>알림을 불러오지 못했어요</Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            잠시 후 다시 시도해주세요.
-          </Text>
-          {onRetry ? (
-            <Button onPress={onRetry} tone="secondary">
-              다시 시도
-            </Button>
-          ) : null}
-        </View>
+        <StateView
+          actionLabel={onRetry ? '다시 시도' : undefined}
+          alert
+          description="잠시 후 다시 시도해주세요."
+          inline
+          onAction={onRetry}
+          style={styles.state}
+          title="알림을 불러오지 못했어요"
+        />
       ) : (
-        <View style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>프로필이 필요해요</Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            알림을 보려면 사용할 프로필을 먼저 선택해주세요.
-          </Text>
-        </View>
+        <StateView
+          description="알림을 보려면 사용할 프로필을 먼저 선택해주세요."
+          inline
+          style={styles.state}
+          title="프로필이 필요해요"
+        />
       )}
     </ScrollView>
   );
@@ -328,8 +332,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.xxxl,
   },
-  stateTitle: { fontFamily: 'SUIT', fontWeight: '700', textAlign: 'center', ...typography.md },
-  stateDescription: { fontFamily: 'SUIT', textAlign: 'center', ...typography.sm },
   pagination: { alignItems: 'center', borderTopWidth: 1, gap: spacing.md, padding: spacing.lg },
   skeletonItem: {
     alignItems: 'flex-start',
@@ -339,8 +341,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.lg,
   },
-  kindSkeleton: { borderRadius: radii.full, height: 28, width: 28 },
-  avatarSkeleton: { borderRadius: radii.full, height: 28, width: 28 },
   skeletonAvatarRow: {
     alignItems: 'center',
     flexDirection: 'row',

--- a/apps/app/src/components/notification/NotificationList.tsx
+++ b/apps/app/src/components/notification/NotificationList.tsx
@@ -217,7 +217,6 @@ export function NotificationList({ profile }: NotificationListProps) {
       ) : (
         <StateView
           description="새로운 팔로우, 팔로우 요청, 답글, 반응 또는 재게시 알림이 생기면 여기에 표시돼요."
-          inline
           style={styles.state}
           title="아직 알림이 없어요"
         />
@@ -227,7 +226,6 @@ export function NotificationList({ profile }: NotificationListProps) {
           <StateView
             actionLabel="다시 시도"
             alert
-            inline
             onAction={loadMore}
             style={[styles.pagination, { borderColor: theme.border }]}
             title="알림을 더 불러오지 못했어요"
@@ -291,7 +289,6 @@ export function NotificationListState({
           actionLabel={onRetry ? '다시 시도' : undefined}
           alert
           description="잠시 후 다시 시도해주세요."
-          inline
           onAction={onRetry}
           style={styles.state}
           title="알림을 불러오지 못했어요"
@@ -299,7 +296,6 @@ export function NotificationListState({
       ) : (
         <StateView
           description="알림을 보려면 사용할 프로필을 먼저 선택해주세요."
-          inline
           style={styles.state}
           title="프로필이 필요해요"
         />

--- a/apps/app/src/components/post/PostList.tsx
+++ b/apps/app/src/components/post/PostList.tsx
@@ -3,11 +3,10 @@ import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 import { usePaginationScrollRegistration } from '@/components/pagination/PaginationScrollView';
 import { useAutomaticPagination } from '@/components/pagination/useAutomaticPagination';
-import { Button } from '@/components/ui/Button';
-import { Skeleton } from '@/components/ui/StateView';
+import { Skeleton, StateView } from '@/components/ui/StateView';
 import { useToast } from '@/components/ui/ToastProvider';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { spacing } from '@/theme/tokens';
 import { PostActionAuthenticationProvider } from './PostActionAuthentication';
 import { PostListItem } from './PostListItem';
 import { PostMediaViewerHostProvider } from './PostMediaViewerHost';
@@ -174,11 +173,11 @@ function PostListSkeleton() {
       <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
         {[0, 1, 2].map((item) => (
           <View key={item} style={[styles.skeletonItem, { borderColor: theme.border }]}>
-            <View
-              style={[
-                styles.avatarSkeleton,
-                { backgroundColor: theme.surface, borderColor: theme.border },
-              ]}
+            <Skeleton
+              circular
+              height={48}
+              style={[styles.avatarSkeleton, { borderColor: theme.border }]}
+              width={48}
             />
             <View style={styles.skeletonCopy}>
               <View style={styles.skeletonHeader}>
@@ -212,18 +211,16 @@ function PostListState({
   onRetry?: () => void;
   title: string;
 }) {
-  const theme = useTheme();
-
   return (
-    <View accessibilityRole={alert ? 'alert' : undefined} style={styles.state}>
-      <Text style={[styles.stateTitle, { color: theme.text }]}>{title}</Text>
-      <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>{description}</Text>
-      {onRetry ? (
-        <Button onPress={onRetry} style={styles.retry} tone="secondary">
-          다시 시도
-        </Button>
-      ) : null}
-    </View>
+    <StateView
+      actionLabel={onRetry ? '다시 시도' : undefined}
+      alert={alert}
+      description={description}
+      inline
+      onAction={onRetry}
+      style={styles.state}
+      title={title}
+    />
   );
 }
 
@@ -239,19 +236,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.sm,
     paddingTop: spacing.sm,
   },
-  avatarSkeleton: { borderRadius: radii.full, borderWidth: 1, height: 48, width: 48 },
+  avatarSkeleton: { borderWidth: 1 },
   skeletonCopy: { flex: 1, minWidth: 0 },
   skeletonHeader: { gap: spacing.sm },
   skeletonBody: { gap: 10, marginTop: spacing.md },
   state: { alignItems: 'center', paddingHorizontal: spacing.lg, paddingVertical: spacing.xxxl },
-  stateTitle: { fontFamily: 'SUIT', fontWeight: '700', textAlign: 'center', ...typography.md },
-  stateDescription: {
-    fontFamily: 'SUIT',
-    marginTop: spacing.xs,
-    textAlign: 'center',
-    ...typography.sm,
-  },
-  retry: { marginTop: spacing.lg },
   srOnly: {
     height: 1,
     left: 0,

--- a/apps/app/src/components/post/PostList.tsx
+++ b/apps/app/src/components/post/PostList.tsx
@@ -216,7 +216,6 @@ function PostListState({
       actionLabel={onRetry ? '다시 시도' : undefined}
       alert={alert}
       description={description}
-      inline
       onAction={onRetry}
       style={styles.state}
       title={title}

--- a/apps/app/src/components/profile/ProfileConnectionList.tsx
+++ b/apps/app/src/components/profile/ProfileConnectionList.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 import { Button } from '@/components/ui/Button';
-import { Skeleton } from '@/components/ui/StateView';
+import { Skeleton, StateView } from '@/components/ui/StateView';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { spacing, typography } from '@/theme/tokens';
 import { ProfileListItem } from './ProfileListItem';
 import type { ProfileConnectionList_followersProfile$key } from './__generated__/ProfileConnectionList_followersProfile.graphql';
 import type { ProfileConnectionList_followingProfile$key } from './__generated__/ProfileConnectionList_followingProfile.graphql';
@@ -104,11 +104,11 @@ export function ProfileConnectionListState({
           <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
             {[0, 1, 2].map((item) => (
               <View key={item} style={[styles.skeletonItem, { borderColor: theme.border }]}>
-                <View
-                  style={[
-                    styles.avatarSkeleton,
-                    { backgroundColor: theme.surface, borderColor: theme.border },
-                  ]}
+                <Skeleton
+                  circular
+                  height={40}
+                  style={[styles.avatarSkeleton, { borderColor: theme.border }]}
+                  width={40}
                 />
                 <View style={styles.skeletonCopy}>
                   <Skeleton height={12} width={160} />
@@ -122,17 +122,15 @@ export function ProfileConnectionListState({
           </Text>
         </>
       ) : (
-        <View accessibilityRole="alert" style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>{text.errorTitle}</Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            잠시 후 다시 시도해주세요.
-          </Text>
-          {onRetry ? (
-            <Button onPress={onRetry} style={styles.stateAction} tone="secondary">
-              다시 시도
-            </Button>
-          ) : null}
-        </View>
+        <StateView
+          actionLabel={onRetry ? '다시 시도' : undefined}
+          alert
+          description="잠시 후 다시 시도해주세요."
+          inline
+          onAction={onRetry}
+          style={styles.state}
+          title={text.errorTitle}
+        />
       )}
     </View>
   );
@@ -208,40 +206,42 @@ function ConnectionList({ hasNext, isLoadingNext, kind, loadNext, profiles }: Co
       {profiles.length ? (
         profiles.map((item) => <ProfileListItem key={item.cursor} linked profile={item.profile} />)
       ) : (
-        <View style={styles.state}>
-          <Text style={[styles.stateTitle, { color: theme.text }]}>{text.emptyTitle}</Text>
-          <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-            {text.emptyDescription}
-          </Text>
-        </View>
+        <StateView
+          description={text.emptyDescription}
+          inline
+          style={styles.state}
+          title={text.emptyTitle}
+        />
       )}
       {hasNext || loadError ? (
-        <View style={[styles.pagination, { borderColor: theme.border }]}>
-          {loadError ? (
-            <>
-              <Text accessibilityRole="alert" style={[styles.stateTitle, { color: theme.text }]}>
-                {text.loadError}
+        loadError ? (
+          <StateView
+            actionLabel="다시 시도"
+            alert
+            description="잠시 후 다시 시도해주세요."
+            inline
+            onAction={loadMore}
+            style={[styles.pagination, { borderColor: theme.border }]}
+            title={text.loadError}
+          />
+        ) : (
+          <View style={[styles.pagination, { borderColor: theme.border }]}>
+            <Button
+              accessibilityState={{ busy: isLoadingNext, disabled: isLoadingNext }}
+              disabled={isLoadingNext}
+              onPress={loadMore}
+              style={styles.paginationAction}
+              tone="secondary"
+            >
+              {isLoadingNext ? '불러오는 중' : '더 불러오기'}
+            </Button>
+            {isLoadingNext ? (
+              <Text accessibilityLiveRegion="polite" style={styles.srOnly}>
+                {text.loadingNextLabel}
               </Text>
-              <Text style={[styles.stateDescription, { color: theme.textSecondary }]}>
-                잠시 후 다시 시도해주세요.
-              </Text>
-            </>
-          ) : null}
-          <Button
-            accessibilityState={{ busy: isLoadingNext, disabled: isLoadingNext }}
-            disabled={isLoadingNext}
-            onPress={loadMore}
-            style={styles.paginationAction}
-            tone="secondary"
-          >
-            {isLoadingNext ? '불러오는 중' : loadError ? '다시 시도' : '더 불러오기'}
-          </Button>
-          {isLoadingNext ? (
-            <Text accessibilityLiveRegion="polite" style={styles.srOnly}>
-              {text.loadingNextLabel}
-            </Text>
-          ) : null}
-        </View>
+            ) : null}
+          </View>
+        )
       ) : null}
     </View>
   );
@@ -275,14 +275,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.xxxl,
   },
-  stateTitle: { fontFamily: 'SUIT', fontWeight: '700', textAlign: 'center', ...typography.md },
-  stateDescription: {
-    fontFamily: 'SUIT',
-    marginTop: spacing.xs,
-    textAlign: 'center',
-    ...typography.sm,
-  },
-  stateAction: { marginTop: spacing.lg },
   pagination: { alignItems: 'center', borderTopWidth: 1, padding: spacing.lg },
   paginationAction: { marginTop: spacing.md },
   skeletonItem: {
@@ -293,7 +285,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
   },
-  avatarSkeleton: { borderRadius: radii.full, borderWidth: 1, height: 40, width: 40 },
+  avatarSkeleton: { borderWidth: 1 },
   skeletonCopy: { flex: 1, gap: spacing.sm, minWidth: 0 },
   srOnly: {
     height: 1,

--- a/apps/app/src/components/profile/ProfileConnectionList.tsx
+++ b/apps/app/src/components/profile/ProfileConnectionList.tsx
@@ -126,7 +126,6 @@ export function ProfileConnectionListState({
           actionLabel={onRetry ? '다시 시도' : undefined}
           alert
           description="잠시 후 다시 시도해주세요."
-          inline
           onAction={onRetry}
           style={styles.state}
           title={text.errorTitle}
@@ -208,7 +207,6 @@ function ConnectionList({ hasNext, isLoadingNext, kind, loadNext, profiles }: Co
       ) : (
         <StateView
           description={text.emptyDescription}
-          inline
           style={styles.state}
           title={text.emptyTitle}
         />
@@ -219,7 +217,6 @@ function ConnectionList({ hasNext, isLoadingNext, kind, loadNext, profiles }: Co
             actionLabel="다시 시도"
             alert
             description="잠시 후 다시 시도해주세요."
-            inline
             onAction={loadMore}
             style={[styles.pagination, { borderColor: theme.border }]}
             title={text.loadError}

--- a/apps/app/src/components/profile/ProfileHero.test.ts
+++ b/apps/app/src/components/profile/ProfileHero.test.ts
@@ -57,7 +57,9 @@ mockModule('react-relay', {
 });
 mockModule(new URL('../../theme/ThemeProvider.tsx', import.meta.url), {
   useTheme: () => ({
-    background: '#ffffff',
+    background: '#legacy-background',
+    backgroundCanvas: '#semantic-canvas',
+    backgroundSurface: '#semantic-surface',
     border: '#dddddd',
     primary: '#ffee99',
     surface: '#eeeeee',
@@ -132,6 +134,26 @@ describe('ProfileHero cover geometry', () => {
     assert.ok(renderer);
 
     assert.deepEqual(findCoverStyle(), { aspectRatio: 3, width: '100%' });
+  });
+
+  it('loading branch uses the semantic surface and canvas roles', async () => {
+    await act(async () => {
+      renderer = create(createElement(ProfileHero, { loading: true }));
+    });
+    assert.ok(renderer);
+
+    const cover = renderer.root.find(
+      (node) =>
+        (node.type as unknown) === 'View' &&
+        Array.isArray(node.props.style) &&
+        node.props.style[0]?.width === '100%',
+    );
+    const avatar = renderer.root.find(
+      (node) => (node.type as unknown) === 'Skeleton' && node.props.circular === true,
+    );
+
+    assert.equal(cover.props.style[1].backgroundColor, '#semantic-surface');
+    assert.equal(avatar.props.style[1].borderColor, '#semantic-canvas');
   });
 });
 

--- a/apps/app/src/components/profile/ProfileHero.tsx
+++ b/apps/app/src/components/profile/ProfileHero.tsx
@@ -54,11 +54,11 @@ export function ProfileHero({ action, loading = false, profile = null }: Profile
         <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
           <View style={[styles.cover, { backgroundColor: theme.surface }]} />
           <View style={styles.body}>
-            <View
-              style={[
-                styles.avatarSkeleton,
-                { backgroundColor: theme.surface, borderColor: theme.background },
-              ]}
+            <Skeleton
+              circular
+              height={80}
+              style={[styles.avatarSkeleton, { borderColor: theme.background }]}
+              width={80}
             />
             <View style={styles.skeletonCopy}>
               <Skeleton height={20} width="50%" />
@@ -166,11 +166,8 @@ const styles = StyleSheet.create({
   avatarRow: { alignItems: 'flex-start', flexDirection: 'row', justifyContent: 'space-between' },
   avatarBorder: { borderRadius: radii.full, marginTop: -40, padding: spacing.xs },
   avatarSkeleton: {
-    borderRadius: radii.full,
     borderWidth: spacing.xs,
-    height: 80,
     marginTop: -40,
-    width: 80,
   },
   action: { marginTop: spacing.md },
   displayName: { fontFamily: 'SUIT', fontWeight: '700', marginTop: spacing.md, ...typography.xl },

--- a/apps/app/src/components/profile/ProfileHero.tsx
+++ b/apps/app/src/components/profile/ProfileHero.tsx
@@ -52,12 +52,12 @@ export function ProfileHero({ action, loading = false, profile = null }: Profile
     return (
       <View>
         <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
-          <View style={[styles.cover, { backgroundColor: theme.surface }]} />
+          <View style={[styles.cover, { backgroundColor: theme.backgroundSurface }]} />
           <View style={styles.body}>
             <Skeleton
               circular
               height={80}
-              style={[styles.avatarSkeleton, { borderColor: theme.background }]}
+              style={[styles.avatarSkeleton, { borderColor: theme.backgroundCanvas }]}
               width={80}
             />
             <View style={styles.skeletonCopy}>

--- a/apps/app/src/components/ui/StateView.test.ts
+++ b/apps/app/src/components/ui/StateView.test.ts
@@ -44,7 +44,7 @@ before(async () => {
   stateViewModule = await import('./StateView');
 });
 
-test('alert StateView consumes the danger subtle foreground pair', async () => {
+test('alert StateView uses the danger subtle pair and secondary recovery action', async () => {
   assert.ok(stateViewModule);
   const { StateView } = stateViewModule;
   let renderer: ReactTestRenderer | undefined;
@@ -65,27 +65,7 @@ test('alert StateView consumes the danger subtle foreground pair', async () => {
   assert.equal(root?.props.style[1].backgroundColor, 'danger-subtle');
   assert.equal(text[0]?.props.style[1].color, 'danger-on-subtle');
   assert.equal(text[1]?.props.style[1].color, 'danger-on-subtle');
-  assert.equal(renderer?.root.findByType(ButtonHost).props.tone, undefined);
-  await act(async () => renderer?.unmount());
-});
-
-test('inline StateView applies compact padding before consumer geometry', async () => {
-  assert.ok(stateViewModule);
-  const { StateView } = stateViewModule;
-  let renderer: ReactTestRenderer | undefined;
-  await act(async () => {
-    renderer = create(
-      createElement(StateView, {
-        inline: true,
-        style: { paddingVertical: 48 },
-        title: '비어 있어요',
-      }),
-    );
-  });
-
-  const style = renderer?.root.findByType(ViewHost).props.style;
-  assert.equal(style[1].padding, 16);
-  assert.equal(style[2].paddingVertical, 48);
+  assert.equal(renderer?.root.findByType(ButtonHost).props.tone, 'secondary');
   await act(async () => renderer?.unmount());
 });
 

--- a/apps/app/src/components/ui/StateView.test.ts
+++ b/apps/app/src/components/ui/StateView.test.ts
@@ -28,11 +28,12 @@ mockModule('@/theme/ThemeProvider', {
     feedbackDangerSubtle: 'danger-subtle',
     foregroundPrimary: 'foreground',
     foregroundSecondary: 'secondary',
+    stateDisabledSurface: 'disabled-surface',
   }),
 });
 mockModule('@/theme/tokens', {
-  radius: { 8: 8, 12: 12 },
-  space: { 8: 8, 32: 32 },
+  radius: { 8: 8, 12: 12, full: 999 },
+  space: { 8: 8, 16: 16, 32: 32 },
   textStyles: { uiCopyM: {}, uiLabelL: {} },
 });
 mockModule('./Button', { Button: ButtonHost });
@@ -65,5 +66,52 @@ test('alert StateView consumes the danger subtle foreground pair', async () => {
   assert.equal(text[0]?.props.style[1].color, 'danger-on-subtle');
   assert.equal(text[1]?.props.style[1].color, 'danger-on-subtle');
   assert.equal(renderer?.root.findByType(ButtonHost).props.tone, undefined);
+  await act(async () => renderer?.unmount());
+});
+
+test('inline StateView applies compact padding before consumer geometry', async () => {
+  assert.ok(stateViewModule);
+  const { StateView } = stateViewModule;
+  let renderer: ReactTestRenderer | undefined;
+  await act(async () => {
+    renderer = create(
+      createElement(StateView, {
+        inline: true,
+        style: { paddingVertical: 48 },
+        title: '비어 있어요',
+      }),
+    );
+  });
+
+  const style = renderer?.root.findByType(ViewHost).props.style;
+  assert.equal(style[1].padding, 16);
+  assert.equal(style[2].paddingVertical, 48);
+  await act(async () => renderer?.unmount());
+});
+
+test('circular Skeleton keeps consumer border and margin before primitive semantics', async () => {
+  assert.ok(stateViewModule);
+  const { Skeleton } = stateViewModule;
+  let renderer: ReactTestRenderer | undefined;
+  await act(async () => {
+    renderer = create(
+      createElement(Skeleton, {
+        circular: true,
+        height: 40,
+        style: { borderWidth: 1, marginTop: -20 },
+        width: 40,
+      }),
+    );
+  });
+
+  const style = renderer?.root.findByType(ViewHost).props.style;
+  assert.equal(style[0].borderWidth, 1);
+  assert.equal(style[0].marginTop, -20);
+  assert.deepEqual(style[1], {
+    backgroundColor: 'disabled-surface',
+    borderRadius: 999,
+    height: 40,
+    width: 40,
+  });
   await act(async () => renderer?.unmount());
 });

--- a/apps/app/src/components/ui/StateView.tsx
+++ b/apps/app/src/components/ui/StateView.tsx
@@ -6,6 +6,7 @@ import type { StyleProp, ViewStyle } from 'react-native';
 
 type StateViewProps = {
   actionLabel?: string;
+  actionStyle?: StyleProp<ViewStyle>;
   alert?: boolean;
   description?: string;
   inline?: boolean;
@@ -17,6 +18,7 @@ type StateViewProps = {
 
 export function StateView({
   actionLabel,
+  actionStyle,
   alert = false,
   description,
   inline = false,
@@ -71,7 +73,11 @@ export function StateView({
           {description}
         </Text>
       ) : null}
-      {actionLabel && onAction ? <Button onPress={onAction}>{actionLabel}</Button> : null}
+      {actionLabel && onAction ? (
+        <Button onPress={onAction} style={actionStyle}>
+          {actionLabel}
+        </Button>
+      ) : null}
     </View>
   );
 }

--- a/apps/app/src/components/ui/StateView.tsx
+++ b/apps/app/src/components/ui/StateView.tsx
@@ -9,7 +9,6 @@ type StateViewProps = {
   actionStyle?: StyleProp<ViewStyle>;
   alert?: boolean;
   description?: string;
-  inline?: boolean;
   loading?: boolean;
   onAction?: () => void;
   style?: StyleProp<ViewStyle>;
@@ -21,7 +20,6 @@ export function StateView({
   actionStyle,
   alert = false,
   description,
-  inline = false,
   loading = false,
   onAction,
   style,
@@ -35,7 +33,6 @@ export function StateView({
       accessibilityRole={alert ? 'alert' : undefined}
       style={[
         styles.root,
-        ...(inline ? [styles.inline] : []),
         ...(style ? [style] : []),
         ...(alert
           ? [{ backgroundColor: theme.feedbackDangerSubtle, borderRadius: radius[12] }]
@@ -74,7 +71,7 @@ export function StateView({
         </Text>
       ) : null}
       {actionLabel && onAction ? (
-        <Button onPress={onAction} style={actionStyle}>
+        <Button onPress={onAction} style={actionStyle} tone="secondary">
           {actionLabel}
         </Button>
       ) : null}
@@ -112,7 +109,6 @@ export function Skeleton({
 
 const styles = StyleSheet.create({
   root: { alignItems: 'center', gap: space[8], padding: space[32] },
-  inline: { padding: space[16] },
   title: { textAlign: 'center', ...textStyles.uiLabelL },
   description: { textAlign: 'center', ...textStyles.uiCopyM },
   loaderFallback: textStyles.uiLabelL,

--- a/apps/app/src/components/ui/StateView.tsx
+++ b/apps/app/src/components/ui/StateView.tsx
@@ -2,13 +2,16 @@ import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { useReducedMotion, useTheme } from '@/theme/ThemeProvider';
 import { radius, space, textStyles } from '@/theme/tokens';
 import { Button } from './Button';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 type StateViewProps = {
   actionLabel?: string;
   alert?: boolean;
   description?: string;
+  inline?: boolean;
   loading?: boolean;
   onAction?: () => void;
+  style?: StyleProp<ViewStyle>;
   title: string;
 };
 
@@ -16,8 +19,10 @@ export function StateView({
   actionLabel,
   alert = false,
   description,
+  inline = false,
   loading = false,
   onAction,
+  style,
   title,
 }: StateViewProps) {
   const theme = useTheme();
@@ -28,9 +33,11 @@ export function StateView({
       accessibilityRole={alert ? 'alert' : undefined}
       style={[
         styles.root,
-        alert
-          ? { backgroundColor: theme.feedbackDangerSubtle, borderRadius: radius[12] }
-          : undefined,
+        ...(inline ? [styles.inline] : []),
+        ...(style ? [style] : []),
+        ...(alert
+          ? [{ backgroundColor: theme.feedbackDangerSubtle, borderRadius: radius[12] }]
+          : []),
       ]}
     >
       {loading ? (
@@ -70,28 +77,36 @@ export function StateView({
 }
 
 export function Skeleton({
+  circular = false,
   height = 20,
+  style,
   width = '100%',
 }: {
+  circular?: boolean;
   height?: number;
+  style?: StyleProp<ViewStyle>;
   width?: number | `${number}%`;
 }) {
   const theme = useTheme();
   return (
     <View
       accessibilityElementsHidden
-      style={{
-        backgroundColor: theme.stateDisabledSurface,
-        borderRadius: radius[8],
-        height,
-        width,
-      }}
+      style={[
+        style,
+        {
+          backgroundColor: theme.stateDisabledSurface,
+          borderRadius: circular ? radius.full : radius[8],
+          height,
+          width,
+        },
+      ]}
     />
   );
 }
 
 const styles = StyleSheet.create({
   root: { alignItems: 'center', gap: space[8], padding: space[32] },
+  inline: { padding: space[16] },
   title: { textAlign: 'center', ...textStyles.uiLabelL },
   description: { textAlign: 'center', ...textStyles.uiCopyM },
   loaderFallback: textStyles.uiLabelL,

--- a/apps/app/src/stories/Bookmarks.stories.tsx
+++ b/apps/app/src/stories/Bookmarks.stories.tsx
@@ -410,6 +410,7 @@ export const StatesAndCanonicalLinks: Story = {
     expect(canvas.getByText('북마크 목록을 불러오는 중입니다.')).toBeVisible();
     expect(canvas.getByText('아직 북마크가 없어요')).toBeVisible();
     expect(canvas.getByText('북마크 목록을 불러오지 못했어요')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '다시 시도' })).toHaveStyle({ minHeight: '44px' });
     const headings = canvas.getAllByRole('heading', { name: '북마크' });
     expect(headings).toHaveLength(4);
     for (const heading of headings) {

--- a/apps/app/src/stories/Primitives.stories.tsx
+++ b/apps/app/src/stories/Primitives.stories.tsx
@@ -47,6 +47,7 @@ function PrimitivesCatalog() {
 
       <Section title="Loading placeholders">
         <View style={{ gap: space[8] }}>
+          <Skeleton circular height={48} width={48} />
           <Skeleton height={80} />
           <Skeleton width="70%" />
           <Skeleton width="45%" />
@@ -55,6 +56,7 @@ function PrimitivesCatalog() {
 
       <Section title="Loading, empty, error">
         <StateView loading title="불러오는 중입니다." />
+        <StateView inline title="인라인 상태입니다." />
         <StateView description="첫 항목이 생기면 여기에 표시돼요." title="아직 항목이 없어요" />
         <StateView
           actionLabel="다시 시도"

--- a/apps/app/src/stories/Primitives.stories.tsx
+++ b/apps/app/src/stories/Primitives.stories.tsx
@@ -56,7 +56,6 @@ function PrimitivesCatalog() {
 
       <Section title="Loading, empty, error">
         <StateView loading title="불러오는 중입니다." />
-        <StateView inline title="인라인 상태입니다." />
         <StateView description="첫 항목이 생기면 여기에 표시돼요." title="아직 항목이 없어요" />
         <StateView
           actionLabel="다시 시도"

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -148,6 +148,7 @@ Figma의 [`08 Component Usage Mapping`](https://www.figma.com/design/Erj975S6vVP
 - Modal, Sheet와 Menu는 `background/elevated`, `border/default`, `overlay/scrim`을 사용한다. Fullscreen media는 이 표준 scrim에서 제외한다.
 - Toast와 inline feedback은 Info/Success/Warning/Danger pair 중 실제 의미를 선택한다.
 - StateView root는 fill을 갖지 않고 host 평면을 상속한다. Route loading·empty·retry는 canvas 위에 두고, alert만 feedback subtle block을 사용할 수 있다. 이미 경계가 있는 component 내부 StateView는 그 component의 surface를 상속하되 스스로 surface를 선택하지 않는다.
+- StateView의 action은 retry·복귀 같은 상태 복구 행동이므로 Button의 secondary tone을 사용한다. 저장·생성 같은 화면의 primary action은 StateView 밖에서 해당 consumer가 소유한다.
 - Loading은 별도 의미색을 만들지 않고 현재 surface의 foreground 또는 action의 `on-base`를 사용한다. 진행 상태는 색상 외 접근성 정보로 함께 제공한다.
 
 ## Legacy와 개발 token 이관


### PR DESCRIPTION
## 무엇을 변경했는지

- StateView에 consumer-owned `style` 경계를 유지하고 실효 없는 `inline` mode를 제거했습니다.
- StateView의 상태 복구 action을 `secondary` tone으로 통일했습니다.
- Skeleton에 원형 placeholder 표현을 추가했습니다.
- FollowRequestList, PostList, BookmarkList, NotificationList,
  ProfileConnectionList, ProfileHero의 loading/empty/error/retry 표현을
  공용 primitive로 이관했습니다.

## 주요 결정

- StateView action은 retry·복귀용 `secondary`이며 primary action은 consumer가 StateView 밖에서 소유합니다.
- 공용 primitive는 상태 의미와 색상·radius를 소유합니다.
- consumer는 row 크기, pagination, border, 간격과 배치를 계속 소유합니다.
- 별도 SkeletonRow 추상화는 만들지 않았습니다.
- 기존 문구, callback, live announcement와 현재 콘텐츠 보존 동작을 유지했습니다.

## 검증

- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:unit` — 331/331
- `pnpm --filter @kosmo/app build-storybook`
- `pnpm --filter @kosmo/app test:storybook` — 360/360
- Web Storybook의 Primitives, FollowRequests, Posts, Bookmarks,
  Notifications, ProfileHero, ProfileConnection 상태 수동 확인
- ProfileHero의 80px 원형 placeholder와 40px 커버 겹침 확인

## 남은 검증

- Native runtime, VoiceOver, TalkBack은 확인하지 않았습니다.

## 의존성

- 선행 작업 DSN-19 PR #574가 main에 병합된 뒤 해당 main 위로 재배치했습니다.