### PR TITLE
SPA 초기 로드에서 잘못된 동적 경로가 노출되지 않게 한다

### DIFF
--- a/apps/web/e2e/auth-routes.e2e.ts
+++ b/apps/web/e2e/auth-routes.e2e.ts
@@ -5,7 +5,7 @@ import { eq } from 'drizzle-orm';
 import { createE2ESession, resetE2EDatabase, setE2ESessionCookie } from './db-fixtures';
 import { expect, test } from './fixtures';
 import { isGraphQLOperation } from './graphql';
-import type { APIRequestContext } from '@playwright/test';
+import type { APIRequestContext, Page } from '@playwright/test';
 
 const loginCodeVerifierCookie = 'kosmo_oidc_code_verifier';
 const loginStateCookie = 'kosmo_oidc_state';
@@ -14,6 +14,7 @@ const oidcOrigin = process.env.PUBLIC_OIDC_ISSUER ?? 'http://127.0.0.1:4300';
 const nativeOidcClientId = process.env.PUBLIC_OIDC_NATIVE_CLIENT_ID ?? 'kosmo-e2e-native-client';
 const nativeSessionEndpoint = new URL('/graphql', apiOrigin).toString();
 const nativeSessionOperationName = 'E2ENativeOidcSessionExchange';
+const historyPathStorageKey = 'kosmo-e2e-history-paths';
 const nativeSessionMutation = `
   mutation E2ENativeOidcSessionExchange($input: ExchangeNativeOidcSessionInput!) {
     exchangeNativeOidcSession(input: $input) {
@@ -111,6 +112,38 @@ async function authorizeNativeCode(
   expect(callbackUrl.searchParams.get('state')).toBe(state);
 
   return callbackUrl;
+}
+
+async function installHistoryPathTracer(page: Page) {
+  await page.addInitScript((storageKey: string) => {
+    const record = (method: string) => {
+      const entries = JSON.parse(sessionStorage.getItem(storageKey) ?? '[]') as string[];
+      entries.push(`${method}:${location.pathname}${location.search}`);
+      sessionStorage.setItem(storageKey, JSON.stringify(entries));
+    };
+
+    record('document');
+
+    for (const method of ['pushState', 'replaceState'] as const) {
+      const original = history[method];
+      history[method] = function (...args) {
+        const result = original.apply(this, args);
+        record(method);
+        return result;
+      };
+    }
+  }, historyPathStorageKey);
+}
+
+async function getHistoryPaths(page: Page) {
+  return page.evaluate(
+    (storageKey: string) => JSON.parse(sessionStorage.getItem(storageKey) ?? '[]') as string[],
+    historyPathStorageKey,
+  );
+}
+
+function expectNoUndefinedHistoryPaths(historyPaths: readonly string[]) {
+  expect(historyPaths.filter((path) => path.includes('/undefined/undefined'))).toEqual([]);
 }
 
 test.beforeEach(async () => {
@@ -248,36 +281,13 @@ test('mock OIDC로 로그인하면 보호 홈으로 이동하고 세션이 유�
 
     await route.continue();
   });
-  await page.addInitScript(() => {
-    const storageKey = 'kosmo-e2e-history-paths';
-    const record = (method: string) => {
-      const entries = JSON.parse(sessionStorage.getItem(storageKey) ?? '[]') as string[];
-      entries.push(`${method}:${location.pathname}${location.search}`);
-      sessionStorage.setItem(storageKey, JSON.stringify(entries));
-    };
-
-    record('document');
-
-    for (const method of ['pushState', 'replaceState'] as const) {
-      const original = history[method];
-      history[method] = function (...args) {
-        const result = original.apply(this, args);
-        record(method);
-        return result;
-      };
-    }
-  });
+  await installHistoryPathTracer(page);
 
   await page.goto('/');
   await page.getByRole('link', { name: '시작하기' }).click();
 
   await expect(page).toHaveURL(/\/home$/);
-  const historyPaths = await page.evaluate(() =>
-    JSON.parse(sessionStorage.getItem('kosmo-e2e-history-paths') ?? '[]'),
-  );
-  expect(historyPaths).not.toContain('pushState:/undefined/undefined');
-  expect(historyPaths).not.toContain('replaceState:/undefined/undefined');
-  expect(historyPaths).not.toContain('document:/undefined/undefined');
+  expectNoUndefinedHistoryPaths(await getHistoryPaths(page));
   await expect(page.getByRole('heading', { name: '프로필을 만들어 시작하세요' })).toBeVisible();
   await page.getByRole('button', { name: '프로필 만들기' }).click();
   await expect(page.getByLabel('프로필 전환')).toBeVisible();
@@ -569,6 +579,27 @@ test.describe('로그인 사용자 보호 라우트', () => {
 
     await setE2ESessionCookie(context, token);
   });
+
+  for (const path of ['/', '/home'] as const) {
+    test(`${path}의 인증된 cold load는 undefined/undefined를 history에 기록하지 않는다`, async ({
+      page,
+    }) => {
+      await page.route('**/graphql', async (route) => {
+        if (isGraphQLOperation(route.request().postData(), 'UniversalShellQuery')) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        await route.continue();
+      });
+      await installHistoryPathTracer(page);
+
+      await page.goto(path);
+      await expect(page).toHaveURL(/\/home$/);
+      await expect(page.getByRole('heading', { name: '홈' })).toBeVisible();
+
+      expectNoUndefinedHistoryPaths(await getHistoryPaths(page));
+    });
+  }
 
   test('Settings route-owned back은 direct/fresh detail을 root로 replace하고 forward에서 detail을 복원하지 않는다', async ({
     page,

--- a/patches/expo-router@56.2.13.patch
+++ b/patches/expo-router@56.2.13.patch
@@ -1,0 +1,17 @@
+diff --git a/build/fork/useLinking.js b/build/fork/useLinking.js
+index 6911c31922fd72621bfaa46c47b83274216a4744..3a8efab734b6bbf6d554dc42ac2d6ffa38c13c54 100644
+--- a/build/fork/useLinking.js
++++ b/build/fork/useLinking.js
+@@ -304,6 +304,12 @@ function useLinking(ref, { enabled = true, config, getStateFromPath = native_1.g
+             }
+             const pendingPath = pendingPopStatePathRef.current;
+             const route = (0, native_1.findFocusedRoute)(state);
++            // A focused group route means its nested navigator has not mounted yet.
++            // Resolving a path from this partial state can rewrite the URL to the
++            // group's first screen before the child navigator reports its state.
++            if (route && /^\([^/]+\)$/.test(route.name)) {
++                return;
++            }
+             const path = getPathForRoute(route, state);
+             // START FORK
+             // previousStateRef.current = state;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ overrides:
   react-native-reanimated: 4.3.1
   react-native-worklets: 0.8.3
 
+patchedDependencies:
+  expo-router@56.2.13: 2ba055c9355c7e29a95a30990f7553e5571141af8cf2b4c84a36f948e2cf16a9
+
 importers:
 
   .:
@@ -204,7 +207,7 @@ importers:
         version: 56.0.15(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)
       expo-router:
         specifier: ~56.2.13
-        version: 56.2.13(91005b009d21ea23b3408f0ce38c43c8)
+        version: 56.2.13(patch_hash=2ba055c9355c7e29a95a30990f7553e5571141af8cf2b4c84a36f948e2cf16a9)(91005b009d21ea23b3408f0ce38c43c8)
       expo-secure-store:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.14)
@@ -8327,7 +8330,7 @@ snapshots:
       ws: 8.21.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.13(91005b009d21ea23b3408f0ce38c43c8)
+      expo-router: 56.2.13(patch_hash=2ba055c9355c7e29a95a30990f7553e5571141af8cf2b4c84a36f948e2cf16a9)(91005b009d21ea23b3408f0ce38c43c8)
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -8617,7 +8620,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 56.0.16(@expo/log-box@56.0.14)(expo@56.0.14)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)
-      expo-router: 56.2.13(91005b009d21ea23b3408f0ce38c43c8)
+      expo-router: 56.2.13(patch_hash=2ba055c9355c7e29a95a30990f7553e5571141af8cf2b4c84a36f948e2cf16a9)(91005b009d21ea23b3408f0ce38c43c8)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -12012,7 +12015,7 @@ snapshots:
     dependencies:
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3)
 
-  expo-router@56.2.13(91005b009d21ea23b3408f0ce38c43c8):
+  expo-router@56.2.13(patch_hash=2ba055c9355c7e29a95a30990f7553e5571141af8cf2b4c84a36f948e2cf16a9)(91005b009d21ea23b3408f0ce38c43c8):
     dependencies:
       '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)
       '@expo/metro-runtime': 56.0.16(@expo/log-box@56.0.14)(expo@56.0.14)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,3 +50,5 @@ overrides:
   'xcode@3.0.1>uuid': 11.1.1
   react-native-reanimated: 4.3.1
   react-native-worklets: 0.8.3
+patchedDependencies:
+  expo-router@56.2.13: patches/expo-router@56.2.13.patch


### PR DESCRIPTION
## 무엇을 변경했나요

- Expo Router 56.2.13의 웹 linking 동기화에 pnpm patch를 적용해 nested navigator가 아직 없는 부분 route group을 history에 직렬화하지 않게 했습니다.
- 기존 history tracer를 재사용 가능한 E2E helper로 정리했습니다.
- 인증된 상태에서 `/`와 `/home`을 cold load하고 `UniversalShellQuery`를 지연해도 `/undefined/undefined`가 기록되지 않는 회귀 테스트를 추가했습니다.

## 왜 변경했나요

PR #632의 `initialRouteName` 완화 이후에도 SPA 최초 로드 중 Expo Router가 불완전한 `(tabs)` state를 첫 동적 route로 직렬화하면서 주소창에 `/undefined/undefined`를 일시 노출했습니다. 기존 테스트는 로그인 직후만 검사해 인증 세션이 유지된 cold load를 놓쳤습니다.

Linear: https://linear.app/byulmaru/issue/PROD-733
Upstream: https://github.com/expo/expo/issues/48346

## 이번 PR의 주요 결정

dependency patch를 우선하지 않는 원칙에 따라 정식 릴리스와 앱 레벨 대안을 다시 확인했습니다.

- Expo Router 56 계열 최신 `56.2.16`, 최신 `57.0.16`, upstream `main` 모두 해당 수정이 없습니다.
- shell query를 Router Stack보다 먼저 로드하는 작은 대안은 unpatched `/home` cold-load E2E에서 `replaceState:/undefined/undefined`를 그대로 기록했습니다.
- `<Slot />`을 query boundary 밖에 하나만 유지하는 대안은 shell 상태·접근성·native/web layout을 약 500줄 재구성해야 해 이 결함보다 회귀 면적이 컸습니다.
- loading fallback에 두 번째 `<Slot />`을 두는 대안은 route remount와 effect 중복 위험 때문에 제외했습니다.

따라서 serializer의 정상 group fallback이나 앱 shell 구조를 바꾸지 않고, 웹 history 동기화가 transient group state를 건너뛰는 upstream 제안과 동일한 6줄 guard를 예외적으로 선택했습니다.

## 어떻게 확인할 수 있나요

- `CI=true pnpm install --frozen-lockfile --ignore-scripts --offline`
- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/web check`
- `pnpm lint:eslint`
- `pnpm lint:prettier`
- 격리 PostgreSQL과 별도 포트에서 `apps/web/e2e/auth-routes.e2e.ts` 전체 33개 통과
- 설치된 Expo Router patch 적용과 Android source 보존 확인
- GitHub CI 13개 전체 통과

## 아직 어떤 문제가 남았나요

PR은 아직 merge·배포되지 않았습니다. Expo Router upstream 수정이 릴리스되면 이 patch를 제거하고 동일 cold-load 회귀 테스트로 정식 구현을 검증해야 합니다.

Stack: main -> PROD-733