### PR TITLE
Settings destination의 parent-back 계약을 명시한다

### DIFF
--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -75,8 +75,9 @@ PostComposer presentation은 `Rail`과 `Overlay`만 사용한다. 중앙 timelin
   먼저 만들지 않는다.
 - `full` Web settings route family에서는 전역 sidebar 다음 공간을 Settings 전용 master-detail workspace로
   사용하고 일반 `RightRail`을 표시하지 않는다.
-- `compact` Web, `< compact` mobile Web과 Android·iOS에서는 root 목록과 detail을 한 화면씩 표시하며 내부
-  detail에서 back navigation으로 root 목록에 돌아간다.
+- `compact` Web, `< compact` mobile Web과 Android·iOS에서는 root 목록과 선택한 category·detail destination을
+  한 화면씩 표시하며, 내부 destination의 back navigation은 [설정 페이지](./settings.md)에 정의된 명시적인
+  parent를 연다.
 
 ## 프로필 편집 진입
 

--- a/docs/design/page-header.md
+++ b/docs/design/page-header.md
@@ -52,10 +52,10 @@ Web `/search`는 모든 breakpoint에서 중앙 컬럼 최상단에 높이 `64px
 - 모바일 Web과 Android/iOS `/home`: `UniversalShell`이 메뉴 버튼, 브랜드 마크와 native safe-area를 소유한다. 홈 route는 헤더를 렌더링하지 않는다.
 - Web `/search`: 검색 route가 모든 breakpoint의 `64px` 검색 도구막대와 검색 상태를 소유한다. 모바일 Web
   `< compact`에서 `UniversalShell`은 기본 메뉴 전용 헤더 대신 drawer action과 가장자리 스와이프만 제공한다.
-- `<768px` 모바일 Web `/compose`, `/notifications`와 `/settings` root: `UniversalShell`이 메뉴 버튼과 텍스트 제목을 하나의 app bar로 렌더링한다. `/notifications`에서는 같은 app bar가 `모두 읽음` trailing action도 소유하고, Settings 내부 detail에서는 같은 위치에 뒤로가기와 detail 제목을 렌더링한다. route의 loading, error, empty와 content 상태는 셸 헤더 아래에서 전환하며 자체 PageHeader를 렌더링하지 않는다.
+- `<768px` 모바일 Web `/compose`, `/notifications`와 `/settings` root: `UniversalShell`이 메뉴 버튼과 텍스트 제목을 하나의 app bar로 렌더링한다. `/notifications`에서는 같은 app bar가 `모두 읽음` trailing action도 소유하고, Settings 내부 category·detail destination에서는 같은 위치에 뒤로가기와 현재 destination 제목을 렌더링한다. route의 loading, error, empty와 content 상태는 셸 헤더 아래에서 전환하며 자체 PageHeader를 렌더링하지 않는다.
 - `<768px` 모바일 Web 게시글 상세: `UniversalShell`이 기존 `router.back()` 동작을 사용하는 뒤로가기 버튼과 `게시글` 제목을 하나의 app bar로 렌더링한다. route는 별도 sticky PageHeader와 그 offset을 만들지 않는다.
 - Android/iOS의 알림·글쓰기·게시글 상세와 compact/full Web: 모바일 Web 셸 헤더가 없으므로 route 또는 화면의 최상위 scroll content가 기존 텍스트·뒤로가기 헤더를 소유한다. Native 게시글 상세에서는 `PostDetailFrame`이 첫 번째 sticky child를 계속 소유한다.
-- Android/iOS와 compact Web의 `/settings` root·detail: settings route가 현재 화면의 text header를 scroll content의 첫 heading으로 소유한다. detail header는 뒤로가기를 제공하고 Native safe area는 모바일 셸이 바깥에서 소유한다.
+- Android/iOS와 compact Web의 `/settings` root·category·detail destination: settings route가 현재 화면의 text header를 scroll content의 첫 heading으로 소유한다. category·detail header는 뒤로가기를 제공하고 Native safe area는 모바일 셸이 바깥에서 소유한다.
 - full Web의 settings route family: Settings master pane이 `설정` heading을, detail pane이 현재 설정 heading을 소유한다. 일반 route `PageHeader`와 `RightRail`을 중복하지 않는다.
 - 북마크 등 이 변경에 포함되지 않은 PageHeader 소비 화면은 기존 route 소유권을 유지한다.
 - compact/full Web `/home`: 모바일 셸 헤더가 없으므로 홈 route가 브랜드 헤더를 소유한다.

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -21,7 +21,7 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   우측 레일에는 같은 진입점을 중복하지 않는다.
 - route와 page shell이 함께 동작하는 slice에서만 진입점을 노출한다. 진입점만 먼저 노출해 준비되지 않은
   화면이나 generic placeholder로 이동시키지 않는다.
-- `설정` navigation은 `/settings`와 지원되는 내부 detail route에서 현재 page 상태를 노출한다. 다른
+- `설정` navigation은 `/settings`와 지원되는 내부 category·detail route에서 현재 page 상태를 노출한다. 다른
   shell-level 주요 route에서 `/settings`로 forward navigation하면 [breakpoints.md](./breakpoints.md)의
   scroll 정책에 따라 문서 최상단에서 시작한다.
 
@@ -36,8 +36,8 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   두 상태를 하나의 혼합 목록으로 표시하지 않는다. 세부 action과 Profile 상태는
   [Profile Mute·Block 디자인 계약](./profile-mute-block.md)을 따른다.
 - full Web의 `/settings`는 `게시물 기본 공개 범위`를 기본 선택해 detail에 표시한다. compact Web, mobile Web,
-  Android와 iOS의 `/settings`는 root 목록부터 표시하고, 내부 진입점을 선택하면 한 화면짜리 detail로
-  이동한다.
+  Android와 iOS의 `/settings`는 root 목록부터 표시하고, 내부 진입점을 선택하면 한 화면짜리 category 또는
+  detail destination으로 이동한다.
 - 향후 승인된 항목은 direct destination, 하위 목록을 여는 category 또는 기존 독립 화면으로 이동하는
   destination으로 추가할 수 있다. 모든 detail을 Settings workspace 안에 강제로 넣거나 현재 구현에 미래
   category를 위한 disabled item·placeholder를 만들지 않는다.
@@ -119,11 +119,12 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   `/settings` root이고, 중첩 destination의 parent는 바로 위 category다. direct·deep link로 연 경우에도 같은
   parent를 사용한다.
 - `< compact` mobile Web의 root에서는 `UniversalShell`이 메뉴 action과 `설정` heading을 가진 공용
-  [PageHeader](./page-header.md)를 렌더링한다. 내부 detail에서는 shell이 back action과 detail heading을
-  렌더링하고 route 본문은 같은 heading을 복제하지 않는다.
-- Android·iOS와 compact Web에서는 root 또는 detail route가 자기 text `PageHeader`를 scroll content의 첫
-  heading으로 렌더링한다. detail header는 back action을 제공하고 Native safe area는 mobile shell이 소유한다.
-- Android·iOS one-pane route는 `PageHeader`부터 root/detail content 전체를 하나의 platform vertical
+  [PageHeader](./page-header.md)를 렌더링한다. 내부 category·detail destination에서는 shell이 back action과
+  현재 destination heading을 렌더링하고 route 본문은 같은 heading을 복제하지 않는다.
+- Android·iOS와 compact Web에서는 root 또는 category·detail destination route가 자기 text `PageHeader`를
+  scroll content의 첫 heading으로 렌더링한다. category·detail header는 back action을 제공하고 Native safe
+  area는 mobile shell이 소유한다.
+- Android·iOS one-pane route는 `PageHeader`부터 root·category·detail content 전체를 하나의 platform vertical
   `ScrollView`에 둔다. compact·mobile·full Web은 기존 document scroll을 계속 사용한다.
 - full Web에서는 master pane의 `설정` heading과 detail pane의 현재 화면 heading을 각각 노출한다. 같은 pane
   안에 중복 heading을 만들지 않는다.
@@ -148,8 +149,9 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
 
 ## 접근성
 
-- root 화면과 master pane은 `설정` heading을, detail 화면과 detail pane은 현재 설정 이름 heading을
-  programmatic하게 노출한다. 시각적으로 없는 category heading을 screen reader 전용으로 반복하지 않는다.
+- root 화면과 master pane은 `설정` heading을, one-pane category·detail 화면과 full Web detail pane은 현재
+  destination heading을 programmatic하게 노출한다. 시각적으로 없는 category heading을 screen reader 전용으로
+  반복하지 않는다.
 - root/master 목록의 문서·보조기술 읽기 순서는 `설정` heading → `계정 설정` 외부 진입점 → `테마`와 현재
   선택값 → `게시물 기본 공개 범위` → `뮤트 및 차단`이다. full Web에서는 이어서 detail heading과 현재
   선택된 content를 읽는다.
@@ -186,7 +188,7 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
   `userInterfaceStyle` build config·`StatusBar`, Web `theme-color` 적용, 남은 route·shell·domain consumer의
   semantic token 이관·예외 정리와 지원 플랫폼의 대표 Light/Dark 화면·주요 interaction state·system chrome
   검증을 소유한다.
-- PROD-685의 통합 검증은 자식 기능의 세부 테스트를 반복하지 않는다. 지원 navigation surface, root/detail
+- PROD-685의 통합 검증은 자식 기능의 세부 테스트를 반복하지 않는다. 지원 navigation surface, root/category/detail
   전환, full workspace, 외부/내부 소유 경계, 반응형 heading·focus·reflow가 함께 동작하는지 확인한다.
 - PROD-685는 구현과 검증 증거를 PROD-684에 인계하고, PROD-684가 최종 Settings 통합·OpenSpec 정합성 확인과
   archive를 소유한다.

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -112,9 +112,12 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
 
 ## Compact·mobile·Native layout과 header
 
-- compact Web, mobile Web, Android와 iOS에서는 Settings root 목록과 detail을 동시에 나누어 표시하지 않고
-  한 화면씩 보여 준다. 내부 detail의 back action은 이전 navigation stack의 화면과 무관하게 `/settings`
-  root 목록을 명시적으로 연다.
+- compact Web, mobile Web, Android와 iOS에서는 Settings root 목록과 선택한 category·detail destination을
+  동시에 나누어 표시하지 않고 한 화면씩 보여 준다.
+- 모든 내부 category·detail destination은 명시적인 parent를 가진다. back action은 이전 navigation stack의
+  화면과 무관하게 해당 parent를 명시적으로 연다. root의 직접 진입점이 여는 1단계 destination의 parent는
+  `/settings` root이고, 중첩 destination의 parent는 바로 위 category다. direct·deep link로 연 경우에도 같은
+  parent를 사용한다.
 - `< compact` mobile Web의 root에서는 `UniversalShell`이 메뉴 action과 `설정` heading을 가진 공용
   [PageHeader](./page-header.md)를 렌더링한다. 내부 detail에서는 shell이 back action과 detail heading을
   렌더링하고 route 본문은 같은 heading을 복제하지 않는다.

--- a/openspec/changes/archive/2026-08-08-add-settings-page-shell/decisions.md
+++ b/openspec/changes/archive/2026-08-08-add-settings-page-shell/decisions.md
@@ -32,22 +32,24 @@ Product behavior는 canonical 문서와 최신 Linear 계약에서 파생하고,
 - Decision Date: 2026-08-06
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/settings.md`, `docs/design/breakpoints.md`,
-  `docs/design/page-header.md`, `PROD-685`
+  `docs/design/page-header.md`, `PROD-685`, `PROD-838`
 - Status: Active
 - Context / Problem: 장기적으로 다양한 설정을 제공하려면 하나의 긴 form이나 600px 중앙 평면 목록보다
   Settings 내부 navigation과 detail을 단계적으로 탐색할 수 있어야 한다. 동시에 기존 global sidebar와 다른
   route의 feed/right rail 계약을 바꾸면 안 된다.
-- Decision Outcome: `/settings`는 canonical hub이고 지원되는 내부 detail은 같은 route family에 속한다. full
+- Decision Outcome: `/settings`는 canonical hub이고 지원되는 내부 destination은 같은 route family에 속한다. full
   Web은 global sidebar를 유지하고 일반 RightRail을 숨긴 뒤 center+right 폭을 약 320px master와 flexible
-  detail workspace로 사용한다. compact/mobile/native는 root 목록과 detail을 한 화면씩 보여 주며 detail의
-  back action은 이전 navigation stack과 무관하게 `/settings` root를 명시적으로 연다. Settings navigation은
-  root와 내부 detail에서 current 상태를 유지한다.
+  detail workspace로 사용한다. compact/mobile/native는 root 목록과 category·detail destination을 한 화면씩
+  보여 주며 모든 내부 destination은 명시적인 parent를 가진다. root의 직접 entry가 여는 1단계 destination의
+  parent는 `/settings` root이고, 중첩 destination의 parent는 바로 위 category이며, direct/deep link에서도
+  back action은 이전 navigation stack과 무관하게 이 parent를 명시적으로 연다. Settings navigation은 root와
+  내부 destination에서 current 상태를 유지한다.
 - Alternatives Considered: 모든 platform의 600px 중앙 column에 master+detail을 동시에 압축하는 방식,
   Mastodon처럼 영구 tree와 긴 form을 한 화면에 표시하는 방식, 모든 platform에서 root/detail을 동시에
   표시하는 방식. 각각 가독성, 가용 폭 또는 작은 화면 navigation과 충돌해 채택하지 않았다.
 - Consequences: `UniversalShell`은 full settings route에서만 일반 RightRail visibility와 content max width를
-  달리해야 한다. route family는 mobile Web root/detail header와 compact/native route-owned back header를
-  구분해야 하며 Web document scroll을 유지해야 한다.
+  달리해야 한다. route family는 mobile Web root/category/detail header와 compact/native route-owned back
+  header를 구분해야 하며 Web document scroll을 유지해야 한다.
 - Confirmation / Follow-up: full workspace 폭·pane 경계·RightRail 부재와 다른 route rail 유지, compact/mobile/
   native root-first·deep link·unrelated-history back·heading 중복 부재를 검증한다.
 
@@ -324,19 +326,23 @@ Product behavior는 canonical 문서와 최신 Linear 계약에서 파생하고,
 - Confirmation / Follow-up: 최신 Linear relation, PROD-645/667 결과, page-level runtime, Figma 후속 정렬,
   delta spec 정합성을 archive 전에 확인한다.
 
-### Settings detail 복귀는 Web document replace와 Native Settings stack pop을 사용한다
+### 1단계 Profile detail 복귀는 Web document replace와 Native Settings stack pop을 사용한다
 
 - Decision Date: 2026-08-08
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/design/settings.md`, `PROD-684`; Expo Router 56.2.13 route tree와 Web E2E;
-  Native runtime QA `PROD-727`
+  Native runtime QA `PROD-727`; generic parent contract `PROD-838`
 - Status: Active
-- Context / Problem: Settings detail의 back은 이전 unrelated 화면이 아니라 `/settings` root를 열어야 한다.
-  그러나 nested Settings layout에서 `router.replace`·`navigate`·`dismissTo`를 사용한 Web 후보는 root에서
-  detail로 이동한 history에서 `/undefined/undefined` 또는 무동작을 재현했다.
+- Context / Problem: 2026-08-08 당시 root의 직접 entry가 여는 Profile detail의 back은 이전 unrelated 화면이
+  아니라 `/settings` root를 열어야 했다. 그러나 nested Settings layout에서 `router.replace`·`navigate`·
+  `dismissTo`를 사용한 Web 후보는 root에서 detail로 이동한 history에서 `/undefined/undefined` 또는 무동작을
+  재현했다.
 - Decision Outcome: Settings layout은 `unstable_settings.initialRouteName = 'index'`로 root anchor를 둔다.
-  Web은 `location.replace('/settings')`로 현재 detail document를 root로 교체하고, Android·iOS는 Settings
-  layout의 `Slot`이 생성하는 `StackRouter`에서 `router.back()`으로 detail을 pop한다.
+  Web은 `location.replace('/settings')`로 당시 root의 직접 Profile detail document를 root로 교체하고,
+  Android·iOS는 Settings layout의 `Slot`이 생성하는 `StackRouter`에서 `router.back()`으로 해당 1단계 detail을
+  pop한다. 이 기록은 2026-08-08 당시 1단계 Profile detail의 구현 증거이며, 모든 detail이 root로 돌아간다는
+  일반화는 `PROD-838`에서 대체됐다. 현재 destination별 parent와 back 계약은 위 Derived Contract 및 `PROD-838`
+  active spec을 따른다.
 - Alternatives Considered: 모든 platform에서 `router.replace`, `navigate`, `dismissTo`, 조건부 `dismiss` 또는
   `back`을 사용하는 방식. Web 실제 history에서 root destination과 stale detail 제거를 함께 만족하지 못해
   채택하지 않았다.
@@ -391,3 +397,6 @@ Product behavior는 canonical 문서와 최신 Linear 계약에서 파생하고,
   `PROD-685가 구현 증거를 만들고 PROD-684가 최종 archive를 소유한다`로 대체됐다.
 - `PROD-685가 구현 증거를 만들고 PROD-684가 최종 archive를 소유한다` — 2026-08-08
   자동화된 통합 증거와 실제 runtime QA를 분리하는 PROD-684/PROD-727 책임으로 대체됐다.
+- 모든 Settings detail의 back destination을 `/settings` root로 일반화한 2026-08-06·08 결정은 2026-08-25
+  `PROD-838`의 명시적인 destination별 parent 계약으로 대체됐다. 당시 구현된 root 직접 1단계 Profile detail의
+  root parent와 구현 증거는 유지한다.

--- a/openspec/changes/archive/2026-08-08-add-settings-page-shell/decisions.md
+++ b/openspec/changes/archive/2026-08-08-add-settings-page-shell/decisions.md
@@ -5,6 +5,10 @@
 Product behavior는 canonical 문서와 최신 Linear 계약에서 파생하고, 여러 구현 slice가 함께 지켜야 할 좁은
 구현 경계만 Implementation Choice로 남긴다.
 
+> **Reconciliation (2026-08-25, PROD-838):** 아래의 dated decision body는 2026-08-08 archive 당시 계약과
+> 구현 증거를 보존한다. 모든 Settings detail을 root로 일반화한 부분만 destination별 parent 계약으로
+> supersede됐으며, 현재 generic contract는 canonical 문서와 active spec을 따른다.
+
 ## Decision Records
 
 ### `/settings` 하나를 canonical 설정 route로 사용한다
@@ -32,24 +36,22 @@ Product behavior는 canonical 문서와 최신 Linear 계약에서 파생하고,
 - Decision Date: 2026-08-06
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/settings.md`, `docs/design/breakpoints.md`,
-  `docs/design/page-header.md`, `PROD-685`, `PROD-838`
+  `docs/design/page-header.md`, `PROD-685`
 - Status: Active
 - Context / Problem: 장기적으로 다양한 설정을 제공하려면 하나의 긴 form이나 600px 중앙 평면 목록보다
   Settings 내부 navigation과 detail을 단계적으로 탐색할 수 있어야 한다. 동시에 기존 global sidebar와 다른
   route의 feed/right rail 계약을 바꾸면 안 된다.
-- Decision Outcome: `/settings`는 canonical hub이고 지원되는 내부 destination은 같은 route family에 속한다. full
+- Decision Outcome: `/settings`는 canonical hub이고 지원되는 내부 detail은 같은 route family에 속한다. full
   Web은 global sidebar를 유지하고 일반 RightRail을 숨긴 뒤 center+right 폭을 약 320px master와 flexible
-  detail workspace로 사용한다. compact/mobile/native는 root 목록과 category·detail destination을 한 화면씩
-  보여 주며 모든 내부 destination은 명시적인 parent를 가진다. root의 직접 entry가 여는 1단계 destination의
-  parent는 `/settings` root이고, 중첩 destination의 parent는 바로 위 category이며, direct/deep link에서도
-  back action은 이전 navigation stack과 무관하게 이 parent를 명시적으로 연다. Settings navigation은 root와
-  내부 destination에서 current 상태를 유지한다.
+  detail workspace로 사용한다. compact/mobile/native는 root 목록과 detail을 한 화면씩 보여 주며 detail의
+  back action은 이전 navigation stack과 무관하게 `/settings` root를 명시적으로 연다. Settings navigation은
+  root와 내부 detail에서 current 상태를 유지한다.
 - Alternatives Considered: 모든 platform의 600px 중앙 column에 master+detail을 동시에 압축하는 방식,
   Mastodon처럼 영구 tree와 긴 form을 한 화면에 표시하는 방식, 모든 platform에서 root/detail을 동시에
   표시하는 방식. 각각 가독성, 가용 폭 또는 작은 화면 navigation과 충돌해 채택하지 않았다.
 - Consequences: `UniversalShell`은 full settings route에서만 일반 RightRail visibility와 content max width를
-  달리해야 한다. route family는 mobile Web root/category/detail header와 compact/native route-owned back
-  header를 구분해야 하며 Web document scroll을 유지해야 한다.
+  달리해야 한다. route family는 mobile Web root/detail header와 compact/native route-owned back header를
+  구분해야 하며 Web document scroll을 유지해야 한다.
 - Confirmation / Follow-up: full workspace 폭·pane 경계·RightRail 부재와 다른 route rail 유지, compact/mobile/
   native root-first·deep link·unrelated-history back·heading 중복 부재를 검증한다.
 
@@ -326,23 +328,19 @@ Product behavior는 canonical 문서와 최신 Linear 계약에서 파생하고,
 - Confirmation / Follow-up: 최신 Linear relation, PROD-645/667 결과, page-level runtime, Figma 후속 정렬,
   delta spec 정합성을 archive 전에 확인한다.
 
-### 1단계 Profile detail 복귀는 Web document replace와 Native Settings stack pop을 사용한다
+### Settings detail 복귀는 Web document replace와 Native Settings stack pop을 사용한다
 
 - Decision Date: 2026-08-08
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/design/settings.md`, `PROD-684`; Expo Router 56.2.13 route tree와 Web E2E;
-  Native runtime QA `PROD-727`; generic parent contract `PROD-838`
+  Native runtime QA `PROD-727`
 - Status: Active
-- Context / Problem: 2026-08-08 당시 root의 직접 entry가 여는 Profile detail의 back은 이전 unrelated 화면이
-  아니라 `/settings` root를 열어야 했다. 그러나 nested Settings layout에서 `router.replace`·`navigate`·
-  `dismissTo`를 사용한 Web 후보는 root에서 detail로 이동한 history에서 `/undefined/undefined` 또는 무동작을
-  재현했다.
+- Context / Problem: Settings detail의 back은 이전 unrelated 화면이 아니라 `/settings` root를 열어야 한다.
+  그러나 nested Settings layout에서 `router.replace`·`navigate`·`dismissTo`를 사용한 Web 후보는 root에서
+  detail로 이동한 history에서 `/undefined/undefined` 또는 무동작을 재현했다.
 - Decision Outcome: Settings layout은 `unstable_settings.initialRouteName = 'index'`로 root anchor를 둔다.
-  Web은 `location.replace('/settings')`로 당시 root의 직접 Profile detail document를 root로 교체하고,
-  Android·iOS는 Settings layout의 `Slot`이 생성하는 `StackRouter`에서 `router.back()`으로 해당 1단계 detail을
-  pop한다. 이 기록은 2026-08-08 당시 1단계 Profile detail의 구현 증거이며, 모든 detail이 root로 돌아간다는
-  일반화는 `PROD-838`에서 대체됐다. 현재 destination별 parent와 back 계약은 위 Derived Contract 및 `PROD-838`
-  active spec을 따른다.
+  Web은 `location.replace('/settings')`로 현재 detail document를 root로 교체하고, Android·iOS는 Settings
+  layout의 `Slot`이 생성하는 `StackRouter`에서 `router.back()`으로 detail을 pop한다.
 - Alternatives Considered: 모든 platform에서 `router.replace`, `navigate`, `dismissTo`, 조건부 `dismiss` 또는
   `back`을 사용하는 방식. Web 실제 history에서 root destination과 stale detail 제거를 함께 만족하지 못해
   채택하지 않았다.

--- a/openspec/changes/archive/2026-08-08-add-settings-page-shell/design.md
+++ b/openspec/changes/archive/2026-08-08-add-settings-page-shell/design.md
@@ -11,6 +11,10 @@ PROD-645는 Byulmaru ID가 소유한 Account Settings 외부 진입점을, PROD-
 PROD-685는 production route·navigation·두 child 조립과 자동화된 page-level 검증을, PROD-684는 최종 Settings
 통합과 change 완료·archive를 소유한다. Backend 계약은 PROD-648에 남고 이 change가 재구현하지 않는다.
 
+> **Reconciliation (2026-08-25):** 아래의 root-only back 서술은 2026-08-08 당시 1단계 Profile detail의 구현
+> 증거다. 현재 모든 Settings 내부 destination의 generic parent/back 계약은 `PROD-838`이 정의하며, 1단계
+> destination은 `/settings`, 중첩 destination은 바로 위 category를 parent로 사용한다.
+
 ## Goals / Non-Goals
 
 **Goals:**

--- a/openspec/changes/archive/2026-08-08-add-settings-page-shell/specs/settings-page-shell/spec.md
+++ b/openspec/changes/archive/2026-08-08-add-settings-page-shell/specs/settings-page-shell/spec.md
@@ -22,9 +22,9 @@
 - **THEN** 시스템은 `/settings` root 목록을 열고 drawer를 닫는다
 - **AND** 하단 탭 바와 일반 우측 레일에는 별도 `설정` 항목을 표시하지 않는다
 
-#### Scenario: 내부 detail에서도 설정 current 상태를 유지한다
+#### Scenario: 내부 category와 detail에서도 설정 current 상태를 유지한다
 
-- **WHEN** 사용자가 지원되는 Settings 내부 detail route를 연다
+- **WHEN** 사용자가 지원되는 Settings 내부 category 또는 detail route를 연다
 - **THEN** shell의 `설정` navigation은 현재 route family를 page-current로 노출한다
 
 #### Scenario: 준비되지 않은 진입점을 노출하지 않는다
@@ -77,7 +77,7 @@
 
 ### Requirement: Full Web workspace와 one-pane responsive navigation
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/page-header.md`, `docs/design/breakpoints.md`, `PROD-685` — full Web의 Settings route family는 전역 sidebar를 유지하고 일반 `RightRail`을 숨긴 뒤 기존 center+right 영역을 Settings wide workspace로 사용해야 한다(MUST). workspace는 약 320px master pane과 남은 폭을 채우는 detail pane을 제공해야 하며(MUST), `/settings` hub는 `게시물 기본 공개 범위` entry를 기본 selected 상태로 두고 Profile detail을 표시해야 한다(MUST). compact Web, mobile Web, Android와 iOS의 `/settings`는 root 목록부터 표시하고 내부 entry를 선택했을 때 한 화면짜리 detail로 이동해야 하며(MUST), detail은 back navigation으로 root에 돌아갈 수 있어야 한다(MUST). 다른 route의 center 600px·RightRail visibility와 기존 `compact=768`, `full=1280` breakpoint를 변경해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/page-header.md`, `docs/design/breakpoints.md`, `PROD-685`, `PROD-838` — full Web의 Settings route family는 전역 sidebar를 유지하고 일반 `RightRail`을 숨긴 뒤 기존 center+right 영역을 Settings wide workspace로 사용해야 한다(MUST). workspace는 약 320px master pane과 남은 폭을 채우는 detail pane을 제공해야 하며(MUST), `/settings` hub는 `게시물 기본 공개 범위` entry를 기본 selected 상태로 두고 Profile detail을 표시해야 한다(MUST). compact Web, mobile Web, Android와 iOS의 `/settings`는 root 목록부터 표시하고 내부 entry를 선택했을 때 한 화면짜리 category 또는 detail destination으로 이동해야 한다(MUST). 모든 내부 destination은 명시적인 parent를 가져야 하고(MUST), back navigation은 이전 history·navigation stack과 무관하게 해당 parent를 열어야 한다(MUST). root의 직접 entry가 여는 1단계 destination의 parent는 `/settings` root여야 하며(MUST), 중첩 destination의 parent는 바로 위 category여야 한다(MUST). 다른 route의 center 600px·RightRail visibility와 기존 `compact=768`, `full=1280` breakpoint를 변경해서는 안 된다(MUST NOT).
 
 #### Scenario: full Web에서 Settings master-detail을 표시한다
 
@@ -91,31 +91,37 @@
 - **WHEN** 사용자가 Settings route family 밖의 기존 full Web route를 연다
 - **THEN** shell은 기존 중앙 최대 600px와 일반 RightRail visibility를 유지한다
 
-#### Scenario: compact와 mobile에서 root부터 detail로 이동한다
+#### Scenario: compact와 mobile에서 root부터 1단계 destination으로 이동한다
 
 - **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 `/settings`를 연다
-- **THEN** 화면은 두 entry가 있는 root 목록부터 표시한다
-- **AND** `게시물 기본 공개 범위`를 선택하면 Profile detail 한 화면으로 이동한다
-- **AND** back action은 Settings root 목록으로 돌아간다
+- **THEN** 화면은 승인된 entry가 있는 root 목록부터 표시한다
+- **AND** root의 직접 entry를 선택하면 해당 1단계 destination 한 화면으로 이동한다
+- **AND** back action은 명시적인 parent인 Settings root 목록으로 돌아간다
 
-#### Scenario: 이전 navigation stack과 무관하게 Settings root로 돌아간다
+#### Scenario: 중첩 destination에서 바로 위 category로 돌아간다
 
-- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 unrelated 화면이 이전 history 또는 navigation stack에 남아 있는 상태에서 direct/deep link로 내부 Settings detail을 연다
-- **AND** 사용자가 detail의 back action을 실행한다
-- **THEN** 시스템은 이전 unrelated 화면을 열지 않고 `/settings` root 목록을 연다
+- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 Settings category에서 중첩 destination을 연다
+- **AND** 사용자가 중첩 destination의 back action을 실행한다
+- **THEN** 시스템은 `/settings` root로 건너뛰지 않고 바로 위 category를 연다
+
+#### Scenario: 이전 navigation stack과 무관하게 명시적인 parent로 돌아간다
+
+- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 unrelated 화면이 이전 history 또는 navigation stack에 남아 있는 상태에서 direct/deep link로 내부 Settings category 또는 detail destination을 연다
+- **AND** 사용자가 destination의 back action을 실행한다
+- **THEN** 시스템은 이전 unrelated 화면을 열지 않고 해당 destination의 명시적인 parent를 연다
 
 #### Scenario: mobile Web heading을 중복하지 않는다
 
-- **WHEN** mobile Web 사용자가 Settings root 또는 detail을 연다
-- **THEN** `UniversalShell`은 root에서 menu+`설정`, detail에서 back+detail heading을 표시한다
+- **WHEN** mobile Web 사용자가 Settings root 또는 category·detail destination을 연다
+- **THEN** `UniversalShell`은 root에서 menu+`설정`, category·detail destination에서 back+현재 destination heading을 표시한다
 - **AND** route content는 같은 heading을 복제하지 않는다
 
 #### Scenario: compact와 Native heading을 중복하지 않는다
 
-- **WHEN** Android·iOS 또는 compact Web 사용자가 Settings root 또는 detail을 연다
-- **THEN** route는 root 또는 detail의 text header를 첫 heading으로 표시하고 detail에 back action을 제공한다
-- **AND** Android·iOS에서는 하나의 vertical `ScrollView`가 route header와 root 또는 detail content 전체를 포함한다
-- **AND** 긴 detail title은 leading action 다음의 가용 폭 안에서 여러 줄로 reflow한다
+- **WHEN** Android·iOS 또는 compact Web 사용자가 Settings root 또는 category·detail destination을 연다
+- **THEN** route는 현재 destination의 text header를 첫 heading으로 표시하고 category·detail destination에 back action을 제공한다
+- **AND** Android·iOS에서는 하나의 vertical `ScrollView`가 route header와 root·category·detail content 전체를 포함한다
+- **AND** 긴 destination title은 leading action 다음의 가용 폭 안에서 여러 줄로 reflow한다
 
 ### Requirement: Profile detail 상태 소유
 
@@ -147,7 +153,7 @@
 
 ### Requirement: Settings 접근성 계약
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-685` — root 화면과 full master pane은 `설정` heading을, Profile detail 화면과 pane은 현재 설정 이름 heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위`여야 하며(MUST), full Web에서는 이어서 detail heading과 Profile content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-685` — root 화면과 full master pane은 `설정` heading을, one-pane category·detail 화면과 full detail pane은 현재 destination heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위`여야 하며(MUST), full Web에서는 이어서 detail heading과 Profile content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
 
 #### Scenario: screen reader가 master와 detail을 구분한다
 
@@ -164,7 +170,7 @@
 
 #### Scenario: 작은 화면과 font scaling에서 정보를 유지한다
 
-- **WHEN** 사용자가 Web reflow 또는 Android·iOS font scaling으로 Settings root나 detail을 확대한다
+- **WHEN** 사용자가 Web reflow 또는 Android·iOS font scaling으로 Settings root나 category·detail destination을 확대한다
 - **THEN** label·description·현재 Profile identity와 action을 계속 사용할 수 있다
 - **AND** 핵심 기능이 불필요한 가로 scroll이나 잘린 text에 의존하지 않는다
 

--- a/openspec/changes/archive/2026-08-08-add-settings-page-shell/specs/settings-page-shell/spec.md
+++ b/openspec/changes/archive/2026-08-08-add-settings-page-shell/specs/settings-page-shell/spec.md
@@ -1,3 +1,7 @@
+> **Reconciliation (2026-08-25, PROD-838):** 이 archived delta의 requirement와 scenario는 2026-08-08 당시
+> root 직접 1단계 Profile detail의 root-only back 계약을 보존한다. 현재 Settings destination별 parent/back
+> 계약은 canonical `docs/design/settings.md`와 active `openspec/specs/settings-page-shell/spec.md`를 따른다.
+
 ## ADDED Requirements
 
 ### Requirement: Canonical Settings route family와 진입점
@@ -22,9 +26,9 @@
 - **THEN** 시스템은 `/settings` root 목록을 열고 drawer를 닫는다
 - **AND** 하단 탭 바와 일반 우측 레일에는 별도 `설정` 항목을 표시하지 않는다
 
-#### Scenario: 내부 category와 detail에서도 설정 current 상태를 유지한다
+#### Scenario: 내부 detail에서도 설정 current 상태를 유지한다
 
-- **WHEN** 사용자가 지원되는 Settings 내부 category 또는 detail route를 연다
+- **WHEN** 사용자가 지원되는 Settings 내부 detail route를 연다
 - **THEN** shell의 `설정` navigation은 현재 route family를 page-current로 노출한다
 
 #### Scenario: 준비되지 않은 진입점을 노출하지 않는다
@@ -77,7 +81,7 @@
 
 ### Requirement: Full Web workspace와 one-pane responsive navigation
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/page-header.md`, `docs/design/breakpoints.md`, `PROD-685`, `PROD-838` — full Web의 Settings route family는 전역 sidebar를 유지하고 일반 `RightRail`을 숨긴 뒤 기존 center+right 영역을 Settings wide workspace로 사용해야 한다(MUST). workspace는 약 320px master pane과 남은 폭을 채우는 detail pane을 제공해야 하며(MUST), `/settings` hub는 `게시물 기본 공개 범위` entry를 기본 selected 상태로 두고 Profile detail을 표시해야 한다(MUST). compact Web, mobile Web, Android와 iOS의 `/settings`는 root 목록부터 표시하고 내부 entry를 선택했을 때 한 화면짜리 category 또는 detail destination으로 이동해야 한다(MUST). 모든 내부 destination은 명시적인 parent를 가져야 하고(MUST), back navigation은 이전 history·navigation stack과 무관하게 해당 parent를 열어야 한다(MUST). root의 직접 entry가 여는 1단계 destination의 parent는 `/settings` root여야 하며(MUST), 중첩 destination의 parent는 바로 위 category여야 한다(MUST). 다른 route의 center 600px·RightRail visibility와 기존 `compact=768`, `full=1280` breakpoint를 변경해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/page-header.md`, `docs/design/breakpoints.md`, `PROD-685` — full Web의 Settings route family는 전역 sidebar를 유지하고 일반 `RightRail`을 숨긴 뒤 기존 center+right 영역을 Settings wide workspace로 사용해야 한다(MUST). workspace는 약 320px master pane과 남은 폭을 채우는 detail pane을 제공해야 하며(MUST), `/settings` hub는 `게시물 기본 공개 범위` entry를 기본 selected 상태로 두고 Profile detail을 표시해야 한다(MUST). compact Web, mobile Web, Android와 iOS의 `/settings`는 root 목록부터 표시하고 내부 entry를 선택했을 때 한 화면짜리 detail로 이동해야 하며(MUST), detail은 back navigation으로 root에 돌아갈 수 있어야 한다(MUST). 다른 route의 center 600px·RightRail visibility와 기존 `compact=768`, `full=1280` breakpoint를 변경해서는 안 된다(MUST NOT).
 
 #### Scenario: full Web에서 Settings master-detail을 표시한다
 
@@ -91,37 +95,31 @@
 - **WHEN** 사용자가 Settings route family 밖의 기존 full Web route를 연다
 - **THEN** shell은 기존 중앙 최대 600px와 일반 RightRail visibility를 유지한다
 
-#### Scenario: compact와 mobile에서 root부터 1단계 destination으로 이동한다
+#### Scenario: compact와 mobile에서 root부터 detail로 이동한다
 
 - **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 `/settings`를 연다
-- **THEN** 화면은 승인된 entry가 있는 root 목록부터 표시한다
-- **AND** root의 직접 entry를 선택하면 해당 1단계 destination 한 화면으로 이동한다
-- **AND** back action은 명시적인 parent인 Settings root 목록으로 돌아간다
+- **THEN** 화면은 두 entry가 있는 root 목록부터 표시한다
+- **AND** `게시물 기본 공개 범위`를 선택하면 Profile detail 한 화면으로 이동한다
+- **AND** back action은 Settings root 목록으로 돌아간다
 
-#### Scenario: 중첩 destination에서 바로 위 category로 돌아간다
+#### Scenario: 이전 navigation stack과 무관하게 Settings root로 돌아간다
 
-- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 Settings category에서 중첩 destination을 연다
-- **AND** 사용자가 중첩 destination의 back action을 실행한다
-- **THEN** 시스템은 `/settings` root로 건너뛰지 않고 바로 위 category를 연다
-
-#### Scenario: 이전 navigation stack과 무관하게 명시적인 parent로 돌아간다
-
-- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 unrelated 화면이 이전 history 또는 navigation stack에 남아 있는 상태에서 direct/deep link로 내부 Settings category 또는 detail destination을 연다
-- **AND** 사용자가 destination의 back action을 실행한다
-- **THEN** 시스템은 이전 unrelated 화면을 열지 않고 해당 destination의 명시적인 parent를 연다
+- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 unrelated 화면이 이전 history 또는 navigation stack에 남아 있는 상태에서 direct/deep link로 내부 Settings detail을 연다
+- **AND** 사용자가 detail의 back action을 실행한다
+- **THEN** 시스템은 이전 unrelated 화면을 열지 않고 `/settings` root 목록을 연다
 
 #### Scenario: mobile Web heading을 중복하지 않는다
 
-- **WHEN** mobile Web 사용자가 Settings root 또는 category·detail destination을 연다
-- **THEN** `UniversalShell`은 root에서 menu+`설정`, category·detail destination에서 back+현재 destination heading을 표시한다
+- **WHEN** mobile Web 사용자가 Settings root 또는 detail을 연다
+- **THEN** `UniversalShell`은 root에서 menu+`설정`, detail에서 back+detail heading을 표시한다
 - **AND** route content는 같은 heading을 복제하지 않는다
 
 #### Scenario: compact와 Native heading을 중복하지 않는다
 
-- **WHEN** Android·iOS 또는 compact Web 사용자가 Settings root 또는 category·detail destination을 연다
-- **THEN** route는 현재 destination의 text header를 첫 heading으로 표시하고 category·detail destination에 back action을 제공한다
-- **AND** Android·iOS에서는 하나의 vertical `ScrollView`가 route header와 root·category·detail content 전체를 포함한다
-- **AND** 긴 destination title은 leading action 다음의 가용 폭 안에서 여러 줄로 reflow한다
+- **WHEN** Android·iOS 또는 compact Web 사용자가 Settings root 또는 detail을 연다
+- **THEN** route는 root 또는 detail의 text header를 첫 heading으로 표시하고 detail에 back action을 제공한다
+- **AND** Android·iOS에서는 하나의 vertical `ScrollView`가 route header와 root 또는 detail content 전체를 포함한다
+- **AND** 긴 detail title은 leading action 다음의 가용 폭 안에서 여러 줄로 reflow한다
 
 ### Requirement: Profile detail 상태 소유
 
@@ -153,7 +151,7 @@
 
 ### Requirement: Settings 접근성 계약
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-685` — root 화면과 full master pane은 `설정` heading을, one-pane category·detail 화면과 full detail pane은 현재 destination heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위`여야 하며(MUST), full Web에서는 이어서 detail heading과 Profile content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-685` — root 화면과 full master pane은 `설정` heading을, Profile detail 화면과 pane은 현재 설정 이름 heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위`여야 하며(MUST), full Web에서는 이어서 detail heading과 Profile content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
 
 #### Scenario: screen reader가 master와 detail을 구분한다
 
@@ -170,7 +168,7 @@
 
 #### Scenario: 작은 화면과 font scaling에서 정보를 유지한다
 
-- **WHEN** 사용자가 Web reflow 또는 Android·iOS font scaling으로 Settings root나 category·detail destination을 확대한다
+- **WHEN** 사용자가 Web reflow 또는 Android·iOS font scaling으로 Settings root나 detail을 확대한다
 - **THEN** label·description·현재 Profile identity와 action을 계속 사용할 수 있다
 - **AND** 핵심 기능이 불필요한 가로 scroll이나 잘린 text에 의존하지 않는다
 

--- a/openspec/specs/settings-page-shell/spec.md
+++ b/openspec/specs/settings-page-shell/spec.md
@@ -41,14 +41,15 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 ### Requirement: 현재 Settings root와 공통 item 정보 구조
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/profile-mute-block.md`, `PROD-685`, `DSN-53`; 기능 경계 `PROD-645`, `PROD-667`, Mute·Block runtime `PROD-814`, `PROD-823`, `PROD-813` — Settings root는 시각 label `계정 설정`인 Byulmaru ID 외부 진입점과 `게시물 기본 공개 범위`, `뮤트 및 차단` 내부 진입점을 이 순서로 직접 제공해야 한다(MUST). `뮤트 및 차단`은 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 제공하는 category를 열어야 하며(MUST), 두 상태를 하나의 혼합 목록으로 표시해서는 안 된다(MUST NOT). 현재 세 entry를 위해 한 항목짜리 `계정`·`프로필` category를 만들어서는 안 되며(MUST NOT), 별도 canonical·Linear 승인이 없는 미래 category를 disabled item·placeholder·범용 registry로 노출해서는 안 된다(MUST NOT). 공통 presentational `SettingsItem`은 부모 container 폭에 맞는 row geometry와 필수 label·선택적 leading·description·trailing content·selected presentation을 조합할 수 있어야 한다(MUST). `SettingsItem`이 Link·Pressable·focus·accessible name·feature 조회·저장·persistence semantics를 추론하거나 소유해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/profile-mute-block.md`, `PROD-685`, `DSN-53`, `DSN-54`; 기능 경계 `PROD-645`, `PROD-667`, 테마 runtime `PROD-812`, Mute·Block runtime `PROD-814`, `PROD-823`, `PROD-813` — Settings root는 시각 label `계정 설정`인 Byulmaru ID 외부 진입점과 현재 선택값을 함께 보여 주는 `테마`, `게시물 기본 공개 범위`, `뮤트 및 차단` 내부 진입점을 이 순서로 직접 제공해야 한다(MUST). `테마`는 `/settings/theme` detail을 열어야 하며(MUST), `뮤트 및 차단`은 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 제공하는 category를 열어야 한다(MUST). 두 Mute·Block 상태를 하나의 혼합 목록으로 표시해서는 안 된다(MUST NOT). 현재 네 entry를 위해 한 항목짜리 `계정`·`화면 설정`·`프로필` category를 만들어서는 안 되며(MUST NOT), 별도 canonical·Linear 승인이 없는 미래 category를 disabled item·placeholder·범용 registry로 노출해서는 안 된다(MUST NOT). 공통 presentational `SettingsItem`은 부모 container 폭에 맞는 row geometry와 필수 label·선택적 leading·description·trailing content·selected presentation을 조합할 수 있어야 한다(MUST). `SettingsItem`이 Link·Pressable·focus·accessible name·feature 조회·저장·persistence semantics를 추론하거나 소유해서는 안 된다(MUST NOT).
 
-#### Scenario: 현재 승인된 세 entry를 직접 표시한다
+#### Scenario: 현재 승인된 네 entry를 직접 표시한다
 
 - **WHEN** 인증 사용자가 `/settings` root를 연다
-- **THEN** root는 첫 번째 시각 label `계정 설정`의 Byulmaru ID 외부 entry, 두 번째 `게시물 기본 공개 범위`, 세 번째 `뮤트 및 차단` 내부 entry를 표시한다
+- **THEN** root는 첫 번째 시각 label `계정 설정`의 Byulmaru ID 외부 entry, 두 번째 현재 선택값을 함께 보여 주는 `테마`, 세 번째 `게시물 기본 공개 범위`, 네 번째 `뮤트 및 차단` 내부 entry를 표시한다
+- **AND** `테마`를 선택하면 `/settings/theme` detail을 연다
 - **AND** `뮤트 및 차단`을 선택하면 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 제공한다
-- **AND** `계정` 또는 `프로필` 한 항목짜리 category를 중간 단계로 표시하지 않는다
+- **AND** `계정`, `화면 설정` 또는 `프로필` 한 항목짜리 category를 중간 단계로 표시하지 않는다
 
 #### Scenario: 같은 item 문법을 다른 폭에서 사용한다
 
@@ -161,18 +162,19 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 ### Requirement: Settings 접근성 계약
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/profile-mute-block.md`, `docs/design/accessibility.md`, `PROD-685`, `DSN-53` — root 화면과 full master pane은 `설정` heading을, one-pane category·detail 화면과 full detail pane은 현재 destination heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위` → `뮤트 및 차단`이어야 하며(MUST), full Web에서는 이어서 detail heading과 현재 선택된 content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/profile-mute-block.md`, `docs/design/accessibility.md`, `PROD-685`, `DSN-53`, `DSN-54` — root 화면과 full master pane은 `설정` heading을, one-pane category·detail 화면과 full detail pane은 현재 destination heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `테마`와 현재 선택값 → `게시물 기본 공개 범위` → `뮤트 및 차단`이어야 하며(MUST), full Web에서는 이어서 detail heading과 현재 선택된 content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
 
 #### Scenario: screen reader가 master와 detail을 구분한다
 
 - **WHEN** screen reader 사용자가 full Web `/settings`를 heading과 control 단위로 탐색한다
-- **THEN** `설정` heading과 세 root entry 다음에 `게시물 기본 공개 범위` detail heading과 현재 Profile content가 노출된다
+- **THEN** `설정` heading과 네 root entry 다음에 `게시물 기본 공개 범위` detail heading과 현재 Profile content가 노출된다
+- **AND** `테마` entry의 현재 선택값을 accessible name과 state로 구분할 수 있다
 - **AND** Account 외부 destination, selected 내부 entry와 현재 Profile control을 accessible name과 state로 구분할 수 있다
 
 #### Scenario: keyboard로 full workspace를 탐색한다
 
 - **WHEN** Web keyboard 사용자가 full Settings workspace의 interactive control을 순서대로 이동한다
-- **THEN** Tab focus는 master의 `계정 설정`·`게시물 기본 공개 범위`·`뮤트 및 차단` entry 다음 detail의 interactive control로 이동한다
+- **THEN** Tab focus는 master의 `계정 설정`·`테마`·`게시물 기본 공개 범위`·`뮤트 및 차단` entry 다음 detail의 interactive control로 이동한다
 - **AND** heading과 비상호작용 Profile identity는 tab stop이 아니다
 - **AND** focus-visible, selected, disabled와 busy 상태를 색상만으로 전달하지 않는다
 
@@ -190,7 +192,7 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 - **WHEN** PROD-645와 PROD-667의 통합 가능한 구현 결과가 준비됐다
 - **THEN** PROD-645의 Byulmaru ID 외부 진입점은 Settings root의 첫 entry로 표시된다
-- **AND** PROD-667의 Kosmo Profile 기능은 두 번째 entry가 여는 detail에 현재 대상과 함께 표시된다
+- **AND** PROD-667의 Kosmo Profile 기능은 세 번째 entry가 여는 detail에 현재 대상과 함께 표시된다
 - **AND** Account 외부 이동과 Profile 조회·저장은 각각 자기 자식 기능 경계가 처리한다
 
 #### Scenario: 페이지 수준 통합을 검증한다

--- a/openspec/specs/settings-page-shell/spec.md
+++ b/openspec/specs/settings-page-shell/spec.md
@@ -29,9 +29,9 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 - **THEN** 시스템은 `/settings` root 목록을 열고 drawer를 닫는다
 - **AND** 하단 탭 바와 일반 우측 레일에는 별도 `설정` 항목을 표시하지 않는다
 
-#### Scenario: 내부 detail에서도 설정 current 상태를 유지한다
+#### Scenario: 내부 category와 detail에서도 설정 current 상태를 유지한다
 
-- **WHEN** 사용자가 지원되는 Settings 내부 detail route를 연다
+- **WHEN** 사용자가 지원되는 Settings 내부 category 또는 detail route를 연다
 - **THEN** shell의 `설정` navigation은 현재 route family를 page-current로 노출한다
 
 #### Scenario: 준비되지 않은 진입점을 노출하지 않는다
@@ -119,16 +119,16 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 #### Scenario: mobile Web heading을 중복하지 않는다
 
-- **WHEN** mobile Web 사용자가 Settings root 또는 detail을 연다
-- **THEN** `UniversalShell`은 root에서 menu+`설정`, detail에서 back+detail heading을 표시한다
+- **WHEN** mobile Web 사용자가 Settings root 또는 category·detail destination을 연다
+- **THEN** `UniversalShell`은 root에서 menu+`설정`, category·detail destination에서 back+현재 destination heading을 표시한다
 - **AND** route content는 같은 heading을 복제하지 않는다
 
 #### Scenario: compact와 Native heading을 중복하지 않는다
 
-- **WHEN** Android·iOS 또는 compact Web 사용자가 Settings root 또는 detail을 연다
-- **THEN** route는 root 또는 detail의 text header를 첫 heading으로 표시하고 detail에 back action을 제공한다
-- **AND** Android·iOS에서는 하나의 vertical `ScrollView`가 route header와 root 또는 detail content 전체를 포함한다
-- **AND** 긴 detail title은 leading action 다음의 가용 폭 안에서 여러 줄로 reflow한다
+- **WHEN** Android·iOS 또는 compact Web 사용자가 Settings root 또는 category·detail destination을 연다
+- **THEN** route는 현재 destination의 text header를 첫 heading으로 표시하고 category·detail destination에 back action을 제공한다
+- **AND** Android·iOS에서는 하나의 vertical `ScrollView`가 route header와 root·category·detail content 전체를 포함한다
+- **AND** 긴 destination title은 leading action 다음의 가용 폭 안에서 여러 줄로 reflow한다
 
 ### Requirement: Profile detail 상태 소유
 
@@ -160,7 +160,7 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 ### Requirement: Settings 접근성 계약
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-685` — root 화면과 full master pane은 `설정` heading을, Profile detail 화면과 pane은 현재 설정 이름 heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위`여야 하며(MUST), full Web에서는 이어서 detail heading과 Profile content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-685` — root 화면과 full master pane은 `설정` heading을, one-pane category·detail 화면과 full detail pane은 현재 destination heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위`여야 하며(MUST), full Web에서는 이어서 detail heading과 Profile content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
 
 #### Scenario: screen reader가 master와 detail을 구분한다
 
@@ -177,7 +177,7 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 #### Scenario: 작은 화면과 font scaling에서 정보를 유지한다
 
-- **WHEN** 사용자가 Web reflow 또는 Android·iOS font scaling으로 Settings root나 detail을 확대한다
+- **WHEN** 사용자가 Web reflow 또는 Android·iOS font scaling으로 Settings root나 category·detail destination을 확대한다
 - **THEN** label·description·현재 Profile identity와 action을 계속 사용할 수 있다
 - **AND** 핵심 기능이 불필요한 가로 scroll이나 잘린 text에 의존하지 않는다
 

--- a/openspec/specs/settings-page-shell/spec.md
+++ b/openspec/specs/settings-page-shell/spec.md
@@ -84,7 +84,7 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 ### Requirement: Full Web workspace와 one-pane responsive navigation
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/page-header.md`, `docs/design/breakpoints.md`, `PROD-685` — full Web의 Settings route family는 전역 sidebar를 유지하고 일반 `RightRail`을 숨긴 뒤 기존 center+right 영역을 Settings wide workspace로 사용해야 한다(MUST). workspace는 약 320px master pane과 남은 폭을 채우는 detail pane을 제공해야 하며(MUST), `/settings` hub는 `게시물 기본 공개 범위` entry를 기본 selected 상태로 두고 Profile detail을 표시해야 한다(MUST). compact Web, mobile Web, Android와 iOS의 `/settings`는 root 목록부터 표시하고 내부 entry를 선택했을 때 한 화면짜리 detail로 이동해야 하며(MUST), detail은 back navigation으로 root에 돌아갈 수 있어야 한다(MUST). 다른 route의 center 600px·RightRail visibility와 기존 `compact=768`, `full=1280` breakpoint를 변경해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/page-header.md`, `docs/design/breakpoints.md`, `PROD-685`, `PROD-838` — full Web의 Settings route family는 전역 sidebar를 유지하고 일반 `RightRail`을 숨긴 뒤 기존 center+right 영역을 Settings wide workspace로 사용해야 한다(MUST). workspace는 약 320px master pane과 남은 폭을 채우는 detail pane을 제공해야 하며(MUST), `/settings` hub는 `게시물 기본 공개 범위` entry를 기본 selected 상태로 두고 Profile detail을 표시해야 한다(MUST). compact Web, mobile Web, Android와 iOS의 `/settings`는 root 목록부터 표시하고 내부 entry를 선택했을 때 한 화면짜리 category 또는 detail destination으로 이동해야 한다(MUST). 모든 내부 destination은 명시적인 parent를 가져야 하고(MUST), back navigation은 이전 history·navigation stack과 무관하게 해당 parent를 열어야 한다(MUST). root의 직접 entry가 여는 1단계 destination의 parent는 `/settings` root여야 하며(MUST), 중첩 destination의 parent는 바로 위 category여야 한다(MUST). 다른 route의 center 600px·RightRail visibility와 기존 `compact=768`, `full=1280` breakpoint를 변경해서는 안 된다(MUST NOT).
 
 #### Scenario: full Web에서 Settings master-detail을 표시한다
 
@@ -98,18 +98,24 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 - **WHEN** 사용자가 Settings route family 밖의 기존 full Web route를 연다
 - **THEN** shell은 기존 중앙 최대 600px와 일반 RightRail visibility를 유지한다
 
-#### Scenario: compact와 mobile에서 root부터 detail로 이동한다
+#### Scenario: compact와 mobile에서 root부터 1단계 destination으로 이동한다
 
 - **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 `/settings`를 연다
-- **THEN** 화면은 두 entry가 있는 root 목록부터 표시한다
-- **AND** `게시물 기본 공개 범위`를 선택하면 Profile detail 한 화면으로 이동한다
-- **AND** back action은 Settings root 목록으로 돌아간다
+- **THEN** 화면은 승인된 entry가 있는 root 목록부터 표시한다
+- **AND** root의 직접 entry를 선택하면 해당 1단계 destination 한 화면으로 이동한다
+- **AND** back action은 명시적인 parent인 Settings root 목록으로 돌아간다
 
-#### Scenario: 이전 navigation stack과 무관하게 Settings root로 돌아간다
+#### Scenario: 중첩 destination에서 바로 위 category로 돌아간다
 
-- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 unrelated 화면이 이전 history 또는 navigation stack에 남아 있는 상태에서 direct/deep link로 내부 Settings detail을 연다
-- **AND** 사용자가 detail의 back action을 실행한다
-- **THEN** 시스템은 이전 unrelated 화면을 열지 않고 `/settings` root 목록을 연다
+- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 Settings category에서 중첩 destination을 연다
+- **AND** 사용자가 중첩 destination의 back action을 실행한다
+- **THEN** 시스템은 `/settings` root로 건너뛰지 않고 바로 위 category를 연다
+
+#### Scenario: 이전 navigation stack과 무관하게 명시적인 parent로 돌아간다
+
+- **WHEN** compact Web, mobile Web, Android 또는 iOS 사용자가 unrelated 화면이 이전 history 또는 navigation stack에 남아 있는 상태에서 direct/deep link로 내부 Settings category 또는 detail destination을 연다
+- **AND** 사용자가 destination의 back action을 실행한다
+- **THEN** 시스템은 이전 unrelated 화면을 열지 않고 해당 destination의 명시적인 parent를 연다
 
 #### Scenario: mobile Web heading을 중복하지 않는다
 

--- a/openspec/specs/settings-page-shell/spec.md
+++ b/openspec/specs/settings-page-shell/spec.md
@@ -41,12 +41,13 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 ### Requirement: 현재 Settings root와 공통 item 정보 구조
 
-**Authority / Provenance:** `docs/design/settings.md`, `PROD-685`; 기능 경계 `PROD-645`, `PROD-667` — Settings root는 시각 label `계정 설정`인 Byulmaru ID 외부 진입점과 `게시물 기본 공개 범위` 내부 진입점을 이 순서로 직접 제공해야 한다(MUST). 현재 두 entry를 위해 한 항목짜리 `계정`·`프로필` category를 만들어서는 안 되며(MUST NOT), 별도 canonical·Linear 승인이 없는 미래 category를 disabled item·placeholder·범용 registry로 노출해서는 안 된다(MUST NOT). 공통 presentational `SettingsItem`은 부모 container 폭에 맞는 row geometry와 필수 label·선택적 leading·description·trailing content·selected presentation을 조합할 수 있어야 한다(MUST). `SettingsItem`이 Link·Pressable·focus·accessible name·feature 조회·저장·persistence semantics를 추론하거나 소유해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/profile-mute-block.md`, `PROD-685`, `DSN-53`; 기능 경계 `PROD-645`, `PROD-667`, Mute·Block runtime `PROD-814`, `PROD-823`, `PROD-813` — Settings root는 시각 label `계정 설정`인 Byulmaru ID 외부 진입점과 `게시물 기본 공개 범위`, `뮤트 및 차단` 내부 진입점을 이 순서로 직접 제공해야 한다(MUST). `뮤트 및 차단`은 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 제공하는 category를 열어야 하며(MUST), 두 상태를 하나의 혼합 목록으로 표시해서는 안 된다(MUST NOT). 현재 세 entry를 위해 한 항목짜리 `계정`·`프로필` category를 만들어서는 안 되며(MUST NOT), 별도 canonical·Linear 승인이 없는 미래 category를 disabled item·placeholder·범용 registry로 노출해서는 안 된다(MUST NOT). 공통 presentational `SettingsItem`은 부모 container 폭에 맞는 row geometry와 필수 label·선택적 leading·description·trailing content·selected presentation을 조합할 수 있어야 한다(MUST). `SettingsItem`이 Link·Pressable·focus·accessible name·feature 조회·저장·persistence semantics를 추론하거나 소유해서는 안 된다(MUST NOT).
 
-#### Scenario: 현재 승인된 두 entry를 직접 표시한다
+#### Scenario: 현재 승인된 세 entry를 직접 표시한다
 
 - **WHEN** 인증 사용자가 `/settings` root를 연다
-- **THEN** root는 첫 번째 시각 label `계정 설정`의 Byulmaru ID 외부 entry와 두 번째 `게시물 기본 공개 범위` 내부 entry를 표시한다
+- **THEN** root는 첫 번째 시각 label `계정 설정`의 Byulmaru ID 외부 entry, 두 번째 `게시물 기본 공개 범위`, 세 번째 `뮤트 및 차단` 내부 entry를 표시한다
+- **AND** `뮤트 및 차단`을 선택하면 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 제공한다
 - **AND** `계정` 또는 `프로필` 한 항목짜리 category를 중간 단계로 표시하지 않는다
 
 #### Scenario: 같은 item 문법을 다른 폭에서 사용한다
@@ -160,18 +161,18 @@ Kosmo의 canonical `/settings` route family, responsive master-detail/one-pane s
 
 ### Requirement: Settings 접근성 계약
 
-**Authority / Provenance:** `docs/design/settings.md`, `docs/design/accessibility.md`, `PROD-685` — root 화면과 full master pane은 `설정` heading을, one-pane category·detail 화면과 full detail pane은 현재 destination heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위`여야 하며(MUST), full Web에서는 이어서 detail heading과 Profile content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
+**Authority / Provenance:** `docs/design/settings.md`, `docs/design/profile-mute-block.md`, `docs/design/accessibility.md`, `PROD-685`, `DSN-53` — root 화면과 full master pane은 `설정` heading을, one-pane category·detail 화면과 full detail pane은 현재 destination heading을 programmatic하게 노출해야 한다(MUST). 시각적으로 없는 category heading을 screen reader 전용으로 반복해서는 안 된다(MUST NOT). root/master 목록의 문서·보조기술 순서는 `설정` heading → 시각 label `계정 설정`의 Byulmaru ID 외부 entry → `게시물 기본 공개 범위` → `뮤트 및 차단`이어야 하며(MUST), full Web에서는 이어서 detail heading과 현재 선택된 content를 노출해야 한다(MUST). Account entry는 accessible name에서 Byulmaru ID 외부 서비스로 이동함을 전달해야 하고(MUST), 내부 entry는 selected/current destination을, Profile control은 Kosmo 내부 기능과 현재 대상을 전달해야 한다(MUST). heading과 비상호작용 identity는 tab stop이어서는 안 된다(MUST NOT). Web pointer target은 24×24 CSS px minimum 또는 공식 예외를 충족해야 하고(MUST), iOS는 기본 44×44pt, Android는 48×48dp touch target을 사용해야 한다(MUST).
 
 #### Scenario: screen reader가 master와 detail을 구분한다
 
 - **WHEN** screen reader 사용자가 full Web `/settings`를 heading과 control 단위로 탐색한다
-- **THEN** `설정` heading과 두 root entry 다음에 `게시물 기본 공개 범위` detail heading과 현재 Profile content가 노출된다
+- **THEN** `설정` heading과 세 root entry 다음에 `게시물 기본 공개 범위` detail heading과 현재 Profile content가 노출된다
 - **AND** Account 외부 destination, selected 내부 entry와 현재 Profile control을 accessible name과 state로 구분할 수 있다
 
 #### Scenario: keyboard로 full workspace를 탐색한다
 
 - **WHEN** Web keyboard 사용자가 full Settings workspace의 interactive control을 순서대로 이동한다
-- **THEN** Tab focus는 master의 Account·Profile entry 다음 detail의 interactive control로 이동한다
+- **THEN** Tab focus는 master의 `계정 설정`·`게시물 기본 공개 범위`·`뮤트 및 차단` entry 다음 detail의 interactive control로 이동한다
 - **AND** heading과 비상호작용 Profile identity는 tab stop이 아니다
 - **AND** focus-visible, selected, disabled와 busy 상태를 색상만으로 전달하지 않는다
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `settings.md`, `breakpoints.md`, `page-header.md`의 parent와 one-pane header/back 계약을 정렬했습니다.
- active `settings-page-shell` spec에는 현재 parent/category/header 계약과 네 root entry(`계정 설정` → `테마` → `게시물 기본 공개 범위` → `뮤트 및 차단`)·접근성 순서를 반영했습니다.
- archived `settings-page-shell` spec과 archive decisions/design은 2026-08-08 본문을 보존하고, 2026-08-25 reconciliation/supersession만 기록했습니다.
- DSN-53 전용 설계, production 코드·테스트는 변경하지 않았습니다.

## 왜 변경했는지

PR #659 리뷰에서 중첩 Settings destination과 기존 `/settings` root-only back 계약 사이의 공백이 확인됐습니다. root-only 문구는 DSN-53 이전부터 존재했으므로 Profile moderation 전용 예외가 아니라 Settings 공통 계약으로 정리했습니다.

## 이번 PR의 주요 결정

### destination별 명시적 parent를 사용한다

- 결정자: 이예은
- 선택: root 직접 entry가 여는 1단계 destination은 `/settings`를, 중첩 destination은 바로 위 category를 parent로 사용합니다. direct·deep link에서도 같은 parent를 엽니다.
- 고려한 대안: 모든 destination에서 `/settings`로 돌아가기, DSN-53에만 예외 추가
- 이유: 중첩 정보 구조를 보존하면서 기능별 예외 없이 Settings 전체에 같은 navigation 원칙을 적용하기 위해서입니다.
- 감수한 결과: 후속 production 구현은 history/pop에 의존하지 않고 destination별 parent를 명시해야 합니다.
- 관련 근거: PROD-838, `docs/design/settings.md`, PR #659 리뷰 스레드

## 어떻게 확인할 수 있는지

- Prettier 검사 통과
- `settings-page-shell` strict validation 통과
- active OpenSpec 전체 69/69 통과
- `git diff --check` 통과
- 독립 재검토에서 actionable finding 없음
- GitHub CI 13/13 통과

## 아직 어떤 문제가 남았는지

- production routing·navigation 구현과 runtime 테스트는 이번 PR 범위가 아닙니다.
- PR #659의 리뷰 스레드는 이 후속 PR이 merge될 때까지 unresolved로 유지합니다.

Stack: main -> PROD-838
Linear: https://linear.app/byulmaru/issue/PROD-838

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>