### PR TITLE
Admin Account 조회가 배포 환경에서 데이터베이스에 연결되게 한다

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
               set -euo pipefail
               helm lint apps/helm --set env=dev
               rendered="$(helm template kosmo apps/helm --namespace kosmo-dev --set env=dev)"
+              admin="$(helm template kosmo apps/helm --namespace kosmo-dev --set env=dev --show-only templates/admin/deployment.yaml)"
+              for env in PGPASSWORD PGHOST PGPORT PGUSER PGDATABASE; do grep -Fq -- "- name: $env" <<<"$admin"; done
               grep -Eq '^kind: Deployment$' <<<"$rendered"
               grep -Eq '^kind: Service$' <<<"$rendered"
               grep -Eq '^kind: Ingress$' <<<"$rendered"

--- a/apps/helm/templates/admin/deployment.yaml
+++ b/apps/helm/templates/admin/deployment.yaml
@@ -45,6 +45,19 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kosmo.runtimeDatabasePasswordSecretName" . | quote }}
+                  key: password
+            - name: PGHOST
+              value: {{ printf "%s-rw" (include "kosmo.postgresName" .) | quote }}
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: kosmo_runtime
+            - name: PGDATABASE
+              value: kosmo
           livenessProbe:
             httpGet:
               path: /healthz

--- a/apps/helm/templates/vaultstaticsecret.yaml
+++ b/apps/helm/templates/vaultstaticsecret.yaml
@@ -135,6 +135,8 @@ spec:
     - kind: "argo.Rollout"
       name: {{ printf "%s-web" $.Release.Name | trunc 63 | trimSuffix "-" | quote }}
     - kind: "Deployment"
+      name: {{ printf "%s-admin" $.Release.Name | trunc 63 | trimSuffix "-" | quote }}
+    - kind: "Deployment"
       name: {{ printf "%s-worker" $.Release.Name | trunc 63 | trimSuffix "-" | quote }}
     - kind: "Deployment"
       name: {{ printf "%s-fedify-consumer" $.Release.Name | trunc 63 | trimSuffix "-" | quote }}


### PR DESCRIPTION
## 무엇을 변경했나요

- Admin Deployment에 runtime PostgreSQL 접속 환경을 주입합니다.
- runtime DB 비밀번호가 갱신되면 Admin Deployment도 재시작합니다.
- Admin 전용 Helm manifest에 필수 PostgreSQL 환경 변수가 있는지 CI에서 확인합니다.

## 왜 변경했나요

PROD-691 배포 후 `/accounts`가 HTTP 500과 `Admin Console unavailable`을 반환했습니다. Account loader는 DB를 조회하지만 Admin Pod에는 접속 정보가 없어 실제 dev 환경에서 사용할 수 없었습니다.

## 이번 PR의 주요 결정

없음. API·Web·Worker가 이미 사용하는 `kosmo_runtime` DB 접속 경계를 Admin에도 동일하게 적용합니다.

## 어떻게 확인할 수 있나요

- `helm lint apps/helm --set env=dev`
- Admin 전용 dev manifest의 `PGPASSWORD`, `PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE` 확인
- dev/prod `helm template` 확인
- `actionlint .github/workflows/test.yml`
- `prettier --check` 대상 파일 통과

## 아직 어떤 문제가 남았나요

- 머지 후 dev 배포가 반영되면 `https://kosmo-dev-admin.tail1fdd55.ts.net/accounts`가 200으로 응답하는지 다시 확인해야 합니다.

Stack: main -> PROD-691-db-runtime
