### PR TITLE
Web E2E를 독립 Temporal shard로 병렬 실행한다

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,39 +20,23 @@ jobs:
         include:
           - name: Root
             command: pnpm test:eslint
-            database: false
-            id: root
-            playwright: false
           - name: Core
             command: pnpm --filter @kosmo/core test
             database: true
-            id: core
-            playwright: false
           - name: Fedify
             command: pnpm --filter @kosmo/fedify test
             database: true
-            id: fedify
-            playwright: false
           - name: API
             command: pnpm --filter @kosmo/api test
             database: true
-            id: api
-            playwright: false
           - name: App
             command: pnpm --filter @kosmo/app test
-            database: false
-            id: app
             playwright: true
           - name: Web
             command: pnpm --filter @kosmo/web check && pnpm --filter @kosmo/web test:unit
-            database: false
-            id: web
-            playwright: false
           - name: Worker
             command: pnpm --filter @kosmo/worker test
             database: true
-            id: worker
-            playwright: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -108,7 +92,7 @@ jobs:
         run: pnpm db:test:drop
 
   web_e2e:
-    name: Web E2E (shard ${{ matrix.shard }}/${{ matrix.total }})
+    name: Web E2E (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     strategy:
@@ -116,19 +100,13 @@ jobs:
       matrix:
         include:
           - shard: 1
-            total: 3
-            database_name: kosmo_test_web_e2e_shard_1
             port_offset: 10000
           - shard: 2
-            total: 3
-            database_name: kosmo_test_web_e2e_shard_2
             port_offset: 20000
           - shard: 3
-            total: 3
-            database_name: kosmo_test_web_e2e_shard_3
             port_offset: 30000
     env:
-      DATABASE_URL: postgres://kosmo:kosmo@localhost:54329/${{ matrix.database_name }}
+      DATABASE_URL: postgres://kosmo:kosmo@localhost:54329/kosmo_test_web_e2e_shard_${{ matrix.shard }}
       KOSMO_TEST_PORT_OFFSET: ${{ matrix.port_offset }}
     steps:
       - name: Checkout repository
@@ -175,7 +153,7 @@ jobs:
         run: pnpm --filter @kosmo/app exec playwright install chromium
 
       - name: Run Web E2E shard
-        run: node scripts/test-db.mjs run -- pnpm test:e2e:database --shard=${{ matrix.shard }}/${{ matrix.total }}
+        run: node scripts/test-db.mjs run -- pnpm test:e2e:database --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: Upload Playwright artifacts
         if: failure()
@@ -202,9 +180,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Require every test suite
-        env:
-          TEST_SUITES_RESULT: ${{ needs.test-suites.result }}
-          WEB_E2E_RESULT: ${{ needs.web_e2e.result }}
         run: |
-          test "${TEST_SUITES_RESULT}" = success
-          test "${WEB_E2E_RESULT}" = success
+          test "${{ needs.test-suites.result }}" = success
+          test "${{ needs.web_e2e.result }}" = success

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,21 +116,17 @@ jobs:
       matrix:
         include:
           - shard: 1
-            total: 4
+            total: 3
             database_name: kosmo_test_web_e2e_shard_1
             port_offset: 10000
           - shard: 2
-            total: 4
+            total: 3
             database_name: kosmo_test_web_e2e_shard_2
             port_offset: 20000
           - shard: 3
-            total: 4
+            total: 3
             database_name: kosmo_test_web_e2e_shard_3
             port_offset: 30000
-          - shard: 4
-            total: 4
-            database_name: kosmo_test_web_e2e_shard_4
-            port_offset: 40000
     env:
       DATABASE_URL: postgres://kosmo:kosmo@localhost:54329/${{ matrix.database_name }}
       KOSMO_TEST_PORT_OFFSET: ${{ matrix.port_offset }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
         run: pnpm --filter @kosmo/app exec playwright install --with-deps chromium
 
       - name: Run Web E2E shard
-        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/${{ matrix.total }}
+        run: node scripts/test-db.mjs run -- pnpm test:e2e:database --shard=${{ matrix.shard }}/${{ matrix.total }}
 
       - name: Upload Playwright artifacts
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright Chromium
+      - name: Get Playwright version
+        id: playwright-version
         if: matrix.playwright
-        run: pnpm --filter @kosmo/app exec playwright install --with-deps chromium
+        shell: bash
+        run: echo "version=$(pnpm --filter @kosmo/app exec playwright --version | sed 's/^Version //')" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        if: matrix.playwright
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright OS dependencies
+        if: matrix.playwright
+        run: pnpm --filter @kosmo/app exec playwright install-deps chromium
+
+      - name: Install Playwright Chromium
+        if: matrix.playwright && steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @kosmo/app exec playwright install chromium
 
       - name: Run ${{ matrix.name }} tests
         run: ${{ matrix.command }}
@@ -133,8 +151,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        shell: bash
+        run: echo "version=$(pnpm --filter @kosmo/app exec playwright --version | sed 's/^Version //')" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright OS dependencies
+        run: pnpm --filter @kosmo/app exec playwright install-deps chromium
+
       - name: Install Playwright Chromium
-        run: pnpm --filter @kosmo/app exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @kosmo/app exec playwright install chromium
 
       - name: Run Web E2E shard
         run: node scripts/test-db.mjs run -- pnpm test:e2e:database --shard=${{ matrix.shard }}/${{ matrix.total }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,17 +116,21 @@ jobs:
       matrix:
         include:
           - shard: 1
-            total: 3
+            total: 4
             database_name: kosmo_test_web_e2e_shard_1
             port_offset: 10000
           - shard: 2
-            total: 3
+            total: 4
             database_name: kosmo_test_web_e2e_shard_2
             port_offset: 20000
           - shard: 3
-            total: 3
+            total: 4
             database_name: kosmo_test_web_e2e_shard_3
             port_offset: 30000
+          - shard: 4
+            total: 4
+            database_name: kosmo_test_web_e2e_shard_4
+            port_offset: 40000
     env:
       DATABASE_URL: postgres://kosmo:kosmo@localhost:54329/${{ matrix.database_name }}
       KOSMO_TEST_PORT_OFFSET: ${{ matrix.port_offset }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,13 +116,17 @@ jobs:
       matrix:
         include:
           - shard: 1
-            total: 2
+            total: 3
             database_name: kosmo_test_web_e2e_shard_1
             port_offset: 10000
           - shard: 2
-            total: 2
+            total: 3
             database_name: kosmo_test_web_e2e_shard_2
             port_offset: 20000
+          - shard: 3
+            total: 3
+            database_name: kosmo_test_web_e2e_shard_3
+            port_offset: 30000
     env:
       DATABASE_URL: postgres://kosmo:kosmo@localhost:54329/${{ matrix.database_name }}
       KOSMO_TEST_PORT_OFFSET: ${{ matrix.port_offset }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,10 @@ jobs:
             id: app
             playwright: true
           - name: Web
-            command: pnpm --filter @kosmo/web test
-            database: true
+            command: pnpm --filter @kosmo/web check && pnpm --filter @kosmo/web test:unit
+            database: false
             id: web
-            playwright: true
+            playwright: false
           - name: Worker
             command: pnpm --filter @kosmo/worker test
             database: true
@@ -85,11 +85,65 @@ jobs:
       - name: Run ${{ matrix.name }} tests
         run: ${{ matrix.command }}
 
+      - name: Clean up test database
+        if: always() && matrix.database
+        run: pnpm db:test:drop
+
+  web_e2e:
+    name: Web E2E (shard ${{ matrix.shard }}/${{ matrix.total }})
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            total: 2
+            database_name: kosmo_test_web_e2e_shard_1
+            port_offset: 10000
+          - shard: 2
+            total: 2
+            database_name: kosmo_test_web_e2e_shard_2
+            port_offset: 20000
+    env:
+      DATABASE_URL: postgres://kosmo:kosmo@localhost:54329/${{ matrix.database_name }}
+      KOSMO_TEST_PORT_OFFSET: ${{ matrix.port_offset }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: true
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @kosmo/app exec playwright install --with-deps chromium
+
+      - name: Run Web E2E shard
+        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/${{ matrix.total }}
+
       - name: Upload Playwright artifacts
-        if: failure() && matrix.id == 'web'
+        if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-artifacts-${{ matrix.id }}
+          name: playwright-artifacts-web-shard-${{ matrix.shard }}
           path: |
             apps/web/playwright-report
             apps/web/test-results
@@ -97,17 +151,22 @@ jobs:
           retention-days: 7
 
       - name: Clean up test database
-        if: always() && matrix.database
+        if: always()
         run: pnpm db:test:drop
 
   test:
     name: Test
     if: always()
-    needs: test-suites
+    needs:
+      - test-suites
+      - web_e2e
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Require every test suite
         env:
           TEST_SUITES_RESULT: ${{ needs.test-suites.result }}
-        run: test "${TEST_SUITES_RESULT}" = success
+          WEB_E2E_RESULT: ${{ needs.web_e2e.result }}
+        run: |
+          test "${TEST_SUITES_RESULT}" = success
+          test "${WEB_E2E_RESULT}" = success


### PR DESCRIPTION
## 무엇을 변경했는지

- Web 정적 검사와 unit test는 기존 `Test (Web)` matrix job에서 한 번만 실행합니다.
- Web E2E를 세 개의 독립 Playwright shard job으로 병렬 실행합니다.
- shard마다 고유한 `DATABASE_URL`, `KOSMO_TEST_PORT_OFFSET`, Temporal server, Worker, API, Web 구성을 사용합니다.
- 실패 artifact를 shard별 이름으로 업로드하고, 최종 `Test` gate가 일반 suite와 세 shard를 모두 요구하게 했습니다.
- Playwright 버전을 cache key에 포함해 Chromium browser bundle을 GitHub Actions cache로 재사용합니다. OS 의존성은 runner마다 계속 설치합니다.

## 왜 변경했는지

PROD-829에서 Web E2E가 실제 Temporal server와 production Worker를 사용하면서 기존 단일 `Test (Web)` baseline이 6분 11초가 됐습니다. 공유 DB를 test마다 reset하는 현재 계약 때문에 한 process의 Playwright workers를 늘릴 수 없으므로, 전체 계약과 workers=1을 유지한 채 process 자체를 격리해 wall-clock을 줄입니다.

추가 관측에서 pnpm store는 cache hit였지만 Playwright browser 약 282 MB는 매 job 다시 내려받고 있었습니다. browser bundle만 버전별로 캐시해 이 중복 다운로드를 제거합니다.

## 이번 PR의 주요 결정

### E2E를 3개 독립 shard로 분리

- 결정자: @jiyu
- 선택: Web check/unit은 한 번만 유지하고 E2E만 3개의 GitHub Actions job으로 분리합니다.
- 고려한 대안: 한 process의 Playwright workers 증가, 2-shard, 4-shard
- 이유: workers 증가는 공유 DB reset 간섭을 만듭니다. 실제 2/3/4-shard 실험에서 3-shard는 2-shard보다 평균 wall-clock을 22초 줄였고, 4-shard의 추가 개선은 평균 4초로 실행 변동폭보다 작았습니다.
- 감수한 결과: 3-shard 평균 compute는 2-shard보다 157초(29.0%) 증가합니다. 4-shard는 여기서 다시 140초(20.0%) 증가하지만 평균 wall-clock은 4초(1.8%)만 줄어 최종 구성에서 제외했습니다.
- 관련 근거: [PROD-830](https://linear.app/byulmaru/issue/PROD-830/web-e2e를-독립-temporal-shard로-병렬-실행한다)

### Playwright browser bundle만 캐시

- 선택: Playwright 버전과 runner OS/architecture를 key로 `~/.cache/ms-playwright`를 캐시합니다.
- 이유: pnpm store와 달리 browser bundle은 기존 cache 대상이 아니어서 매 Playwright job 다운로드되고 있었습니다.
- 제외: Expo/Metro cache는 shard별 환경값과 무효화 정책이 복잡해 이번 PR에서 제외했습니다. PostgreSQL image cache도 현재 pull 구간이 약 8초라 별도 cache 복원 비용보다 유리하다는 근거가 없어 제외했습니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/test.yml`
- `CI=true pnpm exec prettier --check .github/workflows/test.yml`
- `CI=true pnpm --filter @kosmo/web check`
- `CI=true pnpm --filter @kosmo/web test:unit` — 35개 통과
- Playwright `--list`
  - 전체: 114개
  - 2-shard: `68 / 46`
  - 3-shard: `41 / 41 / 32`
  - 4-shard: `31 / 37 / 23 / 23`
  - 모든 구성에서 unique 114개, overlap/missing/extra 0개

| 구성 | 관측 | Web lane wall-clock | Web lane compute | 결과 |
| --- | ---: | ---: | ---: | --- |
| baseline 1-shard | 1회 | 371초 | 371초 | 통과 |
| [2-shard + cache hit](https://github.com/byulmaru/kosmo/actions/runs/32753626837/attempts/2) | 1회 | 250초 | 540초 | 통과 |
| [3-shard](https://github.com/byulmaru/kosmo/actions/runs/32799023528) | 1회차 | 219초 | 685초 | 통과 |
| [3-shard 최종 HEAD](https://github.com/byulmaru/kosmo/actions/runs/32799651743) | 2회차 | 236초 | 708초 | 통과 |
| 3-shard 평균 | 2회 | 228초 | 697초 | 최종 선택 |
| [4-shard](https://github.com/byulmaru/kosmo/actions/runs/32799351263/attempts/1) | 1회차 | 219초 | 822초 | 통과 |
| [4-shard](https://github.com/byulmaru/kosmo/actions/runs/32799351263/attempts/2) | 2회차 | 228초 | 850초 | 통과 |
| 4-shard 평균 | 2회 | 224초 | 836초 | 제외 |

- 3-shard 평균 wall-clock 228초는 baseline 371초보다 143초(38.5%) 짧습니다.
- 4-shard의 3-shard 대비 평균 4초 개선은 3-shard 실행 간 변동폭 17초보다 작고, 임계 경로가 shard 2의 37개/5파일 묶음으로 남았습니다.
- 모든 CI 관측에서 DB reset, port bind, Temporal workflow drain 간섭은 없었고 최종 aggregate `Test`가 통과했습니다.

## 아직 어떤 문제가 남았는지

- Playwright OS 의존성, pnpm relink, PostgreSQL 시작, Expo export는 여전히 각 shard에서 수행됩니다.
- 테스트 파일별 실행시간이 달라 개수만으로 shard 시간이 균등해지지 않습니다. 4-shard 이상의 추가 최적화는 shard 수 증가보다 test file 분할 또는 setup 재사용 계약 변경이 먼저 필요합니다.

Stack: main -> PROD-830
