### PR TITLE
인바운드 관측 결과를 호출부에 명시한다

### DIFF
--- a/packages/fedify/index.ts
+++ b/packages/fedify/index.ts
@@ -12,9 +12,6 @@ export {
   isExternalInboundError,
   markInboundErrorObserved,
   observeInbound,
-  observeInboundExternalFailure,
-  observeInboundNoop,
-  observeInboundRejected,
   setInboundObservabilityReporter,
   withInboundObservability,
 } from './src/inbound-observability';

--- a/packages/fedify/src/inbound-accept-follow.ts
+++ b/packages/fedify/src/inbound-accept-follow.ts
@@ -4,7 +4,7 @@ import { and, eq } from 'drizzle-orm';
 import { isHttpUri } from './activitypub-uri';
 import { isCompatibleOutboundFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
-import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Follow } from '@fedify/vocab';
 
@@ -26,7 +26,8 @@ export const handleInboundAcceptFollow = async ({
     !isHttpUri(objectUri) ||
     objectUri.href !== followeeActorUri.href
   ) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Accept',
       actorOrigin: followerActorUri?.origin,
       handler: 'accept',
@@ -39,7 +40,8 @@ export const handleInboundAcceptFollow = async ({
 
   const followerProfile = await resolveInboundLocalRecipient(context, followerActorUri);
   if (!followerProfile) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Accept',
       actorOrigin: followerActorUri.origin,
       handler: 'accept',
@@ -84,7 +86,8 @@ export const handleInboundAcceptFollow = async ({
       projection,
     )
   ) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Accept',
       actorOrigin: followerActorUri.origin,
       handler: 'accept',
@@ -99,7 +102,8 @@ export const handleInboundAcceptFollow = async ({
   // generation check above remains authoritative; once it matches, a
   // repeated Accept is an idempotent protocol noop.
   if (profileFollow) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Accept',
       actorOrigin: followerActorUri.origin,
       handler: 'accept',
@@ -125,7 +129,8 @@ export const handleInboundAcceptFollow = async ({
     throw new Error('Unexpected inbound Accept transition result');
   }
   if (transition.result.kind === 'ALREADY_ESTABLISHED') {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Accept',
       actorOrigin: followerActorUri.origin,
       handler: 'accept',
@@ -134,7 +139,8 @@ export const handleInboundAcceptFollow = async ({
       reasonCode: 'duplicate_accept_noop',
     });
   } else if (transition.result.kind === 'NOOP') {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Accept',
       actorOrigin: followerActorUri.origin,
       handler: 'accept',

--- a/packages/fedify/src/inbound-accept.ts
+++ b/packages/fedify/src/inbound-accept.ts
@@ -2,11 +2,7 @@ import { Follow } from '@fedify/vocab';
 import { NotFoundError } from '@kosmo/core/error';
 import { isHttpUri } from './activitypub-uri';
 import { handleInboundAcceptFollow } from './inbound-accept-follow';
-import {
-  observeInboundExternalFailure,
-  observeInboundNoop,
-  observeInboundRejected,
-} from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import { findUsableStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Accept } from '@fedify/vocab';
@@ -17,7 +13,8 @@ export const handleInboundAccept = async (
 ): Promise<void> => {
   const actorUri = accept.actorId;
   if (!isHttpUri(actorUri)) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Accept',
       handler: 'accept',
       phase: 'validation',
@@ -31,7 +28,8 @@ export const handleInboundAccept = async (
     remoteActor = await findUsableStoredRemoteProfileActorByUri(actorUri);
   } catch (error) {
     if (error instanceof NotFoundError) {
-      observeInboundNoop({
+      observeInbound({
+        outcome: 'noop',
         activityType: 'Accept',
         actorOrigin: actorUri.origin,
         error,
@@ -44,7 +42,8 @@ export const handleInboundAccept = async (
     throw error;
   }
   if (!remoteActor) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Accept',
       actorOrigin: actorUri.origin,
       handler: 'accept',
@@ -59,7 +58,8 @@ export const handleInboundAccept = async (
     suppressError: true,
   });
   if (object === null) {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Accept',
       actorOrigin: actorUri.origin,
       handler: 'accept',
@@ -76,7 +76,8 @@ export const handleInboundAccept = async (
       followeeProfileId: remoteActor.profile.id,
     });
   } else {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Accept',
       actorOrigin: actorUri.origin,
       handler: 'accept',

--- a/packages/fedify/src/inbound-announce.ts
+++ b/packages/fedify/src/inbound-announce.ts
@@ -6,7 +6,7 @@ import { NotFoundError, PermissionDeniedError, ValidationError } from '@kosmo/co
 import { repostPost } from '@kosmo/core/services';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Announce } from '@fedify/vocab';
@@ -27,7 +27,8 @@ export const handleInboundAnnounce = async (
   const objectHref = uniqueHref(announce.objectIds);
 
   if (!isHttpUri(activityUri) || !actorHref || !objectHref) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Announce',
       handler: 'announce',
       phase: 'validation',
@@ -39,7 +40,8 @@ export const handleInboundAnnounce = async (
   const actorUri = new URL(actorHref);
   const objectUri = new URL(objectHref);
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri) || activityUri.origin !== actorUri.origin) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Announce',
       actorOrigin: actorUri.origin,
       handler: 'announce',
@@ -56,7 +58,8 @@ export const handleInboundAnnounce = async (
     (storedActor.instance.state !== InstanceState.ACTIVE &&
       storedActor.instance.state !== InstanceState.UNRESPONSIVE)
   ) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Announce',
       actorOrigin: actorUri.origin,
       handler: 'announce',
@@ -69,7 +72,8 @@ export const handleInboundAnnounce = async (
 
   const sourcePostId = await findPostByActivityPubUri(context, objectUri);
   if (!sourcePostId) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Announce',
       actorOrigin: actorUri.origin,
       handler: 'announce',
@@ -91,7 +95,8 @@ export const handleInboundAnnounce = async (
     });
   } catch (error) {
     if (isExpectedRepostRejection(error)) {
-      observeInboundRejected({
+      observeInbound({
+        outcome: 'rejected',
         activityType: 'Announce',
         actorOrigin: actorUri.origin,
         handler: 'announce',

--- a/packages/fedify/src/inbound-create-note.ts
+++ b/packages/fedify/src/inbound-create-note.ts
@@ -10,7 +10,7 @@ import { createPost } from '@kosmo/core/services';
 import { and, eq } from 'drizzle-orm';
 import { findPostByActivityPubUri } from './activitypub-post-uri';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Note } from '@fedify/vocab';
 import type { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
@@ -140,7 +140,8 @@ export const handleInboundCreateNote = async ({
   receivedAt: Temporal.Instant;
 }): Promise<void> => {
   if (note.id?.href !== objectUri) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',
@@ -153,7 +154,8 @@ export const handleInboundCreateNote = async ({
 
   const attributionUri = uniqueHref(note.attributionIds);
   if (attributionUri !== actorUri) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',
@@ -173,7 +175,8 @@ export const handleInboundCreateNote = async ({
         ? PostVisibility.FOLLOWERS
         : undefined;
   if (!visibility) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',
@@ -191,7 +194,8 @@ export const handleInboundCreateNote = async ({
       followeeProfileId: storedActor.profile.id,
     }))
   ) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',
@@ -215,7 +219,8 @@ export const handleInboundCreateNote = async ({
     media = await projectRemoteNoteMedia(note);
   } catch (error) {
     if (error instanceof TypeError) {
-      observeInboundRejected({
+      observeInbound({
+        outcome: 'rejected',
         activityType: 'Create',
         actorOrigin: actorUri,
         handler: 'create',
@@ -240,7 +245,8 @@ export const handleInboundCreateNote = async ({
   } satisfies Parameters<typeof createPost>[0];
 
   const observeDuplicateCreate = () =>
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',
@@ -257,7 +263,8 @@ export const handleInboundCreateNote = async ({
     }
   } catch (error) {
     if (error instanceof ValidationError && error.field === 'media') {
-      observeInboundRejected({
+      observeInbound({
+        outcome: 'rejected',
         activityType: 'Create',
         actorOrigin: actorUri,
         handler: 'create',
@@ -277,7 +284,8 @@ export const handleInboundCreateNote = async ({
       throw error;
     }
 
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',

--- a/packages/fedify/src/inbound-create.ts
+++ b/packages/fedify/src/inbound-create.ts
@@ -4,11 +4,7 @@ import { Note } from '@fedify/vocab';
 import { InstanceState } from '@kosmo/core/enums';
 import { uniqueHref } from './activitypub-uri';
 import { handleInboundCreateNote } from './inbound-create-note';
-import {
-  observeInboundExternalFailure,
-  observeInboundNoop,
-  observeInboundRejected,
-} from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import { findStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
 import type { Create } from '@fedify/vocab';
@@ -22,7 +18,8 @@ export const handleInboundCreate = async (
   const objectUri = uniqueHref(create.objectIds);
 
   if (!actorUri || !objectUri) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Create',
       handler: 'create',
       phase: 'validation',
@@ -37,7 +34,8 @@ export const handleInboundCreate = async (
     (storedActor.instance.state !== InstanceState.ACTIVE &&
       storedActor.instance.state !== InstanceState.UNRESPONSIVE)
   ) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',
@@ -51,7 +49,8 @@ export const handleInboundCreate = async (
   try {
     object = await create.getObject({ documentLoader: context.documentLoader });
   } catch {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Create',
       actorOrigin: actorUri,
       handler: 'create',
@@ -74,7 +73,8 @@ export const handleInboundCreate = async (
     return;
   }
 
-  observeInboundExternalFailure({
+  observeInbound({
+    outcome: 'external_failure',
     activityType: 'Create',
     actorOrigin: actorUri,
     handler: 'create',

--- a/packages/fedify/src/inbound-delete.ts
+++ b/packages/fedify/src/inbound-delete.ts
@@ -14,11 +14,7 @@ import { InstanceKind } from '@kosmo/core/enums';
 import { deletePost } from '@kosmo/core/services';
 import { and, eq, isNotNull } from 'drizzle-orm';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import {
-  observeInboundExternalFailure,
-  observeInboundNoop,
-  observeInboundRejected,
-} from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Delete } from '@fedify/vocab';
 
@@ -36,7 +32,8 @@ export const handleInboundDelete = async (
   const objectUri = objectHref ? new URL(objectHref) : null;
 
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri)) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Delete',
       handler: 'delete',
       phase: 'validation',
@@ -51,7 +48,8 @@ export const handleInboundDelete = async (
     suppressError: true,
   });
   if (embedded === null && !activity.objectId) {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Delete',
       actorOrigin: actorUri.origin,
       handler: 'delete',
@@ -66,7 +64,8 @@ export const handleInboundDelete = async (
     embedded !== null &&
     (!(embedded instanceof Tombstone) || embedded.id?.href !== objectUri.href)
   ) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Delete',
       actorOrigin: actorUri.origin,
       handler: 'delete',
@@ -96,7 +95,8 @@ export const handleInboundDelete = async (
     .then(first);
 
   if (!row) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Delete',
       actorOrigin: actorUri.origin,
       handler: 'delete',

--- a/packages/fedify/src/inbound-follow.ts
+++ b/packages/fedify/src/inbound-follow.ts
@@ -20,12 +20,7 @@ import { and, eq } from 'drizzle-orm';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
 import { sendAcceptFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
-import {
-  observeInbound,
-  observeInboundExternalFailure,
-  observeInboundNoop,
-  observeInboundRejected,
-} from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import {
   findOrMaterializeRemoteProfileActorByUri,
   findStoredRemoteProfileActorByUri,
@@ -49,7 +44,8 @@ export const handleInboundFollow = async (
   const objectUri = follow.objectId;
 
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri)) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Follow',
       handler: 'follow',
       phase: 'validation',
@@ -61,7 +57,8 @@ export const handleInboundFollow = async (
   // Local validation intentionally precedes every remote lookup.
   const localRecipient = await resolveInboundLocalRecipient(context, objectUri);
   if (!localRecipient) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Follow',
       actorOrigin: actorUri.origin,
       handler: 'follow',
@@ -78,7 +75,8 @@ export const handleInboundFollow = async (
     remoteActor = await findOrMaterializeRemoteProfileActorByUri({ actorUri, context, now });
   } catch (error) {
     if (isExpectedRemoteActorRejection(error)) {
-      observeInboundExternalFailure({
+      observeInbound({
+        outcome: 'external_failure',
         activityType: 'Follow',
         actorOrigin: actorUri.origin,
         handler: 'follow',
@@ -109,7 +107,8 @@ export const handleInboundFollow = async (
 
   if (result.result.kind !== 'ESTABLISHED') {
     if (!result.result.created) {
-      observeInboundNoop({
+      observeInbound({
+        outcome: 'noop',
         activityType: 'Follow',
         actorOrigin: actorUri.origin,
         handler: 'follow',
@@ -122,7 +121,8 @@ export const handleInboundFollow = async (
   }
 
   if (!result.result.created) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Follow',
       actorOrigin: actorUri.origin,
       handler: 'follow',
@@ -133,7 +133,8 @@ export const handleInboundFollow = async (
   }
 
   if (!remoteActor.actor.inboxUri) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Follow',
       actorOrigin: actorUri.origin,
       handler: 'follow',
@@ -158,7 +159,8 @@ export const handleInboundFollow = async (
     });
   } catch {
     // The projection is authoritative; delivery retries belong to a separate slice.
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Follow',
       actorOrigin: actorUri.origin,
       handler: 'follow',
@@ -231,7 +233,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   const actorHref = uniqueHref(undo.actorIds);
   const actorUri = actorHref ? new URL(actorHref) : null;
   if (!isHttpUri(actorUri)) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Undo',
       handler: 'undo',
       phase: 'validation',
@@ -242,7 +245,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
 
   const objectHref = uniqueHref(undo.objectIds);
   if (undo.objectIds.length > 0 && !objectHref) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Undo',
       actorOrigin: actorUri.origin,
       handler: 'undo',
@@ -253,7 +257,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   }
   const objectUri = objectHref ? new URL(objectHref) : null;
   if (objectUri && !isHttpUri(objectUri)) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Undo',
       actorOrigin: actorUri.origin,
       handler: 'undo',
@@ -269,7 +274,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
       return;
     }
     if (announceResult === 'ignored') {
-      observeInboundNoop({
+      observeInbound({
+        outcome: 'noop',
         activityType: 'Undo',
         actorOrigin: actorUri.origin,
         handler: 'undo',
@@ -288,7 +294,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     remoteActor = await findUsableStoredRemoteProfileActorByUri(actorUri);
   } catch (error) {
     if (isExpectedRemoteActorRejection(error)) {
-      observeInboundExternalFailure({
+      observeInbound({
+        outcome: 'external_failure',
         activityType: 'Undo',
         actorOrigin: actorUri.origin,
         handler: 'undo',
@@ -303,7 +310,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   }
 
   if (!remoteActor || remoteActor.instance.state !== InstanceState.ACTIVE) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Undo',
       actorOrigin: actorUri.origin,
       handler: 'undo',
@@ -321,7 +329,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     suppressError: true,
   });
   if (embedded === null && !undo.objectId) {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Undo',
       actorOrigin: actorUri.origin,
       handler: 'undo',
@@ -334,7 +343,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   if (embedded instanceof Follow) {
     const objectUri = embedded.objectId;
     if (!isHttpUri(objectUri) || uniqueHref(embedded.actorIds) !== actorUri.href) {
-      observeInboundRejected({
+      observeInbound({
+        outcome: 'rejected',
         activityType: 'Undo',
         actorOrigin: actorUri.origin,
         objectOrigin: objectUri?.origin,
@@ -347,7 +357,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
 
     const localRecipient = await resolveInboundLocalRecipient(context, objectUri);
     if (!localRecipient) {
-      observeInboundRejected({
+      observeInbound({
+        outcome: 'rejected',
         activityType: 'Undo',
         actorOrigin: actorUri.origin,
         objectOrigin: objectUri.origin,
@@ -381,7 +392,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
         origin: 'ACTIVITYPUB',
       });
       if (!result.changed) {
-        observeInboundNoop({
+        observeInbound({
+          outcome: 'noop',
           activityType: 'Undo',
           actorOrigin: actorUri.origin,
           handler: 'undo',
@@ -406,7 +418,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
       .then(first);
 
     if (!pendingRequest) {
-      observeInboundNoop({
+      observeInbound({
+        outcome: 'noop',
         activityType: 'Undo',
         actorOrigin: actorUri.origin,
         handler: 'undo',
@@ -429,7 +442,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
       throw new Error('Unexpected inbound Undo transition result');
     }
     if (!result.result.changed) {
-      observeInboundNoop({
+      observeInbound({
+        outcome: 'noop',
         activityType: 'Undo',
         actorOrigin: actorUri.origin,
         handler: 'undo',
@@ -442,7 +456,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
   }
 
   if (embedded !== null && !(embedded instanceof Like) && !(embedded instanceof EmojiReact)) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Undo',
       actorOrigin: actorUri.origin,
       objectOrigin: objectUri?.origin,
@@ -459,7 +474,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
     ((embedded instanceof Like || embedded instanceof EmojiReact) &&
       uniqueHref(embedded.actorIds) !== actorUri.href)
   ) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Undo',
       actorOrigin: actorUri.origin,
       objectOrigin: activityUri?.origin,
@@ -486,7 +502,8 @@ export const handleInboundUndo = async (context: InboxContext<void>, undo: Undo)
       }),
   });
   if (result.reactionId === null) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Undo',
       actorOrigin: actorUri.origin,
       objectOrigin: activityUri.origin,

--- a/packages/fedify/src/inbound-observability.ts
+++ b/packages/fedify/src/inbound-observability.ts
@@ -250,12 +250,3 @@ export const withInboundObservability =
       throw normalizedError;
     }
   };
-
-export const observeInboundNoop = (observation: Omit<InboundObservation, 'outcome'>) =>
-  observeInbound({ ...observation, outcome: 'noop' });
-
-export const observeInboundRejected = (observation: Omit<InboundObservation, 'outcome'>) =>
-  observeInbound({ ...observation, outcome: 'rejected' });
-
-export const observeInboundExternalFailure = (observation: Omit<InboundObservation, 'outcome'>) =>
-  observeInbound({ ...observation, outcome: 'external_failure' });

--- a/packages/fedify/src/inbound-reaction.ts
+++ b/packages/fedify/src/inbound-reaction.ts
@@ -4,11 +4,7 @@ import { Like } from '@fedify/vocab';
 import { materializeInboundReaction } from '@kosmo/core/services';
 import { reactionTypeSchema } from '@kosmo/core/validation';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import {
-  observeInbound,
-  observeInboundNoop,
-  observeInboundRejected,
-} from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { EmojiReact } from '@fedify/vocab';
 
@@ -29,7 +25,8 @@ export const handleInboundReaction = async (
   const actorUri = uniqueHref(activity.actorIds);
   const objectUri = uniqueHref(activity.objectIds);
   if (!isHttpUri(activityUri) || !actorUri || !objectUri) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: activity instanceof Like ? 'Like' : 'EmojiReact',
       handler: 'reaction',
       phase: 'validation',
@@ -57,7 +54,8 @@ export const handleInboundReaction = async (
   });
   const activityType = activity instanceof Like ? 'Like' : 'EmojiReact';
   if (result.kind === 'REJECTED') {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType,
       actorOrigin: actorUri,
       handler: 'reaction',
@@ -66,7 +64,8 @@ export const handleInboundReaction = async (
       reasonCode: 'reaction_projection_rejected',
     });
   } else if (result.kind === 'DUPLICATE') {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType,
       actorOrigin: actorUri,
       handler: 'reaction',

--- a/packages/fedify/src/inbound-reject-follow.ts
+++ b/packages/fedify/src/inbound-reject-follow.ts
@@ -9,7 +9,7 @@ import { and, eq } from 'drizzle-orm';
 import { isHttpUri } from './activitypub-uri';
 import { isCompatibleOutboundFollowActivity } from './follow-delivery';
 import { resolveInboundLocalRecipient } from './inbound-local-recipient';
-import { observeInboundNoop, observeInboundRejected } from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import type { InboxContext } from '@fedify/fedify';
 import type { Follow } from '@fedify/vocab';
 
@@ -31,7 +31,8 @@ export const handleInboundRejectFollow = async ({
     !isHttpUri(objectUri) ||
     objectUri.href !== followeeActorUri.href
   ) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Reject',
       actorOrigin: followerActorUri?.origin,
       handler: 'reject',
@@ -44,7 +45,8 @@ export const handleInboundRejectFollow = async ({
 
   const followerProfile = await resolveInboundLocalRecipient(context, followerActorUri);
   if (!followerProfile) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Reject',
       actorOrigin: followerActorUri.origin,
       handler: 'reject',
@@ -88,7 +90,8 @@ export const handleInboundRejectFollow = async ({
       projection,
     )
   ) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Reject',
       actorOrigin: followerActorUri.origin,
       handler: 'reject',
@@ -116,7 +119,8 @@ export const handleInboundRejectFollow = async ({
       throw new Error('Unexpected inbound Reject transition result');
     }
     if (!result.result.changed) {
-      observeInboundNoop({
+      observeInbound({
+        outcome: 'noop',
         activityType: 'Reject',
         actorOrigin: followerActorUri.origin,
         handler: 'reject',
@@ -134,7 +138,8 @@ export const handleInboundRejectFollow = async ({
     origin: 'ACTIVITYPUB',
   });
   if (!removed.changed) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Reject',
       actorOrigin: followerActorUri.origin,
       handler: 'reject',

--- a/packages/fedify/src/inbound-reject.ts
+++ b/packages/fedify/src/inbound-reject.ts
@@ -3,11 +3,7 @@ import '@kosmo/core/polyfill';
 import { Follow } from '@fedify/vocab';
 import { NotFoundError } from '@kosmo/core/error';
 import { isHttpUri } from './activitypub-uri';
-import {
-  observeInboundExternalFailure,
-  observeInboundNoop,
-  observeInboundRejected,
-} from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import { handleInboundRejectFollow } from './inbound-reject-follow';
 import { findUsableStoredRemoteProfileActorByUri } from './remote-actor-materialization';
 import type { InboxContext } from '@fedify/fedify';
@@ -19,7 +15,8 @@ export const handleInboundReject = async (
 ): Promise<void> => {
   const actorUri = reject.actorId;
   if (!isHttpUri(actorUri)) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Reject',
       handler: 'reject',
       phase: 'validation',
@@ -33,7 +30,8 @@ export const handleInboundReject = async (
     remoteActor = await findUsableStoredRemoteProfileActorByUri(actorUri);
   } catch (error) {
     if (error instanceof NotFoundError) {
-      observeInboundNoop({
+      observeInbound({
+        outcome: 'noop',
         activityType: 'Reject',
         actorOrigin: actorUri.origin,
         error,
@@ -46,7 +44,8 @@ export const handleInboundReject = async (
     throw error;
   }
   if (!remoteActor) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Reject',
       actorOrigin: actorUri.origin,
       handler: 'reject',
@@ -61,7 +60,8 @@ export const handleInboundReject = async (
     suppressError: true,
   });
   if (object === null) {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Reject',
       actorOrigin: actorUri.origin,
       handler: 'reject',
@@ -78,7 +78,8 @@ export const handleInboundReject = async (
       followeeProfileId: remoteActor.profile.id,
     });
   } else {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Reject',
       actorOrigin: actorUri.origin,
       handler: 'reject',

--- a/packages/fedify/src/inbound-update.ts
+++ b/packages/fedify/src/inbound-update.ts
@@ -3,11 +3,7 @@ import '@kosmo/core/polyfill';
 import { isActor } from '@fedify/vocab';
 import { ConflictError } from '@kosmo/core/error';
 import { isHttpUri, uniqueHref } from './activitypub-uri';
-import {
-  observeInboundExternalFailure,
-  observeInboundNoop,
-  observeInboundRejected,
-} from './inbound-observability';
+import { observeInbound } from './inbound-observability';
 import {
   findStoredRemoteProfileActorByUri,
   materializeRemoteProfileActor,
@@ -31,7 +27,8 @@ export const handleInboundUpdate = async (
   const objectUri = objectHref ? new URL(objectHref) : null;
 
   if (!isHttpUri(actorUri) || !isHttpUri(objectUri) || actorUri.href !== objectUri.href) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Update',
       actorOrigin: actorUri?.origin,
       handler: 'update',
@@ -48,7 +45,8 @@ export const handleInboundUpdate = async (
     suppressError: true,
   });
   if (object === null) {
-    observeInboundExternalFailure({
+    observeInbound({
+      outcome: 'external_failure',
       activityType: 'Update',
       actorOrigin: actorUri?.origin,
       handler: 'update',
@@ -60,7 +58,8 @@ export const handleInboundUpdate = async (
   }
 
   if (!isActor(object) || object.id?.href !== actorUri.href) {
-    observeInboundRejected({
+    observeInbound({
+      outcome: 'rejected',
       activityType: 'Update',
       actorOrigin: actorUri.origin,
       handler: 'update',
@@ -73,7 +72,8 @@ export const handleInboundUpdate = async (
 
   const stored = await findStoredRemoteProfileActorByUri(actorUri);
   if (!stored) {
-    observeInboundNoop({
+    observeInbound({
+      outcome: 'noop',
       activityType: 'Update',
       actorOrigin: actorUri.origin,
       handler: 'update',
@@ -95,7 +95,8 @@ export const handleInboundUpdate = async (
     });
   } catch (error) {
     if (error instanceof ConflictError || error instanceof RemoteActorMaterializationError) {
-      observeInboundExternalFailure({
+      observeInbound({
+        outcome: 'external_failure',
         activityType: 'Update',
         actorOrigin: actorUri.origin,
         handler: 'update',


### PR DESCRIPTION
## 무엇을 변경했나요

- `observeInboundNoop`, `observeInboundRejected`, `observeInboundExternalFailure`를 제거했습니다.
- 모든 인바운드 처리 지점에서 `observeInbound`의 `outcome`을 직접 명시합니다.
- 사용되지 않는 공개 export를 제거했습니다.

## 왜 변경했나요

관측 결과 하나만 고정하는 얇은 wrapper가 실제 기록되는 outcome을 호출부에서 숨기고 있었습니다. 처리 흐름을 읽는 위치에서 관측 동작까지 바로 확인할 수 있게 합니다.

## 이번 PR의 주요 결정

없음. 동작과 payload를 유지한 행동 보존 리팩터링입니다.

## 어떻게 확인할 수 있나요

- `pnpm --filter @kosmo/fedify lint:tsc`
- `inbound-observability.test.ts` 5/5
- ESLint, Prettier, `git diff --check`

전체 Fedify unit suite는 로컬 PostgreSQL 미기동으로 실행되지 않았습니다(`ECONNREFUSED 127.0.0.1:5432`).

## 아직 어떤 문제가 남았나요

없음.

Stack: `main → #670 → #674 → 이 PR`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>