### PR TITLE
기반 리소스 적용 뒤에 DB migration을 실행한다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   restart_dev:
-    name: Restart Dev Rollouts
+    name: Restart Dev Workloads
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: [self-hosted, macOS]
     env:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -88,7 +88,7 @@ jobs:
 
           argocd --server "${ARGOCD_SERVER}" --grpc-web app sync kosmo-dev --timeout 600
 
-      - name: Restart dev rollouts
+      - name: Restart dev workloads
         env:
           ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
         shell: bash
@@ -102,3 +102,9 @@ jobs:
               --namespace kosmo-dev \
               --resource-name "${rollout}"
           done
+
+          argocd --server "${ARGOCD_SERVER}" --grpc-web app actions run kosmo-dev restart \
+            --group apps \
+            --kind Deployment \
+            --namespace kosmo-dev \
+            --all

--- a/apps/helm/templates/api/hpa.yaml
+++ b/apps/helm/templates/api/hpa.yaml
@@ -3,6 +3,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: api

--- a/apps/helm/templates/api/rollout.yaml
+++ b/apps/helm/templates/api/rollout.yaml
@@ -4,6 +4,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   name: {{ printf "%s-api" .Release.Name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: api

--- a/apps/helm/templates/database-migration-job.yaml
+++ b/apps/helm/templates/database-migration-job.yaml
@@ -17,9 +17,9 @@ metadata:
     app.kubernetes.io/version: {{ .Values.version | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   activeDeadlineSeconds: 600
   backoffLimit: 0

--- a/apps/helm/templates/fedify-consumer.yaml
+++ b/apps/helm/templates/fedify-consumer.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ printf "%s-fedify-consumer" .Release.Name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: fedify-consumer

--- a/apps/helm/templates/web/hpa.yaml
+++ b/apps/helm/templates/web/hpa.yaml
@@ -3,6 +3,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: web

--- a/apps/helm/templates/web/rollout.yaml
+++ b/apps/helm/templates/web/rollout.yaml
@@ -4,6 +4,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
   name: {{ printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: web

--- a/apps/helm/templates/worker.yaml
+++ b/apps/helm/templates/worker.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ printf "%s-worker" .Release.Name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   labels:
     helm.sh/chart: {{ include "kosmo.chart" . }}
     app.kubernetes.io/name: worker

--- a/docs/operations/production-migrations.md
+++ b/docs/operations/production-migrations.md
@@ -2,15 +2,15 @@
 
 ## 책임
 
-Production migration은 API/Web과 같은 immutable release image를 사용하지만 database 권한은 분리한다.
+Production migration은 모든 활성화 workload와 같은 immutable release image를 사용하지만 database 권한은 분리한다.
 
 - PROD-562 구현은 production migration 전용 database identity와 Kubernetes Secret을 준비한다.
 - PROD-564의 Helm Job은 그 Secret의 `username`과 `password`만 읽고 기존 `migrate` command를 실행한다.
-- API/Web의 runtime Secret을 migration에 복제하거나 migration 장애 시 fallback으로 사용하지 않는다.
-- PROD-563 구현은 production 대상 PR의 merge를 production 배포 승인으로 삼고, merge로 발생한 production push의 migration/API/Web 전체를 별도 승인 없이 배포한다. 같은 build digest의 migration Job 성공 뒤에만 API/Web을 활성화한다.
+- Runtime workload의 Secret을 migration에 복제하거나 migration 장애 시 fallback으로 사용하지 않는다.
+- PROD-563 구현은 production 대상 PR의 merge를 production 배포 승인으로 삼고, merge로 발생한 production push의 migration과 모든 활성화 workload를 별도 승인 없이 배포한다. 같은 build digest의 migration Job 성공 뒤에만 wave 2 workload를 활성화한다.
 - PROD-545는 runtime 준비, restore rehearsal, 첫 production release와 public smoke의 최종 통합을 검증한다.
 
-Migration database identity에는 schema migration에 필요한 권한만 부여한다. API/Web database identity에는 DDL 권한을 부여하지 않는다.
+Migration database identity에는 schema migration에 필요한 권한만 부여한다. Runtime workload database identity에는 DDL 권한을 부여하지 않는다.
 
 ## Helm interface
 
@@ -21,11 +21,11 @@ Production migration Job은 다음 값만 사용한다.
 - `workloads.enabled=true`
 - `migration.enabled=true`
 
-Job, API와 Web은 모두 `image@sha256:...` 형태의 같은 image reference를 렌더한다. Production migration에서 mutable tag나 유효하지 않은 digest를 사용하면 Helm render가 실패한다.
+Job과 모든 활성화 workload는 `image@sha256:...` 형태의 같은 image reference를 렌더한다. Production migration에서 mutable tag나 유효하지 않은 digest를 사용하면 Helm render가 실패한다.
 
-Migration Job은 기반 리소스가 적용되는 기본 Sync wave 뒤의 wave 1에서 실행하고, API/Web과 background workload는 Job 성공 뒤 wave 2에서 교체한다. Migration을 `PreSync`로 실행하거나 workload와 같은 wave에 배치하지 않는다.
+Migration Job은 기반 리소스가 적용되는 기본 Sync wave 뒤의 wave 1에서 실행하고, API·Web Rollout·HPA와 background Deployment는 Job 성공 뒤 wave 2에서 교체한다. Migration을 `PreSync`로 실행하거나 workload와 같은 wave에 배치하지 않는다.
 
-첫 release 전 runtime bootstrap은 `workloads.enabled=false`로 API/Web Service·Rollout·HTTPRoute를 렌더하지 않고 PostgreSQL, backup과 Secret 기반만 준비한다. 보호된 `production` push의 자동 배포가 `prod` Environment의 credential·OIDC 범위와 감사 기록을 사용해 digest와 함께 workload와 migration을 활성화한다. `prod` Environment는 사람의 추가 승인 gate가 아니다.
+첫 release 전 runtime bootstrap은 `workloads.enabled=false`로 API·Web Service·Rollout·HTTPRoute와 background Deployment를 렌더하지 않고 PostgreSQL, backup과 Secret 기반만 준비한다. 보호된 `production` push의 자동 배포가 `prod` Environment의 credential·OIDC 범위와 감사 기록을 사용해 digest와 함께 workload와 migration을 활성화한다. `prod` Environment는 사람의 추가 승인 gate가 아니다.
 
 Migration 대상은 Helm release의 PostgreSQL read-write Service, `5432` port와 `kosmo` database로 고정한다. Job은 `<release>-postgres-migration` Secret의 `username`과 `password`만 읽으며 database URL, host, database 또는 Secret 이름/key를 release 입력으로 받지 않는다. Secret이 없거나 key가 누락되면 Kubernetes가 container를 시작할 수 없고 runtime credential로 재시도하지 않는다.
 
@@ -56,7 +56,7 @@ history가 함께 commit되고, 실패하면 그 파일의 변경만 함께 roll
 2. Merge로 발생한 보호된 `production` push가 production image를 build하고 digest와 immutable source SHA를 확정한다.
 3. 같은 workflow가 `prod` Environment의 credential·OIDC 범위와 감사 기록을 사용해 별도 사람 승인 없이 배포를 진행한다.
 4. 같은 digest와 migration Secret으로 migration Job을 실행하고 완료를 기다린다.
-5. Job이 성공한 경우에만 같은 digest의 API/Web workload를 활성화한다.
+5. Job이 성공한 경우에만 같은 digest의 API·Web Rollout·HPA와 background Deployment를 wave 2에서 활성화한다.
 6. Job이 실패하면 배포를 중단하고 기존 workload를 그대로 유지한다. 수정 PR 또는 DB와 호환되는 revert PR을 `production`에 merge해 새 push로 재시도한다.
 
 Tag push와 수동 workflow 실행은 production migration을 시작하지 않는다. 배포 전체 절차와 검증 증거는 [Production release 운영 runbook](./production-release.md)을 따른다.
@@ -81,7 +81,7 @@ Contract SQL은 transition image에 미리 포함하지 않는다. 각 단계는
 
 - Credential 또는 Secret 실패: SQL을 실행하지 않는다. Runtime credential로 우회하지 않는다.
 - Advisory lock 실패: 다른 migration을 확인하고 종료된 뒤 원인을 수정한 production PR을 merge해 새 production push와 같은 자동 경로로 재시도한다.
-- SQL 또는 timeout 실패: 실패한 migration 파일의 schema와 history를 rollback하고 API/Web 활성화를 중단한다. Drizzle history를 수동 성공 처리하지 않는다.
+- SQL 또는 timeout 실패: 실패한 migration 파일의 schema와 history를 rollback하고 wave 2 workload 활성화를 중단한다. Drizzle history를 수동 성공 처리하지 않는다.
 - 부분 적용: 앞서 성공한 파일의 schema와 history는 유지한다. 자동 down migration이나 database rollback을 실행하지 않고, 원인을 수정한 새 production push가 이미 적용된 name/hash를 건너뛰고 아직 적용되지 않은 파일만 재시도하거나 새 forward migration을 사용한다.
 - Destructive migration의 restore 판단: 해당 schema migration runbook과 [Production PostgreSQL backup과 복구](./postgres-backup.md)를 따른다.
 

--- a/docs/operations/production-migrations.md
+++ b/docs/operations/production-migrations.md
@@ -23,6 +23,8 @@ Production migration Job은 다음 값만 사용한다.
 
 Job, API와 Web은 모두 `image@sha256:...` 형태의 같은 image reference를 렌더한다. Production migration에서 mutable tag나 유효하지 않은 digest를 사용하면 Helm render가 실패한다.
 
+Migration Job은 기반 리소스가 적용되는 기본 Sync wave 뒤의 wave 1에서 실행하고, API/Web과 background workload는 Job 성공 뒤 wave 2에서 교체한다. Migration을 `PreSync`로 실행하거나 workload와 같은 wave에 배치하지 않는다.
+
 첫 release 전 runtime bootstrap은 `workloads.enabled=false`로 API/Web Service·Rollout·HTTPRoute를 렌더하지 않고 PostgreSQL, backup과 Secret 기반만 준비한다. 보호된 `production` push의 자동 배포가 `prod` Environment의 credential·OIDC 범위와 감사 기록을 사용해 digest와 함께 workload와 migration을 활성화한다. `prod` Environment는 사람의 추가 승인 gate가 아니다.
 
 Migration 대상은 Helm release의 PostgreSQL read-write Service, `5432` port와 `kosmo` database로 고정한다. Job은 `<release>-postgres-migration` Secret의 `username`과 `password`만 읽으며 database URL, host, database 또는 Secret 이름/key를 release 입력으로 받지 않는다. Secret이 없거나 key가 누락되면 Kubernetes가 container를 시작할 수 없고 runtime credential로 재시도하지 않는다.

--- a/docs/operations/production-release.md
+++ b/docs/operations/production-release.md
@@ -24,7 +24,7 @@ Production 대상 PR, review와 필수 check는 branch ruleset이 전담한다. 
 - 장기 `production` branch는 직접 push와 history rewrite를 금지하고 PR로만 갱신한다.
 - Production PR에는 필요한 review, CI checks와 migration 호환성 검토가 있어야 한다. PR merge가 production 배포 의도를 확정한다.
 - Workflow는 merge 후 push event의 immutable full SHA를 checkout·image source·Argo CD source로 사용한다. Mutable branch 이름이나 Git tag를 workload identity로 사용하지 않는다.
-- Migration Job, API와 Web은 workflow가 생성한 하나의 digest-pinned image를 사용한다. Migration이 성공한 뒤에만 API와 Web을 활성화한다. 상세 경계는 [Production migration 실행 경계](./production-migrations.md)를 따른다.
+- Migration Job과 모든 활성화 workload는 workflow가 생성한 하나의 digest-pinned image를 사용한다. Migration이 성공한 뒤에만 API·Web Rollout·HPA와 background Deployment를 활성화한다. 상세 경계는 [Production migration 실행 경계](./production-migrations.md)를 따른다.
 - Git tag push는 build·source 선택·배포·승인을 시작하지 않는다. 기존 Web의 `버전: <tag>` 표시는 표시 tag 공급 방식을 정할 때까지 비활성화되어 있으며, 이번 release에는 version label 입력을 만들지 않는다.
 - Production 배포는 실행 중인 run을 취소하지 않는다. 여러 production push가 대기하면 GitHub Actions는 기존 `PROD-563` 계약처럼 최신 pending SHA만 다음 release로 유지할 수 있다. 최신 SHA는 앞선 production history를 포함하며, 대체된 pending run은 Actions 취소 기록으로 식별한다.
 
@@ -34,9 +34,9 @@ Production 대상 PR, review와 필수 check는 branch ruleset이 전담한다. 
 2. 필수 reviewer와 CI checks가 통과했는지 확인한다. Merge 전에는 production build·migration·deploy가 시작되지 않는다.
 3. PR을 merge한다. 이 merge가 유일한 사람의 승인이고, 결과로 생성된 production push가 자동 release를 시작한다.
 4. Docker build 결과의 commit SHA와 image digest를 workflow summary에서 확인한다. `prod` Environment 단계에서 별도 승인 버튼을 누르지 않는다.
-5. 같은 digest의 migration Job이 성공하고 Argo CD `kosmo-prod`가 해당 production SHA를 source revision으로 사용한 뒤 API와 Web Rollout이 Healthy인지 확인한다. Migration 실패 시 API와 Web 활성화가 진행되지 않는다.
+5. 같은 digest의 migration Job이 성공하고 Argo CD `kosmo-prod`가 해당 production SHA를 source revision으로 사용한 뒤 API·Web Rollout·HPA와 background Deployment가 Healthy인지 확인한다. Migration 실패 시 wave 2 workload 활성화가 진행되지 않는다.
 6. [Production migration 실행 경계](./production-migrations.md), [OpenPanel 제품 분석 운영](./openpanel.md), [Sentry 오류 수집 운영](./sentry.md)의 배포 후 검증과 public smoke를 실행한다.
-7. Merged PR과 review·check 이력은 GitHub PR/branch history에서 확인한다. Workflow summary와 Linear/incident 기록에는 actor, production commit, Argo source revision, image digest, migration·Rollout·smoke 결과만 남긴다. Credential, connection string, database row와 사용자 콘텐츠는 남기지 않는다.
+7. Merged PR과 review·check 이력은 GitHub PR/branch history에서 확인한다. Workflow summary와 Linear/incident 기록에는 actor, production commit, Argo source revision, image digest, migration·workload·smoke 결과만 남긴다. Credential, connection string, database row와 사용자 콘텐츠는 남기지 않는다.
 
 ## Production-first hotfix
 
@@ -56,8 +56,8 @@ Rollback은 과거 tag를 다시 배포하거나 branch history를 되돌리는 
 Release는 다음을 모두 확인해야 완료로 기록한다.
 
 - Merged production PR과 merge actor가 확인된다.
-- Build SHA, Argo source revision과 migration/API/Web image digest가 일치한다.
-- Migration Job이 성공하고 API·Web Rollout이 Healthy다.
+- Build SHA, Argo source revision과 migration 및 모든 활성화 workload의 image digest가 일치한다.
+- Migration Job이 성공하고 API·Web Rollout·HPA와 background Deployment가 Healthy다.
 - Production smoke와 OpenPanel/Sentry 배포 후 검증 결과가 기록된다.
 - Version label이 이 변경에서 다시 활성화되지 않았다.
 

--- a/memory/database-migrations.md
+++ b/memory/database-migrations.md
@@ -78,8 +78,8 @@ Argo CD `PostSync` 성공만으로 이 gate를 대체하지 않는다. `PostSync
 ### 4. Contract / post-migrate
 
 - gate를 통과한 뒤 별도 PR과 release에서 legacy column/table/constraint를 제거한다.
-- contract는 승인된 별도 Job으로 실행하거나, 나중 release에 처음 포함해 그 release의 PreSync에서 실행할 수
-  있다. 어느 방식이든 구버전이 다시 실행될 가능성이 없어야 한다.
+- contract는 승인된 별도 Job으로 실행하거나, 나중 release에 처음 포함해 그 release의 migration-gated
+  `Sync` wave 1에서 실행할 수 있다. 어느 방식이든 구버전이 다시 실행될 가능성이 없어야 한다.
 - contract 실행 후 schema, application error, mismatch와 rollback 가능 범위를 다시 확인한다.
 - contract와 함께 compatibility code를 제거할 수 있지만, 독립적으로 rollback해야 한다면 cleanup PR을 한 번 더
   분리한다.

--- a/memory/script.md
+++ b/memory/script.md
@@ -56,7 +56,7 @@
 
 ## Dev database migrations
 
-- dev 배포는 `Deploy Dev`가 `kosmo-dev` 애플리케이션을 full sync하고, dev 전용 Argo CD `PreSync` Job이 같은 `main` 런타임 이미지의 `migrate` entrypoint를 실행한 뒤 기존 API/web Rollout을 restart한다. sync나 migration이 실패하면 restart하지 않는다.
+- dev 배포는 `Deploy Dev`가 `kosmo-dev` 애플리케이션을 full sync하고, Argo CD `Sync` wave 1 Job이 같은 `main` 런타임 이미지의 `migrate` entrypoint를 실행한 뒤 wave 2 workload를 교체하고 기존 API/web Rollout을 restart한다. sync나 migration이 실패하면 workload를 교체하거나 restart하지 않는다.
 - migration runner는 Drizzle history와 PostgreSQL advisory lock을 사용한다. 적용된 history의 각 name이 local migration에 존재하고 hash가 같은지 검증하되, DB row 순서가 local timestamp 정렬과 달라도 같은 name/hash 집합이면 유효하게 인식한다. 이미 적용된 name을 제외한 파일만 local reader 순서로 실행하고, 각 파일의 SQL과 history insert를 독립 transaction으로 commit한다. 한 파일 실패 시 해당 파일은 rollback되고 앞서 성공한 파일은 유지되며, 재실행은 적용된 name/hash를 건너뛰고 미적용 파일만 이어간다. `Deploy Dev` 실행도 취소하지 않고 직렬화하므로 동일 DB에 migration을 동시에 적용하지 않는다.
 - dev migration은 기존 dev DB와 credential을 그대로 사용하고 데이터를 reset하지 않는다. dev downtime은 허용한다.
 - 로컬에서는 `pnpm --filter @kosmo/core db:migrate`로 같은 runner를 실행한다. `packages/core/drizzle.config.ts`의 `out`과 `migrations`가 migration directory와 Drizzle history schema/table의 source of truth이며, 런타임 이미지에는 config가 가리키는 migration 파일이 포함된다. Database URL과 `DATABASE_MIGRATION_ROLE`은 runtime PostgreSQL 환경 설정으로 유지한다.

--- a/memory/script.md
+++ b/memory/script.md
@@ -56,7 +56,7 @@
 
 ## Dev database migrations
 
-- dev 배포는 `Deploy Dev`가 `kosmo-dev` 애플리케이션을 full sync하고, Argo CD `Sync` wave 1 Job이 같은 `main` 런타임 이미지의 `migrate` entrypoint를 실행한 뒤 wave 2 workload를 교체하고 기존 API/web Rollout을 restart한다. sync나 migration이 실패하면 workload를 교체하거나 restart하지 않는다.
+- dev 배포는 `Deploy Dev`가 `kosmo-dev` 애플리케이션을 full sync하고, Argo CD `Sync` wave 1 Job이 같은 `main` 런타임 이미지의 `migrate` entrypoint를 실행한 뒤 wave 2 workload를 적용하고 API/web Rollout과 렌더된 background Deployment를 restart한다. sync나 migration이 실패하면 workload를 교체하거나 restart하지 않는다.
 - migration runner는 Drizzle history와 PostgreSQL advisory lock을 사용한다. 적용된 history의 각 name이 local migration에 존재하고 hash가 같은지 검증하되, DB row 순서가 local timestamp 정렬과 달라도 같은 name/hash 집합이면 유효하게 인식한다. 이미 적용된 name을 제외한 파일만 local reader 순서로 실행하고, 각 파일의 SQL과 history insert를 독립 transaction으로 commit한다. 한 파일 실패 시 해당 파일은 rollback되고 앞서 성공한 파일은 유지되며, 재실행은 적용된 name/hash를 건너뛰고 미적용 파일만 이어간다. `Deploy Dev` 실행도 취소하지 않고 직렬화하므로 동일 DB에 migration을 동시에 적용하지 않는다.
 - dev migration은 기존 dev DB와 credential을 그대로 사용하고 데이터를 reset하지 않는다. dev downtime은 허용한다.
 - 로컬에서는 `pnpm --filter @kosmo/core db:migrate`로 같은 runner를 실행한다. `packages/core/drizzle.config.ts`의 `out`과 `migrations`가 migration directory와 Drizzle history schema/table의 source of truth이며, 런타임 이미지에는 config가 가리키는 migration 파일이 포함된다. Database URL과 `DATABASE_MIGRATION_ROLE`은 runtime PostgreSQL 환경 설정으로 유지한다.

--- a/openspec/changes/adopt-production-release-branch/decisions.md
+++ b/openspec/changes/adopt-production-release-branch/decisions.md
@@ -47,7 +47,7 @@
 - Authority / Provenance: `PROD-764`, `PROD-563`, `PROD-564`
 - Status: Active
 - Context / Problem: 연속 push 사이 mutable branch를 다시 읽거나 main chart가 사용되면 image와 manifest가 달라질 수 있다.
-- Decision Outcome: Workflow가 확인한 production full SHA에서 image를 build하고 같은 SHA를 Argo source에, 하나의 digest를 migration/API/Web에 전달한다.
+- Decision Outcome: Workflow가 확인한 production full SHA에서 image를 build하고 같은 SHA를 Argo source에, 하나의 digest를 migration과 모든 활성화 workload에 전달한다.
 - Alternatives Considered: Argo source에 mutable `production` 문자열을 넘기는 방식은 승인 중 branch 이동을 재현하지 못해 채택하지 않았다.
 - Consequences: 배포는 production branch를 따르되 실행 identity는 그 branch의 확인된 immutable commit이다.
 - Confirmation / Follow-up: Workflow 기록과 live Argo/image를 대조한다.

--- a/openspec/changes/adopt-production-release-branch/design.md
+++ b/openspec/changes/adopt-production-release-branch/design.md
@@ -9,7 +9,7 @@
 - Production 대상 PR merge를 승인으로 삼아 그 push SHA를 자동 build·배포한다.
 - Tag push와 production credential·배포의 연결을 제거한다.
 - 기존 Web version label을 주석 처리해 production build의 tag 입력 의존성을 제거한다.
-- Image, migration/API/Web digest와 Helm source를 같은 production SHA로 고정한다.
+- Image, migration 및 모든 활성화 workload digest와 Helm source를 같은 production SHA로 고정한다.
 - Revert PR을 새 release로 배포해 rollback한다.
 - Main dev build와 migration barrier를 유지한다.
 
@@ -36,7 +36,7 @@
 2. Docker workflow의 tag push trigger를 제거한다. Main push는 dev build를 유지하고 protected production push는 해당 event SHA의 production build·deploy를 자동 시작한다.
 3. Production branch ruleset이 대상 PR의 필수 review와 checks를 유일한 사람 승인 gate로 강제한다. Workflow는 보호된 production push를 신뢰하고 PR 연결 관계를 다시 조회하지 않으며, `prod` Environment의 required reviewer와 별도 manual dispatch는 제거한다.
 4. Production build 조건을 하나의 판정으로 사용해 prod Vault role, OpenPanel Client ID, stable preservation metadata와 deploy job을 선택하고 `EXPO_PUBLIC_RELEASE_TAG` 입력에는 의존하지 않는다.
-5. Deploy job은 event의 full SHA와 build가 만든 하나의 digest를 Argo CD source, migration, API와 Web에 전달한다. 실행 중인 production run은 취소하지 않고, 여러 pending run은 최신 production SHA로 coalesce한다.
+5. Deploy job은 event의 full SHA와 build가 만든 하나의 digest를 Argo CD source, migration과 모든 활성화 workload에 전달한다. 실행 중인 production run은 취소하지 않고, 여러 pending run은 최신 production SHA로 coalesce한다.
 6. Terraform은 release-time target revision과 Helm parameter만 ignore하고 ECR OIDC trust에서 tag ref를 제거한다. Vault production role은 protected production branch workflow identity만 허용한다.
 7. Production release runbook에 `production PR review/checks → merge → 자동 build·migration·deploy → 검증`을 기록한다.
 8. Rollback은 production revert PR을 같은 절차로 merge해 배포한다.
@@ -70,7 +70,7 @@ GitHub production ruleset과 `prod` Environment 설정은 범용 repository boot
 2. Main에서 workflow, Terraform/IAM, Vault owner 변경, specs와 runbook을 검증·merge하고 필요한 infrastructure apply를 완료한다.
 3. Initial production에서 시작한 PR에 release-control 변경만 반영한다.
 4. Production 대상 PR을 필수 review와 checks로 승인·merge해 자동 배포를 시작한다.
-5. 별도 사람 승인 없이 commit, source SHA, digest, migration과 Rollout 결과를 확인하고 version label이 숨겨졌는지 확인한다.
+5. 별도 사람 승인 없이 commit, source SHA, digest, migration과 모든 활성화 workload 결과를 확인하고 version label이 숨겨졌는지 확인한다.
 6. 실패하면 production에 수정 또는 revert PR을 merge해 재시도한다. 과거 tag 재배포, history rewrite와 DB rollback은 사용하지 않는다.
 
 ## Open Questions

--- a/openspec/changes/adopt-production-release-branch/proposal.md
+++ b/openspec/changes/adopt-production-release-branch/proposal.md
@@ -8,7 +8,7 @@
 - Main의 승인된 변경과 필요한 선행 변경만 production 대상 PR로 반영한다.
 - **BREAKING** Git tag push 기반 production build·배포와 별도 수동 승인을 제거하고, `production` 대상 PR merge를 사람의 승인으로 삼아 그 push SHA를 자동 build·배포한다.
 - 기존 `버전: <tag>` UI는 주석 처리하고 표시 tag의 생성·공급·재활성화는 후속 범위로 미룬다. Tag push 자체에는 배포 시작·source 선택·승인 권한을 부여하지 않는다.
-- Production image와 Argo CD Helm source를 workflow가 확인한 동일 production commit에 고정하고 migration/API/Web에 하나의 digest를 전달한다.
+- Production image와 Argo CD Helm source를 workflow가 확인한 동일 production commit에 고정하고 migration과 모든 활성화 workload에 하나의 digest를 전달한다.
 - Rollback은 과거 tag 재배포가 아니라 production revert PR을 merge해 새 배포로 수행한다.
 - Dev의 main 배포와 기존 migration barrier는 유지한다.
 

--- a/openspec/changes/adopt-production-release-branch/specs/production-release/spec.md
+++ b/openspec/changes/adopt-production-release-branch/specs/production-release/spec.md
@@ -97,7 +97,7 @@
 
 ### Requirement: 이전 application은 production revert로 새 release를 배포한다
 
-**Authority / Provenance:** `PROD-764` — 운영자는 DB와 호환되는 application 변경을 production PR에서 revert하고 그 PR을 merge해 동일한 자동 build·PreSync·sync 경로로 배포해야 한다(MUST). 과거 tag commit을 직접 재배포하거나 production history를 rewrite해서는 안 되며(MUST NOT), DB 상태나 migration history를 자동으로 되돌려서도 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-764` — 운영자는 DB와 호환되는 application 변경을 production PR에서 revert하고 그 PR을 merge해 동일한 자동 build·migration-gated sync 경로로 배포해야 한다(MUST). 과거 tag commit을 직접 재배포하거나 production history를 rewrite해서는 안 되며(MUST NOT), DB 상태나 migration history를 자동으로 되돌려서도 안 된다(MUST NOT).
 
 #### Scenario: Application rollback
 

--- a/openspec/changes/adopt-production-release-branch/specs/production-release/spec.md
+++ b/openspec/changes/adopt-production-release-branch/specs/production-release/spec.md
@@ -60,12 +60,12 @@
 
 ### Requirement: Production branch build와 배포는 같은 digest와 source revision을 사용한다
 
-**Authority / Provenance:** `PROD-764`, `PROD-563`, `PROD-564` — 시스템은 production push SHA에서 생성한 digest-pinned image를 같은 workflow의 deploy job에 직접 전달해야 한다(MUST). Migration Job, API Rollout과 Web Rollout은 그 하나의 digest를 사용해야 하고(MUST), Argo CD Helm source도 같은 production push SHA를 사용해야 한다(MUST). Mutable image tag나 release tag를 workload identity 또는 source selector로 사용해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-764`, `PROD-563`, `PROD-564` — 시스템은 production push SHA에서 생성한 digest-pinned image를 같은 workflow의 deploy job에 직접 전달해야 한다(MUST). Migration Job과 모든 활성화 workload는 그 하나의 digest를 사용해야 하고(MUST), Argo CD Helm source도 같은 production push SHA를 사용해야 한다(MUST). Mutable image tag나 release tag를 workload identity 또는 source selector로 사용해서는 안 된다(MUST NOT).
 
 #### Scenario: Production build 완료
 
 - **WHEN** production push build가 digest를 만든다
-- **THEN** 시스템은 같은 production SHA의 Helm source와 그 digest를 migration, API와 Web에 설정한다
+- **THEN** 시스템은 같은 production SHA의 Helm source와 그 digest를 migration과 모든 활성화 workload에 설정한다
 
 #### Scenario: Build 실패
 
@@ -74,7 +74,7 @@
 
 ### Requirement: Production PR merge가 배포를 승인한다
 
-**Authority / Provenance:** `PROD-764`, `PROD-563` — 필수 review와 checks를 통과한 production 대상 PR merge는 build, migration과 API·Web 배포 전체에 대한 유일한 사람의 승인이어야 한다(MUST). 시스템은 merge 이후 별도 workflow dispatch, GitHub Environment reviewer 또는 migration approval을 요구해서는 안 된다(MUST NOT). GitHub `prod` Environment는 credential·OIDC 범위와 deployment 감사 기록을 위해 사용할 수 있지만(MAY), 사람의 승인 gate가 되어서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-764`, `PROD-563` — 필수 review와 checks를 통과한 production 대상 PR merge는 build, migration과 모든 활성화 workload 배포 전체에 대한 유일한 사람의 승인이어야 한다(MUST). 시스템은 merge 이후 별도 workflow dispatch, GitHub Environment reviewer 또는 migration approval을 요구해서는 안 된다(MUST NOT). GitHub `prod` Environment는 credential·OIDC 범위와 deployment 감사 기록을 위해 사용할 수 있지만(MAY), 사람의 승인 gate가 되어서는 안 된다(MUST NOT).
 
 #### Scenario: PR merge 전
 

--- a/openspec/changes/adopt-production-release-branch/tasks.md
+++ b/openspec/changes/adopt-production-release-branch/tasks.md
@@ -40,7 +40,7 @@ Production 대상 PR merge로 발생한 push가 version tag 입력 없이 동일
 - Production push event의 immutable SHA만 production source로 사용한다.
 - Tag는 build input, checkout, source selector 또는 workload identity로 사용하지 않는다.
 - PR merge 뒤 별도 dispatch, `prod` Environment reviewer 또는 migration approval을 요구하지 않는다.
-- Migration/API/Web은 같은 digest를 사용하고 Sync wave 1 migration 실패 시 wave 2 workload activation을 진행하지 않는다.
+- Migration과 모든 활성화 workload는 같은 digest를 사용하고 Sync wave 1 migration 실패 시 wave 2 workload activation을 진행하지 않는다.
 - Main dev build는 유지한다.
 
 **Verification**
@@ -48,12 +48,12 @@ Production 대상 PR merge로 발생한 push가 version tag 입력 없이 동일
 - Production push, tag push, main push와 manual event trigger matrix
 - 연속 production push에서 실행 중 run 비취소와 latest pending coalescing 검증
 - Prod/dev build input과 Web version label 비노출 검증
-- Argo source SHA와 migration/API/Web digest 대조
+- Argo source SHA와 migration 및 모든 활성화 workload digest 대조
 
 - [x] 2.1 Tag push production trigger를 제거하고 protected production push가 event SHA의 production build·deploy를 자동 시작하게 한다.
 - [x] 2.2 기존 Web version label 렌더링을 주석 처리하고 사용하지 않는 import/style을 제거하며 표시 tag 공급·재활성화를 후속 범위로 분리한다.
 - [x] 2.3 Production build에 prod Vault/OpenPanel/Sentry 설정을 전달하되 `EXPO_PUBLIC_RELEASE_TAG`에 의존하지 않고 dev build 입력을 보존한다.
-- [x] 2.4 별도 사람 승인 없이 full push SHA와 하나의 image digest를 Argo source, migration, API와 Web에 전달하고 production runs를 직렬화한다.
+- [x] 2.4 별도 사람 승인 없이 full push SHA와 하나의 image digest를 Argo source, migration과 모든 활성화 workload에 전달하고 production runs를 직렬화한다.
 - [x] 2.5 GitHub PR/branch history로 승인 이력을 보존하고 workflow에는 actor, production commit, source revision, digest와 결과를 기록하며 PR 연결 관계를 재검증하지 않는다.
 - [x] 2.6 Trigger matrix, version label 비노출, 실행 중 run 보존·latest pending coalescing, 동일 SHA·digest와 migration barrier 검증을 추가하고 관련 check를 통과시킨다.
 
@@ -134,12 +134,12 @@ Release-control 변경만 포함한 production PR이 version tag 입력 없이 m
 **Verification**
 
 - Production PR diff/checks와 migration 무변경
-- Production push 자동 실행, tag push 무동작, commit/source/digest/migration-gated Sync/Rollout 결과
+- Production push 자동 실행, tag push 무동작, commit/source/digest/migration-gated Sync/workload 결과
 - Live Argo/workload 상태와 Web version label 비노출
 - Archive 후 active spec strict validation
 
 - [ ] 5.1 Main merge와 infrastructure apply가 완료된 뒤 release-control commit만 production PR로 반영한다.
 - [ ] 5.2 Tag push만으로 배포가 실행되지 않고 production build가 표시 tag 입력을 요구하지 않음을 확인한다.
-- [ ] 5.3 Production PR을 review/checks 후 merge해 자동 배포하고 추가 사람 승인 없이 commit, version label 비노출, Argo source, digest, migration과 Rollout 결과를 기록한다.
+- [ ] 5.3 Production PR을 review/checks 후 merge해 자동 배포하고 추가 사람 승인 없이 commit, version label 비노출, Argo source, digest, migration과 모든 활성화 workload 결과를 기록한다.
 - [ ] 5.4 전체 완료 조건을 Linear에 기록하고 delta를 active `production-release` spec에 동기화해 OpenSpec을 archive한다.
 - [ ] 5.5 Archive와 active specs를 strict validation해 main에 전달한 뒤 `PROD-764`을 완료한다.

--- a/openspec/changes/adopt-production-release-branch/tasks.md
+++ b/openspec/changes/adopt-production-release-branch/tasks.md
@@ -40,7 +40,7 @@ Production 대상 PR merge로 발생한 push가 version tag 입력 없이 동일
 - Production push event의 immutable SHA만 production source로 사용한다.
 - Tag는 build input, checkout, source selector 또는 workload identity로 사용하지 않는다.
 - PR merge 뒤 별도 dispatch, `prod` Environment reviewer 또는 migration approval을 요구하지 않는다.
-- Migration/API/Web은 같은 digest를 사용하고 PreSync 실패 시 workload activation을 진행하지 않는다.
+- Migration/API/Web은 같은 digest를 사용하고 Sync wave 1 migration 실패 시 wave 2 workload activation을 진행하지 않는다.
 - Main dev build는 유지한다.
 
 **Verification**
@@ -134,7 +134,7 @@ Release-control 변경만 포함한 production PR이 version tag 입력 없이 m
 **Verification**
 
 - Production PR diff/checks와 migration 무변경
-- Production push 자동 실행, tag push 무동작, commit/source/digest/PreSync/Rollout 결과
+- Production push 자동 실행, tag push 무동작, commit/source/digest/migration-gated Sync/Rollout 결과
 - Live Argo/workload 상태와 Web version label 비노출
 - Archive 후 active spec strict validation
 

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/decisions.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/decisions.md
@@ -24,12 +24,12 @@
 - Consequences: Dockerfile과 entrypoint가 migration runtime도 소유한다. Job은 workload와 같은 image와 DB secret을 사용한다.
 - Confirmation / Follow-up: container command, Helm render와 disposable PostgreSQL 실행으로 검증한다.
 
-### GitHub Actions가 full sync를 시작하고 Argo PreSync가 rollout을 gate한다
+### GitHub Actions가 full sync를 시작하고 Argo Sync wave가 workload를 gate한다
 
 - Decision Date: 2026-07-12
 - Status: Accepted
 - Context / Problem: 현재 Deploy Dev는 Argo Rollout restart action만 실행하므로 hook이 실행될 application sync 경계가 없다.
-- Decision Outcome: Docker Build 완료 workflow가 `argocd app sync kosmo-dev`를 실행하고, `PreSync` migration Job 성공 뒤에만 기존 API/web restart action을 실행한다. migration-aware deploy는 취소하지 않고 직렬화한다.
+- Decision Outcome: Docker Build 완료 workflow가 `argocd app sync kosmo-dev`를 실행하고, 기반 리소스 적용 뒤 `Sync` wave 1 migration Job을 실행한다. 성공한 뒤 wave 2 workload를 적용하고 API/web Rollout과 렌더된 background Deployment를 restart한다. migration-aware deploy는 취소하지 않고 직렬화한다.
 - Alternatives Considered: GitHub Actions가 Kubernetes Job을 직접 생성하면 cluster credential과 imperative manifest 관리가 추가된다. `PostSync` destructive migration은 rollback 대상 workload를 깨뜨린다. selective sync는 hook을 실행하지 않는다.
 - Consequences: Argo sync 실패가 workflow 실패로 전파되고 restart step은 실행되지 않는다. 현재 Argo application이 full sync hook을 실행할 수 있어야 한다.
 - Confirmation / Follow-up: workflow ordering과 실패 short-circuit를 정적 검증하고 dev 최초 배포에서 hook 실행을 확인한다.
@@ -60,4 +60,4 @@
 
 ## Superseded Decisions
 
-- 없음.
+- Migration Job을 application resource sync 전 `PreSync`로 실행하고 API/web Rollout만 restart한다. 기반 리소스 → `Sync` wave 1 migration → wave 2 workload 및 전체 렌더된 workload restart 순서가 이를 대체한다.

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/design.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/design.md
@@ -10,7 +10,7 @@ PROD-280은 production용 무중단 expand/contract 체계를 도입하지 않�
 
 - 동일한 dev runtime image가 `migrate` command로 image 안의 SQL migration을 적용한다.
 - Drizzle history와 단일 PostgreSQL advisory lock을 사용해 재실행과 동시 실행을 안전하게 처리한다.
-- Argo CD `PreSync` Job 실패가 rollout restart를 차단한다.
+- Argo CD `Sync` wave 1 Job 실패가 wave 2 workload 교체와 restart를 차단한다.
 - dev `latest` image 정책과 기존 Argo Rollout resource action을 유지한다.
 - PROD-267 migration을 data reset 없이 적용할 실행 경계를 제공한다.
 
@@ -26,7 +26,7 @@ PROD-280은 production용 무중단 expand/contract 체계를 도입하지 않�
 - [`latest`가 migration과 workload 사이에 바뀔 수 있음] → Deploy Dev를 environment 단위로 직렬화하고 Docker Build 성공 직후 full sync와 restart를 한 workflow에서 수행한다. production의 immutable identity 문제는 PROD-269에 남긴다.
 - [GitHub workflow 취소 후 Argo hook이 남을 수 있음] → `cancel-in-progress`를 끄고 PostgreSQL advisory lock으로 겹친 runner가 SQL을 실행하지 못하게 한다.
 - [Drizzle migrator history만으로 동시 실행을 막지 못함] → connection pool을 1로 제한한 session에서 `pg_try_advisory_lock`을 먼저 획득하고 실패 시 즉시 종료한다.
-- [Migration SQL 실패] → Drizzle의 PostgreSQL transaction과 실패 exit status를 사용하며 Argo `PreSync` 실패가 이후 restart step을 차단한다.
+- [Migration SQL 실패] → Drizzle의 PostgreSQL transaction과 실패 exit status를 사용하며 Argo `Sync` wave 1 실패가 이후 wave 2와 restart step을 차단한다.
 - [파괴적 migration 직후 기존 dev workload가 실패할 수 있음] → dev downtime을 허용하고 migration 성공 직후 새 `latest` workload를 restart한다. production에서는 허용하지 않는다.
 - [Argo selective sync는 hook을 실행하지 않음] → Deploy Dev가 resource 선택 없이 application full sync를 호출한다.
 - [Job 자동 retry가 논리 오류를 반복함] → `backoffLimit: 0`, `restartPolicy: Never`와 제한된 실행 시간을 사용한다.
@@ -35,8 +35,8 @@ PROD-280은 production용 무중단 expand/contract 체계를 도입하지 않�
 
 1. runtime image에 `drizzle/`을 복사하고 `migrate` entrypoint를 추가한다.
 2. runner는 `DATABASE_URL`, image 안 migration directory와 단일 connection을 사용해 advisory lock을 획득한 뒤 Drizzle migrator를 실행한다.
-3. Helm chart에 dev workload와 같은 image/DB secret을 사용하는 `PreSync` Job을 추가한다.
-4. Deploy Dev를 직렬화하고 `argocd app sync kosmo-dev` 성공 후에만 API/web restart action을 실행한다.
+3. Helm chart에 dev workload와 같은 image/DB secret을 사용하는 `Sync` wave 1 Job을 추가하고 workload를 wave 2에 배치한다.
+4. Deploy Dev를 직렬화하고 `argocd app sync kosmo-dev` 성공 후에만 API/web Rollout과 렌더된 background Deployment restart action을 실행한다.
 5. disposable test database에서 최초 적용, no-op 재실행, 실패와 lock contention을 검증하고 Helm render와 workflow 순서를 확인한다.
 6. PROD-280을 PROD-267보다 먼저 머지한다. 이후 PROD-267 merge의 Docker Build가 새 migration runner로 pending Plain Text cutover migration을 적용한다.
 

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/proposal.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/proposal.md
@@ -8,8 +8,8 @@ Linear: [PROD-280](https://linear.app/byulmaru/issue/PROD-280/dev-배포-전에-
 
 - runtime image가 version control의 Drizzle SQL migration을 포함하고 독립적인 `migrate` command로 pending migration을 적용한다.
 - migration runner는 Drizzle migration history를 사용하고 PostgreSQL advisory lock으로 동시 실행을 거부한다.
-- Helm chart에 app startup 및 initContainer와 분리된 단일 Argo CD `PreSync` migration Job을 추가한다.
-- Deploy Dev workflow는 Docker Build 성공 후 Argo CD full sync로 migration을 완료하고, 성공한 경우에만 기존 API/web Rollout restart를 실행한다.
+- Helm chart에 app startup 및 initContainer와 분리된 단일 Argo CD `Sync` wave 1 migration Job을 추가하고 workload를 wave 2에 배치한다.
+- Deploy Dev workflow는 Docker Build 성공 후 Argo CD full sync로 migration을 완료하고, 성공한 경우에만 API/web Rollout과 렌더된 background Deployment restart를 실행한다.
 - migration-aware dev deploy를 직렬화해 실행 중 workflow를 새 배포가 취소하지 않게 한다.
 - dev는 기존 `latest` image 정책과 허용된 짧은 downtime을 유지하며 DB data를 reset하지 않는다.
 - production immutable release, expand/transition/contract 승인, backup/restore와 배포 후 smoke는 포함하지 않는다.
@@ -27,6 +27,6 @@ Linear: [PROD-280](https://linear.app/byulmaru/issue/PROD-280/dev-배포-전에-
 ## Impact
 
 - Runtime: `Dockerfile`, `docker-entrypoint.sh`, production dependency로 제공되는 Drizzle migrator와 SQL migration directory.
-- Deployment: `apps/helm`의 `PreSync` Job, DB secret 사용 경계, `.github/workflows/deploy-dev.yml`의 sync/restart 순서와 concurrency.
+- Deployment: `apps/helm`의 migration-gated Sync waves, DB secret 사용 경계, `.github/workflows/deploy-dev.yml`의 sync/restart 순서와 concurrency.
 - Database: Drizzle `__drizzle_migrations` history와 PostgreSQL advisory lock; 기존 domain table과 migration SQL 내용은 변경하지 않는다.
 - Verification: migration runner unit/integration, Helm render, workflow ordering, existing lint/format/OpenSpec validation.

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/specs/dev-database-migrations/spec.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/specs/dev-database-migrations/spec.md
@@ -38,14 +38,15 @@ dev에 배포되는 runtime image는 애플리케이션 server 시작과 분리�
 - **THEN** 새 runner는 lock 해제를 기다리지 않고 migration을 중복 실행하지 않는다
 - **AND** 새 runner는 명시적인 실패 exit status를 반환한다
 
-### Requirement: Dev PreSync migration Job
+### Requirement: Dev Sync migration Job
 
 dev Helm release는 API 또는 web container의 startup/initContainer와 분리된 단일 Kubernetes Job으로 runtime migration command를 실행해야 한다(MUST).
 
-#### Scenario: Argo full sync의 migration 선행 실행
+#### Scenario: Argo full sync의 migration-gated workload 교체
 
 - **WHEN** dev application에 Argo CD full sync가 시작된다
-- **THEN** Argo CD는 application resource sync 전에 migration Job을 `PreSync` hook으로 실행한다
+- **THEN** Argo CD는 기반 리소스를 적용한 뒤 migration Job을 `Sync` wave 1 hook으로 실행한다
+- **AND** dev workload는 migration Job이 성공한 뒤 wave 2에서 교체된다
 - **AND** Job은 dev workload와 같은 `latest` image reference를 사용한다
 - **AND** Job은 단일 Pod에서 재시작 없이 migration command를 실행한다
 
@@ -53,16 +54,16 @@ dev Helm release는 API 또는 web container의 startup/initContainer와 분리�
 
 - **WHEN** migration Job이 실패한다
 - **THEN** Argo CD sync는 실패한다
-- **AND** dev deployment workflow는 API와 web Rollout restart를 실행하지 않는다
+- **AND** dev deployment workflow는 API와 web Rollout 및 background Deployment restart를 실행하지 않는다
 
 ### Requirement: Migration-gated dev rollout
 
-Deploy Dev workflow는 Docker Build 성공 후 migration을 포함한 Argo CD full sync를 완료하고, 성공한 경우에만 API와 web Rollout을 restart해야 한다(MUST).
+Deploy Dev workflow는 Docker Build 성공 후 migration을 포함한 Argo CD full sync를 완료하고, 성공한 경우에만 API와 web Rollout 및 렌더된 background Deployment를 restart해야 한다(MUST).
 
 #### Scenario: Migration 성공 후 rollout
 
 - **WHEN** Docker Build가 성공하고 Argo CD full sync와 migration Job이 성공한다
-- **THEN** deployment workflow는 `kosmo-api`와 `kosmo-web` Rollout restart를 실행한다
+- **THEN** deployment workflow는 `kosmo-api`와 `kosmo-web` Rollout 및 렌더된 background Deployment의 restart를 실행한다
 
 #### Scenario: Dev deploy 직렬 실행
 

--- a/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/tasks.md
+++ b/openspec/changes/archive/2026-07-12-run-dev-db-migrations-before-rollout/tasks.md
@@ -6,11 +6,11 @@
 
 ## 2. Argo migration gate
 
-- [x] 2.1 Add a Helm `PreSync` migration Job that uses the release image and existing dev database secret with one Pod, no automatic retry, a bounded deadline and non-root security context.
+- [x] 2.1 Add a Helm `Sync` wave 1 migration Job that uses the release image and existing dev database secret with one Pod, no automatic retry, a bounded deadline and non-root security context; keep workloads in wave 2.
 - [x] 2.2 Add deterministic Helm render coverage for the migration hook annotations, image, command, database environment, retry and deadline policy.
 
 ## 3. Dev deployment orchestration and verification
 
-- [x] 3.1 Serialize Deploy Dev runs and run an Argo CD application full sync before the existing API/web Rollout restart actions so migration failure prevents restart.
-- [x] 3.2 Update project deployment/script memory with the dev migration command, PreSync gate, `latest` downtime boundary and deferred production/smoke scope.
+- [x] 3.1 Serialize Deploy Dev runs and run an Argo CD application full sync before the API/web Rollout and rendered background Deployment restart actions so migration failure prevents restart.
+- [x] 3.2 Update project deployment/script memory with the dev migration-gated Sync waves, `latest` downtime boundary and deferred production/smoke scope.
 - [x] 3.3 Run migration integration, Helm render, workflow order, TypeScript, lint/format and strict OpenSpec validation, then confirm no application startup or initContainer migration path was introduced.

--- a/openspec/changes/archive/2026-07-30-add-production-migration-gate/decisions.md
+++ b/openspec/changes/archive/2026-07-30-add-production-migration-gate/decisions.md
@@ -11,7 +11,7 @@
 - Authority / Provenance: Linear `PROD-564`, `PROD-269`
 - Status: Active
 - Context / Problem: 서로 다른 build를 사용하면 검토한 migration SQL과 실제 workload code의 identity가 달라질 수 있다.
-- Decision Outcome: Migration Job, API와 Web은 승인된 하나의 `image@sha256:...` identity를 사용한다.
+- Decision Outcome: Migration Job과 모든 활성화 workload는 승인된 하나의 `image@sha256:...` identity를 사용한다.
 - Alternatives Considered: SemVer, `stable` 또는 Git SHA tag 비교는 registry tag 이동 가능성을 제거하지 못해 제외했다. 별도 migration image는 release identity surface를 늘려 제외했다.
 - Consequences: PROD-563 pipeline은 같은 digest를 migration과 workload 배포에 전달해야 한다.
 - Confirmation / Follow-up: Helm render에서 동일 digest 성공과 invalid digest 실패를 검증한다.
@@ -23,7 +23,7 @@
 - Authority / Provenance: Linear `PROD-564`
 - Status: Active
 - Context / Problem: Application runtime에 DDL 권한을 주거나 migration 장애 시 runtime credential로 fallback하면 최소 권한 경계가 사라진다.
-- Decision Outcome: Production migration Job은 별도 Secret/database identity만 사용하고 API/Web은 이를 참조하지 않는다. Secret에서는 `username`과 `password`만 읽으며 접속 대상은 현재 Helm release의 PostgreSQL read-write Service와 `kosmo` database로 고정한다.
+- Decision Outcome: Production migration Job은 별도 Secret/database identity만 사용하고 runtime workload는 이를 참조하지 않는다. Secret에서는 `username`과 `password`만 읽으며 접속 대상은 현재 Helm release의 PostgreSQL read-write Service와 `kosmo` database로 고정한다.
 - Alternatives Considered: CNPG application Secret 재사용은 runtime DDL 권한을 요구해 제외했다. GitHub runner에 database credential을 전달하면 cluster-local secret 경계가 넓어져 제외했다.
 - Consequences: PROD-562가 migration Secret을 제공하며 누락되거나 유효하지 않으면 migration은 실패한다.
 - Confirmation / Follow-up: Prod render에서 고정된 접속 대상, Secret 분리, runtime 미노출과 missing credential failure를 검증한다.
@@ -47,7 +47,7 @@
 - Authority / Provenance: Linear `PROD-563`, `PROD-564`
 - Status: Active
 - Context / Problem: Production tag가 선택한 image에는 migration과 workload가 함께 있다.
-- Decision Outcome: PROD-563의 production release 승인 하나가 migration과 API/Web에 적용된다. Migration 성공 뒤에만 workload를 활성화하며 migration 전용 추가 승인은 만들지 않는다.
+- Decision Outcome: PROD-563의 production release 승인 하나가 migration과 모든 활성화 workload에 적용된다. Migration 성공 뒤에만 workload를 활성화하며 migration 전용 추가 승인은 만들지 않는다.
 - Alternatives Considered: Contract 전용 Environment는 같은 release를 중복 승인해 제외했다.
 - Consequences: Job failure가 workload activation barrier가 된다.
 - Confirmation / Follow-up: PROD-563 pipeline과 PROD-565 첫 release에서 통합 검증한다.

--- a/openspec/changes/archive/2026-07-30-add-production-migration-gate/design.md
+++ b/openspec/changes/archive/2026-07-30-add-production-migration-gate/design.md
@@ -9,7 +9,7 @@ PROD-564는 production migration의 공통 실행 경계만 만든다. PROD-269�
 **Goals:**
 
 - Production migration이 별도 database credential을 사용하게 한다.
-- Migration Job과 API/Web이 같은 immutable release digest를 사용하게 한다.
+- Migration Job과 모든 활성화 workload가 같은 immutable release digest를 사용하게 한다.
 - Migration 실패가 새 workload 활성화를 차단하도록 PROD-563이 소비할 명확한 Job success barrier를 제공한다.
 - Dev migration 동작과 기존 Drizzle runner를 유지한다.
 
@@ -25,7 +25,7 @@ PROD-564는 production migration의 공통 실행 경계만 만든다. PROD-269�
 ### Recommended Approach
 
 1. Production에서 migration이 명시적으로 enabled일 때만 기존 Helm Job을 렌더한다.
-2. Production render는 `imageDigest=sha256:...`를 요구하고 API/Web과 같은 `image@digest` helper를 사용한다.
+2. Production render는 `imageDigest=sha256:...`를 요구하고 모든 활성화 workload와 같은 `image@digest` helper를 사용한다.
 3. Job은 migration 전용 Secret의 `username`과 `password`만 읽는다. Host, port와 database는 현재 Helm release의 production PostgreSQL로 고정하고 `migrate`를 실행한다.
 4. Credential, advisory lock, SQL 또는 timeout 실패는 Job failure로 반환한다. PROD-563은 이 Job 성공 뒤에만 workload 활성화를 진행한다.
 5. 실제 destructive migration은 별도 이슈와 release에서 repository migration policy에 따른 구체 evidence gate를 구현한다.

--- a/openspec/changes/archive/2026-07-30-add-production-migration-gate/proposal.md
+++ b/openspec/changes/archive/2026-07-30-add-production-migration-gate/proposal.md
@@ -1,15 +1,15 @@
 ## Why
 
-현재 Helm migration Job은 dev에서만 렌더되고 application database credential과 mutable `main` image를 사용한다. 이 경계를 그대로 production에 사용하면 migration과 API/Web workload가 서로 다른 build를 실행하거나 runtime identity에 DDL 권한을 요구하게 된다.
+현재 Helm migration Job은 dev에서만 렌더되고 application database credential과 mutable `main` image를 사용한다. 이 경계를 그대로 production에 사용하면 migration과 활성화 workload가 서로 다른 build를 실행하거나 runtime identity에 DDL 권한을 요구하게 된다.
 
 Linear [PROD-564](https://linear.app/byulmaru/issue/PROD-564/프로덕션-migration-job을-release-실행-경계에-연결한다)는 production migration을 동일 immutable release와 별도 database credential로 실행하고, 실패 시 새 workload 활성화를 차단하는 최소 실행 경계를 소유한다.
 
 ## What Changes
 
 - Production migration Job이 runtime workload와 분리된 migration credential만 사용하고 runtime credential로 fallback하지 않게 한다.
-- Migration Job, API와 Web workload가 하나의 immutable image digest를 사용하게 한다.
+- Migration Job과 모든 활성화 workload가 하나의 immutable image digest를 사용하게 한다.
 - Migration Job은 기존 Drizzle runner의 `migrate` command만 실행하고 phase, schema authority 또는 restore command mode를 갖지 않는다.
-- PROD-563의 production release 승인 하나가 migration과 API/Web 배포를 함께 승인하며 migration 성공 전 workload 활성화를 차단한다.
+- PROD-563의 production release 승인 하나가 migration과 모든 활성화 workload 배포를 함께 승인하며 migration 성공 전 workload 활성화를 차단한다.
 - 실제 destructive migration의 phase, backup/restore, compatibility와 rollback 조건은 해당 schema migration 이슈·PR·release가 구체적으로 소유한다.
 
 ## Authority / Provenance

--- a/openspec/changes/archive/2026-07-30-add-production-migration-gate/specs/production-migration-gate/spec.md
+++ b/openspec/changes/archive/2026-07-30-add-production-migration-gate/specs/production-migration-gate/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: 분리된 production migration 권한
 
-**Authority / Provenance:** `PROD-564`, `PROD-616`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), API와 Web runtime credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-564`, `PROD-616`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), runtime workload credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
 
 #### Scenario: Migration credential로 실행
 
@@ -10,7 +10,7 @@
 - **THEN** Job은 production migration 전용 Secret과 database identity로 연결한다
 - **AND** 연결 후 명시적인 database owner role로 전환해 새 schema 객체가 runtime owner의 권한 경계에 남게 한다
 - **AND** 접속 대상은 현재 Helm release의 PostgreSQL read-write Service와 `kosmo` database로 고정된다
-- **AND** API와 Web workload는 같은 credential을 mount하거나 참조하지 않는다
+- **AND** Runtime workload는 같은 credential을 mount하거나 참조하지 않는다
 
 #### Scenario: Migration 대상 입력 금지
 
@@ -26,12 +26,12 @@
 
 ### Requirement: 동일한 immutable release identity
 
-**Authority / Provenance:** `PROD-564`, `PROD-269`. Production migration Job, API와 Web workload는 승인된 release의 동일한 immutable image digest를 사용해야 한다(MUST). Mutable tag 또는 서로 다른 digest로 production migration을 실행해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-564`, `PROD-269`. Production migration Job과 모든 활성화 workload는 승인된 release의 동일한 immutable image digest를 사용해야 한다(MUST). Mutable tag 또는 서로 다른 digest로 production migration을 실행해서는 안 된다(MUST NOT).
 
 #### Scenario: 동일 digest로 렌더
 
 - **WHEN** production release manifest가 렌더된다
-- **THEN** migration Job, API와 Web image reference는 같은 `repository@sha256:...` 값이다
+- **THEN** migration Job과 모든 활성화 workload image reference는 같은 `repository@sha256:...` 값이다
 
 #### Scenario: Mutable production image 거부
 
@@ -56,12 +56,12 @@
 
 ### Requirement: Production release 단일 승인과 실패 차단
 
-**Authority / Provenance:** `PROD-563`, `PROD-564`. 정식 production release 승인은 선택한 immutable image의 migration과 API/Web workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-563`, `PROD-564`. 정식 production release 승인은 선택한 immutable image의 migration과 모든 활성화 workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 된다(MUST NOT).
 
 #### Scenario: Migration 성공
 
 - **WHEN** 승인된 production release의 migration Job이 성공한다
-- **THEN** PROD-563 pipeline은 같은 immutable release의 API와 Web 활성화를 진행할 수 있다
+- **THEN** PROD-563 pipeline은 같은 immutable release의 모든 wave 2 workload 활성화를 진행할 수 있다
 
 #### Scenario: Migration 실패
 

--- a/openspec/changes/archive/2026-07-30-add-production-migration-gate/tasks.md
+++ b/openspec/changes/archive/2026-07-30-add-production-migration-gate/tasks.md
@@ -8,7 +8,7 @@
 
 **Deliverable**
 
-Production migration Job이 별도 database credential과 API/Web과 같은 immutable digest로 기존 Drizzle migration을 실행하며, 실패 시 같은 release의 workload 활성화를 차단할 수 있는 명확한 Job 결과를 제공한다.
+Production migration Job이 별도 database credential과 모든 활성화 workload와 같은 immutable digest로 기존 Drizzle migration을 실행하며, 실패 시 같은 release의 workload 활성화를 차단할 수 있는 명확한 Job 결과를 제공한다.
 
 **Guardrails**
 
@@ -26,7 +26,7 @@ Production migration Job이 별도 database credential과 API/Web과 같은 immu
 - OpenSpec strict validation과 repository format/lint를 통과한다.
 
 - [x] 1.1 Production migration Job이 고정된 database target과 별도 migration Secret의 `username/password`만 사용하고 runtime credential로 fallback하지 않게 한다.
-- [x] 1.2 Migration Job, API와 Web이 동일한 immutable image digest를 렌더하게 한다.
+- [x] 1.2 Migration Job과 모든 활성화 workload가 동일한 immutable image digest를 렌더하게 한다.
 - [x] 1.3 Migration Job을 기존 `migrate` command만 실행하는 단순 실행기로 유지하고 phase/schema-authority/restore 분기를 제거한다.
 - [x] 1.4 Credential, lock, SQL과 timeout 실패 뒤 workload 차단·같은 release 재시도·forward recovery 경계를 운영 문서에 기록한다.
 - [x] 1.5 Dev/prod render, invalid digest, missing Secret, lint/format과 OpenSpec strict validation을 통과하고 PR을 Ready로 갱신한다.

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/decisions.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/decisions.md
@@ -1,6 +1,6 @@
 ## Context
 
-이 기록은 PROD-563의 tag build, production 승인, PreSync와 application 재배포 방식을 구체화한다.
+이 기록은 PROD-563의 tag build, production 승인, migration-gated Sync와 application 재배포 방식을 구체화한다.
 
 ## Decision Records
 
@@ -47,7 +47,7 @@
 - Authority / Provenance: 사용자 결정, PROD-563
 - Status: Active
 - Context / Problem: Tag는 release intent를 나타내지만 production credential과 상태 변경에는 GitHub의 명시적 보호 경계가 필요하다.
-- Decision Outcome: Tag build 성공 뒤 하나의 `prod` Environment job이 migration과 API·Web 전체를 승인하며 승인된 job만 Argo CD OIDC token을 얻는다.
+- Decision Outcome: Tag build 성공 뒤 하나의 `prod` Environment job이 migration과 모든 활성화 workload 전체를 승인하며 승인된 job만 Argo CD OIDC token을 얻는다.
 - Alternatives Considered: Tag push만으로 즉시 배포하면 별도 production 보호가 없고, migration 전용 승인은 같은 release를 중복 승인한다.
 - Consequences: Tag push와 Environment approval 두 행위가 필요하지만 승인 job은 하나뿐이다.
 - Confirmation / Follow-up: Branch build에는 deploy job이 없고 tag deploy에는 Environment 하나와 approval-before-OIDC 순서가 있는지 확인한다.
@@ -76,14 +76,14 @@
 - Consequences: 대체된 pending tag는 production 배포를 시작하지 않으며 별도 deploy step summary 대신 GitHub Actions 취소 기록만 남는다.
 - Confirmation / Follow-up: `cancel-in-progress: false`와 기본 single pending concurrency가 유지되는지 확인한다.
 
-### PreSync 성공 뒤 controller 기본 activation을 사용한다
+### Sync wave 1 migration 성공 뒤 controller 기본 activation을 사용한다
 
 - Decision Date: 2026-07-30
 - Decision Class: Implementation Choice
 - Authority / Provenance: 사용자 결정, PROD-563
 - Status: Active
 - Context / Problem: Cross-Rollout preview coordination과 ReplicaSet recovery가 controller 동작을 pipeline에 중복 구현했다.
-- Decision Outcome: 같은 digest의 PreSync migration 뒤 Argo CD와 Rollout controller 기본 activation을 사용한다. Pipeline은 직접 promotion·ReplicaSet recovery를 수행하지 않는다.
+- Decision Outcome: 기반 리소스 적용 뒤 같은 digest의 Sync wave 1 migration을 실행하고, 성공한 뒤 API·Web Rollout·HPA와 background Deployment를 wave 2에서 적용한다. Argo CD와 Rollout controller 기본 activation을 사용하며 pipeline은 직접 promotion·ReplicaSet recovery를 수행하지 않는다.
 - Alternatives Considered: API·Web 동시 promotion과 selective recovery는 원자성을 보장하지 못하면서 구현과 테스트를 복잡하게 한다.
 - Consequences: API와 Web activation은 원자적이지 않으며 실패 복구는 새 tag를 통한 동일 경로 재배포다.
 - Confirmation / Follow-up: Manifest가 기본 activation을 사용하고 workflow에 Rollout action·ReplicaSet 조회가 없는지 확인한다.
@@ -95,7 +95,7 @@
 - Authority / Provenance: 사용자 결정, PROD-563
 - Status: Active
 - Context / Problem: 별도 rollback 함수나 immutable Release selector는 정상 배포와 다른 경로를 만든다. 반면 pipeline 도입 전 commit에는 현재 승인·배포 workflow가 존재하지 않는다.
-- Decision Outcome: Pipeline 도입 이후 실제 production에 배포됐고 현재 DB와 호환되는 이전 release commit에 새 tag를 붙여 같은 build·approval·PreSync·sync 경로를 실행한다. Pipeline 도입 전 임의 commit은 지원하지 않고 DB는 되돌리지 않는다.
+- Decision Outcome: Pipeline 도입 이후 실제 production에 배포됐고 현재 DB와 호환되는 이전 release commit에 새 tag를 붙여 같은 build·approval·migration-gated sync 경로를 실행한다. Pipeline 도입 전 임의 commit은 지원하지 않고 DB는 되돌리지 않는다.
 - Alternatives Considered: Argo CD history rollback과 이전 Release selector는 각각 승인 경로를 우회하거나 제거된 Release lifecycle을 되살린다.
 - Consequences: 이전 image digest를 그대로 재사용하지 않고 지원 대상인 이전 production release source commit을 다시 build한다. 첫 production release 전에는 rollback 대상 release가 없다.
 - Confirmation / Follow-up: 별도 rollback command가 없고 tag workflow가 commit·digest·결과를 기록하는지 확인한다.
@@ -110,3 +110,4 @@
 - Immutable GitHub Release tag와 asset을 production selector로 사용한다.
 - Release 해석과 별도 production deploy workflow를 사용한다.
 - API·Web preview를 함께 대기해 직접 promotion하고 ReplicaSet을 자동 복구한다.
+- Migration Job을 `PreSync`로 실행하고 API·Web Rollout만 적용한다. 기반 리소스 → Sync wave 1 migration → wave 2 Rollout·HPA·background Deployment 순서가 이를 대체한다.

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/design.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/design.md
@@ -9,8 +9,8 @@ PROD-563은 tag build에서 production sync까지의 release 경계만 소유한
 **Goals:**
 
 - 모든 Git tag를 형식 제한 없이 production build trigger로 사용한다.
-- Build output digest를 한 번의 production 승인 뒤 migration, API와 Web에 동일하게 전달한다.
-- PreSync migration 성공 뒤 controller 기본 activation을 사용한다.
+- Build output digest를 한 번의 production 승인 뒤 migration과 모든 활성화 workload에 동일하게 전달한다.
+- 기반 리소스 적용 뒤 Sync wave 1 migration을 성공시키고 wave 2 controller 기본 activation을 사용한다.
 - Tag, commit, digest와 결과를 workflow 및 Argo CD 기록으로 감사한다.
 - 실행 중인 production 배포는 보존하고 최신 pending tag가 이전 pending tag를 대체한다.
 - 이전 application 재배포는 pipeline 도입 이후 실제 production에 배포된 호환 가능한 이전 release commit에 새 tag를 붙이는 같은 경로를 사용한다.
@@ -30,7 +30,7 @@ PROD-563은 tag build에서 production sync까지의 release 경계만 소유한
 - Tag build와 deploy job은 같은 GitHub Actions workflow run에 있으므로 build job의 digest output을 직접 전달할 수 있다.
 - Helm production render는 tag가 아니라 full digest reference를 요구한다.
 - Argo CD ApplicationSet이 release parameter를 보존하는 seam은 PROD-562가 제공한다.
-- PROD-564 PreSync Job이 없으면 migration-before-workload 순서를 완성할 수 없다.
+- PROD-564 migration Job이 없으면 migration-before-workload 순서를 완성할 수 없다.
 
 ### Recommended Approach
 
@@ -42,7 +42,7 @@ Docker Build의 tag trigger를 모든 tag에 적용하고 별도 SemVer validati
 
 Production deploy job의 고정 concurrency group은 실행 중 job을 취소하지 않고 pending job은 하나만 유지한다. 더 최신 tag build가 도달하면 이전 pending job이 취소되고 최신 pending job이 다음 후보가 된다. 모든 중간 tag를 FIFO로 배포하지 않는다.
 
-Rendered manifest에서 migration, API와 Web image가 build digest와 일치하고 PreSync Job이 하나인지 확인한 뒤 `argocd app sync`를 실행한다. PreSync 성공 뒤 각 Rollout은 controller 기본 activation을 사용한다. Pipeline은 preview polling, promotion action, ReplicaSet discovery나 자동 recovery를 수행하지 않는다.
+Rendered manifest에서 migration과 모든 활성화 workload image가 build digest와 일치하고 Sync wave 1 Job이 하나인지 확인한 뒤 `argocd app sync`를 실행한다. Migration 성공 뒤 wave 2의 각 Rollout·HPA·background Deployment는 controller 기본 activation을 사용한다. Pipeline은 preview polling, promotion action, ReplicaSet discovery나 자동 recovery를 수행하지 않는다.
 
 GitHub Release publish/resolve job과 script, 별도 deploy workflow는 삭제한다. 실패 뒤 application을 되돌려야 하면 pipeline 도입 이후 실제 production에 배포됐고 현재 DB와 호환되는 이전 release commit에 새 tag를 붙여 동일한 build·approval·sync 경로를 실행한다. Pipeline 도입 전 임의 commit은 rollback 대상으로 보장하지 않으며 이는 DB rollback이 아니다.
 
@@ -60,7 +60,7 @@ GitHub Release publish/resolve job과 script, 별도 deploy workflow는 삭제�
 - [최신 pending tag가 이전 pending tag를 대체함] → 중간 tag를 모두 배포하지 않고 실행 중 배포와 최신 후보만 보존한다.
 - [이전 production release commit 재배포는 기존 image 재사용이 아니라 새 build임] → 단순한 단일 경로를 우선하며 각 실행이 만든 digest를 그대로 승인·배포·감사한다.
 - [기존 ECR 7일 expiry가 production digest를 삭제할 수 있음] → `stable`을 배포 선택자가 아닌 lifecycle 보존 표식으로 유지하고 나머지 기존 정리 정책을 보존한다.
-- [API와 Web activation은 원자적이지 않음] → PreSync와 동일 desired digest만 pipeline이 보장하고 진행 상태는 Rollout controller에 맡긴다.
+- [API와 Web activation은 원자적이지 않음] → Migration과 동일 desired digest만 pipeline이 보장하고 진행 상태는 Rollout controller에 맡긴다.
 
 ## Migration Plan
 

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/proposal.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-Production build와 배포가 GitHub Release 발행, 별도 deploy workflow와 tag 형식 검증으로 나뉘어 실제 필요한 경로보다 복잡하다. Git tag가 가리키는 commit을 build한 workflow가 그 결과 digest를 production 승인 뒤 그대로 migration과 API·Web에 전달하면 별도 release 객체나 selector 없이 같은 identity를 보장할 수 있다.
+Production build와 배포가 GitHub Release 발행, 별도 deploy workflow와 tag 형식 검증으로 나뉘어 실제 필요한 경로보다 복잡하다. Git tag가 가리키는 commit을 build한 workflow가 그 결과 digest를 production 승인 뒤 그대로 migration과 모든 활성화 workload에 전달하면 별도 release 객체나 selector 없이 같은 identity를 보장할 수 있다.
 
 ## What Changes
 
 - 모든 Git tag push에서 production image를 build한다. SemVer 또는 다른 tag 이름 규칙을 두지 않는다.
 - Tag build job이 만든 digest를 같은 workflow의 production 승인 job으로 직접 전달한다.
-- Production 승인 뒤 같은 digest를 migration Job, API와 Web Rollout에 설정하고 Argo CD sync를 실행한다.
-- PreSync migration 성공 뒤에는 Argo CD와 Rollout controller의 기본 activation을 사용한다.
+- Production 승인 뒤 같은 digest를 migration Job과 모든 활성화 workload에 설정하고 Argo CD sync를 실행한다.
+- 기반 리소스 적용 뒤 Sync wave 1 migration을 성공시키고 wave 2에서 Argo CD와 workload controller의 기본 activation을 사용한다.
 - GitHub Release, Release asset·attestation, `publish_release`, 별도 deploy workflow와 publish/resolve script를 제거한다.
 - 실행 중인 production 배포는 보존하고 최신 pending tag가 이전 pending tag를 대체한다.
 - 실패 시 pipeline이 ReplicaSet을 복구하지 않는다. Pipeline 도입 이후 실제 production에 배포된 호환 가능한 이전 release commit에 새 tag를 붙이면 같은 build·승인·배포 경로를 다시 실행한다.
@@ -35,4 +35,4 @@ Production build와 배포가 GitHub Release 발행, 별도 deploy workflow와 t
 - Docker build workflow의 tag trigger와 production approval job
 - Helm digest image reference와 production Rollout activation
 - 기존 GitHub Release publish/resolve 및 별도 production deploy workflow 제거
-- `kosmo-prod` Application의 release parameter seam과 PROD-564 PreSync migration Job 소비
+- `kosmo-prod` Application의 release parameter seam과 PROD-564 migration-gated Sync Job 소비

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/specs/production-release/spec.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/specs/production-release/spec.md
@@ -16,12 +16,12 @@
 
 ### Requirement: Tag build와 production 배포는 같은 digest를 사용한다
 
-**Authority / Provenance:** PROD-563 — 시스템은 tag build가 생성한 digest-pinned image identity를 같은 workflow의 production 승인 job에 직접 전달해야 한다(MUST). Migration Job, API Rollout과 Web Rollout은 그 하나의 digest를 사용해야 한다(MUST). GitHub Release, Release asset 또는 mutable container tag를 중간 identity source로 요구해서는 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — 시스템은 tag build가 생성한 digest-pinned image identity를 같은 workflow의 production 승인 job에 직접 전달해야 한다(MUST). Migration Job과 모든 활성화 workload는 그 하나의 digest를 사용해야 한다(MUST). GitHub Release, Release asset 또는 mutable container tag를 중간 identity source로 요구해서는 안 된다(MUST NOT).
 
 #### Scenario: 승인된 tag build
 
 - **WHEN** tag build가 image digest를 만들고 `prod` Environment 승인을 받는다
-- **THEN** 시스템은 그 digest를 migration, API와 Web에 동일하게 설정한다
+- **THEN** 시스템은 그 digest를 migration과 모든 활성화 workload에 동일하게 설정한다
 
 #### Scenario: Build 실패
 
@@ -30,7 +30,7 @@
 
 ### Requirement: Production 배포는 한 번의 명시적 승인을 요구한다
 
-**Authority / Provenance:** PROD-563 — 시스템은 GitHub `prod` Environment 승인을 받은 tag build만 Argo CD production credential을 얻고 배포 상태를 변경하게 해야 한다(MUST). 같은 승인은 migration과 API·Web 전체에 적용되어야 하며(MUST), 별도 verification·migration approval job을 추가해서는 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — 시스템은 GitHub `prod` Environment 승인을 받은 tag build만 Argo CD production credential을 얻고 배포 상태를 변경하게 해야 한다(MUST). 같은 승인은 migration과 모든 활성화 workload 전체에 적용되어야 하며(MUST), 별도 verification·migration approval job을 추가해서는 안 된다(MUST NOT).
 
 시스템은 실행 중인 production 배포를 새 tag 때문에 취소해서는 안 된다(MUST NOT). 새 tag build가 같은 배포 대기열에 도달하면 아직 실행되지 않은 이전 pending tag build를 최신 pending tag build로 대체할 수 있다(MAY).
 
@@ -58,23 +58,23 @@
 - **WHEN** production 배포 실행이 성공하거나 실패하며 종료된다
 - **THEN** 시스템은 요청자, tag, commit, digest와 결과를 workflow 기록에 남긴다
 
-### Requirement: PreSync 뒤 controller 기본 activation을 사용한다
+### Requirement: Migration 뒤 controller 기본 activation을 사용한다
 
-**Authority / Provenance:** PROD-563 — Argo CD는 같은 digest의 production migration Job을 PreSync로 성공시킨 뒤 API와 Web Rollout을 적용해야 한다(MUST). Release pipeline은 두 Rollout의 preview를 교차 대기하거나 직접 승격해서는 안 되며(MUST NOT), 이전 ReplicaSet을 찾아 자동 복구해서도 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — Argo CD는 기반 리소스를 적용한 뒤 같은 digest의 production migration Job을 Sync wave 1로 성공시키고 API와 Web Rollout·HPA 및 background Deployment를 wave 2에서 적용해야 한다(MUST). Release pipeline은 두 Rollout의 preview를 교차 대기하거나 직접 승격해서는 안 되며(MUST NOT), 이전 ReplicaSet을 찾아 자동 복구해서도 안 된다(MUST NOT).
 
 #### Scenario: Migration 성공
 
-- **WHEN** 같은 digest의 PreSync migration이 성공한다
-- **THEN** Argo CD는 API·Web Rollout을 적용하고 각 controller가 기본 activation을 수행한다
+- **WHEN** 같은 digest의 Sync wave 1 migration이 성공한다
+- **THEN** Argo CD는 API·Web Rollout·HPA와 background Deployment를 wave 2에서 적용하고 각 controller가 기본 activation을 수행한다
 
 #### Scenario: Migration 또는 sync 실패
 
-- **WHEN** PreSync migration이나 Argo CD sync가 실패한다
+- **WHEN** migration이나 Argo CD sync가 실패한다
 - **THEN** 실행은 실패로 기록되고 pipeline은 Rollout·ReplicaSet을 직접 복구하지 않는다
 
 ### Requirement: 이전 production release는 같은 tag 경로로 다시 배포한다
 
-**Authority / Provenance:** PROD-563 — 운영자는 이 pipeline 도입 이후 실제 production에 배포됐고 현재 DB와 호환되는 이전 release commit에 새 Git tag를 붙여 같은 build·production 승인·PreSync·sync 경로로 application을 다시 배포할 수 있어야 한다(MUST). Pipeline 도입 전의 임의 commit을 현재 workflow로 배포할 것을 보장하지 않으며, DB rollback이나 destructive migration을 자동 실행해서는 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — 운영자는 이 pipeline 도입 이후 실제 production에 배포됐고 현재 DB와 호환되는 이전 release commit에 새 Git tag를 붙여 같은 build·production 승인·migration-gated sync 경로로 application을 다시 배포할 수 있어야 한다(MUST). Pipeline 도입 전의 임의 commit을 현재 workflow로 배포할 것을 보장하지 않으며, DB rollback이나 destructive migration을 자동 실행해서는 안 된다(MUST NOT).
 
 #### Scenario: 이전 production release commit 재배포
 

--- a/openspec/changes/archive/2026-07-30-add-production-release-pipeline/tasks.md
+++ b/openspec/changes/archive/2026-07-30-add-production-release-pipeline/tasks.md
@@ -30,12 +30,12 @@
 
 **Deliverable**
 
-Tag build가 만든 digest를 같은 workflow의 production 승인 job이 PreSync migration과 API·Web에 배포한다.
+Tag build가 만든 digest를 같은 workflow의 production 승인 job이 Sync wave 1 migration과 wave 2 API·Web·background workload에 배포한다.
 
 **Guardrails**
 
 - `prod` Environment 승인 전 Argo CD credential을 얻거나 상태를 변경하지 않는다.
-- Migration, API와 Web은 같은 build digest를 사용한다.
+- Migration과 모든 활성화 workload는 같은 build digest를 사용한다.
 - Pipeline은 Rollout preview·promotion·ReplicaSet recovery를 직접 조정하지 않는다.
 - 실행 중 배포는 취소하지 않고 최신 pending tag가 이전 pending tag를 대체한다.
 - PROD-562 runtime과 PROD-564 migration credential·Job command를 구현하지 않는다.
@@ -43,10 +43,10 @@ Tag build가 만든 digest를 같은 workflow의 production 승인 job이 PreSyn
 **Verification**
 
 - Tag-only deploy 조건, build dependency, Environment, OIDC와 Argo CD sync 순서를 확인한다.
-- 동일 digest render, PreSync Job 하나와 controller 기본 activation을 확인한다.
+- 동일 digest render, Sync wave 1 Job 하나와 wave 2 controller 기본 activation을 확인한다.
 
 - [x] 2.1 Production deploy를 Docker Build workflow의 tag-only `prod` Environment job으로 이동한다.
-- [x] 2.2 Build digest를 Helm parameter로 전달하고 동일-image PreSync manifest 확인 뒤 Argo CD sync를 실행한다.
+- [x] 2.2 Build digest를 Helm parameter로 전달하고 동일-image migration-gated Sync manifest 확인 뒤 Argo CD sync를 실행한다.
 - [x] 2.3 Production Rollout controller 기본 activation과 custom recovery 부재를 검증한다.
 - [x] 2.4 `prod` Environment의 main-only policy를 제거하고 tag-only 조건은 workflow 한 곳에 둔다.
 - [x] 2.5 고정 concurrency group이 실행 중 배포와 최신 pending tag만 유지하는 계약을 검증한다.

--- a/openspec/changes/archive/2026-08-03-run-drizzle-migrations-per-file/specs/production-migration-gate/spec.md
+++ b/openspec/changes/archive/2026-08-03-run-drizzle-migrations-per-file/specs/production-migration-gate/spec.md
@@ -25,12 +25,12 @@
 
 ### Requirement: Production release 단일 승인과 실패 차단
 
-**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-563`, `PROD-564`, `PROD-656`. 정식 production release 승인은 선택한 immutable image의 migration과 API/Web workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 되며(MUST NOT), 중간 파일 실패 시 성공한 앞 migration의 schema와 history는 함께 유지하고 실패한 파일의 schema와 history는 함께 rollback해야 한다(MUST).
+**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-563`, `PROD-564`, `PROD-656`. 정식 production release 승인은 선택한 immutable image의 migration과 모든 활성화 workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 되며(MUST NOT), 중간 파일 실패 시 성공한 앞 migration의 schema와 history는 함께 유지하고 실패한 파일의 schema와 history는 함께 rollback해야 한다(MUST).
 
 #### Scenario: Migration 성공
 
 - **WHEN** 승인된 production release의 모든 pending migration 파일이 성공한다
-- **THEN** PROD-563 pipeline은 같은 immutable release의 API와 Web 활성화를 진행할 수 있다
+- **THEN** PROD-563 pipeline은 같은 immutable release의 모든 wave 2 workload 활성화를 진행할 수 있다
 
 #### Scenario: Migration 중간 파일 실패
 

--- a/openspec/changes/archive/2026-08-04-accept-nonlinear-drizzle-history/specs/production-migration-gate/spec.md
+++ b/openspec/changes/archive/2026-08-04-accept-nonlinear-drizzle-history/specs/production-migration-gate/spec.md
@@ -31,12 +31,12 @@
 
 ### Requirement: Production release 단일 승인과 실패 차단
 
-**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-563`, `PROD-564`, `PROD-656`. 정식 production release 승인은 선택한 immutable image의 migration과 API/Web workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 되며(MUST NOT), 중간 파일 실패 시 성공한 앞 migration의 schema와 history는 함께 유지하고 실패한 파일의 schema와 history는 함께 rollback해야 한다(MUST).
+**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-563`, `PROD-564`, `PROD-656`. 정식 production release 승인은 선택한 immutable image의 migration과 모든 활성화 workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 되며(MUST NOT), 중간 파일 실패 시 성공한 앞 migration의 schema와 history는 함께 유지하고 실패한 파일의 schema와 history는 함께 rollback해야 한다(MUST).
 
 #### Scenario: Migration 성공
 
 - **WHEN** 승인된 production release의 모든 pending migration 파일이 성공한다
-- **THEN** PROD-563 pipeline은 같은 immutable release의 API와 Web 활성화를 진행할 수 있다
+- **THEN** PROD-563 pipeline은 같은 immutable release의 모든 wave 2 workload 활성화를 진행할 수 있다
 
 #### Scenario: Migration 중간 파일 실패
 

--- a/openspec/specs/dev-database-migrations/spec.md
+++ b/openspec/specs/dev-database-migrations/spec.md
@@ -83,7 +83,7 @@ Deploy Dev workflow는 Docker Build 성공 후 migration을 포함한 Argo CD fu
 #### Scenario: Migration 성공 후 rollout
 
 - **WHEN** Docker Build가 성공하고 Argo CD full sync와 migration Job이 성공한다
-- **THEN** deployment workflow는 `kosmo-api`와 `kosmo-web` Rollout restart를 실행한다
+- **THEN** deployment workflow는 `kosmo-api`와 `kosmo-web` Rollout 및 렌더된 background Deployment의 restart를 실행한다
 
 #### Scenario: Dev deploy 직렬 실행
 

--- a/openspec/specs/dev-database-migrations/spec.md
+++ b/openspec/specs/dev-database-migrations/spec.md
@@ -58,14 +58,15 @@ dev 환경에서 Drizzle SQL migration을 애플리케이션 rollout보다 먼�
 - **THEN** 새 runner는 lock 해제를 기다리지 않고 migration을 중복 실행하지 않는다
 - **AND** 새 runner는 명시적인 실패 exit status를 반환한다
 
-### Requirement: Dev PreSync migration Job
+### Requirement: Dev Sync migration Job
 
 dev Helm release는 API 또는 web container의 startup/initContainer와 분리된 단일 Kubernetes Job으로 runtime migration command를 실행해야 한다(MUST).
 
-#### Scenario: Argo full sync의 migration 선행 실행
+#### Scenario: Argo full sync의 migration-gated workload 교체
 
 - **WHEN** dev application에 Argo CD full sync가 시작된다
-- **THEN** Argo CD는 application resource sync 전에 migration Job을 `PreSync` hook으로 실행한다
+- **THEN** Argo CD는 기반 리소스를 적용한 뒤 migration Job을 `Sync` wave 1 hook으로 실행한다
+- **AND** dev workload는 migration Job이 성공한 뒤 wave 2에서 교체된다
 - **AND** Job은 dev workload와 같은 `main` image reference를 사용한다
 - **AND** Job은 단일 Pod에서 재시작 없이 migration command를 실행한다
 

--- a/openspec/specs/dev-database-migrations/spec.md
+++ b/openspec/specs/dev-database-migrations/spec.md
@@ -74,11 +74,11 @@ dev Helm release는 API 또는 web container의 startup/initContainer와 분리�
 
 - **WHEN** migration Job이 실패한다
 - **THEN** Argo CD sync는 실패한다
-- **AND** dev deployment workflow는 API와 web Rollout restart를 실행하지 않는다
+- **AND** dev deployment workflow는 API와 web Rollout 및 background Deployment restart를 실행하지 않는다
 
 ### Requirement: Migration-gated dev rollout
 
-Deploy Dev workflow는 Docker Build 성공 후 migration을 포함한 Argo CD full sync를 완료하고, 성공한 경우에만 API와 web Rollout을 restart해야 한다(MUST).
+Deploy Dev workflow는 Docker Build 성공 후 migration을 포함한 Argo CD full sync를 완료하고, 성공한 경우에만 API와 web Rollout 및 렌더된 background Deployment를 restart해야 한다(MUST).
 
 #### Scenario: Migration 성공 후 rollout
 

--- a/openspec/specs/production-migration-gate/spec.md
+++ b/openspec/specs/production-migration-gate/spec.md
@@ -2,13 +2,13 @@
 
 ## Purpose
 
-Production migration이 고정된 database 대상과 분리된 credential을 사용하고 API/Web과 동일한 immutable release에서 실행되며, 성공하기 전에는 새 workload가 활성화되지 않도록 하는 실행 경계를 정의한다.
+Production migration이 고정된 database 대상과 분리된 credential을 사용하고 모든 활성화 workload와 동일한 immutable release에서 실행되며, 성공하기 전에는 새 workload가 활성화되지 않도록 하는 실행 경계를 정의한다.
 
 ## Requirements
 
 ### Requirement: 분리된 production migration 권한
 
-**Authority / Provenance:** `PROD-564`, `PROD-616`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), API와 Web runtime credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-564`, `PROD-616`, `memory/database-migrations.md`. Production migration Job은 schema migration에 필요한 별도 database identity와 credential을 사용해야 하며(MUST), runtime workload credential을 사용하거나 migration credential이 없을 때 runtime credential로 fallback해서는 안 된다(MUST NOT).
 
 #### Scenario: Migration credential로 실행
 
@@ -16,7 +16,7 @@ Production migration이 고정된 database 대상과 분리된 credential을 사
 - **THEN** Job은 production migration 전용 Secret과 database identity로 연결한다
 - **AND** 연결 후 명시적인 database owner role로 전환해 새 schema 객체가 runtime owner의 권한 경계에 남게 한다
 - **AND** 접속 대상은 현재 Helm release의 PostgreSQL read-write Service와 `kosmo` database로 고정된다
-- **AND** API와 Web workload는 같은 credential을 mount하거나 참조하지 않는다
+- **AND** Runtime workload는 같은 credential을 mount하거나 참조하지 않는다
 
 #### Scenario: Migration 대상 입력 금지
 
@@ -32,12 +32,12 @@ Production migration이 고정된 database 대상과 분리된 credential을 사
 
 ### Requirement: 동일한 immutable release identity
 
-**Authority / Provenance:** `PROD-564`, `PROD-269`. Production migration Job, API와 Web workload는 승인된 release의 동일한 immutable image digest를 사용해야 한다(MUST). Mutable tag 또는 서로 다른 digest로 production migration을 실행해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `PROD-564`, `PROD-269`. Production migration Job과 모든 활성화 workload는 승인된 release의 동일한 immutable image digest를 사용해야 한다(MUST). Mutable tag 또는 서로 다른 digest로 production migration을 실행해서는 안 된다(MUST NOT).
 
 #### Scenario: 동일 digest로 렌더
 
 - **WHEN** production release manifest가 렌더된다
-- **THEN** migration Job, API와 Web image reference는 같은 `repository@sha256:...` 값이다
+- **THEN** migration Job과 모든 활성화 workload image reference는 같은 `repository@sha256:...` 값이다
 
 #### Scenario: Mutable production image 거부
 
@@ -88,12 +88,12 @@ Production migration이 고정된 database 대상과 분리된 credential을 사
 
 ### Requirement: Production release 단일 승인과 실패 차단
 
-**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-563`, `PROD-564`, `PROD-656`. 정식 production release 승인은 선택한 immutable image의 migration과 API/Web workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 되며(MUST NOT), 중간 파일 실패 시 성공한 앞 migration의 schema와 history는 함께 유지하고 실패한 파일의 schema와 history는 함께 rollback해야 한다(MUST).
+**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-563`, `PROD-564`, `PROD-656`. 정식 production release 승인은 선택한 immutable image의 migration과 모든 활성화 workload 전체에 한 번 적용되어야 한다(MUST). Migration이 성공하기 전에 같은 release의 새 workload를 활성화해서는 안 되며(MUST NOT), 중간 파일 실패 시 성공한 앞 migration의 schema와 history는 함께 유지하고 실패한 파일의 schema와 history는 함께 rollback해야 한다(MUST).
 
 #### Scenario: Migration 성공
 
 - **WHEN** 승인된 production release의 모든 pending migration 파일이 성공한다
-- **THEN** PROD-563 pipeline은 같은 immutable release의 API와 Web 활성화를 진행할 수 있다
+- **THEN** PROD-563 pipeline은 같은 immutable release의 모든 wave 2 workload 활성화를 진행할 수 있다
 
 #### Scenario: Migration 중간 파일 실패
 

--- a/openspec/specs/production-release/spec.md
+++ b/openspec/specs/production-release/spec.md
@@ -64,23 +64,23 @@ Git tag build가 만든 하나의 image digest를 명시적 production 승인 �
 - **WHEN** production 배포 실행이 성공하거나 실패하며 종료된다
 - **THEN** 시스템은 요청자, tag, commit, digest와 결과를 workflow 기록에 남긴다
 
-### Requirement: PreSync 뒤 controller 기본 activation을 사용한다
+### Requirement: Migration 뒤 controller 기본 activation을 사용한다
 
-**Authority / Provenance:** PROD-563 — Argo CD는 같은 digest의 production migration Job을 PreSync로 성공시킨 뒤 API와 Web Rollout을 적용해야 한다(MUST). Release pipeline은 두 Rollout의 preview를 교차 대기하거나 직접 승격해서는 안 되며(MUST NOT), 이전 ReplicaSet을 찾아 자동 복구해서도 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — Argo CD는 기반 리소스를 적용한 뒤 같은 digest의 production migration Job을 Sync wave 1로 성공시키고 API와 Web Rollout을 wave 2에서 적용해야 한다(MUST). Release pipeline은 두 Rollout의 preview를 교차 대기하거나 직접 승격해서는 안 되며(MUST NOT), 이전 ReplicaSet을 찾아 자동 복구해서도 안 된다(MUST NOT).
 
 #### Scenario: Migration 성공
 
-- **WHEN** 같은 digest의 PreSync migration이 성공한다
-- **THEN** Argo CD는 API·Web Rollout을 적용하고 각 controller가 기본 activation을 수행한다
+- **WHEN** 같은 digest의 Sync wave 1 migration이 성공한다
+- **THEN** Argo CD는 API·Web Rollout과 HPA를 wave 2에서 적용하고 각 controller가 기본 activation을 수행한다
 
 #### Scenario: Migration 또는 sync 실패
 
-- **WHEN** PreSync migration이나 Argo CD sync가 실패한다
+- **WHEN** migration이나 Argo CD sync가 실패한다
 - **THEN** 실행은 실패로 기록되고 pipeline은 Rollout·ReplicaSet을 직접 복구하지 않는다
 
 ### Requirement: 이전 production release는 같은 tag 경로로 다시 배포한다
 
-**Authority / Provenance:** PROD-563 — 운영자는 이 pipeline 도입 이후 실제 production에 배포됐고 현재 DB와 호환되는 이전 release commit에 새 Git tag를 붙여 같은 build·production 승인·PreSync·sync 경로로 application을 다시 배포할 수 있어야 한다(MUST). Pipeline 도입 전의 임의 commit을 현재 workflow로 배포할 것을 보장하지 않으며, DB rollback이나 destructive migration을 자동 실행해서는 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — 운영자는 이 pipeline 도입 이후 실제 production에 배포됐고 현재 DB와 호환되는 이전 release commit에 새 Git tag를 붙여 같은 build·production 승인·migration-gated sync 경로로 application을 다시 배포할 수 있어야 한다(MUST). Pipeline 도입 전의 임의 commit을 현재 workflow로 배포할 것을 보장하지 않으며, DB rollback이나 destructive migration을 자동 실행해서는 안 된다(MUST NOT).
 
 #### Scenario: 이전 production release commit 재배포
 

--- a/openspec/specs/production-release/spec.md
+++ b/openspec/specs/production-release/spec.md
@@ -66,12 +66,12 @@ Git tag build가 만든 하나의 image digest를 명시적 production 승인 �
 
 ### Requirement: Migration 뒤 controller 기본 activation을 사용한다
 
-**Authority / Provenance:** PROD-563 — Argo CD는 기반 리소스를 적용한 뒤 같은 digest의 production migration Job을 Sync wave 1로 성공시키고 API와 Web Rollout을 wave 2에서 적용해야 한다(MUST). Release pipeline은 두 Rollout의 preview를 교차 대기하거나 직접 승격해서는 안 되며(MUST NOT), 이전 ReplicaSet을 찾아 자동 복구해서도 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — Argo CD는 기반 리소스를 적용한 뒤 같은 digest의 production migration Job을 Sync wave 1로 성공시키고 API와 Web Rollout·HPA 및 background Deployment를 wave 2에서 적용해야 한다(MUST). Release pipeline은 두 Rollout의 preview를 교차 대기하거나 직접 승격해서는 안 되며(MUST NOT), 이전 ReplicaSet을 찾아 자동 복구해서도 안 된다(MUST NOT).
 
 #### Scenario: Migration 성공
 
 - **WHEN** 같은 digest의 Sync wave 1 migration이 성공한다
-- **THEN** Argo CD는 API·Web Rollout과 HPA를 wave 2에서 적용하고 각 controller가 기본 activation을 수행한다
+- **THEN** Argo CD는 API·Web Rollout·HPA와 background Deployment를 wave 2에서 적용하고 각 controller가 기본 activation을 수행한다
 
 #### Scenario: Migration 또는 sync 실패
 

--- a/openspec/specs/production-release/spec.md
+++ b/openspec/specs/production-release/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Git tag build가 만든 하나의 image digest를 명시적 production 승인 뒤 migration, API와 Web에 배포하는 경계를 정의한다.
+Git tag build가 만든 하나의 image digest를 명시적 production 승인 뒤 migration과 모든 활성화 workload에 배포하는 경계를 정의한다.
 
 ## Requirements
 
@@ -22,12 +22,12 @@ Git tag build가 만든 하나의 image digest를 명시적 production 승인 �
 
 ### Requirement: Tag build와 production 배포는 같은 digest를 사용한다
 
-**Authority / Provenance:** PROD-563 — 시스템은 tag build가 생성한 digest-pinned image identity를 같은 workflow의 production 승인 job에 직접 전달해야 한다(MUST). Migration Job, API Rollout과 Web Rollout은 그 하나의 digest를 사용해야 한다(MUST). GitHub Release, Release asset 또는 mutable container tag를 중간 identity source로 요구해서는 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — 시스템은 tag build가 생성한 digest-pinned image identity를 같은 workflow의 production 승인 job에 직접 전달해야 한다(MUST). Migration Job과 모든 활성화 workload는 그 하나의 digest를 사용해야 한다(MUST). GitHub Release, Release asset 또는 mutable container tag를 중간 identity source로 요구해서는 안 된다(MUST NOT).
 
 #### Scenario: 승인된 tag build
 
 - **WHEN** tag build가 image digest를 만들고 `prod` Environment 승인을 받는다
-- **THEN** 시스템은 그 digest를 migration, API와 Web에 동일하게 설정한다
+- **THEN** 시스템은 그 digest를 migration과 모든 활성화 workload에 동일하게 설정한다
 
 #### Scenario: Build 실패
 
@@ -36,7 +36,7 @@ Git tag build가 만든 하나의 image digest를 명시적 production 승인 �
 
 ### Requirement: Production 배포는 한 번의 명시적 승인을 요구한다
 
-**Authority / Provenance:** PROD-563 — 시스템은 GitHub `prod` Environment 승인을 받은 tag build만 Argo CD production credential을 얻고 배포 상태를 변경하게 해야 한다(MUST). 같은 승인은 migration과 API·Web 전체에 적용되어야 하며(MUST), 별도 verification·migration approval job을 추가해서는 안 된다(MUST NOT).
+**Authority / Provenance:** PROD-563 — 시스템은 GitHub `prod` Environment 승인을 받은 tag build만 Argo CD production credential을 얻고 배포 상태를 변경하게 해야 한다(MUST). 같은 승인은 migration과 모든 활성화 workload 전체에 적용되어야 하며(MUST), 별도 verification·migration approval job을 추가해서는 안 된다(MUST NOT).
 
 시스템은 실행 중인 production 배포를 새 tag 때문에 취소해서는 안 된다(MUST NOT). 새 tag build가 같은 배포 대기열에 도달하면 아직 실행되지 않은 이전 pending tag build를 최신 pending tag build로 대체할 수 있다(MAY).
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `db-migrate`를 `PreSync`에서 `Sync` wave 1 hook으로 옮겼습니다.
- API/Web Rollout·HPA와 Fedify/Worker Deployment를 wave 2로 배치했습니다.
- Dev full sync 성공 뒤 API/Web Rollout과 렌더된 background Deployment를 restart합니다.
- 기반 리소스가 먼저 적용되고 migration이 성공한 뒤에만 workload가 교체되는 순서를 운영 문서와 저장소 memory에 반영했습니다.
- `dev-database-migrations`, `production-migration-gate`, `production-release` active spec과 `adopt-production-release-branch` active change를 같은 Sync wave·전체 workload 계약으로 동기화했습니다.
- 대응하는 archived OpenSpec의 spec·proposal·design·decisions·tasks와 production release/migration runbook, migration memory에 남아 있던 `PreSync`·API/Web-only 표현을 현재 계약으로 맞춰습니다.

## 왜 변경했는지

Production 배포에서 `db-migrate`가 `PreSync`로 실행되면서 같은 sync에서 생성할 `kosmo_api`와 `kosmo_worker` DatabaseRole보다 먼저 실행됐습니다. 그 결과 `GRANT` migration이 `role "kosmo_api" does not exist` (`42704`)로 실패했고 workload 교체가 중단됐습니다.

## 이번 PR의 주요 결정

### 별도 이슈나 operator 상태 장벽 없이 Argo CD 순서만 수정

- 결정자: @robin-maki
- 선택: 기반 리소스는 기존 Sync wave에 두고 migration을 wave 1, workload를 wave 2로 배치합니다.
- 고려한 대안: 별도 이슈/OpenSpec 생성, CNPG reconciliation 상태를 확인하는 별도 readiness 장벽 추가
- 이유: 이번 장애는 `PreSync`가 일반 Sync 리소스보다 먼저 실행된 순서 문제이며, 요청 범위를 그 원인 수정으로 제한합니다.
- 감수한 결과: 이 PR은 CNPG operator 상태 모델이나 별도 prerequisite framework를 도입하지 않습니다.

## 어떻게 확인할 수 있는지

- `helm lint apps/helm --set env=dev --set migration.enabled=true --set worker.enabled=true`
- `helm lint apps/helm --set env=prod --set imageDigest=sha256:0000000000000000000000000000000000000000000000000000000000000000 --set migration.enabled=true --set worker.enabled=true`
- Production Helm render에서 migration `Sync/1`, API/Web Rollout·HPA와 Fedify/Worker Deployment `2` 확인
- Production Helm render에서 migration·API·Web·Fedify·Worker가 모두 같은 digest-pinned image를 사용함을 확인
- `pnpm exec openspec validate --all --strict` — 98개 통과
- `actionlint .github/workflows/deploy-dev.yml`
- `pnpm lint:prettier`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- Production 재배포와 live migration 성공 확인은 이 PR에서 수행하지 않았습니다.
- Argo CD wave는 DatabaseRole CR 제출 순서를 보장하지만 CNPG가 PostgreSQL role을 실제 생성할 때까지 별도 readiness 장벽으로 기다리지는 않습니다. 이번 PR은 합의한 범위에 따라 이 잔여 경합을 추가 구현으로 확장하지 않습니다.
