### PR TITLE
Barman backup sidecar의 메모리 burst를 허용한다

### DIFF
--- a/apps/helm/templates/postgres-backup.yaml
+++ b/apps/helm/templates/postgres-backup.yaml
@@ -78,7 +78,7 @@ spec:
         memory: 96Mi
       limits:
         cpu: 50m
-        memory: 96Mi
+        memory: 384Mi
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup


### PR DESCRIPTION
## 배경

프로덕션 scheduled base backup이 `plugin-barman-cloud` sidecar의 `96Mi` memory limit 초과로 OOMKilled되어 실패했습니다. WAL archive는 복구됐지만 새 base backup 기준점 생성은 막혀 있습니다.

## 변경사항

- Barman instance sidecar memory request는 `96Mi`로 유지합니다.
- memory limit을 `384Mi`로 올려 base backup의 일시적인 peak를 허용합니다.
- request와 limit이 달라지므로 CNPG Pod QoS는 의도적으로 `Burstable`이 됩니다.

## 검증

- `helm lint apps/helm --set env=dev`
- `helm lint apps/helm --set env=prod --set imageDigest=sha256:<64hex> --set workloads.enabled=false`
- prod `helm template`에서 `requests.memory: 96Mi`, `limits.memory: 384Mi` 렌더 확인
- 독립 self-review: 차단 이슈 없음

## 운영 경계

이 PR은 선언 변경까지만 포함합니다. 프로덕션 sync/apply, 수동 base backup 실행, peak working set/RSS 측정은 별도 승인 후 수행합니다.

Linear: [PROD-761](https://linear.app/byulmaru/issue/PROD-761/barman-backup-sidecar-oom을-방지한다)