### PR TITLE
GitHub-hosted runner 전환 잔재를 정리한다

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   lint:
     name: Lint
-    # runs-on: [self-hosted]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -20,7 +20,6 @@ concurrency:
 jobs:
   nuclei:
     name: Nuclei scan
-    # runs-on: [self-hosted]
     runs-on: ubuntu-latest
     env:
       DEFAULT_TARGETS: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,7 +26,6 @@ env:
 jobs:
   semgrep:
     name: Semgrep scan
-    # runs-on: [self-hosted]
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   test-suites:
     name: Test (${{ matrix.name }})
-    # runs-on: [self-hosted]
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -23,7 +23,6 @@ jobs:
   trivy_scan:
     name: Trivy Scan
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    # runs-on: [self-hosted, ARM64]
     runs-on: ubuntu-24.04-arm
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 무엇을 변경했나요

이미 GitHub-hosted runner를 사용하는 다섯 workflow에서 주석 처리된 옛 `runs-on: self-hosted` 줄을 제거했습니다.

- Lint
- Nuclei
- Semgrep
- Test
- Trivy Scan

## 왜 변경했나요

Linux workflow의 GitHub-hosted runner 전환과 실제 dev/production 배포 검증이 끝났습니다. 실행되지 않는 과거 runner 주석을 남겨 두면 현재 구성과 fallback 경계를 오해할 수 있어 제거합니다.

## 이번 PR의 주요 결정

- 실행 중인 `runs-on`, trigger, 권한, 조건과 step은 변경하지 않습니다.
- 네이티브 앱 전용 macOS self-hosted workflow 두 개는 명시적으로 제외합니다.
- 별도 OpenSpec이나 추상화 없이 죽은 주석만 삭제합니다.

## 어떻게 확인할 수 있나요

- `mise exec -- actionlint`로 변경된 다섯 workflow 검증
- Prettier와 `git diff --check` 통과
- `.github/workflows`의 남은 `self-hosted` 참조가 제외 대상인 iOS 두 곳뿐임을 확인
- 독립 동작 보존 리뷰와 과설계 리뷰 모두 finding 없음
- [Docker Build](https://github.com/byulmaru/kosmo/actions/runs/32871159660): hosted ARM, cache hit, image push 성공
- [Deploy Dev](https://github.com/byulmaru/kosmo/actions/runs/32871454423): Argo CD action, Tailnet, sync/restart 성공
- [Production Release](https://github.com/byulmaru/kosmo/actions/runs/32871341647): hosted ARM, Tailnet, Vault, build/push, digest, Argo Healthy 성공

## 아직 어떤 문제가 남았나요

- `ios-ad-hoc-distribution.yml`과 `ios-device-onboarding.yml`은 사용자의 현재 제외 범위에 따라 macOS self-hosted runner를 유지합니다.
- Linux self-hosted runner 외부 인프라 폐기는 이 저장소 정리 PR의 범위가 아닙니다.

Linear: [PROD-845](https://linear.app/byulmaru/issue/PROD-845/github-hosted-runner-전환-잔재를-정리한다)

Stack: `main -> PROD-845`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>