### PR TITLE
레포지토리에 Ponytail 플러그인을 설치한다

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "kosmo",
+  "interface": {
+    "displayName": "Kosmo"
+  },
+  "plugins": [
+    {
+      "name": "ponytail",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/DietrichGebert/ponytail.git",
+        "sha": "2ed6c52c9d7e5e56942508591085fd45dea277d3"
+      },
+      "policy": {
+        "installation": "INSTALLED_BY_DEFAULT",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}


### PR DESCRIPTION
## 무엇을 변경했나요

- `.agents/plugins/marketplace.json`에 Kosmo 레포지토리 마켓플레이스를 추가했습니다.
- Ponytail 원격 소스를 upstream commit `2ed6c52c9d7e5e56942508591085fd45dea277d3`로 고정했습니다.
- 저장소 사용자에게 Ponytail이 기본 설치되도록 `INSTALLED_BY_DEFAULT` 정책을 적용했습니다.
- Stack: main -> install-repository-ponytail

## 왜 변경했나요

개인별 전역 설치에 기대지 않고 Kosmo 저장소를 여는 모든 사용자가 같은 Ponytail 구성과 버전을 사용하도록 하기 위해서입니다.

## 이번 PR의 주요 결정

### 원격 소스를 SHA로 고정

- 결정자: 사용자
- 선택: 플러그인을 저장소에 복제하지 않고 공식 Git URL과 commit SHA를 레포지토리 마켓플레이스에서 참조합니다.
- 고려한 대안: Ponytail 플러그인 전체를 저장소에 vendoring하거나 `main` 브랜치를 가리킵니다.
- 이유: 한 파일만 유지하면서도 설치 결과를 재현할 수 있습니다.
- 감수한 결과: Ponytail 업데이트는 SHA를 명시적으로 갱신해야 합니다.
- 관련 근거: https://learn.chatgpt.com/ko-KR/docs/changelog

## 어떻게 확인할 수 있나요

- `jq`로 marketplace JSON 구조와 설치 정책을 확인했습니다.
- `pnpm exec prettier --check .agents/plugins/marketplace.json`을 통과했습니다.
- `git diff --check`를 통과했습니다.
- `git ls-remote https://github.com/DietrichGebert/ponytail.git`에서 고정 SHA가 upstream `main`에 존재함을 확인했습니다.

## 아직 어떤 문제가 남았나요

- 현재 실행 중인 Codex 세션에서는 새 레포지토리 마켓플레이스를 다시 로드하지 않으므로, 병합 후 새 세션 또는 앱 재시작에서 자동 설치 노출을 확인해야 합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>