### PR TITLE
Semgrep 스캔 대상 누락 가능성을 줄인다

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   # Update only after validating the new version in a Semgrep run.
-  SEMGREP_VERSION: '1.171.0'
+  SEMGREP_VERSION: '1.173.0'
   SEMGREP_CONFIGS: >-
     --config=p/default
     --config=p/javascript


### PR DESCRIPTION
## 무엇을 변경했는지

- Semgrep 설치 버전을 `1.171.0`에서 `1.173.0`으로 업데이트했습니다.
- 기존 config, JSON artifact, annotation, Job Summary, Slack 알림과 실행 실패 처리는 유지했습니다.

## 왜 변경했는지

Semgrep `1.173.0`은 경로 필터링 실패로 대상 파일이 결과와 skipped 목록에서 조용히 누락될 수 있던 문제를 수정합니다. 또한 일부 규칙의 중복 finding 생성을 수정해 스캔 결과 무결성을 개선합니다.

Linear: [PROD-774](https://linear.app/byulmaru/issue/PROD-774/semgrep을-11730으로-업데이트해-스캔-대상-누락을-방지한다)

## 이번 PR의 주요 결정

### `1.173.0`을 7일 안정화 기준의 일회성 예외로 적용한다

- 결정자: 사용자
- 선택: 공식 릴리스 후 7일이 지나기 전이지만 Semgrep `1.173.0`으로 업데이트
- 고려한 대안: 저장소의 npm 패키지 기준과 동일하게 7일 경과 후 업데이트
- 이유: 스캔 대상 파일이 조용히 누락될 수 있는 문제와 중복 finding 문제가 KOSMO의 스캔 무결성에 직접 관련됩니다.
- 감수한 결과: 일반 안정화 기간보다 이르게 도입하므로 원격 Semgrep 실행과 결과 artifact를 필수로 확인합니다.
- 관련 근거: [Semgrep v1.173.0](https://github.com/semgrep/semgrep/releases/tag/v1.173.0)

이 결정은 `1.173.0`에만 적용하며 `pnpm-workspace.yaml`의 `minimumReleaseAge` 정책은 변경하지 않습니다.

## 어떻게 확인할 수 있는지

- [x] `pnpm exec prettier --check .github/workflows/semgrep.yml`
- [x] `git diff --check`
- [x] GitHub-hosted Ubuntu/Python 3.12에서 Semgrep `1.173.0` 설치·실행 확인
- [x] 1,882개 파일 스캔 및 `semgrep-report` JSON artifact 업로드 확인
- [x] 기존 결과 처리와 실패 전파 경로 유지 확인

## 아직 어떤 문제가 남았는지

없음. 셀프호스트 러너는 점진적으로 제거할 계획이므로 macOS ARM64 검증은 이 PR의 완료 조건으로 두지 않습니다.

Stack: `main` → `prod-774`
