### PR TITLE
PostComposer의 Rail·Overlay 디자인 계약을 기록한다

### DIFF
--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -26,9 +26,12 @@ Settings master pane은 약 `320px`, detail pane은 남은 폭을 사용한다. 
 
 ## 글쓰기 진입
 
-- `< compact`: 하단 탭 바의 글쓰기가 유일한 shell-level 진입점이다. mobile drawer에는 중복 글쓰기 버튼을 표시하지 않는다.
-- `compact`~`full`: 우측 레일이 없으므로 아이콘 레일의 글쓰기 버튼.
-- `≥ full`: 우측 레일 컴포저가 담당하며, 사이드바 글쓰기 버튼은 표시하지 않는다. mobile drawer에도 중복 글쓰기 버튼을 표시하지 않는다.
+PostComposer presentation은 `Rail`과 `Overlay`만 사용한다. 중앙 timeline inline composer나 별도 `/compose` route를 canonical presentation으로 두지 않는다. `Overlay` 폭과 화면 바깥 gutter는 parent surface가 소유하고 PostComposer는 내부 spacing·state를 소유한다. 현행 `/compose` route와 header ownership은 Product migration 전까지의 호환 계약이다.
+
+- `< compact`: 하단 탭 바의 글쓰기가 유일한 shell-level 진입점이며 mobile fullscreen Overlay를 연다. 게시 성공 뒤에는 timeline으로 돌아간다. mobile drawer에는 중복 글쓰기 버튼을 표시하지 않는다.
+- `compact`~`full`: 우측 레일이 없으므로 아이콘 레일의 글쓰기 버튼이 desktop modal Overlay를 연다.
+- `≥ full`: 우측 레일의 embedded PostComposer가 기본 작성 surface다. 별도 큰 글쓰기 CTA를 추가하지 않고 composer header의 Expand action으로 desktop modal Overlay를 연다. 사이드바와 mobile drawer에는 중복 글쓰기 버튼을 표시하지 않는다.
+- `Surface=Overlay`에서는 composer-level Expand를 숨기고 `Surface=Rail`에서만 표시한다. Modal의 close·focus·Escape·backdrop, mobile keyboard avoidance와 게시 후 복귀는 consumer/runtime가 소유한다.
 
 ## Web 검색 상단바
 


### PR DESCRIPTION
## 무엇을 변경했는지

- breakpoint별 PostComposer presentation을 `Rail`과 `Overlay`로 정리했습니다.
- full Web RightRail은 embedded composer와 Expand action을 사용하고 별도 큰 글쓰기 CTA를 두지 않도록 명시했습니다.
- compact Web은 modal Overlay, mobile은 fullscreen Overlay를 여는 흐름을 기록했습니다.
- Overlay의 바깥 geometry와 modal lifecycle은 consumer가, composer 내부 spacing·state는 PostComposer가 소유하도록 경계를 적었습니다.

## 왜 변경했는지

DSN-43 Figma source가 기존 `Center` 의미를 제거하고 `Surface=Rail|Overlay`로 바뀌었지만 canonical breakpoint 문서는 `/compose` route와 presentation 차이를 명시하지 않아 handoff가 어긋날 수 있었습니다.

## 어떻게 확인할 수 있는지

- `./node_modules/.bin/prettier --check docs/design/breakpoints.md`
- `git diff --check`
- DSN-43 Figma source 및 Light/Dark specimen readback

## 아직 어떤 문제가 남았는지

- modal open/close, focus restore, keyboard avoidance, mobile 게시 후 timeline 복귀는 별도 Product 범위입니다.
- 기존 `/compose` 및 inline Reply screen 정리는 이 문서 PR에 포함하지 않습니다.