### PR TITLE
테마 선택 흐름을 Settings 계약에 반영한다

### DIFF
--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -177,7 +177,7 @@ Figma의 [`08 Component Usage Mapping`](https://www.figma.com/design/Erj975S6vVP
 
 ## Legacy와 개발 token 이관
 
-기존 Figma Components/Screens는 `[Legacy] Color`에 바인딩돼 있다. DSN-4에서는 아래 대응과 분기 규칙을 고정한다. 실제 Figma 재바인딩은 DSN-13, `tokens.ts`·`ThemeProvider`·공용 primitive는 DSN-19, route·shell·domain consumer는 DSN-21 또는 이미 연결된 Product 이슈가 소유한다.
+기존 Figma Components/Screens는 `[Legacy] Color`에 바인딩돼 있다. DSN-4에서는 아래 대응과 분기 규칙을 고정한다. 실제 Figma 재바인딩은 DSN-13, `tokens.ts`·`ThemeProvider`·공용 primitive는 DSN-19, route·shell·domain consumer의 개별 이관 slice는 DSN-21 또는 이미 연결된 Product 이슈가 소유한다. PROD-812는 이 결과와 남은 inventory를 인수해 프로덕션 전체 Dark 활성화 gate와 통합 검증을 닫는다.
 
 | Legacy Figma / 현재 코드             | Production semantic                                                      | 이관 규칙                                                              |
 | ------------------------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
@@ -204,6 +204,7 @@ Figma의 [`08 Component Usage Mapping`](https://www.figma.com/design/Erj975S6vVP
 
 - **DSN-19:** production semantic token 코드, runtime theme selector와 Button·TextField·ModalSheet·ActionMenu·ToastProvider·StateView 등 공용 primitive를 이관한다.
 - **DSN-21 / 연결된 Product 이슈:** route·shell·domain call-site가 공용 token과 primitive를 소비하도록 이관하고, 화면별 예외를 닫는다. 별도 제품 의미 결정이 필요한 consumer는 연결된 Product 이슈로 분리하되, 이슈가 연결되기 전까지 DSN-21 inventory에 남긴다.
+- **PROD-812:** DSN-19와 DSN-21/연결 Product 이슈의 완료 결과를 재사용하고, 남은 consumer 이관·예외 종결과 지원 플랫폼의 대표 Light/Dark 화면·주요 interaction state 통합 검증을 소유한다. 이 범위가 완료되기 전에는 System/Dark 사용자 선택을 활성화하지 않는다.
 - **DSN-13:** DSN-19와 DSN-21/Product 구현이 확정된 뒤 Figma Components/Screens를 Production Semantic Color로 재바인딩하고 최종 mapping evidence를 갱신한다.
 
 ### 현재 raw·legacy consumer inventory
@@ -237,11 +238,11 @@ PROD-750 scrim migration 대상은 `theme.overlayScrim`을 공통 backdrop으로
 
 ## Runtime theme 전략
 
-Figma와 semantic contract는 Light/Dark를 모두 production 값으로 제공한다. `ThemeProvider`는 명시적 Light/Dark selector API를 제공하고 공용 primitive는 선택된 semantic mode를 소비한다. 앱의 `AppProviders`는 아직 Light를 명시적으로 공급한다. 프로덕션 전체 Dark 활성화 gate는 DSN-21 또는 연결된 Product 이슈의 route·shell·domain consumer 이관까지 완료된 뒤 닫는다.
+Figma와 semantic contract는 Light/Dark를 모두 production 값으로 제공한다. `ThemeProvider`는 명시적 Light/Dark selector API를 제공하고 공용 primitive는 선택된 semantic mode를 소비한다. 앱의 `AppProviders`는 아직 Light를 명시적으로 공급한다. 프로덕션 전체 Dark 활성화 gate는 PROD-812가 DSN-21 또는 연결된 Product 이슈의 남은 route·shell·domain consumer를 semantic token으로 이관하거나 위 inventory의 예외로 닫고, 지원 플랫폼의 대표 화면과 주요 interaction state 검증까지 완료한 뒤 닫는다.
 
 - 공용 primitive가 semantic foreground pair와 interaction state를 소비한다.
 - DSN-19의 공용 primitive raw 값과 DSN-21/Product의 route·shell·domain raw 값이 각각 이관되거나 위 inventory의 예외로 남는다.
-- DSN-19 Storybook에서 공용 primitive의 Light/Dark와 핵심 state를 검증하고, DSN-21/Product가 대표 route·shell consumer의 theme 전환을 검증한다.
+- DSN-19 Storybook의 공용 primitive Light/Dark·핵심 state와 DSN-21/Product의 기존 route·shell consumer 이관 증거를 재사용하고, PROD-812가 남은 inventory 종결과 지원 플랫폼의 대표 theme 전환을 통합 검증한다.
 - Web 자동 대비와 실제 Android/iOS runtime QA를 서로 다른 증거로 기록한다.
 
 ## 예외와 금지

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -243,6 +243,7 @@ Figma와 semantic contract는 Light/Dark를 모두 production 값으로 제공�
 - 공용 primitive가 semantic foreground pair와 interaction state를 소비한다.
 - DSN-19의 공용 primitive raw 값과 DSN-21/Product의 route·shell·domain raw 값이 각각 이관되거나 위 inventory의 예외로 남는다.
 - DSN-19 Storybook의 공용 primitive Light/Dark·핵심 state와 DSN-21/Product의 기존 route·shell consumer 이관 증거를 재사용하고, PROD-812가 남은 inventory 종결과 지원 플랫폼의 대표 theme 전환을 통합 검증한다.
+- PROD-812는 resolved theme를 Native `StatusBar` foreground style과 Web `theme-color`에도 반영하고, Light OS에서 명시적 Dark, Dark OS에서 명시적 Light, `시스템` 선택 중 OS mode 전환을 지원 플랫폼별로 검증한다.
 - Web 자동 대비와 실제 Android/iOS runtime QA를 서로 다른 증거로 기록한다.
 
 ## 예외와 금지

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -209,13 +209,14 @@ Figma의 [`08 Component Usage Mapping`](https://www.figma.com/design/Erj975S6vVP
 
 ### 현재 raw·legacy consumer inventory
 
-아래 목록은 `apps/app/src`의 활성 코드에서 확인한 migration 입력이다. 테스트 fixture와 Storybook assertion의 예시 색상값은 구현 결과에 맞춰 해당 이슈에서 갱신하며 이 표의 별도 consumer로 세지 않는다.
+아래 목록은 `apps/app/src`의 활성 코드와 Native system theme에 영향을 주는 `apps/app/app.config.ts`에서 확인한 migration 입력이다. 테스트 fixture와 Storybook assertion의 예시 색상값은 구현 결과에 맞춰 해당 이슈에서 갱신하며 이 표의 별도 consumer로 세지 않는다.
 
 - **DSN-21 feed plane slice:** `shell/UniversalShell.tsx` root·center plane, `PageHeader.tsx`, `bookmark/BookmarkList.tsx`, `post/PostList.tsx`, `post/PostListItem.tsx`, `post/PostLayout.tsx`, `post/PostThreadLayout.tsx`, `post/PostSourcePresentationView.tsx`의 legacy background·card·border·divider를 분리한다. Route·header·loading·empty host와 연속 feed는 canvas, post·thread row는 no fill/inherit + `border/subtle`, 내부 preview는 `background/surface` + `border/default`를 사용하며 feed·row에는 elevated를 사용하지 않는다.
 
 | Consumer                                                                                                                                                                         | 현재 표현                                                               | 판정                 | 목표 token·규칙                                                                              | 후속 소유                                   |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------- |
 | `theme/tokens.ts`, `ThemeProvider.tsx`                                                                                                                                           | Production semantic Light/Dark와 명시적 selector API; 앱 기본값은 Light | 완료·호환            | legacy flat key는 DSN-21 consumer 이관 동안만 compatibility alias로 유지                     | DSN-19 완료, alias 제거는 DSN-21 이후       |
+| `apps/app/app.config.ts`                                                                                                                                                         | Expo `userInterfaceStyle: 'light'` 고정                                 | 후속                 | `automatic`으로 이관하고 Native rebuild 후 OS Light/Dark의 `시스템` 전환 검증                | PROD-812                                    |
 | `theme/tokens.ts`의 공용 `shadow`                                                                                                                                                | named Light/Dark elevation과 deprecated raw fallback                    | 완료·호환            | 공용 primitive는 named elevation을 사용하고 기존 route/domain import만 fallback 유지         | DSN-19 완료, fallback 제거는 DSN-21 이후    |
 | `ui/Button.tsx`                                                                                                                                                                  | Danger `base/on-base`와 disabled pair                                   | 완료                 | `color/feedback/danger/*`, `color/state/disabled-*`                                          | DSN-19                                      |
 | `ui/ModalSheet.tsx`, `ui/ActionMenu.tsx`                                                                                                                                         | semantic elevated surface, border와 표준 scrim                          | 완료                 | `color/background/elevated`, `color/border/default`, `color/overlay/scrim`                   | DSN-19                                      |
@@ -244,6 +245,7 @@ Figma와 semantic contract는 Light/Dark를 모두 production 값으로 제공�
 - DSN-19의 공용 primitive raw 값과 DSN-21/Product의 route·shell·domain raw 값이 각각 이관되거나 위 inventory의 예외로 남는다.
 - DSN-19 Storybook의 공용 primitive Light/Dark·핵심 state와 DSN-21/Product의 기존 route·shell consumer 이관 증거를 재사용하고, PROD-812가 남은 inventory 종결과 지원 플랫폼의 대표 theme 전환을 통합 검증한다.
 - PROD-812는 resolved theme를 Native `StatusBar` foreground style과 Web `theme-color`에도 반영하고, Light OS에서 명시적 Dark, Dark OS에서 명시적 Light, `시스템` 선택 중 OS mode 전환을 지원 플랫폼별로 검증한다.
+- PROD-812는 Expo `userInterfaceStyle`을 `automatic`으로 이관한 Native rebuild에서 Android/iOS OS Light/Dark 전환이 `시스템` resolved theme에 반영되는지 검증한다.
 - Web 자동 대비와 실제 Android/iOS runtime QA를 서로 다른 증거로 기록한다.
 
 ## 예외와 금지

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -91,6 +91,9 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
 - preference를 실제 Light/Dark `resolved theme`로 해석해 앱 화면, Native `StatusBar` foreground style과 Web
   `theme-color`가 같은 mode를 사용하게 한다. `시스템`은 OS mode 변경을 함께 따르고, 명시적 `라이트`·`다크`는
   OS mode와 무관하게 system chrome에도 동일하게 반영한다.
+- Native의 `시스템`은 `apps/app/app.config.ts`의 Expo `userInterfaceStyle`을 `automatic`으로 이관한 build에서
+  활성화한다. PROD-812는 Native rebuild 후 Android/iOS 각각에서 OS Light/Dark 전환이 resolved theme에
+  반영되는지 검증한다.
 - 이 detail은 Primary Color를 변경하지 않는다. Primary Color가 별도 범위로 승인되면 root의 독립 항목으로
   추가하고, 실제 display 관련 항목이 충분히 늘어나기 전에는 중간 category를 만들지 않는다.
 - Legacy `ThemePresetCard`와 `Profile / Theme` source는 재사용하지 않는다. 별도 preview card·Primary
@@ -176,9 +179,10 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   소유한다. 이 범위를 완료된 PROD-685·PROD-684에 소급해 귀속하지 않는다.
 - DSN-54는 Settings root/master의 테마 현재값 행, `/settings/theme`의 System·Light·Dark 선택 화면,
   Light/Dark 시각 상태와 client-local handoff를 소유한다. PROD-812는 preference 초기값·정규화, 선택값 상태,
-  기기 로컬 persistence와 read/write 실패 semantics, 초기 hydration, app-wide ThemeProvider·Native StatusBar·Web
-  `theme-color` 적용, 남은 route·shell·domain consumer의 semantic token 이관·예외 정리와 지원 플랫폼의 대표
-  Light/Dark 화면·주요 interaction state·system chrome 검증을 소유한다.
+  기기 로컬 persistence와 read/write 실패 semantics, 초기 hydration, app-wide ThemeProvider 적용, Native Expo
+  `userInterfaceStyle` build config·`StatusBar`, Web `theme-color` 적용, 남은 route·shell·domain consumer의
+  semantic token 이관·예외 정리와 지원 플랫폼의 대표 Light/Dark 화면·주요 interaction state·system chrome
+  검증을 소유한다.
 - PROD-685의 통합 검증은 자식 기능의 세부 테스트를 반복하지 않는다. 지원 navigation surface, root/detail
   전환, full workspace, 외부/내부 소유 경계, 반응형 heading·focus·reflow가 함께 동작하는지 확인한다.
 - PROD-685는 구현과 검증 증거를 PROD-684에 인계하고, PROD-684가 최종 Settings 통합·OpenSpec 정합성 확인과

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -75,12 +75,20 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
 - detail 본문은 `테마 설정` section label로 시작하고, 그 아래 기존 `RadioOption` 문법으로 `시스템`,
   `라이트`, `다크` 세 항목을 제공한다. `시스템`은 기기 색상 모드 변경을 따르고, `라이트`와 `다크`는 기기
   설정과 무관하게 해당 모드를 사용한다.
+- preference 초기값은 `시스템`이다. 저장값이 없거나 `시스템`·`라이트`·`다크` 외의 값으로 유효하지 않으면
+  `시스템`으로 정규화한다. `/settings` root의 현재값과 detail radio 선택 상태는 정규화된 preference를
+  동일하게 표시한다.
 - 세 항목 아래에는 `테마 설정은 이 기기에만 적용되며 다른 기기와 동기화되지 않아요.` 안내를 보조 텍스트로
   한 번만 표시한다.
 - 선택은 별도 `저장` action 없이 즉시 화면에 반영하고 같은 기기의 클라이언트 로컬 저장소에 유지한다.
   server·DB에 저장하거나 계정 및 다른 기기로 동기화하지 않으며 성공 feedback도 표시하지 않는다.
+- 로컬 저장에 실패해도 이미 적용한 선택을 rollback하지 않고 현재 세션의 화면, root 현재값과 radio 선택
+  상태에 유지하며 기존 `Toast`로 실패만 알린다. 다음 실행은 마지막으로 성공 저장된 preference를 사용하고,
+  성공 저장값이 없으면 `시스템`으로 시작한다.
 - 앱 시작 시 로컬 선택값 확인이 끝나기 전에는 기존 Splash를 유지해 잘못된 테마가 잠깐 노출되지 않게 한다.
-  로컬 유지 실패는 별도 완료 화면을 만들지 않고 기존 `Toast` 오류 feedback을 사용한다.
+- preference를 실제 Light/Dark `resolved theme`로 해석해 앱 화면, Native `StatusBar` foreground style과 Web
+  `theme-color`가 같은 mode를 사용하게 한다. `시스템`은 OS mode 변경을 함께 따르고, 명시적 `라이트`·`다크`는
+  OS mode와 무관하게 system chrome에도 동일하게 반영한다.
 - 이 detail은 Primary Color를 변경하지 않는다. Primary Color가 별도 범위로 승인되면 root의 독립 항목으로
   추가하고, 실제 display 관련 항목이 충분히 늘어나기 전에는 중간 category를 만들지 않는다.
 - Legacy `ThemePresetCard`와 `Profile / Theme` source는 재사용하지 않는다. 별도 preview card·Primary
@@ -165,9 +173,10 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   검증은 PROD-814, Block 진입점·목록과 Relay 수렴은 PROD-823, Block의 종단 간 검증·archive는 PROD-813이
   소유한다. 이 범위를 완료된 PROD-685·PROD-684에 소급해 귀속하지 않는다.
 - DSN-54는 Settings root/master의 테마 현재값 행, `/settings/theme`의 System·Light·Dark 선택 화면,
-  Light/Dark 시각 상태와 client-local handoff를 소유한다. PROD-812는 선택값 상태, 기기 로컬 persistence,
-  초기 hydration, app-wide ThemeProvider 적용, 남은 route·shell·domain consumer의 semantic token 이관·예외
-  정리와 지원 플랫폼의 대표 Light/Dark 화면·주요 interaction state 검증을 소유한다.
+  Light/Dark 시각 상태와 client-local handoff를 소유한다. PROD-812는 preference 초기값·정규화, 선택값 상태,
+  기기 로컬 persistence와 실패 semantics, 초기 hydration, app-wide ThemeProvider·Native StatusBar·Web
+  `theme-color` 적용, 남은 route·shell·domain consumer의 semantic token 이관·예외 정리와 지원 플랫폼의 대표
+  Light/Dark 화면·주요 interaction state·system chrome 검증을 소유한다.
 - PROD-685의 통합 검증은 자식 기능의 세부 테스트를 반복하지 않는다. 지원 navigation surface, root/detail
   전환, full workspace, 외부/내부 소유 경계, 반응형 heading·focus·reflow가 함께 동작하는지 확인한다.
 - PROD-685는 구현과 검증 증거를 PROD-684에 인계하고, PROD-684가 최종 Settings 통합·OpenSpec 정합성 확인과

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -5,14 +5,17 @@ Kosmo의 인증된 설정은 `/settings`를 canonical hub로 사용하는 route 
 다양한 설정 category와 detail이 추가될 수 있지만, 승인되지 않은 category·placeholder·범용 registry를
 미리 노출하거나 구현하지 않는다.
 
-현재 hub에는 Byulmaru ID가 소유한 Account 설정의 **외부 진입점**과 Kosmo가 소유한 Local Profile의
-`게시물 기본 공개 범위`, `뮤트 및 차단` **내부 진입점**을 제공한다. 실제 행의 label·이동 동작과 접근성
-이름에서 두 서비스와 소유 단위를 명확히 구분한다.
+현재 설정 IA에는 Byulmaru ID가 소유한 Account 설정의 **외부 진입점**, 클라이언트 로컬의 `테마`
+**내부 진입점**, Kosmo가 소유한 Local Profile의 `게시물 기본 공개 범위`, `뮤트 및 차단` **내부 진입점**을
+직접 배치한다. 실제 행의 label·이동 동작과 접근성 이름에서 서비스와 소유 단위를 명확히 구분한다.
+DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 기기 로컬 persistence를 소유한다.
 
 ## Route와 진입점
 
 - Kosmo 설정 hub의 canonical route는 `/settings`다. 내부 설정 detail은 이 route 아래에서 열 수 있지만,
   Byulmaru ID Account 설정을 위한 Kosmo 내부 route나 form은 만들지 않는다.
+- 테마 detail의 canonical 내부 route는 `/settings/theme`다. 홈이나 다른 주요 route에 임시 테마 toggle을
+  중복 배치하지 않는다.
 - full Web sidebar와 compact Web icon rail에는 `설정` 진입점을 주요 navigation 항목으로 표시한다.
 - `< compact` mobile Web과 Android·iOS에서는 mobile drawer에 `설정` 진입점을 표시한다. 하단 탭 바와
   우측 레일에는 같은 진입점을 중복하지 않는다.
@@ -26,9 +29,9 @@ Kosmo의 인증된 설정은 `/settings`를 canonical hub로 사용하는 route 
 
 - Settings는 모든 control을 한 화면에 쌓는 긴 form이 아니라, 진입점 목록에서 category·하위 목록·detail로
   점진적으로 이동하는 탐색 구조를 사용한다.
-- 현재 root 목록에는 시각 label `계정 설정`인 Byulmaru ID 외부 진입점, `게시물 기본 공개 범위`,
-  `뮤트 및 차단` 내부 진입점을 이 순서로 직접 표시한다. 항목 하나만 가진 `계정`·`프로필` 대분류를 만들지
-  않는다.
+- root 목록에는 시각 label `계정 설정`인 Byulmaru ID 외부 진입점, 현재 선택값을 함께 보여 주는 `테마`,
+  `게시물 기본 공개 범위`, `뮤트 및 차단` 내부 진입점을 이 순서로 직접 표시한다. 항목 하나만 가진
+  `계정`·`화면 설정`·`프로필` 대분류를 만들지 않는다.
 - `뮤트 및 차단`은 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 제공하는 하위 목록을 연다.
   두 상태를 하나의 혼합 목록으로 표시하지 않는다. 세부 action과 Profile 상태는
   [Profile Mute·Block 디자인 계약](./profile-mute-block.md)을 따른다.
@@ -64,6 +67,24 @@ Kosmo의 인증된 설정은 `/settings`를 canonical hub로 사용하는 route 
 - chevron이나 현재 값 같은 trailing content는 실제 동작과 정보에 맞을 때만 사용한다. 내부 detail과 외부
   destination은 이동을 전달할 수 있지만, 현재 화면에서 값을 바꾸는 control에는 장식용 chevron을 붙이지
   않는다.
+
+## 테마 설정
+
+- `/settings` root와 full Web master의 `테마` 행은 현재 선택값 `시스템`·`라이트`·`다크` 중 하나를 함께
+  보여 주고 `/settings/theme` detail로 이동한다.
+- detail 본문은 `테마 설정` section label로 시작하고, 그 아래 기존 `RadioOption` 문법으로 `시스템`,
+  `라이트`, `다크` 세 항목을 제공한다. `시스템`은 기기 색상 모드 변경을 따르고, `라이트`와 `다크`는 기기
+  설정과 무관하게 해당 모드를 사용한다.
+- 세 항목 아래에는 `테마 설정은 이 기기에만 적용되며 다른 기기와 동기화되지 않아요.` 안내를 보조 텍스트로
+  한 번만 표시한다.
+- 선택은 별도 `저장` action 없이 즉시 화면에 반영하고 같은 기기의 클라이언트 로컬 저장소에 유지한다.
+  server·DB에 저장하거나 계정 및 다른 기기로 동기화하지 않으며 성공 feedback도 표시하지 않는다.
+- 앱 시작 시 로컬 선택값 확인이 끝나기 전에는 기존 Splash를 유지해 잘못된 테마가 잠깐 노출되지 않게 한다.
+  로컬 유지 실패는 별도 완료 화면을 만들지 않고 기존 `Toast` 오류 feedback을 사용한다.
+- 이 detail은 Primary Color를 변경하지 않는다. Primary Color가 별도 범위로 승인되면 root의 독립 항목으로
+  추가하고, 실제 display 관련 항목이 충분히 늘어나기 전에는 중간 category를 만들지 않는다.
+- Legacy `ThemePresetCard`와 `Profile / Theme` source는 재사용하지 않는다. 별도 preview card·Primary
+  Color·저장 성공 UI를 포함하지 않으며, 현재 Settings 화면 전체가 선택 즉시 반영되는 preview다.
 
 ## Full Web Settings workspace
 
@@ -104,6 +125,8 @@ Kosmo의 인증된 설정은 `/settings`를 canonical hub로 사용하는 route 
   한국어 설명과 재시도 action을 제공한다.
 - Profile 전환 중에는 새 대상의 identity와 데이터가 일치할 때까지 이전 Profile 설정 control을 새 대상의
   값처럼 표시하지 않는다. 세부 request 상태와 늦은 응답 격리는 PROD-667 Profile 기능이 소유한다.
+- 테마 선택에는 저장 버튼·dirty·saving·success 화면을 만들지 않는다. 초기 local hydration은 기존 Splash가,
+  local persistence 실패 feedback은 기존 `Toast`가 소유한다.
 - 기본 게시 공개 범위의 inline option·dropdown·sheet·즉시 저장·명시적 저장 여부는 page shell 계약으로
   고정하지 않는다.
 
@@ -111,9 +134,9 @@ Kosmo의 인증된 설정은 `/settings`를 canonical hub로 사용하는 route 
 
 - root 화면과 master pane은 `설정` heading을, detail 화면과 detail pane은 현재 설정 이름 heading을
   programmatic하게 노출한다. 시각적으로 없는 category heading을 screen reader 전용으로 반복하지 않는다.
-- root/master 목록의 문서·보조기술 읽기 순서는 `설정` heading → `계정 설정` 외부 진입점 →
-  `게시물 기본 공개 범위` → `뮤트 및 차단`이다. full Web에서는 이어서 detail heading과 현재 선택된 content를
-  읽는다.
+- root/master 목록의 문서·보조기술 읽기 순서는 `설정` heading → `계정 설정` 외부 진입점 → `테마`와 현재
+  선택값 → `게시물 기본 공개 범위` → `뮤트 및 차단`이다. full Web에서는 이어서 detail heading과 현재
+  선택된 content를 읽는다.
 - Account 진입점은 시각 label `계정 설정`과 link accessible name·canonical destination에서 Byulmaru ID 외부
   Account Settings로 이동한다는 사실을 전달한다. 내부 진입점은 선택·현재 상태와 destination을, Profile
   control은 Kosmo 내부 기능과 현재 대상을 전달한다.
@@ -141,6 +164,9 @@ Kosmo의 인증된 설정은 `/settings`를 canonical hub로 사용하는 route 
 - `뮤트 및 차단`의 Figma IA·source·대표 consumer는 DSN-53이 소유한다. runtime의 Mute 진입점·목록·통합
   검증은 PROD-814, Block 진입점·목록과 Relay 수렴은 PROD-823, Block의 종단 간 검증·archive는 PROD-813이
   소유한다. 이 범위를 완료된 PROD-685·PROD-684에 소급해 귀속하지 않는다.
+- DSN-54는 Settings root/master의 테마 현재값 행, `/settings/theme`의 System·Light·Dark 선택 화면,
+  Light/Dark 시각 상태와 client-local handoff를 소유한다. PROD-812는 선택값 상태, 기기 로컬 persistence,
+  초기 hydration과 app-wide ThemeProvider 적용을 소유한다.
 - PROD-685의 통합 검증은 자식 기능의 세부 테스트를 반복하지 않는다. 지원 navigation surface, root/detail
   전환, full workspace, 외부/내부 소유 경계, 반응형 heading·focus·reflow가 함께 동작하는지 확인한다.
 - PROD-685는 구현과 검증 증거를 PROD-684에 인계하고, PROD-684가 최종 Settings 통합·OpenSpec 정합성 확인과
@@ -154,6 +180,9 @@ Kosmo의 인증된 설정은 `/settings`를 canonical hub로 사용하는 route 
 - 브라우저·OS가 소유하는 외부 navigation 결과와 URL 지원 확인·loading·error·retry·lock 상태
 - Profile 기본 게시 공개 범위의 DB, GraphQL, Relay와 Composer 계약
 - 공개 범위 control의 구체적인 선택·저장 UI
+- 홈 또는 다른 주요 route의 테마 toggle과 임시 진입점
+- 테마 선택값의 server·DB 저장, 계정 동기화와 기기 간 동기화
+- Primary Color 변경과 아직 필요하지 않은 `화면 설정`·`테마 설정` 중간 category
 - 알림 설정, Follow Approval Policy와 아직 승인되지 않은 설정 category·placeholder
 - 미래 category 전체를 위한 범용 registry나 현재 승인되지 않은 destination route
 - settings 밖 기존 route의 전역 shell·RightRail 동작 변경

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -166,7 +166,8 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   소유한다. 이 범위를 완료된 PROD-685·PROD-684에 소급해 귀속하지 않는다.
 - DSN-54는 Settings root/master의 테마 현재값 행, `/settings/theme`의 System·Light·Dark 선택 화면,
   Light/Dark 시각 상태와 client-local handoff를 소유한다. PROD-812는 선택값 상태, 기기 로컬 persistence,
-  초기 hydration과 app-wide ThemeProvider 적용을 소유한다.
+  초기 hydration, app-wide ThemeProvider 적용, 남은 route·shell·domain consumer의 semantic token 이관·예외
+  정리와 지원 플랫폼의 대표 Light/Dark 화면·주요 interaction state 검증을 소유한다.
 - PROD-685의 통합 검증은 자식 기능의 세부 테스트를 반복하지 않는다. 지원 navigation surface, root/detail
   전환, full workspace, 외부/내부 소유 경계, 반응형 heading·focus·reflow가 함께 동작하는지 확인한다.
 - PROD-685는 구현과 검증 증거를 PROD-684에 인계하고, PROD-684가 최종 Settings 통합·OpenSpec 정합성 확인과

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -86,6 +86,8 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   상태에 유지하며 기존 `Toast`로 실패만 알린다. 다음 실행은 마지막으로 성공 저장된 preference를 사용하고,
   성공 저장값이 없으면 `시스템`으로 시작한다.
 - 앱 시작 시 로컬 선택값 확인이 끝나기 전에는 기존 Splash를 유지해 잘못된 테마가 잠깐 노출되지 않게 한다.
+  저장소 read가 예외로 실패하면 preference를 `시스템`으로 fallback해 hydration을 완료하고 Splash를 해제하며,
+  기존 `Toast`로 실패를 알린다. 이 실패 경로에서는 저장소 재쓰기를 시도하지 않는다.
 - preference를 실제 Light/Dark `resolved theme`로 해석해 앱 화면, Native `StatusBar` foreground style과 Web
   `theme-color`가 같은 mode를 사용하게 한다. `시스템`은 OS mode 변경을 함께 따르고, 명시적 `라이트`·`다크`는
   OS mode와 무관하게 system chrome에도 동일하게 반영한다.
@@ -174,7 +176,7 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   소유한다. 이 범위를 완료된 PROD-685·PROD-684에 소급해 귀속하지 않는다.
 - DSN-54는 Settings root/master의 테마 현재값 행, `/settings/theme`의 System·Light·Dark 선택 화면,
   Light/Dark 시각 상태와 client-local handoff를 소유한다. PROD-812는 preference 초기값·정규화, 선택값 상태,
-  기기 로컬 persistence와 실패 semantics, 초기 hydration, app-wide ThemeProvider·Native StatusBar·Web
+  기기 로컬 persistence와 read/write 실패 semantics, 초기 hydration, app-wide ThemeProvider·Native StatusBar·Web
   `theme-color` 적용, 남은 route·shell·domain consumer의 semantic token 이관·예외 정리와 지원 플랫폼의 대표
   Light/Dark 화면·주요 interaction state·system chrome 검증을 소유한다.
 - PROD-685의 통합 검증은 자식 기능의 세부 테스트를 반복하지 않는다. 지원 navigation surface, root/detail


### PR DESCRIPTION
## 무엇을 변경했나요

- Settings root/master에 현재값을 표시하는 `테마` 진입점 계약을 추가했습니다.
- `/settings/theme`의 `테마 설정` 섹션과 System·Light·Dark 선택 흐름을 문서화했습니다.
- 즉시 반영, 기기 로컬 유지, Splash hydration, 실패 Toast와 접근성 handoff를 명시했습니다.
- legacy ThemePresetCard 미재사용과 Primary Color 제외 범위를 기록했습니다.

## 왜 변경했나요

PROD-812가 일관된 Settings IA와 active Foundation을 기준으로 runtime 테마 선택을 구현할 수 있도록 DSN-54의 Figma 결과를 canonical 문서에 반영합니다.

## 이번 PR의 주요 결정

### Settings에서 테마를 직접 선택한다

- 결정자: @yeeun-uwu
- 선택: Settings root에 `테마`를 직접 배치하고 detail에서 System·Light·Dark를 선택합니다.
- 고려한 대안: 홈 임시 toggle, `화면 설정` 중간 category
- 이유: 현재 설정 항목 수에는 직접 진입이 가장 단순하며 홈과 Settings의 중복 상태를 만들지 않습니다.
- 감수한 결과: Primary Color가 승인되면 별도 범위에서 IA를 다시 검토해야 합니다.
- 관련 근거: DSN-54, `docs/design/settings.md`

### 선택값은 즉시 반영하고 기기에만 유지한다

- 결정자: @yeeun-uwu
- 선택: 저장 버튼과 성공 화면 없이 즉시 반영하며 다른 기기와 동기화하지 않습니다.
- 고려한 대안: 명시적 저장, 계정·서버 동기화
- 이유: 테마는 계정 데이터가 아니며 기기별 선택으로 충분합니다.
- 감수한 결과: 다른 기기에서는 테마를 다시 선택해야 합니다.
- 관련 근거: DSN-54, PROD-812

## 어떻게 확인할 수 있나요

- ThemePreferenceControl과 Mobile 390·Web 1024·1440 consumer를 시각 확인했습니다.
- legacy·remote·detached instance가 없고 KOSMO Semantic Color/Foundation/Typography binding을 사용하는지 확인했습니다.
- `git diff --check`를 통과했습니다.
- 문서 전용 변경이므로 runtime 자동 테스트는 추가하지 않았습니다.

## 아직 어떤 문제가 남았나요

- persistence, System 감지와 ThemeProvider 적용은 PROD-812에서 구현합니다.
- 이 PR은 최종 사람 검토와 머지를 위해 Draft로 생성합니다.

Stack: main → dsn-54
Linear: DSN-54

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>