### PR TITLE
PROD-689 Admin Console 조회 계약을 확정한다

### DIFF
--- a/docs/architecture/admin-console.md
+++ b/docs/architecture/admin-console.md
@@ -1,0 +1,98 @@
+# Admin Console v1 아키텍처
+
+## 목적과 범위
+
+Admin Console은 신뢰된 Tailscale proxy 뒤에서 KOSMO의 Account와 Profile 운영 정보를 읽는 내부 Web
+surface다. v1은 Account, Profile과 Account-Profile Membership을 변경하지 않는다.
+
+이 문서는 요청이 신뢰 경계를 통과해 권한별 read projection으로 변환되는 구조를 정의한다. 객체별 허용
+필드와 제외 필드는 [Admin Console Read Policy](../domain/policies/admin-console-read.md), Capability Holder와
+`Account.Operator`의 분리는
+[ADR 0025](../domain/decisions/0025-admin-console-capability-holder-boundary.md)가 소유한다. 구체적인 route,
+GraphQL field, 저장 모델과 UI layout은 각 구현 slice에서 정한다.
+
+## 신뢰 경계
+
+Admin Console 인가의 유일한 입력은 신뢰된 Tailscale proxy가 전달한 app capability다. proxy identity
+header의 login과 display name은 현재 요청 주체를 표시하기 위한 선택적 metadata이며 인가, Account 매핑,
+조회 filter 또는 projection 계산에 사용하지 않는다.
+
+- Capability Holder는 Kosmo Account가 아니며 `Account.Operator` 권한을 얻지 않는다.
+- identity header가 없어도 capability가 유효하면 허용된 read를 수행할 수 있다.
+- client가 직접 주입한 capability·identity header나 신뢰된 proxy를 우회한 요청은 인가 입력으로 사용하지
+  않는다.
+- frontend navigation이나 화면 표시 여부는 server-side action 검증을 대신하지 않는다.
+
+Admin ingress는 Tailscale Serve가 전달한 capability와 identity wire header를 RFC 2047 decode하고 UTF-8로
+검증한 뒤 downstream에 전달한다. capability header 정규화 실패는 data query 전에 요청을 거부하고, 선택적인
+identity header 정규화 실패는 해당 metadata가 없는 것으로 취급해 인가 결과를 바꾸지 않는다. 도메인 정책은
+이 경계를 통과한 정규화된 capability JSON만 소비한다.
+
+## 요청 처리 경계
+
+```text
+Trusted Tailscale proxy
+  -> Admin Console entry
+  -> wire header normalization
+  -> capability payload validation
+  -> supported action set calculation
+  -> action-scoped query / loader
+  -> policy projection
+  -> response
+```
+
+1. entry는 trusted proxy 경계를 확인하고 capability·identity wire header를 RFC 2047 decode한 뒤 UTF-8로
+   검증한다.
+2. 정규화된 capability payload에 target namespace가 없으면 grant 없음으로 처리한다. target namespace가
+   존재하지만 그 값, parameter object 또는 `action` 배열 타입이 malformed이면 payload 전체를 거부한다.
+   정확한 schema와 valid/malformed 사례는
+   [Admin Console Read Policy](../domain/policies/admin-console-read.md)를 따른다.
+3. `byulmaru.co/cap/kosmo-admin` namespace의 알려진 action만 모아 합집합을 계산한다. unknown action과
+   wildcard는 grant를 만들지 않는다.
+4. 필요한 action이 없으면 대상 query나 loader를 실행하기 전에 요청을 거부한다.
+5. query 계층은 action에 허용된 객체만 읽고
+   [Admin Console Read Policy](../domain/policies/admin-console-read.md)의 projection을 적용한다.
+6. response 조합은 권한 없는 객체나 관계를 `null`, `0`, 빈 배열 또는 placeholder로 암시하지 않는다.
+
+wire header 정규화 이후의 read 흐름은 특정 transport에 종속되지 않는다. read-only query는 state-changing
+application action이 아니므로 불필요한 `packages/core/services` pass-through service를 만들지 않는다. 구현은
+[Core 서비스 경계](./core-services.md)의 read query/loader 방향을 따른다.
+
+## Projection 분리
+
+세 read projection은 서로 독립된 권한 경계다.
+
+| projection                 | 필요한 action                   | 책임                                        |
+| -------------------------- | ------------------------------- | ------------------------------------------- |
+| Account                    | `account.read`                  | Account 목록·상세와 OIDC subject exact 검색 |
+| Profile                    | `profile.read`                  | Profile 목록·상세                           |
+| Account-Profile Membership | `account.read` + `profile.read` | 두 객체 사이의 관계와 양방향 탐색           |
+
+Account와 Profile projection은 상대 객체의 존재, Membership, 관계 count를 포함하지 않는다. 두 action을 모두
+가진 요청도 관계 정보는 별도 Membership projection으로만 받는다. selected Profile은 Membership이 아니라
+Session 상태이므로 세 projection 모두에 포함하지 않는다.
+
+OIDC subject, credential, Session token, private key를 포함한 세부 필드 경계는 architecture 문서에서 반복하지
+않고 [Admin Console Read Policy](../domain/policies/admin-console-read.md)를 따른다.
+
+## 실패 경계
+
+- trusted proxy 경계를 확인할 수 없거나 capability header 정규화에 실패하거나 정규화된 payload가
+  malformed이면 data query 전에 거부한다.
+- capability가 유효하지만 필요한 action이 없으면 해당 객체나 관계 query 전에 거부한다.
+- 권한 검증을 통과한 뒤의 not-found와 내부 query 실패는 인가 실패와 구분한다.
+- 외부 응답에는 capability payload, proxy header, 내부 경로와 backend 원문 오류를 포함하지 않는다.
+
+## 로깅 제외
+
+Admin Console v1은 성공·실패 조회, capability 판정, identity/capability snapshot, proxy 우회·위조 header를
+위한 Admin-specific logging, audit 또는 security-event contract를 만들지 않는다. 기존 공통 runtime
+오류·접근 로그의 생명주기는 이 아키텍처가 변경하지 않는다.
+
+## 전달 경계
+
+- `PROD-690`은 trusted proxy와 capability 검증 기반을 소유한다.
+- `PROD-691`과 `PROD-692`는 각각 Account와 Profile read projection을 소유한다.
+- `PROD-693`은 두 action을 모두 요구하는 Membership relation projection을 소유한다.
+- OpenSpec, 애플리케이션 구현, Figma와 배포는 PROD-689 및 이 문서의 범위가 아니다.
+- 취소된 `DSN-59`의 화면·검토·구현 범위는 이 architecture 문서로 복원하지 않는다.

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -88,6 +88,8 @@ Account 요청에서 Profile이 주체인 행동의 `Account.Active`는 해당 P
 ## 조회 정책
 
 - [Post List Policy](./policies/post-list.md): Home, Local, Profile, Hashtag Post List의 후보와 제어 결정.
+- [Admin Console Read Policy](./policies/admin-console-read.md): Capability Holder의 Account, Profile,
+  Account-Profile Membership 교차 객체 조회 범위와 필드.
 
 ## 결정과 기록
 
@@ -114,6 +116,7 @@ Account 요청에서 Profile이 주체인 행동의 `Account.Active`는 해당 P
 - [ADR 0022: Post Content Revision Media Nodes](./decisions/0022-post-content-revision-media-nodes.md)
 - [ADR 0023: Profile Viewer Membership Edit Eligibility](./decisions/0023-profile-viewer-membership-edit-eligibility.md)
 - [ADR 0024: Application Policy and Runtime DB Boundary](./decisions/0024-application-policy-and-runtime-db-boundary.md)
+- [ADR 0025: Admin Console Capability Holder Boundary](./decisions/0025-admin-console-capability-holder-boundary.md)
 - [2026-06-28 DDD 명세 점검 기록](./records/2026-06-28-ddd-spec-audit.md)
 - [2026-06-29 결정 반영 기록](./records/2026-06-29-decision-round.md)
 - [2026-06-29 PR 리뷰 반영 기록](./records/2026-06-29-pr-review-followup.md)

--- a/docs/domain/decisions/0025-admin-console-capability-holder-boundary.md
+++ b/docs/domain/decisions/0025-admin-console-capability-holder-boundary.md
@@ -1,0 +1,76 @@
+# ADR 0025: Admin Console Capability Holder Boundary
+
+## 상태
+
+Accepted
+
+## 날짜
+
+2026-08-25
+
+## 맥락
+
+Admin Console은 Kosmo의 일반 사용자 인증과 별도로 신뢰된 proxy에서 전달한 capability를 사용해 Account,
+Profile과 Account-Profile Membership을 읽어야 한다. 기존 도메인에서 운영자 행동의 주체는
+`Account.Operator`인 Kosmo Account다. proxy identity header를 Account 인증이나 운영자 권한으로 해석하면
+인증 주체, 운영자 Mutation 권한, 운영자용 read-only 도구의 경계가 합쳐진다.
+
+Tailscale proxy는 요청에 identity header를 제공할 수 있지만 header의 존재나 표시 값만으로 권한을 결정할
+수 없다. 반대로 capability가 유효한 요청은 표시용 identity header가 없어도 읽기 정책을 적용할 수 있어야
+한다.
+
+## 결정
+
+- Admin Console 요청 주체를 `Capability Holder`라는 별도 개념으로 둔다. Capability Holder는 Kosmo
+  Account가 아니며 `Account.Operator` 사실을 갖지 않는다.
+- Admin Console capability namespace는 `byulmaru.co/cap/kosmo-admin`으로 고정한다.
+- v1 action은 `account.read`와 `profile.read`만 지원한다. 두 action을 가진 경우에만
+  Account-Profile Membership을 읽을 수 있다.
+- 인가의 유일한 근거는 신뢰된 proxy가 전달한 capability다. identity header는 선택적인 display metadata이며
+  인가, Account 매핑, `Account.Operator` 판정에 사용하지 않는다.
+- Tailscale identity를 표시할 때는 login과 display name만 사용하고 profile picture header는 사용하지 않는다.
+- 유효한 capability object가 여러 개면 지원 action을 union한다. 알 수 없는 action은 권한을 부여하지 않고
+  무시하며 wildcard는 지원하지 않는다. target namespace가 없으면 grant 없음으로 처리하고, 존재하는 target
+  namespace의 parameter object가 하나라도 malformed이면 payload 전체를 거부한다.
+- 상세한 Account, Profile, Membership 필드와 단일 action별 제외 범위는
+  [Admin Console Read Policy](../policies/admin-console-read.md)가 소유한다.
+- Admin Console v1은 읽기 전용이다. 이 경계는 기존 Account 인증, Profile Owner/Member 사실,
+  `Account.Operator` 기반 운영자 Mutation 권한을 변경하지 않는다.
+- Admin-specific 성공·실패 조회 감사, capability/identity snapshot, malformed·인가 실패·proxy 우회·위조
+  header security event logging, 검색값 및 보존 기간은 v1에서 모두 제외한다. 기존 공통 runtime 오류·접근
+  로그의 동작은 이 결정의 범위가 아니다.
+
+## 이유
+
+Capability와 identity header를 분리하면 proxy가 현재 요청 주체를 표시할 수 있으면서도 표시 문자열의 변조,
+누락, Account 변경이 읽기 권한을 만들지 않는다. 여러 capability object의 union은 proxy가 capability를
+분리해 전달해도 동일한 action 집합을 계산하게 하며, malformed payload 전체 거부는 일부 object만 적용하는
+모호한 부분 허용을 막는다.
+
+`Account.Operator`를 재사용하지 않으면 Admin Console read-only 도구가 Account/Profile Mutation이나 내부
+운영자 권한을 우연히 상속하지 않는다. Membership을 두 read action의 교집합으로 제한하면 Account와 Profile
+중 하나만 읽을 수 있는 요청에서 두 객체 사이의 관계나 관계 count가 새 정보 경로가 되는 것도 막는다.
+
+## 결과
+
+- Capability Holder의 identity가 Account와 같아 보여도 Account self, Member, Owner, Operator 관계는
+  성립하지 않는다.
+- Admin Console의 객체 조합과 노출 필드는 [Admin Console Read Policy](../policies/admin-console-read.md)
+  하나에서 확인할 수 있다.
+- Account, Profile, Membership 객체 문서의 기존 domain fact와 Mutation 권한은 유지된다.
+- 감사와 security-event logging을 후속으로 도입하려면 이 ADR과 정책을 갱신하는 별도 결정이 필요하다.
+
+## 근거
+
+- [PROD-689](https://linear.app/byulmaru/issue/PROD-689)
+- [Account](../objects/account.md)
+- [Profile](../objects/profile.md)
+- [Account-Profile Membership](../objects/account-profile-membership.md)
+- [ADR 0019: Selected Profile Authorization Boundary](./0019-selected-profile-authorization-boundary.md)
+
+## 문서 반영
+
+- [Admin Console Read Policy](../policies/admin-console-read.md)는 capability 검증, action 조합, 객체별 필드와
+  제외 범위를 정의한다.
+- [Account](../objects/account.md)는 Admin Console 정책과 별개인 Account.Operator 사실을 유지하고,
+  Account 표시 이름과 OIDC subject를 Account 속성으로 정의한다.

--- a/docs/domain/objects/account-profile-membership.md
+++ b/docs/domain/objects/account-profile-membership.md
@@ -30,6 +30,10 @@ Account-Profile Membership은 Account와 Profile의 역할 기반 관계다. Loc
 같은 Account와 Profile 조합에는 Membership이 하나만 존재한다. Local Profile에는 Owner Role Membership이
 항상 하나 이상 존재한다.
 
+Admin Console의 Membership 조회는 [Admin Console Read Policy](../policies/admin-console-read.md)가 정한
+두 capability action의 조합으로만 제공한다. 이는 `Profile.Owner`, `Profile.Member`,
+`Membership.Account`라는 기존 관계 사실이나 해당 관계를 변경하는 행동 권한을 바꾸지 않는다.
+
 ## 행동
 
 | 행동                   | 행동 주체 Account | 대상 객체  | 입력값          | 권한                                   | 조건                                                                                                                  | 결과                                                 |

--- a/docs/domain/objects/account.md
+++ b/docs/domain/objects/account.md
@@ -17,9 +17,14 @@ Account가 아니라 Profile이다.
 
 ## 속성
 
-| 속성      | 타입/nullability | 검증 정책                      | 존재 조건 | 조회 조건                | 조회 권한                              |
-| --------- | ---------------- | ------------------------------ | --------- | ------------------------ | -------------------------------------- |
-| 생성 시각 | 시각, 필수       | 생성 결과로 기록하며 변경 불가 | 항상      | 대상 Account의 내부 조회 | `Account.Self` 또는 `Account.Operator` |
+| 속성         | 타입/nullability | 검증 정책                                                              | 존재 조건 | 조회 조건                | 조회 권한                              |
+| ------------ | ---------------- | ---------------------------------------------------------------------- | --------- | ------------------------ | -------------------------------------- |
+| OIDC subject | 문자열, 필수     | 신뢰한 OIDC 인증 결과의 subject를 보존하며 하나의 Account에만 연결한다 | 항상      | 대상 Account의 내부 조회 | `Account.Self` 또는 `Account.Operator` |
+| 표시 이름    | 문자열, 필수     | 신뢰한 OIDC 인증 결과에서 제공된 표시 값을 보존한다                    | 항상      | 대상 Account의 내부 조회 | `Account.Self` 또는 `Account.Operator` |
+| 생성 시각    | 시각, 필수       | 생성 결과로 기록하며 변경 불가                                         | 항상      | 대상 Account의 내부 조회 | `Account.Self` 또는 `Account.Operator` |
+
+Admin Console의 Account 목록·상세와 OIDC subject exact 검색은 일반 Account 조회 권한을 확장하지 않고
+[Admin Console Read Policy](../policies/admin-console-read.md)의 `account.read` 조건으로만 제공한다.
 
 ## 관계
 
@@ -55,4 +60,7 @@ Account 대상 Operational Notification 읽음 처리는 요청할 수 있다.
 
 ## 제외/보류
 
-- 인증 수단과 Account 표시 이름은 현재 도메인 명세에서 정의하지 않는다.
+- OIDC 인증 수단 자체와 Session credential은 Account 속성이 아니며 [Session](./session.md)과 인증 경계가
+  소유한다.
+- Admin Console에서 OIDC subject를 목록이나 부분 검색에 노출하는 것은 제외한다. 전체 subject 상세와 exact
+  검색은 [Admin Console Read Policy](../policies/admin-console-read.md)가 정한 조건을 따른다.

--- a/docs/domain/objects/profile.md
+++ b/docs/domain/objects/profile.md
@@ -47,6 +47,7 @@ Local Profile과 Remote Profile은 Profile Origin 상태 차원으로 구분한�
 | bio                  | 표시 가능한 평문 문자열, nullable | 앞뒤 공백 제거 후 500자 이하. Remote 원본 markup은 비표시 내용을 제외하고 의미 있는 평문으로 정규화한다 | 항상            | Profile 조회 정책 통과     | 없음             |
 | 팔로워 수            | 0 이상 정수, 필수                 | 저장된 best-effort Follow Relationship 수다                                                             | 항상            | Profile 조회 정책 통과     | 없음             |
 | 팔로잉 수            | 0 이상 정수, 필수                 | 저장된 best-effort Follow Relationship 수다                                                             | 항상            | Profile 조회 정책 통과     | 없음             |
+| 생성 시각            | 시각, 필수                        | 생성 결과로 기록하며 변경 불가                                                                          | 항상            | Profile 조회 정책 통과     | 없음             |
 | 기본 Post Visibility | Post Visibility, 필수             | Public, Unlisted, Followers Only 중 하나이며 값이 없으면 Unlisted로 해석한다                            | Origin이 Local  | Account가 Profile Member다 | `Profile.Member` |
 | Remote URL           | URL, 필수                         | 원격 원본 Profile URL                                                                                   | Origin이 Remote | Profile 조회 정책 통과     | 없음             |
 | Profile Link         | URL 목록, nullable                | 각 항목은 유효한 URL이다                                                                                | Origin이 Local  | Profile 조회 정책 통과     | 없음             |

--- a/docs/domain/policies/admin-console-read.md
+++ b/docs/domain/policies/admin-console-read.md
@@ -1,0 +1,196 @@
+# Admin Console Read Policy
+
+## 정의
+
+Admin Console Read Policy는 durable 객체가 아니라 신뢰된 proxy가 전달한 capability와 Account, Profile,
+Account-Profile Membership을 함께 소비해 운영자용 읽기 결과의 접근 범위와 노출 필드를 결정하는 교차 객체
+조회 정책이다. 이 정책은 객체를 변경하지 않으며 Capability Holder를 Kosmo 도메인의 Account 또는
+`Account.Operator`로 만들지 않는다.
+
+## Capability Holder
+
+Capability Holder는 신뢰된 proxy가 전달한 유효한 capability를 가진 요청 주체다. Tailscale proxy가 제공하는
+login, display name과 같은 identity header는 현재 Capability Holder를 화면에 표시하기 위한 선택적 metadata일
+뿐이며 인가의 근거가 아니다.
+
+- capability가 유효하면 identity header가 없어도 조회를 허용한다.
+- identity header가 없으면 화면에는 `식별 정보 없는 Capability Holder`로 표시한다.
+- Tailscale identity를 표시할 때는 login과 display name만 사용하며 profile picture header는 사용하지 않는다.
+- ingress 정규화에 실패한 identity metadata는 없는 것으로 취급하며 인가 결과를 바꾸지 않는다.
+- identity header의 Account 일치 여부나 표시 이름은 capability에 없는 action을 부여하지 않는다.
+- Capability Holder는 이 정책의 읽기 결과만 사용할 수 있으며 Account 인증, Profile Owner/Member 관계,
+  `Account.Operator` 사실을 획득하지 않는다.
+
+## Capability 계약
+
+이 정책이 소비하는 capability의 namespace는 `byulmaru.co/cap/kosmo-admin`이다. 지원하는 action은 다음과
+같다.
+
+| action         | 허용하는 조회 범위                          |
+| -------------- | ------------------------------------------- |
+| `account.read` | Account 목록, 상세, OIDC subject exact 검색 |
+| `profile.read` | Profile 목록과 상세                         |
+
+Admin ingress가 wire header 정규화를 마친 뒤 이 정책에 전달하는 capability payload의 canonical envelope는
+다음과 같다.
+
+```http
+Tailscale-App-Capabilities: {"byulmaru.co/cap/kosmo-admin":[{"action":["account.read"]},{"action":["profile.read"]}]}
+```
+
+정규화된 payload는 JSON object다. 이 정책의 namespace 값은 parameter object 배열이며, 각 parameter의
+선택적 `action` key는 문자열 배열이다. target namespace가 없는 JSON object는 유효하지만 grant를 만들지
+않는다. 다음 parameter 입력은 유효하다.
+
+| parameter 예시                               | 판정                                                    |
+| -------------------------------------------- | ------------------------------------------------------- |
+| `{"action":["account.read"]}`                | `account.read` grant                                    |
+| `{"action":["account.read","unknown"]}`      | `account.read`만 grant하고 unknown action은 무시        |
+| `{"action":["account.read","account.read"]}` | 중복을 제거해 `account.read` 하나로 계산                |
+| `{}` 또는 `{"action":[]}`                    | 유효하지만 grant 없음                                   |
+| `{"action":["profile.read"],"future":true}`  | `profile.read`만 grant하고 unknown parameter key는 무시 |
+
+정규화된 Capability payload는 다음 순서로 검증한다.
+
+1. payload가 JSON object가 아니면 payload 전체를 malformed로 거부한다.
+2. 이 정책의 namespace가 없으면 유효한 grant 없음으로 처리한다. namespace가 존재하지만 값이 배열이 아니면
+   payload 전체를 malformed로 거부한다.
+3. 이 정책의 namespace 배열에 object가 아닌 값이 하나라도 있으면 payload 전체를 malformed로 거부한다.
+4. parameter에 `action`이 있고 그 값이 배열이 아니거나 문자열이 아닌 항목을 하나라도 포함하면 payload 전체를
+   malformed로 거부한다.
+5. 이 정책의 namespace가 아닌 key와 parameter의 알 수 없는 key는 grant를 만들지 않고 무시한다.
+6. `action` 누락과 빈 배열은 유효하지만 grant를 만들지 않는다.
+7. 알 수 없는 action은 권한을 부여하지 않고 무시한다. wildcard action은 지원하지 않으며 `*`도 알 수 없는
+   action으로 취급한다.
+8. 여러 valid parameter object가 있으면 지원 action을 합집합으로 계산하고 중복 action은 하나로 축약한다.
+
+따라서 malformed payload, 필요한 action이 없는 payload, capability가 없는 요청은 해당 조회 범위를 허용하지
+않는다. identity header는 이 검증을 대신하지 않는다.
+
+## Action 조합
+
+| 보유 action                     | Account | Profile | Account-Profile Membership |
+| ------------------------------- | :-----: | :-----: | :------------------------: |
+| 없음                            |  금지   |  금지   |            금지            |
+| `account.read`                  |  허용   |  금지   |            금지            |
+| `profile.read`                  |  금지   |  허용   |            금지            |
+| `account.read` + `profile.read` |  허용   |  허용   |            허용            |
+
+권한이 없는 객체 또는 관계는 `null`, `0`, 빈 placeholder로 바꾸지 않고 결과 구조에서 제외한다. 직접 조회가
+정책 action을 충족하지 않으면 대상 데이터 계산 전에 접근을 거부한다.
+
+## Account 조회
+
+`account.read`가 있을 때만 Account를 조회한다. Account의 일반 자기 자신/운영자 조회와 별개로 이 정책의
+조회 결과는 다음 필드만 사용한다.
+
+### 목록과 기본 검색
+
+- Account ID
+- Account 표시 이름
+- Account State
+- 생성 시각
+
+OIDC subject는 목록 결과에 포함하지 않는다. OIDC subject를 사용한 검색은 전체 값의 exact match만 허용하며,
+부분 문자열·prefix·contains 검색은 제공하지 않는다. exact match 결과도 목록 조회 결과를 사용하고 OIDC
+subject 자체는 상세 조회에서만 반환한다.
+
+### 상세
+
+단독 Account 상세 projection은 목록 필드와 전체 OIDC subject를 반환한다. 이 projection 안에서는 다음을 함께
+탐색하거나 노출하지 않는다.
+
+- Profile 또는 Account-Profile Membership
+- selected Profile과 Session 상태
+- Session credential, token, OIDC session key
+- private key와 그 밖의 credential 값
+
+Account ID는 관계 조회 권한이나 Profile 조회 권한을 대신하지 않는다. 두 action을 모두 가진 경우에도
+Profile과 Membership은 아래의 별도 Membership relation projection으로만 제공한다.
+
+## Profile 조회
+
+`profile.read`가 있을 때만 Profile을 조회한다. 공개 Profile의 노출 조건과 별개로 Admin Console 조회 결과는
+운영에 필요한 Lifecycle State와 Suspension State를 포함할 수 있다.
+
+### 목록
+
+목록은 Profile ID, handle, 표시 handle, 표시 이름, avatar, Profile Origin, Lifecycle State, Suspension State를
+반환한다. `handle`과 `표시 handle`은 서로 다른 필드이며 둘 다 목록 projection에 포함한다.
+
+### 상세
+
+상세는 다음 Profile의 공개 표현과 운영 필드를 반환한다.
+
+- Profile ID
+- handle, 표시 handle, qualified handle
+- 표시 이름, bio
+- avatar, header
+- Profile Link와 Remote URL
+- Profile Tag
+- Followers Count, Following Count
+- Profile Origin, Profile Lifecycle State, Profile Suspension State
+- Instance Domain
+- 생성 시각
+
+현재 v1 projection은 Instance에서 Domain만 확정한다. Instance Type, Safety/Reachability/Service State와 각
+사유, Instance 생성 시각, Profile 역관계는 이번 PROD-689 범위에 포함하지 않으며 영구 제외 여부는 결정하지
+않는다.
+
+단독 Profile projection은 다음을 반환하지 않는다.
+
+- Account ID, Account 표시 이름, OIDC subject 등 Account 식별자
+- Account-Profile Membership의 존재 여부, Role, count
+- selected Profile, Session 상태 또는 credential
+
+Followers Count와 Following Count는 Profile의 소셜 관계 count이며 Membership count와 다르다. Profile의
+공개 조회에서 숨겨지는 상태를 Admin Console이 반환할 수 있다는 사실은 일반 공개 Profile 정책을 변경하지
+않는다. 두 action을 모두 가진 경우에도 Account와 Membership은 아래의 별도 Membership relation
+projection으로만 제공한다.
+
+## Account-Profile Membership 조회
+
+Account-Profile Membership은 단독 Account/Profile projection과 분리된 relation projection이다.
+`account.read`와 `profile.read`를 모두 가진 경우에만 조회한다. 한 action만 있는 경우 Account나 Profile
+결과에 Membership 존재 여부, Role 또는 count를 포함하지 않는다.
+
+Membership 결과는 다음을 제공한다.
+
+- Account ID
+- Profile ID
+- Account Profile Role (`Owner` 또는 `Member`)
+- 연결 시각
+- 해당 Account의 Membership count
+- 해당 Profile의 Membership count
+- Membership에서 Account로, Account에서 Membership으로의 양방향 탐색
+- Membership에서 Profile로, Profile에서 Membership으로의 양방향 탐색
+
+양방향 탐색은 두 action을 모두 검증한 뒤 같은 정책 범위 안에서만 허용한다. 이 정책은 Membership의
+`Profile.Owner`, `Profile.Member`, `Membership.Account` 사실을 새로 만들거나 변경하지 않는다.
+
+## 민감 정보와 로깅
+
+- credential, Session token, OIDC session key, private key와 같은 값은 마스킹해 반환하지 않고 조회 결과에서
+  제외한다.
+- Admin Console v1은 성공 조회, 검색, 상세, 관계 조회를 영속 감사하지 않는다.
+- capability 없음, malformed capability, 필요한 action 부족, trusted proxy 우회 또는 위조 header와 같은
+  Admin-specific security event도 이 정책에서 기록·보존하지 않는다.
+- capability snapshot, identity header, 검색값, 대상·결과와 보존 기간을 별도 계약으로 만들지 않는다.
+- 기존 공통 runtime 오류·접근 로그의 생명주기는 이 정책에서 변경하지 않는다.
+
+## 제외/보류
+
+- Capability Holder의 Account 자동 매핑과 `Account.Operator` 승격
+- Admin Console을 통한 Account, Profile, Membership Mutation
+- wildcard와 capability 위임
+- Profile과 Account 사이의 hidden relation을 단일 action으로 노출하는 조회 결과
+- selected Profile, Session, credential 정보
+- Admin-specific audit, security-event, query logging과 별도 보존 정책
+
+## 확정 용어
+
+- Capability Holder: capability를 보유한 Admin Console 요청 주체
+- Admin Console Read Policy: Admin Console 교차 객체 읽기 정책
+- capability namespace: `byulmaru.co/cap/kosmo-admin`
+- `account.read`: Account 읽기 action
+- `profile.read`: Profile 읽기 action


### PR DESCRIPTION
## 무엇을 변경했나요

- Admin Console의 읽기 전용 권한·정보 노출 정책과 `Capability Holder` 경계 ADR을 추가했습니다.
- Account, Profile, Membership의 단독/관계 projection과 Admin Console의 신뢰·요청 처리 아키텍처를 문서화했습니다.
- Account/Profile 객체 문서를 새 계약에 맞췄습니다.
- PROD-689/690/691/692/693 Linear 범위를 같은 계약으로 정렬하고 취소된 DSN-59를 blocker에서 제거했습니다.

## 왜 변경했나요

구현 전에 capability action과 객체별 정보 경계를 확정하지 않으면 한쪽 read 권한으로 반대쪽 객체나 Membership을 추론하거나, 표시용 identity header를 인가 근거로 오용할 수 있습니다. 후속 구현 이슈가 하나의 canonical 계약을 소비하도록 경계를 먼저 고정합니다.

## 이번 PR의 주요 결정

- `Capability Holder`는 Kosmo `Account.Operator`와 별개입니다.
- namespace는 `byulmaru.co/cap/kosmo-admin`, action은 `account.read`와 `profile.read`입니다.
- target namespace의 envelope, parameter object 또는 `action` 배열 타입이 malformed이면 payload 전체를 거부하고, unknown/wildcard action은 권한을 주지 않습니다.
- `Tailscale-App-Capabilities`의 target envelope와 parameter shape를 고정하되 unknown key는 무시하고, `action` 누락·빈 배열은 유효한 grant 없음으로 처리합니다.
- Account/Profile 단독 projection과 두 action을 모두 요구하는 Membership relation projection을 분리합니다.
- Profile 상세의 Instance는 현재 v1에서 Domain만 확정하고 나머지 하위 필드의 영구 제외 여부는 결정하지 않습니다.
- identity header는 표시 전용이며 없더라도 유효한 capability가 있으면 조회를 허용합니다.
- Admin-specific logging, audit, security-event logging은 v1에서 전부 제외합니다. 기존 공통 runtime 로그는 변경하지 않습니다.
- 취소된 DSN-59의 화면 범위는 복원하지 않습니다.

### Tailscale wire 정규화 책임

- 결정자: @robin-maki
- 선택: RFC 2047·UTF-8 wire 정규화와 실패 처리는 Admin ingress와 PROD-690이 소유하고, 도메인 정책은 정규화된 capability JSON만 소비합니다.
- 고려한 대안: RFC 2047 decode 순서와 오류 처리를 도메인 정책에 직접 포함하는 방식을 검토했습니다.
- 이유: wire encoding은 transport 경계의 책임이며, 도메인 정책은 transport와 무관한 action·projection 판정에 집중해야 합니다.
- 감수한 결과: capability 정규화 실패의 거부와 identity metadata 누락 처리는 아키텍처 계약을 함께 읽어야 하며, 구체적인 decoder와 테스트는 PROD-690에서 결정합니다.
- 관련 근거: `docs/architecture/admin-console.md`, `docs/domain/policies/admin-console-read.md`, PROD-689, PROD-690

## 어떻게 확인할 수 있나요

- `pnpm lint:prettier`
- `git diff --check`
- 변경 문서의 로컬 Markdown 링크 127개 확인
- Tailscale Serve 공식 소스·테스트의 RFC 2047 Q-encoding 경로와 계약 대조
- correctness self-review와 over-engineering review 반영

## 아직 어떤 문제가 남았나요

- 애플리케이션/API/UI 구현은 PROD-690/691/692/693이 담당합니다.
- UI 디자인, OpenSpec, Figma, 배포는 이 PR 범위가 아닙니다.
- 저장소 전체 permission reference 검사는 main에도 존재하는 기존 4건 때문에 실패하며, 이 문서 변경에서 새 오류는 추가하지 않았습니다.

결정권자: @robin-maki

Stack: `main → PROD-689`
