### PR TITLE
GraphQL 권한 경계를 application policy로 되돌린다

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ to point at another path.
 
 Application processes read their PostgreSQL connection only from `PGHOST`,
 `PGPORT`, `PGUSER`, `PGDATABASE`, and `PGPASSWORD`. Vault environments used by
-`pnpm dev` must provide those keys. The Fedify queue keeps its separate database
-URL and role boundary.
+`pnpm dev` must provide those keys. Until PROD-779 removes the GraphQL operation
+session, the operation pool also requires `OPERATION_DATABASE_URL`. The Fedify
+queue keeps its separate database URL and role boundary. The target connection
+boundary after that transition is documented in
+[ADR 0024](docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md).
 
 The API uses `MEDIA_STORAGE_SERVICE_ORIGIN` and `MEDIA_STORAGE_SERVICE_API_KEY`
 to issue browser upload URLs and persist the completed public representation

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ such as `pnpm dev`. The default secret path is
 or `node scripts/vault-run.mjs --secret-path secret/kubernetes/kosmo/dev -- <command>`
 to point at another path.
 
-Application processes read their default PostgreSQL connection only from
-`PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE`, and `PGPASSWORD`. Vault environments
-used by `pnpm dev` must provide those keys. Separate connection boundaries such
-as the GraphQL operation pool and Fedify queue keep their dedicated URL inputs.
+Application processes read their PostgreSQL connection only from `PGHOST`,
+`PGPORT`, `PGUSER`, `PGDATABASE`, and `PGPASSWORD`. Vault environments used by
+`pnpm dev` must provide those keys. The Fedify queue keeps its separate database
+URL and role boundary.
 
 The API uses `MEDIA_STORAGE_SERVICE_ORIGIN` and `MEDIA_STORAGE_SERVICE_API_KEY`
 to issue browser upload URLs and persist the completed public representation

--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -57,31 +57,23 @@ core는 검증된 Profile identity를 받아 action에 고유한 상태, 관계,
 `actorProfileId`와 `sourcePostId`를 전달한다. 향후 ActivityPub Repost ingress가 생기면 signature와
 Remote actor 검증 뒤 같은 action을 재사용할 수 있지만, ingress와 delivery는 현재 Repost 범위가 아니다.
 
-## GraphQL operation DB 경계
+## GraphQL authorization과 DB 경계
 
-GraphQL user-data query, result projection과 domain action은 실행 중인 operation의 `ctx.db`를 사용한다.
-Mutation도 root domain action뿐 아니라 반환 payload의 nested result resolver와 loader까지 같은 operation
-`ctx.db`를 사용한다. 이 경계에는 GraphQL resolver, loader와 그 resolver가 호출하는 core action의 모든
-operation SQL이 포함되며, global 또는 raw DB fallback을 추가하지 않는다.
+GraphQL 진입점은 caller 인증, Active Account, selected Profile Membership과 selected Profile 조회 가능
+상태를 검증한다. Post visibility, owner 조건과 interaction 가능 여부는 중앙 application policy helper가
+소유하며, resolver와 selector가 같은 조건을 별도로 만들지 않는다. 목록의 후보, 정렬과 pagination도
+application query 계층이 계산한다.
 
-`selectProfile` Mutation이 `Sessions.activeProfileId`와 `ctx.session.profileId`를 selected Profile로
-전환하면, 같은 operation Database에서 `selectProfile`이 소유하는 action-local narrow transaction 안에서 session-level
-`kosmo.profile_id`도 새 Profile UUID로 갱신해야 한다. 이 설정은 transaction 완료 뒤 이어지는
-top-level Mutation field가 같은 operation session에서 관찰할 수 있어야 하며, `kosmo.account_id`는
-그대로 유지한다. 이는 operation-wide transaction이 아니라 새로 추가하는 `selectProfile`-owned
-narrow transaction 경계다. 이 경계는 같은 operation의 serial sibling 사이 stale GUC를 막는 범위이며,
-authorization concurrency, locking 또는 TOCTOU safety를 보장하는 계약이 아니다.
+GraphQL의 요청별 가시성·owner policy는 PostgreSQL RLS나 session actor state로 계산하지 않는다.
+GraphQL application SQL은 표준 `PGHOST`/`PGPORT`/`PGUSER`/`PGDATABASE`/`PGPASSWORD`로 구성한 process
+shared DB access 경계를 사용하고, API, Web과 Worker는 하나의 shared non-owner runtime role을 사용한다.
+GraphQL operation 전용 DB session, actor GUC, operation-scoped `ctx.db`와 `OPERATION_DATABASE_URL`은
+target architecture에 포함하지 않는다.
 
-다음 두 종류의 SQL은 operation session 밖에서 표준 `PGHOST`/`PGPORT`/`PGUSER`/`PGDATABASE`/`PGPASSWORD`로 구성한 process 기본 direct DB를 사용한다.
-
-- request authentication과 process startup/bootstrap에서 실행하는 identity 또는 초기화 SQL
-- 인증된 `searchProfiles`가 명시적인 remote handle을 처음 materialize할 때 Fedify가 소유한 remote actor
-  materialization trusted side effect
-
-`searchProfiles`의 예외는 materialization 단계에만 적용한다. materialization이 끝난 뒤 최종 Profile 검색과
-result projection은 해당 GraphQL operation의 `ctx.db`에서 실행한다. Fedify inbound/delivery, Temporal
-Workflow/Activity와 worker entry는 이 GraphQL RLS DB 경계에 포함하지 않으며, 각자의 direct DB lifecycle을
-유지한다. 이 change는 RLS policy·grant나 credential을 바꾸지 않는다.
+Fedify MessageQueue의 별도 database/role과 migration owner 경계는 유지한다. Fedify inbound/delivery,
+Temporal Workflow/Activity와 worker의 기능·policy는 이 GraphQL authorization 결정으로 변경하지 않는다.
+세부 결정과 전환 경계는
+[ADR 0024](../domain/decisions/0024-application-policy-and-runtime-db-boundary.md)를 따른다.
 
 ## Public contract
 

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -112,6 +112,8 @@ Account 요청에서 Profile이 주체인 행동의 `Account.Active`는 해당 P
 - [ADR 0020: Profile Tag Shared Hashtag Identity](./decisions/0020-profile-tag-shared-hashtag-identity.md)
 - [ADR 0021: Hashtag 관련 Profile 목록 탐색 Contract](./decisions/0021-hashtag-related-profile-navigation.md)
 - [ADR 0022: Post Content Revision Media Nodes](./decisions/0022-post-content-revision-media-nodes.md)
+- [ADR 0023: Profile Viewer Membership Edit Eligibility](./decisions/0023-profile-viewer-membership-edit-eligibility.md)
+- [ADR 0024: Application Policy and Runtime DB Boundary](./decisions/0024-application-policy-and-runtime-db-boundary.md)
 - [2026-06-28 DDD 명세 점검 기록](./records/2026-06-28-ddd-spec-audit.md)
 - [2026-06-29 결정 반영 기록](./records/2026-06-29-decision-round.md)
 - [2026-06-29 PR 리뷰 반영 기록](./records/2026-06-29-pr-review-followup.md)

--- a/docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md
+++ b/docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md
@@ -1,0 +1,56 @@
+# ADR 0024: Application Policy and Runtime DB Boundary
+
+## 상태
+
+Accepted
+
+## 날짜
+
+2026-08-16
+
+## 결정
+
+- GraphQL 사용자 데이터의 SNS 가시성 및 owner 권한에는 PostgreSQL Row-Level Security를 사용하지 않는다.
+  이 결정은 PostgreSQL RLS의 모든 사용을 금지하는 일반 원칙이 아니라, 차단·팔로우·공개 범위와
+  interaction 권한처럼 요청 actor에 따라 달라지는 Kosmo GraphQL 정책의 경계를 정한다.
+- GraphQL 진입점은 caller 인증, Active Account와 selected Profile Membership 및 selected Profile 조회
+  가능 상태를 검증한다. 이 경계를 통과한 resolver와 application action은 검증된 identity를 사용한다.
+- Post visibility, owner 조건과 interaction 가능 여부는 기존 중앙 application policy helper가 소유한다.
+  resolver와 selector는 이 policy를 재구현하지 않고, 목록의 후보·정렬·pagination도 application query
+  계층에서 계산한다.
+- PostgreSQL은 foreign key, unique, 상태 불변식과 runtime object ACL을 강제한다. GraphQL의 요청별
+  가시성·owner business rule을 DB session actor state로 계산하지 않는다.
+- GraphQL operation 전용 DB session, actor GUC, operation-scoped `ctx.db`와
+  `OPERATION_DATABASE_URL`은 target architecture에서 제거한다. GraphQL application SQL은 process의
+  shared DB access 경계를 사용한다.
+- API, Web과 Worker application runtime은 표준 `PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE`,
+  `PGPASSWORD`와 하나의 shared non-owner runtime role을 사용한다. migration owner와 Fedify queue의
+  별도 database/role 경계는 유지한다.
+- 이 전환은 hidden/deleted Post owner cleanup, `DELETE RETURNING` mutation payload, Notification cleanup,
+  viewer-independent Reaction count를 변경하지 않는다.
+
+## 근거
+
+- 기존 application policy가 GraphQL 조회와 action의 가시성·owner 조건을 중앙화하고 있다. RLS를 추가해도
+  application이 소유해야 하는 후보·정렬·pagination과 transport 결과 계약은 사라지지 않는다.
+- 요청마다 변하는 차단·팔로우·공개 범위 정책을 DB session과 policy에 중복하면 query plan, connection
+  lifecycle과 장애 원인의 결합이 커진다.
+- 단일 non-owner runtime role과 object ACL은 application runtime이 schema owner 권한을 갖지 않게 하면서,
+  요청별 actor credential과 role 분리를 유지하는 비용은 제거한다.
+- 향후 cache, precomputed timeline, search index, sharding 또는 service 분리를 도입할 때 같은 application
+  policy contract를 각 read model에 적용할 수 있어야 한다.
+
+## 전환
+
+- 이미 main에 병합된 Post/PostContent와 Bookmark RLS는 새 compensating migration으로 제거한다.
+- 미병합 Reaction 및 Follow Request RLS 변경은 merge하지 않는다.
+- RLS consumer가 제거된 뒤 operation session, actor helper와 전용 PgBouncer Pooler를 제거한다.
+- runtime role 통합은 별도 구현 slice가 소유한다. production role drop, Secret sync/apply, cutover와 live
+  verification은 이 결정의 실행 범위가 아니며 별도 승인이 필요하다.
+
+## 관련 결정
+
+- [ADR 0003: Policy Ownership Clarifications](./0003-policy-ownership-clarifications.md)
+- [ADR 0019: Selected Profile Authorization Boundary](./0019-selected-profile-authorization-boundary.md)
+- [Core 서비스 경계](../../architecture/core-services.md)
+- [PROD-776](https://linear.app/byulmaru/issue/PROD-776/postgresql-rls-%EC%A0%84%ED%99%98%EC%9D%84-%EC%B2%A0%ED%9A%8C%ED%95%98%EA%B3%A0-application-policy-%EA%B2%BD%EA%B3%84%EB%A5%BC-%ED%99%95%EC%A0%95%ED%95%9C%EB%8B%A4)

--- a/docs/operations/postgres-session-pool.md
+++ b/docs/operations/postgres-session-pool.md
@@ -1,5 +1,10 @@
 # PostgreSQL PgBouncer session pool 운영
 
+> [!IMPORTANT]
+> 이 문서는 GraphQL operation session과 RLS 전환의 과거 운영·incident·rollback 기록이다. 현재 target
+> architecture는 [ADR 0024](../domain/decisions/0024-application-policy-and-runtime-db-boundary.md)로
+> 대체되었다. 이 문서의 production 명령은 새 전환 계획과 별도 승인 없이 실행하지 않는다.
+
 ## 운영 경계
 
 이 문서는 CloudNativePG가 생성한 read-write PgBouncer Pooler를 기존 PostgreSQL Cluster 옆에 배포하고 확인하는 절차를 정의한다.

--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -61,7 +61,7 @@
   outcome일 때만 core 반환값에 포함한다.
 - core가 Fedify 같은 protocol/delivery package를 호출하는 사실만으로 경계 위반으로 판단하지 않는다.
   core public contract가 protocol 전용 타입에 의존하는지를 기준으로 판단한다.
-- production DB composition은 shared pool과 operation 전용 `Database`를 포함한다. operation·post-commit SQL을 같은 session에 유지하는 service는 `Database`를 받고, caller transaction에 합류하는 action만 `DatabaseHandle`(`Database | Transaction`)을 `getDatabaseConnection(handle)`로 선택해 transaction/savepoint 의미를 보존한다. `Transaction`은 post-commit·context 수명 경계로 전달하지 않고 test-only generic DB 추상화를 추가하지 않는다.
+- production DB composition은 process shared `Database`와 명시적인 secondary connection만 포함한다. GraphQL operation 전용 `Database`, actor GUC와 operation-scoped `ctx.db`는 target architecture에 포함하지 않는다. caller transaction에 합류하는 action만 `DatabaseHandle`(`Database | Transaction`)을 `getDatabaseConnection(handle)`로 선택해 transaction/savepoint 의미를 보존한다. `Transaction`은 post-commit·context 수명 경계로 전달하지 않고 test-only generic DB 추상화를 추가하지 않는다.
 - 명시적 비관적 DB 락은 동시성 위반이 금전 거래처럼 심각하고 되돌리기 어려운 피해를 만드는 use case에만 사용한다. 팔로우 요청처럼 드문 race의 영향이 작고 복구 가능한 social interaction은 락으로 완전 직렬화하지 않으며, 상세 판단과 리뷰 근거는 `memory/database-design.md`의 Runtime Locking Policy를 따른다.
 - `packages/core/db`는 DB client, schema, relation과 DB 전용 utility를 소유하고 account/session 생성 같은 application transaction은 소유하지 않는다.
 - OIDC discovery와 code exchange처럼 transport 또는 protocol-specific 검증은 API/BFF 경계에 남기고, core service에는 검증된 identity와 business input만 전달한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- GraphQL 사용자 데이터의 SNS 가시성·owner 권한을 PostgreSQL RLS가 아니라 기존 중앙 application policy가 소유하도록 ADR 0024를 추가했습니다.
- GraphQL operation 전용 DB session, actor GUC, operation-scoped `ctx.db`, `OPERATION_DATABASE_URL`을 target architecture에서 제외했습니다.
- application runtime은 표준 `PG*`와 단일 non-owner role을 사용하고 migration owner 및 Fedify queue 경계는 별도로 유지하도록 문서를 정렬했습니다.
- 기존 PgBouncer session-pool 문서는 삭제하지 않고 historical/superseded 문서로 표시했습니다.

## 왜 변경했는지

기존 Kosmo는 Post visibility, selected Profile membership과 owner/action predicate를 application helper에 이미 중앙화하고 있습니다. 요청별로 변하는 SNS 가시성 정책을 PostgreSQL session과 RLS에도 중복하면 connection lifecycle, query plan과 장애 분석의 결합이 커집니다. RLS 전환을 철회하고 application policy를 canonical enforcement 경계로 유지하기로 결정했습니다.

## 이번 PR의 주요 결정

### GraphQL 사용자 데이터 권한은 application policy가 소유한다

- 결정자: @robin-maki
- 선택: GraphQL 사용자 데이터의 SNS 가시성·owner 정책에 PostgreSQL RLS를 사용하지 않습니다.
- 고려한 대안: 기존 application predicate와 PostgreSQL RLS를 병행하거나, predicate를 제거하고 RLS로 전환하는 방안
- 이유: 기존 중앙 policy를 유지하면서 cache, search index, precomputed timeline과 향후 service 분리에서도 같은 계약을 재사용하기 위함입니다.
- 감수한 결과: DB가 요청별 business policy 누락을 자동으로 막아주지 않으므로 resolver와 selector는 중앙 policy를 일관되게 사용해야 합니다.
- 관련 근거: PROD-776, ADR 0024

### runtime credential 분리를 단일 non-owner role로 단순화한다

- 결정자: @robin-maki
- 선택: API, Web과 Worker application runtime은 표준 `PG*`와 하나의 non-owner role을 사용합니다.
- 고려한 대안: `kosmo_api`와 `kosmo_worker`를 RLS/BYPASSRLS 기준으로 계속 분리하는 방안
- 이유: RLS를 사용하지 않으므로 요청 경계별 credential 분리와 BYPASSRLS가 제공하던 독립 목적이 사라졌습니다.
- 감수한 결과: workload별 DB principal 격리는 포기하지만 schema owner와 runtime의 최소권한 경계는 유지합니다.
- 관련 근거: PROD-776, PROD-780, ADR 0024

## 어떻게 확인할 수 있는지

- `git diff --check`
- Prettier check: 변경된 Markdown 6개 파일 통과
- 문서 링크와 Linear issue dependency를 수동 대조

## 아직 어떤 문제가 남았는지

- PROD-777: Post/PostContent RLS compensating migration
- PROD-778: Bookmark RLS compensating migration
- PROD-779: operation session, actor GUC, `ctx.db`, PgBouncer 제거
- PROD-780: application runtime role 통합
- production preflight, sync/apply, cutover와 live verification은 별도 승인 범위입니다.
