### PR TITLE
Android Play 배포를 비공개 Alpha 트랙으로 전환한다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -1,4 +1,4 @@
-name: Android Google Play Internal Distribution
+name: Android Google Play Alpha Distribution
 
 on:
   workflow_dispatch:
@@ -8,12 +8,12 @@ permissions:
   id-token: write
 
 concurrency:
-  group: android-play-internal-distribution
+  group: android-play-alpha-distribution
   cancel-in-progress: false
 
 jobs:
   distribute:
-    name: Build and upload Android Release AAB
+    name: Build and upload Android Alpha AAB
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -210,9 +210,9 @@ jobs:
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Build and upload signed Release AAB with Fastlane
+      - name: Build and upload signed Alpha AAB with Fastlane
         working-directory: apps/app
-        run: bundle exec fastlane android distribute_internal
+        run: bundle exec fastlane android distribute_alpha
 
       - name: Write Actions summary
         if: success()
@@ -225,7 +225,7 @@ jobs:
           artifact_sha256="${artifact_sha256%% *}"
           artifact_size_bytes="$(wc -c < "${aab_path}" | tr -d '[:space:]')"
           {
-            echo '## Android Google Play internal testing'
+            echo '## Android Google Play closed testing (Alpha)'
             echo
             echo '- Package: moe.kos'
             echo "- Version code: \`${KOSMO_ANDROID_VERSION_CODE}\`"

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -21,17 +21,15 @@ After a successful callback, native login sends only the authorization code, PKC
 
 Native projects are generated with `expo prebuild --clean`; they are not source-of-truth files.
 
-## Android Google Play internal testing
+## Android Google Play closed testing (Alpha)
 
-`Android Google Play Internal Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, Fastlane이 upload key로 서명한 Release AAB를 빌드해 Google Play internal track에 업로드한다. Play가 package name, versionCode, upload certificate를 검증한다. versionCode는 workflow 시작 시 UTC Unix seconds에서 `2020-01-01`을 뺀 값으로 계산하며, 첫 수동 release의 versionCode `1`보다 크고 Android signed 32-bit 범위 안에 있다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다.
+`Android Google Play Alpha Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, Fastlane이 upload key로 서명한 Release AAB를 빌드해 Google Play closed testing의 Alpha track에 업로드한다. Play가 package name, versionCode, upload certificate를 검증한다. versionCode는 workflow 시작 시 UTC Unix seconds에서 `2020-01-01`을 뺀 값으로 계산하며, 첫 수동 release의 versionCode `1`보다 크고 Android signed 32-bit 범위 안에 있다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다. 기존 internal testing release는 Play Console에 남아 있으며 이 workflow가 변경하지 않는다.
 
-첫 배포 전에는 Play Console에서 다음 절차를 수동으로 완료해야 한다. CI가 Play Console의 최초 app/signing bootstrap을 대신하지 않는다.
+이 앱의 Play app, Google 관리 Play App Signing, upload key는 이미 설정되어 있다. Alpha track의 첫 signed AAB는 이 workflow가 업로드한다. Play Console에서 다음 Alpha 설정과 CI 자산을 확인한다.
 
-1. package name `moe.kos`로 app을 만든다.
-2. upload key를 관리자 장비에서 생성한다. 첫 AAB와 이후 CI AAB는 같은 upload key로 서명해야 하며, Google이 관리하는 app signing key와는 별개다.
-3. Play Console에서 internal testing track의 첫 release를 준비하고, 해당 release에서 Google 관리 Play App Signing을 설정한 뒤 upload key로 서명한 첫 signed AAB를 수동 업로드한다. tester 목록과 opt-in 링크도 설정한다.
-4. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.
-5. 기존 승인형 `prod` GitHub Environment에 다음 non-secret variable만 넣는다. 새 Environment는 만들지 않는다.
+1. closed testing의 Alpha track에 Doply tester 목록을 연결하고 출시 국가/지역에 대한민국을 포함한다.
+2. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.
+3. 기존 승인형 `prod` GitHub Environment에 다음 non-secret variable만 넣는다. 새 Environment는 만들지 않는다.
 
 | 이름                             | 종류     | 값                                                              |
 | -------------------------------- | -------- | --------------------------------------------------------------- |
@@ -39,7 +37,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `GCP_WORKLOAD_IDENTITY_PROVIDER` | variable | `terraform output -raw android_play_workload_identity_provider` |
 | `ANDROID_RELEASE_KEY_ALIAS`      | variable | upload key 생성 시 사용한 alias                                 |
 
-6. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. 운영자가 Vault CLI/UI에서 사용하는 KV v2 logical path는 `secret/kosmo/prod/android-play`다. Workflow와 Vault ACL policy에서 사용하는 KV v2 API path는 `secret/data/kosmo/prod/android-play`이며, `/data/`는 CLI/UI logical path에 포함하지 않는다. 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 API path를 읽도록 한다.
+4. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. 운영자가 Vault CLI/UI에서 사용하는 KV v2 logical path는 `secret/kosmo/prod/android-play`다. Workflow와 Vault ACL policy에서 사용하는 KV v2 API path는 `secret/data/kosmo/prod/android-play`이며, `/data/`는 CLI/UI logical path에 포함하지 않는다. 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 API path를 읽도록 한다.
 
 | Field                             | 값                                 |
 | --------------------------------- | ---------------------------------- |
@@ -47,7 +45,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `ANDROID_RELEASE_STORE_PASSWORD`  | upload keystore password           |
 | `ANDROID_RELEASE_KEY_PASSWORD`    | upload key password                |
 
-`Android Google Play Internal Distribution`은 조직 수준 `VAULT_ADDR`와 `VAULT_GITHUB_ACTIONS_AUDIENCE`, 저장소 수준 `TAILSCALE_OAUTH_CLIENT_ID`와 `TAILSCALE_AUDIENCE`를 사용한다. Vault tailnet에 접속한 뒤 GitHub OIDC JWT로 `kosmo-android-play` role을 인증하고 실행 중에만 서명 값을 읽는다. Vault role과 policy는 `prod` Environment의 이 workflow만 해당 경로를 읽도록 제한해야 한다.
+`Android Google Play Alpha Distribution`은 조직 수준 `VAULT_ADDR`와 `VAULT_GITHUB_ACTIONS_AUDIENCE`, 저장소 수준 `TAILSCALE_OAUTH_CLIENT_ID`와 `TAILSCALE_AUDIENCE`를 사용한다. Vault tailnet에 접속한 뒤 GitHub OIDC JWT로 `kosmo-android-play` role을 인증하고 실행 중에만 서명 값을 읽는다. Vault role과 policy는 `prod` Environment의 이 workflow만 해당 경로를 읽도록 제한해야 한다.
 
 upload key 예시는 다음과 같다. password는 명령행이나 저장소에 넣지 말고 `keytool` prompt에서 입력한다.
 

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -547,8 +547,8 @@ platform :ios do
 end
 
 platform :android do
-  desc 'Build and upload the Android Release AAB to the Play internal track'
-  lane :distribute_internal do
+  desc 'Build and upload the Android Release AAB to the Play Alpha track'
+  lane :distribute_alpha do
     require_environment!('GOOGLE_APPLICATION_CREDENTIALS', 'KOSMO_ANDROID_AAB_PATH')
     aab_path = File.expand_path(ENV.fetch('KOSMO_ANDROID_AAB_PATH'))
     credentials_path = File.expand_path(ENV.fetch('GOOGLE_APPLICATION_CREDENTIALS'))
@@ -572,7 +572,7 @@ platform :android do
       skip_upload_images: true,
       skip_upload_metadata: true,
       skip_upload_screenshots: true,
-      track: 'internal',
+      track: 'alpha',
     )
   end
 end


### PR DESCRIPTION
## 무엇을 변경했는지

- Android Play 배포 workflow의 대상을 내부 테스트에서 비공개 테스트 Alpha로 전환했습니다.
- Fastlane lane이 signed Release AAB를 한 번 빌드하고 `track: alpha`로 한 번 업로드하도록 변경했습니다.
- workflow 표시명, Actions summary와 앱 운영 문서를 Alpha 기준으로 맞췄습니다.
- Play Console Alpha에 기존 Doply 테스터 목록 39명을 연결하고 출시 국가에 대한민국을 추가했습니다.

## 왜 변경했는지

실제 테스트 대상은 Google Play 내부 테스트가 아니라 Doply 테스터를 위한 비공개 테스트입니다. 기존 internal 자동화는 Alpha 출시 준비를 충족하지 못했고, Alpha에는 release·테스터 연결·출시 국가가 없었습니다. [PROD-886](https://linear.app/byulmaru/issue/PROD-886/android-aab를-google-play-비공개-테스트-트랙으로-자동-배포한다)이 이 전환을 소유합니다.

## 이번 PR의 주요 결정

### Alpha만 자동 배포

- 결정자: @robin-maki
- 선택: 기존 `prod` Environment 승인 뒤 AAB를 한 번 빌드해 Alpha에만 업로드합니다.
- 고려한 대안: internal 유지, Alpha와 Production 동시 배포
- 이유: internal은 필요하지 않고 현재 계정은 Production 제출 자격이 없습니다.
- 감수한 결과: Production 제출·승격·공개 rollout은 자격 취득 뒤 PROD-873에서 진행합니다.

### 기존 workflow 파일 경로 유지

- 결정자: @robin-maki
- 선택: 표시명과 동작은 Alpha로 바꾸되 `.github/workflows/android-play-internal-distribution.yml` 경로는 유지합니다.
- 고려한 대안: workflow 파일을 Alpha 이름으로 변경
- 이유: GCP WIF와 Vault role이 현재 파일의 exact `workflow_ref`를 신뢰하므로, 이름만 바꾸기 위한 별도 인프라 rollout을 만들지 않습니다.
- 감수한 결과: 파일명에는 기존 internal 명칭이 남지만 실행 대상과 문서 계약에는 사용되지 않습니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/android-play-internal-distribution.yml`
- `./node_modules/.bin/prettier --check .github/workflows/android-play-internal-distribution.yml apps/app/README.md`
- `ruby -c apps/app/fastlane/Fastfile`
- `git diff --check origin/main...HEAD`
- Play Console에서 Alpha의 Doply 목록 39명 연결과 대한민국 타겟팅을 확인했습니다.
- Luna Ponytail 최종 검토에서 추가 finding이 없음을 확인했습니다.

## 아직 어떤 문제가 남았는지

- workflow는 `main`에서만 실행되므로 실제 Alpha AAB 업로드와 Play 검토 상태 확인은 병합 후 수행합니다.
- Production 자격 취득·심사·공개 출시는 PROD-873에 남습니다.
- 실제 설치·업데이트·launch·로그인 smoke는 PROD-287 범위입니다.

Stack: main -> PROD-886

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>