### PR TITLE
Deploy Dev를 GitHub 호스티드 러너로 전환한다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,8 +1,6 @@
 name: Deploy Dev
 
 on:
-  push:
-    branches: [PROD-834]
   workflow_run:
     workflows: [Docker Build]
     branches: [main]
@@ -19,7 +17,7 @@ concurrency:
 jobs:
   restart_dev:
     name: Restart Dev Workloads
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04-arm
     env:
       ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -18,10 +18,17 @@ jobs:
   restart_dev:
     name: Restart Dev Workloads
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted, macOS]
+    runs-on: ubuntu-24.04-arm
     env:
       ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net
     steps:
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: tag:github-actions
+
       - name: Get Argo CD token
         id: argocd-token
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -75,7 +82,7 @@ jobs:
               ;;
           esac
 
-          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-darwin-${argocd_arch}"
+          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-${argocd_arch}"
           chmod 555 "${RUNNER_TEMP}/argocd"
           echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,6 +1,8 @@
 name: Deploy Dev
 
 on:
+  push:
+    branches: [PROD-834]
   workflow_run:
     workflows: [Docker Build]
     branches: [main]
@@ -17,7 +19,7 @@ concurrency:
 jobs:
   restart_dev:
     name: Restart Dev Workloads
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04-arm
     env:
       ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net


### PR DESCRIPTION
## 무엇을 변경했나요

- Deploy Dev job을 고정 `self-hosted macOS`에서 GitHub-hosted `ubuntu-24.04-arm`으로 전환했습니다.
- Kosmo 전용 Tailscale OIDC credential과 `tag:github-actions`로 Tailnet에 연결합니다.
- Argo CD CLI asset을 macOS에서 Linux ARM에 맞게 변경했습니다.
- 기존 Docker Build `workflow_run(main)`, GitHub OIDC → Dex token exchange, sync/restart 동작과 직렬 실행 경계는 유지했습니다.

## 왜 변경했나요

Docker Build가 GitHub-hosted runner로 전환된 뒤에도 downstream Deploy Dev가 고정 Mac runner에 남아 있었습니다. 동일한 Tailnet·OIDC 경계를 재사용해 dev 배포의 self-hosted runner 의존성을 제거합니다.

Linear: [PROD-834](https://linear.app/byulmaru/issue/PROD-834/deploy-dev를-github-hosted-runner로-전환한다)

## 이번 PR의 주요 결정

- 결정자: @robin-maki
- runner: `ubuntu-24.04-arm`
- 네트워크: 기존 Kosmo 전용 Tailscale OIDC와 `tag:github-actions -> tag:dev-tools tcp:443` 재사용
- 연결 검증: 별도 ping 없이 실제 `ARGOCD_SERVER` Dex token exchange 결과 사용
- 권한 경계: main subject만 sync/restart를 허용하는 Argo CD RBAC 유지; branch 검증을 위해 권한을 확대하지 않음
- 제외: digest 기반 배포 계약(PROD-100), Argo CD CLI checksum/provenance hardening(PROD-763), production runner 전환

## 검증

- `pnpm exec prettier --check .github/workflows/deploy-dev.yml`
- `actionlint .github/workflows/deploy-dev.yml`
- `git diff --check`
- correctness self-review: 새 blocker 없음
- complexity self-review: `Lean already. Ship.`
- 기존 main/self-hosted baseline: [Deploy Dev #32817710075](https://github.com/byulmaru/kosmo/actions/runs/32817710075), sync/restart 성공
- GitHub-hosted branch 검증: [Deploy Dev #32817995846](https://github.com/byulmaru/kosmo/actions/runs/32817995846)
  - GitHub-hosted Ubuntu ARM runner 배정 성공
  - Tailscale 연결 성공
  - GitHub OIDC → Argo CD Dex token exchange 성공
  - Linux ARM Argo CD CLI 설치·서버 RPC 성공
  - sync는 branch subject `repo:byulmaru/kosmo:ref:refs/heads/PROD-834`에 대한 기존 Argo CD RBAC로 `PermissionDenied`
  - sync 실패 뒤 restart가 실행되지 않는 fail-closed 경계 확인
- 일회성 branch trigger는 최종 workflow에서 제거

## merge 후 운영 검증

main Docker Build 성공 뒤 생성되는 Deploy Dev run에서 아래를 확인합니다.

- main subject의 `kosmo-dev` sync 성공
- API/Web Rollout과 background Deployment restart 성공
- runner label이 `ubuntu-24.04-arm`이며 self-hosted runner가 사용되지 않음

PROD-834는 이 운영 증거가 확인될 때까지 완료 처리하지 않습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>