### PR TITLE
Home 자동 pagination의 중복 요청 flake를 제거한다

### DIFF
--- a/apps/app/src/components/pagination/useAutomaticPagination.test.ts
+++ b/apps/app/src/components/pagination/useAutomaticPagination.test.ts
@@ -232,6 +232,53 @@ describe('useAutomaticPagination', () => {
     }
   });
 
+  it('Web 성공 재측정이 Relay 최신 render 뒤 stale effect로 같은 page를 재요청하지 않는다', async () => {
+    await renderHook(options());
+    await runAnimationFrame();
+    assert.equal(loadRequests.length, 1);
+
+    const request = loadRequests[0];
+    assert.ok(request);
+    const scheduledTimers: Array<() => void> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((callback: () => void) => {
+      scheduledTimers.push(callback);
+      return 1;
+    }) as typeof setTimeout;
+
+    try {
+      await act(() => {
+        request.onComplete(null);
+        const flushSyncRenderer = renderer as ReactTestRenderer & {
+          unstable_flushSync(callback: () => void): void;
+        };
+        flushSyncRenderer.unstable_flushSync(() => {
+          renderer?.update(
+            createElement(
+              HookProbe,
+              options({ hasNext: false, isLoadingNext: false, itemCount: 40 }),
+            ),
+          );
+        });
+
+        const completeSuccess = scheduledTimers.shift();
+        assert.ok(completeSuccess);
+        completeSuccess();
+
+        const callbacks = [...animationFrames.values()];
+        animationFrames.clear();
+        callbacks.forEach((callback) => callback(0));
+      });
+      assert.equal(
+        loadRequests.length,
+        1,
+        'Relay hasNext=false가 반영된 page를 stale closure로 재요청하지 않는다',
+      );
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
   it('Web page 실패는 자동 재시도를 막고 수동 재시도만 허용한다', async () => {
     await renderHook(options());
     await runAnimationFrame();

--- a/apps/app/src/components/pagination/useAutomaticPagination.ts
+++ b/apps/app/src/components/pagination/useAutomaticPagination.ts
@@ -46,16 +46,31 @@ export function useAutomaticPagination({
     offset: 0,
     viewportLength: 0,
   });
+  const latestOptionsRef = useRef({
+    hasNext,
+    isLoadingNext,
+    loadNext,
+    pageSize,
+    webScrollTarget,
+  });
+  latestOptionsRef.current = {
+    hasNext,
+    isLoadingNext,
+    loadNext,
+    pageSize,
+    webScrollTarget,
+  };
 
   const loadNextPage = useCallback(() => {
-    if (!hasNext || isLoadingNext || requestInFlightRef.current) {
+    const latestOptions = latestOptionsRef.current;
+    if (!latestOptions.hasNext || latestOptions.isLoadingNext || requestInFlightRef.current) {
       return;
     }
 
     requestInFlightRef.current = true;
     pageErrorRef.current = false;
     setLoadError(false);
-    loadNext(pageSize, {
+    latestOptions.loadNext(latestOptions.pageSize, {
       onComplete: (error) => {
         pageErrorRef.current = Boolean(error);
         setLoadError(Boolean(error));
@@ -64,7 +79,7 @@ export function useAutomaticPagination({
           return;
         }
         setTimeout(() => {
-          if (Platform.OS === 'web' && webScrollTarget === 'document') {
+          if (Platform.OS === 'web' && latestOptionsRef.current.webScrollTarget === 'document') {
             window.requestAnimationFrame(() => {
               requestInFlightRef.current = false;
               webNearEndCheckRef.current?.();
@@ -75,7 +90,7 @@ export function useAutomaticPagination({
         }, 0);
       },
     });
-  }, [hasNext, isLoadingNext, loadNext, pageSize, webScrollTarget]);
+  }, []);
 
   const maybeLoadNextPage = useCallback(
     (metrics: ScrollMetrics) => {


### PR DESCRIPTION
## 무엇을 변경했는지

- `useAutomaticPagination`의 요청 guard가 render마다 최신 `hasNext`, `isLoadingNext`, `loadNext`, page size와 Web scroll target을 읽도록 정렬했습니다.
- 성공 후 재측정 RAF가 이전 effect의 closure를 호출하더라도 최신 Relay 상태에서 요청 가능 여부를 다시 확인합니다.
- Relay render와 effect 갱신 사이의 race에서 같은 page를 다시 요청하지 않는 unit regression test를 추가했습니다.

## 왜 변경했는지

[PROD-772](https://linear.app/byulmaru/issue/PROD-772/home-post-list-%EC%9E%90%EB%8F%99-pagination-story%EA%B0%80-%EC%9A%94%EC%B2%AD%EC%9D%84-%EB%91%90-%EB%B2%88-%EB%B0%9C%EC%83%9D%EC%8B%9C%ED%82%A4%EB%8A%94-flake%EB%A5%BC-%EC%A0%9C%EA%B1%B0%ED%95%9C%EB%8B%A4)의 Home 자동 pagination Story가 성공 응답 직후 간헐적으로 같은 cursor를 두 번 요청했습니다. 계측 결과 성공 재측정 RAF가 최신 Relay render 뒤 effect 갱신보다 먼저 실행되면서 이전 `check` closure를 호출하는 race였습니다. assertion 완화나 retry 없이 제품 hook의 최신 상태 확인 경계를 고쳤습니다.

## 이번 PR의 주요 결정

없음. PROD-772와 PROD-662의 기존 자동 pagination 계약을 변경하지 않고, 성공 뒤 재측정과 중복 요청 방지 계약을 그대로 복구했습니다. 새 OpenSpec은 만들지 않았습니다.

## 어떻게 확인할 수 있는지

- 대상 Story 수정 전 반복: 20회 중 4회 동일 cursor 중복 요청 재현
- 대상 Story 수정 후 반복: 20/20 통과
- `pnpm --filter @kosmo/app exec node --experimental-test-module-mocks --import tsx --test src/components/pagination/useAutomaticPagination.test.ts`: 7/7 통과
- `pnpm --filter @kosmo/app test`: App Storybook 364/364를 포함한 전체 검증 통과
- `CI=true pnpm lint:prettier`: 통과

## 아직 어떤 문제가 남았는지

없음.

Stack: main -> PROD-772

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>