### PR TITLE
Android Play 배포의 빌드와 업로드를 Fastlane에 맡긴다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -19,7 +19,6 @@ jobs:
     timeout-minutes: 60
     environment: prod
     env:
-      ANDROID_RELEASE_CERTIFICATE_SHA256: ${{ vars.ANDROID_RELEASE_CERTIFICATE_SHA256 }}
       ANDROID_RELEASE_KEY_ALIAS: ${{ vars.ANDROID_RELEASE_KEY_ALIAS }}
       EXPO_NO_GIT_STATUS: '1'
       GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
@@ -48,18 +47,6 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - name: Install bundletool
-        shell: bash
-        run: |
-          set -euo pipefail
-          bundletool_path="${RUNNER_TEMP}/bundletool-all-1.18.3.jar"
-          curl --fail --silent --show-error --location \
-            --output "${bundletool_path}" \
-            "https://github.com/google/bundletool/releases/download/1.18.3/bundletool-all-1.18.3.jar"
-          echo "a099cfa1543f55593bc2ed16a70a7c67fe54b1747bb7301f37fdfd6d91028e29  ${bundletool_path}" \
-            | sha256sum --check --strict
-          echo "ANDROID_BUNDLETOOL_JAR=${bundletool_path}" >> "${GITHUB_ENV}"
-
       - name: Set up Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
@@ -68,18 +55,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:?Android SDK root is required}}"
           sdkmanager --install \
             "platforms;android-36" \
             "build-tools;36.0.0" \
             "ndk;27.1.12297006" \
             "cmake;3.22.1"
-
-          export PATH="${sdk_root}/cmdline-tools/latest/bin:${sdk_root}/build-tools/36.0.0:${PATH}"
-          test -x "${sdk_root}/build-tools/36.0.0/aapt2"
-          {
-            echo "ANDROID_SDK_ROOT=${sdk_root}"
-          } >> "${GITHUB_ENV}"
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
@@ -110,7 +90,6 @@ jobs:
           set -euo pipefail
 
           for name in \
-            ANDROID_RELEASE_CERTIFICATE_SHA256 \
             ANDROID_RELEASE_KEY_ALIAS \
             GCP_SERVICE_ACCOUNT \
             GCP_WORKLOAD_IDENTITY_PROVIDER; do
@@ -122,12 +101,6 @@ jobs:
 
           if [[ "${ANDROID_RELEASE_KEY_ALIAS}" == *$'\n'* || "${ANDROID_RELEASE_KEY_ALIAS}" == *$'\r'* ]]; then
             echo "::error::ANDROID_RELEASE_KEY_ALIAS must not contain line breaks."
-            exit 1
-          fi
-
-          certificate="${ANDROID_RELEASE_CERTIFICATE_SHA256//:/}"
-          if [[ ! "${certificate}" =~ ^[0-9A-Fa-f]{64}$ ]]; then
-            echo "::error::ANDROID_RELEASE_CERTIFICATE_SHA256 must be a SHA-256 fingerprint."
             exit 1
           fi
 
@@ -228,57 +201,6 @@ jobs:
           pnpm relay
           pnpm exec expo prebuild --clean --platform android --no-install
 
-      - name: Build signed Release AAB
-        working-directory: apps/app/android
-        run: ./gradlew :app:bundleRelease --no-daemon
-
-      - name: Verify Release AAB
-        id: verify
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          aab_path="${KOSMO_ANDROID_AAB_PATH}"
-          test -s "${aab_path}"
-          unzip -Z1 "${aab_path}" | grep -Fxq 'base/manifest/AndroidManifest.xml'
-
-          read_manifest_value() {
-            java -jar "${ANDROID_BUNDLETOOL_JAR}" dump manifest \
-              --bundle="${aab_path}" \
-              --module=base \
-              --xpath="$1" \
-              | tr -d '\r\n'
-          }
-          package_name="$(read_manifest_value '/manifest/@package')"
-          version_code="$(read_manifest_value '/manifest/@android:versionCode')"
-          version_name="$(read_manifest_value '/manifest/@android:versionName')"
-          [[ "${package_name}" == 'moe.kos' ]] || { echo "::error::AAB package is ${package_name}."; exit 1; }
-          [[ "${version_code}" == "${KOSMO_ANDROID_VERSION_CODE}" ]] || { echo "::error::AAB versionCode is ${version_code}."; exit 1; }
-          [[ -n "${version_name}" ]] || { echo "::error::AAB versionName is empty."; exit 1; }
-
-          jarsigner_output="$(LC_ALL=C jarsigner -verify "${aab_path}" 2>&1)"
-          if ! grep -Fq 'jar verified.' <<< "${jarsigner_output}"; then
-            echo "::error::AAB signature verification did not report a verified JAR."
-            printf '%s\n' "${jarsigner_output}"
-            exit 1
-          fi
-          actual_certificate="$(LC_ALL=C keytool -printcert -jarfile "${aab_path}" | sed -n 's/^[[:space:]]*SHA256:[[:space:]]*//p' | head -n 1 | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]')"
-          expected_certificate="${ANDROID_RELEASE_CERTIFICATE_SHA256//:/}"
-          expected_certificate="${expected_certificate^^}"
-          [[ "${actual_certificate}" =~ ^[0-9A-F]{64}$ ]] || { echo "::error::AAB signing certificate was not found."; exit 1; }
-          [[ "${actual_certificate}" == "${expected_certificate}" ]] || { echo "::error::AAB signing certificate fingerprint mismatch."; exit 1; }
-
-          artifact_sha256="$(shasum -a 256 "${aab_path}" | awk '{print $1}')"
-          artifact_size_bytes="$(wc -c < "${aab_path}" | tr -d '[:space:]')"
-          {
-            echo "package_name=${package_name}"
-            echo "version_code=${version_code}"
-            echo "version_name=${version_name}"
-            echo "certificate_sha256=${actual_certificate}"
-            echo "artifact_sha256=${artifact_sha256}"
-            echo "artifact_size_bytes=${artifact_size_bytes}"
-          } >> "${GITHUB_OUTPUT}"
-
       - name: Authenticate to Google Cloud for Play upload
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -288,30 +210,27 @@ jobs:
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Upload AAB to Play internal testing
+      - name: Build and upload signed Release AAB with Fastlane
         working-directory: apps/app
-        run: bundle exec fastlane android upload_internal
+        run: bundle exec fastlane android distribute_internal
 
       - name: Write Actions summary
         if: success()
-        env:
-          ARTIFACT_SHA256: ${{ steps.verify.outputs.artifact_sha256 }}
-          ARTIFACT_SIZE_BYTES: ${{ steps.verify.outputs.artifact_size_bytes }}
-          CERTIFICATE_SHA256: ${{ steps.verify.outputs.certificate_sha256 }}
-          PACKAGE_NAME: ${{ steps.verify.outputs.package_name }}
-          VERSION_CODE: ${{ steps.verify.outputs.version_code }}
-          VERSION_NAME: ${{ steps.verify.outputs.version_name }}
         shell: bash
         run: |
           set -euo pipefail
+          aab_path="${KOSMO_ANDROID_AAB_PATH}"
+          test -s "${aab_path}"
+          artifact_sha256="$(shasum -a 256 "${aab_path}")"
+          artifact_sha256="${artifact_sha256%% *}"
+          artifact_size_bytes="$(wc -c < "${aab_path}" | tr -d '[:space:]')"
           {
             echo '## Android Google Play internal testing'
             echo
-            echo "- Package: \`${PACKAGE_NAME}\`"
-            echo "- Version: \`${VERSION_NAME} (${VERSION_CODE})\`"
-            echo "- Upload certificate SHA-256: \`${CERTIFICATE_SHA256}\`"
-            echo "- AAB SHA-256: \`${ARTIFACT_SHA256}\`"
-            echo "- AAB size: \`${ARTIFACT_SIZE_BYTES} bytes\`"
+            echo '- Package: moe.kos'
+            echo "- Version code: \`${KOSMO_ANDROID_VERSION_CODE}\`"
+            echo "- AAB SHA-256: \`${artifact_sha256}\`"
+            echo "- AAB size: \`${artifact_size_bytes} bytes\`"
             echo "- Source: \`${GITHUB_SHA}\`"
             echo "- Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -23,7 +23,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 
 ## Android Google Play internal testing
 
-`Android Google Play Internal Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, upload key로 서명한 Release AAB 하나를 빌드·검증한 뒤 Google Play internal track에 업로드한다. versionCode는 workflow 시작 시 UTC Unix seconds에서 `2020-01-01`을 뺀 값으로 계산하며, 첫 수동 release의 versionCode `1`보다 크고 Android signed 32-bit 범위 안에 있다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다.
+`Android Google Play Internal Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, Fastlane이 upload key로 서명한 Release AAB를 빌드해 Google Play internal track에 업로드한다. Play가 package name, versionCode, upload certificate를 검증한다. versionCode는 workflow 시작 시 UTC Unix seconds에서 `2020-01-01`을 뺀 값으로 계산하며, 첫 수동 release의 versionCode `1`보다 크고 Android signed 32-bit 범위 안에 있다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다.
 
 첫 배포 전에는 Play Console에서 다음 절차를 수동으로 완료해야 한다. CI가 Play Console의 최초 app/signing bootstrap을 대신하지 않는다.
 
@@ -33,12 +33,11 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 4. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.
 5. 기존 승인형 `prod` GitHub Environment에 다음 non-secret variable만 넣는다. 새 Environment는 만들지 않는다.
 
-| 이름                                 | 종류     | 값                                                              |
-| ------------------------------------ | -------- | --------------------------------------------------------------- |
-| `GCP_SERVICE_ACCOUNT`                | variable | `terraform output -raw android_play_service_account`            |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER`     | variable | `terraform output -raw android_play_workload_identity_provider` |
-| `ANDROID_RELEASE_KEY_ALIAS`          | variable | upload key 생성 시 사용한 alias                                 |
-| `ANDROID_RELEASE_CERTIFICATE_SHA256` | variable | upload certificate의 SHA-256 fingerprint                        |
+| 이름                             | 종류     | 값                                                              |
+| -------------------------------- | -------- | --------------------------------------------------------------- |
+| `GCP_SERVICE_ACCOUNT`            | variable | `terraform output -raw android_play_service_account`            |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | variable | `terraform output -raw android_play_workload_identity_provider` |
+| `ANDROID_RELEASE_KEY_ALIAS`      | variable | upload key 생성 시 사용한 alias                                 |
 
 6. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. 운영자가 Vault CLI/UI에서 사용하는 KV v2 logical path는 `secret/kosmo/prod/android-play`다. Workflow와 Vault ACL policy에서 사용하는 KV v2 API path는 `secret/data/kosmo/prod/android-play`이며, `/data/`는 CLI/UI logical path에 포함하지 않는다. 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 API path를 읽도록 한다.
 
@@ -65,7 +64,7 @@ keytool -list -v -keystore kosmo-android-upload.jks
 base64 < kosmo-android-upload.jks | tr -d '\n'
 ```
 
-base64 결과와 password는 shell history, 저장소, GitHub 로그에 남기지 말고 위 Vault field에만 기록한다. `ANDROID_RELEASE_CERTIFICATE_SHA256`은 Play Console에 등록한 upload certificate와 일치해야 한다. upload key를 바꿀 때는 Vault field만 교체하지 말고 Play Console의 upload key reset 절차를 먼저 완료한다. 실제 Play Store 설치·업데이트·실기기 launch와 native login/GraphQL 검증은 PROD-287의 책임이며, 이 workflow는 API/OIDC 환경값이나 ADB/device smoke를 요구하지 않는다.
+base64 결과와 password는 shell history, 저장소, GitHub 로그에 남기지 말고 위 Vault field에만 기록한다. upload key를 바꿀 때는 Vault field만 교체하지 말고 Play Console의 upload key reset 절차를 먼저 완료한다. 실제 Play Store 설치·업데이트·실기기 launch와 native login/GraphQL 검증은 PROD-287의 책임이며, 이 workflow는 API/OIDC 환경값이나 ADB/device smoke를 요구하지 않는다.
 
 ## iOS Ad Hoc Firebase distribution
 

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -248,13 +248,21 @@ platform :ios do
 end
 
 platform :android do
-  desc 'Upload the signed Android Release AAB to the Play internal track'
-  lane :upload_internal do
+  desc 'Build and upload the Android Release AAB to the Play internal track'
+  lane :distribute_internal do
     require_environment!('GOOGLE_APPLICATION_CREDENTIALS', 'KOSMO_ANDROID_AAB_PATH')
     aab_path = File.expand_path(ENV.fetch('KOSMO_ANDROID_AAB_PATH'))
     credentials_path = File.expand_path(ENV.fetch('GOOGLE_APPLICATION_CREDENTIALS'))
-    UI.user_error!("AAB was not created at #{aab_path}.") unless File.file?(aab_path) && File.size?(aab_path)
     UI.user_error!("Google credentials were not created at #{credentials_path}.") unless File.file?(credentials_path) && File.size?(credentials_path)
+
+    gradle(
+      build_type: 'Release',
+      flags: '--no-daemon',
+      project_dir: 'android',
+      task: 'bundle',
+    )
+
+    UI.user_error!("AAB was not created at #{aab_path}.") unless File.file?(aab_path) && File.size?(aab_path)
 
     upload_to_play_store(
       aab: aab_path,


### PR DESCRIPTION
## 무엇을 변경했는지

- Android Play internal distribution workflow는 `prod` Environment에서 Vault signing credentials와 Google Cloud WIF를 준비하고, clean Expo CNG Android prebuild를 실행합니다.
- prebuild 뒤 `bundle exec fastlane android distribute_internal`을 한 번 호출합니다. Fastlane lane은 `bundleRelease --no-daemon`으로 signed AAB를 빌드하고 `upload_to_play_store`로 internal track에 업로드합니다.
- GHA가 직접 수행하던 bundletool 설치/checksum, apkanalyzer/aapt2 PATH, manifest/certificate parser, jarsigner/keytool 검사, `ANDROID_RELEASE_CERTIFICATE_SHA256` 입력을 제거했습니다. 업로드 성공 뒤 기존 AAB path를 확인하고 `shasum`/`wc`로 hash/size와 `moe.kos`, `KOSMO_ANDROID_VERSION_CODE`, commit/run metadata를 Actions summary에 남깁니다.
- signing/Vault cleanup, versionCode 산출, concurrency, `prod` Environment 보호는 유지했습니다.

## 왜 변경했는지

- 실제 run `33704968331`에서 GHA의 자체 AAB parser가 업로드 전에 실패했습니다.
- 사용자가 custom validation을 과도한 구조로 판단했고, 빌드와 Play 업로드를 Fastlane 책임으로 모아 실제 스토어 경로와 같은 흐름으로 단순화하기로 결정했습니다.

## 이번 PR의 주요 결정

### Fastlane이 Android Release AAB 빌드와 Play 업로드를 함께 소유

- 결정자: @robin-maki
- 선택: Fastlane `distribute_internal`이 signed Release AAB를 한 번 빌드하고 Play internal track에 업로드한다.
- 고려한 대안: GHA가 AAB를 빌드하고 custom 검증을 수행한 뒤 Fastlane으로 업로드하는 방식, GHA가 빌드와 Play validation을 각각 수행하는 방식.
- 이유: build/upload 책임을 한 lane에 응집하고 custom parser를 제거해 코드와 실패 지점을 줄이며, 이후 실제 store release 경로와 일치시킨다.
- 감수한 결과: GHA에서 package/version/certificate 상세 precheck를 수행하지 않고 Gradle build와 Play upload failure를 authority로 삼는다.
- 관련 근거: Linear PROD-285 최신 계약.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/android-play-internal-distribution.yml`
- `./node_modules/.bin/prettier --check .github/workflows/android-play-internal-distribution.yml apps/app/README.md`
- `ruby -c apps/app/fastlane/Fastfile`
- Fastlane 2.237.0의 `upload_to_play_store` action inputs와 `android distribute_internal` lane listing 확인
- `git diff --check`
- 구현 worker와 Ponytail reviewer의 최신 diff 검토 통과

## 아직 어떤 문제가 남았는지

- workflow는 `main`에서만 실행되므로 merge 후 GitHub-hosted run이 필요합니다.
- Play Console 최초 수동 AAB 업로드, Play App Signing bootstrap, internal tester 설정과 실제 upload는 아직 운영 gate입니다.
- 기존 `prod` Environment에 사용하지 않는 `ANDROID_RELEASE_CERTIFICATE_SHA256` 변수가 남아 있을 수 있어 별도 정리가 필요합니다.
- versionCode는 workflow 생성 값의 충돌을 피하지만, 기존 active Play track에 더 높은 수동 versionCode가 있다면 현재 정책으로는 보장되지 않습니다.

Stack: main -> PROD-285-fastlane-distribution

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>