### PR TITLE
PROD-690 Admin Console 접근 계약을 단순화한다

### DIFF
--- a/docs/architecture/admin-console.md
+++ b/docs/architecture/admin-console.md
@@ -5,94 +5,88 @@
 Admin Console은 신뢰된 Tailscale proxy 뒤에서 KOSMO의 Account와 Profile 운영 정보를 읽는 내부 Web
 surface다. v1은 Account, Profile과 Account-Profile Membership을 변경하지 않는다.
 
-이 문서는 요청이 신뢰 경계를 통과해 권한별 read projection으로 변환되는 구조를 정의한다. 객체별 허용
-필드와 제외 필드는 [Admin Console Read Policy](../domain/policies/admin-console-read.md), Capability Holder와
-`Account.Operator`의 분리는
-[ADR 0025](../domain/decisions/0025-admin-console-capability-holder-boundary.md)가 소유한다. 구체적인 route,
-GraphQL field, 저장 모델과 UI layout은 각 구현 slice에서 정한다.
+이 문서는 요청이 Tailscale 접근 경계를 통과해 read projection으로 변환되는 구조를 정의한다. 객체별 허용
+필드와 제외 필드는 [Admin Console Read Policy](../domain/policies/admin-console-read.md), Admin Console
+Viewer와 `Account.Operator`의 분리는
+[ADR 0026](../domain/decisions/0026-admin-console-tailscale-access-boundary.md)가 소유한다. 구체적인 route, GraphQL
+field, 저장 모델과 UI layout은 각 구현 slice에서 정한다.
 
 ## 신뢰 경계
 
-Admin Console 인가의 유일한 입력은 신뢰된 Tailscale proxy가 전달한 app capability다. proxy identity
-header의 login과 display name은 현재 요청 주체를 표시하기 위한 선택적 metadata이며 인가, Account 매핑,
-조회 filter 또는 projection 계산에 사용하지 않는다.
+Admin Console 진입 권한의 source of truth는 Tailscale 접근 정책이다. 허용된 주체의 요청만 신뢰된 Tailscale
+Operator Ingress와 Admin Service의 네트워크 경계를 통해 runtime에 도달한다. 애플리케이션은 App
+Capabilities나 객체별 action을 추가로 계산하지 않는다.
 
-- Capability Holder는 Kosmo Account가 아니며 `Account.Operator` 권한을 얻지 않는다.
-- identity header가 없어도 capability가 유효하면 허용된 read를 수행할 수 있다.
-- client가 직접 주입한 capability·identity header나 신뢰된 proxy를 우회한 요청은 인가 입력으로 사용하지
-  않는다.
-- frontend navigation이나 화면 표시 여부는 server-side action 검증을 대신하지 않는다.
+- Admin Console Viewer는 Kosmo Account가 아니며 `Account.Operator` 권한을 얻지 않는다.
+- 진입이 허용된 Viewer는 Account, Profile, Account-Profile Membership projection을 모두 읽을 수 있다.
+- proxy identity header의 login과 display name은 선택적 표시 metadata이며 인가, Account 매핑, 조회 filter
+  또는 projection 계산에 사용하지 않는다.
+- client가 직접 주입한 identity header나 신뢰된 proxy를 우회한 ClusterIP·Pod IP 요청은 Admin Console
+  접근 경계가 아니다.
+- public Gateway, Funnel 또는 외부 LoadBalancer는 Admin Console entry로 사용하지 않는다.
 
-Admin ingress는 Tailscale Serve가 전달한 capability와 identity wire header를 RFC 2047 decode하고 UTF-8로
-검증한 뒤 downstream에 전달한다. capability header 정규화 실패는 data query 전에 요청을 거부하고, 선택적인
-identity header 정규화 실패는 해당 metadata가 없는 것으로 취급해 인가 결과를 바꾸지 않는다. 도메인 정책은
-이 경계를 통과한 정규화된 capability JSON만 소비한다.
+Admin ingress가 제공하는 identity wire header의 인코딩은 transport 구현에서 정규화한다. RFC 2047 decode와
+UTF-8 검증에 실패한 선택적 identity는 없는 것으로 취급하며 접근 결과를 바꾸지 않는다. 도메인 정책은
+transport header를 인가 입력으로 소비하지 않는다.
 
 ## 요청 처리 경계
 
 ```text
-Trusted Tailscale proxy
+Tailscale access policy
+  -> trusted Operator Ingress
+  -> network-restricted Admin Service
   -> Admin Console entry
-  -> wire header normalization
-  -> capability payload validation
-  -> supported action set calculation
-  -> action-scoped query / loader
+  -> viewer-scoped query / loader
   -> policy projection
   -> response
 ```
 
-1. entry는 trusted proxy 경계를 확인하고 capability·identity wire header를 RFC 2047 decode한 뒤 UTF-8로
-   검증한다.
-2. 정규화된 capability payload에 target namespace가 없으면 grant 없음으로 처리한다. target namespace가
-   존재하지만 그 값, parameter object 또는 `action` 배열 타입이 malformed이면 payload 전체를 거부한다.
-   정확한 schema와 valid/malformed 사례는
-   [Admin Console Read Policy](../domain/policies/admin-console-read.md)를 따른다.
-3. `byulmaru.co/cap/kosmo-admin` namespace의 알려진 action만 모아 합집합을 계산한다. unknown action과
-   wildcard는 grant를 만들지 않는다.
-4. 필요한 action이 없으면 대상 query나 loader를 실행하기 전에 요청을 거부한다.
-5. query 계층은 action에 허용된 객체만 읽고
-   [Admin Console Read Policy](../domain/policies/admin-console-read.md)의 projection을 적용한다.
-6. response 조합은 권한 없는 객체나 관계를 `null`, `0`, 빈 배열 또는 placeholder로 암시하지 않는다.
+1. Tailscale 접근 정책은 요청 주체가 Admin Console entry에 연결할 수 있는지 결정한다.
+2. Operator Ingress는 허용된 요청을 ClusterIP Admin Service로 전달하고 선택적 identity metadata를 제공한다.
+3. NetworkPolicy는 Admin workload의 ingress를 해당 proxy 경계와 필요한 health probe로 제한한다. 실제
+   operator-generated proxy label은 배포 대상 버전과 live cluster에서 확인한 뒤 selector로 고정한다.
+4. query 계층은 [Admin Console Read Policy](../domain/policies/admin-console-read.md)의 projection을 적용한다.
+5. response 조합은 Account, Profile, Membership projection을 구조적으로 분리한다.
 
-wire header 정규화 이후의 read 흐름은 특정 transport에 종속되지 않는다. read-only query는 state-changing
-application action이 아니므로 불필요한 `packages/core/services` pass-through service를 만들지 않는다. 구현은
-[Core 서비스 경계](./core-services.md)의 read query/loader 방향을 따른다.
+read-only query는 state-changing application action이 아니므로 불필요한 `packages/core/services`
+pass-through service를 만들지 않는다. 구현은 [Core 서비스 경계](./core-services.md)의 read query/loader 방향을
+따른다.
 
 ## Projection 분리
 
-세 read projection은 서로 독립된 권한 경계다.
+세 projection은 같은 Admin Console Viewer에게 열리지만 응답 책임은 분리한다.
 
-| projection                 | 필요한 action                   | 책임                                        |
-| -------------------------- | ------------------------------- | ------------------------------------------- |
-| Account                    | `account.read`                  | Account 목록·상세와 OIDC subject exact 검색 |
-| Profile                    | `profile.read`                  | Profile 목록·상세                           |
-| Account-Profile Membership | `account.read` + `profile.read` | 두 객체 사이의 관계와 양방향 탐색           |
+| projection                 | 책임                                        |
+| -------------------------- | ------------------------------------------- |
+| Account                    | Account 목록·상세와 OIDC subject exact 검색 |
+| Profile                    | Profile 목록·상세                           |
+| Account-Profile Membership | 두 객체 사이의 관계와 양방향 탐색           |
 
-Account와 Profile projection은 상대 객체의 존재, Membership, 관계 count를 포함하지 않는다. 두 action을 모두
-가진 요청도 관계 정보는 별도 Membership projection으로만 받는다. selected Profile은 Membership이 아니라
-Session 상태이므로 세 projection 모두에 포함하지 않는다.
+Account와 Profile projection은 상대 객체의 존재, Membership, 관계 count를 포함하지 않는다. 관계 정보는 별도
+Membership projection으로만 받는다. selected Profile은 Membership이 아니라 Session 상태이므로 세
+projection 모두에 포함하지 않는다.
 
 OIDC subject, credential, Session token, private key를 포함한 세부 필드 경계는 architecture 문서에서 반복하지
 않고 [Admin Console Read Policy](../domain/policies/admin-console-read.md)를 따른다.
 
 ## 실패 경계
 
-- trusted proxy 경계를 확인할 수 없거나 capability header 정규화에 실패하거나 정규화된 payload가
-  malformed이면 data query 전에 거부한다.
-- capability가 유효하지만 필요한 action이 없으면 해당 객체나 관계 query 전에 거부한다.
-- 권한 검증을 통과한 뒤의 not-found와 내부 query 실패는 인가 실패와 구분한다.
-- 외부 응답에는 capability payload, proxy header, 내부 경로와 backend 원문 오류를 포함하지 않는다.
+- Tailscale 접근 정책에서 허용되지 않은 주체는 Admin Console entry에 연결할 수 없어야 한다.
+- trusted proxy와 NetworkPolicy 경계를 우회한 ClusterIP·Pod IP 요청은 runtime에 도달할 수 없어야 한다.
+- 선택적 identity 정규화 실패는 metadata 누락으로 처리하며 허용된 Viewer의 접근을 바꾸지 않는다.
+- query의 not-found와 내부 실패는 연결 접근 실패와 구분한다.
+- 외부 응답에는 proxy header, 내부 경로와 backend 원문 오류를 포함하지 않는다.
 
 ## 로깅 제외
 
-Admin Console v1은 성공·실패 조회, capability 판정, identity/capability snapshot, proxy 우회·위조 header를
-위한 Admin-specific logging, audit 또는 security-event contract를 만들지 않는다. 기존 공통 runtime
-오류·접근 로그의 생명주기는 이 아키텍처가 변경하지 않는다.
+Admin Console v1은 성공·실패 조회, identity snapshot, 접근 거부, proxy 우회·위조 header를 위한
+Admin-specific logging, audit 또는 security-event contract를 만들지 않는다. 기존 공통 runtime 오류·접근
+로그의 생명주기는 이 아키텍처가 변경하지 않는다.
 
 ## 전달 경계
 
-- `PROD-690`은 trusted proxy와 capability 검증 기반을 소유한다.
+- `PROD-690`은 독립 runtime, Tailscale Operator Ingress와 직접 접근 차단 기반을 소유한다.
 - `PROD-691`과 `PROD-692`는 각각 Account와 Profile read projection을 소유한다.
-- `PROD-693`은 두 action을 모두 요구하는 Membership relation projection을 소유한다.
+- `PROD-693`은 Membership relation projection을 소유한다.
 - OpenSpec, 애플리케이션 구현, Figma와 배포는 PROD-689 및 이 문서의 범위가 아니다.
 - 취소된 `DSN-59`의 화면·검토·구현 범위는 이 architecture 문서로 복원하지 않는다.

--- a/docs/architecture/admin-console.md
+++ b/docs/architecture/admin-console.md
@@ -21,8 +21,10 @@ Capabilities나 객체별 action을 추가로 계산하지 않는다.
 - 진입이 허용된 Viewer는 Account, Profile, Account-Profile Membership projection을 모두 읽을 수 있다.
 - proxy identity header의 login과 display name은 선택적 표시 metadata이며 인가, Account 매핑, 조회 filter
   또는 projection 계산에 사용하지 않는다.
-- client가 직접 주입한 identity header나 신뢰된 proxy를 우회한 ClusterIP·Pod IP 요청은 Admin Console
-  접근 경계가 아니다.
+- client가 직접 주입한 identity header나 일반 workload가 신뢰된 proxy를 우회한 ClusterIP·Pod IP 요청은
+  Admin Console 접근 경계가 아니다.
+- Kubernetes node 자체, kubelet과 node 권한을 가진 운영 주체의 node-origin 연결은 신뢰된 인프라로 보고
+  이번 위협 모델의 차단 대상에서 제외한다.
 - public Gateway, Funnel 또는 외부 LoadBalancer는 Admin Console entry로 사용하지 않는다.
 
 Admin ingress가 제공하는 identity wire header의 인코딩은 transport 구현에서 정규화한다. RFC 2047 decode와
@@ -43,8 +45,9 @@ Tailscale access policy
 
 1. Tailscale 접근 정책은 요청 주체가 Admin Console entry에 연결할 수 있는지 결정한다.
 2. Operator Ingress는 허용된 요청을 ClusterIP Admin Service로 전달하고 선택적 identity metadata를 제공한다.
-3. NetworkPolicy는 Admin workload의 ingress를 해당 proxy 경계와 필요한 health probe로 제한한다. 실제
-   operator-generated proxy label은 배포 대상 버전과 live cluster에서 확인한 뒤 selector로 고정한다.
+3. NetworkPolicy는 일반 workload에서 오는 Admin ingress를 해당 proxy 경계로 제한한다. node-origin probe와
+   연결은 차단 대상으로 삼지 않는다. 실제 operator-generated proxy label은 배포 대상 버전과 live cluster에서
+   확인한 뒤 selector로 고정한다.
 4. query 계층은 [Admin Console Read Policy](../domain/policies/admin-console-read.md)의 projection을 적용한다.
 5. response 조합은 Account, Profile, Membership projection을 구조적으로 분리한다.
 
@@ -72,7 +75,9 @@ OIDC subject, credential, Session token, private key를 포함한 세부 필드 
 ## 실패 경계
 
 - Tailscale 접근 정책에서 허용되지 않은 주체는 Admin Console entry에 연결할 수 없어야 한다.
-- trusted proxy와 NetworkPolicy 경계를 우회한 ClusterIP·Pod IP 요청은 runtime에 도달할 수 없어야 한다.
+- 일반 workload가 trusted proxy와 NetworkPolicy 경계를 우회한 ClusterIP·Pod IP 요청은 runtime에 도달할 수
+  없어야 한다.
+- node-origin 연결과 node 권한을 가진 운영 주체는 이 아키텍처의 차단 보장 범위에 포함하지 않는다.
 - 선택적 identity 정규화 실패는 metadata 누락으로 처리하며 허용된 Viewer의 접근을 바꾸지 않는다.
 - query의 not-found와 내부 실패는 연결 접근 실패와 구분한다.
 - 외부 응답에는 proxy header, 내부 경로와 backend 원문 오류를 포함하지 않는다.

--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -88,7 +88,7 @@ Account 요청에서 Profile이 주체인 행동의 `Account.Active`는 해당 P
 ## 조회 정책
 
 - [Post List Policy](./policies/post-list.md): Home, Local, Profile, Hashtag Post List의 후보와 제어 결정.
-- [Admin Console Read Policy](./policies/admin-console-read.md): Capability Holder의 Account, Profile,
+- [Admin Console Read Policy](./policies/admin-console-read.md): Admin Console Viewer의 Account, Profile,
   Account-Profile Membership 교차 객체 조회 범위와 필드.
 
 ## 결정과 기록
@@ -116,7 +116,8 @@ Account 요청에서 Profile이 주체인 행동의 `Account.Active`는 해당 P
 - [ADR 0022: Post Content Revision Media Nodes](./decisions/0022-post-content-revision-media-nodes.md)
 - [ADR 0023: Profile Viewer Membership Edit Eligibility](./decisions/0023-profile-viewer-membership-edit-eligibility.md)
 - [ADR 0024: Application Policy and Runtime DB Boundary](./decisions/0024-application-policy-and-runtime-db-boundary.md)
-- [ADR 0025: Admin Console Capability Holder Boundary](./decisions/0025-admin-console-capability-holder-boundary.md)
+- [ADR 0025: Admin Console Capability Holder Boundary (Superseded)](./decisions/0025-admin-console-capability-holder-boundary.md)
+- [ADR 0026: Admin Console Tailscale Access Boundary](./decisions/0026-admin-console-tailscale-access-boundary.md)
 - [2026-06-28 DDD 명세 점검 기록](./records/2026-06-28-ddd-spec-audit.md)
 - [2026-06-29 결정 반영 기록](./records/2026-06-29-decision-round.md)
 - [2026-06-29 PR 리뷰 반영 기록](./records/2026-06-29-pr-review-followup.md)

--- a/docs/domain/decisions/0025-admin-console-capability-holder-boundary.md
+++ b/docs/domain/decisions/0025-admin-console-capability-holder-boundary.md
@@ -2,7 +2,7 @@
 
 ## 상태
 
-Accepted
+Superseded by [ADR 0026](./0026-admin-console-tailscale-access-boundary.md)
 
 ## 날짜
 

--- a/docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md
+++ b/docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md
@@ -25,6 +25,8 @@ projection만 허용하는 애플리케이션 capability 계층은 두지 않는
   `Account.Operator` 사실을 갖지 않는다.
 - Admin Console 진입 권한의 source of truth는 Tailscale 접근 정책이다. 신뢰된 Tailscale proxy와 네트워크
   경계를 우회한 요청은 Admin Console 읽기 경계가 아니다.
+- 일반 workload의 proxy 우회는 차단하지만 Kubernetes node 자체, kubelet과 node 권한을 가진 운영 주체는
+  신뢰된 인프라로 보고 v1 위협 모델의 차단 대상에서 제외한다.
 - v1은 all-or-nothing 접근 모델을 사용한다. 진입이 허용된 Viewer는 Account, Profile,
   Account-Profile Membership 읽기 projection을 모두 사용할 수 있다.
 - 애플리케이션은 Tailscale App Capabilities, `account.read`, `profile.read` 또는 객체별 Admin Console action을

--- a/docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md
+++ b/docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md
@@ -1,0 +1,75 @@
+# ADR 0026: Admin Console Tailscale Access Boundary
+
+## 상태
+
+Accepted
+
+## 날짜
+
+2026-08-27
+
+## 맥락
+
+Admin Console은 Kosmo의 일반 사용자 인증과 별도로 Tailscale 접근 제어를 통과한 운영자에게 Account, Profile과
+Account-Profile Membership 읽기를 제공해야 한다. 기존 도메인에서 운영자 행동의 주체는
+`Account.Operator`인 Kosmo Account다. Tailscale identity를 Account 인증이나 운영자 권한으로 해석하면 인증
+주체, 운영자 Mutation 권한, 운영자용 read-only 도구의 경계가 합쳐진다.
+
+v1의 세 읽기 범위를 서로 다른 권한으로 나눌 제품 요구는 없다. 따라서 연결 권한을 통과한 주체에게 일부
+projection만 허용하는 애플리케이션 capability 계층은 두지 않는다. 이 결정은 App Capability와 객체별 action을
+사용한 [ADR 0025](./0025-admin-console-capability-holder-boundary.md)를 대체한다.
+
+## 결정
+
+- Admin Console 요청 주체를 `Admin Console Viewer`라는 별도 개념으로 둔다. Viewer는 Kosmo Account가 아니며
+  `Account.Operator` 사실을 갖지 않는다.
+- Admin Console 진입 권한의 source of truth는 Tailscale 접근 정책이다. 신뢰된 Tailscale proxy와 네트워크
+  경계를 우회한 요청은 Admin Console 읽기 경계가 아니다.
+- v1은 all-or-nothing 접근 모델을 사용한다. 진입이 허용된 Viewer는 Account, Profile,
+  Account-Profile Membership 읽기 projection을 모두 사용할 수 있다.
+- 애플리케이션은 Tailscale App Capabilities, `account.read`, `profile.read` 또는 객체별 Admin Console action을
+  소비하거나 계산하지 않는다.
+- identity header는 선택적인 display metadata이며 인가, Account 매핑, `Account.Operator` 판정에 사용하지
+  않는다. login과 display name만 사용하고 profile picture header는 사용하지 않는다.
+- 상세한 Account, Profile, Membership 필드와 projection 분리는
+  [Admin Console Read Policy](../policies/admin-console-read.md)가 소유한다.
+- Admin Console v1은 읽기 전용이다. 이 경계는 기존 Account 인증, Profile Owner/Member 사실,
+  `Account.Operator` 기반 운영자 Mutation 권한을 변경하지 않는다.
+- Admin-specific 성공·실패 조회 감사, identity snapshot, 접근 실패·proxy 우회·위조 header security event
+  logging, 검색값 및 보존 기간은 v1에서 모두 제외한다. 기존 공통 runtime 오류·접근 로그의 동작은 이 결정의
+  범위가 아니다.
+
+## 이유
+
+Tailscale 접근 정책을 단일 진입 권한으로 사용하면 별도 capability 전달 경로와 action 조합 없이 필요한
+read-only surface를 제공할 수 있다. identity header를 표시 용도로만 제한하면 표시 문자열의 변조, 누락,
+Account 변경이 Kosmo 도메인 권한을 만들지 않는다.
+
+`Account.Operator`를 재사용하지 않으면 Admin Console read-only 도구가 Account/Profile Mutation이나 내부
+운영자 권한을 우연히 상속하지 않는다. 세 projection을 구조적으로 분리하면 같은 Viewer에게 모두 허용하면서도
+Account나 Profile 응답을 통해 관계 정보를 암묵적으로 노출하지 않는다.
+
+## 결과
+
+- Admin Console Viewer의 identity가 Account와 같아 보여도 Account self, Member, Owner, Operator 관계는
+  성립하지 않는다.
+- Admin Console의 객체 조합과 노출 필드는 [Admin Console Read Policy](../policies/admin-console-read.md)
+  하나에서 확인할 수 있다.
+- Account, Profile, Membership 객체 문서의 기존 domain fact와 Mutation 권한은 유지된다.
+- 객체별 Admin Console 권한이나 감사·security-event logging을 도입하려면 이 ADR과 정책을 갱신하는 별도
+  결정이 필요하다.
+
+## 근거
+
+- [PROD-689](https://linear.app/byulmaru/issue/PROD-689)
+- [Account](../objects/account.md)
+- [Profile](../objects/profile.md)
+- [Account-Profile Membership](../objects/account-profile-membership.md)
+- [ADR 0019: Selected Profile Authorization Boundary](./0019-selected-profile-authorization-boundary.md)
+
+## 문서 반영
+
+- [Admin Console Read Policy](../policies/admin-console-read.md)는 단일 접근 경계, 객체별 필드와 projection
+  분리를 정의한다.
+- [Account](../objects/account.md)는 Admin Console 정책과 별개인 Account.Operator 사실을 유지하고,
+  Account 표시 이름과 OIDC subject를 Account 속성으로 정의한다.

--- a/docs/domain/objects/account-profile-membership.md
+++ b/docs/domain/objects/account-profile-membership.md
@@ -31,7 +31,7 @@ Account-Profile Membership은 Account와 Profile의 역할 기반 관계다. Loc
 항상 하나 이상 존재한다.
 
 Admin Console의 Membership 조회는 [Admin Console Read Policy](../policies/admin-console-read.md)가 정한
-두 capability action의 조합으로만 제공한다. 이는 `Profile.Owner`, `Profile.Member`,
+Admin Console Viewer projection으로만 제공한다. 이는 `Profile.Owner`, `Profile.Member`,
 `Membership.Account`라는 기존 관계 사실이나 해당 관계를 변경하는 행동 권한을 바꾸지 않는다.
 
 ## 행동

--- a/docs/domain/objects/account.md
+++ b/docs/domain/objects/account.md
@@ -24,7 +24,7 @@ Account가 아니라 Profile이다.
 | 생성 시각    | 시각, 필수       | 생성 결과로 기록하며 변경 불가                                         | 항상      | 대상 Account의 내부 조회 | `Account.Self` 또는 `Account.Operator` |
 
 Admin Console의 Account 목록·상세와 OIDC subject exact 검색은 일반 Account 조회 권한을 확장하지 않고
-[Admin Console Read Policy](../policies/admin-console-read.md)의 `account.read` 조건으로만 제공한다.
+[Admin Console Read Policy](../policies/admin-console-read.md)의 Admin Console Viewer projection으로만 제공한다.
 
 ## 관계
 

--- a/docs/domain/policies/admin-console-read.md
+++ b/docs/domain/policies/admin-console-read.md
@@ -28,14 +28,16 @@ Tailscale proxy가 제공하는 login, display name과 같은 identity header는
 
 Admin Console v1은 객체별 권한을 나누지 않는 all-or-nothing 접근 모델을 사용한다.
 
-| 요청 경계                                  | Account | Profile | Account-Profile Membership |
-| ------------------------------------------ | :-----: | :-----: | :------------------------: |
-| Tailscale 접근 정책과 신뢰 경계를 통과함   |  허용   |  허용   |            허용            |
-| 허용되지 않은 tailnet 주체 또는 proxy 우회 |  금지   |  금지   |            금지            |
+| 요청 경계                                                  | Account | Profile | Account-Profile Membership |
+| ---------------------------------------------------------- | :-----: | :-----: | :------------------------: |
+| Tailscale 접근 정책과 신뢰 경계를 통과함                   |  허용   |  허용   |            허용            |
+| 허용되지 않은 tailnet 주체 또는 일반 workload의 proxy 우회 |  금지   |  금지   |            금지            |
 
 Tailscale 접근 정책은 누가 Admin Console entry에 연결할 수 있는지를 결정한다. 애플리케이션은 그 결정을
 `account.read`, `profile.read` 같은 action으로 다시 나누거나 identity header에서 추론하지 않는다. 신뢰된
-proxy를 우회한 ClusterIP, Pod IP 또는 공개 ingress 경로는 Admin Console 읽기 경계가 아니다.
+proxy를 우회한 일반 workload의 ClusterIP, Pod IP 또는 공개 ingress 경로는 Admin Console 읽기 경계가 아니다.
+Kubernetes node 자체와 kubelet을 포함한 node-origin 연결은 이미 node 권한을 가진 신뢰된 인프라 주체로 보고
+이번 위협 모델의 차단 대상에서 제외한다.
 
 세 projection은 같은 Viewer에게 열리지만 결과 구조에서는 분리한다. 한 projection에 다른 객체나 관계를
 `null`, `0`, 빈 placeholder로 암시하거나 편의상 합치지 않는다.

--- a/docs/domain/policies/admin-console-read.md
+++ b/docs/domain/policies/admin-console-read.md
@@ -2,87 +2,47 @@
 
 ## 정의
 
-Admin Console Read Policy는 durable 객체가 아니라 신뢰된 proxy가 전달한 capability와 Account, Profile,
-Account-Profile Membership을 함께 소비해 운영자용 읽기 결과의 접근 범위와 노출 필드를 결정하는 교차 객체
-조회 정책이다. 이 정책은 객체를 변경하지 않으며 Capability Holder를 Kosmo 도메인의 Account 또는
+Admin Console Read Policy는 durable 객체가 아니라 Tailscale 접근 제어를 통과한 Admin Console Viewer와
+Account, Profile, Account-Profile Membership을 함께 소비해 운영자용 읽기 결과의 노출 필드를 결정하는 교차
+객체 조회 정책이다. 이 정책은 객체를 변경하지 않으며 Admin Console Viewer를 Kosmo 도메인의 Account 또는
 `Account.Operator`로 만들지 않는다.
 
-## Capability Holder
+## Admin Console Viewer
 
-Capability Holder는 신뢰된 proxy가 전달한 유효한 capability를 가진 요청 주체다. Tailscale proxy가 제공하는
-login, display name과 같은 identity header는 현재 Capability Holder를 화면에 표시하기 위한 선택적 metadata일
-뿐이며 인가의 근거가 아니다.
+Admin Console Viewer는 Tailscale 접근 정책에 따라 Admin Console 진입이 허용된 요청 주체다. 애플리케이션은
+별도의 app capability나 객체별 action을 계산하지 않는다. 진입이 허용된 Viewer는 v1의 Account, Profile,
+Account-Profile Membership 읽기 projection을 모두 사용할 수 있다.
 
-- capability가 유효하면 identity header가 없어도 조회를 허용한다.
-- identity header가 없으면 화면에는 `식별 정보 없는 Capability Holder`로 표시한다.
+Tailscale proxy가 제공하는 login, display name과 같은 identity header는 현재 Viewer를 화면에 표시하기 위한
+선택적 metadata일 뿐이며 애플리케이션 인가의 근거가 아니다.
+
+- identity header가 없어도 Tailscale 접근 경계를 통과한 요청에는 읽기를 허용한다.
+- identity header가 없으면 화면에는 `식별 정보 없는 Admin Console Viewer`로 표시한다.
 - Tailscale identity를 표시할 때는 login과 display name만 사용하며 profile picture header는 사용하지 않는다.
-- ingress 정규화에 실패한 identity metadata는 없는 것으로 취급하며 인가 결과를 바꾸지 않는다.
-- identity header의 Account 일치 여부나 표시 이름은 capability에 없는 action을 부여하지 않는다.
-- Capability Holder는 이 정책의 읽기 결과만 사용할 수 있으며 Account 인증, Profile Owner/Member 관계,
+- ingress 정규화에 실패한 identity metadata는 없는 것으로 취급하며 접근 결과를 바꾸지 않는다.
+- identity header의 Account 일치 여부나 표시 이름은 추가 권한을 부여하지 않는다.
+- Admin Console Viewer는 이 정책의 읽기 결과만 사용할 수 있으며 Account 인증, Profile Owner/Member 관계,
   `Account.Operator` 사실을 획득하지 않는다.
 
-## Capability 계약
+## 접근 계약
 
-이 정책이 소비하는 capability의 namespace는 `byulmaru.co/cap/kosmo-admin`이다. 지원하는 action은 다음과
-같다.
+Admin Console v1은 객체별 권한을 나누지 않는 all-or-nothing 접근 모델을 사용한다.
 
-| action         | 허용하는 조회 범위                          |
-| -------------- | ------------------------------------------- |
-| `account.read` | Account 목록, 상세, OIDC subject exact 검색 |
-| `profile.read` | Profile 목록과 상세                         |
+| 요청 경계                                  | Account | Profile | Account-Profile Membership |
+| ------------------------------------------ | :-----: | :-----: | :------------------------: |
+| Tailscale 접근 정책과 신뢰 경계를 통과함   |  허용   |  허용   |            허용            |
+| 허용되지 않은 tailnet 주체 또는 proxy 우회 |  금지   |  금지   |            금지            |
 
-Admin ingress가 wire header 정규화를 마친 뒤 이 정책에 전달하는 capability payload의 canonical envelope는
-다음과 같다.
+Tailscale 접근 정책은 누가 Admin Console entry에 연결할 수 있는지를 결정한다. 애플리케이션은 그 결정을
+`account.read`, `profile.read` 같은 action으로 다시 나누거나 identity header에서 추론하지 않는다. 신뢰된
+proxy를 우회한 ClusterIP, Pod IP 또는 공개 ingress 경로는 Admin Console 읽기 경계가 아니다.
 
-```http
-Tailscale-App-Capabilities: {"byulmaru.co/cap/kosmo-admin":[{"action":["account.read"]},{"action":["profile.read"]}]}
-```
-
-정규화된 payload는 JSON object다. 이 정책의 namespace 값은 parameter object 배열이며, 각 parameter의
-선택적 `action` key는 문자열 배열이다. target namespace가 없는 JSON object는 유효하지만 grant를 만들지
-않는다. 다음 parameter 입력은 유효하다.
-
-| parameter 예시                               | 판정                                                    |
-| -------------------------------------------- | ------------------------------------------------------- |
-| `{"action":["account.read"]}`                | `account.read` grant                                    |
-| `{"action":["account.read","unknown"]}`      | `account.read`만 grant하고 unknown action은 무시        |
-| `{"action":["account.read","account.read"]}` | 중복을 제거해 `account.read` 하나로 계산                |
-| `{}` 또는 `{"action":[]}`                    | 유효하지만 grant 없음                                   |
-| `{"action":["profile.read"],"future":true}`  | `profile.read`만 grant하고 unknown parameter key는 무시 |
-
-정규화된 Capability payload는 다음 순서로 검증한다.
-
-1. payload가 JSON object가 아니면 payload 전체를 malformed로 거부한다.
-2. 이 정책의 namespace가 없으면 유효한 grant 없음으로 처리한다. namespace가 존재하지만 값이 배열이 아니면
-   payload 전체를 malformed로 거부한다.
-3. 이 정책의 namespace 배열에 object가 아닌 값이 하나라도 있으면 payload 전체를 malformed로 거부한다.
-4. parameter에 `action`이 있고 그 값이 배열이 아니거나 문자열이 아닌 항목을 하나라도 포함하면 payload 전체를
-   malformed로 거부한다.
-5. 이 정책의 namespace가 아닌 key와 parameter의 알 수 없는 key는 grant를 만들지 않고 무시한다.
-6. `action` 누락과 빈 배열은 유효하지만 grant를 만들지 않는다.
-7. 알 수 없는 action은 권한을 부여하지 않고 무시한다. wildcard action은 지원하지 않으며 `*`도 알 수 없는
-   action으로 취급한다.
-8. 여러 valid parameter object가 있으면 지원 action을 합집합으로 계산하고 중복 action은 하나로 축약한다.
-
-따라서 malformed payload, 필요한 action이 없는 payload, capability가 없는 요청은 해당 조회 범위를 허용하지
-않는다. identity header는 이 검증을 대신하지 않는다.
-
-## Action 조합
-
-| 보유 action                     | Account | Profile | Account-Profile Membership |
-| ------------------------------- | :-----: | :-----: | :------------------------: |
-| 없음                            |  금지   |  금지   |            금지            |
-| `account.read`                  |  허용   |  금지   |            금지            |
-| `profile.read`                  |  금지   |  허용   |            금지            |
-| `account.read` + `profile.read` |  허용   |  허용   |            허용            |
-
-권한이 없는 객체 또는 관계는 `null`, `0`, 빈 placeholder로 바꾸지 않고 결과 구조에서 제외한다. 직접 조회가
-정책 action을 충족하지 않으면 대상 데이터 계산 전에 접근을 거부한다.
+세 projection은 같은 Viewer에게 열리지만 결과 구조에서는 분리한다. 한 projection에 다른 객체나 관계를
+`null`, `0`, 빈 placeholder로 암시하거나 편의상 합치지 않는다.
 
 ## Account 조회
 
-`account.read`가 있을 때만 Account를 조회한다. Account의 일반 자기 자신/운영자 조회와 별개로 이 정책의
-조회 결과는 다음 필드만 사용한다.
+Admin Console Viewer의 Account 조회 결과는 다음 필드만 사용한다.
 
 ### 목록과 기본 검색
 
@@ -105,13 +65,12 @@ subject 자체는 상세 조회에서만 반환한다.
 - Session credential, token, OIDC session key
 - private key와 그 밖의 credential 값
 
-Account ID는 관계 조회 권한이나 Profile 조회 권한을 대신하지 않는다. 두 action을 모두 가진 경우에도
-Profile과 Membership은 아래의 별도 Membership relation projection으로만 제공한다.
+Profile과 Membership은 아래의 별도 projection으로만 제공한다.
 
 ## Profile 조회
 
-`profile.read`가 있을 때만 Profile을 조회한다. 공개 Profile의 노출 조건과 별개로 Admin Console 조회 결과는
-운영에 필요한 Lifecycle State와 Suspension State를 포함할 수 있다.
+공개 Profile의 노출 조건과 별개로 Admin Console Viewer의 Profile 조회 결과는 운영에 필요한 Lifecycle State와
+Suspension State를 포함할 수 있다.
 
 ### 목록
 
@@ -134,7 +93,7 @@ Profile과 Membership은 아래의 별도 Membership relation projection으로�
 - 생성 시각
 
 현재 v1 projection은 Instance에서 Domain만 확정한다. Instance Type, Safety/Reachability/Service State와 각
-사유, Instance 생성 시각, Profile 역관계는 이번 PROD-689 범위에 포함하지 않으며 영구 제외 여부는 결정하지
+사유, Instance 생성 시각, Profile 역관계는 이번 PR 범위에 포함하지 않으며 영구 제외 여부는 결정하지
 않는다.
 
 단독 Profile projection은 다음을 반환하지 않는다.
@@ -145,14 +104,11 @@ Profile과 Membership은 아래의 별도 Membership relation projection으로�
 
 Followers Count와 Following Count는 Profile의 소셜 관계 count이며 Membership count와 다르다. Profile의
 공개 조회에서 숨겨지는 상태를 Admin Console이 반환할 수 있다는 사실은 일반 공개 Profile 정책을 변경하지
-않는다. 두 action을 모두 가진 경우에도 Account와 Membership은 아래의 별도 Membership relation
-projection으로만 제공한다.
+않는다. Account와 Membership은 아래의 별도 projection으로만 제공한다.
 
 ## Account-Profile Membership 조회
 
 Account-Profile Membership은 단독 Account/Profile projection과 분리된 relation projection이다.
-`account.read`와 `profile.read`를 모두 가진 경우에만 조회한다. 한 action만 있는 경우 Account나 Profile
-결과에 Membership 존재 여부, Role 또는 count를 포함하지 않는다.
 
 Membership 결과는 다음을 제공한다.
 
@@ -165,7 +121,7 @@ Membership 결과는 다음을 제공한다.
 - Membership에서 Account로, Account에서 Membership으로의 양방향 탐색
 - Membership에서 Profile로, Profile에서 Membership으로의 양방향 탐색
 
-양방향 탐색은 두 action을 모두 검증한 뒤 같은 정책 범위 안에서만 허용한다. 이 정책은 Membership의
+양방향 탐색은 같은 Admin Console Viewer 정책 범위 안에서만 허용한다. 이 정책은 Membership의
 `Profile.Owner`, `Profile.Member`, `Membership.Account` 사실을 새로 만들거나 변경하지 않는다.
 
 ## 민감 정보와 로깅
@@ -173,24 +129,20 @@ Membership 결과는 다음을 제공한다.
 - credential, Session token, OIDC session key, private key와 같은 값은 마스킹해 반환하지 않고 조회 결과에서
   제외한다.
 - Admin Console v1은 성공 조회, 검색, 상세, 관계 조회를 영속 감사하지 않는다.
-- capability 없음, malformed capability, 필요한 action 부족, trusted proxy 우회 또는 위조 header와 같은
-  Admin-specific security event도 이 정책에서 기록·보존하지 않는다.
-- capability snapshot, identity header, 검색값, 대상·결과와 보존 기간을 별도 계약으로 만들지 않는다.
+- 접근 거부, trusted proxy 우회 또는 위조 identity header와 같은 Admin-specific security event도 이 정책에서
+  기록·보존하지 않는다.
+- identity header, 검색값, 대상·결과와 보존 기간을 별도 계약으로 만들지 않는다.
 - 기존 공통 runtime 오류·접근 로그의 생명주기는 이 정책에서 변경하지 않는다.
 
 ## 제외/보류
 
-- Capability Holder의 Account 자동 매핑과 `Account.Operator` 승격
+- Admin Console Viewer의 Account 자동 매핑과 `Account.Operator` 승격
 - Admin Console을 통한 Account, Profile, Membership Mutation
-- wildcard와 capability 위임
-- Profile과 Account 사이의 hidden relation을 단일 action으로 노출하는 조회 결과
+- 객체별 Admin Console action과 권한 위임
 - selected Profile, Session, credential 정보
 - Admin-specific audit, security-event, query logging과 별도 보존 정책
 
 ## 확정 용어
 
-- Capability Holder: capability를 보유한 Admin Console 요청 주체
+- Admin Console Viewer: Tailscale 접근 정책에 따라 Admin Console 진입이 허용된 요청 주체
 - Admin Console Read Policy: Admin Console 교차 객체 읽기 정책
-- capability namespace: `byulmaru.co/cap/kosmo-admin`
-- `account.read`: Account 읽기 action
-- `profile.read`: Profile 읽기 action

--- a/openspec/changes/add-admin-console-foundation/.openspec.yaml
+++ b/openspec/changes/add-admin-console-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-08-27

--- a/openspec/changes/add-admin-console-foundation/decisions.md
+++ b/openspec/changes/add-admin-console-foundation/decisions.md
@@ -1,0 +1,97 @@
+## Context
+
+이 기록은 PROD-689와 ADR 0026의 단일 Admin Console Viewer 계약을 PROD-690의 runtime·cluster 전달 경계로
+구현하기 위한 결정을 남긴다.
+
+## Decision Records
+
+### Tailscale 접근 정책을 단일 admission 근거로 사용한다
+
+- Decision Date: 2026-08-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/policies/admin-console-read.md`,
+  `docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md`, `docs/architecture/admin-console.md`,
+  `PROD-689`, `PROD-690`
+- Status: Active
+- Context / Problem: v1의 Account, Profile, Membership 읽기를 서로 다른 application 권한으로 나눌 제품 요구가
+  없다.
+- Decision Outcome: Tailscale 접근 정책을 통과한 Admin Console Viewer에게 하나의 admission을 부여한다.
+  애플리케이션은 App Capability와 객체별 action을 소비하거나 계산하지 않는다.
+- Alternatives Considered: App Capability action 분리는 불필요한 전달·검증 경계를 만들고 현재 Operator
+  Ingress가 `AcceptAppCaps`를 선언하지도 않으므로 선택하지 않았다.
+- Consequences: 후속 세 read projection은 같은 Viewer gate를 공유하되 응답 구조와 필드 계약은 분리한다.
+- Confirmation / Follow-up: Linear PROD-689~693과 canonical 문서를 같은 계약으로 유지한다.
+
+### Tailscale Operator Ingress와 ClusterIP Service를 사용한다
+
+- Decision Date: 2026-08-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/admin-console.md`, `PROD-690`
+- Status: Active
+- Context / Problem: App Capability 전달이 필요하지 않으므로 same-Pod Serve sidecar와 독립 node lifecycle을
+  운영할 이유가 없다.
+- Decision Outcome: `ingressClassName: tailscale` Ingress가 ClusterIP Admin Service로 요청을 전달한다.
+  public Gateway/HTTPRoute, Funnel과 application LoadBalancer는 만들지 않는다.
+- Alternatives Considered: Serve sidecar는 별도 node state·credential·lifecycle을 만들고 public ingress는 내부
+  Admin surface를 노출하므로 선택하지 않았다.
+- Consequences: Operator가 proxy identity와 lifecycle을 소유하며 Admin Pod는 일반 HTTP listener를 사용한다.
+- Confirmation / Follow-up: Helm render와 dev tailnet hostname 응답으로 전달 경계를 확인한다.
+
+### NetworkPolicy로 Admin workload 직접 접근을 차단한다
+
+- Decision Date: 2026-08-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/admin-console.md`, `PROD-690`
+- Status: Active
+- Context / Problem: ClusterIP와 Pod IP는 cluster·VPC 경로에서 직접 접근될 수 있어 Tailscale admission을 우회할
+  수 있다.
+- Decision Outcome: Admin workload ingress를 기본 거부하고 해당 Operator proxy와 필요한 probe source만
+  application port에 허용한다.
+- Alternatives Considered: ClusterIP type, tailnet ACL 추정 또는 caller header 검사는 직접 network path를
+  닫지 못하므로 선택하지 않았다.
+- Consequences: generated proxy label과 probe source를 Operator 버전 및 live cluster에서 확인해야 한다.
+- Confirmation / Follow-up: Helm fixture와 dev의 임의 Pod·VPC direct-access test로 차단을 확인한다.
+
+### 선택적 identity는 표시 metadata로만 사용한다
+
+- Decision Date: 2026-08-27
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/policies/admin-console-read.md`, `docs/architecture/admin-console.md`,
+  `PROD-689`, `PROD-690`
+- Status: Active
+- Context / Problem: Tailscale login과 display name은 현재 Viewer를 설명할 수 있지만 admission과 Kosmo 도메인
+  권한을 대신할 수 없다.
+- Decision Outcome: 제공된 login과 display name만 정규화해 표시한다. 누락·정규화 실패는 익명 Viewer label로
+  대체하고 접근 결과를 바꾸지 않는다.
+- Alternatives Considered: identity를 인가나 Account 매핑에 사용하면 Tailscale 주체와 Kosmo 도메인 주체가
+  합쳐지므로 선택하지 않았다.
+- Consequences: profile picture header는 사용하지 않고 identity 처리 실패는 요청 실패가 아니다.
+- Confirmation / Follow-up: identity 있음·없음·정규화 실패 fixture에서 같은 shell 접근 결과를 검증한다.
+
+### Admin-specific 관측 기능을 추가하지 않는다
+
+- Decision Date: 2026-08-27
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/policies/admin-console-read.md`,
+  `docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md`, `docs/architecture/admin-console.md`,
+  `PROD-689`, `PROD-690`
+- Status: Active
+- Context / Problem: 기존 Web/API middleware를 재사용하면 이번 v1에서 제외한 Admin-specific 기록을 함께
+  도입할 수 있다.
+- Decision Outcome: Admin package는 request logger, Sentry, audit writer나 identity snapshot을 연결하지 않는다.
+- Alternatives Considered: 기존 Web/API 관측 경계 재사용과 새 Admin security-event는 upstream 제외 범위를
+  바꾸므로 선택하지 않았다.
+- Consequences: 검증은 응답·network·workload 상태로 수행한다.
+- Confirmation / Follow-up: package dependency와 source에서 해당 integration이 없는지 정적으로 확인한다.
+
+## Remaining Decisions
+
+- dev tailnet hostname과 허용 principal은 live 배포 전에 확인한다.
+- NetworkPolicy selector에 사용할 Operator-generated proxy label과 probe source는 대상 Operator 버전과 live
+  resource에서 확인한다.
+
+## Superseded Decisions
+
+- 같은 Pod의 Tailscale Serve sidecar, `AcceptAppCaps`, localhost shell listener, 별도 probe listener, RFC 2047
+  capability decoder와 persistent node-state Secret을 사용한다는 초안 결정은 App Capability를 사용하지 않는
+  것으로 확정하면서 구현 전에 폐기했다.

--- a/openspec/changes/add-admin-console-foundation/decisions.md
+++ b/openspec/changes/add-admin-console-foundation/decisions.md
@@ -45,12 +45,15 @@
 - Status: Active
 - Context / Problem: ClusterIP와 Pod IP는 cluster·VPC 경로에서 직접 접근될 수 있어 Tailscale admission을 우회할
   수 있다.
-- Decision Outcome: Admin workload ingress를 기본 거부하고 해당 Operator proxy와 필요한 probe source만
-  application port에 허용한다.
+- Decision Outcome: 일반 workload에서 오는 Admin ingress를 기본 거부하고 해당 Operator proxy만 application
+  port에 허용한다. Kubernetes node 자체, kubelet과 node 권한을 가진 운영 주체의 node-origin 연결은 차단
+  범위에서 제외한다.
 - Alternatives Considered: ClusterIP type, tailnet ACL 추정 또는 caller header 검사는 직접 network path를
   닫지 못하므로 선택하지 않았다.
-- Consequences: generated proxy label과 probe source를 Operator 버전 및 live cluster에서 확인해야 한다.
-- Confirmation / Follow-up: Helm fixture와 dev의 임의 Pod·VPC direct-access test로 차단을 확인한다.
+- Consequences: generated proxy label을 Operator 버전 및 live cluster에서 확인해야 한다. node로 source NAT된
+  경로까지 차단했다고 주장하지 않는다.
+- Confirmation / Follow-up: Helm fixture와 dev의 일반 Pod·node 밖 VPC direct-access test로 차단을 확인하고
+  관찰된 source 경계를 함께 기록한다.
 
 ### 선택적 identity는 표시 metadata로만 사용한다
 
@@ -87,8 +90,8 @@
 ## Remaining Decisions
 
 - dev tailnet hostname과 허용 principal은 live 배포 전에 확인한다.
-- NetworkPolicy selector에 사용할 Operator-generated proxy label과 probe source는 대상 Operator 버전과 live
-  resource에서 확인한다.
+- NetworkPolicy selector에 사용할 Operator-generated proxy label은 대상 Operator 버전과 live resource에서
+  확인한다.
 
 ## Superseded Decisions
 

--- a/openspec/changes/add-admin-console-foundation/design.md
+++ b/openspec/changes/add-admin-console-foundation/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`apps/web`과 `apps/api`는 Hono 기반 Node runtime이며 하나의 application image를 서로 다른 entrypoint로
+실행한다. `apps/helm`은 공개 runtime을 Argo Rollout, ClusterIP Service와 Gateway API HTTPRoute로 배포하지만,
+Admin Console은 이 공개 경계를 재사용할 수 없다.
+
+Tailscale Operator Ingress는 Kubernetes Service를 L7 proxy한다. Admin Console의 admission은 tailnet의 접근
+정책이 소유하며 애플리케이션은 App Capability header나 객체별 action을 해석하지 않는다. ClusterIP와 Pod IP는
+cluster 또는 VPC 경로에서 직접 접근될 수 있으므로 Service type만으로 신뢰 경계가 닫히지 않는다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 공개 runtime과 분리된 Admin shell·probe runtime을 만든다.
+- Tailscale 접근 정책에서 허용된 Viewer에게 v1 읽기 전체의 공통 admission을 제공한다.
+- Operator Ingress 뒤의 ClusterIP Service와 NetworkPolicy로 직접 Service·Pod 접근을 차단한다.
+- runtime, image, Helm render와 trust-boundary fixture를 자동 검증한다.
+
+**Non-Goals:**
+
+- Account, Profile, Membership data query와 GraphQL schema
+- Tailscale App Capability, `AcceptAppCaps`, `Tailscale-App-Capabilities`와 application-level action authorization
+- same-Pod Tailscale Serve sidecar, node state와 bootstrap credential
+- public Gateway/HTTPRoute, Funnel 또는 application LoadBalancer
+- Kosmo Account/Operator 매핑
+- Admin-specific logging, audit, security event와 snapshot
+
+## Implementation Guidance
+
+### Recommended Approach
+
+`apps/admin`은 Pod network에서 하나의 작은 Hono app을 실행한다. `GET /healthz`와 read-only shell route만
+제공하고 정의되지 않은 route는 기본 거부한다. shell은 외부 asset이나 data query 없이 현재 Admin Console
+Viewer의 선택적 표시 metadata만 보여준다.
+
+선택적 identity header가 제공되면 login과 display name만 정규화해 표시한다. identity 누락이나 정규화 실패는
+`식별 정보 없는 Admin Console Viewer`로 처리하며 admission 결과를 바꾸지 않는다. profile picture header나
+identity 값을 Kosmo Account에 매핑하지 않는다.
+
+Helm은 Admin Deployment, ClusterIP Service와 `ingressClassName: tailscale` Ingress를 만든다. public
+Gateway/HTTPRoute와 application LoadBalancer는 만들지 않는다. Tailscale 접근 정책의 principal, hostname과
+grant 자체는 cluster 외부 운영 설정이므로 repository에 사용자 식별자나 credential 값을 저장하지 않는다.
+
+NetworkPolicy는 Admin workload를 기본 거부하고 Operator가 생성한 해당 Ingress proxy와 필요한 workload
+probe만 application port에 접근하도록 허용한다. selector에 사용할 generated proxy label은 배포 대상 Operator
+버전과 live cluster에서 확인한 뒤 고정한다. label을 확인하기 전 특정 값을 durable 계약으로 가정하지 않는다.
+
+### Known Traps
+
+- App Capability 전달을 위해 미지원 annotation이나 Serve sidecar를 추가하지 않는다.
+- ClusterIP, caller IP, Host, `X-Forwarded-*`, identity header 또는 내부 shared secret을 application admission
+  근거로 사용하지 않는다.
+- public Gateway/HTTPRoute, Funnel이나 application LoadBalancer로 별도 entry를 만들지 않는다.
+- NetworkPolicy 없이 ClusterIP만 만들고 직접 접근 차단을 완료로 판단하지 않는다.
+- Admin runtime에 기존 Web/API의 Sentry 또는 request logging middleware를 연결하지 않는다.
+
+## Risks / Trade-offs
+
+- [Generated proxy label은 Operator 버전과 실제 resource에 의존함] → dev에서 생성된 proxy Pod label을 확인한
+  뒤 policy selector를 고정하고 Helm fixture와 live direct-access test를 함께 둔다.
+- [NetworkPolicy가 proxy 또는 probe까지 차단할 수 있음] → proxy와 probe source를 각각 검증하고 readiness와
+  tailnet 응답을 별도 증거로 수집한다.
+- [Tailscale 접근 정책은 repository 밖에서 관리됨] → 허용·거부 principal의 실제 설정을 repository 검증과
+  분리하고, dev tailnet 통합 전제와 관찰 결과를 명시한다.
+
+## Migration Plan
+
+1. Admin package, image entrypoint와 Helm render를 배포 전 검증한다.
+2. dev Operator 버전, generated proxy label, hostname과 Tailscale 접근 정책 준비를 확인한다.
+3. dev에 Deployment, Service, Ingress와 NetworkPolicy를 sync하고 workload readiness를 확인한다.
+4. 허용된 Viewer와 허용되지 않은 tailnet 주체의 hostname 접근을 각각 검증한다.
+5. 임의 Pod·VPC 경로의 ClusterIP·Pod IP 접근과 공개 인터넷 노출이 차단됨을 별도로 확인한다.
+6. rollback은 application revision과 Helm resource를 이전 revision으로 되돌린다. tailnet 접근 정책 변경은 별도
+   운영 절차를 따른다.
+
+## Open Questions
+
+- dev tailnet의 hostname과 허용 principal은 배포 전에 확인해야 한다. repository 기본값은 사용자 식별자나
+  credential을 소유하지 않는다.
+- 현재 환경에서는 live cluster의 generated proxy label, Operator 동작과 직접 접근 차단을 확인하지 못했으므로
+  실제 배포 증거는 아직 없다.

--- a/openspec/changes/add-admin-console-foundation/design.md
+++ b/openspec/changes/add-admin-console-foundation/design.md
@@ -14,7 +14,7 @@ cluster 또는 VPC 경로에서 직접 접근될 수 있으므로 Service type�
 
 - 공개 runtime과 분리된 Admin shell·probe runtime을 만든다.
 - Tailscale 접근 정책에서 허용된 Viewer에게 v1 읽기 전체의 공통 admission을 제공한다.
-- Operator Ingress 뒤의 ClusterIP Service와 NetworkPolicy로 직접 Service·Pod 접근을 차단한다.
+- Operator Ingress 뒤의 ClusterIP Service와 NetworkPolicy로 일반 workload의 직접 Service·Pod 접근을 차단한다.
 - runtime, image, Helm render와 trust-boundary fixture를 자동 검증한다.
 
 **Non-Goals:**
@@ -42,9 +42,10 @@ Helm은 Admin Deployment, ClusterIP Service와 `ingressClassName: tailscale` Ing
 Gateway/HTTPRoute와 application LoadBalancer는 만들지 않는다. Tailscale 접근 정책의 principal, hostname과
 grant 자체는 cluster 외부 운영 설정이므로 repository에 사용자 식별자나 credential 값을 저장하지 않는다.
 
-NetworkPolicy는 Admin workload를 기본 거부하고 Operator가 생성한 해당 Ingress proxy와 필요한 workload
-probe만 application port에 접근하도록 허용한다. selector에 사용할 generated proxy label은 배포 대상 Operator
-버전과 live cluster에서 확인한 뒤 고정한다. label을 확인하기 전 특정 값을 durable 계약으로 가정하지 않는다.
+NetworkPolicy는 일반 workload에서 오는 Admin ingress를 기본 거부하고 Operator가 생성한 해당 Ingress
+proxy만 application port에 접근하도록 허용한다. Kubernetes node 자체와 kubelet probe를 포함한 node-origin
+연결은 차단 범위에서 제외한다. selector에 사용할 generated proxy label은 배포 대상 Operator 버전과 live
+cluster에서 확인한 뒤 고정한다. label을 확인하기 전 특정 값을 durable 계약으로 가정하지 않는다.
 
 ### Known Traps
 
@@ -52,15 +53,18 @@ probe만 application port에 접근하도록 허용한다. selector에 사용할
 - ClusterIP, caller IP, Host, `X-Forwarded-*`, identity header 또는 내부 shared secret을 application admission
   근거로 사용하지 않는다.
 - public Gateway/HTTPRoute, Funnel이나 application LoadBalancer로 별도 entry를 만들지 않는다.
-- NetworkPolicy 없이 ClusterIP만 만들고 직접 접근 차단을 완료로 판단하지 않는다.
+- NetworkPolicy 없이 ClusterIP만 만들고 일반 workload의 직접 접근 차단을 완료로 판단하지 않는다.
 - Admin runtime에 기존 Web/API의 Sentry 또는 request logging middleware를 연결하지 않는다.
 
 ## Risks / Trade-offs
 
 - [Generated proxy label은 Operator 버전과 실제 resource에 의존함] → dev에서 생성된 proxy Pod label을 확인한
   뒤 policy selector를 고정하고 Helm fixture와 live direct-access test를 함께 둔다.
-- [NetworkPolicy가 proxy 또는 probe까지 차단할 수 있음] → proxy와 probe source를 각각 검증하고 readiness와
-  tailnet 응답을 별도 증거로 수집한다.
+- [NetworkPolicy selector가 Operator proxy를 차단할 수 있음] → generated proxy source를 확인하고 workload
+  readiness와 tailnet 응답을 별도 증거로 수집한다.
+- [표준 NetworkPolicy는 node-origin traffic을 차단하지 않음] → node 자체, kubelet과 node 권한을 가진 운영
+  주체는 신뢰된 인프라로 보고 v1 위협 모델에서 제외한다. node로 source NAT된 경로까지 차단했다고 주장하지
+  않고 live direct-access 결과에 source 경계를 함께 기록한다.
 - [Tailscale 접근 정책은 repository 밖에서 관리됨] → 허용·거부 principal의 실제 설정을 repository 검증과
   분리하고, dev tailnet 통합 전제와 관찰 결과를 명시한다.
 
@@ -70,7 +74,8 @@ probe만 application port에 접근하도록 허용한다. selector에 사용할
 2. dev Operator 버전, generated proxy label, hostname과 Tailscale 접근 정책 준비를 확인한다.
 3. dev에 Deployment, Service, Ingress와 NetworkPolicy를 sync하고 workload readiness를 확인한다.
 4. 허용된 Viewer와 허용되지 않은 tailnet 주체의 hostname 접근을 각각 검증한다.
-5. 임의 Pod·VPC 경로의 ClusterIP·Pod IP 접근과 공개 인터넷 노출이 차단됨을 별도로 확인한다.
+5. 일반 Pod와 node 밖 VPC 경로의 ClusterIP·Pod IP 접근 및 공개 인터넷 노출이 차단됨을 별도로 확인하고,
+   node-origin 또는 node로 source NAT된 경로는 차단 증거에서 제외한다.
 6. rollback은 application revision과 Helm resource를 이전 revision으로 되돌린다. tailnet 접근 정책 변경은 별도
    운영 절차를 따른다.
 

--- a/openspec/changes/add-admin-console-foundation/proposal.md
+++ b/openspec/changes/add-admin-console-foundation/proposal.md
@@ -9,8 +9,8 @@ Kosmo에는 공개 Web/API와 분리되고 Tailscale 접근 제어로만 진입�
 - 독립 workspace package `apps/admin`에 `/healthz`, 기본 deny와 읽기 전용 빈 Admin Console shell을 추가한다.
 - Tailscale 접근 정책을 통과한 Viewer가 별도 app capability나 객체별 action 없이 shell에 진입하도록 한다.
 - Admin runtime을 기존 application image와 entrypoint에 포함한다.
-- Tailscale Operator Ingress, ClusterIP Service와 NetworkPolicy를 추가해 Operator proxy에서만 Admin workload에
-  도달하도록 한다.
+- Tailscale Operator Ingress, ClusterIP Service와 NetworkPolicy를 추가해 일반 workload에서는 Operator
+  proxy를 통해서만 Admin workload에 도달하도록 한다. node-origin 연결은 차단 범위에서 제외한다.
 - public Gateway/HTTPRoute, Funnel, application LoadBalancer는 추가하지 않는다.
 - 선택적 Tailscale login과 display name은 표시 metadata로만 사용하고 애플리케이션 인가에는 사용하지 않는다.
 - Admin-specific logging, audit, security event와 identity snapshot은 추가하지 않는다.

--- a/openspec/changes/add-admin-console-foundation/proposal.md
+++ b/openspec/changes/add-admin-console-foundation/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Kosmo에는 공개 Web/API와 분리되고 Tailscale 접근 제어로만 진입할 수 있는 Admin Console runtime이 없다.
+후속 Account·Profile·Membership 조회를 추가하기 전에 독립 shell, cluster 전달 경계와 직접 접근 차단을 하나의
+기반으로 제공해야 한다.
+
+## What Changes
+
+- 독립 workspace package `apps/admin`에 `/healthz`, 기본 deny와 읽기 전용 빈 Admin Console shell을 추가한다.
+- Tailscale 접근 정책을 통과한 Viewer가 별도 app capability나 객체별 action 없이 shell에 진입하도록 한다.
+- Admin runtime을 기존 application image와 entrypoint에 포함한다.
+- Tailscale Operator Ingress, ClusterIP Service와 NetworkPolicy를 추가해 Operator proxy에서만 Admin workload에
+  도달하도록 한다.
+- public Gateway/HTTPRoute, Funnel, application LoadBalancer는 추가하지 않는다.
+- 선택적 Tailscale login과 display name은 표시 metadata로만 사용하고 애플리케이션 인가에는 사용하지 않는다.
+- Admin-specific logging, audit, security event와 identity snapshot은 추가하지 않는다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/policies/admin-console-read.md`,
+  `docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md`,
+  `docs/architecture/admin-console.md`
+- Linear Contract: `PROD-689`
+- Linear Implementation: `PROD-690`
+
+## Capabilities
+
+이 섹션의 capability는 OpenSpec 기능 단위이며 Tailscale App Capability가 아니다.
+
+### New Capabilities
+
+- `admin-console-foundation`: 독립 Admin runtime, Tailscale admission, trusted Operator Ingress와 network
+  isolation을 정의한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/admin`: 신규 Node/Hono runtime, read-only shell과 테스트
+- `Dockerfile`, `docker-entrypoint.sh`, workspace lockfile: Admin runtime build·실행 포함
+- `apps/helm`: Admin Deployment, ClusterIP Service, Tailscale Operator Ingress와 NetworkPolicy
+- CI/검증: package unit test, image boot, Helm render와 trust-boundary fixture

--- a/openspec/changes/add-admin-console-foundation/specs/admin-console-foundation/spec.md
+++ b/openspec/changes/add-admin-console-foundation/specs/admin-console-foundation/spec.md
@@ -49,21 +49,26 @@
 
 ### Requirement: Trusted Tailscale Operator Ingress와 network isolation
 
-**Authority / Provenance:** `docs/architecture/admin-console.md`, `PROD-689`, `PROD-690`. Admin Console 요청은 Tailscale Operator Ingress에서 ClusterIP Admin Service를 거쳐 Admin workload에 도달해야 한다(MUST). NetworkPolicy는 해당 Operator proxy와 필요한 workload probe만 application port에 허용해야 하며(MUST), ClusterIP·Pod IP·public Gateway·Funnel·application LoadBalancer를 통한 우회 entry를 허용해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/architecture/admin-console.md`, `PROD-689`, `PROD-690`. Admin Console 요청은 Tailscale Operator Ingress에서 ClusterIP Admin Service를 거쳐 Admin workload에 도달해야 한다(MUST). NetworkPolicy는 일반 workload source 중 해당 Operator proxy만 application port에 허용해야 하며(MUST), 일반 workload가 ClusterIP·Pod IP·public Gateway·Funnel·application LoadBalancer를 우회 entry로 사용하게 해서는 안 된다(MUST NOT). Kubernetes node 자체, kubelet과 node 권한을 가진 운영 주체의 node-origin 연결은 이 차단 요구 범위에 포함하지 않는다.
 
 #### Scenario: 허용되지 않은 tailnet 주체 차단
 
 - **WHEN** Tailscale 접근 정책에서 허용되지 않은 주체가 Admin Console hostname을 요청한다
 - **THEN** 요청은 Admin runtime에 도달하지 않는다
 
-#### Scenario: Service 또는 Pod 직접 접근 차단
+#### Scenario: 일반 workload의 Service 또는 Pod 직접 접근 차단
 
-- **WHEN** 임의의 cluster Pod나 VPC 경로에서 ClusterIP 또는 Admin Pod IP에 직접 접근한다
+- **WHEN** 일반 cluster Pod나 node 밖 VPC source에서 ClusterIP 또는 Admin Pod IP에 직접 접근한다
 - **THEN** NetworkPolicy는 application 연결을 허용하지 않는다
+
+#### Scenario: Node-origin 연결은 위협 모델에서 제외
+
+- **WHEN** Kubernetes node 자체, kubelet 또는 node 권한을 가진 운영 주체가 Admin workload에 연결한다
+- **THEN** 시스템은 해당 연결의 차단을 이 requirement의 완료 조건으로 요구하지 않는다
 
 #### Scenario: Caller 주입 header로 우회할 수 없음
 
-- **WHEN** caller가 identity나 proxy 관련 header를 직접 주입해 Service 또는 Pod에 접근한다
+- **WHEN** 일반 workload caller가 identity나 proxy 관련 header를 직접 주입해 Service 또는 Pod에 접근한다
 - **THEN** header 값과 무관하게 network 경계를 우회할 수 없다
 
 #### Scenario: 공개 인터넷 비노출

--- a/openspec/changes/add-admin-console-foundation/specs/admin-console-foundation/spec.md
+++ b/openspec/changes/add-admin-console-foundation/specs/admin-console-foundation/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: 독립 Admin Console runtime
+
+**Authority / Provenance:** `docs/architecture/admin-console.md`, `PROD-689`, `PROD-690`. 시스템은 공개 Web·API와 분리된 `apps/admin` runtime을 제공해야 한다(MUST). runtime은 workload probe용 `GET /healthz`와 읽기 전용 Admin Console shell만 제공하고, 정의되지 않은 endpoint는 기본 거부해야 한다(MUST).
+
+#### Scenario: workload 상태 확인
+
+- **WHEN** cluster workload probe가 `GET /healthz`를 호출한다
+- **THEN** 성공 상태를 반환한다
+
+#### Scenario: 정의되지 않은 endpoint 거부
+
+- **WHEN** 요청이 `GET /healthz`나 허용된 Admin Console shell route가 아닌 endpoint를 호출한다
+- **THEN** runtime은 요청을 거부하고 Admin data나 내부 오류 정보를 반환하지 않는다
+
+### Requirement: 단일 Admin Console Viewer 접근
+
+**Authority / Provenance:** `docs/domain/policies/admin-console-read.md`, `docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md`, `docs/architecture/admin-console.md`, `PROD-689`, `PROD-690`. Admin Console은 Tailscale 접근 정책을 통과한 Admin Console Viewer에게 shell 접근을 허용해야 하며(MUST), 별도의 App Capability나 객체별 action을 요구해서는 안 된다(MUST NOT). 후속 v1 Account, Profile, Account-Profile Membership projection은 모두 같은 Viewer admission을 사용해야 한다(MUST).
+
+#### Scenario: 허용된 Viewer의 shell 접근
+
+- **WHEN** Tailscale 접근 정책에서 허용된 Viewer가 지정된 tailnet hostname으로 shell을 요청한다
+- **THEN** Admin Console은 별도의 action 검사 없이 읽기 전용 shell을 반환한다
+
+#### Scenario: v1 읽기 범위의 단일 admission
+
+- **WHEN** 허용된 Viewer가 후속 Account, Profile 또는 Account-Profile Membership projection을 요청한다
+- **THEN** 각 projection은 같은 Viewer admission을 사용하고 application-level action으로 접근을 나누지 않는다
+
+#### Scenario: Identity를 인가에 사용하지 않음
+
+- **WHEN** identity header가 없거나 임의의 login·display name이 제공된다
+- **THEN** runtime은 해당 값을 admission, Account 매핑 또는 `Account.Operator` 판정에 사용하지 않는다
+
+### Requirement: 선택적 Admin Console Viewer 표시
+
+**Authority / Provenance:** `docs/domain/policies/admin-console-read.md`, `docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md`, `docs/architecture/admin-console.md`, `PROD-689`, `PROD-690`. Admin Console은 trusted proxy가 제공한 login과 display name만 현재 Viewer의 선택적 표시 metadata로 사용해야 하며(MUST), identity 누락이나 정규화 실패가 admission 결과를 바꾸게 해서는 안 된다(MUST NOT). profile picture header를 사용해서는 안 된다(MUST NOT).
+
+#### Scenario: Identity header가 없는 허용 요청
+
+- **WHEN** 허용된 Viewer의 login과 display name이 제공되지 않는다
+- **THEN** shell은 접근을 유지하고 `식별 정보 없는 Admin Console Viewer`를 표시한다
+
+#### Scenario: Identity 정규화 실패
+
+- **WHEN** 선택적 identity metadata를 정상 문자열로 정규화할 수 없다
+- **THEN** runtime은 해당 metadata를 누락으로 취급하고 Viewer의 접근 결과를 유지한다
+
+### Requirement: Trusted Tailscale Operator Ingress와 network isolation
+
+**Authority / Provenance:** `docs/architecture/admin-console.md`, `PROD-689`, `PROD-690`. Admin Console 요청은 Tailscale Operator Ingress에서 ClusterIP Admin Service를 거쳐 Admin workload에 도달해야 한다(MUST). NetworkPolicy는 해당 Operator proxy와 필요한 workload probe만 application port에 허용해야 하며(MUST), ClusterIP·Pod IP·public Gateway·Funnel·application LoadBalancer를 통한 우회 entry를 허용해서는 안 된다(MUST NOT).
+
+#### Scenario: 허용되지 않은 tailnet 주체 차단
+
+- **WHEN** Tailscale 접근 정책에서 허용되지 않은 주체가 Admin Console hostname을 요청한다
+- **THEN** 요청은 Admin runtime에 도달하지 않는다
+
+#### Scenario: Service 또는 Pod 직접 접근 차단
+
+- **WHEN** 임의의 cluster Pod나 VPC 경로에서 ClusterIP 또는 Admin Pod IP에 직접 접근한다
+- **THEN** NetworkPolicy는 application 연결을 허용하지 않는다
+
+#### Scenario: Caller 주입 header로 우회할 수 없음
+
+- **WHEN** caller가 identity나 proxy 관련 header를 직접 주입해 Service 또는 Pod에 접근한다
+- **THEN** header 값과 무관하게 network 경계를 우회할 수 없다
+
+#### Scenario: 공개 인터넷 비노출
+
+- **WHEN** tailnet 밖 또는 공개 인터넷에서 Admin Console hostname이나 backend 주소에 접근한다
+- **THEN** Admin Console shell과 backend endpoint에 연결할 수 없다
+
+### Requirement: Admin-specific 로깅 제외
+
+**Authority / Provenance:** `docs/domain/policies/admin-console-read.md`, `docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md`, `docs/architecture/admin-console.md`, `PROD-689`, `PROD-690`. 이 변경은 Admin-specific logging, audit, security event, identity snapshot과 별도 보존 정책을 추가해서는 안 된다(MUST NOT).
+
+#### Scenario: 접근 성공과 실패 처리
+
+- **WHEN** Admin Console 요청이 성공하거나 Tailscale 접근 거부·proxy 우회로 차단된다
+- **THEN** runtime은 해당 사건을 위한 Admin-specific log, audit record, security event 또는 snapshot을 생성하지
+  않는다

--- a/openspec/changes/add-admin-console-foundation/tasks.md
+++ b/openspec/changes/add-admin-console-foundation/tasks.md
@@ -1,0 +1,86 @@
+## 1. PROD-690 Admin runtime
+
+**Authority / Provenance**
+
+- `docs/domain/policies/admin-console-read.md`
+- `docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md`
+- `docs/architecture/admin-console.md`
+- `PROD-689`
+- `PROD-690`
+
+**Deliverable**
+
+독립 Admin runtime이 workload probe와 읽기 전용 shell을 제공한다.
+
+**Guardrails**
+
+- application-level App Capability나 객체별 action 검사를 추가하지 않는다.
+- 선택적 identity는 표시 metadata로만 사용하며 Kosmo Account에 매핑하지 않는다.
+- 정의되지 않은 route는 기본 거부하고 Admin-specific logging은 추가하지 않는다.
+
+**Verification**
+
+- package typecheck와 unit test로 probe, default deny, identity 독립성과 shell 응답을 검증한다.
+
+- [ ] 1.1 독립 workspace package와 probe·shell runtime을 추가한다.
+- [ ] 1.2 선택적 Viewer identity 표시와 익명 fallback을 구현한다.
+- [ ] 1.3 identity·route matrix unit test를 추가하고 package check를 통과시킨다.
+
+## 2. PROD-690 Image와 Tailscale Operator Ingress 배포
+
+**Authority / Provenance**
+
+- `docs/architecture/admin-console.md`
+- `PROD-690`
+
+**Deliverable**
+
+기존 application image가 Admin runtime을 실행하고, Tailscale Operator Ingress와 ClusterIP Service를 통해서만
+tailnet 요청이 Admin workload에 도달한다.
+
+**Guardrails**
+
+- public Gateway/HTTPRoute, Funnel과 application LoadBalancer를 만들지 않는다.
+- App Capability, Serve sidecar, Admin 전용 Tailscale node state나 bootstrap credential을 만들지 않는다.
+- Admin workload ingress는 기본 거부하고 해당 Operator proxy와 필요한 probe만 허용한다.
+
+**Verification**
+
+- image boot smoke와 dev/prod Helm lint·render로 entrypoint, Deployment, Service, Ingress, NetworkPolicy,
+  probe와 public resource 부재를 확인한다.
+
+- [ ] 2.1 application image와 entrypoint에 Admin runtime을 포함한다.
+- [ ] 2.2 Admin Deployment, ClusterIP Service와 Tailscale Operator Ingress를 Helm에 추가한다.
+- [ ] 2.3 generated proxy label과 probe source를 확인하고 최소 NetworkPolicy를 추가한다.
+- [ ] 2.4 Admin image boot와 dev/prod Helm render 검증을 추가하고 통과시킨다.
+
+## 3. PROD-690 통합 검증과 운영 handoff
+
+**Authority / Provenance**
+
+- `docs/domain/policies/admin-console-read.md`
+- `docs/architecture/admin-console.md`
+- `PROD-690`
+
+**Deliverable**
+
+repository 검증과 실제 dev tailnet 관찰이 Admin shell의 허용·거부, 직접 접근 차단과 배포 readiness를 구분해
+증명한다.
+
+**Guardrails**
+
+- artifact, Helm render와 CI 성공을 실제 tailnet 배포·접속 증거로 대체하지 않는다.
+- 사용자 식별자, credential 값과 identity header를 문서·test output·PR에 기록하지 않는다.
+- OpenSpec archive는 이 change의 모든 task와 live 검증이 끝난 뒤 별도로 판단한다.
+
+**Verification**
+
+- workspace lint/test와 OpenSpec strict validation을 실행한다.
+- dev workload Ready, tailnet 허용·거부 Viewer, ClusterIP·Pod IP direct access 차단과 공개 인터넷 비노출을 실제
+  환경에서 확인한다.
+
+- [ ] 3.1 접근 정책 prerequisite, deploy·검증·rollback 절차를 사용자 식별자나 credential 값 없이 문서화한다.
+- [ ] 3.2 workspace lint/test, image와 Helm 검증, OpenSpec strict validation을 통과시킨다.
+- [ ] 3.3 dev에서 workload readiness와 Operator Ingress 전달을 확인한다.
+- [ ] 3.4 dev tailnet의 허용·거부 접근과 임의 Pod·VPC direct access·공개 인터넷 비노출을 확인한다.
+- [ ] 3.5 모든 repository와 live 검증이 끝난 뒤 change archive 담당과 완료 여부를 확정한다.

--- a/openspec/changes/add-admin-console-foundation/tasks.md
+++ b/openspec/changes/add-admin-console-foundation/tasks.md
@@ -42,7 +42,8 @@ tailnet 요청이 Admin workload에 도달한다.
 
 - public Gateway/HTTPRoute, Funnel과 application LoadBalancer를 만들지 않는다.
 - App Capability, Serve sidecar, Admin 전용 Tailscale node state나 bootstrap credential을 만들지 않는다.
-- Admin workload ingress는 기본 거부하고 해당 Operator proxy와 필요한 probe만 허용한다.
+- 일반 workload의 Admin ingress는 기본 거부하고 해당 Operator proxy만 허용한다. node-origin 연결은 차단
+  범위에서 제외한다.
 
 **Verification**
 
@@ -51,7 +52,7 @@ tailnet 요청이 Admin workload에 도달한다.
 
 - [ ] 2.1 application image와 entrypoint에 Admin runtime을 포함한다.
 - [ ] 2.2 Admin Deployment, ClusterIP Service와 Tailscale Operator Ingress를 Helm에 추가한다.
-- [ ] 2.3 generated proxy label과 probe source를 확인하고 최소 NetworkPolicy를 추가한다.
+- [ ] 2.3 generated proxy label을 확인하고 일반 workload source를 제한하는 최소 NetworkPolicy를 추가한다.
 - [ ] 2.4 Admin image boot와 dev/prod Helm render 검증을 추가하고 통과시킨다.
 
 ## 3. PROD-690 통합 검증과 운영 handoff
@@ -76,11 +77,13 @@ repository 검증과 실제 dev tailnet 관찰이 Admin shell의 허용·거부,
 **Verification**
 
 - workspace lint/test와 OpenSpec strict validation을 실행한다.
-- dev workload Ready, tailnet 허용·거부 Viewer, ClusterIP·Pod IP direct access 차단과 공개 인터넷 비노출을 실제
-  환경에서 확인한다.
+- dev workload Ready, tailnet 허용·거부 Viewer, 일반 Pod·node 밖 VPC source의 ClusterIP·Pod IP direct access
+  차단과 공개 인터넷 비노출을 실제 환경에서 확인한다. node-origin과 node로 source NAT된 경로는 차단 증거에서
+  제외하고 source 경계를 기록한다.
 
 - [ ] 3.1 접근 정책 prerequisite, deploy·검증·rollback 절차를 사용자 식별자나 credential 값 없이 문서화한다.
 - [ ] 3.2 workspace lint/test, image와 Helm 검증, OpenSpec strict validation을 통과시킨다.
 - [ ] 3.3 dev에서 workload readiness와 Operator Ingress 전달을 확인한다.
-- [ ] 3.4 dev tailnet의 허용·거부 접근과 임의 Pod·VPC direct access·공개 인터넷 비노출을 확인한다.
+- [ ] 3.4 dev tailnet의 허용·거부 접근과 일반 Pod·node 밖 VPC direct access·공개 인터넷 비노출을 확인하고,
+      node-origin 예외를 구분해 기록한다.
 - [ ] 3.5 모든 repository와 live 검증이 끝난 뒤 change archive 담당과 완료 여부를 확정한다.


### PR DESCRIPTION
## 무엇을 변경했나요

- Admin Console 접근 모델을 Tailscale App Capabilities에서 Tailscale 접근 정책 기반 단일 Viewer admission으로 변경했습니다.
- ADR 0025를 Superseded로 보존하고 ADR 0026, domain policy, architecture, object 문서를 새 계약에 맞췄습니다.
- PROD-690 구현용 OpenSpec proposal/spec/design/decisions/tasks를 추가했습니다.
- 배포 경계를 Operator Ingress → ClusterIP Service → NetworkPolicy로 정하고 public entry와 일반 workload의 직접 Pod/Service 접근을 제외했습니다.
- PROD-689~693 Linear 계약도 같은 admission과 분리된 projection 책임으로 정렬했습니다.
- Admin-specific logging, audit, security event와 identity snapshot은 전부 제외했습니다.

## 왜 변경했나요

현재 Tailscale Operator Ingress는 App Capabilities 전달을 지원하지 않으며, v1 읽기를 객체별 권한으로 나눌 제품 요구도 없습니다. Serve sidecar와 capability parser 없이 Tailscale 접근 정책을 admission source로 사용하면 더 단순한 신뢰 경계로 같은 목표를 달성할 수 있습니다.

## 이번 PR의 주요 결정

### Tailscale 접근 정책을 단일 admission으로 사용

- 결정자: @robin-maki
- 선택: 허용된 Viewer는 Account, Profile, Membership v1 읽기 전체에 접근합니다.
- 고려한 대안: Tailscale App Capabilities와 객체별 action
- 이유: 현재 Operator Ingress가 App Capabilities를 전달하지 않고 객체별 권한 분리 요구도 없습니다.
- 감수한 결과: 세 projection은 권한이 아니라 응답 구조와 필드 책임으로만 분리합니다.

### Node-origin 연결은 차단 범위에서 제외

- 결정자: @robin-maki
- 선택: 일반 workload의 우회는 NetworkPolicy로 차단하지만 Kubernetes node 자체, kubelet과 node 권한을 가진 운영 주체는 신뢰된 인프라로 봅니다.
- 고려한 대안: Cilium host policy 등으로 node-origin까지 차단
- 이유: node 권한을 획득한 주체까지 이번 Admin Console 경계에서 방어할 필요는 없습니다.
- 감수한 결과: node-origin 또는 node로 source NAT된 경로까지 차단했다고 주장하지 않으며 live 검증에서 source 경계를 구분합니다.

### Identity와 로깅

- identity는 선택적 표시 metadata일 뿐 인가나 Kosmo Account 매핑에 사용하지 않습니다.
- Admin-specific logging, audit, security event와 identity snapshot은 전부 제외합니다.

## 어떻게 확인할 수 있나요

- `openspec validate add-admin-console-foundation --strict`
- 변경 파일 Prettier check
- `git diff --check`
- docs/domain Markdown link check
- canonical/OpenSpec/Linear 정합성 서브에이전트 리뷰

## 아직 어떤 문제가 남았나요

- Admin runtime, image, Helm Service/Ingress/NetworkPolicy 구현
- Operator-generated proxy label과 dev tailnet principal 확인
- 일반 Pod·node 밖 VPC source의 direct access 차단과 node-origin 예외를 구분한 live 검증
- 구현과 live 검증이 남아 있어 이 PR은 Draft입니다.

Stack: main -> PROD-690