### PR TITLE
iOS 업로드 전 중복 IPA 검증을 제거한다

### DIFF
--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -68,8 +68,6 @@ end
 
 platform :ios do
   private_lane :load_apple_api_key do
-    require_environment!('APPLE_API_KEY_ID', 'APPLE_API_ISSUER_ID', 'APPLE_API_KEY_PATH')
-
     app_store_connect_api_key(
       key_id: ENV.fetch('APPLE_API_KEY_ID'),
       issuer_id: ENV.fetch('APPLE_API_ISSUER_ID'),

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -97,7 +97,13 @@ platform :ios do
       UI.user_error!('IPA must contain exactly one app bundle.') unless app_bundles.one?
 
       app_bundle = app_bundles.first
-      info = Plist.parse_xml(File.join(app_bundle, 'Info.plist'))
+      info_plist_path = File.join(app_bundle, 'Info.plist')
+      info_xml_path = File.join(directory, 'Info.plist.xml')
+      sh(
+        "plutil -convert xml1 -o #{Shellwords.escape(info_xml_path)} " \
+        "#{Shellwords.escape(info_plist_path)}",
+      )
+      info = Plist.parse_xml(info_xml_path)
       UI.user_error!('IPA Info.plist is missing.') unless info
 
       bundle_id = info['CFBundleIdentifier'].to_s

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -1,10 +1,8 @@
 require 'base64'
-require 'digest'
 require 'fileutils'
 require 'plist'
 require 'securerandom'
 require 'shellwords'
-require 'tmpdir'
 
 default_platform(:ios)
 opt_out_usage
@@ -81,89 +79,15 @@ platform :ios do
     )
   end
 
-  private_lane :verify_app_store_ipa do |options|
-    raw_ipa_path = options.fetch(:ipa_path)
-    UI.user_error!('Fastlane did not produce a signed IPA.') if raw_ipa_path.to_s.empty?
-
-    ipa_path = File.expand_path(raw_ipa_path)
-    expected_team_id = options.fetch(:team_id)
-    expected_profile_uuid = options.fetch(:profile_uuid)
-    expected_build_number = build_number!
-    UI.user_error!("IPA was not created at #{ipa_path}.") unless File.file?(ipa_path) && File.size?(ipa_path)
-
-    Dir.mktmpdir('kosmo-ipa-') do |directory|
-      sh("unzip -qq #{Shellwords.escape(ipa_path)} -d #{Shellwords.escape(directory)}")
-      app_bundles = Dir[File.join(directory, 'Payload', '*.app')]
-      UI.user_error!('IPA must contain exactly one app bundle.') unless app_bundles.one?
-
-      app_bundle = app_bundles.first
-      info_plist_path = File.join(app_bundle, 'Info.plist')
-      info_xml_path = File.join(directory, 'Info.plist.xml')
-      sh(
-        "plutil -convert xml1 -o #{Shellwords.escape(info_xml_path)} " \
-        "#{Shellwords.escape(info_plist_path)}",
-      )
-      info = Plist.parse_xml(info_xml_path)
-      UI.user_error!('IPA Info.plist is missing.') unless info
-
-      bundle_id = info['CFBundleIdentifier'].to_s
-      version_name = info['CFBundleShortVersionString'].to_s
-      build_number = info['CFBundleVersion'].to_s
-      UI.user_error!('IPA bundle identifier does not match moe.kos.') unless bundle_id == BUNDLE_IDENTIFIER
-      UI.user_error!('IPA build number does not match IOS_BUILD_NUMBER.') unless build_number == expected_build_number
-      UI.user_error!('IPA version is empty.') if version_name.empty?
-
-      embedded_profile_path = File.join(app_bundle, 'embedded.mobileprovision')
-      UI.user_error!('IPA does not embed a provisioning profile.') unless File.file?(embedded_profile_path)
-
-      embedded_profile_plist_path = File.join(directory, 'embedded.mobileprovision.plist')
-      sh(
-        "security cms -D -i #{Shellwords.escape(embedded_profile_path)} " \
-        "> #{Shellwords.escape(embedded_profile_plist_path)}",
-      )
-      profile = Plist.parse_xml(embedded_profile_plist_path)
-      UI.user_error!('Embedded provisioning profile is invalid.') unless profile
-
-      profile_uuid = profile['UUID'].to_s
-      profile_team_id = Array(profile['TeamIdentifier']).first.to_s
-      application_identifier = profile.dig('Entitlements', 'application-identifier').to_s
-      UI.user_error!('IPA provisioning profile UUID mismatch.') unless profile_uuid == expected_profile_uuid
-      UI.user_error!('IPA provisioning profile team mismatch.') unless profile_team_id == expected_team_id
-      UI.user_error!('IPA provisioning profile app identifier mismatch.') unless application_identifier == "#{expected_team_id}.#{BUNDLE_IDENTIFIER}"
-      UI.user_error!('IPA contains an Ad Hoc provisioning profile.') if profile.key?('ProvisionedDevices')
-      UI.user_error!('IPA contains a universal provisioning profile.') if profile['ProvisionsAllDevices'] == true
-      UI.user_error!('IPA contains a development provisioning profile.') if profile.dig('Entitlements', 'get-task-allow') == true
-
-      signing_output = sh("codesign --display --verbose=4 #{Shellwords.escape(app_bundle)} 2>&1")
-      sh("codesign --verify --deep --strict --verbose=2 #{Shellwords.escape(app_bundle)}")
-      UI.user_error!('IPA is not signed with an Apple Distribution certificate.') unless signing_output.match?(/^Authority=(?:Apple|iPhone) Distribution/m)
-      UI.user_error!('IPA signing team does not match the provisioning profile.') unless signing_output.match?(/TeamIdentifier=#{Regexp.escape(expected_team_id)}(?:\s|$)/)
-
-      {
-        bundle_identifier: bundle_id,
-        version_name: version_name,
-        build_number: build_number,
-        team_id: profile_team_id,
-        profile_uuid: profile_uuid,
-        artifact_sha256: Digest::SHA256.file(ipa_path).hexdigest,
-        artifact_size_bytes: File.size(ipa_path),
-      }
-    end
-  end
-
-  private_lane :write_testflight_summary do |options|
+  private_lane :write_testflight_summary do |uploaded_build|
     summary_path = ENV['GITHUB_STEP_SUMMARY']
     return unless summary_path && !summary_path.empty?
 
     File.open(summary_path, 'a') do |file|
       file.puts('## iOS TestFlight internal testing')
       file.puts
-      file.puts("- Bundle: `#{options.fetch(:bundle_identifier)}`")
-      file.puts("- Version: `#{options.fetch(:version_name)} (#{options.fetch(:build_number)})`")
-      file.puts("- Team: `#{options.fetch(:team_id)}`")
-      file.puts("- App Store provisioning profile: `#{options.fetch(:profile_uuid)}`")
-      file.puts("- IPA SHA-256: `#{options.fetch(:artifact_sha256)}`")
-      file.puts("- IPA size: `#{options.fetch(:artifact_size_bytes)} bytes`")
+      file.puts("- Bundle: `#{BUNDLE_IDENTIFIER}`")
+      file.puts("- Version: `#{uploaded_build.app_version} (#{uploaded_build.version})`")
       file.puts('- Processing: completed')
       file.puts('- TestFlight group: `Internal Testers`')
       file.puts("- Source: `#{ENV.fetch('GITHUB_SHA', 'local')}`")
@@ -287,11 +211,8 @@ platform :ios do
         derived_data_path: File.join(signing_dir, 'derived-data'),
         xcargs: "DEVELOPMENT_TEAM=#{team_id} PRODUCT_BUNDLE_IDENTIFIER=#{BUNDLE_IDENTIFIER} CURRENT_PROJECT_VERSION=#{build_number} CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE_SPECIFIER=#{profile_uuid}",
       )
-      metadata = verify_app_store_ipa(
-        ipa_path: ipa_path,
-        team_id: team_id,
-        profile_uuid: profile_uuid,
-      )
+      ipa_path = File.expand_path(ipa_path.to_s)
+      UI.user_error!("Fastlane did not produce a signed IPA at #{ipa_path}.") unless File.file?(ipa_path) && File.size?(ipa_path)
 
       upload_to_testflight(
         api_key: api_key,
@@ -305,21 +226,19 @@ platform :ios do
 
       uploaded_build = Spaceship::ConnectAPI::Build.all(
         app_id: app.id,
-        version: metadata.fetch(:version_name),
-        build_number: metadata.fetch(:build_number),
+        build_number: build_number,
         platform: Spaceship::ConnectAPI::Platform::IOS,
         processing_states: Spaceship::ConnectAPI::Build::ProcessingState::VALID,
       ).find do |build|
         build.processing_state == Spaceship::ConnectAPI::Build::ProcessingState::VALID &&
           build.bundle_id == BUNDLE_IDENTIFIER &&
-          build.app_version == metadata.fetch(:version_name) &&
-          build.version == metadata.fetch(:build_number)
+          build.version == build_number
       end
       UI.user_error!('Uploaded IPA was not found as a valid App Store Connect build.') unless uploaded_build
       UI.user_error!('Uploaded App Store Connect build is not ready for internal testing.') unless uploaded_build.ready_for_internal_testing?
       UI.user_error!('Uploaded App Store Connect build was not assigned to Internal Testers.') unless internal_group.fetch_builds.any? { |build| build.id == uploaded_build.id }
 
-      write_testflight_summary(metadata)
+      write_testflight_summary(uploaded_build)
     rescue StandardError => error
       primary_error = error
     ensure


### PR DESCRIPTION
## 무엇을 변경했는지

- Fastlane이 생성한 IPA를 다시 풀어 `Info.plist`, 내장 provisioning profile, codesign을 검사하던 중복 검증을 제거합니다.
- IPA 파일 존재 확인과 단일 `upload_to_testflight` 호출은 유지합니다.
- 업로드 후 App Store Connect의 `VALID` build, processing 완료, `Internal Testers` 할당을 확인하고 서버가 반환한 버전과 빌드 번호를 summary에 기록합니다.

## 왜 변경했는지

동일한 Fastlane lane이 fresh GitHub-hosted macOS runner에서 `build_app`으로 IPA를 만들고 즉시 App Store Connect에 업로드합니다. Xcode export와 App Store Connect가 서명 및 배포 유효성을 검사하므로, 업로드 직전에 IPA를 다시 풀어 같은 내용을 증명하는 경로는 이 배포 구조에서 불필요한 중복이었습니다. 이 중복 검증은 Xcode 26의 binary `Info.plist`를 XML 전용 parser로 읽으면서 실제 업로드 전에 실패하기도 했습니다.

## 이번 PR의 주요 결정

### 배포 성공 여부는 빌드 도구와 App Store Connect 결과로 판정한다

- 결정자: @robin-maki
- 선택: IPA 내부 심층 재검증을 제거하고, 생성된 IPA 존재와 업로드 후 App Store Connect build 상태 및 내부 테스터 할당만 확인합니다.
- 고려한 대안: binary plist를 임시 XML로 변환해 기존 심층 검증을 유지
- 이유: 외부 IPA를 받아 업로드하는 흐름이 아니며, 같은 lane의 `build_app` 결과를 바로 업로드하므로 중복 검증의 운영 복잡성이 이점보다 큽니다.
- 감수한 결과: workflow 자체는 IPA 내부 provisioning profile과 codesign을 별도로 재검증하지 않고 Xcode export 및 App Store Connect 검증을 신뢰합니다.
- 관련 근거: PROD-876, Actions run 33725773289 attempt 5

## 어떻게 확인할 수 있는지

- Ruby 3.4 `ruby -c apps/app/fastlane/Fastfile`
- `git diff --check`
- Ponytail read-only review: no finding
- `build_app` 1회, `upload_to_testflight` 1회 및 cleanup 경계 정적 확인

## 아직 어떤 문제가 남았는지

- 병합 후 GitHub-hosted macOS에서 TestFlight 업로드, processing, `Internal Testers` 할당까지 전체 live workflow 재검증이 필요합니다.

Stack: main -> prod-876-binary-plist-verification
