### PR TITLE
[PROD-885] Web HEIC 업로드를 미지원 형식으로 안내한다

### DIFF
--- a/apps/app/src/components/media/imageUpload.test.ts
+++ b/apps/app/src/components/media/imageUpload.test.ts
@@ -255,7 +255,12 @@ for (const testCase of [
     mimeType: 'IMAGE/HEIF',
     name: 'asset MIME type case-insensitively',
   },
-  { fileName: 'image.HEIF', fileType: '', mimeType: '', name: 'file extension' },
+  {
+    fileName: 'image.HEIF',
+    fileType: 'image/jpeg',
+    mimeType: 'image/jpeg',
+    name: 'file extension',
+  },
 ] as const) {
   test(`rejects Web ${testCase.name} before issuing an upload`, async (t) => {
     let issueCalled = false;

--- a/apps/app/src/components/media/imageUpload.test.ts
+++ b/apps/app/src/components/media/imageUpload.test.ts
@@ -244,6 +244,53 @@ test('uses decoded dimensions for clipboard assets whose metadata is 0x0', async
 
 for (const testCase of [
   {
+    fileName: 'image.heic',
+    fileType: 'image/heic',
+    mimeType: 'image/jpeg',
+    name: 'file MIME type',
+  },
+  {
+    fileName: 'image.heic',
+    fileType: 'image/jpeg',
+    mimeType: 'IMAGE/HEIF',
+    name: 'asset MIME type case-insensitively',
+  },
+  { fileName: 'image.HEIF', fileType: '', mimeType: '', name: 'file extension' },
+] as const) {
+  test(`rejects Web ${testCase.name} before issuing an upload`, async (t) => {
+    let issueCalled = false;
+    const fetchMock = t.mock.method(globalThis, 'fetch', async () => {
+      throw new Error('fetch must not run');
+    });
+    createManipulatorContext = () => {
+      throw new Error('normalization must not run');
+    };
+
+    await assert.rejects(
+      uploadImage({
+        asset: createAsset({
+          file: new File(['image'], testCase.fileName, { type: testCase.fileType }),
+          mimeType: testCase.mimeType,
+        }),
+        complete: async () => undefined,
+        isActive: () => true,
+        issue: async () => {
+          issueCalled = true;
+          return { mediaId: 'media-unsupported', uploadUrl: 'https://upload.example/unsupported' };
+        },
+      }),
+      (error: unknown) =>
+        error instanceof ImageUploadError &&
+        error.failure.stage === 'transfer' &&
+        error.failure.reason === 'unsupported-format',
+    );
+    assert.equal(issueCalled, false);
+    assert.equal(fetchMock.mock.callCount(), 0);
+  });
+}
+
+for (const testCase of [
+  {
     dimensions: { height: 2000, width: 3000 },
     expectedResizeCalls: [{ height: 1365, width: 2048 }],
     name: 'keeps decoded landscape ratio when resizing to the maximum dimension',

--- a/apps/app/src/components/media/imageUpload.ts
+++ b/apps/app/src/components/media/imageUpload.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { asImageUploadError, assertImageUploadResponse } from './imageUploadErrors';
+import {
+  asImageUploadError,
+  assertImageUploadResponse,
+  ImageUploadError,
+} from './imageUploadErrors';
 import type { ImageRef } from 'expo-image-manipulator';
 import type { ImagePickerAsset } from 'expo-image-picker';
 
@@ -116,6 +120,16 @@ export async function uploadImage({
 }): Promise<string | null> {
   if (!isActive()) {
     return null;
+  }
+
+  if (
+    asset.file &&
+    ([asset.mimeType, asset.file.type].some((mimeType) =>
+      ['image/heic', 'image/heif'].includes(mimeType?.toLowerCase() ?? ''),
+    ) ||
+      /\.(heic|heif)$/i.test(asset.file.name))
+  ) {
+    throw new ImageUploadError({ reason: 'unsupported-format', stage: 'transfer' });
   }
 
   let issued: IssuedImageUpload;


### PR DESCRIPTION
## 무엇을 변경했나요

- Web 이미지 업로드 경계에서 HEIC/HEIF MIME을 대소문자와 무관하게 감지합니다.
- MIME이 HEIC/HEIF가 아니어도 파일명이 `.heic`/`.heif`이면 확장자 fallback으로 식별합니다.
- 감지 즉시 기존 `transfer/unsupported-format` 오류를 반환해 Media 발급, 정규화, PUT, 완료 처리를 실행하지 않습니다.
- MIME 두 경로와 확장자 fallback을 table-driven unit test로 고정했습니다.

## 왜 변경했나요

`dev.kos.moe`에서 일반 PNG와 4096×4096 PNG는 WebP로 변환되어 업로드됐지만, 동일 원본의 HEIC는 Media API PUT 전에 실패했습니다. 이 실패가 일시적 오류로 표시되어 재시도로 해결될 것처럼 안내되는 문제를 바로잡습니다.

## 이번 PR의 주요 결정

### 실제 HEIC 변환은 진행하지 않음

- 결정자: @Jiyu Park
- 선택: 이번 PR은 기존 미지원 형식 안내만 적용하며, Web HEIC 디코딩과 WebP 변환을 다루던 PROD-658은 오픈소스 라이선스 고지 문제로 취소합니다.
- 고려한 대안: WASM decoder와 Web Worker를 이용해 실제 HEIC 변환 지원
- 이유: decoder 도입에 필요한 오픈소스 라이선스 고지 문제를 현재 해결하지 않기로 했습니다.
- 감수한 결과: Web HEIC/HEIF 업로드는 계속 지원되지 않습니다.
- 관련 근거: PROD-657, PROD-658, PROD-881

## 어떻게 확인할 수 있나요

- `CI=true pnpm --filter @kosmo/app test:unit` — 383/383 통과
- `CI=true pnpm --filter @kosmo/app check` — 통과
- touched Prettier 및 `git diff --check` — 통과
- 기존 dev 재현: PNG/WebP 업로드 성공, HEIC는 PUT 전에 실패

## 아직 어떤 문제가 남았나요

- 실제 Web HEIC/HEIF 변환은 오픈소스 라이선스 고지 문제로 취소되어 미지원 상태를 유지합니다.
- 수정본의 `dev.kos.moe` 수동 검증은 배포 후 수행해야 합니다.

Stack: main -> PROD-885

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
