### PR TITLE
Admin Console을 탐색 가능한 대시보드로 만든다

### DIFF
--- a/apps/admin/components.json
+++ b/apps/admin/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://shadcn-svelte.com/schema.json",
+  "tailwind": {
+    "css": "src/app.css",
+    "baseColor": "neutral"
+  },
+  "aliases": {
+    "components": "$lib/components",
+    "utils": "$lib/utils",
+    "ui": "$lib/components/ui",
+    "hooks": "$lib/hooks",
+    "lib": "$lib"
+  },
+  "typescript": true,
+  "registry": "https://shadcn-svelte.com/registry",
+  "style": "vega",
+  "iconLibrary": "lucide",
+  "menuColor": "default",
+  "menuAccent": "subtle"
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -19,12 +19,20 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@fontsource-variable/inter": "^5.3.0",
+    "@internationalized/date": "^3.12.3",
+    "@lucide/svelte": "^1.34.0",
     "@sveltejs/adapter-node": "^5.5.7",
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@tailwindcss/vite": "^4.3.3",
+    "bits-ui": "^2.19.0",
+    "clsx": "^2.1.1",
+    "shadcn-svelte": "^1.5.0",
     "svelte-check": "^4.7.6",
+    "tailwind-merge": "^3.6.0",
     "tailwind-variants": "^3.3.1",
     "tailwindcss": "^4.3.3",
+    "tw-animate-css": "^1.4.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.10"
   }

--- a/apps/admin/src/app.css
+++ b/apps/admin/src/app.css
@@ -1,4 +1,9 @@
 @import 'tailwindcss';
+@import 'tw-animate-css';
+@import 'shadcn-svelte/tailwind.css';
+@import '@fontsource-variable/inter';
+
+@custom-variant dark (&:is(.dark *));
 
 :root {
   --background: oklch(1 0 0);
@@ -8,6 +13,31 @@
   --muted: oklch(0.97 0 0);
   --border: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --input: oklch(0.922 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 @theme inline {
@@ -18,6 +48,38 @@
   --color-primary: var(--primary);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  --font-sans: 'Inter Variable', sans-serif;
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-input: var(--input);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
 }
 
 @layer base {
@@ -28,4 +90,41 @@
   body {
     @apply bg-background text-foreground;
   }
+  html {
+    @apply font-sans;
+  }
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.87 0 0);
+  --chart-2: oklch(0.556 0 0);
+  --chart-3: oklch(0.439 0 0);
+  --chart-4: oklch(0.371 0 0);
+  --chart-5: oklch(0.269 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }

--- a/apps/admin/src/lib/components/app-sidebar.svelte
+++ b/apps/admin/src/lib/components/app-sidebar.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import LayoutDashboardIcon from '@lucide/svelte/icons/layout-dashboard';
+  import UsersIcon from '@lucide/svelte/icons/users';
+  import { resolve } from '$app/paths';
+  import { page } from '$app/state';
+  import * as Sidebar from '$lib/components/ui/sidebar';
+
+  let {
+    viewer,
+  }: {
+    viewer: { label: string; login?: string };
+  } = $props();
+</script>
+
+<Sidebar.Root collapsible="icon">
+  <Sidebar.Header>
+    <Sidebar.Menu>
+      <Sidebar.MenuItem>
+        <Sidebar.MenuButton size="lg" tooltipContent="Kosmo Admin Console">
+          {#snippet child({ props })}
+            <a {...props} href={resolve('/')}>
+              <span
+                aria-hidden="true"
+                class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary font-bold text-primary-foreground"
+                >K</span
+              >
+              <span class="grid text-left text-sm leading-tight">
+                <span class="truncate font-semibold">Kosmo</span>
+                <span class="truncate text-xs">Admin Console</span>
+              </span>
+            </a>
+          {/snippet}
+        </Sidebar.MenuButton>
+      </Sidebar.MenuItem>
+    </Sidebar.Menu>
+  </Sidebar.Header>
+
+  <Sidebar.Content>
+    <Sidebar.Group>
+      <Sidebar.GroupLabel>Workspace</Sidebar.GroupLabel>
+      <Sidebar.GroupContent>
+        <Sidebar.Menu>
+          <Sidebar.MenuItem>
+            <Sidebar.MenuButton isActive={page.url.pathname === '/'} tooltipContent="Overview">
+              {#snippet child({ props })}
+                <a
+                  {...props}
+                  aria-current={page.url.pathname === '/' ? 'page' : undefined}
+                  href={resolve('/')}
+                >
+                  <LayoutDashboardIcon />
+                  <span>Overview</span>
+                </a>
+              {/snippet}
+            </Sidebar.MenuButton>
+          </Sidebar.MenuItem>
+          <Sidebar.MenuItem>
+            <Sidebar.MenuButton
+              isActive={page.url.pathname.startsWith('/accounts')}
+              tooltipContent="Accounts"
+            >
+              {#snippet child({ props })}
+                <a
+                  {...props}
+                  aria-current={page.url.pathname.startsWith('/accounts') ? 'page' : undefined}
+                  href={resolve('/accounts')}
+                >
+                  <UsersIcon />
+                  <span>Accounts</span>
+                </a>
+              {/snippet}
+            </Sidebar.MenuButton>
+          </Sidebar.MenuItem>
+        </Sidebar.Menu>
+      </Sidebar.GroupContent>
+    </Sidebar.Group>
+  </Sidebar.Content>
+
+  <Sidebar.Footer>
+    <div class="flex min-w-0 items-center gap-2 rounded-md p-2 group-data-[collapsible=icon]:p-1">
+      <span
+        aria-hidden="true"
+        class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-sm font-semibold"
+        >{viewer.label.slice(0, 1).toUpperCase()}</span
+      >
+      <div class="grid min-w-0 text-sm leading-tight group-data-[collapsible=icon]:hidden">
+        <span class="truncate font-medium">{viewer.label}</span>
+        {#if viewer.login && viewer.login !== viewer.label}
+          <span class="truncate text-xs text-muted-foreground">{viewer.login}</span>
+        {/if}
+      </div>
+    </div>
+  </Sidebar.Footer>
+  <Sidebar.Rail />
+</Sidebar.Root>

--- a/apps/admin/src/lib/components/ui/badge/badge.svelte
+++ b/apps/admin/src/lib/components/ui/badge/badge.svelte
@@ -1,26 +1,52 @@
-<script lang="ts">
+<script lang="ts" module>
   import { tv } from 'tailwind-variants';
-  import type { Snippet } from 'svelte';
   import type { VariantProps } from 'tailwind-variants';
 
-  const variants = tv({
-    base: 'inline-flex h-5 w-fit items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+  export const badgeVariants = tv({
+    base: 'h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none',
     variants: {
       variant: {
-        default: 'border-transparent bg-primary text-primary-foreground',
-        outline: 'border-border text-foreground',
+        default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
+        secondary: 'bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80',
+        destructive:
+          'bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20',
+        outline: 'border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground',
+        ghost: 'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
     },
-    defaultVariants: { variant: 'default' },
+    defaultVariants: {
+      variant: 'default',
+    },
   });
 
+  export type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
+</script>
+
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAnchorAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
   let {
-    children,
+    ref = $bindable(null),
+    href,
+    class: className,
     variant = 'default',
-  }: {
-    children: Snippet;
-    variant?: VariantProps<typeof variants>['variant'];
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAnchorAttributes> & {
+    variant?: BadgeVariant;
   } = $props();
 </script>
 
-<span class={variants({ variant })}>{@render children()}</span>
+<svelte:element
+  this={href ? 'a' : 'span'}
+  bind:this={ref}
+  data-slot="badge"
+  {href}
+  class={cn(badgeVariants({ variant }), className)}
+  {...restProps}
+>
+  {@render children?.()}
+</svelte:element>

--- a/apps/admin/src/lib/components/ui/badge/index.ts
+++ b/apps/admin/src/lib/components/ui/badge/index.ts
@@ -1,1 +1,2 @@
 export { default as Badge } from './badge.svelte';
+export { type BadgeVariant, badgeVariants } from './badge.svelte';

--- a/apps/admin/src/lib/components/ui/button/button.svelte
+++ b/apps/admin/src/lib/components/ui/button/button.svelte
@@ -1,38 +1,93 @@
-<script lang="ts">
+<script lang="ts" module>
   import { tv } from 'tailwind-variants';
-  import { resolve } from '$app/paths';
-  import type { Snippet } from 'svelte';
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
   import type { VariantProps } from 'tailwind-variants';
-  import type { PathnameWithSearchOrHash } from '$app/types';
+  import type { WithElementRef } from '$lib/utils.js';
 
-  const variants = tv({
-    base: 'inline-flex items-center justify-center rounded-lg border text-sm font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/50',
+  export const buttonVariants = tv({
+    base: "rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     variants: {
       variant: {
-        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
-        outline: 'border-border bg-background text-foreground hover:bg-muted',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        outline:
+          'border-border bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+        ghost:
+          'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
+        destructive:
+          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-8 px-2.5',
-        sm: 'h-7 px-2.5 text-[0.8rem]',
+        default:
+          'h-9 gap-1.5 px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: 'h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5',
+        lg: 'h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        icon: 'size-9',
+        'icon-xs':
+          "size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm':
+          'size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md',
+        'icon-lg': 'size-10',
       },
     },
-    defaultVariants: { variant: 'default', size: 'default' },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
   });
 
-  let {
-    children,
-    href,
-    size = 'default',
-    variant = 'default',
-  }: {
-    children: Snippet;
-    href: PathnameWithSearchOrHash;
-    size?: VariantProps<typeof variants>['size'];
-    variant?: VariantProps<typeof variants>['variant'];
-  } = $props();
+  export type ButtonVariant = VariantProps<typeof buttonVariants>['variant'];
+  export type ButtonSize = VariantProps<typeof buttonVariants>['size'];
+
+  export type ButtonProps = WithElementRef<HTMLButtonAttributes> &
+    WithElementRef<HTMLAnchorAttributes> & {
+      variant?: ButtonVariant;
+      size?: ButtonSize;
+    };
 </script>
 
-<a class={variants({ variant, size })} href={resolve(href)}>
-  {@render children()}
-</a>
+<script lang="ts">
+  let {
+    class: className,
+    variant = 'default',
+    size = 'default',
+    ref = $bindable(null),
+    href = undefined,
+    type = 'button',
+    disabled,
+    children,
+    ...restProps
+  }: ButtonProps = $props();
+</script>
+
+{#if href}
+  <!-- eslint-disable svelte/no-navigation-without-resolve -- reusable component accepts internal and external URLs -->
+  <a
+    bind:this={ref}
+    data-slot="button"
+    class={cn(buttonVariants({ variant, size }), className)}
+    href={disabled ? undefined : href}
+    aria-disabled={disabled}
+    role={disabled ? 'link' : undefined}
+    tabindex={disabled ? -1 : undefined}
+    {...restProps}
+  >
+    {@render children?.()}
+  </a>
+  <!-- eslint-enable svelte/no-navigation-without-resolve -->
+{:else}
+  <button
+    bind:this={ref}
+    data-slot="button"
+    class={cn(buttonVariants({ variant, size }), className)}
+    {type}
+    {disabled}
+    {...restProps}
+  >
+    {@render children?.()}
+  </button>
+{/if}

--- a/apps/admin/src/lib/components/ui/button/index.ts
+++ b/apps/admin/src/lib/components/ui/button/index.ts
@@ -1,1 +1,13 @@
-export { default as Button } from './button.svelte';
+import Root, { buttonVariants } from './button.svelte';
+import type { ButtonProps, ButtonSize, ButtonVariant } from './button.svelte';
+
+export {
+  //
+  Root as Button,
+  type ButtonProps,
+  type ButtonSize,
+  type ButtonVariant,
+  buttonVariants,
+  type ButtonProps as Props,
+  Root,
+};

--- a/apps/admin/src/lib/components/ui/card/card-action.svelte
+++ b/apps/admin/src/lib/components/ui/card/card-action.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="card-action"
+  class={cn(
+    'cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/card/card-content.svelte
+++ b/apps/admin/src/lib/components/ui/card/card-content.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="card-content"
+  class={cn('px-(--card-spacing)', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/card/card-description.svelte
+++ b/apps/admin/src/lib/components/ui/card/card-description.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLParagraphElement>> = $props();
+</script>
+
+<p
+  bind:this={ref}
+  data-slot="card-description"
+  class={cn('text-sm text-muted-foreground', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</p>

--- a/apps/admin/src/lib/components/ui/card/card-footer.svelte
+++ b/apps/admin/src/lib/components/ui/card/card-footer.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="card-footer"
+  class={cn(
+    'rounded-b-xl px-(--card-spacing) [.border-t]:pt-(--card-spacing) flex items-center',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/card/card-header.svelte
+++ b/apps/admin/src/lib/components/ui/card/card-header.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="card-header"
+  class={cn(
+    'gap-1 rounded-t-xl px-(--card-spacing) [.border-b]:pb-(--card-spacing) group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/card/card-title.svelte
+++ b/apps/admin/src/lib/components/ui/card/card-title.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="card-title"
+  class={cn('text-base leading-normal font-medium group-data-[size=sm]/card:text-sm', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/card/card.svelte
+++ b/apps/admin/src/lib/components/ui/card/card.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    size = 'default',
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> & { size?: 'default' | 'sm' } = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="card"
+  data-size={size}
+  class={cn(
+    'gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-xs ring-1 ring-foreground/10 [--card-spacing:--spacing(6)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/card/index.ts
+++ b/apps/admin/src/lib/components/ui/card/index.ts
@@ -1,0 +1,25 @@
+import Root from './card.svelte';
+import Action from './card-action.svelte';
+import Content from './card-content.svelte';
+import Description from './card-description.svelte';
+import Footer from './card-footer.svelte';
+import Header from './card-header.svelte';
+import Title from './card-title.svelte';
+
+export {
+  Action,
+  //
+  Root as Card,
+  Action as CardAction,
+  Content as CardContent,
+  Description as CardDescription,
+  Footer as CardFooter,
+  Header as CardHeader,
+  Title as CardTitle,
+  Content,
+  Description,
+  Footer,
+  Header,
+  Root,
+  Title,
+};

--- a/apps/admin/src/lib/components/ui/input/index.ts
+++ b/apps/admin/src/lib/components/ui/input/index.ts
@@ -1,0 +1,7 @@
+import Root from './input.svelte';
+
+export {
+  //
+  Root as Input,
+  Root,
+};

--- a/apps/admin/src/lib/components/ui/input/input.svelte
+++ b/apps/admin/src/lib/components/ui/input/input.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLInputAttributes, HTMLInputTypeAttribute } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  type InputType = Exclude<HTMLInputTypeAttribute, 'file'>;
+
+  type Props = WithElementRef<
+    Omit<HTMLInputAttributes, 'type'> &
+      ({ type: 'file'; files?: FileList } | { type?: InputType; files?: undefined })
+  >;
+
+  let {
+    ref = $bindable(null),
+    value = $bindable(),
+    type,
+    files = $bindable(),
+    class: className,
+    'data-slot': dataSlot = 'input',
+    ...restProps
+  }: Props = $props();
+</script>
+
+{#if type === 'file'}
+  <input
+    bind:this={ref}
+    data-slot={dataSlot}
+    class={cn(
+      'h-9 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+      className,
+    )}
+    type="file"
+    bind:files
+    bind:value
+    {...restProps}
+  />
+{:else}
+  <input
+    bind:this={ref}
+    data-slot={dataSlot}
+    class={cn(
+      'h-9 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+      className,
+    )}
+    {type}
+    bind:value
+    {...restProps}
+  />
+{/if}

--- a/apps/admin/src/lib/components/ui/separator/index.ts
+++ b/apps/admin/src/lib/components/ui/separator/index.ts
@@ -1,0 +1,7 @@
+import Root from './separator.svelte';
+
+export {
+  Root,
+  //
+  Root as Separator,
+};

--- a/apps/admin/src/lib/components/ui/separator/separator.svelte
+++ b/apps/admin/src/lib/components/ui/separator/separator.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { Separator as SeparatorPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    'data-slot': dataSlot = 'separator',
+    ...restProps
+  }: SeparatorPrimitive.RootProps = $props();
+</script>
+
+<SeparatorPrimitive.Root
+  bind:ref
+  data-slot={dataSlot}
+  class={cn(
+    'shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px',
+    // this is different in shadcn/ui but self-stretch breaks things for us
+    'data-[orientation=vertical]:h-full',
+    className,
+  )}
+  {...restProps}
+/>

--- a/apps/admin/src/lib/components/ui/sheet/index.ts
+++ b/apps/admin/src/lib/components/ui/sheet/index.ts
@@ -1,0 +1,34 @@
+import Root from './sheet.svelte';
+import Close from './sheet-close.svelte';
+import Content from './sheet-content.svelte';
+import Description from './sheet-description.svelte';
+import Footer from './sheet-footer.svelte';
+import Header from './sheet-header.svelte';
+import Overlay from './sheet-overlay.svelte';
+import Portal from './sheet-portal.svelte';
+import Title from './sheet-title.svelte';
+import Trigger from './sheet-trigger.svelte';
+
+export {
+  Close,
+  Content,
+  Description,
+  Footer,
+  Header,
+  Overlay,
+  Portal,
+  Root,
+  //
+  Root as Sheet,
+  Close as SheetClose,
+  Content as SheetContent,
+  Description as SheetDescription,
+  Footer as SheetFooter,
+  Header as SheetHeader,
+  Overlay as SheetOverlay,
+  Portal as SheetPortal,
+  Title as SheetTitle,
+  Trigger as SheetTrigger,
+  Title,
+  Trigger,
+};

--- a/apps/admin/src/lib/components/ui/sheet/sheet-close.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+
+  let { ref = $bindable(null), ...restProps }: SheetPrimitive.CloseProps = $props();
+</script>
+
+<SheetPrimitive.Close bind:ref data-slot="sheet-close" {...restProps} />

--- a/apps/admin/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,0 +1,55 @@
+<script lang="ts" module>
+  export type Side = 'top' | 'right' | 'bottom' | 'left';
+</script>
+
+<script lang="ts">
+  import XIcon from '@lucide/svelte/icons/x';
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { cn } from '$lib/utils.js';
+  import SheetOverlay from './sheet-overlay.svelte';
+  import SheetPortal from './sheet-portal.svelte';
+  import type { ComponentProps, Snippet } from 'svelte';
+  import type { WithoutChildrenOrChild } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    side = 'right',
+    showCloseButton = true,
+    portalProps,
+    children,
+    ...restProps
+  }: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
+    portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetPortal>>;
+    side?: Side;
+    showCloseButton?: boolean;
+    children: Snippet;
+  } = $props();
+</script>
+
+<SheetPortal {...portalProps}>
+  <SheetOverlay />
+  <SheetPrimitive.Content
+    bind:ref
+    data-slot="sheet-content"
+    data-side={side}
+    class={cn(
+      'fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10',
+      className,
+    )}
+    {...restProps}
+  >
+    {@render children?.()}
+    {#if showCloseButton}
+      <SheetPrimitive.Close data-slot="sheet-close">
+        {#snippet child({ props })}
+          <Button variant="ghost" class="absolute top-4 right-4" size="icon-sm" {...props}>
+            <XIcon />
+            <span class="sr-only">Close</span>
+          </Button>
+        {/snippet}
+      </SheetPrimitive.Close>
+    {/if}
+  </SheetPrimitive.Content>
+</SheetPortal>

--- a/apps/admin/src/lib/components/ui/sheet/sheet-description.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: SheetPrimitive.DescriptionProps = $props();
+</script>
+
+<SheetPrimitive.Description
+  bind:ref
+  data-slot="sheet-description"
+  class={cn('text-sm text-muted-foreground', className)}
+  {...restProps}
+/>

--- a/apps/admin/src/lib/components/ui/sheet/sheet-footer.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-footer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sheet-footer"
+  class={cn('gap-2 p-4 mt-auto flex flex-col', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sheet/sheet-header.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-header.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sheet-header"
+  class={cn('gap-1.5 p-4 flex flex-col', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sheet/sheet-overlay.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-overlay.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: SheetPrimitive.OverlayProps = $props();
+</script>
+
+<SheetPrimitive.Overlay
+  bind:ref
+  data-slot="sheet-overlay"
+  class={cn('bg-black/10 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50', className)}
+  {...restProps}
+/>

--- a/apps/admin/src/lib/components/ui/sheet/sheet-portal.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+
+  let { ...restProps }: SheetPrimitive.PortalProps = $props();
+</script>
+
+<SheetPrimitive.Portal {...restProps} />

--- a/apps/admin/src/lib/components/ui/sheet/sheet-title.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: SheetPrimitive.TitleProps = $props();
+</script>
+
+<SheetPrimitive.Title
+  bind:ref
+  data-slot="sheet-title"
+  class={cn('font-medium text-foreground', className)}
+  {...restProps}
+/>

--- a/apps/admin/src/lib/components/ui/sheet/sheet-trigger.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+
+  let { ref = $bindable(null), ...restProps }: SheetPrimitive.TriggerProps = $props();
+</script>
+
+<SheetPrimitive.Trigger bind:ref data-slot="sheet-trigger" {...restProps} />

--- a/apps/admin/src/lib/components/ui/sheet/sheet.svelte
+++ b/apps/admin/src/lib/components/ui/sheet/sheet.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Dialog as SheetPrimitive } from 'bits-ui';
+
+  let { open = $bindable(false), ...restProps }: SheetPrimitive.RootProps = $props();
+</script>
+
+<SheetPrimitive.Root bind:open {...restProps} />

--- a/apps/admin/src/lib/components/ui/sidebar/constants.ts
+++ b/apps/admin/src/lib/components/ui/sidebar/constants.ts
@@ -1,0 +1,6 @@
+export const SIDEBAR_COOKIE_NAME = 'sidebar_state';
+export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+export const SIDEBAR_WIDTH = '16rem';
+export const SIDEBAR_WIDTH_MOBILE = '18rem';
+export const SIDEBAR_WIDTH_ICON = '3rem';
+export const SIDEBAR_KEYBOARD_SHORTCUT = 'b';

--- a/apps/admin/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/apps/admin/src/lib/components/ui/sidebar/context.svelte.ts
@@ -1,0 +1,79 @@
+import { getContext, setContext } from 'svelte';
+import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
+import { SIDEBAR_KEYBOARD_SHORTCUT } from './constants.js';
+
+type Getter<T> = () => T;
+
+export type SidebarStateProps = {
+  /**
+   * A getter function that returns the current open state of the sidebar.
+   * We use a getter function here to support `bind:open` on the `Sidebar.Provider`
+   * component.
+   */
+  open: Getter<boolean>;
+
+  /**
+   * A function that sets the open state of the sidebar. To support `bind:open`, we need
+   * a source of truth for changing the open state to ensure it will be synced throughout
+   * the sub-components and any `bind:` references.
+   */
+  setOpen: (open: boolean) => void;
+};
+
+class SidebarState {
+  readonly props: SidebarStateProps;
+  open = $derived.by(() => this.props.open());
+  openMobile = $state(false);
+  setOpen: SidebarStateProps['setOpen'];
+  #isMobile: IsMobile;
+  state = $derived.by(() => (this.open ? 'expanded' : 'collapsed'));
+
+  constructor(props: SidebarStateProps) {
+    this.setOpen = props.setOpen;
+    this.#isMobile = new IsMobile();
+    this.props = props;
+  }
+
+  // Convenience getter for checking if the sidebar is mobile
+  // without this, we would need to use `sidebar.isMobile.current` everywhere
+  get isMobile() {
+    return this.#isMobile.current;
+  }
+
+  // Event handler to apply to the `<svelte:window>`
+  handleShortcutKeydown = (e: KeyboardEvent) => {
+    if (e.key === SIDEBAR_KEYBOARD_SHORTCUT && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      this.toggle();
+    }
+  };
+
+  setOpenMobile = (value: boolean) => {
+    this.openMobile = value;
+  };
+
+  toggle = () => {
+    return this.#isMobile.current ? (this.openMobile = !this.openMobile) : this.setOpen(!this.open);
+  };
+}
+
+const SYMBOL_KEY = 'scn-sidebar';
+
+/**
+ * Instantiates a new `SidebarState` instance and sets it in the context.
+ *
+ * @param props The constructor props for the `SidebarState` class.
+ * @returns  The `SidebarState` instance.
+ */
+export function setSidebar(props: SidebarStateProps): SidebarState {
+  return setContext(Symbol.for(SYMBOL_KEY), new SidebarState(props));
+}
+
+/**
+ * Retrieves the `SidebarState` instance from the context. This is a class instance,
+ * so you cannot destructure it.
+ * @returns The `SidebarState` instance.
+ */
+export function useSidebar(): SidebarState {
+  return getContext(Symbol.for(SYMBOL_KEY));
+}

--- a/apps/admin/src/lib/components/ui/sidebar/index.ts
+++ b/apps/admin/src/lib/components/ui/sidebar/index.ts
@@ -1,0 +1,75 @@
+import { useSidebar } from './context.svelte.js';
+import Root from './sidebar.svelte';
+import Content from './sidebar-content.svelte';
+import Footer from './sidebar-footer.svelte';
+import Group from './sidebar-group.svelte';
+import GroupAction from './sidebar-group-action.svelte';
+import GroupContent from './sidebar-group-content.svelte';
+import GroupLabel from './sidebar-group-label.svelte';
+import Header from './sidebar-header.svelte';
+import Input from './sidebar-input.svelte';
+import Inset from './sidebar-inset.svelte';
+import Menu from './sidebar-menu.svelte';
+import MenuAction from './sidebar-menu-action.svelte';
+import MenuBadge from './sidebar-menu-badge.svelte';
+import MenuButton from './sidebar-menu-button.svelte';
+import MenuItem from './sidebar-menu-item.svelte';
+import MenuSkeleton from './sidebar-menu-skeleton.svelte';
+import MenuSub from './sidebar-menu-sub.svelte';
+import MenuSubButton from './sidebar-menu-sub-button.svelte';
+import MenuSubItem from './sidebar-menu-sub-item.svelte';
+import Provider from './sidebar-provider.svelte';
+import Rail from './sidebar-rail.svelte';
+import Separator from './sidebar-separator.svelte';
+import Trigger from './sidebar-trigger.svelte';
+
+export {
+  Content,
+  Footer,
+  Group,
+  GroupAction,
+  GroupContent,
+  GroupLabel,
+  Header,
+  Input,
+  Inset,
+  Menu,
+  MenuAction,
+  MenuBadge,
+  MenuButton,
+  MenuItem,
+  MenuSkeleton,
+  MenuSub,
+  MenuSubButton,
+  MenuSubItem,
+  Provider,
+  Rail,
+  Root,
+  Separator,
+  //
+  Root as Sidebar,
+  Content as SidebarContent,
+  Footer as SidebarFooter,
+  Group as SidebarGroup,
+  GroupAction as SidebarGroupAction,
+  GroupContent as SidebarGroupContent,
+  GroupLabel as SidebarGroupLabel,
+  Header as SidebarHeader,
+  Input as SidebarInput,
+  Inset as SidebarInset,
+  Menu as SidebarMenu,
+  MenuAction as SidebarMenuAction,
+  MenuBadge as SidebarMenuBadge,
+  MenuButton as SidebarMenuButton,
+  MenuItem as SidebarMenuItem,
+  MenuSkeleton as SidebarMenuSkeleton,
+  MenuSub as SidebarMenuSub,
+  MenuSubButton as SidebarMenuSubButton,
+  MenuSubItem as SidebarMenuSubItem,
+  Provider as SidebarProvider,
+  Rail as SidebarRail,
+  Separator as SidebarSeparator,
+  Trigger as SidebarTrigger,
+  Trigger,
+  useSidebar,
+};

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-content.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-content.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sidebar-content"
+  data-sidebar="content"
+  class={cn(
+    'no-scrollbar gap-2 flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-footer.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-footer.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sidebar-footer"
+  data-sidebar="footer"
+  class={cn('gap-2 p-2 flex flex-col', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-group-action.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-group-action.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    child,
+    ...restProps
+  }: WithElementRef<HTMLButtonAttributes> & {
+    child?: Snippet<[{ props: Record<string, unknown> }]>;
+  } = $props();
+
+  const mergedProps = $derived({
+    class: cn(
+      'absolute top-3.5 right-3 w-5 rounded-md p-0 text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
+      className,
+    ),
+    'data-slot': 'sidebar-group-action',
+    'data-sidebar': 'group-action',
+    ...restProps,
+  });
+</script>
+
+{#if child}
+  {@render child({ props: mergedProps })}
+{:else}
+  <button bind:this={ref} {...mergedProps}>
+    {@render children?.()}
+  </button>
+{/if}

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-group-content.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-group-content.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sidebar-group-content"
+  data-sidebar="group-content"
+  class={cn('text-sm w-full', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-group-label.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-group-label.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    children,
+    child,
+    class: className,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> & {
+    child?: Snippet<[{ props: Record<string, unknown> }]>;
+  } = $props();
+
+  const mergedProps = $derived({
+    class: cn(
+      'h-8 rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0',
+      className,
+    ),
+    'data-slot': 'sidebar-group-label',
+    'data-sidebar': 'group-label',
+    ...restProps,
+  });
+</script>
+
+{#if child}
+  {@render child({ props: mergedProps })}
+{:else}
+  <div bind:this={ref} {...mergedProps}>
+    {@render children?.()}
+  </div>
+{/if}

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-group.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-group.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sidebar-group"
+  data-sidebar="group"
+  class={cn('p-2 relative flex w-full min-w-0 flex-col', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-header.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-header.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sidebar-header"
+  data-sidebar="header"
+  class={cn('gap-2 p-2 flex flex-col', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-input.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-input.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Input } from '$lib/components/ui/input/index.js';
+  import { cn } from '$lib/utils.js';
+  import type { ComponentProps } from 'svelte';
+
+  let {
+    ref = $bindable(null),
+    value = $bindable(''),
+    class: className,
+    ...restProps
+  }: ComponentProps<typeof Input> = $props();
+</script>
+
+<Input
+  bind:ref
+  bind:value
+  data-slot="sidebar-input"
+  data-sidebar="input"
+  class={cn('h-8 w-full bg-background shadow-none', className)}
+  {...restProps}
+/>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<main
+  bind:this={ref}
+  data-slot="sidebar-inset"
+  class={cn(
+    'bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</main>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    showOnHover = false,
+    children,
+    child,
+    ...restProps
+  }: WithElementRef<HTMLButtonAttributes> & {
+    child?: Snippet<[{ props: Record<string, unknown> }]>;
+    showOnHover?: boolean;
+  } = $props();
+
+  const mergedProps = $derived({
+    class: cn(
+      'absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 text-sidebar-foreground ring-sidebar-ring peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
+      showOnHover &&
+        'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground md:opacity-0 data-open:opacity-100',
+      className,
+    ),
+    'data-slot': 'sidebar-menu-action',
+    'data-sidebar': 'menu-action',
+    ...restProps,
+  });
+</script>
+
+{#if child}
+  {@render child({ props: mergedProps })}
+{:else}
+  <button bind:this={ref} {...mergedProps}>
+    {@render children?.()}
+  </button>
+{/if}

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-badge.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-badge.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sidebar-menu-badge"
+  data-sidebar="menu-badge"
+  class={cn(
+    'pointer-events-none absolute right-1 flex h-5 min-w-5 rounded-md px-1 text-xs font-medium text-sidebar-foreground peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
@@ -1,0 +1,103 @@
+<script lang="ts" module>
+  import { tv } from 'tailwind-variants';
+  import type { VariantProps } from 'tailwind-variants';
+
+  export const sidebarMenuButtonVariants = tv({
+    base: 'gap-2 rounded-md p-2 text-left text-sm ring-sidebar-ring transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground peer/menu-button group/menu-button flex w-full items-center overflow-hidden outline-hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate',
+    variants: {
+      variant: {
+        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        outline:
+          'bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]',
+      },
+      size: {
+        default: 'h-8 text-sm',
+        sm: 'h-7 text-xs',
+        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  });
+
+  export type SidebarMenuButtonVariant = VariantProps<typeof sidebarMenuButtonVariants>['variant'];
+  export type SidebarMenuButtonSize = VariantProps<typeof sidebarMenuButtonVariants>['size'];
+</script>
+
+<script lang="ts">
+  import { mergeProps } from 'bits-ui';
+  import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+  import { cn } from '$lib/utils.js';
+  import { useSidebar } from './context.svelte.js';
+  import type { ComponentProps, Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef, WithoutChildrenOrChild } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    child,
+    variant = 'default',
+    size = 'default',
+    isActive = false,
+    tooltipContent,
+    tooltipContentProps,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+    isActive?: boolean;
+    variant?: SidebarMenuButtonVariant;
+    size?: SidebarMenuButtonSize;
+    tooltipContent?: Snippet | string;
+    tooltipContentProps?: WithoutChildrenOrChild<ComponentProps<typeof Tooltip.Content>>;
+    child?: Snippet<[{ props: Record<string, unknown> }]>;
+  } = $props();
+
+  const sidebar = useSidebar();
+
+  const buttonProps = $derived({
+    class: cn(sidebarMenuButtonVariants({ variant, size }), className),
+    'data-slot': 'sidebar-menu-button',
+    'data-sidebar': 'menu-button',
+    'data-size': size,
+    'data-active': isActive,
+    ...restProps,
+  });
+</script>
+
+{#snippet Button({ props }: { props?: Record<string, unknown> })}
+  {@const mergedProps = mergeProps(buttonProps, props)}
+  {#if child}
+    {@render child({ props: mergedProps })}
+  {:else}
+    <button bind:this={ref} {...mergedProps}>
+      {@render children?.()}
+    </button>
+  {/if}
+{/snippet}
+
+{#if !tooltipContent}
+  {@render Button({})}
+{:else}
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        {@render Button({ props })}
+      {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content
+      side="right"
+      align="center"
+      hidden={sidebar.state !== 'collapsed' || sidebar.isMobile}
+      {...tooltipContentProps}
+    >
+      {#if typeof tooltipContent === 'string'}
+        {tooltipContent}
+      {:else if tooltipContent}
+        {@render tooltipContent()}
+      {/if}
+    </Tooltip.Content>
+  </Tooltip.Root>
+{/if}

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-item.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-item.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLLIElement>, HTMLLIElement> = $props();
+</script>
+
+<li
+  bind:this={ref}
+  data-slot="sidebar-menu-item"
+  data-sidebar="menu-item"
+  class={cn('group/menu-item relative', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</li>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    showIcon = false,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> & {
+    showIcon?: boolean;
+  } = $props();
+
+  // Random width between 50% and 90%
+  const width = `${Math.floor(Math.random() * 40) + 50}%`;
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="sidebar-menu-skeleton"
+  data-sidebar="menu-skeleton"
+  class={cn('h-8 gap-2 rounded-md px-2 flex items-center', className)}
+  {...restProps}
+>
+  {#if showIcon}
+    <Skeleton class="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />
+  {/if}
+  <Skeleton
+    class="h-4 max-w-(--skeleton-width) flex-1"
+    data-sidebar="menu-skeleton-text"
+    style="--skeleton-width: {width};"
+  />
+  {@render children?.()}
+</div>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { Snippet } from 'svelte';
+  import type { HTMLAnchorAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    children,
+    child,
+    class: className,
+    size = 'md',
+    isActive = false,
+    ...restProps
+  }: WithElementRef<HTMLAnchorAttributes> & {
+    child?: Snippet<[{ props: Record<string, unknown> }]>;
+    size?: 'sm' | 'md';
+    isActive?: boolean;
+  } = $props();
+
+  const mergedProps = $derived({
+    class: cn(
+      'h-7 gap-2 rounded-md px-2 text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:text-sidebar-accent-foreground flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0',
+      className,
+    ),
+    'data-slot': 'sidebar-menu-sub-button',
+    'data-sidebar': 'menu-sub-button',
+    'data-size': size,
+    'data-active': isActive,
+    ...restProps,
+  });
+</script>
+
+{#if child}
+  {@render child({ props: mergedProps })}
+{:else}
+  <a bind:this={ref} {...mergedProps}>
+    {@render children?.()}
+  </a>
+{/if}

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-sub-item.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-sub-item.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    children,
+    class: className,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLLIElement>> = $props();
+</script>
+
+<li
+  bind:this={ref}
+  data-slot="sidebar-menu-sub-item"
+  data-sidebar="menu-sub-item"
+  class={cn('group/menu-sub-item relative', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</li>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-sub.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu-sub.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();
+</script>
+
+<ul
+  bind:this={ref}
+  data-slot="sidebar-menu-sub"
+  data-sidebar="menu-sub"
+  class={cn(
+    'mx-3.5 translate-x-px gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden flex min-w-0 flex-col',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</ul>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-menu.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-menu.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLUListElement>, HTMLUListElement> = $props();
+</script>
+
+<ul
+  bind:this={ref}
+  data-slot="sidebar-menu"
+  data-sidebar="menu"
+  class={cn('gap-1 flex w-full min-w-0 flex-col', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</ul>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+  import { cn } from '$lib/utils.js';
+  import {
+    SIDEBAR_COOKIE_MAX_AGE,
+    SIDEBAR_COOKIE_NAME,
+    SIDEBAR_WIDTH,
+    SIDEBAR_WIDTH_ICON,
+  } from './constants.js';
+  import { setSidebar } from './context.svelte.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    open = $bindable(true),
+    onOpenChange = () => {},
+    class: className,
+    style,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  } = $props();
+
+  const sidebar = setSidebar({
+    open: () => open,
+    setOpen: (value: boolean) => {
+      open = value;
+      onOpenChange(value);
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+  });
+</script>
+
+<svelte:window onkeydown={sidebar.handleShortcutKeydown} />
+
+<Tooltip.Provider delayDuration={0}>
+  <div
+    data-slot="sidebar-wrapper"
+    style="--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
+    class={cn(
+      'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
+      className,
+    )}
+    bind:this={ref}
+    {...restProps}
+  >
+    {@render children?.()}
+  </div>
+</Tooltip.Provider>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-rail.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-rail.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import { useSidebar } from './context.svelte.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> = $props();
+
+  const sidebar = useSidebar();
+</script>
+
+<button
+  bind:this={ref}
+  data-sidebar="rail"
+  data-slot="sidebar-rail"
+  aria-label="Toggle Sidebar"
+  tabindex={-1}
+  onclick={sidebar.toggle}
+  title="Toggle Sidebar"
+  class={cn(
+    'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
+    'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
+    '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+    'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar',
+    '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+    '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</button>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-separator.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-separator.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Separator } from '$lib/components/ui/separator/index.js';
+  import { cn } from '$lib/utils.js';
+  import type { ComponentProps } from 'svelte';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: ComponentProps<typeof Separator> = $props();
+</script>
+
+<Separator
+  bind:ref
+  data-slot="sidebar-separator"
+  data-sidebar="separator"
+  class={cn('mx-2 bg-sidebar-border w-auto', className)}
+  {...restProps}
+/>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { cn } from '$lib/utils.js';
+  import { useSidebar } from './context.svelte.js';
+  import type { ComponentProps } from 'svelte';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    onclick,
+    ...restProps
+  }: ComponentProps<typeof Button> & {
+    onclick?: (e: MouseEvent) => void;
+  } = $props();
+
+  const sidebar = useSidebar();
+</script>
+
+<Button
+  bind:ref
+  data-sidebar="trigger"
+  data-slot="sidebar-trigger"
+  variant="ghost"
+  size="icon-sm"
+  class={cn('cn-sidebar-trigger', className)}
+  type="button"
+  onclick={(e) => {
+    onclick?.(e);
+    sidebar.toggle();
+  }}
+  {...restProps}
+>
+  <PanelLeftIcon />
+  <span class="sr-only">Toggle Sidebar</span>
+</Button>

--- a/apps/admin/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/apps/admin/src/lib/components/ui/sidebar/sidebar.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import * as Sheet from '$lib/components/ui/sheet/index.js';
+  import { cn } from '$lib/utils.js';
+  import { SIDEBAR_WIDTH_MOBILE } from './constants.js';
+  import { useSidebar } from './context.svelte.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    side = 'left',
+    variant = 'sidebar',
+    collapsible = 'offcanvas',
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+    side?: 'left' | 'right';
+    variant?: 'sidebar' | 'floating' | 'inset';
+    collapsible?: 'offcanvas' | 'icon' | 'none';
+  } = $props();
+
+  const sidebar = useSidebar();
+</script>
+
+{#if collapsible === 'none'}
+  <div
+    class={cn(
+      'flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground',
+      className,
+    )}
+    bind:this={ref}
+    {...restProps}
+  >
+    {@render children?.()}
+  </div>
+{:else if sidebar.isMobile}
+  <Sheet.Root bind:open={() => sidebar.openMobile, (v) => sidebar.setOpenMobile(v)} {...restProps}>
+    <Sheet.Content
+      bind:ref
+      data-sidebar="sidebar"
+      data-slot="sidebar"
+      data-mobile="true"
+      class={cn(
+        'w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden',
+        className,
+      )}
+      style="--sidebar-width: {SIDEBAR_WIDTH_MOBILE};"
+      {side}
+    >
+      <Sheet.Header class="sr-only">
+        <Sheet.Title>Sidebar</Sheet.Title>
+        <Sheet.Description>Displays the mobile sidebar.</Sheet.Description>
+      </Sheet.Header>
+      <div class="flex h-full w-full flex-col">
+        {@render children?.()}
+      </div>
+    </Sheet.Content>
+  </Sheet.Root>
+{:else}
+  <div
+    bind:this={ref}
+    class="group peer hidden text-sidebar-foreground md:block"
+    data-state={sidebar.state}
+    data-collapsible={sidebar.state === 'collapsed' ? collapsible : ''}
+    data-variant={variant}
+    data-side={side}
+    data-slot="sidebar"
+  >
+    <!-- This is what handles the sidebar gap on desktop -->
+    <div
+      data-slot="sidebar-gap"
+      class={cn(
+        'transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent',
+        'group-data-[collapsible=offcanvas]:w-0',
+        'group-data-[side=right]:rotate-180',
+        variant === 'floating' || variant === 'inset'
+          ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
+          : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
+      )}
+    ></div>
+    <div
+      data-slot="sidebar-container"
+      class={cn(
+        'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
+        side === 'left'
+          ? 'start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]'
+          : 'end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]',
+        // Adjust the padding for floating and inset variants.
+        variant === 'floating' || variant === 'inset'
+          ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
+          : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s',
+        className,
+      )}
+      {...restProps}
+    >
+      <div
+        data-sidebar="sidebar"
+        data-slot="sidebar-inner"
+        class="bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border flex size-full flex-col"
+      >
+        {@render children?.()}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/apps/admin/src/lib/components/ui/skeleton/index.ts
+++ b/apps/admin/src/lib/components/ui/skeleton/index.ts
@@ -1,0 +1,7 @@
+import Root from './skeleton.svelte';
+
+export {
+  Root,
+  //
+  Root as Skeleton,
+};

--- a/apps/admin/src/lib/components/ui/skeleton/skeleton.svelte
+++ b/apps/admin/src/lib/components/ui/skeleton/skeleton.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef, WithoutChildren } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="skeleton"
+  class={cn('rounded-md bg-muted animate-pulse', className)}
+  {...restProps}
+></div>

--- a/apps/admin/src/lib/components/ui/table/index.ts
+++ b/apps/admin/src/lib/components/ui/table/index.ts
@@ -1,0 +1,28 @@
+import Root from './table.svelte';
+import Body from './table-body.svelte';
+import Caption from './table-caption.svelte';
+import Cell from './table-cell.svelte';
+import Footer from './table-footer.svelte';
+import Head from './table-head.svelte';
+import Header from './table-header.svelte';
+import Row from './table-row.svelte';
+
+export {
+  Body,
+  Caption,
+  Cell,
+  Footer,
+  Head,
+  Header,
+  Root,
+  Row,
+  //
+  Root as Table,
+  Body as TableBody,
+  Caption as TableCaption,
+  Cell as TableCell,
+  Footer as TableFooter,
+  Head as TableHead,
+  Header as TableHeader,
+  Row as TableRow,
+};

--- a/apps/admin/src/lib/components/ui/table/table-body.svelte
+++ b/apps/admin/src/lib/components/ui/table/table-body.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<tbody
+  bind:this={ref}
+  data-slot="table-body"
+  class={cn('[&_tr:last-child]:border-0', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</tbody>

--- a/apps/admin/src/lib/components/ui/table/table-caption.svelte
+++ b/apps/admin/src/lib/components/ui/table/table-caption.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<caption
+  bind:this={ref}
+  data-slot="table-caption"
+  class={cn('mt-4 text-sm text-muted-foreground', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</caption>

--- a/apps/admin/src/lib/components/ui/table/table-cell.svelte
+++ b/apps/admin/src/lib/components/ui/table/table-cell.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLTdAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLTdAttributes> = $props();
+</script>
+
+<td
+  bind:this={ref}
+  data-slot="table-cell"
+  class={cn('p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</td>

--- a/apps/admin/src/lib/components/ui/table/table-footer.svelte
+++ b/apps/admin/src/lib/components/ui/table/table-footer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<tfoot
+  bind:this={ref}
+  data-slot="table-footer"
+  class={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</tfoot>

--- a/apps/admin/src/lib/components/ui/table/table-head.svelte
+++ b/apps/admin/src/lib/components/ui/table/table-head.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLThAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLThAttributes> = $props();
+</script>
+
+<th
+  bind:this={ref}
+  data-slot="table-head"
+  class={cn(
+    'h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</th>

--- a/apps/admin/src/lib/components/ui/table/table-header.svelte
+++ b/apps/admin/src/lib/components/ui/table/table-header.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<thead
+  bind:this={ref}
+  data-slot="table-header"
+  class={cn('[&_tr]:border-b', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</thead>

--- a/apps/admin/src/lib/components/ui/table/table-row.svelte
+++ b/apps/admin/src/lib/components/ui/table/table-row.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();
+</script>
+
+<tr
+  bind:this={ref}
+  data-slot="table-row"
+  class={cn(
+    'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</tr>

--- a/apps/admin/src/lib/components/ui/table/table.svelte
+++ b/apps/admin/src/lib/components/ui/table/table.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLTableAttributes } from 'svelte/elements';
+  import type { WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLTableAttributes> = $props();
+</script>
+
+<div data-slot="table-container" class="relative w-full overflow-x-auto">
+  <table
+    bind:this={ref}
+    data-slot="table"
+    class={cn('w-full caption-bottom text-sm', className)}
+    {...restProps}
+  >
+    {@render children?.()}
+  </table>
+</div>

--- a/apps/admin/src/lib/components/ui/tooltip/index.ts
+++ b/apps/admin/src/lib/components/ui/tooltip/index.ts
@@ -1,0 +1,19 @@
+import Root from './tooltip.svelte';
+import Content from './tooltip-content.svelte';
+import Portal from './tooltip-portal.svelte';
+import Provider from './tooltip-provider.svelte';
+import Trigger from './tooltip-trigger.svelte';
+
+export {
+  Content,
+  Portal,
+  Provider,
+  Root,
+  //
+  Root as Tooltip,
+  Content as TooltipContent,
+  Portal as TooltipPortal,
+  Provider as TooltipProvider,
+  Trigger as TooltipTrigger,
+  Trigger,
+};

--- a/apps/admin/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/apps/admin/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { Tooltip as TooltipPrimitive } from 'bits-ui';
+  import { cn } from '$lib/utils.js';
+  import TooltipPortal from './tooltip-portal.svelte';
+  import type { ComponentProps } from 'svelte';
+  import type { WithoutChildrenOrChild } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    sideOffset = 0,
+    side = 'top',
+    children,
+    arrowClasses,
+    portalProps,
+    ...restProps
+  }: TooltipPrimitive.ContentProps & {
+    arrowClasses?: string;
+    portalProps?: WithoutChildrenOrChild<ComponentProps<typeof TooltipPortal>>;
+  } = $props();
+</script>
+
+<TooltipPortal {...portalProps}>
+  <TooltipPrimitive.Content
+    bind:ref
+    data-slot="tooltip-content"
+    {sideOffset}
+    {side}
+    class={cn(
+      'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin) bg-foreground text-background',
+      className,
+    )}
+    {...restProps}
+  >
+    {@render children?.()}
+    <TooltipPrimitive.Arrow>
+      {#snippet child({ props })}
+        <div
+          class={cn(
+            'size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] z-50 bg-foreground fill-foreground',
+            'data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%+2px)]',
+            'data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%+1px)]',
+            'data-[side=right]:translate-x-[calc(50%+2px)] data-[side=right]:translate-y-1/2',
+            'data-[side=left]:-translate-y-[calc(50%-3px)]',
+            arrowClasses,
+          )}
+          {...props}
+        ></div>
+      {/snippet}
+    </TooltipPrimitive.Arrow>
+  </TooltipPrimitive.Content>
+</TooltipPortal>

--- a/apps/admin/src/lib/components/ui/tooltip/tooltip-portal.svelte
+++ b/apps/admin/src/lib/components/ui/tooltip/tooltip-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+  let { ...restProps }: TooltipPrimitive.PortalProps = $props();
+</script>
+
+<TooltipPrimitive.Portal {...restProps} />

--- a/apps/admin/src/lib/components/ui/tooltip/tooltip-provider.svelte
+++ b/apps/admin/src/lib/components/ui/tooltip/tooltip-provider.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+  let { delayDuration = 0, ...restProps }: TooltipPrimitive.ProviderProps = $props();
+</script>
+
+<TooltipPrimitive.Provider {delayDuration} {...restProps} />

--- a/apps/admin/src/lib/components/ui/tooltip/tooltip-trigger.svelte
+++ b/apps/admin/src/lib/components/ui/tooltip/tooltip-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" generics="T = never">
+  import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+  let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps<T> = $props();
+</script>
+
+<TooltipPrimitive.Trigger bind:ref data-slot="tooltip-trigger" {...restProps} />

--- a/apps/admin/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/apps/admin/src/lib/components/ui/tooltip/tooltip.svelte
@@ -1,0 +1,7 @@
+<script lang="ts" generics="T = never">
+  import { Tooltip as TooltipPrimitive } from 'bits-ui';
+
+  let { open = $bindable(false), ...restProps }: TooltipPrimitive.RootProps<T> = $props();
+</script>
+
+<TooltipPrimitive.Root bind:open {...restProps} />

--- a/apps/admin/src/lib/hooks/is-mobile.svelte.ts
+++ b/apps/admin/src/lib/hooks/is-mobile.svelte.ts
@@ -1,0 +1,9 @@
+import { MediaQuery } from 'svelte/reactivity';
+
+const DEFAULT_MOBILE_BREAKPOINT = 768;
+
+export class IsMobile extends MediaQuery {
+  constructor(breakpoint: number = DEFAULT_MOBILE_BREAKPOINT) {
+    super(`max-width: ${breakpoint - 1}px`);
+  }
+}

--- a/apps/admin/src/lib/utils.ts
+++ b/apps/admin/src/lib/utils.ts
@@ -1,0 +1,14 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import type { ClassValue } from 'clsx';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type WithoutChild<T> = T extends { child?: any } ? Omit<T, 'child'> : T;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type WithoutChildren<T> = T extends { children?: any } ? Omit<T, 'children'> : T;
+export type WithoutChildrenOrChild<T> = WithoutChildren<WithoutChild<T>>;
+export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & { ref?: U | null };

--- a/apps/admin/src/routes/+layout.svelte
+++ b/apps/admin/src/routes/+layout.svelte
@@ -1,133 +1,23 @@
 <script lang="ts">
   import '../app.css';
 
+  import AppSidebar from '$lib/components/app-sidebar.svelte';
+  import { Separator } from '$lib/components/ui/separator';
+  import * as Sidebar from '$lib/components/ui/sidebar';
   import type { Snippet } from 'svelte';
+  import type { LayoutData } from './$types';
 
-  let { children }: { children: Snippet } = $props();
+  let { children, data }: { children: Snippet; data: LayoutData } = $props();
 </script>
 
-{@render children()}
-
-<style>
-  :global(:root) {
-    color-scheme: light;
-    font-family:
-      Inter,
-      ui-sans-serif,
-      system-ui,
-      -apple-system,
-      BlinkMacSystemFont,
-      'Segoe UI',
-      sans-serif;
-    font-synthesis: none;
-    text-rendering: optimizeLegibility;
-    --color-accent: #4f46e5;
-    --color-accent-strong: #3730a3;
-    --color-border: #dbe1ea;
-    --color-border-muted: #edf0f5;
-    --color-foreground: #172033;
-    --color-foreground-muted: #647087;
-    --color-surface: #ffffff;
-    --color-surface-muted: #f7f8fb;
-    --shadow-card: 0 0.5rem 1.5rem rgb(23 32 51 / 6%);
-  }
-
-  :global(html) {
-    background: var(--color-surface-muted);
-  }
-
-  :global(body) {
-    margin: 0;
-    min-width: 20rem;
-    background: var(--color-surface-muted);
-    color: var(--color-foreground);
-  }
-
-  :global(a) {
-    color: inherit;
-  }
-
-  :global(main.admin-page) {
-    box-sizing: border-box;
-    margin: 0 auto;
-    max-width: 76rem;
-    padding: 3rem 1.5rem 5rem;
-  }
-
-  :global(.admin-header) {
-    align-items: flex-start;
-    display: flex;
-    gap: 1.5rem;
-    justify-content: space-between;
-    margin-bottom: 2rem;
-  }
-
-  :global(.admin-header h1) {
-    font-size: clamp(1.75rem, 4vw, 2.25rem);
-    letter-spacing: -0.03em;
-    line-height: 1.1;
-    margin: 0.25rem 0 0;
-  }
-
-  :global(.admin-header p) {
-    color: var(--color-foreground-muted);
-    margin: 0.5rem 0 0;
-  }
-
-  :global(.admin-eyebrow) {
-    color: var(--color-accent-strong) !important;
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    margin: 0 !important;
-    text-transform: uppercase;
-  }
-
-  :global(.admin-actions) {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
-
-  :global(.admin-description) {
-    color: var(--color-foreground-muted);
-    line-height: 1.5;
-    margin: 0;
-  }
-
-  :global(.admin-empty) {
-    border: 1px dashed var(--color-border);
-    border-radius: 0.75rem;
-    color: var(--color-foreground-muted);
-    padding: 3rem 1.5rem;
-    text-align: center;
-  }
-
-  :global(.admin-pagination) {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: 1rem;
-  }
-
-  :global(.account-link) {
-    color: var(--color-accent-strong);
-    font-weight: 600;
-    text-decoration: none;
-  }
-
-  :global(.account-link:hover) {
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
-  }
-
-  @media (max-width: 36rem) {
-    :global(main.admin-page) {
-      padding: 2rem 1rem 4rem;
-    }
-
-    :global(.admin-header) {
-      flex-direction: column;
-    }
-  }
-</style>
+<Sidebar.Provider>
+  <AppSidebar viewer={data.viewer} />
+  <Sidebar.Inset>
+    <header class="flex h-14 shrink-0 items-center gap-2 border-b px-4">
+      <Sidebar.Trigger />
+      <Separator orientation="vertical" class="mr-2 h-4!" />
+      <span class="text-sm font-medium">Kosmo Admin Console</span>
+    </header>
+    <div class="flex flex-1 flex-col p-4 md:p-6">{@render children()}</div>
+  </Sidebar.Inset>
+</Sidebar.Provider>

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+  import UsersIcon from '@lucide/svelte/icons/users';
+  import { resolve } from '$app/paths';
   import { Button } from '$lib/components/ui/button';
-  import type { PageData } from './$types';
-
-  let { data }: { data: PageData } = $props();
+  import * as Card from '$lib/components/ui/card';
 </script>
 
 <svelte:head>
@@ -10,18 +10,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 </svelte:head>
 
-<main class="admin-page">
-  <header class="admin-header">
-    <div>
-      <p class="admin-eyebrow">Admin Console</p>
-      <h1>Kosmo Admin Console</h1>
-      <p class="admin-description">{data.viewer.label}</p>
-      {#if data.viewer.login && data.viewer.login !== data.viewer.label}
-        <p class="admin-description">{data.viewer.login}</p>
-      {/if}
-    </div>
-    <nav aria-label="Admin Console navigation" class="admin-actions">
-      <Button href="/accounts">Accounts</Button>
-    </nav>
+<div class="mx-auto flex w-full max-w-6xl flex-col gap-6">
+  <header>
+    <p class="text-sm font-medium text-muted-foreground">Admin Console</p>
+    <h1 class="text-2xl font-semibold tracking-tight">Overview</h1>
+    <p class="mt-1 text-sm text-muted-foreground">Kosmo 운영 데이터를 조회합니다.</p>
   </header>
-</main>
+
+  <Card.Root class="max-w-xl">
+    <Card.Header>
+      <Card.Title class="flex items-center gap-2"><UsersIcon class="size-5" /> Accounts</Card.Title>
+      <Card.Description>Account 목록과 상세 정보를 확인합니다.</Card.Description>
+    </Card.Header>
+    <Card.Footer>
+      <Button href={resolve('/accounts')}>Accounts 열기</Button>
+    </Card.Footer>
+  </Card.Root>
+</div>

--- a/apps/admin/src/routes/accounts/+page.svelte
+++ b/apps/admin/src/routes/accounts/+page.svelte
@@ -2,6 +2,7 @@
   import { resolve } from '$app/paths';
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
+  import * as Table from '$lib/components/ui/table';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -11,110 +12,63 @@
   <title>Accounts · Kosmo Admin Console</title>
 </svelte:head>
 
-<main class="admin-page">
-  <header class="admin-header">
-    <div>
-      <p class="admin-eyebrow">Admin Console</p>
-      <h1>Accounts</h1>
-      <p class="admin-description">Account 목록 · 읽기 전용</p>
-    </div>
-    <nav aria-label="Account actions" class="admin-actions">
-      <Button href="/" variant="outline">Console</Button>
-    </nav>
+<div class="mx-auto flex w-full max-w-6xl flex-col gap-6">
+  <header>
+    <p class="text-sm font-medium text-muted-foreground">Admin Console</p>
+    <h1 class="text-2xl font-semibold tracking-tight">Accounts</h1>
+    <p class="mt-1 text-sm text-muted-foreground">Account 목록 · 읽기 전용</p>
   </header>
 
   {#if data.accounts.length === 0}
-    <p class="admin-empty">Account가 없습니다.</p>
+    <div class="rounded-lg border border-dashed p-12 text-center text-sm text-muted-foreground">
+      Account가 없습니다.
+    </div>
   {:else}
-    <div class="account-table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">ID</th>
-            <th scope="col">Display name</th>
-            <th scope="col">State</th>
-            <th scope="col">Created at</th>
-          </tr>
-        </thead>
-        <tbody>
+    <div class="overflow-hidden rounded-lg border">
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            <Table.Head>ID</Table.Head>
+            <Table.Head>Display name</Table.Head>
+            <Table.Head>State</Table.Head>
+            <Table.Head>Created at</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
           {#each data.accounts as account (account.id)}
-            <tr>
-              <td>
-                <a class="account-link" href={resolve(`/accounts/${account.id}`)}>{account.id}</a>
-              </td>
-              <td>{account.displayName}</td>
-              <td>
+            <Table.Row>
+              <Table.Cell class="font-medium">
+                <a class="hover:underline" href={resolve(`/accounts/${account.id}`)}>{account.id}</a
+                >
+              </Table.Cell>
+              <Table.Cell>{account.displayName}</Table.Cell>
+              <Table.Cell>
                 <Badge variant={account.state === 'ACTIVE' ? 'default' : 'outline'}>
                   {account.state}
                 </Badge>
-              </td>
-              <td><time datetime={account.createdAt}>{account.createdAt}</time></td>
-            </tr>
+              </Table.Cell>
+              <Table.Cell><time datetime={account.createdAt}>{account.createdAt}</time></Table.Cell>
+            </Table.Row>
           {/each}
-        </tbody>
-      </table>
+        </Table.Body>
+      </Table.Root>
     </div>
 
     {#if data.previousCursor || data.nextCursor}
-      <nav aria-label="Account pagination" class="admin-pagination">
+      <nav aria-label="Account pagination" class="flex justify-end gap-2">
         {#if data.previousCursor}
           <Button
-            href={`/accounts?cursor=${data.previousCursor}&direction=previous`}
+            href={resolve(`/accounts?cursor=${data.previousCursor}&direction=previous`)}
             size="sm"
             variant="outline">이전 50개</Button
           >
         {/if}
         {#if data.nextCursor}
-          <Button href={`/accounts?cursor=${data.nextCursor}`} size="sm" variant="outline">
+          <Button href={resolve(`/accounts?cursor=${data.nextCursor}`)} size="sm" variant="outline">
             다음 50개
           </Button>
         {/if}
       </nav>
     {/if}
   {/if}
-</main>
-
-<style>
-  .account-table-wrapper {
-    overflow-x: auto;
-    border: 1px solid var(--color-border);
-    border-radius: 0.75rem;
-    background: var(--color-surface);
-    box-shadow: var(--shadow-card);
-  }
-
-  table {
-    border-collapse: collapse;
-    min-width: 42rem;
-    width: 100%;
-  }
-
-  th,
-  td {
-    border-bottom: 1px solid var(--color-border-muted);
-    padding: 0.875rem 1rem;
-    text-align: left;
-    vertical-align: middle;
-  }
-
-  th {
-    color: var(--color-foreground-muted);
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-  }
-
-  td {
-    color: var(--color-foreground);
-    font-size: 0.875rem;
-  }
-
-  tbody tr:last-child td {
-    border-bottom: 0;
-  }
-
-  tbody tr:hover {
-    background: var(--color-surface-muted);
-  }
-</style>
+</div>

--- a/apps/admin/src/routes/accounts/[id]/+page.svelte
+++ b/apps/admin/src/routes/accounts/[id]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { resolve } from '$app/paths';
   import { Badge } from '$lib/components/ui/badge';
   import { Button } from '$lib/components/ui/button';
+  import * as Card from '$lib/components/ui/card';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -10,87 +12,44 @@
   <title>{data.account.displayName} · Account · Kosmo Admin Console</title>
 </svelte:head>
 
-<main class="admin-page">
-  <header class="admin-header">
+<div class="mx-auto flex w-full max-w-6xl flex-col gap-6">
+  <header class="flex flex-wrap items-start justify-between gap-4">
     <div>
-      <p class="admin-eyebrow">Account detail</p>
-      <h1>{data.account.displayName}</h1>
-      <p class="admin-description">읽기 전용 Account 상세</p>
+      <p class="text-sm font-medium text-muted-foreground">Account detail</p>
+      <h1 class="text-2xl font-semibold tracking-tight">{data.account.displayName}</h1>
+      <p class="mt-1 text-sm text-muted-foreground">읽기 전용 Account 상세</p>
     </div>
-    <nav aria-label="Account actions" class="admin-actions">
-      <Button href="/accounts" variant="outline">Accounts</Button>
-    </nav>
+    <Button href={resolve('/accounts')} variant="outline">Accounts</Button>
   </header>
 
-  <dl class="account-detail">
-    <div>
-      <dt>ID</dt>
-      <dd>{data.account.id}</dd>
-    </div>
-    <div>
-      <dt>Display name</dt>
-      <dd>{data.account.displayName}</dd>
-    </div>
-    <div>
-      <dt>State</dt>
-      <dd>
-        <Badge variant={data.account.state === 'ACTIVE' ? 'default' : 'outline'}>
-          {data.account.state}
-        </Badge>
-      </dd>
-    </div>
-    <div>
-      <dt>Created at</dt>
-      <dd><time datetime={data.account.createdAt}>{data.account.createdAt}</time></dd>
-    </div>
-    <div>
-      <dt>OIDC subject</dt>
-      <dd class="account-detail-value">{data.account.oidcSubject}</dd>
-    </div>
-  </dl>
-</main>
-
-<style>
-  .account-detail {
-    border: 1px solid var(--color-border);
-    border-radius: 0.75rem;
-    background: var(--color-surface);
-    box-shadow: var(--shadow-card);
-    margin: 0;
-  }
-
-  .account-detail > div {
-    display: grid;
-    gap: 1rem;
-    grid-template-columns: minmax(8rem, 12rem) 1fr;
-    padding: 1rem 1.25rem;
-  }
-
-  .account-detail > div + div {
-    border-top: 1px solid var(--color-border-muted);
-  }
-
-  dt {
-    color: var(--color-foreground-muted);
-    font-size: 0.8125rem;
-    font-weight: 700;
-  }
-
-  dd {
-    margin: 0;
-    overflow-wrap: anywhere;
-  }
-
-  .account-detail-value {
-    font-family:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
-    font-size: 0.875rem;
-  }
-
-  @media (max-width: 36rem) {
-    .account-detail > div {
-      gap: 0.375rem;
-      grid-template-columns: 1fr;
-    }
-  }
-</style>
+  <Card.Root>
+    <Card.Content class="grid gap-0 px-0">
+      <dl class="divide-y">
+        <div class="grid gap-1 px-6 py-4 sm:grid-cols-[12rem_1fr] sm:gap-4">
+          <dt class="text-sm font-medium text-muted-foreground">ID</dt>
+          <dd class="break-all">{data.account.id}</dd>
+        </div>
+        <div class="grid gap-1 px-6 py-4 sm:grid-cols-[12rem_1fr] sm:gap-4">
+          <dt class="text-sm font-medium text-muted-foreground">Display name</dt>
+          <dd>{data.account.displayName}</dd>
+        </div>
+        <div class="grid gap-1 px-6 py-4 sm:grid-cols-[12rem_1fr] sm:gap-4">
+          <dt class="text-sm font-medium text-muted-foreground">State</dt>
+          <dd>
+            <Badge variant={data.account.state === 'ACTIVE' ? 'default' : 'outline'}>
+              {data.account.state}
+            </Badge>
+          </dd>
+        </div>
+        <div class="grid gap-1 px-6 py-4 sm:grid-cols-[12rem_1fr] sm:gap-4">
+          <dt class="text-sm font-medium text-muted-foreground">Created at</dt>
+          <dd><time datetime={data.account.createdAt}>{data.account.createdAt}</time></dd>
+        </div>
+        <div class="grid gap-1 px-6 py-4 sm:grid-cols-[12rem_1fr] sm:gap-4">
+          <dt class="text-sm font-medium text-muted-foreground">OIDC subject</dt>
+          <dd class="break-all font-mono text-sm">{data.account.oidcSubject}</dd>
+        </div>
+      </dl>
+    </Card.Content>
+  </Card.Root>
+</div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,6 +79,12 @@ const config = ts.config(
     },
   },
   {
+    files: ['**/*.svelte.{js,ts}'],
+    languageOptions: {
+      parser: ts.parser,
+    },
+  },
+  {
     ignores: [
       '**/node_modules/**',
       '**/dist/**',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,15 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@internationalized/date':
+        specifier: ^3.12.3
+        version: 3.12.3
+      '@lucide/svelte':
+        specifier: ^1.34.0
+        version: 1.34.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))
       '@sveltejs/adapter-node':
         specifier: ^5.5.7
         version: 5.5.7(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
@@ -121,15 +130,30 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      bits-ui:
+        specifier: ^2.19.0
+        version: 2.19.0(@internationalized/date@3.12.3)(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      shadcn-svelte:
+        specifier: ^1.5.0
+        version: 1.5.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))
       svelte-check:
         specifier: ^4.7.6
         version: 4.7.6(picomatch@4.0.4)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
       tailwind-variants:
         specifier: ^3.3.1
         version: 3.3.1(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -335,7 +359,7 @@ importers:
         version: 10.4.6(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10))(@vitest/runner@4.1.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.1.10)
       '@storybook/react-vite':
         specifier: ^10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
       '@types/react':
         specifier: ~19.2.15
         version: 19.2.15
@@ -441,7 +465,7 @@ importers:
         version: link:../../packages/fedify
       '@temporalio/worker':
         specifier: ^1.22.0
-        version: 1.22.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)
+        version: 1.22.0(@swc/helpers@0.5.23)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)
       '@temporalio/workflow':
         specifier: ^1.22.0
         version: 1.22.0
@@ -469,7 +493,7 @@ importers:
         version: 1.22.0
       '@temporalio/testing':
         specifier: ^1.22.0
-        version: 1.22.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)
+        version: 1.22.0(@swc/helpers@0.5.23)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)
 
   packages/core:
     dependencies:
@@ -1526,6 +1550,18 @@ packages:
     resolution: {integrity: sha512-QnbJfq/lUNCRY+TTXo87fuIpGCCaOYt280tmbuI112B/1vF0feIneK0/qhoTZNslRDhwwg1YcYDX0suxq2h6tw==}
     engines: {node: '>=20.19.0'}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@fontsource-variable/inter@5.3.0':
+    resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
+
   '@graphql-tools/executor@1.5.3':
     resolution: {integrity: sha512-mgBFC0bsrZPZLu9EnydpMnAuQ8Iiq0CEbUcsmvXsm2/iYektGHDN/+bmb7hicA6dWZtdPfklYJmr21WD0GnOfA==}
     engines: {node: '>=16.0.0'}
@@ -1742,6 +1778,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -1911,6 +1950,11 @@ packages:
 
   '@logtape/logtape@2.2.1':
     resolution: {integrity: sha512-SkRptJUEAbGuf+/blXDxDa8sSq8no+lxJlfwPTMzrHIULOMsNZRaqT2qF3H9tmGOsaLYc+uF3orRCQfoH0qKzA==}
+
+  '@lucide/svelte@1.34.0':
+    resolution: {integrity: sha512-sHFL8KVSaPXv0dsmdUTq4q/tj8clT2XYejnoSg0mHObpXWn/9SfET4f14v/7VOba1IsbPIW9+sWaq+Qq1wTdNA==}
+    peerDependencies:
+      svelte: ^5
 
   '@multiformats/base-x@4.0.1':
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
@@ -3279,6 +3323,9 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
@@ -3449,9 +3496,6 @@ packages:
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
-  '@types/css-font-loading-module@0.0.7':
-    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -3962,6 +4006,13 @@ packages:
 
   birecord@0.1.2:
     resolution: {integrity: sha512-5PAPTTmMpMEb+GuMb5DebfBkipRGyIW9+gtwEBSoDA9xkhHILm04+hZQ702pMksu3d8YAuGkmgTzQWcKqTPScA==}
+
+  bits-ui@2.19.0:
+    resolution: {integrity: sha512-dHDm5Jw2NZJgLRvHAwPeuR4BnZij+AqTIq33OqVfo+qiMXontoC/yIvGT5TZaviv7OuBdJ2QUy2JPQ2yKBvF6w==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@internationalized/date': ^3.8.1
+      svelte: ^5.33.0
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -5358,6 +5409,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
@@ -6080,6 +6134,9 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -6807,6 +6864,15 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  runed@0.35.1:
+    resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.21.0
+      svelte: ^5.7.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -6898,6 +6964,12 @@ packages:
   sf-symbols-typescript@2.2.0:
     resolution: {integrity: sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==}
     engines: {node: '>=10'}
+
+  shadcn-svelte@1.5.0:
+    resolution: {integrity: sha512-fcxTeUwEIvELkL/h0Vg2i/9Sf6exAmLG5u3GXc0aN8CA+3fNffKQnfrTdMgkjUEmx9XP619I+wcJOvlr5aDWYQ==}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
 
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -7117,6 +7189,9 @@ packages:
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   styleq@0.1.3:
     resolution: {integrity: sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==}
 
@@ -7156,6 +7231,12 @@ packages:
     peerDependenciesMeta:
       svelte:
         optional: true
+
+  svelte-toolbelt@0.10.6:
+    resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.30.2
 
   svelte@5.56.4:
     resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
@@ -7213,6 +7294,9 @@ packages:
   syncpack@14.3.1:
     resolution: {integrity: sha512-TCqOY6Z7TH5yHV3saI6sHb5XRsZ8m2DaI4FQMonKT7UoCKL2WBiI54PLEFDSv1F2sL1BZA5e1opprf190ohirg==}
     engines: {node: '>=14.17.0'}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -7354,6 +7438,9 @@ packages:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -9123,6 +9210,19 @@ snapshots:
       - '@types/node'
       - rxjs
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
+
+  '@fontsource-variable/inter@5.3.0': {}
+
   '@graphql-tools/executor@1.5.3(graphql@16.14.0)':
     dependencies:
       '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
@@ -9339,6 +9439,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.2
 
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
   '@isaacs/ttlcache@1.4.1': {}
 
   '@jest/schemas@29.6.3':
@@ -9521,6 +9625,10 @@ snapshots:
       tslib: 2.8.1
 
   '@logtape/logtape@2.2.1': {}
+
+  '@lucide/svelte@1.34.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))':
+    dependencies:
+      svelte: 5.56.4(@typescript-eslint/types@8.62.1)
 
   '@multiformats/base-x@4.0.1': {}
 
@@ -10492,9 +10600,9 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
       storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.3.0
       vite: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -10503,7 +10611,7 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.11
@@ -10511,7 +10619,7 @@ snapshots:
       esbuild: 0.28.1
       rollup: 4.60.3
       vite: 8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
 
   '@storybook/global@5.0.0': {}
 
@@ -10529,11 +10637,11 @@ snapshots:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(supports-color@8.1.1)(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -10652,7 +10760,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.15.47':
     optional: true
 
-  '@swc/core@1.15.47':
+  '@swc/core@1.15.47(@swc/helpers@0.5.23)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.28
@@ -10669,8 +10777,13 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.15.47
       '@swc/core-win32-ia32-msvc': 1.15.47
       '@swc/core-win32-x64-msvc': 1.15.47
+      '@swc/helpers': 0.5.23
 
   '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@swc/types@0.1.28':
     dependencies:
@@ -10785,14 +10898,14 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.5
 
-  '@temporalio/testing@1.22.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)':
+  '@temporalio/testing@1.22.0(@swc/helpers@0.5.23)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)':
     dependencies:
       '@temporalio/activity': 1.22.0
       '@temporalio/client': 1.22.0
       '@temporalio/common': 1.22.0
       '@temporalio/core-bridge': 1.22.0
       '@temporalio/proto': 1.22.0
-      '@temporalio/worker': 1.22.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)
+      '@temporalio/worker': 1.22.0(@swc/helpers@0.5.23)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)
       '@temporalio/workflow': 1.22.0
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -10810,10 +10923,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@temporalio/worker@1.22.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)':
+  '@temporalio/worker@1.22.0(@swc/helpers@0.5.23)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(tslib@2.8.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@swc/core': 1.15.47
+      '@swc/core': 1.15.47(@swc/helpers@0.5.23)
       '@temporalio/activity': 1.22.0
       '@temporalio/client': 1.22.0
       '@temporalio/common': 1.22.0
@@ -10827,11 +10940,11 @@ snapshots:
       protobufjs: 7.6.5
       rxjs: 7.8.2
       source-map: 0.7.6
-      source-map-loader: 5.0.0(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
+      source-map-loader: 5.0.0(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
       supports-color: 8.1.1
-      swc-loader: 0.2.7(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
+      swc-loader: 0.2.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
       unionfs: 4.6.0
-      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -10912,8 +11025,6 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/cookie@0.6.0': {}
-
-  '@types/css-font-loading-module@0.0.7': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -11574,6 +11685,19 @@ snapshots:
   big-integer@1.6.52: {}
 
   birecord@0.1.2: {}
+
+  bits-ui@2.19.0(@internationalized/date@3.12.3)(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1)):
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/dom': 1.8.0
+      '@internationalized/date': 3.12.3
+      esm-env: 1.2.2
+      runed: 0.35.1(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))
+      svelte: 5.56.4(@typescript-eslint/types@8.62.1)
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))
+      tabbable: 6.5.0
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
 
   boolbase@1.0.0: {}
 
@@ -13038,6 +13162,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   inline-style-prefixer@7.0.1:
     dependencies:
       css-in-js-utils: 3.1.0
@@ -13737,15 +13863,15 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
     optionalDependencies:
-      '@swc/core': 1.15.47
+      '@swc/core': 1.15.47(@swc/helpers@0.5.23)
       esbuild: 0.28.1
       lightningcss: 1.32.0
       postcss: 8.5.25
@@ -13790,6 +13916,8 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -14637,6 +14765,15 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  runed@0.35.1(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1)):
+    dependencies:
+      dequal: 2.0.3
+      esm-env: 1.2.2
+      lz-string: 1.5.0
+      svelte: 5.56.4(@typescript-eslint/types@8.62.1)
+    optionalDependencies:
+      '@sveltejs/kit': 2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -14750,6 +14887,14 @@ snapshots:
 
   sf-symbols-typescript@2.2.0: {}
 
+  shadcn-svelte@1.5.0(svelte@5.56.4(@typescript-eslint/types@8.62.1)):
+    dependencies:
+      commander: 14.0.3
+      node-fetch-native: 1.6.7
+      postcss: 8.5.25
+      svelte: 5.56.4(@typescript-eslint/types@8.62.1)
+      tailwind-merge: 3.6.0
+
   shallowequal@1.1.0: {}
 
   shebang-command@2.0.0:
@@ -14826,11 +14971,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)):
+  source-map-loader@5.0.0(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
 
   source-map-support@0.5.21:
     dependencies:
@@ -14974,6 +15119,10 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   styleq@0.1.3: {}
 
   supports-color@5.5.0:
@@ -15020,6 +15169,15 @@ snapshots:
     optionalDependencies:
       svelte: 5.56.4(@typescript-eslint/types@8.62.1)
 
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1)):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.35.1(@sveltejs/kit@2.70.3(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))
+      style-to-object: 1.0.14
+      svelte: 5.56.4(@typescript-eslint/types@8.62.1)
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
+
   svelte@5.56.4(@typescript-eslint/types@8.62.1):
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -15041,11 +15199,11 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  swc-loader@0.2.7(@swc/core@1.15.47)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)):
+  swc-loader@0.2.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
-      '@swc/core': 1.15.47
+      '@swc/core': 1.15.47(@swc/helpers@0.5.23)
       '@swc/counter': 0.1.3
-      webpack: 5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
+      webpack: 5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)
 
   symbol-tree@3.2.4: {}
 
@@ -15084,8 +15242,9 @@ snapshots:
       syncpack-windows-arm64: 14.3.1
       syncpack-windows-x64: 14.3.1
 
-  tailwind-merge@3.6.0:
-    optional: true
+  tabbable@6.5.0: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwind-variants@3.3.1(tailwind-merge@3.6.0)(tailwindcss@4.3.3):
     optionalDependencies:
@@ -15197,6 +15356,8 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
     dependencies:
@@ -15431,7 +15592,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25):
+  webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -15447,7 +15608,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.109.2(@swc/core@1.15.47)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3


### PR DESCRIPTION
## 무엇을 변경했나요

- 공식 shadcn-svelte Sidebar를 Admin 공통 셸에 적용했습니다.
- Overview와 Accounts의 활성 메뉴, 접기, 모바일 Sheet, Viewer footer를 구성했습니다.
- Overview는 Card, Account 목록은 Table, 상세는 Card로 교체했습니다.
- 기존 route의 수동 style 블록을 제거하고 shadcn Vega 토큰과 Tailwind utility를 사용합니다.

## 왜 변경했나요

기존 Admin Console은 목록에 접근할 수는 있었지만 화면 구조와 탐색 맥락이 부족했습니다. 현재 두 화면의 기능 범위는 그대로 두고, 운영 도구로 사용할 수 있는 대시보드 셸을 제공합니다.

## 이번 PR의 주요 결정

### 공식 shadcn 컴포넌트를 소유합니다

- 결정자: 작성자
- 선택: shadcn-svelte의 Sidebar, Sheet, Tooltip, Card, Table, Button, Badge 소스를 사용합니다.
- 고려한 대안: 수동 CSS 기반 sidebar, sidebar-01 데모 블록 전체 이식
- 이유: 반응형 동작과 접근성 계약은 공식 컴포넌트에 맡기고 수동 CSS를 줄이면서, 실제 route 두 개만 표시하기 위함입니다.
- 감수한 결과: 생성된 UI 소스와 bits-ui 계열 개발 의존성을 Admin 앱이 소유합니다.
- 관련 근거: PROD-691의 Admin Account 조회 범위에 적용했습니다.

## 어떻게 확인할 수 있나요

- `pnpm --filter @kosmo/admin check`
- `pnpm --filter @kosmo/admin exec vitest run --exclude '**/*.database.test.ts'`
- `pnpm --filter @kosmo/admin build`
- ESLint, Prettier, syncpack
- 로컬 브라우저에서 Sidebar, 활성 메뉴, Overview Card 렌더링 확인
- adapter-node production 응답과 no-store/CSP 유지 확인

Stack: `main -> PROD-691-dashboard`

## 아직 어떤 문제가 남았나요

- merge 후 Dev 배포에서 실제 Account 데이터와 모바일 Sheet 동작을 확인합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>