### PR TITLE
Android Alpha 최초 업로드를 draft로 허용한다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -2,6 +2,15 @@ name: Android Google Play Alpha Distribution
 
 on:
   workflow_dispatch:
+    inputs:
+      release_status:
+        description: Play release status for the Alpha release
+        required: true
+        type: choice
+        options:
+          - draft
+          - completed
+        default: completed
 
 permissions:
   contents: read
@@ -20,6 +29,7 @@ jobs:
     environment: prod
     env:
       ANDROID_RELEASE_KEY_ALIAS: ${{ vars.ANDROID_RELEASE_KEY_ALIAS }}
+      ANDROID_PLAY_RELEASE_STATUS: ${{ inputs.release_status }}
       EXPO_NO_GIT_STATUS: '1'
       GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -228,6 +238,7 @@ jobs:
             echo '## Android Google Play closed testing (Alpha)'
             echo
             echo '- Package: moe.kos'
+            echo "- Release status: \`${ANDROID_PLAY_RELEASE_STATUS}\`"
             echo "- Version code: \`${KOSMO_ANDROID_VERSION_CODE}\`"
             echo "- AAB SHA-256: \`${artifact_sha256}\`"
             echo "- AAB size: \`${artifact_size_bytes} bytes\`"

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -25,7 +25,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 
 `Android Google Play Alpha Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, Fastlane이 upload key로 서명한 Release AAB를 빌드해 Google Play closed testing의 Alpha track에 업로드한다. Play가 package name, versionCode, upload certificate를 검증한다. versionCode는 workflow 시작 시 UTC Unix seconds에서 `2020-01-01`을 뺀 값으로 계산하며, 첫 수동 release의 versionCode `1`보다 크고 Android signed 32-bit 범위 안에 있다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다. 기존 internal testing release는 Play Console에 남아 있으며 이 workflow가 변경하지 않는다.
 
-이 앱의 Play app, Google 관리 Play App Signing, upload key는 이미 설정되어 있다. Alpha track의 첫 signed AAB는 이 workflow가 업로드한다. Play Console에서 다음 Alpha 설정과 CI 자산을 확인한다.
+이 앱의 Play app, Google 관리 Play App Signing, upload key는 이미 설정되어 있다. Alpha track의 첫 signed AAB는 이 workflow가 업로드한다. 앱이 아직 draft 상태인 최초 실행에서는 workflow dispatch의 `release_status`를 `draft`로 선택하고, 업로드 후 Play Console에서 Alpha release를 검토 제출한다. 앱 검토가 끝나 draft 상태를 벗어난 뒤의 실행은 기본값인 `completed`를 사용한다. Play Console에서 다음 Alpha 설정과 CI 자산을 확인한다.
 
 1. closed testing의 Alpha track에 Doply tester 목록을 연결하고 출시 국가/지역에 대한민국을 포함한다.
 2. [Terraform outputs](../terraform/README.md)의 `android_play_service_account` service account를 Play Console Users and permissions에 추가하고 `Release apps to testing tracks` 권한만 부여한다.

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -550,6 +550,8 @@ platform :android do
   desc 'Build and upload the Android Release AAB to the Play Alpha track'
   lane :distribute_alpha do
     require_environment!('GOOGLE_APPLICATION_CREDENTIALS', 'KOSMO_ANDROID_AAB_PATH')
+    release_status = ENV.fetch('ANDROID_PLAY_RELEASE_STATUS', 'completed')
+    UI.user_error!('ANDROID_PLAY_RELEASE_STATUS must be draft or completed.') unless %w[draft completed].include?(release_status)
     aab_path = File.expand_path(ENV.fetch('KOSMO_ANDROID_AAB_PATH'))
     credentials_path = File.expand_path(ENV.fetch('GOOGLE_APPLICATION_CREDENTIALS'))
     UI.user_error!("Google credentials were not created at #{credentials_path}.") unless File.file?(credentials_path) && File.size?(credentials_path)
@@ -567,7 +569,7 @@ platform :android do
       aab: aab_path,
       package_name: BUNDLE_IDENTIFIER,
       json_key: credentials_path,
-      release_status: 'completed',
+      release_status: release_status,
       skip_upload_changelogs: true,
       skip_upload_images: true,
       skip_upload_metadata: true,


### PR DESCRIPTION
## 무엇을 변경했는지

- Android Alpha workflow에 `draft`와 `completed` release status 선택을 추가했습니다.
- 선택한 상태를 기존 Fastlane `distribute_alpha` lane의 단일 업로드에 전달합니다.
- 기본값은 이후 자동 배포에 사용할 `completed`로 유지했습니다.
- Actions summary와 앱 운영 문서에 실제 release status 및 최초 draft 제출 절차를 기록했습니다.

## 왜 변경했는지

병합 후 실행한 [Actions run 33717912693](https://github.com/byulmaru/kosmo/actions/runs/33717912693)에서 signed AAB 빌드는 성공했지만, 아직 draft 상태인 Play 앱에 `completed` release를 생성할 수 없어 Alpha 업로드가 거부됐습니다. 로컬 빌드로 우회하지 않고 기존 GitHub Actions가 최초 draft 업로드도 소유하게 합니다. 관련 이슈는 [PROD-886](https://linear.app/byulmaru/issue/PROD-886/android-aab를-google-play-비공개-테스트-트랙으로-자동-배포한다)입니다.

## 이번 PR의 주요 결정

### 최초 실행만 draft 사용

- 결정자: @robin-maki
- 선택: 최초 bootstrap run에서는 `draft`를 선택하고, 앱 검토 후에는 기본값 `completed`를 사용합니다.
- 고려한 대안: 로컬에서 AAB를 다시 빌드해 수동 업로드, workflow를 draft 전용으로 변경
- 이유: 이미 CI의 서명 빌드가 성공했으며 서명 키를 로컬로 옮길 이유가 없습니다.
- 감수한 결과: 최초 draft 업로드 뒤 Play Console에서 Google 검토 제출은 한 번 수동으로 수행해야 합니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/android-play-internal-distribution.yml`
- `./node_modules/.bin/prettier --check .github/workflows/android-play-internal-distribution.yml apps/app/README.md`
- `ruby -c apps/app/fastlane/Fastfile`
- `git diff --check origin/main...HEAD`
- Luna Ponytail 최종 검토에서 추가 finding이 없음을 확인했습니다.

## 아직 어떤 문제가 남았는지

- 병합 후 `release_status=draft`로 실제 Alpha 업로드를 다시 실행해야 합니다.
- 업로드된 첫 Alpha release의 Google 검토 제출과 완료 상태는 Play Console에서 확인해야 합니다.
- Production은 자격 취득 후 PROD-873에서 진행합니다.

Stack: main -> PROD-886-draft-bootstrap

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>