### PR TITLE
Admin에서 Account 목록과 상세를 조회할 수 있게 한다

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -7,17 +7,24 @@
     "build": "vite build",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "dev": "vite dev --host 0.0.0.0 --port 8080",
-    "test": "pnpm check && vitest run"
+    "test": "pnpm check && vitest run --exclude '**/*.database.test.ts' && pnpm test:database",
+    "test:database": "cd ../.. && node scripts/test-db.mjs run -- pnpm --filter @kosmo/admin test:database:isolated",
+    "test:database:isolated": "cd ../.. && pnpm db:test:push && pnpm --filter @kosmo/admin exec vitest run src/lib/server/accounts.database.test.ts"
   },
   "dependencies": {
+    "@kosmo/core": "workspace:*",
     "@sveltejs/kit": "^2.70.3",
+    "drizzle-orm": "1.0.0-beta.22",
     "svelte": "^5.56.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^5.5.7",
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "@tailwindcss/vite": "^4.3.3",
     "svelte-check": "^4.7.6",
+    "tailwind-variants": "^3.3.1",
+    "tailwindcss": "^4.3.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.10"
   }

--- a/apps/admin/src/app.css
+++ b/apps/admin/src/app.css
@@ -1,0 +1,31 @@
+@import 'tailwindcss';
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.97 0 0);
+  --border: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+}
+
+@theme inline {
+  --color-ring: var(--ring);
+  --color-border: var(--border);
+  --color-muted: var(--muted);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/admin/src/lib/components/ui/badge/badge.svelte
+++ b/apps/admin/src/lib/components/ui/badge/badge.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { tv } from 'tailwind-variants';
+  import type { Snippet } from 'svelte';
+  import type { VariantProps } from 'tailwind-variants';
+
+  const variants = tv({
+    base: 'inline-flex h-5 w-fit items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        outline: 'border-border text-foreground',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  });
+
+  let {
+    children,
+    variant = 'default',
+  }: {
+    children: Snippet;
+    variant?: VariantProps<typeof variants>['variant'];
+  } = $props();
+</script>
+
+<span class={variants({ variant })}>{@render children()}</span>

--- a/apps/admin/src/lib/components/ui/badge/index.ts
+++ b/apps/admin/src/lib/components/ui/badge/index.ts
@@ -1,0 +1,1 @@
+export { default as Badge } from './badge.svelte';

--- a/apps/admin/src/lib/components/ui/button/button.svelte
+++ b/apps/admin/src/lib/components/ui/button/button.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { tv } from 'tailwind-variants';
+  import { resolve } from '$app/paths';
+  import type { Snippet } from 'svelte';
+  import type { VariantProps } from 'tailwind-variants';
+  import type { PathnameWithSearchOrHash } from '$app/types';
+
+  const variants = tv({
+    base: 'inline-flex items-center justify-center rounded-lg border text-sm font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50',
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+        outline: 'border-border bg-background text-foreground hover:bg-muted',
+      },
+      size: {
+        default: 'h-8 px-2.5',
+        sm: 'h-7 px-2.5 text-[0.8rem]',
+      },
+    },
+    defaultVariants: { variant: 'default', size: 'default' },
+  });
+
+  let {
+    children,
+    href,
+    size = 'default',
+    variant = 'default',
+  }: {
+    children: Snippet;
+    href: PathnameWithSearchOrHash;
+    size?: VariantProps<typeof variants>['size'];
+    variant?: VariantProps<typeof variants>['variant'];
+  } = $props();
+</script>
+
+<a class={variants({ variant, size })} href={resolve(href)}>
+  {@render children()}
+</a>

--- a/apps/admin/src/lib/components/ui/button/index.ts
+++ b/apps/admin/src/lib/components/ui/button/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './button.svelte';

--- a/apps/admin/src/lib/server/accounts.database.test.ts
+++ b/apps/admin/src/lib/server/accounts.database.test.ts
@@ -1,0 +1,82 @@
+import '@kosmo/core/polyfill';
+
+import { Accounts, db, pg } from '@kosmo/core/db';
+import { AccountState } from '@kosmo/core/enums';
+import { inArray } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { load as loadAccount } from '../../routes/accounts/[id]/+page.server';
+import { getAccount, listAccounts } from './accounts';
+
+const fixtureIds = Array.from({ length: 51 }, (_, index) => {
+  return `ffffffff-ffff-7000-8000-${String(index + 1).padStart(12, '0')}`;
+});
+const upperBound = 'ffffffff-ffff-7000-8000-ffffffffffff';
+
+describe('Admin Account read projection', () => {
+  beforeAll(async () => {
+    await db.insert(Accounts).values(
+      fixtureIds.map((id, index) => ({
+        id,
+        displayName: `Account ${index + 1}`,
+        oidcSubject: `subject-${id}`,
+        state: AccountState.ACTIVE,
+      })),
+    );
+  });
+
+  afterAll(async () => {
+    await db.delete(Accounts).where(inArray(Accounts.id, fixtureIds));
+    await pg.end();
+  });
+
+  test('returns an explicit list projection ordered by descending Account ID', async () => {
+    const page = await listAccounts(upperBound);
+
+    expect(page.accounts).toHaveLength(50);
+    expect(page.accounts.map(({ id }) => id)).toEqual(fixtureIds.slice().reverse().slice(0, 50));
+    expect(page.accounts[0]).toEqual({
+      id: fixtureIds[50],
+      displayName: 'Account 51',
+      state: AccountState.ACTIVE,
+      createdAt: expect.any(String),
+    });
+    expect(page.accounts.every((account) => !('oidcSubject' in account))).toBe(true);
+    expect(page.nextCursor).toBe(fixtureIds[1]);
+  });
+
+  test('uses the last list ID as a keyset cursor for the next page', async () => {
+    const page = await listAccounts(upperBound);
+    const nextPage = await listAccounts(page.nextCursor ?? undefined);
+
+    expect(nextPage.accounts.map(({ id }) => id)).toEqual([fixtureIds[0]]);
+    expect(nextPage.previousCursor).toBe(fixtureIds[0]);
+    expect(nextPage.nextCursor).toBeNull();
+
+    const previousPage = await listAccounts(nextPage.previousCursor ?? undefined, 'previous');
+
+    expect(previousPage.accounts.map(({ id }) => id)).toEqual(
+      fixtureIds.slice().reverse().slice(0, 50),
+    );
+    expect(previousPage.previousCursor).toBeNull();
+    expect(previousPage.nextCursor).toBe(fixtureIds[1]);
+  });
+
+  test('returns full OIDC subject only from Account detail and 404s missing IDs', async () => {
+    const account = await getAccount(fixtureIds[0]!);
+
+    expect(account).toEqual({
+      id: fixtureIds[0],
+      displayName: 'Account 1',
+      state: AccountState.ACTIVE,
+      createdAt: expect.any(String),
+      oidcSubject: `subject-${fixtureIds[0]}`,
+    });
+    expect(await getAccount('00000000-0000-7000-8000-000000000000')).toBeUndefined();
+
+    await expect(
+      loadAccount({ params: { id: '00000000-0000-7000-8000-000000000000' } } as Parameters<
+        typeof loadAccount
+      >[0]),
+    ).rejects.toMatchObject({ status: 404, body: { message: 'Not Found' } });
+  });
+});

--- a/apps/admin/src/lib/server/accounts.ts
+++ b/apps/admin/src/lib/server/accounts.ts
@@ -1,0 +1,91 @@
+import { Accounts, db, first } from '@kosmo/core/db';
+import { asc, desc, eq, gt, lt } from 'drizzle-orm';
+import { z } from 'zod';
+
+export const accountIdSchema = z.uuid();
+
+const pageSize = 50;
+
+export const listAccounts = async (cursor?: string, direction: 'next' | 'previous' = 'next') => {
+  const rows = await db
+    .select({
+      id: Accounts.id,
+      displayName: Accounts.displayName,
+      state: Accounts.state,
+      createdAt: Accounts.createdAt,
+    })
+    .from(Accounts)
+    .where(
+      cursor
+        ? direction === 'previous'
+          ? gt(Accounts.id, cursor)
+          : lt(Accounts.id, cursor)
+        : undefined,
+    )
+    .orderBy(direction === 'previous' ? asc(Accounts.id) : desc(Accounts.id))
+    .limit(pageSize + 1);
+  const hasNextPage = rows.length > pageSize;
+  const accounts = (
+    direction === 'previous' ? rows.slice(0, pageSize).reverse() : rows.slice(0, pageSize)
+  ).map(({ createdAt, ...account }) => ({ ...account, createdAt: createdAt.toString() }));
+
+  const firstAccount = accounts.at(0);
+  const lastAccount = accounts.at(-1);
+  const previousPage =
+    direction === 'next' && cursor && firstAccount
+      ? await db
+          .select({ id: Accounts.id })
+          .from(Accounts)
+          .where(gt(Accounts.id, cursor))
+          .orderBy(asc(Accounts.id))
+          .limit(1)
+          .then(first)
+      : undefined;
+  const nextPage =
+    direction === 'previous' && lastAccount
+      ? await db
+          .select({ id: Accounts.id })
+          .from(Accounts)
+          .where(lt(Accounts.id, lastAccount.id))
+          .orderBy(desc(Accounts.id))
+          .limit(1)
+          .then(first)
+      : undefined;
+
+  return {
+    accounts,
+    previousCursor:
+      direction === 'previous'
+        ? hasNextPage
+          ? (firstAccount?.id ?? null)
+          : null
+        : previousPage && firstAccount
+          ? firstAccount.id
+          : null,
+    nextCursor:
+      direction === 'previous'
+        ? nextPage && lastAccount
+          ? lastAccount.id
+          : null
+        : hasNextPage
+          ? (lastAccount?.id ?? null)
+          : null,
+  };
+};
+
+export const getAccount = async (id: string) => {
+  const account = await db
+    .select({
+      id: Accounts.id,
+      displayName: Accounts.displayName,
+      state: Accounts.state,
+      createdAt: Accounts.createdAt,
+      oidcSubject: Accounts.oidcSubject,
+    })
+    .from(Accounts)
+    .where(eq(Accounts.id, id))
+    .limit(1)
+    .then(first);
+
+  return account ? { ...account, createdAt: account.createdAt.toString() } : undefined;
+};

--- a/apps/admin/src/routes/+layout.svelte
+++ b/apps/admin/src/routes/+layout.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import '../app.css';
+
+  import type { Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
+</script>
+
+{@render children()}
+
+<style>
+  :global(:root) {
+    color-scheme: light;
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      sans-serif;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    --color-accent: #4f46e5;
+    --color-accent-strong: #3730a3;
+    --color-border: #dbe1ea;
+    --color-border-muted: #edf0f5;
+    --color-foreground: #172033;
+    --color-foreground-muted: #647087;
+    --color-surface: #ffffff;
+    --color-surface-muted: #f7f8fb;
+    --shadow-card: 0 0.5rem 1.5rem rgb(23 32 51 / 6%);
+  }
+
+  :global(html) {
+    background: var(--color-surface-muted);
+  }
+
+  :global(body) {
+    margin: 0;
+    min-width: 20rem;
+    background: var(--color-surface-muted);
+    color: var(--color-foreground);
+  }
+
+  :global(a) {
+    color: inherit;
+  }
+
+  :global(main.admin-page) {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: 76rem;
+    padding: 3rem 1.5rem 5rem;
+  }
+
+  :global(.admin-header) {
+    align-items: flex-start;
+    display: flex;
+    gap: 1.5rem;
+    justify-content: space-between;
+    margin-bottom: 2rem;
+  }
+
+  :global(.admin-header h1) {
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    letter-spacing: -0.03em;
+    line-height: 1.1;
+    margin: 0.25rem 0 0;
+  }
+
+  :global(.admin-header p) {
+    color: var(--color-foreground-muted);
+    margin: 0.5rem 0 0;
+  }
+
+  :global(.admin-eyebrow) {
+    color: var(--color-accent-strong) !important;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    margin: 0 !important;
+    text-transform: uppercase;
+  }
+
+  :global(.admin-actions) {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  :global(.admin-description) {
+    color: var(--color-foreground-muted);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  :global(.admin-empty) {
+    border: 1px dashed var(--color-border);
+    border-radius: 0.75rem;
+    color: var(--color-foreground-muted);
+    padding: 3rem 1.5rem;
+    text-align: center;
+  }
+
+  :global(.admin-pagination) {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+
+  :global(.account-link) {
+    color: var(--color-accent-strong);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  :global(.account-link:hover) {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  @media (max-width: 36rem) {
+    :global(main.admin-page) {
+      padding: 2rem 1rem 4rem;
+    }
+
+    :global(.admin-header) {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Button } from '$lib/components/ui/button';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -9,10 +10,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 </svelte:head>
 
-<main>
-  <h1>Kosmo Admin Console</h1>
-  <p>{data.viewer.label}</p>
-  {#if data.viewer.login && data.viewer.login !== data.viewer.label}
-    <p>{data.viewer.login}</p>
-  {/if}
+<main class="admin-page">
+  <header class="admin-header">
+    <div>
+      <p class="admin-eyebrow">Admin Console</p>
+      <h1>Kosmo Admin Console</h1>
+      <p class="admin-description">{data.viewer.label}</p>
+      {#if data.viewer.login && data.viewer.login !== data.viewer.label}
+        <p class="admin-description">{data.viewer.login}</p>
+      {/if}
+    </div>
+    <nav aria-label="Admin Console navigation" class="admin-actions">
+      <Button href="/accounts">Accounts</Button>
+    </nav>
+  </header>
 </main>

--- a/apps/admin/src/routes/accounts/+page.server.ts
+++ b/apps/admin/src/routes/accounts/+page.server.ts
@@ -1,0 +1,18 @@
+import { error } from '@sveltejs/kit';
+import { accountIdSchema, listAccounts } from '$lib/server/accounts';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ url }) => {
+  const cursor = url.searchParams.get('cursor');
+  const direction = url.searchParams.get('direction');
+
+  if (
+    (cursor && !accountIdSchema.safeParse(cursor).success) ||
+    (direction && direction !== 'previous') ||
+    (direction === 'previous' && !cursor)
+  ) {
+    error(404, 'Not Found');
+  }
+
+  return listAccounts(cursor ?? undefined, direction === 'previous' ? 'previous' : 'next');
+};

--- a/apps/admin/src/routes/accounts/+page.svelte
+++ b/apps/admin/src/routes/accounts/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+  <title>Accounts · Kosmo Admin Console</title>
+</svelte:head>
+
+<main class="admin-page">
+  <header class="admin-header">
+    <div>
+      <p class="admin-eyebrow">Admin Console</p>
+      <h1>Accounts</h1>
+      <p class="admin-description">Account 목록 · 읽기 전용</p>
+    </div>
+    <nav aria-label="Account actions" class="admin-actions">
+      <Button href="/" variant="outline">Console</Button>
+    </nav>
+  </header>
+
+  {#if data.accounts.length === 0}
+    <p class="admin-empty">Account가 없습니다.</p>
+  {:else}
+    <div class="account-table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">ID</th>
+            <th scope="col">Display name</th>
+            <th scope="col">State</th>
+            <th scope="col">Created at</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each data.accounts as account (account.id)}
+            <tr>
+              <td>
+                <a class="account-link" href={resolve(`/accounts/${account.id}`)}>{account.id}</a>
+              </td>
+              <td>{account.displayName}</td>
+              <td>
+                <Badge variant={account.state === 'ACTIVE' ? 'default' : 'outline'}>
+                  {account.state}
+                </Badge>
+              </td>
+              <td><time datetime={account.createdAt}>{account.createdAt}</time></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+
+    {#if data.previousCursor || data.nextCursor}
+      <nav aria-label="Account pagination" class="admin-pagination">
+        {#if data.previousCursor}
+          <Button
+            href={`/accounts?cursor=${data.previousCursor}&direction=previous`}
+            size="sm"
+            variant="outline">이전 50개</Button
+          >
+        {/if}
+        {#if data.nextCursor}
+          <Button href={`/accounts?cursor=${data.nextCursor}`} size="sm" variant="outline">
+            다음 50개
+          </Button>
+        {/if}
+      </nav>
+    {/if}
+  {/if}
+</main>
+
+<style>
+  .account-table-wrapper {
+    overflow-x: auto;
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    background: var(--color-surface);
+    box-shadow: var(--shadow-card);
+  }
+
+  table {
+    border-collapse: collapse;
+    min-width: 42rem;
+    width: 100%;
+  }
+
+  th,
+  td {
+    border-bottom: 1px solid var(--color-border-muted);
+    padding: 0.875rem 1rem;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  th {
+    color: var(--color-foreground-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  td {
+    color: var(--color-foreground);
+    font-size: 0.875rem;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  tbody tr:hover {
+    background: var(--color-surface-muted);
+  }
+</style>

--- a/apps/admin/src/routes/accounts/[id]/+page.server.ts
+++ b/apps/admin/src/routes/accounts/[id]/+page.server.ts
@@ -1,0 +1,19 @@
+import { error } from '@sveltejs/kit';
+import { accountIdSchema, getAccount } from '$lib/server/accounts';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params }) => {
+  const id = accountIdSchema.safeParse(params.id);
+
+  if (!id.success) {
+    error(404, 'Not Found');
+  }
+
+  const account = await getAccount(id.data);
+
+  if (!account) {
+    error(404, 'Not Found');
+  }
+
+  return { account };
+};

--- a/apps/admin/src/routes/accounts/[id]/+page.svelte
+++ b/apps/admin/src/routes/accounts/[id]/+page.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+  <title>{data.account.displayName} · Account · Kosmo Admin Console</title>
+</svelte:head>
+
+<main class="admin-page">
+  <header class="admin-header">
+    <div>
+      <p class="admin-eyebrow">Account detail</p>
+      <h1>{data.account.displayName}</h1>
+      <p class="admin-description">읽기 전용 Account 상세</p>
+    </div>
+    <nav aria-label="Account actions" class="admin-actions">
+      <Button href="/accounts" variant="outline">Accounts</Button>
+    </nav>
+  </header>
+
+  <dl class="account-detail">
+    <div>
+      <dt>ID</dt>
+      <dd>{data.account.id}</dd>
+    </div>
+    <div>
+      <dt>Display name</dt>
+      <dd>{data.account.displayName}</dd>
+    </div>
+    <div>
+      <dt>State</dt>
+      <dd>
+        <Badge variant={data.account.state === 'ACTIVE' ? 'default' : 'outline'}>
+          {data.account.state}
+        </Badge>
+      </dd>
+    </div>
+    <div>
+      <dt>Created at</dt>
+      <dd><time datetime={data.account.createdAt}>{data.account.createdAt}</time></dd>
+    </div>
+    <div>
+      <dt>OIDC subject</dt>
+      <dd class="account-detail-value">{data.account.oidcSubject}</dd>
+    </div>
+  </dl>
+</main>
+
+<style>
+  .account-detail {
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    background: var(--color-surface);
+    box-shadow: var(--shadow-card);
+    margin: 0;
+  }
+
+  .account-detail > div {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(8rem, 12rem) 1fr;
+    padding: 1rem 1.25rem;
+  }
+
+  .account-detail > div + div {
+    border-top: 1px solid var(--color-border-muted);
+  }
+
+  dt {
+    color: var(--color-foreground-muted);
+    font-size: 0.8125rem;
+    font-weight: 700;
+  }
+
+  dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .account-detail-value {
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+    font-size: 0.875rem;
+  }
+
+  @media (max-width: 36rem) {
+    .account-detail > div {
+      gap: 0.375rem;
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/admin/src/routes/accounts/[id]/account.loader.test.ts
+++ b/apps/admin/src/routes/accounts/[id]/account.loader.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest';
+import { load as loadAccount } from './+page.server';
+
+test('rejects a malformed account ID with a generic 404', async () => {
+  await expect(
+    loadAccount({ params: { id: 'not-a-uuid' } } as Parameters<typeof loadAccount>[0]),
+  ).rejects.toMatchObject({ status: 404, body: { message: 'Not Found' } });
+});

--- a/apps/admin/src/routes/accounts/accounts.loader.test.ts
+++ b/apps/admin/src/routes/accounts/accounts.loader.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+import { load as loadAccounts } from './+page.server';
+
+test.each([
+  'http://admin.test/accounts?cursor=not-a-uuid',
+  'http://admin.test/accounts?direction=previous',
+])('rejects malformed pagination with a generic 404', async (url) => {
+  await expect(
+    loadAccounts({
+      url: new URL(url),
+    } as Parameters<typeof loadAccounts>[0]),
+  ).rejects.toMatchObject({ status: 404, body: { message: 'Not Found' } });
+});

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    "skipLibCheck": true,
     "strict": true
   }
 }

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,6 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [tailwindcss(), sveltekit()],
 });

--- a/docs/architecture/admin-console.md
+++ b/docs/architecture/admin-console.md
@@ -59,11 +59,11 @@ pass-through service를 만들지 않는다. 구현은 [Core 서비스 경계](.
 
 세 projection은 같은 Admin Console Viewer에게 열리지만 응답 책임은 분리한다.
 
-| projection                 | 책임                                        |
-| -------------------------- | ------------------------------------------- |
-| Account                    | Account 목록·상세와 OIDC subject exact 검색 |
-| Profile                    | Profile 목록·상세                           |
-| Account-Profile Membership | 두 객체 사이의 관계와 양방향 탐색           |
+| projection                 | 책임                              |
+| -------------------------- | --------------------------------- |
+| Account                    | Account 목록·상세                 |
+| Profile                    | Profile 목록·상세                 |
+| Account-Profile Membership | 두 객체 사이의 관계와 양방향 탐색 |
 
 Account와 Profile projection은 상대 객체의 존재, Membership, 관계 count를 포함하지 않는다. 관계 정보는 별도
 Membership projection으로만 받는다. selected Profile은 Membership이 아니라 Session 상태이므로 세

--- a/docs/domain/decisions/0025-admin-console-capability-holder-boundary.md
+++ b/docs/domain/decisions/0025-admin-console-capability-holder-boundary.md
@@ -37,7 +37,7 @@ Tailscale proxy는 요청에 identity header를 제공할 수 있지만 header�
 - Admin Console v1은 읽기 전용이다. 이 경계는 기존 Account 인증, Profile Owner/Member 사실,
   `Account.Operator` 기반 운영자 Mutation 권한을 변경하지 않는다.
 - Admin-specific 성공·실패 조회 감사, capability/identity snapshot, malformed·인가 실패·proxy 우회·위조
-  header security event logging, 검색값 및 보존 기간은 v1에서 모두 제외한다. 기존 공통 runtime 오류·접근
+  header security event logging 및 보존 기간은 v1에서 모두 제외한다. 기존 공통 runtime 오류·접근
   로그의 동작은 이 결정의 범위가 아니다.
 
 ## 이유

--- a/docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md
+++ b/docs/domain/decisions/0026-admin-console-tailscale-access-boundary.md
@@ -38,7 +38,7 @@ projection만 허용하는 애플리케이션 capability 계층은 두지 않는
 - Admin Console v1은 읽기 전용이다. 이 경계는 기존 Account 인증, Profile Owner/Member 사실,
   `Account.Operator` 기반 운영자 Mutation 권한을 변경하지 않는다.
 - Admin-specific 성공·실패 조회 감사, identity snapshot, 접근 실패·proxy 우회·위조 header security event
-  logging, 검색값 및 보존 기간은 v1에서 모두 제외한다. 기존 공통 runtime 오류·접근 로그의 동작은 이 결정의
+  logging 및 보존 기간은 v1에서 모두 제외한다. 기존 공통 runtime 오류·접근 로그의 동작은 이 결정의
   범위가 아니다.
 
 ## 이유

--- a/docs/domain/objects/account.md
+++ b/docs/domain/objects/account.md
@@ -23,7 +23,7 @@ Account가 아니라 Profile이다.
 | 표시 이름    | 문자열, 필수     | 신뢰한 OIDC 인증 결과에서 제공된 표시 값을 보존한다                    | 항상      | 대상 Account의 내부 조회 | `Account.Self` 또는 `Account.Operator` |
 | 생성 시각    | 시각, 필수       | 생성 결과로 기록하며 변경 불가                                         | 항상      | 대상 Account의 내부 조회 | `Account.Self` 또는 `Account.Operator` |
 
-Admin Console의 Account 목록·상세와 OIDC subject exact 검색은 일반 Account 조회 권한을 확장하지 않고
+Admin Console의 Account 목록·상세는 일반 Account 조회 권한을 확장하지 않고
 [Admin Console Read Policy](../policies/admin-console-read.md)의 Admin Console Viewer projection으로만 제공한다.
 
 ## 관계
@@ -62,5 +62,3 @@ Account 대상 Operational Notification 읽음 처리는 요청할 수 있다.
 
 - OIDC 인증 수단 자체와 Session credential은 Account 속성이 아니며 [Session](./session.md)과 인증 경계가
   소유한다.
-- Admin Console에서 OIDC subject를 목록이나 부분 검색에 노출하는 것은 제외한다. 전체 subject 상세와 exact
-  검색은 [Admin Console Read Policy](../policies/admin-console-read.md)가 정한 조건을 따른다.

--- a/docs/domain/policies/admin-console-read.md
+++ b/docs/domain/policies/admin-console-read.md
@@ -46,16 +46,14 @@ Kubernetes node 자체와 kubelet을 포함한 node-origin 연결은 이미 node
 
 Admin Console Viewer의 Account 조회 결과는 다음 필드만 사용한다.
 
-### 목록과 기본 검색
+### 목록
 
 - Account ID
 - Account 표시 이름
 - Account State
 - 생성 시각
 
-OIDC subject는 목록 결과에 포함하지 않는다. OIDC subject를 사용한 검색은 전체 값의 exact match만 허용하며,
-부분 문자열·prefix·contains 검색은 제공하지 않는다. exact match 결과도 목록 조회 결과를 사용하고 OIDC
-subject 자체는 상세 조회에서만 반환한다.
+OIDC subject는 목록 결과에 포함하지 않는다.
 
 ### 상세
 
@@ -130,10 +128,10 @@ Membership 결과는 다음을 제공한다.
 
 - credential, Session token, OIDC session key, private key와 같은 값은 마스킹해 반환하지 않고 조회 결과에서
   제외한다.
-- Admin Console v1은 성공 조회, 검색, 상세, 관계 조회를 영속 감사하지 않는다.
+- Admin Console v1은 성공 조회, 상세, 관계 조회를 영속 감사하지 않는다.
 - 접근 거부, trusted proxy 우회 또는 위조 identity header와 같은 Admin-specific security event도 이 정책에서
   기록·보존하지 않는다.
-- identity header, 검색값, 대상·결과와 보존 기간을 별도 계약으로 만들지 않는다.
+- identity header, 대상·결과와 보존 기간을 별도 계약으로 만들지 않는다.
 - 기존 공통 runtime 오류·접근 로그의 생명주기는 이 정책에서 변경하지 않는다.
 
 ## 제외/보류

--- a/openspec/changes/add-admin-account-read-projection/.openspec.yaml
+++ b/openspec/changes/add-admin-account-read-projection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-09-03

--- a/openspec/changes/add-admin-account-read-projection/decisions.md
+++ b/openspec/changes/add-admin-account-read-projection/decisions.md
@@ -1,0 +1,59 @@
+## Context
+
+이 기록은 PROD-691의 Account 목록·상세 계약과 현재 SvelteKit Admin runtime, Account UUIDv7 schema를
+대조해 구현 전에 확정한 선택을 정리한다.
+
+## Decision Records
+
+### Account ID keyset pagination
+
+- Decision Date: 2026-09-03
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/domain/policies/admin-console-read.md`, `docs/architecture/admin-console.md`,
+  `PROD-691`
+- Status: Active
+- Context / Problem: Account 목록은 운영 중 row가 추가되어도 안정적인 순서와 페이지 경계가 필요하다.
+- Decision Outcome: UUIDv7 Account ID를 역순 정렬과 opaque cursor 값으로 함께 사용하고 페이지 크기는 50개로
+  고정한다.
+- Alternatives Considered: offset pagination은 삽입 중 중복·누락 위험이 있고, 생성 시각 cursor는 ID와 별도
+  tie-breaker가 필요해 선택하지 않았다.
+- Consequences: 다음 페이지는 현재 cursor보다 작은 ID를 조회하고 이전 페이지도 ID keyset 경계로 계산한다.
+- Confirmation / Follow-up: DB-backed query test에서 정렬, 50개 경계와 이전·다음 cursor를 확인한다.
+
+### SvelteKit server loader에서 read query 직접 호출
+
+- Decision Date: 2026-09-03
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/architecture/admin-console.md`, `PROD-689`, `PROD-691`
+- Status: Active
+- Context / Problem: Admin 화면만 사용하는 read projection에 별도 transport나 state-changing service 경계가
+  필요한지 정해야 한다.
+- Decision Outcome: 목록·상세 loader가 공용 database handle을 사용하는 read query 계층을 직접 호출한다.
+- Alternatives Considered: 별도 REST, GraphQL 또는 pass-through application service는 현재 단일 server-rendered
+  consumer에 계약과 운영 경계를 추가하므로 선택하지 않았다.
+- Consequences: query 결과가 곧 page data의 서버 입력이며 browser bundle에는 database code가 포함되지 않는다.
+- Confirmation / Follow-up: production build와 loader test에서 server-only import 경계를 확인한다.
+
+### 필요한 shadcn-svelte component source만 소유
+
+- Decision Date: 2026-09-03
+- Decision Class: Implementation Choice
+- Authority / Provenance: `docs/architecture/admin-console.md`, `PROD-691`
+- Status: Active
+- Context / Problem: Account table과 상태 표시에 일관된 기본 UI가 필요하지만 Admin 전용 대형 component layer는
+  필요하지 않다.
+- Decision Outcome: 현재 화면이 사용하는 shadcn-svelte source component만 Admin package에 생성하고 직접
+  조합한다.
+- Alternatives Considered: 모든 component 설치와 공용 UI package는 사용하지 않는 코드와 결합을 늘리고,
+  무스타일 직접 구현은 이후 화면의 기본 상호작용 일관성을 낮춰 선택하지 않았다.
+- Consequences: Admin은 자체 Svelte UI source와 필요한 최소 styling dependency를 소유한다.
+- Confirmation / Follow-up: 생성된 component와 runtime dependency가 실제 화면에서 사용되는지 diff review로
+  확인한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/add-admin-account-read-projection/design.md
+++ b/openspec/changes/add-admin-account-read-projection/design.md
@@ -1,0 +1,66 @@
+## Context
+
+PROD-690은 독립 SvelteKit Admin runtime과 Tailscale Viewer 경계를 제공한다. PROD-691은 기존 Account
+테이블을 읽어 첫 운영 화면을 제공해야 하며, canonical read policy의 목록·상세 필드 분리를 그대로 유지해야
+한다. Account ID는 UUIDv7이라 정렬과 cursor 양쪽에 사용할 수 있다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Account 목록과 상세를 server-rendered Admin 화면으로 제공한다.
+- 조회 결과를 허용된 필드로 명시적으로 projection한다.
+- 50개 단위 ID keyset pagination과 일반 404·오류 경계를 제공한다.
+- 현재 Admin Viewer metadata와 no-store/CSP 경계를 유지한다.
+
+**Non-Goals:**
+
+- Account mutation
+- Profile·Membership·Session 조회
+- REST·GraphQL API
+- Admin-specific logging 또는 audit
+
+## Implementation Guidance
+
+### Current Constraints
+
+- Admin은 `apps/admin`의 SvelteKit server runtime이며 request Viewer는 hooks에서 `locals`로 전달된다.
+- 공용 database handle과 Account schema는 `@kosmo/core/db`가 소유한다.
+- 목록이 Account row 전체를 읽으면 OIDC subject가 목록 경계로 유입되므로 explicit select가 필요하다.
+- offset pagination은 데이터 추가 중 페이지 중복·누락을 만들 수 있다.
+
+### Recommended Approach
+
+`$lib/server`의 작은 read query 모듈에서 Drizzle로 필요한 column만 select한다. 목록은 `id desc`와
+`id < cursor` 조건으로 51개를 읽어 50개와 다음 cursor를 구분하고, 상세는 UUID ID exact lookup을 한다.
+각 route의 server loader가 query를 직접 호출해 page data를 반환한다. 화면은 Svelte component와 필요한 최소
+shadcn-svelte source component만 사용한다.
+
+### Allowed Alternatives
+
+동일한 projection, 정렬, cursor와 loader 경계를 지키는 한 query 조립 위치와 UI component 구성은 달라질 수
+있다.
+
+### Known Traps
+
+- Account table 전체 row를 목록 loader에 전달하지 않는다.
+- cursor를 생성 시각으로 다시 변환하거나 offset과 섞지 않는다.
+- Viewer identity를 Account filter 또는 권한 판단에 사용하지 않는다.
+
+## Risks / Trade-offs
+
+- [UUIDv7 ID 순서가 Account 생성 순서를 대표한다] → 현재 schema의 UUIDv7 생성 계약을 사용하고 ID를 그대로
+  cursor로 반환한다.
+- [51번째 row lookahead가 한 건 더 읽는다] → 고정 page size에서 다음 페이지 존재 여부를 정확히 판단하는
+  단순한 비용으로 수용한다.
+- [DB 오류가 framework 오류 화면으로 전파될 수 있다] → production 오류 화면이 내부 메시지를 노출하지 않는
+  기존 SvelteKit 경계를 유지한다.
+
+## Migration Plan
+
+schema migration 없이 Admin image를 교체한다. rollback은 이전 Admin image로 되돌리며 database 상태는 변경되지
+않는다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/add-admin-account-read-projection/proposal.md
+++ b/openspec/changes/add-admin-account-read-projection/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Admin Console 기반은 배포됐지만 운영자가 Account를 확인할 수 있는 읽기 화면이 없다. PROD-691은 기존
+Tailscale Viewer 경계 안에서 Account 목록과 상세를 제공해 첫 번째 실제 운영 조회 흐름을 완성한다.
+
+## What Changes
+
+- Account ID 역순 keyset pagination으로 한 페이지에 최대 50개의 Account 목록을 제공한다.
+- Account 목록에는 ID, 표시 이름, State, 생성 시각만 반환한다.
+- Account ID로 상세를 조회하고 목록 필드와 전체 OIDC subject를 반환한다.
+- 목록과 상세를 SvelteKit server loader에서 read query 계층으로 직접 조회한다.
+- Account를 찾을 수 없거나 잘못된 ID가 전달되면 일반 404를 반환하고 내부 조회 오류는 노출하지 않는다.
+- Admin shell에서 Account 목록으로 이동할 수 있는 링크를 제공한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/policies/admin-console-read.md`, `docs/architecture/admin-console.md`
+- Linear Contract: `PROD-689`
+- Linear Implementations: `PROD-691`
+
+## Capabilities
+
+### New Capabilities
+
+- `admin-account-read-projection`: Admin Console Viewer를 위한 분리된 Account 목록·상세 projection과 조회 실패
+  경계를 정의한다.
+
+### Modified Capabilities
+
+없음.
+
+## Impact
+
+- `apps/admin`: Account read query, 목록·상세 server loader와 Svelte UI
+- `packages/core/db`: 기존 Account schema와 공용 database handle 사용
+- workspace dependency/lockfile: Admin에서 `@kosmo/core`와 최소 UI 스타일 도구 사용
+- canonical Admin Console 문서와 CI: Account projection 계약 및 DB-backed Admin 검증

--- a/openspec/changes/add-admin-account-read-projection/specs/admin-account-read-projection/spec.md
+++ b/openspec/changes/add-admin-account-read-projection/specs/admin-account-read-projection/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: 분리된 Account 목록 projection
+
+**Authority / Provenance:** `docs/domain/policies/admin-console-read.md`, `docs/architecture/admin-console.md`, `PROD-689`, `PROD-691`. Admin Console은 같은 Viewer admission을 사용하는 Account 목록을 MUST 제공한다. 목록은 Account ID, 표시 이름, State, 생성 시각만 MUST 반환하며, Account ID 역순 keyset으로 페이지당 최대 50개를 MUST 반환한다.
+
+#### Scenario: 첫 Account 페이지 조회
+
+- **WHEN** Admin Console Viewer가 cursor 없이 Account 목록을 요청한다
+- **THEN** Account ID 역순으로 최대 50개의 허용 필드와 다음 페이지 cursor를 반환한다
+
+#### Scenario: 다음 Account 페이지 조회
+
+- **WHEN** Admin Console Viewer가 이전 결과의 cursor로 Account 목록을 요청한다
+- **THEN** cursor보다 작은 Account ID의 다음 결과를 중복 없이 반환한다
+
+#### Scenario: 이전 Account 페이지 조회
+
+- **WHEN** Admin Console Viewer가 첫 페이지 이후의 Account 목록을 보고 있다
+- **THEN** Account ID keyset 경계를 유지하면서 이전 페이지로 이동할 수 있다
+
+### Requirement: Account ID 상세 projection
+
+**Authority / Provenance:** `docs/domain/policies/admin-console-read.md`, `docs/architecture/admin-console.md`, `PROD-689`, `PROD-691`. Admin Console은 Account ID로 단일 Account 상세를 MUST 조회한다. 상세는 목록 필드와 전체 OIDC subject만 반환하고 Profile, Membership, Session 또는 credential 정보를 MUST NOT 합친다.
+
+#### Scenario: Account 상세 조회
+
+- **WHEN** Admin Console Viewer가 존재하는 Account ID의 상세를 요청한다
+- **THEN** 해당 Account의 허용된 상세 필드와 전체 OIDC subject를 반환한다
+
+#### Scenario: 존재하지 않는 Account
+
+- **WHEN** Admin Console Viewer가 존재하지 않거나 유효하지 않은 Account ID의 상세를 요청한다
+- **THEN** 일반 404를 반환하고 내부 조회 정보를 노출하지 않는다
+
+### Requirement: Server-side read query 경계
+
+**Authority / Provenance:** `docs/domain/policies/admin-console-read.md`, `docs/architecture/admin-console.md`, `PROD-689`, `PROD-691`. Account projection은 SvelteKit server loader에서 read query 계층을 MUST 호출하며, 별도 REST 또는 GraphQL endpoint나 state-changing application action을 MUST NOT 만든다.
+
+#### Scenario: Account 화면 요청
+
+- **WHEN** Admin Console Viewer가 Account 목록 또는 상세 화면을 요청한다
+- **THEN** server loader가 Account projection을 조회해 page data로 전달한다
+
+#### Scenario: 지원하지 않는 mutation 요청
+
+- **WHEN** caller가 Account 화면 경계에 mutation method를 요청한다
+- **THEN** Account 상태를 변경하지 않고 method를 거부한다

--- a/openspec/changes/add-admin-account-read-projection/tasks.md
+++ b/openspec/changes/add-admin-account-read-projection/tasks.md
@@ -73,5 +73,5 @@ Account read projection이 기존 Admin runtime과 repository 검증 경계에�
 - PR head의 GitHub CI 결과를 확인한다.
 
 - [x] 3.1 canonical 문서와 dependency·build 구성을 구현과 일치시킨다.
-- [ ] 3.2 로컬 repository 검증을 통과시킨다.
-- [ ] 3.3 GitHub Stack PR을 게시하고 새 head의 CI를 통과시킨다.
+- [x] 3.2 로컬 repository 검증을 통과시킨다.
+- [x] 3.3 GitHub Stack PR을 게시하고 새 head의 CI를 통과시킨다.

--- a/openspec/changes/add-admin-account-read-projection/tasks.md
+++ b/openspec/changes/add-admin-account-read-projection/tasks.md
@@ -1,0 +1,77 @@
+## 1. PROD-691 Account read projection
+
+**Authority / Provenance**
+
+- `docs/domain/policies/admin-console-read.md`
+- `docs/architecture/admin-console.md`
+- `PROD-691`
+
+**Deliverable**
+
+Admin Console Viewer가 허용 필드만 포함한 Account 목록과 Account ID 상세를 읽을 수 있다.
+
+**Guardrails**
+
+- 목록은 Account ID 역순 keyset으로 최대 50개를 반환하고 이전·다음 페이지를 제공한다.
+- 상세만 전체 OIDC subject를 반환한다.
+- Account 상태를 변경하지 않는다.
+
+**Verification**
+
+- DB-backed test에서 projection 필드, 정렬, 페이지 경계, 상세와 not-found를 검증한다.
+
+- [x] 1.1 Account 목록과 상세 read query를 구현한다.
+- [x] 1.2 목록 pagination과 상세 실패 경계의 DB-backed test를 추가한다.
+
+## 2. PROD-691 Account Admin 화면
+
+**Authority / Provenance**
+
+- `docs/domain/policies/admin-console-read.md`
+- `docs/architecture/admin-console.md`
+- `PROD-691`
+
+**Deliverable**
+
+Admin shell에서 Account 목록으로 이동하고 목록 row에서 Account 상세를 확인할 수 있다.
+
+**Guardrails**
+
+- 기존 Tailscale Viewer admission과 no-store/CSP 응답 경계를 유지한다.
+- 별도 REST·GraphQL transport를 추가하지 않는다.
+
+**Verification**
+
+- loader와 UI test에서 정상 목록·상세, cursor validation, 404와 read-only method 경계를 확인한다.
+- Svelte typecheck와 production build를 통과시킨다.
+
+- [x] 2.1 Account 목록·상세 server loader와 route를 구현한다.
+- [x] 2.2 현재 화면에 필요한 최소 shadcn-svelte component로 목록·상세 UI를 구성한다.
+- [x] 2.3 root shell에 Account 목록 navigation을 추가한다.
+- [x] 2.4 loader·UI 검증과 Admin package check·build를 통과시킨다.
+
+## 3. PROD-691 전달과 통합 검증
+
+**Authority / Provenance**
+
+- `docs/domain/policies/admin-console-read.md`
+- `docs/architecture/admin-console.md`
+- `PROD-691`
+
+**Deliverable**
+
+Account read projection이 기존 Admin runtime과 repository 검증 경계에서 배포 가능한 상태다.
+
+**Guardrails**
+
+- schema migration과 Admin-specific logging을 추가하지 않는다.
+- canonical 문서와 구현의 projection 책임을 일치시킨다.
+
+**Verification**
+
+- OpenSpec strict validation, repository lint·format·dependency 검사와 Admin image 검증을 통과시킨다.
+- PR head의 GitHub CI 결과를 확인한다.
+
+- [x] 3.1 canonical 문서와 dependency·build 구성을 구현과 일치시킨다.
+- [ ] 3.2 로컬 repository 검증을 통과시킨다.
+- [ ] 3.3 GitHub Stack PR을 게시하고 새 head의 CI를 통과시킨다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,15 @@ importers:
 
   apps/admin:
     dependencies:
+      '@kosmo/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@sveltejs/kit':
         specifier: ^2.70.3
         version: 2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      drizzle-orm:
+        specifier: 1.0.0-beta.22
+        version: 1.0.0-beta.22(@opentelemetry/api@1.9.1)(postgres@3.4.9)(zod@4.4.3)
       svelte:
         specifier: ^5.56.4
         version: 5.56.4(@typescript-eslint/types@8.62.1)
@@ -112,9 +118,18 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.3.0
         version: 7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       svelte-check:
         specifier: ^4.7.6
         version: 4.7.6(picomatch@4.0.4)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)
+      tailwind-variants:
+        specifier: ^3.3.1
+        version: 3.3.1(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -3266,6 +3281,100 @@ packages:
 
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@temporalio/activity@1.22.0':
     resolution: {integrity: sha512-hrPeELIMloFWVrwmDfG1lh3uFNkaYp1ZHpcpWmJniTeSyxqCqLdil4lBOv11FByb6HeKxE6rsvOOUohulyVhRg==}
@@ -7105,6 +7214,24 @@ packages:
     resolution: {integrity: sha512-TCqOY6Z7TH5yHV3saI6sHb5XRsZ8m2DaI4FQMonKT7UoCKL2WBiI54PLEFDSv1F2sL1BZA5e1opprf190ohirg==}
     engines: {node: '>=14.17.0'}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwind-variants@3.3.1:
+    resolution: {integrity: sha512-4pAvwUtM4HKBiRZftncAbpn6V9Hhwoa5Fl7O2u5zbp7Z5Cvu+/o/6+176WY3WCEES209543quG8zFIcXCsc5Jw==}
+    engines: {node: '>=16.9.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
+      tailwindcss:
+        optional: true
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -10548,6 +10675,74 @@ snapshots:
   '@swc/types@0.1.28':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@temporalio/activity@1.22.0':
     dependencies:
@@ -14888,6 +15083,16 @@ snapshots:
       syncpack-linux-x64-musl: 14.3.1
       syncpack-windows-arm64: 14.3.1
       syncpack-windows-x64: 14.3.1
+
+  tailwind-merge@3.6.0:
+    optional: true
+
+  tailwind-variants@3.3.1(tailwind-merge@3.6.0)(tailwindcss@4.3.3):
+    optionalDependencies:
+      tailwind-merge: 3.6.0
+      tailwindcss: 4.3.3
+
+  tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `/accounts`에 Account ID 역순 목록과 UUID keyset 기반 이전·다음 페이지를 추가했습니다.
- `/accounts/[id]`에서 Account 기본 필드와 전체 OIDC subject를 읽는 상세 화면을 추가했습니다.
- 목록 projection에서는 OIDC subject를 선택하지 않고, 잘못된 cursor·ID와 없는 Account는 일반 404로 처리합니다.
- root shell에서 Accounts로 이동할 수 있게 하고 현재 화면에 필요한 Button·Badge만 shadcn-svelte 스타일로 구성했습니다.
- canonical 문서와 `add-admin-account-read-projection` OpenSpec을 현재 목록·상세 계약에 맞췄습니다.

## 왜 변경했는지

운영자가 Admin Console에서 Account를 식별하고 상세 정보를 확인할 수 있는 첫 read projection이 필요합니다. 별도 API 계층이나 변경 기능을 만들지 않고 기존 SvelteKit runtime 안에서 읽기 흐름만 제공합니다.

## 이번 PR의 주요 결정

### SvelteKit server loader에서 read query를 직접 호출

- 결정자: 작성자
- 선택: Admin server loader가 `@kosmo/core/db` 기반 read query를 직접 호출합니다.
- 고려한 대안: 별도 REST 또는 GraphQL endpoint 추가
- 이유: 현재 Admin 전용 read projection에 별도 transport 계약이 필요하지 않습니다.
- 감수한 결과: 이 projection은 Admin SvelteKit runtime에 종속됩니다.
- 관련 근거: `openspec/changes/add-admin-account-read-projection/decisions.md`

### Account ID keyset으로 이전·다음 페이지 제공

- 결정자: 작성자
- 선택: Account UUID ID 역순, 페이지당 50개, 이전·다음 cursor를 사용합니다.
- 고려한 대안: offset pagination
- 이유: 정렬 기준과 cursor를 하나의 안정적인 Account ID 경계로 유지할 수 있습니다.
- 감수한 결과: 임의 페이지 번호 이동은 제공하지 않습니다.
- 관련 근거: `openspec/changes/add-admin-account-read-projection/decisions.md`

### 필요한 shadcn-svelte 스타일 소스만 유지

- 결정자: 작성자
- 선택: 현재 링크와 상태 표시에 필요한 Button·Badge variant만 저장소 소스로 유지합니다.
- 고려한 대안: 전체 generated component API 유지
- 이유: 현재 화면에서 쓰지 않는 mutation button, variant, utility 표면을 만들지 않기 위해서입니다.
- 감수한 결과: 새 UI 동작이 생기면 해당 시점에 component API를 확장해야 합니다.
- 관련 근거: `openspec/changes/add-admin-account-read-projection/decisions.md`

## 어떻게 확인할 수 있는지

- `CI=true pnpm lint:eslint`
- `pnpm lint:prettier`
- `CI=true pnpm lint:syncpack`
- `CI=true pnpm --filter @kosmo/admin check`
- `CI=true pnpm --filter @kosmo/admin exec vitest run --exclude '**/*.database.test.ts'`
- `CI=true pnpm --filter @kosmo/admin build`
- `pnpm exec openspec validate add-admin-account-read-projection --strict`
- pnpm 11.22 `install --frozen-lockfile --ignore-scripts`

로컬 호스트에는 Docker CLI가 없어 DB-backed test와 Admin image boot를 직접 실행하지 못했습니다. PR의 `Test (Admin)`·`Test (Admin Image)`를 포함한 전체 CI에서 새 head 기준으로 확인했습니다.

## 아직 어떤 문제가 남았는지

없음.

Stack: `main -> PROD-691`
