### PR TITLE
PROD-799 새 PR 생성을 GitHub Stack으로 통일한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@
 - Push tracked layers with `gh stack push` and create or update pull requests with `gh stack submit`.
   For two or more pull requests, submit must also create or update the remote GitHub Stack object.
   A one-layer Stack remains locally tracked and its standalone pull request has a null REST `stack`
-  field until another layer is submitted. Do not silently fall back to `gh pr create` when
-  `gh stack` is unavailable or fails, and do not accept an ordinary unstacked pull request fallback
-  offered by the extension; report the blocker and the unchanged state.
+  field until another layer is submitted. If `gh stack` is unavailable or fails, do not fall back
+  to `gh pr create` or an ordinary unstacked pull request; report the blocker and observed
+  local/remote state, including partial branch, pull request, Stack, auto-merge, or Draft changes.
 - Do not use `gh stack submit --auto` by default. Use the interactive editor, or a narrower explicit
   command whose title, body, Draft/Ready transitions, and affected existing pull requests have been
   reviewed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,32 @@
 - Use the Question tool when asking the user to decide between implementation options or unresolved requirements.
 - Do not add a `Co-authored-by` trailer for the agent in commits or PR descriptions. The author of record is the human running the agent; agent attribution belongs in the PR body or Linear, not in the git trailer.
 
+## GitHub Stacked Pull Requests
+
+- Create every new pull request, including a standalone pull request, as a GitHub Stack with the
+  official `github/gh-stack` GitHub CLI extension. A standalone pull request is a one-layer Stack.
+- Before branch or pull request work, verify the extension with `gh extension list` and
+  `gh stack --version`. If it is missing, install it for the current user with
+  `gh extension install github/gh-stack`; it is a local CLI extension, not a repository dependency.
+- Start the first layer from the latest trunk with `gh stack init --base main <Linear issue ID>`.
+  Add each later layer only from the current top with `gh stack add <Linear issue ID>`.
+- Push tracked layers with `gh stack push` and create or update pull requests with `gh stack submit`.
+  For two or more pull requests, submit must also create or update the remote GitHub Stack object.
+  A one-layer Stack remains locally tracked and its standalone pull request has a null REST `stack`
+  field until another layer is submitted. Do not silently fall back to `gh pr create` when
+  `gh stack` is unavailable or fails, and do not accept an ordinary unstacked pull request fallback
+  offered by the extension; report the blocker and the unchanged state.
+- Do not use `gh stack submit --auto` by default. Use the interactive editor, or a narrower explicit
+  command whose title, body, Draft/Ready transitions, and affected existing pull requests have been
+  reviewed.
+- After submission, verify local Stack state with `gh stack view --json` and GitHub pull request
+  head/base/stack state with the pull request REST API. For multi-layer Stacks, a base retarget or a
+  successful branch push alone does not prove that the remote GitHub Stack object exists.
+- GitHub Stack merge is distinct from pull request auto-merge and merge queue registration. Stacked
+  pull requests currently cannot retain ordinary auto-merge; report any auto-merge removal or queue
+  state change instead of hiding it. A queued Stack may land in separate groups and is not merged
+  until GitHub reports the pull requests as merged.
+
 ## CodeGraph In Linked Worktrees
 
 - For this repository, consider CodeGraph initialized only when the current worktree contains

--- a/memory/commit-pr.md
+++ b/memory/commit-pr.md
@@ -14,8 +14,8 @@
 - 하나의 브랜치는 하나의 Linear 이슈에 대응시키는 것을 기본으로 한다.
 - 새 PR은 단일 PR도 1-layer GitHub Stack으로 추적하고 `gh stack submit`으로 생성한다.
 - 후속 PR은 현재 Stack top에서 `gh stack add <Linear issue ID>`로 추가한다.
-- `gh stack`을 사용할 수 없거나 실패하면 `gh pr create`나 extension이 제안하는 일반 unstacked
-  PR로 우회하지 않고 blocker와 변경되지 않은 상태를 보고한다.
+- `gh stack`을 사용할 수 없거나 실패하면 `gh pr create`나 일반 unstacked PR로 우회하지 않고
+  blocker와 관찰한 local/remote 상태를 보고한다.
 - 커밋은 되돌릴 수 있는 작업 체크포인트로 자주 남기되, 의도하지 않은 사용자 변경은 staging하지 않는다.
 - PR은 리뷰어가 독립적으로 이해하고 검증할 수 있는 하나의 기능적 변화만 담는다.
 - stacked PR의 리뷰 순서는 GitHub PR의 `baseRefName`/`headRefName`과 로컬 Git ancestry가 함께 결정한다.

--- a/memory/commit-pr.md
+++ b/memory/commit-pr.md
@@ -4,7 +4,7 @@
 
 - 커밋, 브랜치, PR, stacked PR 작업을 시작할 때 항상 먼저 읽는 짧은 라우터다.
 - 세부 절차는 작업 상황에 맞는 하위 메모리만 추가로 읽는다.
-- 기본 도구는 Git CLI와 GitHub CLI(`gh`)다.
+- 기본 도구는 Git CLI와 공식 `github/gh-stack` GitHub CLI extension의 `gh stack`이다.
 
 ## Always Apply
 
@@ -12,9 +12,14 @@
 - 커밋/브랜치/PR 작업 전 `git status --short --branch`로 현재 위치와 변경 범위를 확인한다.
 - 브랜치 이름은 관련 Linear 이슈 ID를 그대로 사용한다.
 - 하나의 브랜치는 하나의 Linear 이슈에 대응시키는 것을 기본으로 한다.
+- 새 PR은 단일 PR도 1-layer GitHub Stack으로 추적하고 `gh stack submit`으로 생성한다.
+- 후속 PR은 현재 Stack top에서 `gh stack add <Linear issue ID>`로 추가한다.
+- `gh stack`을 사용할 수 없거나 실패하면 `gh pr create`나 extension이 제안하는 일반 unstacked
+  PR로 우회하지 않고 blocker와 변경되지 않은 상태를 보고한다.
 - 커밋은 되돌릴 수 있는 작업 체크포인트로 자주 남기되, 의도하지 않은 사용자 변경은 staging하지 않는다.
 - PR은 리뷰어가 독립적으로 이해하고 검증할 수 있는 하나의 기능적 변화만 담는다.
 - stacked PR의 리뷰 순서는 GitHub PR의 `baseRefName`/`headRefName`과 로컬 Git ancestry가 함께 결정한다.
+- Stack 생성·변경의 검증 기준과 1-layer REST 예외는 `memory/git-pr-workflow.md`를 따른다.
 - PR 제목과 본문은 한국어로 작성한다.
 - PR 제목에는 `[codex]` 같은 agent/tool 출처 prefix를 넣지 않는다.
 - PR 제목과 본문은 작업 시작 시 확인한 사용자 의도를 반영한다.
@@ -36,7 +41,9 @@
 ## Minimum Checklist
 
 - 현재 브랜치가 `main`이 아닌 적절한 작업 브랜치인가.
+- `github/gh-stack` extension이 설치되어 있고 `gh stack --version`이 성공하는가.
 - 브랜치 이름이 대응되는 Linear 이슈 ID와 일치하는가.
+- 단일 PR을 포함해 현재 브랜치가 의도한 Stack에 추적되고 있는가.
 - PR이 하나의 기능적 변화로 설명되는가.
 - 독립적으로 테스트하거나 수동 검증할 수 있는가.
 - 제목이 구현 방식이 아니라 PR의 의도와 달성하려는 결과를 설명하는가.

--- a/memory/git-pr-workflow.md
+++ b/memory/git-pr-workflow.md
@@ -4,12 +4,28 @@
 
 - 브랜치 생성, 커밋, push, PR 생성/수정, 기본 stacked PR 작업을 할 때 적용한다.
 - 기본 운영 규칙은 먼저 `memory/commit-pr.md`를 따른다.
-- 복잡한 rebase, reparent, squash merge 이후 stack 유지보수는 `memory/git-stack-maintenance.md`를 따른다.
+- 복잡한 rebase, reparent, squash merge 이후 Stack 유지보수는
+  `memory/git-stack-maintenance.md`를 따른다.
 
 ## Source Of Truth
 
-- Git 브랜치 ancestry와 GitHub PR의 `baseRefName`/`headRefName`을 source of truth로 삼는다.
-- stacked PR에서는 GitHub PR base가 리뷰 순서를 결정하므로 모든 PR의 `baseRefName`이 의도한 부모 브랜치를 가리키는지 확인한다.
+- `gh stack view --json`의 trunk와 branch order, Git 브랜치 ancestry, GitHub PR REST API의
+  base/head/stack, GitHub 원격 Stack 객체를 함께 source of truth로 삼는다.
+- stacked PR에서는 GitHub PR base가 리뷰 순서를 결정하므로 모든 PR의 `baseRefName`이 의도한
+  부모 브랜치를 가리키는지 확인한다. 단순 base retarget만으로 원격 Stack 생성이나 연결을
+  완료했다고 판단하지 않는다.
+
+## Tooling Contract
+
+- 공식 도구는 `github/gh-stack` GitHub CLI extension이다.
+  - 설치 확인: `gh extension list`, `gh stack --version`
+  - 없을 때 사용자 환경에 설치: `gh extension install github/gh-stack`
+- extension은 사용자 로컬 GitHub CLI에 설치하며 repository dependency나 workspace package로
+  추가하지 않는다.
+- `gh stack`이 없거나 명령이 실패하면 원인과 현재 local/remote 상태를 보고하고 멈춘다.
+  일반 `gh pr create`나 extension이 제안하는 ordinary unstacked PR fallback으로 우회하지 않는다.
+- 1-layer Stack은 local tracking과 `gh stack submit` 경로를 사용하지만 GitHub REST의 PR
+  `stack` 필드는 `null`이다. 원격 Stack 객체는 PR이 2개 이상일 때 생성된다.
 
 ## Common Checks
 
@@ -17,9 +33,9 @@
   - `git status --short --branch`
   - `git branch --show-current`
   - `git log --oneline --graph --decorate --all -n 30`
-- PR이 이미 있거나 stack base를 확인해야 하면 GitHub의 PR base를 확인한다.
+- PR과 Stack 상태를 확인한다.
+  - `gh stack view --json`
   - `gh pr view --json number,title,headRefName,baseRefName,isDraft,state,url`
-- 열린 PR 목록과 stack 상태가 필요하면 다음 명령을 사용한다.
   - `gh pr list --state open --json number,title,headRefName,baseRefName,isDraft,url`
 
 ## Branch Policy
@@ -31,16 +47,28 @@
 
 ## Create A Branch
 
-- 첫 PR 브랜치는 최신 trunk에서 만든다.
+- 새 작업은 단일 PR이어도 1-layer Stack으로 시작한다.
   - `git fetch origin`
   - `git switch main`
   - `git pull --ff-only`
-  - `git switch -c <Linear issue ID>`
-- 후속 PR 브랜치는 부모 브랜치에서 만든다.
-  - `git fetch origin`
-  - `git switch <parent-branch>`
-  - `git pull --ff-only origin <parent-branch>`
-  - `git switch -c <Linear issue ID>`
+  - `gh stack init --base main <Linear issue ID>`
+- 후속 PR 브랜치는 current top에서만 Stack에 추가한다.
+  - `gh stack top`
+  - `gh stack add <Linear issue ID>`
+- `gh stack add`는 현재 HEAD에서 새 branch를 만들고 Stack top으로 checkout한다. branch 자동 생성
+  이름 대신 Linear issue ID를 명시한다.
+
+## Adopt Existing Branches Or Pull Requests
+
+- 기존 branch chain은 먼저 bottom-to-top linear ancestry와 예상 PR base를 확인한 뒤 adopt한다.
+  - `git merge-base --is-ancestor <lower-branch> <upper-branch>`
+  - `gh stack init --base main <bottom-branch> <next-branch> ... <top-branch>`
+  - `gh stack view --json`
+- 기존 열린 PR이 있으면 안전한 대화형 `gh stack submit`에서 기존 PR 연결과 변경될 base/Ready
+  상태를 확인한다. 기존 PR의 title/body는 editor에서 잠기므로 필요하면 별도 `gh pr edit`이나
+  GitHub UI에서 명시적으로 수정한다. `gh stack submit --auto`를 기본값으로 쓰지 않는다.
+- submit 후에는 각 PR의 base/head/stack과, 2-layer 이상이면 원격 Stack 객체를 다시 확인한다.
+  기존 PR base만 맞췄다고 adopt가 끝난 것은 아니다.
 
 ## Create A Commit
 
@@ -55,26 +83,45 @@
 
 ## Open A PR
 
-- 원격 브랜치를 먼저 올린다.
-  - `git push -u origin HEAD`
-- 첫 PR은 `main`을 base로 연다.
-  - `gh pr create --draft --base main --head <branch> --title "<Korean title>" --body "<Korean body>"`
-- 후속 PR은 부모 브랜치를 base로 연다.
-  - `gh pr create --draft --base <parent-branch> --head <branch> --title "<Korean title>" --body "<Korean body>"`
-- PR 본문에는 stack 위치를 명시한다.
+- branch만 원격에 올릴 때는 `gh stack push`를 사용한다. 이 명령은 PR이나 원격 Stack 객체를
+  만들지 않는다.
+- PR은 `gh stack submit`으로 생성하거나 갱신한다. 2-layer 이상이면 이 명령이 원격 Stack 객체도
+  함께 생성하거나 갱신해야 한다.
+  - 기본은 대화형 editor에서 PR별 한국어 제목, 본문, Draft/Ready 상태, 포함 범위를 확인한다.
+  - 검증이 끝난 PR은 repository Ready 정책에 맞게 Ready로 제출한다.
+  - `--open`은 Stack의 새 PR과 기존 PR을 모두 Ready로 바꾸려는 의도가 명확할 때만 쓴다.
+  - `--auto`는 editor를 생략하고 자동 제목과 더 넓은 PR 변경을 적용할 수 있으므로 기본값으로
+    쓰지 않는다.
+- PR 본문에는 Stack 위치를 명시한다.
   - `Stack: main -> <parent-branch> -> <this-branch>`
-- 이미 열린 PR의 base가 틀리면 다음 명령으로 고친다.
-  - `gh pr edit <branch-or-pr-number> --base <parent-branch>`
+- submit 직후 다음을 확인한다.
+  - `gh stack view --json`
+  - `gh pr view <branch-or-pr-number> --json number,title,headRefName,baseRefName,isDraft,state,url`
+  - `gh api "repos/{owner}/{repo}/pulls/<number>" --jq '{base:.base.ref,head:.head.ref,stack:.stack}'`
+  - 2-layer 이상이면 `gh api "repos/{owner}/{repo}/stacks?pull_request=<number>"`로 원격 Stack
+    객체와 bottom-to-top branch order
+- 1-layer PR의 REST `stack: null`은 공식 API의 정상 표현이다. 이 경우 local 1-layer tracking과
+  `gh stack submit` 생성 경로는 보고하되 원격 Stack 객체가 생성됐다고 주장하지 않는다.
+- `gh stack submit`이 실패하면 부분적으로 생성·수정된 PR, branch push, auto-merge/Draft 상태를
+  조회해 보고하고 멈춘다. `gh pr create`나 ordinary unstacked PR fallback으로 나머지를 만들지
+  않는다.
 
 ## Edit A PR
 
-- 열린 PR의 제목, 본문, base, Draft/Ready 상태 변경은 `gh` 명령을 사용한다.
+- 열린 PR의 제목, 본문, Draft/Ready 상태 같은 Stack 구조와 무관한 변경에는 일반 `gh pr` 명령을
+  사용할 수 있다.
+- PR base나 Stack 순서를 바꿀 때는 `memory/git-stack-maintenance.md`의 `gh stack` restructure와
+  submit 절차를 따른다. `gh pr edit --base`만 실행하고 Stack 변경이 끝났다고 주장하지 않는다.
 - PR 본문 형식은 `memory/pr-writing.md`를 따른다.
-- Ready for review로 전환하기 전에는 현재 HEAD가 정상 동작하고 PR 범위가 리뷰 가능한 단위인지 다시 확인한다.
+- Ready for review로 전환하기 전에는 현재 HEAD가 정상 동작하고 PR 범위가 리뷰 가능한 단위인지
+  다시 확인한다.
 
 ## Merge And Closeout
 
 - merge 직전에 PR head SHA, base, checks, merge state와 unresolved review thread를 새로 조회한다.
-- merge queue 또는 auto-merge 등록은 merge 완료가 아니다. squash merge를 요청할 때는 가능하면 확인한 head
-  SHA를 `--match-head-commit <sha>`로 고정하고, 등록 뒤 `state: MERGED`, `mergedAt`, `mergeCommit.oid`를
-  다시 확인한다.
+- Stack merge는 `gh stack merge` 또는 GitHub Stack UI/API의 bottom-up merge 흐름을 사용한다.
+- stacked PR에는 기존 PR auto-merge를 사용할 수 없으므로 Stack 생성 과정에서 auto-merge가
+  해제되면 반드시 보고한다. 일반 auto-merge 해제를 merge나 queue 등록으로 표현하지 않는다.
+- merge queue를 사용하는 repository에서는 Stack이 함께 queue에 들어가도 각 PR이 별도 group으로
+  처리될 수 있다. queue 등록은 merge 완료가 아니며, 각 PR의 `state: MERGED`, `mergedAt`,
+  `mergeCommit.oid`를 다시 확인한다.

--- a/memory/git-stack-maintenance.md
+++ b/memory/git-stack-maintenance.md
@@ -2,103 +2,112 @@
 
 ## Purpose
 
-- 부모 브랜치 rewrite, squash merge 이후 자식 PR 이어가기, reparent, force-push가 필요할 때 적용한다.
+- 기존 branch/PR adopt, 부모 branch rewrite, cascading rebase, reparent, squash merge 이후 Stack
+  유지보수에 적용한다.
 - 기본 브랜치/PR 작업은 `memory/git-pr-workflow.md`를 따른다.
-- 이 문서는 Git 브랜치 ancestry와 GitHub PR base를 직접 관리하는 공식 stack 유지보수 절차다.
+- 공식 `github/gh-stack` extension으로 local branch chain, PR base, 다층 원격 GitHub Stack 객체를
+  함께 관리하되 Git 복구·lease 검증 규칙을 약화하지 않는다.
 
 ## Safety Rules
 
-- stack을 재작성하기 전에는 현재 브랜치 위치를 복구 가능한 백업 브랜치로 남긴다.
+- 변경 전 `gh stack view --json`, PR API, `git log --graph`로 현재 trunk, branch order, PR
+  base/head, 원격 Stack을 기록한다.
+- Stack을 재작성하기 전에 영향받는 모든 branch tip을 복구 가능한 backup branch로 남긴다.
   - `git branch backup/<branch>-<timestamp> <branch>`
-- 원격 브랜치가 rebase나 force-push로 rewrite되어 일반 fetch가 non-fast-forward로 거절되면, 대상 브랜치와 PR head를 먼저 확인한 뒤 해당 ref만 명시적으로 갱신한다.
-  - `git fetch origin +refs/heads/<branch>:refs/remotes/origin/<branch>`
-  - 모든 remote branch에 broad force refspec을 적용하지 않는다.
-- 여러 층을 다시 쓰는 작업에서는 각 브랜치의 직전 부모 tip을 잃지 않도록 영향받는 하위 브랜치 tip을 모두 먼저 백업한다.
-- `git rebase --onto <new-base> <old-base> <branch>`의 `<old-base>`는 항상 해당 브랜치가 기존에 쌓여 있던 직전 부모의 이전 tip이어야 한다.
-- rebase 또는 reparent 후에는 `git range-diff`나 `git log --graph`로 의도한 커밋만 이동했는지 확인한다.
-- 공유 브랜치를 다시 push할 때는 branch별 expected remote SHA를 지정한 `--force-with-lease=<branch>:<expected-remote-sha>`만 사용한다.
-  - rebase 전에 `git fetch origin` 후 `git rev-parse origin/<branch>`로 `<expected-remote-sha>`를 기록한다.
-  - rebase 전에 `git merge-base --is-ancestor origin/<branch> <branch>`로 로컬 브랜치가 원격 head를 포함하는지 확인한다.
-  - 원격 head가 로컬에 포함되어 있지 않으면 force-push하지 않는다. `git log --oneline <branch>..origin/<branch>`로 원격-only 커밋을 확인하고, 필요한 커밋을 먼저 통합한 뒤 다시 진행한다.
-  - 기본 `git push --force-with-lease`는 직전 `fetch`로 갱신된 원격 추적 ref를 기준으로 삼을 수 있어, 로컬에 포함하지 않은 원격 변경을 덮어쓸 수 있으므로 사용하지 않는다.
-
-## Update A Child After Parent Rewrite
-
-- 부모 브랜치가 force-push나 rebase로 다시 쓰일 수 있으면 자식 브랜치의 기존 base였던 부모 tip을 먼저 백업 ref나 commit SHA로 남긴다.
-  - `<old-parent-tip>`은 자식 브랜치가 쌓여 있던 이전 부모 tip이며, fetch/pull/rebase로 ref가 이동하기 전에 `git rev-parse <parent-branch>` 또는 `git rev-parse origin/<parent-branch>`로 확인한다.
-  - `<old-parent-tip>`은 자식 브랜치 히스토리에 포함된 경계 커밋이어야 하므로, 의심스러우면 `git merge-base --is-ancestor <old-parent-tip> <child-branch>`로 확인한다.
-  - `git branch backup/<parent-branch>-before-update-<timestamp> <old-parent-tip>`
-  - `git branch backup/<child-branch>-before-parent-update-<timestamp> <child-branch>`
-  - `git branch backup/<grandchild-branch>-before-parent-update-<timestamp> <grandchild-branch>`
-- 부모 브랜치가 push된 최신 상태라면 자식 고유 커밋만 새 부모 브랜치 위로 rebase한다.
-  - `git fetch origin`
-  - `git switch <child-branch>`
-  - `git rev-parse origin/<child-branch>`로 `<expected-child-remote-sha>`를 기록
-  - `git merge-base --is-ancestor origin/<child-branch> <child-branch>`
-  - `git rebase --onto origin/<parent-branch> backup/<parent-branch>-before-update-<timestamp> <child-branch>`
-  - `git push --force-with-lease=<child-branch>:<expected-child-remote-sha> origin <child-branch>`
-- 자식 PR이 또 다른 PR의 부모라면, 그 아래 브랜치도 갱신된 직전 부모 브랜치 위로 차례대로 rebase한다.
-  - `git switch <grandchild-branch>`
-  - `git rev-parse origin/<grandchild-branch>`로 `<expected-grandchild-remote-sha>`를 기록
-  - `git merge-base --is-ancestor origin/<grandchild-branch> <grandchild-branch>`
-  - `git rebase --onto <child-branch> backup/<child-branch>-before-parent-update-<timestamp> <grandchild-branch>`
-  - `git push --force-with-lease=<grandchild-branch>:<expected-grandchild-remote-sha> origin <grandchild-branch>`
-  - `gh pr edit <grandchild-branch> --base <child-branch>`
-- 더 깊은 stack도 같은 규칙을 반복한다. 예를 들어 `main -> A -> B -> C -> D`에서 `A`가 rewrite되면 `B`는 갱신된 `A` 위로 옮기고, `C`는 갱신된 `B` 위로, `D`는 갱신된 `C` 위로 옮긴다.
-- 부모 브랜치가 fast-forward로만 변경됐다는 점이 확실할 때는 `git rebase origin/<parent-branch>`도 동작하지만, 부모가 rewrite됐거나 확실하지 않으면 사용하지 않는다.
-- `git rebase origin/<parent-branch>`는 `<upstream>`만 지정하는 형태라 old-base 경계를 받지 못한다. 부모가 rewrite된 뒤 이 명령을 쓰면 기존 부모 커밋까지 자식 브랜치에서 replay되어 충돌하거나 자식 PR diff에 부모 변경이 섞일 수 있다.
-- 충돌 해결 후에는 `git status`, 관련 테스트, `git log --graph`를 확인한다.
-
-## Continue Child PR After Parent Squash Merge
-
-- 부모 PR을 squash merge하기 전, 또는 merge 직후 부모 ref를 삭제하거나 prune하기 전에 rebase 경계로 사용할 기존 branch tip을 백업 ref나 commit SHA로 남긴다.
-  - 이 백업은 작업 중인 파일을 보관하기 위한 것이 아니라, `git rebase --onto`의 `<old-base>` 기준점을 잃지 않기 위한 것이다.
-  - `git stash`는 uncommitted worktree/index 변경 보관용이므로 이 기준점을 대체하지 못한다.
-  - `git branch backup/<merged-parent>-before-squash-<timestamp> <merged-parent>`
-  - `git branch backup/<child-branch>-before-squash-<timestamp> <child-branch>`
-  - `git branch backup/<grandchild-branch>-before-squash-<timestamp> <grandchild-branch>`
-- 이미 부모 ref가 삭제됐다면 먼저 local reflog, PR commit 목록, 또는 남아 있는 descendant 히스토리에서 이전 부모 tip을 복구해 백업한 뒤 진행한다.
-- squash merge된 PR의 직계 자식만 최신 `main` 위로 옮긴다.
-  - `git fetch origin`
-  - `git switch <child-branch>`
-  - `git rev-parse origin/<child-branch>`로 `<expected-child-remote-sha>`를 기록
-  - `git merge-base --is-ancestor origin/<child-branch> <child-branch>`
-  - `git rebase --onto origin/main backup/<merged-parent>-before-squash-<timestamp> <child-branch>`
-  - `git push --force-with-lease=<child-branch>:<expected-child-remote-sha> origin <child-branch>`
-  - `gh pr edit <child-branch> --base main`
-- 손자 이하 브랜치도 결과적으로 새 `main`을 포함하도록 다시 써진다. 다만 `main` 위로 직접 옮기지 않고, 갱신된 직전 부모 브랜치 위로 차례대로 옮긴다.
-  - `git switch <grandchild-branch>`
-  - `git rev-parse origin/<grandchild-branch>`로 `<expected-grandchild-remote-sha>`를 기록
-  - `git merge-base --is-ancestor origin/<grandchild-branch> <grandchild-branch>`
-  - `git rebase --onto <child-branch> backup/<child-branch>-before-squash-<timestamp> <grandchild-branch>`
-  - `git push --force-with-lease=<grandchild-branch>:<expected-grandchild-remote-sha> origin <grandchild-branch>`
-  - `gh pr edit <grandchild-branch> --base <child-branch>`
-- 더 깊은 stack도 같은 규칙을 반복한다. 예를 들어 `main -> A -> B -> C -> D`에서 `A`가 squash merge되면 `B`만 `origin/main` 위로 옮기고, `C`는 갱신된 `B` 위로, `D`는 갱신된 `C` 위로 옮긴다. 이 과정을 끝내면 `C`와 `D`도 새 `main` 위의 히스토리를 갖지만, PR base는 각각 `B`, `C`로 유지된다.
-- 3층 이상 stack의 맨 위 브랜치에서 `git rebase --onto origin/main <merged-parent> <top-branch>`를 바로 실행하면 중간 PR의 커밋까지 맨 위 PR에 포함될 수 있으므로 사용하지 않는다.
-
-## Reparent A PR
-
-- PR의 부모를 바꿔야 하면 local ancestry와 GitHub PR base를 같이 바꾼다. 이때도 현재 브랜치가 쌓여 있던 기존 부모 tip을 rebase 경계로 남긴다.
-  - `<old-parent-tip>`은 현재 브랜치가 기존에 쌓여 있던 직전 부모의 이전 tip이며, fetch/pull/rebase로 ref가 이동하기 전에 기록한다.
-  - 의심스러우면 `git merge-base --is-ancestor <old-parent-tip> <branch>`로 `<old-parent-tip>`이 현재 브랜치 히스토리에 포함된 경계인지 확인한다.
-  - `git branch backup/<old-parent-branch>-before-reparent-<timestamp> <old-parent-tip>`
-  - `git branch backup/<branch>-before-reparent-<timestamp> <branch>`
-  - `git branch backup/<child-branch>-before-reparent-<timestamp> <child-branch>`
-  - `git branch backup/<grandchild-branch>-before-reparent-<timestamp> <grandchild-branch>`
-  - `git fetch origin`
-  - `git switch <branch>`
-  - `git rev-parse origin/<branch>`로 `<expected-branch-remote-sha>`를 기록
+- `git fetch origin` 후 branch별 expected remote SHA를 기록하고 원격-only commit이 없는지 확인한다.
+  - `git rev-parse origin/<branch>`
   - `git merge-base --is-ancestor origin/<branch> <branch>`
-  - `git rebase --onto origin/<new-parent-branch> backup/<old-parent-branch>-before-reparent-<timestamp> <branch>`
-  - `git push --force-with-lease=<branch>:<expected-branch-remote-sha> origin <branch>`
-  - `gh pr edit <branch> --base <new-parent-branch>`
-- reparent한 브랜치가 또 다른 PR의 부모라면, 하위 브랜치들도 갱신된 직전 부모 브랜치 위로 차례대로 rebase한다.
-  - `git switch <child-branch>`
-  - `git rev-parse origin/<child-branch>`로 `<expected-child-remote-sha>`를 기록
-  - `git merge-base --is-ancestor origin/<child-branch> <child-branch>`
-  - `git rebase --onto <branch> backup/<branch>-before-reparent-<timestamp> <child-branch>`
-  - `git push --force-with-lease=<child-branch>:<expected-child-remote-sha> origin <child-branch>`
-  - `gh pr edit <child-branch> --base <branch>`
-- 더 깊은 하위 브랜치도 같은 규칙을 반복한다. 각 단계의 old-base는 해당 브랜치가 기존에 쌓여 있던 직전 부모의 reparent 전 tip이며, 이 old-base로 쓸 직전 부모 tip도 첫 rebase 전에 백업해 둔다.
-- 기존 부모 브랜치가 rewrite됐거나 rewrite 여부가 불확실하면 `origin/<old-parent-branch>`를 old-base로 직접 쓰지 않는다.
-- reparent 후에는 `gh pr view --json headRefName,baseRefName,url`로 GitHub base가 맞는지 확인한다.
+  - 원격 head가 포함되지 않으면 `git log --oneline <branch>..origin/<branch>`를 확인하고 멈춘다.
+- restructure/rebase 전 worktree가 clean하고 merge/rebase가 진행 중이 아니며 queued PR이 없는지
+  확인한다.
+- rebase 또는 reparent 뒤 `git range-diff`와 `git log --graph`로 각 layer의 고유 commit만
+  이동했는지 확인한다.
+- `gh stack push`는 branch별 explicit `--force-with-lease`를 사용하지만 multi-branch push는
+  atomic하지 않다. 일부 branch만 갱신될 수 있으므로 명령 후 모든 remote SHA를 다시 확인한다.
+- 수동 복구 push가 필요하면 반드시 기록한 SHA를 넣은
+  `git push --force-with-lease=<branch>:<expected-remote-sha> origin <branch>`만 사용한다.
+  인자 없는 `--force-with-lease`나 broad force refspec은 사용하지 않는다.
+- `gh stack`이 실패하면 `gh pr create`, extension이 제안하는 ordinary unstacked PR, base
+  retarget으로 우회하지 않는다. 부분 branch push, PR 상태, 원격 Stack 상태를 조회해 blocker로
+  보고한다.
+
+## Adopt Existing Branches Or Pull Requests
+
+- 기존 branch는 bottom-to-top linear ancestry를 먼저 검증한다.
+  - `git merge-base --is-ancestor <bottom-branch> <next-branch>`
+  - 더 깊은 branch도 같은 검사를 반복한다.
+- local Stack으로 adopt한다.
+  - `gh stack init --base main <bottom-branch> <next-branch> ... <top-branch>`
+  - `gh stack view --json`
+- 기존 열린 PR은 대화형 `gh stack submit`에서 연결 대상과 변경될 base/Draft 상태를 확인해
+  submit한다. `--auto`를 기본값으로 사용하지 않는다.
+- submit 뒤 PR REST API에서 `main <- bottom <- ... <- top` base/head chain을 확인하고, 2-layer
+  이상이면 원격 GitHub Stack 객체가 존재하는지 확인한다. base retarget만으로 adopt 완료를
+  주장하지 않는다.
+
+## Cascading Rebase And Sync
+
+- 최신 trunk를 반영하는 일반 흐름은 backup과 expected SHA 기록 후 공식 명령을 사용한다.
+  - 전체 동기화: `gh stack sync`
+  - 충돌을 직접 처리할 cascading rebase: `gh stack rebase`
+  - 현재 branch 위쪽만: `gh stack rebase --upstack`
+  - trunk를 건드리지 않고 layer끼리만: `gh stack rebase --no-trunk`
+- `gh stack sync`는 fetch, trunk fast-forward, cascading rebase, lease push, PR/Stack sync를 함께
+  수행한다. remote와 local Stack이 diverged됐다는 선택지가 나오면 어느 쪽을 source of truth로
+  삼을지 추론하지 않고 멈춰 보고한다. 2-layer 이상이면 sync 뒤 원격 Stack 객체도 검증한다.
+- 충돌 시 파일과 기존 parent boundary를 확인한다. 의도가 명확하면 해결·stage 후
+  `gh stack rebase --continue`, 불명확하면 `gh stack rebase --abort`로 모든 branch를 복원한다.
+- 성공 뒤 rebase 전 backup과 각 새 branch 사이를 `git range-diff`하고, `gh stack push` 또는
+  `gh stack submit` 뒤 local/remote SHA와 PR base/head를 다시 확인한다.
+
+## Reparent Or Restructure A Stack
+
+- 같은 Stack 안에서 parent/order를 바꾸려면 backup과 expected SHA를 기록한 뒤
+  `gh stack modify`를 사용한다. TUI에서 reorder/drop/fold/insert/rename 결과를 저장하면 cascading
+  rebase가 적용된다.
+- 충돌은 `gh stack modify --continue`로 이어가거나 `gh stack modify --abort`로 pre-modify 상태를
+  복원한다.
+- 저장 후 다음 검사를 통과해야 remote에 반영한다.
+  - `git merge-base --is-ancestor <new-parent> <branch>`
+  - `git range-diff <old-parent>..<backup-branch> <new-parent>..<branch>`
+  - `git log --oneline --graph --decorate --all -n 30`
+- `gh stack submit`으로 branch를 push하고 PR base를 갱신하며, 2-layer 이상이면 원격 Stack 객체를
+  다시 만든다. 이후 `gh stack view --json`과 PR API를 함께 확인한다.
+- 다른 Stack으로 옮기는 등 `gh stack modify`로 표현할 수 없는 변경은 blocker로 보고한다.
+  원격 Stack 삭제·재생성이 명시적으로 승인되면 `gh stack unstack`, 안전한 Git ancestry 변경,
+  `gh stack init --base <trunk> <branches...>`, `gh stack submit` 순서로 복구한다. `unstack`은 PR을
+  보존해도 원격 Stack 객체를 변경하므로 상태 변경을 숨기지 않는다.
+- `gh pr edit --base`만으로 reparent 완료를 주장하지 않는다.
+
+## Continue After Parent Merge
+
+- merge 전 영향받는 branch tip을 backup하고 Stack/PR 상태를 기록한다. squash merge 후 원래
+  commit이 사라져도 official CLI는 merged PR 경계를 `--onto` 방식으로 처리한다.
+- merge 직후 다음을 수행한다.
+  - `gh stack sync`
+  - conflict가 나면 `gh stack rebase`로 전환해 해결하거나 abort한다.
+  - `git range-diff`와 `git log --graph`로 미병합 branch의 고유 commit만 남았는지 확인한다.
+  - `gh stack submit` 후 남은 PR의 base/head와, 2-layer 이상이면 원격 Stack order를 확인한다.
+- 중간 PR만 고립해서 merge할 수 있다고 가정하지 않는다. Stack merge는 선택한 PR과 그 아래
+  미병합 PR을 bottom-up으로 처리하고, 위쪽 PR은 자동 cascading rebase 대상이 된다.
+
+## Merge, Auto-Merge, And Merge Queue
+
+- Stack은 `gh stack merge` 또는 GitHub Stack UI/API로 merge한다. direct Stack merge는 선택한
+  PR까지 all-or-nothing이지만, merge queue에서는 PR들이 함께 등록되어도 별도 group으로 순차
+  처리될 수 있다.
+- stacked PR에는 일반 auto-merge가 지원되지 않는다. 기존 PR을 Stack으로 연결하면서 auto-merge가
+  해제되면 정확히 보고하고, 이를 Stack merge 요청이나 queue 등록으로 표현하지 않는다.
+- queue 등록, merge 요청, green check는 완료가 아니다. 모든 대상 PR의 `state: MERGED`,
+  `mergedAt`, `mergeCommit.oid`와 남은 Stack order를 확인한다.
+
+## Manual Recovery Boundary
+
+- official CLI가 실패한 뒤 local ancestry 복구가 필요할 때만 backup을 기준으로 수동
+  `git rebase --onto <new-base> <old-parent-tip> <branch>`를 사용한다.
+- `<old-parent-tip>`은 branch가 기존에 쌓인 직전 parent의 이전 tip이어야 하며, 사용 전
+  `git merge-base --is-ancestor <old-parent-tip> <branch>`로 경계를 확인한다.
+- 자식부터 한 번에 trunk로 옮기지 않는다. `main -> A -> B -> C`에서 A가 바뀌면 B를 A 위로,
+  C를 갱신된 B 위로 차례대로 옮긴다.
+- 수동 복구 뒤에도 explicit lease push와 `gh stack submit`을 거쳐야 한다. 다층 Stack은 local
+  ancestry와 PR base가 맞더라도 원격 GitHub Stack 객체 검증 전에는 완료가 아니다.


### PR DESCRIPTION
## 무엇을 변경했나요

- 모든 신규 PR을 단일 PR까지 공식 `github/gh-stack` 흐름으로 생성하도록 repository instruction을 추가했습니다.
- 기본 branch/PR 절차를 `gh stack init/add/push/submit`과 REST Stack 검증 기준으로 전환했습니다.
- 기존 branch/PR adopt, cascading rebase, reparent, squash merge 이후 sync를 공식 Stack 명령과 정렬하면서 backup, range-diff, explicit lease 규칙을 유지했습니다.
- stacked PR auto-merge 미지원과 merge queue의 비원자적 처리, 상태 변경 보고 의무를 명시했습니다.

## 왜 변경했나요

기존 문서는 신규 PR을 `gh pr create`로 만들고 PR base를 직접 조정하도록 안내해 GitHub의 공식 Stack 객체와 로컬 branch chain이 분리될 수 있었습니다. 새 PR 생성 경로를 공식 `gh stack`으로 통일하고 실패 시 우회하지 않게 해, 리뷰 순서와 원격 Stack 상태를 검증 가능한 한 흐름으로 관리합니다.

## 이번 PR의 주요 결정

### 모든 신규 PR을 공식 GitHub Stack 흐름으로 생성

- 결정자: @robin-maki
- 선택: 단일 PR도 local 1-layer Stack으로 추적하고 `gh stack submit`으로 생성하며, 후속 PR은 current top에서 `gh stack add`로 추가합니다.
- 고려한 대안: 단일 PR은 `gh pr create`를 유지하고 다층 작업에만 `gh stack`을 사용합니다.
- 이유: PR 수와 무관하게 생성·검증 절차를 하나로 유지하고 후속 layer 추가 시 별도 adopt 없이 Stack을 이어가기 위해서입니다.
- 감수한 결과: 공식 REST 계약상 1-layer PR의 `stack`은 `null`이며, 원격 Stack 객체는 2-layer 이상에서만 생성됩니다.
- 관련 근거: [PROD-799](https://linear.app/byulmaru/issue/PROD-799/새-pull-request를-github-공식-stacked-pr-흐름으로-생성한다), [GitHub Stacked PR Quick Start](https://github.github.com/gh-stack/getting-started/quick-start/), [REST API](https://github.github.com/gh-stack/reference/rest-api/)

### `gh stack` 실패를 blocker로 유지

- 결정자: @robin-maki
- 선택: `gh stack`이 없거나 실패하면 `gh pr create` 또는 extension이 제안하는 ordinary unstacked PR로 우회하지 않습니다.
- 고려한 대안: 일반 PR을 먼저 만든 뒤 base retarget이나 사후 adopt로 보정합니다.
- 이유: branch push나 base retarget만으로는 공식 원격 Stack 객체 생성과 Stack membership을 증명할 수 없기 때문입니다.
- 감수한 결과: extension 또는 repository Stack 기능이 막히면 PR 생성이 중단되고 blocker 해소가 필요합니다.
- 관련 근거: [PROD-799](https://linear.app/byulmaru/issue/PROD-799/새-pull-request를-github-공식-stacked-pr-흐름으로-생성한다), [gh-stack CLI](https://github.github.com/gh-stack/reference/cli/)

## 어떻게 확인할 수 있나요

- `git diff --check`
- `pnpm exec prettier --check AGENTS.md memory/commit-pr.md memory/git-pr-workflow.md memory/git-stack-maintenance.md memory/pr-writing.md .github/pull_request_template.md`
- 저장소 전체 검색으로 신규 PR 생성용 `gh pr create`, `git push -u origin HEAD`, 직접 base retarget 지시가 남지 않았음을 확인했습니다. 남은 `gh pr create`/`gh pr edit --base` 문자열은 우회 금지 규칙뿐입니다.
- `gh extension list`, `gh stack --version`에서 `github/gh-stack v0.1.0`을 확인했습니다.
- `gh stack view --json`에서 `main <- PROD-799` 1-layer local Stack을 확인했습니다.

Stack: main -> PROD-799

## 아직 어떤 문제가 남았나요

없음. 이 PR은 문서와 협업 절차만 변경하며 dev 또는 production 동작을 증명하지 않습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>