### PR TITLE
Android 테스트 배포를 Google Play 출시 경로와 일치시킨다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -1,0 +1,292 @@
+name: Android Google Play Internal Distribution
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: android-play-internal-distribution
+  cancel-in-progress: false
+
+jobs:
+  distribute:
+    name: Build and upload Android Release AAB
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    environment: android-play-internal-distribution
+    env:
+      ANDROID_RELEASE_CERTIFICATE_SHA256: ${{ vars.ANDROID_RELEASE_CERTIFICATE_SHA256 }}
+      ANDROID_RELEASE_KEY_ALIAS: ${{ vars.ANDROID_RELEASE_KEY_ALIAS }}
+      EXPO_NO_GIT_STATUS: '1'
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      KOSMO_ANDROID_AAB_PATH: ${{ github.workspace }}/apps/app/android/app/build/outputs/bundle/release/app-release.aab
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+
+      - name: Set up Java
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.0.0
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Install Android SDK packages
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:?Android SDK root is required}}"
+          sdkmanager --install \
+            "platforms;android-36" \
+            "build-tools;36.0.0" \
+            "ndk;27.1.12297006" \
+            "cmake;3.22.1"
+
+          export PATH="${sdk_root}/cmdline-tools/latest/bin:${sdk_root}/build-tools/36.0.0:${PATH}"
+          apkanalyzer_path="$(command -v apkanalyzer)"
+          test -x "${apkanalyzer_path}"
+          test -x "${sdk_root}/build-tools/36.0.0/aapt2"
+          {
+            echo "ANDROID_APKANALYZER=${apkanalyzer_path}"
+            echo "ANDROID_SDK_ROOT=${sdk_root}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set up Ruby and Fastlane
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
+        with:
+          bundler-cache: true
+          ruby: '3.4'
+          working-directory: apps/app
+
+      - name: Calculate Android version code
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ponytail: avoid a pre-build Play API query; replace this offset before 2086.
+          version_code=$(( $(date -u +%s) - 1577836800 ))
+          if (( version_code < 1 || version_code > 2147483647 )); then
+            echo "::error::KOSMO_ANDROID_VERSION_CODE is outside the signed 32-bit Android limit."
+            exit 1
+          fi
+          echo "KOSMO_ANDROID_VERSION_CODE=${version_code}" >> "${GITHUB_ENV}"
+
+      - name: Validate Android Play inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for name in \
+            ANDROID_RELEASE_CERTIFICATE_SHA256 \
+            ANDROID_RELEASE_KEY_ALIAS \
+            GCP_SERVICE_ACCOUNT \
+            GCP_WORKLOAD_IDENTITY_PROVIDER; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::${name} must be set in android-play-internal-distribution."
+              exit 1
+            fi
+          done
+
+          if [[ "${ANDROID_RELEASE_KEY_ALIAS}" == *$'\n'* || "${ANDROID_RELEASE_KEY_ALIAS}" == *$'\r'* ]]; then
+            echo "::error::ANDROID_RELEASE_KEY_ALIAS must not contain line breaks."
+            exit 1
+          fi
+
+          certificate="${ANDROID_RELEASE_CERTIFICATE_SHA256//:/}"
+          if [[ ! "${certificate}" =~ ^[0-9A-Fa-f]{64}$ ]]; then
+            echo "::error::ANDROID_RELEASE_CERTIFICATE_SHA256 must be a SHA-256 fingerprint."
+            exit 1
+          fi
+
+      - name: Restore Android upload key
+        shell: bash
+        env:
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2016
+          node --input-type=module -e '
+            import fs from "node:fs";
+            import path from "node:path";
+
+            const required = (name) => {
+              const value = process.env[name] ?? "";
+              if (value.length === 0) throw new Error(`${name} is required.`);
+              if (/\r|\n/u.test(value)) throw new Error(`${name} must not contain line breaks.`);
+              return value;
+            };
+
+            const encoded = required("ANDROID_RELEASE_KEYSTORE_BASE64");
+            const storePassword = required("ANDROID_RELEASE_STORE_PASSWORD");
+            const keyAlias = required("ANDROID_RELEASE_KEY_ALIAS");
+            const keyPassword = required("ANDROID_RELEASE_KEY_PASSWORD");
+            if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(encoded)) {
+              throw new Error("ANDROID_RELEASE_KEYSTORE_BASE64 must be a single valid base64 value.");
+            }
+            const keystore = Buffer.from(encoded, "base64");
+            if (keystore.length === 0 || keystore.toString("base64") !== encoded) {
+              throw new Error("ANDROID_RELEASE_KEYSTORE_BASE64 is invalid or empty.");
+            }
+
+            const escapeProperty = (value) => {
+              let result = "";
+              for (let index = 0; index < value.length; index += 1) {
+                const character = value[index];
+                const code = value.charCodeAt(index);
+                if (character === "\\") result += "\\\\";
+                else if (character === "=" || character === ":" || character === "#" || character === "!") result += `\\${character}`;
+                else if (character === " " && (index === 0 || index === value.length - 1)) result += "\\ ";
+                else if (code === 0x09) result += "\\t";
+                else if (code === 0x0c) result += "\\f";
+                else if (code < 0x20 || code > 0x7e) result += `\\u${code.toString(16).padStart(4, "0")}`;
+                else result += character;
+              }
+              return result;
+            };
+
+            let signingDir;
+            try {
+              signingDir = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, "kosmo-android-signing-"));
+              fs.appendFileSync(
+                process.env.GITHUB_ENV,
+                `KOSMO_ANDROID_SIGNING_DIR=${signingDir}\n`,
+              );
+
+              const keystorePath = path.join(signingDir, "upload.jks");
+              const gradleHome = path.join(signingDir, "gradle");
+              fs.mkdirSync(gradleHome, { mode: 0o700 });
+              fs.writeFileSync(keystorePath, keystore, { mode: 0o600 });
+
+              const properties = [
+                `android.injected.signing.store.file=${escapeProperty(keystorePath)}`,
+                `android.injected.signing.store.password=${escapeProperty(storePassword)}`,
+                `android.injected.signing.key.alias=${escapeProperty(keyAlias)}`,
+                `android.injected.signing.key.password=${escapeProperty(keyPassword)}`,
+              ].join("\n");
+              const propertiesPath = path.join(gradleHome, "gradle.properties");
+              fs.writeFileSync(propertiesPath, `${properties}\n`, { mode: 0o600 });
+              fs.appendFileSync(process.env.GITHUB_ENV, `GRADLE_USER_HOME=${gradleHome}\n`);
+            } catch (error) {
+              if (signingDir) fs.rmSync(signingDir, { recursive: true, force: true });
+              throw error;
+            }
+          '
+
+      - name: Generate clean Expo Android project
+        working-directory: apps/app
+        run: |
+          pnpm relay
+          pnpm exec expo prebuild --clean --platform android --no-install
+
+      - name: Build signed Release AAB
+        working-directory: apps/app/android
+        run: ./gradlew :app:bundleRelease --no-daemon
+
+      - name: Verify Release AAB
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          aab_path="${KOSMO_ANDROID_AAB_PATH}"
+          test -s "${aab_path}"
+          test -x "${ANDROID_APKANALYZER}"
+          unzip -Z1 "${aab_path}" | grep -Fxq 'base/manifest/AndroidManifest.xml'
+
+          package_name="$("${ANDROID_APKANALYZER}" manifest application-id "${aab_path}" | tr -d '\r\n')"
+          version_code="$("${ANDROID_APKANALYZER}" manifest version-code "${aab_path}" | tr -d '\r\n')"
+          version_name="$("${ANDROID_APKANALYZER}" manifest version-name "${aab_path}" | tr -d '\r\n')"
+          [[ "${package_name}" == 'moe.kos' ]] || { echo "::error::AAB package is ${package_name}."; exit 1; }
+          [[ "${version_code}" == "${KOSMO_ANDROID_VERSION_CODE}" ]] || { echo "::error::AAB versionCode is ${version_code}."; exit 1; }
+          [[ -n "${version_name}" ]] || { echo "::error::AAB versionName is empty."; exit 1; }
+
+          jarsigner_output="$(LC_ALL=C jarsigner -verify "${aab_path}" 2>&1)"
+          if ! grep -Fq 'jar verified.' <<< "${jarsigner_output}"; then
+            echo "::error::AAB signature verification did not report a verified JAR."
+            printf '%s\n' "${jarsigner_output}"
+            exit 1
+          fi
+          actual_certificate="$(LC_ALL=C keytool -printcert -jarfile "${aab_path}" | sed -n 's/^[[:space:]]*SHA256:[[:space:]]*//p' | head -n 1 | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]')"
+          expected_certificate="${ANDROID_RELEASE_CERTIFICATE_SHA256//:/}"
+          expected_certificate="${expected_certificate^^}"
+          [[ "${actual_certificate}" =~ ^[0-9A-F]{64}$ ]] || { echo "::error::AAB signing certificate was not found."; exit 1; }
+          [[ "${actual_certificate}" == "${expected_certificate}" ]] || { echo "::error::AAB signing certificate fingerprint mismatch."; exit 1; }
+
+          artifact_sha256="$(shasum -a 256 "${aab_path}" | awk '{print $1}')"
+          artifact_size_bytes="$(wc -c < "${aab_path}" | tr -d '[:space:]')"
+          {
+            echo "package_name=${package_name}"
+            echo "version_code=${version_code}"
+            echo "version_name=${version_name}"
+            echo "certificate_sha256=${actual_certificate}"
+            echo "artifact_sha256=${artifact_sha256}"
+            echo "artifact_size_bytes=${artifact_size_bytes}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Authenticate to Google Cloud for Play upload
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          create_credentials_file: true
+          cleanup_credentials: true
+          export_environment_variables: true
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Upload AAB to Play internal testing
+        working-directory: apps/app
+        run: bundle exec fastlane android upload_internal
+
+      - name: Write Actions summary
+        if: success()
+        env:
+          ARTIFACT_SHA256: ${{ steps.verify.outputs.artifact_sha256 }}
+          ARTIFACT_SIZE_BYTES: ${{ steps.verify.outputs.artifact_size_bytes }}
+          CERTIFICATE_SHA256: ${{ steps.verify.outputs.certificate_sha256 }}
+          PACKAGE_NAME: ${{ steps.verify.outputs.package_name }}
+          VERSION_CODE: ${{ steps.verify.outputs.version_code }}
+          VERSION_NAME: ${{ steps.verify.outputs.version_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo '## Android Google Play internal testing'
+            echo
+            echo "- Package: \`${PACKAGE_NAME}\`"
+            echo "- Version: \`${VERSION_NAME} (${VERSION_CODE})\`"
+            echo "- Upload certificate SHA-256: \`${CERTIFICATE_SHA256}\`"
+            echo "- AAB SHA-256: \`${ARTIFACT_SHA256}\`"
+            echo "- AAB size: \`${ARTIFACT_SIZE_BYTES} bytes\`"
+            echo "- Source: \`${GITHUB_SHA}\`"
+            echo "- Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Remove signing and generated files
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          rm -f -- \
+            "${GOOGLE_APPLICATION_CREDENTIALS:-}" \
+            "${GOOGLE_GHA_CREDS_PATH:-}"
+          rm -rf -- \
+            "${KOSMO_ANDROID_SIGNING_DIR:-}" \
+            "${GITHUB_WORKSPACE}/apps/app/android"

--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    environment: android-play-internal-distribution
+    environment: prod
     env:
       ANDROID_RELEASE_CERTIFICATE_SHA256: ${{ vars.ANDROID_RELEASE_CERTIFICATE_SHA256 }}
       ANDROID_RELEASE_KEY_ALIAS: ${{ vars.ANDROID_RELEASE_KEY_ALIAS }}
@@ -99,7 +99,7 @@ jobs:
             GCP_SERVICE_ACCOUNT \
             GCP_WORKLOAD_IDENTITY_PROVIDER; do
             if [[ -z "${!name:-}" ]]; then
-              echo "::error::${name} must be set in android-play-internal-distribution."
+              echo "::error::${name} must be set in the prod Environment."
               exit 1
             fi
           done

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -21,6 +21,46 @@ After a successful callback, native login sends only the authorization code, PKC
 
 Native projects are generated with `expo prebuild --clean`; they are not source-of-truth files.
 
+## Android Google Play internal testing
+
+`Android Google Play Internal Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, upload key로 서명한 Release AAB 하나를 빌드·검증한 뒤 Google Play internal track에 업로드한다. versionCode는 workflow 시작 시 UTC Unix seconds에서 `2020-01-01`을 뺀 값으로 계산하며, 첫 수동 release의 versionCode `1`보다 크고 Android signed 32-bit 범위 안에 있다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다.
+
+첫 배포 전에는 Play Console에서 다음 절차를 수동으로 완료해야 한다. CI가 Play Console의 최초 app/signing bootstrap을 대신하지 않는다.
+
+1. package name `moe.kos`로 app을 만들고 Google Play App Signing을 설정한다.
+2. upload key를 관리자 장비에서 생성한다. 첫 AAB와 이후 CI AAB는 같은 upload key로 서명해야 하며, Google이 관리하는 app signing key와는 별개다.
+3. Play Console에서 첫 signed AAB 업로드와 internal testing track 생성을 완료하고 tester 목록과 opt-in 링크를 설정한다.
+4. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.
+5. `android-play-internal-distribution` GitHub Environment를 만들고 `main`만 허용한 뒤 required reviewer를 설정한다.
+6. 해당 Environment에 다음 값을 넣는다.
+
+| 이름                                 | 종류     | 값                                                              |
+| ------------------------------------ | -------- | --------------------------------------------------------------- |
+| `GCP_SERVICE_ACCOUNT`                | variable | `terraform output -raw android_play_service_account`            |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER`     | variable | `terraform output -raw android_play_workload_identity_provider` |
+| `ANDROID_RELEASE_KEY_ALIAS`          | variable | upload key 생성 시 사용한 alias                                 |
+| `ANDROID_RELEASE_CERTIFICATE_SHA256` | variable | upload certificate의 SHA-256 fingerprint                        |
+| `ANDROID_RELEASE_KEYSTORE_BASE64`    | secret   | 줄바꿈 없는 upload keystore base64                              |
+| `ANDROID_RELEASE_STORE_PASSWORD`     | secret   | upload keystore password                                        |
+| `ANDROID_RELEASE_KEY_PASSWORD`       | secret   | upload key password                                             |
+
+upload key 예시는 다음과 같다. password는 명령행이나 저장소에 넣지 말고 `keytool` prompt에서 입력한다.
+
+```sh
+umask 077
+keytool -genkeypair -v \
+  -keystore kosmo-android-upload.jks \
+  -storetype JKS \
+  -alias kosmo-upload \
+  -keyalg RSA \
+  -keysize 4096 \
+  -validity 10000
+keytool -list -v -keystore kosmo-android-upload.jks
+base64 < kosmo-android-upload.jks | tr -d '\n'
+```
+
+`ANDROID_RELEASE_CERTIFICATE_SHA256`은 Play Console에 등록한 upload certificate와 일치해야 한다. upload key를 바꿀 때는 secret만 교체하지 말고 Play Console의 upload key reset 절차를 먼저 완료한다. 실제 Play Store 설치·업데이트·실기기 launch와 native login/GraphQL 검증은 PROD-287의 책임이며, 이 workflow는 API/OIDC 환경값이나 ADB/device smoke를 요구하지 않는다.
+
 ## iOS Ad Hoc Firebase distribution
 
 The two manual workflows build from a clean CNG project, not a committed `ios/` directory. `IOS_BUILD_NUMBER` is set to the GitHub Actions run ID, so each serialized run has a unique numeric build number. Before upload, Fastlane verifies the generated Xcode team and bundle ID, embedded Ad Hoc profile, distribution certificate, registered devices, IPA build number, and that the number is newer than the latest Firebase iOS release.

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -31,8 +31,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 2. upload key를 관리자 장비에서 생성한다. 첫 AAB와 이후 CI AAB는 같은 upload key로 서명해야 하며, Google이 관리하는 app signing key와는 별개다.
 3. Play Console에서 첫 signed AAB 업로드와 internal testing track 생성을 완료하고 tester 목록과 opt-in 링크를 설정한다.
 4. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.
-5. `android-play-internal-distribution` GitHub Environment를 만들고 `main`만 허용한 뒤 required reviewer를 설정한다.
-6. 해당 Environment에 다음 값을 넣는다.
+5. 기존 승인형 `prod` GitHub Environment에 다음 값을 넣는다. 새 Environment는 만들지 않는다.
 
 | 이름                                 | 종류     | 값                                                              |
 | ------------------------------------ | -------- | --------------------------------------------------------------- |

--- a/apps/app/app.config.ts
+++ b/apps/app/app.config.ts
@@ -1,5 +1,23 @@
 import type { ExpoConfig } from 'expo/config';
 
+function androidVersionCode(): number {
+  const configured = process.env.KOSMO_ANDROID_VERSION_CODE;
+  if (configured === undefined) {
+    return 1;
+  }
+
+  if (!/^[1-9]\d*$/.test(configured)) {
+    throw new Error('KOSMO_ANDROID_VERSION_CODE must be a positive integer.');
+  }
+
+  const versionCode = Number(configured);
+  if (!Number.isSafeInteger(versionCode) || versionCode > 2_147_483_647) {
+    throw new Error('KOSMO_ANDROID_VERSION_CODE is outside Android versionCode limits.');
+  }
+
+  return versionCode;
+}
+
 const publicEnvironmentAliases = {
   EXPO_PUBLIC_API_ORIGIN: 'PUBLIC_API_ORIGIN',
   EXPO_PUBLIC_OIDC_ISSUER: 'PUBLIC_OIDC_ISSUER',
@@ -41,7 +59,7 @@ const config: ExpoConfig = {
       foregroundImage: './assets/brand/app-icon-android-foreground.png',
     },
     package: 'moe.kos',
-    versionCode: 1,
+    versionCode: androidVersionCode(),
     predictiveBackGestureEnabled: true,
   },
   web: {

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -246,3 +246,26 @@ platform :ios do
     end
   end
 end
+
+platform :android do
+  desc 'Upload the signed Android Release AAB to the Play internal track'
+  lane :upload_internal do
+    require_environment!('GOOGLE_APPLICATION_CREDENTIALS', 'KOSMO_ANDROID_AAB_PATH')
+    aab_path = File.expand_path(ENV.fetch('KOSMO_ANDROID_AAB_PATH'))
+    credentials_path = File.expand_path(ENV.fetch('GOOGLE_APPLICATION_CREDENTIALS'))
+    UI.user_error!("AAB was not created at #{aab_path}.") unless File.file?(aab_path) && File.size?(aab_path)
+    UI.user_error!("Google credentials were not created at #{credentials_path}.") unless File.file?(credentials_path) && File.size?(credentials_path)
+
+    upload_to_play_store(
+      aab: aab_path,
+      package_name: BUNDLE_IDENTIFIER,
+      json_key: credentials_path,
+      release_status: 'completed',
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_metadata: true,
+      skip_upload_screenshots: true,
+      track: 'internal',
+    )
+  end
+end

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -6,9 +6,9 @@
 
 - 기존 Firebase 활성화와 Android/iOS 앱 등록 (`moe.kos`), 그리고 과도기 App Distribution 리소스
 - Google Play Developer API 활성화, Android Publisher 전용 service account와 최소 WIF 권한
-- 각 store workflow에 필요한 GitHub Actions Workload Identity Federation. Android Play는 `main`의 정확한 workflow와 protected Environment만 허용한다.
+- 각 store workflow에 필요한 GitHub Actions Workload Identity Federation. Android Play는 `main`의 정확한 workflow와 기존 `prod` Environment만 허용한다.
 - Terraform plan/apply가 공유하는 GitHub Actions WIF 서비스 계정
-- GitHub에서 직접 관리하는 Actions environment와 변수 (`android-play-internal-distribution`, `native-test-distribution`, 승인형 `ios-device-onboarding`, `terraform-apply`, 승인형 `prod` release)
+- GitHub에서 직접 관리하는 Actions environment와 변수 (`native-test-distribution`, 승인형 `ios-device-onboarding`, `terraform-apply`, 승인형 `prod` release)
 - Firebase provider가 지원하지 않는 `native-testers` group의 멱등 REST bootstrap
 - `byulmaru-kosmo-prod-postgresql-backups-822638974464` PostgreSQL backup bucket과 `byulmaru-kosmo-prod-postgres-backup` EKS Pod Identity role
 - Argo CD `kosmo` ApplicationSet이 생성하는 `kosmo-dev` Application과 별도 `kosmo-prod` Application의 선언
@@ -46,7 +46,7 @@ Production PostgreSQL backup은 `s3://byulmaru-kosmo-prod-postgresql-backups-822
 
 ## Google Play 내부 테스트 bootstrap
 
-Android store 배포는 [Google Play Developer API](https://developers.google.com/android-publisher/getting_started)와 Google Play Console을 사용한다. Terraform은 API 활성화, 전용 service account, `main`의 정확한 workflow와 `android-play-internal-distribution` Environment만 신뢰하는 WIF provider, 그리고 해당 service account의 `roles/iam.workloadIdentityUser` binding만 관리한다. Play Console app·첫 AAB·app signing·upload key·tester·track·권한과 `supply` 선행 조건은 [앱의 Android Google Play 배포 절차](../app/README.md)에서 수동으로 관리한다. 정적 service account JSON key는 만들거나 저장하지 않는다.
+Android store 배포는 [Google Play Developer API](https://developers.google.com/android-publisher/getting_started)와 Google Play Console을 사용한다. Terraform은 API 활성화, 전용 service account, `main`의 정확한 workflow와 기존 `prod` Environment만 신뢰하는 WIF provider, 그리고 해당 service account의 `roles/iam.workloadIdentityUser` binding만 관리한다. Play Console app·첫 AAB·app signing·upload key·tester·track·권한과 `supply` 선행 조건은 [앱의 Android Google Play 배포 절차](../app/README.md)에서 수동으로 관리한다. 정적 service account JSON key는 만들거나 저장하지 않는다.
 
 Terraform 적용 후 다음 값을 확인한다.
 
@@ -92,6 +92,6 @@ bucket은 `byulmaru-terraform-state`, state key는 `kosmo/terraform.tfstate`이�
 
 ## Rotation과 revocation
 
-정적 Google credential은 없으므로 정기 key rotation은 필요하지 않다. repository, workflow, branch 또는 environment가 바뀌면 WIF provider의 숫자 ID 기반 trust condition을 먼저 수정하고 저장한 plan을 적용한다. Android Play provider는 `main`의 `.github/workflows/android-play-internal-distribution.yml`과 `android-play-internal-distribution` Environment만 허용한다. Firebase provider는 기존 iOS 과도기 workflow만 허용하며 Android Play 경로에서 재사용하지 않는다.
+정적 Google credential은 없으므로 정기 key rotation은 필요하지 않다. repository, workflow, branch 또는 environment가 바뀌면 WIF provider의 숫자 ID 기반 trust condition을 먼저 수정하고 저장한 plan을 적용한다. Android Play provider는 `main`의 `.github/workflows/android-play-internal-distribution.yml`과 기존 `prod` Environment만 허용한다. Firebase provider는 기존 iOS 과도기 workflow만 허용하며 Android Play 경로에서 재사용하지 않는다.
 
 긴급 차단은 WIF provider에 `disabled = true`를 추가해 적용한다. 영구 폐기는 service account의 `roles/iam.workloadIdentityUser` binding을 제거한 plan을 먼저 적용한 뒤, 별도 검토로 보호된 provider와 service account의 deletion policy를 해제한다.

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -4,11 +4,11 @@
 
 ## 관리 범위
 
-- Firebase 활성화와 Android/iOS 앱 등록 (`moe.kos`)
-- Firebase App Distribution 서비스 계정과 최소 IAM 권한
-- `main`에 저장된 지정 workflow와 `prod` Environment 승인 뒤의 exact `repo:byulmaru/kosmo:environment:prod` release만 허용하는 GitHub Actions Workload Identity Federation
+- 기존 Firebase 활성화와 Android/iOS 앱 등록 (`moe.kos`), 그리고 과도기 App Distribution 리소스
+- Google Play Developer API 활성화, Android Publisher 전용 service account와 최소 WIF 권한
+- 각 store workflow에 필요한 GitHub Actions Workload Identity Federation. Android Play는 `main`의 정확한 workflow와 protected Environment만 허용한다.
 - Terraform plan/apply가 공유하는 GitHub Actions WIF 서비스 계정
-- GitHub에서 직접 관리하는 Actions environment와 변수 (`native-test-distribution`, 승인형 `ios-device-onboarding`, `terraform-apply`, 승인형 `prod` release)
+- GitHub에서 직접 관리하는 Actions environment와 변수 (`android-play-internal-distribution`, `native-test-distribution`, 승인형 `ios-device-onboarding`, `terraform-apply`, 승인형 `prod` release)
 - Firebase provider가 지원하지 않는 `native-testers` group의 멱등 REST bootstrap
 - `byulmaru-kosmo-prod-postgresql-backups-822638974464` PostgreSQL backup bucket과 `byulmaru-kosmo-prod-postgres-backup` EKS Pod Identity role
 - Argo CD `kosmo` ApplicationSet이 생성하는 `kosmo-dev` Application과 별도 `kosmo-prod` Application의 선언
@@ -34,7 +34,7 @@ Terraform 실행 시에는 장기 credential 파일 대신 현재 `gcloud` 계�
 ./scripts/ensure-ci-aws-role.sh
 ```
 
-GCP 리소스를 적용한 뒤 native/onboarding Environment와 변수는 [앱의 iOS Ad Hoc 관리자 설정](../app/README.md#one-time-administrator-setup)에 따라 GitHub에서 직접 관리한다. `terraform-apply` Environment는 `main`만 허용한다. Terraform workflow의 repository 변수 `GCP_TERRAFORM_PROVIDER`, `GCP_TERRAFORM_SERVICE_ACCOUNT`는 각 Terraform output을 기준으로 설정하고, `AWS_TERRAFORM_ROLE_ARN`은 `ensure-ci-aws-role.sh`의 마지막 출력값으로 설정한다. Production GitHub 설정은 [Production release 운영](../../docs/operations/production-release.md)의 첫 전환 절차에서 적용하고 live API로 검증한다.
+GCP 리소스를 적용한 뒤 store/native Environment와 변수는 각 workflow의 bootstrap 절차에 따라 GitHub에서 직접 관리한다. `terraform-apply` Environment는 `main`만 허용한다. Terraform workflow의 repository 변수 `GCP_TERRAFORM_PROVIDER`, `GCP_TERRAFORM_SERVICE_ACCOUNT`는 각 Terraform output을 기준으로 설정하고, `AWS_TERRAFORM_ROLE_ARN`은 `ensure-ci-aws-role.sh`의 마지막 출력값으로 설정한다. Production GitHub 설정은 [Production release 운영](../../docs/operations/production-release.md)의 첫 전환 절차에서 적용하고 live API로 검증한다.
 
 `main`을 push하면 Docker Build는 dev image를 build하고 기존 `Deploy Dev` 경로로 자동 배포한다. Production release는 이 push로 시작하지 않으며, Main에 저장된 release workflow를 `main` ref에서 `workflow_dispatch`로 실행할 때만 요청된다. `target_sha`를 입력하면 해당 full SHA를 사용하고, 비워 두면 preflight가 실행 시점의 최신 `main` commit을 immutable target으로 확정한다. `prod` Environment required reviewer의 한 번의 승인 전에는 production source checkout, prod Vault/Sentry credential 접근과 prod image build를 수행하지 않는다. 승인 뒤 gated job이 resolved target SHA에서 prod 설정 image를 별도로 build해 GHCR에 push하고, 그 immutable digest를 production migration과 모든 활성화 workload에 사용한다. `target_sha`를 생략해 최신 `main`을 target으로 선택한 경우에는 dev image와 prod image가 같은 source SHA를 사용할 수 있지만, 명시적 target SHA dispatch에서는 서로 다른 source를 사용할 수 있다. 두 image는 환경별 Web 설정을 포함하므로 동일 digest일 필요가 없다.
 
@@ -42,7 +42,18 @@ Main에 저장된 release workflow를 `main` ref에서 `workflow_dispatch`로 �
 
 Production PostgreSQL backup은 `s3://byulmaru-kosmo-prod-postgresql-backups-822638974464/kosmo-prod/`에 저장한다. Bucket 객체는 S3의 기본 SSE-S3 암호화를 사용하며 별도 default encryption resource를 관리하지 않는다. Bucket은 public access 차단, TLS-only policy, versioning과 lifecycle을 사용하며 Terraform destroy로 제거되지 않는다. `byulmaru-kosmo-prod-postgres-backup` role은 EKS Pod Identity 전용이며 Barman의 bucket 확인을 위한 bucket-level list 권한과 `kosmo-prod/` prefix의 backup/WAL 객체 관리 권한만 가진다. Bucket과 role ARN은 각각 `postgres_backup_bucket_arn`, `postgres_backup_role_arn` Terraform output으로 확인한다.
 
-`ios-device-onboarding`은 `robin-maki`의 승인을 요구한다. Firebase WIF 입력, `MATCH_GIT_URL`, Apple signing secret과 공개 native test 설정은 `apps/app/README.md`의 iOS Ad Hoc 배포 절차에 따라 각 environment에 직접 넣는다.
+`ios-device-onboarding`은 `robin-maki`의 승인을 요구한다. Firebase WIF 입력, `MATCH_GIT_URL`, Apple signing secret과 공개 native test 설정은 [앱의 현재 iOS 배포 절차](../app/README.md)에 따라 각 environment에 직접 넣는다.
+
+## Google Play 내부 테스트 bootstrap
+
+Android store 배포는 [Google Play Developer API](https://developers.google.com/android-publisher/getting_started)와 Google Play Console을 사용한다. Terraform은 API 활성화, 전용 service account, `main`의 정확한 workflow와 `android-play-internal-distribution` Environment만 신뢰하는 WIF provider, 그리고 해당 service account의 `roles/iam.workloadIdentityUser` binding만 관리한다. Play Console app·첫 AAB·app signing·upload key·tester·track·권한과 `supply` 선행 조건은 [앱의 Android Google Play 배포 절차](../app/README.md)에서 수동으로 관리한다. 정적 service account JSON key는 만들거나 저장하지 않는다.
+
+Terraform 적용 후 다음 값을 확인한다.
+
+```sh
+terraform output -raw android_play_service_account
+terraform output -raw android_play_workload_identity_provider
+```
 
 그 뒤 `apps/terraform/**` 또는 Terraform workflow가 바뀐 PR에서는 GCP/Firebase/IAM/WIF plan을 실행해 PR comment와 artifact로 남긴다. Plan artifact는 저장소의 Actions 보존 기간만큼 유지하며 apply는 병합된 PR head와 일치하는 미만료 artifact만 선택한다.
 
@@ -81,6 +92,6 @@ bucket은 `byulmaru-terraform-state`, state key는 `kosmo/terraform.tfstate`이�
 
 ## Rotation과 revocation
 
-정적 Google credential은 없으므로 정기 key rotation은 필요하지 않다. repository, workflow, branch 또는 environment가 바뀌면 WIF provider의 숫자 ID 기반 trust condition을 먼저 수정하고 저장한 plan을 적용한다. 현재 distribution provider는 `main`의 `ios-ad-hoc-distribution.yml`과 승인형 `ios-device-onboarding.yml`만 허용한다.
+정적 Google credential은 없으므로 정기 key rotation은 필요하지 않다. repository, workflow, branch 또는 environment가 바뀌면 WIF provider의 숫자 ID 기반 trust condition을 먼저 수정하고 저장한 plan을 적용한다. Android Play provider는 `main`의 `.github/workflows/android-play-internal-distribution.yml`과 `android-play-internal-distribution` Environment만 허용한다. Firebase provider는 기존 iOS 과도기 workflow만 허용하며 Android Play 경로에서 재사용하지 않는다.
 
 긴급 차단은 WIF provider에 `disabled = true`를 추가해 적용한다. 영구 폐기는 service account의 `roles/iam.workloadIdentityUser` binding을 제거한 plan을 먼저 적용한 뒤, 별도 검토로 보호된 provider와 service account의 deletion policy를 해제한다.

--- a/apps/terraform/main.tf
+++ b/apps/terraform/main.tf
@@ -7,10 +7,9 @@ locals {
   github_repository_id = "1207798099"
   github_owner_id      = "29172280"
 
-  app_identifier           = "moe.kos"
-  distribution_group       = "native-testers"
-  android_play_environment = "android-play-internal-distribution"
-  android_play_workflow    = ".github/workflows/android-play-internal-distribution.yml"
+  app_identifier        = "moe.kos"
+  distribution_group    = "native-testers"
+  android_play_workflow = ".github/workflows/android-play-internal-distribution.yml"
   native_distribution_workflows = {
     "ios-device-onboarding"    = ".github/workflows/ios-device-onboarding.yml"
     "native-test-distribution" = ".github/workflows/ios-ad-hoc-distribution.yml"
@@ -200,7 +199,7 @@ resource "google_iam_workload_identity_pool_provider" "android_play" {
     "assertion.repository_owner_id == '${local.github_owner_id}'",
     "assertion.event_name == 'workflow_dispatch'",
     "assertion.ref == 'refs/heads/main'",
-    "assertion.environment == '${local.android_play_environment}'",
+    "assertion.environment == 'prod'",
     "assertion.workflow_ref == '${local.github_owner}/${local.github_repository}/${local.android_play_workflow}@refs/heads/main'",
   ])
 

--- a/apps/terraform/main.tf
+++ b/apps/terraform/main.tf
@@ -7,8 +7,10 @@ locals {
   github_repository_id = "1207798099"
   github_owner_id      = "29172280"
 
-  app_identifier     = "moe.kos"
-  distribution_group = "native-testers"
+  app_identifier           = "moe.kos"
+  distribution_group       = "native-testers"
+  android_play_environment = "android-play-internal-distribution"
+  android_play_workflow    = ".github/workflows/android-play-internal-distribution.yml"
   native_distribution_workflows = {
     "ios-device-onboarding"    = ".github/workflows/ios-device-onboarding.yml"
     "native-test-distribution" = ".github/workflows/ios-ad-hoc-distribution.yml"
@@ -60,6 +62,7 @@ resource "google_project_service" "required" {
   project  = local.firebase_project_id
   for_each = toset([
     "cloudresourcemanager.googleapis.com",
+    "androidpublisher.googleapis.com",
     "firebase.googleapis.com",
     "firebaseappdistribution.googleapis.com",
     "iam.googleapis.com",
@@ -166,6 +169,53 @@ resource "google_service_account_iam_member" "github_actions" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.credential/native-distribution"
 
   depends_on = [google_iam_workload_identity_pool_provider.kosmo]
+}
+
+resource "google_service_account" "android_play_publisher" {
+  provider = google-beta
+  project  = local.firebase_project_id
+
+  account_id      = "android-play-publisher"
+  display_name    = "Google Play internal testing from GitHub Actions"
+  deletion_policy = "PREVENT"
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_iam_workload_identity_pool_provider" "android_play" {
+  provider = google-beta
+  project  = local.firebase_project_id
+
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
+  workload_identity_pool_provider_id = "kosmo-android-play"
+  display_name                       = "Kosmo Android Play internal testing"
+  deletion_policy                    = "PREVENT"
+
+  attribute_mapping = {
+    "attribute.credential" = "'android-play'"
+    "google.subject"       = "assertion.sub"
+  }
+  attribute_condition = join(" && ", [
+    "assertion.repository_id == '${local.github_repository_id}'",
+    "assertion.repository_owner_id == '${local.github_owner_id}'",
+    "assertion.event_name == 'workflow_dispatch'",
+    "assertion.ref == 'refs/heads/main'",
+    "assertion.environment == '${local.android_play_environment}'",
+    "assertion.workflow_ref == '${local.github_owner}/${local.github_repository}/${local.android_play_workflow}@refs/heads/main'",
+  ])
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account_iam_member" "android_play_publisher" {
+  provider           = google-beta
+  service_account_id = google_service_account.android_play_publisher.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.credential/android-play"
+
+  depends_on = [google_iam_workload_identity_pool_provider.android_play]
 }
 
 resource "google_service_account" "terraform" {

--- a/apps/terraform/outputs.tf
+++ b/apps/terraform/outputs.tf
@@ -22,6 +22,14 @@ output "gcp_workload_identity_provider" {
   value = google_iam_workload_identity_pool_provider.kosmo.name
 }
 
+output "android_play_service_account" {
+  value = google_service_account.android_play_publisher.email
+}
+
+output "android_play_workload_identity_provider" {
+  value = google_iam_workload_identity_pool_provider.android_play.name
+}
+
 output "terraform_gcp_service_account" {
   value = google_service_account.terraform.email
 }


### PR DESCRIPTION
## 무엇을 변경했나요

- `main`에서 수동 실행하는 protected GitHub Actions workflow가 clean Expo CNG prebuild, signed Release AAB 한 번의 빌드, package/version/upload certificate 검증과 Google Play internal track 업로드를 직접 수행합니다.
- Expo config가 CI에서 주입한 Android `versionCode`를 검증해 사용하고, Fastlane은 이미 검증된 AAB의 Play 업로드만 담당합니다.
- Android Publisher API, 전용 service account와 정확한 workflow·environment만 신뢰하는 WIF provider를 Terraform에 추가했습니다.
- Play Console, Google 관리 Play App Signing, 별도 upload key, 첫 수동 AAB와 기존 `prod` Environment의 변수·secret 준비 절차는 앱 README 한 곳에 정리했습니다.

## 왜 변경했나요

Firebase App Distribution의 APK 설치 경로는 실제 Google Play 출시의 AAB, Play App Signing, Play Store 설치·업데이트 경로와 다릅니다. 내부 테스트부터 실제 출시와 같은 artifact와 배포 경로를 사용해 PROD-873의 production rollout으로 이어지는 차이를 줄입니다.

## 이번 PR의 주요 결정

- PROD-285에서 Android 테스트 배포를 Firebase가 아닌 Google Play internal testing으로 전환했습니다. production과 같은 경로를 얻는 대신 Play Console app과 첫 AAB를 한 번 수동으로 준비해야 합니다.
- Google이 app signing key를 관리하고 CI는 별도 upload key만 보관합니다. 새 GitHub Environment를 만들지 않고 기존 승인형 `prod`와 WIF를 사용하며, 정적 Google service account key는 만들지 않습니다.
- GitHub Actions가 prebuild·build·검증을 소유하고 Fastlane은 `upload_to_play_store` 호출 하나만 소유합니다. 별도 공통 배포 기반이나 WIF smoke는 추가하지 않았습니다.
- `versionCode`는 2020년 이후 경과 초로 계산하고 workflow를 직렬화합니다. Play 전체 track을 사전 조회하지 않으며 PROD-873도 같은 체계를 재사용합니다.
- 실제 Play Store 설치·업데이트·launch·native login·GraphQL 검증은 PROD-287로 유지했습니다. 보류된 `EXPO_PUBLIC_API_ORIGIN`과 OIDC 값은 이 workflow의 입력이 아닙니다.
- 앱 동작 계약을 바꾸지 않는 release tooling 변경이므로 별도 OpenSpec change는 만들지 않았습니다.

관련 이슈: [PROD-285](https://linear.app/byulmaru/issue/PROD-285), [PROD-287](https://linear.app/byulmaru/issue/PROD-287), [PROD-873](https://linear.app/byulmaru/issue/PROD-873)

Stack: `main ← PROD-285`

## 어떻게 확인할 수 있나요

다음 검증을 통과했습니다.

- `actionlint .github/workflows/android-play-internal-distribution.yml`
- `pnpm --filter @kosmo/app check`
- Expo config의 기본 `versionCode=1`, 주입값 `123`, 잘못된 `0` 거부
- `ruby -c apps/app/fastlane/Fastfile`
- 변경된 YAML/Markdown/TypeScript Prettier 검사
- `terraform fmt -check`
- `terraform validate`
- `git diff --check`
- clean Expo Android prebuild

Terraform 적용과 아래 bootstrap이 끝난 뒤 `main`의 `Android Google Play Internal Distribution` workflow를 수동 실행해 Actions summary의 package/version/certificate/AAB hash/source/run과 Play internal release를 대조합니다.

## 아직 어떤 문제가 남았나요

- Play Console의 `moe.kos` app과 Play App Signing이 아직 없으므로 upload key 생성, 첫 signed AAB 수동 업로드, internal tester 설정, service account 권한과 기존 `prod` Environment에 변수·secret 추가가 필요합니다.
- 실제 GitHub Actions signed AAB 빌드와 Play upload는 위 bootstrap 및 병합 전에는 검증할 수 없습니다.
- 로컬 임시 keystore Gradle 빌드는 의존성 컴파일·Metro 단계에서 장시간 정체되어 signed AAB 최종 생성까지 확인하지 못했습니다. Fastlane 실호출도 로컬 gem 환경이 없어 실행하지 않았습니다.
- 실제 기기 설치·업데이트·login smoke는 PROD-287에서 검증합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
