### PR TITLE
Search와 반응 프로필 탭을 공용 primitive로 이관한다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/search.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/search.tsx
@@ -23,6 +23,7 @@ import { getShellLayout } from '@/components/shell/shellLayout';
 import { Button } from '@/components/ui/Button';
 import { IconButton } from '@/components/ui/IconButton';
 import { StateView } from '@/components/ui/StateView';
+import { Tab, TabList } from '@/components/ui/Tabs';
 import { addRecentSearch, readRecentSearches, writeRecentSearches } from '@/lib/recentSearches';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -595,38 +596,20 @@ export default function SearchScreen() {
 
       {phase === 'results' ? (
         <View style={web && styles.webContent}>
-          <View
+          <TabList
             accessibilityLabel="검색 결과 유형"
-            accessibilityRole="tablist"
-            style={[styles.tabs, { backgroundColor: theme.card, borderColor: theme.border }]}
+            onValueChange={(tab) => {
+              if (tab !== activeTab) {
+                navigate(query, tab, 'tab');
+              }
+            }}
+            value={activeTab}
+            variant="underline"
           >
             {tabs.map((tab) => (
-              <Pressable
-                aria-selected={activeTab === tab.value}
-                accessibilityRole="tab"
-                accessibilityState={{ selected: activeTab === tab.value }}
-                key={tab.value}
-                onPress={() => {
-                  if (tab.value !== activeTab) {
-                    navigate(query, tab.value, 'tab');
-                  }
-                }}
-                style={styles.tab}
-              >
-                <Text
-                  style={[
-                    styles.tabLabel,
-                    { color: activeTab === tab.value ? theme.text : theme.textSecondary },
-                  ]}
-                >
-                  {tab.label}
-                </Text>
-                {activeTab === tab.value ? (
-                  <View style={[styles.tabIndicator, { backgroundColor: theme.text }]} />
-                ) : null}
-              </Pressable>
+              <Tab key={tab.value} option={tab} />
             ))}
-          </View>
+          </TabList>
           {activeTab === SearchTab.PEOPLE ? (
             <PeopleResults handle={query} />
           ) : (
@@ -723,7 +706,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     ...typography.sm,
   },
-  tabs: { borderBottomWidth: 1, flexDirection: 'row', height: 44 },
   pagination: {
     alignItems: 'center',
     gap: spacing.sm,
@@ -734,20 +716,5 @@ const styles = StyleSheet.create({
     fontFamily: 'SUIT',
     textAlign: 'center',
     ...typography.xsm,
-  },
-  tab: {
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'center',
-    minHeight: 44,
-  },
-  tabLabel: { fontFamily: 'SUIT', fontWeight: '600', ...typography.xsm },
-  tabIndicator: {
-    borderRadius: radii.full,
-    bottom: 0,
-    height: 2,
-    left: '30%',
-    position: 'absolute',
-    right: '30%',
   },
 });

--- a/apps/app/src/components/reaction/ReactionProfilesModal.tsx
+++ b/apps/app/src/components/reaction/ReactionProfilesModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+import { Modal, Pressable, ScrollView, StyleSheet } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { RouteBoundary } from '@/components/RouteBoundary';
 import { StateView } from '@/components/ui/StateView';
+import { Tab, TabList } from '@/components/ui/Tabs';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing } from '@/theme/tokens';
 import { ReactionProfileConnection } from './ReactionProfileConnection';
@@ -88,41 +89,26 @@ export function ReactionProfilesModal({
           onPress={(event) => event.stopPropagation()}
           style={[styles.surface, { backgroundColor: theme.card, borderColor: theme.border }]}
         >
-          <ScrollView
-            accessibilityRole="tablist"
-            contentContainerStyle={styles.tabs}
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            style={styles.tabsScroll}
+          <TabList
+            accessibilityLabel="반응 유형"
+            onValueChange={(type) => {
+              setFetchKey(0);
+              setReactionType(type);
+            }}
+            value={reactionType}
+            variant="pill"
           >
-            {reactionCounts.map(({ count, type }) => {
-              const selected = type === reactionType;
-
-              return (
-                <Pressable
-                  accessibilityLabel={`${type} 반응 ${count}개`}
-                  accessibilityRole="tab"
-                  accessibilityState={{ selected }}
-                  aria-selected={selected}
-                  key={type}
-                  onPress={() => {
-                    setFetchKey(0);
-                    setReactionType(type);
-                  }}
-                  style={({ pressed }) => [
-                    styles.tab,
-                    {
-                      backgroundColor: selected ? theme.background : theme.card,
-                      borderColor: selected ? theme.primary : theme.border,
-                      opacity: pressed ? 0.85 : 1,
-                    },
-                  ]}
-                >
-                  <Text style={[styles.tabLabel, { color: theme.text }]}>{`${type} ${count}`}</Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
+            {reactionCounts.map(({ count, type }) => (
+              <Tab
+                key={type}
+                option={{
+                  accessibilityLabel: `${type} 반응 ${count}개`,
+                  label: `${type} ${count}`,
+                  value: type,
+                }}
+              />
+            ))}
+          </TabList>
           <ScrollView contentContainerStyle={styles.content}>
             <RouteBoundary
               key={reactionType}
@@ -157,23 +143,5 @@ const styles = StyleSheet.create({
     maxWidth: 420,
     width: '100%',
   },
-  tabs: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: spacing.xs,
-    paddingHorizontal: spacing.lg,
-    paddingTop: spacing.lg,
-  },
-  tabsScroll: { flexGrow: 0, maxWidth: '100%' },
-  tab: {
-    alignItems: 'center',
-    borderRadius: radii.sm,
-    borderWidth: 1,
-    flexShrink: 0,
-    justifyContent: 'center',
-    minHeight: 32,
-    paddingHorizontal: spacing.sm,
-  },
-  tabLabel: { fontFamily: 'SUIT', fontSize: 14, fontWeight: '700', lineHeight: 20 },
   content: { padding: spacing.lg },
 });

--- a/apps/app/src/components/ui/Tabs.tsx
+++ b/apps/app/src/components/ui/Tabs.tsx
@@ -95,9 +95,24 @@ export function TabList<Value extends string>({
       <View
         accessibilityLabel={accessibilityLabel}
         accessibilityRole="tablist"
-        style={[styles.underlineList, { backgroundColor: theme.card, borderColor: theme.border }]}
+        style={[
+          styles.underlineList,
+          {
+            backgroundColor: Platform.OS === 'android' ? 'transparent' : theme.card,
+            borderColor: theme.border,
+          },
+        ]}
         {...(web ? ({ role: 'tablist' } as WebTabListProps) : undefined)}
       >
+        {Platform.OS === 'android' ? (
+          <View
+            pointerEvents="none"
+            style={[
+              styles.underlineVisualBackdrop,
+              { backgroundColor: theme.card, borderColor: theme.border },
+            ]}
+          />
+        ) : null}
         {children}
       </View>
     );
@@ -279,7 +294,7 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
 
 const styles = StyleSheet.create({
   underlineList: {
-    borderBottomWidth: borderWidths[1],
+    borderBottomWidth: Platform.OS === 'android' ? 0 : borderWidths[1],
     flexDirection: 'row',
     height: Platform.OS === 'android' ? 48 : 44,
   },
@@ -288,16 +303,25 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     minHeight: Platform.OS === 'android' ? 48 : 44,
+    paddingBottom: Platform.OS === 'android' ? space[4] : 0,
     paddingHorizontal: space[8],
   },
   underlineLabel: textStyles.uiLabelS,
   tabIndicator: {
     borderRadius: radius.full,
-    bottom: 0,
+    bottom: Platform.OS === 'android' ? space[4] : 0,
     height: borderWidths[2],
     left: '30%',
     position: 'absolute',
     right: '30%',
+  },
+  underlineVisualBackdrop: {
+    borderBottomWidth: borderWidths[1],
+    height: 44,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
   pillScroll: { flexGrow: 0, maxWidth: '100%' },
   pillList: {

--- a/apps/app/src/components/ui/Tabs.tsx
+++ b/apps/app/src/components/ui/Tabs.tsx
@@ -223,7 +223,9 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
                   ? theme.background
                   : theme.card
                 : 'transparent'
-              : theme.card,
+              : Platform.OS === 'android'
+                ? 'transparent'
+                : theme.card,
           borderColor:
             context.variant === 'pill'
               ? web

--- a/apps/app/src/components/ui/Tabs.tsx
+++ b/apps/app/src/components/ui/Tabs.tsx
@@ -177,7 +177,6 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
       accessibilityRole="tab"
       accessibilityState={{ disabled, selected }}
       disabled={disabled}
-      hitSlop={Platform.OS === 'web' ? undefined : space[8]}
       onBlur={() => setFocusVisible(false)}
       onFocus={(event) => {
         if (Platform.OS !== 'web') {
@@ -203,13 +202,26 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
         context.variant === 'pill' ? styles.pillTab : styles.underlineTab,
         {
           backgroundColor:
-            context.variant === 'pill' ? (selected ? theme.background : theme.card) : theme.card,
-          borderColor: context.variant === 'pill' && selected ? theme.primary : theme.border,
+            context.variant === 'pill'
+              ? web
+                ? selected
+                  ? theme.background
+                  : theme.card
+                : 'transparent'
+              : theme.card,
+          borderColor:
+            context.variant === 'pill'
+              ? web
+                ? selected
+                  ? theme.primary
+                  : theme.border
+                : 'transparent'
+              : theme.border,
           opacity: disabled ? 0.45 : (web ? webPressed : state.pressed) ? 0.85 : 1,
           ...(focusVisible
             ? {
                 outlineColor: theme.stateFocusRing,
-                outlineOffset: 2,
+                outlineOffset: context.variant === 'pill' ? -2 : 2,
                 outlineStyle: 'solid',
                 outlineWidth: borderWidths[2],
               }
@@ -233,16 +245,31 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
           } as WebTabProps)
         : undefined)}
     >
-      <Text
-        style={[
-          context.variant === 'pill' ? styles.pillLabel : styles.underlineLabel,
-          {
-            color: context.variant === 'underline' && !selected ? theme.textSecondary : theme.text,
-          },
-        ]}
-      >
-        {option.label}
-      </Text>
+      {context.variant === 'pill' && !web ? (
+        <View
+          style={[
+            styles.pillSurface,
+            {
+              backgroundColor: selected ? theme.background : theme.card,
+              borderColor: selected ? theme.primary : theme.border,
+            },
+          ]}
+        >
+          <Text style={[styles.pillLabel, { color: theme.text }]}>{option.label}</Text>
+        </View>
+      ) : (
+        <Text
+          style={[
+            context.variant === 'pill' ? styles.pillLabel : styles.underlineLabel,
+            {
+              color:
+                context.variant === 'underline' && !selected ? theme.textSecondary : theme.text,
+            },
+          ]}
+        >
+          {option.label}
+        </Text>
+      )}
       {context.variant === 'underline' && selected && !disabled ? (
         <View style={[styles.tabIndicator, { backgroundColor: theme.text }]} />
       ) : null}
@@ -254,13 +281,13 @@ const styles = StyleSheet.create({
   underlineList: {
     borderBottomWidth: borderWidths[1],
     flexDirection: 'row',
-    height: 44,
+    height: Platform.OS === 'android' ? 48 : 44,
   },
   underlineTab: {
     alignItems: 'center',
     flex: 1,
     justifyContent: 'center',
-    minHeight: 44,
+    minHeight: Platform.OS === 'android' ? 48 : 44,
     paddingHorizontal: space[8],
   },
   underlineLabel: textStyles.uiLabelS,
@@ -278,13 +305,27 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: space[4],
     paddingHorizontal: space[16],
-    paddingTop: space[16],
+    paddingTop:
+      Platform.OS === 'web'
+        ? space[16]
+        : Platform.OS === 'android'
+          ? space[8]
+          : space[8] + borderWidths[2],
   },
   pillTab: {
     alignItems: 'center',
+    borderRadius: Platform.OS === 'web' ? radius[8] : 0,
+    borderWidth: Platform.OS === 'web' ? borderWidths[1] : 0,
+    flexShrink: 0,
+    height: Platform.OS === 'web' ? 32 : Platform.OS === 'android' ? 48 : 44,
+    justifyContent: 'center',
+    minWidth: Platform.OS === 'web' ? undefined : Platform.OS === 'android' ? 48 : 44,
+    paddingHorizontal: Platform.OS === 'web' ? space[8] : 0,
+  },
+  pillSurface: {
+    alignItems: 'center',
     borderRadius: radius[8],
     borderWidth: borderWidths[1],
-    flexShrink: 0,
     height: 32,
     justifyContent: 'center',
     paddingHorizontal: space[8],

--- a/apps/app/src/components/ui/Tabs.tsx
+++ b/apps/app/src/components/ui/Tabs.tsx
@@ -42,9 +42,8 @@ type WebTabListProps = { role: 'tablist' };
 type WebTabProps = {
   'aria-disabled': boolean;
   'aria-selected': boolean;
-  onMouseDown: () => void;
-  onMouseUp: () => void;
   onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
+  onPointerCancel: () => void;
   onPointerDown: () => void;
   onPointerUp: () => void;
   role: 'tab';
@@ -113,8 +112,8 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
 
   const theme = useTheme();
   const optionRef = useRef<View>(null);
-  const [pressed, setPressed] = useState(false);
   const [focusVisible, setFocusVisible] = useState(false);
+  const [webPressed, setWebPressed] = useState(false);
   context.optionRefs.set(option.value, optionRef);
 
   const disabled = Boolean(option.disabled);
@@ -189,17 +188,21 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
         setFocusVisible(Boolean(target.matches?.(':focus-visible')));
       }}
       onKeyDown={onKeyDown}
-      onPressIn={() => setPressed(true)}
-      onPress={() => {
+      onPress={(event) => {
         if (disabled) {
           return;
+        }
+        if (
+          web &&
+          (event.nativeEvent as unknown as { type?: string } | undefined)?.type === 'click'
+        ) {
+          setFocusVisible(false);
         }
         context.setFocusValue(option.value);
         if (!selected) {
           context.onValueChange(option.value);
         }
       }}
-      onPressOut={() => setPressed(false)}
       ref={optionRef}
       style={(state) => [
         context.variant === 'pill' ? styles.pillTab : styles.underlineTab,
@@ -207,7 +210,7 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
           backgroundColor:
             context.variant === 'pill' ? (selected ? theme.background : theme.card) : theme.card,
           borderColor: context.variant === 'pill' && selected ? theme.primary : theme.border,
-          opacity: disabled ? 0.45 : pressed || state.pressed ? 0.85 : 1,
+          opacity: disabled ? 0.45 : (web ? webPressed : state.pressed) ? 0.85 : 1,
           ...(focusVisible
             ? {
                 outlineColor: theme.stateFocusRing,
@@ -222,17 +225,13 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
         ? ({
             'aria-disabled': disabled,
             'aria-selected': selected,
-            onMouseDown: () => {
-              setFocusVisible(false);
-              setPressed(true);
-            },
-            onMouseUp: () => setPressed(false),
             onKeyDown,
+            onPointerCancel: () => setWebPressed(false),
             onPointerDown: () => {
               setFocusVisible(false);
-              setPressed(true);
+              setWebPressed(true);
             },
-            onPointerUp: () => setPressed(false),
+            onPointerUp: () => setWebPressed(false),
             role: 'tab',
             tabIndex,
           } as WebTabProps)

--- a/apps/app/src/components/ui/Tabs.tsx
+++ b/apps/app/src/components/ui/Tabs.tsx
@@ -45,6 +45,7 @@ type WebTabProps = {
   onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
   onPointerCancel: () => void;
   onPointerDown: () => void;
+  onPointerLeave: () => void;
   onPointerUp: () => void;
   role: 'tab';
   tabIndex: -1 | 0;
@@ -188,15 +189,9 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
         setFocusVisible(Boolean(target.matches?.(':focus-visible')));
       }}
       onKeyDown={onKeyDown}
-      onPress={(event) => {
+      onPress={() => {
         if (disabled) {
           return;
-        }
-        if (
-          web &&
-          (event.nativeEvent as unknown as { type?: string } | undefined)?.type === 'click'
-        ) {
-          setFocusVisible(false);
         }
         context.setFocusValue(option.value);
         if (!selected) {
@@ -231,6 +226,7 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
               setFocusVisible(false);
               setWebPressed(true);
             },
+            onPointerLeave: () => setWebPressed(false),
             onPointerUp: () => setWebPressed(false),
             role: 'tab',
             tabIndex,

--- a/apps/app/src/components/ui/Tabs.tsx
+++ b/apps/app/src/components/ui/Tabs.tsx
@@ -153,9 +153,7 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
     if (event.key === ' ' || event.key === 'Spacebar') {
       event.preventDefault();
       context.setFocusValue(option.value);
-      if (!selected) {
-        context.onValueChange(option.value);
-      }
+      context.onValueChange(option.value);
       return;
     }
 
@@ -208,9 +206,7 @@ export function Tab<Value extends string>({ option }: TabProps<Value>) {
           return;
         }
         context.setFocusValue(option.value);
-        if (!selected) {
-          context.onValueChange(option.value);
-        }
+        context.onValueChange(option.value);
       }}
       ref={optionRef}
       style={(state) => [

--- a/apps/app/src/components/ui/Tabs.tsx
+++ b/apps/app/src/components/ui/Tabs.tsx
@@ -1,0 +1,298 @@
+import { Children, createContext, useContext, useEffect, useRef, useState } from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, radius, space, textStyles } from '@/theme/tokens';
+import type { ReactElement, RefObject } from 'react';
+import type { ViewStyle } from 'react-native';
+
+export type TabVariant = 'pill' | 'underline';
+
+export type TabOption<Value extends string> = Readonly<{
+  accessibilityLabel?: string;
+  disabled?: boolean;
+  label: string;
+  value: Value;
+}>;
+
+export type TabListProps<Value extends string> = {
+  accessibilityLabel: string;
+  children: ReactElement<TabProps<Value>> | readonly ReactElement<TabProps<Value>>[];
+  onValueChange: (value: Value) => void;
+  value: Value;
+  variant: TabVariant;
+};
+
+export type TabProps<Value extends string> = {
+  option: TabOption<Value>;
+};
+
+type TabContextValue = Readonly<{
+  focusValue: string;
+  onValueChange: (value: string) => void;
+  optionRefs: Map<string, RefObject<View | null>>;
+  options: readonly TabOption<string>[];
+  setFocusValue: (value: string) => void;
+  value: string;
+  variant: TabVariant;
+}>;
+
+const TabContext = createContext<TabContextValue | null>(null);
+
+type WebTabListProps = { role: 'tablist' };
+type WebTabProps = {
+  'aria-disabled': boolean;
+  'aria-selected': boolean;
+  onMouseDown: () => void;
+  onMouseUp: () => void;
+  onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
+  onPointerDown: () => void;
+  onPointerUp: () => void;
+  role: 'tab';
+  tabIndex: -1 | 0;
+};
+
+export function TabList<Value extends string>({
+  accessibilityLabel,
+  children,
+  onValueChange,
+  value,
+  variant,
+}: TabListProps<Value>) {
+  const theme = useTheme();
+  const [focusValue, setFocusValue] = useState<string>(value);
+  const optionRefs = useRef(new Map<string, RefObject<View | null>>());
+  const options = Children.toArray(children).map(
+    (child) => (child as ReactElement<TabProps<Value>>).props.option,
+  );
+  const web = Platform.OS === 'web';
+
+  useEffect(() => setFocusValue(value), [value]);
+
+  const contextValue: TabContextValue = {
+    focusValue,
+    onValueChange: onValueChange as (value: string) => void,
+    optionRefs: optionRefs.current,
+    options: options as readonly TabOption<string>[],
+    setFocusValue,
+    value,
+    variant,
+  };
+
+  const content =
+    variant === 'pill' ? (
+      <ScrollView
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="tablist"
+        contentContainerStyle={styles.pillList}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.pillScroll}
+        {...(web ? ({ role: 'tablist' } as WebTabListProps) : undefined)}
+      >
+        {children}
+      </ScrollView>
+    ) : (
+      <View
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="tablist"
+        style={[styles.underlineList, { backgroundColor: theme.card, borderColor: theme.border }]}
+        {...(web ? ({ role: 'tablist' } as WebTabListProps) : undefined)}
+      >
+        {children}
+      </View>
+    );
+
+  return <TabContext.Provider value={contextValue}>{content}</TabContext.Provider>;
+}
+
+export function Tab<Value extends string>({ option }: TabProps<Value>) {
+  const context = useContext(TabContext);
+  if (!context) {
+    throw new Error('Tab은 TabList 안에서 사용해야 합니다.');
+  }
+
+  const theme = useTheme();
+  const optionRef = useRef<View>(null);
+  const [pressed, setPressed] = useState(false);
+  const [focusVisible, setFocusVisible] = useState(false);
+  context.optionRefs.set(option.value, optionRef);
+
+  const disabled = Boolean(option.disabled);
+  const selected = context.value === option.value;
+  const enabledOptions = context.options.filter((candidate) => !candidate.disabled);
+  const focusEnabled = enabledOptions.some((candidate) => candidate.value === context.focusValue);
+  const selectedEnabled = enabledOptions.some((candidate) => candidate.value === context.value);
+  const tabStopValue = focusEnabled
+    ? context.focusValue
+    : selectedEnabled
+      ? context.value
+      : enabledOptions[0]?.value;
+  const tabIndex = disabled || option.value !== tabStopValue ? -1 : 0;
+  const web = Platform.OS === 'web';
+
+  const onKeyDown = (event: { key: string; preventDefault: () => void }) => {
+    if (disabled || !web || enabledOptions.length === 0) {
+      return;
+    }
+
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      context.setFocusValue(option.value);
+      if (!selected) {
+        context.onValueChange(option.value);
+      }
+      return;
+    }
+
+    const currentIndex = enabledOptions.findIndex(({ value }) => value === option.value);
+    if (currentIndex < 0) {
+      return;
+    }
+
+    const target =
+      event.key === 'Home'
+        ? enabledOptions[0]
+        : event.key === 'End'
+          ? enabledOptions.at(-1)
+          : event.key === 'ArrowRight'
+            ? enabledOptions[(currentIndex + 1) % enabledOptions.length]
+            : event.key === 'ArrowLeft'
+              ? enabledOptions[(currentIndex - 1 + enabledOptions.length) % enabledOptions.length]
+              : undefined;
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    context.setFocusValue(target.value);
+    const targetRef = context.optionRefs.get(target.value)?.current as unknown as {
+      focus?: () => void;
+    } | null;
+    targetRef?.focus?.();
+  };
+
+  return (
+    <Pressable
+      accessibilityLabel={option.accessibilityLabel ?? option.label}
+      accessibilityRole="tab"
+      accessibilityState={{ disabled, selected }}
+      disabled={disabled}
+      hitSlop={Platform.OS === 'web' ? undefined : space[8]}
+      onBlur={() => setFocusVisible(false)}
+      onFocus={(event) => {
+        if (Platform.OS !== 'web') {
+          return;
+        }
+        const target = event.currentTarget as unknown as {
+          matches?: (selector: string) => boolean;
+        };
+        setFocusVisible(Boolean(target.matches?.(':focus-visible')));
+      }}
+      onKeyDown={onKeyDown}
+      onPressIn={() => setPressed(true)}
+      onPress={() => {
+        if (disabled) {
+          return;
+        }
+        context.setFocusValue(option.value);
+        if (!selected) {
+          context.onValueChange(option.value);
+        }
+      }}
+      onPressOut={() => setPressed(false)}
+      ref={optionRef}
+      style={(state) => [
+        context.variant === 'pill' ? styles.pillTab : styles.underlineTab,
+        {
+          backgroundColor:
+            context.variant === 'pill' ? (selected ? theme.background : theme.card) : theme.card,
+          borderColor: context.variant === 'pill' && selected ? theme.primary : theme.border,
+          opacity: disabled ? 0.45 : pressed || state.pressed ? 0.85 : 1,
+          ...(focusVisible
+            ? {
+                outlineColor: theme.stateFocusRing,
+                outlineOffset: 2,
+                outlineStyle: 'solid',
+                outlineWidth: borderWidths[2],
+              }
+            : { outlineStyle: 'none' }),
+        } as ViewStyle,
+      ]}
+      {...(web
+        ? ({
+            'aria-disabled': disabled,
+            'aria-selected': selected,
+            onMouseDown: () => {
+              setFocusVisible(false);
+              setPressed(true);
+            },
+            onMouseUp: () => setPressed(false),
+            onKeyDown,
+            onPointerDown: () => {
+              setFocusVisible(false);
+              setPressed(true);
+            },
+            onPointerUp: () => setPressed(false),
+            role: 'tab',
+            tabIndex,
+          } as WebTabProps)
+        : undefined)}
+    >
+      <Text
+        style={[
+          context.variant === 'pill' ? styles.pillLabel : styles.underlineLabel,
+          {
+            color: context.variant === 'underline' && !selected ? theme.textSecondary : theme.text,
+          },
+        ]}
+      >
+        {option.label}
+      </Text>
+      {context.variant === 'underline' && selected && !disabled ? (
+        <View style={[styles.tabIndicator, { backgroundColor: theme.text }]} />
+      ) : null}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  underlineList: {
+    borderBottomWidth: borderWidths[1],
+    flexDirection: 'row',
+    height: 44,
+  },
+  underlineTab: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    minHeight: 44,
+    paddingHorizontal: space[8],
+  },
+  underlineLabel: textStyles.uiLabelS,
+  tabIndicator: {
+    borderRadius: radius.full,
+    bottom: 0,
+    height: borderWidths[2],
+    left: '30%',
+    position: 'absolute',
+    right: '30%',
+  },
+  pillScroll: { flexGrow: 0, maxWidth: '100%' },
+  pillList: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: space[4],
+    paddingHorizontal: space[16],
+    paddingTop: space[16],
+  },
+  pillTab: {
+    alignItems: 'center',
+    borderRadius: radius[8],
+    borderWidth: borderWidths[1],
+    flexShrink: 0,
+    height: 32,
+    justifyContent: 'center',
+    paddingHorizontal: space[8],
+  },
+  pillLabel: textStyles.uiLabelM,
+});

--- a/apps/app/src/stories/Reactions.stories.tsx
+++ b/apps/app/src/stories/Reactions.stories.tsx
@@ -812,11 +812,17 @@ export const SwitchingReactionTypeDoesNotReuseProfileRows: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: '반응한 프로필 보기' }));
     await expect(screen.findByText('Heart Type Profile')).resolves.toBeVisible();
-    await userEvent.click(screen.getByRole('tab', { name: '🎉 반응 7개' }));
+    const heartTab = screen.getByRole('tab', { name: '❤️ 반응 12개' });
+    const partyTab = screen.getByRole('tab', { name: '🎉 반응 7개' });
+    heartTab.focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(partyTab).toHaveFocus();
+    expect(partyTab).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('Heart Type Profile')).toBeVisible();
+    await userEvent.keyboard('{Enter}');
     expect(screen.queryByText('Heart Type Profile')).not.toBeInTheDocument();
     await expect(screen.findByText('Party Type Profile')).resolves.toBeVisible();
-    expect(screen.queryByText('Heart Type Profile')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('🎉 반응')).toBeVisible();
+    expect(partyTab).toHaveAttribute('aria-selected', 'true');
     await userEvent.click(screen.getByLabelText('반응한 프로필 닫기'));
   },
 };

--- a/apps/app/src/stories/Search.stories.tsx
+++ b/apps/app/src/stories/Search.stories.tsx
@@ -163,6 +163,20 @@ export const PreparedNonPeopleTabs: Story = {
   parameters: {
     router: { params: { q: '별마루', tab: 'popular' }, pathname: '/search' },
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tablist = canvas.getByRole('tablist', { name: '검색 결과 유형' });
+    const popular = within(tablist).getByRole('tab', { name: '인기' });
+    const latest = within(tablist).getByRole('tab', { name: '최신' });
+    const media = within(tablist).getByRole('tab', { name: '미디어' });
+    const people = within(tablist).getByRole('tab', { name: '사람' });
+    expect(popular).toHaveAttribute('aria-selected', 'true');
+    expect(popular).toHaveAttribute('tabindex', '0');
+    [latest, media, people].forEach((tab) => {
+      expect(tab).toHaveAttribute('aria-selected', 'false');
+      expect(tab).toHaveAttribute('tabindex', '-1');
+    });
+  },
 };
 
 export const RecentSearchInteraction: Story = {

--- a/apps/app/src/stories/Tabs.stories.tsx
+++ b/apps/app/src/stories/Tabs.stories.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { Tab, TabList } from '@/components/ui/Tabs';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { TabOption, TabVariant } from '@/components/ui/Tabs';
+
+type TabValue = 'latest' | 'media' | 'popular';
+
+const options = [
+  { label: '인기', value: 'popular' },
+  { disabled: true, label: '최신', value: 'latest' },
+  { label: '미디어', value: 'media' },
+] satisfies readonly TabOption<TabValue>[];
+
+const onValueChange = fn();
+
+function TabsCatalog({ variant = 'underline' }: { variant?: TabVariant }) {
+  const [value, setValue] = useState<TabValue>('popular');
+
+  return (
+    <TabList
+      accessibilityLabel="검색 결과 유형"
+      onValueChange={(nextValue) => {
+        onValueChange(nextValue);
+        setValue(nextValue);
+      }}
+      value={value}
+      variant={variant}
+    >
+      {options.map((option) => (
+        <Tab key={option.value} option={option} />
+      ))}
+    </TabList>
+  );
+}
+
+const meta = {
+  component: TabsCatalog,
+  title: 'KOSMO/UI/Tabs',
+} satisfies Meta<typeof TabsCatalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('tablist', { name: '검색 결과 유형' });
+    const popular = within(group).getByRole('tab', { name: '인기' });
+    const latest = within(group).getByRole('tab', { name: '최신' });
+    const media = within(group).getByRole('tab', { name: '미디어' });
+
+    expect(popular).toHaveAttribute('aria-selected', 'true');
+    expect(popular).toHaveAttribute('tabindex', '0');
+    expect(latest).toHaveAttribute('aria-disabled', 'true');
+    expect(latest).toHaveAttribute('tabindex', '-1');
+    expect(latest).toHaveStyle({ opacity: '0.45' });
+    expect(media).toHaveAttribute('tabindex', '-1');
+
+    await userEvent.tab();
+    expect(popular).toHaveFocus();
+    expect(getComputedStyle(popular).outlineWidth).toBe('2px');
+
+    await userEvent.keyboard('{ArrowRight}');
+    expect(media).toHaveFocus();
+    expect(media).toHaveAttribute('aria-selected', 'false');
+    await userEvent.keyboard(' ');
+    expect(media).toHaveAttribute('aria-selected', 'true');
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard('{Home}');
+    expect(popular).toHaveFocus();
+    expect(popular).toHaveAttribute('aria-selected', 'false');
+    await userEvent.keyboard('{End}');
+    expect(media).toHaveFocus();
+    expect(media).toHaveAttribute('aria-selected', 'true');
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(popular).toHaveFocus();
+    expect(popular).toHaveAttribute('aria-selected', 'false');
+    await userEvent.keyboard('{Enter}');
+    expect(popular).toHaveAttribute('aria-selected', 'true');
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+
+    await userEvent.pointer({ keys: '[MouseLeft>]', target: media });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(getComputedStyle(media).opacity).toBe('0.85');
+    await userEvent.click(media);
+    expect(media).toHaveFocus();
+    expect(media).toHaveAttribute('aria-selected', 'true');
+    expect(getComputedStyle(media).outlineWidth).not.toBe('2px');
+    expect(onValueChange).toHaveBeenCalledTimes(3);
+  },
+};
+
+export const PillVariant: Story = {
+  args: { variant: 'pill' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('tablist', { name: '검색 결과 유형' });
+    const popular = within(group).getByRole('tab', { name: '인기' });
+    const latest = within(group).getByRole('tab', { name: '최신' });
+
+    expect(popular).toHaveAttribute('aria-selected', 'true');
+    expect(popular).toHaveStyle({ borderRadius: '8px', height: '32px' });
+    expect(latest).toHaveAttribute('aria-disabled', 'true');
+    expect(latest).toHaveStyle({ opacity: '0.45' });
+  },
+};

--- a/apps/app/src/stories/Tabs.stories.tsx
+++ b/apps/app/src/stories/Tabs.stories.tsx
@@ -96,6 +96,7 @@ export const InteractionContract: Story = {
 export const PillVariant: Story = {
   args: { variant: 'pill' },
   play: async ({ canvasElement }) => {
+    onValueChange.mockClear();
     const canvas = within(canvasElement);
     const group = canvas.getByRole('tablist', { name: '검색 결과 유형' });
     const popular = within(group).getByRole('tab', { name: '인기' });
@@ -103,7 +104,23 @@ export const PillVariant: Story = {
 
     expect(popular).toHaveAttribute('aria-selected', 'true');
     expect(popular).toHaveStyle({ borderRadius: '8px', height: '32px' });
+    expect(getComputedStyle(popular).backgroundColor).toBe('rgb(255, 255, 255)');
+    expect(getComputedStyle(popular).borderColor).toBe('rgb(252, 231, 154)');
     expect(latest).toHaveAttribute('aria-disabled', 'true');
     expect(latest).toHaveStyle({ opacity: '0.45' });
+
+    await userEvent.tab();
+    expect(popular).toHaveFocus();
+    expect(getComputedStyle(popular).outlineWidth).toBe('2px');
+
+    await userEvent.pointer({ keys: '[MouseLeft>]', target: popular });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(getComputedStyle(popular).opacity).toBe('0.85');
+    await userEvent.click(popular);
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    expect(getComputedStyle(latest).pointerEvents).toBe('none');
+    latest.click();
+    expect(onValueChange).not.toHaveBeenCalled();
   },
 };

--- a/apps/app/src/stories/Tabs.stories.tsx
+++ b/apps/app/src/stories/Tabs.stories.tsx
@@ -80,6 +80,7 @@ export const InteractionContract: Story = {
     expect(popular).toHaveAttribute('aria-selected', 'false');
     await userEvent.keyboard('{Enter}');
     expect(popular).toHaveAttribute('aria-selected', 'true');
+    expect(getComputedStyle(popular).outlineWidth).toBe('2px');
     expect(onValueChange).toHaveBeenCalledTimes(2);
 
     await userEvent.pointer({ keys: '[MouseLeft>]', target: media });

--- a/apps/app/src/stories/Tabs.stories.tsx
+++ b/apps/app/src/stories/Tabs.stories.tsx
@@ -113,6 +113,7 @@ export const PillVariant: Story = {
     await userEvent.tab();
     expect(popular).toHaveFocus();
     expect(getComputedStyle(popular).outlineWidth).toBe('2px');
+    expect(getComputedStyle(popular).outlineOffset).toBe('-2px');
 
     await userEvent.pointer({ keys: '[MouseLeft>]', target: popular });
     await new Promise((resolve) => setTimeout(resolve, 50));

--- a/apps/app/src/stories/Tabs.stories.tsx
+++ b/apps/app/src/stories/Tabs.stories.tsx
@@ -119,10 +119,11 @@ export const PillVariant: Story = {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(getComputedStyle(popular).opacity).toBe('0.85');
     await userEvent.click(popular);
-    expect(onValueChange).not.toHaveBeenCalled();
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenLastCalledWith('popular');
 
     expect(getComputedStyle(latest).pointerEvents).toBe('none');
     latest.click();
-    expect(onValueChange).not.toHaveBeenCalled();
+    expect(onValueChange).toHaveBeenCalledTimes(1);
   },
 };

--- a/docs/design/foundations.md
+++ b/docs/design/foundations.md
@@ -101,6 +101,6 @@ Fullscreen media와 제품 고유 shadow는 일괄 치환하지 않고 아래 In
 - DSN-19: `tokens.ts`에 numeric spacing·radius·border·icon, role typography와 Light/Dark elevation을 구현했다. 기존 `spacing`·`radii`·`typography`·`shadow` export는 DSN-21 consumer 이관 동안만 deprecated compatibility alias로 유지한다.
 - DSN-19: Button·TextField·TextArea·ModalSheet·ActionMenu·StateView·Skeleton·ToastProvider·Avatar가 승인 foundation과 semantic color를 직접 소비한다.
 - DSN-21 또는 연결된 Product 이슈: route, shell, domain consumer와 상태를 이관·검증한다.
-- PROD-752: Search와 ReactionProfilesModal의 raw tab을 공용 `TabList`·`Tab`으로 이관하고, consumer별 상태·layout·lifecycle은 유지한다.
+- PROD-752: Search와 ReactionProfilesModal의 raw tab을 공용 `TabList`·`Tab`으로 이관하고, consumer별 상태·lifecycle은 유지한다. 보이는 surface와 상단 위치는 유지하되, 겹치지 않는 Native 접근성 target을 실제 layout box로 확보하면서 Search Android의 다음 콘텐츠는 4dp, ReactionProfilesModal은 iOS 6pt·Android 8dp 아래로 이동하는 전환기 geometry를 허용한다. 이 geometry는 DSN-13 리디자인·최종 재바인딩에서 다시 확정한다.
 - PROD-753: FeedbackForm·ProfileDefaultPostVisibilityControl의 radio semantics와 Web keyboard 동작을 공용 `RadioGroup`·`RadioOption`으로 수렴하고, mutation·dirty/submitting·Relay actor lifecycle과 option layout은 각 consumer에 유지한다.
 - DSN-13: 선행 구현 후 Components/Screens를 최종 재바인딩하고 evidence를 남긴다.

--- a/docs/design/foundations.md
+++ b/docs/design/foundations.md
@@ -101,5 +101,6 @@ Fullscreen media와 제품 고유 shadow는 일괄 치환하지 않고 아래 In
 - DSN-19: `tokens.ts`에 numeric spacing·radius·border·icon, role typography와 Light/Dark elevation을 구현했다. 기존 `spacing`·`radii`·`typography`·`shadow` export는 DSN-21 consumer 이관 동안만 deprecated compatibility alias로 유지한다.
 - DSN-19: Button·TextField·TextArea·ModalSheet·ActionMenu·StateView·Skeleton·ToastProvider·Avatar가 승인 foundation과 semantic color를 직접 소비한다.
 - DSN-21 또는 연결된 Product 이슈: route, shell, domain consumer와 상태를 이관·검증한다.
+- PROD-752: Search와 ReactionProfilesModal의 raw tab을 공용 `TabList`·`Tab`으로 이관하고, consumer별 상태·layout·lifecycle은 유지한다.
 - PROD-753: FeedbackForm·ProfileDefaultPostVisibilityControl의 radio semantics와 Web keyboard 동작을 공용 `RadioGroup`·`RadioOption`으로 수렴하고, mutation·dirty/submitting·Relay actor lifecycle과 option layout은 각 consumer에 유지한다.
 - DSN-13: 선행 구현 후 Components/Screens를 최종 재바인딩하고 evidence를 남긴다.

--- a/docs/design/reactions.md
+++ b/docs/design/reactions.md
@@ -17,7 +17,7 @@ Reaction Quick Picker는 현재 제공된 Reaction option을 빠르게 선택하
 ### 형태
 
 - Web option은 Figma Post Action Bar의 28px 밀도와 함께 사용할 수 있도록 32×32 CSS px의 둥근 사각형으로 정규화하며 radius는 12px이다. emoji는 20px, option 사이 gap과 panel padding은 각각 4px이다. border를 포함한 panel의 전체 높이는 약 42px이다.
-- 이번 Web 우선 변경은 Native selector와 icon+count summary token의 interaction geometry를 변경하지 않는다. 이 control들은 iOS·Android 모두 44 logical unit을 사용하고 Profile tab은 32 minimum을 사용하므로 Android 48×48dp baseline을 아직 충족하지 않는다. 공통 `IconButton` 대상인 summary More는 아래 별도 계약을 사용한다. Native 출시 전 나머지 control도 iOS 44pt·Android 48dp target으로 복구하고 assistive technology·touch runtime에서 검증한다.
+- 이번 Web 우선 변경은 Native selector와 icon+count summary token의 interaction geometry를 변경하지 않는다. 이 control들은 iOS·Android 모두 44 logical unit을 유지하므로 Android 48×48dp baseline을 아직 충족하지 않는다. Profile tab은 PROD-752에서 공용 `Tab`으로 이관해 iOS 44pt·Android 48dp의 실제 layout box를 사용하며, 그 결과 ReactionProfilesModal의 다음 콘텐츠가 iOS 6pt·Android 8dp 아래로 이동하는 전환기 geometry를 허용한다. 이 Profile tab geometry는 DSN-13 리디자인·최종 재바인딩에서 다시 확정한다. 공통 `IconButton` 대상인 summary More는 아래 별도 계약을 사용한다. Native 출시 전 나머지 control도 iOS 44pt·Android 48dp target으로 복구하고 assistive technology·touch runtime에서 검증한다.
 - 바깥 컨테이너는 border가 있는 둥근 직사각형이며 radius는 16px이다.
 - option 자체에는 border를 표시하지 않는다.
 - 선택 여부는 border가 아니라 option 아래에 분리한 배경 layer로만 구분한다.


### PR DESCRIPTION
## 무엇을 변경했는지
- controlled `TabList`·`Tab` primitive와 `underline`·`pill` variant를 추가했습니다.
- [x] Search 결과 유형 탭 이관
- [x] ReactionProfilesModal 반응 탭 이관
- Web manual activation·roving tabindex·disabled/focus-visible/pressed 상태를 공용화했습니다.
- Native는 보이는 geometry와 실제 interaction box를 분리해 인접 target이 겹치지 않도록 했습니다.
- 이미 선택된 enabled 탭을 다시 활성화해도 consumer callback을 전달하도록 base 동작을 복원했습니다.
- Reaction 제품 문서의 Profile tab 계약을 공용 primitive의 iOS 44pt·Android 48dp geometry와 정렬했습니다.

## 왜 변경했는지
두 소비처가 중복 구현한 tab 접근성·키보드·시각 상태를 한곳에서 관리해 이후 Figma 디자인 변경이 함께 전파되도록 합니다.

## 이번 PR의 주요 결정
- Search의 URL/query와 ReactionProfilesModal의 reaction/fetch/modal lifecycle은 소비처가 계속 소유합니다.
- Arrow/Home/End는 focus만 이동하고 Enter/Space 또는 press가 탭을 활성화합니다. 이미 선택된 enabled 탭도 consumer callback을 받습니다.
- 현재 underline/pill 외형과 legacy palette는 유지하며 새 style escape hatch나 dependency를 추가하지 않습니다.
- pill의 보이는 32px geometry는 유지합니다.
- Native interaction box는 겹치는 hitSlop 없이 iOS 44pt·Android 48dp 이상으로 구성했고, Android underline의 보이는 44px geometry도 유지합니다.
- 그 결과 생기는 Search Android +4dp, Reaction modal iOS +6pt·Android +8dp 콘텐츠 시작점 이동은 현 단계에서 유지하고, DSN-13 리디자인·최종 재바인딩에서 다시 확정합니다.
- Web pill focus ring은 horizontal ScrollView 안에서 잘리지 않도록 inset으로 표시합니다.

## 어떻게 확인할 수 있는지
- 최신 head GitHub Actions — Lint·Semgrep·Test 전체 matrix와 종합 Test 통과
- `pnpm --filter @kosmo/app test` — 통과 실행에서 26개 파일·363개 테스트 통과
- `node scripts/test-db.mjs run -- pnpm test:e2e:database -- e2e/search.e2e.ts` — 17/17 통과
- Tabs·Search·Reactions focused Storybook 검증 — 통과
- `pnpm --filter @kosmo/app check` — 통과
- `git diff --check origin/main...HEAD` — 통과
- 저장소 지침 finding 2건과 canonical 문서 불일치 수정 후 독립 Sol 재리뷰 — 승인

## 아직 남은 문제
- iOS/Android 실제 기기·시뮬레이터에서 VoiceOver/TalkBack focus boundary와 touch target runtime은 확인하지 못했습니다.
- 로컬 전체 앱 테스트 반복 실행에서는 변경 범위 밖 `Posts.stories.tsx`의 interaction test가 서로 다른 지점에서 간헐적으로 실패했지만, 최신 head의 GitHub `Test (App)`은 통과했습니다.
- 전체 앱 테스트에는 변경 전부터 존재한 Relay fixture warning noise가 출력됩니다.
