### PR TITLE
GitHub-hosted Docker Build의 캐시를 활성화한다

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker Build
 
 on:
   push:
-    branches: [main, PROD-835]
+    branches: [main]
 
 env:
   ENVIRONMENT: dev
@@ -72,7 +72,7 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=sha
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=main
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, PROD-835]
 
 env:
   ENVIRONMENT: dev
@@ -72,7 +72,7 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=sha
-            type=raw,value=main
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -86,7 +86,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build,ignore-error=true
           no-cache-filters: |
             app-build
             runtime

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,7 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-24.04-arm
     permissions:
+      actions: read
       contents: read
       id-token: write
       packages: write
@@ -42,8 +43,6 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           name: kosmo
-          cleanup: false
-          cache-binary: false
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -86,6 +85,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
           no-cache-filters: |
             app-build
             runtime


### PR DESCRIPTION
## 무엇을 변경했나요

- Docker Build의 BuildKit cache source를 `type=gha,scope=docker-build`로 설정했습니다.
- 중간 stage까지 저장하도록 `cache-to: type=gha,mode=max,scope=docker-build`를 설정했습니다.
- GitHub-hosted ephemeral runner에 남아 있던 `cleanup: false`, `cache-binary: false` override를 제거했습니다.
- Buildx가 GitHub cache key를 효율적으로 조회할 수 있도록 job 권한에 `actions: read`를 추가했습니다.
- 기존 `app-build`, `runtime`의 `no-cache-filters`와 Vault/GHCR/image push 동작은 유지했습니다.

## 왜 변경했나요

Docker Build가 self-hosted runner에서 GitHub-hosted ARM runner로 전환되어 run 사이의 로컬 상태가 더 이상 유지되지 않습니다. self-hosted 환경에서는 원격 GitHub cache의 네트워크 비용이 더 컸지만, ephemeral hosted runner에서는 재사용 가능한 BuildKit layer를 GitHub Actions cache에서 복원하는 편이 유리한지 실제 run으로 확인할 필요가 있습니다.

관련 이슈: [PROD-834](https://linear.app/byulmaru/issue/PROD-834/deploy-dev를-github-hosted-runner로-전환한다)

이 PR은 runner 전환의 두 번째 layer이며, [#654](https://github.com/byulmaru/kosmo/pull/654)가 먼저 merge되어야 합니다.

## 이번 PR의 주요 결정

### GitHub Actions cache backend를 사용한다

- 결정자: @robin-maki
- 선택: `type=gha`, 고정 `docker-build` scope, `mode=max`
- 고려한 대안: runner 로컬 cache 유지, registry cache, 별도 cache 인프라
- 이유: GitHub-hosted runner에서 별도 인프라 없이 run 간 cache를 재사용할 수 있고, `mode=max`가 dependency 등 중간 stage도 보존합니다.
- 감수한 결과: cold build에는 cache export 비용이 추가되며, GitHub Actions cache 용량·eviction·rate limit의 영향을 받습니다.
- 관련 근거: [Docker GHA cache backend](https://docs.docker.com/build/cache/backends/gha/)

### cache 장애는 이미지 빌드를 막지 않는다

- 결정자: @robin-maki
- 선택: `ignore-error=true`로 cache export 실패를 비차단 처리합니다.
- 고려한 대안: cache export 실패 시 Docker Build 전체 실패
- 이유: cache는 성능 최적화이며, GitHub cache service 장애가 정상적인 이미지 빌드·배포의 가용성을 낮추면 안 됩니다.
- 감수한 결과: cache export 회귀가 workflow 결론에는 반영되지 않으므로 build log와 실행 시간을 별도로 관찰해야 합니다.

## 어떻게 확인할 수 있나요

- `pnpm exec prettier --check .github/workflows/docker-build.yml`
- `actionlint .github/workflows/docker-build.yml`
- `git diff --check`
- GitHub-hosted ARM 실제 검증: [Docker Build run 32820146731](https://github.com/byulmaru/kosmo/actions/runs/32820146731)
  - attempt 1: 4분 7초, cache export 성공
  - attempt 2: 2분 19초, cache manifest import 및 다수 `CACHED` layer 확인
  - warm attempt는 cold attempt보다 1분 48초 짧았고, 기존 무캐시 main [run 32817493186](https://github.com/byulmaru/kosmo/actions/runs/32817493186)의 job 2분 45초보다 26초 짧았습니다.
  - branch 검증에서는 SHA tag만 push했고 main tag와 Trivy용 artifact는 생성하지 않았습니다.
- 임시 `PROD-835` push trigger와 branch의 `main` tag 차단 조건은 최종 workflow에서 제거했습니다.

## 아직 어떤 문제가 남았나요

- branch cache는 GitHub의 cache 접근 제한 때문에 merge 뒤 main의 첫 run에 그대로 재사용된다고 보장할 수 없습니다. merge 후 main 첫 run이 cache를 seed하고, 그 다음 main run에서 cache hit와 시간을 다시 확인해야 합니다.
- `RUN --mount=type=cache`의 pnpm store 자체는 이 설정만으로 영속화되지 않지만, 변경 없는 dependency layer는 재사용됩니다.
- Argo CD CLI 설치 무결성은 [PROD-763](https://linear.app/byulmaru/issue/PROD-763/security-argo-cd-cli-다운로드-무결성-검증을-강제한다)의 별도 범위입니다.

Stack: main -> PROD-834 (#654) -> PROD-835 (#658)
