### PR TITLE
Repost Announce와 Undo의 책임을 다시 분리한다

### DIFF
--- a/packages/core/temporal/post-create-effects.test.ts
+++ b/packages/core/temporal/post-create-effects.test.ts
@@ -1,13 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  KOSMO_TASK_QUEUE,
   POST_CREATE_EFFECTS_WORKFLOW_TYPE,
   postCreateEffectsWorkflowId,
   postCreateEffectsWorkflowStartOptions,
 } from './post-create-effects';
-import { KOSMO_TASK_QUEUE } from './task-queue';
 
-test('Post Create effects Workflow keeps its existing stable external contract', () => {
+test('Post Create effects Workflow start는 Post ID와 origin을 포함한 stable start policy를 사용한다', () => {
   const input = {
     postId: '00000000-0000-8000-8000-000000000001',
     origin: 'LOCAL' as const,

--- a/packages/core/temporal/post-create-effects.ts
+++ b/packages/core/temporal/post-create-effects.ts
@@ -1,5 +1,7 @@
 import { KOSMO_TASK_QUEUE } from './task-queue';
 
+export { KOSMO_TASK_QUEUE } from './task-queue';
+
 export const POST_CREATE_EFFECTS_WORKFLOW_TYPE = 'postCreateEffectsWorkflow';
 
 export type PostCreateEffectsInput = {

--- a/packages/fedify/src/repost-delivery.test.ts
+++ b/packages/fedify/src/repost-delivery.test.ts
@@ -238,32 +238,6 @@ describe('ActivityPub Local Repost delivery', () => {
     assert.equal(fixture.calls[1]!.options.orderingKey, `activitypub-repost:${repost.id}`);
   });
 
-  test('Announce acceptance와 Tombstone이 경합하면 같은 ordering key의 Undo로 수렴한다', async () => {
-    const author = await createProfile({ kind: InstanceKind.LOCAL });
-    const source = await createContentPost(author.id);
-    const repost = await createRepost(author.id, source.id);
-    const follower = await createRemoteActorProfile();
-    await db.insert(ProfileFollows).values({
-      followeeProfileId: author.id,
-      followerProfileId: follower.id,
-    });
-    const fixture = createContextFixture(async (callIndex) => {
-      if (callIndex === 1) {
-        await db.update(Posts).set({ state: PostState.DELETED }).where(eq(Posts.id, repost.id));
-      }
-    });
-    mock.method(federation, 'createContext', () => fixture.context);
-
-    await sendRepostAnnounce(repost.id);
-
-    assert.deepEqual(
-      fixture.calls.map(({ activity }) => activity.constructor),
-      [Announce, Undo],
-    );
-    assert.equal(fixture.calls[0]!.options.orderingKey, `activitypub-repost:${repost.id}`);
-    assert.equal(fixture.calls[1]!.options.orderingKey, fixture.calls[0]!.options.orderingKey);
-  });
-
   test('unsupported 또는 unavailable projection과 recipient 부재는 전송하지 않는다', async () => {
     const author = await createProfile({ kind: InstanceKind.LOCAL });
     const follower = await createRemoteActorProfile();
@@ -323,7 +297,7 @@ interface SendActivityCall {
   readonly sender: { readonly identifier: string };
 }
 
-const createContextFixture = (afterSend?: (callIndex: number) => Promise<void>) => {
+const createContextFixture = () => {
   const calls: SendActivityCall[] = [];
   const context = {
     canonicalOrigin: publicOrigin,
@@ -335,7 +309,6 @@ const createContextFixture = (afterSend?: (callIndex: number) => Promise<void>) 
       options: { orderingKey: string; preferSharedInbox: boolean },
     ) => {
       calls.push({ activity, options, recipients, sender });
-      await afterSend?.(calls.length);
     },
   } as unknown as Context<void>;
   return { calls, context };

--- a/packages/fedify/src/repost-delivery.ts
+++ b/packages/fedify/src/repost-delivery.ts
@@ -223,19 +223,8 @@ const sendRepostActivity = async (repostId: string, kind: RepostDeliveryKind): P
   });
 };
 
-export const sendRepostAnnounce = async (repostId: string): Promise<void> => {
-  await sendRepostActivity(repostId, 'ANNOUNCE');
-
-  const deleted = await db
-    .select({ id: Posts.id })
-    .from(Posts)
-    .where(and(eq(Posts.id, repostId), eq(Posts.state, PostState.DELETED)))
-    .limit(1)
-    .then(first);
-  if (deleted) {
-    await sendRepostActivity(repostId, 'UNDO');
-  }
-};
+export const sendRepostAnnounce = async (repostId: string): Promise<void> =>
+  sendRepostActivity(repostId, 'ANNOUNCE');
 
 export const sendRepostUndo = async (repostId: string): Promise<void> =>
   sendRepostActivity(repostId, 'UNDO');


### PR DESCRIPTION
## 무엇을 변경했는지

- `sendRepostAnnounce`가 Announce 전송 뒤 Post 상태를 다시 조회해 보상 Undo를 보내던 동작을 제거했습니다.
- 그 보상 동작만 검증하던 경합 테스트와 테스트 전용 `afterSend` callback을 제거했습니다.
- `KOSMO_TASK_QUEUE`의 기존 `post-create-effects` 공개 export를 복구하고 관련 테스트 import와 제목을 원래 계약에 맞췄습니다.

## 왜 변경했는지

PR #618에서 추가된 보상 Undo는 [PROD-725](https://linear.app/byulmaru/issue/PROD-725/repost-%EC%83%9D%EC%84%B1%EA%B3%BC-postrepost-delete-%ED%9B%84%EC%86%8D-%ED%9A%A8%EA%B3%BC%EB%A5%BC-temporal-workflow%EB%A1%9C-%EC%A0%84%ED%99%98%ED%95%9C%EB%8B%A4)의 Workflow 전환 범위나 PROD-495의 기존 Announce/Undo 계약에 근거가 없었습니다. Announce와 Undo는 각각 Repost create/delete Workflow가 소유하므로, Announce Activity가 삭제 경합을 자체 보정하지 않게 기존 책임 경계를 복구합니다.

## 이번 PR의 주요 결정

없음. 최신 Linear 계약과 archive된 OpenSpec을 변경하지 않고, 그 범위를 벗어난 구현을 제거했습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/core test:unit` — 59/59 통과
- `pnpm test:fedify` — Fedify 230/230, consumer 1/1 통과
- `pnpm --filter @kosmo/fedify lint:tsc` — 통과
- 변경 파일 ESLint 및 Prettier — 통과
- `git diff --check` — 통과
- 독립 correctness 및 범위/단순성 self-review — finding 없음

## 아직 어떤 문제가 남았는지

없음. 이 PR은 로컬 코드와 자동화 테스트 증거만 제공하며 dev-live Temporal history 또는 production cutover 증거가 아닙니다. production sync/apply/cutover/live verification은 수행하지 않았습니다.
