### PR TITLE
production 리뷰 수정으로 main 테스트 계보를 복구한다

### DIFF
--- a/apps/api/tests/integration/graphql/operation-context.test.ts
+++ b/apps/api/tests/integration/graphql/operation-context.test.ts
@@ -1,27 +1,35 @@
 import '@kosmo/core/polyfill';
 
 import assert from 'node:assert/strict';
-import { after, test } from 'node:test';
-import { pg } from '@kosmo/core/db';
+import { after, before, test } from 'node:test';
 import { Hono } from 'hono';
-import { deriveContext } from '../../../src/context';
-import { yoga } from '../../../src/graphql';
-import type { Env } from '../../../src/context';
+import type * as CoreDb from '@kosmo/core/db';
+import type { deriveContext as DeriveContext, Env } from '../../../src/context';
+import type { yoga as YogaRouter } from '../../../src/graphql';
 
 process.env.NODE_ENV = 'production';
+
+let pg: typeof CoreDb.pg;
+let deriveContext: typeof DeriveContext;
+let yoga: typeof YogaRouter;
+let app: Hono<Env>;
+
+before(async () => {
+  ({ pg } = await import('@kosmo/core/db'));
+  ({ deriveContext } = await import('../../../src/context'));
+  ({ yoga } = await import('../../../src/graphql'));
+
+  app = new Hono<Env>();
+  app.use('*', async (c, next) => {
+    c.set('context', await deriveContext(c));
+    return next();
+  });
+  app.route('/graphql', yoga);
+});
 
 after(async () => {
   await pg.end();
 });
-
-const app = new Hono<Env>();
-
-app.use('*', async (c, next) => {
-  c.set('context', await deriveContext(c));
-  return next();
-});
-
-app.route('/graphql', yoga);
 
 test('does not execute a JSON array body as a batch', async () => {
   const response = await app.request('/graphql', {


### PR DESCRIPTION
## 무엇을 변경했는지

- `apps/api/tests/integration/graphql/operation-context.test.ts`에서 `NODE_ENV=production`을 설정한 뒤 DB·context·Yoga 모듈을 동적으로 import하도록 테스트 부트스트랩을 정렬했습니다.
- 테스트 앱과 종료 hook도 동일한 초기화 단계에서 구성하도록 바꿨습니다.

## 왜 변경했는지

PR #615의 production release 리뷰에서 정적 import가 `NODE_ENV=production` 설정보다 먼저 실행되어 integration 테스트 환경이 의도와 다르게 초기화될 수 있다는 지적이 있었습니다. Production release에는 반영된 이 수정이 `main` 계보에는 아직 없어, 후속 릴리스 수정이 다음 개발 브랜치에서 사라지지 않도록 복구합니다.

## 이번 PR의 주요 결정

- 새로운 동작·정책 결정은 없습니다. PR #615의 production 리뷰 수정 중 테스트 부트스트랩 변경만 최신 `main`에 반영했습니다.
- production 환경과 DB에는 어떤 변경도 수행하지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm exec prettier --check apps/api/tests/integration/graphql/operation-context.test.ts`
- `pnpm --filter @kosmo/api lint:tsc`
- 별도 포트의 disposable PostgreSQL에서 `pnpm --filter @kosmo/api test:integration`: 228 tests, 227 pass, 1 skipped, 0 failed
- `git diff --check`

## 아직 어떤 문제가 남아 있는지

없음. GitHub required checks는 PR 생성 후 실행됩니다.

Related: PROD-779, PR #615