### PR TITLE
Profile Update 후속 효과를 Temporal Workflow로 전환한다

### DIFF
--- a/apps/api/src/graphql/resolvers/profile/mutation/update.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/update.ts
@@ -1,4 +1,3 @@
-import { db } from '@kosmo/core/db';
 import { PostVisibility, ProfileFollowPolicy } from '@kosmo/core/enums';
 import { ValidationError } from '@kosmo/core/error';
 import { updateProfile } from '@kosmo/core/services';
@@ -25,21 +24,17 @@ builder.mutationField('updateProfile', (t) =>
     },
     resolve: async (_, { input }, ctx) => {
       try {
-        const result = await updateProfile(
-          {
-            accountId: ctx.session.accountId,
-            profileId: ctx.session.profileId,
-            displayName: input.displayName ?? undefined,
-            bio: input.bio,
-            followPolicy: input.followPolicy ?? undefined,
-            defaultPostVisibility: input.defaultPostVisibility,
-            tags: input.tags,
-            avatarMediaId: input.avatarId === undefined ? undefined : (input.avatarId?.id ?? null),
-            headerMediaId: input.headerId === undefined ? undefined : (input.headerId?.id ?? null),
-          },
-          db,
-        );
-        await result.postCommit();
+        const result = await updateProfile({
+          accountId: ctx.session.accountId,
+          profileId: ctx.session.profileId,
+          displayName: input.displayName ?? undefined,
+          bio: input.bio,
+          followPolicy: input.followPolicy ?? undefined,
+          defaultPostVisibility: input.defaultPostVisibility,
+          tags: input.tags,
+          avatarMediaId: input.avatarId === undefined ? undefined : (input.avatarId?.id ?? null),
+          headerMediaId: input.headerId === undefined ? undefined : (input.headerId?.id ?? null),
+        });
 
         return {
           profile: result.profile,

--- a/apps/api/tests/integration/graphql/profile.test.ts
+++ b/apps/api/tests/integration/graphql/profile.test.ts
@@ -21,6 +21,7 @@ import {
 import { decodeGlobalId, encodeGlobalId as globalId } from '@kosmo/core/global-id';
 import { postContentDocumentFromText } from '@kosmo/core/post-content/server';
 import { isConfiguredLocalProfile } from '@kosmo/core/profile';
+import { temporalClient } from '@kosmo/core/temporal/client';
 import { normalizeHandle } from '@kosmo/core/utils';
 import { profileTagNormalizationParityCases } from '@kosmo/core/validation/profile-tag-parity-fixture';
 import { and, count, eq, ne } from 'drizzle-orm';
@@ -955,20 +956,10 @@ describe('GraphQL remote profile boundary', () => {
     });
   });
 
-  test('Profile Update delivery 실패 뒤에도 committed GraphQL payload를 반환한다', async () => {
+  test('Profile Update Workflow start 실패 뒤에도 committed GraphQL payload를 반환한다', async () => {
     const auth = await createAuthenticatedSession();
-    const remoteInstance = await createRemoteInstance({ domain: 'profile-update.remote.example' });
-    const remote = await createProfile({
-      handle: 'profile-update-follower',
-      instanceId: remoteInstance.id,
-    });
-    await createRemoteActor(remote.id, remoteInstance.domain);
-    await db.insert(ProfileFollows).values({
-      followeeProfileId: auth.profile.id,
-      followerProfileId: remote.id,
-    });
-    const delivery = mock.method(globalThis, 'fetch', async () => {
-      throw new Error('delivery failed');
+    const start = mock.method(temporalClient.workflow, 'start', async () => {
+      throw new Error('Temporal unavailable');
     });
     const errorLog = mock.method(console, 'error', () => undefined);
 
@@ -976,7 +967,7 @@ describe('GraphQL remote profile boundary', () => {
       const result = await requestGraphQL<{
         updateProfile: { profile: { bio: string | null; id: string } };
       }>(
-        `mutation UpdateProfileAfterDeliveryFailure {
+        `mutation UpdateProfileAfterWorkflowStartFailure {
           updateProfile(input: { bio: "Committed bio" }) {
             profile { bio id }
           }
@@ -990,12 +981,14 @@ describe('GraphQL remote profile boundary', () => {
         bio: 'Committed bio',
         id: globalId('Profile', auth.profile.id),
       });
-      assert.ok(delivery.mock.callCount() > 0);
+      assert.equal(start.mock.callCount(), 1);
       assert.equal(errorLog.mock.callCount(), 1);
       assert.equal(
         errorLog.mock.calls[0]?.arguments[0],
-        'Post-commit ActivityPub Local Profile Update delivery failed',
+        'Profile Update effects Workflow start failed',
       );
+      assert.equal(errorLog.mock.calls[0]?.arguments[1]?.profileId, auth.profile.id);
+      assert.equal(typeof errorLog.mock.calls[0]?.arguments[1]?.updateId, 'string');
       assert.equal(
         await db
           .select({ bio: Profiles.bio })
@@ -1006,7 +999,7 @@ describe('GraphQL remote profile boundary', () => {
         'Committed bio',
       );
     } finally {
-      delivery.mock.restore();
+      start.mock.restore();
       errorLog.mock.restore();
     }
   });

--- a/apps/worker/src/activities.ts
+++ b/apps/worker/src/activities.ts
@@ -19,3 +19,4 @@ export {
   sendReaction as sendReactionActivity,
   sendReactionUndo as sendReactionUndoActivity,
 } from '@kosmo/fedify';
+export { sendLocalProfileUpdate as sendLocalProfileUpdateActivity } from '@kosmo/fedify';

--- a/apps/worker/src/workflows.test.ts
+++ b/apps/worker/src/workflows.test.ts
@@ -158,3 +158,49 @@ test(
     });
   },
 );
+
+test(
+  'Profile Update Effects Workflow는 production registry에서 stable input으로 Activity를 재시도한다',
+  { timeout: 120_000 },
+  async (t) => {
+    const environment = await TestWorkflowEnvironment.createLocal({
+      server: { executable: { type: 'cached-download', version: 'v1.8.2' } },
+    });
+    t.after(() => environment.teardown());
+    const taskQueue = `${KOSMO_TASK_QUEUE}-profile-update-test-${process.pid}`;
+    const profileId = '00000000-0000-8000-8000-000000000201';
+    const updateId = '00000000-0000-8000-8000-000000000202';
+    const calls: Array<{ readonly profileId: string; readonly updateId: string }> = [];
+    let attempts = 0;
+
+    const worker = await Worker.create({
+      activities: {
+        sendLocalProfileUpdateActivity: async (input: { profileId: string; updateId: string }) => {
+          attempts += 1;
+          calls.push(input);
+          if (attempts === 1) {
+            throw ApplicationFailure.retryable('queue handoff failed');
+          }
+        },
+      },
+      connection: environment.nativeConnection,
+      namespace: environment.namespace,
+      taskQueue,
+      workflowsPath,
+    });
+
+    await worker.runUntil(async () => {
+      await environment.client.workflow.execute('profileUpdateEffectsWorkflow', {
+        args: [{ profileId, updateId }],
+        taskQueue,
+        workflowId: updateId,
+      });
+    });
+
+    assert.equal(attempts, 2);
+    assert.deepEqual(calls, [
+      { profileId, updateId },
+      { profileId, updateId },
+    ]);
+  },
+);

--- a/apps/worker/src/workflows/index.ts
+++ b/apps/worker/src/workflows/index.ts
@@ -1,5 +1,6 @@
 export { postCreateEffectsWorkflow } from './create';
 export { postDeleteWorkflow } from './delete';
+export { profileUpdateEffectsWorkflow } from './profile-update';
 export { reactionCreateEffectsWorkflow } from './reaction-create';
 export { reactionDeleteEffectsWorkflow } from './reaction-delete';
 export { postRepostWorkflow } from './repost';

--- a/apps/worker/src/workflows/profile-update.ts
+++ b/apps/worker/src/workflows/profile-update.ts
@@ -1,0 +1,21 @@
+import { proxyActivities } from '@temporalio/workflow';
+import type * as activities from '../activities';
+
+type ProfileUpdateEffectsInput = {
+  readonly profileId: string;
+  readonly updateId: string;
+};
+
+const { sendLocalProfileUpdateActivity } = proxyActivities<
+  Pick<typeof activities, 'sendLocalProfileUpdateActivity'>
+>({
+  retry: { maximumAttempts: 10 },
+  startToCloseTimeout: '1 minute',
+});
+
+export async function profileUpdateEffectsWorkflow({
+  profileId,
+  updateId,
+}: ProfileUpdateEffectsInput): Promise<void> {
+  await sendLocalProfileUpdateActivity({ profileId, updateId });
+}

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/.openspec.yaml
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-18

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/decisions.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/decisions.md
@@ -1,0 +1,49 @@
+## Context
+
+이 기록은 PROD-665와 canonical Profile/Core 경계에 따라 Profile 상태 transaction을 유지하고 commit 이후 ActivityPub 효과만 Temporal로 이전하는 선택을 정리한다. Stable identity의 구체 구현은 2026-08-18 사용자 확인에서 자동 생성 방식을 선택했다.
+
+## Decision Records
+
+### Profile 상태 transaction은 Core에 유지한다
+
+- Decision Date: 2026-08-18
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-665`
+- Status: Active
+- Context / Problem: 기존 action은 상태 transaction과 후속 Fedify 효과를 `postCommit` 반환형으로 나눠 caller가 조립한다.
+- Decision Outcome: Core action이 기본 database의 Profile update transaction을 동기적으로 완료하고, 실제 actor-visible commit 뒤 Workflow start만 직접 시도한다.
+- Alternatives Considered: Transaction Activity로 상태 변경 이동, caller database handle과 `postCommit` 유지. 전자는 승인된 책임 경계를 바꾸고 후자는 PROD-665의 제거 대상이다.
+- Consequences: GraphQL caller는 database handle이나 lifecycle callback을 조립하지 않는다. Start 실패는 commit된 Profile 성공을 변경하지 않는다.
+- Confirmation / Follow-up: Core/API 테스트에서 rollback·no-op·start failure 경계를 검증한다.
+
+### Update identity를 자동 생성해 Temporal Workflow ID로 그대로 사용한다
+
+- Decision Date: 2026-08-18
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/core-services.md`, `PROD-665`
+- Status: Active
+- Context / Problem: Temporal은 Workflow ID를 필수로 요구하고, 같은 Profile의 연속 update는 서로 다른 실행이어야 하며, 같은 Activity retry는 ActivityPub Update identity를 재사용해야 한다.
+- Decision Outcome: 실제 actor-visible 변경이 확정된 transaction 안에서 UUID update identity를 자동 생성한다. Commit 뒤 Temporal start의 Workflow ID에는 prefix를 추가하지 않고 이 identity 자체를 전달하며, ActivityPub Update IRI도 같은 identity에서 파생한다.
+- Alternatives Considered: Profile ID만 사용하면 후속 update가 기존 실행과 충돌한다. DB projection version은 migration과 ordering 계약을 추가한다. 별도 Workflow ID 규칙은 update identity와 중복된다.
+- Consequences: Rollback된 변경의 identity는 폐기된다. DB에 update identity를 저장하지 않으며 commit-to-start gap의 backfill에는 사용할 수 없다.
+- Confirmation / Follow-up: Core start 인자와 Fedify retry가 같은 identity를 유지하는지 검증한다.
+
+### Profile projection은 latest-at-delivery로 읽는다
+
+- Decision Date: 2026-08-18
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-665`
+- Status: Active
+- Context / Problem: 빠른 연속 Profile update가 각 commit 시점 snapshot을 보존하려면 version 또는 별도 durable projection이 필요하다.
+- Decision Outcome: Activity는 실행 시점의 최신 committed Profile·Media를 기존 canonical Person projection으로 읽는다. Cross-update ordering과 commit 시점 snapshot은 보장하지 않는다.
+- Alternatives Considered: Profile version, Workflow input snapshot, ordering ledger. 모두 현재 이슈가 제외한 새 DB·ordering 계약을 만든다.
+- Consequences: 서로 다른 update Workflow가 같은 최신 projection을 전달하거나 원격에서 순서가 바뀔 수 있으며 last-write-wins로 수용한다.
+- Confirmation / Follow-up: 빠른 연속 update dev 검증에서 별도 identity와 latest projection 동작을 확인하되 순서 보장으로 해석하지 않는다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- PROD-629의 호출마다 새 Activity UUID를 생성하는 direct post-commit delivery 선택은 stable retry identity를 요구하는 PROD-665로 대체된다.

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/design.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/design.md
@@ -1,0 +1,69 @@
+## Context
+
+현재 Profile update action은 optional database handle을 받아 transaction에 합류하고, 결과의 `postCommit`이 Fedify Profile Update delivery를 직접 실행한다. GraphQL resolver는 database handle 전달과 callback 실행을 조립하며, delivery 함수는 호출마다 새 ActivityPub Update ID를 생성한다. 이 구조에서는 queue handoff 실패를 Worker restart 뒤 재시도할 수 없고 같은 Activity retry에서 identity도 유지할 수 없다.
+
+PROD-665는 상태 transaction을 Temporal로 옮기지 않는다. Core action이 기존 Profile persistence와 actor-visible 변경 판정을 유지하고, 실제 commit 뒤 후속 delivery만 하나의 Effects Workflow로 연결한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Core가 Profile update transaction과 commit 이후 Workflow start 시도를 소유한다.
+- 실제 actor-visible 변경만 Workflow를 시작한다.
+- 동일 Workflow retry에서 stable ActivityPub Update identity를 유지한다.
+- Worker Activity가 delivery 시점의 최신 committed Profile을 queue에 handoff한다.
+- API의 database handle과 `postCommit` 조립을 제거한다.
+
+**Non-Goals:**
+
+- Profile transaction을 Temporal Activity로 옮기지 않는다.
+- projection version, update ledger, ordering, outbox, receipt, relay 또는 backfill을 만들지 않는다.
+- GraphQL schema, UI, DB schema, Fedify consumer runtime을 변경하지 않는다.
+- production sync·rollout·live verification을 수행하지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Actor-visible 변경은 displayName, bio, followPolicy, avatar와 header 관계다. Tag와 default Post visibility는 현재 canonical Person projection 대상이 아니다.
+- Delivery 함수는 최신 Profile·Media를 읽는 기존 canonical projection과 recipient dispatcher를 이미 재사용한다.
+- Temporal SDK는 start마다 Workflow ID를 요구한다.
+- 같은 Profile의 빠른 연속 변경은 각기 별도 효과 실행이어야 하므로 Profile ID만 Workflow ID로 사용할 수 없다.
+
+### Recommended Approach
+
+Core transaction이 실제 actor-visible 변경을 확정할 때 UUID update identity를 생성해 transaction 결과와 함께 반환한다. Rollback되면 identity도 폐기된다. Transaction commit 뒤 Core는 `{ profileId, updateId }`를 인자로 Profile Update Workflow를 직접 start하고, Temporal Workflow ID에는 별도 prefix 없이 update identity 자체를 사용한다. Start 실패는 그 자리에서 관측하고 Profile 결과는 유지한다.
+
+Worker의 Profile Update Workflow는 private input type을 소유하고 단일 delivery Activity를 호출한다. Activity registration은 기존 production activities namespace에 Fedify delivery 함수를 alias하는 수준으로 유지한다. 별도 Core Temporal contract file이나 start helper를 만들지 않는다.
+
+Fedify delivery 함수는 Profile ID와 update identity를 받아 기존 canonical Person projection과 recipient dispatcher를 사용하고, Update IRI의 마지막 segment에 update identity를 사용한다. Activity retry는 같은 입력을 다시 받아 같은 IRI를 구성한다.
+
+### Allowed Alternatives
+
+Update IRI의 정확한 path 표현은 같은 update identity가 retry 동안 같은 canonical IRI로 이어지고 기존 actor URI 아래에 남는 한 구현자가 선택할 수 있다.
+
+### Known Traps
+
+- Profile ID를 Workflow ID로 사용하면 첫 완료 실행과 후속 update가 충돌한다.
+- Activity 안에서 UUID를 새로 만들면 retry마다 다른 ActivityPub Update가 된다.
+- Profile snapshot을 Workflow input에 넣으면 latest-at-delivery 계약과 어긋난다.
+- 별도 start helper, workflow별 Core contract file, test-only export는 이 단일 호출 경계를 숨기기만 한다.
+- Workflow start 실패를 GraphQL 실패로 전파하면 이미 commit된 Profile 결과와 caller 응답이 불일치한다.
+
+## Risks / Trade-offs
+
+- [Commit과 Workflow start 사이 process 종료로 효과 유실] → 이번 범위는 durable intent를 추가하지 않고 이 loss window를 명시적으로 수용한다.
+- [빠른 연속 update가 같은 최신 projection을 전달하거나 원격 순서가 뒤바뀜] → last-write-wins를 수용하고 version·ordering 보장을 주장하지 않는다.
+- [Activity retry가 queue message를 중복 수락시킬 수 있음] → stable ActivityPub identity를 재사용하고 queue acceptance 이후 remote retry는 Fedify가 소유한다.
+
+## Migration Plan
+
+1. Core Profile action과 API caller를 자체 transaction·direct Workflow start 경계로 전환한다.
+2. Fedify delivery에 stable update identity 입력을 추가한다.
+3. 기존 Worker registry에 Profile Update Workflow와 Activity를 추가한다.
+4. 정적·통합 검증과 exact revision dev retry·restart 검증을 수행한다.
+5. Rollback은 application revision을 이전 버전으로 되돌린다. DB migration은 없다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/proposal.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Profile 수정 transaction은 Core가 동기적으로 소유하지만, federation-visible 변경의 `Update(Person)` 전달은 caller가 실행하는 process-local `postCommit`에 남아 있다. Commit된 변경의 후속 효과를 Temporal Activity retry와 Worker restart로 복구할 수 있도록 상태 변경은 유지하고 전달 효과만 Workflow로 이전해야 한다.
+
+## What Changes
+
+- 실제 federation-visible Profile 변경 commit 뒤에만 Profile Update Effects Workflow를 시작한다.
+- 각 변경에 stable update identity를 부여하고 같은 Workflow retry에서 동일한 ActivityPub Update identity를 재사용한다.
+- Activity는 실행 시점의 최신 committed Profile projection을 읽어 canonical `Update(Person)`을 Fedify queue에 handoff한다.
+- displayName, bio, followPolicy, avatar, header 변경만 Workflow를 시작하고, Tag·default Post visibility 변경과 no-op은 시작하지 않는다.
+- Core Profile action의 optional database handle과 반환형 `postCommit`, GraphQL caller의 callback 실행을 제거한다.
+- Commit과 Workflow start 사이 유실, start 실패, 빠른 연속 수정의 last-write-wins를 명시적으로 수용한다.
+- Profile projection version, ordering 보장, outbox·receipt·relay, DB migration과 production rollout은 추가하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`
+- Linear Contract: `PROD-665`
+- Linear Implementations: `PROD-629`, `PROD-448`
+
+## Capabilities
+
+### New Capabilities
+
+- `temporal-profile-update-effects`: Committed federation-visible Profile 변경 뒤 canonical `Update(Person)` queue handoff를 retry하는 Effects Workflow 계약
+
+### Modified Capabilities
+
+- `profile`: Core-owned Profile update transaction과 실제 actor projection 변경 뒤 Workflow start 경계
+- `activitypub-local-profile-update-delivery`: stable update identity, latest-at-delivery projection과 Temporal Activity queue handoff 경계
+- `temporal-worker-runtime-foundation`: Profile Update Effects Workflow와 Activity의 compile-time 등록 및 retry·restart 검증
+
+## Impact
+
+- Core Profile update service가 자체 transaction과 commit 이후 Workflow start 시도를 소유한다.
+- API caller의 Profile update 경계에서 database handle과 `postCommit`이 사라진다.
+- Fedify Profile Update delivery가 stable update identity를 입력받는다.
+- 기존 단일 Worker registry에 Profile Update Workflow와 delivery Activity가 추가된다.
+- GraphQL schema, Profile DB schema, canonical Person projection, Fedify MessageQueue consumer와 production runtime은 변경하지 않는다.

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/activitypub-local-profile-update-delivery/spec.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/activitypub-local-profile-update-delivery/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: Commit 이후 Profile Update lifecycle
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-629`, `PROD-665` 시스템은 Profile 변경 transaction이 성공적으로 commit된 뒤에만 outbound ActivityPub Profile Update Effects Workflow를 시작해야 하고(MUST), Core action이 transaction과 Workflow start 시도를 소유해야 한다(MUST). Caller-owned database handle과 반환형 post-commit lifecycle을 사용해서는 안 된다(MUST NOT).
+
+#### Scenario: Top-level Profile update commit
+
+- **WHEN** application이 federation-visible Local Profile 변경을 commit한다
+- **THEN** Core action은 commit된 Profile 결과를 반환한다
+- **AND** 실제 actor-visible 변경이면 commit 뒤 Profile Update Effects Workflow start를 시도한다
+
+#### Scenario: Validation failure 또는 rollback
+
+- **WHEN** Profile update가 validation·authorization 실패로 거부되거나 transaction이 rollback된다
+- **THEN** 시스템은 해당 미반영 변경을 위한 ActivityPub Update Workflow를 시작하지 않는다
+
+#### Scenario: Caller-side lifecycle 제거
+
+- **WHEN** GraphQL entry가 Profile update action을 호출한다
+- **THEN** caller는 database handle을 전달하지 않는다
+- **AND** caller는 별도 post-commit lifecycle을 받거나 실행하지 않는다
+
+### Requirement: Canonical Update Person projection
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `PROD-628`, `PROD-629`, `PROD-665` 시스템은 committed Local Profile의 stable actor identity와 canonical `Person` projection을 재사용한 ActivityPub `Update(Person)`을 구성해야 한다(MUST). 각 committed actor-visible 변경의 update identity는 해당 Workflow와 Activity retry에서 stable해야 한다(MUST).
+
+#### Scenario: Construct Local Profile Update
+
+- **WHEN** Profile Update Activity가 실행된다
+- **THEN** `Update.actor`는 변경된 Profile의 canonical local actor URI다
+- **AND** embedded `Update.object`는 PROD-628의 canonical `Person` projection이다
+- **AND** embedded `Person.id`는 `Update.actor`와 같다
+- **AND** Update는 해당 actor의 followers collection을 audience로 표현한다
+- **AND** Update IRI는 Workflow input의 stable update identity를 사용한다
+
+#### Scenario: Preserve latest committed representation
+
+- **WHEN** displayName, bio, avatar, header 또는 Follow Approval Policy 변경 뒤 Update를 구성한다
+- **THEN** embedded `Person`은 delivery 시점의 최신 committed Profile/Media 표현을 사용한다
+- **AND** actor dispatcher와 다른 전용 JSON projection을 만들지 않는다
+- **AND** actor key identity, inbox/outbox, followers/following과 shared inbox identity를 변경하지 않는다
+
+### Requirement: Remote follower direct delivery
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-448`, `PROD-512`, `PROD-629`, `PROD-665` 시스템은 Local Profile Update를 공통 outbound recipient dispatcher를 통해 usable established ActivityPub remote followers 대상으로 Fedify PostgreSQL outbox/fan-out queue에 handoff해야 한다(MUST). Queue handoff 전 실패는 Temporal Activity retry가 소유하고(MUST), follower 부재와 Workflow start·Activity 실패는 committed Profile 결과에서 격리해야 한다(MUST).
+
+#### Scenario: Deliver to active remote followers
+
+- **WHEN** 변경된 Local Profile에 usable established ActivityPub remote follower가 있다
+- **THEN** 시스템은 공통 recipient dispatcher로 같은 Update activity를 queue에 handoff한다
+- **AND** 동일 actor는 한 recipient로 중복 제거한다
+- **AND** 유효한 shared inbox가 있으면 Fedify shared inbox preference를 적용한다
+
+#### Scenario: No remote followers
+
+- **WHEN** 변경된 Local Profile에 usable established ActivityPub remote follower가 없다
+- **THEN** 시스템은 queue handoff 또는 remote HTTP delivery를 호출하지 않는다
+- **AND** committed Profile update를 성공 결과로 유지한다
+
+#### Scenario: Delivery failure isolation
+
+- **WHEN** commit 이후 Workflow start, Update projection 또는 queue handoff가 실패한다
+- **THEN** 시스템은 Profile ID와 update identity와 함께 해당 경계의 오류를 관측한다
+- **AND** committed Profile과 GraphQL mutation 성공 결과를 rollback하거나 실패로 바꾸지 않는다
+- **AND** start가 수락된 Workflow의 projection 또는 queue handoff 실패는 Temporal Activity가 재시도한다
+- **AND** handoff 수락 뒤 remote delivery retry와 최종 실패는 Fedify consumer가 관측한다
+
+#### Scenario: Commit과 Workflow start 사이 loss window
+
+- **WHEN** application process가 Profile commit 이후 Workflow start 수락 전에 종료된다
+- **THEN** 이 capability는 transactional domain intent, relay, reconciliation 또는 delivery history를 보장하지 않는다
+- **AND** committed Profile 결과는 유지된다
+
+#### Scenario: Queue handoff 이후 producer 종료
+
+- **WHEN** Fedify PostgreSQL queue가 Update를 수락한 뒤 producer process가 종료된다
+- **THEN** 수락된 message는 별도 Fedify consumer가 처리할 수 있다
+- **AND** producer는 remote delivery를 직접 재시도하지 않는다

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/profile/spec.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/profile/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Profile updates
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/domain/objects/account-profile-membership.md`, `docs/domain/decisions/0008-relationship-report-state-exclusions.md`, `docs/architecture/core-services.md`, `PROD-489`, `PROD-648`, `PROD-665` 프로필의 Owner는 활성 Local Profile의 표시 이름, bio, 팔로우 정책과 기본 Post Visibility를 수정할 수 있어야 한다(MUST). Member는 Profile 운영 권한을 갖지 않으며 Profile을 수정할 수 없어야 한다(MUST NOT). Core Profile action은 수정 transaction을 직접 소유하고 실제 actor-visible 변경 commit 뒤의 effects Workflow start를 직접 시도해야 하며(MUST), caller database handle이나 caller-side post-commit lifecycle을 공개해서는 안 된다(MUST NOT).
+
+#### Scenario: Update profile as owner
+
+- **WHEN** 프로필의 `OWNER` 계정이 활성 Local Profile 수정을 요청한다
+- **THEN** 시스템은 제공된 displayName, bio, followPolicy, defaultPostVisibility 값을 갱신한다
+- **AND** 생략된 값은 변경하지 않는다
+- **AND** mutation은 `UpdateProfilePayload.profile`로 갱신된 `Profile`을 반환하며 기본값은 nullable `private` projection의 non-null `defaultPostVisibility`로 조회할 수 있다
+
+#### Scenario: Update missing or inaccessible profile
+
+- **WHEN** 수정 대상 프로필이 없거나 활성 상태가 아니거나 현재 계정과 연결되어 있지 않다
+- **THEN** 시스템은 profile not found 오류를 반환한다
+
+#### Scenario: Reject profile update without owner role
+
+- **WHEN** 현재 계정이 대상 프로필의 `OWNER`가 아니다
+- **THEN** 시스템은 owner permission required 오류를 반환한다
+
+#### Scenario: Reject unsupported default visibility
+
+- **WHEN** Owner가 기본 Post Visibility로 `DIRECT` 또는 지원하지 않는 값을 제출한다
+- **THEN** 시스템은 field validation 오류로 거부한다
+- **AND** 기존 Profile 기본값과 다른 Profile 속성을 부분 변경하지 않는다
+
+#### Scenario: Reject Remote Profile setting update
+
+- **WHEN** Account가 Remote Profile의 기본 Post Visibility 변경을 요청한다
+- **THEN** 시스템은 Profile 설정을 만들거나 변경하지 않는다
+
+#### Scenario: Core-owned Profile update transaction
+
+- **WHEN** GraphQL caller가 Profile 수정을 요청한다
+- **THEN** Core action은 기본 database로 transaction을 완료한 뒤 Profile 결과를 반환한다
+- **AND** caller는 database handle이나 post-commit callback을 전달하거나 실행하지 않는다

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/temporal-profile-update-effects/spec.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/temporal-profile-update-effects/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Committed Profile Update effects Workflow
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-665` 시스템은 federation-visible Local Profile 변경이 실제로 commit된 경우에만 변경마다 자동 생성한 stable update identity와 Profile ID로 Profile Update Effects Workflow를 시작해야 한다(MUST). Temporal이 요구하는 Workflow ID에는 그 update identity를 그대로 사용해 같은 Profile의 연속 변경을 별도 실행으로 구분해야 하며(MUST), 같은 실행의 retry와 restart는 기존 실행으로 수렴해야 한다(MUST). Profile transaction은 Core action이 동기적으로 소유해야 하고(MUST), caller database handle, caller-side `postCommit`, transaction Activity를 사용해서는 안 된다(MUST NOT).
+
+#### Scenario: Actor-visible 변경 commit
+
+- **WHEN** displayName, bio, followPolicy, avatar 또는 header가 저장된 현재 값과 다르게 commit된다
+- **THEN** Core action은 해당 commit을 위한 update identity를 자동 생성한다
+- **AND** Profile ID와 update identity로 Profile Update Effects Workflow를 시작한다
+- **AND** 같은 Profile의 다른 변경은 별도 update identity와 Workflow 실행을 갖는다
+
+#### Scenario: 비대상 또는 no-op 변경
+
+- **WHEN** Tag·default Post visibility만 변경되거나 actor-visible 입력이 저장된 값과 같다
+- **THEN** Core action은 Profile Update Effects Workflow를 시작하지 않는다
+
+#### Scenario: 거부 또는 rollback
+
+- **WHEN** Profile update가 validation·authorization 실패로 거부되거나 transaction이 rollback된다
+- **THEN** 시스템은 해당 미반영 변경을 위한 Workflow를 시작하지 않는다
+
+#### Scenario: Workflow start 실패
+
+- **WHEN** Profile commit 뒤 Temporal Workflow start가 실패한다
+- **THEN** 시스템은 Profile ID와 update identity와 함께 실패를 관측한다
+- **AND** committed Profile과 GraphQL mutation 성공 결과를 rollback하거나 실패로 바꾸지 않는다
+
+### Requirement: Latest-at-delivery Profile projection
+
+**Authority / Provenance:** `docs/domain/objects/profile.md`, `docs/architecture/core-services.md`, `PROD-665` Profile Update Effects Workflow의 Activity는 실행 시점의 최신 committed Profile과 Media를 읽어 canonical `Update(Person)`을 Fedify queue에 handoff해야 한다(MUST). 같은 Workflow 실행의 Activity retry는 동일한 update identity와 ActivityPub activity IRI를 재사용해야 한다(MUST). 시스템은 빠른 연속 Profile 변경의 delivery ordering, 각 commit 시점 projection, cross-update exactly-once를 보장해서는 안 된다(MUST NOT).
+
+#### Scenario: Activity retry
+
+- **WHEN** 같은 Profile Update Activity가 queue handoff 실패 뒤 retry된다
+- **THEN** Activity는 같은 update identity로 같은 ActivityPub Update IRI를 구성한다
+- **AND** 실행 시점의 최신 committed Profile projection을 다시 읽는다
+
+#### Scenario: 빠른 연속 Profile 변경
+
+- **WHEN** 같은 Profile의 actor-visible 값이 연속으로 commit되고 각 Workflow Activity가 실행된다
+- **THEN** 각 Workflow는 서로 다른 update identity를 유지한다
+- **AND** 각 Activity는 실행 시점의 최신 committed projection을 전달할 수 있다
+- **AND** 이 capability는 commit 순서와 원격 관측 순서를 일치시키는 projection version 또는 ordering ledger를 만들지 않는다
+
+#### Scenario: Worker restart
+
+- **WHEN** accepted Profile Update Effects Workflow 처리 중 Worker가 재시작된다
+- **THEN** Workflow는 같은 Profile ID와 update identity로 Activity 실행을 재개할 수 있다
+
+### Requirement: Profile Update 효과의 실패 경계
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-448`, `PROD-665` Temporal Activity 성공 경계는 Fedify PostgreSQL queue acceptance여야 한다(MUST). Queue acceptance 전 실패는 Temporal Activity retry가 소유하고(MUST), acceptance 뒤 remote delivery retry와 최종 실패는 Fedify consumer가 소유해야 한다(MUST). Commit과 Workflow start 사이의 durable intent, reconciliation 또는 backfill은 이 capability가 보장해서는 안 된다(MUST NOT).
+
+#### Scenario: Queue handoff 전 실패
+
+- **WHEN** canonical projection 구성 또는 Fedify queue handoff가 실패한다
+- **THEN** Temporal은 Profile Update Activity를 설정된 정책으로 재시도한다
+
+#### Scenario: Queue acceptance 이후 실패
+
+- **WHEN** Fedify queue가 Update를 수락한 뒤 remote delivery가 실패한다
+- **THEN** Fedify consumer가 기존 정책으로 remote delivery를 재시도하고 최종 실패를 관측한다
+- **AND** Temporal Activity는 remote delivery 완료를 기다리지 않는다
+
+#### Scenario: Commit과 Workflow start 사이 종료
+
+- **WHEN** application process가 Profile commit 뒤 Workflow start 수락 전에 종료된다
+- **THEN** committed Profile은 유지된다
+- **AND** 이 capability는 해당 변경의 Workflow backfill 또는 전달을 보장하지 않는다

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/temporal-worker-runtime-foundation/spec.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/specs/temporal-worker-runtime-foundation/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: 고정 business registration과 singleton Worker host
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-722`, `PROD-725`, `PROD-665`. 시스템은 Worker production entrypoint에 compile-time의 실제 business Workflow·Activity registry와 task queue를 정확히 하나 제공해야 한다(MUST). Registry는 기존 Post Create, Repost create, Post Delete, Repost Delete Workflow·Activity와 새 Profile Update Effects Workflow·Activity를 함께 등록하고 event별 Workflow source를 정적으로 조립해야 한다(MUST). 기존 Post Create Workflow type `postCreateEffectsWorkflow`와 ID `post-create-effects:{postId}`는 유지해야 하며(MUST), Repost create는 type `postRepostWorkflow`·ID `post-repost:{postId}`, Post Delete는 type `postDeleteWorkflow`·ID `post-delete:{postId}`, Repost Delete는 type `repostDeleteWorkflow`·ID `repost-delete:{postId}`를 사용해야 한다(MUST). Profile Update Workflow type은 `profileUpdateEffectsWorkflow`를 사용하고 Temporal이 요구하는 Workflow ID에는 자동 생성한 update identity를 그대로 전달해야 한다(MUST). Entrypoint 자체는 이 registry로 process-global Worker host를 정확히 한 번 시작해야 하며(MUST), exported `runWorker`/`startWorker` lifecycle, optional registration, registration 부재를 검사하는 정상 실행 경로, idle Worker 상태 또는 같은 process에서 Worker host를 다시 시작할 수 있는 범용 startup API를 제공해서는 안 된다(MUST NOT).
+
+#### Scenario: Production Worker 시작
+
+- **WHEN** Worker production entrypoint를 실행한다
+- **THEN** 시스템은 compile-time에 구성된 기존 Post Create, Repost create, Post Delete, Repost Delete Workflow·Activity와 Profile Update Effects Workflow·Activity registry 및 하나의 task queue로 Worker host를 정확히 한 번 시작한다
+- **AND** caller가 registration을 전달하거나 두 번째 Worker host를 시작할 수 있는 public startup API를 제공하지 않는다
+
+#### Scenario: 기존 Post Create 외부 identity 보존
+
+- **WHEN** Profile Update Workflow source를 기존 Worker registry에 추가한다
+- **THEN** Post Create Workflow type `postCreateEffectsWorkflow`와 ID `post-create-effects:{postId}`는 변경하지 않는다
+- **AND** Repost create는 `postRepostWorkflow`/`post-repost:{postId}`, Post Delete는 `postDeleteWorkflow`/`post-delete:{postId}`, Repost Delete는 `repostDeleteWorkflow`/`repost-delete:{postId}`를 유지한다
+
+#### Scenario: Profile Update 외부 identity
+
+- **WHEN** actor-visible Profile 변경이 commit되어 Effects Workflow를 시작한다
+- **THEN** Workflow type은 `profileUpdateEffectsWorkflow`다
+- **AND** Workflow ID는 자동 생성된 update identity 자체다
+- **AND** Activity는 같은 update identity를 canonical `Update(Person)` IRI에 재사용한다
+
+#### Scenario: domain별 registration 조립
+
+- **WHEN** Repost create, Post Delete, Repost Delete 또는 Profile Update Workflow와 Activity를 Worker registry에 추가한다
+- **THEN** event별 Workflow 구현과 type·identity 계약은 분리된 source module에 남고 production entrypoint가 고정 registry로 조립한다
+- **AND** Workflow마다 Worker host, task queue, Core contract file 또는 범용 runtime abstraction을 새로 만들지 않는다
+
+#### Scenario: 실제 effects registration 없는 build 방지
+
+- **WHEN** Worker package의 production entrypoint와 registration을 정적·자동화 검증한다
+- **THEN** entrypoint에는 optional 또는 empty registration 경로가 존재하지 않는다
+- **AND** smoke Workflow·검증 전용 task queue·health-only idle runtime 또는 test-only business registration으로 business registration 부재를 숨기지 않는다

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/tasks.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/tasks.md
@@ -1,0 +1,82 @@
+## 1. PROD-665 Profile update transaction과 Workflow start
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/architecture/core-services.md`
+- `PROD-665`
+
+**Deliverable**
+
+Core가 Profile 수정 transaction을 완료하고 실제 actor-visible commit에만 stable identity의 Effects Workflow start를 시도하며, API caller는 database handle이나 post-commit callback을 조립하지 않는다.
+
+**Guardrails**
+
+- displayName, bio, followPolicy, avatar, header의 실제 변경만 효과 대상이다.
+- Tag, default Post visibility, no-op, validation·authorization 실패와 rollback에는 Workflow가 없다.
+- Start 실패와 commit-to-start gap은 committed Profile 성공을 바꾸지 않는다.
+- Transaction Activity, projection version, outbox, receipt, relay와 DB migration을 추가하지 않는다.
+
+**Verification**
+
+- Core service와 GraphQL integration에서 실제 변경, no-op, 비대상 변경, rollback, start 실패 격리를 검증한다.
+
+- [x] 1.1 Profile action이 자체 transaction과 실제 actor-visible 변경 판정을 유지하며 commit 뒤 Workflow start를 소유하도록 구현한다.
+- [x] 1.2 API caller의 database handle 전달과 post-commit callback 실행을 제거한다.
+- [x] 1.3 Core/API 테스트를 새 Workflow start 경계로 갱신하고 관련 검증을 통과시킨다.
+
+## 2. PROD-665 Profile Update delivery Activity
+
+**Authority / Provenance**
+
+- `docs/domain/objects/profile.md`
+- `docs/architecture/core-services.md`
+- `PROD-448`
+- `PROD-629`
+- `PROD-665`
+
+**Deliverable**
+
+Accepted Profile Update Workflow가 stable update identity로 delivery 시점의 최신 canonical `Update(Person)`을 Fedify queue에 handoff하고 Worker restart·Activity retry에서 재개된다.
+
+**Guardrails**
+
+- Temporal Workflow ID는 자동 생성한 update identity 자체다.
+- 같은 Activity retry는 동일한 ActivityPub Update identity를 재사용한다.
+- 빠른 연속 update는 latest-at-delivery/last-write-wins이며 ordering 또는 commit 시점 snapshot을 보장하지 않는다.
+- 기존 singleton Worker와 compile-time registry를 사용하고 별도 host, enable flag, startup wrapper, Core contract file 또는 test-only export를 추가하지 않는다.
+- Temporal Activity 성공 경계는 Fedify queue acceptance다.
+
+**Verification**
+
+- Fedify delivery의 stable identity와 최신 projection, 실제 production Workflow bundle의 Activity 실행·retry를 검증한다.
+
+- [x] 2.1 Fedify Profile Update delivery가 입력된 stable identity로 canonical Update IRI를 구성하도록 구현한다.
+- [x] 2.2 기존 Worker registry에 Profile Update Effects Workflow와 delivery Activity를 추가한다.
+- [x] 2.3 Fedify/Worker 테스트를 stable retry identity와 production bundle 경계로 갱신하고 관련 검증을 통과시킨다.
+
+## 3. PROD-665 통합 검증과 handoff
+
+**Authority / Provenance**
+
+- `docs/architecture/core-services.md`
+- `PROD-665`
+
+**Deliverable**
+
+구현 revision이 정적·통합 검증과 dev의 rapid update·retry·restart 증거를 갖고, OpenSpec 완료 여부가 PR readiness와 별도로 기록된다.
+
+**Guardrails**
+
+- PR/CI를 dev 또는 production live evidence로 대체하지 않는다.
+- Production sync·apply·cutover·live verification을 수행하지 않는다.
+- OpenSpec archive는 전체 task와 dev 검증이 완료된 뒤 이 작업의 owner가 수행한다.
+
+**Verification**
+
+- OpenSpec strict validation, 관련 package typecheck/lint/test, PR CI, exact revision dev evidence를 각각 구분해 기록한다.
+
+- [x] 3.1 OpenSpec strict validation과 관련 Core/API/Fedify/Worker 정적·통합 검증을 완료한다.
+- [ ] 3.2 구현을 commit·push하고 Ready PR로 handoff하되 production 증거로 과장하지 않는다.
+- [ ] 3.3 Exact revision을 dev에서 빠른 연속 Profile update, Activity retry, Worker restart로 검증한다.
+- [ ] 3.4 전체 task와 delta sync 가능성을 재확인한 뒤 이 change를 archive한다.

--- a/openspec/changes/transition-profile-update-effects-to-temporal-workflow/tasks.md
+++ b/openspec/changes/transition-profile-update-effects-to-temporal-workflow/tasks.md
@@ -77,6 +77,6 @@ Accepted Profile Update Workflow가 stable update identity로 delivery 시점의
 - OpenSpec strict validation, 관련 package typecheck/lint/test, PR CI, exact revision dev evidence를 각각 구분해 기록한다.
 
 - [x] 3.1 OpenSpec strict validation과 관련 Core/API/Fedify/Worker 정적·통합 검증을 완료한다.
-- [ ] 3.2 구현을 commit·push하고 Ready PR로 handoff하되 production 증거로 과장하지 않는다.
+- [x] 3.2 구현을 commit·push하고 Ready PR로 handoff하되 production 증거로 과장하지 않는다.
 - [ ] 3.3 Exact revision을 dev에서 빠른 연속 Profile update, Activity retry, Worker restart로 검증한다.
 - [ ] 3.4 전체 task와 delta sync 가능성을 재확인한 뒤 이 change를 archive한다.

--- a/packages/core/services/profile-update.test.ts
+++ b/packages/core/services/profile-update.test.ts
@@ -4,7 +4,6 @@ import { and, eq, inArray } from 'drizzle-orm';
 import {
   AccountProfiles,
   Accounts,
-  ActivityPubActors,
   db,
   firstOrThrow,
   Hashtags,
@@ -12,7 +11,6 @@ import {
   Media,
   pg,
   ProfileFollowRequests,
-  ProfileFollows,
   ProfileHashtags,
   ProfileMedia,
   Profiles,
@@ -20,7 +18,6 @@ import {
 import {
   AccountProfileRole,
   AccountState,
-  ActivityPubActorType,
   InstanceKind,
   InstanceState,
   MediaSource,
@@ -31,6 +28,8 @@ import {
   ProfileState,
 } from '../enums';
 import { NotFoundError, PermissionDeniedError, ValidationError } from '../error';
+import { temporalClient } from '../temporal/client';
+import { KOSMO_TASK_QUEUE } from '../temporal/task-queue';
 import { updateProfile } from './profile-update';
 
 after(async () => pg.end());
@@ -43,20 +42,17 @@ const createProfileFixture = async ({
   instanceKind = InstanceKind.LOCAL,
   profileState = ProfileState.ACTIVE,
   accountState = AccountState.ACTIVE,
-  canonicalOrigin,
   role = AccountProfileRole.OWNER,
 }: {
   instanceKind?: InstanceKind;
   profileState?: ProfileState;
   accountState?: AccountState;
-  canonicalOrigin?: string;
   role?: AccountProfileRole;
 } = {}) => {
   const suffix = crypto.randomUUID();
   const instance = await db
     .insert(Instances)
     .values({
-      canonicalOrigin,
       domain: `${suffix}.example`,
       kind: instanceKind,
       state: InstanceState.ACTIVE,
@@ -134,22 +130,6 @@ const readProfileMedia = (profileId: string) =>
     .from(ProfileMedia)
     .where(eq(ProfileMedia.profileId, profileId))
     .then((rows) => rows.toSorted((a, b) => a.kind.localeCompare(b.kind)));
-
-const createRemoteFollower = async (followeeProfileId: string) => {
-  const remote = await createProfileFixture({ instanceKind: InstanceKind.ACTIVITYPUB });
-  const actorUri = `https://${remote.instance.domain}/users/${remote.profile.id}`;
-  await db.insert(ActivityPubActors).values({
-    inboxUri: `${actorUri}/inbox`,
-    profileId: remote.profile.id,
-    sharedInboxUri: `https://${remote.instance.domain}/inbox`,
-    type: ActivityPubActorType.PERSON,
-    uri: actorUri,
-  });
-  await db.insert(ProfileFollows).values({
-    followeeProfileId,
-    followerProfileId: remote.profile.id,
-  });
-};
 
 test('Profile Media 관계는 kind별 하나만 허용하고 관계 삭제 시 Media를 보존한다', async () => {
   const { account, profile } = await createProfileFixture();
@@ -632,29 +612,6 @@ test('Member와 inactive Account는 거부되고 관계없는 Account와 Remote/
   );
 });
 
-test('호출 transaction이 rollback되면 scalar와 relation이 모두 복구된다', async () => {
-  const { account, profile } = await createProfileFixture();
-  await updateProfile({ accountId: account.id, profileId: profile.id, tags: ['before'] });
-
-  await assert.rejects(
-    db.transaction(async (tx) => {
-      await updateProfile(
-        { accountId: account.id, profileId: profile.id, displayName: 'Rollback', tags: ['after'] },
-        tx,
-      );
-      throw new Error('rollback');
-    }),
-    /rollback/,
-  );
-  const persisted = await db
-    .select()
-    .from(Profiles)
-    .where(eq(Profiles.id, profile.id))
-    .then(firstOrThrow);
-  assert.equal(persisted.displayName, profile.displayName);
-  assert.deepEqual(await readTags(profile.id), ['before']);
-});
-
 test('서로 다른 Profile의 같은 tags 역순 동시 update가 모두 성공한다', async () => {
   const first = await createProfileFixture();
   const second = await createProfileFixture();
@@ -703,10 +660,8 @@ test('동시 partial scalar update는 서로 다른 필드를 모두 보존한�
   assert.deepEqual(persisted, { displayName: 'Display name', bio: 'Bio' });
 });
 
-test('실제 actor 표현 변경만 one-shot postCommit delivery lifecycle을 만든다', async () => {
-  const fixture = await createProfileFixture({
-    canonicalOrigin: `https://${crypto.randomUUID()}.local.example`,
-  });
+test('실제 actor 표현 변경만 Profile Update effects Workflow를 시작한다', async () => {
+  const fixture = await createProfileFixture();
   const avatar = await createMedia({
     accountId: fixture.account.id,
     profileId: fixture.profile.id,
@@ -715,22 +670,20 @@ test('실제 actor 표현 변경만 one-shot postCommit delivery lifecycle을 �
     accountId: fixture.account.id,
     profileId: fixture.profile.id,
   });
-  await createRemoteFollower(fixture.profile.id);
-  const delivery = mock.method(
-    globalThis,
-    'fetch',
-    async () => new Response(null, { status: 202 }),
-  );
+  const start = mock.method(temporalClient.workflow, 'start', async () => undefined as never);
 
   const first = await updateProfile({
     accountId: fixture.account.id,
     displayName: 'Changed',
     profileId: fixture.profile.id,
   });
-  const firstPostCommit = first.postCommit();
-  assert.equal(first.postCommit(), firstPostCommit);
-  await firstPostCommit;
-  assert.equal(delivery.mock.callCount(), 1);
+  assert.equal(start.mock.callCount(), 1);
+  const firstStart = start.mock.calls[0]?.arguments[1];
+  const firstArgs = firstStart?.args?.[0];
+  assert.equal(start.mock.calls[0]?.arguments[0], 'profileUpdateEffectsWorkflow');
+  assert.equal(firstStart?.taskQueue, KOSMO_TASK_QUEUE);
+  assert.equal(firstStart?.workflowId, firstArgs?.updateId);
+  assert.equal(firstArgs?.profileId, first.profile.id);
 
   for (const input of [
     { bio: 'Changed bio' },
@@ -745,9 +698,9 @@ test('실제 actor 표현 변경만 one-shot postCommit delivery lifecycle을 �
       profileId: fixture.profile.id,
       ...input,
     });
-    await result.postCommit();
+    assert.equal(result.profile.id, fixture.profile.id);
   }
-  assert.equal(delivery.mock.callCount(), 7);
+  assert.equal(start.mock.callCount(), 7);
 
   const noOp = await updateProfile({
     accountId: fixture.account.id,
@@ -755,78 +708,29 @@ test('실제 actor 표현 변경만 one-shot postCommit delivery lifecycle을 �
     bio: '  Changed bio  ',
     displayName: 'Changed',
     followPolicy: ProfileFollowPolicy.APPROVAL_REQUIRED,
+    defaultPostVisibility: PostVisibility.UNLISTED,
     headerMediaId: null,
     profileId: fixture.profile.id,
     tags: ['tag_only'],
   });
-  await noOp.postCommit();
-  assert.equal(delivery.mock.callCount(), 7);
+  assert.equal(noOp.profile.id, fixture.profile.id);
+  assert.equal(start.mock.callCount(), 7);
 });
 
-test('caller-owned transaction은 outer commit 뒤 실행할 postCommit lifecycle을 반환한다', async () => {
-  const fixture = await createProfileFixture({
-    canonicalOrigin: `https://${crypto.randomUUID()}.local.example`,
-  });
-  await createRemoteFollower(fixture.profile.id);
-  const delivery = mock.method(
-    globalThis,
-    'fetch',
-    async () => new Response(null, { status: 202 }),
-  );
-  let result: Awaited<ReturnType<typeof updateProfile>> | undefined;
-
-  await db.transaction(async (tx) => {
-    result = await updateProfile(
-      {
-        accountId: fixture.account.id,
-        displayName: 'Committed',
-        profileId: fixture.profile.id,
-      },
-      tx,
-    );
-    assert.equal(delivery.mock.callCount(), 0);
-  });
-
-  assert.ok(result);
-  await result.postCommit();
-  assert.equal(delivery.mock.callCount(), 1);
-
-  await assert.rejects(
-    db.transaction(async (tx) => {
-      await updateProfile(
-        {
-          accountId: fixture.account.id,
-          displayName: 'Rolled back',
-          profileId: fixture.profile.id,
-        },
-        tx,
-      );
-      throw new Error('rollback');
-    }),
-    /rollback/,
-  );
-  assert.equal(delivery.mock.callCount(), 1);
-});
-
-test('postCommit delivery 실패는 committed Profile 결과를 유지하고 관측한다', async () => {
-  const fixture = await createProfileFixture({
-    canonicalOrigin: `https://${crypto.randomUUID()}.local.example`,
-  });
-  await createRemoteFollower(fixture.profile.id);
-  const delivery = mock.method(globalThis, 'fetch', async () => {
-    throw new Error('delivery failed');
+test('Workflow start 실패는 committed Profile 결과를 유지하고 관측한다', async () => {
+  const fixture = await createProfileFixture();
+  const start = mock.method(temporalClient.workflow, 'start', async () => {
+    throw new Error('Temporal unavailable');
   });
   const errorLog = mock.method(console, 'error', () => undefined);
 
   const result = await updateProfile({
     accountId: fixture.account.id,
-    bio: 'Committed despite delivery failure',
+    bio: 'Committed despite Workflow start failure',
     profileId: fixture.profile.id,
   });
-  await result.postCommit();
-
-  assert.ok(delivery.mock.callCount() > 0);
-  assert.equal(result.profile.bio, 'Committed despite delivery failure');
+  assert.equal(start.mock.callCount(), 1);
+  assert.equal(result.profile.bio, 'Committed despite Workflow start failure');
   assert.equal(
     await db
       .select({ bio: Profiles.bio })
@@ -834,12 +738,13 @@ test('postCommit delivery 실패는 committed Profile 결과를 유지하고 관
       .where(eq(Profiles.id, fixture.profile.id))
       .then(firstOrThrow)
       .then(({ bio }) => bio),
-    'Committed despite delivery failure',
+    'Committed despite Workflow start failure',
   );
   assert.equal(errorLog.mock.callCount(), 1);
   assert.equal(
     errorLog.mock.calls[0]?.arguments[0],
-    'Post-commit ActivityPub Local Profile Update delivery failed',
+    'Profile Update effects Workflow start failed',
   );
   assert.equal(errorLog.mock.calls[0]?.arguments[1]?.profileId, fixture.profile.id);
+  assert.equal(typeof errorLog.mock.calls[0]?.arguments[1]?.updateId, 'string');
 });

--- a/packages/core/services/profile-update.ts
+++ b/packages/core/services/profile-update.ts
@@ -1,9 +1,10 @@
+import { randomUUID } from 'node:crypto';
 import { and, eq, inArray, isNotNull, ne } from 'drizzle-orm';
 import {
   AccountProfiles,
   Accounts,
+  db,
   first,
-  getDatabaseConnection,
   Hashtags,
   Instances,
   Media,
@@ -23,9 +24,9 @@ import {
   ProfileState,
 } from '../enums';
 import { NotFoundError, PermissionDeniedError, ValidationError } from '../error';
+import { temporalClient } from '../temporal/client';
+import { KOSMO_TASK_QUEUE } from '../temporal/task-queue';
 import { profileBioSchema, profileTagsSchema } from '../validation';
-import { noPostCommit, oncePostCommit } from './post-commit';
-import type { DatabaseHandle } from '../db';
 import type { ProfileFollowPolicy } from '../enums';
 
 export type UpdateProfileInput = {
@@ -41,7 +42,6 @@ export type UpdateProfileInput = {
 };
 
 export type UpdateProfileResult = {
-  readonly postCommit: () => Promise<void>;
   readonly profile: typeof Profiles.$inferSelect;
 };
 
@@ -115,11 +115,8 @@ const normalizeDefaultPostVisibility = (
   return visibility;
 };
 
-export const updateProfile = async (
-  input: UpdateProfileInput,
-  tx?: DatabaseHandle,
-): Promise<UpdateProfileResult> => {
-  const result = await getDatabaseConnection(tx).transaction(async (tx) => {
+export const updateProfile = async (input: UpdateProfileInput): Promise<UpdateProfileResult> => {
+  const result = await db.transaction(async (tx) => {
     const profile = await tx
       .select({ profile: Profiles, actorRole: AccountProfiles.role })
       .from(Profiles)
@@ -288,23 +285,30 @@ export const updateProfile = async (
         });
     }
 
-    return { actorProjectionChanged: actorProjectionActuallyChanged, profile: updatedProfile };
+    return {
+      profile: updatedProfile,
+      updateId: actorProjectionActuallyChanged ? randomUUID() : undefined,
+    };
   });
 
-  return {
-    profile: result.profile,
-    postCommit: result.actorProjectionChanged
-      ? oncePostCommit(async () => {
-          try {
-            const { sendLocalProfileUpdate } = await import('@kosmo/fedify');
-            await sendLocalProfileUpdate(result.profile.id);
-          } catch (error) {
-            console.error('Post-commit ActivityPub Local Profile Update delivery failed', {
-              error,
-              profileId: result.profile.id,
-            });
-          }
-        })
-      : noPostCommit,
-  };
+  const updateId = result.updateId;
+  if (updateId) {
+    try {
+      await temporalClient.withDeadline(Date.now() + 5_000, () =>
+        temporalClient.workflow.start('profileUpdateEffectsWorkflow', {
+          args: [{ profileId: result.profile.id, updateId }],
+          taskQueue: KOSMO_TASK_QUEUE,
+          workflowId: updateId,
+        }),
+      );
+    } catch (error) {
+      console.error('Profile Update effects Workflow start failed', {
+        error,
+        profileId: result.profile.id,
+        updateId,
+      });
+    }
+  }
+
+  return { profile: result.profile };
 };

--- a/packages/fedify/src/local-profile-update-delivery.test.ts
+++ b/packages/fedify/src/local-profile-update-delivery.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 
 after(async () => pg.end());
 
-test('Update(Person)는 canonical actor 표현·followers audience·unique activity identity를 쓴다', async () => {
+test('Update(Person)는 canonical actor 표현과 안정적인 activity identity를 쓴다', async () => {
   const local = await createLocalProfile();
   const avatar = await createMedia(local.accountId, local.profile.id, 'avatar');
   const header = await createMedia(local.accountId, local.profile.id, 'header');
@@ -55,14 +55,24 @@ test('Update(Person)는 canonical actor 표현·followers audience·unique activ
   const fixture = await createContextFixture(local);
   mock.method(localOutboundFederation, 'createContext', () => fixture.context);
 
-  await sendLocalProfileUpdate(local.profile.id);
-  await sendLocalProfileUpdate(local.profile.id);
+  await sendLocalProfileUpdate({
+    profileId: local.profile.id,
+    updateId: '00000000-0000-8000-8000-000000000001',
+  });
+  await sendLocalProfileUpdate({
+    profileId: local.profile.id,
+    updateId: '00000000-0000-8000-8000-000000000001',
+  });
 
   assert.equal(fixture.calls.length, 2);
   const [first, second] = fixture.calls;
   assert.ok(first?.activity instanceof Update);
   assert.ok(second?.activity instanceof Update);
-  assert.notEqual(first.activity.id?.href, second.activity.id?.href);
+  assert.equal(
+    first.activity.id?.href,
+    `${fixture.actorUri.href}/updates/00000000-0000-8000-8000-000000000001`,
+  );
+  assert.equal(first.activity.id?.href, second.activity.id?.href);
   assert.equal(first.activity.actorId?.href, fixture.actorUri.href);
   assert.deepEqual(
     first.activity.toIds.map((uri) => uri.href),
@@ -94,7 +104,10 @@ test('remote follower가 없으면 HTTP delivery를 시작하지 않는다', asy
   const fixture = await createContextFixture(local);
   mock.method(localOutboundFederation, 'createContext', () => fixture.context);
 
-  await sendLocalProfileUpdate(local.profile.id);
+  await sendLocalProfileUpdate({
+    profileId: local.profile.id,
+    updateId: '00000000-0000-8000-8000-000000000002',
+  });
 
   assert.equal(fixture.calls.length, 0);
 });
@@ -109,7 +122,13 @@ test('recipient delivery 실패는 caller가 격리할 수 있도록 reject한�
   const fixture = await createContextFixture(local, true);
   mock.method(localOutboundFederation, 'createContext', () => fixture.context);
 
-  await assert.rejects(sendLocalProfileUpdate(local.profile.id), /delivery failed/);
+  await assert.rejects(
+    sendLocalProfileUpdate({
+      profileId: local.profile.id,
+      updateId: '00000000-0000-8000-8000-000000000003',
+    }),
+    /delivery failed/,
+  );
 });
 
 type LocalFixture = Awaited<ReturnType<typeof createLocalProfile>>;

--- a/packages/fedify/src/local-profile-update-delivery.ts
+++ b/packages/fedify/src/local-profile-update-delivery.ts
@@ -7,7 +7,13 @@ import { localOutboundFederation } from './local-outbound-federation';
 import { createLocalProfilePerson } from './local-profile-person';
 import { dispatchActivityPubActivity } from './outbound-recipient-dispatch';
 
-export const sendLocalProfileUpdate = async (profileId: string): Promise<void> => {
+export const sendLocalProfileUpdate = async ({
+  profileId,
+  updateId,
+}: {
+  readonly profileId: string;
+  readonly updateId: string;
+}): Promise<void> => {
   const source = await db
     .select({
       canonicalOrigin: Instances.canonicalOrigin,
@@ -51,7 +57,7 @@ export const sendLocalProfileUpdate = async (profileId: string): Promise<void> =
   const actorPathname = actorUri.pathname.replace(/\/$/, '');
   const activity = new Update({
     actor: actorUri,
-    id: new URL(`${actorPathname}/updates/${crypto.randomUUID()}`, actorUri),
+    id: new URL(`${actorPathname}/updates/${updateId}`, actorUri),
     object,
     tos: [context.getFollowersUri(profileId)],
   });


### PR DESCRIPTION
Stack: main -> PROD-665

## 무엇을 변경했는지

- Core가 Profile update transaction을 직접 소유하고, displayName·bio·followPolicy·avatar·header의 실제 변경 commit 뒤에만 Temporal Workflow를 시작하게 했습니다.
- GraphQL caller의 database handle 전달과 `postCommit` 실행을 제거했습니다.
- 각 실제 변경에 자동 생성한 `updateId`를 Temporal Workflow ID와 ActivityPub `Update(Person)` identity에 재사용합니다.
- Worker의 기존 singleton registry에 Profile Update Workflow와 Fedify delivery Activity를 추가했습니다.
- Activity는 실행 시점의 최신 committed Profile projection을 기존 recipient dispatcher로 Fedify queue에 handoff합니다.
- PROD-665 계약과 기존 Profile/ActivityPub/Worker capability의 delta를 OpenSpec에 기록했습니다.

## 왜 변경했는지

기존 Profile Update 전달은 process-local `postCommit`에서 직접 실행되어 queue handoff 실패를 Temporal Activity retry와 Worker restart로 복구할 수 없었습니다. Profile 상태 transaction은 Core에 유지하면서 commit 이후의 외부 효과만 재시도 가능한 Worker 경계로 옮깁니다.

## 이번 PR의 주요 결정

### 변경마다 자동 생성한 update identity를 그대로 재사용

- 결정자: @robin-maki
- 선택: 실제 actor-visible commit마다 UUID를 자동 생성하고, 별도 prefix 없이 Temporal Workflow ID와 ActivityPub Update identity에 함께 사용합니다.
- 고려한 대안: Profile ID만 사용, DB projection version 추가
- 이유: Profile ID만 사용하면 연속 수정이 같은 Workflow identity와 충돌하고, DB version은 현재 범위를 넘어 migration과 ordering 계약을 추가합니다.
- 감수한 결과: DB에 identity를 보존하지 않으므로 commit과 Workflow start 사이 유실은 복구하지 않으며, 빠른 연속 수정은 latest-at-delivery/last-write-wins입니다.
- 관련 근거: [PROD-665](https://linear.app/byulmaru/issue/PROD-665), [OpenSpec decision](https://github.com/byulmaru/kosmo/blob/PROD-665/openspec/changes/transition-profile-update-effects-to-temporal-workflow/decisions.md)

구현 중 새로 추가한 durable decision은 없습니다. 최신 canonical·Linear와 대조한 OpenSpec 결정을 그대로 적용했습니다.

## 어떻게 확인할 수 있는지

- Core unit: 55/55
- Core services: 161/161
- API integration: 222 pass, 1 skip
- Fedify: 230/230
- Fedify consumer: 1/1
- Worker unit: 3/3
- Worker production Workflow bundle: 2/2
- API/Fedify TypeScript, Worker build, repository ESLint/Prettier 통과
- OpenSpec strict validation: 102/102
- `git diff --check` 통과

## 아직 어떤 문제가 남았는지

- PR/CI는 dev 또는 production cutover 증거가 아닙니다.
- Exact revision의 dev rapid consecutive update, Activity retry, Worker restart 검증은 아직 수행하지 않았습니다.
- 위 dev 검증과 전체 task 완료 전에는 OpenSpec을 archive하지 않습니다.
- Production sync·apply·cutover·live verification은 이 PR 범위가 아니며 수행하지 않았습니다.
