### PR TITLE
Play 배포용 WIF가 Terraform에서 생성되게 한다

### DIFF
--- a/apps/terraform/main.tf
+++ b/apps/terraform/main.tf
@@ -187,7 +187,7 @@ resource "google_iam_workload_identity_pool_provider" "android_play" {
 
   workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
   workload_identity_pool_provider_id = "kosmo-android-play"
-  display_name                       = "Kosmo Android Play internal testing"
+  display_name                       = "Kosmo Android Play"
   deletion_policy                    = "PREVENT"
 
   attribute_mapping = {


### PR DESCRIPTION
## 무엇을 변경했나요

- Android Play용 Workload Identity Pool Provider의 표시 이름을 GCP의 32자 제한 안으로 줄였습니다.
- provider ID, trust condition, 서비스 계정과 IAM binding은 변경하지 않았습니다.

## 왜 변경했나요

PR #703 병합 후 Terraform Apply에서 provider 표시 이름이 32자를 초과해 HTTP 400으로 실패했습니다. Android Publisher API와 Play 서비스 계정은 생성됐지만 WIF provider와 impersonation binding은 적용되지 않아 이를 복구합니다.

## 이번 PR의 주요 결정

없음. 실패한 표시 이름만 줄이고 PROD-285에서 검토한 인증 경계와 배포 구조는 그대로 유지합니다.

관련 이슈: [PROD-285](https://linear.app/byulmaru/issue/PROD-285)
선행 PR: [#703](https://github.com/byulmaru/kosmo/pull/703)
실패한 Apply: [Terraform #597](https://github.com/byulmaru/kosmo/actions/runs/33606298796)

Stack: `main ← PROD-285-wif-display-name`

## 어떻게 확인할 수 있나요

- `terraform fmt -check`
- `terraform validate`
- `git diff --check`

병합 후 Terraform Apply에서 WIF provider와 `roles/iam.workloadIdentityUser` binding 생성까지 확인합니다.

## 아직 어떤 문제가 남았나요

Play Console 앱, upload key, 최초 signed AAB와 `prod` Environment 값 설정은 Terraform 복구 후 계속 진행해야 합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>