### PR TITLE
Terraform workflow를 GitHub-hosted runner로 전환한다

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -38,7 +38,7 @@ jobs:
   plan:
     name: Terraform Plan
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout
@@ -59,6 +59,13 @@ jobs:
           create_credentials_file: true
           export_environment_variables: true
           cleanup_credentials: true
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: tag:github-actions
 
       - name: Authenticate to Argo CD
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -214,7 +221,7 @@ jobs:
   apply:
     name: Terraform Apply
     if: ${{ github.event_name == 'push' }}
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04-arm
     environment: terraform-apply
 
     steps:
@@ -236,6 +243,13 @@ jobs:
           create_credentials_file: true
           export_environment_variables: true
           cleanup_credentials: true
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: tag:github-actions
 
       - name: Authenticate to Argo CD
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## 무엇을 변경했나요

- Terraform Plan과 Apply의 runner를 `ubuntu-24.04-arm`으로 전환했습니다.
- 두 job에서 Argo CD 인증 전에 pinned Tailscale action으로 Tailnet에 연결합니다.
- 기존 AWS/GCP OIDC, Argo CD Dex 교환, plan artifact, reviewed-plan 비교, state lock과 apply environment 계약은 유지했습니다.

## 왜 변경했나요

Terraform workflow가 고정 self-hosted runner에 의존하고 있었습니다. 클라우드 인증은 이미 GitHub OIDC 기반이므로, private Argo CD endpoint 접근만 Tailnet 연결로 대체해 GitHub-hosted runner에서 동일한 흐름을 실행합니다.

## 이번 PR의 주요 결정

### Plan과 Apply를 한 PR에서 전환합니다

- 결정자: @robin-maki
- 선택: 두 job을 이 1-layer Stack PR에서 함께 전환합니다.
- 고려한 대안: Plan과 Apply를 별도 이슈 또는 별도 PR layer로 분리합니다.
- 이유: 같은 workflow와 인증 경계를 공유하고, workflow 파일 변경 자체가 PR에서는 Plan을, merge 후 main에서는 Apply를 순서대로 실행합니다.
- 감수한 결과: Apply의 실제 hosted-runner 증거는 merge 후 main run에서 확보합니다.
- 관련 근거: [PROD-837](https://linear.app/byulmaru/issue/PROD-837/terraform-workflow를-github-hosted-runner로-전환한다)

## 어떻게 확인할 수 있나요

- `pnpm lint:prettier -- .github/workflows/terraform.yml`
- `mise exec -- actionlint .github/workflows/terraform.yml`
- `git diff --check`
- linux/arm64용 Argo CD, AWS, Google Beta provider lock 확인
- [Terraform Plan run 32826427592](https://github.com/byulmaru/kosmo/actions/runs/32826427592): hosted ARM, AWS/GCP OIDC, Tailscale, Dex, init/validate/plan, PR comment와 artifact 성공

## 아직 어떤 문제가 남았나요

- 현재 reviewed plan은 `argocd_application.kosmo_prod`의 `argocd.argoproj.io/deletion-approved` annotation을 제거합니다(`0 add / 1 change / 0 destroy`). Runner 전환과 무관한 live drift이므로 merge 전에 이 변경을 함께 적용할지 확인해야 합니다.
- merge 후 `terraform-apply` Environment 승인을 거쳐 hosted ARM Apply 성공을 확인해야 합니다.
- Production Release와 iOS runner 전환은 이번 범위에서 제외합니다.

Stack: main -> PROD-837

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>