### PR TITLE
프로필 헤더 투명 영역의 배경색을 통일한다

### DIFF
--- a/apps/app/src/components/profile/ProfileEditImageFields.tsx
+++ b/apps/app/src/components/profile/ProfileEditImageFields.tsx
@@ -208,7 +208,7 @@ export function ProfileEditImageFields({
         draft={header}
         onEdit={onHeaderEdit}
         onRemove={onHeaderRemove}
-        style={[styles.headerPreview, { backgroundColor: theme.surface }]}
+        style={[styles.headerPreview, { backgroundColor: theme.primary }]}
         testID="profile-edit-header-preview"
       />
 

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -597,7 +597,7 @@ export function ProfileSwitcher({
       <View
         style={[
           styles.cover,
-          { backgroundColor: theme.surface },
+          { backgroundColor: theme.primary },
           Platform.OS === 'web' && !active?.header?.url && webCover,
         ]}
       >

--- a/apps/app/src/stories/ProfileEdit.stories.tsx
+++ b/apps/app/src/stories/ProfileEdit.stories.tsx
@@ -5,6 +5,7 @@ import { ProfileEditDiscardDialog } from '@/components/profile/ProfileEditDiscar
 import { ProfileEditImageFields } from '@/components/profile/ProfileEditImageFields';
 import { ProfileEditScreen } from '@/components/profile/ProfileEditScreen';
 import { ProfileTagEditor } from '@/components/profile/ProfileTagEditor';
+import { colors } from '@/theme/tokens';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type {
   ProfileEditDraft,
@@ -225,6 +226,7 @@ export const ImageFields: Story = {
     const avatarButton = canvas.getByRole('button', { name: '아바타 이미지 편집' });
 
     expect(headerButton).toBe(canvas.getByTestId('profile-edit-header-preview'));
+    expect(headerButton).toHaveStyle({ backgroundColor: colors.light.primary });
     expect(avatarButton).toBe(canvas.getByTestId('profile-edit-avatar-preview'));
     expect(canvas.queryByText(/현재.*유지/)).not.toBeInTheDocument();
     expect(canvas.queryByRole('button', { name: '교체' })).not.toBeInTheDocument();

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -19,7 +19,7 @@ import { SidebarNavigation } from '@/components/shell/SidebarNavigation';
 import { UniversalShell } from '@/components/shell/UniversalShell';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { SessionProvider } from '@/session/SessionProvider';
-import { spacing } from '@/theme/tokens';
+import { colors, spacing } from '@/theme/tokens';
 import { profile, shellQuery } from './fixtures';
 import { Catalog, Section } from './StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -1035,6 +1035,7 @@ export const ProfileSwitcherImagePresentation: Story = {
     const activeSurface = canvas.getByLabelText('활성 프로필');
     const cover = activeSurface.firstElementChild as HTMLElement;
     expect(cover.contains(headerImage)).toBe(true);
+    expect(cover).toHaveStyle({ backgroundColor: colors.light.primary });
     expect(getComputedStyle(cover).filter).toBe('none');
 
     await userEvent.click(canvas.getByRole('button', { name: '프로필 목록' }));


### PR DESCRIPTION
## 무엇을 변경했나요

- 사이드메뉴의 활성 프로필 헤더 배경을 Primary 색상으로 변경했습니다.
- 프로필 편집 헤더 미리보기 배경도 같은 Primary 색상으로 변경했습니다.
- 두 화면의 실제 header surface가 Primary 배경을 사용하는지 Storybook 회귀 검증을 추가했습니다.
- 공용 토큰, 이미지 업로드, Relay, crop과 레이아웃은 변경하지 않았습니다.

## 왜 변경했나요

투명 영역이 있는 헤더 이미지는 소비 화면의 배경색을 그대로 보여 줍니다. 기존에는 프로필 화면은 노란색, 사이드메뉴와 편집 미리보기는 회색을 사용해 같은 이미지가 화면마다 다르게 보였습니다.

PROD-635에서 세 화면의 배경색을 동일하게 맞춰 투명 영역이 일관되게 표시되도록 합니다.

## 이번 PR의 주요 결정

### 프로필 화면의 기존 Primary 배경을 기준으로 정렬

- 결정자: @yeeun-uwu
- 선택: 사이드메뉴와 편집 미리보기의 header consumer만 `theme.primary`로 변경
- 고려한 대안: 프로필 화면을 `surface`로 변경하거나 공용 header token·primitive를 추가
- 이유: 기존 프로필 화면 계약을 유지하면서 불일치한 소비자 두 곳만 수정하는 가장 작은 변경이기 때문
- 감수한 결과: 사이드메뉴의 header 없음 gradient/filter fallback은 기존 표현을 유지
- 관련 근거: [PROD-635](https://linear.app/byulmaru/issue/PROD-635/투명한-프로필-헤더-이미지의-화면별-배경색-불일치), `docs/design/colors.md`, `docs/design/profile-hero.md`, `docs/design/profile-edit.md`

## 어떻게 확인할 수 있나요

- TDD RED: 새 Primary assertion 2개 실패, 기존 86개 통과
- 타깃 Storybook: 88/88 통과
- `pnpm --filter @kosmo/app check` 통과
- `pnpm --filter @kosmo/app test` 전체 통과
  - Storybook 24 files, 360/360 통과
- Web Storybook 수동 확인
  - 편집 헤더와 사이드메뉴 cover: `rgb(252, 231, 154)`
  - 기존 사이드메뉴 header 없음 gradient와 `blur(1px)` 유지

## 아직 어떤 문제가 남았나요

- Android/iOS 실제 런타임 시각 검증은 수행하지 않았습니다.
- 기존 Relay fixture, React `act`, deprecation warning은 이번 범위에서 변경하지 않았습니다.