### PR TITLE
Profile connections E2E가 DB reset 전에 Home query를 완료하게 한다

### DIFF
--- a/apps/web/e2e/profile-connections.e2e.ts
+++ b/apps/web/e2e/profile-connections.e2e.ts
@@ -47,6 +47,16 @@ const mutateFollow = async (
     { id: profileId },
   );
 
+const gotoHome = async (page: Page) => {
+  const homeResponse = waitForGraphQLOperation(page, 'HomePageQuery');
+  await page.goto('/home');
+
+  const response = await homeResponse;
+  const body = (await response.json()) as { errors?: unknown[] };
+  expect(response.ok(), JSON.stringify(body, null, 2)).toBe(true);
+  expect(body.errors, JSON.stringify(body, null, 2)).toBeUndefined();
+};
+
 test('UNRESPONSIVE remote profile은 Web에서 follow와 unfollow할 수 있다', async ({
   context,
   page,
@@ -214,7 +224,7 @@ test('post-commit delivery 실패에도 Web GraphQL payload와 DB 상태가 일�
     handle: 'e2e-delivery-approval',
   });
   await setE2ESessionCookie(context, viewer.token);
-  await page.goto('/home');
+  await gotoHome(page);
 
   const follow = await mutateFollow(page, 'followProfile', toGlobalId('Profile', openRemote.id));
   expect(follow.errors).toBeUndefined();
@@ -285,7 +295,7 @@ test('동시 follow와 unfollow는 저장 count를 한 번만 갱신한다', asy
   const viewerId = toGlobalId('Profile', viewer.profile!.id);
 
   await setE2ESessionCookie(context, viewer.token);
-  await page.goto('/home');
+  await gotoHome(page);
 
   const followResponses = await Promise.all([
     mutateFollow(page, 'followProfile', targetId),
@@ -355,7 +365,7 @@ test('unfollow 저장 count는 0 미만으로 감소하지 않는다', async ({ 
   });
 
   await setE2ESessionCookie(context, viewer.token);
-  await page.goto('/home');
+  await gotoHome(page);
   const response = await mutateFollow(page, 'unfollowProfile', toGlobalId('Profile', target.id));
   expect(response.errors).toBeUndefined();
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `profile-connections.e2e.ts`의 `/home` 진입이 `HomePageQuery` 응답까지 끝난 뒤 follow/unfollow mutation과 DB 검증을 시작하도록 `gotoHome` fixture helper를 추가했습니다.
- 응답의 HTTP 성공과 GraphQL error 부재도 확인해, 테스트가 시작한 서버 작업이 다음 테스트의 `TRUNCATE ... CASCADE`와 겹치지 않게 했습니다.
- 제품 follow/unfollow transaction, retry, lock, GraphQL resolver와 DB handle은 변경하지 않았습니다.

## 왜 변경했는지

- [PROD-757](https://linear.app/byulmaru/issue/PROD-757/profile-connections-web-e2e의-동시-followunfollow-deadlock-flake를-제거한다)
- [최초 실패 attempt 1](https://github.com/byulmaru/kosmo/actions/runs/31471711723/attempts/1)은 `profile-connections.e2e.ts:281`에서 PostgreSQL `deadlock detected`, 101 passed / 1 failed를 기록했지만 PostgreSQL DETAIL, 충돌 query와 PID는 보존하지 않았습니다. 같은 head의 attempt 2와 이후 fresh head들은 통과했습니다.
- 같은 pair의 concurrent follow/unfollow는 모두 follower Profile → followee Profile 순서로 count row를 갱신하며 loser가 count를 다시 갱신하지 않아, 현재 경로 자체의 lock cycle 근거는 확인하지 못했습니다.
- 반면 바로 앞 테스트를 포함한 세 `/home` 진입은 `HomePageQuery`를 기다리지 않았습니다. E2E reset은 현재 `profile`을 `profile_follow`보다 먼저 AccessExclusive로 잠그며, DML lock mode를 사용한 무변경 로컬 재현에서 application의 `profile_follow` → `profile` 순서와 교차해 PostgreSQL 40P01 cycle이 성립함을 확인했습니다. 따라서 제품 retry나 lock을 추가하지 않고 구체적인 미완료 route query를 await합니다.

## 이번 PR의 주요 결정

없음. 최신 Linear의 fixture completion 범위를 적용했으며 관찰 가능한 제품 행동, public contract와 durable decision을 변경하지 않았습니다. 새 OpenSpec은 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- 수정 전 재현 시도
  - 문제 테스트 50회: 50 passed, deadlock 재현 안 됨
  - `profile-connections.e2e.ts --repeat-each=10`: 90 passed, deadlock 재현 안 됨
- lock mechanism 확인
  - application 모델: `profile_follow ROW EXCLUSIVE` → `profile ROW EXCLUSIVE`
  - reset 모델: `profile ACCESS EXCLUSIVE` → `profile_follow ACCESS EXCLUSIVE`
  - 데이터 변경 없는 `LOCK TABLE` 재현에서 relation OID와 PostgreSQL DETAIL로 40P01 cycle 확인
- 수정 후
  - `pnpm test:e2e profile-connections.e2e.ts --grep '동시 follow와 unfollow' --repeat-each=50 --reporter=dot` — 50 passed
  - `pnpm test:e2e profile-connections.e2e.ts --reporter=line` — 9 passed
  - `pnpm --filter @kosmo/web test` — TypeScript 통과, unit 35 passed, Web E2E 102 passed
  - Prettier, `git diff --check` 통과

## 아직 어떤 문제가 남았는지

- 최초 CI 실패에는 PostgreSQL DETAIL/query가 없어 실제 deadlock participant를 확정하지 못했습니다. 로컬 lock 재현은 reset 경합이 가능한 기제를 증명하지만, 최초 CI의 정확한 query를 복원한 것은 아닙니다.
- 수정 후 파일 전체 `--repeat-each=10` 시도는 첫 9개 테스트가 통과한 뒤 worker-scoped `pg.end()` teardown이 30초를 초과해 중단했습니다. deadlock은 아니었고 정상 단일 worker 수명 및 전체 Web E2E는 통과했습니다.
- PROD-755/#580은 별도 Profile route query completion을 수정한 선행 사례이며, 이번 `/home` 경로와 같은 실패였다고 간주하지 않았습니다.
- PROD-710/#581의 폐기된 explicit Fedify DB handle 구조는 되살리지 않았습니다. GraphQL operation만 `ctx.db`를 사용하고 그 외 runtime/core service는 workload 기본 DB를 사용하는 현재 계약을 유지합니다.
- production sync/apply/cutover는 수행하지 않았습니다.
