### PR TITLE
Post 삭제 실패 로그의 포맷 문자열을 상수로 고정한다

### DIFF
--- a/apps/api/tests/integration/graphql/post-repost.test.ts
+++ b/apps/api/tests/integration/graphql/post-repost.test.ts
@@ -365,7 +365,15 @@ describe('GraphQL Repost', () => {
     assert.equal(deleted.state, PostState.DELETED);
     assert.equal(start.mock.callCount(), 1);
     assert.equal(errorLog.mock.callCount(), 1);
-    assert.equal(errorLog.mock.calls[0]?.arguments[0], 'Repost Delete Workflow start failed');
+    const errorLogCall = errorLog.mock.calls[0];
+    assert.ok(errorLogCall);
+    assert.equal(errorLogCall.arguments[0], '%s Workflow start failed');
+    assert.equal(errorLogCall.arguments[1], 'Repost Delete');
+    assert.deepEqual(errorLogCall.arguments[2], {
+      error: new Error('Temporal unavailable'),
+      origin: 'LOCAL',
+      postId: repost.id,
+    });
   });
 
   test('deletePost payload는 선택된 Profile의 viewerRepost와 최신 Source count만 반환한다', async () => {

--- a/apps/api/tests/integration/graphql/post.test.ts
+++ b/apps/api/tests/integration/graphql/post.test.ts
@@ -662,7 +662,15 @@ describe('Post Reply GraphQL 경계', () => {
     assert.equal(result.data?.deletePost.postId, encodeGlobalId('Post', post.id));
     assert.equal(start.mock.callCount(), 1);
     assert.equal(errorLog.mock.callCount(), 1);
-    assert.equal(errorLog.mock.calls[0]?.arguments[0], 'Post Delete Workflow start failed');
+    const errorLogCall = errorLog.mock.calls[0];
+    assert.ok(errorLogCall);
+    assert.equal(errorLogCall.arguments[0], '%s Workflow start failed');
+    assert.equal(errorLogCall.arguments[1], 'Post Delete');
+    assert.deepEqual(errorLogCall.arguments[2], {
+      error: new Error('Temporal unavailable'),
+      origin: 'LOCAL',
+      postId: post.id,
+    });
   });
 
   test('Reply 삭제 transaction 실패는 ActivityPub delivery를 호출하지 않는다', async (t) => {

--- a/packages/core/services/post.ts
+++ b/packages/core/services/post.ts
@@ -402,7 +402,7 @@ export const deletePost = async ({
             }),
       );
     } catch (error) {
-      console.error(`${isRepostDelete ? 'Repost Delete' : 'Post Delete'} Workflow start failed`, {
+      console.error('%s Workflow start failed', isRepostDelete ? 'Repost Delete' : 'Post Delete', {
         error,
         origin,
         postId: deleted.id,


### PR DESCRIPTION
## 무엇을 변경했는지

- Post/Repost Delete Workflow 시작 실패 로그의 첫 번째 인자를 리터럴 포맷 문자열로 고정했습니다.
- Post Delete와 Repost Delete 구분, error·origin·postId 컨텍스트는 유지했습니다.
- API 통합 테스트가 포맷 문자열, 라벨, 구조화 컨텍스트를 각각 검증하도록 갱신했습니다.

## 왜 변경했는지

Post/Repost 구분 라벨을 포함한 템플릿 리터럴이 Semgrep의 unsafe-formatstring 규칙에 탐지됐습니다. 현재 동적 부분은 공격자 입력이 아니라 두 고정 라벨 중 하나이므로 실제 공격자 제어 경계는 확인되지 않았습니다. 첫 번째 인자를 리터럴 포맷 문자열로 고정해 이 불변 조건을 코드에 명시하고 정적 분석 경고를 제거합니다.

관련 이슈: [PROD-798](https://linear.app/byulmaru/issue/PROD-798/post-삭제-workflow-실패-로그의-동적-포맷-문자열을-제거한다)

## 이번 PR의 주요 결정

없음. 사용자 동작·도메인 계약·로그 출력 의미를 변경하지 않는 국소 하드닝입니다.

## 어떻게 확인할 수 있는지

- pnpm exec prettier --check packages/core/services/post.ts
- pnpm exec eslint packages/core/services/post.ts --max-warnings 0
- 단일 파일 TypeScript strict 검사
- git diff --check
- Node util.format probe로 기존 출력 동등성과 치환 값 내부 포맷 지정자 비재해석 확인
- 격리 PostgreSQL에서 관련 API 통합 테스트 46개 통과
- PR CI 전체 통과: Semgrep, Lint, Root, Core, Fedify, API, App, Web, Worker

## 아직 어떤 문제가 남았는지

없음.
