### PR TITLE
Post detail E2E가 실제 원격 응답 완료를 기다리게 한다

### DIFF
--- a/apps/web/e2e/post-detail.e2e.ts
+++ b/apps/web/e2e/post-detail.e2e.ts
@@ -1,22 +1,28 @@
 import { PostVisibility } from '@kosmo/core/enums';
 import {
   createE2EPost,
-  createE2EProfile,
+  createE2ERemoteProfile,
   createE2ESession,
   resetE2EDatabase,
   setE2ESessionCookie,
 } from './db-fixtures';
 import { expect, test } from './fixtures';
-import {
-  isGraphQLOperation,
-  readGraphQLOperation,
-  toGlobalId,
-  waitForGraphQLOperation,
-} from './graphql';
+import { readGraphQLOperation, toGlobalId, waitForGraphQLOperation } from './graphql';
+import type { Page } from '@playwright/test';
 
 test.beforeEach(async () => {
   await resetE2EDatabase();
 });
+
+const gotoPostDetail = async (page: Page, path: string) => {
+  const detailResponse = waitForGraphQLOperation(page, 'PostDetailQuery');
+  await page.goto(path);
+
+  const response = await detailResponse;
+  const body = (await response.json()) as { errors?: unknown[] };
+  expect(response.ok(), JSON.stringify(body, null, 2)).toBe(true);
+  expect(body.errors, JSON.stringify(body, null, 2)).toBeUndefined();
+};
 
 test('게시글 목록에서 상세로 이동하고 뒤로 가며 deep-link handle을 정규화한다', async ({
   context,
@@ -68,46 +74,25 @@ test('게시글 목록에서 상세로 이동하고 뒤로 가며 deep-link hand
 test('연합 프로필 게시글은 relativeHandle URL을 유지하고 정규화한다', async ({ context, page }) => {
   const body = 'E2E federated post detail body';
   const viewer = await createE2ESession({ handle: 'e2e-federated-detail-viewer' });
-  const author = await createE2EProfile({ handle: 'e2e-federated-author' });
+  const domain = 'remote.example';
+  const author = await createE2ERemoteProfile({ domain, handle: 'e2e-federated-author' });
   const post = await createE2EPost({
     body,
     profileId: author.id,
     visibility: PostVisibility.PUBLIC,
   });
   const postId = toGlobalId('Post', post.id);
-  const relativeHandle = `@${author.handle}@remote.example`;
+  const relativeHandle = `@${author.handle}@${domain}`;
 
   await setE2ESessionCookie(context, viewer.token);
-  await page.route('**/graphql', async (route) => {
-    if (!isGraphQLOperation(route.request().postData(), 'PostDetailQuery')) {
-      await route.continue();
-      return;
-    }
-
-    const response = await route.fetch();
-    const responseBody = (await response.json()) as {
-      data?: { node?: { profile?: { relativeHandle: string } | null } | null };
-    };
-    const profile = responseBody.data?.node?.profile;
-
-    if (profile) {
-      profile.relativeHandle = relativeHandle;
-    }
-
-    await route.fulfill({
-      body: JSON.stringify(responseBody),
-      contentType: 'application/json',
-      status: response.status(),
-    });
-  });
 
   const canonicalPath = `/${relativeHandle}/${postId}`;
 
-  await page.goto(canonicalPath);
+  await gotoPostDetail(page, canonicalPath);
   await expect.poll(() => decodeURIComponent(new URL(page.url()).pathname)).toBe(canonicalPath);
   await expect(page.getByText(body)).toBeVisible();
 
-  await page.goto(`/wrong-handle/${postId}`);
+  await gotoPostDetail(page, `/wrong-handle/${postId}`);
   await expect.poll(() => decodeURIComponent(new URL(page.url()).pathname)).toBe(canonicalPath);
   await expect(page.getByText(body)).toBeVisible();
 });


### PR DESCRIPTION
## 무엇을 변경했는지

- 연합 프로필 게시글 상세 E2E가 응답을 변조하는 `page.route(... route.fetch())` 대신 실제 ActivityPub 원격 프로필 fixture를 사용하게 했습니다.
- canonical URL과 wrong-handle URL에서 `PostDetailQuery` 응답을 명시적으로 기다리고, HTTP 성공과 GraphQL error 부재를 확인하게 했습니다.
- PR #626/PROD-725의 Fedify·Core 코드는 변경하지 않았습니다.

## 왜 변경했는지

PR #626 merge queue의 [Test run](https://github.com/byulmaru/kosmo/actions/runs/32095392726)에서 이 테스트의 `route.fetch()`가 `read ECONNRESET`으로 한 번 실패했습니다. 동일 tree의 일반 PR CI와 직후 merge-group run은 통과했고 최근 Test workflow 100건에서도 같은 오류는 한 번뿐이므로 제품 회귀로 확정하지 않았습니다.

다만 기존 테스트는 실제 `PostDetailQuery` 완료를 기다리지 않은 채 5초 본문 locator에 의존하고, 원격 `relativeHandle`을 만들기 위해 모든 GraphQL 요청을 가로채 별도 네트워크 왕복을 추가했습니다. 로컬 격리 DB 반복에서 기존 경로는 50회 중 2회 세션 splash에 고착됐습니다. 실제 원격 fixture만 적용한 중간안도 50회 중 1회 고착되어, 최종안에서는 query 완료 경계까지 명시했습니다.

관련 Linear: [PROD-789](https://linear.app/byulmaru/issue/PROD-789/post-detail-web-e2e의-routefetch-econnreset-flake를-제거한다)

## 이번 PR의 주요 결정

없음. 기존 원격 프로필 `relativeHandle`과 route 정규화 계약은 바꾸지 않고, 테스트가 실제 fixture/API 응답으로 그 계약을 검증하게 했습니다. 제품 행동 변화가 없는 test-only 수정이므로 새 OpenSpec은 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/web check`
- `pnpm --filter @kosmo/web test:unit` — 35 passed
- 수정 전 대상 반복 — 48 passed, 2 failed (세션 splash 고착)
- 실제 원격 fixture만 적용한 중간안 — 49 passed, 1 failed (세션 splash 고착)
- 최종안 대상 반복 — 50 passed
- 최종안 `post-detail.e2e.ts` 전체 — 3 passed
- E2E는 격리 DB와 시스템 Chrome(`PLAYWRIGHT_BROWSER_CHANNEL=chrome`)으로 실행했습니다.
- GitHub Actions 전체 Web suite는 이 PR에서 확인합니다.

## 아직 어떤 문제가 남았는지

최초 CI의 TCP reset보다 아래 단계 원인은 artifact에 trace/API stderr가 없어 확정하지 못했습니다. 이번 변경은 재시도나 실패 무시가 아니라, 직접 실패한 테스트 전용 network interception을 제거하고 누락된 query completion 경계를 닫습니다.