### PR TITLE
Figma MCP 편집이 Preview 폰트를 사용하게 한다

### DIFF
--- a/.codex/skills/kosmo-design-audit/references/audit-rules.md
+++ b/.codex/skills/kosmo-design-audit/references/audit-rules.md
@@ -59,7 +59,9 @@ raw 값 자체만으로 대체 token을 추측하지 않는다. 기존 semantic 
 
 ## 4. Typography와 content resilience
 
-- UI는 SUIT, 본문·읽기 콘텐츠는 Pretendard 역할 계약을 우선한다. Figma MCP preview 대체 폰트는 실제 token geometry를 바꾸는 근거가 아니다.
+- Production 감사 계약은 UI `SUIT`, 본문·읽기 콘텐츠 `Pretendard Variable`이다.
+- Figma MCP로 text를 생성·수정할 때는 `docs/design/typography.md`의 현재 `MCP Preview` 대응인 UI `IBM Plex Sans KR`, 본문 `Noto Sans KR`을 사용한다. 변경 전에 `listAvailableFontsAsync()`로 정확한 family·style을 확인하고 `loadFontAsync()`로 로드한다.
+- 이 MCP Preview 대치는 Production 계약 위반 finding이 아니다. font size, line height, letter spacing token을 바꾸거나 Preview geometry를 Production token 변경 근거로 사용하지 않는다.
 - 12px는 역할 확인 신호다. canonical role이 본문·주요 정보·핵심 action으로 확인될 때만 finding으로 판정한다.
 - line height, weight, truncation, max lines, textAutoResize가 역할과 맞는지 확인한다.
 - 긴 한국어, 영어 확장, 숫자·날짜, 빈 값, 오류 문구에서 overlap·잘림·위계 붕괴를 확인한다.


### PR DESCRIPTION
## 무엇을 변경했나요

- Production 감사 폰트를 UI `SUIT`, 본문 `Pretendard Variable`로 명확히 구분했습니다.
- Figma MCP 편집에는 UI `IBM Plex Sans KR`, 본문 `Noto Sans KR`을 사용하도록 규정했습니다.
- MCP Preview 대치를 Production 계약 위반으로 판정하지 않도록 명시했습니다.
- 폰트 변경 전 availability 확인과 로드를 요구하고, Preview geometry로 Production token을 바꾸지 않도록 했습니다.

## 왜 변경했나요

기존 감사 규칙은 Production 폰트만 명시해, MCP가 해당 폰트를 로드할 수 없을 때 실제로 사용할 family를 결정할 수 없었습니다. 이 때문에 MCP 편집이 중단되거나 Preview 폰트를 Production 위반으로 잘못 판정할 수 있었습니다.

## 이번 PR의 주요 결정

### MCP 편집과 Production 감사의 폰트 계약 분리

- 결정자: @yeeun-uwu
- 선택: Production은 SUIT/Pretendard 계약을 유지하고, MCP 편집은 canonical `MCP Preview` 대응을 사용합니다.
- 고려한 대안: MCP에서도 Production 폰트를 강제하거나 임의의 가용 폰트를 선택하는 방식
- 이유: MCP는 Production 폰트를 직접 로드할 수 없으며 `docs/design/typography.md`에 Preview 대응이 이미 정의되어 있습니다.
- 감수한 결과: Preview geometry는 Production typography 검증 근거로 사용할 수 없습니다.
- 관련 근거: `docs/design/typography.md`

## 어떻게 확인할 수 있나요

- `pnpm exec prettier --check .codex/skills/kosmo-design-audit/references/audit-rules.md`
- `git diff --check`
- 변경 전·후 스킬 해석 회귀 시나리오 확인
- `quick_validate.py`는 PyYAML 부재로 중단되어 동일 frontmatter 검사를 Ruby 표준 YAML parser로 대체했습니다.
- 제품 코드는 변경하지 않아 제품 테스트는 실행하지 않았습니다.

## 아직 어떤 문제가 남았나요

- 실제 Figma 파일은 변경하지 않았으며 `listAvailableFontsAsync()`의 live 결과는 확인하지 않았습니다.