### PR TITLE
Android Play 배포가 AAB 검증에서 중단되지 않게 한다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -48,6 +48,18 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      - name: Install bundletool
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundletool_path="${RUNNER_TEMP}/bundletool-all-1.18.3.jar"
+          curl --fail --silent --show-error --location \
+            --output "${bundletool_path}" \
+            "https://github.com/google/bundletool/releases/download/1.18.3/bundletool-all-1.18.3.jar"
+          echo "a099cfa1543f55593bc2ed16a70a7c67fe54b1747bb7301f37fdfd6d91028e29  ${bundletool_path}" \
+            | sha256sum --check --strict
+          echo "ANDROID_BUNDLETOOL_JAR=${bundletool_path}" >> "${GITHUB_ENV}"
+
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
@@ -64,11 +76,8 @@ jobs:
             "cmake;3.22.1"
 
           export PATH="${sdk_root}/cmdline-tools/latest/bin:${sdk_root}/build-tools/36.0.0:${PATH}"
-          apkanalyzer_path="$(command -v apkanalyzer)"
-          test -x "${apkanalyzer_path}"
           test -x "${sdk_root}/build-tools/36.0.0/aapt2"
           {
-            echo "ANDROID_APKANALYZER=${apkanalyzer_path}"
             echo "ANDROID_SDK_ROOT=${sdk_root}"
           } >> "${GITHUB_ENV}"
 
@@ -231,12 +240,18 @@ jobs:
 
           aab_path="${KOSMO_ANDROID_AAB_PATH}"
           test -s "${aab_path}"
-          test -x "${ANDROID_APKANALYZER}"
           unzip -Z1 "${aab_path}" | grep -Fxq 'base/manifest/AndroidManifest.xml'
 
-          package_name="$("${ANDROID_APKANALYZER}" manifest application-id "${aab_path}" | tr -d '\r\n')"
-          version_code="$("${ANDROID_APKANALYZER}" manifest version-code "${aab_path}" | tr -d '\r\n')"
-          version_name="$("${ANDROID_APKANALYZER}" manifest version-name "${aab_path}" | tr -d '\r\n')"
+          read_manifest_value() {
+            java -jar "${ANDROID_BUNDLETOOL_JAR}" dump manifest \
+              --bundle="${aab_path}" \
+              --module=base \
+              --xpath="$1" \
+              | tr -d '\r\n'
+          }
+          package_name="$(read_manifest_value '/manifest/@package')"
+          version_code="$(read_manifest_value '/manifest/@android:versionCode')"
+          version_name="$(read_manifest_value '/manifest/@android:versionName')"
           [[ "${package_name}" == 'moe.kos' ]] || { echo "::error::AAB package is ${package_name}."; exit 1; }
           [[ "${version_code}" == "${KOSMO_ANDROID_VERSION_CODE}" ]] || { echo "::error::AAB versionCode is ${version_code}."; exit 1; }
           [[ -n "${version_name}" ]] || { echo "::error::AAB versionName is empty."; exit 1; }


### PR DESCRIPTION
## 무엇을 변경했는지

- APK 전용 `apkanalyzer` 메타데이터 조회를 checksum-pinned 공식 `bundletool-all-1.18.3.jar`의 `dump manifest` 조회로 교체했습니다.
- bundletool을 runner 임시 디렉터리에 다운로드하고 SHA-256 digest를 검증합니다.
- 이제 dead `ANDROID_APKANALYZER` 환경 변수·설정·검증 plumbing은 제거하고, 기존 signing·package/version·certificate·hash·size 검증은 유지합니다.

## 왜 변경했는지

- run `33704968331`에서 signed AAB 빌드는 성공했지만, APK 전용 `apkanalyzer`가 AAB 내부의 `/AndroidManifest.xml`을 찾다가 `NoSuchFileException`으로 upload 전에 중단됐습니다.
- AAB의 base module manifest를 직접 읽는 공식 bundletool 경로로 바꿔 실제 AAB 형식에 맞는 검증을 수행합니다.

## 이번 PR의 주요 결정

- 새 제품 결정은 없습니다. 기존 AAB artifact validation 계약에 Android 공식 도구를 적용했습니다.
- 두 번째 build, 별도 artifact upload, device logic, Play bootstrap workaround는 추가하지 않았습니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/android-play-internal-distribution.yml`
- `./node_modules/.bin/prettier --check .github/workflows/android-play-internal-distribution.yml`
- `ruby -c apps/app/fastlane/Fastfile`
- `git diff --check`
- 공식 bundletool 1.18.3 asset SHA-256 digest 확인
- synthetic AAB에서 `moe.kos`, versionCode `123`, versionName `1.2.3` 추출 확인

## 아직 어떤 문제가 남았는지

- workflow는 `main`에서만 실행하므로 merge 후 실제 GitHub-hosted run을 재실행해야 합니다.
- Play Console의 최초 signed AAB 수동 업로드와 Play App Signing bootstrap은 아직 남아 있습니다.
- 실제 GCP WIF 인증과 Play upload 성공은 이 PR에서 검증하지 않았습니다.

Stack: main -> PROD-285-aab-verification

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>