### PR TITLE
KOSMO Figma 디자인 감사 기준을 공유한다

### DIFF
--- a/.codex/skills/kosmo-design-audit/SKILL.md
+++ b/.codex/skills/kosmo-design-audit/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: kosmo-design-audit
+description: Use when reviewing or auditing KOSMO Figma components, screens, foundations, tokens, variants, states, accessibility, Light/Dark behavior, responsive layouts, or design-system drift before a Figma edit, redesign, handoff, or source-component cleanup; not for implementing or reviewing production UI code.
+---
+
+# KOSMO Design Audit
+
+설치된 `figma:figma-use`로 Figma 구조를 읽고, KOSMO 디자인 시스템의 누락과 드리프트를 근거 중심으로 감사한다. 감사와 수정은 분리하며 source component의 문제를 consumer override로 가리지 않는다.
+
+## 적용 범위
+
+- Figma 감사·수정에만 사용한다. 대상은 source component, variable, style이며 수정은 승인 후에만 수행한다.
+- production React Native·Web 컴포넌트 구현이나 코드 리뷰에는 사용하지 않는다. 코드와 문서는 Figma 계약을 확인하는 근거로만 읽는다.
+
+## 기준 선택
+
+- 컴포넌트의 제품 동작·구성·시각적 의도는 이번 Figma 감사·수정에서 사용자가 승인한 대상별 계약을 우선한다.
+- foundation token 값은 현재 기준 브랜치에 머지된 `docs/design/*.md`와 canonical token 정의를 우선한다.
+- 사용자가 미병합 PR·제안을 명시적으로 선택하면 해당 작업에서만 `후보 계약`으로 사용하고, 현재 계약·후보 계약·Figma 상태를 분리해 보고한다.
+- 현재 Figma source, variable, style은 감사 대상이자 증거다. canonical foundation과 충돌하면 Figma 값을 authority로 삼지 않고 드리프트로 보고한다.
+- [audit-rules.md](references/audit-rules.md)의 일반 규칙과 시각적 취향은 위 계약을 덮어쓰지 않는다.
+
+공유된 authority끼리 충돌하면 조용히 하나를 선택하지 말고 충돌과 필요한 결정을 보고한다.
+
+## 감사 절차
+
+1. 정확한 Figma 파일, node ID, source/instance 여부, 대상 플랫폼과 확인할 상태를 정한다.
+2. foundation을 검사하면 기준 브랜치와 canonical source revision을 먼저 확인한다. 현재 worktree 문서를 머지된 계약으로 가정하지 말고, `docs/design/README.md`가 연결하는 공통 문서와 대상 컴포넌트 문서만 읽는다.
+3. 모든 `use_figma` 호출 전에 `figma:figma-use`를 로드한다. 감사 단계에서는 읽기 전용 JavaScript만 실행한다.
+4. [figma-inspection.md](references/figma-inspection.md)에 따라 구조·binding·variant 증거를 수집한다. screenshot은 시각 증거, variable 정의는 token 증거로 따로 다룬다.
+5. [audit-rules.md](references/audit-rules.md)를 적용해 `확정`, `위험`, `검증 공백`으로 분류한다.
+6. 문제를 숨기는 instance override가 아니라 source에서 고칠 최소 범위를 제안한다.
+
+사용자가 제공한 증거만 사용하도록 제한했거나 Figma 접근이 없으면 도구 호출을 생략한다. 제공 증거로 확정 가능한 항목과 최소 증거 누락을 분리한다.
+
+## 수정 경계
+
+- 감사 중에는 Figma를 변경하지 않는다. 사용자가 처음부터 수정을 요청해도 먼저 감사 결과와 정확한 node·값·영향 범위를 보여주고 승인을 기다린다.
+- 승인 후에만 `figma:figma-use`와 필요한 Figma 생성 스킬로 source를 작은 단위로 수정하고 readback한다.
+- source와 consumer lifecycle을 한 변경에 섞지 않는다. 텍스트 등 의도된 instance override는 보존한다.
+- Dark, state, runtime 증거가 없으면 `통과`로 결론내리지 않는다.
+- Figma만으로 keyboard, screen reader, 실제 hit area, runtime reflow 또는 WCAG 전체 준수를 주장하지 않는다.
+
+## 결과 형식
+
+먼저 결론과 검사 범위를 적고, 발견사항은 아래 필드를 사용한다.
+
+| 우선순위 | 판정 | node | 근거 | 기준 | 영향 | 최소 조치 | 남은 검증 |
+| -------- | ---- | ---- | ---- | ---- | ---- | --------- | --------- |
+
+마지막에 다음을 분리한다.
+
+- 자동 확인 완료
+- 자동 확인 가능·미실행
+- 수동·runtime 확인 필요
+- 수정 전 필요한 결정
+
+문제가 없으면 검사한 node·mode·state와 검사하지 못한 범위를 함께 보고한다.

--- a/.codex/skills/kosmo-design-audit/agents/openai.yaml
+++ b/.codex/skills/kosmo-design-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'KOSMO Design Audit'
+  short_description: 'Figma 디자인 시스템의 구조·토큰·상태 누락을 점검합니다'
+  default_prompt: 'Use $kosmo-design-audit to audit this KOSMO Figma target before any edits.'

--- a/.codex/skills/kosmo-design-audit/references/audit-rules.md
+++ b/.codex/skills/kosmo-design-audit/references/audit-rules.md
@@ -91,7 +91,7 @@ raw 값 자체만으로 대체 token을 추측하지 않는다. 기존 semantic 
 
 ## 8. Responsive, platform, motion
 
-- Web compact `<768`, 기본 `>=768`, full canvas `>=1280` 계약과 Native mobile shell을 섞지 않는다.
+- mobile Web `<768`, compact Web `768–1279`, full Web `>=1280` 계약과 Native mobile shell을 섞지 않는다.
 - fixed width/height, min/max, wrap, safe area, keyboard avoidance, zoom·reflow 위험을 확인한다.
 - 같은 디자인이라도 Web과 iOS·Android target, focus, hover, system inset 증거를 분리한다.
 - motion이 있으면 enter/exit, spatial relation, interruption, reduced-motion 대체를 확인한다. motion이 없는데 state 이름만으로 animation을 요구하지 않는다.

--- a/.codex/skills/kosmo-design-audit/references/audit-rules.md
+++ b/.codex/skills/kosmo-design-audit/references/audit-rules.md
@@ -1,0 +1,107 @@
+# KOSMO Figma 감사 규칙
+
+이 문서는 검사 체크리스트다. authority는 `SKILL.md`의 대상별 계약과 foundation token 기준을 구분해 적용한다.
+
+## 판정과 우선순위
+
+- `확정`: Figma 구조, 값, binding 또는 screenshot으로 직접 증명됨.
+- `위험`: 정황은 있으나 의도, mode, consumer 영향 또는 runtime 확인이 더 필요함.
+- `검증 공백`: 현재 증거로 판정할 수 없음. 결함으로 부풀리지 않음.
+- `P1`: 콘텐츠 손실, 조작 불가, 중대한 접근성·테마 파손.
+- `P2`: source 계약 또는 반복 사용에서 실제 결함을 만들 가능성이 큼.
+- `P3`: 일관성·유지보수·polish 문제. 단독으로 긴급 수정을 요구하지 않음.
+
+raw·primitive·legacy binding 위반은 기본 `P2`다. 필수 theme에서 실제 콘텐츠·조작 파손이 확인된 경우에만 `P1`로 올린다.
+
+## 1. Source와 재사용
+
+- 반복 UI는 기존 source component와 component property를 우선한다.
+- instance가 source 문제를 override로 가리거나 detached되었는지 확인한다.
+- source 수정은 영향받는 instance와 의도된 override를 먼저 열거한다.
+- 비슷해 보여도 제품 동작·정보 구조가 다르면 억지로 합치지 않는다.
+- source cleanup과 consumer의 fetch, navigation, modal lifecycle은 분리한다.
+
+자동 확인 후보: node type, main component, component properties, variant properties, override 존재, 동일 이름·유사 구조 반복.
+
+## 2. Token과 binding
+
+- 새 UI의 색은 `KOSMO Semantic Color`만 직접 사용한다. raw hex와 primitive·legacy 직접 binding을 찾는다.
+- spacing, radius, border는 감사 시점의 기준 브랜치에 머지된 `docs/design/foundations.md`와 canonical token 정의에서 읽는다. 이 스킬에 값 목록을 복제하지 않는다.
+- 현재 worktree가 기준 브랜치와 다르면 기준 브랜치 계약과 worktree·후보 변경을 분리한다. merge 여부나 revision을 확인하지 못하면 token-scale 통과·위반을 확정하지 않는다.
+- 사용자가 미병합 PR·제안을 명시적으로 선택하면 그 값을 `후보 계약`으로 표시한다. 현재 계약 위반과 후보 계약으로의 migration gap을 서로 다른 finding으로 보고한다.
+- 후보 계약이 머지되면 갱신된 canonical 문서와 token 정의를 사용한다. PR 번호나 과도기 값을 이 스킬에 고정하지 않는다.
+- typography는 숫자 조합보다 역할을 먼저 확인한다. 동일 역할의 raw font 값과 unbound text style을 찾는다.
+- motion은 semantic motion token을 사용하고 raw duration·easing을 찾는다.
+- mode-specific 값을 고정한 binding이나 Light만 존재하는 semantic variable을 확인한다.
+
+raw 값 자체만으로 대체 token을 추측하지 않는다. 기존 semantic role을 찾지 못하면 `수정 전 결정`으로 남긴다.
+
+## 3. Layout과 geometry
+
+- 구조적으로 흐르는 콘텐츠가 manual x/y에 의존하는지 확인한다. 긴 텍스트에서 overlap·clip 가능성이 있으면 대표 문자열로 검증한다.
+- Auto Layout의 direction, padding, gap, alignment, wrap, Hug/Fill/Fixed가 콘텐츠 계약과 맞는지 확인한다.
+- clipContent, fixed height, absolute position, negative spacing이 focus ring·텍스트·badge를 자르는지 확인한다.
+- icon의 시각 크기와 interactive target 크기를 혼동하지 않는다.
+- screenshot의 optical alignment와 구조상 alignment를 분리한다.
+
+### 중첩 모서리 반경
+
+`outer radius = inner radius + inset`은 다음 조건을 모두 만족할 때만 적용한다.
+
+1. parent와 child가 모두 보이는 rounded surface다.
+2. child 윤곽이 parent 윤곽을 일정한 inset으로 따라가도록 의도됐다.
+3. 해당 corner의 실제 inset이 균일하다.
+4. corner smoothing, mask, 비대칭 padding 또는 optical correction이 없다.
+
+예: parent와 child의 실제 painted contour inset이 `12`이고 inner radius가 `8`이면 outer 후보는 `20`이다. padding 값만으로 inset을 확정하지 않으며 stroke alignment·weight를 포함해 측정한다.
+
+다음에는 적용하지 않는다: 카드 안의 독립 Button, 관련 없는 descendant, pill·circle, 투명 hit-area wrapper, 한쪽 corner만 맞닿는 구성, asymmetric padding, squircle/corner smoothing, 의도된 optical correction. 숫자만 보고 자동 수정하지 말고 x/y·크기·corner별 inset과 screenshot을 함께 확인한다.
+
+## 4. Typography와 content resilience
+
+- UI는 SUIT, 본문·읽기 콘텐츠는 Pretendard 역할 계약을 우선한다. Figma MCP preview 대체 폰트는 실제 token geometry를 바꾸는 근거가 아니다.
+- 12px는 역할 확인 신호다. canonical role이 본문·주요 정보·핵심 action으로 확인될 때만 finding으로 판정한다.
+- line height, weight, truncation, max lines, textAutoResize가 역할과 맞는지 확인한다.
+- 긴 한국어, 영어 확장, 숫자·날짜, 빈 값, 오류 문구에서 overlap·잘림·위계 붕괴를 확인한다.
+- RTL은 제품 지원 범위가 확인된 경우에만 합격 조건으로 강제하고, 아니면 검증 공백으로 기록한다.
+
+## 5. State와 variant
+
+- interaction 주체별로 default, hover, pressed, focus, selected, disabled, loading, error, empty, success 중 실제로 필요한 상태를 확인한다.
+- container가 비상호작용이면 내부 Button 상태를 container에 복제하지 않는다.
+- focus와 selected를 같은 상태로 취급하지 않는다.
+- disabled·loading에서 label, affordance, contrast, pointer/keyboard 동작 계약이 함께 있는지 확인한다.
+- state 누락과 단순히 현재 감사 범위에 state 증거가 없는 경우를 구분한다.
+
+## 6. Color, theme, elevation
+
+- primitive → semantic Light/Dark → component mapping을 확인한다.
+- surface, foreground, border, accent, destructive, focus 역할이 의미와 맞는지 확인한다.
+- selected와 focus, scrim과 surface elevation을 서로 대신 쓰지 않는다.
+- solid foreground/background를 해석할 수 있으면 대비를 계산할 수 있지만 `대비 후보`로 보고한다. opacity, image, gradient, blend가 있으면 screenshot과 runtime 검증을 남긴다.
+- 일반 텍스트 4.5:1, 큰 텍스트·focus·control boundary 3:1은 검사 기준이며 Figma 감사만으로 WCAG 전체 준수를 선언하지 않는다.
+
+## 7. Accessibility
+
+- 의미 있는 control의 role, accessible name, state 표현이 디자인 계약에 있는지 확인한다.
+- Web target baseline은 24 CSS px, KOSMO Web IconButton은 32px, iOS는 44pt, Android는 48dp 계약과 비교한다.
+- 인접 target 간격과 focus ring clipping을 geometry로 점검한다.
+- color-only, icon-only, hover-only 전달을 찾는다.
+- keyboard order·activation, focus-visible, screen reader announcement, VoiceOver·TalkBack, 실제 hitSlop은 runtime 검증으로 남긴다.
+
+## 8. Responsive, platform, motion
+
+- Web compact `<768`, 기본 `>=768`, full canvas `>=1280` 계약과 Native mobile shell을 섞지 않는다.
+- fixed width/height, min/max, wrap, safe area, keyboard avoidance, zoom·reflow 위험을 확인한다.
+- 같은 디자인이라도 Web과 iOS·Android target, focus, hover, system inset 증거를 분리한다.
+- motion이 있으면 enter/exit, spatial relation, interruption, reduced-motion 대체를 확인한다. motion이 없는데 state 이름만으로 animation을 요구하지 않는다.
+
+## 9. 제품 품질 렌즈
+
+OpenAI Product Design audit framework의 다음 렌즈를 구조 검사 뒤에 적용한다: discoverability, information architecture, friction, hierarchy/clarity, trust, default/empty states, copy/CTA, consistency. 구조적 결함과 polish 제안을 분리하고, 취향을 규칙처럼 강제하지 않는다.
+
+참고 프레임워크:
+
+- OpenAI Product Design audit framework: https://github.com/openai/role-specific-plugins
+- Figma custom rules: https://developers.figma.com/docs/figma-mcp-server/add-custom-rules/
+- Vercel Web Interface Guidelines: https://github.com/vercel-labs/web-interface-guidelines

--- a/.codex/skills/kosmo-design-audit/references/figma-inspection.md
+++ b/.codex/skills/kosmo-design-audit/references/figma-inspection.md
@@ -1,0 +1,178 @@
+# Figma 증거 수집
+
+## 도구 역할
+
+- `get_metadata`: 페이지·node 범위를 좁히는 overview. 상세 판정 근거로 단독 사용하지 않는다.
+- `use_figma`: 구조, geometry, style·variable binding, component·variant를 읽는 주 도구. 모든 호출 전에 `figma:figma-use`를 로드하고 `skillNames: "figma-use"`를 전달한다.
+- `get_screenshot`: 실제 위계, clipping, optical alignment, Light/Dark의 시각 증거.
+- `get_variable_defs`: 선택 node에 적용된 variable과 해석값.
+- `search_design_system`: 대체할 기존 component·variable·style을 찾을 때만 사용한다.
+
+감사 단계의 `use_figma` 코드는 `setCurrentPageAsync`, node 생성·삭제, property assignment, variable/style 생성, `figma.notify`를 호출하지 않는다.
+
+## 1차 구조 덤프
+
+`TARGET_NODE_ID`만 바꿔 실행한다. 대형 screen은 먼저 하위 section으로 범위를 좁힌다.
+
+```js
+const TARGET_NODE_ID = '200:1';
+const MAX_NODES = 400;
+const root = await figma.getNodeByIdAsync(TARGET_NODE_ID);
+if (!root) return { error: `Node not found: ${TARGET_NODE_ID}` };
+
+const mixed = (value) => (typeof value === 'symbol' ? 'MIXED' : value);
+const aliases = (value) =>
+  Object.fromEntries(
+    Object.entries(value ?? {}).map(([key, alias]) => [
+      key,
+      Array.isArray(alias) ? alias.map((item) => item?.id ?? null) : (alias?.id ?? null),
+    ]),
+  );
+const paints = (value) =>
+  Array.isArray(value)
+    ? value.map((paint) => ({
+        type: paint.type,
+        visible: paint.visible,
+        opacity: paint.opacity,
+        color: paint.type === 'SOLID' ? paint.color : undefined,
+        boundVariables: aliases(paint.boundVariables),
+      }))
+    : mixed(value);
+
+const nodes = [];
+const visit = async (node) => {
+  if (nodes.length >= MAX_NODES) return;
+  const isText = node.type === 'TEXT';
+  const mainComponent = node.type === 'INSTANCE' ? await node.getMainComponentAsync() : null;
+  nodes.push({
+    id: node.id,
+    name: node.name,
+    type: node.type,
+    parentId: node.parent?.id,
+    visible: node.visible,
+    opacity: 'opacity' in node ? node.opacity : undefined,
+    x: 'x' in node ? node.x : undefined,
+    y: 'y' in node ? node.y : undefined,
+    width: 'width' in node ? node.width : undefined,
+    height: 'height' in node ? node.height : undefined,
+    layoutMode: 'layoutMode' in node ? node.layoutMode : undefined,
+    layoutPositioning: 'layoutPositioning' in node ? node.layoutPositioning : undefined,
+    primaryAxisSizingMode: 'primaryAxisSizingMode' in node ? node.primaryAxisSizingMode : undefined,
+    counterAxisSizingMode: 'counterAxisSizingMode' in node ? node.counterAxisSizingMode : undefined,
+    padding:
+      'paddingTop' in node
+        ? {
+            top: node.paddingTop,
+            right: node.paddingRight,
+            bottom: node.paddingBottom,
+            left: node.paddingLeft,
+          }
+        : undefined,
+    itemSpacing: 'itemSpacing' in node ? node.itemSpacing : undefined,
+    clipContent: 'clipsContent' in node ? node.clipsContent : undefined,
+    cornerRadius: 'cornerRadius' in node ? mixed(node.cornerRadius) : undefined,
+    corners:
+      'topLeftRadius' in node
+        ? {
+            topLeft: node.topLeftRadius,
+            topRight: node.topRightRadius,
+            bottomRight: node.bottomRightRadius,
+            bottomLeft: node.bottomLeftRadius,
+          }
+        : undefined,
+    cornerSmoothing: 'cornerSmoothing' in node ? node.cornerSmoothing : undefined,
+    fills: 'fills' in node ? paints(node.fills) : undefined,
+    strokes: 'strokes' in node ? paints(node.strokes) : undefined,
+    strokeWeight: 'strokeWeight' in node ? mixed(node.strokeWeight) : undefined,
+    styleIds: {
+      fill: 'fillStyleId' in node ? mixed(node.fillStyleId) : undefined,
+      stroke: 'strokeStyleId' in node ? mixed(node.strokeStyleId) : undefined,
+      effect: 'effectStyleId' in node ? mixed(node.effectStyleId) : undefined,
+      text: 'textStyleId' in node ? mixed(node.textStyleId) : undefined,
+    },
+    boundVariables: 'boundVariables' in node ? aliases(node.boundVariables) : undefined,
+    mainComponentId: mainComponent?.id,
+    componentProperties: 'componentProperties' in node ? node.componentProperties : undefined,
+    variantProperties: 'variantProperties' in node ? node.variantProperties : undefined,
+    text: isText
+      ? {
+          length: node.characters.length,
+          textAutoResize: node.textAutoResize,
+          fontName: mixed(node.fontName),
+          fontSize: mixed(node.fontSize),
+          lineHeight: mixed(node.lineHeight),
+          hasMissingFont: node.hasMissingFont,
+        }
+      : undefined,
+  });
+  if ('children' in node) {
+    for (const child of node.children) await visit(child);
+  }
+};
+
+await visit(root);
+const componentSet =
+  root.type === 'COMPONENT_SET' ? root : root.parent?.type === 'COMPONENT_SET' ? root.parent : null;
+return {
+  target: { id: root.id, name: root.name, type: root.type },
+  componentContext: {
+    componentSet: componentSet ? { id: componentSet.id, name: componentSet.name } : null,
+    siblingVariants: componentSet
+      ? componentSet.children.map((node) => ({
+          id: node.id,
+          name: node.name,
+          type: node.type,
+        }))
+      : [],
+    propertyDefinitions:
+      'componentPropertyDefinitions' in root ? root.componentPropertyDefinitions : undefined,
+  },
+  nodeCount: nodes.length,
+  truncated: nodes.length >= MAX_NODES,
+  nodes,
+};
+```
+
+source 수정 제안 직전에만 영향 범위를 별도로 수집한다. `COMPONENT_SET`이면 실제 수정할 child component마다 실행한다.
+
+```js
+const SOURCE_NODE_ID = '200:1';
+const MAX_INSTANCES = 200;
+const source = await figma.getNodeByIdAsync(SOURCE_NODE_ID);
+if (!source || source.type !== 'COMPONENT') {
+  return { error: `Component not found: ${SOURCE_NODE_ID}` };
+}
+const instances = await source.getInstancesAsync();
+return {
+  source: { id: source.id, name: source.name },
+  total: instances.length,
+  truncated: instances.length > MAX_INSTANCES,
+  instances: instances.slice(0, MAX_INSTANCES).map((node) => ({
+    id: node.id,
+    name: node.name,
+    parentId: node.parent?.id,
+    componentProperties: node.componentProperties,
+  })),
+};
+```
+
+이 목록은 consumer 수와 component property override를 보여준다. text·nested override 등 세부 override가 노출되지 않으면 임의로 추정하지 말고 영향 범위 검증 공백으로 남긴다.
+
+## 판정 순서
+
+1. source/instance와 감사 범위를 확인한다.
+2. raw 값, style ID, variable alias를 함께 본다. raw 해석값이 있어도 binding이 있으면 raw 사용으로 오판하지 않는다.
+3. parent padding, child x/y·크기, corner별 radius를 비교한 뒤에만 nested radius 후보를 판단한다.
+4. variant 이름만 보고 state 완성도를 선언하지 않는다. 실제 component properties와 대표 screenshot을 확인한다.
+5. Light/Dark는 같은 source·내용·크기의 evidence pair로 비교한다.
+6. 긴 한국어·영어 확장은 source를 바꾸지 않는 임시 대표 instance나 기존 specimen이 있을 때 검사한다. 감사 단계에서 새 node를 만들지 않는다.
+7. Figma에서 증명할 수 없는 항목은 runtime 검증 목록으로 이동한다.
+
+## 최소 증거 묶음
+
+- target source node ID와 scope screenshot
+- 구조 덤프의 relevant node 일부
+- 적용 variable 정의와 mode
+- 필요한 state·variant screenshot
+- source 수정 시 영향받는 instance와 override 요약
+- 확인하지 못한 platform·theme·state·runtime 목록


### PR DESCRIPTION
## 무엇을 변경했나요

- 프로젝트 로컬 `kosmo-design-audit` 스킬을 추가했습니다.
- Figma 구조, token binding, variant, source·instance 영향 범위를 읽기 전용으로 수집하는 절차를 정의했습니다.
- layout, typography, state, Light/Dark, 접근성, 반응형과 nested radius 감사 규칙을 추가했습니다.

## 왜 변경했나요

Figma 디자인 시스템 작업이 육안 확인에 과도하게 의존하고, LLM이 token binding이나 중첩 모서리 관계처럼 당연하지만 놓치기 쉬운 규칙을 일관되게 검사하지 못하는 문제를 줄이기 위해 추가했습니다.

## 이번 PR의 주요 결정

### Figma 감사와 production 코드 구현 분리

- 결정자: @yeeun-uwu
- 선택: 이 스킬을 Figma source component, variable, style 감사와 승인된 Figma 수정에만 사용합니다.
- 고려한 대안: production React Native·Web 컴포넌트 리뷰까지 포함하거나 개인 로컬 스킬로만 유지
- 이유: Figma 계약과 코드 구현 증거를 섞지 않으면서 KOSMO 디자인 문서와 같은 버전으로 관리하기 위함입니다.
- 감수한 결과: production UI 코드 검증은 별도 코드 리뷰 절차가 필요합니다.
- 관련 근거: `docs/design/`

### foundation token 값 비복제

- 결정자: @yeeun-uwu
- 선택: spacing·radius·border 값을 스킬에 고정하지 않고, 기준 브랜치에 머지된 foundation 문서와 canonical token 정의를 읽습니다.
- 고려한 대안: 현재 token 목록 또는 미병합 PR의 후보 값을 스킬에 직접 기록
- 이유: foundation 변경 후 스킬 규칙이 오래된 값으로 남는 것을 방지하기 위함입니다.
- 감수한 결과: 감사 전에 기준 브랜치와 canonical revision 확인이 필요합니다.
- 관련 근거: `docs/design/foundations.md`

## 어떻게 확인할 수 있나요

- frontmatter와 요구사항 assertion 8개 통과
- 내부 참조와 trailing whitespace 검사 통과
- `Card/Media` 사례로 token authority와 nested radius 조건을 재검증
- 공식 `quick_validate.py`는 로컬 환경의 PyYAML 누락으로 실행하지 못했으며 동일 frontmatter 검사를 Ruby YAML 파서로 확인

## 아직 어떤 문제가 남았나요

- 실제 Figma 파일을 대상으로 한 read-only dry-run은 아직 수행하지 않았습니다.
