### PR TITLE
실제 사용에 맞춰 디자인 시스템 파운데이션을 축소한다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/compose.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/compose.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { Skeleton } from '@/components/ui/StateView';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useTheme } from '@/theme/ThemeProvider';
-import { spacing, typography } from '@/theme/tokens';
+import { space, spacing, typography } from '@/theme/tokens';
 import type { ComposePageQuery } from './__generated__/ComposePageQuery.graphql';
 
 const ComposeQuery = graphql`
@@ -135,7 +135,7 @@ const styles = StyleSheet.create({
   content: {
     alignSelf: 'center',
     flexGrow: 1,
-    gap: 20,
+    gap: space[16],
     maxWidth: 624,
     paddingHorizontal: spacing.xl,
     paddingVertical: spacing.xxl,
@@ -147,7 +147,7 @@ const styles = StyleSheet.create({
   },
   loadingAction: { alignItems: 'flex-end' },
   stateCard: {
-    padding: 20,
+    padding: space[16],
   },
   stateTitle: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
   stateDescription: { fontFamily: 'SUIT', marginTop: spacing.xs, ...typography.sm },

--- a/apps/app/src/app/index.tsx
+++ b/apps/app/src/app/index.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/components/ui/Button';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useSession } from '@/session/SessionProvider';
 import { useTheme } from '@/theme/ThemeProvider';
-import { breakpoints, radii, spacing, typography } from '@/theme/tokens';
+import { breakpoints, radii, space, spacing, typography } from '@/theme/tokens';
 import type { Href } from 'expo-router';
 import type { TextStyle } from 'react-native';
 import type { IndexScreenExchangeNativeOidcSessionMutation } from './__generated__/IndexScreenExchangeNativeOidcSessionMutation.graphql';
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
   desktopHero: { justifyContent: 'center' },
   heroContent: {
     alignItems: 'flex-start',
-    gap: 20,
+    gap: space[16],
     maxWidth: 620,
   },
   betaNotice: { gap: spacing.xs },

--- a/apps/app/src/components/shell/LogoutControl.tsx
+++ b/apps/app/src/components/shell/LogoutControl.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-nati
 import { IconButton } from '@/components/ui/IconButton';
 import { useLogout } from '@/session/logout';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { radii, spacing, textStyles, typography } from '@/theme/tokens';
 import { useNavigationGuard } from './NavigationGuardContext';
 import type { StyleProp, ViewStyle } from 'react-native';
 
@@ -89,6 +89,6 @@ const styles = StyleSheet.create({
     paddingVertical: 0,
     width: 44,
   },
-  label: { fontFamily: 'SUIT', fontSize: 14, lineHeight: 20 },
+  label: textStyles.uiCopyM,
   error: { fontFamily: 'SUIT', marginTop: spacing.xs, ...typography.xsm },
 });

--- a/apps/app/src/components/shell/LogoutControl.tsx
+++ b/apps/app/src/components/shell/LogoutControl.tsx
@@ -89,6 +89,6 @@ const styles = StyleSheet.create({
     paddingVertical: 0,
     width: 44,
   },
-  label: { fontFamily: 'SUIT', fontSize: 14, lineHeight: 21 },
+  label: { fontFamily: 'SUIT', fontSize: 14, lineHeight: 20 },
   error: { fontFamily: 'SUIT', marginTop: spacing.xs, ...typography.xsm },
 });

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -20,7 +20,7 @@ import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useElevation, useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing, typography } from '@/theme/tokens';
+import { radii, space, spacing, textStyles, typography } from '@/theme/tokens';
 import { useNavigationGuard } from './NavigationGuardContext';
 import { NavigationLink } from './NavigationLink';
 import {
@@ -776,10 +776,10 @@ const styles = StyleSheet.create({
     width: 280,
   },
   redesignedMenu: { overflow: 'hidden' },
-  menuItems: { gap: 2 },
+  menuItems: { gap: space[0] },
   redesignedMenuRegion: { flexShrink: 1, minHeight: 0 },
   profileList: { flexShrink: 1, minHeight: 0 },
-  profileListContent: { gap: 2 },
+  profileListContent: { gap: space[0] },
   pickerFooter: { flexShrink: 0 },
   backdrop: {
     alignItems: 'center',
@@ -795,7 +795,7 @@ const styles = StyleSheet.create({
     gap: 10,
     padding: spacing.sm,
   },
-  unselectedProfile: { paddingVertical: spacing.xs },
+  unselectedProfile: { paddingVertical: space[8] },
   profileAvatar: { position: 'relative' },
   profileUnreadDot: {
     height: 12,
@@ -806,7 +806,7 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   profileLabel: { flex: 1, minWidth: 0 },
-  divider: { height: 1, marginVertical: 2, width: '100%' },
+  divider: { height: 1, marginVertical: space[4], width: '100%' },
   createForm: { gap: spacing.xs, padding: spacing.xs },
   createRow: { flexDirection: 'row', gap: spacing.sm },
   input: {
@@ -831,5 +831,5 @@ const styles = StyleSheet.create({
     padding: spacing.sm,
   },
   addIcon: { alignItems: 'center', justifyContent: 'center', width: 32 },
-  addLabel: { fontFamily: 'SUIT', fontWeight: '500', ...typography.sm },
+  addLabel: textStyles.uiLabelM,
 });

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -379,6 +379,6 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.md,
   },
   feedbackFooterItem: { height: 48, minHeight: 48 },
-  footerLabel: { fontFamily: 'SUIT', fontSize: 14, lineHeight: 21 },
+  footerLabel: { fontFamily: 'SUIT', fontSize: 14, lineHeight: 20 },
   footerLabelGrow: { flex: 1 },
 });

--- a/apps/app/src/components/shell/SidebarNavigation.tsx
+++ b/apps/app/src/components/shell/SidebarNavigation.tsx
@@ -13,7 +13,7 @@ import {
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useTheme } from '@/theme/ThemeProvider';
-import { radii, spacing } from '@/theme/tokens';
+import { radii, spacing, textStyles } from '@/theme/tokens';
 import { LogoutControl } from './LogoutControl';
 import { NavigationLink } from './NavigationLink';
 import { ProfileSwitcher } from './ProfileSwitcher';
@@ -379,6 +379,6 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.md,
   },
   feedbackFooterItem: { height: 48, minHeight: 48 },
-  footerLabel: { fontFamily: 'SUIT', fontSize: 14, lineHeight: 20 },
+  footerLabel: textStyles.uiCopyM,
   footerLabelGrow: { flex: 1 },
 });

--- a/apps/app/src/components/ui/Button.test.ts
+++ b/apps/app/src/components/ui/Button.test.ts
@@ -43,7 +43,7 @@ mockModule('@/theme/tokens', {
   radius: { 8: 8 },
   space: { 8: 8, 16: 16 },
   spacing: { sm: 8, lg: 16 },
-  textStyles: { uiLabelM: { fontSize: 14, lineHeight: 21 } },
+  textStyles: { uiLabelM: { fontSize: 14, lineHeight: 20 } },
   typography: { sm: { fontSize: 14, lineHeight: 20 } },
 });
 

--- a/apps/app/src/stories/Foundations.stories.tsx
+++ b/apps/app/src/stories/Foundations.stories.tsx
@@ -154,7 +154,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 132,
   },
-  icon: { borderRadius: radius[2], borderWidth: borderWidths[2] },
+  icon: { borderRadius: radius[4], borderWidth: borderWidths[2] },
   measure: { alignItems: 'center', gap: space[4], minWidth: 64 },
   name: textStyles.uiLabelS,
   radius: { alignItems: 'center', height: 72, justifyContent: 'center', width: 96 },

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -442,8 +442,8 @@ export const FeedbackNavigationCurrentState: Story = {
     expect(link).toHaveStyle({ backgroundColor: 'rgb(255, 249, 230)' });
     expect(link.nextElementSibling).toContainElement(logout);
     expect(link.parentElement).toHaveStyle({ borderTopWidth: '1px' });
-    expect(feedbackLabel).toHaveStyle({ fontSize: '14px', lineHeight: '21px' });
-    expect(logoutLabel).toHaveStyle({ fontSize: '14px', lineHeight: '21px' });
+    expect(feedbackLabel).toHaveStyle({ fontSize: '14px', lineHeight: '20px' });
+    expect(logoutLabel).toHaveStyle({ fontSize: '14px', lineHeight: '20px' });
     expect(link.querySelector('svg')).toHaveAttribute('height', '20');
     expect(link.querySelector('svg')).toHaveAttribute('width', '20');
     expect(logout.querySelector('svg')).toHaveAttribute('height', '20');

--- a/apps/app/src/stories/Shell.stories.tsx
+++ b/apps/app/src/stories/Shell.stories.tsx
@@ -1007,7 +1007,7 @@ export const ProfileSwitcherUnreadPresence: Story = {
     expect(unreadDot).toHaveStyle({ height: '12px', width: '12px' });
     expect(selectedOption).not.toHaveAccessibleName(/1/);
     expect(unreadOption).not.toHaveAccessibleName(/127/);
-    expect(unreadOption.getBoundingClientRect().height).toBe(52);
+    expect(unreadOption.getBoundingClientRect().height).toBe(60);
     expect(unreadDot.getBoundingClientRect().right).toBeLessThanOrEqual(
       unreadOption.getBoundingClientRect().right,
     );

--- a/apps/app/src/theme/tokens.ts
+++ b/apps/app/src/theme/tokens.ts
@@ -183,16 +183,12 @@ export const colors = {
 
 export const space = {
   0: 0,
-  2: 2,
   4: 4,
   8: 8,
   12: 12,
   16: 16,
-  20: 20,
   24: 24,
-  28: 28,
   32: 32,
-  40: 40,
   48: 48,
 } as const;
 
@@ -209,7 +205,6 @@ export const spacing = {
 
 export const radius = {
   0: 0,
-  2: 2,
   4: 4,
   8: 8,
   12: 12,
@@ -236,13 +231,10 @@ export const fontSizes = {
   12: 12,
   14: 14,
   16: 16,
-  18: 18,
   20: 20,
   24: 24,
-  30: 30,
-  38: 38,
 } as const;
-export const fontWeights = { normal: '400', medium: '500', semibold: '600', bold: '700' } as const;
+export const fontWeights = { normal: '400', semibold: '600', bold: '700' } as const;
 export const lineHeights = { tight: 1.15, snug: 1.3, relaxed: 1.5 } as const;
 
 const textStyle = (
@@ -253,20 +245,15 @@ const textStyle = (
 ): TextStyle => ({ fontFamily, fontSize, fontWeight, lineHeight: fontSize * lineHeightRatio });
 
 export const textStyles = {
-  contentL: textStyle(fontFamilies.content, fontSizes[18], lineHeights.relaxed, fontWeights.normal),
   contentM: textStyle(fontFamilies.content, fontSizes[16], lineHeights.relaxed, fontWeights.normal),
-  contentS: textStyle(fontFamilies.content, fontSizes[14], lineHeights.relaxed, fontWeights.normal),
   uiCopyL: textStyle(fontFamilies.ui, fontSizes[16], lineHeights.relaxed, fontWeights.normal),
   uiCopyM: textStyle(fontFamilies.ui, fontSizes[14], lineHeights.relaxed, fontWeights.normal),
   uiCopyS: textStyle(fontFamilies.ui, fontSizes[12], lineHeights.snug, fontWeights.normal),
-  uiDisplay: textStyle(fontFamilies.ui, fontSizes[38], lineHeights.tight, fontWeights.bold),
-  uiHeadingL: textStyle(fontFamilies.ui, fontSizes[30], lineHeights.tight, fontWeights.bold),
   uiHeadingM: textStyle(fontFamilies.ui, fontSizes[24], lineHeights.tight, fontWeights.bold),
   uiHeadingS: textStyle(fontFamilies.ui, fontSizes[20], lineHeights.snug, fontWeights.bold),
   uiLabelL: textStyle(fontFamilies.ui, fontSizes[16], lineHeights.relaxed, fontWeights.semibold),
   uiLabelM: textStyle(fontFamilies.ui, fontSizes[14], lineHeights.relaxed, fontWeights.semibold),
   uiLabelS: textStyle(fontFamilies.ui, fontSizes[12], lineHeights.snug, fontWeights.semibold),
-  uiTitle: textStyle(fontFamilies.ui, fontSizes[18], lineHeights.snug, fontWeights.semibold),
 } satisfies Record<string, TextStyle>;
 
 /** @deprecated Use role-based `textStyles` for new work. */
@@ -276,7 +263,6 @@ export const typography = {
   md: { fontSize: 16, lineHeight: 24 },
   lg: { fontSize: 20, lineHeight: 30 },
   xl: { fontSize: 24, lineHeight: 32 },
-  display: { fontSize: 44, lineHeight: 48 },
 } satisfies Record<string, TextStyle>;
 
 export const breakpoints = { compact: 768, full: 1280 } as const;

--- a/apps/app/src/theme/tokens.ts
+++ b/apps/app/src/theme/tokens.ts
@@ -247,12 +247,18 @@ const textStyle = (
 export const textStyles = {
   contentM: textStyle(fontFamilies.content, fontSizes[16], lineHeights.relaxed, fontWeights.normal),
   uiCopyL: textStyle(fontFamilies.ui, fontSizes[16], lineHeights.relaxed, fontWeights.normal),
-  uiCopyM: textStyle(fontFamilies.ui, fontSizes[14], lineHeights.relaxed, fontWeights.normal),
+  uiCopyM: {
+    ...textStyle(fontFamilies.ui, fontSizes[14], lineHeights.relaxed, fontWeights.normal),
+    lineHeight: 20,
+  },
   uiCopyS: textStyle(fontFamilies.ui, fontSizes[12], lineHeights.snug, fontWeights.normal),
   uiHeadingM: textStyle(fontFamilies.ui, fontSizes[24], lineHeights.tight, fontWeights.bold),
   uiHeadingS: textStyle(fontFamilies.ui, fontSizes[20], lineHeights.snug, fontWeights.bold),
   uiLabelL: textStyle(fontFamilies.ui, fontSizes[16], lineHeights.relaxed, fontWeights.semibold),
-  uiLabelM: textStyle(fontFamilies.ui, fontSizes[14], lineHeights.relaxed, fontWeights.semibold),
+  uiLabelM: {
+    ...textStyle(fontFamilies.ui, fontSizes[14], lineHeights.relaxed, fontWeights.semibold),
+    lineHeight: 20,
+  },
   uiLabelS: textStyle(fontFamilies.ui, fontSizes[12], lineHeights.snug, fontWeights.semibold),
 } satisfies Record<string, TextStyle>;
 

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -20,6 +20,16 @@ Primitive Color
 - Light와 Dark는 동일한 semantic 이름을 사용하고 primitive alias만 교체한다.
 - 모든 semantic variable은 Light/Dark 값을 모두 가지며 literal 값 없이 primitive를 alias한다.
 
+## Primitive 팔레트 단계 수
+
+Primitive 팔레트는 색상별 단계 수를 기계적으로 맞추지 않는다. 각 hue는 실제 semantic role, interaction state와 Light/Dark 대비 조합에 필요한 단계만 소유한다. 팔레트 열의 길이가 같은지는 품질 기준이 아니며, 사용처가 없는 보간 색상을 다른 hue와 개수를 맞추기 위해 추가하지 않는다.
+
+- 새 단계는 연결할 semantic token과 실제 consumer, 목표 대비 조합이 함께 확인된 경우에만 추가한다.
+- 기존 단계는 semantic alias와 활성 consumer가 없고 대비 검증에도 필요하지 않을 때만 제거한다.
+- 같은 값이 여러 역할에 필요하면 primitive를 중복하지 않고 semantic token이 하나의 primitive를 alias한다.
+- 제품 UI는 팔레트 단계 수와 관계없이 semantic token만 소비한다.
+- Figma `01 Foundations`는 색상별 현재 단계와 용도를 그대로 보여주고, 단계 수 차이를 오류처럼 채우거나 숨기지 않는다.
+
 Figma variable의 code syntax가 개발 target 이름이다.
 
 | 플랫폼  | 형식                   | 예시                             |

--- a/docs/design/foundations.md
+++ b/docs/design/foundations.md
@@ -7,17 +7,17 @@
 - UI 텍스트는 SUIT Variable, 본문은 Pretendard Variable을 사용한다.
 - 역할을 먼저 선택하고 size, weight, leading을 임의로 조합하지 않는다.
 - 12px는 시간, 핸들, 비핵심 metadata에만 사용한다. 읽거나 선택해야 하는 정보는 14px 이상이다.
-- line-height는 font size별 고정 px가 아니라 역할별 비율로 유지한다.
+- line-height는 역할별로 정의한다. `UI/Copy/M`과 `UI/Label/M`은 14px 글자에 고정 20px을 공유하고, 나머지는 표의 역할별 비율을 유지한다.
 
 | 역할           | 크기 | Line height | Weight | 대표 용도                     |
 | -------------- | ---: | ----------: | -----: | ----------------------------- |
 | `UI/Heading/M` |   24 |        115% |    700 | 중간 제목                     |
 | `UI/Heading/S` |   20 |        130% |    700 | 모바일 section 제목           |
 | `UI/Copy/L`    |   16 |        150% |    400 | 읽고 선택하는 기본 UI 텍스트  |
-| `UI/Copy/M`    |   14 |        150% |    400 | helper·validation·보조 설명   |
+| `UI/Copy/M`    |   14 |        20px |    400 | helper·validation·보조 설명   |
 | `UI/Copy/S`    |   12 |        130% |    400 | 시간·핸들·비핵심 metadata     |
 | `UI/Label/L`   |   16 |        150% |    600 | 사용자 이름·강한 action label |
-| `UI/Label/M`   |   14 |        150% |    600 | 버튼·탭·action count          |
+| `UI/Label/M`   |   14 |        20px |    600 | 버튼·탭·action count          |
 | `UI/Label/S`   |   12 |        130% |    600 | 짧은 비핵심 badge label       |
 | `Content/M`    |   16 |        150% |    400 | 기본 포스트 본문              |
 

--- a/docs/design/foundations.md
+++ b/docs/design/foundations.md
@@ -11,27 +11,24 @@
 
 | 역할           | 크기 | Line height | Weight | 대표 용도                     |
 | -------------- | ---: | ----------: | -----: | ----------------------------- |
-| `UI/Display`   |   38 |        115% |    700 | 제한적으로 사용하는 display   |
-| `UI/Heading/L` |   30 |        115% |    700 | 큰 화면 제목                  |
 | `UI/Heading/M` |   24 |        115% |    700 | 중간 제목                     |
 | `UI/Heading/S` |   20 |        130% |    700 | 모바일 section 제목           |
-| `UI/Title`     |   18 |        130% |    600 | 설정·surface 제목             |
 | `UI/Copy/L`    |   16 |        150% |    400 | 읽고 선택하는 기본 UI 텍스트  |
 | `UI/Copy/M`    |   14 |        150% |    400 | helper·validation·보조 설명   |
 | `UI/Copy/S`    |   12 |        130% |    400 | 시간·핸들·비핵심 metadata     |
 | `UI/Label/L`   |   16 |        150% |    600 | 사용자 이름·강한 action label |
 | `UI/Label/M`   |   14 |        150% |    600 | 버튼·탭·action count          |
 | `UI/Label/S`   |   12 |        130% |    600 | 짧은 비핵심 badge label       |
-| `Content/L`    |   18 |        150% |    400 | 강조 본문                     |
 | `Content/M`    |   16 |        150% |    400 | 기본 포스트 본문              |
-| `Content/S`    |   14 |        150% |    400 | 보조 본문·설명                |
+
+Beta Landing의 hero title `30/36/700`은 정식 Landing 전환 때 폐기하거나 다시 설계할 component-local 예외다. 공용 `UI/Heading/L` 또는 `UI/Display`의 근거로 사용하지 않으며, 다른 화면에서도 같은 역할이 확인될 때만 공용 typography 승격을 검토한다.
 
 MCP Preview font 대응과 Production runtime 로딩 규칙은 [typography.md](./typography.md)를 따른다.
 
 ## Spacing, radius, border width
 
-- spacing은 `0, 2, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48`의 범용 숫자 scale을 사용한다.
-- radius는 `0, 2, 4, 8, 12, 16, 20, 24, full(999)`을 사용한다. `10`, `14` radius는 만들지 않는다.
+- spacing은 `0, 4, 8, 12, 16, 24, 32, 48`의 범용 숫자 scale을 사용한다.
+- radius는 `0, 4, 8, 12, 16, 20, 24, full(999)`을 사용한다. `2`, `10`, `14` radius는 만들지 않는다.
 - border width는 `0, 1, 2`만 사용한다. `1`은 기본 경계, `2`는 focus·강조, `0`은 명시적 경계 제거다.
 - scale 밖 spacing은 component-local optical correction으로만 허용한다. component, platform, 시각적 이유, 비교 evidence와 Design owner 승인을 기록하고 전역 token으로 승격하지 않는다.
 
@@ -47,6 +44,7 @@ Density는 별도 runtime mode나 새 token collection이 아니라 `space/*`를
 
 - Figma·component에 명시된 spacing 계약이 있으면 recipe보다 우선한다.
 - Compact·Spacious는 명시적 opt-in만 허용한다. 부모, route, theme에서 자동 상속하지 않는다.
+- ProfileSwitcher처럼 연속된 선택 행은 부모 gap을 `0`으로 둔다. 행 내부 padding은 콘텐츠 높이에 맞춰 retained scale에서 선택하되 interactive target `48px` 이상을 지킨다. 현재 코드와 Figma source의 미선택 option은 vertical padding `8`과 높이 `60px`을 사용하며, divider만 vertical margin `4`를 사용한다.
 - breakpoint는 layout 단계만 결정한다. typography, line-height, interactive target을 함께 축소하지 않는다.
 - PostLayout의 avatar와 body처럼 의도된 도메인 geometry는 해당 component가 계속 소유한다.
 - 기존 화면에 Standard를 소급 적용하거나 Components/Screens binding을 자동 변경하지 않는다.

--- a/docs/design/typography.md
+++ b/docs/design/typography.md
@@ -33,7 +33,7 @@
 - React Native `Text`/`TextInput`은 CSS font 상속에 의존하지 않는다. 공용 primitive와 각 text style은 용도에 맞는 `fontFamily`를 명시한다.
   - UI, 버튼, 내비게이션, 라벨, heading: `fontFamily: 'SUIT'`
   - 포스트 본문, 긴 글 입력: `fontFamily: 'Pretendard'`
-- font size/line height는 `apps/app/src/theme/tokens.ts`의 `typography` token을 사용한다. 화면에서 같은 Foundation 값을 raw number로 반복하지 않는다.
+- 새 구현은 `apps/app/src/theme/tokens.ts`의 역할 기반 `textStyles`를 사용한다. 기존 consumer는 DSN-21 이관 완료 전까지 deprecated `typography` 호환 alias를 사용할 수 있으며, 화면에서 같은 Foundation 값을 raw number로 반복하지 않는다.
 - React Native Web Storybook은 전용 `@font-face` 설정으로 같은 npm package의 Variable WOFF2 asset을
   `SUIT`와 `Pretendard` family로 등록한다. Expo runtime의 `useFonts` loader는 사용하지 않지만,
   component의 production family name과 asset은 동일하게 유지한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- 공용 typography를 실제 재사용 역할 9개로 축소했습니다.
- `UI/Copy/M`과 `UI/Label/M`의 14px leading을 20px로 맞추고, branch에서 직접 수정한 shell label도 `textStyles.uiCopyM`을 소비하도록 연결했습니다.
- spacing을 `0, 4, 8, 12, 16, 24, 32, 48`로 정리하고 radius `2`를 제거했습니다.
- Landing·Compose·ProfileSwitcher consumer와 Storybook 검증을 새 계약에 맞췄습니다.
- 컬러 팔레트 단계 수가 hue별로 달라도 되는 기준과 현재 Foundation 계약을 문서화했습니다.

## 왜 변경했는지

8월 15일 멘토링 피드백을 바탕으로, 사용처 없는 값을 유지하거나 색상별 단계 수를 기계적으로 맞추지 않고 실제 semantic role과 consumer가 있는 공용 값만 남기기 위해 변경했습니다.

관련 이슈: [DSN-46](https://linear.app/byulmaru/issue/DSN-46)

## 이번 PR의 주요 결정

### 컬러 팔레트 단계 수

- 결정자: @yeeun-uwu
- 선택: 색상별 단계 수를 통일하지 않고 semantic role·상태·대비에 필요한 단계만 유지
- 고려한 대안: 사용하지 않는 보간색을 추가해 모든 팔레트 길이를 통일
- 이유: 팔레트 개수보다 실제 semantic consumer와 Light/Dark 대비가 품질 기준이기 때문
- 감수한 결과: hue별 팔레트 길이는 계속 다를 수 있음

### 14px UI leading

- 결정자: @yeeun-uwu
- 선택: `UI/Copy/M 14/20/400`, `UI/Label/M 14/20/600`
- 이유: 21px의 불필요한 홀수 leading을 없애면서 100% leading보다 한국어 glyph 여유를 보존하는 중립적인 값이기 때문
- 구현 원칙: control 높이는 line-height가 아니라 component의 padding·min-height가 소유하며, typography role 자체에 전역 단일 행·truncate 계약은 추가하지 않음
- font 대응: Figma/MCP에서는 IBM Plex Sans KR, Production runtime에서는 SUIT를 사용

### Beta Landing 제목

- 결정자: @yeeun-uwu
- 선택: `30/36/700`을 공용 Heading으로 유지하지 않고 component-local 임시 예외로 유지
- 이유: 현재 Beta Landing의 단일 consumer이며 정식 Landing에서 다시 설계할 값이기 때문

### 코드 typography 정본

- 새 구현은 역할 기반 `textStyles`를 사용
- 기존 `typography` consumer는 DSN-21 이관 완료 전까지 deprecated 호환 alias로 유지

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check`: Relay compiler·TypeScript 통과
- Button 단위 테스트 4개 통과
- Shell Storybook 테스트 55개 통과
- 변경 파일 Prettier 검사와 `git diff --check` 통과
- 제거 token·style의 tracked source 잔존 참조 0건
- Figma spacing 8개, radius 8개, typography style 9개만 존재
- Figma `UI/Copy/M`·`UI/Label/M`: IBM Plex Sans KR 14/20 readback
- 활성 Figma 페이지의 `UI/Label/M` 677개: 줄바꿈 0건, 높이 20px
- Figma ProfileSwitcher 원본 69개 option: 높이 60px, padding 8px, list gap 0, divider 상하 4px
- Figma Semantic Color 66개: Light/Dark 값 누락 0건, 깨진 local alias 0건
- Figma Landing source: hero gap 16px 및 `30/36/700` 임시 예외 설명 확인

## 아직 어떤 문제가 남았는지

- legacy `typography` consumer의 역할 기반 이관과 raw legacy typography 정리는 DSN-21에서 진행합니다.
- Figma의 migration history artifact는 전체 매핑 완료 전까지 유지하고, canonical `docs/design`에는 현재 유효한 계약만 기록합니다.
- Native 실기기에서의 폰트 baseline 시각 검증은 이번 PR에서 별도로 수행하지 않았습니다.
