### PR TITLE
인증 직후 잘못된 동적 경로가 노출되지 않게 한다

### DIFF
--- a/apps/app/src/app/(tabs)/_layout.tsx
+++ b/apps/app/src/app/(tabs)/_layout.tsx
@@ -1,5 +1,9 @@
 import { UniversalShell } from '@/components/shell/UniversalShell';
 
+export const unstable_settings = {
+  initialRouteName: '(protected)',
+};
+
 export default function TabsLayout() {
   return <UniversalShell />;
 }

--- a/apps/web/e2e/auth-routes.e2e.ts
+++ b/apps/web/e2e/auth-routes.e2e.ts
@@ -241,10 +241,43 @@ test('세션 확인이 실패해도 루트 온보딩과 로그인 진입점을 �
 });
 
 test('mock OIDC로 로그인하면 보호 홈으로 이동하고 세션이 유지된다', async ({ page }) => {
+  await page.route('**/graphql', async (route) => {
+    if (isGraphQLOperation(route.request().postData(), 'UniversalShellQuery')) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    await route.continue();
+  });
+  await page.addInitScript(() => {
+    const storageKey = 'kosmo-e2e-history-paths';
+    const record = (method: string) => {
+      const entries = JSON.parse(sessionStorage.getItem(storageKey) ?? '[]') as string[];
+      entries.push(`${method}:${location.pathname}${location.search}`);
+      sessionStorage.setItem(storageKey, JSON.stringify(entries));
+    };
+
+    record('document');
+
+    for (const method of ['pushState', 'replaceState'] as const) {
+      const original = history[method];
+      history[method] = function (...args) {
+        const result = original.apply(this, args);
+        record(method);
+        return result;
+      };
+    }
+  });
+
   await page.goto('/');
   await page.getByRole('link', { name: '시작하기' }).click();
 
   await expect(page).toHaveURL(/\/home$/);
+  const historyPaths = await page.evaluate(() =>
+    JSON.parse(sessionStorage.getItem('kosmo-e2e-history-paths') ?? '[]'),
+  );
+  expect(historyPaths).not.toContain('pushState:/undefined/undefined');
+  expect(historyPaths).not.toContain('replaceState:/undefined/undefined');
+  expect(historyPaths).not.toContain('document:/undefined/undefined');
   await expect(page.getByRole('heading', { name: '프로필을 만들어 시작하세요' })).toBeVisible();
   await page.getByRole('button', { name: '프로필 만들기' }).click();
   await expect(page.getByLabel('프로필 전환')).toBeVisible();


### PR DESCRIPTION
## 무엇을 변경했는지

- 탭 route tree의 초기 화면을 `(protected)`로 명시했습니다.
- mock OIDC 인증 E2E에서 `UniversalShellQuery` 응답을 지연시켜 초기 로딩 구간을 유지합니다.
- 인증 전후의 document·`pushState`·`replaceState` 경로를 기록하고 `/undefined/undefined`가 한 번도 나타나지 않는지 검증합니다.

## 왜 변경했는지

인증 직후 OpenPanel 세션이 `/undefined/undefined`에서 시작한 뒤 약 200ms 안에 `/home`으로 바뀌는 기록이 반복됐습니다. 인증 콜백 자체는 항상 `/home`으로 리다이렉트하지만, 탭 navigator에 초기 자식이 지정되지 않아 Expo Router가 준비되지 않은 route state에서 두 동적 segment를 가진 게시물 route를 선택했습니다. 이때 누락된 `profileHandle`과 `postId`가 각각 문자열 `undefined`로 직렬화됐습니다.

이 PR은 OpenPanel 수집에서 해당 경로를 제외하지 않습니다. navigation state가 처음부터 유효한 보호 route를 선택하게 해 잘못된 URL 자체가 생기지 않도록 합니다.

## 이번 PR의 주요 결정

### 수집 필터 대신 route 초기 상태를 수정한다

- 결정자: @robin-maki
- 선택: OpenPanel 필터링 없이 Expo Router 탭 navigator의 초기 route를 명시합니다.
- 고려한 대안: OpenPanel 자동 screen view에서 `/undefined/undefined`만 제외하는 방식
- 이유: 수집 제외는 잘못된 URL 발생을 숨길 뿐 실제 navigation 문제를 해결하지 않기 때문입니다.
- 감수한 결과: Expo Router의 `unstable_settings` API에 의존하지만 전체 route 구조 개편 없이 원인을 가장 좁게 수정합니다.
- 관련 근거: [PROD-733](https://linear.app/byulmaru/issue/PROD-733)

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:unit` — 338 passed
- `pnpm --filter @kosmo/web test:e2e e2e/auth-routes.e2e.ts --grep 'mock OIDC|Settings route-owned|보호 shell과 페이지 heading|/search에서 보호 shell'` — 7 passed
- `pnpm lint:prettier --check 'apps/app/src/app/(tabs)/_layout.tsx' apps/web/e2e/auth-routes.e2e.ts`
- `git diff --check`

## 아직 어떤 문제가 남았는지

- 프로덕션 반영 후 OpenPanel 신규 세션에서 `/undefined/undefined`가 더 이상 생성되지 않는지는 배포 후 별도 확인이 필요합니다.