### PR TITLE
Android Play 배포가 서명 키를 Vault에서 사용하게 한다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -137,8 +137,8 @@ jobs:
           jwtGithubAudience: ${{ env.VAULT_GITHUB_ACTIONS_AUDIENCE }}
           exportEnv: false
           secrets: |
-            secret/data/kosmo/prod/android-play ANDROID_RELEASE_KEYSTORE_BASE64 | ANDROID_RELEASE_KEYSTORE_BASE64
-            secret/data/kosmo/prod/android-play ANDROID_RELEASE_STORE_PASSWORD | ANDROID_RELEASE_STORE_PASSWORD
+            secret/data/kosmo/prod/android-play ANDROID_RELEASE_KEYSTORE_BASE64 | ANDROID_RELEASE_KEYSTORE_BASE64 ;
+            secret/data/kosmo/prod/android-play ANDROID_RELEASE_STORE_PASSWORD | ANDROID_RELEASE_STORE_PASSWORD ;
             secret/data/kosmo/prod/android-play ANDROID_RELEASE_KEY_PASSWORD | ANDROID_RELEASE_KEY_PASSWORD
 
       - name: Restore Android upload key

--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -137,9 +137,9 @@ jobs:
           jwtGithubAudience: ${{ env.VAULT_GITHUB_ACTIONS_AUDIENCE }}
           exportEnv: false
           secrets: |
-            secret/data/ci/kosmo/android-play ANDROID_RELEASE_KEYSTORE_BASE64 | ANDROID_RELEASE_KEYSTORE_BASE64
-            secret/data/ci/kosmo/android-play ANDROID_RELEASE_STORE_PASSWORD | ANDROID_RELEASE_STORE_PASSWORD
-            secret/data/ci/kosmo/android-play ANDROID_RELEASE_KEY_PASSWORD | ANDROID_RELEASE_KEY_PASSWORD
+            secret/data/kosmo/prod/android-play ANDROID_RELEASE_KEYSTORE_BASE64 | ANDROID_RELEASE_KEYSTORE_BASE64
+            secret/data/kosmo/prod/android-play ANDROID_RELEASE_STORE_PASSWORD | ANDROID_RELEASE_STORE_PASSWORD
+            secret/data/kosmo/prod/android-play ANDROID_RELEASE_KEY_PASSWORD | ANDROID_RELEASE_KEY_PASSWORD
 
       - name: Restore Android upload key
         shell: bash

--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -7,10 +7,6 @@ permissions:
   contents: read
   id-token: write
 
-env:
-  VAULT_ADDR: https://vault.tail1fdd55.ts.net
-  VAULT_GITHUB_ACTIONS_AUDIENCE: https://vault.tail1fdd55.ts.net
-
 concurrency:
   group: android-play-internal-distribution
   cancel-in-progress: false
@@ -130,11 +126,11 @@ jobs:
         id: android_signing
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
-          url: ${{ env.VAULT_ADDR }}
+          url: ${{ vars.VAULT_ADDR }}
           path: github-actions
           method: jwt
           role: kosmo-android-play
-          jwtGithubAudience: ${{ env.VAULT_GITHUB_ACTIONS_AUDIENCE }}
+          jwtGithubAudience: ${{ vars.VAULT_GITHUB_ACTIONS_AUDIENCE }}
           exportEnv: false
           secrets: |
             secret/data/kosmo/prod/android-play ANDROID_RELEASE_KEYSTORE_BASE64 | ANDROID_RELEASE_KEYSTORE_BASE64 ;

--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  VAULT_ADDR: https://vault.tail1fdd55.ts.net
+  VAULT_GITHUB_ACTIONS_AUDIENCE: https://vault.tail1fdd55.ts.net
+
 concurrency:
   group: android-play-internal-distribution
   cancel-in-progress: false
@@ -29,6 +33,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Connect to Tailscale for Vault
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: tag:github-actions
 
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
@@ -115,12 +126,27 @@ jobs:
             exit 1
           fi
 
+      - name: Load Android signing credentials from Vault
+        id: android_signing
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ env.VAULT_ADDR }}
+          path: github-actions
+          method: jwt
+          role: kosmo-android-play
+          jwtGithubAudience: ${{ env.VAULT_GITHUB_ACTIONS_AUDIENCE }}
+          exportEnv: false
+          secrets: |
+            secret/data/ci/kosmo/android-play ANDROID_RELEASE_KEYSTORE_BASE64 | ANDROID_RELEASE_KEYSTORE_BASE64
+            secret/data/ci/kosmo/android-play ANDROID_RELEASE_STORE_PASSWORD | ANDROID_RELEASE_STORE_PASSWORD
+            secret/data/ci/kosmo/android-play ANDROID_RELEASE_KEY_PASSWORD | ANDROID_RELEASE_KEY_PASSWORD
+
       - name: Restore Android upload key
         shell: bash
         env:
-          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
-          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}
-          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ steps.android_signing.outputs.ANDROID_RELEASE_KEY_PASSWORD }}
+          ANDROID_RELEASE_KEYSTORE_BASE64: ${{ steps.android_signing.outputs.ANDROID_RELEASE_KEYSTORE_BASE64 }}
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ steps.android_signing.outputs.ANDROID_RELEASE_STORE_PASSWORD }}
         run: |
           set -euo pipefail
           # shellcheck disable=SC2016

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,8 +7,6 @@ on:
 env:
   ENVIRONMENT: dev
   SENTRY_RELEASE: kosmo@${{ github.sha }}
-  VAULT_ADDR: https://vault.tail1fdd55.ts.net
-  VAULT_GITHUB_ACTIONS_AUDIENCE: https://vault.tail1fdd55.ts.net
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -55,11 +53,11 @@ jobs:
         id: sentry
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
-          url: ${{ env.VAULT_ADDR }}
+          url: ${{ vars.VAULT_ADDR }}
           path: github-actions
           method: jwt
           role: kosmo-build-dev
-          jwtGithubAudience: ${{ env.VAULT_GITHUB_ACTIONS_AUDIENCE }}
+          jwtGithubAudience: ${{ vars.VAULT_GITHUB_ACTIONS_AUDIENCE }}
           exportEnv: false
           secrets: |
             secret/data/kubernetes/kosmo/${{ env.ENVIRONMENT }} EXPO_PUBLIC_SENTRY_DSN | EXPO_PUBLIC_SENTRY_DSN

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -14,8 +14,6 @@ permissions:
 
 env:
   ENVIRONMENT: prod
-  VAULT_ADDR: https://vault.tail1fdd55.ts.net
-  VAULT_GITHUB_ACTIONS_AUDIENCE: https://vault.tail1fdd55.ts.net
 
 jobs:
   production_deploy:
@@ -77,11 +75,11 @@ jobs:
         id: sentry
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
-          url: ${{ env.VAULT_ADDR }}
+          url: ${{ vars.VAULT_ADDR }}
           path: github-actions
           method: jwt
           role: kosmo-build-prod
-          jwtGithubAudience: ${{ env.VAULT_GITHUB_ACTIONS_AUDIENCE }}
+          jwtGithubAudience: ${{ vars.VAULT_GITHUB_ACTIONS_AUDIENCE }}
           exportEnv: false
           secrets: |
             secret/data/kubernetes/kosmo/prod EXPO_PUBLIC_SENTRY_DSN | EXPO_PUBLIC_SENTRY_DSN

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -27,9 +27,9 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 
 첫 배포 전에는 Play Console에서 다음 절차를 수동으로 완료해야 한다. CI가 Play Console의 최초 app/signing bootstrap을 대신하지 않는다.
 
-1. package name `moe.kos`로 app을 만들고 Google Play App Signing을 설정한다.
+1. package name `moe.kos`로 app을 만든다.
 2. upload key를 관리자 장비에서 생성한다. 첫 AAB와 이후 CI AAB는 같은 upload key로 서명해야 하며, Google이 관리하는 app signing key와는 별개다.
-3. Play Console에서 첫 signed AAB 업로드와 internal testing track 생성을 완료하고 tester 목록과 opt-in 링크를 설정한다.
+3. Play Console에서 internal testing track의 첫 release를 준비하고, 해당 release에서 Google 관리 Play App Signing을 설정한 뒤 upload key로 서명한 첫 signed AAB를 수동 업로드한다. tester 목록과 opt-in 링크도 설정한다.
 4. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.
 5. 기존 승인형 `prod` GitHub Environment에 다음 non-secret variable만 넣는다. 새 Environment는 만들지 않는다.
 
@@ -40,7 +40,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `ANDROID_RELEASE_KEY_ALIAS`          | variable | upload key 생성 시 사용한 alias                                 |
 | `ANDROID_RELEASE_CERTIFICATE_SHA256` | variable | upload certificate의 SHA-256 fingerprint                        |
 
-6. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. Vault KV v2 경로 `secret/data/kosmo/prod/android-play`에 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 경로를 읽도록 한다.
+6. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. 운영자가 Vault CLI/UI에서 사용하는 KV v2 logical path는 `secret/kosmo/prod/android-play`다. Workflow와 Vault ACL policy에서 사용하는 KV v2 API path는 `secret/data/kosmo/prod/android-play`이며, `/data/`는 CLI/UI logical path에 포함하지 않는다. 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 API path를 읽도록 한다.
 
 | Field                             | 값                                 |
 | --------------------------------- | ---------------------------------- |

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -48,7 +48,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `ANDROID_RELEASE_STORE_PASSWORD`  | upload keystore password           |
 | `ANDROID_RELEASE_KEY_PASSWORD`    | upload key password                |
 
-`Android Google Play Internal Distribution`은 기존 저장소 수준 `TAILSCALE_OAUTH_CLIENT_ID`와 `TAILSCALE_AUDIENCE`로 Vault tailnet에 접속한 뒤, GitHub OIDC JWT로 `kosmo-android-play` role을 인증하고 실행 중에만 이 값을 읽는다. Vault role과 policy는 `prod` Environment의 이 workflow만 해당 경로를 읽도록 제한해야 한다.
+`Android Google Play Internal Distribution`은 조직 수준 `VAULT_ADDR`와 `VAULT_GITHUB_ACTIONS_AUDIENCE`, 저장소 수준 `TAILSCALE_OAUTH_CLIENT_ID`와 `TAILSCALE_AUDIENCE`를 사용한다. Vault tailnet에 접속한 뒤 GitHub OIDC JWT로 `kosmo-android-play` role을 인증하고 실행 중에만 서명 값을 읽는다. Vault role과 policy는 `prod` Environment의 이 workflow만 해당 경로를 읽도록 제한해야 한다.
 
 upload key 예시는 다음과 같다. password는 명령행이나 저장소에 넣지 말고 `keytool` prompt에서 입력한다.
 

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -40,7 +40,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `ANDROID_RELEASE_KEY_ALIAS`          | variable | upload key 생성 시 사용한 alias                                 |
 | `ANDROID_RELEASE_CERTIFICATE_SHA256` | variable | upload certificate의 SHA-256 fingerprint                        |
 
-6. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. Vault KV v2 경로 `secret/data/ci/kosmo/android-play`에 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 경로를 읽도록 한다.
+6. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. Vault KV v2 경로 `secret/data/kosmo/prod/android-play`에 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 경로를 읽도록 한다.
 
 | Field                             | 값                                 |
 | --------------------------------- | ---------------------------------- |

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -31,7 +31,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 2. upload key를 관리자 장비에서 생성한다. 첫 AAB와 이후 CI AAB는 같은 upload key로 서명해야 하며, Google이 관리하는 app signing key와는 별개다.
 3. Play Console에서 첫 signed AAB 업로드와 internal testing track 생성을 완료하고 tester 목록과 opt-in 링크를 설정한다.
 4. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.
-5. 기존 승인형 `prod` GitHub Environment에 다음 값을 넣는다. 새 Environment는 만들지 않는다.
+5. 기존 승인형 `prod` GitHub Environment에 다음 non-secret variable만 넣는다. 새 Environment는 만들지 않는다.
 
 | 이름                                 | 종류     | 값                                                              |
 | ------------------------------------ | -------- | --------------------------------------------------------------- |
@@ -39,9 +39,16 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `GCP_WORKLOAD_IDENTITY_PROVIDER`     | variable | `terraform output -raw android_play_workload_identity_provider` |
 | `ANDROID_RELEASE_KEY_ALIAS`          | variable | upload key 생성 시 사용한 alias                                 |
 | `ANDROID_RELEASE_CERTIFICATE_SHA256` | variable | upload certificate의 SHA-256 fingerprint                        |
-| `ANDROID_RELEASE_KEYSTORE_BASE64`    | secret   | 줄바꿈 없는 upload keystore base64                              |
-| `ANDROID_RELEASE_STORE_PASSWORD`     | secret   | upload keystore password                                        |
-| `ANDROID_RELEASE_KEY_PASSWORD`       | secret   | upload key password                                             |
+
+6. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. Vault KV v2 경로 `secret/data/ci/kosmo/android-play`에 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 경로를 읽도록 한다.
+
+| Field                             | 값                                 |
+| --------------------------------- | ---------------------------------- |
+| `ANDROID_RELEASE_KEYSTORE_BASE64` | 줄바꿈 없는 upload keystore base64 |
+| `ANDROID_RELEASE_STORE_PASSWORD`  | upload keystore password           |
+| `ANDROID_RELEASE_KEY_PASSWORD`    | upload key password                |
+
+`Android Google Play Internal Distribution`은 기존 저장소 수준 `TAILSCALE_OAUTH_CLIENT_ID`와 `TAILSCALE_AUDIENCE`로 Vault tailnet에 접속한 뒤, GitHub OIDC JWT로 `kosmo-android-play` role을 인증하고 실행 중에만 이 값을 읽는다. Vault role과 policy는 `prod` Environment의 이 workflow만 해당 경로를 읽도록 제한해야 한다.
 
 upload key 예시는 다음과 같다. password는 명령행이나 저장소에 넣지 말고 `keytool` prompt에서 입력한다.
 
@@ -58,7 +65,7 @@ keytool -list -v -keystore kosmo-android-upload.jks
 base64 < kosmo-android-upload.jks | tr -d '\n'
 ```
 
-`ANDROID_RELEASE_CERTIFICATE_SHA256`은 Play Console에 등록한 upload certificate와 일치해야 한다. upload key를 바꿀 때는 secret만 교체하지 말고 Play Console의 upload key reset 절차를 먼저 완료한다. 실제 Play Store 설치·업데이트·실기기 launch와 native login/GraphQL 검증은 PROD-287의 책임이며, 이 workflow는 API/OIDC 환경값이나 ADB/device smoke를 요구하지 않는다.
+base64 결과와 password는 shell history, 저장소, GitHub 로그에 남기지 말고 위 Vault field에만 기록한다. `ANDROID_RELEASE_CERTIFICATE_SHA256`은 Play Console에 등록한 upload certificate와 일치해야 한다. upload key를 바꿀 때는 Vault field만 교체하지 말고 Play Console의 upload key reset 절차를 먼저 완료한다. 실제 Play Store 설치·업데이트·실기기 launch와 native login/GraphQL 검증은 PROD-287의 책임이며, 이 workflow는 API/OIDC 환경값이나 ADB/device smoke를 요구하지 않는다.
 
 ## iOS Ad Hoc Firebase distribution
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Android Play 배포 workflow가 Tailscale로 Vault에 연결해 JKS와 서명 비밀번호를 읽도록 변경했습니다.
- Vault action 출력은 서명 복원 단계에만 전달하고 GitHub Secrets에는 서명 키 복사본을 두지 않습니다.
- Android Play, dev Docker build, production release workflow가 Vault 주소와 GitHub OIDC audience를 조직 변수에서 직접 읽도록 공통화했습니다.
- 앱 README에 GitHub 변수와 Vault logical/API 경로, 필드, role, 최초 Play release 절차를 정리했습니다.

## 왜 변경했는지

PROD-285의 Android upload key를 Vault 한 곳에서 관리하고, GitHub Environment Secrets에 장기 credential을 복제하지 않기 위해서입니다.

## 이번 PR의 주요 결정

### 기존 prod Environment와 전용 Vault role을 함께 사용한다

- 결정자: @robin-maki
- 선택: 기존 GitHub `prod` Environment를 재사용하고 Android 서명 키는 `kosmo-android-play` Vault role로만 읽습니다.
- 고려한 대안: 별도 GitHub Environment를 추가하거나 기존 `kosmo-build-prod` Vault role을 재사용합니다.
- 이유: Environment를 늘리지 않으면서 production runtime secret과 Android 서명 키의 접근 권한은 분리할 수 있습니다.
- 감수한 결과: Kubernetes Terraform에서 전용 Vault role과 policy를 관리해야 합니다.
- 관련 근거: PROD-285

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/docker-build.yml .github/workflows/production-release.yml .github/workflows/android-play-internal-distribution.yml`
- `pnpm exec prettier --check .github/workflows/docker-build.yml .github/workflows/production-release.yml .github/workflows/android-play-internal-distribution.yml apps/app/README.md`
- `ruby -c apps/app/fastlane/Fastfile`
- `git diff --check`
- Kubernetes #90/#91의 merge·apply와 live Vault role/policy, 새 KV 경로를 확인했습니다.

## 아직 어떤 문제가 남았는지

- GitHub Actions의 signed AAB 생성과 Google Play 업로드는 아직 실제 실행으로 검증하지 않았습니다.
- Google Play API 자동 업로드 전에 필요한 최초 signed AAB 수동 업로드가 남아 있다면 별도로 완료해야 합니다.

Stack: main -> PROD-285-vault
