### PR TITLE
Android Play 배포가 Fastlane 설정에서 중단되지 않게 한다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -79,7 +79,7 @@ jobs:
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           bundler-cache: true
-          ruby: '3.4'
+          ruby-version: '3.4'
           working-directory: apps/app
 
       - name: Calculate Android version code


### PR DESCRIPTION
## 무엇을 변경했는지

- Android Play 배포 workflow의 `ruby/setup-ruby` 입력을 공식 `ruby-version: '3.4'`로 수정했습니다.

## 왜 변경했는지

실제 첫 실행 #33702966498에서 알 수 없는 `ruby` 입력이 전달되어 Ruby 버전이 설정되지 않고 Fastlane 단계가 중단됐습니다. 공식 action 입력명을 사용해 이 실행 경로를 정상화합니다.

## 이번 PR의 주요 결정

없음. 확인된 `ruby/setup-ruby` action input만 수정했습니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/android-play-internal-distribution.yml`
- `pnpm exec prettier --check .github/workflows/android-play-internal-distribution.yml`
- `ruby -c apps/app/fastlane/Fastfile`
- `git diff --check`
- `ruby/setup-ruby` 공식 action metadata에서 `ruby-version` input 확인

## 아직 어떤 문제가 남았는지

- 이 workflow는 `main`에서만 실행되므로, 병합 후 GitHub-hosted runner에서 live 재실행해야 합니다.
- Google Play 최초 signed AAB 수동 bootstrap이 필요합니다.
- Vault field 존재 및 OIDC 연결은 다음 live 실행에서 검증해야 합니다.

Stack: `main -> PROD-285-ruby-fix`
