### PR TITLE
Production release 중복과 CNPG sync drift를 제거한다

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -21,13 +21,19 @@ env:
   VAULT_GITHUB_ACTIONS_AUDIENCE: https://vault.tail1fdd55.ts.net
 
 jobs:
-  automatic_deploy:
-    name: Approve, Build and Deploy Production (main ${{ github.sha }})
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  production_deploy:
+    name: >-
+      Approve, Build and Deploy Production
+      (${{ github.event_name == 'workflow_dispatch' && format('manual {0}', needs.manual_preflight.outputs.target_sha) || format('main {0}', github.sha) }})
+    needs: manual_preflight
+    if: >-
+      always() &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && needs.manual_preflight.result == 'success'))
     runs-on: [self-hosted, ARM64]
     environment:
       name: prod
-      url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+      url: ${{ github.event_name == 'workflow_dispatch' && needs.manual_preflight.outputs.target_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}
     concurrency:
       group: production-release
       cancel-in-progress: false
@@ -37,13 +43,14 @@ jobs:
       packages: write
     env:
       ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net
-      TARGET_SHA: ${{ github.sha }}
+      RELEASE_TRIGGER: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'automatic' }}
+      TARGET_SHA: ${{ github.event_name == 'workflow_dispatch' && needs.manual_preflight.outputs.target_sha || github.sha }}
 
     steps:
-      - name: Checkout main commit after approval
+      - name: Checkout target commit after approval
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ env.TARGET_SHA }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -89,7 +96,7 @@ jobs:
             ghcr.io/${{ github.repository }}
             ${{ env.AWS_ECR_REPOSITORY_URL }}
           tags: |
-            type=raw,value=prod-sha-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+            type=raw,value=prod-sha-${{ env.TARGET_SHA }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Build and push production image
         id: build
@@ -111,7 +118,7 @@ jobs:
             EXPO_PUBLIC_SENTRY_DSN=${{ steps.sentry.outputs.EXPO_PUBLIC_SENTRY_DSN }}
             SENTRY_ORG=${{ vars.SENTRY_ORG }}
             SENTRY_PROJECT=${{ vars.SENTRY_PROJECT }}
-            SENTRY_RELEASE=kosmo@${{ github.sha }}
+            SENTRY_RELEASE=kosmo@${{ env.TARGET_SHA }}
             SENTRY_UPLOAD_REQUIRED=1
           secret-envs: |
             sentry_auth_token=SENTRY_AUTH_TOKEN
@@ -255,7 +262,7 @@ jobs:
             --image-manifest "${image_manifest}" \
             --image-digest "${IMAGE_DIGEST}"
 
-      - name: Record automatic production release
+      - name: Record production release
         if: always()
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
@@ -263,16 +270,18 @@ jobs:
         shell: bash
         run: |
           {
-            echo "### Automatic production release"
+            echo "### ${RELEASE_TRIGGER^} production release"
             echo
-            echo "- Trigger: push (main candidate)"
+            echo "- Trigger: ${RELEASE_TRIGGER}"
             echo "- Requester: ${GITHUB_ACTOR}"
             echo "- Workflow definition ref: ${GITHUB_REF}"
             echo "- Target SHA: ${TARGET_SHA}"
-            echo "- Candidate image: ghcr.io/${GITHUB_REPOSITORY}@${IMAGE_DIGEST}"
+            echo "- Image identity: ghcr.io/${GITHUB_REPOSITORY}@${IMAGE_DIGEST}"
             echo "- Argo source revision: ${TARGET_SHA}"
             echo "- Approval boundary: prod Environment"
-            echo "- Dev build/deploy: separate Docker Build and Deploy Dev workflows"
+            if [[ "${RELEASE_TRIGGER}" == "automatic" ]]; then
+              echo "- Dev build/deploy: separate Docker Build and Deploy Dev workflows"
+            fi
             echo "- Result: ${RESULT}"
             echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} (attempt ${GITHUB_RUN_ATTEMPT})"
           } >> "${GITHUB_STEP_SUMMARY}"
@@ -337,261 +346,4 @@ jobs:
             echo "- Target commit: [${TARGET_SHA}](${TARGET_URL})"
             echo "- Target code checkout/build: deferred until prod Environment approval"
             echo "- Production credentials: not requested during preflight"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-  manual_deploy:
-    name: Approve and Deploy Production (manual ${{ needs.manual_preflight.outputs.target_sha }})
-    if: github.event_name == 'workflow_dispatch' && needs.manual_preflight.result == 'success'
-    needs: manual_preflight
-    runs-on: [self-hosted, ARM64]
-    environment:
-      name: prod
-      url: ${{ needs.manual_preflight.outputs.target_url }}
-    concurrency:
-      group: production-release
-      cancel-in-progress: false
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    env:
-      ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net
-      TARGET_SHA: ${{ needs.manual_preflight.outputs.target_sha }}
-      SENTRY_RELEASE: kosmo@${{ needs.manual_preflight.outputs.target_sha }}
-
-    steps:
-      - name: Checkout target commit after approval
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ needs.manual_preflight.outputs.target_sha }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          name: kosmo-production-manual
-          cleanup: false
-          cache-binary: false
-
-      - name: Log in to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
-        with:
-          role-to-assume: arn:aws:iam::822638974464:role/github-actions-kosmo-ecr-push
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Load production Sentry DSN from Vault
-        id: sentry
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-        with:
-          url: ${{ env.VAULT_ADDR }}
-          path: github-actions
-          method: jwt
-          role: kosmo-build-prod
-          jwtGithubAudience: ${{ env.VAULT_GITHUB_ACTIONS_AUDIENCE }}
-          exportEnv: false
-          secrets: |
-            secret/data/kubernetes/kosmo/prod EXPO_PUBLIC_SENTRY_DSN | EXPO_PUBLIC_SENTRY_DSN
-
-      - name: Log in to ECR
-        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
-
-      - name: Extract manual production metadata
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ env.AWS_ECR_REPOSITORY_URL }}
-          tags: |
-            type=raw,value=prod-sha-${{ needs.manual_preflight.outputs.target_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-
-      - name: Build and push manual production image
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          no-cache-filters: |
-            app-build
-            runtime
-          build-args: |
-            EXPO_PUBLIC_ENVIRONMENT=${{ env.ENVIRONMENT }}
-            EXPO_PUBLIC_OPENPANEL_CLIENT_ID=${{ vars.EXPO_PUBLIC_OPENPANEL_CLIENT_ID }}
-            EXPO_PUBLIC_SENTRY_DSN=${{ steps.sentry.outputs.EXPO_PUBLIC_SENTRY_DSN }}
-            SENTRY_ORG=${{ vars.SENTRY_ORG }}
-            SENTRY_PROJECT=${{ vars.SENTRY_PROJECT }}
-            SENTRY_RELEASE=${{ env.SENTRY_RELEASE }}
-            SENTRY_UPLOAD_REQUIRED=1
-          secret-envs: |
-            sentry_auth_token=SENTRY_AUTH_TOKEN
-
-      - name: Validate manual production image digest
-        env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "${IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Manual production build did not produce a valid image digest."
-            exit 1
-          fi
-
-      - name: Get Argo CD token
-        id: argocd-token
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const githubToken = await core.getIDToken();
-            core.setSecret(githubToken);
-
-            const response = await fetch(`https://${process.env.ARGOCD_SERVER}/api/dex/token`, {
-              method: "POST",
-              headers: {
-                authorization: `Basic ${Buffer.from("argo-cd-cli:").toString("base64")}`,
-              },
-              body: new URLSearchParams({
-                connector_id: "github-actions",
-                grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-                scope: "openid email profile federated:id",
-                requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
-                subject_token: githubToken,
-                subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
-              }),
-            });
-
-            if (!response.ok) {
-              throw new Error(`Dex token exchange failed: ${response.status} ${await response.text()}`);
-            }
-
-            const { access_token: dexToken } = await response.json();
-            if (!dexToken) {
-              throw new Error("Dex token response did not include an access token.");
-            }
-
-            core.setSecret(dexToken);
-            core.setOutput("token", dexToken);
-
-      - name: Install Argo CD CLI
-        env:
-          ARGOCD_CLI_VERSION: v3.4.2
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          case "$(uname -s)" in
-            Darwin) argocd_os=darwin ;;
-            Linux) argocd_os=linux ;;
-            *)
-              echo "::error::Unsupported runner OS: $(uname -s)"
-              exit 1
-              ;;
-          esac
-
-          case "$(uname -m)" in
-            x86_64) argocd_arch=amd64 ;;
-            aarch64 | arm64) argocd_arch=arm64 ;;
-            *)
-              echo "::error::Unsupported runner architecture: $(uname -m)"
-              exit 1
-              ;;
-          esac
-
-          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_CLI_VERSION}/argocd-${argocd_os}-${argocd_arch}"
-          chmod 555 "${RUNNER_TEMP}/argocd"
-          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
-
-      - name: Sync migration and production workloads
-        env:
-          ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          argocd --server "${ARGOCD_SERVER}" --grpc-web app set kosmo-prod \
-            --revision "${TARGET_SHA}" \
-            -p "version=${TARGET_SHA}" \
-            -p "imageDigest=${IMAGE_DIGEST}" \
-            -p "migration.enabled=true" \
-            --validate
-
-          argocd --server "${ARGOCD_SERVER}" --grpc-web app sync kosmo-prod \
-            --revision "${TARGET_SHA}" \
-            --prune \
-            --timeout 600
-          argocd --server "${ARGOCD_SERVER}" --grpc-web app wait kosmo-prod \
-            --sync \
-            --health \
-            --timeout 600
-
-          app_json="$(argocd --server "${ARGOCD_SERVER}" --grpc-web app get kosmo-prod --output json)"
-          actual_source_revision="$(jq -r '.status.sync.revision' <<<"${app_json}")"
-          actual_image_digest="$(jq -r '.spec.source.helm.parameters[] | select(.name == "imageDigest") | .value' <<<"${app_json}")"
-          if [[ "${actual_source_revision}" != "${TARGET_SHA}" ]]; then
-            echo "::error::Argo CD synced revision ${actual_source_revision}, expected ${TARGET_SHA}."
-            exit 1
-          fi
-          if [[ "${actual_image_digest}" != "${IMAGE_DIGEST}" ]]; then
-            echo "::error::Argo CD image digest ${actual_image_digest}, expected ${IMAGE_DIGEST}."
-            exit 1
-          fi
-
-      - name: Configure AWS credentials for stable tag
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
-        with:
-          role-to-assume: arn:aws:iam::822638974464:role/github-actions-kosmo-ecr-push
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Promote approved digest to ECR stable
-        env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          image_manifest="$(aws ecr batch-get-image \
-            --repository-name kosmo \
-            --image-ids imageDigest="${IMAGE_DIGEST}" \
-            --query 'images[0].imageManifest' \
-            --output text)"
-          if [[ -z "${image_manifest}" || "${image_manifest}" == "None" ]]; then
-            echo "::error::ECR image manifest was not found for ${IMAGE_DIGEST}."
-            exit 1
-          fi
-          aws ecr put-image \
-            --repository-name kosmo \
-            --image-tag stable \
-            --image-manifest "${image_manifest}" \
-            --image-digest "${IMAGE_DIGEST}"
-
-      - name: Record manual production release
-        if: always()
-        env:
-          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-          RESULT: ${{ job.status }}
-        shell: bash
-        run: |
-          {
-            echo "### Manual production release"
-            echo
-            echo "- Trigger: workflow_dispatch"
-            echo "- Requester: ${GITHUB_ACTOR}"
-            echo "- Workflow definition ref: ${GITHUB_REF}"
-            echo "- Target commit: ${TARGET_SHA}"
-            echo "- Image identity: ghcr.io/${GITHUB_REPOSITORY}@${IMAGE_DIGEST}"
-            echo "- Argo source revision: ${TARGET_SHA}"
-            echo "- Approval boundary: prod Environment"
-            echo "- Result: ${RESULT}"
-            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} (attempt ${GITHUB_RUN_ATTEMPT})"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/apps/helm/templates/postgres-runtime-roles.yaml
+++ b/apps/helm/templates/postgres-runtime-roles.yaml
@@ -118,12 +118,6 @@ spec:
   name: kosmo_runtime
   login: true
   inherit: true
-  superuser: false
-  createdb: false
-  createrole: false
-  replication: false
-  bypassrls: false
-  inRoles: []
   passwordSecret:
     name: {{ include "kosmo.runtimeDatabasePasswordSecretName" . }}
   databaseRoleReclaimPolicy: retain

--- a/openspec/changes/deploy-production-from-main-or-sha/design.md
+++ b/openspec/changes/deploy-production-from-main-or-sha/design.md
@@ -32,6 +32,7 @@
 - Environment를 참조하는 job의 GitHub OIDC subject는 branch ref가 아니라 `environment:prod`가 된다. Automatic과 manual production build는 모두 이 exact subject를 공유한다.
 - `kosmo-prod`의 Terraform bootstrap source는 `production`이지만 release workflow는 full SHA와 Helm parameter를 imperative overlay로 소유한다. 좁은 `ignore_changes`는 유지하면서 bootstrap ref만 바꿔야 한다.
 - Active `adopt-production-release-branch` change가 같은 capability의 obsolete production branch delta와 미완료 live task를 가진다. 새 delta를 적용한 뒤 과거 delta가 다시 sync되지 않도록 superseded 생명주기를 명시해야 한다.
+- 첫 main release에서 새 `kosmo_runtime` DatabaseRole의 명시적 false/empty 기본값을 CNPG가 live spec에서 생략해 workload와 migration이 성공한 뒤에도 Argo CD가 OutOfSync로 남았다. Runtime role manifest는 privilege 의미를 바꾸거나 broad ignore rule을 추가하지 않고 CNPG의 현재 canonical default 표현과 일치해야 한다.
 
 ### Recommended Approach
 
@@ -45,6 +46,7 @@
 8. ECR OIDC trust와 외부 Vault prod build role은 automatic과 manual gated build가 사용하는 exact `repo:byulmaru/kosmo:environment:prod` identity만 허용한다. main ref, `refs/heads/production`, tag와 일반 branch identity는 허용하지 않는다.
 9. Terraform의 `kosmo-prod` bootstrap revision을 main으로 바꾸되 release-time full SHA와 Helm parameter ignore 경계는 유지한다. GitHub `prod` Environment에는 required reviewer를 설정하고 main workflow에서 시작되는 automatic/manual gated job을 허용한다.
 10. Runbook과 audit summary는 automatic main과 manual target을 구분하고 target SHA, build digest, Argo revision, migration/workload와 smoke 결과를 기록한다.
+11. `kosmo_runtime` DatabaseRole은 CNPG가 생략하는 `false` privilege 기본값과 빈 `inRoles`를 manifest에서도 생략한다. `login`, `inherit`, password Secret과 reclaim policy는 유지하고 다른 role 또는 Argo diff ignore 범위는 넓히지 않는다.
 
 ### Allowed Alternatives
 

--- a/openspec/changes/deploy-production-from-main-or-sha/design.md
+++ b/openspec/changes/deploy-production-from-main-or-sha/design.md
@@ -37,10 +37,10 @@
 
 1. 기존 Docker Build와 Deploy Dev는 main의 dev build·배포 전용으로 남기고 `production` trigger와 prod 조건을 제거한다. Dev artifact tag는 production release metadata와 충돌하지 않는 suffix를 사용하고 Trivy용 digest artifact는 유지한다.
 2. 별도 Production Release workflow가 `push: main`과 `workflow_dispatch`를 처리한다. Production job에만 `prod` Environment를 걸어 Dev workflow 완료와 보안 scan을 막지 않으면서 production 전체 경계를 승인 뒤로 이동한다.
-3. Main push 경로는 event full SHA와 release metadata만 승인 job에 전달하고 production source를 checkout하거나 Vault/ECR/Sentry credential을 요청하지 않는다. `prod` Environment 승인 뒤 하나의 gated job이 main full SHA를 checkout하고 prod Vault role·ECR login·Sentry upload secret을 얻어 image를 build한다.
+3. Automatic과 manual release는 하나의 production deploy job 정의를 공유한다. Main push 경로는 event full SHA를 target으로 선택하고 production source를 checkout하거나 Vault/ECR/Sentry credential을 요청하기 전에 `prod` Environment 승인을 기다린다. 승인 뒤 shared gated job이 main full SHA를 checkout하고 prod Vault role·ECR login·Sentry upload secret을 얻어 image를 build한다.
 4. Automatic gated job은 build output digest를 같은 job의 migration-gated Argo sync에 전달하고, Argo source를 main full SHA로 고정해 revision을 검증한다. Sync와 post-deploy 검증이 성공한 뒤에만 같은 digest에 `stable` 보존 tag를 이동한다.
 5. Manual dispatch는 workflow ref가 main인지와 입력이 40자리 SHA인지 먼저 확인하고 GitHub commit API로 repository object를 해석한다. Preflight output을 Environment URL과 job 이름에 사용해 reviewer가 실제 target commit을 확인할 수 있게 한다.
-6. Manual gated job은 승인 뒤 target SHA를 checkout하고 prod image를 build한 뒤 같은 job에서 digest-pinned Argo sync·revision 검증과 성공한 digest의 `stable` 이동을 수행한다. `SENTRY_RELEASE`, checkout, Helm version과 Argo revision은 dispatch workflow의 `github.sha`가 아니라 resolved target SHA를 사용한다.
+6. Manual preflight가 성공하면 같은 shared gated job이 resolved target SHA를 선택한다. 승인 뒤 target SHA를 checkout하고 prod image를 build한 뒤 digest-pinned Argo sync·revision 검증과 성공한 digest의 `stable` 이동을 수행한다. `SENTRY_RELEASE`, checkout, Helm version과 Argo revision은 dispatch workflow의 `github.sha`가 아니라 resolved target SHA를 사용한다.
 7. Automatic과 manual deploy는 하나의 production concurrency group을 공유하고 실행 중 job을 취소하지 않는다. Native queue가 이전 pending job을 최신 pending job으로 대체하면 취소 기록을 남기고 필요 시 해당 SHA release를 다시 실행한다.
 8. ECR OIDC trust와 외부 Vault prod build role은 automatic과 manual gated build가 사용하는 exact `repo:byulmaru/kosmo:environment:prod` identity만 허용한다. main ref, `refs/heads/production`, tag와 일반 branch identity는 허용하지 않는다.
 9. Terraform의 `kosmo-prod` bootstrap revision을 main으로 바꾸되 release-time full SHA와 Helm parameter ignore 경계는 유지한다. GitHub `prod` Environment에는 required reviewer를 설정하고 main workflow에서 시작되는 automatic/manual gated job을 허용한다.

--- a/openspec/changes/deploy-production-from-main-or-sha/proposal.md
+++ b/openspec/changes/deploy-production-from-main-or-sha/proposal.md
@@ -17,7 +17,7 @@
 
 - Canonical: 없음. 이 변경은 제품 도메인·디자인이 아니라 repository와 운영 release 계약을 변경하며, 운영 절차는 `docs/operations/production-release.md`, `docs/operations/production-migrations.md`, `docs/operations/openpanel.md`, `docs/operations/sentry.md`가 설명한다.
 - Linear Contract: `PROD-783`
-- Linear Implementations: `PROD-783`
+- Linear Implementations: `PROD-783`, `PROD-790`
 
 ## Capabilities
 

--- a/openspec/changes/deploy-production-from-main-or-sha/proposal.md
+++ b/openspec/changes/deploy-production-from-main-or-sha/proposal.md
@@ -32,6 +32,7 @@
 ## Impact
 
 - `.github/workflows/docker-build.yml`, `.github/workflows/deploy-dev.yml`과 production release workflow: trigger, 환경별 build, artifact·digest 전달, Environment 승인, manual SHA preflight와 concurrency
+- `apps/helm/templates/postgres-runtime-roles.yaml`: CNPG가 생략하는 runtime DatabaseRole의 false/empty 기본값과 Argo CD sync 정합성
 - `apps/terraform/argocd.tf`, `apps/terraform/ecr.tf`: production bootstrap source, release overlay ownership, OIDC ref trust와 image lifecycle metadata
 - 외부 Vault GitHub Actions role과 GitHub `prod` Environment: exact `environment:prod` identity, required reviewer와 deployment policy
 - `docs/operations/production-release.md`, `docs/operations/production-migrations.md`, `docs/operations/openpanel.md`, `docs/operations/sentry.md`, `apps/terraform/README.md`

--- a/openspec/changes/deploy-production-from-main-or-sha/tasks.md
+++ b/openspec/changes/deploy-production-from-main-or-sha/tasks.md
@@ -144,7 +144,7 @@ Repository 변경이 리뷰 가능한 PR로 전달되고, 승인된 순서로 ma
 - [ ] 5.5 모든 production branch 참조 제거와 rollback 경로를 확인한 뒤 별도 운영 승인으로 production ruleset/branch를 폐기하고 결과를 기록한다.
 - [ ] 5.6 `adopt-production-release-branch`를 obsolete delta 미적용 방식으로 archive하고 이 change의 delta를 active spec에 동기화해 strict validation한 뒤 `PROD-783`을 완료한다.
 
-## 6. PROD-790 Automatic·manual production deploy job 통합
+## 6. PROD-790 Production deploy 중복·CNPG sync drift 제거
 
 **Authority / Provenance**
 
@@ -152,7 +152,7 @@ Repository 변경이 리뷰 가능한 PR로 전달되고, 승인된 순서로 ma
 
 **Deliverable**
 
-Automatic main과 manual full-SHA release가 하나의 Environment-gated production deploy job 구현을 공유한다.
+Automatic main과 manual full-SHA release가 하나의 Environment-gated production deploy job 구현을 공유하고, runtime DatabaseRole의 CNPG 기본값 정규화가 production sync 완료를 막지 않는다.
 
 **Guardrails**
 
@@ -160,11 +160,15 @@ Automatic main과 manual full-SHA release가 하나의 Environment-gated product
 - Push에서는 skipped manual preflight 때문에 production deploy가 skip되지 않고, manual dispatch에서는 성공한 preflight output만 target으로 사용한다.
 - 두 trigger 모두 `prod` 승인 뒤 checkout·credential·build·Argo sync·stable 승격 순서와 공용 concurrency를 유지한다.
 - 이번 구현은 self-hosted runner에 새 도구나 상태를 사전 설치하지 않으며 GitHub-hosted runner 전환은 별도 범위로 남긴다.
+- Runtime DatabaseRole은 `login`, `inherit`, password Secret과 retain reclaim policy를 유지하고 CNPG가 생략하는 false/empty privilege 기본값만 생략한다.
+- Dangerous privilege drift를 숨길 수 있는 broad Argo ignore rule을 추가하거나 기존 role 선언을 일괄 변경하지 않는다.
 
 **Verification**
 
 - Actionlint로 push/manual job 조건, skipped dependency와 expression 문법을 검증한다.
 - Workflow diff에서 target SHA, Environment URL, Sentry release, image metadata, Argo revision과 audit trigger가 event별로 올바른지 검토한다.
+- Helm render와 live read-only spec 비교로 runtime DatabaseRole의 privilege 의미와 CNPG canonical 형태가 일치하는지 확인한다.
 - OpenSpec strict validation과 PR CI를 통과시킨다.
 
 - [x] 6.1 Automatic/manual 중복 deploy job을 단일 shared gated job으로 통합하고 event별 target·audit identity와 기존 승인·배포 경계를 검증한다.
+- [x] 6.2 Runtime DatabaseRole에서 CNPG가 생략하는 false/empty 기본값을 제거하고 Helm render·live spec 비교로 Argo sync drift 원인을 해소한다.

--- a/openspec/changes/deploy-production-from-main-or-sha/tasks.md
+++ b/openspec/changes/deploy-production-from-main-or-sha/tasks.md
@@ -143,3 +143,28 @@ Repository 변경이 리뷰 가능한 PR로 전달되고, 승인된 순서로 ma
 - [ ] 5.4 승인된 시점에 manual full-SHA release 경로를 검증하고 승인 전 target code/secret 부재와 승인 후 same-SHA/digest 결과를 기록한다.
 - [ ] 5.5 모든 production branch 참조 제거와 rollback 경로를 확인한 뒤 별도 운영 승인으로 production ruleset/branch를 폐기하고 결과를 기록한다.
 - [ ] 5.6 `adopt-production-release-branch`를 obsolete delta 미적용 방식으로 archive하고 이 change의 delta를 active spec에 동기화해 strict validation한 뒤 `PROD-783`을 완료한다.
+
+## 6. PROD-790 Automatic·manual production deploy job 통합
+
+**Authority / Provenance**
+
+- `PROD-790`
+
+**Deliverable**
+
+Automatic main과 manual full-SHA release가 하나의 Environment-gated production deploy job 구현을 공유한다.
+
+**Guardrails**
+
+- Manual preflight는 승인 전에 main workflow ref, full SHA 형식과 repository commit 존재 여부를 계속 검증한다.
+- Push에서는 skipped manual preflight 때문에 production deploy가 skip되지 않고, manual dispatch에서는 성공한 preflight output만 target으로 사용한다.
+- 두 trigger 모두 `prod` 승인 뒤 checkout·credential·build·Argo sync·stable 승격 순서와 공용 concurrency를 유지한다.
+- 이번 구현은 self-hosted runner에 새 도구나 상태를 사전 설치하지 않으며 GitHub-hosted runner 전환은 별도 범위로 남긴다.
+
+**Verification**
+
+- Actionlint로 push/manual job 조건, skipped dependency와 expression 문법을 검증한다.
+- Workflow diff에서 target SHA, Environment URL, Sentry release, image metadata, Argo revision과 audit trigger가 event별로 올바른지 검토한다.
+- OpenSpec strict validation과 PR CI를 통과시킨다.
+
+- [x] 6.1 Automatic/manual 중복 deploy job을 단일 shared gated job으로 통합하고 event별 target·audit identity와 기존 승인·배포 경계를 검증한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- `automatic_deploy`와 `manual_deploy`에 중복되어 있던 production checkout·credential·build·Argo sync·stable 승격을 하나의 `production_deploy` job으로 통합했습니다.
- Push에서는 event의 `github.sha`, manual dispatch에서는 검증된 `manual_preflight` output을 target SHA와 Environment URL로 선택합니다.
- Push에서 skip된 manual preflight 때문에 shared deploy가 함께 skip되지 않도록 `always()`와 event별 조건을 명시했습니다.
- Sentry release, image metadata, Argo revision과 workflow summary가 선택된 target SHA와 automatic/manual trigger를 사용하도록 통합했습니다.
- 첫 main release를 `Healthy / OutOfSync`로 남긴 `kosmo-postgres-runtime` DatabaseRole의 명시적 false/empty 기본값을 CNPG live canonical 형태에 맞게 생략했습니다.
- `deploy-production-from-main-or-sha` OpenSpec에 PROD-790 구현 책임, shared job 구조와 CNPG drift 수정 경계를 반영했습니다.

## 왜 변경했는지

PROD-783의 automatic main release와 manual full-SHA release는 target SHA 선택과 audit 문구를 제외하면 같은 승인·build·배포 계약을 사용하지만 구현은 두 job에 거의 그대로 복제되어 있었습니다. 한 경로만 수정되어 승인·credential·migration·stable 경계에 drift가 생기는 위험과 workflow 검토 비용을 줄이기 위해 공통 구현으로 수렴합니다.

또한 첫 main production release에서는 workload와 migration이 정상 적용됐지만 새 runtime DatabaseRole에서 CNPG가 false privilege 기본값과 빈 membership을 live spec에 저장하지 않아 Argo CD sync가 600초 뒤 exit 20으로 실패했습니다. 선언을 CNPG의 기본값 표현과 맞춰 실제 privilege를 바꾸지 않고 지속적인 OutOfSync를 제거합니다.

- Linear: [PROD-790](https://linear.app/byulmaru/issue/PROD-790/production-release의-중복과-cnpg-sync-drift를-제거한다)
- 선행 계약: [PROD-783](https://linear.app/byulmaru/issue/PROD-783/main-기반-devprod-배포와-별도-sha-production-release를-지원한다)
- 선행 PR: [#622](https://github.com/byulmaru/kosmo/pull/622)
- CNPG 기본값 근거: [CloudNativePG DatabaseRole API](https://cloudnative-pg.io/docs/devel/cloudnative-pg.v1/#postgresql.cnpg.io/v1.DatabaseRoleSpec)

## 이번 PR의 주요 결정

### Automatic과 manual이 하나의 deploy job 정의를 공유한다

- 결정자: @robin-maki
- 선택: Manual preflight는 유지하고, 승인 뒤 checkout부터 stable 승격까지는 하나의 Environment-gated job으로 통합합니다.
- 고려한 대안: 기존처럼 automatic/manual deploy job을 각각 유지하는 방식을 고려했습니다.
- 이유: 두 경로가 동일한 보안·배포 계약을 가지므로 구현도 한 벌이어야 이후 변경이 서로 어긋나지 않습니다.
- 감수한 결과: Shared job이 event 종류와 preflight 결과에 따라 target SHA·URL·audit trigger를 expression으로 선택해야 합니다.
- 관련 근거: PROD-790, `openspec/changes/deploy-production-from-main-or-sha`

### Runtime role의 기본값만 canonical 형태로 정규화한다

- 결정자: @robin-maki
- 선택: 새 runtime DatabaseRole에서 CNPG가 생략하는 `false` privilege 필드와 빈 `inRoles`만 생략합니다.
- 고려한 대안: 모든 DatabaseRole을 일괄 변경하거나 DatabaseRole privilege 필드를 Argo `ignoreDifferences`로 숨기는 방식을 고려했습니다.
- 이유: 기존 role은 현재 live spec과 일치하고, broad ignore는 향후 `superuser`·`bypassrls` 같은 위험한 privilege drift를 숨길 수 있습니다.
- 감수한 결과: 기존 role과 runtime role의 manifest 표기 방식은 당분간 다르지만 각각 현재 live canonical spec과 일치합니다.
- 관련 근거: PROD-790, 첫 production run `32101460857`

### Runner 전환은 별도 범위로 남긴다

- 결정자: @robin-maki
- 선택: 이번 PR은 현재 self-hosted runner를 유지하고 runner-local 사전 설치를 추가하지 않습니다. 장기적으로 GitHub-hosted runner로 전환합니다.
- 고려한 대안: 이번 수정과 함께 runner를 즉시 전환하는 방식을 고려했습니다.
- 이유: Runner 전환에는 Argo/Vault 네트워크 접근, architecture, Docker build 성능과 credential 경계의 별도 검증이 필요합니다.
- 감수한 결과: 현재 runner 표기는 당분간 유지되며 전환 작업이 별도로 필요합니다.
- 관련 근거: PROD-790

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/production-release.yml` 통과
- `helm lint apps/helm --set env=prod --set imageDigest=sha256:<64 hex> --set migration.enabled=true` 통과
- 같은 prod 값으로 Helm render 통과, runtime role이 `login`, `inherit`, password Secret과 retain policy를 유지하는지 확인
- Live read-only 조회에서 runtime role `status.applied: true`, production workload·migration 성공과 단일 OutOfSync 원인을 확인
- Rendered role에 대한 `kubectl diff`에서 runtime `spec` 차이 없음 확인. 전체 command는 Argo tracking annotation 차이 때문에 exit 1
- 관련 workflow·Helm·OpenSpec 파일 Prettier check 통과
- `openspec validate --all --strict`: 100/100 통과
- `git diff --check` 통과
- Workflow diff에서 push/manual target SHA, Environment URL, Sentry release, image metadata, Argo revision, audit trigger와 skipped preflight 조건을 검토했습니다.
- 새 head `e1e658bb` 기준 Lint, Semgrep, Root/Core/API/App/Fedify/Web/Worker 테스트 전체 통과

## 아직 어떤 문제가 남았는지

- 수정된 runtime role과 release workflow는 merge 뒤 다음 승인된 production release에서 live 검증해야 합니다. 이번 PR에서는 cluster apply·Argo sync·production 재배포를 수행하지 않았습니다.
- GitHub-hosted runner 전환은 이 PR에 포함하지 않습니다.
