### PR TITLE
Argo CD CLI 설치를 action으로 표준화한다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,8 +20,16 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04-arm
     env:
+      ARGOCD_CLI_VERSION: 3.4.2
       ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net
     steps:
+      - name: Install Argo CD CLI
+        uses: clowdhaus/argo-cd-action@946f488cf2607049c2e6ca86902ac50783927ec1 # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          version: ${{ env.ARGOCD_CLI_VERSION }}
+
       - name: Connect to Tailscale
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
         with:
@@ -63,28 +71,6 @@ jobs:
 
             core.setSecret(dexToken);
             core.setOutput("token", dexToken);
-
-      - name: Install Argo CD CLI
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if command -v argocd >/dev/null 2>&1; then
-            exit 0
-          fi
-
-          case "$(uname -m)" in
-            x86_64) argocd_arch=amd64 ;;
-            aarch64 | arm64) argocd_arch=arm64 ;;
-            *)
-              echo "::error::Unsupported runner architecture: $(uname -m)"
-              exit 1
-              ;;
-          esac
-
-          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-${argocd_arch}"
-          chmod 555 "${RUNNER_TEMP}/argocd"
-          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
 
       - name: Sync dev application
         env:

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -37,6 +37,7 @@ jobs:
       id-token: write
       packages: write
     env:
+      ARGOCD_CLI_VERSION: 3.4.2
       ARGOCD_SERVER: argocd-aws.tail1fdd55.ts.net
       TARGET_SHA: ${{ needs.manual_preflight.outputs.target_sha }}
 
@@ -45,6 +46,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.TARGET_SHA }}
+
+      - name: Install Argo CD CLI
+        uses: clowdhaus/argo-cd-action@946f488cf2607049c2e6ca86902ac50783927ec1 # v4.2.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          version: ${{ env.ARGOCD_CLI_VERSION }}
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
@@ -158,35 +166,6 @@ jobs:
 
             core.setSecret(dexToken);
             core.setOutput("token", dexToken);
-
-      - name: Install Argo CD CLI
-        env:
-          ARGOCD_CLI_VERSION: v3.4.2
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          case "$(uname -s)" in
-            Darwin) argocd_os=darwin ;;
-            Linux) argocd_os=linux ;;
-            *)
-              echo "::error::Unsupported runner OS: $(uname -s)"
-              exit 1
-              ;;
-          esac
-
-          case "$(uname -m)" in
-            x86_64) argocd_arch=amd64 ;;
-            aarch64 | arm64) argocd_arch=arm64 ;;
-            *)
-              echo "::error::Unsupported runner architecture: $(uname -m)"
-              exit 1
-              ;;
-          esac
-
-          curl -sSfL -o "${RUNNER_TEMP}/argocd" "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_CLI_VERSION}/argocd-${argocd_os}-${argocd_arch}"
-          chmod 555 "${RUNNER_TEMP}/argocd"
-          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
 
       - name: Sync migration and production workloads
         env:


### PR DESCRIPTION
## 무엇을 변경했나요

- Dev와 Production 워크플로의 수동 Argo CD CLI 다운로드를 `clowdhaus/argo-cd-action` v4.2.0의 고정 commit으로 교체했습니다.
- Argo CD CLI 버전을 두 워크플로 모두 3.4.2로 고정했습니다.
- CLI 설치를 Tailscale 연결 및 Dex 토큰 교환보다 먼저 실행합니다.

## 왜 변경했나요

기존 워크플로마다 OS·architecture 판별과 직접 다운로드 로직을 중복해서 관리하고 있었습니다. 설치 전용 액션으로 통일해 이 로직을 제거하고, 액션이 제공하는 공식 release checksum 검증과 tool cache를 사용합니다.

## 이번 PR의 주요 결정

- 액션 commit과 CLI 버전만 명시적으로 고정합니다.
- 별도 SHA256 고정이나 중복 검증 step은 두지 않습니다.
- 기존 Dev sync·restart와 Production set·sync·wait·revision/digest 검증 명령은 변경하지 않습니다.

## 어떻게 확인할 수 있나요

- `mise exec -- actionlint .github/workflows/deploy-dev.yml .github/workflows/production-release.yml`
- `./node_modules/.bin/prettier --check .github/workflows/deploy-dev.yml .github/workflows/production-release.yml`
- `git diff --check PROD-844..PROD-763`
- 액션의 고정 commit에서 Linux ARM64 지원과 공식 `cli_checksums.txt` 검증 동작을 확인했습니다.

## 아직 어떤 문제가 남았나요

- checksum 파일이나 대상 항목이 없는 비정상 release에서는 액션이 경고 후 검증을 생략하며, 이를 strict하게 만드는 옵션은 현재 없습니다.
- Dev 워크플로는 main의 Docker Build 성공 후에만 실행되고 Production Release는 승인이 필요한 수동 워크플로라, 실제 설치·Tailnet·Dex·Argo 연결은 머지 후 실행으로 확인해야 합니다.

Linear: [PROD-763](https://linear.app/byulmaru/issue/PROD-763/security-argo-cd-cli-다운로드-무결성-검증을-강제한다)

Stack: `main -> PROD-844 -> PROD-763`
