### PR TITLE
Temporal sibling effect settlement를 공용화한다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,9 @@
 - Before branch or pull request work, verify the extension with `gh extension list` and
   `gh stack --version`. If it is missing, install it for the current user with
   `gh extension install github/gh-stack`; it is a local CLI extension, not a repository dependency.
-- Start the first layer from the latest trunk with `gh stack init --base main <Linear issue ID>`.
-  Add each later layer only from the current top with `gh stack add <Linear issue ID>`.
+- Start the first layer from the latest trunk with `gh stack init --base main <branch>`.
+  Add each later layer only from the current top with `gh stack add <branch>`.
+- Feature and contract branches use their Linear issue ID. A behavior-preserving simple refactor may use a descriptive branch without creating a Linear issue solely for the pull request.
 - Push tracked layers with `gh stack push` and create or update pull requests with `gh stack submit`.
   For two or more pull requests, submit must also create or update the remote GitHub Stack object.
   A one-layer Stack remains locally tracked and its standalone pull request has a null REST `stack`
@@ -111,6 +112,7 @@
 - `memory/database-migrations.md`: additive와 breaking DB 변경 분류, expand/transition/contract
   이슈·PR·배포 순서, backfill과 contract gate.
 - `memory/graphql-style.md`: GraphQL resolver structure, object refs, enum registration, Node ID, and resolver style.
+- `memory/temporal-workflows.md`: Temporal Workflow file structure, shared effect settlement, Activity aliases, and post-commit start conventions.
 
 ## Design Docs
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -17,6 +17,7 @@
     "@kosmo/fedify": "workspace:*",
     "@temporalio/worker": "^1.22.0",
     "@temporalio/workflow": "^1.22.0",
+    "ts-pattern": "^5.9.0",
     "tsx": "^4.22.4"
   },
   "devDependencies": {

--- a/apps/worker/src/workflows/create.ts
+++ b/apps/worker/src/workflows/create.ts
@@ -1,4 +1,6 @@
 import { proxyActivities } from '@temporalio/workflow';
+import { match } from 'ts-pattern';
+import { settleEffects } from './settle-effects';
 import type * as activities from '../activities';
 
 type PostCreateEffectsInput = {
@@ -17,16 +19,9 @@ export async function postCreateEffectsWorkflow({
   postId,
   origin,
 }: PostCreateEffectsInput): Promise<void> {
-  const effects = [createReplyNotificationActivity(postId)];
-  if (origin === 'LOCAL') {
-    effects.push(sendLocalPostCreateActivity(postId));
-  }
-
-  const results = await Promise.allSettled(effects);
-  const failure = results.find(
-    (result): result is PromiseRejectedResult => result.status === 'rejected',
-  );
-  if (failure) {
-    throw failure.reason;
-  }
+  const notification = createReplyNotificationActivity(postId);
+  await match(origin)
+    .with('LOCAL', () => settleEffects([notification, sendLocalPostCreateActivity(postId)]))
+    .with('ACTIVITYPUB', () => notification)
+    .exhaustive();
 }

--- a/apps/worker/src/workflows/create.ts
+++ b/apps/worker/src/workflows/create.ts
@@ -19,9 +19,11 @@ export async function postCreateEffectsWorkflow({
   postId,
   origin,
 }: PostCreateEffectsInput): Promise<void> {
-  const notification = createReplyNotificationActivity(postId);
-  await match(origin)
-    .with('LOCAL', () => settleEffects([notification, sendLocalPostCreateActivity(postId)]))
-    .with('ACTIVITYPUB', () => notification)
-    .exhaustive();
+  await settleEffects([
+    createReplyNotificationActivity(postId),
+    ...match(origin)
+      .with('LOCAL', () => [sendLocalPostCreateActivity(postId)])
+      .with('ACTIVITYPUB', () => [])
+      .exhaustive(),
+  ]);
 }

--- a/apps/worker/src/workflows/reaction-create.ts
+++ b/apps/worker/src/workflows/reaction-create.ts
@@ -1,4 +1,6 @@
 import { proxyActivities } from '@temporalio/workflow';
+import { match } from 'ts-pattern';
+import { settleEffects } from './settle-effects';
 import type * as activities from '../activities';
 
 type ReactionCreateEffectsInput = {
@@ -17,16 +19,9 @@ export async function reactionCreateEffectsWorkflow({
   reactionId,
   origin,
 }: ReactionCreateEffectsInput): Promise<void> {
-  const effects = [createReactionNotificationActivity(reactionId)];
-  if (origin === 'LOCAL') {
-    effects.push(sendReactionActivity(reactionId));
-  }
-
-  const results = await Promise.allSettled(effects);
-  const failure = results.find(
-    (result): result is PromiseRejectedResult => result.status === 'rejected',
-  );
-  if (failure) {
-    throw failure.reason;
-  }
+  const notification = createReactionNotificationActivity(reactionId);
+  await match(origin)
+    .with('LOCAL', () => settleEffects([notification, sendReactionActivity(reactionId)]))
+    .with('ACTIVITYPUB', () => notification)
+    .exhaustive();
 }

--- a/apps/worker/src/workflows/reaction-create.ts
+++ b/apps/worker/src/workflows/reaction-create.ts
@@ -19,9 +19,11 @@ export async function reactionCreateEffectsWorkflow({
   reactionId,
   origin,
 }: ReactionCreateEffectsInput): Promise<void> {
-  const notification = createReactionNotificationActivity(reactionId);
-  await match(origin)
-    .with('LOCAL', () => settleEffects([notification, sendReactionActivity(reactionId)]))
-    .with('ACTIVITYPUB', () => notification)
-    .exhaustive();
+  await settleEffects([
+    createReactionNotificationActivity(reactionId),
+    ...match(origin)
+      .with('LOCAL', () => [sendReactionActivity(reactionId)])
+      .with('ACTIVITYPUB', () => [])
+      .exhaustive(),
+  ]);
 }

--- a/apps/worker/src/workflows/reaction-delete.ts
+++ b/apps/worker/src/workflows/reaction-delete.ts
@@ -27,14 +27,11 @@ export async function reactionDeleteEffectsWorkflow({
   createdAt,
   origin,
 }: ReactionDeleteEffectsInput): Promise<void> {
-  const notification = deleteReactionNotificationActivity(id);
-  await match(origin)
-    .with('LOCAL', () =>
-      settleEffects([
-        notification,
-        sendReactionUndoActivity({ id, profileId, postId, type, createdAt }),
-      ]),
-    )
-    .with('ACTIVITYPUB', () => notification)
-    .exhaustive();
+  await settleEffects([
+    deleteReactionNotificationActivity(id),
+    ...match(origin)
+      .with('LOCAL', () => [sendReactionUndoActivity({ id, profileId, postId, type, createdAt })])
+      .with('ACTIVITYPUB', () => [])
+      .exhaustive(),
+  ]);
 }

--- a/apps/worker/src/workflows/reaction-delete.ts
+++ b/apps/worker/src/workflows/reaction-delete.ts
@@ -1,4 +1,6 @@
 import { proxyActivities } from '@temporalio/workflow';
+import { match } from 'ts-pattern';
+import { settleEffects } from './settle-effects';
 import type * as activities from '../activities';
 
 type ReactionDeleteEffectsInput = {
@@ -25,24 +27,14 @@ export async function reactionDeleteEffectsWorkflow({
   createdAt,
   origin,
 }: ReactionDeleteEffectsInput): Promise<void> {
-  const effects = [deleteReactionNotificationActivity(id)];
-  if (origin === 'LOCAL') {
-    effects.push(
-      sendReactionUndoActivity({
-        id,
-        profileId,
-        postId,
-        type,
-        createdAt,
-      }),
-    );
-  }
-
-  const results = await Promise.allSettled(effects);
-  const failure = results.find(
-    (result): result is PromiseRejectedResult => result.status === 'rejected',
-  );
-  if (failure) {
-    throw failure.reason;
-  }
+  const notification = deleteReactionNotificationActivity(id);
+  await match(origin)
+    .with('LOCAL', () =>
+      settleEffects([
+        notification,
+        sendReactionUndoActivity({ id, profileId, postId, type, createdAt }),
+      ]),
+    )
+    .with('ACTIVITYPUB', () => notification)
+    .exhaustive();
 }

--- a/apps/worker/src/workflows/repost-delete.ts
+++ b/apps/worker/src/workflows/repost-delete.ts
@@ -16,9 +16,11 @@ const { deleteRepostNotificationActivity, sendRepostUndoActivity } = proxyActivi
 });
 
 export async function repostDeleteWorkflow({ postId, origin }: RepostDeleteInput): Promise<void> {
-  const notification = deleteRepostNotificationActivity(postId);
-  await match(origin)
-    .with('LOCAL', () => settleEffects([notification, sendRepostUndoActivity(postId)]))
-    .with('ACTIVITYPUB', () => notification)
-    .exhaustive();
+  await settleEffects([
+    deleteRepostNotificationActivity(postId),
+    ...match(origin)
+      .with('LOCAL', () => [sendRepostUndoActivity(postId)])
+      .with('ACTIVITYPUB', () => [])
+      .exhaustive(),
+  ]);
 }

--- a/apps/worker/src/workflows/repost-delete.ts
+++ b/apps/worker/src/workflows/repost-delete.ts
@@ -1,4 +1,6 @@
 import { proxyActivities } from '@temporalio/workflow';
+import { match } from 'ts-pattern';
+import { settleEffects } from './settle-effects';
 import type * as activities from '../activities';
 
 type RepostDeleteInput = {
@@ -14,16 +16,9 @@ const { deleteRepostNotificationActivity, sendRepostUndoActivity } = proxyActivi
 });
 
 export async function repostDeleteWorkflow({ postId, origin }: RepostDeleteInput): Promise<void> {
-  const effects = [deleteRepostNotificationActivity(postId)];
-  if (origin === 'LOCAL') {
-    effects.push(sendRepostUndoActivity(postId));
-  }
-
-  const results = await Promise.allSettled(effects);
-  const failure = results.find(
-    (result): result is PromiseRejectedResult => result.status === 'rejected',
-  );
-  if (failure) {
-    throw failure.reason;
-  }
+  const notification = deleteRepostNotificationActivity(postId);
+  await match(origin)
+    .with('LOCAL', () => settleEffects([notification, sendRepostUndoActivity(postId)]))
+    .with('ACTIVITYPUB', () => notification)
+    .exhaustive();
 }

--- a/apps/worker/src/workflows/repost.ts
+++ b/apps/worker/src/workflows/repost.ts
@@ -1,4 +1,6 @@
 import { proxyActivities } from '@temporalio/workflow';
+import { match } from 'ts-pattern';
+import { settleEffects } from './settle-effects';
 import type * as activities from '../activities';
 
 type PostRepostInput = {
@@ -14,16 +16,9 @@ const { createRepostNotificationActivity, sendRepostAnnounceActivity } = proxyAc
 });
 
 export async function postRepostWorkflow({ postId, origin }: PostRepostInput): Promise<void> {
-  const effects = [createRepostNotificationActivity(postId)];
-  if (origin === 'LOCAL') {
-    effects.push(sendRepostAnnounceActivity(postId));
-  }
-
-  const results = await Promise.allSettled(effects);
-  const failure = results.find(
-    (result): result is PromiseRejectedResult => result.status === 'rejected',
-  );
-  if (failure) {
-    throw failure.reason;
-  }
+  const notification = createRepostNotificationActivity(postId);
+  await match(origin)
+    .with('LOCAL', () => settleEffects([notification, sendRepostAnnounceActivity(postId)]))
+    .with('ACTIVITYPUB', () => notification)
+    .exhaustive();
 }

--- a/apps/worker/src/workflows/repost.ts
+++ b/apps/worker/src/workflows/repost.ts
@@ -16,9 +16,11 @@ const { createRepostNotificationActivity, sendRepostAnnounceActivity } = proxyAc
 });
 
 export async function postRepostWorkflow({ postId, origin }: PostRepostInput): Promise<void> {
-  const notification = createRepostNotificationActivity(postId);
-  await match(origin)
-    .with('LOCAL', () => settleEffects([notification, sendRepostAnnounceActivity(postId)]))
-    .with('ACTIVITYPUB', () => notification)
-    .exhaustive();
+  await settleEffects([
+    createRepostNotificationActivity(postId),
+    ...match(origin)
+      .with('LOCAL', () => [sendRepostAnnounceActivity(postId)])
+      .with('ACTIVITYPUB', () => [])
+      .exhaustive(),
+  ]);
 }

--- a/apps/worker/src/workflows/settle-effects.ts
+++ b/apps/worker/src/workflows/settle-effects.ts
@@ -1,0 +1,9 @@
+export const settleEffects = async (effects: readonly Promise<void>[]): Promise<void> => {
+  const results = await Promise.allSettled(effects);
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  if (failure) {
+    throw failure.reason;
+  }
+};

--- a/memory/coding-style.md
+++ b/memory/coding-style.md
@@ -6,6 +6,7 @@
 - 이 메모는 PR 본문이 아니라 다른 사람 PR에 `robin-maki`가 직접 남긴 리뷰에서 반복된 기준을 일반화한 것이다.
 - 세부 영역은 기존 메모를 우선한다.
   - GraphQL resolver/API 세부 구조: `memory/graphql-style.md`
+  - Temporal Workflow/Activity와 post-commit start 구조: `memory/temporal-workflows.md`
   - Expo Router/React Native Web/React Relay/Storybook: `memory/frontend-react-native.md`
   - DB/Drizzle schema: `memory/database-design.md`
   - 스크립트/CI/명령 실행: `memory/script.md`

--- a/memory/commit-pr.md
+++ b/memory/commit-pr.md
@@ -10,10 +10,11 @@
 
 - AI로 작업을 시작할 때는 사용자의 의도를 먼저 물어보고, 이미 대화에 명확히 드러난 의도가 있으면 그 의도를 작업 맥락으로 기록한다.
 - 커밋/브랜치/PR 작업 전 `git status --short --branch`로 현재 위치와 변경 범위를 확인한다.
-- 브랜치 이름은 관련 Linear 이슈 ID를 그대로 사용한다.
-- 하나의 브랜치는 하나의 Linear 이슈에 대응시키는 것을 기본으로 한다.
+- 기능·계약 변경 브랜치 이름은 관련 Linear 이슈 ID를 그대로 사용한다.
+- 행동을 보존하는 단순 리팩터링은 PR을 만들기 위해 Linear 이슈를 별도로 생성하지 않고 설명적인 브랜치 이름을 사용할 수 있다.
+- 이슈가 있는 작업은 하나의 브랜치가 하나의 Linear 이슈에 대응시키는 것을 기본으로 한다.
 - 새 PR은 단일 PR도 1-layer GitHub Stack으로 추적하고 `gh stack submit`으로 생성한다.
-- 후속 PR은 현재 Stack top에서 `gh stack add <Linear issue ID>`로 추가한다.
+- 후속 PR은 현재 Stack top에서 `gh stack add <branch>`로 추가한다.
 - `gh stack`을 사용할 수 없거나 실패하면 `gh pr create`나 일반 unstacked PR로 우회하지 않고
   blocker와 관찰한 local/remote 상태를 보고한다.
 - 커밋은 되돌릴 수 있는 작업 체크포인트로 자주 남기되, 의도하지 않은 사용자 변경은 staging하지 않는다.
@@ -42,7 +43,7 @@
 
 - 현재 브랜치가 `main`이 아닌 적절한 작업 브랜치인가.
 - `github/gh-stack` extension이 설치되어 있고 `gh stack --version`이 성공하는가.
-- 브랜치 이름이 대응되는 Linear 이슈 ID와 일치하는가.
+- 기능·계약 변경 브랜치는 대응되는 Linear 이슈 ID와 일치하는가. 이슈 없는 브랜치라면 행동 보존 단순 리팩터링인가.
 - 단일 PR을 포함해 현재 브랜치가 의도한 Stack에 추적되고 있는가.
 - PR이 하나의 기능적 변화로 설명되는가.
 - 독립적으로 테스트하거나 수동 검증할 수 있는가.

--- a/memory/git-pr-workflow.md
+++ b/memory/git-pr-workflow.md
@@ -40,9 +40,10 @@
 
 ## Branch Policy
 
-- 브랜치 이름은 관련 Linear 이슈 ID를 그대로 사용한다.
+- 기능·계약 변경 브랜치 이름은 관련 Linear 이슈 ID를 그대로 사용한다.
 - 별도 접두어나 설명어를 붙이기보다 이슈 추적성과 연결성을 우선한다.
-- 하나의 브랜치는 하나의 Linear 이슈에 대응시키는 것을 기본으로 한다.
+- 행동을 보존하는 단순 리팩터링은 PR을 만들기 위해 Linear 이슈를 생성하지 않고 설명적인 브랜치 이름을 사용할 수 있다.
+- 이슈가 있는 작업은 하나의 브랜치가 하나의 Linear 이슈에 대응시키는 것을 기본으로 한다.
 - PR 설명과 커밋 맥락도 같은 이슈를 중심으로 정렬한다.
 
 ## Create A Branch
@@ -51,12 +52,11 @@
   - `git fetch origin`
   - `git switch main`
   - `git pull --ff-only`
-  - `gh stack init --base main <Linear issue ID>`
+  - `gh stack init --base main <branch>`
 - 후속 PR 브랜치는 current top에서만 Stack에 추가한다.
   - `gh stack top`
-  - `gh stack add <Linear issue ID>`
-- `gh stack add`는 현재 HEAD에서 새 branch를 만들고 Stack top으로 checkout한다. branch 자동 생성
-  이름 대신 Linear issue ID를 명시한다.
+  - `gh stack add <branch>`
+- `gh stack add`는 현재 HEAD에서 새 branch를 만들고 Stack top으로 checkout한다. 기능·계약 변경은 Linear issue ID를, 행동 보존 단순 리팩터링은 설명적인 branch 이름을 명시한다.
 
 ## Adopt Existing Branches Or Pull Requests
 

--- a/memory/temporal-workflows.md
+++ b/memory/temporal-workflows.md
@@ -19,8 +19,9 @@
 - `workflows/index.ts`는 Worker bundle에 포함할 Workflow를 re-export하기만 한다. 실행 로직이나 adapter를 두지 않는다.
 - 한 Workflow에서 서로 독립적인 sibling Activity를 모두 시도해야 하면 공용 `settleEffects`를 사용한다. 이 helper는 모든 Promise가 settle될 때까지 기다린 뒤 실패가 있으면 하나를 다시 throw한다.
 - `settleEffects` 같은 deterministic Workflow 전용 공통 로직은 `workflows` 아래 공용 모듈 한 곳에 둔다. 특정 domain Workflow 파일에 복사하거나 그 파일의 private helper로 두지 않는다.
-- Activity가 하나뿐이면 배열이나 `settleEffects`로 감싸지 않고 직접 `await`한다.
-- origin이나 transition variant가 실행할 Activity 조합을 바꾸면 early return을 반복하지 않고 `ts-pattern`의 exhaustive match로 실행 Promise를 선택한 뒤 한 번만 `await`한다.
+- Workflow effect는 개수와 관계없이 `settleEffects`로 정산해 종료와 실패 보고 경계를 일관되게 유지한다.
+- origin이나 transition variant와 무관하게 실행하는 Activity는 match 바깥에서 선언한다. `ts-pattern`의 exhaustive match는 variant별 추가 Activity만 선택하고, 공통 Activity를 각 branch에 반복해서 나열하지 않는다.
+- notification과 effect 목록처럼 한 번만 소비하는 중간 변수는 만들지 않는다. 공통 Activity와 variant별 추가 Activity를 `settleEffects([...])` 호출에 함께 인라인해 실제 실행 조합을 한 위치에서 읽을 수 있게 한다.
 - Workflow code에서는 wall clock, network, database와 process-local state에 직접 접근하지 않고 Temporal이 허용하는 deterministic API와 proxied Activity만 사용한다.
 
 ## Starting A Workflow

--- a/memory/temporal-workflows.md
+++ b/memory/temporal-workflows.md
@@ -1,0 +1,55 @@
+# Temporal Workflow Memory
+
+## Purpose
+
+- Kosmo의 Temporal Workflow, Activity 등록과 domain transaction 이후 Workflow start 코드를 작성하거나 리뷰할 때 이 문서를 따른다.
+- 이 문서는 코드 구조와 실행 경계에 관한 개발 규칙이다. 각 domain의 실제 transition, retry 허용 범위와 delivery 성공 의미는 canonical domain 문서와 해당 capability가 소유한다.
+
+## Ownership And Flow
+
+- domain state transition, 권한, transaction과 멱등성 판정은 `packages/core/services`가 소유한다.
+- 실제 transition이 commit된 뒤 그 결과를 소유한 core service가 `temporalClient.workflow.start(...)`를 직접 호출한다.
+- Workflow는 적용할 effect를 선택하고 Activity를 조율한다. DB domain transition을 Workflow나 Activity로 옮기지 않는다.
+- Activity는 Notification projection이나 Fedify queue handoff처럼 retry 가능한 하나의 외부 효과 경계를 소유한다.
+- Workflow start 실패가 이미 commit된 domain 결과를 바꾸지 않는 capability에서는 start 호출부가 deadline과 오류 격리를 명시한다.
+
+## Workflow Source Structure
+
+- `apps/worker/src/workflows`에서는 exported Workflow 하나를 파일 하나가 소유한다. create/delete처럼 lifecycle이 다르면 파일도 나눈다.
+- `workflows/index.ts`는 Worker bundle에 포함할 Workflow를 re-export하기만 한다. 실행 로직이나 adapter를 두지 않는다.
+- 한 Workflow에서 서로 독립적인 sibling Activity를 모두 시도해야 하면 공용 `settleEffects`를 사용한다. 이 helper는 모든 Promise가 settle될 때까지 기다린 뒤 실패가 있으면 하나를 다시 throw한다.
+- `settleEffects` 같은 deterministic Workflow 전용 공통 로직은 `workflows` 아래 공용 모듈 한 곳에 둔다. 특정 domain Workflow 파일에 복사하거나 그 파일의 private helper로 두지 않는다.
+- Activity가 하나뿐이면 배열이나 `settleEffects`로 감싸지 않고 직접 `await`한다.
+- origin이나 transition variant가 실행할 Activity 조합을 바꾸면 early return을 반복하지 않고 `ts-pattern`의 exhaustive match로 실행 Promise를 선택한 뒤 한 번만 `await`한다.
+- Workflow code에서는 wall clock, network, database와 process-local state에 직접 접근하지 않고 Temporal이 허용하는 deterministic API와 proxied Activity만 사용한다.
+
+## Starting A Workflow
+
+- commit 결과와 transition을 소유한 service가 Workflow type, input과 stable Workflow ID를 호출 위치에서 읽을 수 있게 직접 적는다.
+- Workflow type, ID prefix와 log message만 채우는 domain 전용 pass-through wrapper는 만들지 않는다. 이런 wrapper는 실제 transition과 Workflow identity를 떨어뜨리고 다른 service의 직접 start 패턴과 어긋난다.
+- 조건별 Workflow start가 대부분 하나이고 각 start 오류를 이미 격리한다면 Promise를 `effects` 배열에 push한 뒤 `Promise.all`로 모으지 않는다. 한 transaction 결과에서 두 Workflow가 필요한 경우에도 각 조건에서 직접 `await`해 type, input과 identity를 가까이 둔다. 실제 동시 start가 계약인 경우에만 배열과 병렬 대기를 사용한다.
+- start에는 repository의 공통 task queue, bounded deadline, `USE_EXISTING` conflict policy와 `REJECT_DUPLICATE` reuse policy를 명시한다. capability가 다른 정책을 요구하면 canonical/Linear/OpenSpec 결정을 먼저 갱신한다.
+- post-commit start 오류는 최소 identity와 transition context로 관찰하고 committed action 결과와 분리한다. observer callback 자체의 실패도 결과를 바꾸지 않는다.
+- 공용 start helper는 여러 domain이 정말 같은 호출 정책과 오류 계약을 공유하고, Workflow type·ID·input을 호출부에서 숨기지 않을 때만 도입한다. 한 domain의 두 Workflow를 줄이기 위한 wrapper는 공용 abstraction의 근거가 아니다.
+
+## Activity Registration And Adapters
+
+- `apps/worker/src/activities.ts`는 production Activity registry다.
+- 기존 core/fedify 함수의 input, return과 오류 의미가 Activity 계약과 같으면 `export { source as activityName }`로 직접 alias한다.
+- 단순히 같은 인자를 다음 함수에 전달하고 같은 Promise를 반환하는 Worker adapter 파일이나 async wrapper를 만들지 않는다.
+- adapter는 input 변환, dependency composition, retry 경계에 필요한 validation 또는 Activity 고유 관찰처럼 실제 책임이 있을 때만 둔다.
+- Activity 이름은 Workflow history와 운영 조회에 남는 public runtime identity이므로 rename은 호환성 영향을 검토한다.
+
+## Inputs And Identity
+
+- Workflow input은 JSON-serializable한 immutable 최소 snapshot이어야 한다. 삭제 뒤 필요한 값은 source transaction 결과에서 확보하고, Activity가 삭제된 source row를 다시 읽는 것으로 복원하지 않는다.
+- create effect는 stable source identity를 우선 사용하고 Activity가 현재 projection을 조회하게 한다.
+- input type은 한 Workflow에서만 쓰면 Workflow 파일 가까이에 둔다. Worker, core와 protocol adapter가 실제로 같은 shape를 소비할 때만 neutral contract module로 공유한다. 이름만 같은 type을 package마다 복제하지 않는다.
+- Workflow ID는 logical generation을 구분하는 immutable source ID를 포함한다. create/delete와 서로 다른 source kind가 완료된 같은 ID를 공유하지 않게 한다.
+
+## Verification
+
+- Worker build로 Workflow bundle과 Activity type wiring을 확인한다.
+- production registry를 사용하는 Workflow test로 origin/transition 분기, sibling Activity 전부 시도, retry와 restart 재개를 확인한다.
+- core service test로 실제 commit에만 start되는지, duplicate/no-op/rollback에서는 start되지 않는지, type/input/ID와 start 실패 격리를 확인한다.
+- PR/CI 검증과 exact revision dev의 Temporal history, Activity retry, Worker restart 증거를 구분한다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
       '@temporalio/workflow':
         specifier: ^1.22.0
         version: 1.22.0
+      ts-pattern:
+        specifier: ^5.9.0
+        version: 5.9.0
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -4497,6 +4500,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
## 무엇을 변경했나요

- 독립적인 sibling Activity를 모두 settle한 뒤 첫 실패를 다시 전파하는 공용 `settleEffects`를 추가했습니다.
- Post, Reaction create/delete, Repost create/delete Workflow의 중복 `Promise.allSettled` 코드를 공용 helper로 교체했습니다.
- 공통 notification과 `ts-pattern`이 선택한 origin별 추가 delivery를 `settleEffects([...])` 한 곳에 인라인했습니다.
- effect 개수와 관계없이 같은 `settleEffects` 종료·실패 보고 경계를 사용하도록 공용 Temporal Workflow 규칙을 기록했습니다.
- 행동 보존 단순 리팩터링의 이슈 없는 PR 예외를 저장소 규칙에 기록했습니다.

## 왜 변경했나요

Follow 전용 durable effect Workflow도 같은 sibling settlement가 필요하지만, 이 실행 규칙은 Follow 도메인의 책임이 아닙니다. 공용 기반을 최하단 PR로 분리해 기존 Post·Reaction·Repost Workflow와 이후 Follow Workflow가 같은 deterministic orchestration을 재사용하게 합니다.

## 이번 PR의 주요 결정

### 공용 settlement를 Follow보다 먼저 둔다

- 결정자: @jiyu
- 선택: `settleEffects`와 기존 Workflow 적용을 이슈 없는 최하단 리팩터링 PR로 분리합니다. 공통 notification과 `ts-pattern`이 선택한 origin별 추가 delivery를 한 호출에 인라인하고, effect가 하나여도 같은 settlement 경계를 사용합니다.
- 고려한 대안: Follow foundation PR에 포함하거나 공용 helper를 제거하거나 notification을 origin branch마다 반복하거나 effect가 하나일 때 별도 await 경로를 둡니다.
- 이유: settlement는 Follow effect가 아니라 여러 Workflow가 공유하는 실행 규칙입니다. 한 번만 소비하는 `notification`·`effects` 변수가 실제 Activity 조합을 가리지 않게 하고, 개수에 따라 종료 계약도 달라지지 않는 편이 읽기 쉽습니다.
- 감수한 결과: Worker가 기존 workspace 의존성인 `ts-pattern`을 직접 의존하며, Follow 관련 PR들은 이 PR이 먼저 merge되어야 합니다.

## 어떻게 확인할 수 있나요

- Worker TypeScript build 통과
- `pnpm --filter @kosmo/worker test:workflow` — 2/2 통과
- 변경 파일 Prettier check 통과
- `git diff --check` 통과

## 아직 어떤 문제가 남았나요

- Activity scheduling 조건은 변경하지 않았습니다. Post create는 기존처럼 Reply Notification Activity를 항상 예약하고, root Post의 no-op 여부는 Activity 내부 projection 조회가 판단합니다.
- Follow Workflow·Activity·caller·OpenSpec은 상위 PR들이 소유합니다.

Stack #677의 1/5입니다.

Stack: `main -> temporal-settle-effects (#676)`
