### PR TITLE
Production Release를 GitHub-hosted runner로 전환한다

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -24,7 +24,7 @@ jobs:
       (manual ${{ needs.manual_preflight.outputs.target_sha }})
     needs: manual_preflight
     if: needs.manual_preflight.result == 'success'
-    runs-on: [self-hosted, ARM64]
+    runs-on: ubuntu-24.04-arm
     environment:
       name: prod
       url: ${{ needs.manual_preflight.outputs.target_url }}
@@ -32,6 +32,7 @@ jobs:
       group: production-release
       cancel-in-progress: false
     permissions:
+      actions: read
       contents: read
       id-token: write
       packages: write
@@ -45,12 +46,17 @@ jobs:
         with:
           ref: ${{ env.TARGET_SHA }}
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: tag:github-actions
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           name: kosmo-production
-          cleanup: false
-          cache-binary: false
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -91,6 +97,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=production-release
+          cache-to: type=gha,mode=max,scope=production-release,ignore-error=true
           no-cache-filters: |
             app-build
             runtime


### PR DESCRIPTION
## 무엇을 변경했나요

- Production Release 실행기를 self-hosted ARM64에서 GitHub-hosted `ubuntu-24.04-arm`으로 전환했습니다.
- Vault와 Argo CD에 접근하기 전에 Tailscale에 연결하도록 했습니다.
- BuildKit의 GitHub Actions 캐시를 `production-release` scope로 읽고 쓰도록 했습니다.

## 왜 변경했나요

Production 이미지 빌드와 배포가 self-hosted runner의 가용성에 묶여 있었습니다. 이미 검증한 GitHub-hosted ARM과 Tailnet 연결 경로를 Production Release에도 적용해 러너 의존성을 줄이고, GitHub-hosted 환경에서는 원격 BuildKit 캐시를 활용합니다.

## 이번 PR의 주요 결정

- Production 승인, 대상 SHA 검증, 동시성 제어, 이미지 digest 검증, Argo CD sync·wait 계약은 그대로 유지합니다.
- 캐시 장애가 릴리스를 막지 않도록 `ignore-error=true`를 사용합니다.
- `app-build`와 `runtime`은 기존처럼 캐시하지 않아 릴리스 시점 산출물의 재생성을 유지합니다.

## 어떻게 확인할 수 있나요

- `mise exec -- actionlint .github/workflows/production-release.yml`
- `./node_modules/.bin/prettier --check .github/workflows/production-release.yml`
- `git diff --check main..PROD-844`
- 독립 셀프리뷰에서 runner, 권한, 승인·digest·sync 보존과 단계 순서를 확인했습니다.

## 아직 어떤 문제가 남았나요

- PR에서는 승인된 실제 Production Release를 안전하게 실행할 수 없어 GitHub-hosted ARM의 Tailnet, Vault, GHCR push, Argo Dex 연결은 머지 후 승인된 릴리스에서 확인해야 합니다.
- 캐시 cold seed와 이후 hit 및 성능 개선도 실제 릴리스 실행 전에는 증명되지 않았습니다.

Linear: [PROD-844](https://linear.app/byulmaru/issue/PROD-844/production-release를-github-hosted-runner로-전환한다)

Stack: `main -> PROD-844`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>