### PR TITLE
PROD-831 런타임별 서버 이미지 빌드를 분리한다

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github
 .web-build.env
 node_modules
+**/node_modules
 .expo
 dist
 apps/app/android

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 .pnpm-store
 dist
+/server-dist/
+/.server-dist-staging/
 .turbo
 .pnpm-store/
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,28 +84,50 @@ RUN find apps/app/dist -type f \( \
 FROM app-build AS server-artifacts
 
 RUN set -eux; \
-  for artifact in web api fedify-consumer migration; do \
+  for artifact in web api fedify-consumer migration worker; do \
     test -s "/app/server-dist/${artifact}/index.mjs"; \
     test ! -e "/app/server-dist/${artifact}/runtime-package.json"; \
   done; \
-  test -s /app/server-dist/worker/index.mjs; \
-  test -s /app/server-dist/worker/workflow-bundle.js; \
-  test -s /app/server-dist/worker/runtime-package.json
+  test -s /app/server-dist/worker/workflow-bundle.js
 
-# The Worker host keeps Temporal's native/runtime packages external. All other
-# server runtimes are self-contained ESM artifacts and need no install stage.
-FROM base AS worker-runtime-deps
+# Deploy each production dependency tree directly from the workspace lockfile.
+# Public hoisting lets the external imports in each JavaScript artifact resolve
+# from /app/node_modules without a generated runtime manifest.
+FROM app-build AS web-runtime-deps
+
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  pnpm --offline --filter @kosmo/web "--config.public-hoist-pattern=*" deploy --legacy --prod \
+    --ignore-scripts --store-dir=/var/cache/pnpm/store /runtime-deploy
+
+FROM app-build AS api-runtime-deps
+
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  pnpm --offline --filter @kosmo/api "--config.public-hoist-pattern=*" deploy --legacy --prod \
+    --ignore-scripts --store-dir=/var/cache/pnpm/store /runtime-deploy
+
+FROM app-build AS fedify-consumer-runtime-deps
+
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  pnpm --offline --filter @kosmo/fedify-consumer "--config.public-hoist-pattern=*" deploy --legacy --prod \
+    --ignore-scripts --store-dir=/var/cache/pnpm/store /runtime-deploy
+
+FROM app-build AS migration-runtime-deps
+
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  pnpm --offline --filter @kosmo/core "--config.public-hoist-pattern=*" deploy --legacy --prod \
+    --ignore-scripts --store-dir=/var/cache/pnpm/store /runtime-deploy
+
+FROM app-build AS worker-runtime-deps
 
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY --from=server-artifacts /app/server-dist/worker/runtime-package.json /runtime-deploy/package.json
-
 RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store set -eux; \
   test "${TARGETOS}" = linux; \
   test "${TARGETARCH}" = arm64; \
+  pnpm --offline --filter @kosmo/worker "--config.public-hoist-pattern=*" deploy --legacy --prod \
+    --ignore-scripts --store-dir=/var/cache/pnpm/store /runtime-deploy; \
   cd /runtime-deploy; \
-  pnpm install --prod --no-frozen-lockfile --ignore-scripts --store-dir=/var/cache/pnpm/store; \
   pnpm rebuild --pending
 
 RUN set -eux; \
@@ -140,6 +162,7 @@ ENV EXPO_WEB_ROOT=/app/apps/app/dist
 COPY --from=server-artifacts --chown=app:app /app/server-dist/web/index.mjs /app/server-dist/web/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/web/meta.json /app/server-dist/web/meta.json
 COPY --from=app-build --chown=app:app /app/apps/app/dist /app/apps/app/dist
+COPY --from=web-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -151,6 +174,7 @@ FROM split-runtime-base AS api-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/api/index.mjs /app/server-dist/api/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/api/meta.json /app/server-dist/api/meta.json
+COPY --from=api-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -165,7 +189,6 @@ ENV TEMPORAL_WORKFLOW_BUNDLE_PATH=/app/server-dist/worker/workflow-bundle.js
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/index.mjs /app/server-dist/worker/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/workflow-bundle.js /app/server-dist/worker/workflow-bundle.js
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/meta.json /app/server-dist/worker/meta.json
-COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/runtime-package.json /app/server-dist/worker/runtime-package.json
 COPY --from=worker-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
@@ -178,6 +201,7 @@ FROM split-runtime-base AS fedify-consumer-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/index.mjs /app/server-dist/fedify-consumer/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/meta.json /app/server-dist/fedify-consumer/meta.json
+COPY --from=fedify-consumer-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -189,6 +213,7 @@ FROM split-runtime-base AS migration-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/index.mjs /app/server-dist/migration/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/meta.json /app/server-dist/migration/meta.json
+COPY --from=migration-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 COPY --chown=app:app drizzle /app/drizzle
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,38 +86,58 @@ FROM app-build AS server-artifacts
 RUN set -eux; \
   for artifact in web api fedify-consumer migration; do \
     test -s "/app/server-dist/${artifact}/index.mjs"; \
+    test -s "/app/server-dist/${artifact}/runtime-package.json"; \
   done; \
   test -s /app/server-dist/worker/index.mjs; \
-  test -s /app/server-dist/worker/workflow-bundle.js
+  test -s /app/server-dist/worker/workflow-bundle.js; \
+  test -s /app/server-dist/worker/runtime-package.json
 
-# Temporal Client and jsdom stay external because they load package-relative
-# proto/CSS assets. Only Web, API, and Fedify Consumer copy this exact runtime
-# tree; Migration remains dependency-free.
-FROM deps AS asset-runtime-deps
+# Install each build-graph-derived runtime manifest independently. Package
+# names live only in the generated artifact; Docker preserves the package
+# manager's transitive dependency, asset, peer, and native module layout.
+FROM deps AS split-runtime-deps-base
 
-RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store set -eux; \
-  mkdir /runtime-deploy; \
-  cd /runtime-deploy; \
-  node -e "const fs = require('node:fs'); const { createRequire } = require('node:module'); const coreRequire = createRequire('/app/packages/core/package.json'); const clientVersion = coreRequire('@temporalio/client/package.json').version; const jsdomVersion = coreRequire('jsdom/package.json').version; fs.writeFileSync('package.json', JSON.stringify({ private: true, dependencies: { '@temporalio/client': clientVersion, jsdom: jsdomVersion } }, null, 2) + '\n'); fs.writeFileSync('pnpm-workspace.yaml', '')"; \
-  pnpm install --prod --no-frozen-lockfile --ignore-scripts --store-dir=/var/cache/pnpm/store
+COPY pnpm-workspace.yaml /runtime-deploy/pnpm-workspace.yaml
 
-# Worker adds the SDK host and Node-API bridge to the shared asset-backed
-# runtime boundary, then retains only the Linux/ARM64 native release.
-FROM deps AS worker-deps
+FROM split-runtime-deps-base AS web-runtime-deps
+
+COPY --from=server-artifacts /app/server-dist/web/runtime-package.json /runtime-deploy/package.json
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
+
+FROM split-runtime-deps-base AS api-runtime-deps
+
+COPY --from=server-artifacts /app/server-dist/api/runtime-package.json /runtime-deploy/package.json
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
+
+FROM split-runtime-deps-base AS fedify-consumer-runtime-deps
+
+COPY --from=server-artifacts /app/server-dist/fedify-consumer/runtime-package.json /runtime-deploy/package.json
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
+
+FROM split-runtime-deps-base AS migration-runtime-deps
+
+COPY --from=server-artifacts /app/server-dist/migration/runtime-package.json /runtime-deploy/package.json
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
+  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
+
+FROM split-runtime-deps-base AS worker-runtime-deps
 
 ARG TARGETOS
 ARG TARGETARCH
 
+COPY --from=server-artifacts /app/server-dist/worker/runtime-package.json /runtime-deploy/package.json
+
 RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store set -eux; \
   test "${TARGETOS}" = linux; \
   test "${TARGETARCH}" = arm64; \
-  mkdir /worker-deploy; \
-  cd /worker-deploy; \
-  node -e "const fs = require('node:fs'); const { createRequire } = require('node:module'); const workerRequire = createRequire('/app/apps/worker/package.json'); const coreRequire = createRequire('/app/packages/core/package.json'); const workerVersion = workerRequire('@temporalio/worker/package.json').version; const clientVersion = coreRequire('@temporalio/client/package.json').version; const jsdomVersion = coreRequire('jsdom/package.json').version; fs.writeFileSync('package.json', JSON.stringify({ private: true, dependencies: { '@temporalio/client': clientVersion, '@temporalio/worker': workerVersion, jsdom: jsdomVersion } }, null, 2) + '\n'); const allowed = ['@swc/core', 'core-js', 'esbuild', 'protobufjs']; fs.writeFileSync('pnpm-workspace.yaml', 'allowBuilds:\n' + allowed.map((name) => '  ' + JSON.stringify(name) + ': true').join('\n') + '\n')"; \
+  cd /runtime-deploy; \
   pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
 
 RUN set -eux; \
-  bridge_entrypoint="$(cd /worker-deploy && node -e "const { createRequire } = require('node:module'); const workerRequire = createRequire(require.resolve('@temporalio/worker/package.json')); process.stdout.write(workerRequire.resolve('@temporalio/core-bridge'))")"; \
+  bridge_entrypoint="$(cd /runtime-deploy && node -e "const { createRequire } = require('node:module'); const workerRequire = createRequire(require.resolve('@temporalio/worker/package.json')); process.stdout.write(workerRequire.resolve('@temporalio/core-bridge'))")"; \
   bridge_root="$(dirname "${bridge_entrypoint}")"; \
   test -d "${bridge_root}/releases/aarch64-unknown-linux-gnu"; \
   find "${bridge_root}/releases" -mindepth 1 -maxdepth 1 \
@@ -147,8 +167,9 @@ ENV EXPO_WEB_ROOT=/app/apps/app/dist
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/web/index.mjs /app/server-dist/web/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/web/meta.json /app/server-dist/web/meta.json
+COPY --from=server-artifacts --chown=app:app /app/server-dist/web/runtime-package.json /app/server-dist/web/runtime-package.json
 COPY --from=app-build --chown=app:app /app/apps/app/dist /app/apps/app/dist
-COPY --from=asset-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
+COPY --from=web-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -160,7 +181,8 @@ FROM split-runtime-base AS api-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/api/index.mjs /app/server-dist/api/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/api/meta.json /app/server-dist/api/meta.json
-COPY --from=asset-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
+COPY --from=server-artifacts --chown=app:app /app/server-dist/api/runtime-package.json /app/server-dist/api/runtime-package.json
+COPY --from=api-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -175,7 +197,8 @@ ENV TEMPORAL_WORKFLOW_BUNDLE_PATH=/app/server-dist/worker/workflow-bundle.js
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/index.mjs /app/server-dist/worker/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/workflow-bundle.js /app/server-dist/worker/workflow-bundle.js
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/meta.json /app/server-dist/worker/meta.json
-COPY --from=worker-deps --chown=app:app /worker-deploy/node_modules /app/node_modules
+COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/runtime-package.json /app/server-dist/worker/runtime-package.json
+COPY --from=worker-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -187,7 +210,8 @@ FROM split-runtime-base AS fedify-consumer-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/index.mjs /app/server-dist/fedify-consumer/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/meta.json /app/server-dist/fedify-consumer/meta.json
-COPY --from=asset-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
+COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/runtime-package.json /app/server-dist/fedify-consumer/runtime-package.json
+COPY --from=fedify-consumer-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -199,6 +223,8 @@ FROM split-runtime-base AS migration-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/index.mjs /app/server-dist/migration/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/meta.json /app/server-dist/migration/meta.json
+COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/runtime-package.json /app/server-dist/migration/runtime-package.json
+COPY --from=migration-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 COPY --chown=app:app drizzle /app/drizzle
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,151 @@ COPY apps ./apps
 COPY packages ./packages
 COPY scripts ./scripts
 
+# Docker COPY replaces the ignored workspace node_modules entries. Restore the
+# dependency links from the immutable deps stage so build tools resolve from
+# their owning workspace without another install or lifecycle run.
+COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
+COPY --from=deps /app/apps/app/node_modules ./apps/app/node_modules
+COPY --from=deps /app/apps/fedify-consumer/node_modules ./apps/fedify-consumer/node_modules
+COPY --from=deps /app/apps/worker/node_modules ./apps/worker/node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
+COPY --from=deps /app/packages/fedify/node_modules ./packages/fedify/node_modules
+
 RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN,required=false \
   pnpm build:sentry-artifacts
 RUN find apps/app/dist -type f \( \
       -name '*.css' -o -name '*.html' -o -name '*.js' -o -name '*.json' \
       -o -name '*.mjs' -o -name '*.svg' -o -name '*.ttf' -o -name '*.wasm' \
     \) -exec gzip -9 -n -k {} +
+
+# Keep the artifact contract in a named stage so every split image consumes the
+# exact output that passed the Sentry build (including server source-map
+# handling). The final images copy only their entry module, never this stage's
+# workspace or node_modules.
+FROM app-build AS server-artifacts
+
+RUN set -eux; \
+  for artifact in web api fedify-consumer migration; do \
+    test -s "/app/server-dist/${artifact}/index.mjs"; \
+  done; \
+  test -s /app/server-dist/worker/index.mjs; \
+  test -s /app/server-dist/worker/workflow-bundle.js
+
+# Temporal Client and jsdom stay external because they load package-relative
+# proto/CSS assets. Only Web, API, and Fedify Consumer copy this exact runtime
+# tree; Migration remains dependency-free.
+FROM deps AS asset-runtime-deps
+
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store set -eux; \
+  mkdir /runtime-deploy; \
+  cd /runtime-deploy; \
+  node -e "const fs = require('node:fs'); const { createRequire } = require('node:module'); const coreRequire = createRequire('/app/packages/core/package.json'); const clientVersion = coreRequire('@temporalio/client/package.json').version; const jsdomVersion = coreRequire('jsdom/package.json').version; fs.writeFileSync('package.json', JSON.stringify({ private: true, dependencies: { '@temporalio/client': clientVersion, jsdom: jsdomVersion } }, null, 2) + '\n'); fs.writeFileSync('pnpm-workspace.yaml', '')"; \
+  pnpm install --prod --no-frozen-lockfile --ignore-scripts --store-dir=/var/cache/pnpm/store
+
+# Worker adds the SDK host and Node-API bridge to the shared asset-backed
+# runtime boundary, then retains only the Linux/ARM64 native release.
+FROM deps AS worker-deps
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store set -eux; \
+  test "${TARGETOS}" = linux; \
+  test "${TARGETARCH}" = arm64; \
+  mkdir /worker-deploy; \
+  cd /worker-deploy; \
+  node -e "const fs = require('node:fs'); const { createRequire } = require('node:module'); const workerRequire = createRequire('/app/apps/worker/package.json'); const coreRequire = createRequire('/app/packages/core/package.json'); const workerVersion = workerRequire('@temporalio/worker/package.json').version; const clientVersion = coreRequire('@temporalio/client/package.json').version; const jsdomVersion = coreRequire('jsdom/package.json').version; fs.writeFileSync('package.json', JSON.stringify({ private: true, dependencies: { '@temporalio/client': clientVersion, '@temporalio/worker': workerVersion, jsdom: jsdomVersion } }, null, 2) + '\n'); const allowed = ['@swc/core', 'core-js', 'esbuild', 'protobufjs']; fs.writeFileSync('pnpm-workspace.yaml', 'allowBuilds:\n' + allowed.map((name) => '  ' + JSON.stringify(name) + ': true').join('\n') + '\n')"; \
+  pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
+
+RUN set -eux; \
+  bridge_entrypoint="$(cd /worker-deploy && node -e "const { createRequire } = require('node:module'); const workerRequire = createRequire(require.resolve('@temporalio/worker/package.json')); process.stdout.write(workerRequire.resolve('@temporalio/core-bridge'))")"; \
+  bridge_root="$(dirname "${bridge_entrypoint}")"; \
+  test -d "${bridge_root}/releases/aarch64-unknown-linux-gnu"; \
+  find "${bridge_root}/releases" -mindepth 1 -maxdepth 1 \
+    ! -name aarch64-unknown-linux-gnu -exec rm -rf {} +; \
+  test "$(find "${bridge_root}/releases" -mindepth 2 -maxdepth 2 -type f -name index.node | wc -l | tr -d ' ')" = 1
+
+FROM base AS split-runtime-base
+
+ARG SENTRY_RELEASE
+
+ENV NODE_ENV=production \
+  HOST=0.0.0.0 \
+  PORT=8080 \
+  SENTRY_RELEASE=${SENTRY_RELEASE}
+
+RUN groupadd --system --gid 10001 app \
+  && useradd --system --uid 10001 --gid app --home-dir /app --shell /usr/sbin/nologin app \
+  && chown app:app /app
+
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && rm -rf /var/lib/apt/lists/*
+
+FROM split-runtime-base AS web-runtime
+
+ENV EXPO_WEB_ROOT=/app/apps/app/dist
+
+COPY --from=server-artifacts --chown=app:app /app/server-dist/web/index.mjs /app/server-dist/web/index.mjs
+COPY --from=server-artifacts --chown=app:app /app/server-dist/web/meta.json /app/server-dist/web/meta.json
+COPY --from=app-build --chown=app:app /app/apps/app/dist /app/apps/app/dist
+COPY --from=asset-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
+
+USER app
+
+EXPOSE 8080
+
+ENTRYPOINT ["node", "/app/server-dist/web/index.mjs"]
+
+FROM split-runtime-base AS api-runtime
+
+COPY --from=server-artifacts --chown=app:app /app/server-dist/api/index.mjs /app/server-dist/api/index.mjs
+COPY --from=server-artifacts --chown=app:app /app/server-dist/api/meta.json /app/server-dist/api/meta.json
+COPY --from=asset-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
+
+USER app
+
+EXPOSE 8080
+
+ENTRYPOINT ["node", "/app/server-dist/api/index.mjs"]
+
+FROM split-runtime-base AS worker-runtime
+
+ENV TEMPORAL_WORKFLOW_BUNDLE_PATH=/app/server-dist/worker/workflow-bundle.js
+
+COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/index.mjs /app/server-dist/worker/index.mjs
+COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/workflow-bundle.js /app/server-dist/worker/workflow-bundle.js
+COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/meta.json /app/server-dist/worker/meta.json
+COPY --from=worker-deps --chown=app:app /worker-deploy/node_modules /app/node_modules
+
+USER app
+
+EXPOSE 8080
+
+ENTRYPOINT ["node", "/app/server-dist/worker/index.mjs"]
+
+FROM split-runtime-base AS fedify-consumer-runtime
+
+COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/index.mjs /app/server-dist/fedify-consumer/index.mjs
+COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/meta.json /app/server-dist/fedify-consumer/meta.json
+COPY --from=asset-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
+
+USER app
+
+EXPOSE 8080
+
+ENTRYPOINT ["node", "/app/server-dist/fedify-consumer/index.mjs"]
+
+FROM split-runtime-base AS migration-runtime
+
+COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/index.mjs /app/server-dist/migration/index.mjs
+COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/meta.json /app/server-dist/migration/meta.json
+COPY --chown=app:app drizzle /app/drizzle
+
+USER app
+
+ENTRYPOINT ["node", "/app/server-dist/migration/index.mjs"]
 
 FROM workspace AS runtime-files
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,44 +86,15 @@ FROM app-build AS server-artifacts
 RUN set -eux; \
   for artifact in web api fedify-consumer migration; do \
     test -s "/app/server-dist/${artifact}/index.mjs"; \
-    test -s "/app/server-dist/${artifact}/runtime-package.json"; \
+    test ! -e "/app/server-dist/${artifact}/runtime-package.json"; \
   done; \
   test -s /app/server-dist/worker/index.mjs; \
   test -s /app/server-dist/worker/workflow-bundle.js; \
   test -s /app/server-dist/worker/runtime-package.json
 
-# Install each build-graph-derived runtime manifest independently. Package
-# names live only in the generated artifact; Docker preserves the package
-# manager's transitive dependency, asset, peer, and native module layout.
-FROM deps AS split-runtime-deps-base
-
-COPY pnpm-workspace.yaml /runtime-deploy/pnpm-workspace.yaml
-
-FROM split-runtime-deps-base AS web-runtime-deps
-
-COPY --from=server-artifacts /app/server-dist/web/runtime-package.json /runtime-deploy/package.json
-RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
-  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
-
-FROM split-runtime-deps-base AS api-runtime-deps
-
-COPY --from=server-artifacts /app/server-dist/api/runtime-package.json /runtime-deploy/package.json
-RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
-  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
-
-FROM split-runtime-deps-base AS fedify-consumer-runtime-deps
-
-COPY --from=server-artifacts /app/server-dist/fedify-consumer/runtime-package.json /runtime-deploy/package.json
-RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
-  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
-
-FROM split-runtime-deps-base AS migration-runtime-deps
-
-COPY --from=server-artifacts /app/server-dist/migration/runtime-package.json /runtime-deploy/package.json
-RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store \
-  cd /runtime-deploy && pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
-
-FROM split-runtime-deps-base AS worker-runtime-deps
+# The Worker host keeps Temporal's native/runtime packages external. All other
+# server runtimes are self-contained ESM artifacts and need no install stage.
+FROM base AS worker-runtime-deps
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -134,7 +105,8 @@ RUN --mount=type=cache,id=kosmo-pnpm-store,target=/var/cache/pnpm/store set -eux
   test "${TARGETOS}" = linux; \
   test "${TARGETARCH}" = arm64; \
   cd /runtime-deploy; \
-  pnpm install --prod --no-frozen-lockfile --store-dir=/var/cache/pnpm/store
+  pnpm install --prod --no-frozen-lockfile --ignore-scripts --store-dir=/var/cache/pnpm/store; \
+  pnpm rebuild --pending
 
 RUN set -eux; \
   bridge_entrypoint="$(cd /runtime-deploy && node -e "const { createRequire } = require('node:module'); const workerRequire = createRequire(require.resolve('@temporalio/worker/package.json')); process.stdout.write(workerRequire.resolve('@temporalio/core-bridge'))")"; \
@@ -167,9 +139,7 @@ ENV EXPO_WEB_ROOT=/app/apps/app/dist
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/web/index.mjs /app/server-dist/web/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/web/meta.json /app/server-dist/web/meta.json
-COPY --from=server-artifacts --chown=app:app /app/server-dist/web/runtime-package.json /app/server-dist/web/runtime-package.json
 COPY --from=app-build --chown=app:app /app/apps/app/dist /app/apps/app/dist
-COPY --from=web-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -181,8 +151,6 @@ FROM split-runtime-base AS api-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/api/index.mjs /app/server-dist/api/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/api/meta.json /app/server-dist/api/meta.json
-COPY --from=server-artifacts --chown=app:app /app/server-dist/api/runtime-package.json /app/server-dist/api/runtime-package.json
-COPY --from=api-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -210,8 +178,6 @@ FROM split-runtime-base AS fedify-consumer-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/index.mjs /app/server-dist/fedify-consumer/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/meta.json /app/server-dist/fedify-consumer/meta.json
-COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/runtime-package.json /app/server-dist/fedify-consumer/runtime-package.json
-COPY --from=fedify-consumer-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
 
@@ -223,8 +189,6 @@ FROM split-runtime-base AS migration-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/index.mjs /app/server-dist/migration/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/meta.json /app/server-dist/migration/meta.json
-COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/runtime-package.json /app/server-dist/migration/runtime-package.json
-COPY --from=migration-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 COPY --chown=app:app drizzle /app/drizzle
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,6 @@ FROM split-runtime-base AS web-runtime
 ENV EXPO_WEB_ROOT=/app/apps/app/dist
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/web/index.mjs /app/server-dist/web/index.mjs
-COPY --from=server-artifacts --chown=app:app /app/server-dist/web/meta.json /app/server-dist/web/meta.json
 COPY --from=app-build --chown=app:app /app/apps/app/dist /app/apps/app/dist
 COPY --from=web-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
@@ -173,7 +172,6 @@ ENTRYPOINT ["node", "/app/server-dist/web/index.mjs"]
 FROM split-runtime-base AS api-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/api/index.mjs /app/server-dist/api/index.mjs
-COPY --from=server-artifacts --chown=app:app /app/server-dist/api/meta.json /app/server-dist/api/meta.json
 COPY --from=api-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
@@ -188,7 +186,6 @@ ENV TEMPORAL_WORKFLOW_BUNDLE_PATH=/app/server-dist/worker/workflow-bundle.js
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/index.mjs /app/server-dist/worker/index.mjs
 COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/workflow-bundle.js /app/server-dist/worker/workflow-bundle.js
-COPY --from=server-artifacts --chown=app:app /app/server-dist/worker/meta.json /app/server-dist/worker/meta.json
 COPY --from=worker-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
@@ -200,7 +197,6 @@ ENTRYPOINT ["node", "/app/server-dist/worker/index.mjs"]
 FROM split-runtime-base AS fedify-consumer-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/index.mjs /app/server-dist/fedify-consumer/index.mjs
-COPY --from=server-artifacts --chown=app:app /app/server-dist/fedify-consumer/meta.json /app/server-dist/fedify-consumer/meta.json
 COPY --from=fedify-consumer-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 
 USER app
@@ -212,7 +208,6 @@ ENTRYPOINT ["node", "/app/server-dist/fedify-consumer/index.mjs"]
 FROM split-runtime-base AS migration-runtime
 
 COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/index.mjs /app/server-dist/migration/index.mjs
-COPY --from=server-artifacts --chown=app:app /app/server-dist/migration/meta.json /app/server-dist/migration/meta.json
 COPY --from=migration-runtime-deps --chown=app:app /runtime-deploy/node_modules /app/node_modules
 COPY --chown=app:app drizzle /app/drizzle
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -32,11 +32,11 @@
     "hono": "^4.12.34",
     "openid-client": "6.8.4",
     "remeda": "^2.34.1",
-    "tsx": "^4.22.4",
     "uuid": "^14.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@fedify/vocab": "2.3.0"
+    "@fedify/vocab": "2.3.0",
+    "tsx": "^4.22.4"
   }
 }

--- a/apps/fedify-consumer/package.json
+++ b/apps/fedify-consumer/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@kosmo/core": "workspace:*",
-    "@kosmo/fedify": "workspace:*",
+    "@kosmo/fedify": "workspace:*"
+  },
+  "devDependencies": {
     "tsx": "^4.22.4"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "temporal-polyfill": "^0.3.2",
+    "tsx": "^4.22.4",
     "uuid": "^14.0.1",
     "vitest": "^4.1.10"
   },
@@ -25,7 +26,6 @@
     "@sentry/node": "^10.66.0",
     "drizzle-orm": "1.0.0-beta.22",
     "hono": "^4.12.34",
-    "openid-client": "6.8.4",
-    "tsx": "^4.22.4"
+    "openid-client": "6.8.4"
   }
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,13 +19,13 @@
     "@temporalio/workflow": "^1.22.0",
     "drizzle-orm": "1.0.0-beta.22",
     "ts-pattern": "^5.9.0",
-    "tsx": "^4.22.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@fedify/fedify": "^2.3.0",
     "@fedify/vocab": "2.3.0",
     "@temporalio/client": "^1.22.0",
-    "@temporalio/testing": "^1.22.0"
+    "@temporalio/testing": "^1.22.0",
+    "tsx": "^4.22.4"
   }
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -9,7 +9,7 @@
     "test": "pnpm test:unit && pnpm test:workflow && pnpm test:database",
     "test:database": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/worker test:database:isolated",
     "test:database:isolated": "cd ../.. && pnpm db:test:push && pnpm --filter @kosmo/worker exec node --import tsx --import ../../packages/core/temporal/test-client.ts --test --test-concurrency=1 src/activities.database.test.ts src/profile-follow-activities.database.test.ts",
-    "test:unit": "pnpm build && node --import tsx --test src/worker.test.ts",
+    "test:unit": "pnpm build && node --import tsx --test src/worker.test.ts src/workflow-bundle.test.ts",
     "test:workflow": "node --import tsx --test src/workflows.test.ts"
   },
   "dependencies": {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,6 +6,7 @@ import { closeFedifyQueue } from '@kosmo/fedify';
 import { NativeConnection, Worker } from '@temporalio/worker';
 import * as activities from './activities';
 import { healthStatus, validateWorkerEnvironment } from './worker';
+import { getWorkflowRegistration } from './workflow-bundle';
 
 if (import.meta.main) {
   try {
@@ -18,9 +19,24 @@ if (import.meta.main) {
     server.listen(port, host);
     await once(server, 'listening');
 
+    let terminatingDuringStartup = false;
     const terminateDuringStartup = () => {
+      if (terminatingDuringStartup) {
+        return;
+      }
+      terminatingDuringStartup = true;
       process.off('SIGTERM', terminateDuringStartup);
-      queueMicrotask(() => process.kill(process.pid, 'SIGTERM'));
+      void (async () => {
+        try {
+          await closeFedifyQueue();
+          await pg.end({ timeout: 5 });
+          await server[Symbol.asyncDispose]();
+        } finally {
+          // PID 1 does not apply Node's default SIGTERM exit after a listener
+          // handles it, so finish the startup-only shutdown explicitly.
+          process.exit(0);
+        }
+      })();
     };
     process.once('SIGTERM', terminateDuringStartup);
 
@@ -32,23 +48,25 @@ if (import.meta.main) {
         connection,
         namespace,
         taskQueue: KOSMO_TASK_QUEUE,
-        workflowsPath: new URL('./workflows/index.ts', import.meta.url).pathname,
+        ...getWorkflowRegistration(),
       });
       const running = worker.run();
       process.off('SIGTERM', terminateDuringStartup);
       await running;
     } finally {
       process.off('SIGTERM', terminateDuringStartup);
-      try {
-        await connection?.close();
-      } finally {
+      if (!terminatingDuringStartup) {
         try {
-          await closeFedifyQueue();
+          await connection?.close();
         } finally {
           try {
-            await pg.end({ timeout: 5 });
+            await closeFedifyQueue();
           } finally {
-            await server[Symbol.asyncDispose]();
+            try {
+              await pg.end({ timeout: 5 });
+            } finally {
+              await server[Symbol.asyncDispose]();
+            }
           }
         }
       }

--- a/apps/worker/src/worker.test.ts
+++ b/apps/worker/src/worker.test.ts
@@ -74,6 +74,6 @@ test('Temporal connect 중 SIGTERM을 process 종료로 전달한다', { timeout
   child.kill('SIGTERM');
   const [code, signal] = await once(child, 'exit');
 
-  assert.equal(code, null);
-  assert.equal(signal, 'SIGTERM');
+  assert.equal(code, 0);
+  assert.equal(signal, null);
 });

--- a/apps/worker/src/workflow-bundle.test.ts
+++ b/apps/worker/src/workflow-bundle.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { getWorkflowRegistration } from './workflow-bundle';
+
+test('local Worker registration keeps the TypeScript workflowsPath fallback', () => {
+  assert.deepEqual(getWorkflowRegistration({ NODE_ENV: 'development' }), {
+    workflowsPath: new URL('./workflows/index.ts', import.meta.url).pathname,
+  });
+});
+
+test('production Worker registration uses the prebuilt workflow bundle', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'kosmo-worker-bundle-'));
+  t.after(() => rm(directory, { force: true, recursive: true }));
+  const bundlePath = join(directory, 'workflow-bundle.js');
+  await writeFile(bundlePath, 'var __TEMPORAL__ = {};');
+
+  assert.deepEqual(
+    getWorkflowRegistration({
+      NODE_ENV: 'production',
+      TEMPORAL_WORKFLOW_BUNDLE_PATH: bundlePath,
+    }),
+    { workflowBundle: { codePath: bundlePath } },
+  );
+});
+
+test('production Worker registration fails before connect when its bundle is missing', () => {
+  assert.throws(
+    () =>
+      getWorkflowRegistration({
+        NODE_ENV: 'production',
+        TEMPORAL_WORKFLOW_BUNDLE_PATH: '/tmp/kosmo-workflow-bundle-does-not-exist.js',
+      }),
+    /Temporal Workflow bundle is missing/,
+  );
+});

--- a/apps/worker/src/workflow-bundle.test.ts
+++ b/apps/worker/src/workflow-bundle.test.ts
@@ -11,6 +11,12 @@ test('local Worker registration keeps the TypeScript workflowsPath fallback', ()
   });
 });
 
+test('source Worker registration keeps the workflowsPath fallback in production-like tests', () => {
+  assert.deepEqual(getWorkflowRegistration({ NODE_ENV: 'production' }), {
+    workflowsPath: new URL('./workflows/index.ts', import.meta.url).pathname,
+  });
+});
+
 test('production Worker registration uses the prebuilt workflow bundle', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'kosmo-worker-bundle-'));
   t.after(() => rm(directory, { force: true, recursive: true }));

--- a/apps/worker/src/workflow-bundle.ts
+++ b/apps/worker/src/workflow-bundle.ts
@@ -19,14 +19,16 @@ export function getWorkflowRegistration(
   environment: NodeJS.ProcessEnv = process.env,
 ): WorkflowRegistration {
   const configuredBundlePath = environment.TEMPORAL_WORKFLOW_BUNDLE_PATH?.trim();
-  const production = environment.NODE_ENV === 'production';
 
-  if (production || configuredBundlePath) {
-    const codePath = configuredBundlePath || defaultWorkflowBundlePath;
-    if (production && !existsSync(codePath)) {
-      throw new Error(`Temporal Workflow bundle is missing: ${codePath}`);
+  if (configuredBundlePath) {
+    if (!existsSync(configuredBundlePath)) {
+      throw new Error(`Temporal Workflow bundle is missing: ${configuredBundlePath}`);
     }
-    return { workflowBundle: { codePath } };
+    return { workflowBundle: { codePath: configuredBundlePath } };
+  }
+
+  if (existsSync(defaultWorkflowBundlePath)) {
+    return { workflowBundle: { codePath: defaultWorkflowBundlePath } };
   }
 
   return { workflowsPath: sourceWorkflowPath };

--- a/apps/worker/src/workflow-bundle.ts
+++ b/apps/worker/src/workflow-bundle.ts
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { WorkerOptions } from '@temporalio/worker';
+
+type WorkflowRegistration = Pick<WorkerOptions, 'workflowBundle' | 'workflowsPath'>;
+
+const sourceWorkflowPath = fileURLToPath(new URL('./workflows/index.ts', import.meta.url));
+const defaultWorkflowBundlePath = fileURLToPath(new URL('./workflow-bundle.js', import.meta.url));
+
+/**
+ * Resolve the workflow registration for the current execution boundary.
+ *
+ * `workflowsPath` intentionally remains the local-development fallback. The
+ * production artifact is emitted beside the bundled Worker host, so the
+ * default production path is stable even when Docker does not provide an
+ * environment override.
+ */
+export function getWorkflowRegistration(
+  environment: NodeJS.ProcessEnv = process.env,
+): WorkflowRegistration {
+  const configuredBundlePath = environment.TEMPORAL_WORKFLOW_BUNDLE_PATH?.trim();
+  const production = environment.NODE_ENV === 'production';
+
+  if (production || configuredBundlePath) {
+    const codePath = configuredBundlePath || defaultWorkflowBundlePath;
+    if (production && !existsSync(codePath)) {
+      throw new Error(`Temporal Workflow bundle is missing: ${codePath}`);
+    }
+    return { workflowBundle: { codePath } };
+  }
+
+  return { workflowsPath: sourceWorkflowPath };
+}

--- a/docs/operations/server-runtime-image-baseline.md
+++ b/docs/operations/server-runtime-image-baseline.md
@@ -52,43 +52,16 @@ configuration guard까지 도달한다는 baseline이다.
 
 ## Split image artifact gate
 
-같은 Node 26.5.1 base와 Linux/ARM64 platform에서 2026-08-25에 non-Worker single-file과
-Worker 전용 runtime manifest 설계로 다섯 final target을 다시 빌드했다. Inspect size와
-`docker save | gzip -1 -n`을 위 baseline과 같은 방식으로 측정했다. 앞선 수동
-allowlist와 모든 runtime에 generated manifest를 설치하던 구현의 측정치는 설계 재검토로
-폐기했으며 아래 결과가 현재 artifact gate 증거다.
+Literal single-file과 generated runtime manifest 설계의 기존 측정치는 package별 bundler
+patch와 중복 dependency contract에 의존해 폐기했다. 현재 설계는 다섯 runtime의
+workspace-owned code만 JavaScript artifact로 bundle하고, third-party package는 각
+workspace manifest와 root lockfile에서 생성한 production dependency tree로 제공한다.
+`runtime-package.json`은 생성하지 않으며 모든 final image에서 TypeScript source와 `tsx`를
+제외한다. Worker는 추가로 prebuilt Workflow bundle과 target Linux/ARM64 native bridge를
+사용한다.
 
-| Runtime         |  Inspect size | Baseline 대비 | Compressed size | Baseline 대비 | Layers |
-| --------------- | ------------: | ------------: | --------------: | ------------: | -----: |
-| Web             | 229,558,639 B |        -62.0% |   228,109,170 B |        -62.0% |     10 |
-| API             | 219,219,236 B |        -63.7% |   217,825,248 B |        -63.7% |      9 |
-| Worker          | 254,047,801 B |        -58.0% |   252,371,743 B |        -57.9% |     12 |
-| Fedify Consumer | 218,605,921 B |        -63.8% |   217,214,688 B |        -63.8% |      9 |
-| Migration       | 216,006,671 B |        -64.3% |   214,590,379 B |        -64.2% |     10 |
-
-모든 image는 UID/GID 10001의 고정 `node /app/server-dist/<runtime>/index.mjs`
-entrypoint를 사용한다. Web만 Expo static/precompressed asset을, Migration만
-version-controlled `drizzle/` SQL을 포함한다. Web/API/Fedify Consumer/Migration은
-workspace code와 third-party dependency를 각 `index.mjs`에 bundle하며
-`runtime-package.json`과 `/app/node_modules`가 없다. API가 현재 사용하는
-`@temporalio/client`도 API artifact에 포함된다. 모든 image에서 workspace TypeScript
-source, `tsx`, server source map과 source-map reference가 제거됐다.
-
-기존 runtime stage와 동일하게 final image 공통 base에서 Debian package update/upgrade를
-수행한 뒤 측정했다.
-
-Worker는 prebuilt Workflow bundle을 사용하며 build graph가
-`@temporalio/client`와 `@temporalio/worker` 1.22.0을 Worker 전용 runtime manifest에
-자동 포함한다. `core-bridge`는
-`aarch64-unknown-linux-gnu/index.node` 하나만 보존했으며 container에서 SDK와 bridge를
-실제로 load했다.
-
-재설계 후 Web container 내부에서 `/health` 200을 확인했고 JSDOM의 package-relative
-stylesheet/JSON 경계를 호출하는 bundle 회귀 테스트를 통과했다. Worker container에서는
-Temporal SDK와 ARM64 bridge를 실제로 load했다. Worker manifest의 direct dependency가
-모두 설치됐고 non-Worker image에서는 Worker SDK/native bridge가 resolve되지 않았다.
-
-다섯 고정 JavaScript entrypoint는 빈 환경에서 실행해 Web/API/Worker/Fedify가
-`TEMPORAL_ADDRESS is required`, Migration이 database configuration guard까지 도달함을
-확인했다. 이는 artifact/container gate이며 dev rollout이나 production release 증거가
-아니다. Helm과 CI/CD consumer는 아직 기존 single image를 유지한다.
+현재 pull request CI는 Docker target을 build하지 않으며 main 전용 Docker workflow도 아직
+기존 single image contract를 사용한다. 따라서 새 설계의 다섯 Linux/ARM64 image에 대한
+compressed/uncompressed size, layer, external import resolution, boot/health와 asset 검증은
+완료 증거가 아니다. 이 표와 결과는 artifact gate를 실제 CI 또는 승인된 build runner에서
+다시 수행한 뒤에만 기록한다. 그 전에는 Helm·CI/CD consumer 전환을 시작하지 않는다.

--- a/docs/operations/server-runtime-image-baseline.md
+++ b/docs/operations/server-runtime-image-baseline.md
@@ -1,0 +1,90 @@
+# Server runtime image baseline
+
+PROD-831의 runtime image 분리 전 비교 기준이다. 2026-08-25에 commit
+`b3998ca473ba45c148c1e7ca15ded587fe195f4e`의 기존 `Dockerfile`을
+`docker buildx build --platform linux/arm64 --load`로 빌드했다.
+
+## Image
+
+| 항목                                         |                                                                        값 |
+| -------------------------------------------- | ------------------------------------------------------------------------: |
+| Image                                        |                                         `kosmo-runtime-baseline:prod-831` |
+| OCI digest                                   | `sha256:924b891fe73bba0098ac3ad795e8307d545732e6a78238040e9acee8ce57d395` |
+| Platform                                     |                                                             `linux/arm64` |
+| Docker inspect size                          |                                                         604,325,627 bytes |
+| `docker save \| gzip -1 -n` size             |                                                         599,958,769 bytes |
+| RootFS layers                                |                                                                        27 |
+| `/app` apparent size                         |                                                                   533 MiB |
+| `/app/node_modules` apparent size            |                                                                   506 MiB |
+| Expo Web static artifact                     |                                                                    20 MiB |
+| TypeScript source files                      |                                                                     9,987 |
+| `@temporalio/core-bridge@1.22.0`             |                                                                   156 MiB |
+| `core-bridge` files across platform releases |                                                                       595 |
+
+Build 단계는 1,293개 package를 설치했고 runtime production install은 306개
+package를 설치했다. 가장 큰 application layer는 모든 runtime의 공용 production
+dependency tree이며 `docker history`의 가상 크기는 2 GB로 표시된다. Content-addressed
+layer deduplication 때문에 이 값은 image inspect size와 직접 합산하지 않는다.
+
+## Runtime commands
+
+기존 image는 non-root `app` 사용자로 실행되지만 하나의 dispatcher와 `tsx`에 다섯
+runtime이 모두 의존한다.
+
+| Command        | 실행 경로                                             |
+| -------------- | ----------------------------------------------------- |
+| `web`          | `node --import tsx apps/web/src/server/index.ts`      |
+| `api`          | `node --import tsx apps/api/src/index.ts`             |
+| `worker`       | `node --import tsx apps/worker/src/index.ts`          |
+| `fedify-queue` | `node --import tsx apps/fedify-consumer/src/index.ts` |
+| `migrate`      | `node --import tsx packages/core/db/migrate.ts`       |
+
+각 workspace runtime에 `tsx` 실행 파일과 package가 존재한다. 새 image gate는 같은
+platform에서 각 image가 고정 JavaScript entrypoint로 실행되는지, 허용된 asset 외
+TypeScript source와 `tsx`가 없는지, 그리고 inspect/archive 크기와 주요 layer가 이
+baseline보다 작은지를 확인한다.
+
+각 command를 빈 환경에서 8초 제한으로 실행한 smoke에서는 Web/API/Worker/Fedify가
+모두 TypeScript graph를 load한 뒤 `TEMPORAL_ADDRESS is required`로 종료했고,
+Migration은 `DATABASE_URL` 또는 PostgreSQL 환경이 필요하다는 검증 오류로 종료했다.
+따라서 이는 service health 증거가 아니라 기존 entry graph가 `tsx`로 시작되고 필수
+configuration guard까지 도달한다는 baseline이다.
+
+## Split image artifact gate
+
+같은 Node 26.5.1 base와 Linux/ARM64 platform에서 2026-08-25에 다섯 final target을
+빌드했다. Inspect size와 `docker save | gzip -1 -n`을 위 baseline과 같은 방식으로
+측정했다.
+
+| Runtime         |  Inspect size | Baseline 대비 | Compressed size | Baseline 대비 | Layers |
+| --------------- | ------------: | ------------: | --------------: | ------------: | -----: |
+| Web             | 234,813,490 B |        -61.1% |   233,362,980 B |        -61.1% |     11 |
+| API             | 224,473,255 B |        -62.9% |   223,078,141 B |        -62.8% |     10 |
+| Worker          | 256,556,592 B |        -57.5% |   254,879,238 B |        -57.5% |     11 |
+| Fedify Consumer | 223,862,903 B |        -63.0% |   222,467,261 B |        -62.9% |     10 |
+| Migration       | 216,006,633 B |        -64.3% |   214,590,803 B |        -64.2% |     10 |
+
+모든 image는 UID/GID 10001의 고정 `node /app/server-dist/<runtime>/index.mjs`
+entrypoint를 사용한다. Web만 Expo static/precompressed asset을, Migration만
+version-controlled `drizzle/` SQL을 포함한다. Migration은 `node_modules` 없이
+실행되고, Web/API/Fedify는 package-relative CSS/proto를 읽는 `jsdom`과
+`@temporalio/client`만 명시적 runtime tree로 둔다. 모든 image에서 workspace
+TypeScript source, `tsx`, server source map과 source-map reference가 제거됐다.
+
+기존 runtime stage와 동일하게 final image 공통 base에서 Debian package update/upgrade를
+수행한 뒤 측정했다.
+
+Worker는 prebuilt Workflow bundle과 공통 asset runtime tree에
+`@temporalio/worker` 1.22.0만 추가한다. `core-bridge`는
+`aarch64-unknown-linux-gnu/index.node` 하나만 보존했으며 container에서 SDK와 bridge를
+실제로 load했다. 격리 container smoke는 `/health` 200, Temporal 연결 전 `/ready`
+503, startup SIGTERM exit 0을 확인했다.
+
+Web container에서는 `/health`와 Expo static root가 모두 200임을 확인했다. API는
+필수 configuration guard 뒤 실제 local-instance database query까지 실행됐고, API
+unit 28개가 통과했다.
+
+다섯 고정 JavaScript entrypoint는 빈 환경에서 실행해 Web/API/Worker/Fedify가
+`TEMPORAL_ADDRESS is required`, Migration이 database configuration guard까지 도달함을
+확인했다. 이는 artifact/container gate이며 dev rollout이나 production release 증거가
+아니다. Helm과 CI/CD consumer는 아직 기존 single image를 유지한다.

--- a/docs/operations/server-runtime-image-baseline.md
+++ b/docs/operations/server-runtime-image-baseline.md
@@ -52,37 +52,41 @@ configuration guard까지 도달한다는 baseline이다.
 
 ## Split image artifact gate
 
-같은 Node 26.5.1 base와 Linux/ARM64 platform에서 2026-08-25에 다섯 final target을
-빌드했다. Inspect size와 `docker save | gzip -1 -n`을 위 baseline과 같은 방식으로
-측정했다.
+같은 Node 26.5.1 base와 Linux/ARM64 platform에서 2026-08-25에 build-graph 기반
+runtime manifest 설계로 다섯 final target을 다시 빌드했다. Inspect size와
+`docker save | gzip -1 -n`을 위 baseline과 같은 방식으로 측정했다. 앞선 수동
+`@temporalio/client`/`jsdom` allowlist 구현의 측정치는 설계 재검토로 폐기했으며 아래
+결과가 현재 artifact gate 증거다.
 
 | Runtime         |  Inspect size | Baseline 대비 | Compressed size | Baseline 대비 | Layers |
 | --------------- | ------------: | ------------: | --------------: | ------------: | -----: |
-| Web             | 234,813,490 B |        -61.1% |   233,362,980 B |        -61.1% |     11 |
-| API             | 224,473,255 B |        -62.9% |   223,078,141 B |        -62.8% |     10 |
-| Worker          | 256,556,592 B |        -57.5% |   254,879,238 B |        -57.5% |     11 |
-| Fedify Consumer | 223,862,903 B |        -63.0% |   222,467,261 B |        -62.9% |     10 |
-| Migration       | 216,006,633 B |        -64.3% |   214,590,803 B |        -64.2% |     10 |
+| Web             | 250,780,614 B |        -58.5% |   249,245,153 B |        -58.5% |     12 |
+| API             | 242,258,405 B |        -59.9% |   240,778,158 B |        -59.9% |     11 |
+| Worker          | 267,076,316 B |        -55.8% |   265,305,658 B |        -55.8% |     12 |
+| Fedify Consumer | 234,413,725 B |        -61.2% |   232,940,732 B |        -61.2% |     11 |
+| Migration       | 218,173,208 B |        -63.9% |   216,731,925 B |        -63.9% |     12 |
 
 모든 image는 UID/GID 10001의 고정 `node /app/server-dist/<runtime>/index.mjs`
 entrypoint를 사용한다. Web만 Expo static/precompressed asset을, Migration만
-version-controlled `drizzle/` SQL을 포함한다. Migration은 `node_modules` 없이
-실행되고, Web/API/Fedify는 package-relative CSS/proto를 읽는 `jsdom`과
-`@temporalio/client`만 명시적 runtime tree로 둔다. 모든 image에서 workspace
-TypeScript source, `tsx`, server source map과 source-map reference가 제거됐다.
+version-controlled `drizzle/` SQL을 포함한다. 각 artifact는 workspace application
+code를 bundle하고 third-party bare import와 설치 version을 esbuild graph에서 자동
+생성한 `runtime-package.json`에 기록한다. 각 final image의 작은 production
+`node_modules`는 이 manifest에서 pnpm이 설치하며, Dockerfile과 검사에는 현재 package
+이름 allowlist가 없다. 모든 image에서 workspace TypeScript source, `tsx`, server
+source map과 source-map reference가 제거됐다.
 
 기존 runtime stage와 동일하게 final image 공통 base에서 Debian package update/upgrade를
 수행한 뒤 측정했다.
 
-Worker는 prebuilt Workflow bundle과 공통 asset runtime tree에
-`@temporalio/worker` 1.22.0만 추가한다. `core-bridge`는
+Worker는 prebuilt Workflow bundle을 사용하며 build graph가
+`@temporalio/worker` 1.22.0을 runtime manifest에 자동 포함한다. `core-bridge`는
 `aarch64-unknown-linux-gnu/index.node` 하나만 보존했으며 container에서 SDK와 bridge를
-실제로 load했다. 격리 container smoke는 `/health` 200, Temporal 연결 전 `/ready`
-503, startup SIGTERM exit 0을 확인했다.
+실제로 load했다.
 
-Web container에서는 `/health`와 Expo static root가 모두 200임을 확인했다. API는
-필수 configuration guard 뒤 실제 local-instance database query까지 실행됐고, API
-unit 28개가 통과했다.
+재설계 후 Web container 내부에서 `/health` 200을 확인했고 Worker container에서
+Temporal SDK와 ARM64 bridge를 실제로 load했다. 다섯 image의 generated manifest에
+기록된 direct dependency가 모두 설치됐고 non-Worker image에서는 Worker SDK/native
+bridge가 resolve되지 않았다.
 
 다섯 고정 JavaScript entrypoint는 빈 환경에서 실행해 Web/API/Worker/Fedify가
 `TEMPORAL_ADDRESS is required`, Migration이 database configuration guard까지 도달함을

--- a/docs/operations/server-runtime-image-baseline.md
+++ b/docs/operations/server-runtime-image-baseline.md
@@ -52,41 +52,41 @@ configuration guard까지 도달한다는 baseline이다.
 
 ## Split image artifact gate
 
-같은 Node 26.5.1 base와 Linux/ARM64 platform에서 2026-08-25에 build-graph 기반
-runtime manifest 설계로 다섯 final target을 다시 빌드했다. Inspect size와
+같은 Node 26.5.1 base와 Linux/ARM64 platform에서 2026-08-25에 non-Worker single-file과
+Worker 전용 runtime manifest 설계로 다섯 final target을 다시 빌드했다. Inspect size와
 `docker save | gzip -1 -n`을 위 baseline과 같은 방식으로 측정했다. 앞선 수동
-`@temporalio/client`/`jsdom` allowlist 구현의 측정치는 설계 재검토로 폐기했으며 아래
-결과가 현재 artifact gate 증거다.
+allowlist와 모든 runtime에 generated manifest를 설치하던 구현의 측정치는 설계 재검토로
+폐기했으며 아래 결과가 현재 artifact gate 증거다.
 
 | Runtime         |  Inspect size | Baseline 대비 | Compressed size | Baseline 대비 | Layers |
 | --------------- | ------------: | ------------: | --------------: | ------------: | -----: |
-| Web             | 250,780,614 B |        -58.5% |   249,245,153 B |        -58.5% |     12 |
-| API             | 242,258,405 B |        -59.9% |   240,778,158 B |        -59.9% |     11 |
-| Worker          | 267,076,316 B |        -55.8% |   265,305,658 B |        -55.8% |     12 |
-| Fedify Consumer | 234,413,725 B |        -61.2% |   232,940,732 B |        -61.2% |     11 |
-| Migration       | 218,173,208 B |        -63.9% |   216,731,925 B |        -63.9% |     12 |
+| Web             | 229,558,639 B |        -62.0% |   228,109,170 B |        -62.0% |     10 |
+| API             | 219,219,236 B |        -63.7% |   217,825,248 B |        -63.7% |      9 |
+| Worker          | 254,047,801 B |        -58.0% |   252,371,743 B |        -57.9% |     12 |
+| Fedify Consumer | 218,605,921 B |        -63.8% |   217,214,688 B |        -63.8% |      9 |
+| Migration       | 216,006,671 B |        -64.3% |   214,590,379 B |        -64.2% |     10 |
 
 모든 image는 UID/GID 10001의 고정 `node /app/server-dist/<runtime>/index.mjs`
 entrypoint를 사용한다. Web만 Expo static/precompressed asset을, Migration만
-version-controlled `drizzle/` SQL을 포함한다. 각 artifact는 workspace application
-code를 bundle하고 third-party bare import와 설치 version을 esbuild graph에서 자동
-생성한 `runtime-package.json`에 기록한다. 각 final image의 작은 production
-`node_modules`는 이 manifest에서 pnpm이 설치하며, Dockerfile과 검사에는 현재 package
-이름 allowlist가 없다. 모든 image에서 workspace TypeScript source, `tsx`, server
-source map과 source-map reference가 제거됐다.
+version-controlled `drizzle/` SQL을 포함한다. Web/API/Fedify Consumer/Migration은
+workspace code와 third-party dependency를 각 `index.mjs`에 bundle하며
+`runtime-package.json`과 `/app/node_modules`가 없다. API가 현재 사용하는
+`@temporalio/client`도 API artifact에 포함된다. 모든 image에서 workspace TypeScript
+source, `tsx`, server source map과 source-map reference가 제거됐다.
 
 기존 runtime stage와 동일하게 final image 공통 base에서 Debian package update/upgrade를
 수행한 뒤 측정했다.
 
 Worker는 prebuilt Workflow bundle을 사용하며 build graph가
-`@temporalio/worker` 1.22.0을 runtime manifest에 자동 포함한다. `core-bridge`는
+`@temporalio/client`와 `@temporalio/worker` 1.22.0을 Worker 전용 runtime manifest에
+자동 포함한다. `core-bridge`는
 `aarch64-unknown-linux-gnu/index.node` 하나만 보존했으며 container에서 SDK와 bridge를
 실제로 load했다.
 
-재설계 후 Web container 내부에서 `/health` 200을 확인했고 Worker container에서
-Temporal SDK와 ARM64 bridge를 실제로 load했다. 다섯 image의 generated manifest에
-기록된 direct dependency가 모두 설치됐고 non-Worker image에서는 Worker SDK/native
-bridge가 resolve되지 않았다.
+재설계 후 Web container 내부에서 `/health` 200을 확인했고 JSDOM의 package-relative
+stylesheet/JSON 경계를 호출하는 bundle 회귀 테스트를 통과했다. Worker container에서는
+Temporal SDK와 ARM64 bridge를 실제로 load했다. Worker manifest의 direct dependency가
+모두 설치됐고 non-Worker image에서는 Worker SDK/native bridge가 resolve되지 않았다.
 
 다섯 고정 JavaScript entrypoint는 빈 환경에서 실행해 Web/API/Worker/Fedify가
 `TEMPORAL_ADDRESS is required`, Migration이 database configuration guard까지 도달함을

--- a/openspec/changes/split-server-runtime-images/.openspec.yaml
+++ b/openspec/changes/split-server-runtime-images/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-24

--- a/openspec/changes/split-server-runtime-images/decisions.md
+++ b/openspec/changes/split-server-runtime-images/decisions.md
@@ -11,9 +11,9 @@
 - Authority / Provenance: `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, Linear `PROD-831`
 - Status: Active
 - Context / Problem: 공통 runtime image가 Web, API, Worker, Fedify Consumer와 migration의 source와 dependency를 모두 포함하고 `tsx`로 실행해 각 workload의 pull/runtime surface가 불필요하게 크다.
-- Decision Outcome: Web, API, Temporal Worker, Fedify Consumer와 migration을 build 단계의 JavaScript artifact와 서로 다른 다섯 final image로 제공한다. Workspace application code는 bundle하고 third-party runtime dependency는 build graph에서 자동 생성한 artifact별 manifest로 설치한다. Web/API/Fedify/Migration image에는 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 두지 않고 Web image만 Expo static artifact를 포함한다.
+- Decision Outcome: Web, API, Temporal Worker, Fedify Consumer와 migration을 build 단계의 JavaScript artifact와 서로 다른 다섯 final image로 제공한다. Web/API/Fedify/Migration은 workspace application code와 third-party runtime dependency를 단일 JavaScript artifact로 bundle하고 runtime `node_modules`를 두지 않는다. Worker만 Temporal SDK/native runtime을 build graph 기반 manifest로 설치한다. 모든 image에서 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 제거하고 Web image만 Expo static artifact를 포함한다.
 - Alternatives Considered: 하나의 image에서 JavaScript만 사전 compile하는 방식은 Worker와 Web asset/dependency를 모든 workload에 계속 배포하므로 제외했다. Runtime별 source tree와 production `node_modules`만 prune하는 방식은 `tsx` 직접 실행과 불필요한 package surface를 유지하므로 제외했다.
-- Consequences: Docker build와 registry output은 다섯 개로 늘지만 각 workload는 자신의 runtime layer만 pull한다. Runtime import가 바뀌면 manifest가 자동으로 따라가며 Dockerfile이나 검사 코드의 package allowlist를 함께 수정하지 않는다. Helm, scanner와 release workflow도 runtime별 identity를 처리해야 한다.
+- Consequences: Docker build와 registry output은 다섯 개로 늘지만 각 workload는 자신의 runtime layer만 pull한다. Non-Worker runtime import는 단일 bundle graph가 자동으로 따라가고 Worker external import만 generated manifest에 반영된다. Helm, scanner와 release workflow도 runtime별 identity를 처리해야 한다.
 - Confirmation / Follow-up: 같은 Linux/ARM64 build에서 artifact, filesystem, dependency graph, boot/health와 compressed/uncompressed image size를 runtime별로 기록한다.
 
 ### Artifact gate 통과 뒤 release 계약을 전환한다
@@ -28,17 +28,17 @@
 - Consequences: 하나의 Linear/OpenSpec 안에 두 implementation slice가 생긴다. 첫 slice의 성공은 두 번째 slice나 dev/production 적용 성공을 증명하지 않는다.
 - Confirmation / Follow-up: Tasks와 PR evidence에서 artifact/CI, dev rollout, production 적용을 별도 proof tier로 보고한다.
 
-### Third-party runtime dependency는 build graph에서 자동 도출한다
+### Non-Worker dependency는 bundle하고 Worker SDK만 build graph에서 external 설치한다
 
 - Decision Date: 2026-08-25
 - Decision Class: Implementation Choice
 - Authority / Provenance: Linear `PROD-831`, 2026-08-25 사용자 재검토
 - Status: Active
 - Context / Problem: 최초 artifact 구현은 일부 external package 이름을 build script와 Dockerfile에 수동으로 나열하고 검사 코드가 정확한 root dependency 집합을 고정했다. API가 Temporal client를 사용하거나 package asset·dynamic import 경계가 바뀌면 여러 파일을 동시에 수정해야 해 runtime 분리가 미래의 정상적인 의존성 변경을 깨뜨릴 수 있었다.
-- Decision Outcome: Workspace-owned application code는 bundle하되 third-party bare import는 모두 같은 규칙으로 externalize한다. Build graph에서 artifact별 package와 설치 version을 자동 수집한 runtime manifest를 생성하고 package manager가 transitive dependency와 package-relative asset/native layout을 설치한다. 정확한 package 이름 집합이나 package-manager 내부 경로는 Dockerfile과 테스트 계약에 수동으로 고정하지 않는다.
-- Alternatives Considered: `pnpm deploy --legacy` 전체 tree는 workspace TypeScript source, `tsx`와 사용하지 않는 production dependency까지 포함해 image 분리 효과를 크게 줄이므로 제외했다. 일부 package만 수동 externalize하는 방식은 사용자가 지적한 변경 취약성을 유지하므로 폐기했다. 모든 third-party package를 bundle하는 방식은 filesystem asset과 native/dynamic resolution을 package별로 다시 구현해야 하므로 제외했다.
-- Consequences: Final image에는 artifact별 작은 production `node_modules`가 존재하지만 범용 workspace tree나 source는 없다. 새 third-party import는 build 결과와 manifest를 통해 자동 반영되며 Worker만 target native binary pruning을 추가로 수행한다.
-- Confirmation / Follow-up: Metafile external import와 generated manifest 일치, `@kosmo/*`·`tsx` 부재, package install, 다섯 container boot/health와 non-Worker Temporal native 부재를 검증한다.
+- Decision Outcome: Web/API/Fedify/Migration은 workspace-owned code와 third-party runtime dependency를 각각 하나의 JavaScript artifact로 완전 bundle한다. API의 `@temporalio/client`도 bundle하며 runtime package install을 하지 않는다. Worker application/Activity host code는 bundle하지만 `@temporalio/worker`와 그 SDK/native dependency는 build graph 기반 manifest로 external 설치한다. 정확한 Worker package 이름 집합이나 package-manager 내부 경로는 Dockerfile과 테스트 계약에 수동으로 고정하지 않는다.
+- Alternatives Considered: 모든 runtime을 generated manifest로 설치하는 방식은 네 non-Worker image에도 `node_modules`와 synthetic install 재현성 문제를 남겨 제외했다. Worker SDK까지 완전 bundle하는 방식은 Temporal의 Node-API native module, worker thread, VM sandbox와 SDK 내부 build-time bundler resolution을 깨뜨려 제외했다. `pnpm deploy --legacy` 전체 tree는 workspace source, `tsx`와 사용하지 않는 dependency까지 포함해 제외했다.
+- Consequences: Web/API/Fedify/Migration final image는 단일 server JavaScript와 필요한 static/SQL asset만 가지며 dependency manifest와 runtime `node_modules`가 없다. Worker만 작은 production `node_modules`와 target native binary pruning을 유지한다. API가 새 Temporal Client API를 호출해도 `@temporalio/client`는 같은 bundle graph에 자동 포함된다. 현재 HTML parsing/serialization 전용 JSDOM bundle은 package data를 inline하고 사용하지 않는 synchronous XHR worker 경로를 제외한다.
+- Confirmation / Follow-up: 네 non-Worker artifact의 external non-builtin import 부재와 runtime `node_modules` 부재, Worker metafile external import와 generated manifest 일치, 다섯 container boot/health 및 Worker native load를 검증한다.
 
 ### Temporal Workflow는 production image 시작 전에 bundle한다
 
@@ -47,7 +47,7 @@
 - Authority / Provenance: Linear `PROD-730`, `PROD-831`
 - Status: Active
 - Context / Problem: 현재 Worker는 `workflowsPath`의 TypeScript source를 startup 때 Webpack으로 bundle한다. 일반 server처럼 완전 bundle하면 Temporal native `.node` resolution이 깨질 수 있고, 기존 경로를 유지하면 TypeScript source와 Webpack/SWC를 runtime artifact 경계에 계속 요구한다.
-- Decision Outcome: Build와 runtime에서 exact same `@temporalio/worker` version을 사용해 Workflow code를 `bundleWorkflowCode`로 사전 생성하고, production Worker는 `workflowBundle`을 전달한다. Worker host의 third-party package도 공통 build-graph manifest 경계를 따르며 final image에는 target Linux/ARM64에서 SDK resolution에 필요한 production dependency와 native artifact만 둔다.
+- Decision Outcome: Build와 runtime에서 exact same `@temporalio/worker` version을 사용해 Workflow code를 `bundleWorkflowCode`로 사전 생성하고, production Worker는 `workflowBundle`을 전달한다. Worker application/Activity host code는 bundle하되 Temporal Worker SDK와 그 runtime package는 build-graph manifest 경계를 따르며 final image에는 target Linux/ARM64에서 SDK resolution에 필요한 production dependency와 native artifact만 둔다.
 - Alternatives Considered: Production `workflowsPath` 유지 방식은 runtime bundling과 TypeScript source 제거 목표를 위반해 제외했다. Native package를 single-file bundle 안에 강제로 넣는 방식은 ABI와 dynamic resolution 위험 때문에 제외했다. Temporal Worker 전체 dependency tree를 다른 runtime에도 공유하는 방식은 image 분리 목적을 위반해 제외했다.
 - Consequences: Worker image는 다른 image보다 크고 external package tree를 가질 수 있다. Workflow bundle 생성과 Worker runtime package version은 lockfile과 build에서 일치해야 한다.
 - Confirmation / Follow-up: Linux/ARM64 Node 26.5.1 container에서 native load, Worker create, health/readiness와 SIGTERM lifecycle을 검증하고 다른 runtime image에 Temporal Worker dependency가 없는지 확인한다.

--- a/openspec/changes/split-server-runtime-images/decisions.md
+++ b/openspec/changes/split-server-runtime-images/decisions.md
@@ -11,9 +11,9 @@
 - Authority / Provenance: `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, Linear `PROD-831`
 - Status: Active
 - Context / Problem: 공통 runtime image가 Web, API, Worker, Fedify Consumer와 migration의 source와 dependency를 모두 포함하고 `tsx`로 실행해 각 workload의 pull/runtime surface가 불필요하게 크다.
-- Decision Outcome: Web, API, Temporal Worker, Fedify Consumer와 migration을 build 단계의 JavaScript artifact와 서로 다른 다섯 final image로 제공한다. Web/API/Fedify/Migration image에는 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 두지 않고 Web image만 Expo static artifact를 포함한다.
+- Decision Outcome: Web, API, Temporal Worker, Fedify Consumer와 migration을 build 단계의 JavaScript artifact와 서로 다른 다섯 final image로 제공한다. Workspace application code는 bundle하고 third-party runtime dependency는 build graph에서 자동 생성한 artifact별 manifest로 설치한다. Web/API/Fedify/Migration image에는 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 두지 않고 Web image만 Expo static artifact를 포함한다.
 - Alternatives Considered: 하나의 image에서 JavaScript만 사전 compile하는 방식은 Worker와 Web asset/dependency를 모든 workload에 계속 배포하므로 제외했다. Runtime별 source tree와 production `node_modules`만 prune하는 방식은 `tsx` 직접 실행과 불필요한 package surface를 유지하므로 제외했다.
-- Consequences: Docker build와 registry output은 다섯 개로 늘지만 각 workload는 자신의 runtime layer만 pull한다. Helm, scanner와 release workflow도 runtime별 identity를 처리해야 한다.
+- Consequences: Docker build와 registry output은 다섯 개로 늘지만 각 workload는 자신의 runtime layer만 pull한다. Runtime import가 바뀌면 manifest가 자동으로 따라가며 Dockerfile이나 검사 코드의 package allowlist를 함께 수정하지 않는다. Helm, scanner와 release workflow도 runtime별 identity를 처리해야 한다.
 - Confirmation / Follow-up: 같은 Linux/ARM64 build에서 artifact, filesystem, dependency graph, boot/health와 compressed/uncompressed image size를 runtime별로 기록한다.
 
 ### Artifact gate 통과 뒤 release 계약을 전환한다
@@ -28,6 +28,18 @@
 - Consequences: 하나의 Linear/OpenSpec 안에 두 implementation slice가 생긴다. 첫 slice의 성공은 두 번째 slice나 dev/production 적용 성공을 증명하지 않는다.
 - Confirmation / Follow-up: Tasks와 PR evidence에서 artifact/CI, dev rollout, production 적용을 별도 proof tier로 보고한다.
 
+### Third-party runtime dependency는 build graph에서 자동 도출한다
+
+- Decision Date: 2026-08-25
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-831`, 2026-08-25 사용자 재검토
+- Status: Active
+- Context / Problem: 최초 artifact 구현은 일부 external package 이름을 build script와 Dockerfile에 수동으로 나열하고 검사 코드가 정확한 root dependency 집합을 고정했다. API가 Temporal client를 사용하거나 package asset·dynamic import 경계가 바뀌면 여러 파일을 동시에 수정해야 해 runtime 분리가 미래의 정상적인 의존성 변경을 깨뜨릴 수 있었다.
+- Decision Outcome: Workspace-owned application code는 bundle하되 third-party bare import는 모두 같은 규칙으로 externalize한다. Build graph에서 artifact별 package와 설치 version을 자동 수집한 runtime manifest를 생성하고 package manager가 transitive dependency와 package-relative asset/native layout을 설치한다. 정확한 package 이름 집합이나 package-manager 내부 경로는 Dockerfile과 테스트 계약에 수동으로 고정하지 않는다.
+- Alternatives Considered: `pnpm deploy --legacy` 전체 tree는 workspace TypeScript source, `tsx`와 사용하지 않는 production dependency까지 포함해 image 분리 효과를 크게 줄이므로 제외했다. 일부 package만 수동 externalize하는 방식은 사용자가 지적한 변경 취약성을 유지하므로 폐기했다. 모든 third-party package를 bundle하는 방식은 filesystem asset과 native/dynamic resolution을 package별로 다시 구현해야 하므로 제외했다.
+- Consequences: Final image에는 artifact별 작은 production `node_modules`가 존재하지만 범용 workspace tree나 source는 없다. 새 third-party import는 build 결과와 manifest를 통해 자동 반영되며 Worker만 target native binary pruning을 추가로 수행한다.
+- Confirmation / Follow-up: Metafile external import와 generated manifest 일치, `@kosmo/*`·`tsx` 부재, package install, 다섯 container boot/health와 non-Worker Temporal native 부재를 검증한다.
+
 ### Temporal Workflow는 production image 시작 전에 bundle한다
 
 - Decision Date: 2026-08-25
@@ -35,7 +47,7 @@
 - Authority / Provenance: Linear `PROD-730`, `PROD-831`
 - Status: Active
 - Context / Problem: 현재 Worker는 `workflowsPath`의 TypeScript source를 startup 때 Webpack으로 bundle한다. 일반 server처럼 완전 bundle하면 Temporal native `.node` resolution이 깨질 수 있고, 기존 경로를 유지하면 TypeScript source와 Webpack/SWC를 runtime artifact 경계에 계속 요구한다.
-- Decision Outcome: Build와 runtime에서 exact same `@temporalio/worker` version을 사용해 Workflow code를 `bundleWorkflowCode`로 사전 생성하고, production Worker는 `workflowBundle`을 전달한다. Worker host JavaScript는 Temporal native/runtime package를 external로 유지할 수 있으며 final image에는 target Linux/ARM64에서 SDK resolution에 필요한 최소 production dependency tree만 둔다.
+- Decision Outcome: Build와 runtime에서 exact same `@temporalio/worker` version을 사용해 Workflow code를 `bundleWorkflowCode`로 사전 생성하고, production Worker는 `workflowBundle`을 전달한다. Worker host의 third-party package도 공통 build-graph manifest 경계를 따르며 final image에는 target Linux/ARM64에서 SDK resolution에 필요한 production dependency와 native artifact만 둔다.
 - Alternatives Considered: Production `workflowsPath` 유지 방식은 runtime bundling과 TypeScript source 제거 목표를 위반해 제외했다. Native package를 single-file bundle 안에 강제로 넣는 방식은 ABI와 dynamic resolution 위험 때문에 제외했다. Temporal Worker 전체 dependency tree를 다른 runtime에도 공유하는 방식은 image 분리 목적을 위반해 제외했다.
 - Consequences: Worker image는 다른 image보다 크고 external package tree를 가질 수 있다. Workflow bundle 생성과 Worker runtime package version은 lockfile과 build에서 일치해야 한다.
 - Confirmation / Follow-up: Linux/ARM64 Node 26.5.1 container에서 native load, Worker create, health/readiness와 SIGTERM lifecycle을 검증하고 다른 runtime image에 Temporal Worker dependency가 없는지 확인한다.

--- a/openspec/changes/split-server-runtime-images/decisions.md
+++ b/openspec/changes/split-server-runtime-images/decisions.md
@@ -11,9 +11,9 @@
 - Authority / Provenance: `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, Linear `PROD-831`
 - Status: Active
 - Context / Problem: 공통 runtime image가 Web, API, Worker, Fedify Consumer와 migration의 source와 dependency를 모두 포함하고 `tsx`로 실행해 각 workload의 pull/runtime surface가 불필요하게 크다.
-- Decision Outcome: Web, API, Temporal Worker, Fedify Consumer와 migration을 build 단계의 JavaScript artifact와 서로 다른 다섯 final image로 제공한다. Web/API/Fedify/Migration은 workspace application code와 third-party runtime dependency를 단일 JavaScript artifact로 bundle하고 runtime `node_modules`를 두지 않는다. Worker만 Temporal SDK/native runtime을 build graph 기반 manifest로 설치한다. 모든 image에서 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 제거하고 Web image만 Expo static artifact를 포함한다.
-- Alternatives Considered: 하나의 image에서 JavaScript만 사전 compile하는 방식은 Worker와 Web asset/dependency를 모든 workload에 계속 배포하므로 제외했다. Runtime별 source tree와 production `node_modules`만 prune하는 방식은 `tsx` 직접 실행과 불필요한 package surface를 유지하므로 제외했다.
-- Consequences: Docker build와 registry output은 다섯 개로 늘지만 각 workload는 자신의 runtime layer만 pull한다. Non-Worker runtime import는 단일 bundle graph가 자동으로 따라가고 Worker external import만 generated manifest에 반영된다. Helm, scanner와 release workflow도 runtime별 identity를 처리해야 한다.
+- Decision Outcome: Web, API, Temporal Worker, Fedify Consumer와 migration을 build 단계의 JavaScript artifact와 서로 다른 다섯 final image로 제공한다. Workspace-owned code는 artifact로 bundle하고 third-party package는 각 workspace의 root lockfile 기반 production dependency tree로 배치한다. 모든 image에서 TypeScript source, `tsx`, 범용 workspace dependency와 개발 dependency를 제거하고 Web image만 Expo static artifact를 포함한다.
+- Alternatives Considered: 하나의 image에서 JavaScript만 사전 compile하는 방식은 Worker와 Web asset/dependency를 모든 workload에 계속 배포하므로 제외했다. Literal single-file bundle은 package-relative asset과 native resolution을 위해 package별 patch가 필요해 제외했다.
+- Consequences: Docker build와 registry output은 다섯 개로 늘지만 각 workload는 자신의 runtime layer만 pull한다. Runtime package 변경은 workspace manifest와 lockfile이 소유하고 별도 runtime manifest를 동기화하지 않는다. Helm, scanner와 release workflow도 runtime별 identity를 처리해야 한다.
 - Confirmation / Follow-up: 같은 Linux/ARM64 build에서 artifact, filesystem, dependency graph, boot/health와 compressed/uncompressed image size를 runtime별로 기록한다.
 
 ### Artifact gate 통과 뒤 release 계약을 전환한다
@@ -28,17 +28,17 @@
 - Consequences: 하나의 Linear/OpenSpec 안에 두 implementation slice가 생긴다. 첫 slice의 성공은 두 번째 slice나 dev/production 적용 성공을 증명하지 않는다.
 - Confirmation / Follow-up: Tasks와 PR evidence에서 artifact/CI, dev rollout, production 적용을 별도 proof tier로 보고한다.
 
-### Non-Worker dependency는 bundle하고 Worker SDK만 build graph에서 external 설치한다
+### Third-party dependency는 runtime별 production tree로 배치한다
 
 - Decision Date: 2026-08-25
 - Decision Class: Implementation Choice
 - Authority / Provenance: Linear `PROD-831`, 2026-08-25 사용자 재검토
 - Status: Active
 - Context / Problem: 최초 artifact 구현은 일부 external package 이름을 build script와 Dockerfile에 수동으로 나열하고 검사 코드가 정확한 root dependency 집합을 고정했다. API가 Temporal client를 사용하거나 package asset·dynamic import 경계가 바뀌면 여러 파일을 동시에 수정해야 해 runtime 분리가 미래의 정상적인 의존성 변경을 깨뜨릴 수 있었다.
-- Decision Outcome: Web/API/Fedify/Migration은 workspace-owned code와 third-party runtime dependency를 각각 하나의 JavaScript artifact로 완전 bundle한다. API의 `@temporalio/client`도 bundle하며 runtime package install을 하지 않는다. Worker application/Activity host code는 bundle하지만 `@temporalio/worker`와 그 SDK/native dependency는 build graph 기반 manifest로 external 설치한다. 정확한 Worker package 이름 집합이나 package-manager 내부 경로는 Dockerfile과 테스트 계약에 수동으로 고정하지 않는다.
-- Alternatives Considered: 모든 runtime을 generated manifest로 설치하는 방식은 네 non-Worker image에도 `node_modules`와 synthetic install 재현성 문제를 남겨 제외했다. Worker SDK까지 완전 bundle하는 방식은 Temporal의 Node-API native module, worker thread, VM sandbox와 SDK 내부 build-time bundler resolution을 깨뜨려 제외했다. `pnpm deploy --legacy` 전체 tree는 workspace source, `tsx`와 사용하지 않는 dependency까지 포함해 제외했다.
-- Consequences: Web/API/Fedify/Migration final image는 단일 server JavaScript와 필요한 static/SQL asset만 가지며 dependency manifest와 runtime `node_modules`가 없다. Worker만 작은 production `node_modules`와 target native binary pruning을 유지한다. API가 새 Temporal Client API를 호출해도 `@temporalio/client`는 같은 bundle graph에 자동 포함된다. 현재 HTML parsing/serialization 전용 JSDOM bundle은 package data를 inline하고 사용하지 않는 synchronous XHR worker 경로를 제외한다.
-- Confirmation / Follow-up: 네 non-Worker artifact의 external non-builtin import 부재와 runtime `node_modules` 부재, Worker metafile external import와 generated manifest 일치, 다섯 container boot/health 및 Worker native load를 검증한다.
+- Decision Outcome: 다섯 runtime의 workspace-owned code는 각각 하나의 JavaScript artifact로 bundle하고 third-party package는 external로 둔다. 각 final image는 해당 workspace를 root lockfile에서 production deploy한 dependency tree를 사용한다. 생성 runtime manifest, package별 bundler patch와 정확한 package allowlist를 두지 않는다.
+- Alternatives Considered: Literal single-file bundle은 JSDOM 등 package-relative asset을 위해 custom transform이 필요하고 dependency 변경에 취약해 제외했다. Build graph에서 synthetic runtime manifest를 생성하는 방식은 package manager가 이미 소유하는 manifest/lockfile 계약을 중복해 제외했다. Workspace 전체 hoisted install은 Expo·TypeScript 등 다른 runtime과 개발 dependency까지 포함해 제외했다.
+- Consequences: Literal single-file보다 image가 크지만 package 호환성과 의존성 변경 경계가 단순해진다. API가 `@temporalio/client`를 사용하면 API workspace dependency와 lockfile만으로 image에 반영된다. 각 final image에는 작은 production `node_modules`가 있으며 TypeScript source와 `tsx`는 없다.
+- Confirmation / Follow-up: artifact metadata의 external import가 각 final image에서 모두 resolve되는지, 다섯 container boot/health와 Worker native load를 검증한다.
 
 ### Temporal Workflow는 production image 시작 전에 bundle한다
 
@@ -47,7 +47,7 @@
 - Authority / Provenance: Linear `PROD-730`, `PROD-831`
 - Status: Active
 - Context / Problem: 현재 Worker는 `workflowsPath`의 TypeScript source를 startup 때 Webpack으로 bundle한다. 일반 server처럼 완전 bundle하면 Temporal native `.node` resolution이 깨질 수 있고, 기존 경로를 유지하면 TypeScript source와 Webpack/SWC를 runtime artifact 경계에 계속 요구한다.
-- Decision Outcome: Build와 runtime에서 exact same `@temporalio/worker` version을 사용해 Workflow code를 `bundleWorkflowCode`로 사전 생성하고, production Worker는 `workflowBundle`을 전달한다. Worker application/Activity host code는 bundle하되 Temporal Worker SDK와 그 runtime package는 build-graph manifest 경계를 따르며 final image에는 target Linux/ARM64에서 SDK resolution에 필요한 production dependency와 native artifact만 둔다.
+- Decision Outcome: Build와 runtime에서 exact same `@temporalio/worker` version을 사용해 Workflow code를 `bundleWorkflowCode`로 사전 생성하고, production Worker는 `workflowBundle`을 전달한다. Worker application/Activity host code는 bundle하되 Temporal Worker SDK는 Worker workspace의 production dependency tree에서 설치하며 final image에는 target Linux/ARM64에서 SDK resolution에 필요한 dependency와 native artifact만 둔다.
 - Alternatives Considered: Production `workflowsPath` 유지 방식은 runtime bundling과 TypeScript source 제거 목표를 위반해 제외했다. Native package를 single-file bundle 안에 강제로 넣는 방식은 ABI와 dynamic resolution 위험 때문에 제외했다. Temporal Worker 전체 dependency tree를 다른 runtime에도 공유하는 방식은 image 분리 목적을 위반해 제외했다.
 - Consequences: Worker image는 다른 image보다 크고 external package tree를 가질 수 있다. Workflow bundle 생성과 Worker runtime package version은 lockfile과 build에서 일치해야 한다.
 - Confirmation / Follow-up: Linux/ARM64 Node 26.5.1 container에서 native load, Worker create, health/readiness와 SIGTERM lifecycle을 검증하고 다른 runtime image에 Temporal Worker dependency가 없는지 확인한다.

--- a/openspec/changes/split-server-runtime-images/decisions.md
+++ b/openspec/changes/split-server-runtime-images/decisions.md
@@ -38,7 +38,7 @@
 - Decision Outcome: 다섯 runtime의 workspace-owned code는 각각 하나의 JavaScript artifact로 bundle하고 third-party package는 external로 둔다. 각 final image는 해당 workspace를 root lockfile에서 production deploy한 dependency tree를 사용한다. 생성 runtime manifest, package별 bundler patch와 정확한 package allowlist를 두지 않는다.
 - Alternatives Considered: Literal single-file bundle은 JSDOM 등 package-relative asset을 위해 custom transform이 필요하고 dependency 변경에 취약해 제외했다. Build graph에서 synthetic runtime manifest를 생성하는 방식은 package manager가 이미 소유하는 manifest/lockfile 계약을 중복해 제외했다. Workspace 전체 hoisted install은 Expo·TypeScript 등 다른 runtime과 개발 dependency까지 포함해 제외했다.
 - Consequences: Literal single-file보다 image가 크지만 package 호환성과 의존성 변경 경계가 단순해진다. API가 `@temporalio/client`를 사용하면 API workspace dependency와 lockfile만으로 image에 반영된다. 각 final image에는 작은 production `node_modules`가 있으며 TypeScript source와 `tsx`는 없다.
-- Confirmation / Follow-up: artifact metadata의 external import가 각 final image에서 모두 resolve되는지, 다섯 container boot/health와 Worker native load를 검증한다.
+- Confirmation / Follow-up: 각 workspace production dependency tree와 다섯 container boot/health, Worker native load를 검증한다.
 
 ### Temporal Workflow는 production image 시작 전에 bundle한다
 

--- a/openspec/changes/split-server-runtime-images/decisions.md
+++ b/openspec/changes/split-server-runtime-images/decisions.md
@@ -1,0 +1,97 @@
+## Context
+
+이 기록은 2026-08-25에 승인된 Linear `PROD-831`, 현재 single-image Docker/Helm/release 구조, `PROD-288`과 `PROD-783`의 immutable release 안전성, `PROD-730`의 Temporal Worker 경계 및 `PROD-516`의 server source map 계약을 반영한다. 제품 도메인 행동은 바꾸지 않고 server artifact, container와 release identity를 분리한다.
+
+## Decision Records
+
+### 다섯 runtime별 사전 생성 JavaScript artifact와 전용 image
+
+- Decision Date: 2026-08-25
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, Linear `PROD-831`
+- Status: Active
+- Context / Problem: 공통 runtime image가 Web, API, Worker, Fedify Consumer와 migration의 source와 dependency를 모두 포함하고 `tsx`로 실행해 각 workload의 pull/runtime surface가 불필요하게 크다.
+- Decision Outcome: Web, API, Temporal Worker, Fedify Consumer와 migration을 build 단계의 JavaScript artifact와 서로 다른 다섯 final image로 제공한다. Web/API/Fedify/Migration image에는 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 두지 않고 Web image만 Expo static artifact를 포함한다.
+- Alternatives Considered: 하나의 image에서 JavaScript만 사전 compile하는 방식은 Worker와 Web asset/dependency를 모든 workload에 계속 배포하므로 제외했다. Runtime별 source tree와 production `node_modules`만 prune하는 방식은 `tsx` 직접 실행과 불필요한 package surface를 유지하므로 제외했다.
+- Consequences: Docker build와 registry output은 다섯 개로 늘지만 각 workload는 자신의 runtime layer만 pull한다. Helm, scanner와 release workflow도 runtime별 identity를 처리해야 한다.
+- Confirmation / Follow-up: 같은 Linux/ARM64 build에서 artifact, filesystem, dependency graph, boot/health와 compressed/uncompressed image size를 runtime별로 기록한다.
+
+### Artifact gate 통과 뒤 release 계약을 전환한다
+
+- Decision Date: 2026-08-25
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-831`
+- Status: Active
+- Context / Problem: Dynamic import, `import.meta`, native module, Workflow bundle 또는 migration asset 경로가 깨진 상태에서 Helm과 release input까지 동시에 바꾸면 artifact 실패와 배포 계약 실패를 분리하기 어렵다.
+- Decision Outcome: 먼저 다섯 artifact와 image의 build·boot·dependency·size gate를 완료하고, 모든 결과가 통과한 뒤에만 Helm과 dev/production workflow를 runtime digest set으로 전환한다.
+- Alternatives Considered: Docker, Helm과 production workflow를 한 번에 전환하는 방식은 사용자가 선택한 검증 선행 경계와 맞지 않아 제외했다. 검증만 하고 배포 전환을 별도 이슈로 미루는 방식은 승인된 통합 이슈 범위와 맞지 않아 제외했다.
+- Consequences: 하나의 Linear/OpenSpec 안에 두 implementation slice가 생긴다. 첫 slice의 성공은 두 번째 slice나 dev/production 적용 성공을 증명하지 않는다.
+- Confirmation / Follow-up: Tasks와 PR evidence에서 artifact/CI, dev rollout, production 적용을 별도 proof tier로 보고한다.
+
+### Temporal Workflow는 production image 시작 전에 bundle한다
+
+- Decision Date: 2026-08-25
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-730`, `PROD-831`
+- Status: Active
+- Context / Problem: 현재 Worker는 `workflowsPath`의 TypeScript source를 startup 때 Webpack으로 bundle한다. 일반 server처럼 완전 bundle하면 Temporal native `.node` resolution이 깨질 수 있고, 기존 경로를 유지하면 TypeScript source와 Webpack/SWC를 runtime artifact 경계에 계속 요구한다.
+- Decision Outcome: Build와 runtime에서 exact same `@temporalio/worker` version을 사용해 Workflow code를 `bundleWorkflowCode`로 사전 생성하고, production Worker는 `workflowBundle`을 전달한다. Worker host JavaScript는 Temporal native/runtime package를 external로 유지할 수 있으며 final image에는 target Linux/ARM64에서 SDK resolution에 필요한 최소 production dependency tree만 둔다.
+- Alternatives Considered: Production `workflowsPath` 유지 방식은 runtime bundling과 TypeScript source 제거 목표를 위반해 제외했다. Native package를 single-file bundle 안에 강제로 넣는 방식은 ABI와 dynamic resolution 위험 때문에 제외했다. Temporal Worker 전체 dependency tree를 다른 runtime에도 공유하는 방식은 image 분리 목적을 위반해 제외했다.
+- Consequences: Worker image는 다른 image보다 크고 external package tree를 가질 수 있다. Workflow bundle 생성과 Worker runtime package version은 lockfile과 build에서 일치해야 한다.
+- Confirmation / Follow-up: Linux/ARM64 Node 26.5.1 container에서 native load, Worker create, health/readiness와 SIGTERM lifecycle을 검증하고 다른 runtime image에 Temporal Worker dependency가 없는지 확인한다.
+
+### Runtime image는 고정 entrypoint를 사용한다
+
+- Decision Date: 2026-08-25
+- Decision Class: Implementation Choice
+- Authority / Provenance: Linear `PROD-831`
+- Status: Active
+- Context / Problem: 기존 `docker-entrypoint.sh`는 하나의 image에서 command로 다섯 TypeScript entrypoint를 고른다. 전용 image에서도 이 dispatcher를 유지하면 잘못된 runtime command와 source/dependency 재결합 가능성이 남는다.
+- Decision Outcome: 각 final image는 자신의 사전 생성 Node JavaScript만 시작하는 고정 entrypoint를 사용하고 다른 runtime command를 선택하는 공통 dispatcher를 포함하지 않는다.
+- Alternatives Considered: 동일 dispatcher를 모든 image에 복사하되 사용 가능한 command만 줄이는 방식은 불필요한 shell 분기와 동일 파일 소유권을 유지하므로 제외했다.
+- Consequences: Helm template의 `args: web|api|worker|fedify-queue|migrate`는 제거되거나 image 고유 command와 충돌하지 않게 정리해야 한다. Runtime 선택은 image reference가 소유한다.
+- Confirmation / Follow-up: 각 rendered workload/Job의 image와 command를 검사하고 다른 runtime command로 시작할 수 없음을 container smoke에서 확인한다.
+
+### 단일 digest를 원자적인 runtime digest release set으로 일반화한다
+
+- Decision Date: 2026-08-25
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-288`, `PROD-783`, `PROD-831`
+- Status: Active
+- Context / Problem: 기존 migration과 workload의 동일 digest는 mutable tag race를 막지만 전용 runtime image는 서로 다른 content digest를 가진다.
+- Decision Outcome: 하나의 release는 동일 source full SHA와 승인된 단일 build run이 생성한 `web`, `api`, `worker`, `fedify-consumer`, `migration`의 digest-pinned reference를 정확히 하나씩 가진다. 다섯 값을 완전한 set으로 검증·기록·Argo mutation하고, migration image의 wave 1 성공 뒤 같은 set의 workload image를 wave 2에 적용한다.
+- Alternatives Considered: Migration과 workload가 서로 다른 SHA/build의 digest를 독립 선택하는 방식은 기존 compatibility barrier를 잃어 제외했다. 모든 runtime content를 다시 하나의 OCI image로 합치는 방식은 image 분리 목표를 무효화해 제외했다. 일부 실패 digest를 이전 release에서 채우는 방식은 release atomicity를 깨므로 제외했다.
+- Consequences: 하나의 `imageDigest` parameter와 audit field가 다섯 runtime 값으로 확장된다. Build, Trivy, Helm과 production summary는 누락과 partial mutation을 실패로 처리해야 한다.
+- Confirmation / Follow-up: Automatic main과 manual full-SHA release 모두 source SHA, build run, 다섯 digest, Argo source/parameter와 migration/workload image를 대조한다.
+
+### Server source map은 build secret 경계에서 업로드하고 image에서 제거한다
+
+- Decision Date: 2026-08-25
+- Decision Class: Derived Contract
+- Authority / Provenance: Linear `PROD-516`, `PROD-831`
+- Status: Active
+- Context / Problem: JavaScript bundle 전환은 runtime stack 위치를 바꾸므로 source map 없이 API/Web 오류 symbolication이 악화된다. 반대로 map이나 upload token이 final image에 남으면 source와 credential 노출이 생긴다.
+- Decision Outcome: API/Web server bundle의 external source map을 같은 Sentry release로 inject·upload·validate한 뒤 final image 복사 전에 map과 sourceMappingURL을 제거한다. Upload token은 BuildKit secret 경계로만 전달한다.
+- Alternatives Considered: Source map을 생성하지 않는 방식은 PROD-516/831 observability 계약을 충족하지 않아 제외했다. Map을 final image에 두는 방식과 token을 build argument로 전달하는 방식은 노출 위험 때문에 제외했다.
+- Consequences: Server bundle build가 Sentry artifact stage와 연결되고 upload-required build에서는 upload 실패가 release build를 실패시킨다.
+- Confirmation / Follow-up: Upload 결과와 API/Web artifact debug identity를 확인하고 final image filesystem, metadata와 runtime env에 map/token이 없는지 검사한다.
+
+### Production-release delta는 선행 active change archive 뒤 적용한다
+
+- Decision Date: 2026-08-25
+- Decision Class: Implementation Choice
+- Authority / Provenance: `memory/issue-openspec-workflow.md`, Linear `PROD-783`, `PROD-831`
+- Status: Active
+- Context / Problem: Current canonical `production-release` spec은 과거 tag 계약이고, main/manual SHA 계약은 아직 active `deploy-production-from-main-or-sha` change의 delta에 있다. 두 active change가 같은 requirement를 서로 다른 archive 순서로 수정하면 canonical sync가 충돌할 수 있다.
+- Decision Outcome: Artifact/image gate는 독립 진행할 수 있지만, PROD-831의 production-release implementation과 archive 전에 `deploy-production-from-main-or-sha`의 current authority, remaining tasks와 archive 상태를 refresh하고 main/manual SHA delta를 canonical에 먼저 동기화한다. 이 change는 그 canonical requirement를 runtime digest set으로 수정한다.
+- Alternatives Considered: 두 active delta를 archive 순서 없이 병렬 적용하는 방식은 requirement provenance와 archive 결과가 비결정적이어서 제외했다. PROD-831을 기존 change에 합치는 방식은 unrelated remaining live credential/release completion과 image 최적화 생명주기를 결합하므로 제외했다.
+- Consequences: Artifact slice가 완료돼도 선행 change archive가 끝나지 않으면 release contract slice와 이 change archive는 완료할 수 없다. 이를 blocker 우회 없이 별도 evidence gap으로 보고한다.
+- Confirmation / Follow-up: Release slice 시작 전에 `openspec status`, canonical `production-release` 내용과 PROD-783 Linear/current comments를 다시 확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/split-server-runtime-images/design.md
+++ b/openspec/changes/split-server-runtime-images/design.md
@@ -41,25 +41,26 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 
 ### Recommended Approach
 
-1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 Web, API, Fedify Consumer, migration 및 Worker host entry를 ESM JavaScript로 생성한다. Metafile을 남겨 runtime별 포함 dependency와 크기 검증에 사용한다.
-2. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성한다. Production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker host bundle은 Temporal native/runtime package를 external로 두고, 전용 production dependency tree와 target native binary를 Worker image에만 복사한다.
+1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 Web, API, Fedify Consumer, migration 및 Worker host entry의 workspace application code를 ESM JavaScript로 생성한다. Third-party bare import는 일관되게 external로 두고 esbuild build graph에서 package 이름과 설치 version을 자동 도출한 artifact별 runtime manifest를 함께 생성한다. Dockerfile이나 검사 코드에 package 이름 allowlist를 중복하지 않는다.
+2. 각 final image는 생성된 runtime manifest를 package manager로 설치해 transitive dependency, package-relative asset과 native module 구조를 보존한다. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성하고 production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker image에서만 target Linux/ARM64 native binary를 보존한다.
 3. Migration entry는 final artifact 위치에서 함께 복사된 `drizzle/` directory를 deterministic하게 resolve해 `runDatabaseMigrations({ migrationsFolder })`에 전달한다. Database target·credential 입력 계약은 바꾸지 않는다.
-4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 각 final target은 고정된 Node entrypoint를 사용하고 다중 runtime source/command dispatcher를 복사하지 않는다. Web target만 Expo asset을 받는다.
+4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 각 target은 자신의 generated runtime manifest만 설치하고 고정된 Node entrypoint를 사용하며 다중 runtime source/command dispatcher를 복사하지 않는다. Web target만 Expo asset을 받는다.
 5. 같은 repository에 runtime별 immutable build tag를 push하고 build output의 다섯 digest를 하나의 manifest/structured output으로 조립한다. Digest는 정규식뿐 아니라 runtime key 완전성, source full SHA와 build run identity를 검증한다.
 6. Helm values는 공통 repository와 runtime별 digest/version map을 받고 helper가 workload 이름에 대응하는 image reference를 만든다. Production은 모든 runtime에 digest를 요구하고, dev는 같은 build가 발행한 runtime별 tag 또는 digest를 사용한다.
 7. Argo CD parameter mutation은 한 command/job에서 다섯 값을 함께 설정한 뒤 source revision과 실제 parameter set을 다시 읽어 검증한다. Migration Job은 `migration` image로 wave 1, 네 workload는 대응 image로 wave 2를 유지한다.
 8. Sentry upload stage는 API/Web server external source map을 기존 browser artifact와 함께 inject/upload/validate하고, final image 복사 전에 map과 sourceMappingURL을 제거한다. Secret mount를 사용하고 token을 build argument나 layer로 전달하지 않는다.
-9. Artifact gate는 동일 Linux/ARM64 platform에서 build, filesystem/dependency inspection, container boot/health, image size와 layer 비교를 수행한다. 이 gate와 OpenSpec/issue review가 끝난 뒤에만 Helm·workflow 전환 slice를 시작한다.
+9. Artifact gate는 동일 Linux/ARM64 platform에서 generated manifest 정합성, filesystem 경계, container boot/health, image size와 layer 비교를 수행한다. 정확한 package allowlist나 pnpm 내부 경로는 테스트 계약으로 고정하지 않는다. 이 gate와 OpenSpec/issue review가 끝난 뒤에만 Helm·workflow 전환 slice를 시작한다.
 
 ### Allowed Alternatives
 
 - esbuild 대신 ESM, static dynamic import, `import.meta` 의미, source map과 metafile-equivalent dependency 검증을 만족하는 다른 bundler를 사용할 수 있다.
 - Runtime별 image는 같은 OCI repository의 runtime tag를 공유하거나 별도 repository를 사용할 수 있다. Helm에는 최종 `repository@digest`가 runtime별로 명확하고 release set이 원자적으로 검증되어야 한다.
-- Worker host는 검증 결과 완전 bundle보다 production-only external dependency tree가 더 안전하면 Temporal package 전체를 external로 유지할 수 있다. 어느 경우에도 Workflow는 prebuilt bundle이어야 하고 다른 runtime image에는 Worker dependency가 들어가면 안 된다.
+- Third-party dependency를 모두 bundle하는 대안은 package-relative asset과 native/dynamic resolution을 artifact마다 별도 처리하지 않고도 동등한 자동 추적과 boot 증거를 제공할 때만 사용할 수 있다. 어느 경우에도 package 이름의 수동 allowlist를 runtime 계약으로 두지 않는다.
 
 ### Known Traps
 
 - Transitive esbuild 설치에 의존해 build script를 추가하지 않는다. 사용 도구는 workspace의 명시적 dependency여야 한다.
+- External package 이름을 Dockerfile, build script와 검사 코드에 각각 수동으로 나열하지 않는다. Import graph가 바뀌면 generated runtime manifest가 함께 바뀌고 package manager가 transitive tree를 소유해야 한다.
 - Worker `workflowsPath`를 `.js`로만 바꾸고 startup bundling을 유지하지 않는다. 이는 Webpack/SWC와 Workflow source를 runtime에 다시 넣는다.
 - Native package directory를 임의로 평탄화하거나 `.node` 파일 하나만 위치를 바꿔 copy하지 않는다. SDK의 platform resolution 경로를 보존하고 container에서 load한다.
 - Migration bundle의 새 `import.meta.url`에서 기존 `drizzle.config.ts` 상대 경로가 우연히 맞는다고 가정하지 않는다.
@@ -72,7 +73,7 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 
 - [다섯 image build로 CI job과 registry artifact 수가 증가한다] → 공통 BuildKit stage/cache를 공유하고 release manifest 하나로 digest를 조립하되 각 runtime 결과와 scanner 상태를 별도로 보존한다.
 - [Worker image는 native bridge 때문에 다른 image보다 계속 클 수 있다] → 다른 runtime에서 완전히 격리하고 target binary만 남기며, Worker 크기는 현재 단일 image와 별도로 비교한다.
-- [Bundling이 package의 dynamic loading 또는 filesystem asset을 누락할 수 있다] → metafile inspection과 실제 container boot/health 및 주요 dynamic path test를 gate로 둔다.
+- [Bundling이 application의 dynamic loading을 누락하거나 external package manifest가 실제 import와 어긋날 수 있다] → workspace code의 metafile, generated manifest 정합성과 실제 container boot/health 및 주요 dynamic path test를 gate로 둔다.
 - [Server source map upload가 build credential 범위를 넓힌다] → 기존 Sentry secret mount와 승인 경계를 재사용하고 final image 및 로그의 부재를 검사한다.
 - [Runtime별 digest를 부분 적용하면 migration/workload compatibility가 깨진다] → 완전한 set validation, 단일 Argo mutation과 post-write verification 후에만 sync한다.
 - [Active production-release change와 archive 순서가 충돌할 수 있다] → `deploy-production-from-main-or-sha`의 current contract를 먼저 canonical에 동기화·archive하고 이 change의 release delta를 적용한다. Artifact slice는 이 integration gate와 독립적으로 검증할 수 있다.

--- a/openspec/changes/split-server-runtime-images/design.md
+++ b/openspec/changes/split-server-runtime-images/design.md
@@ -36,34 +36,36 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 - Worker host를 일반 server와 함께 완전 bundle하면 Temporal native `.node` resolution과 SDK 내부 bundler dependency가 깨질 수 있다. 반대로 `workflowsPath`를 유지하면 final image에서 TypeScript source와 runtime Webpack을 제거할 수 없다.
 - `@temporalio/core-bridge` package는 여러 OS/architecture binary를 포함한다. Worker image는 target Linux/ARM64 artifact를 보존하면서 다른 platform artifact를 제거했을 때 SDK resolution이 실제 container에서 성공하는지 확인해야 한다.
 - Migration artifact는 `drizzle/` SQL directory를 별도 asset으로 가져야 한다. Runtime-configurable database/schema authority를 새로 만들지 않고 artifact layout에서 deterministic하게 경로를 계산해야 한다.
+- Core의 JSDOM 사용은 HTML parsing/serialization으로 한정되지만 JSDOM은 stylesheet·JSON과 사용하지 않는 synchronous XHR worker file을 package-relative 경로로 참조한다. Single-file build는 실제 사용하는 data asset을 inline하고 synchronous XHR worker resolution을 제거한 뒤 현재 parsing/serialization 경로를 실행해 검증해야 한다.
 - Production Argo parameter update가 다섯 digest 중 일부만 적용되면 migration과 workload가 서로 다른 release가 된다. 생성, validation과 parameter mutation은 완전한 set 단위여야 한다.
 - Current Temporal SDK의 공식 지원 Node 범위와 repository의 Node 26 target이 다를 수 있으므로, Linux/ARM64 Node 26.5.1 container boot와 Worker lifecycle 증거 없이 host build 성공만으로 호환성을 주장하지 않는다.
 
 ### Recommended Approach
 
-1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 Web, API, Fedify Consumer, migration 및 Worker host entry의 workspace application code를 ESM JavaScript로 생성한다. Third-party bare import는 일관되게 external로 두고 esbuild build graph에서 package 이름과 설치 version을 자동 도출한 artifact별 runtime manifest를 함께 생성한다. Dockerfile이나 검사 코드에 package 이름 allowlist를 중복하지 않는다.
-2. 각 final image는 생성된 runtime manifest를 package manager로 설치해 transitive dependency, package-relative asset과 native module 구조를 보존한다. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성하고 production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker image에서만 target Linux/ARM64 native binary를 보존한다.
+1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 Web, API, Fedify Consumer와 migration의 workspace application code 및 third-party runtime dependency를 각각 하나의 ESM JavaScript artifact로 생성한다. API의 `@temporalio/client` 호출도 같은 artifact에 포함한다. Worker application/Activity host code는 bundle하되 `@temporalio/worker`와 그 SDK runtime dependency는 external로 두고 esbuild build graph에서 설치 version을 자동 도출한 Worker runtime manifest를 생성한다.
+2. Web/API/Fedify/Migration final image는 단일 JavaScript artifact와 필요한 static/SQL asset만 복사하고 runtime package install을 하지 않는다. Worker final image만 생성된 runtime manifest를 package manager로 설치해 native module 구조를 보존한다. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성하고 production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker image에서만 target Linux/ARM64 native binary를 보존한다.
 3. Migration entry는 final artifact 위치에서 함께 복사된 `drizzle/` directory를 deterministic하게 resolve해 `runDatabaseMigrations({ migrationsFolder })`에 전달한다. Database target·credential 입력 계약은 바꾸지 않는다.
-4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 각 target은 자신의 generated runtime manifest만 설치하고 고정된 Node entrypoint를 사용하며 다중 runtime source/command dispatcher를 복사하지 않는다. Web target만 Expo asset을 받는다.
+4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 네 non-Worker target은 단일 artifact를 고정 Node entrypoint로 실행하고 Worker target만 generated runtime manifest를 설치한다. 어느 target도 다중 runtime source/command dispatcher를 복사하지 않으며 Web target만 Expo asset을 받는다.
 5. 같은 repository에 runtime별 immutable build tag를 push하고 build output의 다섯 digest를 하나의 manifest/structured output으로 조립한다. Digest는 정규식뿐 아니라 runtime key 완전성, source full SHA와 build run identity를 검증한다.
 6. Helm values는 공통 repository와 runtime별 digest/version map을 받고 helper가 workload 이름에 대응하는 image reference를 만든다. Production은 모든 runtime에 digest를 요구하고, dev는 같은 build가 발행한 runtime별 tag 또는 digest를 사용한다.
 7. Argo CD parameter mutation은 한 command/job에서 다섯 값을 함께 설정한 뒤 source revision과 실제 parameter set을 다시 읽어 검증한다. Migration Job은 `migration` image로 wave 1, 네 workload는 대응 image로 wave 2를 유지한다.
 8. Sentry upload stage는 API/Web server external source map을 기존 browser artifact와 함께 inject/upload/validate하고, final image 복사 전에 map과 sourceMappingURL을 제거한다. Secret mount를 사용하고 token을 build argument나 layer로 전달하지 않는다.
-9. Artifact gate는 동일 Linux/ARM64 platform에서 generated manifest 정합성, filesystem 경계, container boot/health, image size와 layer 비교를 수행한다. 정확한 package allowlist나 pnpm 내부 경로는 테스트 계약으로 고정하지 않는다. 이 gate와 OpenSpec/issue review가 끝난 뒤에만 Helm·workflow 전환 slice를 시작한다.
+9. Artifact gate는 동일 Linux/ARM64 platform에서 네 non-Worker artifact의 single-file import closure와 runtime `node_modules` 부재, Worker generated manifest 정합성, filesystem 경계, container boot/health, image size와 layer 비교를 수행한다. 정확한 Worker package allowlist나 pnpm 내부 경로는 테스트 계약으로 고정하지 않는다. 이 gate와 OpenSpec/issue review가 끝난 뒤에만 Helm·workflow 전환 slice를 시작한다.
 
 ### Allowed Alternatives
 
 - esbuild 대신 ESM, static dynamic import, `import.meta` 의미, source map과 metafile-equivalent dependency 검증을 만족하는 다른 bundler를 사용할 수 있다.
 - Runtime별 image는 같은 OCI repository의 runtime tag를 공유하거나 별도 repository를 사용할 수 있다. Helm에는 최종 `repository@digest`가 runtime별로 명확하고 release set이 원자적으로 검증되어야 한다.
-- Third-party dependency를 모두 bundle하는 대안은 package-relative asset과 native/dynamic resolution을 artifact마다 별도 처리하지 않고도 동등한 자동 추적과 boot 증거를 제공할 때만 사용할 수 있다. 어느 경우에도 package 이름의 수동 allowlist를 runtime 계약으로 두지 않는다.
+- Worker SDK까지 단일 bundle하는 대안은 Temporal native module과 Workflow sandbox의 package-relative resolution을 별도 처리하지 않고도 동등한 ABI·lifecycle 증거를 제공할 때만 사용할 수 있다. 현재는 공식 Node/native runtime 경계를 보존한다.
 
 ### Known Traps
 
 - Transitive esbuild 설치에 의존해 build script를 추가하지 않는다. 사용 도구는 workspace의 명시적 dependency여야 한다.
-- External package 이름을 Dockerfile, build script와 검사 코드에 각각 수동으로 나열하지 않는다. Import graph가 바뀌면 generated runtime manifest가 함께 바뀌고 package manager가 transitive tree를 소유해야 한다.
+- Non-Worker runtime에 package install stage나 dependency manifest를 남기지 않는다. Worker external package 이름을 Dockerfile과 검사 코드에 중복 나열하지 않고 build graph가 runtime manifest를 소유하게 한다.
 - Worker `workflowsPath`를 `.js`로만 바꾸고 startup bundling을 유지하지 않는다. 이는 Webpack/SWC와 Workflow source를 runtime에 다시 넣는다.
 - Native package directory를 임의로 평탄화하거나 `.node` 파일 하나만 위치를 바꿔 copy하지 않는다. SDK의 platform resolution 경로를 보존하고 container에서 load한다.
 - Migration bundle의 새 `import.meta.url`에서 기존 `drizzle.config.ts` 상대 경로가 우연히 맞는다고 가정하지 않는다.
+- Bundled JSDOM을 synchronous XHR 용도로 확장하지 않는다. 그런 요구가 생기면 별도 worker asset을 포함하는 artifact 계약이나 DOM 구현 변경을 먼저 결정한다.
 - 한 digest가 실패했을 때 이전 release의 해당 runtime digest로 채워 완전한 set처럼 만들지 않는다.
 - Dev의 mutable `main` tag 하나를 다섯 runtime에 다시 사용하거나 production digest 검증을 tag 존재로 대체하지 않는다.
 - Source map upload 실패를 성공으로 삼키거나 source map/token을 final layer에 복사하지 않는다.
@@ -73,7 +75,7 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 
 - [다섯 image build로 CI job과 registry artifact 수가 증가한다] → 공통 BuildKit stage/cache를 공유하고 release manifest 하나로 digest를 조립하되 각 runtime 결과와 scanner 상태를 별도로 보존한다.
 - [Worker image는 native bridge 때문에 다른 image보다 계속 클 수 있다] → 다른 runtime에서 완전히 격리하고 target binary만 남기며, Worker 크기는 현재 단일 image와 별도로 비교한다.
-- [Bundling이 application의 dynamic loading을 누락하거나 external package manifest가 실제 import와 어긋날 수 있다] → workspace code의 metafile, generated manifest 정합성과 실제 container boot/health 및 주요 dynamic path test를 gate로 둔다.
+- [Bundling이 application의 dynamic loading이나 package-relative asset을 누락할 수 있다] → 네 non-Worker artifact의 import closure와 실제 container boot/health 및 주요 dynamic path test를 gate로 두고, Worker는 generated manifest 정합성과 native load를 별도로 검증한다.
 - [Server source map upload가 build credential 범위를 넓힌다] → 기존 Sentry secret mount와 승인 경계를 재사용하고 final image 및 로그의 부재를 검사한다.
 - [Runtime별 digest를 부분 적용하면 migration/workload compatibility가 깨진다] → 완전한 set validation, 단일 Argo mutation과 post-write verification 후에만 sync한다.
 - [Active production-release change와 archive 순서가 충돌할 수 있다] → `deploy-production-from-main-or-sha`의 current contract를 먼저 canonical에 동기화·archive하고 이 change의 release delta를 적용한다. Artifact slice는 이 integration gate와 독립적으로 검증할 수 있다.

--- a/openspec/changes/split-server-runtime-images/design.md
+++ b/openspec/changes/split-server-runtime-images/design.md
@@ -42,7 +42,7 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 
 ### Recommended Approach
 
-1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 다섯 runtime의 workspace-owned code를 각각 하나의 ESM JavaScript artifact로 생성한다. Third-party package는 external import로 유지하며 artifact metadata에 기록한다.
+1. 명시적인 server build dependency로 esbuild를 추가하고 한 번의 build에서 다섯 runtime의 workspace-owned code를 각각 하나의 ESM JavaScript artifact로 생성한다. Third-party package는 external import로 유지하고 workspace manifest와 lockfile의 production dependency tree가 제공한다. 별도 artifact metadata나 build manifest는 생성하지 않는다.
 2. 각 final image는 해당 workspace를 root lockfile에서 `pnpm deploy --legacy --prod`한 production dependency tree와 JavaScript artifact를 조립한다. 생성 `runtime-package.json`이나 수동 package allowlist는 두지 않는다. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성하고 production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker image에서만 target Linux/ARM64 native binary를 보존한다.
 3. Migration entry는 final artifact 위치에서 함께 복사된 `drizzle/` directory를 deterministic하게 resolve해 `runDatabaseMigrations({ migrationsFolder })`에 전달한다. Database target·credential 입력 계약은 바꾸지 않는다.
 4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 각 target은 자신의 artifact와 production dependency tree를 고정 Node entrypoint로 실행한다. 어느 target도 다중 runtime source/command dispatcher를 복사하지 않으며 Web target만 Expo asset을 받는다.
@@ -54,7 +54,7 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 
 ### Allowed Alternatives
 
-- esbuild 대신 ESM, static dynamic import, `import.meta` 의미, source map과 metafile-equivalent dependency 검증을 만족하는 다른 bundler를 사용할 수 있다.
+- esbuild 대신 ESM, static dynamic import, `import.meta` 의미와 source map 생성을 만족하는 다른 bundler를 사용할 수 있다.
 - Runtime별 image는 같은 OCI repository의 runtime tag를 공유하거나 별도 repository를 사용할 수 있다. Helm에는 최종 `repository@digest`가 runtime별로 명확하고 release set이 원자적으로 검증되어야 한다.
 - Worker SDK까지 단일 bundle하는 대안은 Temporal native module과 Workflow sandbox의 package-relative resolution을 별도 처리하지 않고도 동등한 ABI·lifecycle 증거를 제공할 때만 사용할 수 있다. 현재는 공식 Node/native runtime 경계를 보존한다.
 

--- a/openspec/changes/split-server-runtime-images/design.md
+++ b/openspec/changes/split-server-runtime-images/design.md
@@ -1,0 +1,94 @@
+## Context
+
+현재 `Dockerfile`은 모든 workspace production dependency를 한 runtime stage에 설치하고 API, Web, Worker, Fedify Consumer, Core/Fedify source 및 `drizzle/`을 함께 복사한다. `docker-entrypoint.sh`는 다섯 command를 모두 `node --import tsx`로 실행한다. 이 구조에서는 Web/API/Fedify/Migration Pod도 Temporal Worker의 native bridge와 Webpack/SWC dependency를 포함하며, 현재 설치 기준 `@temporalio/core-bridge`는 여러 platform binary를 함께 보유한다.
+
+Helm의 모든 workload와 migration Job은 공통 `image`/`imageDigest`를 사용하고 production release workflow는 하나의 digest를 Argo CD에 전달한다. 이 단일 digest는 mutable tag race를 막지만 runtime image를 분리하려면 동일 source와 build를 증명하는 원자적인 digest set으로 일반화해야 한다.
+
+Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 Node native module을 사용하고 현재 `workflowsPath`는 startup 때 TypeScript Workflow source를 Webpack으로 bundle한다. SDK는 production에서 `bundleWorkflowCode`로 만든 bundle을 `workflowBundle`로 전달하는 경로를 제공하며, build와 runtime의 Temporal Worker version이 정확히 같아야 한다. Migration은 현재 `drizzle.config.ts`의 `import.meta.url` 기준 상대 경로로 SQL directory를 찾으므로 bundle 위치를 바꾸면 asset 경로가 깨질 수 있다.
+
+`deploy-production-from-main-or-sha` change가 아직 active인 상태에서 canonical `production-release` spec은 이전 tag 기반 계약을 담고 있다. 이 change의 production-release delta는 그 active change가 canonical로 archive된 뒤 적용할 수 있도록 integration 순서를 명시해야 한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 다섯 runtime을 TypeScript loader 없이 사전 생성 JavaScript artifact로 실행한다.
+- 각 final image가 자신의 artifact, asset과 필요한 production runtime dependency만 포함하게 한다.
+- Worker Workflow를 build 때 사전 bundle하고 Linux/ARM64 native runtime 경계를 검증한다.
+- 같은 source full SHA와 build run의 다섯 immutable digest를 하나의 release set으로 원자적으로 전달한다.
+- 기존 dev/production migration barrier, Environment 승인, automatic/manual SHA release와 감사 경계를 보존한다.
+- 동일 Linux/ARM64 조건에서 현재 단일 image와 새 image의 compressed/uncompressed size 및 layer를 비교한다.
+
+**Non-Goals:**
+
+- Node major 또는 base image 선택 변경
+- Browser runtime config 도입이나 dev/prod Web artifact 통합
+- Temporal Server 배포, Workflow/Activity domain contract 또는 task queue identity 변경
+- Database schema/down migration 변경
+- Production 승인 없는 live apply
+
+## Implementation Guidance
+
+### Current Constraints
+
+- API/Web/Fedify code와 `packages/core/services`에는 static string dynamic import가 있고 entrypoint/migration에는 `import.meta.main` 또는 `import.meta.url` 경계가 있다. Bundle smoke는 단순 build 성공 외에 이 runtime branch를 실행해야 한다.
+- Web image만 Expo export, font와 precompressed static asset이 필요하다. 다른 image가 `apps/app/dist`를 상속하면 분리 효과가 줄어든다.
+- Worker host를 일반 server와 함께 완전 bundle하면 Temporal native `.node` resolution과 SDK 내부 bundler dependency가 깨질 수 있다. 반대로 `workflowsPath`를 유지하면 final image에서 TypeScript source와 runtime Webpack을 제거할 수 없다.
+- `@temporalio/core-bridge` package는 여러 OS/architecture binary를 포함한다. Worker image는 target Linux/ARM64 artifact를 보존하면서 다른 platform artifact를 제거했을 때 SDK resolution이 실제 container에서 성공하는지 확인해야 한다.
+- Migration artifact는 `drizzle/` SQL directory를 별도 asset으로 가져야 한다. Runtime-configurable database/schema authority를 새로 만들지 않고 artifact layout에서 deterministic하게 경로를 계산해야 한다.
+- Production Argo parameter update가 다섯 digest 중 일부만 적용되면 migration과 workload가 서로 다른 release가 된다. 생성, validation과 parameter mutation은 완전한 set 단위여야 한다.
+- Current Temporal SDK의 공식 지원 Node 범위와 repository의 Node 26 target이 다를 수 있으므로, Linux/ARM64 Node 26.5.1 container boot와 Worker lifecycle 증거 없이 host build 성공만으로 호환성을 주장하지 않는다.
+
+### Recommended Approach
+
+1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 Web, API, Fedify Consumer, migration 및 Worker host entry를 ESM JavaScript로 생성한다. Metafile을 남겨 runtime별 포함 dependency와 크기 검증에 사용한다.
+2. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성한다. Production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker host bundle은 Temporal native/runtime package를 external로 두고, 전용 production dependency tree와 target native binary를 Worker image에만 복사한다.
+3. Migration entry는 final artifact 위치에서 함께 복사된 `drizzle/` directory를 deterministic하게 resolve해 `runDatabaseMigrations({ migrationsFolder })`에 전달한다. Database target·credential 입력 계약은 바꾸지 않는다.
+4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 각 final target은 고정된 Node entrypoint를 사용하고 다중 runtime source/command dispatcher를 복사하지 않는다. Web target만 Expo asset을 받는다.
+5. 같은 repository에 runtime별 immutable build tag를 push하고 build output의 다섯 digest를 하나의 manifest/structured output으로 조립한다. Digest는 정규식뿐 아니라 runtime key 완전성, source full SHA와 build run identity를 검증한다.
+6. Helm values는 공통 repository와 runtime별 digest/version map을 받고 helper가 workload 이름에 대응하는 image reference를 만든다. Production은 모든 runtime에 digest를 요구하고, dev는 같은 build가 발행한 runtime별 tag 또는 digest를 사용한다.
+7. Argo CD parameter mutation은 한 command/job에서 다섯 값을 함께 설정한 뒤 source revision과 실제 parameter set을 다시 읽어 검증한다. Migration Job은 `migration` image로 wave 1, 네 workload는 대응 image로 wave 2를 유지한다.
+8. Sentry upload stage는 API/Web server external source map을 기존 browser artifact와 함께 inject/upload/validate하고, final image 복사 전에 map과 sourceMappingURL을 제거한다. Secret mount를 사용하고 token을 build argument나 layer로 전달하지 않는다.
+9. Artifact gate는 동일 Linux/ARM64 platform에서 build, filesystem/dependency inspection, container boot/health, image size와 layer 비교를 수행한다. 이 gate와 OpenSpec/issue review가 끝난 뒤에만 Helm·workflow 전환 slice를 시작한다.
+
+### Allowed Alternatives
+
+- esbuild 대신 ESM, static dynamic import, `import.meta` 의미, source map과 metafile-equivalent dependency 검증을 만족하는 다른 bundler를 사용할 수 있다.
+- Runtime별 image는 같은 OCI repository의 runtime tag를 공유하거나 별도 repository를 사용할 수 있다. Helm에는 최종 `repository@digest`가 runtime별로 명확하고 release set이 원자적으로 검증되어야 한다.
+- Worker host는 검증 결과 완전 bundle보다 production-only external dependency tree가 더 안전하면 Temporal package 전체를 external로 유지할 수 있다. 어느 경우에도 Workflow는 prebuilt bundle이어야 하고 다른 runtime image에는 Worker dependency가 들어가면 안 된다.
+
+### Known Traps
+
+- Transitive esbuild 설치에 의존해 build script를 추가하지 않는다. 사용 도구는 workspace의 명시적 dependency여야 한다.
+- Worker `workflowsPath`를 `.js`로만 바꾸고 startup bundling을 유지하지 않는다. 이는 Webpack/SWC와 Workflow source를 runtime에 다시 넣는다.
+- Native package directory를 임의로 평탄화하거나 `.node` 파일 하나만 위치를 바꿔 copy하지 않는다. SDK의 platform resolution 경로를 보존하고 container에서 load한다.
+- Migration bundle의 새 `import.meta.url`에서 기존 `drizzle.config.ts` 상대 경로가 우연히 맞는다고 가정하지 않는다.
+- 한 digest가 실패했을 때 이전 release의 해당 runtime digest로 채워 완전한 set처럼 만들지 않는다.
+- Dev의 mutable `main` tag 하나를 다섯 runtime에 다시 사용하거나 production digest 검증을 tag 존재로 대체하지 않는다.
+- Source map upload 실패를 성공으로 삼키거나 source map/token을 final layer에 복사하지 않는다.
+- Image build/CI 성공을 dev rollout, production approval 또는 production health 증거로 보고하지 않는다.
+
+## Risks / Trade-offs
+
+- [다섯 image build로 CI job과 registry artifact 수가 증가한다] → 공통 BuildKit stage/cache를 공유하고 release manifest 하나로 digest를 조립하되 각 runtime 결과와 scanner 상태를 별도로 보존한다.
+- [Worker image는 native bridge 때문에 다른 image보다 계속 클 수 있다] → 다른 runtime에서 완전히 격리하고 target binary만 남기며, Worker 크기는 현재 단일 image와 별도로 비교한다.
+- [Bundling이 package의 dynamic loading 또는 filesystem asset을 누락할 수 있다] → metafile inspection과 실제 container boot/health 및 주요 dynamic path test를 gate로 둔다.
+- [Server source map upload가 build credential 범위를 넓힌다] → 기존 Sentry secret mount와 승인 경계를 재사용하고 final image 및 로그의 부재를 검사한다.
+- [Runtime별 digest를 부분 적용하면 migration/workload compatibility가 깨진다] → 완전한 set validation, 단일 Argo mutation과 post-write verification 후에만 sync한다.
+- [Active production-release change와 archive 순서가 충돌할 수 있다] → `deploy-production-from-main-or-sha`의 current contract를 먼저 canonical에 동기화·archive하고 이 change의 release delta를 적용한다. Artifact slice는 이 integration gate와 독립적으로 검증할 수 있다.
+
+## Migration Plan
+
+1. 현재 single image를 Linux/ARM64에서 다시 build해 size/layer와 다섯 command의 baseline을 기록한다.
+2. JavaScript artifact와 다섯 Docker target을 추가하고 local/package/container gate를 통과시킨다. 이 단계에서는 Helm과 배포 workflow 입력을 바꾸지 않는다.
+3. `deploy-production-from-main-or-sha`의 remaining authority/archive 상태를 refresh하고 production-release canonical spec이 main/manual SHA 계약을 포함하는지 확인한다.
+4. Dev build가 runtime별 image/tag와 완전한 digest manifest를 게시하되 기존 deploy consumer는 유지해 registry output만 검증한다.
+5. Helm과 Deploy Dev를 runtime image set으로 원자적으로 전환하고 render, migration wave, workload health와 image reference를 dev에서 검증한다.
+6. Production workflow를 승인 뒤 다섯 image build, set validation, migration-gated sync와 audit summary로 전환한다. Static validation과 review가 끝나도 별도 production 승인을 받기 전에는 live sync하지 않는다.
+7. 승인된 production release에서 migration과 네 workload의 source SHA/build run/digest, health와 smoke를 확인한다.
+
+Rollback은 DB-compatible 이전 full SHA를 같은 five-image build와 approval 경로로 새 release set으로 build·배포한다. Partial runtime digest rollback, mutable tag 이동과 database history rollback은 사용하지 않는다. 배포 계약 전환 전 artifact 단계의 rollback은 새 Docker target/build script 사용을 중단하고 기존 single-image workflow를 유지한다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/split-server-runtime-images/design.md
+++ b/openspec/changes/split-server-runtime-images/design.md
@@ -36,21 +36,21 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 - Worker host를 일반 server와 함께 완전 bundle하면 Temporal native `.node` resolution과 SDK 내부 bundler dependency가 깨질 수 있다. 반대로 `workflowsPath`를 유지하면 final image에서 TypeScript source와 runtime Webpack을 제거할 수 없다.
 - `@temporalio/core-bridge` package는 여러 OS/architecture binary를 포함한다. Worker image는 target Linux/ARM64 artifact를 보존하면서 다른 platform artifact를 제거했을 때 SDK resolution이 실제 container에서 성공하는지 확인해야 한다.
 - Migration artifact는 `drizzle/` SQL directory를 별도 asset으로 가져야 한다. Runtime-configurable database/schema authority를 새로 만들지 않고 artifact layout에서 deterministic하게 경로를 계산해야 한다.
-- Core의 JSDOM 사용은 HTML parsing/serialization으로 한정되지만 JSDOM은 stylesheet·JSON과 사용하지 않는 synchronous XHR worker file을 package-relative 경로로 참조한다. Single-file build는 실제 사용하는 data asset을 inline하고 synchronous XHR worker resolution을 제거한 뒤 현재 parsing/serialization 경로를 실행해 검증해야 한다.
+- Third-party package는 package-relative asset과 dynamic resolution을 사용할 수 있으므로 package 내부 구조를 build script에서 패치하거나 단일 파일에 강제로 넣지 않는다.
 - Production Argo parameter update가 다섯 digest 중 일부만 적용되면 migration과 workload가 서로 다른 release가 된다. 생성, validation과 parameter mutation은 완전한 set 단위여야 한다.
 - Current Temporal SDK의 공식 지원 Node 범위와 repository의 Node 26 target이 다를 수 있으므로, Linux/ARM64 Node 26.5.1 container boot와 Worker lifecycle 증거 없이 host build 성공만으로 호환성을 주장하지 않는다.
 
 ### Recommended Approach
 
-1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 Web, API, Fedify Consumer와 migration의 workspace application code 및 third-party runtime dependency를 각각 하나의 ESM JavaScript artifact로 생성한다. API의 `@temporalio/client` 호출도 같은 artifact에 포함한다. Worker application/Activity host code는 bundle하되 `@temporalio/worker`와 그 SDK runtime dependency는 external로 두고 esbuild build graph에서 설치 version을 자동 도출한 Worker runtime manifest를 생성한다.
-2. Web/API/Fedify/Migration final image는 단일 JavaScript artifact와 필요한 static/SQL asset만 복사하고 runtime package install을 하지 않는다. Worker final image만 생성된 runtime manifest를 package manager로 설치해 native module 구조를 보존한다. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성하고 production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker image에서만 target Linux/ARM64 native binary를 보존한다.
+1. 명시적인 server build dependency로 esbuild를 추가하고 공통 build script에서 다섯 runtime의 workspace-owned code를 각각 하나의 ESM JavaScript artifact로 생성한다. Third-party package는 external import로 유지하며 artifact metadata에 기록한다.
+2. 각 final image는 해당 workspace를 root lockfile에서 `pnpm deploy --legacy --prod`한 production dependency tree와 JavaScript artifact를 조립한다. 생성 `runtime-package.json`이나 수동 package allowlist는 두지 않는다. Worker Workflow는 같은 lockfile의 `@temporalio/worker`가 제공하는 `bundleWorkflowCode`로 별도 생성하고 production host는 `workflowsPath` 대신 image 안의 prebuilt `workflowBundle.codePath`를 사용한다. Worker image에서만 target Linux/ARM64 native binary를 보존한다.
 3. Migration entry는 final artifact 위치에서 함께 복사된 `drizzle/` directory를 deterministic하게 resolve해 `runDatabaseMigrations({ migrationsFolder })`에 전달한다. Database target·credential 입력 계약은 바꾸지 않는다.
-4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 네 non-Worker target은 단일 artifact를 고정 Node entrypoint로 실행하고 Worker target만 generated runtime manifest를 설치한다. 어느 target도 다중 runtime source/command dispatcher를 복사하지 않으며 Web target만 Expo asset을 받는다.
+4. Dockerfile은 공통 dependency/build stage와 `web`, `api`, `worker`, `fedify-consumer`, `migration` final target을 둔다. 각 target은 자신의 artifact와 production dependency tree를 고정 Node entrypoint로 실행한다. 어느 target도 다중 runtime source/command dispatcher를 복사하지 않으며 Web target만 Expo asset을 받는다.
 5. 같은 repository에 runtime별 immutable build tag를 push하고 build output의 다섯 digest를 하나의 manifest/structured output으로 조립한다. Digest는 정규식뿐 아니라 runtime key 완전성, source full SHA와 build run identity를 검증한다.
 6. Helm values는 공통 repository와 runtime별 digest/version map을 받고 helper가 workload 이름에 대응하는 image reference를 만든다. Production은 모든 runtime에 digest를 요구하고, dev는 같은 build가 발행한 runtime별 tag 또는 digest를 사용한다.
 7. Argo CD parameter mutation은 한 command/job에서 다섯 값을 함께 설정한 뒤 source revision과 실제 parameter set을 다시 읽어 검증한다. Migration Job은 `migration` image로 wave 1, 네 workload는 대응 image로 wave 2를 유지한다.
 8. Sentry upload stage는 API/Web server external source map을 기존 browser artifact와 함께 inject/upload/validate하고, final image 복사 전에 map과 sourceMappingURL을 제거한다. Secret mount를 사용하고 token을 build argument나 layer로 전달하지 않는다.
-9. Artifact gate는 동일 Linux/ARM64 platform에서 네 non-Worker artifact의 single-file import closure와 runtime `node_modules` 부재, Worker generated manifest 정합성, filesystem 경계, container boot/health, image size와 layer 비교를 수행한다. 정확한 Worker package allowlist나 pnpm 내부 경로는 테스트 계약으로 고정하지 않는다. 이 gate와 OpenSpec/issue review가 끝난 뒤에만 Helm·workflow 전환 slice를 시작한다.
+9. Artifact gate는 동일 Linux/ARM64 platform에서 각 artifact의 external import가 해당 production dependency tree에서 해석되는지, filesystem 경계, container boot/health, Worker native ABI, image size와 layer를 검사한다. 정확한 package allowlist나 pnpm 내부 경로는 테스트 계약으로 고정하지 않는다. 이 gate와 OpenSpec/issue review가 끝난 뒤에만 Helm·workflow 전환 slice를 시작한다.
 
 ### Allowed Alternatives
 
@@ -61,11 +61,10 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 ### Known Traps
 
 - Transitive esbuild 설치에 의존해 build script를 추가하지 않는다. 사용 도구는 workspace의 명시적 dependency여야 한다.
-- Non-Worker runtime에 package install stage나 dependency manifest를 남기지 않는다. Worker external package 이름을 Dockerfile과 검사 코드에 중복 나열하지 않고 build graph가 runtime manifest를 소유하게 한다.
+- Generated runtime manifest나 package별 bundler patch를 만들지 않는다. Runtime package 추가·제거는 workspace manifest와 root lockfile만 소유하게 한다.
 - Worker `workflowsPath`를 `.js`로만 바꾸고 startup bundling을 유지하지 않는다. 이는 Webpack/SWC와 Workflow source를 runtime에 다시 넣는다.
 - Native package directory를 임의로 평탄화하거나 `.node` 파일 하나만 위치를 바꿔 copy하지 않는다. SDK의 platform resolution 경로를 보존하고 container에서 load한다.
 - Migration bundle의 새 `import.meta.url`에서 기존 `drizzle.config.ts` 상대 경로가 우연히 맞는다고 가정하지 않는다.
-- Bundled JSDOM을 synchronous XHR 용도로 확장하지 않는다. 그런 요구가 생기면 별도 worker asset을 포함하는 artifact 계약이나 DOM 구현 변경을 먼저 결정한다.
 - 한 digest가 실패했을 때 이전 release의 해당 runtime digest로 채워 완전한 set처럼 만들지 않는다.
 - Dev의 mutable `main` tag 하나를 다섯 runtime에 다시 사용하거나 production digest 검증을 tag 존재로 대체하지 않는다.
 - Source map upload 실패를 성공으로 삼키거나 source map/token을 final layer에 복사하지 않는다.
@@ -75,7 +74,7 @@ Temporal Worker는 일반 server bundle과 다르다. `@temporalio/worker`는 No
 
 - [다섯 image build로 CI job과 registry artifact 수가 증가한다] → 공통 BuildKit stage/cache를 공유하고 release manifest 하나로 digest를 조립하되 각 runtime 결과와 scanner 상태를 별도로 보존한다.
 - [Worker image는 native bridge 때문에 다른 image보다 계속 클 수 있다] → 다른 runtime에서 완전히 격리하고 target binary만 남기며, Worker 크기는 현재 단일 image와 별도로 비교한다.
-- [Bundling이 application의 dynamic loading이나 package-relative asset을 누락할 수 있다] → 네 non-Worker artifact의 import closure와 실제 container boot/health 및 주요 dynamic path test를 gate로 두고, Worker는 generated manifest 정합성과 native load를 별도로 검증한다.
+- [Production dependency tree가 불필요한 transitive package를 일부 포함할 수 있다] → package internals를 패치하지 않는 호환성과 유지보수성을 우선하고, 각 runtime image가 baseline보다 작은지와 external import resolution을 gate로 둔다.
 - [Server source map upload가 build credential 범위를 넓힌다] → 기존 Sentry secret mount와 승인 경계를 재사용하고 final image 및 로그의 부재를 검사한다.
 - [Runtime별 digest를 부분 적용하면 migration/workload compatibility가 깨진다] → 완전한 set validation, 단일 Argo mutation과 post-write verification 후에만 sync한다.
 - [Active production-release change와 archive 순서가 충돌할 수 있다] → `deploy-production-from-main-or-sha`의 current contract를 먼저 canonical에 동기화·archive하고 이 change의 release delta를 적용한다. Artifact slice는 이 integration gate와 독립적으로 검증할 수 있다.

--- a/openspec/changes/split-server-runtime-images/proposal.md
+++ b/openspec/changes/split-server-runtime-images/proposal.md
@@ -4,8 +4,8 @@
 
 ## What Changes
 
-- Web, API, Fedify Consumer와 migration의 workspace application code와 third-party runtime dependency를 실제 실행 graph의 단일 JavaScript artifact로 bundle하며, 최종 image에서 runtime `node_modules`, TypeScript source와 `tsx`를 제거한다.
-- Temporal Worker application/Activity host code와 Workflow code를 build 단계에서 각각 준비하고, `@temporalio/worker`와 SDK runtime dependency만 build graph 기반 manifest로 external 설치해 target Linux/ARM64 native/runtime artifact를 보존한다.
+- 다섯 runtime의 workspace application code를 JavaScript artifact로 bundle하고, third-party package는 각 workspace의 root lockfile 기반 production dependency tree로 배치한다. 생성 runtime manifest 없이 최종 image에서 TypeScript source와 `tsx`를 제거한다.
+- Temporal Worker application/Activity host code와 Workflow code를 build 단계에서 각각 준비하고, Worker production dependency tree에서 target Linux/ARM64 native/runtime artifact를 보존한다.
 - Web, API, Worker, Fedify Consumer와 migration을 서로 다른 final image로 만들고 각 image의 dependency 구성, boot 동작과 크기를 검증한다.
 - **BREAKING** Helm과 dev/production release identity를 단일 application image digest에서 동일 source SHA와 승인된 build run이 생성한 다섯 runtime image digest의 검증된 release set으로 변경한다.
 - 전용 migration image가 같은 release set의 workload image보다 먼저 실행되고 성공해야 한다는 Argo CD migration barrier를 유지한다.
@@ -38,4 +38,4 @@
 - Deployment: Helm image values/helper와 Web/API/Worker/Fedify Consumer/Migration template, Argo CD parameter 전달과 migration wave.
 - Delivery: dev Docker Build/Deploy workflow, automatic·manual production release workflow, runtime별 digest 검증·감사 기록과 Trivy 대상.
 - Observability: API/Web server source map 생성·Sentry upload와 최종 image 제외.
-- Dependencies: JavaScript bundler를 명시적 build dependency로 추가한다. Web/API/Fedify/Migration dependency는 artifact에 포함하고 Temporal Worker SDK와 native package만 build graph 기반 manifest의 target ABI external runtime dependency로 유지한다.
+- Dependencies: JavaScript bundler를 명시적 build dependency로 추가한다. 각 runtime의 production dependency는 workspace manifest와 root lockfile에서 배치하며, Temporal Worker image만 target ABI native package를 유지한다.

--- a/openspec/changes/split-server-runtime-images/proposal.md
+++ b/openspec/changes/split-server-runtime-images/proposal.md
@@ -4,7 +4,7 @@
 
 ## What Changes
 
-- Web, API, Fedify Consumer와 migration은 실제 실행 graph를 JavaScript로 bundle하고, 최종 image에서 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 제거한다.
+- Web, API, Fedify Consumer와 migration의 workspace application code는 실제 실행 graph를 JavaScript로 bundle한다. Third-party bare import는 build graph에서 자동 도출한 runtime manifest로 package manager가 설치하며, 최종 image에서 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 제거한다.
 - Temporal Worker host와 Workflow code를 build 단계에서 각각 준비하고, Worker image에는 target Linux/ARM64에서 필요한 Temporal native/runtime artifact만 남긴다.
 - Web, API, Worker, Fedify Consumer와 migration을 서로 다른 final image로 만들고 각 image의 dependency 구성, boot 동작과 크기를 검증한다.
 - **BREAKING** Helm과 dev/production release identity를 단일 application image digest에서 동일 source SHA와 승인된 build run이 생성한 다섯 runtime image digest의 검증된 release set으로 변경한다.
@@ -38,4 +38,4 @@
 - Deployment: Helm image values/helper와 Web/API/Worker/Fedify Consumer/Migration template, Argo CD parameter 전달과 migration wave.
 - Delivery: dev Docker Build/Deploy workflow, automatic·manual production release workflow, runtime별 digest 검증·감사 기록과 Trivy 대상.
 - Observability: API/Web server source map 생성·Sentry upload와 최종 image 제외.
-- Dependencies: JavaScript bundler를 명시적 build dependency로 추가하며, Temporal native package는 Worker final image의 최소 external runtime dependency로 유지한다.
+- Dependencies: JavaScript bundler를 명시적 build dependency로 추가하고 artifact별 third-party runtime manifest를 build graph에서 생성한다. Temporal native package는 Worker final image의 target ABI external runtime dependency로 유지한다.

--- a/openspec/changes/split-server-runtime-images/proposal.md
+++ b/openspec/changes/split-server-runtime-images/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+현재 하나의 Docker image가 Web, API, Temporal Worker, Fedify Consumer와 migration의 TypeScript source 및 production dependency를 모두 포함하고 `tsx`로 직접 실행되어, 각 workload가 사용하지 않는 dependency와 특히 큰 Temporal native runtime까지 함께 배포한다. PROD-831은 각 runtime을 사전 생성 JavaScript artifact와 전용 image로 분리하되, 기존 immutable release와 migration barrier를 runtime별 digest set으로 일반화해 이미지 크기를 줄이고 배포 안전성을 유지한다.
+
+## What Changes
+
+- Web, API, Fedify Consumer와 migration은 실제 실행 graph를 JavaScript로 bundle하고, 최종 image에서 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 제거한다.
+- Temporal Worker host와 Workflow code를 build 단계에서 각각 준비하고, Worker image에는 target Linux/ARM64에서 필요한 Temporal native/runtime artifact만 남긴다.
+- Web, API, Worker, Fedify Consumer와 migration을 서로 다른 final image로 만들고 각 image의 dependency 구성, boot 동작과 크기를 검증한다.
+- **BREAKING** Helm과 dev/production release identity를 단일 application image digest에서 동일 source SHA와 승인된 build run이 생성한 다섯 runtime image digest의 검증된 release set으로 변경한다.
+- 전용 migration image가 같은 release set의 workload image보다 먼저 실행되고 성공해야 한다는 Argo CD migration barrier를 유지한다.
+- Server JavaScript source map을 Sentry release에 연결하되 upload credential과 source map을 최종 image에서 제외한다.
+- Artifact build·boot·dependency·size gate가 통과하기 전에는 Helm과 release workflow의 runtime별 image set 전환을 시작하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`; 적용되는 `docs/design` 문서 없음.
+- Linear Contract: `PROD-831` (Issue Gate 승인: 2026-08-25).
+- Linear Implementations: 없음. 관련 선행 계약은 `PROD-288`, `PROD-516`, `PROD-730`, `PROD-783`.
+
+## Capabilities
+
+### New Capabilities
+
+- `server-runtime-images`: 다섯 server runtime의 사전 생성 JavaScript artifact, 전용 final image, dependency·boot·size 검증과 server source map 경계를 정의한다.
+
+### Modified Capabilities
+
+- `production-release`: 승인된 production build와 감사 identity를 하나의 digest가 아니라 동일 source/build의 runtime image digest set으로 전달한다.
+- `production-migration-gate`: migration과 workload의 동일 digest 조건을 같은 release set의 전용 migration/workload digest 및 기존 wave barrier로 일반화한다.
+- `dev-database-migrations`: dev migration Job과 workload가 같은 mutable image가 아니라 같은 build의 runtime별 image set을 사용하게 한다.
+- `temporal-worker-runtime-foundation`: 공통 runtime image의 TypeScript Worker source 실행을 사전 생성 host/Workflow artifact와 전용 Worker image로 전환한다.
+- `fedify-postgres-message-queue-runtime`: Fedify producer와 consumer가 단일 공통 image 대신 같은 release set에서 각자 지정된 runtime image를 사용한다.
+
+## Impact
+
+- Build/runtime: `Dockerfile`, server build script와 package manifest, `docker-entrypoint.sh`, Worker Workflow bundling, migration artifact path, Expo Web static artifact 조립.
+- Deployment: Helm image values/helper와 Web/API/Worker/Fedify Consumer/Migration template, Argo CD parameter 전달과 migration wave.
+- Delivery: dev Docker Build/Deploy workflow, automatic·manual production release workflow, runtime별 digest 검증·감사 기록과 Trivy 대상.
+- Observability: API/Web server source map 생성·Sentry upload와 최종 image 제외.
+- Dependencies: JavaScript bundler를 명시적 build dependency로 추가하며, Temporal native package는 Worker final image의 최소 external runtime dependency로 유지한다.

--- a/openspec/changes/split-server-runtime-images/proposal.md
+++ b/openspec/changes/split-server-runtime-images/proposal.md
@@ -4,8 +4,8 @@
 
 ## What Changes
 
-- Web, API, Fedify Consumer와 migration의 workspace application code는 실제 실행 graph를 JavaScript로 bundle한다. Third-party bare import는 build graph에서 자동 도출한 runtime manifest로 package manager가 설치하며, 최종 image에서 TypeScript source, `tsx`, 범용 workspace `node_modules`와 개발 dependency를 제거한다.
-- Temporal Worker host와 Workflow code를 build 단계에서 각각 준비하고, Worker image에는 target Linux/ARM64에서 필요한 Temporal native/runtime artifact만 남긴다.
+- Web, API, Fedify Consumer와 migration의 workspace application code와 third-party runtime dependency를 실제 실행 graph의 단일 JavaScript artifact로 bundle하며, 최종 image에서 runtime `node_modules`, TypeScript source와 `tsx`를 제거한다.
+- Temporal Worker application/Activity host code와 Workflow code를 build 단계에서 각각 준비하고, `@temporalio/worker`와 SDK runtime dependency만 build graph 기반 manifest로 external 설치해 target Linux/ARM64 native/runtime artifact를 보존한다.
 - Web, API, Worker, Fedify Consumer와 migration을 서로 다른 final image로 만들고 각 image의 dependency 구성, boot 동작과 크기를 검증한다.
 - **BREAKING** Helm과 dev/production release identity를 단일 application image digest에서 동일 source SHA와 승인된 build run이 생성한 다섯 runtime image digest의 검증된 release set으로 변경한다.
 - 전용 migration image가 같은 release set의 workload image보다 먼저 실행되고 성공해야 한다는 Argo CD migration barrier를 유지한다.
@@ -38,4 +38,4 @@
 - Deployment: Helm image values/helper와 Web/API/Worker/Fedify Consumer/Migration template, Argo CD parameter 전달과 migration wave.
 - Delivery: dev Docker Build/Deploy workflow, automatic·manual production release workflow, runtime별 digest 검증·감사 기록과 Trivy 대상.
 - Observability: API/Web server source map 생성·Sentry upload와 최종 image 제외.
-- Dependencies: JavaScript bundler를 명시적 build dependency로 추가하고 artifact별 third-party runtime manifest를 build graph에서 생성한다. Temporal native package는 Worker final image의 target ABI external runtime dependency로 유지한다.
+- Dependencies: JavaScript bundler를 명시적 build dependency로 추가한다. Web/API/Fedify/Migration dependency는 artifact에 포함하고 Temporal Worker SDK와 native package만 build graph 기반 manifest의 target ABI external runtime dependency로 유지한다.

--- a/openspec/changes/split-server-runtime-images/specs/dev-database-migrations/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/dev-database-migrations/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Dev Sync migration Job
+
+**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-656`, `PROD-831`. Dev Helm release는 API 또는 web container의 startup/initContainer와 분리된 단일 Kubernetes Job으로 runtime migration command를 실행해야 한다(MUST). Job은 같은 source full SHA와 build identity에서 생성·검증된 runtime release set의 전용 `migration` image를 사용해야 하며(MUST), API, Web, Temporal Worker와 Fedify Consumer workload는 같은 release set의 각 지정 image를 사용해야 한다(MUST). Migration Job이 성공하기 전에는 해당 release set의 workload를 교체하거나 활성화해서는 안 된다(MUST NOT).
+
+#### Scenario: Argo full sync의 migration-gated workload 교체
+
+- **WHEN** dev application에 같은 source full SHA와 build identity를 가진 runtime image release set으로 Argo CD full sync가 시작된다
+- **THEN** Argo CD는 기반 리소스를 적용한 뒤 release set의 전용 `migration` image를 사용하는 migration Job을 `Sync` wave 1 hook으로 실행한다
+- **AND** dev workload는 migration Job이 성공한 뒤 wave 2에서 교체된다
+- **AND** API, Web, Temporal Worker와 Fedify Consumer workload는 release set에서 각자 지정된 image reference를 사용한다
+- **AND** Job은 단일 Pod에서 재시작 없이 migration command를 실행한다
+
+#### Scenario: Runtime release set 불일치
+
+- **WHEN** migration image 또는 workload image가 source full SHA·build identity가 서로 다른 release set에서 전달되거나 지정 image가 누락된다
+- **THEN** Helm render 또는 Argo CD sync는 workload activation 전에 실패한다
+- **AND** migration Job은 다른 release set의 image를 사용해 실행하거나 성공을 가장하지 않는다
+
+#### Scenario: Migration Job 실패
+
+- **WHEN** migration Job이 실패한다
+- **THEN** Argo CD sync는 실패한다
+- **AND** dev deployment workflow는 API와 web Rollout 및 background Deployment restart를 실행하지 않는다
+
+### Requirement: Migration-gated dev rollout
+
+Deploy Dev workflow는 같은 source full SHA와 build identity에서 생성된 runtime image release set의 Docker Build와 검증이 성공한 후 migration을 포함한 Argo CD full sync를 완료하고, 성공한 경우에만 API와 web Rollout 및 렌더된 background Deployment를 restart해야 한다(MUST).
+
+#### Scenario: Migration 성공 후 rollout
+
+- **WHEN** runtime image release set의 Docker Build·검증이 성공하고 Argo CD full sync와 migration Job이 성공한다
+- **THEN** deployment workflow는 release set의 지정 image를 사용해 `kosmo-api`와 `kosmo-web` Rollout 및 렌더된 background Deployment의 restart를 실행한다
+
+#### Scenario: Dev deploy 직렬 실행
+
+- **WHEN** migration-aware dev deployment가 실행 중인 동안 새 runtime image release set build가 완료된다
+- **THEN** 시스템은 실행 중 deployment를 취소하지 않는다
+- **AND** 같은 environment의 migration-aware deployment를 동시에 실행하지 않는다
+
+#### Scenario: Dev downtime 허용
+
+- **WHEN** 기존 workload와 호환되지 않는 migration을 dev에 적용한다
+- **THEN** 시스템은 migration과 새 release set workload restart 사이의 일시적인 dev 오류를 허용한다
+- **AND** 시스템은 production 수준의 무중단 호환 또는 rollback 보장을 이 dev workflow에서 제공하지 않는다

--- a/openspec/changes/split-server-runtime-images/specs/fedify-postgres-message-queue-runtime/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/fedify-postgres-message-queue-runtime/spec.md
@@ -1,0 +1,102 @@
+## MODIFIED Requirements
+
+### Requirement: 독립 Fedify queue consumer runtime
+
+**Authority / Provenance:** PROD-448, PROD-709, PROD-715 PR #564, PROD-831. 시스템은 Web/API request runtime과 Temporal Worker 없이도 Fedify inbox/outbox/fan-out queue를 소비할 수 있는 별도 runtime을 제공해야 한다(MUST). 이 runtime은 독립적으로 배포·확장·재시작·rollback할 수 있고(MUST), process 생존과 queue listen 실행 상태를 구분하는 health/readiness와 graceful shutdown을 제공해야 한다(MUST). Queue consumer는 같은 source full SHA와 build identity에서 생성·검증된 runtime release set의 지정된 `fedify-consumer` image를 사용해야 하며(MUST), Web/API producer는 같은 release set의 지정된 `web`/`api` image를 사용해야 한다(MUST).
+
+#### Scenario: consumer 단독 시작
+
+- **WHEN** Fedify PostgreSQL credential과 queue 구성이 유효하고 release set의 지정된 `fedify-consumer` image로 queue consumer runtime만 시작한다
+- **THEN** runtime은 Web listener나 Temporal task queue를 시작하지 않고 Fedify inbox/outbox/fan-out consumer를 시작한다
+- **AND** liveness는 process 생존을, readiness는 consumer가 종료 중이 아니고 Fedify queue listen을 실행 중임을 나타낸다
+
+#### Scenario: 잘못된 consumer 구성
+
+- **WHEN** 필수 Fedify PostgreSQL queue URL·credential 또는 runtime 구성이 누락되거나 부분 설정된다
+- **THEN** runtime은 queue consumer를 시작하지 않고 명확한 구성 오류로 readiness를 제공하지 않는다
+- **AND** API 역할 credential이나 owner fallback으로 조용히 전환하지 않는다
+
+#### Scenario: API outbound producer transport credential
+
+- **WHEN** 같은 release set의 지정된 `api` image로 API runtime을 Helm으로 배포한다
+- **THEN** API는 domain `DATABASE_URL` 및 trusted Worker execution credential과 분리된 완전한 Fedify queue transport URL·credential을 사용한다
+- **AND** derived transport credential으로 연결할 수 없으면 owner/API/Worker credential 또는 direct delivery로 조용히 fallback하지 않고 adapter 오류를 반환한다
+
+#### Scenario: producer와 consumer의 release set image
+
+- **WHEN** Web/API producer와 Fedify queue consumer를 같은 release로 배포한다
+- **THEN** Web은 `web`, API는 `api`, consumer는 `fedify-consumer`로 지정된 image를 하나의 source full SHA·build identity release set에서 사용한다
+- **AND** producer와 consumer는 범용 application image를 공유하거나 서로 다른 release set의 image를 섞어 사용하지 않는다
+
+#### Scenario: graceful shutdown
+
+- **WHEN** queue consumer runtime이 종료 신호를 받는다
+- **THEN** readiness를 먼저 내리고 새 작업 수락을 중단한 뒤 Fedify queue listener와 PostgreSQL connection을 정리한다
+- **AND** 종료 중인 작업을 완료된 것으로 잘못 확인하거나 Temporal Worker drain과 결합하지 않는다
+
+#### Scenario: 독립 확장과 rollback
+
+- **WHEN** 운영자가 Fedify queue backlog에 맞춰 consumer replica 수를 바꾸거나 consumer Deployment를 rollback한다
+- **THEN** Web/API와 Temporal Worker replica 또는 배포 상태를 함께 바꿀 필요가 없다
+- **AND** 같은 PostgreSQL queue의 ordering과 다중 worker 안전성은 Fedify adapter가 유지한다
+
+### Requirement: Production 활성화 승인 경계
+
+**Authority / Provenance:** PROD-448, PROD-722, PROD-831. chart는 queue 전용 환경·실행 여부 분기 없이 Fedify queue database와 credential을 선언하고, 동일 source full SHA와 build identity에서 생성·검증된 immutable runtime release set의 지정된 `web`, `api`, `fedify-consumer` image가 전달되면 API/Web producer connection과 consumer를 application workload와 함께 render해야 한다(MUST). Chart-wide 또는 Worker별 workload activation key는 queue producer/consumer resource 존재를 제어해서는 안 된다(MUST NOT). Production Argo sync/apply는 queue database·credential 준비, adapter의 최초 table initialization, consumer rollout과 트래픽 cutover의 현재 검증 증거를 제시한 뒤 별도 사용자 승인을 받아야 한다(MUST).
+
+#### Scenario: queue runtime을 단일 구성으로 렌더함
+
+- **WHEN** dev 또는 production에서 동일 source full SHA와 build identity를 가진 유효한 immutable runtime image release set으로 Helm runtime을 render한다
+- **THEN** chart는 queue 전용 실행 flag 없이 API/Web queue connection과 독립 consumer Deployment를 함께 렌더한다
+- **AND** API, Web과 consumer는 release set의 지정된 `api`, `web`, `fedify-consumer` image reference를 사용한다
+- **AND** Database/DatabaseRole/VSO와 runtime은 namespace와 Vault source path 외에 동일한 구조를 사용한다
+
+#### Scenario: production release render
+
+- **WHEN** production release가 승인된 build run의 유효한 immutable runtime image digest set과 source full SHA를 함께 전달해 Helm을 render한다
+- **THEN** chart는 queue Database/DatabaseRole과 VSO Secret 선언 및 API/Web/consumer workload를 release set의 지정 image로 함께 렌더한다
+- **AND** queue 전용 enable flag나 credential selector를 요구하지 않는다
+
+#### Scenario: runtime image release set 불일치
+
+- **WHEN** API, Web 또는 consumer image가 서로 다른 source full SHA·build identity release set에서 전달되거나 지정 image가 누락된다
+- **THEN** Helm render 또는 Argo CD sync는 producer·consumer workload activation 전에 실패한다
+- **AND** queue credential을 다른 workload credential로 대체하거나 일부 image만 조용히 활성화하지 않는다
+
+#### Scenario: legacy workload activation values are inert
+
+- **WHEN** 유효한 immutable runtime image release set과 함께 과거 workload activation 값을 추가해 Helm을 render한다
+- **THEN** API/Web/consumer workload와 queue declarations가 모두 render되고 과거 값이 resource 존재를 바꾸지 않는다
+
+#### Scenario: producer mode의 derived queue connection
+
+- **WHEN** Web 또는 API workload를 배포한다
+- **THEN** Helm은 release에서 파생한 전용 Secret과 기존 CloudNativePG direct read-write Service의 queue URL을 runtime에 주입하고 official adapter가 첫 enqueue에서 connection 대상 database의 queue table/index를 idempotent하게 초기화하게 한다
+- **AND** 별도 queue selector나 environment 분기가 없으며 adapter 오류는 direct delivery나 owner/API DB fallback으로 우회하지 않는다
+
+#### Scenario: dev queue database 격리
+
+- **WHEN** dev Fedify queue runtime을 배포한다
+- **THEN** 기존 CloudNativePG cluster 안의 별도 `kosmo_fedify_queue` database와 전용 login/Secret을 사용한다
+- **AND** official adapter가 해당 database 안의 queue table/index implicit DDL을 소유하며 domain database schema, `search_path` helper 또는 custom queue migration을 추가하지 않는다
+- **AND** queue connection은 API/domain DB와 Worker trusted execution credential을 재사용하거나 fallback하지 않는다
+- **AND** chart는 queue database 준비 flag나 configurable queue URL 없이 같은 전용 role·direct read-write Service·database connection을 파생한다
+
+#### Scenario: production queue database 선언
+
+- **WHEN** production Helm을 render한다
+- **THEN** chart는 environment 분기 없이 production namespace의 CloudNativePG cluster 안에 별도 `kosmo_fedify_queue` Database/DatabaseRole과 `kubernetes/kosmo/prod/fedify-queue` source의 release-derived queue 전용 basic-auth Secret 동기화를 선언한다
+- **AND** runtime이 활성화될 때 사용할 queue URL은 production CloudNativePG direct read-write Service의 전용 role과 `kosmo_fedify_queue` database에서 파생되며 domain/API/Worker database 또는 다른 Secret selector를 받을 수 없다
+- **AND** 이 선언은 resource apply, Vault value write, adapter initialization, consumer rollout 또는 producer cutover를 시작하지 않는다
+
+#### Scenario: 구현 PR 완료
+
+- **WHEN** 코드, chart, 격리 database의 adapter initialization과 비production 검증이 완료되어 PR이 review-ready 상태가 된다
+- **THEN** production declaration 외의 Argo CD sync/apply, Vault value write, database apply와 live traffic cutover는 실행하지 않는다
+- **AND** PR completion evidence와 dev live verification, production activation 상태를 각각 구분해 보고한다
+
+#### Scenario: 별도 production 승인
+
+- **WHEN** 사용자가 정확한 production queue database·credential 준비, 최초 adapter initialization, rollout 또는 cutover 대상을 별도로 승인한다
+- **THEN** 승인된 작업만 현재 production 상태를 다시 확인한 뒤 수행한다
+- **AND** 승인되지 않은 다른 production mutation으로 범위를 넓히지 않는다

--- a/openspec/changes/split-server-runtime-images/specs/production-migration-gate/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/production-migration-gate/spec.md
@@ -1,0 +1,91 @@
+## MODIFIED Requirements
+
+### Requirement: 동일한 immutable release identity
+
+**Authority / Provenance:** `PROD-564`, `PROD-269`, `PROD-831`. Production migration Job과 모든 활성화 workload는 승인된 release의 동일한 source full SHA와 build run에 귀속된 다섯 runtime digest release set을 사용해야 한다 (MUST). Release set은 `web`, `api`, `worker`, `fedify-consumer`, `migration` 각 runtime의 `repository@sha256:<digest>` reference를 정확히 하나씩 포함해야 하며 (MUST). Migration Job은 `migration` digest를 사용하고 API, Web, Temporal Worker와 Fedify Consumer는 각각 대응하는 digest를 사용해야 한다 (MUST). Mutable tag, 누락·추가 runtime, 서로 다른 source SHA·build run의 digest 또는 release set 밖의 digest로 production migration을 실행해서는 안 된다 (MUST NOT).
+
+#### Scenario: 동일 digest로 렌더
+
+- **WHEN** production release manifest가 렌더된다
+- **THEN** migration Job과 모든 활성화 workload image reference는 같은 release set의 source full SHA·build run을 가리키고, `migration`, `api`, `web`, `worker`, `fedify-consumer`에 대응하는 각 `repository@sha256:...` 값을 사용한다
+
+#### Scenario: Mutable production image 거부
+
+- **WHEN** production migration이 tag-only image, 유효하지 않은 digest 또는 다른 release set의 digest로 구성된다
+- **THEN** manifest render는 migration Job을 생성하기 전에 실패한다
+
+#### Scenario: 불완전한 runtime release set 거부
+
+- **WHEN** production release 입력에 다섯 runtime 중 하나가 없거나 같은 source full SHA와 build run에 귀속되지 않은 digest가 섞여 있다
+- **THEN** 시스템은 migration Job과 workload manifest를 생성하지 않고 release를 실패로 기록한다
+
+### Requirement: 단순한 migration 실행기
+
+**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-564`, `PROD-656`, `PROD-831`. Production migration Job은 승인된 runtime digest release set의 `migration` image가 제공하는 `migrate` command만 실행해야 하며 (MUST), 이 command는 version-controlled Drizzle migration 형식과 기존 history를 유지하면서 DB history의 각 적용 name/hash를 local migration과 검증하고 적용된 name을 제외한 pending migration 파일의 SQL과 history insert를 독립 transaction으로 적용해야 한다 (MUST). DB row 순서가 local timestamp 정렬과 달라도 같은 name/hash 집합이면 유효하게 인식해야 하며 (MUST), local에 없는 history, hash 변경과 중복 name/history는 새 SQL 전에 거부해야 한다 (MUST NOT). Generic phase selector, schema authority input, database target input, restore-point command 또는 backup/compatibility collector를 포함해서는 안 된다 (MUST NOT).
+
+#### Scenario: Production migration 실행
+
+- **WHEN** production migration Job이 승인된 runtime digest release set으로 렌더된다
+- **THEN** container image는 release set의 `migration` digest이고 container argument는 `migrate`이다
+- **AND** runner는 기존 Drizzle migration directory, history와 advisory lock을 사용한다
+- **AND** 각 pending migration 파일의 SQL과 history insert를 같은 독립 transaction에서 적용한다
+
+#### Scenario: 비선형 existing history 재실행
+
+- **WHEN** production database의 Drizzle history row 순서가 local migration timestamp 정렬과 다르지만 모든 적용 name/hash가 local과 일치한다
+- **THEN** runner는 history row와 ID를 재작성하지 않고 이미 적용된 name을 건너뛴다
+- **AND** 아직 적용되지 않은 migration만 local version-control 순서로 실행한다
+
+#### Scenario: Legacy history 승격
+
+- **WHEN** production database의 기존 Drizzle history에 name이 없고 각 row의 timestamp/hash가 local migration과 대응한다
+- **THEN** runner는 Drizzle beta.22와 호환되는 timestamp 우선·hash 보조 mapping으로 name을 backfill한다
+- **AND** 기존 history row 순서와 ID를 보존한 뒤 pending migration을 local 순서로 실행한다
+- **AND** unknown·ambiguous·duplicate mapping은 history shape 또는 schema를 변경하거나 새 SQL을 실행하기 전에 실패한다
+
+#### Scenario: History 무결성 위반
+
+- **WHEN** production database history에 local에 없는 name, hash가 변경된 name 또는 duplicate name이 있다
+- **THEN** runner는 새 migration SQL을 실행하기 전에 실패한다
+- **AND** history를 현재 local 상태로 덮어쓰거나 재정렬하지 않는다
+
+#### Scenario: Production enum 연속 migration
+
+- **WHEN** 승인된 release set에 기존 enum 값을 추가하는 migration과 그 값을 사용하는 다음 migration이 함께 pending이다
+- **THEN** runner는 enum 추가 파일을 history와 함께 commit한 뒤 다음 파일을 별도 transaction으로 실행한다
+- **AND** migration SQL 내부의 수동 `COMMIT; BEGIN;`이나 enum별 preflight를 요구하지 않는다
+
+#### Scenario: Destructive migration 조건
+
+- **WHEN** 실제 schema change가 contract migration을 포함한다
+- **THEN** 해당 migration 이슈·PR·release가 backup/restore evidence, 구버전 workload compatibility와 rollback window를 구체적으로 정의하고 검증한다
+- **AND** generic production migration Job은 이를 JSON metadata나 command mode로 추상화하지 않는다
+
+### Requirement: Production release 단일 승인과 실패 차단
+
+**Authority / Provenance:** `docs/operations/production-migrations.md`, `memory/database-migrations.md`, Linear `PROD-269`, `PROD-563`, `PROD-564`, `PROD-656`, `PROD-831`. 정식 production release 승인은 선택한 source full SHA와 승인된 build run에 귀속된 완전한 다섯 runtime digest release set의 migration과 모든 활성화 workload 전체에 한 번 적용되어야 한다 (MUST). Migration이 성공하기 전에 같은 release set의 새 workload를 활성화해서는 안 되며 (MUST NOT), 중간 파일 실패 시 성공한 앞 migration의 schema와 history는 함께 유지하고 실패한 파일의 schema와 history는 함께 rollback해야 한다 (MUST).
+
+#### Scenario: Migration 성공
+
+- **WHEN** 승인된 production release set의 모든 pending migration 파일이 성공한다
+- **THEN** PROD-563 pipeline은 같은 source full SHA·build run의 `migration` digest를 사용한 wave 1 완료 뒤 `api`, `web`, `worker`, `fedify-consumer` digest를 대응하는 모든 wave 2 workload에 활성화할 수 있다
+
+#### Scenario: Migration 중간 파일 실패
+
+- **WHEN** credential, SQL, advisory lock 또는 timeout으로 production migration Job이 실패한다
+- **THEN** 같은 release set의 새 workload 활성화는 실행되지 않는다
+- **AND** 실패한 migration 파일의 schema·data 변경과 history insert는 함께 남지 않는다
+- **AND** 앞에서 성공한 migration 파일의 schema 변경과 history는 함께 남는다
+- **AND** database rollback을 자동 실행하거나 실패한 migration을 적용 완료로 기록하지 않는다
+
+#### Scenario: 실패한 release의 재실행
+
+- **WHEN** 실패 원인을 수정한 새 승인 release가 같은 database에서 완전한 runtime digest release set의 `migration` command를 실행한다
+- **THEN** runner는 앞서 성공해 history에 기록된 파일을 다시 실행하지 않는다
+- **AND** 이전에 실패한 파일을 포함해 history에 없는 파일만 local version-control 순서로 적용을 계속한다
+- **AND** 새 release set은 source full SHA·build run이 일치하는 다섯 digest를 사용하며 이전 또는 다른 release set의 digest를 섞지 않는다
+
+#### Scenario: 중복 승인 금지
+
+- **WHEN** production release가 완전한 runtime digest release set으로 승인됐다
+- **THEN** migration만을 위한 별도 Environment 또는 추가 수동 승인을 요구하지 않는다

--- a/openspec/changes/split-server-runtime-images/specs/production-release/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/production-release/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: Main production release는 Environment 승인 뒤 같은 SHA와 digest로 build·배포한다
+
+**Authority / Provenance:** `PROD-783` (2026-08-18 contract update), `PROD-564`, `PROD-831` — 시스템은 main push의 production release가 `prod` Environment 승인 전에는 main SHA를 production job에서 checkout하거나 Vault/Sentry credential을 요청하거나 production runtime image를 build하거나 Argo CD production 상태를 변경하지 않도록 해야 한다 (MUST). 승인 뒤 하나의 gated build run이 event의 immutable main full SHA를 checkout하고 Web, API, Temporal Worker, Fedify Consumer와 migration의 다섯 runtime image를 모두 build해야 하며 (MUST), 그 build run의 완전한 runtime digest release set과 source full SHA를 같은 gated release에서 migration Job과 대응하는 모든 활성화 production workload에 직접 전달해야 한다 (MUST). Runtime digest release set은 `web`, `api`, `worker`, `fedify-consumer`, `migration` 각 항목의 `repository@sha256:<digest>` reference를 정확히 하나씩 포함해야 하며 (MUST), 서로 다른 source SHA·build run의 digest를 섞거나 mutable tag를 중간 identity source로 사용해서는 안 된다 (MUST NOT). GitHub Release, Release asset 또는 승인 시점의 최신 main ref를 identity source로 사용해서는 안 된다 (MUST NOT).
+
+#### Scenario: 승인 대기 중인 main release
+
+- **WHEN** main production release가 `prod` Environment 승인을 기다린다
+- **THEN** 시스템은 production source checkout, Vault/Sentry credential 접근, 다섯 runtime image build, Argo CD production credential 획득과 production 상태 변경을 실행하지 않는다
+
+#### Scenario: 승인된 main release
+
+- **WHEN** main production release가 `prod` Environment 승인을 받는다
+- **THEN** 하나의 gated build run이 main event의 full SHA를 checkout해 다섯 runtime image를 build하고, 같은 source full SHA와 build run에 귀속된 `web`, `api`, `worker`, `fedify-consumer`, `migration` digest set으로 migration과 각 production workload를 sync한다
+
+#### Scenario: Main이 승인 대기 중 이동함
+
+- **WHEN** release approval이 대기 중인 동안 더 새로운 commit이 main에 merge된다
+- **THEN** 기존 release의 source와 runtime digest release set identity는 승인 시점의 최신 main이 아니라 event의 기존 full SHA와 승인 뒤 생성된 해당 build run의 완전한 digest set으로 유지된다
+
+#### Scenario: Runtime digest release set이 불완전함
+
+- **WHEN** 승인된 build run이 다섯 runtime 중 하나라도 digest를 만들지 못하거나 다른 source SHA·build run의 digest를 포함한다
+- **THEN** 시스템은 완전한 release set을 만들지 못한 release의 Argo CD production 상태 변경과 workload 배포를 실행하지 않고 release를 실패로 기록한다
+
+### Requirement: 임의 repository commit을 수동 production release로 선택할 수 있다
+
+**Authority / Provenance:** `PROD-783`, `PROD-831` — 운영자는 main에 저장된 workflow를 수동 실행해 repository에 존재하는 정확한 40자리 commit SHA를 production release target으로 선택할 수 있어야 한다 (MUST). 시스템은 workflow 실행 ref가 `main`인지, 입력이 full SHA 형식인지와 해당 commit이 repository에 존재하는지를 승인 전에 검증해야 한다 (MUST).
+
+입력 target의 code checkout, prod secret·credential 접근, production runtime image build와 Argo CD 상태 변경은 `prod` Environment 승인 뒤에만 실행해야 한다 (MUST). Target commit에 포함된 workflow 정의를 실행해서는 안 된다 (MUST NOT). 승인 뒤 하나의 gated build run이 target SHA에서 Web, API, Temporal Worker, Fedify Consumer와 migration의 다섯 runtime image를 모두 build하고, 그 build run에 귀속된 완전한 runtime digest release set과 target SHA를 같은 gated release에서 migration과 모든 production workload에 전달해야 한다 (MUST). Release set은 `web`, `api`, `worker`, `fedify-consumer`, `migration`의 digest-pinned reference를 모두 포함해야 하며 (MUST), 다른 SHA·build run의 digest나 mutable tag를 사용해서는 안 된다 (MUST NOT).
+
+#### Scenario: 유효한 수동 target
+
+- **WHEN** 운영자가 main workflow에서 repository에 존재하는 40자리 commit SHA를 입력한다
+- **THEN** 시스템은 target commit 링크와 SHA를 승인 정보에 표시하고 승인 전에는 target code를 실행하지 않는다
+
+#### Scenario: 승인된 수동 target
+
+- **WHEN** 유효한 manual target이 `prod` Environment 승인을 받는다
+- **THEN** 시스템은 target SHA를 checkout해 다섯 runtime image를 하나의 gated build run에서 build하고, 그 build run의 완전한 digest release set과 같은 target SHA로 production migration·workload를 배포한다
+
+#### Scenario: 신뢰할 수 없는 dispatch ref
+
+- **WHEN** manual workflow가 main 이외의 workflow ref에서 시작되거나 입력 SHA가 유효하지 않거나 repository에 존재하지 않는다
+- **THEN** 시스템은 target code checkout, prod secret 접근, build와 production 배포 전에 실행을 거부한다
+
+#### Scenario: 수동 runtime digest release set 생성 실패
+
+- **WHEN** 승인된 manual target의 gated build run이 다섯 runtime 중 하나의 digest를 만들지 못하거나 release set의 source SHA·build run이 일치하지 않는다
+- **THEN** 시스템은 migration과 production workload를 배포하지 않고 해당 manual release를 실패로 기록한다
+
+### Requirement: Production 배포는 하나의 승인과 직렬화된 실행 경계를 사용한다
+
+**Authority / Provenance:** `PROD-783` (2026-08-18 contract update), `PROD-831` — 시스템은 automatic main과 manual SHA release마다 GitHub `prod` Environment reviewer의 한 번의 명시적 승인을 요구해야 한다 (MUST). 같은 승인은 해당 release의 production checkout, build credential, 다섯 runtime image build, 완전한 runtime digest release set 생성, migration과 모든 활성화 workload 변경 전체에 적용되어야 하며 (MUST), 별도 build·verification·migration approval을 추가해서는 안 된다 (MUST NOT).
+
+실행 중인 production 배포는 새 automatic 또는 manual release request 때문에 취소되어서는 안 된다 (MUST NOT). 이미 실행 중인 release 뒤에 승인된 release request가 여러 개 대기하면 시스템은 최신 pending request만 다음 실행으로 유지할 수 있으며 (MAY), 대체된 request는 Actions 취소 기록으로 식별하고 필요하면 같은 automatic 또는 manual full-SHA 승인 경로를 다시 실행할 수 있어야 한다 (MUST).
+
+#### Scenario: 승인 전
+
+- **WHEN** automatic 또는 manual production release가 `prod` 승인을 기다린다
+- **THEN** 시스템은 production checkout, build credential, 다섯 runtime image build와 production 상태 변경을 실행하지 않는다
+
+#### Scenario: 실행 중 새 release request 승인
+
+- **WHEN** production 배포가 실행 중인 동안 다른 release request가 승인된다
+- **THEN** 실행 중인 배포는 계속되고 새 release request는 같은 production 실행 경계에서 대기한다
+
+#### Scenario: Pending release request 대체
+
+- **WHEN** 하나의 release가 실행 중이고 pending request가 있는 상태에서 더 최신 release request가 같은 대기열에 도달한다
+- **THEN** 시스템은 실행 중인 release와 그 완전한 runtime digest release set을 유지하고 이전 pending request를 취소 기록으로 남긴 뒤 최신 request를 다음 실행으로 유지할 수 있다
+
+### Requirement: Production 배포 결과를 immutable identity로 감사할 수 있다
+
+**Authority / Provenance:** `PROD-783`, `PROD-831` — 시스템은 실제 production release를 시작한 각 실행의 trigger 종류, 요청자, workflow definition ref, target full SHA, 승인된 build run identity, `web`·`api`·`worker`·`fedify-consumer`·`migration` 다섯 runtime digest와 Argo CD source revision 및 최종 결과를 감사 가능한 기록에 남겨야 한다 (MUST). Automatic main release에서는 dev build·배포 결과와 승인 뒤 prod build·승인·배포 결과를 구분해야 한다 (MUST). Credential, database 내용과 사용자 콘텐츠를 기록해서는 안 된다 (MUST NOT).
+
+#### Scenario: Automatic main release 종료
+
+- **WHEN** main production release가 성공하거나 실패하며 종료된다
+- **THEN** 시스템은 automatic trigger, main target SHA, `prod` 승인 뒤 실행한 build run, 다섯 runtime digest, Argo source revision, dev/prod 경계와 결과를 workflow 기록에 남긴다
+
+#### Scenario: Manual SHA release 종료
+
+- **WHEN** manual SHA production 배포가 성공하거나 실패하며 종료된다
+- **THEN** 시스템은 manual trigger, main workflow ref, 입력 target SHA, 승인된 build run, 다섯 runtime digest, Argo source revision과 결과를 workflow 기록에 남긴다
+
+### Requirement: Migration 뒤 controller 기본 activation을 사용한다
+
+**Authority / Provenance:** `PROD-783`, `PROD-564`, `PROD-831` — Argo CD는 기반 리소스를 적용한 뒤 선택한 runtime digest release set의 `migration` image로 production migration Job을 Sync wave 1에서 성공시키고, 같은 release set의 `api`, `web`, `worker`, `fedify-consumer` image를 대응하는 API·Web Rollout·HPA 및 background Deployment에 wave 2에서 적용해야 한다 (MUST). Release set의 다섯 digest는 같은 source full SHA와 승인된 build run에 귀속되어야 하며 (MUST). Release pipeline은 두 Rollout의 preview를 교차 대기하거나 직접 승격해서는 안 되며 (MUST NOT), 이전 ReplicaSet을 찾아 자동 복구해서도 안 된다 (MUST NOT).
+
+#### Scenario: Migration 성공
+
+- **WHEN** 같은 source full SHA와 build run의 `migration` digest를 사용하는 Sync wave 1 migration이 성공한다
+- **THEN** Argo CD는 그 release set의 `api`·`web` Rollout·HPA와 `worker`·`fedify-consumer` background Deployment를 wave 2에서 적용하고 각 controller가 기본 activation을 수행한다
+
+#### Scenario: Migration 또는 sync 실패
+
+- **WHEN** runtime digest release set 검증, migration 또는 Argo CD sync가 실패한다
+- **THEN** 실행은 실패로 기록되고 wave 2 workload는 활성화되지 않으며 pipeline은 Rollout·ReplicaSet을 직접 복구하지 않는다

--- a/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
@@ -20,7 +20,7 @@
 
 **Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-831`. 시스템은 Web, API, Temporal Worker, Fedify consumer와 migration을 서로 분리된 다섯 final image로 제공해야 한다(MUST). 각 image는 해당 runtime의 사전 생성 artifact와 production 실행에 필요한 dependency만 포함해야 하며(MUST), 다른 runtime의 source, 범용 workspace `node_modules` 또는 development dependency를 포함해서는 안 된다(MUST NOT).
 
-Web, API, Fedify consumer와 migration artifact의 third-party runtime dependency는 단일 JavaScript artifact에 포함되어야 하며(MUST), 해당 final image는 runtime `node_modules`를 포함해서는 안 된다(MUST NOT). Worker application/Activity host code는 bundle하되 Temporal Worker SDK와 native/runtime dependency는 build graph의 external import에서 자동 도출한 Worker manifest로 설치해야 한다(MUST). Dockerfile이나 검증 코드가 현재 Worker package 이름의 수동 allowlist를 runtime 계약으로 가져서는 안 된다(MUST NOT).
+다섯 runtime의 workspace-owned code는 JavaScript artifact에 포함되어야 하며(MUST), third-party package는 각 workspace manifest와 root lockfile에서 생성한 production dependency tree로 제공해야 한다(MUST). 생성 runtime manifest, package별 bundler patch 또는 수동 package allowlist를 runtime 계약으로 가져서는 안 된다(MUST NOT).
 
 #### Scenario: runtime image 선택
 
@@ -34,12 +34,12 @@ Web, API, Fedify consumer와 migration artifact의 third-party runtime dependenc
 - **THEN** image에는 해당 runtime artifact, 필요한 production dependency와 target runtime 파일만 남는다
 - **AND** TypeScript source, `tsx`, workspace 전체 `node_modules`와 development dependency는 final image에 존재하지 않는다
 
-#### Scenario: runtime import 변경이 artifact 또는 Worker manifest에 반영된다
+#### Scenario: runtime import 변경이 artifact와 production dependency tree에 반영된다
 
 - **WHEN** API를 포함한 어느 runtime의 workspace code가 새로운 third-party package를 production 경로에서 import하거나 기존 import를 제거한다
-- **THEN** Web/API/Fedify/Migration artifact build는 해당 import를 같은 단일 JavaScript artifact에 자동으로 포함한다
-- **AND** Worker SDK/runtime external import만 generated Worker manifest에 자동 반영된다
-- **AND** Dockerfile package 목록 또는 exact dependency allowlist test를 수동으로 동기화할 필요가 없다
+- **THEN** workspace-owned import는 해당 JavaScript artifact에 포함되고 third-party import는 artifact metadata에 기록된다
+- **AND** workspace manifest와 root lockfile에서 생성한 해당 runtime의 production dependency tree가 third-party package를 제공한다
+- **AND** generated runtime manifest, Dockerfile package 목록 또는 exact dependency allowlist test를 수동으로 동기화할 필요가 없다
 
 ### Requirement: Worker target platform과 최소 native/runtime dependency
 

--- a/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
@@ -20,6 +20,8 @@
 
 **Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-831`. 시스템은 Web, API, Temporal Worker, Fedify consumer와 migration을 서로 분리된 다섯 final image로 제공해야 한다(MUST). 각 image는 해당 runtime의 사전 생성 artifact와 production 실행에 필요한 dependency만 포함해야 하며(MUST), 다른 runtime의 source, 범용 workspace `node_modules` 또는 development dependency를 포함해서는 안 된다(MUST NOT).
 
+각 artifact의 third-party runtime dependency는 build graph의 external import에서 자동 도출한 manifest로 설치해야 한다(MUST). Dockerfile이나 검증 코드가 현재 package 이름의 수동 allowlist를 runtime 계약으로 가져서는 안 된다(MUST NOT).
+
 #### Scenario: runtime image 선택
 
 - **WHEN** release build가 다섯 server runtime image를 생성한다
@@ -31,6 +33,12 @@
 - **WHEN** final image의 filesystem과 production dependency graph를 검사한다
 - **THEN** image에는 해당 runtime artifact, 필요한 production dependency와 target runtime 파일만 남는다
 - **AND** TypeScript source, `tsx`, workspace 전체 `node_modules`와 development dependency는 final image에 존재하지 않는다
+
+#### Scenario: runtime import 변경이 manifest에 반영된다
+
+- **WHEN** API를 포함한 어느 runtime의 workspace code가 새로운 third-party package를 production 경로에서 import하거나 기존 import를 제거한다
+- **THEN** artifact build가 해당 runtime manifest를 build graph에 맞게 자동으로 갱신한다
+- **AND** 다른 runtime의 manifest, Dockerfile package 목록 또는 exact dependency allowlist test를 수동으로 동기화할 필요가 없다
 
 ### Requirement: Worker target platform과 최소 native/runtime dependency
 

--- a/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
@@ -37,7 +37,7 @@
 #### Scenario: runtime import 변경이 artifact와 production dependency tree에 반영된다
 
 - **WHEN** API를 포함한 어느 runtime의 workspace code가 새로운 third-party package를 production 경로에서 import하거나 기존 import를 제거한다
-- **THEN** workspace-owned import는 해당 JavaScript artifact에 포함되고 third-party import는 artifact metadata에 기록된다
+- **THEN** workspace-owned import는 해당 JavaScript artifact에 포함되고 third-party import는 workspace manifest와 root lockfile의 production dependency tree에서 해석된다
 - **AND** workspace manifest와 root lockfile에서 생성한 해당 runtime의 production dependency tree가 third-party package를 제공한다
 - **AND** generated runtime manifest, Dockerfile package 목록 또는 exact dependency allowlist test를 수동으로 동기화할 필요가 없다
 

--- a/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
@@ -20,7 +20,7 @@
 
 **Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-831`. 시스템은 Web, API, Temporal Worker, Fedify consumer와 migration을 서로 분리된 다섯 final image로 제공해야 한다(MUST). 각 image는 해당 runtime의 사전 생성 artifact와 production 실행에 필요한 dependency만 포함해야 하며(MUST), 다른 runtime의 source, 범용 workspace `node_modules` 또는 development dependency를 포함해서는 안 된다(MUST NOT).
 
-각 artifact의 third-party runtime dependency는 build graph의 external import에서 자동 도출한 manifest로 설치해야 한다(MUST). Dockerfile이나 검증 코드가 현재 package 이름의 수동 allowlist를 runtime 계약으로 가져서는 안 된다(MUST NOT).
+Web, API, Fedify consumer와 migration artifact의 third-party runtime dependency는 단일 JavaScript artifact에 포함되어야 하며(MUST), 해당 final image는 runtime `node_modules`를 포함해서는 안 된다(MUST NOT). Worker application/Activity host code는 bundle하되 Temporal Worker SDK와 native/runtime dependency는 build graph의 external import에서 자동 도출한 Worker manifest로 설치해야 한다(MUST). Dockerfile이나 검증 코드가 현재 Worker package 이름의 수동 allowlist를 runtime 계약으로 가져서는 안 된다(MUST NOT).
 
 #### Scenario: runtime image 선택
 
@@ -34,11 +34,12 @@
 - **THEN** image에는 해당 runtime artifact, 필요한 production dependency와 target runtime 파일만 남는다
 - **AND** TypeScript source, `tsx`, workspace 전체 `node_modules`와 development dependency는 final image에 존재하지 않는다
 
-#### Scenario: runtime import 변경이 manifest에 반영된다
+#### Scenario: runtime import 변경이 artifact 또는 Worker manifest에 반영된다
 
 - **WHEN** API를 포함한 어느 runtime의 workspace code가 새로운 third-party package를 production 경로에서 import하거나 기존 import를 제거한다
-- **THEN** artifact build가 해당 runtime manifest를 build graph에 맞게 자동으로 갱신한다
-- **AND** 다른 runtime의 manifest, Dockerfile package 목록 또는 exact dependency allowlist test를 수동으로 동기화할 필요가 없다
+- **THEN** Web/API/Fedify/Migration artifact build는 해당 import를 같은 단일 JavaScript artifact에 자동으로 포함한다
+- **AND** Worker SDK/runtime external import만 generated Worker manifest에 자동 반영된다
+- **AND** Dockerfile package 목록 또는 exact dependency allowlist test를 수동으로 동기화할 필요가 없다
 
 ### Requirement: Worker target platform과 최소 native/runtime dependency
 

--- a/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/server-runtime-images/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: 서버 runtime별 사전 생성 JavaScript artifact
+
+**Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `docs/architecture/core-services.md`, `PROD-831`. 시스템은 Web/BFF, API, Temporal Worker, Fedify consumer와 database migration의 실제 production 실행 graph를 build 단계에서 사전 생성한 JavaScript artifact로 만들어야 한다(MUST). Runtime은 TypeScript source를 직접 해석하거나 `tsx`를 통해 시작해서는 안 되며(MUST NOT), Worker host와 Temporal Workflow bundle도 Worker image가 시작되기 전에 생성되어야 한다(MUST).
+
+#### Scenario: 다섯 runtime artifact 생성
+
+- **WHEN** 승인된 source SHA에 대해 production runtime build를 실행한다
+- **THEN** 시스템은 Web/BFF, API, Temporal Worker host·Workflow, Fedify consumer와 migration command가 각각 소비할 수 있는 JavaScript artifact를 생성한다
+- **AND** artifact 생성은 final image를 만들기 전에 완료된다
+
+#### Scenario: 생성 artifact로 runtime 시작
+
+- **WHEN** Web/BFF, API, Worker, Fedify consumer 또는 migration runtime을 해당 final image에서 시작한다
+- **THEN** process는 사전 생성된 JavaScript entry/artifact를 실행한다
+- **AND** TypeScript source를 직접 실행하거나 `tsx` CLI를 resolution하는 경로가 없다
+
+### Requirement: runtime별 전용 final image와 dependency 경계
+
+**Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-831`. 시스템은 Web, API, Temporal Worker, Fedify consumer와 migration을 서로 분리된 다섯 final image로 제공해야 한다(MUST). 각 image는 해당 runtime의 사전 생성 artifact와 production 실행에 필요한 dependency만 포함해야 하며(MUST), 다른 runtime의 source, 범용 workspace `node_modules` 또는 development dependency를 포함해서는 안 된다(MUST NOT).
+
+#### Scenario: runtime image 선택
+
+- **WHEN** release build가 다섯 server runtime image를 생성한다
+- **THEN** Web, API, Worker, Fedify consumer와 migration은 각자의 final image와 명시적 boot command를 가진다
+- **AND** 한 runtime을 실행하기 위해 다른 runtime image의 source나 package tree를 복사하지 않는다
+
+#### Scenario: production dependency 경계
+
+- **WHEN** final image의 filesystem과 production dependency graph를 검사한다
+- **THEN** image에는 해당 runtime artifact, 필요한 production dependency와 target runtime 파일만 남는다
+- **AND** TypeScript source, `tsx`, workspace 전체 `node_modules`와 development dependency는 final image에 존재하지 않는다
+
+### Requirement: Worker target platform과 최소 native/runtime dependency
+
+**Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `docs/architecture/core-services.md`, `PROD-831`. Temporal Worker artifact와 Worker final image는 release target인 Linux/ARM64에서 실행 가능하도록 build되어야 한다(MUST). Worker image는 host·Workflow 실행에 실제 필요한 Temporal native/runtime artifact만 target ABI에 맞게 포함해야 하며(MUST), build 환경의 다른 architecture용 native binary나 사용하지 않는 범용 dependency를 배포해서는 안 된다(MUST NOT).
+
+#### Scenario: Linux/ARM64 Worker build
+
+- **WHEN** Linux/ARM64 target으로 Worker artifact와 final image를 build한다
+- **THEN** host와 Workflow bundle이 target Node runtime에서 load되고 Worker process가 시작된다
+- **AND** native module은 Linux/ARM64 ABI와 일치한다
+
+#### Scenario: native dependency 검증 실패
+
+- **WHEN** Worker final image의 native/runtime dependency가 target ABI와 일치하지 않거나 host·Workflow 실행에 필요한 artifact가 누락된다
+- **THEN** Worker image build 또는 boot 검증은 실패한다
+- **AND** 해당 image digest는 release runtime image set에 포함되지 않는다
+
+### Requirement: runtime artifact build·boot·dependency·size gate
+
+**Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-831`. 시스템은 다섯 runtime image 각각에 대해 artifact 생성, production dependency, target boot과 image size를 검증하는 gate를 제공해야 한다(MUST). 동일 Linux/ARM64 조건에서 각 final image의 compressed size는 현재 single runtime image보다 작아야 하며(MUST), 감소 원인을 포함·제외 dependency와 layer로 설명할 수 있어야 한다(MUST). 모든 runtime image가 같은 source SHA와 승인된 build run에서 생성되고 각 gate를 통과하기 전에는 Helm 또는 release workflow가 runtime별 image digest set으로 전환되어서는 안 된다(MUST NOT).
+
+#### Scenario: 전체 runtime gate 통과
+
+- **WHEN** 다섯 runtime image의 artifact, dependency, Linux/ARM64 boot과 size 검증이 모두 성공한다
+- **THEN** 시스템은 source SHA와 build run을 식별하는 runtime image digest set을 release workflow와 Helm 입력으로 전달할 수 있다
+- **AND** 다섯 final image 각각의 compressed/uncompressed size와 주요 layer가 current single-image baseline과 함께 기록되고 각 compressed size가 baseline보다 작다
+
+#### Scenario: runtime gate 실패
+
+- **WHEN** 하나 이상의 runtime image에서 artifact 생성, dependency, boot 또는 size gate가 실패한다
+- **THEN** build는 실패하고 불완전한 runtime image digest set을 release workflow와 Helm에 전달하지 않는다
+- **AND** 다른 runtime image가 개별적으로 성공했다는 이유로 해당 release를 활성화하지 않는다
+
+#### Scenario: image size 감소 실패
+
+- **WHEN** 같은 Linux/ARM64 조건에서 하나 이상의 final image compressed size가 current single-image baseline 이상이거나 size 차이를 dependency와 layer로 설명할 수 없다
+- **THEN** artifact gate는 실패한다
+- **AND** Helm과 release workflow의 runtime image set 전환을 시작하지 않는다
+
+### Requirement: server source map과 upload credential의 final image 제외
+
+**Authority / Provenance:** `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-831`. 서버 JavaScript artifact의 source map은 같은 release identity로 Sentry에 연결·업로드할 수 있어야 한다(MUST). Upload credential은 build secret 경계로만 전달해야 하며(MUST), source map과 upload credential은 production final image와 runtime environment에 포함되어서는 안 된다(MUST NOT).
+
+#### Scenario: source map upload
+
+- **WHEN** API 또는 Web/BFF server artifact를 build하고 Sentry source map upload를 활성화한다
+- **THEN** 시스템은 해당 release identity로 source map을 업로드한다
+- **AND** upload credential은 image layer, build argument 또는 runtime environment에 기록하지 않는다
+
+#### Scenario: source map final image 검사
+
+- **WHEN** API와 Web/BFF final image를 source map 및 credential 노출 여부로 검사한다
+- **THEN** runtime JavaScript artifact는 source map reference 없이 실행 가능하다
+- **AND** source map 파일과 Sentry upload credential은 final image filesystem과 runtime environment에서 발견되지 않는다

--- a/openspec/changes/split-server-runtime-images/specs/temporal-worker-runtime-foundation/spec.md
+++ b/openspec/changes/split-server-runtime-images/specs/temporal-worker-runtime-foundation/spec.md
@@ -1,0 +1,102 @@
+## MODIFIED Requirements
+
+### Requirement: 고정 business registration과 singleton Worker host
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-722`, `PROD-725`, `PROD-665`, `PROD-723`, `PROD-831`. 시스템은 전용 Worker final image에서 사전 생성된 host JavaScript와 Workflow bundle을 실행하더라도 Worker production entrypoint에 compile-time의 실제 business Workflow·Activity registry와 task queue를 정확히 하나 제공해야 한다(MUST). Registry는 Post Create, Repost create, Post Delete, Repost Delete, Profile Update Effects, Reaction Create Effects와 Reaction Delete Effects Workflow·Activity를 함께 등록하고 event별 Workflow source를 정적으로 조립해야 한다(MUST). 기존 Post Create Workflow type `postCreateEffectsWorkflow`와 ID `post-create-effects:{postId}`는 유지해야 하며(MUST), Repost create는 type `postRepostWorkflow`·ID `post-repost:{postId}`, Post Delete는 type `postDeleteWorkflow`·ID `post-delete:{postId}`, Repost Delete는 type `repostDeleteWorkflow`·ID `repost-delete:{postId}`를 사용해야 한다(MUST). Profile Update Workflow type은 `profileUpdateEffectsWorkflow`를 사용하고 Temporal이 요구하는 Workflow ID에는 자동 생성한 update identity를 그대로 전달해야 한다(MUST). Reaction create/delete Workflow는 각각 `reactionCreateEffectsWorkflow`와 `reactionDeleteEffectsWorkflow` type을 사용해야 한다(MUST). Entrypoint 자체는 이 registry로 process-global Worker host를 정확히 한 번 시작해야 하며(MUST), exported `runWorker`/`startWorker` lifecycle, optional registration, registration 부재를 검사하는 정상 실행 경로, idle Worker 상태 또는 같은 process에서 Worker host를 다시 시작할 수 있는 범용 startup API를 제공해서는 안 된다(MUST NOT). Artifact packaging과 image 분리는 이 registration, task queue와 Workflow 외부 identity를 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: Production Worker 시작
+
+- **WHEN** 전용 Worker final image가 사전 생성된 host JavaScript와 Workflow bundle 및 유효한 runtime 환경으로 실행된다
+- **THEN** 시스템은 compile-time에 구성된 Post Create, Repost create, Post Delete, Repost Delete, Profile Update Effects, Reaction Create Effects와 Reaction Delete Effects Workflow·Activity registry 및 하나의 task queue로 Worker host를 정확히 한 번 시작한다
+- **AND** caller가 registration을 전달하거나 두 번째 Worker host를 시작할 수 있는 public startup API를 제공하지 않는다
+
+#### Scenario: 기존 Post Create 외부 identity 보존
+
+- **WHEN** Profile Update 또는 Reaction Effects Workflow source를 build artifact와 기존 Worker registry에 추가한다
+- **THEN** Post Create Workflow type `postCreateEffectsWorkflow`와 ID `post-create-effects:{postId}`는 변경하지 않는다
+- **AND** Repost create는 `postRepostWorkflow`/`post-repost:{postId}`, Post Delete는 `postDeleteWorkflow`/`post-delete:{postId}`, Repost Delete는 `repostDeleteWorkflow`/`repost-delete:{postId}`를 유지한다
+
+#### Scenario: Profile Update 외부 identity
+
+- **WHEN** actor-visible Profile 변경이 commit되어 Effects Workflow를 시작한다
+- **THEN** Workflow type은 `profileUpdateEffectsWorkflow`다
+- **AND** Workflow ID는 자동 생성된 update identity 자체다
+- **AND** Activity는 같은 update identity를 canonical `Update(Person)` IRI에 재사용한다
+
+#### Scenario: domain별 registration 조립
+
+- **WHEN** Repost create, Post Delete, Repost Delete, Profile Update 또는 Reaction create/delete Workflow와 Activity를 Worker registry와 사전 생성 bundle에 추가한다
+- **THEN** event별 Workflow 구현과 type·identity 계약은 분리된 source module에 남고 production entrypoint가 고정 registry로 조립한다
+- **AND** Workflow마다 Worker host, task queue, Core contract file 또는 범용 runtime abstraction을 새로 만들지 않는다
+
+#### Scenario: 실제 effects registration 없는 build 방지
+
+- **WHEN** Worker package의 production entrypoint, 사전 생성 bundle과 registration을 정적·자동화 검증한다
+- **THEN** entrypoint에는 optional 또는 empty registration 경로가 존재하지 않는다
+- **AND** smoke Workflow·검증 전용 task queue·health-only idle runtime 또는 test-only business registration으로 business registration 부재를 숨기지 않는다
+
+### Requirement: 등록된 Worker의 health와 종료 lifecycle
+
+**Authority / Provenance:** `PROD-730`, `PROD-831`. 시스템은 전용 Worker final image에서 실제 Worker registration을 실행할 때 재사용할 HTTP liveness/readiness와 SIGTERM graceful shutdown 경계를 제공해야 한다(MUST). 사전 생성 host JavaScript와 Workflow bundle 및 image dependency 분리는 이 health/lifecycle 계약을 변경해서는 안 된다(MUST NOT). Liveness는 process가 동작 중인지 나타내고, readiness는 Temporal Worker가 task polling을 받을 준비가 된 뒤에만 성공하며 종료가 시작되면 실패로 전환해야 한다(MUST). Foundation은 connect/create 중 SIGTERM이 process에 흡수되지 않는 경계를 package-level child-process test로 검증해야 하며(MUST), 실제 RUNNING 이후 readiness 전이와 Temporal task drain 통합 검증은 Worker를 활성화하는 첫 business capability가 수행해야 한다(MUST).
+
+#### Scenario: Worker startup 중 SIGTERM 수신
+
+- **WHEN** 전용 Worker final image의 Temporal connection 또는 Worker 생성이 완료되기 전에 process가 SIGTERM을 수신한다
+- **THEN** process는 signal을 흡수해 health-only 상태로 남지 않고 SIGTERM으로 종료한다
+
+#### Scenario: Worker가 준비되기 전 health
+
+- **WHEN** Worker process가 시작됐지만 Temporal Worker가 polling 준비를 마치지 못했다
+- **THEN** liveness는 성공할 수 있지만 readiness는 실패한다
+
+#### Scenario: Worker가 준비된 후 health
+
+- **WHEN** 등록된 Temporal Worker가 polling 준비를 마친다
+- **THEN** liveness와 readiness가 모두 성공한다
+
+#### Scenario: 실행 중 SIGTERM 수신
+
+- **WHEN** 준비된 Worker process가 SIGTERM을 수신한다
+- **THEN** readiness는 즉시 실패로 전환된다
+- **AND** process는 새 task 수신을 중단하고 진행 중인 Temporal task의 graceful shutdown을 시도한 뒤 종료한다
+
+### Requirement: 공통 runtime image의 Worker entrypoint
+
+**Authority / Provenance:** `PROD-730`, `PROD-831`. Kosmo Worker는 API/Web/Fedify consumer/migration과 분리된 전용 final image를 사용해야 하며(MUST). 해당 image는 Worker package의 production 실행에 필요한 사전 생성 host JavaScript, 사전 생성 Workflow bundle과 target Linux/ARM64의 최소 runtime dependency만 포함하고 고정 Worker entrypoint를 제공해야 한다(MUST). Worker image는 TypeScript source, `tsx`, 범용 workspace `node_modules`, development dependency 또는 다른 runtime을 선택하는 공통 command dispatcher를 포함해서는 안 된다(MUST NOT).
+
+#### Scenario: Worker image command 선택
+
+- **WHEN** 전용 Worker final image를 Worker command로 실행한다
+- **THEN** image entrypoint는 `apps/worker`의 사전 생성 production host JavaScript를 실행한다
+- **AND** host는 build 단계에서 생성된 Workflow bundle과 target runtime dependency를 사용한다
+
+#### Scenario: Worker image에 TypeScript 실행 경로가 없음
+
+- **WHEN** 전용 Worker final image의 entrypoint와 filesystem을 검사한다
+- **THEN** Worker는 `tsx` 또는 TypeScript source를 resolution하지 않고 시작한다
+- **AND** image에는 Worker가 사용하지 않는 workspace-wide dependency와 development dependency가 없다
+
+### Requirement: Application workload의 상시 Worker component
+
+**Authority / Provenance:** `docs/architecture/core-services.md`, `PROD-722`, `PROD-831`. Kosmo Helm chart는 유효한 immutable runtime image set이 지정된 모든 환경에서 API, Web, Fedify consumer와 함께 전용 Worker final image를 사용하는 Worker Deployment 및 전용 ServiceAccount를 항상 생성해야 한다(MUST). Worker 또는 chart-wide workload activation key로 이 component를 숨겨서는 안 된다(MUST NOT). dev는 1개, prod는 2개의 replica를 기본값으로 render하고, 전용 Worker image의 명시적 command, HTTP liveness/readiness probe와 환경별 Temporal endpoint·namespace를 전달해야 한다(MUST). Worker image와 image set의 digest는 같은 승인된 release source에 속해야 하며(MUST). production 실제 sync·rollout은 별도 사용자 승인 없이는 수행해서는 안 된다(MUST NOT).
+
+#### Scenario: dev application workload render
+
+- **WHEN** 유효한 immutable runtime image set과 함께 dev chart를 render한다
+- **THEN** API, Web, Fedify consumer와 함께 전용 Worker image를 사용하는 1개 replica, Worker command, HTTP probes 및 dev Temporal endpoint·namespace를 가진 Deployment와 ServiceAccount가 activation key 없이 render된다
+
+#### Scenario: prod application workload render
+
+- **WHEN** 유효한 immutable runtime image set과 함께 prod chart를 render한다
+- **THEN** API, Web, Fedify consumer와 함께 전용 Worker image를 사용하는 2개 replica, Worker command, HTTP probes 및 prod Temporal endpoint·namespace를 가진 Deployment와 ServiceAccount가 activation key 없이 render된다
+
+#### Scenario: legacy activation values are inert
+
+- **WHEN** 유효한 immutable runtime image set과 함께 과거 workload 또는 Worker activation 값을 추가해 chart를 render한다
+- **THEN** API, Web, Fedify consumer와 Worker가 모두 render되고 과거 값이 workload 존재 여부를 바꾸지 않는다
+
+#### Scenario: Worker lifecycle의 dev 검증
+
+- **WHEN** 첫 Post Create effects registration을 포함한 exact revision의 전용 Worker image를 dev에 적용한다
+- **THEN** Worker가 실제 task queue를 poll하는 RUNNING 상태에서 readiness가 성공한다
+- **AND** restart 뒤 accepted effects Workflow가 복구되고 SIGTERM 시 readiness가 실패한 뒤 진행 중 task의 graceful drain을 시도한다

--- a/openspec/changes/split-server-runtime-images/tasks.md
+++ b/openspec/changes/split-server-runtime-images/tasks.md
@@ -22,8 +22,8 @@
 
 - [x] 1.1 현재 single image의 Linux/ARM64 build, 다섯 command, filesystem/dependency, compressed/uncompressed size와 layer baseline을 기록한다.
 - [x] 1.2 선택한 JavaScript bundler를 pnpm CLI로 명시적 workspace build dependency에 추가하고 lockfile 정합성을 확인한다.
-- [ ] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map, workspace code bundle, external import metadata와 clean/stale output 처리를 구현한다.
-- [ ] 1.4 Build script의 성공, compile 오류, 누락 entry, workspace package bundle, third-party external import와 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
+- [ ] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map, workspace code bundle과 clean/stale output 처리를 구현한다.
+- [ ] 1.4 실제 다섯 entry의 build, workspace package bundle, third-party external import, source map과 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
 
 ## 2. PROD-831 Web·API·Fedify·Migration JavaScript artifact
 

--- a/openspec/changes/split-server-runtime-images/tasks.md
+++ b/openspec/changes/split-server-runtime-images/tasks.md
@@ -22,8 +22,8 @@
 
 - [x] 1.1 현재 single image의 Linux/ARM64 build, 다섯 command, filesystem/dependency, compressed/uncompressed size와 layer baseline을 기록한다.
 - [x] 1.2 선택한 JavaScript bundler를 pnpm CLI로 명시적 workspace build dependency에 추가하고 lockfile 정합성을 확인한다.
-- [x] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map·build-graph 기반 runtime manifest와 clean/stale output 처리를 구현한다.
-- [x] 1.4 Build script의 성공, compile 오류, 누락 entry, runtime manifest 정합성과 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
+- [x] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map, non-Worker single-file closure, Worker build-graph 기반 runtime manifest와 clean/stale output 처리를 구현한다.
+- [x] 1.4 Build script의 성공, compile 오류, 누락 entry, non-Worker external import 부재, Worker runtime manifest 정합성과 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
 
 ## 2. PROD-831 Web·API·Fedify·Migration JavaScript artifact
 
@@ -48,10 +48,10 @@ Web BFF, GraphQL API, Fedify Consumer와 migration이 TypeScript source/`tsx` �
 - 네 artifact를 Node에서 직접 실행하고 dynamic import, `import.meta.main`, health/static route, queue shutdown과 migration asset path의 focused test/smoke를 수행한다.
 - API/Web external source map의 sourcesContent/debug identity, upload-required 실패와 final artifact map/reference 제거를 검증한다.
 
-- [x] 2.1 Web/API/Fedify Consumer production entry graph와 자동 생성 third-party runtime manifest를 만들고 기존 runtime 행동을 보존한다.
+- [x] 2.1 Web/API/Fedify Consumer production entry graph와 third-party dependency를 각각 단일 JavaScript artifact로 만들고 기존 runtime 행동을 보존한다.
 - [x] 2.2 Migration JavaScript entry와 `drizzle/` asset의 deterministic path를 구현하고 기존 migration history·lock·transaction tests를 통과시킨다.
 - [x] 2.3 API/Web server source map을 기존 Sentry release build에 inject·upload·validate하고 final runtime artifact에서 map/reference를 제거한다.
-- [x] 2.4 네 artifact가 generated manifest로 설치된 dependency와 함께 `tsx`·TypeScript source 없이 시작되는 package/focused smoke를 추가하고 dynamic loading·shutdown 회귀를 검증한다.
+- [x] 2.4 네 artifact가 runtime `node_modules`, `tsx`·TypeScript source 없이 시작되는 package/focused smoke를 추가하고 Temporal Client, dynamic loading·shutdown 회귀를 검증한다.
 
 ## 3. PROD-831 Temporal Worker prebuilt artifact와 native runtime
 
@@ -78,8 +78,8 @@ Temporal Worker가 고정 business registry를 가진 사전 생성 host JavaScr
 
 - [x] 3.1 Production Workflow registry를 exact `@temporalio/worker` version으로 build-time bundle하고 누락/추가 Workflow export를 검증한다.
 - [x] 3.2 Worker host가 production에서 prebuilt `workflowBundle`을 사용하고 기존 fixed Activity registry와 task queue를 보존하게 한다.
-- [x] 3.3 Worker host의 build-graph 기반 runtime manifest와 Linux/ARM64 Temporal native/runtime production dependency tree를 조립한다.
-- [x] 3.4 Worker package tests와 Linux/ARM64 container smoke로 generated manifest, native load, Workflow bundle, health/readiness 및 graceful shutdown을 검증한다.
+- [x] 3.3 Worker application/Activity host를 bundle하고 Temporal SDK external import의 build-graph 기반 runtime manifest와 Linux/ARM64 native/runtime production dependency tree를 조립한다.
+- [x] 3.4 Worker package tests와 Linux/ARM64 container smoke로 generated manifest, native load, Workflow bundle, health/readiness 및 graceful shutdown을 다시 검증한다.
 
 ## 4. PROD-831 다섯 final image와 artifact gate
 
@@ -104,11 +104,11 @@ Web, API, Worker, Fedify Consumer와 Migration final image가 고정 entrypoint�
 - 다섯 Docker target을 Linux/ARM64로 build하고 고정 command, non-root 실행, filesystem, package tree, asset과 health/exit를 검사한다.
 - 각 target의 compressed/uncompressed size와 history를 baseline과 비교하고 dependency/layer 감소 원인을 기록한다.
 
-- [x] 4.1 공통 build cache와 generated runtime manifest를 재사용하면서 Web/API/Worker/Fedify Consumer/Migration을 분리하는 다섯 final Docker target을 구현한다.
+- [x] 4.1 공통 build cache를 재사용하면서 네 single-file runtime과 generated Worker runtime manifest로 Web/API/Worker/Fedify Consumer/Migration을 분리하는 다섯 final Docker target을 구현한다.
 - [x] 4.2 각 final image를 고정 Node entrypoint와 non-root runtime으로 실행하고 기존 다중 command dispatcher 의존을 제거한다.
-- [x] 4.3 Runtime별 manifest/filesystem 경계, static/migration/Workflow asset과 `tsx`·TypeScript source 부재를 검증하되 exact package allowlist나 package-manager 내부 경로를 고정하지 않는다.
-- [x] 4.4 다섯 image의 Linux/ARM64 boot/health/exit smoke와 baseline 대비 compressed/uncompressed size/layer gate를 통과시키고 결과를 PROD-831에 기록한다.
-- [x] 4.5 Artifact gate 결과를 리뷰해 모두 통과하지 않으면 후속 Helm/CI/CD task를 시작하지 않고 실패 원인과 남은 증거를 보고한다.
+- [x] 4.3 Non-Worker single-file/filesystem 경계, Worker manifest, static/migration/Workflow asset과 `tsx`·TypeScript source 부재를 검증하되 exact Worker package allowlist나 package-manager 내부 경로를 고정하지 않는다.
+- [x] 4.4 다섯 image의 Linux/ARM64 boot/health/exit smoke와 baseline 대비 compressed/uncompressed size/layer gate를 다시 통과시키고 결과를 PROD-831에 기록한다.
+- [x] 4.5 Artifact gate 결과를 다시 리뷰해 모두 통과하지 않으면 후속 Helm/CI/CD task를 시작하지 않고 실패 원인과 남은 증거를 보고한다.
 
 ## 5. PROD-831 OpenSpec integration과 Helm runtime image set
 

--- a/openspec/changes/split-server-runtime-images/tasks.md
+++ b/openspec/changes/split-server-runtime-images/tasks.md
@@ -22,8 +22,8 @@
 
 - [x] 1.1 현재 single image의 Linux/ARM64 build, 다섯 command, filesystem/dependency, compressed/uncompressed size와 layer baseline을 기록한다.
 - [x] 1.2 선택한 JavaScript bundler를 pnpm CLI로 명시적 workspace build dependency에 추가하고 lockfile 정합성을 확인한다.
-- [x] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map, non-Worker single-file closure, Worker build-graph 기반 runtime manifest와 clean/stale output 처리를 구현한다.
-- [x] 1.4 Build script의 성공, compile 오류, 누락 entry, non-Worker external import 부재, Worker runtime manifest 정합성과 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
+- [ ] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map, workspace code bundle, external import metadata와 clean/stale output 처리를 구현한다.
+- [ ] 1.4 Build script의 성공, compile 오류, 누락 entry, workspace package bundle, third-party external import와 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
 
 ## 2. PROD-831 Web·API·Fedify·Migration JavaScript artifact
 
@@ -48,10 +48,10 @@ Web BFF, GraphQL API, Fedify Consumer와 migration이 TypeScript source/`tsx` �
 - 네 artifact를 Node에서 직접 실행하고 dynamic import, `import.meta.main`, health/static route, queue shutdown과 migration asset path의 focused test/smoke를 수행한다.
 - API/Web external source map의 sourcesContent/debug identity, upload-required 실패와 final artifact map/reference 제거를 검증한다.
 
-- [x] 2.1 Web/API/Fedify Consumer production entry graph와 third-party dependency를 각각 단일 JavaScript artifact로 만들고 기존 runtime 행동을 보존한다.
+- [ ] 2.1 Web/API/Fedify Consumer production entry graph의 workspace code를 각각 JavaScript artifact로 만들고 third-party package는 runtime dependency tree에서 해석되게 하며 기존 runtime 행동을 보존한다.
 - [x] 2.2 Migration JavaScript entry와 `drizzle/` asset의 deterministic path를 구현하고 기존 migration history·lock·transaction tests를 통과시킨다.
 - [x] 2.3 API/Web server source map을 기존 Sentry release build에 inject·upload·validate하고 final runtime artifact에서 map/reference를 제거한다.
-- [x] 2.4 네 artifact가 runtime `node_modules`, `tsx`·TypeScript source 없이 시작되는 package/focused smoke를 추가하고 Temporal Client, dynamic loading·shutdown 회귀를 검증한다.
+- [ ] 2.4 네 artifact가 runtime별 production `node_modules`에서 external import를 해석하고 `tsx`·TypeScript source 없이 시작되는 package/focused smoke를 추가해 Temporal Client, dynamic loading·shutdown 회귀를 검증한다.
 
 ## 3. PROD-831 Temporal Worker prebuilt artifact와 native runtime
 
@@ -78,8 +78,8 @@ Temporal Worker가 고정 business registry를 가진 사전 생성 host JavaScr
 
 - [x] 3.1 Production Workflow registry를 exact `@temporalio/worker` version으로 build-time bundle하고 누락/추가 Workflow export를 검증한다.
 - [x] 3.2 Worker host가 production에서 prebuilt `workflowBundle`을 사용하고 기존 fixed Activity registry와 task queue를 보존하게 한다.
-- [x] 3.3 Worker application/Activity host를 bundle하고 Temporal SDK external import의 build-graph 기반 runtime manifest와 Linux/ARM64 native/runtime production dependency tree를 조립한다.
-- [x] 3.4 Worker package tests와 Linux/ARM64 container smoke로 generated manifest, native load, Workflow bundle, health/readiness 및 graceful shutdown을 다시 검증한다.
+- [ ] 3.3 Worker application/Activity host를 bundle하고 Worker workspace의 production dependency tree와 Linux/ARM64 native/runtime artifact를 조립한다.
+- [ ] 3.4 Worker package tests와 Linux/ARM64 container smoke로 external import resolution, native load, Workflow bundle, health/readiness 및 graceful shutdown을 다시 검증한다.
 
 ## 4. PROD-831 다섯 final image와 artifact gate
 
@@ -104,11 +104,11 @@ Web, API, Worker, Fedify Consumer와 Migration final image가 고정 entrypoint�
 - 다섯 Docker target을 Linux/ARM64로 build하고 고정 command, non-root 실행, filesystem, package tree, asset과 health/exit를 검사한다.
 - 각 target의 compressed/uncompressed size와 history를 baseline과 비교하고 dependency/layer 감소 원인을 기록한다.
 
-- [x] 4.1 공통 build cache를 재사용하면서 네 single-file runtime과 generated Worker runtime manifest로 Web/API/Worker/Fedify Consumer/Migration을 분리하는 다섯 final Docker target을 구현한다.
+- [ ] 4.1 공통 build cache를 재사용하면서 runtime별 production dependency tree로 Web/API/Worker/Fedify Consumer/Migration을 분리하는 다섯 final Docker target을 구현한다.
 - [x] 4.2 각 final image를 고정 Node entrypoint와 non-root runtime으로 실행하고 기존 다중 command dispatcher 의존을 제거한다.
-- [x] 4.3 Non-Worker single-file/filesystem 경계, Worker manifest, static/migration/Workflow asset과 `tsx`·TypeScript source 부재를 검증하되 exact Worker package allowlist나 package-manager 내부 경로를 고정하지 않는다.
-- [x] 4.4 다섯 image의 Linux/ARM64 boot/health/exit smoke와 baseline 대비 compressed/uncompressed size/layer gate를 다시 통과시키고 결과를 PROD-831에 기록한다.
-- [x] 4.5 Artifact gate 결과를 다시 리뷰해 모두 통과하지 않으면 후속 Helm/CI/CD task를 시작하지 않고 실패 원인과 남은 증거를 보고한다.
+- [ ] 4.3 Runtime별 filesystem과 external import resolution, static/migration/Workflow asset 및 `tsx`·TypeScript source 부재를 검증하되 exact package allowlist나 package-manager 내부 경로를 고정하지 않는다.
+- [ ] 4.4 다섯 image의 Linux/ARM64 boot/health/exit smoke와 baseline 대비 compressed/uncompressed size/layer gate를 다시 통과시키고 결과를 PROD-831에 기록한다.
+- [ ] 4.5 Artifact gate 결과를 다시 리뷰해 모두 통과하지 않으면 후속 Helm/CI/CD task를 시작하지 않고 실패 원인과 남은 증거를 보고한다.
 
 ## 5. PROD-831 OpenSpec integration과 Helm runtime image set
 

--- a/openspec/changes/split-server-runtime-images/tasks.md
+++ b/openspec/changes/split-server-runtime-images/tasks.md
@@ -22,8 +22,8 @@
 
 - [x] 1.1 현재 single image의 Linux/ARM64 build, 다섯 command, filesystem/dependency, compressed/uncompressed size와 layer baseline을 기록한다.
 - [x] 1.2 선택한 JavaScript bundler를 pnpm CLI로 명시적 workspace build dependency에 추가하고 lockfile 정합성을 확인한다.
-- [x] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map·dependency metadata contract와 clean/stale output 처리를 구현한다.
-- [x] 1.4 Build script의 성공, compile 오류, 누락 entry와 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
+- [x] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map·build-graph 기반 runtime manifest와 clean/stale output 처리를 구현한다.
+- [x] 1.4 Build script의 성공, compile 오류, 누락 entry, runtime manifest 정합성과 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
 
 ## 2. PROD-831 Web·API·Fedify·Migration JavaScript artifact
 
@@ -48,10 +48,10 @@ Web BFF, GraphQL API, Fedify Consumer와 migration이 TypeScript source/`tsx` �
 - 네 artifact를 Node에서 직접 실행하고 dynamic import, `import.meta.main`, health/static route, queue shutdown과 migration asset path의 focused test/smoke를 수행한다.
 - API/Web external source map의 sourcesContent/debug identity, upload-required 실패와 final artifact map/reference 제거를 검증한다.
 
-- [x] 2.1 Web/API/Fedify Consumer production entry graph를 ESM JavaScript artifact로 생성하고 기존 runtime 행동을 보존한다.
+- [x] 2.1 Web/API/Fedify Consumer production entry graph와 자동 생성 third-party runtime manifest를 만들고 기존 runtime 행동을 보존한다.
 - [x] 2.2 Migration JavaScript entry와 `drizzle/` asset의 deterministic path를 구현하고 기존 migration history·lock·transaction tests를 통과시킨다.
 - [x] 2.3 API/Web server source map을 기존 Sentry release build에 inject·upload·validate하고 final runtime artifact에서 map/reference를 제거한다.
-- [x] 2.4 네 artifact가 `tsx`와 TypeScript source 없이 시작되는 package/focused smoke를 추가하고 dynamic loading·shutdown 회귀를 검증한다.
+- [x] 2.4 네 artifact가 generated manifest로 설치된 dependency와 함께 `tsx`·TypeScript source 없이 시작되는 package/focused smoke를 추가하고 dynamic loading·shutdown 회귀를 검증한다.
 
 ## 3. PROD-831 Temporal Worker prebuilt artifact와 native runtime
 
@@ -78,8 +78,8 @@ Temporal Worker가 고정 business registry를 가진 사전 생성 host JavaScr
 
 - [x] 3.1 Production Workflow registry를 exact `@temporalio/worker` version으로 build-time bundle하고 누락/추가 Workflow export를 검증한다.
 - [x] 3.2 Worker host가 production에서 prebuilt `workflowBundle`을 사용하고 기존 fixed Activity registry와 task queue를 보존하게 한다.
-- [x] 3.3 Worker host bundle의 external runtime 경계와 Linux/ARM64 Temporal native/runtime production dependency tree를 조립한다.
-- [x] 3.4 Worker package tests와 Linux/ARM64 container smoke로 native load, Workflow bundle, health/readiness 및 graceful shutdown을 검증한다.
+- [x] 3.3 Worker host의 build-graph 기반 runtime manifest와 Linux/ARM64 Temporal native/runtime production dependency tree를 조립한다.
+- [x] 3.4 Worker package tests와 Linux/ARM64 container smoke로 generated manifest, native load, Workflow bundle, health/readiness 및 graceful shutdown을 검증한다.
 
 ## 4. PROD-831 다섯 final image와 artifact gate
 
@@ -104,9 +104,9 @@ Web, API, Worker, Fedify Consumer와 Migration final image가 고정 entrypoint�
 - 다섯 Docker target을 Linux/ARM64로 build하고 고정 command, non-root 실행, filesystem, package tree, asset과 health/exit를 검사한다.
 - 각 target의 compressed/uncompressed size와 history를 baseline과 비교하고 dependency/layer 감소 원인을 기록한다.
 
-- [x] 4.1 공통 build cache를 재사용하면서 Web/API/Worker/Fedify Consumer/Migration을 분리하는 다섯 final Docker target을 구현한다.
+- [x] 4.1 공통 build cache와 generated runtime manifest를 재사용하면서 Web/API/Worker/Fedify Consumer/Migration을 분리하는 다섯 final Docker target을 구현한다.
 - [x] 4.2 각 final image를 고정 Node entrypoint와 non-root runtime으로 실행하고 기존 다중 command dispatcher 의존을 제거한다.
-- [x] 4.3 Runtime별 filesystem/dependency allow/deny, static/migration/Workflow asset과 `tsx`·TypeScript source 부재 검증을 추가한다.
+- [x] 4.3 Runtime별 manifest/filesystem 경계, static/migration/Workflow asset과 `tsx`·TypeScript source 부재를 검증하되 exact package allowlist나 package-manager 내부 경로를 고정하지 않는다.
 - [x] 4.4 다섯 image의 Linux/ARM64 boot/health/exit smoke와 baseline 대비 compressed/uncompressed size/layer gate를 통과시키고 결과를 PROD-831에 기록한다.
 - [x] 4.5 Artifact gate 결과를 리뷰해 모두 통과하지 않으면 후속 Helm/CI/CD task를 시작하지 않고 실패 원인과 남은 증거를 보고한다.
 

--- a/openspec/changes/split-server-runtime-images/tasks.md
+++ b/openspec/changes/split-server-runtime-images/tasks.md
@@ -1,0 +1,231 @@
+## 1. PROD-831 Current single-image baseline과 build contract
+
+**Authority / Provenance**
+
+- `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`
+- `PROD-831`
+
+**Deliverable**
+
+현재 Linux/ARM64 single image의 command별 실행 경계, compressed/uncompressed size, layer와 포함 dependency를 재현 가능한 baseline으로 기록하고 server artifact build 도구를 workspace의 명시적 contract로 준비한다.
+
+**Guardrails**
+
+- Base image와 Node major를 이번 변경에서 함께 바꾸지 않는다.
+- Transitive dependency로 우연히 설치된 bundler에 의존하지 않는다.
+- Baseline image build 성공을 새 artifact나 dev/production runtime 성공으로 간주하지 않는다.
+
+**Verification**
+
+- 현재 Docker target을 Linux/ARM64로 build하고 Web/API/Worker/Fedify/Migration command, image inspect/history와 size를 기록한다.
+- Bundler가 package manifest/lockfile에 명시적으로 선언되고 clean install/build에서 resolution되는지 확인한다.
+
+- [x] 1.1 현재 single image의 Linux/ARM64 build, 다섯 command, filesystem/dependency, compressed/uncompressed size와 layer baseline을 기록한다.
+- [x] 1.2 선택한 JavaScript bundler를 pnpm CLI로 명시적 workspace build dependency에 추가하고 lockfile 정합성을 확인한다.
+- [x] 1.3 Server artifact build의 입력·출력·target Node/ESM·source map·dependency metadata contract와 clean/stale output 처리를 구현한다.
+- [x] 1.4 Build script의 성공, compile 오류, 누락 entry와 stale artifact 제거를 검증하고 관련 package/type check를 통과시킨다.
+
+## 2. PROD-831 Web·API·Fedify·Migration JavaScript artifact
+
+**Authority / Provenance**
+
+- `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`
+- `PROD-516`
+- `PROD-831`
+
+**Deliverable**
+
+Web BFF, GraphQL API, Fedify Consumer와 migration이 TypeScript source/`tsx` 없이 사전 생성 JavaScript와 필요한 asset으로 시작되고 API/Web 오류의 source map 정합성을 유지한다.
+
+**Guardrails**
+
+- 기존 API/Web health, Expo static root, GraphQL/Fedify routing, consumer lifecycle와 migration history/lock/transaction 계약을 바꾸지 않는다.
+- Migration artifact는 version-controlled `drizzle/` SQL만 사용하고 database/schema authority input을 추가하지 않는다.
+- Sentry upload token과 server source map은 final image/runtime/log에 남기지 않는다.
+
+**Verification**
+
+- 네 artifact를 Node에서 직접 실행하고 dynamic import, `import.meta.main`, health/static route, queue shutdown과 migration asset path의 focused test/smoke를 수행한다.
+- API/Web external source map의 sourcesContent/debug identity, upload-required 실패와 final artifact map/reference 제거를 검증한다.
+
+- [x] 2.1 Web/API/Fedify Consumer production entry graph를 ESM JavaScript artifact로 생성하고 기존 runtime 행동을 보존한다.
+- [x] 2.2 Migration JavaScript entry와 `drizzle/` asset의 deterministic path를 구현하고 기존 migration history·lock·transaction tests를 통과시킨다.
+- [x] 2.3 API/Web server source map을 기존 Sentry release build에 inject·upload·validate하고 final runtime artifact에서 map/reference를 제거한다.
+- [x] 2.4 네 artifact가 `tsx`와 TypeScript source 없이 시작되는 package/focused smoke를 추가하고 dynamic loading·shutdown 회귀를 검증한다.
+
+## 3. PROD-831 Temporal Worker prebuilt artifact와 native runtime
+
+**Authority / Provenance**
+
+- `docs/architecture/core-services.md`
+- `PROD-730`
+- `PROD-831`
+
+**Deliverable**
+
+Temporal Worker가 고정 business registry를 가진 사전 생성 host JavaScript와 exact SDK version의 prebuilt Workflow bundle로 Linux/ARM64에서 시작하며, 필요한 native/runtime dependency만 Worker image 경계에 남는다.
+
+**Guardrails**
+
+- Workflow/Activity type, ID, task queue, registration, health/readiness와 SIGTERM drain 계약을 변경하지 않는다.
+- Production에서 `workflowsPath`로 TypeScript source를 다시 bundle하지 않는다.
+- Target ABI를 확인하지 않은 native binary 삭제·이동 또는 다른 runtime image와의 Temporal dependency 공유를 하지 않는다.
+
+**Verification**
+
+- Prebuilt Workflow bundle의 모든 production Workflow export와 build/runtime SDK version 일치를 검사한다.
+- Linux/ARM64 Node 26.5.1 container에서 native load, connect/create, health/readiness와 startup/running SIGTERM lifecycle을 검증한다.
+
+- [x] 3.1 Production Workflow registry를 exact `@temporalio/worker` version으로 build-time bundle하고 누락/추가 Workflow export를 검증한다.
+- [x] 3.2 Worker host가 production에서 prebuilt `workflowBundle`을 사용하고 기존 fixed Activity registry와 task queue를 보존하게 한다.
+- [x] 3.3 Worker host bundle의 external runtime 경계와 Linux/ARM64 Temporal native/runtime production dependency tree를 조립한다.
+- [x] 3.4 Worker package tests와 Linux/ARM64 container smoke로 native load, Workflow bundle, health/readiness 및 graceful shutdown을 검증한다.
+
+## 4. PROD-831 다섯 final image와 artifact gate
+
+**Authority / Provenance**
+
+- `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`
+- `PROD-831`
+
+**Deliverable**
+
+Web, API, Worker, Fedify Consumer와 Migration final image가 고정 entrypoint와 runtime별 최소 artifact/dependency만 포함하고, 전환 전에 build·boot·dependency·size gate를 모두 통과한다.
+
+**Guardrails**
+
+- Web image만 Expo static/precompressed asset을 포함한다.
+- Final image에는 다른 runtime command를 고르는 공통 dispatcher를 두지 않는다.
+- 각 image의 compressed size는 같은 Linux/ARM64 baseline single image보다 작아야 한다.
+- 하나라도 gate가 실패하면 Helm/release workflow 전환을 시작하지 않는다.
+
+**Verification**
+
+- 다섯 Docker target을 Linux/ARM64로 build하고 고정 command, non-root 실행, filesystem, package tree, asset과 health/exit를 검사한다.
+- 각 target의 compressed/uncompressed size와 history를 baseline과 비교하고 dependency/layer 감소 원인을 기록한다.
+
+- [x] 4.1 공통 build cache를 재사용하면서 Web/API/Worker/Fedify Consumer/Migration을 분리하는 다섯 final Docker target을 구현한다.
+- [x] 4.2 각 final image를 고정 Node entrypoint와 non-root runtime으로 실행하고 기존 다중 command dispatcher 의존을 제거한다.
+- [x] 4.3 Runtime별 filesystem/dependency allow/deny, static/migration/Workflow asset과 `tsx`·TypeScript source 부재 검증을 추가한다.
+- [x] 4.4 다섯 image의 Linux/ARM64 boot/health/exit smoke와 baseline 대비 compressed/uncompressed size/layer gate를 통과시키고 결과를 PROD-831에 기록한다.
+- [x] 4.5 Artifact gate 결과를 리뷰해 모두 통과하지 않으면 후속 Helm/CI/CD task를 시작하지 않고 실패 원인과 남은 증거를 보고한다.
+
+## 5. PROD-831 OpenSpec integration과 Helm runtime image set
+
+**Authority / Provenance**
+
+- `memory/issue-openspec-workflow.md`
+- `PROD-288`
+- `PROD-730`
+- `PROD-783`
+- `PROD-831`
+
+**Deliverable**
+
+Current main/manual SHA production-release contract를 canonical에 보존한 뒤 Helm이 같은 source/build의 완전한 runtime image set을 각 workload와 migration에 적용한다.
+
+**Guardrails**
+
+- `deploy-production-from-main-or-sha`가 canonical에 archive되기 전에 이 change의 production-release delta를 구현 완료 또는 archive하지 않는다.
+- Production은 다섯 valid digest를 모두 요구하며 partial/mixed set을 render하지 않는다.
+- Migration은 `migration` image로 wave 1, API/Web/Worker/Fedify Consumer는 대응 image로 wave 2를 유지한다.
+- DB role/credential, queue database, replica, probe와 workload 상시 activation 계약을 바꾸지 않는다.
+
+**Verification**
+
+- Linear PROD-783/current comments, active change status와 canonical production-release requirement를 refresh해 archive 순서를 증명한다.
+- Dev/prod Helm render에서 runtime별 image, 누락/invalid/mixed input 실패, migration wave와 workload command/env/probe를 검증한다.
+
+- [ ] 5.1 `deploy-production-from-main-or-sha`의 remaining tasks, Linear authority와 archive 상태를 refresh하고 canonical main/manual SHA production-release contract를 확인한다.
+- [ ] 5.2 공통 repository와 runtime별 version/digest set을 표현하는 Helm values/helper contract를 구현하고 production 완전성 검증을 추가한다.
+- [ ] 5.3 Web/API/Worker/Fedify Consumer/Migration template이 대응 image와 고정 entrypoint를 사용하도록 전환하고 기존 runtime env, probe와 wave를 보존한다.
+- [ ] 5.4 Dev/prod render에서 valid set, 누락·invalid·mixed set 거부, legacy activation inertness와 migration-before-workload 순서를 검증한다.
+
+## 6. PROD-831 Dev build·scan·deployment release set
+
+**Authority / Provenance**
+
+- `PROD-288`
+- `PROD-783`
+- `PROD-831`
+
+**Deliverable**
+
+Main dev build가 동일 full SHA/build run의 다섯 runtime image를 GHCR에 게시·검사하고, 완전한 set을 한 번에 dev Argo CD에 전달해 migration 뒤 workload를 배포한다.
+
+**Guardrails**
+
+- 후속 build가 실행 중 dev release의 image identity를 부분적으로 바꾸지 않는다.
+- 한 runtime build/scan/digest가 실패하면 불완전한 set을 deploy하지 않는다.
+- Deploy Dev 직렬화와 migration 실패 시 workload restart 차단을 유지한다.
+
+**Verification**
+
+- Workflow static validation에서 다섯 build output, source/build identity, set completeness, artifact 전달과 scan fan-out/fan-in을 확인한다.
+- Dev sync에서 migration Job과 네 workload의 실제 image reference, source SHA, health와 실패 차단을 관찰한다.
+
+- [ ] 6.1 Main Docker Build가 다섯 target을 같은 full SHA/build run으로 build·push하고 runtime별 immutable digest를 structured artifact로 출력하게 한다.
+- [ ] 6.2 Trivy와 build result가 다섯 image를 모두 검사하고 하나의 실패도 release set/deploy 성공으로 합치지 않게 한다.
+- [ ] 6.3 Deploy Dev가 완전한 runtime image set과 source revision을 Argo CD에 원자적으로 설정하고 post-write 값을 다시 검증하게 한다.
+- [ ] 6.4 Workflow static checks와 dev live sync에서 migration image wave 1, 네 workload 대응 image wave 2, health와 release set identity를 검증한다.
+
+## 7. PROD-831 Production runtime digest set release
+
+**Authority / Provenance**
+
+- `docs/operations/production-migrations.md`
+- `memory/database-migrations.md`
+- `PROD-564`
+- `PROD-783`
+- `PROD-831`
+
+**Deliverable**
+
+Automatic main과 manual full-SHA production release가 한 번의 `prod` 승인 뒤 같은 gated build run의 다섯 immutable digest를 만들고 migration-gated Argo sync와 감사 기록에 사용한다.
+
+**Guardrails**
+
+- 승인 전 production checkout, Vault/Sentry credential, image build와 Argo mutation을 실행하지 않는다.
+- Automatic/manual 경로는 같은 set validation·concurrency·migration barrier를 사용한다.
+- Partial set, mutable tag, 다른 SHA/build digest 혼합, migration 실패와 scanner 실패는 workload activation 전에 release를 실패시킨다.
+- Production live release는 별도 명시적 승인과 current-state refresh 없이 실행하지 않는다.
+
+**Verification**
+
+- Workflow/action static validation으로 approval boundary, five-digest output, automatic/manual target SHA, set validation, single Argo mutation, post-write check와 audit summary를 검증한다.
+- 승인된 live release에서 source SHA/build run, 다섯 GHCR digest, Argo revision, migration result, workload images/health와 smoke를 각각 기록한다.
+
+- [ ] 7.1 승인 뒤 production build가 다섯 runtime image를 GHCR에 게시하고 완전한 digest set을 검증하도록 automatic/manual 공용 release 경계를 전환한다.
+- [ ] 7.2 Production Argo mutation이 source full SHA와 다섯 digest를 원자적으로 설정·재조회하고 `migration` wave 성공 뒤 네 workload를 활성화하게 한다.
+- [ ] 7.3 Production workflow summary/audit가 trigger, requester, workflow ref, target SHA, build run, 다섯 digest, Argo revision과 단계별 결과를 기록하게 한다.
+- [ ] 7.4 Action/workflow/Helm/OpenSpec strict validation과 관련 repository check를 통과시키고 PR/CI/dev/production evidence를 분리해 보고한다.
+- [ ] 7.5 별도 production 승인 후에만 current Argo/GHCR/database/runtime 상태를 refresh하고 첫 runtime digest set release와 smoke를 수행·기록한다.
+
+## 8. PROD-831 Documentation, completion과 archive
+
+**Authority / Provenance**
+
+- `memory/issue-openspec-workflow.md`
+- `PROD-516`
+- `PROD-783`
+- `PROD-831`
+
+**Deliverable**
+
+Build, runtime, release와 운영 문서가 runtime image set 계약과 실제 검증 결과에 일치하고, PROD-831 전체 범위의 완료 증거를 소유한 작업에서 OpenSpec과 Linear를 완료한다.
+
+**Guardrails**
+
+- Artifact/CI, dev runtime, production release 증거를 서로 대체하지 않는다.
+- PROD-516 source map 소유권과 `deploy-production-from-main-or-sha` canonical sync를 중복·상충 상태로 남기지 않는다.
+- 구현 PR 하나의 완료나 production 배포 없이 문서가 작성됐다는 이유만으로 change를 archive하지 않는다.
+
+**Verification**
+
+- 운영 문서, active/canonical OpenSpec, Linear 관계와 실제 Docker/Helm/workflow 상태를 대조한다.
+- 모든 task, required validation, dev 증거와 승인된 production evidence가 있을 때 strict archive를 수행한다.
+
+- [ ] 8.1 Docker build, dev deployment, production release/migration, rollback과 Sentry runbook을 runtime image set 계약에 맞게 갱신한다.
+- [ ] 8.2 PROD-516과 PROD-783 관련 OpenSpec/Linear artifact의 superseded·shared scope를 정리하고 중복된 single-digest 문장을 동기화한다.
+- [ ] 8.3 Full repository checks, OpenSpec strict validation, image size report, dev runtime과 승인된 production evidence를 최종 대조한다.
+- [ ] 8.4 PROD-831의 모든 완료 조건과 integration verification이 충족된 뒤 이 change를 strict archive하고 Linear 상태를 갱신한다.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
   "scripts": {
+    "build:server-artifacts": "node scripts/build-server-artifacts.mjs",
     "build:sentry-artifacts": "node scripts/build-sentry-artifacts.mjs",
     "db:test:down": "node scripts/test-db.mjs down",
     "db:test:drop": "node scripts/test-db.mjs drop",
@@ -32,6 +33,7 @@
     "@optique/run": "^1.1.1",
     "@sentry/cli": "^3.6.0",
     "@types/node": "^25.6.2",
+    "esbuild": "^0.28.1",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/packages/core/db/migrate-entry.ts
+++ b/packages/core/db/migrate-entry.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { runDatabaseMigrations } from './migrate';
+
+export function resolveRuntimeMigrationsFolder(entrypointUrl: string): string {
+  const entrypointDirectory = dirname(fileURLToPath(entrypointUrl));
+  const artifactDirectory = resolve(entrypointDirectory, '../../drizzle');
+  if (existsSync(artifactDirectory)) {
+    return artifactDirectory;
+  }
+  return resolve(entrypointDirectory, '../../../drizzle');
+}
+
+const entrypoint = process.argv[1] ? pathToFileURL(process.argv[1]).href : undefined;
+
+if (entrypoint === import.meta.url) {
+  await runDatabaseMigrations({
+    migrationsFolder: resolveRuntimeMigrationsFolder(import.meta.url),
+  });
+}

--- a/packages/core/db/migrate.ts
+++ b/packages/core/db/migrate.ts
@@ -1,4 +1,3 @@
-import { pathToFileURL } from 'node:url';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import postgres from 'postgres';
 import drizzleConfig from '../drizzle.config';
@@ -409,10 +408,4 @@ export async function runDatabaseMigrations({
       }
     }
   }
-}
-
-const entrypointUrl = process.argv[1] ? pathToFileURL(process.argv[1]).href : undefined;
-
-if (entrypointUrl === import.meta.url) {
-  await runDatabaseMigrations();
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "zod": "^4.4.3"
   },
   "scripts": {
-    "db:migrate": "node --import tsx db/migrate.ts",
+    "db:migrate": "node --import tsx db/migrate-entry.ts",
     "drizzle:generate": "node ../../scripts/vault-run.mjs -- drizzle-kit generate",
     "drizzle:push": "node ../../scripts/vault-run.mjs -- drizzle-kit push",
     "drizzle:studio": "node ../../scripts/vault-run.mjs -- drizzle-kit studio",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,6 @@
     "postgres": "^3.4.9",
     "prosemirror-model": "^1.25.10",
     "temporal-polyfill": "^0.3.2",
-    "tsx": "^4.22.4",
     "uuid": "^14.0.1",
     "zod": "^4.4.3"
   },
@@ -55,6 +54,7 @@
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",
-    "drizzle-kit": "1.0.0-beta.22"
+    "drizzle-kit": "1.0.0-beta.22",
+    "tsx": "^4.22.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,9 +153,6 @@ importers:
       remeda:
         specifier: ^2.34.1
         version: 2.34.1
-      tsx:
-        specifier: ^4.22.4
-        version: 4.22.4
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
@@ -166,6 +163,9 @@ importers:
       '@fedify/vocab':
         specifier: 2.3.0
         version: 2.3.0
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
 
   apps/app:
     dependencies:
@@ -338,6 +338,7 @@ importers:
       '@kosmo/fedify':
         specifier: workspace:*
         version: link:../../packages/fedify
+    devDependencies:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -365,9 +366,6 @@ importers:
       openid-client:
         specifier: 6.8.4
         version: 6.8.4
-      tsx:
-        specifier: ^4.22.4
-        version: 4.22.4
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -375,6 +373,9 @@ importers:
       temporal-polyfill:
         specifier: ^0.3.2
         version: 0.3.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
@@ -402,9 +403,6 @@ importers:
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
-      tsx:
-        specifier: ^4.22.4
-        version: 4.22.4
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -421,6 +419,9 @@ importers:
       '@temporalio/testing':
         specifier: ^1.22.0
         version: 1.22.0(esbuild@0.28.1)(tslib@2.8.1)
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
 
   packages/core:
     dependencies:
@@ -448,9 +449,6 @@ importers:
       temporal-polyfill:
         specifier: ^0.3.2
         version: 0.3.2
-      tsx:
-        specifier: ^4.22.4
-        version: 4.22.4
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
@@ -464,6 +462,9 @@ importers:
       drizzle-kit:
         specifier: 1.0.0-beta.22
         version: 1.0.0-beta.22
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
 
   packages/fedify:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@types/node':
         specifier: ^25.6.2
         version: 25.6.2
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -389,7 +392,7 @@ importers:
         version: link:../../packages/fedify
       '@temporalio/worker':
         specifier: ^1.22.0
-        version: 1.22.0(tslib@2.8.1)
+        version: 1.22.0(esbuild@0.28.1)(tslib@2.8.1)
       '@temporalio/workflow':
         specifier: ^1.22.0
         version: 1.22.0
@@ -417,7 +420,7 @@ importers:
         version: 1.22.0
       '@temporalio/testing':
         specifier: ^1.22.0
-        version: 1.22.0(tslib@2.8.1)
+        version: 1.22.0(esbuild@0.28.1)(tslib@2.8.1)
 
   packages/core:
     dependencies:
@@ -10273,14 +10276,14 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.5
 
-  '@temporalio/testing@1.22.0(tslib@2.8.1)':
+  '@temporalio/testing@1.22.0(esbuild@0.28.1)(tslib@2.8.1)':
     dependencies:
       '@temporalio/activity': 1.22.0
       '@temporalio/client': 1.22.0
       '@temporalio/common': 1.22.0
       '@temporalio/core-bridge': 1.22.0
       '@temporalio/proto': 1.22.0
-      '@temporalio/worker': 1.22.0(tslib@2.8.1)
+      '@temporalio/worker': 1.22.0(esbuild@0.28.1)(tslib@2.8.1)
       '@temporalio/workflow': 1.22.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -10298,7 +10301,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@temporalio/worker@1.22.0(tslib@2.8.1)':
+  '@temporalio/worker@1.22.0(esbuild@0.28.1)(tslib@2.8.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@swc/core': 1.15.47
@@ -10315,11 +10318,11 @@ snapshots:
       protobufjs: 7.6.5
       rxjs: 7.8.2
       source-map: 0.7.6
-      source-map-loader: 5.0.0(webpack@5.109.2(@swc/core@1.15.47))
+      source-map-loader: 5.0.0(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1))
       supports-color: 8.1.1
-      swc-loader: 0.2.7(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47))
+      swc-loader: 0.2.7(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1))
       unionfs: 4.6.0
-      webpack: 5.109.2(@swc/core@1.15.47)
+      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -13165,15 +13168,16 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.47)(esbuild@0.28.1)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.109.2(@swc/core@1.15.47)
+      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)
     optionalDependencies:
       '@swc/core': 1.15.47
+      esbuild: 0.28.1
 
   minimizer-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.109.2(esbuild@0.28.1)):
     dependencies:
@@ -14235,11 +14239,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.109.2(@swc/core@1.15.47)):
+  source-map-loader@5.0.0(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.109.2(@swc/core@1.15.47)
+      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)
 
   source-map-support@0.5.21:
     dependencies:
@@ -14425,11 +14429,11 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  swc-loader@0.2.7(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47)):
+  swc-loader@0.2.7(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)):
     dependencies:
       '@swc/core': 1.15.47
       '@swc/counter': 0.1.3
-      webpack: 5.109.2(@swc/core@1.15.47)
+      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)
 
   symbol-tree@3.2.4: {}
 
@@ -14795,7 +14799,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.109.2(@swc/core@1.15.47):
+  webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -14811,7 +14815,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.47)(esbuild@0.28.1)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3

--- a/scripts/build-sentry-artifacts.mjs
+++ b/scripts/build-sentry-artifacts.mjs
@@ -21,6 +21,7 @@ const run = (command, args, options = {}) => {
   }
 };
 
+run('pnpm', ['build:server-artifacts']);
 run('pnpm', ['--filter', '@kosmo/app', 'relay']);
 run('pnpm', [
   '--filter',
@@ -35,9 +36,11 @@ run('pnpm', [
   'external',
 ]);
 
-const artifactPath = 'apps/app/dist';
+const artifactPaths = ['apps/app/dist', 'server-dist/api', 'server-dist/web'];
 
-run(sentryCli, ['sourcemaps', 'inject', artifactPath, '--quiet']);
+for (const artifactPath of artifactPaths) {
+  run(sentryCli, ['sourcemaps', 'inject', artifactPath, '--quiet']);
+}
 
 const walkFiles = async (directory) => {
   const entries = await readdir(directory, { recursive: true, withFileTypes: true });
@@ -46,9 +49,10 @@ const walkFiles = async (directory) => {
     .map((entry) => path.join(entry.parentPath, entry.name));
 };
 
-const mapFiles = (await walkFiles(artifactPath)).filter((file) => file.endsWith('.map'));
+const filesByArtifact = await Promise.all(artifactPaths.map(walkFiles));
+const mapFiles = filesByArtifact.flat().filter((file) => file.endsWith('.map'));
 if (mapFiles.length === 0) {
-  throw new Error(`No source maps were generated under ${artifactPath}`);
+  throw new Error(`No source maps were generated under ${artifactPaths.join(', ')}`);
 }
 
 for (const mapFile of mapFiles) {
@@ -85,7 +89,7 @@ if (missingUploadConfiguration.length === 0) {
     [
       'sourcemaps',
       'upload',
-      artifactPath,
+      ...artifactPaths,
       '--org',
       organization,
       '--project',
@@ -103,7 +107,7 @@ if (missingUploadConfiguration.length === 0) {
   console.log('Sentry upload skipped; generated source maps were validated locally.');
 }
 
-const files = await walkFiles(artifactPath);
+const files = filesByArtifact.flat();
 await Promise.all(files.filter((file) => file.endsWith('.map')).map((file) => rm(file)));
 await Promise.all(
   files

--- a/scripts/build-server-artifacts.mjs
+++ b/scripts/build-server-artifacts.mjs
@@ -1,197 +1,61 @@
-import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
-import { builtinModules, createRequire } from 'node:module';
-import { dirname, join, resolve } from 'node:path';
-import process from 'node:process';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
 import { buildTemporalWorkflowBundle } from './build-temporal-workflow-bundle.mjs';
 
 const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const outputRoot = join(workspaceRoot, 'server-dist');
-const stagingRoot = join(workspaceRoot, '.server-dist-staging');
+export const SERVER_ARTIFACT_OUTPUT_ROOT = resolve(workspaceRoot, 'server-dist');
 
-export const SERVER_ARTIFACT_TARGET = 'node26';
-export const SERVER_ARTIFACT_OUTPUT_ROOT = outputRoot;
+const entryPoints = {
+  web: 'apps/web/src/server/index.ts',
+  api: 'apps/api/src/index.ts',
+  worker: 'apps/worker/src/index.ts',
+  'fedify-consumer': 'apps/fedify-consumer/src/index.ts',
+  migration: 'packages/core/db/migrate-entry.ts',
+};
 
-export const SERVER_ARTIFACTS = [
-  {
-    name: 'web',
-    entryPoint: 'apps/web/src/server/index.ts',
+const bundleWorkspacePackages = {
+  name: 'bundle-workspace-packages',
+  setup(buildContext) {
+    buildContext.onResolve({ filter: /^@kosmo\// }, (arguments_) => ({
+      path: createRequire(arguments_.importer).resolve(arguments_.path),
+    }));
   },
-  {
-    name: 'api',
-    entryPoint: 'apps/api/src/index.ts',
-  },
-  {
-    name: 'fedify-consumer',
-    entryPoint: 'apps/fedify-consumer/src/index.ts',
-  },
-  {
-    name: 'migration',
-    entryPoint: 'packages/core/db/migrate-entry.ts',
-  },
-  {
-    name: 'worker',
-    entryPoint: 'apps/worker/src/index.ts',
-  },
-];
+};
 
-const artifactFileName = 'index.mjs';
-const nodeBuiltins = new Set([
-  ...builtinModules,
-  ...builtinModules.map((moduleName) => `node:${moduleName}`),
-]);
+export async function buildServerArtifacts() {
+  await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
 
-function isPackageSpecifier(specifier) {
-  return !nodeBuiltins.has(specifier) && !specifier.startsWith('<');
-}
-
-function bundleWorkspacePackagesPlugin() {
-  return {
-    name: 'bundle-workspace-packages',
-    setup(buildContext) {
-      buildContext.onResolve({ filter: /^@kosmo\// }, (arguments_) => {
-        return { path: createRequire(arguments_.importer).resolve(arguments_.path) };
-      });
-    },
-  };
-}
-
-function externalNonBuiltinImportsFromMetafile(metafile) {
-  return [
-    ...new Set(
-      Object.values(metafile.inputs)
-        .flatMap(({ imports }) => imports)
-        .map(({ path, external }) => (external && isPackageSpecifier(path) ? path : undefined))
-        .filter(Boolean),
-    ),
-  ].sort();
-}
-
-function assertArtifactSource(entryPoint) {
-  if (!entryPoint.endsWith('.ts')) {
-    throw new Error(`Server artifact entrypoint must be TypeScript source: ${entryPoint}`);
-  }
-}
-
-async function buildArtifact({ name, entryPoint }, artifactRoot) {
-  assertArtifactSource(entryPoint);
-
-  const outputDirectory = join(artifactRoot, name);
-  const absoluteEntryPoint = join(workspaceRoot, entryPoint);
-  const outputFile = join(outputDirectory, artifactFileName);
-
-  await mkdir(outputDirectory, { recursive: true });
-
-  let buildResult;
   try {
-    buildResult = await build({
+    await build({
       absWorkingDir: workspaceRoot,
       banner: {
         js: "import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);",
       },
       bundle: true,
-      entryPoints: [absoluteEntryPoint],
+      entryNames: '[name]/index',
+      entryPoints,
       format: 'esm',
-      metafile: true,
-      outfile: outputFile,
-      platform: 'node',
+      outdir: SERVER_ARTIFACT_OUTPUT_ROOT,
+      outExtension: { '.js': '.mjs' },
       packages: 'external',
-      plugins: [bundleWorkspacePackagesPlugin()],
+      platform: 'node',
+      plugins: [bundleWorkspacePackages],
       sourcemap: 'external',
       sourcesContent: true,
-      target: SERVER_ARTIFACT_TARGET,
-      write: true,
+      target: 'node26',
+    });
+    await buildTemporalWorkflowBundle({
+      outputDir: resolve(SERVER_ARTIFACT_OUTPUT_ROOT, 'worker'),
     });
   } catch (error) {
-    await rm(outputDirectory, { force: true, recursive: true });
-    throw new Error(
-      `Failed to build ${name} server artifact from ${entryPoint}: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
-  }
-
-  if (!buildResult.metafile) {
-    throw new Error(`esbuild did not return dependency metadata for ${name}.`);
-  }
-
-  const externalImports = externalNonBuiltinImportsFromMetafile(buildResult.metafile);
-  const metadata = {
-    artifact: name,
-    entryPoint,
-    format: 'esm',
-    nodeTarget: SERVER_ARTIFACT_TARGET,
-    externalImports,
-    files: [artifactFileName, `${artifactFileName}.map`, 'meta.json'],
-    inputs: buildResult.metafile.inputs,
-    outputs: buildResult.metafile.outputs,
-  };
-
-  await writeFile(join(outputDirectory, 'meta.json'), `${JSON.stringify(metadata, null, 2)}\n`);
-
-  return {
-    name,
-    entryPoint,
-    directory: relativeOutputDirectory(name),
-    files: metadata.files,
-    externalImports,
-    bytes: (await readFile(outputFile)).byteLength,
-  };
-}
-
-function relativeOutputDirectory(name) {
-  return join('server-dist', name);
-}
-
-export async function buildServerArtifacts({ artifacts = SERVER_ARTIFACTS } = {}) {
-  await rm(stagingRoot, { force: true, recursive: true });
-  await rm(outputRoot, { force: true, recursive: true });
-  await mkdir(stagingRoot, { recursive: true });
-
-  try {
-    const builtArtifacts = [];
-    for (const artifact of artifacts) {
-      builtArtifacts.push(await buildArtifact(artifact, stagingRoot));
-    }
-
-    const workerArtifact = builtArtifacts.find(({ name }) => name === 'worker');
-    if (workerArtifact) {
-      const workflowMetadata = await buildTemporalWorkflowBundle({
-        outputDir: join(stagingRoot, 'worker'),
-      });
-      const normalizedWorkflowMetadata = {
-        ...workflowMetadata,
-        artifact: join('server-dist', 'worker', 'workflow-bundle.js'),
-      };
-      const workerMetadataPath = join(stagingRoot, 'worker', 'meta.json');
-      const workerMetadata = JSON.parse(await readFile(workerMetadataPath, 'utf8'));
-
-      workerMetadata.files = [...workerMetadata.files, 'workflow-bundle.js'];
-      workerMetadata.workflowBundle = normalizedWorkflowMetadata;
-      await writeFile(`${workerMetadataPath}`, `${JSON.stringify(workerMetadata, null, 2)}\n`);
-      workerArtifact.files = [...workerArtifact.files, 'workflow-bundle.js'];
-      workerArtifact.workflowBundle = normalizedWorkflowMetadata;
-    }
-
-    const manifest = {
-      format: 'esm',
-      nodeTarget: SERVER_ARTIFACT_TARGET,
-      artifacts: builtArtifacts,
-    };
-
-    await writeFile(join(stagingRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
-    await rename(stagingRoot, outputRoot);
-    return manifest;
-  } catch (error) {
-    await rm(stagingRoot, { force: true, recursive: true });
-    await rm(outputRoot, { force: true, recursive: true });
+    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
     throw error;
   }
 }
 
-const entrypointUrl = process.argv[1] ? pathToFileURL(process.argv[1]).href : undefined;
-
-if (entrypointUrl === import.meta.url) {
-  const manifest = await buildServerArtifacts();
-  console.log(`Built ${manifest.artifacts.length} server artifacts under ${outputRoot}`);
+if (import.meta.main) {
+  await buildServerArtifacts();
 }

--- a/scripts/build-server-artifacts.mjs
+++ b/scripts/build-server-artifacts.mjs
@@ -42,158 +42,19 @@ const nodeBuiltins = new Set([
   ...builtinModules.map((moduleName) => `node:${moduleName}`),
 ]);
 
-function packageNameFromSpecifier(specifier) {
-  if (specifier.startsWith('@')) {
-    return specifier.split('/').slice(0, 2).join('/');
-  }
-  return specifier.split('/')[0];
-}
-
 function isPackageSpecifier(specifier) {
   return !nodeBuiltins.has(specifier) && !specifier.startsWith('<');
 }
 
-async function findPackageVersion(resolvedPath, expectedName) {
-  let directory = dirname(resolvedPath);
-  while (directory !== dirname(directory)) {
-    try {
-      const manifest = JSON.parse(await readFile(join(directory, 'package.json'), 'utf8'));
-      if (manifest.name === expectedName && typeof manifest.version === 'string') {
-        return manifest.version;
-      }
-    } catch (error) {
-      if (error?.code !== 'ENOENT') {
-        throw error;
-      }
-    }
-    directory = dirname(directory);
-  }
-  throw new Error(`Could not locate ${expectedName} package metadata from ${resolvedPath}`);
-}
-
-function bundleWorkspacePackagesPlugin({ externalTemporal = false } = {}) {
-  const optionalCanvasNamespace = 'kosmo-optional-canvas';
-  const coreRequire = createRequire(join(workspaceRoot, 'packages/core/package.json'));
-  const jsdomRoot = dirname(coreRequire.resolve('jsdom/package.json'));
-  const jsdomRequire = createRequire(join(jsdomRoot, 'lib/api.js'));
-  const cssTreeRoot = dirname(jsdomRequire.resolve('css-tree/package.json'));
-  const cssTreeDataPatchPath = join(cssTreeRoot, 'lib/data-patch.js');
-  const cssTreeDataPath = join(cssTreeRoot, 'lib/data.js');
-  const cssTreeVersionPath = join(cssTreeRoot, 'lib/version.js');
-  const jsdomComputedStylePath = join(jsdomRoot, 'lib/jsdom/living/css/helpers/computed-style.js');
-  const jsdomXmlHttpRequestPath = join(jsdomRoot, 'lib/jsdom/living/xhr/XMLHttpRequest-impl.js');
+function bundleWorkspacePackagesPlugin() {
   return {
     name: 'bundle-workspace-packages',
     setup(buildContext) {
       buildContext.onResolve({ filter: /^@kosmo\// }, (arguments_) => {
         return { path: createRequire(arguments_.importer).resolve(arguments_.path) };
       });
-      buildContext.onResolve({ filter: /^@temporalio\// }, () => {
-        if (externalTemporal) {
-          return { external: true };
-        }
-        return undefined;
-      });
-      buildContext.onResolve({ filter: /^canvas$/ }, () => ({
-        namespace: optionalCanvasNamespace,
-        path: 'canvas',
-      }));
-      buildContext.onLoad({ filter: /^canvas$/, namespace: optionalCanvasNamespace }, () => ({
-        contents:
-          'throw Object.assign(new Error("Cannot find module \\\'canvas\\\'"), { code: "MODULE_NOT_FOUND" });',
-        loader: 'js',
-      }));
-      buildContext.onLoad({ filter: /computed-style\.js$/ }, async (arguments_) => {
-        if (arguments_.path !== jsdomComputedStylePath) {
-          return undefined;
-        }
-        const [source, stylesheet] = await Promise.all([
-          readFile(arguments_.path, 'utf8'),
-          readFile(join(jsdomRoot, 'lib/jsdom/browser/default-stylesheet.css'), 'utf8'),
-        ]);
-        return {
-          contents: source.replace(
-            /const defaultStyleSheet = fs\.readFileSync\([\s\S]*?\n\);/u,
-            `const defaultStyleSheet = ${JSON.stringify(stylesheet)};`,
-          ),
-          loader: 'js',
-        };
-      });
-      buildContext.onLoad({ filter: /XMLHttpRequest-impl\.js$/ }, async (arguments_) => {
-        if (arguments_.path !== jsdomXmlHttpRequestPath) {
-          return undefined;
-        }
-        const source = await readFile(arguments_.path, 'utf8');
-        return {
-          // Kosmo uses JSDOM for server-side DOM parsing and serialization, not synchronous XHR.
-          // Avoid retaining jsdom's separate worker-thread file in an otherwise single-file artifact.
-          contents: source.replace(
-            'const syncWorkerFile = require.resolve("./xhr-sync-worker.js");',
-            'const syncWorkerFile = undefined;',
-          ),
-          loader: 'js',
-        };
-      });
-      buildContext.onLoad({ filter: /(?:data|version)(?:-patch)?\.js$/ }, async (arguments_) => {
-        if (
-          ![cssTreeDataPatchPath, cssTreeDataPath, cssTreeVersionPath].includes(arguments_.path)
-        ) {
-          return undefined;
-        }
-        const source = await readFile(arguments_.path, 'utf8');
-        if (arguments_.path === cssTreeDataPatchPath) {
-          return {
-            contents: source.replace(
-              /import \{ createRequire \} from 'module';[\s\S]*?const patch = require\('\.\.\/data\/patch\.json'\);/u,
-              "import patch from '../data/patch.json';",
-            ),
-            loader: 'js',
-          };
-        }
-        if (arguments_.path === cssTreeDataPath) {
-          return {
-            contents: source.replace(
-              /import \{ createRequire \} from 'module';[\s\S]*?const mdnSyntaxes = require\('mdn-data\/css\/syntaxes\.json'\);/u,
-              "import patch from './data-patch.js';\nimport mdnAtrules from 'mdn-data/css/at-rules.json';\nimport mdnProperties from 'mdn-data/css/properties.json';\nimport mdnSyntaxes from 'mdn-data/css/syntaxes.json';",
-            ),
-            loader: 'js',
-          };
-        }
-        return {
-          contents: source.replace(
-            /import \{ createRequire \} from 'module';[\s\S]*?export const \{ version \} = require\('\.\.\/package\.json'\);/u,
-            "import packageJson from '../package.json';\nexport const { version } = packageJson;",
-          ),
-          loader: 'js',
-        };
-      });
     },
   };
-}
-
-async function runtimeDependenciesFromMetafile(metafile) {
-  const runtimeDependencies = new Map();
-  for (const [input, metadata] of Object.entries(metafile.inputs)) {
-    const importerRequire = createRequire(join(workspaceRoot, input));
-    for (const dependency of metadata.imports.filter(({ external }) => external)) {
-      const specifier = dependency.path;
-      if (!isPackageSpecifier(specifier)) {
-        continue;
-      }
-      const packageName = packageNameFromSpecifier(specifier);
-      const version = await findPackageVersion(importerRequire.resolve(specifier), packageName);
-      const existingVersion = runtimeDependencies.get(packageName);
-      if (existingVersion !== undefined && existingVersion !== version) {
-        throw new Error(
-          `Runtime dependency ${packageName} resolved to both ${existingVersion} and ${version}`,
-        );
-      }
-      runtimeDependencies.set(packageName, version);
-    }
-  }
-  return Object.fromEntries(
-    [...runtimeDependencies.entries()].sort(([left], [right]) => left.localeCompare(right)),
-  );
 }
 
 function externalNonBuiltinImportsFromMetafile(metafile) {
@@ -235,7 +96,8 @@ async function buildArtifact({ name, entryPoint }, artifactRoot) {
       metafile: true,
       outfile: outputFile,
       platform: 'node',
-      plugins: [bundleWorkspacePackagesPlugin({ externalTemporal: name === 'worker' })],
+      packages: 'external',
+      plugins: [bundleWorkspacePackagesPlugin()],
       sourcemap: 'external',
       sourcesContent: true,
       target: SERVER_ARTIFACT_TARGET,
@@ -254,42 +116,16 @@ async function buildArtifact({ name, entryPoint }, artifactRoot) {
   }
 
   const externalImports = externalNonBuiltinImportsFromMetafile(buildResult.metafile);
-  const isWorker = name === 'worker';
-  if (!isWorker && externalImports.length > 0) {
-    throw new Error(
-      `${name} server artifact has non-builtin external imports: ${externalImports.join(', ')}`,
-    );
-  }
-
-  const dependencies = isWorker ? await runtimeDependenciesFromMetafile(buildResult.metafile) : {};
-  if (isWorker) {
-    const runtimePackage = {
-      name: `@kosmo/runtime-${name}`,
-      private: true,
-      type: 'module',
-      dependencies,
-    };
-    await writeFile(
-      join(outputDirectory, 'runtime-package.json'),
-      `${JSON.stringify(runtimePackage, null, 2)}\n`,
-    );
-  }
-
   const metadata = {
     artifact: name,
     entryPoint,
     format: 'esm',
     nodeTarget: SERVER_ARTIFACT_TARGET,
     externalImports,
-    runtimeDependencies: dependencies,
     files: [artifactFileName, `${artifactFileName}.map`, 'meta.json'],
     inputs: buildResult.metafile.inputs,
     outputs: buildResult.metafile.outputs,
   };
-
-  if (isWorker) {
-    metadata.files.splice(2, 0, 'runtime-package.json');
-  }
 
   await writeFile(join(outputDirectory, 'meta.json'), `${JSON.stringify(metadata, null, 2)}\n`);
 
@@ -299,7 +135,6 @@ async function buildArtifact({ name, entryPoint }, artifactRoot) {
     directory: relativeOutputDirectory(name),
     files: metadata.files,
     externalImports,
-    runtimeDependencies: dependencies,
     bytes: (await readFile(outputFile)).byteLength,
   };
 }

--- a/scripts/build-server-artifacts.mjs
+++ b/scripts/build-server-artifacts.mjs
@@ -1,0 +1,172 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import {
+  assetRuntimeExternalPackages,
+  buildTemporalWorkflowBundle,
+  workerRuntimeExternalPackages,
+} from './build-temporal-workflow-bundle.mjs';
+
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const outputRoot = join(workspaceRoot, 'server-dist');
+const stagingRoot = join(workspaceRoot, '.server-dist-staging');
+
+export const SERVER_ARTIFACT_TARGET = 'node26';
+export const SERVER_ARTIFACT_OUTPUT_ROOT = outputRoot;
+
+export const SERVER_ARTIFACTS = [
+  {
+    name: 'web',
+    entryPoint: 'apps/web/src/server/index.ts',
+    external: assetRuntimeExternalPackages,
+  },
+  {
+    name: 'api',
+    entryPoint: 'apps/api/src/index.ts',
+    external: assetRuntimeExternalPackages,
+  },
+  {
+    name: 'fedify-consumer',
+    entryPoint: 'apps/fedify-consumer/src/index.ts',
+    external: assetRuntimeExternalPackages,
+  },
+  {
+    name: 'migration',
+    entryPoint: 'packages/core/db/migrate-entry.ts',
+  },
+  {
+    name: 'worker',
+    entryPoint: 'apps/worker/src/index.ts',
+    external: workerRuntimeExternalPackages,
+  },
+];
+
+const artifactFileName = 'index.mjs';
+
+function assertArtifactSource(entryPoint) {
+  if (!entryPoint.endsWith('.ts')) {
+    throw new Error(`Server artifact entrypoint must be TypeScript source: ${entryPoint}`);
+  }
+}
+
+async function buildArtifact({ name, entryPoint, external = [] }, artifactRoot) {
+  assertArtifactSource(entryPoint);
+
+  const outputDirectory = join(artifactRoot, name);
+  const absoluteEntryPoint = join(workspaceRoot, entryPoint);
+  const outputFile = join(outputDirectory, artifactFileName);
+
+  await mkdir(outputDirectory, { recursive: true });
+
+  let buildResult;
+  try {
+    buildResult = await build({
+      absWorkingDir: workspaceRoot,
+      banner: {
+        js: "import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);",
+      },
+      bundle: true,
+      entryPoints: [absoluteEntryPoint],
+      external,
+      format: 'esm',
+      metafile: true,
+      outfile: outputFile,
+      platform: 'node',
+      packages: 'bundle',
+      sourcemap: 'external',
+      sourcesContent: true,
+      target: SERVER_ARTIFACT_TARGET,
+      write: true,
+    });
+  } catch (error) {
+    await rm(outputDirectory, { force: true, recursive: true });
+    throw new Error(
+      `Failed to build ${name} server artifact from ${entryPoint}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+
+  if (!buildResult.metafile) {
+    throw new Error(`esbuild did not return dependency metadata for ${name}.`);
+  }
+
+  const metadata = {
+    artifact: name,
+    entryPoint,
+    format: 'esm',
+    nodeTarget: SERVER_ARTIFACT_TARGET,
+    ...(external.length > 0 && { external }),
+    files: [artifactFileName, `${artifactFileName}.map`],
+    inputs: buildResult.metafile.inputs,
+    outputs: buildResult.metafile.outputs,
+  };
+
+  await writeFile(join(outputDirectory, 'meta.json'), `${JSON.stringify(metadata, null, 2)}\n`);
+
+  return {
+    name,
+    entryPoint,
+    directory: relativeOutputDirectory(name),
+    files: metadata.files,
+    bytes: (await readFile(outputFile)).byteLength,
+  };
+}
+
+function relativeOutputDirectory(name) {
+  return join('server-dist', name);
+}
+
+export async function buildServerArtifacts({ artifacts = SERVER_ARTIFACTS } = {}) {
+  await rm(stagingRoot, { force: true, recursive: true });
+  await rm(outputRoot, { force: true, recursive: true });
+  await mkdir(stagingRoot, { recursive: true });
+
+  try {
+    const builtArtifacts = [];
+    for (const artifact of artifacts) {
+      builtArtifacts.push(await buildArtifact(artifact, stagingRoot));
+    }
+
+    const workerArtifact = builtArtifacts.find(({ name }) => name === 'worker');
+    if (workerArtifact) {
+      const workflowMetadata = await buildTemporalWorkflowBundle({
+        outputDir: join(stagingRoot, 'worker'),
+      });
+      const normalizedWorkflowMetadata = {
+        ...workflowMetadata,
+        artifact: join('server-dist', 'worker', 'workflow-bundle.js'),
+      };
+      const workerMetadataPath = join(stagingRoot, 'worker', 'meta.json');
+      const workerMetadata = JSON.parse(await readFile(workerMetadataPath, 'utf8'));
+
+      workerMetadata.files = [...workerMetadata.files, 'workflow-bundle.js'];
+      workerMetadata.workflowBundle = normalizedWorkflowMetadata;
+      await writeFile(`${workerMetadataPath}`, `${JSON.stringify(workerMetadata, null, 2)}\n`);
+      workerArtifact.files = [...workerArtifact.files, 'workflow-bundle.js'];
+      workerArtifact.workflowBundle = normalizedWorkflowMetadata;
+    }
+
+    const manifest = {
+      format: 'esm',
+      nodeTarget: SERVER_ARTIFACT_TARGET,
+      artifacts: builtArtifacts,
+    };
+
+    await writeFile(join(stagingRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+    await rename(stagingRoot, outputRoot);
+    return manifest;
+  } catch (error) {
+    await rm(stagingRoot, { force: true, recursive: true });
+    await rm(outputRoot, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+const entrypointUrl = process.argv[1] ? pathToFileURL(process.argv[1]).href : undefined;
+
+if (entrypointUrl === import.meta.url) {
+  const manifest = await buildServerArtifacts();
+  console.log(`Built ${manifest.artifacts.length} server artifacts under ${outputRoot}`);
+}

--- a/scripts/build-server-artifacts.mjs
+++ b/scripts/build-server-artifacts.mjs
@@ -37,7 +37,6 @@ export const SERVER_ARTIFACTS = [
 ];
 
 const artifactFileName = 'index.mjs';
-const runtimePackageFileName = 'runtime-package.json';
 const nodeBuiltins = new Set([
   ...builtinModules,
   ...builtinModules.map((moduleName) => `node:${moduleName}`),
@@ -48,6 +47,10 @@ function packageNameFromSpecifier(specifier) {
     return specifier.split('/').slice(0, 2).join('/');
   }
   return specifier.split('/')[0];
+}
+
+function isPackageSpecifier(specifier) {
+  return !nodeBuiltins.has(specifier) && !specifier.startsWith('<');
 }
 
 async function findPackageVersion(resolvedPath, expectedName) {
@@ -68,12 +71,101 @@ async function findPackageVersion(resolvedPath, expectedName) {
   throw new Error(`Could not locate ${expectedName} package metadata from ${resolvedPath}`);
 }
 
-function bundleWorkspacePackagesPlugin() {
+function bundleWorkspacePackagesPlugin({ externalTemporal = false } = {}) {
+  const optionalCanvasNamespace = 'kosmo-optional-canvas';
+  const coreRequire = createRequire(join(workspaceRoot, 'packages/core/package.json'));
+  const jsdomRoot = dirname(coreRequire.resolve('jsdom/package.json'));
+  const jsdomRequire = createRequire(join(jsdomRoot, 'lib/api.js'));
+  const cssTreeRoot = dirname(jsdomRequire.resolve('css-tree/package.json'));
+  const cssTreeDataPatchPath = join(cssTreeRoot, 'lib/data-patch.js');
+  const cssTreeDataPath = join(cssTreeRoot, 'lib/data.js');
+  const cssTreeVersionPath = join(cssTreeRoot, 'lib/version.js');
+  const jsdomComputedStylePath = join(jsdomRoot, 'lib/jsdom/living/css/helpers/computed-style.js');
+  const jsdomXmlHttpRequestPath = join(jsdomRoot, 'lib/jsdom/living/xhr/XMLHttpRequest-impl.js');
   return {
     name: 'bundle-workspace-packages',
     setup(buildContext) {
       buildContext.onResolve({ filter: /^@kosmo\// }, (arguments_) => {
         return { path: createRequire(arguments_.importer).resolve(arguments_.path) };
+      });
+      buildContext.onResolve({ filter: /^@temporalio\// }, () => {
+        if (externalTemporal) {
+          return { external: true };
+        }
+        return undefined;
+      });
+      buildContext.onResolve({ filter: /^canvas$/ }, () => ({
+        namespace: optionalCanvasNamespace,
+        path: 'canvas',
+      }));
+      buildContext.onLoad({ filter: /^canvas$/, namespace: optionalCanvasNamespace }, () => ({
+        contents:
+          'throw Object.assign(new Error("Cannot find module \\\'canvas\\\'"), { code: "MODULE_NOT_FOUND" });',
+        loader: 'js',
+      }));
+      buildContext.onLoad({ filter: /computed-style\.js$/ }, async (arguments_) => {
+        if (arguments_.path !== jsdomComputedStylePath) {
+          return undefined;
+        }
+        const [source, stylesheet] = await Promise.all([
+          readFile(arguments_.path, 'utf8'),
+          readFile(join(jsdomRoot, 'lib/jsdom/browser/default-stylesheet.css'), 'utf8'),
+        ]);
+        return {
+          contents: source.replace(
+            /const defaultStyleSheet = fs\.readFileSync\([\s\S]*?\n\);/u,
+            `const defaultStyleSheet = ${JSON.stringify(stylesheet)};`,
+          ),
+          loader: 'js',
+        };
+      });
+      buildContext.onLoad({ filter: /XMLHttpRequest-impl\.js$/ }, async (arguments_) => {
+        if (arguments_.path !== jsdomXmlHttpRequestPath) {
+          return undefined;
+        }
+        const source = await readFile(arguments_.path, 'utf8');
+        return {
+          // Kosmo uses JSDOM for server-side DOM parsing and serialization, not synchronous XHR.
+          // Avoid retaining jsdom's separate worker-thread file in an otherwise single-file artifact.
+          contents: source.replace(
+            'const syncWorkerFile = require.resolve("./xhr-sync-worker.js");',
+            'const syncWorkerFile = undefined;',
+          ),
+          loader: 'js',
+        };
+      });
+      buildContext.onLoad({ filter: /(?:data|version)(?:-patch)?\.js$/ }, async (arguments_) => {
+        if (
+          ![cssTreeDataPatchPath, cssTreeDataPath, cssTreeVersionPath].includes(arguments_.path)
+        ) {
+          return undefined;
+        }
+        const source = await readFile(arguments_.path, 'utf8');
+        if (arguments_.path === cssTreeDataPatchPath) {
+          return {
+            contents: source.replace(
+              /import \{ createRequire \} from 'module';[\s\S]*?const patch = require\('\.\.\/data\/patch\.json'\);/u,
+              "import patch from '../data/patch.json';",
+            ),
+            loader: 'js',
+          };
+        }
+        if (arguments_.path === cssTreeDataPath) {
+          return {
+            contents: source.replace(
+              /import \{ createRequire \} from 'module';[\s\S]*?const mdnSyntaxes = require\('mdn-data\/css\/syntaxes\.json'\);/u,
+              "import patch from './data-patch.js';\nimport mdnAtrules from 'mdn-data/css/at-rules.json';\nimport mdnProperties from 'mdn-data/css/properties.json';\nimport mdnSyntaxes from 'mdn-data/css/syntaxes.json';",
+            ),
+            loader: 'js',
+          };
+        }
+        return {
+          contents: source.replace(
+            /import \{ createRequire \} from 'module';[\s\S]*?export const \{ version \} = require\('\.\.\/package\.json'\);/u,
+            "import packageJson from '../package.json';\nexport const { version } = packageJson;",
+          ),
+          loader: 'js',
+        };
       });
     },
   };
@@ -85,7 +177,7 @@ async function runtimeDependenciesFromMetafile(metafile) {
     const importerRequire = createRequire(join(workspaceRoot, input));
     for (const dependency of metadata.imports.filter(({ external }) => external)) {
       const specifier = dependency.path;
-      if (nodeBuiltins.has(specifier)) {
+      if (!isPackageSpecifier(specifier)) {
         continue;
       }
       const packageName = packageNameFromSpecifier(specifier);
@@ -102,6 +194,17 @@ async function runtimeDependenciesFromMetafile(metafile) {
   return Object.fromEntries(
     [...runtimeDependencies.entries()].sort(([left], [right]) => left.localeCompare(right)),
   );
+}
+
+function externalNonBuiltinImportsFromMetafile(metafile) {
+  return [
+    ...new Set(
+      Object.values(metafile.inputs)
+        .flatMap(({ imports }) => imports)
+        .map(({ path, external }) => (external && isPackageSpecifier(path) ? path : undefined))
+        .filter(Boolean),
+    ),
+  ].sort();
 }
 
 function assertArtifactSource(entryPoint) {
@@ -132,8 +235,7 @@ async function buildArtifact({ name, entryPoint }, artifactRoot) {
       metafile: true,
       outfile: outputFile,
       platform: 'node',
-      plugins: [bundleWorkspacePackagesPlugin()],
-      packages: 'external',
+      plugins: [bundleWorkspacePackagesPlugin({ externalTemporal: name === 'worker' })],
       sourcemap: 'external',
       sourcesContent: true,
       target: SERVER_ARTIFACT_TARGET,
@@ -151,28 +253,43 @@ async function buildArtifact({ name, entryPoint }, artifactRoot) {
     throw new Error(`esbuild did not return dependency metadata for ${name}.`);
   }
 
-  const dependencies = await runtimeDependenciesFromMetafile(buildResult.metafile);
-  const runtimePackage = {
-    name: `@kosmo/runtime-${name}`,
-    private: true,
-    type: 'module',
-    dependencies,
-  };
-  await writeFile(
-    join(outputDirectory, runtimePackageFileName),
-    `${JSON.stringify(runtimePackage, null, 2)}\n`,
-  );
+  const externalImports = externalNonBuiltinImportsFromMetafile(buildResult.metafile);
+  const isWorker = name === 'worker';
+  if (!isWorker && externalImports.length > 0) {
+    throw new Error(
+      `${name} server artifact has non-builtin external imports: ${externalImports.join(', ')}`,
+    );
+  }
+
+  const dependencies = isWorker ? await runtimeDependenciesFromMetafile(buildResult.metafile) : {};
+  if (isWorker) {
+    const runtimePackage = {
+      name: `@kosmo/runtime-${name}`,
+      private: true,
+      type: 'module',
+      dependencies,
+    };
+    await writeFile(
+      join(outputDirectory, 'runtime-package.json'),
+      `${JSON.stringify(runtimePackage, null, 2)}\n`,
+    );
+  }
 
   const metadata = {
     artifact: name,
     entryPoint,
     format: 'esm',
     nodeTarget: SERVER_ARTIFACT_TARGET,
+    externalImports,
     runtimeDependencies: dependencies,
-    files: [artifactFileName, `${artifactFileName}.map`, runtimePackageFileName],
+    files: [artifactFileName, `${artifactFileName}.map`, 'meta.json'],
     inputs: buildResult.metafile.inputs,
     outputs: buildResult.metafile.outputs,
   };
+
+  if (isWorker) {
+    metadata.files.splice(2, 0, 'runtime-package.json');
+  }
 
   await writeFile(join(outputDirectory, 'meta.json'), `${JSON.stringify(metadata, null, 2)}\n`);
 
@@ -181,6 +298,7 @@ async function buildArtifact({ name, entryPoint }, artifactRoot) {
     entryPoint,
     directory: relativeOutputDirectory(name),
     files: metadata.files,
+    externalImports,
     runtimeDependencies: dependencies,
     bytes: (await readFile(outputFile)).byteLength,
   };

--- a/scripts/build-server-artifacts.mjs
+++ b/scripts/build-server-artifacts.mjs
@@ -1,13 +1,10 @@
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { builtinModules, createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { build } from 'esbuild';
-import {
-  assetRuntimeExternalPackages,
-  buildTemporalWorkflowBundle,
-  workerRuntimeExternalPackages,
-} from './build-temporal-workflow-bundle.mjs';
+import { buildTemporalWorkflowBundle } from './build-temporal-workflow-bundle.mjs';
 
 const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const outputRoot = join(workspaceRoot, 'server-dist');
@@ -20,17 +17,14 @@ export const SERVER_ARTIFACTS = [
   {
     name: 'web',
     entryPoint: 'apps/web/src/server/index.ts',
-    external: assetRuntimeExternalPackages,
   },
   {
     name: 'api',
     entryPoint: 'apps/api/src/index.ts',
-    external: assetRuntimeExternalPackages,
   },
   {
     name: 'fedify-consumer',
     entryPoint: 'apps/fedify-consumer/src/index.ts',
-    external: assetRuntimeExternalPackages,
   },
   {
     name: 'migration',
@@ -39,11 +33,76 @@ export const SERVER_ARTIFACTS = [
   {
     name: 'worker',
     entryPoint: 'apps/worker/src/index.ts',
-    external: workerRuntimeExternalPackages,
   },
 ];
 
 const artifactFileName = 'index.mjs';
+const runtimePackageFileName = 'runtime-package.json';
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((moduleName) => `node:${moduleName}`),
+]);
+
+function packageNameFromSpecifier(specifier) {
+  if (specifier.startsWith('@')) {
+    return specifier.split('/').slice(0, 2).join('/');
+  }
+  return specifier.split('/')[0];
+}
+
+async function findPackageVersion(resolvedPath, expectedName) {
+  let directory = dirname(resolvedPath);
+  while (directory !== dirname(directory)) {
+    try {
+      const manifest = JSON.parse(await readFile(join(directory, 'package.json'), 'utf8'));
+      if (manifest.name === expectedName && typeof manifest.version === 'string') {
+        return manifest.version;
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+    directory = dirname(directory);
+  }
+  throw new Error(`Could not locate ${expectedName} package metadata from ${resolvedPath}`);
+}
+
+function bundleWorkspacePackagesPlugin() {
+  return {
+    name: 'bundle-workspace-packages',
+    setup(buildContext) {
+      buildContext.onResolve({ filter: /^@kosmo\// }, (arguments_) => {
+        return { path: createRequire(arguments_.importer).resolve(arguments_.path) };
+      });
+    },
+  };
+}
+
+async function runtimeDependenciesFromMetafile(metafile) {
+  const runtimeDependencies = new Map();
+  for (const [input, metadata] of Object.entries(metafile.inputs)) {
+    const importerRequire = createRequire(join(workspaceRoot, input));
+    for (const dependency of metadata.imports.filter(({ external }) => external)) {
+      const specifier = dependency.path;
+      if (nodeBuiltins.has(specifier)) {
+        continue;
+      }
+      const packageName = packageNameFromSpecifier(specifier);
+      const version = await findPackageVersion(importerRequire.resolve(specifier), packageName);
+      const existingVersion = runtimeDependencies.get(packageName);
+      if (existingVersion !== undefined && existingVersion !== version) {
+        throw new Error(
+          `Runtime dependency ${packageName} resolved to both ${existingVersion} and ${version}`,
+        );
+      }
+      runtimeDependencies.set(packageName, version);
+    }
+  }
+  return Object.fromEntries(
+    [...runtimeDependencies.entries()].sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
 
 function assertArtifactSource(entryPoint) {
   if (!entryPoint.endsWith('.ts')) {
@@ -51,7 +110,7 @@ function assertArtifactSource(entryPoint) {
   }
 }
 
-async function buildArtifact({ name, entryPoint, external = [] }, artifactRoot) {
+async function buildArtifact({ name, entryPoint }, artifactRoot) {
   assertArtifactSource(entryPoint);
 
   const outputDirectory = join(artifactRoot, name);
@@ -69,12 +128,12 @@ async function buildArtifact({ name, entryPoint, external = [] }, artifactRoot) 
       },
       bundle: true,
       entryPoints: [absoluteEntryPoint],
-      external,
       format: 'esm',
       metafile: true,
       outfile: outputFile,
       platform: 'node',
-      packages: 'bundle',
+      plugins: [bundleWorkspacePackagesPlugin()],
+      packages: 'external',
       sourcemap: 'external',
       sourcesContent: true,
       target: SERVER_ARTIFACT_TARGET,
@@ -92,13 +151,25 @@ async function buildArtifact({ name, entryPoint, external = [] }, artifactRoot) 
     throw new Error(`esbuild did not return dependency metadata for ${name}.`);
   }
 
+  const dependencies = await runtimeDependenciesFromMetafile(buildResult.metafile);
+  const runtimePackage = {
+    name: `@kosmo/runtime-${name}`,
+    private: true,
+    type: 'module',
+    dependencies,
+  };
+  await writeFile(
+    join(outputDirectory, runtimePackageFileName),
+    `${JSON.stringify(runtimePackage, null, 2)}\n`,
+  );
+
   const metadata = {
     artifact: name,
     entryPoint,
     format: 'esm',
     nodeTarget: SERVER_ARTIFACT_TARGET,
-    ...(external.length > 0 && { external }),
-    files: [artifactFileName, `${artifactFileName}.map`],
+    runtimeDependencies: dependencies,
+    files: [artifactFileName, `${artifactFileName}.map`, runtimePackageFileName],
     inputs: buildResult.metafile.inputs,
     outputs: buildResult.metafile.outputs,
   };
@@ -110,6 +181,7 @@ async function buildArtifact({ name, entryPoint, external = [] }, artifactRoot) 
     entryPoint,
     directory: relativeOutputDirectory(name),
     files: metadata.files,
+    runtimeDependencies: dependencies,
     bytes: (await readFile(outputFile)).byteLength,
   };
 }

--- a/scripts/build-server-artifacts.test.mjs
+++ b/scripts/build-server-artifacts.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { access, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
@@ -14,7 +14,6 @@ import {
 
 const workspaceRoot = fileURLToPath(new URL('../', import.meta.url));
 const migrationArtifact = SERVER_ARTIFACTS.find(({ name }) => name === 'migration');
-const webArtifact = SERVER_ARTIFACTS.find(({ name }) => name === 'web');
 const execFileAsync = promisify(execFile);
 
 async function exists(path) {
@@ -41,16 +40,14 @@ test('builds every server artifact with ESM metadata and external source maps', 
     assert.equal(worker.workflowBundle.package, '@temporalio/worker');
     assert.match(worker.workflowBundle.workerVersion, /^1\.22\./);
     assert.ok(worker.workflowBundle.workflowExports.length > 0);
-    assert.deepEqual(worker.workflowBundle.externalRuntimePackages, [
-      '@temporalio/client',
-      'jsdom',
-      '@temporalio/worker',
-    ]);
 
     for (const artifact of manifest.artifacts) {
       const directory = join(workspaceRoot, artifact.directory);
       const sourceMap = JSON.parse(await readFile(join(directory, 'index.mjs.map'), 'utf8'));
       const metadata = JSON.parse(await readFile(join(directory, 'meta.json'), 'utf8'));
+      const runtimePackage = JSON.parse(
+        await readFile(join(directory, 'runtime-package.json'), 'utf8'),
+      );
       const source = await readFile(join(directory, 'index.mjs'), 'utf8');
 
       assert.match(source, /\bimport\b/);
@@ -58,6 +55,20 @@ test('builds every server artifact with ESM metadata and external source maps', 
       assert.equal(metadata.nodeTarget, SERVER_ARTIFACT_TARGET);
       assert.ok(Object.keys(metadata.inputs).length > 0);
       assert.ok(sourceMap.sourcesContent?.length > 0);
+      assert.deepEqual(runtimePackage.dependencies, metadata.runtimeDependencies);
+      assert.deepEqual(runtimePackage.dependencies, artifact.runtimeDependencies);
+      assert.equal(runtimePackage.dependencies.tsx, undefined);
+      assert.equal(
+        Object.keys(runtimePackage.dependencies).some((dependency) =>
+          dependency.startsWith('@kosmo/'),
+        ),
+        false,
+      );
+    }
+
+    assert.equal(worker.runtimeDependencies['@temporalio/worker'], '1.22.0');
+    for (const artifact of manifest.artifacts.filter(({ name }) => name !== 'worker')) {
+      assert.equal(artifact.runtimeDependencies['@temporalio/worker'], undefined);
     }
   } finally {
     await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
@@ -90,6 +101,14 @@ test('cleans output when an entrypoint is missing', async () => {
 test('migration artifact resolves its adjacent drizzle asset directory', async () => {
   try {
     await buildServerArtifacts({ artifacts: [migrationArtifact] });
+    const runtimePackage = JSON.parse(
+      await readFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration/runtime-package.json'), 'utf8'),
+    );
+    for (const dependency of Object.keys(runtimePackage.dependencies)) {
+      const target = join(SERVER_ARTIFACT_OUTPUT_ROOT, 'node_modules', dependency);
+      await mkdir(dirname(target), { recursive: true });
+      await symlink(join(workspaceRoot, 'packages/core/node_modules', dependency), target, 'dir');
+    }
     const migrationArtifactPath = pathToFileURL(
       join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs'),
     ).href;
@@ -119,30 +138,32 @@ test('migration source entry resolves the repository drizzle directory', async (
   assert.equal(stdout, join(workspaceRoot, 'drizzle'));
 });
 
-test('bundled CommonJS dependencies execute inside the ESM server artifact', async () => {
-  try {
-    await buildServerArtifacts({ artifacts: [webArtifact] });
-    const artifactPath = join(SERVER_ARTIFACT_OUTPUT_ROOT, 'web', 'index.mjs');
-    const runtimeNodeModules = join(SERVER_ARTIFACT_OUTPUT_ROOT, 'node_modules');
-    await mkdir(runtimeNodeModules);
-    await symlink(
-      join(workspaceRoot, 'packages/core/node_modules/@temporalio'),
-      join(runtimeNodeModules, '@temporalio'),
-      'dir',
-    );
-    await symlink(
-      join(workspaceRoot, 'packages/core/node_modules/jsdom'),
-      join(runtimeNodeModules, 'jsdom'),
-      'dir',
-    );
+test('derives an external runtime package from the build graph', async () => {
+  const fixtureDirectory = join(workspaceRoot, 'packages/core/db/.server-artifact-test');
+  const fixturePath = join(fixtureDirectory, 'runtime-dependency.ts');
+  await mkdir(fixtureDirectory, { recursive: true });
+  await writeFile(fixturePath, "import { z } from 'zod'; export const value = z.string();\n");
 
-    await assert.rejects(execFileAsync(process.execPath, [artifactPath]), (error) => {
-      assert.equal(error.code, 1);
-      assert.match(error.stderr, /TEMPORAL_ADDRESS is required/u);
-      assert.doesNotMatch(error.stderr, /Dynamic require/u);
-      return true;
+  try {
+    const manifest = await buildServerArtifacts({
+      artifacts: [
+        {
+          name: 'runtime-dependency-fixture',
+          entryPoint: 'packages/core/db/.server-artifact-test/runtime-dependency.ts',
+        },
+      ],
     });
+    const [artifact] = manifest.artifacts;
+    assert.match(artifact.runtimeDependencies.zod, /^4\./u);
+    const runtimePackage = JSON.parse(
+      await readFile(
+        join(SERVER_ARTIFACT_OUTPUT_ROOT, 'runtime-dependency-fixture/runtime-package.json'),
+        'utf8',
+      ),
+    );
+    assert.deepEqual(runtimePackage.dependencies, artifact.runtimeDependencies);
   } finally {
+    await rm(fixtureDirectory, { force: true, recursive: true });
     await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
   }
 });

--- a/scripts/build-server-artifacts.test.mjs
+++ b/scripts/build-server-artifacts.test.mjs
@@ -53,30 +53,16 @@ test('builds every server artifact with ESM metadata and external source maps', 
       assert.ok(Object.keys(metadata.inputs).length > 0);
       assert.ok(sourceMap.sourcesContent?.length > 0);
       assert.deepEqual(metadata.externalImports, artifact.externalImports);
-      if (artifact.name === 'worker') {
-        const runtimePackage = JSON.parse(
-          await readFile(join(directory, 'runtime-package.json'), 'utf8'),
-        );
-        assert.deepEqual(runtimePackage.dependencies, metadata.runtimeDependencies);
-        assert.deepEqual(runtimePackage.dependencies, artifact.runtimeDependencies);
-        assert.equal(runtimePackage.dependencies.tsx, undefined);
-        assert.equal(
-          Object.keys(runtimePackage.dependencies).some((dependency) =>
-            dependency.startsWith('@kosmo/'),
-          ),
-          false,
-        );
-      } else {
-        assert.equal(await exists(join(directory, 'runtime-package.json')), false);
-        assert.deepEqual(artifact.externalImports, []);
-        assert.deepEqual(artifact.runtimeDependencies, {});
-      }
+      assert.equal(await exists(join(directory, 'runtime-package.json')), false);
+      assert.equal(
+        artifact.externalImports.some((dependency) => dependency.startsWith('@kosmo/')),
+        false,
+      );
     }
 
     assert.equal(worker.externalImports.includes('@temporalio/worker'), true);
-    assert.equal(worker.runtimeDependencies['@temporalio/worker'], '1.22.0');
     for (const artifact of manifest.artifacts.filter(({ name }) => name !== 'worker')) {
-      assert.equal(artifact.runtimeDependencies['@temporalio/worker'], undefined);
+      assert.equal(artifact.externalImports.includes('@temporalio/worker'), false);
     }
   } finally {
     await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
@@ -106,22 +92,6 @@ test('cleans output when an entrypoint is missing', async () => {
   assert.equal(await exists(SERVER_ARTIFACT_OUTPUT_ROOT), false);
 });
 
-test('migration artifact resolves its adjacent drizzle asset directory', async () => {
-  try {
-    await buildServerArtifacts({ artifacts: [migrationArtifact] });
-    const migrationArtifactPath = pathToFileURL(
-      join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs'),
-    ).href;
-    const { resolveRuntimeMigrationsFolder } = await import(migrationArtifactPath);
-    const expected = join(workspaceRoot, 'drizzle');
-    const artifactUrl = pathToFileURL(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs'));
-
-    assert.equal(resolveRuntimeMigrationsFolder(artifactUrl.href), expected);
-  } finally {
-    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
-  }
-});
-
 test('migration source entry resolves the repository drizzle directory', async () => {
   const entrypointUrl = pathToFileURL(
     join(workspaceRoot, 'packages/core/db/migrate-entry.ts'),
@@ -138,7 +108,7 @@ test('migration source entry resolves the repository drizzle directory', async (
   assert.equal(stdout, join(workspaceRoot, 'drizzle'));
 });
 
-test('bundles a third-party package into a non-Worker artifact', async () => {
+test('keeps third-party packages external without generating a runtime manifest', async () => {
   const fixtureDirectory = join(workspaceRoot, 'packages/core/db/.server-artifact-test');
   const fixturePath = join(fixtureDirectory, 'runtime-dependency.ts');
   await mkdir(fixtureDirectory, { recursive: true });
@@ -154,8 +124,7 @@ test('bundles a third-party package into a non-Worker artifact', async () => {
       ],
     });
     const [artifact] = manifest.artifacts;
-    assert.deepEqual(artifact.externalImports, []);
-    assert.deepEqual(artifact.runtimeDependencies, {});
+    assert.deepEqual(artifact.externalImports, ['zod']);
     assert.equal(
       await exists(
         join(SERVER_ARTIFACT_OUTPUT_ROOT, 'runtime-dependency-fixture/runtime-package.json'),
@@ -168,41 +137,7 @@ test('bundles a third-party package into a non-Worker artifact', async () => {
   }
 });
 
-test('bundles JSDOM package assets into an executable non-Worker artifact', async () => {
-  const fixtureDirectory = join(workspaceRoot, 'packages/core/db/.server-artifact-test');
-  const fixturePath = join(fixtureDirectory, 'jsdom-assets.ts');
-  await mkdir(fixtureDirectory, { recursive: true });
-  await writeFile(
-    fixturePath,
-    "import { JSDOM } from 'jsdom'; export const text = JSDOM.fragment('<p>ready</p>').textContent;\n",
-  );
-
-  try {
-    await buildServerArtifacts({
-      artifacts: [
-        {
-          name: 'jsdom-assets-fixture',
-          entryPoint: 'packages/core/db/.server-artifact-test/jsdom-assets.ts',
-        },
-      ],
-    });
-    const artifactUrl = pathToFileURL(
-      join(SERVER_ARTIFACT_OUTPUT_ROOT, 'jsdom-assets-fixture/index.mjs'),
-    ).href;
-    const artifact = await import(`${artifactUrl}?test=${Date.now()}`);
-
-    assert.equal(artifact.text, 'ready');
-    assert.equal(
-      await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'jsdom-assets-fixture/runtime-package.json')),
-      false,
-    );
-  } finally {
-    await rm(fixtureDirectory, { force: true, recursive: true });
-    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
-  }
-});
-
-test('bundles the Temporal Client into the API artifact', async () => {
+test('keeps the Temporal Client as an API runtime dependency', async () => {
   try {
     const manifest = await buildServerArtifacts({
       artifacts: [SERVER_ARTIFACTS.find(({ name }) => name === 'api')],
@@ -210,9 +145,8 @@ test('bundles the Temporal Client into the API artifact', async () => {
     const [api] = manifest.artifacts;
     const source = await readFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'api/index.mjs'), 'utf8');
 
-    assert.deepEqual(api.externalImports, []);
-    assert.match(source, /node_modules\/\.pnpm\/@temporalio\+client@/u);
-    assert.doesNotMatch(source, /(?:from|import|require)\s*\(?\s*["']@temporalio\/client/u);
+    assert.equal(api.externalImports.includes('@temporalio/client'), true);
+    assert.match(source, /from ["']@temporalio\/client["']/u);
     assert.equal(
       await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'api/runtime-package.json')),
       false,

--- a/scripts/build-server-artifacts.test.mjs
+++ b/scripts/build-server-artifacts.test.mjs
@@ -1,20 +1,10 @@
 import assert from 'node:assert/strict';
-import { execFile } from 'node:child_process';
 import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import test from 'node:test';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { promisify } from 'node:util';
-import {
-  buildServerArtifacts,
-  SERVER_ARTIFACT_OUTPUT_ROOT,
-  SERVER_ARTIFACT_TARGET,
-  SERVER_ARTIFACTS,
-} from './build-server-artifacts.mjs';
+import { buildServerArtifacts, SERVER_ARTIFACT_OUTPUT_ROOT } from './build-server-artifacts.mjs';
 
-const workspaceRoot = fileURLToPath(new URL('../', import.meta.url));
-const migrationArtifact = SERVER_ARTIFACTS.find(({ name }) => name === 'migration');
-const execFileAsync = promisify(execFile);
+const artifacts = ['web', 'api', 'worker', 'fedify-consumer', 'migration'];
 
 async function exists(path) {
   try {
@@ -25,132 +15,30 @@ async function exists(path) {
   }
 }
 
-test('builds every server artifact with ESM metadata and external source maps', async () => {
-  try {
-    const manifest = await buildServerArtifacts();
-
-    assert.equal(manifest.nodeTarget, SERVER_ARTIFACT_TARGET);
-    assert.deepEqual(
-      manifest.artifacts.map(({ name }) => name),
-      SERVER_ARTIFACTS.map(({ name }) => name),
-    );
-    const worker = manifest.artifacts.find(({ name }) => name === 'worker');
-    assert.ok(worker);
-    assert.ok(worker.files.includes('workflow-bundle.js'));
-    assert.equal(worker.workflowBundle.package, '@temporalio/worker');
-    assert.match(worker.workflowBundle.workerVersion, /^1\.22\./);
-    assert.ok(worker.workflowBundle.workflowExports.length > 0);
-
-    for (const artifact of manifest.artifacts) {
-      const directory = join(workspaceRoot, artifact.directory);
-      const sourceMap = JSON.parse(await readFile(join(directory, 'index.mjs.map'), 'utf8'));
-      const metadata = JSON.parse(await readFile(join(directory, 'meta.json'), 'utf8'));
-      const source = await readFile(join(directory, 'index.mjs'), 'utf8');
-
-      assert.match(source, /\bimport\b/);
-      assert.equal(metadata.format, 'esm');
-      assert.equal(metadata.nodeTarget, SERVER_ARTIFACT_TARGET);
-      assert.ok(Object.keys(metadata.inputs).length > 0);
-      assert.ok(sourceMap.sourcesContent?.length > 0);
-      assert.deepEqual(metadata.externalImports, artifact.externalImports);
-      assert.equal(await exists(join(directory, 'runtime-package.json')), false);
-      assert.equal(
-        artifact.externalImports.some((dependency) => dependency.startsWith('@kosmo/')),
-        false,
-      );
-    }
-
-    assert.equal(worker.externalImports.includes('@temporalio/worker'), true);
-    for (const artifact of manifest.artifacts.filter(({ name }) => name !== 'worker')) {
-      assert.equal(artifact.externalImports.includes('@temporalio/worker'), false);
-    }
-  } finally {
-    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
-  }
-});
-
-test('removes stale artifacts before rebuilding', async () => {
+test('builds the five server artifacts and the Temporal Workflow bundle', async () => {
   await mkdir(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale'), { recursive: true });
-  await writeFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale', 'old.mjs'), 'stale');
+  await writeFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale/old.mjs'), 'stale');
 
   try {
-    await buildServerArtifacts({ artifacts: [migrationArtifact] });
-    assert.equal(await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale', 'old.mjs')), false);
-    assert.equal(await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs')), true);
-  } finally {
-    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
-  }
-});
+    await buildServerArtifacts();
 
-test('cleans output when an entrypoint is missing', async () => {
-  await assert.rejects(
-    buildServerArtifacts({
-      artifacts: [{ name: 'broken', entryPoint: 'scripts/does-not-exist.ts' }],
-    }),
-    /Failed to build broken server artifact/,
-  );
-  assert.equal(await exists(SERVER_ARTIFACT_OUTPUT_ROOT), false);
-});
+    for (const artifact of artifacts) {
+      const directory = join(SERVER_ARTIFACT_OUTPUT_ROOT, artifact);
+      const sourceMap = JSON.parse(await readFile(join(directory, 'index.mjs.map'), 'utf8'));
+      assert.ok(sourceMap.sourcesContent?.length > 0);
+      assert.equal(await exists(join(directory, 'meta.json')), false);
+      assert.equal(await exists(join(directory, 'runtime-package.json')), false);
+    }
 
-test('migration source entry resolves the repository drizzle directory', async () => {
-  const entrypointUrl = pathToFileURL(
-    join(workspaceRoot, 'packages/core/db/migrate-entry.ts'),
-  ).href;
-  const tsxLoader = join(workspaceRoot, 'packages/core/node_modules/tsx/dist/loader.mjs');
-  const { stdout } = await execFileAsync(process.execPath, [
-    '--import',
-    tsxLoader,
-    '--input-type=module',
-    '-e',
-    `const module = await import(${JSON.stringify(entrypointUrl)}); process.stdout.write(module.resolveRuntimeMigrationsFolder(${JSON.stringify(entrypointUrl)}));`,
-  ]);
-
-  assert.equal(stdout, join(workspaceRoot, 'drizzle'));
-});
-
-test('keeps third-party packages external without generating a runtime manifest', async () => {
-  const fixtureDirectory = join(workspaceRoot, 'packages/core/db/.server-artifact-test');
-  const fixturePath = join(fixtureDirectory, 'runtime-dependency.ts');
-  await mkdir(fixtureDirectory, { recursive: true });
-  await writeFile(fixturePath, "import { z } from 'zod'; export const value = z.string();\n");
-
-  try {
-    const manifest = await buildServerArtifacts({
-      artifacts: [
-        {
-          name: 'runtime-dependency-fixture',
-          entryPoint: 'packages/core/db/.server-artifact-test/runtime-dependency.ts',
-        },
-      ],
-    });
-    const [artifact] = manifest.artifacts;
-    assert.deepEqual(artifact.externalImports, ['zod']);
+    assert.equal(await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale/old.mjs')), false);
     assert.equal(
-      await exists(
-        join(SERVER_ARTIFACT_OUTPUT_ROOT, 'runtime-dependency-fixture/runtime-package.json'),
-      ),
-      false,
+      await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'worker/workflow-bundle.js')),
+      true,
     );
-  } finally {
-    await rm(fixtureDirectory, { force: true, recursive: true });
-    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
-  }
-});
 
-test('keeps the Temporal Client as an API runtime dependency', async () => {
-  try {
-    const manifest = await buildServerArtifacts({
-      artifacts: [SERVER_ARTIFACTS.find(({ name }) => name === 'api')],
-    });
-    const [api] = manifest.artifacts;
-    const source = await readFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'api/index.mjs'), 'utf8');
-
-    assert.equal(api.externalImports.includes('@temporalio/client'), true);
-    assert.match(source, /from ["']@temporalio\/client["']/u);
-    assert.equal(
-      await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'api/runtime-package.json')),
-      false,
-    );
+    const api = await readFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'api/index.mjs'), 'utf8');
+    assert.match(api, /from ["']@temporalio\/client["']/u);
+    assert.doesNotMatch(api, /from ["']@kosmo\//u);
   } finally {
     await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
   }

--- a/scripts/build-server-artifacts.test.mjs
+++ b/scripts/build-server-artifacts.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { access, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
@@ -45,9 +45,6 @@ test('builds every server artifact with ESM metadata and external source maps', 
       const directory = join(workspaceRoot, artifact.directory);
       const sourceMap = JSON.parse(await readFile(join(directory, 'index.mjs.map'), 'utf8'));
       const metadata = JSON.parse(await readFile(join(directory, 'meta.json'), 'utf8'));
-      const runtimePackage = JSON.parse(
-        await readFile(join(directory, 'runtime-package.json'), 'utf8'),
-      );
       const source = await readFile(join(directory, 'index.mjs'), 'utf8');
 
       assert.match(source, /\bimport\b/);
@@ -55,17 +52,28 @@ test('builds every server artifact with ESM metadata and external source maps', 
       assert.equal(metadata.nodeTarget, SERVER_ARTIFACT_TARGET);
       assert.ok(Object.keys(metadata.inputs).length > 0);
       assert.ok(sourceMap.sourcesContent?.length > 0);
-      assert.deepEqual(runtimePackage.dependencies, metadata.runtimeDependencies);
-      assert.deepEqual(runtimePackage.dependencies, artifact.runtimeDependencies);
-      assert.equal(runtimePackage.dependencies.tsx, undefined);
-      assert.equal(
-        Object.keys(runtimePackage.dependencies).some((dependency) =>
-          dependency.startsWith('@kosmo/'),
-        ),
-        false,
-      );
+      assert.deepEqual(metadata.externalImports, artifact.externalImports);
+      if (artifact.name === 'worker') {
+        const runtimePackage = JSON.parse(
+          await readFile(join(directory, 'runtime-package.json'), 'utf8'),
+        );
+        assert.deepEqual(runtimePackage.dependencies, metadata.runtimeDependencies);
+        assert.deepEqual(runtimePackage.dependencies, artifact.runtimeDependencies);
+        assert.equal(runtimePackage.dependencies.tsx, undefined);
+        assert.equal(
+          Object.keys(runtimePackage.dependencies).some((dependency) =>
+            dependency.startsWith('@kosmo/'),
+          ),
+          false,
+        );
+      } else {
+        assert.equal(await exists(join(directory, 'runtime-package.json')), false);
+        assert.deepEqual(artifact.externalImports, []);
+        assert.deepEqual(artifact.runtimeDependencies, {});
+      }
     }
 
+    assert.equal(worker.externalImports.includes('@temporalio/worker'), true);
     assert.equal(worker.runtimeDependencies['@temporalio/worker'], '1.22.0');
     for (const artifact of manifest.artifacts.filter(({ name }) => name !== 'worker')) {
       assert.equal(artifact.runtimeDependencies['@temporalio/worker'], undefined);
@@ -101,14 +109,6 @@ test('cleans output when an entrypoint is missing', async () => {
 test('migration artifact resolves its adjacent drizzle asset directory', async () => {
   try {
     await buildServerArtifacts({ artifacts: [migrationArtifact] });
-    const runtimePackage = JSON.parse(
-      await readFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration/runtime-package.json'), 'utf8'),
-    );
-    for (const dependency of Object.keys(runtimePackage.dependencies)) {
-      const target = join(SERVER_ARTIFACT_OUTPUT_ROOT, 'node_modules', dependency);
-      await mkdir(dirname(target), { recursive: true });
-      await symlink(join(workspaceRoot, 'packages/core/node_modules', dependency), target, 'dir');
-    }
     const migrationArtifactPath = pathToFileURL(
       join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs'),
     ).href;
@@ -138,7 +138,7 @@ test('migration source entry resolves the repository drizzle directory', async (
   assert.equal(stdout, join(workspaceRoot, 'drizzle'));
 });
 
-test('derives an external runtime package from the build graph', async () => {
+test('bundles a third-party package into a non-Worker artifact', async () => {
   const fixtureDirectory = join(workspaceRoot, 'packages/core/db/.server-artifact-test');
   const fixturePath = join(fixtureDirectory, 'runtime-dependency.ts');
   await mkdir(fixtureDirectory, { recursive: true });
@@ -154,16 +154,70 @@ test('derives an external runtime package from the build graph', async () => {
       ],
     });
     const [artifact] = manifest.artifacts;
-    assert.match(artifact.runtimeDependencies.zod, /^4\./u);
-    const runtimePackage = JSON.parse(
-      await readFile(
+    assert.deepEqual(artifact.externalImports, []);
+    assert.deepEqual(artifact.runtimeDependencies, {});
+    assert.equal(
+      await exists(
         join(SERVER_ARTIFACT_OUTPUT_ROOT, 'runtime-dependency-fixture/runtime-package.json'),
-        'utf8',
       ),
+      false,
     );
-    assert.deepEqual(runtimePackage.dependencies, artifact.runtimeDependencies);
   } finally {
     await rm(fixtureDirectory, { force: true, recursive: true });
+    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
+  }
+});
+
+test('bundles JSDOM package assets into an executable non-Worker artifact', async () => {
+  const fixtureDirectory = join(workspaceRoot, 'packages/core/db/.server-artifact-test');
+  const fixturePath = join(fixtureDirectory, 'jsdom-assets.ts');
+  await mkdir(fixtureDirectory, { recursive: true });
+  await writeFile(
+    fixturePath,
+    "import { JSDOM } from 'jsdom'; export const text = JSDOM.fragment('<p>ready</p>').textContent;\n",
+  );
+
+  try {
+    await buildServerArtifacts({
+      artifacts: [
+        {
+          name: 'jsdom-assets-fixture',
+          entryPoint: 'packages/core/db/.server-artifact-test/jsdom-assets.ts',
+        },
+      ],
+    });
+    const artifactUrl = pathToFileURL(
+      join(SERVER_ARTIFACT_OUTPUT_ROOT, 'jsdom-assets-fixture/index.mjs'),
+    ).href;
+    const artifact = await import(`${artifactUrl}?test=${Date.now()}`);
+
+    assert.equal(artifact.text, 'ready');
+    assert.equal(
+      await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'jsdom-assets-fixture/runtime-package.json')),
+      false,
+    );
+  } finally {
+    await rm(fixtureDirectory, { force: true, recursive: true });
+    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
+  }
+});
+
+test('bundles the Temporal Client into the API artifact', async () => {
+  try {
+    const manifest = await buildServerArtifacts({
+      artifacts: [SERVER_ARTIFACTS.find(({ name }) => name === 'api')],
+    });
+    const [api] = manifest.artifacts;
+    const source = await readFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'api/index.mjs'), 'utf8');
+
+    assert.deepEqual(api.externalImports, []);
+    assert.match(source, /node_modules\/\.pnpm\/@temporalio\+client@/u);
+    assert.doesNotMatch(source, /(?:from|import|require)\s*\(?\s*["']@temporalio\/client/u);
+    assert.equal(
+      await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'api/runtime-package.json')),
+      false,
+    );
+  } finally {
     await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
   }
 });

--- a/scripts/build-server-artifacts.test.mjs
+++ b/scripts/build-server-artifacts.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { access, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import {
+  buildServerArtifacts,
+  SERVER_ARTIFACT_OUTPUT_ROOT,
+  SERVER_ARTIFACT_TARGET,
+  SERVER_ARTIFACTS,
+} from './build-server-artifacts.mjs';
+
+const workspaceRoot = fileURLToPath(new URL('../', import.meta.url));
+const migrationArtifact = SERVER_ARTIFACTS.find(({ name }) => name === 'migration');
+const webArtifact = SERVER_ARTIFACTS.find(({ name }) => name === 'web');
+const execFileAsync = promisify(execFile);
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('builds every server artifact with ESM metadata and external source maps', async () => {
+  try {
+    const manifest = await buildServerArtifacts();
+
+    assert.equal(manifest.nodeTarget, SERVER_ARTIFACT_TARGET);
+    assert.deepEqual(
+      manifest.artifacts.map(({ name }) => name),
+      SERVER_ARTIFACTS.map(({ name }) => name),
+    );
+    const worker = manifest.artifacts.find(({ name }) => name === 'worker');
+    assert.ok(worker);
+    assert.ok(worker.files.includes('workflow-bundle.js'));
+    assert.equal(worker.workflowBundle.package, '@temporalio/worker');
+    assert.match(worker.workflowBundle.workerVersion, /^1\.22\./);
+    assert.ok(worker.workflowBundle.workflowExports.length > 0);
+    assert.deepEqual(worker.workflowBundle.externalRuntimePackages, [
+      '@temporalio/client',
+      'jsdom',
+      '@temporalio/worker',
+    ]);
+
+    for (const artifact of manifest.artifacts) {
+      const directory = join(workspaceRoot, artifact.directory);
+      const sourceMap = JSON.parse(await readFile(join(directory, 'index.mjs.map'), 'utf8'));
+      const metadata = JSON.parse(await readFile(join(directory, 'meta.json'), 'utf8'));
+      const source = await readFile(join(directory, 'index.mjs'), 'utf8');
+
+      assert.match(source, /\bimport\b/);
+      assert.equal(metadata.format, 'esm');
+      assert.equal(metadata.nodeTarget, SERVER_ARTIFACT_TARGET);
+      assert.ok(Object.keys(metadata.inputs).length > 0);
+      assert.ok(sourceMap.sourcesContent?.length > 0);
+    }
+  } finally {
+    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
+  }
+});
+
+test('removes stale artifacts before rebuilding', async () => {
+  await mkdir(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale'), { recursive: true });
+  await writeFile(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale', 'old.mjs'), 'stale');
+
+  try {
+    await buildServerArtifacts({ artifacts: [migrationArtifact] });
+    assert.equal(await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'stale', 'old.mjs')), false);
+    assert.equal(await exists(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs')), true);
+  } finally {
+    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
+  }
+});
+
+test('cleans output when an entrypoint is missing', async () => {
+  await assert.rejects(
+    buildServerArtifacts({
+      artifacts: [{ name: 'broken', entryPoint: 'scripts/does-not-exist.ts' }],
+    }),
+    /Failed to build broken server artifact/,
+  );
+  assert.equal(await exists(SERVER_ARTIFACT_OUTPUT_ROOT), false);
+});
+
+test('migration artifact resolves its adjacent drizzle asset directory', async () => {
+  try {
+    await buildServerArtifacts({ artifacts: [migrationArtifact] });
+    const migrationArtifactPath = pathToFileURL(
+      join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs'),
+    ).href;
+    const { resolveRuntimeMigrationsFolder } = await import(migrationArtifactPath);
+    const expected = join(workspaceRoot, 'drizzle');
+    const artifactUrl = pathToFileURL(join(SERVER_ARTIFACT_OUTPUT_ROOT, 'migration', 'index.mjs'));
+
+    assert.equal(resolveRuntimeMigrationsFolder(artifactUrl.href), expected);
+  } finally {
+    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
+  }
+});
+
+test('migration source entry resolves the repository drizzle directory', async () => {
+  const entrypointUrl = pathToFileURL(
+    join(workspaceRoot, 'packages/core/db/migrate-entry.ts'),
+  ).href;
+  const tsxLoader = join(workspaceRoot, 'packages/core/node_modules/tsx/dist/loader.mjs');
+  const { stdout } = await execFileAsync(process.execPath, [
+    '--import',
+    tsxLoader,
+    '--input-type=module',
+    '-e',
+    `const module = await import(${JSON.stringify(entrypointUrl)}); process.stdout.write(module.resolveRuntimeMigrationsFolder(${JSON.stringify(entrypointUrl)}));`,
+  ]);
+
+  assert.equal(stdout, join(workspaceRoot, 'drizzle'));
+});
+
+test('bundled CommonJS dependencies execute inside the ESM server artifact', async () => {
+  try {
+    await buildServerArtifacts({ artifacts: [webArtifact] });
+    const artifactPath = join(SERVER_ARTIFACT_OUTPUT_ROOT, 'web', 'index.mjs');
+    const runtimeNodeModules = join(SERVER_ARTIFACT_OUTPUT_ROOT, 'node_modules');
+    await mkdir(runtimeNodeModules);
+    await symlink(
+      join(workspaceRoot, 'packages/core/node_modules/@temporalio'),
+      join(runtimeNodeModules, '@temporalio'),
+      'dir',
+    );
+    await symlink(
+      join(workspaceRoot, 'packages/core/node_modules/jsdom'),
+      join(runtimeNodeModules, 'jsdom'),
+      'dir',
+    );
+
+    await assert.rejects(execFileAsync(process.execPath, [artifactPath]), (error) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /TEMPORAL_ADDRESS is required/u);
+      assert.doesNotMatch(error.stderr, /Dynamic require/u);
+      return true;
+    });
+  } finally {
+    await rm(SERVER_ARTIFACT_OUTPUT_ROOT, { force: true, recursive: true });
+  }
+});

--- a/scripts/build-temporal-workflow-bundle.mjs
+++ b/scripts/build-temporal-workflow-bundle.mjs
@@ -1,0 +1,158 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { isAbsolute, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = fileURLToPath(new URL('../', import.meta.url));
+const workerManifestPath = resolve(repositoryRoot, 'apps/worker/package.json');
+const workerRequire = createRequire(workerManifestPath);
+
+export const productionWorkflowExports = [
+  'postCreateEffectsWorkflow',
+  'postDeleteWorkflow',
+  'profileUpdateEffectsWorkflow',
+  'reactionCreateEffectsWorkflow',
+  'reactionDeleteEffectsWorkflow',
+  'postRepostWorkflow',
+  'repostDeleteWorkflow',
+];
+
+// These packages stay external to the Worker host bundle. Their production
+// dependency tree, including the target @temporalio/core-bridge .node binary,
+// belongs only to the Worker final image.
+export const assetRuntimeExternalPackages = ['@temporalio/client', 'jsdom'];
+export const workerRuntimeExternalPackages = [
+  ...assetRuntimeExternalPackages,
+  '@temporalio/worker',
+];
+
+function parseArguments(arguments_) {
+  const options = {
+    outputDir: resolve(repositoryRoot, 'server-dist/worker'),
+  };
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === '--output-dir') {
+      const value = arguments_[index + 1];
+      if (!value) {
+        throw new Error('--output-dir requires a path');
+      }
+      options.outputDir = isAbsolute(value) ? value : resolve(repositoryRoot, value);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  return options;
+}
+
+function temporalLogger() {
+  const log = (level, message, metadata) => {
+    const suffix = metadata === undefined ? '' : ` ${JSON.stringify(metadata)}`;
+    process.stderr.write(`[temporal-workflow-bundle] ${level}: ${message}${suffix}\n`);
+  };
+  return {
+    debug(message, metadata) {
+      log('debug', message, metadata);
+    },
+    info(message, metadata) {
+      log('info', message, metadata);
+    },
+    warn(message, metadata) {
+      log('warn', message, metadata);
+    },
+    error(message, metadata) {
+      log('error', message, metadata);
+    },
+  };
+}
+
+function sourceExportNames(source) {
+  return [...source.matchAll(/export\s*\{([^}]+)\}/g)]
+    .flatMap(([, exports]) =>
+      exports
+        .split(',')
+        .map((entry) => entry.trim().split(/\s+as\s+/u)[1] || entry.trim().split(/\s+/u)[0])
+        .filter(Boolean),
+    )
+    .sort();
+}
+
+function assertEqualNames(actual, expected, description) {
+  const actualValue = JSON.stringify(actual);
+  const expectedValue = JSON.stringify(expected);
+  if (actualValue !== expectedValue) {
+    throw new Error(`${description} mismatch: expected ${expectedValue}, received ${actualValue}`);
+  }
+}
+
+async function writeAtomically(path, contents) {
+  const temporaryPath = `${path}.${process.pid}.tmp`;
+  await writeFile(temporaryPath, contents, 'utf8');
+  await rename(temporaryPath, path);
+}
+
+/**
+ * Build the Temporal Workflow bundle used by the production Worker host.
+ *
+ * This intentionally delegates Workflow compilation to the exact
+ * @temporalio/worker package resolved from apps/worker. The Worker host can
+ * remain an ESM artifact with Temporal's native/runtime packages externalized,
+ * while this bundle is loaded through WorkerOptions.workflowBundle.
+ */
+export async function buildTemporalWorkflowBundle({
+  outputDir = resolve(repositoryRoot, 'server-dist/worker'),
+} = {}) {
+  const workflowSourcePath = resolve(repositoryRoot, 'apps/worker/src/workflows/index.ts');
+  const workflowBundlePath = resolve(outputDir, 'workflow-bundle.js');
+  const workflowSource = await readFile(workflowSourcePath, 'utf8');
+  const sourceNames = sourceExportNames(workflowSource);
+  assertEqualNames(sourceNames, [...productionWorkflowExports].sort(), 'Workflow registry');
+
+  const workerPackagePath = workerRequire.resolve('@temporalio/worker/package.json');
+  const workerPackage = JSON.parse(await readFile(workerPackagePath, 'utf8'));
+  const { bundleWorkflowCode } = workerRequire('@temporalio/worker');
+
+  await mkdir(outputDir, { recursive: true });
+  await rm(workflowBundlePath, { force: true });
+
+  const bundle = await bundleWorkflowCode({
+    logger: temporalLogger(),
+    workflowsPath: workflowSourcePath,
+  });
+  const missingExports = productionWorkflowExports.filter((name) => !bundle.code.includes(name));
+  if (missingExports.length > 0) {
+    throw new Error(`Workflow bundle is missing exports: ${missingExports.join(', ')}`);
+  }
+
+  const runtimeCode = bundle.code.replace(/^\/\/# sourceMappingURL=data:.*$/gmu, '');
+  if (/sourceMappingURL/u.test(runtimeCode)) {
+    throw new Error('Workflow runtime bundle still contains a source map reference.');
+  }
+
+  await writeAtomically(workflowBundlePath, runtimeCode);
+  return {
+    artifact: relative(repositoryRoot, workflowBundlePath),
+    bytes: Buffer.byteLength(runtimeCode),
+    package: '@temporalio/worker',
+    workerVersion: workerPackage.version,
+    externalRuntimePackages: [...workerRuntimeExternalPackages],
+    workflowSource: relative(repositoryRoot, workflowSourcePath),
+    workflowExports: [...productionWorkflowExports],
+  };
+}
+
+if (import.meta.main) {
+  try {
+    const { outputDir } = parseArguments(process.argv.slice(2));
+    const metadata = await buildTemporalWorkflowBundle({ outputDir });
+    process.stdout.write(`${JSON.stringify(metadata)}\n`);
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.stack || error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/build-temporal-workflow-bundle.mjs
+++ b/scripts/build-temporal-workflow-bundle.mjs
@@ -17,15 +17,6 @@ export const productionWorkflowExports = [
   'repostDeleteWorkflow',
 ];
 
-// These packages stay external to the Worker host bundle. Their production
-// dependency tree, including the target @temporalio/core-bridge .node binary,
-// belongs only to the Worker final image.
-export const assetRuntimeExternalPackages = ['@temporalio/client', 'jsdom'];
-export const workerRuntimeExternalPackages = [
-  ...assetRuntimeExternalPackages,
-  '@temporalio/worker',
-];
-
 function parseArguments(arguments_) {
   const options = {
     outputDir: resolve(repositoryRoot, 'server-dist/worker'),
@@ -138,7 +129,6 @@ export async function buildTemporalWorkflowBundle({
     bytes: Buffer.byteLength(runtimeCode),
     package: '@temporalio/worker',
     workerVersion: workerPackage.version,
-    externalRuntimePackages: [...workerRuntimeExternalPackages],
     workflowSource: relative(repositoryRoot, workflowSourcePath),
     workflowExports: [...productionWorkflowExports],
   };

--- a/scripts/build-temporal-workflow-bundle.mjs
+++ b/scripts/build-temporal-workflow-bundle.mjs
@@ -10,6 +10,8 @@ const workerRequire = createRequire(workerManifestPath);
 export const productionWorkflowExports = [
   'postCreateEffectsWorkflow',
   'postDeleteWorkflow',
+  'profileFollowPairWorkflow',
+  'profileFollowRemovalWorkflow',
   'profileUpdateEffectsWorkflow',
   'reactionCreateEffectsWorkflow',
   'reactionDeleteEffectsWorkflow',

--- a/scripts/check-server-runtime-image.mjs
+++ b/scripts/check-server-runtime-image.mjs
@@ -63,6 +63,7 @@ const manifest = existsSync(manifestPath)
   ? JSON.parse(readFileSync(manifestPath, 'utf8'))
   : undefined;
 const dependencies = Object.keys(manifest?.dependencies ?? {}).sort();
+const nodeModules = existsSync('/app/node_modules');
 let workerPackage;
 try {
   workerPackage = createRequire(entrypoint).resolve('@temporalio/worker/package.json');
@@ -97,7 +98,8 @@ process.stdout.write(JSON.stringify({
   sourceMapReference: artifactFiles
     .filter((path) => /\.(?:c|m)?js$/u.test(path))
     .some((path) => readFileSync(path, 'utf8').includes('sourceMappingURL=')),
-  manifest: manifest !== undefined,
+  runtimePackage: manifest !== undefined,
+  nodeModules,
   dependencies,
   missingDependencies: dependencies.filter(
     (dependency) => !existsSync(join('/app/node_modules', dependency)),
@@ -212,7 +214,11 @@ export async function checkRuntimeImage({
     runtime,
     entrypoint: contract.entrypoint,
   });
-  const requiredFiles = ['index.mjs', 'meta.json', 'runtime-package.json'].map((file) =>
+  const requiredFiles = ['index.mjs', 'meta.json'];
+  if (contract.worker) {
+    requiredFiles.push('runtime-package.json');
+  }
+  const requiredArtifactFiles = requiredFiles.map((file) =>
     artifactPath(contract.artifactDirectory, file),
   );
 
@@ -229,15 +235,20 @@ export async function checkRuntimeImage({
     `unexpected artifact directories: ${probe.artifactDirectories.join(', ')}`,
   );
   assert(
-    requiredFiles.every((file) => probe.artifactFiles.includes(file)),
-    'artifact, metadata, or generated runtime manifest is missing',
+    requiredArtifactFiles.every((file) => probe.artifactFiles.includes(file)),
+    'artifact, metadata, or Worker runtime manifest is missing',
   );
   assert(probe.sourceFiles.length === 0, `TypeScript source remains: ${probe.sourceFiles[0]}`);
   assert(probe.mapFiles.length === 0 && !probe.sourceMapReference, 'source map remains');
-  assert(
-    probe.manifest && probe.missingDependencies.length === 0,
-    'runtime manifest is incomplete',
-  );
+  if (contract.worker) {
+    assert(probe.runtimePackage && probe.nodeModules, 'Worker runtime dependencies are missing');
+    assert(probe.missingDependencies.length === 0, 'Worker runtime manifest is incomplete');
+  } else {
+    assert(
+      !probe.runtimePackage && !probe.nodeModules,
+      'non-Worker image contains runtime dependencies',
+    );
+  }
   assert(!probe.tsx, 'runtime manifest contains tsx');
   assert(probe.expo === Boolean(contract.expo), 'Expo assets are in the wrong image');
   assert(

--- a/scripts/check-server-runtime-image.mjs
+++ b/scripts/check-server-runtime-image.mjs
@@ -7,406 +7,188 @@ export const RUNTIME_IMAGE_CONTRACTS = Object.freeze({
   web: Object.freeze({
     artifactDirectory: 'web',
     entrypoint: '/app/server-dist/web/index.mjs',
-    requiresExpoDist: true,
-    requiresMigrationAssets: false,
-    requiresRuntimeDependencies: true,
-    requiresWorkerRuntime: false,
+    expo: true,
   }),
   api: Object.freeze({
     artifactDirectory: 'api',
     entrypoint: '/app/server-dist/api/index.mjs',
-    requiresExpoDist: false,
-    requiresMigrationAssets: false,
-    requiresRuntimeDependencies: true,
-    requiresWorkerRuntime: false,
   }),
   worker: Object.freeze({
     artifactDirectory: 'worker',
     entrypoint: '/app/server-dist/worker/index.mjs',
-    requiresExpoDist: false,
-    requiresMigrationAssets: false,
-    requiresRuntimeDependencies: true,
-    requiresWorkerRuntime: true,
+    worker: true,
   }),
   'fedify-consumer': Object.freeze({
     artifactDirectory: 'fedify-consumer',
     entrypoint: '/app/server-dist/fedify-consumer/index.mjs',
-    requiresExpoDist: false,
-    requiresMigrationAssets: false,
-    requiresRuntimeDependencies: true,
-    requiresWorkerRuntime: false,
   }),
   migration: Object.freeze({
     artifactDirectory: 'migration',
     entrypoint: '/app/server-dist/migration/index.mjs',
-    requiresExpoDist: false,
-    requiresMigrationAssets: true,
-    requiresRuntimeDependencies: false,
-    requiresWorkerRuntime: false,
+    migrations: true,
   }),
 });
 
 const runtimeNames = Object.keys(RUNTIME_IMAGE_CONTRACTS);
 
-export const RUNTIME_PROBE_SCRIPT = String.raw`
+const probeSource = String.raw`
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 
 const runtime = process.env.KOSMO_RUNTIME;
 const entrypoint = process.env.KOSMO_ENTRYPOINT;
-const artifactRoot = '/app/server-dist';
 
-function collectFiles(root) {
-  if (!existsSync(root)) {
-    return [];
-  }
-
+function walk(root) {
+  if (!existsSync(root)) return [];
   const files = [];
   const pending = [root];
-  while (pending.length > 0) {
+  while (pending.length) {
     const directory = pending.pop();
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.name === 'node_modules') continue;
       const path = join(directory, entry.name);
-      if (entry.isDirectory() && !entry.isSymbolicLink()) {
-        pending.push(path);
-      } else if (entry.isFile() || entry.isSymbolicLink()) {
-        files.push(path);
-      }
+      if (entry.isDirectory() && !entry.isSymbolicLink()) pending.push(path);
+      else files.push(path);
     }
   }
   return files;
 }
 
-function collectCoreBridgeReleases() {
-  const virtualStore = '/app/node_modules/.pnpm';
-  if (!existsSync(virtualStore)) {
-    return [];
-  }
-
-  const releases = [];
-  for (const packageEntry of readdirSync(virtualStore, { withFileTypes: true })) {
-    if (!packageEntry.isDirectory() || !packageEntry.name.startsWith('@temporalio+core-bridge@')) {
-      continue;
-    }
-
-    const releasesPath = join(
-      virtualStore,
-      packageEntry.name,
-      'node_modules/@temporalio/core-bridge/releases',
-    );
-    if (!existsSync(releasesPath)) {
-      continue;
-    }
-
-    for (const releaseEntry of readdirSync(releasesPath, { withFileTypes: true })) {
-      if (!releaseEntry.isDirectory()) {
-        continue;
-      }
-      const binaryPath = join(releasesPath, releaseEntry.name, 'index.node');
-      releases.push({
-        package: packageEntry.name,
-        platform: releaseEntry.name,
-        binary: binaryPath,
-        exists: existsSync(binaryPath),
-      });
-    }
-  }
-  return releases;
+const artifactRoot = '/app/server-dist';
+const artifactDirectory = join(artifactRoot, runtime);
+const artifactFiles = walk(artifactRoot);
+const manifestPath = join(artifactDirectory, 'runtime-package.json');
+const manifest = existsSync(manifestPath)
+  ? JSON.parse(readFileSync(manifestPath, 'utf8'))
+  : undefined;
+const dependencies = Object.keys(manifest?.dependencies ?? {}).sort();
+let workerPackage;
+try {
+  workerPackage = createRequire(entrypoint).resolve('@temporalio/worker/package.json');
+} catch {
+  workerPackage = undefined;
+}
+let bridgeReleases = [];
+if (workerPackage) {
+  const workerRequire = createRequire(workerPackage);
+  const releases = join(dirname(workerRequire.resolve('@temporalio/core-bridge')), 'releases');
+  bridgeReleases = readdirSync(releases, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      platform: entry.name,
+      binary: existsSync(join(releases, entry.name, 'index.node')),
+    }));
 }
 
-const artifactFiles = collectFiles(artifactRoot);
-const runtimeFiles = runtime === 'web' ? collectFiles('/app/apps/app/dist') : [];
-const sourceFiles = [...artifactFiles, ...runtimeFiles].filter((path) => /\.(?:cts|mts|ts|tsx)$/u.test(path));
-const mapFiles = artifactFiles.filter((path) => path.endsWith('.map'));
-const mapReferences = artifactFiles
-  .filter((path) => /\.(?:c|m)?js$/u.test(path))
-  .filter((path) => readFileSync(path, 'utf8').includes('sourceMappingURL='));
-const forbiddenNodeModules = [
-  '/app/node_modules',
-  '/app/apps/api/node_modules',
-  '/app/apps/app/node_modules',
-  '/app/apps/fedify-consumer/node_modules',
-  '/app/apps/worker/node_modules',
-  '/app/apps/web/node_modules',
-  '/app/packages/core/node_modules',
-  '/app/packages/fedify/node_modules',
-].filter((path) => existsSync(path));
-const rootDependencyEntries = existsSync('/app/node_modules')
-  ? readdirSync('/app/node_modules')
-      .filter((name) => name !== '.pnpm' && name !== '.modules.yaml' && name !== '.pnpm-workspace-state-v1.json')
-      .filter((name) => name !== '.package-map.json')
-      .filter((name) => name !== '.bin')
-      .sort()
-  : [];
-const tsxPaths = existsSync('/app/node_modules')
-  ? collectFiles('/app/node_modules').filter((path) => /(?:^|\/)tsx(?:@|\/)/u.test(path))
-  : [];
-
-const report = {
-  runtime,
-  uid: process.getuid?.(),
-  gid: process.getgid?.(),
-  entrypointExists: existsSync(entrypoint),
-  dispatcherExists: existsSync('/app/docker-entrypoint.sh'),
-  artifactFiles,
+process.stdout.write(JSON.stringify({
+  uid: process.getuid(),
+  gid: process.getgid(),
+  entrypoint: existsSync(entrypoint),
+  dispatcher: existsSync('/app/docker-entrypoint.sh'),
   artifactDirectories: existsSync(artifactRoot)
     ? readdirSync(artifactRoot, { withFileTypes: true })
         .filter((entry) => entry.isDirectory())
         .map((entry) => entry.name)
-        .sort()
     : [],
-  sourceFiles,
-  mapFiles,
-  mapReferences,
-  forbiddenNodeModules,
-  rootDependencyEntries,
-  tsxPaths,
-  expoDistExists: existsSync('/app/apps/app/dist'),
-  migrationAssets: existsSync('/app/drizzle')
-    ? collectFiles('/app/drizzle').filter((path) => path.endsWith('.sql'))
-    : [],
-  workflowBundleExists: existsSync('/app/server-dist/worker/workflow-bundle.js'),
-  coreBridgeReleases: collectCoreBridgeReleases(),
-  packageJsonExists: existsSync('/app/package.json'),
-  serverRuntimeSource: existsSync(entrypoint) ? readFileSync(entrypoint, 'utf8') : '',
-};
-
-process.stdout.write(JSON.stringify(report));
+  artifactFiles,
+  sourceFiles: walk('/app').filter((path) => /\.(?:cts|mts|ts|tsx)$/u.test(path)),
+  mapFiles: artifactFiles.filter((path) => path.endsWith('.map')),
+  sourceMapReference: artifactFiles
+    .filter((path) => /\.(?:c|m)?js$/u.test(path))
+    .some((path) => readFileSync(path, 'utf8').includes('sourceMappingURL=')),
+  manifest: manifest !== undefined,
+  dependencies,
+  missingDependencies: dependencies.filter(
+    (dependency) => !existsSync(join('/app/node_modules', dependency)),
+  ),
+  tsx: dependencies.includes('tsx') || existsSync('/app/node_modules/tsx'),
+  workerPackage: workerPackage !== undefined,
+  bridgeReleases,
+  expo: existsSync('/app/apps/app/dist'),
+  migrations: walk('/app/drizzle').some((path) => path.endsWith('.sql')),
+  workflowBundle: existsSync('/app/server-dist/worker/workflow-bundle.js'),
+}));
 `;
 
 function usage() {
-  return [
-    'Usage: node scripts/check-server-runtime-image.mjs --runtime <name> --image <ref> [options]',
-    '',
-    `Runtime names: ${runtimeNames.join(', ')}`,
-    'Options:',
-    '  --platform <platform>       Docker target platform (default: linux/arm64)',
-    '  --baseline-image <ref>      Compare uncompressed image size against this image',
-    '  --docker <path>             Docker executable (default: docker)',
-  ].join('\n');
+  return `Usage: node scripts/check-server-runtime-image.mjs --runtime <${runtimeNames.join('|')}> --image <ref> [--baseline-image <ref>] [--platform <platform>]`;
 }
 
 export function parseArguments(arguments_) {
   const options = { docker: 'docker', platform: 'linux/arm64' };
-
-  for (let index = 0; index < arguments_.length; index += 1) {
-    const argument = arguments_[index];
-    if (argument === '--help' || argument === '-h') {
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index];
+    if (key === '--help' || key === '-h') {
       return { help: true };
     }
-
     const value = arguments_[index + 1];
-    if (!value || value.startsWith('--')) {
-      throw new Error(`Missing value for ${argument}.\n\n${usage()}`);
+    if (!value) {
+      throw new Error(`Missing value for ${key}.\n\n${usage()}`);
     }
-
-    if (argument === '--runtime') {
+    if (key === '--runtime') {
       options.runtime = value;
-    } else if (argument === '--image') {
+    } else if (key === '--image') {
       options.image = value;
-    } else if (argument === '--platform') {
-      options.platform = value;
-    } else if (argument === '--baseline-image') {
+    } else if (key === '--baseline-image') {
       options.baselineImage = value;
-    } else if (argument === '--docker') {
+    } else if (key === '--platform') {
+      options.platform = value;
+    } else if (key === '--docker') {
       options.docker = value;
     } else {
-      throw new Error(`Unknown argument ${argument}.\n\n${usage()}`);
+      throw new Error(`Unknown argument ${key}.\n\n${usage()}`);
     }
-    index += 1;
   }
-
-  if (!options.runtime || !RUNTIME_IMAGE_CONTRACTS[options.runtime]) {
+  if (!RUNTIME_IMAGE_CONTRACTS[options.runtime]) {
     throw new Error(`--runtime must be one of: ${runtimeNames.join(', ')}.\n\n${usage()}`);
   }
   if (!options.image) {
     throw new Error(`--image is required.\n\n${usage()}`);
   }
-
   return options;
 }
 
 async function dockerJson(docker, arguments_) {
-  const { stdout } = await execFileAsync(docker, arguments_, { maxBuffer: 10 * 1024 * 1024 });
+  const { stdout } = await execFileAsync(docker, arguments_, { maxBuffer: 20 * 1024 * 1024 });
   return JSON.parse(stdout);
 }
 
 async function inspectImage(docker, image) {
-  const records = await dockerJson(docker, ['image', 'inspect', image]);
-  if (!Array.isArray(records) || records.length !== 1) {
-    throw new Error(`Docker image inspect returned an unexpected result for ${image}.`);
+  const [record] = await dockerJson(docker, ['image', 'inspect', image]);
+  if (!record) {
+    throw new Error(`Docker image inspect found no record for ${image}.`);
   }
-  return records[0];
+  return record;
 }
 
-async function probeImage({ docker, image, platform, runtime, contract }) {
-  const { stdout } = await execFileAsync(
-    docker,
-    [
-      'run',
-      '--rm',
-      '--platform',
-      platform,
-      '--entrypoint',
-      'node',
-      '--env',
-      `KOSMO_RUNTIME=${runtime}`,
-      '--env',
-      `KOSMO_ENTRYPOINT=${contract.entrypoint}`,
-      image,
-      '--input-type=module',
-      '-e',
-      RUNTIME_PROBE_SCRIPT,
-    ],
-    { maxBuffer: 50 * 1024 * 1024 },
-  );
-  return JSON.parse(stdout);
+async function probeImage({ docker, image, platform, runtime, entrypoint }) {
+  return dockerJson(docker, [
+    'run',
+    '--rm',
+    '--platform',
+    platform,
+    '--entrypoint',
+    'node',
+    '--env',
+    `KOSMO_RUNTIME=${runtime}`,
+    '--env',
+    `KOSMO_ENTRYPOINT=${entrypoint}`,
+    image,
+    '--input-type=module',
+    '-e',
+    probeSource,
+  ]);
 }
 
-function assertCondition(condition, message, failures) {
+function assert(condition, message) {
   if (!condition) {
-    failures.push(message);
+    throw new Error(`Runtime image gate failed: ${message}`);
   }
 }
 
-function validateProbe({ imageRecord, baselineRecord, probe, runtime, contract }) {
-  const failures = [];
-  const config = imageRecord.Config ?? {};
-  const entrypoint = config.Entrypoint ?? [];
-
-  assertCondition(
-    JSON.stringify(entrypoint) === JSON.stringify(['node', contract.entrypoint]),
-    `Entrypoint must be ["node", "${contract.entrypoint}"], received ${JSON.stringify(entrypoint)}.`,
-    failures,
-  );
-  assertCondition(
-    probe.uid === 10001,
-    `Container uid must be 10001, received ${probe.uid}.`,
-    failures,
-  );
-  assertCondition(
-    probe.gid === 10001,
-    `Container gid must be 10001, received ${probe.gid}.`,
-    failures,
-  );
-  assertCondition(
-    probe.entrypointExists,
-    `Entrypoint file is missing: ${contract.entrypoint}.`,
-    failures,
-  );
-  assertCondition(
-    !probe.dispatcherExists,
-    'Legacy docker-entrypoint.sh must not be in split images.',
-    failures,
-  );
-  assertCondition(
-    probe.artifactDirectories.length === 1 &&
-      probe.artifactDirectories[0] === contract.artifactDirectory,
-    `Only ${contract.artifactDirectory} may be under /app/server-dist; received ${probe.artifactDirectories.join(', ')}.`,
-    failures,
-  );
-  assertCondition(
-    probe.artifactFiles.includes(`/app/server-dist/${contract.artifactDirectory}/index.mjs`),
-    'The runtime JavaScript artifact is missing.',
-    failures,
-  );
-  assertCondition(
-    probe.artifactFiles.includes(`/app/server-dist/${contract.artifactDirectory}/meta.json`),
-    'The runtime artifact metadata is missing.',
-    failures,
-  );
-  assertCondition(
-    probe.sourceFiles.length === 0,
-    `TypeScript source is present: ${probe.sourceFiles.join(', ')}.`,
-    failures,
-  );
-  assertCondition(
-    probe.mapFiles.length === 0,
-    `Source maps are present: ${probe.mapFiles.join(', ')}.`,
-    failures,
-  );
-  assertCondition(
-    probe.mapReferences.length === 0,
-    `Source-map references are present: ${probe.mapReferences.join(', ')}.`,
-    failures,
-  );
-  const unexpectedNodeModules = contract.requiresRuntimeDependencies
-    ? probe.forbiddenNodeModules.filter((path) => path !== '/app/node_modules')
-    : probe.forbiddenNodeModules;
-  assertCondition(
-    unexpectedNodeModules.length === 0,
-    `Workspace node_modules are present: ${unexpectedNodeModules.join(', ')}.`,
-    failures,
-  );
-  const expectedRootDependencies = contract.requiresWorkerRuntime
-    ? ['@temporalio', 'jsdom']
-    : contract.requiresRuntimeDependencies
-      ? ['@temporalio', 'jsdom']
-      : [];
-  assertCondition(
-    JSON.stringify(probe.rootDependencyEntries) === JSON.stringify(expectedRootDependencies),
-    `Root runtime dependencies must be ${expectedRootDependencies.join(', ') || '(none)'}; received ${probe.rootDependencyEntries.join(', ') || '(none)'}.`,
-    failures,
-  );
-  assertCondition(probe.tsxPaths.length === 0, 'Runtime dependency tree contains tsx.', failures);
-  assertCondition(
-    contract.requiresExpoDist === probe.expoDistExists,
-    contract.requiresExpoDist
-      ? 'Web static assets are missing.'
-      : 'Non-Web image contains Expo static assets.',
-    failures,
-  );
-  assertCondition(
-    contract.requiresMigrationAssets === probe.migrationAssets.length > 0,
-    contract.requiresMigrationAssets
-      ? 'Migration SQL assets are missing.'
-      : 'Non-Migration image contains drizzle assets.',
-    failures,
-  );
-
-  if (contract.requiresWorkerRuntime) {
-    const expectedRelease = 'aarch64-unknown-linux-gnu';
-    assertCondition(probe.workflowBundleExists, 'Worker Workflow bundle is missing.', failures);
-    assertCondition(
-      probe.coreBridgeReleases.length === 1 &&
-        probe.coreBridgeReleases[0].platform === expectedRelease &&
-        probe.coreBridgeReleases[0].exists,
-      `Worker must retain only ${expectedRelease} core-bridge release.`,
-      failures,
-    );
-  }
-
-  const sizeBytes = imageRecord.Size;
-  const baselineSizeBytes = baselineRecord?.Size;
-  if (baselineSizeBytes !== undefined) {
-    assertCondition(
-      sizeBytes < baselineSizeBytes,
-      `Image size ${sizeBytes} is not smaller than baseline ${baselineSizeBytes}.`,
-      failures,
-    );
-  }
-
-  return {
-    image: imageRecord.RepoTags?.[0] ?? imageRecord.Id,
-    runtime,
-    sizeBytes,
-    layers: imageRecord.RootFS?.Layers?.length ?? null,
-    baselineSizeBytes: baselineSizeBytes ?? null,
-    checks: {
-      entrypoint: entrypoint,
-      uid: probe.uid,
-      gid: probe.gid,
-      artifactDirectory: contract.artifactDirectory,
-      forbiddenNodeModules: probe.forbiddenNodeModules,
-      rootDependencyEntries: probe.rootDependencyEntries,
-      tsxPaths: probe.tsxPaths,
-      sourceFiles: probe.sourceFiles,
-      mapFiles: probe.mapFiles,
-      mapReferences: probe.mapReferences,
-      coreBridgeReleases: probe.coreBridgeReleases,
-    },
-    failures,
-  };
+function artifactPath(directory, file) {
+  return `/app/server-dist/${directory}/${file}`;
 }
 
 export async function checkRuntimeImage({
@@ -423,27 +205,73 @@ export async function checkRuntimeImage({
 
   const imageRecord = await inspectImage(docker, image);
   const baselineRecord = baselineImage ? await inspectImage(docker, baselineImage) : undefined;
-  const probe = await probeImage({ docker, image, platform, runtime, contract });
-  const report = validateProbe({ imageRecord, baselineRecord, probe, runtime, contract });
+  const probe = await probeImage({
+    docker,
+    image,
+    platform,
+    runtime,
+    entrypoint: contract.entrypoint,
+  });
+  const requiredFiles = ['index.mjs', 'meta.json', 'runtime-package.json'].map((file) =>
+    artifactPath(contract.artifactDirectory, file),
+  );
 
-  if (report.failures.length > 0) {
-    throw new Error(
-      `Runtime image gate failed:\n${report.failures.map((failure) => `- ${failure}`).join('\n')}`,
+  assert(
+    JSON.stringify(imageRecord.Config?.Entrypoint) ===
+      JSON.stringify(['node', contract.entrypoint]),
+    `unexpected entrypoint ${JSON.stringify(imageRecord.Config?.Entrypoint)}`,
+  );
+  assert(probe.uid === 10001 && probe.gid === 10001, 'runtime must use uid/gid 10001');
+  assert(probe.entrypoint && !probe.dispatcher, 'fixed JavaScript entrypoint is not isolated');
+  assert(
+    probe.artifactDirectories.length === 1 &&
+      probe.artifactDirectories[0] === contract.artifactDirectory,
+    `unexpected artifact directories: ${probe.artifactDirectories.join(', ')}`,
+  );
+  assert(
+    requiredFiles.every((file) => probe.artifactFiles.includes(file)),
+    'artifact, metadata, or generated runtime manifest is missing',
+  );
+  assert(probe.sourceFiles.length === 0, `TypeScript source remains: ${probe.sourceFiles[0]}`);
+  assert(probe.mapFiles.length === 0 && !probe.sourceMapReference, 'source map remains');
+  assert(
+    probe.manifest && probe.missingDependencies.length === 0,
+    'runtime manifest is incomplete',
+  );
+  assert(!probe.tsx, 'runtime manifest contains tsx');
+  assert(probe.expo === Boolean(contract.expo), 'Expo assets are in the wrong image');
+  assert(
+    probe.migrations === Boolean(contract.migrations),
+    'migration assets are in the wrong image',
+  );
+  assert(probe.workerPackage === Boolean(contract.worker), 'Worker SDK is in the wrong image');
+  if (contract.worker) {
+    assert(probe.workflowBundle, 'prebuilt Workflow bundle is missing');
+    assert(
+      probe.bridgeReleases.length === 1 &&
+        probe.bridgeReleases[0].platform === 'aarch64-unknown-linux-gnu' &&
+        probe.bridgeReleases[0].binary,
+      'Worker must contain only the Linux/ARM64 native bridge',
     );
   }
+  if (baselineRecord) {
+    assert(imageRecord.Size < baselineRecord.Size, 'image is not smaller than the baseline');
+  }
 
-  return report;
+  return {
+    image: imageRecord.RepoTags?.[0] ?? imageRecord.Id,
+    runtime,
+    sizeBytes: imageRecord.Size,
+    baselineSizeBytes: baselineRecord?.Size ?? null,
+    layers: imageRecord.RootFS?.Layers?.length ?? null,
+    dependencies: probe.dependencies,
+  };
 }
 
 if (import.meta.main) {
   try {
     const options = parseArguments(process.argv.slice(2));
-    if (options.help) {
-      console.log(usage());
-    } else {
-      const report = await checkRuntimeImage(options);
-      console.log(JSON.stringify(report, null, 2));
-    }
+    console.log(options.help ? usage() : JSON.stringify(await checkRuntimeImage(options), null, 2));
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/scripts/check-server-runtime-image.mjs
+++ b/scripts/check-server-runtime-image.mjs
@@ -59,10 +59,17 @@ const artifactRoot = '/app/server-dist';
 const artifactDirectory = join(artifactRoot, runtime);
 const artifactFiles = walk(artifactRoot);
 const manifestPath = join(artifactDirectory, 'runtime-package.json');
-const manifest = existsSync(manifestPath)
-  ? JSON.parse(readFileSync(manifestPath, 'utf8'))
-  : undefined;
-const dependencies = Object.keys(manifest?.dependencies ?? {}).sort();
+const metadata = JSON.parse(readFileSync(join(artifactDirectory, 'meta.json'), 'utf8'));
+const externalImports = metadata.externalImports ?? [];
+const runtimeRequire = createRequire(entrypoint);
+const missingExternalImports = externalImports.filter((specifier) => {
+  try {
+    runtimeRequire.resolve(specifier);
+    return false;
+  } catch {
+    return true;
+  }
+});
 const nodeModules = existsSync('/app/node_modules');
 let workerPackage;
 try {
@@ -98,13 +105,11 @@ process.stdout.write(JSON.stringify({
   sourceMapReference: artifactFiles
     .filter((path) => /\.(?:c|m)?js$/u.test(path))
     .some((path) => readFileSync(path, 'utf8').includes('sourceMappingURL=')),
-  runtimePackage: manifest !== undefined,
+  runtimePackage: existsSync(manifestPath),
   nodeModules,
-  dependencies,
-  missingDependencies: dependencies.filter(
-    (dependency) => !existsSync(join('/app/node_modules', dependency)),
-  ),
-  tsx: dependencies.includes('tsx') || existsSync('/app/node_modules/tsx'),
+  externalImports,
+  missingExternalImports,
+  tsx: existsSync('/app/node_modules/tsx'),
   workerPackage: workerPackage !== undefined,
   bridgeReleases,
   expo: existsSync('/app/apps/app/dist'),
@@ -215,9 +220,6 @@ export async function checkRuntimeImage({
     entrypoint: contract.entrypoint,
   });
   const requiredFiles = ['index.mjs', 'meta.json'];
-  if (contract.worker) {
-    requiredFiles.push('runtime-package.json');
-  }
   const requiredArtifactFiles = requiredFiles.map((file) =>
     artifactPath(contract.artifactDirectory, file),
   );
@@ -236,20 +238,17 @@ export async function checkRuntimeImage({
   );
   assert(
     requiredArtifactFiles.every((file) => probe.artifactFiles.includes(file)),
-    'artifact, metadata, or Worker runtime manifest is missing',
+    'artifact or metadata is missing',
   );
   assert(probe.sourceFiles.length === 0, `TypeScript source remains: ${probe.sourceFiles[0]}`);
   assert(probe.mapFiles.length === 0 && !probe.sourceMapReference, 'source map remains');
-  if (contract.worker) {
-    assert(probe.runtimePackage && probe.nodeModules, 'Worker runtime dependencies are missing');
-    assert(probe.missingDependencies.length === 0, 'Worker runtime manifest is incomplete');
-  } else {
-    assert(
-      !probe.runtimePackage && !probe.nodeModules,
-      'non-Worker image contains runtime dependencies',
-    );
-  }
-  assert(!probe.tsx, 'runtime manifest contains tsx');
+  assert(!probe.runtimePackage, 'generated runtime manifest remains');
+  assert(probe.nodeModules, 'production dependency tree is missing');
+  assert(
+    probe.missingExternalImports.length === 0,
+    `external import is missing: ${probe.missingExternalImports[0]}`,
+  );
+  assert(!probe.tsx, 'production dependency tree contains tsx');
   assert(probe.expo === Boolean(contract.expo), 'Expo assets are in the wrong image');
   assert(
     probe.migrations === Boolean(contract.migrations),
@@ -275,7 +274,7 @@ export async function checkRuntimeImage({
     sizeBytes: imageRecord.Size,
     baselineSizeBytes: baselineRecord?.Size ?? null,
     layers: imageRecord.RootFS?.Layers?.length ?? null,
-    dependencies: probe.dependencies,
+    externalImports: probe.externalImports,
   };
 }
 

--- a/scripts/check-server-runtime-image.mjs
+++ b/scripts/check-server-runtime-image.mjs
@@ -58,18 +58,6 @@ function walk(root) {
 const artifactRoot = '/app/server-dist';
 const artifactDirectory = join(artifactRoot, runtime);
 const artifactFiles = walk(artifactRoot);
-const manifestPath = join(artifactDirectory, 'runtime-package.json');
-const metadata = JSON.parse(readFileSync(join(artifactDirectory, 'meta.json'), 'utf8'));
-const externalImports = metadata.externalImports ?? [];
-const runtimeRequire = createRequire(entrypoint);
-const missingExternalImports = externalImports.filter((specifier) => {
-  try {
-    runtimeRequire.resolve(specifier);
-    return false;
-  } catch {
-    return true;
-  }
-});
 const nodeModules = existsSync('/app/node_modules');
 let workerPackage;
 try {
@@ -105,10 +93,8 @@ process.stdout.write(JSON.stringify({
   sourceMapReference: artifactFiles
     .filter((path) => /\.(?:c|m)?js$/u.test(path))
     .some((path) => readFileSync(path, 'utf8').includes('sourceMappingURL=')),
-  runtimePackage: existsSync(manifestPath),
+  runtimePackage: existsSync(join(artifactDirectory, 'runtime-package.json')),
   nodeModules,
-  externalImports,
-  missingExternalImports,
   tsx: existsSync('/app/node_modules/tsx'),
   workerPackage: workerPackage !== undefined,
   bridgeReleases,
@@ -219,7 +205,7 @@ export async function checkRuntimeImage({
     runtime,
     entrypoint: contract.entrypoint,
   });
-  const requiredFiles = ['index.mjs', 'meta.json'];
+  const requiredFiles = ['index.mjs'];
   const requiredArtifactFiles = requiredFiles.map((file) =>
     artifactPath(contract.artifactDirectory, file),
   );
@@ -238,16 +224,12 @@ export async function checkRuntimeImage({
   );
   assert(
     requiredArtifactFiles.every((file) => probe.artifactFiles.includes(file)),
-    'artifact or metadata is missing',
+    'artifact is missing',
   );
   assert(probe.sourceFiles.length === 0, `TypeScript source remains: ${probe.sourceFiles[0]}`);
   assert(probe.mapFiles.length === 0 && !probe.sourceMapReference, 'source map remains');
   assert(!probe.runtimePackage, 'generated runtime manifest remains');
   assert(probe.nodeModules, 'production dependency tree is missing');
-  assert(
-    probe.missingExternalImports.length === 0,
-    `external import is missing: ${probe.missingExternalImports[0]}`,
-  );
   assert(!probe.tsx, 'production dependency tree contains tsx');
   assert(probe.expo === Boolean(contract.expo), 'Expo assets are in the wrong image');
   assert(
@@ -274,7 +256,6 @@ export async function checkRuntimeImage({
     sizeBytes: imageRecord.Size,
     baselineSizeBytes: baselineRecord?.Size ?? null,
     layers: imageRecord.RootFS?.Layers?.length ?? null,
-    externalImports: probe.externalImports,
   };
 }
 

--- a/scripts/check-server-runtime-image.mjs
+++ b/scripts/check-server-runtime-image.mjs
@@ -1,0 +1,451 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const RUNTIME_IMAGE_CONTRACTS = Object.freeze({
+  web: Object.freeze({
+    artifactDirectory: 'web',
+    entrypoint: '/app/server-dist/web/index.mjs',
+    requiresExpoDist: true,
+    requiresMigrationAssets: false,
+    requiresRuntimeDependencies: true,
+    requiresWorkerRuntime: false,
+  }),
+  api: Object.freeze({
+    artifactDirectory: 'api',
+    entrypoint: '/app/server-dist/api/index.mjs',
+    requiresExpoDist: false,
+    requiresMigrationAssets: false,
+    requiresRuntimeDependencies: true,
+    requiresWorkerRuntime: false,
+  }),
+  worker: Object.freeze({
+    artifactDirectory: 'worker',
+    entrypoint: '/app/server-dist/worker/index.mjs',
+    requiresExpoDist: false,
+    requiresMigrationAssets: false,
+    requiresRuntimeDependencies: true,
+    requiresWorkerRuntime: true,
+  }),
+  'fedify-consumer': Object.freeze({
+    artifactDirectory: 'fedify-consumer',
+    entrypoint: '/app/server-dist/fedify-consumer/index.mjs',
+    requiresExpoDist: false,
+    requiresMigrationAssets: false,
+    requiresRuntimeDependencies: true,
+    requiresWorkerRuntime: false,
+  }),
+  migration: Object.freeze({
+    artifactDirectory: 'migration',
+    entrypoint: '/app/server-dist/migration/index.mjs',
+    requiresExpoDist: false,
+    requiresMigrationAssets: true,
+    requiresRuntimeDependencies: false,
+    requiresWorkerRuntime: false,
+  }),
+});
+
+const runtimeNames = Object.keys(RUNTIME_IMAGE_CONTRACTS);
+
+export const RUNTIME_PROBE_SCRIPT = String.raw`
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const runtime = process.env.KOSMO_RUNTIME;
+const entrypoint = process.env.KOSMO_ENTRYPOINT;
+const artifactRoot = '/app/server-dist';
+
+function collectFiles(root) {
+  if (!existsSync(root)) {
+    return [];
+  }
+
+  const files = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        pending.push(path);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(path);
+      }
+    }
+  }
+  return files;
+}
+
+function collectCoreBridgeReleases() {
+  const virtualStore = '/app/node_modules/.pnpm';
+  if (!existsSync(virtualStore)) {
+    return [];
+  }
+
+  const releases = [];
+  for (const packageEntry of readdirSync(virtualStore, { withFileTypes: true })) {
+    if (!packageEntry.isDirectory() || !packageEntry.name.startsWith('@temporalio+core-bridge@')) {
+      continue;
+    }
+
+    const releasesPath = join(
+      virtualStore,
+      packageEntry.name,
+      'node_modules/@temporalio/core-bridge/releases',
+    );
+    if (!existsSync(releasesPath)) {
+      continue;
+    }
+
+    for (const releaseEntry of readdirSync(releasesPath, { withFileTypes: true })) {
+      if (!releaseEntry.isDirectory()) {
+        continue;
+      }
+      const binaryPath = join(releasesPath, releaseEntry.name, 'index.node');
+      releases.push({
+        package: packageEntry.name,
+        platform: releaseEntry.name,
+        binary: binaryPath,
+        exists: existsSync(binaryPath),
+      });
+    }
+  }
+  return releases;
+}
+
+const artifactFiles = collectFiles(artifactRoot);
+const runtimeFiles = runtime === 'web' ? collectFiles('/app/apps/app/dist') : [];
+const sourceFiles = [...artifactFiles, ...runtimeFiles].filter((path) => /\.(?:cts|mts|ts|tsx)$/u.test(path));
+const mapFiles = artifactFiles.filter((path) => path.endsWith('.map'));
+const mapReferences = artifactFiles
+  .filter((path) => /\.(?:c|m)?js$/u.test(path))
+  .filter((path) => readFileSync(path, 'utf8').includes('sourceMappingURL='));
+const forbiddenNodeModules = [
+  '/app/node_modules',
+  '/app/apps/api/node_modules',
+  '/app/apps/app/node_modules',
+  '/app/apps/fedify-consumer/node_modules',
+  '/app/apps/worker/node_modules',
+  '/app/apps/web/node_modules',
+  '/app/packages/core/node_modules',
+  '/app/packages/fedify/node_modules',
+].filter((path) => existsSync(path));
+const rootDependencyEntries = existsSync('/app/node_modules')
+  ? readdirSync('/app/node_modules')
+      .filter((name) => name !== '.pnpm' && name !== '.modules.yaml' && name !== '.pnpm-workspace-state-v1.json')
+      .filter((name) => name !== '.package-map.json')
+      .filter((name) => name !== '.bin')
+      .sort()
+  : [];
+const tsxPaths = existsSync('/app/node_modules')
+  ? collectFiles('/app/node_modules').filter((path) => /(?:^|\/)tsx(?:@|\/)/u.test(path))
+  : [];
+
+const report = {
+  runtime,
+  uid: process.getuid?.(),
+  gid: process.getgid?.(),
+  entrypointExists: existsSync(entrypoint),
+  dispatcherExists: existsSync('/app/docker-entrypoint.sh'),
+  artifactFiles,
+  artifactDirectories: existsSync(artifactRoot)
+    ? readdirSync(artifactRoot, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort()
+    : [],
+  sourceFiles,
+  mapFiles,
+  mapReferences,
+  forbiddenNodeModules,
+  rootDependencyEntries,
+  tsxPaths,
+  expoDistExists: existsSync('/app/apps/app/dist'),
+  migrationAssets: existsSync('/app/drizzle')
+    ? collectFiles('/app/drizzle').filter((path) => path.endsWith('.sql'))
+    : [],
+  workflowBundleExists: existsSync('/app/server-dist/worker/workflow-bundle.js'),
+  coreBridgeReleases: collectCoreBridgeReleases(),
+  packageJsonExists: existsSync('/app/package.json'),
+  serverRuntimeSource: existsSync(entrypoint) ? readFileSync(entrypoint, 'utf8') : '',
+};
+
+process.stdout.write(JSON.stringify(report));
+`;
+
+function usage() {
+  return [
+    'Usage: node scripts/check-server-runtime-image.mjs --runtime <name> --image <ref> [options]',
+    '',
+    `Runtime names: ${runtimeNames.join(', ')}`,
+    'Options:',
+    '  --platform <platform>       Docker target platform (default: linux/arm64)',
+    '  --baseline-image <ref>      Compare uncompressed image size against this image',
+    '  --docker <path>             Docker executable (default: docker)',
+  ].join('\n');
+}
+
+export function parseArguments(arguments_) {
+  const options = { docker: 'docker', platform: 'linux/arm64' };
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === '--help' || argument === '-h') {
+      return { help: true };
+    }
+
+    const value = arguments_[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${argument}.\n\n${usage()}`);
+    }
+
+    if (argument === '--runtime') {
+      options.runtime = value;
+    } else if (argument === '--image') {
+      options.image = value;
+    } else if (argument === '--platform') {
+      options.platform = value;
+    } else if (argument === '--baseline-image') {
+      options.baselineImage = value;
+    } else if (argument === '--docker') {
+      options.docker = value;
+    } else {
+      throw new Error(`Unknown argument ${argument}.\n\n${usage()}`);
+    }
+    index += 1;
+  }
+
+  if (!options.runtime || !RUNTIME_IMAGE_CONTRACTS[options.runtime]) {
+    throw new Error(`--runtime must be one of: ${runtimeNames.join(', ')}.\n\n${usage()}`);
+  }
+  if (!options.image) {
+    throw new Error(`--image is required.\n\n${usage()}`);
+  }
+
+  return options;
+}
+
+async function dockerJson(docker, arguments_) {
+  const { stdout } = await execFileAsync(docker, arguments_, { maxBuffer: 10 * 1024 * 1024 });
+  return JSON.parse(stdout);
+}
+
+async function inspectImage(docker, image) {
+  const records = await dockerJson(docker, ['image', 'inspect', image]);
+  if (!Array.isArray(records) || records.length !== 1) {
+    throw new Error(`Docker image inspect returned an unexpected result for ${image}.`);
+  }
+  return records[0];
+}
+
+async function probeImage({ docker, image, platform, runtime, contract }) {
+  const { stdout } = await execFileAsync(
+    docker,
+    [
+      'run',
+      '--rm',
+      '--platform',
+      platform,
+      '--entrypoint',
+      'node',
+      '--env',
+      `KOSMO_RUNTIME=${runtime}`,
+      '--env',
+      `KOSMO_ENTRYPOINT=${contract.entrypoint}`,
+      image,
+      '--input-type=module',
+      '-e',
+      RUNTIME_PROBE_SCRIPT,
+    ],
+    { maxBuffer: 50 * 1024 * 1024 },
+  );
+  return JSON.parse(stdout);
+}
+
+function assertCondition(condition, message, failures) {
+  if (!condition) {
+    failures.push(message);
+  }
+}
+
+function validateProbe({ imageRecord, baselineRecord, probe, runtime, contract }) {
+  const failures = [];
+  const config = imageRecord.Config ?? {};
+  const entrypoint = config.Entrypoint ?? [];
+
+  assertCondition(
+    JSON.stringify(entrypoint) === JSON.stringify(['node', contract.entrypoint]),
+    `Entrypoint must be ["node", "${contract.entrypoint}"], received ${JSON.stringify(entrypoint)}.`,
+    failures,
+  );
+  assertCondition(
+    probe.uid === 10001,
+    `Container uid must be 10001, received ${probe.uid}.`,
+    failures,
+  );
+  assertCondition(
+    probe.gid === 10001,
+    `Container gid must be 10001, received ${probe.gid}.`,
+    failures,
+  );
+  assertCondition(
+    probe.entrypointExists,
+    `Entrypoint file is missing: ${contract.entrypoint}.`,
+    failures,
+  );
+  assertCondition(
+    !probe.dispatcherExists,
+    'Legacy docker-entrypoint.sh must not be in split images.',
+    failures,
+  );
+  assertCondition(
+    probe.artifactDirectories.length === 1 &&
+      probe.artifactDirectories[0] === contract.artifactDirectory,
+    `Only ${contract.artifactDirectory} may be under /app/server-dist; received ${probe.artifactDirectories.join(', ')}.`,
+    failures,
+  );
+  assertCondition(
+    probe.artifactFiles.includes(`/app/server-dist/${contract.artifactDirectory}/index.mjs`),
+    'The runtime JavaScript artifact is missing.',
+    failures,
+  );
+  assertCondition(
+    probe.artifactFiles.includes(`/app/server-dist/${contract.artifactDirectory}/meta.json`),
+    'The runtime artifact metadata is missing.',
+    failures,
+  );
+  assertCondition(
+    probe.sourceFiles.length === 0,
+    `TypeScript source is present: ${probe.sourceFiles.join(', ')}.`,
+    failures,
+  );
+  assertCondition(
+    probe.mapFiles.length === 0,
+    `Source maps are present: ${probe.mapFiles.join(', ')}.`,
+    failures,
+  );
+  assertCondition(
+    probe.mapReferences.length === 0,
+    `Source-map references are present: ${probe.mapReferences.join(', ')}.`,
+    failures,
+  );
+  const unexpectedNodeModules = contract.requiresRuntimeDependencies
+    ? probe.forbiddenNodeModules.filter((path) => path !== '/app/node_modules')
+    : probe.forbiddenNodeModules;
+  assertCondition(
+    unexpectedNodeModules.length === 0,
+    `Workspace node_modules are present: ${unexpectedNodeModules.join(', ')}.`,
+    failures,
+  );
+  const expectedRootDependencies = contract.requiresWorkerRuntime
+    ? ['@temporalio', 'jsdom']
+    : contract.requiresRuntimeDependencies
+      ? ['@temporalio', 'jsdom']
+      : [];
+  assertCondition(
+    JSON.stringify(probe.rootDependencyEntries) === JSON.stringify(expectedRootDependencies),
+    `Root runtime dependencies must be ${expectedRootDependencies.join(', ') || '(none)'}; received ${probe.rootDependencyEntries.join(', ') || '(none)'}.`,
+    failures,
+  );
+  assertCondition(probe.tsxPaths.length === 0, 'Runtime dependency tree contains tsx.', failures);
+  assertCondition(
+    contract.requiresExpoDist === probe.expoDistExists,
+    contract.requiresExpoDist
+      ? 'Web static assets are missing.'
+      : 'Non-Web image contains Expo static assets.',
+    failures,
+  );
+  assertCondition(
+    contract.requiresMigrationAssets === probe.migrationAssets.length > 0,
+    contract.requiresMigrationAssets
+      ? 'Migration SQL assets are missing.'
+      : 'Non-Migration image contains drizzle assets.',
+    failures,
+  );
+
+  if (contract.requiresWorkerRuntime) {
+    const expectedRelease = 'aarch64-unknown-linux-gnu';
+    assertCondition(probe.workflowBundleExists, 'Worker Workflow bundle is missing.', failures);
+    assertCondition(
+      probe.coreBridgeReleases.length === 1 &&
+        probe.coreBridgeReleases[0].platform === expectedRelease &&
+        probe.coreBridgeReleases[0].exists,
+      `Worker must retain only ${expectedRelease} core-bridge release.`,
+      failures,
+    );
+  }
+
+  const sizeBytes = imageRecord.Size;
+  const baselineSizeBytes = baselineRecord?.Size;
+  if (baselineSizeBytes !== undefined) {
+    assertCondition(
+      sizeBytes < baselineSizeBytes,
+      `Image size ${sizeBytes} is not smaller than baseline ${baselineSizeBytes}.`,
+      failures,
+    );
+  }
+
+  return {
+    image: imageRecord.RepoTags?.[0] ?? imageRecord.Id,
+    runtime,
+    sizeBytes,
+    layers: imageRecord.RootFS?.Layers?.length ?? null,
+    baselineSizeBytes: baselineSizeBytes ?? null,
+    checks: {
+      entrypoint: entrypoint,
+      uid: probe.uid,
+      gid: probe.gid,
+      artifactDirectory: contract.artifactDirectory,
+      forbiddenNodeModules: probe.forbiddenNodeModules,
+      rootDependencyEntries: probe.rootDependencyEntries,
+      tsxPaths: probe.tsxPaths,
+      sourceFiles: probe.sourceFiles,
+      mapFiles: probe.mapFiles,
+      mapReferences: probe.mapReferences,
+      coreBridgeReleases: probe.coreBridgeReleases,
+    },
+    failures,
+  };
+}
+
+export async function checkRuntimeImage({
+  docker = 'docker',
+  image,
+  baselineImage,
+  platform = 'linux/arm64',
+  runtime,
+}) {
+  const contract = RUNTIME_IMAGE_CONTRACTS[runtime];
+  if (!contract) {
+    throw new Error(`Unknown runtime ${runtime}.`);
+  }
+
+  const imageRecord = await inspectImage(docker, image);
+  const baselineRecord = baselineImage ? await inspectImage(docker, baselineImage) : undefined;
+  const probe = await probeImage({ docker, image, platform, runtime, contract });
+  const report = validateProbe({ imageRecord, baselineRecord, probe, runtime, contract });
+
+  if (report.failures.length > 0) {
+    throw new Error(
+      `Runtime image gate failed:\n${report.failures.map((failure) => `- ${failure}`).join('\n')}`,
+    );
+  }
+
+  return report;
+}
+
+if (import.meta.main) {
+  try {
+    const options = parseArguments(process.argv.slice(2));
+    if (options.help) {
+      console.log(usage());
+    } else {
+      const report = await checkRuntimeImage(options);
+      console.log(JSON.stringify(report, null, 2));
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-server-runtime-image.test.mjs
+++ b/scripts/check-server-runtime-image.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseArguments, RUNTIME_IMAGE_CONTRACTS } from './check-server-runtime-image.mjs';
+
+test('runtime image contracts cover exactly the five split targets', () => {
+  assert.deepEqual(Object.keys(RUNTIME_IMAGE_CONTRACTS), [
+    'web',
+    'api',
+    'worker',
+    'fedify-consumer',
+    'migration',
+  ]);
+  assert.deepEqual(
+    Object.values(RUNTIME_IMAGE_CONTRACTS).map(({ entrypoint }) => entrypoint),
+    [
+      '/app/server-dist/web/index.mjs',
+      '/app/server-dist/api/index.mjs',
+      '/app/server-dist/worker/index.mjs',
+      '/app/server-dist/fedify-consumer/index.mjs',
+      '/app/server-dist/migration/index.mjs',
+    ],
+  );
+});
+
+test('asset-backed runtimes carry only their explicit production dependency tree', () => {
+  assert.equal(RUNTIME_IMAGE_CONTRACTS.worker.requiresWorkerRuntime, true);
+  assert.equal(RUNTIME_IMAGE_CONTRACTS.migration.requiresRuntimeDependencies, false);
+  for (const [runtime, contract] of Object.entries(RUNTIME_IMAGE_CONTRACTS)) {
+    if (runtime !== 'worker') {
+      assert.equal(contract.requiresWorkerRuntime, false);
+    }
+  }
+});
+
+test('argument parser requires a known runtime and image', () => {
+  assert.deepEqual(parseArguments(['--runtime', 'api', '--image', 'example/api:local']), {
+    docker: 'docker',
+    platform: 'linux/arm64',
+    runtime: 'api',
+    image: 'example/api:local',
+  });
+  assert.throws(
+    () => parseArguments(['--runtime', 'unknown', '--image', 'example:local']),
+    /must be one of/,
+  );
+  assert.throws(() => parseArguments(['--runtime', 'api']), /--image is required/);
+});

--- a/scripts/check-server-runtime-image.test.mjs
+++ b/scripts/check-server-runtime-image.test.mjs
@@ -22,12 +22,11 @@ test('runtime image contracts cover exactly the five split targets', () => {
   );
 });
 
-test('asset-backed runtimes carry only their explicit production dependency tree', () => {
-  assert.equal(RUNTIME_IMAGE_CONTRACTS.worker.requiresWorkerRuntime, true);
-  assert.equal(RUNTIME_IMAGE_CONTRACTS.migration.requiresRuntimeDependencies, false);
+test('only the Worker contract requires the Temporal native runtime', () => {
+  assert.equal(RUNTIME_IMAGE_CONTRACTS.worker.worker, true);
   for (const [runtime, contract] of Object.entries(RUNTIME_IMAGE_CONTRACTS)) {
     if (runtime !== 'worker') {
-      assert.equal(contract.requiresWorkerRuntime, false);
+      assert.equal(contract.worker, undefined);
     }
   }
 });


### PR DESCRIPTION
## 무엇을 변경했나요

- Web, API, Temporal Worker, Fedify Consumer와 Migration의 workspace-owned code를 Node 26 ESM JavaScript artifact로 bundle합니다.
- Third-party package는 각 workspace manifest와 root lockfile에서 `pnpm deploy --legacy --prod`로 생성한 production dependency tree를 사용합니다.
- `runtime-package.json`, package별 bundler patch와 수동 dependency allowlist를 제거했습니다.
- 다섯 runtime의 `tsx`를 development dependency로 옮겨 final image의 production dependency tree에서 제외했습니다.
- 각 final image는 자신의 JavaScript artifact와 production dependency만 포함하고 고정 Node entrypoint와 non-root user를 사용합니다.
- Worker는 production 시작 전에 Workflow bundle을 생성하고 Linux/ARM64 native bridge만 남깁니다.
- Server build는 다섯 entrypoint를 한 번의 esbuild 호출로 생성하고, 별도 artifact metadata나 build manifest를 만들지 않습니다.
- Image checker는 고정 entrypoint, artifact 격리, production dependency tree, runtime별 asset과 native 경계를 검사합니다.

## 왜 변경했나요

기존 통합 이미지는 다섯 runtime의 TypeScript source와 전체 production dependency를 함께 포함하고 `tsx`로 직접 실행합니다. 앞선 single-file 구현은 이미지가 작았지만 JSDOM 등 package-relative asset을 처리하기 위한 custom transform과 generated runtime manifest를 만들었고, 정상적인 dependency 변경이 build script와 테스트를 쉽게 깨뜨리는 구조였습니다.

이번 변경은 package manager가 이미 소유하는 workspace manifest와 lockfile을 production dependency의 유일한 source of truth로 사용합니다. Literal single-file보다 일부 image가 커지는 대신 package internals를 패치하지 않고 API가 `@temporalio/client` 같은 runtime dependency를 추가해도 일반 dependency 변경만으로 반영됩니다.

## 이번 PR의 주요 결정

### 이번 PR은 artifact 이미지 빌드까지만 포함한다

- 결정자: Jiyu Park
- 선택: 다섯 JavaScript artifact와 Docker target, 검사 도구까지만 포함하고 Helm·CI/CD·dev·production 전환은 후속 PR로 남깁니다.
- 고려한 대안: 이미지 생성과 Helm/release workflow 전환을 한 PR에서 함께 수행하는 방식
- 이유: artifact/runtime 결함과 배포 계약 결함을 별도 gate로 검증하고 롤백 범위를 작게 유지하기 위해서입니다.
- 감수한 결과: 이 PR이 merge되어도 기존 workload는 계속 통합 runtime image를 사용하며 OpenSpec change도 active 상태로 남습니다.
- 관련 근거: [Linear PROD-831](https://linear.app/byulmaru/issue/PROD-831), [OpenSpec tasks](https://github.com/byulmaru/kosmo/blob/PROD-831/openspec/changes/split-server-runtime-images/tasks.md)

### Third-party dependency는 runtime별 production tree로 배치한다

- 결정자: Jiyu Park
- 선택: workspace code만 bundle하고 third-party package는 각 runtime workspace의 production dependency tree로 배치합니다. Generated runtime manifest와 package별 bundler patch는 만들지 않습니다.
- 고려한 대안: 모든 third-party package를 literal single-file로 bundle하는 방식, build graph에서 synthetic runtime manifest를 생성하는 방식, workspace 전체 hoisted install을 공유하는 방식
- 이유: package-relative asset과 native module의 표준 resolution을 유지하면서 dependency contract를 workspace manifest와 root lockfile 한 곳에만 두기 위해서입니다.
- 감수한 결과: literal single-file image보다 커질 수 있으며 runtime별 production `node_modules`가 남습니다.
- 관련 근거: [OpenSpec decisions](https://github.com/byulmaru/kosmo/blob/PROD-831/openspec/changes/split-server-runtime-images/decisions.md)

### Temporal Workflow는 production 시작 전에 별도 bundle한다

- 결정자: Jiyu Park
- 선택: Worker host는 일반 JavaScript artifact로 만들되 Workflow code는 `bundleWorkflowCode`로 사전 생성하고 production Worker에 `workflowBundle`로 전달합니다.
- 고려한 대안: production에서 `workflowsPath`를 사용해 startup bundling을 수행하는 방식, Temporal Worker SDK와 native bridge를 application artifact에 강제로 포함하는 방식
- 이유: Workflow sandbox 경계와 native module resolution을 보존하면서 final image의 TypeScript source와 startup bundling을 제거하기 위해서입니다.
- 감수한 결과: Worker image는 Temporal SDK production tree와 target native bridge를 별도로 유지합니다.
- 관련 근거: [Temporal 공식 production sample](https://github.com/temporalio/samples-typescript/blob/main/production/src/worker.ts)

## 어떻게 확인할 수 있나요

- Server artifact/image checker test: 4/4
- Worker compile/unit/lifecycle test: 7/7
- In-memory Temporal Workflow integration test: 2/2
- API, Web, Fedify Consumer TypeScript check 통과
- Prettier, ESLint, OpenSpec strict validation, `git diff --check` 통과
- GitHub CI: 13/13 통과

다섯 Linux/ARM64 final image의 build·external import resolution·boot/health·compressed size gate는 아직 완료 증거가 아닙니다. PR CI에는 Docker target build가 없고 main 전용 Docker workflow는 아직 기존 single-image contract를 사용합니다. 이 증거가 생기기 전까지 PR은 Draft로 유지합니다.

## 아직 어떤 문제가 남았나요

- 승인된 CI/build runner에서 다섯 Linux/ARM64 target build와 runtime image gate 수행
- 결과에 따른 compressed/uncompressed size와 layer 기준 기록
- Helm workload별 image 연결
- CI/CD의 다섯 image build·scan·push와 digest set 구성
- Dev rollout 및 production release 검증
- OpenSpec 작업 5–8 완료와 archive

Stack: main -> PROD-831

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
