### PR TITLE
[PROD-859] Composer 작성 Profile 전환 상태를 Storybook으로 이관한다

### DIFF
--- a/apps/app/.storybook/main.ts
+++ b/apps/app/.storybook/main.ts
@@ -5,10 +5,14 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const require = createRequire(import.meta.url);
 const sourceDirectory = fileURLToPath(new URL('../src/', import.meta.url));
+const storybookAllowedHost = process.env.STORYBOOK_ALLOWED_HOST;
 
 const config: StorybookConfig = {
   addons: ['@storybook/addon-a11y', '@storybook/addon-vitest'],
-  core: { disableTelemetry: true },
+  core: {
+    disableTelemetry: true,
+    ...(storybookAllowedHost ? { allowedHosts: [storybookAllowedHost] } : {}),
+  },
   framework: { name: '@storybook/react-vite', options: {} },
   stories: ['../src/**/*.stories.@(ts|tsx)'],
   viteFinal: (viteConfig) => ({

--- a/apps/app/src/components/post/ComposerMediaEditor.tsx
+++ b/apps/app/src/components/post/ComposerMediaEditor.tsx
@@ -1,0 +1,682 @@
+import { ArrowLeftIcon, FlagIcon, SquarePenIcon, XIcon } from 'lucide-react-native';
+import {
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import { Button } from '@/components/ui/Button';
+import { IconButton } from '@/components/ui/IconButton';
+import { Tab, TabList } from '@/components/ui/Tabs';
+import { TextArea } from '@/components/ui/TextField';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/tokens';
+import type { ReactNode } from 'react';
+import type { ComposerMediaItem } from './PostComposerMediaControls';
+
+export type ComposerMediaEditorTool = 'alt' | 'sensitive';
+export type ComposerMediaEditorMobileState = 'altKeyboard' | 'default' | 'sensitive';
+
+export type ComposerMediaEditorProps = {
+  readonly media: readonly ComposerMediaItem[];
+  readonly mobileState?: ComposerMediaEditorMobileState;
+  readonly onAltTextChange: (key: string, altText: string) => void;
+  readonly onBack: () => void;
+  readonly onClose: () => void;
+  readonly onDone: () => void;
+  readonly onSelectMedia: (key: string) => void;
+  readonly onSensitiveMediaChange: (value: boolean) => void;
+  readonly onToolChange: (tool: ComposerMediaEditorTool) => void;
+  readonly presentation: 'mobile' | 'web';
+  readonly selectedKey: string;
+  readonly sensitiveMedia: boolean;
+  readonly tool: ComposerMediaEditorTool;
+};
+
+const altTextLimit = 1000;
+
+export function ComposerMediaEditor(props: ComposerMediaEditorProps) {
+  const theme = useTheme();
+  const { height } = useWindowDimensions();
+  const selectedIndex = Math.max(
+    0,
+    props.media.findIndex(({ key }) => key === props.selectedKey),
+  );
+  const selected = props.media[selectedIndex];
+  const mobile = props.presentation === 'mobile';
+  const mobileState =
+    props.mobileState ?? (props.tool === 'sensitive' ? 'sensitive' : 'altKeyboard');
+  const mobileTool =
+    mobileState === 'default' ? null : mobileState === 'altKeyboard' ? 'alt' : 'sensitive';
+
+  return (
+    <View
+      style={[
+        styles.root,
+        mobile
+          ? { height, width: '100%' }
+          : { height: 678, maxWidth: 920, minWidth: 720, width: '100%' },
+        { backgroundColor: theme.backgroundSurface },
+      ]}
+      testID={mobile ? 'mobile-composer-media-editor' : 'web-composer-media-editor'}
+    >
+      <EditorHeader
+        mobile={mobile}
+        onBack={props.onBack}
+        onClose={props.onClose}
+        onDone={props.onDone}
+      />
+
+      {mobile ? (
+        <>
+          <MediaGallery
+            media={props.media}
+            mobile
+            onSelectMedia={props.onSelectMedia}
+            selectedKey={selected?.key}
+          />
+          <MediaPreview
+            mediaCount={props.media.length}
+            selected={selected}
+            selectedIndex={selectedIndex}
+          />
+          <View
+            accessibilityLabel="미디어 편집 도구"
+            style={[styles.mobileActions, { borderColor: theme.borderSubtle }]}
+          >
+            <MobileToolButton
+              icon={<SquarePenIcon color={theme.foregroundPrimary} size={iconSizes[20]} />}
+              label="대체 텍스트 편집"
+              onPress={() => props.onToolChange('alt')}
+              selected={mobileTool === 'alt'}
+            />
+            <MobileToolButton
+              icon={<FlagIcon color={theme.foregroundPrimary} size={iconSizes[20]} />}
+              label="민감도 편집"
+              onPress={() => props.onToolChange('sensitive')}
+              selected={mobileTool === 'sensitive'}
+            />
+          </View>
+          {mobileTool ? (
+            <MobileToolSheet
+              {...props}
+              selected={selected}
+              selectedIndex={selectedIndex}
+              tool={mobileTool}
+            />
+          ) : null}
+          {mobileState === 'altKeyboard' ? <IllustrativeKeyboard /> : null}
+        </>
+      ) : (
+        <>
+          <EditorTabs onToolChange={props.onToolChange} tool={props.tool} />
+          <View style={styles.webBody}>
+            <View style={styles.webWorkspace}>
+              <MediaPreview
+                mediaCount={props.media.length}
+                selected={selected}
+                selectedIndex={selectedIndex}
+              />
+              <MediaGallery
+                media={props.media}
+                onSelectMedia={props.onSelectMedia}
+                selectedKey={selected?.key}
+              />
+            </View>
+            <WebToolPanel {...props} selected={selected} selectedIndex={selectedIndex} />
+          </View>
+          <View style={[styles.footer, { borderColor: theme.borderSubtle }]}>
+            <Text style={[styles.footerCopy, { color: theme.foregroundSecondary }]}>
+              {props.tool === 'sensitive'
+                ? '게시물 전체의 민감도 변경 사항을 Composer 초안에 반영합니다.'
+                : '선택한 이미지의 변경 사항을 Composer 초안에 반영합니다.'}
+            </Text>
+            <Button onPress={props.onDone}>완료</Button>
+          </View>
+        </>
+      )}
+    </View>
+  );
+}
+
+function EditorHeader({
+  mobile,
+  onBack,
+  onClose,
+  onDone,
+}: {
+  readonly mobile: boolean;
+  readonly onBack: () => void;
+  readonly onClose: () => void;
+  readonly onDone: () => void;
+}) {
+  const theme = useTheme();
+
+  return (
+    <View style={[styles.header, { borderColor: theme.borderSubtle }]}>
+      <IconButton
+        accessibilityLabel="미디어 편집에서 뒤로"
+        feedback="opacity"
+        onPress={onBack}
+        targetSize={44}
+        visualSize={32}
+      >
+        <ArrowLeftIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+      </IconButton>
+      <Text accessibilityRole="header" style={[styles.title, { color: theme.foregroundPrimary }]}>
+        미디어 편집
+      </Text>
+      {mobile ? (
+        <Pressable
+          accessibilityLabel="완료"
+          accessibilityRole="button"
+          onPress={onDone}
+          style={({ pressed }) => [styles.mobileDone, pressed && styles.pressed]}
+        >
+          <Text style={[styles.mobileDoneLabel, { color: theme.foregroundPrimary }]}>완료</Text>
+        </Pressable>
+      ) : (
+        <IconButton
+          accessibilityLabel="미디어 편집 닫기"
+          feedback="opacity"
+          onPress={onClose}
+          targetSize={44}
+          visualSize={32}
+        >
+          <XIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+        </IconButton>
+      )}
+    </View>
+  );
+}
+
+function EditorTabs({
+  onToolChange,
+  tool,
+}: {
+  readonly onToolChange: (tool: ComposerMediaEditorTool) => void;
+  readonly tool: ComposerMediaEditorTool;
+}) {
+  return (
+    <TabList
+      accessibilityLabel="미디어 편집 도구"
+      onValueChange={onToolChange}
+      value={tool}
+      variant="underline"
+    >
+      <Tab
+        option={{
+          accessibilityLabel: '이미지 편집 (준비 중)',
+          disabled: true,
+          label: '이미지 편집',
+          value: 'image-edit',
+        }}
+      />
+      <Tab option={{ label: '대체 텍스트', value: 'alt' }} />
+      <Tab option={{ label: '민감도', value: 'sensitive' }} />
+    </TabList>
+  );
+}
+
+function MediaPreview({
+  mediaCount,
+  selected,
+  selectedIndex,
+}: {
+  readonly mediaCount: number;
+  readonly selected: ComposerMediaItem | undefined;
+  readonly selectedIndex: number;
+}) {
+  const theme = useTheme();
+
+  return (
+    <View style={[styles.previewSection, { backgroundColor: theme.backgroundSurface }]}>
+      {selected ? (
+        <Image
+          accessibilityIgnoresInvertColors
+          accessibilityLabel={`선택한 첨부 이미지 ${selectedIndex + 1} 미리보기`}
+          accessibilityRole="image"
+          resizeMode="cover"
+          source={{ uri: selected.asset.uri }}
+          style={styles.selectedPreview}
+        />
+      ) : (
+        <View style={[styles.selectedPreview, { backgroundColor: theme.backgroundElevated }]}>
+          <Text style={[styles.emptyCopy, { color: theme.foregroundSecondary }]}>
+            편집할 미디어가 없습니다.
+          </Text>
+        </View>
+      )}
+      <View style={styles.imageIndex}>
+        <Text style={styles.imageIndexText}>
+          {mediaCount === 0 ? '0 / 0' : `${selectedIndex + 1} / ${mediaCount}`}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function MediaGallery({
+  media,
+  mobile = false,
+  onSelectMedia,
+  selectedKey,
+}: {
+  readonly media: readonly ComposerMediaItem[];
+  readonly mobile?: boolean;
+  readonly onSelectMedia: (key: string) => void;
+  readonly selectedKey: string | undefined;
+}) {
+  const theme = useTheme();
+
+  return (
+    <ScrollView
+      accessibilityLabel="편집할 첨부 이미지 선택"
+      contentContainerStyle={[styles.galleryContent, mobile && styles.mobileGalleryContent]}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={[
+        styles.mediaGallery,
+        mobile && styles.mobileMediaGallery,
+        { borderColor: theme.borderSubtle },
+      ]}
+    >
+      {media.map((item, index) => {
+        const selected = item.key === selectedKey;
+        return (
+          <Pressable
+            accessibilityLabel={`첨부 이미지 ${index + 1} 선택`}
+            accessibilityRole="button"
+            accessibilityState={{ selected }}
+            key={item.key}
+            onPress={() => onSelectMedia(item.key)}
+            style={({ pressed }) => [
+              styles.thumbnailTarget,
+              mobile && styles.mobileThumbnailTarget,
+              {
+                backgroundColor: selected ? theme.actionPrimaryBase : theme.borderSubtle,
+                opacity: pressed ? 0.8 : 1,
+              },
+            ]}
+          >
+            <Image
+              accessibilityIgnoresInvertColors
+              source={{ uri: item.asset.uri }}
+              style={[styles.thumbnail, mobile && styles.mobileThumbnail]}
+            />
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+function WebToolPanel(
+  props: ComposerMediaEditorProps & {
+    readonly selected: ComposerMediaItem | undefined;
+    readonly selectedIndex: number;
+  },
+) {
+  const theme = useTheme();
+
+  return (
+    <View style={[styles.webToolPanel, { borderColor: theme.borderSubtle }]}>
+      {props.tool === 'alt' ? (
+        <AltToolContent
+          altText={props.selected?.altText ?? ''}
+          itemNumber={props.selectedIndex + 1}
+          onAltTextChange={(value) => {
+            if (props.selected) {
+              props.onAltTextChange(props.selected.key, value);
+            }
+          }}
+        />
+      ) : (
+        <SensitiveToolContent
+          itemNumber={props.selectedIndex + 1}
+          onSensitiveMediaChange={props.onSensitiveMediaChange}
+          sensitiveMedia={props.sensitiveMedia}
+        />
+      )}
+    </View>
+  );
+}
+
+function MobileToolSheet(
+  props: ComposerMediaEditorProps & {
+    readonly selected: ComposerMediaItem | undefined;
+    readonly selectedIndex: number;
+  },
+) {
+  const theme = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.mobileToolSheet,
+        props.tool === 'alt' ? styles.mobileAltSheet : styles.mobileSensitiveSheet,
+        { backgroundColor: theme.backgroundElevated, borderColor: theme.borderSubtle },
+      ]}
+      testID="mobile-composer-media-editor-tool-sheet"
+    >
+      {props.tool === 'alt' ? (
+        <AltToolContent
+          altText={props.selected?.altText ?? ''}
+          compact
+          itemNumber={props.selectedIndex + 1}
+          onAltTextChange={(value) => {
+            if (props.selected) {
+              props.onAltTextChange(props.selected.key, value);
+            }
+          }}
+        />
+      ) : (
+        <SensitiveToolContent
+          compact
+          itemNumber={props.selectedIndex + 1}
+          onSensitiveMediaChange={props.onSensitiveMediaChange}
+          sensitiveMedia={props.sensitiveMedia}
+        />
+      )}
+    </View>
+  );
+}
+
+function IllustrativeKeyboard() {
+  const theme = useTheme();
+
+  return (
+    <View
+      accessibilityElementsHidden
+      aria-hidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        styles.keyboard,
+        { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+      ]}
+      testID="mobile-composer-media-editor-keyboard"
+    >
+      {[342, 326, 286, 168].map((width) => (
+        <View
+          key={width}
+          style={[
+            styles.keyboardRow,
+            {
+              backgroundColor: theme.backgroundElevated,
+              borderColor: theme.borderSubtle,
+              width,
+            },
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+function AltToolContent({
+  altText,
+  compact = false,
+  itemNumber,
+  onAltTextChange,
+}: {
+  readonly altText: string;
+  readonly compact?: boolean;
+  readonly itemNumber: number;
+  readonly onAltTextChange: (value: string) => void;
+}) {
+  const theme = useTheme();
+
+  return (
+    <>
+      {!compact ? (
+        <Text style={[styles.eyebrow, { color: theme.foregroundSecondary }]}>
+          이미지 {itemNumber}
+        </Text>
+      ) : null}
+      <Text style={[styles.toolTitle, { color: theme.foregroundPrimary }]}>대체 텍스트</Text>
+      {!compact ? (
+        <Text style={[styles.toolDescription, { color: theme.foregroundSecondary }]}>
+          이미지를 보지 못하는 사람도 게시물의 맥락을 이해할 수 있게 설명합니다.
+        </Text>
+      ) : null}
+      <TextArea
+        accessibilityLabel="이미지 설명"
+        label={compact ? undefined : '이미지 설명'}
+        maxLength={altTextLimit}
+        onChangeText={onAltTextChange}
+        placeholder="이미지에서 중요한 내용을 설명해 주세요."
+        style={compact ? styles.mobileTextArea : undefined}
+        value={altText}
+      />
+      {!compact ? (
+        <>
+          <Text style={[styles.helperCopy, { color: theme.foregroundSecondary }]}>
+            안내문은 입력 영역 밖에 유지됩니다.
+          </Text>
+          <View style={styles.spacer} />
+        </>
+      ) : null}
+      <Text style={[styles.counter, { color: theme.foregroundSecondary }]}>
+        {altText.length} / {altTextLimit}
+      </Text>
+    </>
+  );
+}
+
+function SensitiveToolContent({
+  compact = false,
+  itemNumber,
+  onSensitiveMediaChange,
+  sensitiveMedia,
+}: {
+  readonly compact?: boolean;
+  readonly itemNumber: number;
+  readonly onSensitiveMediaChange: (value: boolean) => void;
+  readonly sensitiveMedia: boolean;
+}) {
+  const theme = useTheme();
+
+  return (
+    <>
+      {!compact ? (
+        <Text style={[styles.eyebrow, { color: theme.foregroundSecondary }]}>
+          이미지 {itemNumber}에서 진입 · 전체 적용
+        </Text>
+      ) : null}
+      <Text style={[styles.toolTitle, { color: theme.foregroundPrimary }]}>민감도</Text>
+      <Text style={[styles.toolDescription, { color: theme.foregroundSecondary }]}>
+        이 설정은 게시물에 첨부한 모든 이미지에 함께 적용됩니다.
+      </Text>
+      <View
+        style={[
+          styles.sensitiveSetting,
+          { backgroundColor: theme.backgroundElevated, borderColor: theme.borderDefault },
+        ]}
+      >
+        <View style={styles.sensitiveCopy}>
+          <Text style={[styles.sensitiveLabel, { color: theme.foregroundPrimary }]}>
+            민감한 이미지
+          </Text>
+          <Text style={[styles.helperCopy, { color: theme.foregroundSecondary }]}>
+            켜면 모든 첨부 이미지를 기본적으로 가립니다.
+          </Text>
+        </View>
+        <Switch
+          accessibilityLabel="민감한 이미지"
+          onValueChange={onSensitiveMediaChange}
+          value={sensitiveMedia}
+        />
+      </View>
+      {!compact ? (
+        <>
+          <View style={styles.spacer} />
+          <Text style={[styles.helperCopy, { color: theme.foregroundSecondary }]}>
+            Post 단위 설정 · 모든 Flag가 함께 바뀝니다.
+          </Text>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+function MobileToolButton({
+  icon,
+  label,
+  onPress,
+  selected,
+}: {
+  readonly icon: ReactNode;
+  readonly label: string;
+  readonly onPress: () => void;
+  readonly selected: boolean;
+}) {
+  const theme = useTheme();
+
+  return (
+    <IconButton
+      accessibilityLabel={label}
+      accessibilityState={{ selected }}
+      feedback="opacity"
+      onPress={onPress}
+      targetSize={44}
+      visualSize={44}
+      visualStyle={{
+        backgroundColor: selected ? theme.actionPrimaryBase : theme.backgroundElevated,
+        borderColor: selected ? theme.actionPrimaryBase : theme.borderDefault,
+        borderRadius: radius[12],
+        borderWidth: borderWidths[1],
+      }}
+    >
+      {icon}
+    </IconButton>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { alignSelf: 'center', overflow: 'hidden' },
+  header: {
+    alignItems: 'center',
+    borderBottomWidth: borderWidths[1],
+    flexDirection: 'row',
+    height: 64,
+    paddingHorizontal: space[12],
+  },
+  title: { flex: 1, textAlign: 'center', ...textStyles.uiHeadingS },
+  mobileDone: { alignItems: 'center', height: 44, justifyContent: 'center', width: 44 },
+  mobileDoneLabel: textStyles.uiLabelM,
+  pressed: { opacity: 0.7 },
+  webBody: { flex: 1, flexDirection: 'row', minHeight: 0 },
+  webWorkspace: { flex: 1, minWidth: 0 },
+  previewSection: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    minHeight: 0,
+    padding: space[24],
+    position: 'relative',
+  },
+  selectedPreview: { borderRadius: radius[12], height: '100%', maxHeight: 390, width: '100%' },
+  emptyCopy: textStyles.uiCopyM,
+  imageIndex: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.72)',
+    borderRadius: radius.full,
+    height: 24,
+    justifyContent: 'center',
+    minWidth: 44,
+    paddingHorizontal: space[8],
+    position: 'absolute',
+    right: 34,
+    top: 34,
+  },
+  imageIndexText: { color: '#ffffff', ...textStyles.uiLabelS },
+  mediaGallery: {
+    borderTopWidth: borderWidths[1],
+    flexGrow: 0,
+    height: 68,
+    width: '100%',
+  },
+  galleryContent: {
+    alignItems: 'center',
+    flexGrow: 1,
+    gap: space[8],
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+  },
+  thumbnailTarget: {
+    alignItems: 'center',
+    borderRadius: radius[8],
+    height: 48,
+    justifyContent: 'center',
+    padding: 2,
+    width: 48,
+  },
+  thumbnail: { borderRadius: radius[4], height: 44, width: 44 },
+  mobileMediaGallery: { height: 76 },
+  mobileGalleryContent: { paddingVertical: 11 },
+  mobileThumbnailTarget: { height: 54, width: 54 },
+  mobileThumbnail: { height: 50, width: 50 },
+  webToolPanel: {
+    borderLeftWidth: borderWidths[1],
+    gap: space[12],
+    padding: 20,
+    width: 280,
+  },
+  eyebrow: textStyles.uiCopyS,
+  toolTitle: { textAlign: 'center', ...textStyles.uiHeadingS },
+  toolDescription: textStyles.uiCopyM,
+  helperCopy: textStyles.uiCopyS,
+  spacer: { flex: 1 },
+  counter: { textAlign: 'right', ...textStyles.uiCopyS },
+  sensitiveSetting: {
+    alignItems: 'center',
+    borderRadius: radius[12],
+    borderWidth: borderWidths[1],
+    flexDirection: 'row',
+    minHeight: 72,
+    padding: space[12],
+  },
+  sensitiveCopy: { flex: 1, gap: space[4] },
+  sensitiveLabel: textStyles.uiLabelM,
+  footer: {
+    alignItems: 'center',
+    borderTopWidth: borderWidths[1],
+    flexDirection: 'row',
+    height: 64,
+    paddingLeft: space[24],
+    paddingRight: 18,
+    paddingVertical: 10,
+  },
+  footerCopy: { flex: 1, ...textStyles.uiCopyM },
+  mobileActions: {
+    alignItems: 'center',
+    borderTopWidth: borderWidths[1],
+    flexDirection: 'row',
+    gap: space[8],
+    height: 66,
+    justifyContent: 'center',
+  },
+  mobileAltSheet: { height: 176 },
+  mobileSensitiveSheet: { height: 184 },
+  mobileToolSheet: {
+    borderTopLeftRadius: radius[16],
+    borderTopRightRadius: radius[16],
+    borderTopWidth: borderWidths[1],
+    gap: space[8],
+    padding: space[16],
+  },
+  mobileTextArea: { minHeight: 80 },
+  keyboard: {
+    alignItems: 'center',
+    borderTopWidth: borderWidths[1],
+    gap: space[12],
+    height: 336,
+    justifyContent: 'center',
+  },
+  keyboardRow: { borderRadius: radius[8], borderWidth: borderWidths[1], height: 44 },
+});

--- a/apps/app/src/components/post/ComposerMediaEditor.tsx
+++ b/apps/app/src/components/post/ComposerMediaEditor.tsx
@@ -208,6 +208,24 @@ function EditorTabs({
   readonly showImageEditPreview: boolean;
   readonly tool: ComposerMediaEditorTool;
 }) {
+  const tabs = [
+    ...(showImageEditPreview
+      ? [
+          <Tab
+            key="image-edit"
+            option={{
+              accessibilityLabel: '이미지 편집 (준비 중)',
+              disabled: true,
+              label: '이미지 편집',
+              value: 'image-edit',
+            }}
+          />,
+        ]
+      : []),
+    <Tab key="alt" option={{ label: '대체 텍스트', value: 'alt' }} />,
+    <Tab key="sensitive" option={{ label: '민감도', value: 'sensitive' }} />,
+  ];
+
   return (
     <TabList
       accessibilityLabel="미디어 편집 도구"
@@ -215,18 +233,7 @@ function EditorTabs({
       value={tool}
       variant="underline"
     >
-      {showImageEditPreview ? (
-        <Tab
-          option={{
-            accessibilityLabel: '이미지 편집 (준비 중)',
-            disabled: true,
-            label: '이미지 편집',
-            value: 'image-edit',
-          }}
-        />
-      ) : null}
-      <Tab option={{ label: '대체 텍스트', value: 'alt' }} />
-      <Tab option={{ label: '민감도', value: 'sensitive' }} />
+      {tabs}
     </TabList>
   );
 }

--- a/apps/app/src/components/post/ComposerMediaEditor.tsx
+++ b/apps/app/src/components/post/ComposerMediaEditor.tsx
@@ -260,7 +260,7 @@ function MediaPreview({
       accessibilityIgnoresInvertColors
       accessibilityLabel={`선택한 첨부 이미지 ${selectedIndex + 1} 미리보기`}
       accessibilityRole="image"
-      resizeMode="cover"
+      resizeMode="contain"
       source={{ uri: selected.asset.uri }}
       style={styles.selectedPreview}
     />

--- a/apps/app/src/components/post/ComposerMediaEditor.tsx
+++ b/apps/app/src/components/post/ComposerMediaEditor.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, FlagIcon, SquarePenIcon, XIcon } from 'lucide-react-native';
+import { ArrowLeftIcon, FlagIcon, XIcon } from 'lucide-react-native';
 import {
   Image,
   Pressable,
@@ -28,6 +28,7 @@ export type ComposerMediaEditorProps = {
   readonly onBack: () => void;
   readonly onClose: () => void;
   readonly onDone: () => void;
+  readonly onPreviewPress?: () => void;
   readonly onSelectMedia: (key: string) => void;
   readonly onSensitiveMediaChange: (value: boolean) => void;
   readonly onToolChange: (tool: ComposerMediaEditorTool) => void;
@@ -82,6 +83,7 @@ export function ComposerMediaEditor(props: ComposerMediaEditorProps) {
           />
           <MediaPreview
             mediaCount={props.media.length}
+            onPreviewPress={props.onPreviewPress}
             selected={selected}
             selectedIndex={selectedIndex}
           />
@@ -90,7 +92,9 @@ export function ComposerMediaEditor(props: ComposerMediaEditorProps) {
             style={[styles.mobileActions, { borderColor: theme.borderSubtle }]}
           >
             <MobileToolButton
-              icon={<SquarePenIcon color={theme.foregroundPrimary} size={iconSizes[20]} />}
+              icon={
+                <Text style={[styles.altToolLabel, { color: theme.foregroundPrimary }]}>ALT</Text>
+              }
               label="대체 텍스트 편집"
               onPress={() => props.onToolChange('alt')}
               selected={mobileTool === 'alt'}
@@ -240,32 +244,47 @@ function EditorTabs({
 
 function MediaPreview({
   mediaCount,
+  onPreviewPress,
   selected,
   selectedIndex,
 }: {
   readonly mediaCount: number;
+  readonly onPreviewPress?: () => void;
   readonly selected: ComposerMediaItem | undefined;
   readonly selectedIndex: number;
 }) {
   const theme = useTheme();
+  const selectedPreview = selected ? (
+    <Image
+      accessibilityElementsHidden={Boolean(onPreviewPress)}
+      accessibilityIgnoresInvertColors
+      accessibilityLabel={`선택한 첨부 이미지 ${selectedIndex + 1} 미리보기`}
+      accessibilityRole="image"
+      resizeMode="cover"
+      source={{ uri: selected.asset.uri }}
+      style={styles.selectedPreview}
+    />
+  ) : (
+    <View style={[styles.selectedPreview, { backgroundColor: theme.backgroundElevated }]}>
+      <Text style={[styles.emptyCopy, { color: theme.foregroundSecondary }]}>
+        편집할 미디어가 없습니다.
+      </Text>
+    </View>
+  );
 
   return (
     <View style={[styles.previewSection, { backgroundColor: theme.backgroundSurface }]}>
-      {selected ? (
-        <Image
-          accessibilityIgnoresInvertColors
+      {selected && onPreviewPress ? (
+        <Pressable
           accessibilityLabel={`선택한 첨부 이미지 ${selectedIndex + 1} 미리보기`}
-          accessibilityRole="image"
-          resizeMode="cover"
-          source={{ uri: selected.asset.uri }}
-          style={styles.selectedPreview}
-        />
+          accessibilityRole="button"
+          onPress={onPreviewPress}
+          style={({ pressed }) => [styles.selectedPreview, pressed && styles.pressed]}
+        >
+          {selectedPreview}
+        </Pressable>
       ) : (
-        <View style={[styles.selectedPreview, { backgroundColor: theme.backgroundElevated }]}>
-          <Text style={[styles.emptyCopy, { color: theme.foregroundSecondary }]}>
-            편집할 미디어가 없습니다.
-          </Text>
-        </View>
+        selectedPreview
       )}
       <View style={styles.imageIndex}>
         <Text style={styles.imageIndexText}>
@@ -659,6 +678,7 @@ const styles = StyleSheet.create({
   },
   sensitiveCopy: { flex: 1, gap: space[4] },
   sensitiveLabel: textStyles.uiLabelM,
+  altToolLabel: textStyles.uiLabelS,
   footer: {
     alignItems: 'center',
     borderTopWidth: borderWidths[1],

--- a/apps/app/src/components/post/ComposerMediaEditor.tsx
+++ b/apps/app/src/components/post/ComposerMediaEditor.tsx
@@ -34,6 +34,7 @@ export type ComposerMediaEditorProps = {
   readonly presentation: 'mobile' | 'web';
   readonly selectedKey: string;
   readonly sensitiveMedia: boolean;
+  readonly showImageEditPreview?: boolean;
   readonly tool: ComposerMediaEditorTool;
 };
 
@@ -113,7 +114,11 @@ export function ComposerMediaEditor(props: ComposerMediaEditorProps) {
         </>
       ) : (
         <>
-          <EditorTabs onToolChange={props.onToolChange} tool={props.tool} />
+          <EditorTabs
+            onToolChange={props.onToolChange}
+            showImageEditPreview={props.showImageEditPreview ?? false}
+            tool={props.tool}
+          />
           <View style={styles.webBody}>
             <View style={styles.webWorkspace}>
               <MediaPreview
@@ -196,9 +201,11 @@ function EditorHeader({
 
 function EditorTabs({
   onToolChange,
+  showImageEditPreview,
   tool,
 }: {
   readonly onToolChange: (tool: ComposerMediaEditorTool) => void;
+  readonly showImageEditPreview: boolean;
   readonly tool: ComposerMediaEditorTool;
 }) {
   return (
@@ -208,14 +215,16 @@ function EditorTabs({
       value={tool}
       variant="underline"
     >
-      <Tab
-        option={{
-          accessibilityLabel: '이미지 편집 (준비 중)',
-          disabled: true,
-          label: '이미지 편집',
-          value: 'image-edit',
-        }}
-      />
+      {showImageEditPreview ? (
+        <Tab
+          option={{
+            accessibilityLabel: '이미지 편집 (준비 중)',
+            disabled: true,
+            label: '이미지 편집',
+            value: 'image-edit',
+          }}
+        />
+      ) : null}
       <Tab option={{ label: '대체 텍스트', value: 'alt' }} />
       <Tab option={{ label: '민감도', value: 'sensitive' }} />
     </TabList>

--- a/apps/app/src/components/post/ComposerMediaEditor.tsx
+++ b/apps/app/src/components/post/ComposerMediaEditor.tsx
@@ -138,7 +138,10 @@ export function ComposerMediaEditor(props: ComposerMediaEditorProps) {
             </View>
             <WebToolPanel {...props} selected={selected} selectedIndex={selectedIndex} />
           </View>
-          <View style={[styles.footer, { borderColor: theme.borderSubtle }]}>
+          <View
+            style={[styles.footer, { borderColor: theme.borderSubtle }]}
+            testID="composer-media-editor-footer"
+          >
             <Text style={[styles.footerCopy, { color: theme.foregroundSecondary }]}>
               {props.tool === 'sensitive'
                 ? '게시물 전체의 민감도 변경 사항을 Composer 초안에 반영합니다.'
@@ -319,6 +322,7 @@ function MediaGallery({
         mobile && styles.mobileMediaGallery,
         { borderColor: theme.borderSubtle },
       ]}
+      testID="composer-media-editor-gallery"
     >
       {media.map((item, index) => {
         const selected = item.key === selectedKey;
@@ -630,7 +634,6 @@ const styles = StyleSheet.create({
   },
   imageIndexText: { color: '#ffffff', ...textStyles.uiLabelS },
   mediaGallery: {
-    borderTopWidth: borderWidths[1],
     flexGrow: 0,
     height: 68,
     width: '100%',
@@ -652,7 +655,7 @@ const styles = StyleSheet.create({
     width: 48,
   },
   thumbnail: { borderRadius: radius[4], height: 44, width: 44 },
-  mobileMediaGallery: { height: 76 },
+  mobileMediaGallery: { borderTopWidth: borderWidths[1], height: 76 },
   mobileGalleryContent: { paddingVertical: 11 },
   mobileThumbnailTarget: { height: 54, width: 54 },
   mobileThumbnail: { height: 50, width: 50 },
@@ -681,7 +684,6 @@ const styles = StyleSheet.create({
   altToolLabel: textStyles.uiLabelS,
   footer: {
     alignItems: 'center',
-    borderTopWidth: borderWidths[1],
     flexDirection: 'row',
     height: 64,
     paddingLeft: space[24],

--- a/apps/app/src/components/post/PostComposerMediaItemsTarget.tsx
+++ b/apps/app/src/components/post/PostComposerMediaItemsTarget.tsx
@@ -49,7 +49,7 @@ export function PostComposerMediaItemsTarget({
       accessibilityLabel={`첨부 이미지 갤러리, ${media.length}개`}
       contentContainerStyle={styles.galleryContent}
       horizontal
-      showsHorizontalScrollIndicator={false}
+      showsHorizontalScrollIndicator={media.length > 2}
       style={styles.gallery}
     >
       {media.map((item, index) => {

--- a/apps/app/src/components/post/PostComposerMediaItemsTarget.tsx
+++ b/apps/app/src/components/post/PostComposerMediaItemsTarget.tsx
@@ -1,4 +1,12 @@
-import { FlagIcon, PenIcon, RefreshCwIcon, XIcon } from 'lucide-react-native';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  FlagIcon,
+  PenIcon,
+  RefreshCwIcon,
+  XIcon,
+} from 'lucide-react-native';
+import { useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -39,167 +47,222 @@ export function PostComposerMediaItemsTarget({
   sensitiveMedia,
 }: PostComposerMediaItemsTargetProps) {
   const theme = useTheme();
+  const galleryRef = useRef<ScrollView>(null);
+  const [galleryWidth, setGalleryWidth] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
 
   if (media.length === 0) {
     return null;
   }
 
-  return (
-    <ScrollView
-      accessibilityLabel={`첨부 이미지 갤러리, ${media.length}개`}
-      contentContainerStyle={styles.galleryContent}
-      horizontal
-      showsHorizontalScrollIndicator={media.length > 2}
-      style={styles.gallery}
-    >
-      {media.map((item, index) => {
-        const itemNumber = index + 1;
-        const ready = item.state === 'ready';
-        const failed = item.state === 'failed';
+  const contentWidth = media.length * itemSize + Math.max(0, media.length - 1) * space[8];
+  const maxScrollOffset = Math.max(0, contentWidth - galleryWidth);
+  const showNavigation =
+    Platform.OS === 'web' && media.length > 2 && (galleryWidth === 0 || maxScrollOffset > 0);
+  const scrollGallery = (direction: -1 | 1) => {
+    const step = itemSize + space[8];
+    const nextOffset = Math.max(0, Math.min(maxScrollOffset, scrollOffset + direction * step));
 
-        return (
-          <View
-            accessibilityLabel={`첨부 이미지 ${itemNumber}, ${
-              item.state === 'uploading' ? '업로드 중' : ready ? '업로드 완료' : '업로드 실패'
-            }`}
-            key={item.key}
-            style={[
-              styles.item,
-              {
-                backgroundColor: failed ? theme.feedbackDangerSubtle : theme.backgroundElevated,
-                borderColor: failed ? theme.feedbackDangerBorder : theme.borderSubtle,
-              },
-            ]}
-          >
-            {ready ? (
-              <Pressable
-                accessibilityLabel={`첨부 이미지 ${itemNumber} 대체 텍스트 편집`}
-                accessibilityRole="button"
-                accessibilityState={{ disabled }}
-                disabled={disabled}
-                onPress={() => onEdit(item.key, 'alt')}
-                style={({ pressed }) => [styles.previewTarget, pressed && styles.pressed]}
-              >
+    galleryRef.current?.scrollTo({ animated: false, x: nextOffset });
+    setScrollOffset(nextOffset);
+  };
+
+  return (
+    <View style={styles.galleryShell}>
+      <ScrollView
+        accessibilityLabel={`첨부 이미지 갤러리, ${media.length}개`}
+        contentContainerStyle={styles.galleryContent}
+        horizontal
+        onLayout={({ nativeEvent }) => setGalleryWidth(nativeEvent.layout.width)}
+        onScroll={({ nativeEvent }) => setScrollOffset(nativeEvent.contentOffset.x)}
+        ref={galleryRef}
+        scrollEventThrottle={16}
+        showsHorizontalScrollIndicator={false}
+        style={styles.gallery}
+      >
+        {media.map((item, index) => {
+          const itemNumber = index + 1;
+          const ready = item.state === 'ready';
+          const failed = item.state === 'failed';
+
+          return (
+            <View
+              accessibilityLabel={`첨부 이미지 ${itemNumber}, ${
+                item.state === 'uploading' ? '업로드 중' : ready ? '업로드 완료' : '업로드 실패'
+              }`}
+              key={item.key}
+              style={[
+                styles.item,
+                {
+                  backgroundColor: failed ? theme.feedbackDangerSubtle : theme.backgroundElevated,
+                  borderColor: failed ? theme.feedbackDangerBorder : theme.borderSubtle,
+                },
+              ]}
+            >
+              {ready ? (
+                <Pressable
+                  accessibilityLabel={`첨부 이미지 ${itemNumber} 대체 텍스트 편집`}
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled }}
+                  disabled={disabled}
+                  onPress={() => onEdit(item.key, 'alt')}
+                  style={({ pressed }) => [styles.previewTarget, pressed && styles.pressed]}
+                >
+                  <Image
+                    accessibilityIgnoresInvertColors
+                    accessibilityLabel={`첨부 이미지 ${itemNumber} 미리보기`}
+                    accessibilityRole="image"
+                    source={{ uri: item.asset.uri }}
+                    style={styles.preview}
+                  />
+                </Pressable>
+              ) : (
                 <Image
                   accessibilityIgnoresInvertColors
                   accessibilityLabel={`첨부 이미지 ${itemNumber} 미리보기`}
                   accessibilityRole="image"
                   source={{ uri: item.asset.uri }}
-                  style={styles.preview}
+                  style={[styles.preview, styles.pendingPreview]}
                 />
-              </Pressable>
-            ) : (
-              <Image
-                accessibilityIgnoresInvertColors
-                accessibilityLabel={`첨부 이미지 ${itemNumber} 미리보기`}
-                accessibilityRole="image"
-                source={{ uri: item.asset.uri }}
-                style={[styles.preview, styles.pendingPreview]}
-              />
-            )}
+              )}
 
-            <IconButton
-              accessibilityLabel={`첨부 이미지 ${itemNumber} 제거`}
-              disabled={disabled}
-              feedback="opacity"
-              onPress={() => onRemove(item.key)}
-              style={styles.removeAction}
-              visualSize={actionVisualSize}
-              visualStyle={[
-                styles.actionVisual,
-                { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
-              ]}
-            >
-              <XIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
-            </IconButton>
-
-            {ready ? (
               <IconButton
-                accessibilityLabel={`첨부 이미지 ${itemNumber} 편집`}
+                accessibilityLabel={`첨부 이미지 ${itemNumber} 제거`}
                 disabled={disabled}
                 feedback="opacity"
-                onPress={() => onEdit(item.key, 'alt')}
-                style={styles.editAction}
+                onPress={() => onRemove(item.key)}
+                style={styles.removeAction}
                 visualSize={actionVisualSize}
                 visualStyle={[
                   styles.actionVisual,
                   { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
                 ]}
               >
-                <PenIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+                <XIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
               </IconButton>
-            ) : item.state === 'uploading' ? (
-              <View
-                style={[styles.uploadingIndicator, { backgroundColor: theme.backgroundSurface }]}
-              >
-                <ActivityIndicator
-                  accessibilityLabel={`첨부 이미지 ${itemNumber} 업로드 중`}
-                  color={theme.foregroundPrimary}
-                />
-              </View>
-            ) : (
-              <IconButton
-                accessibilityLabel={`${itemNumber}번째 이미지 업로드 다시 시도`}
-                disabled={disabled}
-                feedback="opacity"
-                onPress={() => onRetry(item)}
-                style={styles.retryAction}
-                visualSize={actionVisualSize}
-                visualStyle={[
-                  styles.actionVisual,
-                  { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
-                ]}
-              >
-                <RefreshCwIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
-              </IconButton>
-            )}
 
-            {ready && (item.altText.trim() || sensitiveMedia) ? (
-              <View style={styles.statuses}>
-                {item.altText.trim() ? (
-                  <StatusButton
-                    accessibilityLabel={`첨부 이미지 ${itemNumber} ALT 편집`}
-                    disabled={disabled}
-                    onPress={() => onEdit(item.key, 'alt')}
-                  >
-                    <Text style={[styles.statusText, { color: theme.foregroundPrimary }]}>ALT</Text>
-                  </StatusButton>
-                ) : null}
-                {sensitiveMedia ? (
-                  <StatusButton
-                    accessibilityLabel={`첨부 이미지 ${itemNumber} 민감한 이미지 설정 편집`}
-                    disabled={disabled}
-                    onPress={() => onEdit(item.key, 'sensitive')}
-                  >
-                    <FlagIcon color={theme.foregroundPrimary} size={iconSizes[16]} />
-                    <Text style={[styles.statusText, { color: theme.foregroundPrimary }]}>
-                      민감
-                    </Text>
-                  </StatusButton>
-                ) : null}
-              </View>
-            ) : null}
+              {ready ? (
+                <IconButton
+                  accessibilityLabel={`첨부 이미지 ${itemNumber} 편집`}
+                  disabled={disabled}
+                  feedback="opacity"
+                  onPress={() => onEdit(item.key, 'alt')}
+                  style={styles.editAction}
+                  visualSize={actionVisualSize}
+                  visualStyle={[
+                    styles.actionVisual,
+                    { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+                  ]}
+                >
+                  <PenIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+                </IconButton>
+              ) : item.state === 'uploading' ? (
+                <View
+                  style={[styles.uploadingIndicator, { backgroundColor: theme.backgroundSurface }]}
+                >
+                  <ActivityIndicator
+                    accessibilityLabel={`첨부 이미지 ${itemNumber} 업로드 중`}
+                    color={theme.foregroundPrimary}
+                  />
+                </View>
+              ) : (
+                <IconButton
+                  accessibilityLabel={`${itemNumber}번째 이미지 업로드 다시 시도`}
+                  disabled={disabled}
+                  feedback="opacity"
+                  onPress={() => onRetry(item)}
+                  style={styles.retryAction}
+                  visualSize={actionVisualSize}
+                  visualStyle={[
+                    styles.actionVisual,
+                    { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+                  ]}
+                >
+                  <RefreshCwIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+                </IconButton>
+              )}
 
-            {failed ? (
-              <View
-                accessibilityRole="alert"
-                style={[
-                  styles.failureBadge,
-                  {
-                    backgroundColor: theme.feedbackDangerSubtle,
-                    borderColor: theme.feedbackDangerBorder,
-                  },
-                ]}
-              >
-                <Text style={[styles.statusText, { color: theme.feedbackDangerOnSubtle }]}>
-                  업로드 실패
-                </Text>
-              </View>
-            ) : null}
-          </View>
-        );
-      })}
-    </ScrollView>
+              {ready && (item.altText.trim() || sensitiveMedia) ? (
+                <View style={styles.statuses}>
+                  {item.altText.trim() ? (
+                    <StatusButton
+                      accessibilityLabel={`첨부 이미지 ${itemNumber} ALT 편집`}
+                      disabled={disabled}
+                      onPress={() => onEdit(item.key, 'alt')}
+                    >
+                      <Text style={[styles.statusText, { color: theme.foregroundPrimary }]}>
+                        ALT
+                      </Text>
+                    </StatusButton>
+                  ) : null}
+                  {sensitiveMedia ? (
+                    <StatusButton
+                      accessibilityLabel={`첨부 이미지 ${itemNumber} 민감한 이미지 설정 편집`}
+                      disabled={disabled}
+                      onPress={() => onEdit(item.key, 'sensitive')}
+                    >
+                      <FlagIcon color={theme.foregroundPrimary} size={iconSizes[16]} />
+                      <Text style={[styles.statusText, { color: theme.foregroundPrimary }]}>
+                        민감
+                      </Text>
+                    </StatusButton>
+                  ) : null}
+                </View>
+              ) : null}
+
+              {failed ? (
+                <View
+                  accessibilityRole="alert"
+                  style={[
+                    styles.failureBadge,
+                    {
+                      backgroundColor: theme.feedbackDangerSubtle,
+                      borderColor: theme.feedbackDangerBorder,
+                    },
+                  ]}
+                >
+                  <Text style={[styles.statusText, { color: theme.feedbackDangerOnSubtle }]}>
+                    업로드 실패
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          );
+        })}
+      </ScrollView>
+      {showNavigation ? (
+        <>
+          <IconButton
+            accessibilityLabel="첨부 이미지 갤러리 이전"
+            disabled={disabled || scrollOffset <= 0}
+            feedback="opacity"
+            onPress={() => scrollGallery(-1)}
+            style={styles.previousAction}
+            visualSize={actionVisualSize}
+            visualStyle={[
+              styles.navigationVisual,
+              { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+            ]}
+          >
+            <ChevronLeftIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+          </IconButton>
+          <IconButton
+            accessibilityLabel="첨부 이미지 갤러리 다음"
+            disabled={disabled || (galleryWidth > 0 && scrollOffset >= maxScrollOffset)}
+            feedback="opacity"
+            onPress={() => scrollGallery(1)}
+            style={styles.nextAction}
+            visualSize={actionVisualSize}
+            visualStyle={[
+              styles.navigationVisual,
+              { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+            ]}
+          >
+            <ChevronRightIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+          </IconButton>
+        </>
+      ) : null}
+    </View>
   );
 }
 
@@ -241,6 +304,7 @@ function StatusButton({
 }
 
 const styles = StyleSheet.create({
+  galleryShell: { height: itemSize, position: 'relative', width: '100%' },
   gallery: { height: itemSize, width: '100%' },
   galleryContent: { gap: space[8] },
   item: {
@@ -259,8 +323,26 @@ const styles = StyleSheet.create({
     borderRadius: radius.full,
     borderWidth: borderWidths[1],
   },
+  navigationVisual: {
+    borderRadius: radius.full,
+    borderWidth: borderWidths[1],
+  },
   removeAction: { left: space[4], position: 'absolute', top: space[4], zIndex: 2 },
   editAction: { position: 'absolute', right: space[4], top: space[4], zIndex: 2 },
+  previousAction: {
+    left: space[4],
+    marginTop: -actionVisualSize / 2,
+    position: 'absolute',
+    top: '50%',
+    zIndex: 3,
+  },
+  nextAction: {
+    marginTop: -actionVisualSize / 2,
+    position: 'absolute',
+    right: space[4],
+    top: '50%',
+    zIndex: 3,
+  },
   uploadingIndicator: {
     alignItems: 'center',
     borderRadius: radius.full,

--- a/apps/app/src/components/post/PostComposerMediaItemsTarget.tsx
+++ b/apps/app/src/components/post/PostComposerMediaItemsTarget.tsx
@@ -1,0 +1,317 @@
+import { FlagIcon, PenIcon, RefreshCwIcon, XIcon } from 'lucide-react-native';
+import {
+  ActivityIndicator,
+  Image,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { IconButton } from '@/components/ui/IconButton';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/tokens';
+import type { ComposerMediaItem } from './PostComposerMediaControls';
+
+type PostComposerMediaEditTool = 'alt' | 'sensitive';
+
+export type PostComposerMediaItemsTargetProps = {
+  readonly disabled: boolean;
+  readonly media: readonly ComposerMediaItem[];
+  readonly onEdit: (key: string, tool: PostComposerMediaEditTool) => void;
+  readonly onRemove: (key: string) => void;
+  readonly onRetry: (item: ComposerMediaItem) => void;
+  readonly sensitiveMedia: boolean;
+};
+
+const itemSize = 156;
+const actionVisualSize = 32;
+const statusVisualHeight = 28;
+const statusTargetHeight = Platform.select({ android: 48, ios: 44, default: statusVisualHeight });
+
+export function PostComposerMediaItemsTarget({
+  disabled,
+  media,
+  onEdit,
+  onRemove,
+  onRetry,
+  sensitiveMedia,
+}: PostComposerMediaItemsTargetProps) {
+  const theme = useTheme();
+
+  if (media.length === 0) {
+    return null;
+  }
+
+  return (
+    <ScrollView
+      accessibilityLabel={`첨부 이미지 갤러리, ${media.length}개`}
+      contentContainerStyle={styles.galleryContent}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={styles.gallery}
+    >
+      {media.map((item, index) => {
+        const itemNumber = index + 1;
+        const ready = item.state === 'ready';
+        const failed = item.state === 'failed';
+
+        return (
+          <View
+            accessibilityLabel={`첨부 이미지 ${itemNumber}, ${
+              item.state === 'uploading' ? '업로드 중' : ready ? '업로드 완료' : '업로드 실패'
+            }`}
+            key={item.key}
+            style={[
+              styles.item,
+              {
+                backgroundColor: failed ? theme.feedbackDangerSubtle : theme.backgroundElevated,
+                borderColor: failed ? theme.feedbackDangerBorder : theme.borderSubtle,
+              },
+            ]}
+          >
+            {ready ? (
+              <Pressable
+                accessibilityLabel={`첨부 이미지 ${itemNumber} 대체 텍스트 편집`}
+                accessibilityRole="button"
+                accessibilityState={{ disabled }}
+                disabled={disabled}
+                onPress={() => onEdit(item.key, 'alt')}
+                style={({ pressed }) => [styles.previewTarget, pressed && styles.pressed]}
+              >
+                <Image
+                  accessibilityIgnoresInvertColors
+                  accessibilityLabel={`첨부 이미지 ${itemNumber} 미리보기`}
+                  accessibilityRole="image"
+                  source={{ uri: item.asset.uri }}
+                  style={styles.preview}
+                />
+              </Pressable>
+            ) : (
+              <Image
+                accessibilityIgnoresInvertColors
+                accessibilityLabel={`첨부 이미지 ${itemNumber} 미리보기`}
+                accessibilityRole="image"
+                source={{ uri: item.asset.uri }}
+                style={[styles.preview, styles.pendingPreview]}
+              />
+            )}
+
+            <IconButton
+              accessibilityLabel={`첨부 이미지 ${itemNumber} 제거`}
+              disabled={disabled}
+              feedback="opacity"
+              onPress={() => onRemove(item.key)}
+              style={styles.removeAction}
+              visualSize={actionVisualSize}
+              visualStyle={[
+                styles.actionVisual,
+                { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+              ]}
+            >
+              <XIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+            </IconButton>
+
+            {ready ? (
+              <IconButton
+                accessibilityLabel={`첨부 이미지 ${itemNumber} 편집`}
+                disabled={disabled}
+                feedback="opacity"
+                onPress={() => onEdit(item.key, 'alt')}
+                style={styles.editAction}
+                visualSize={actionVisualSize}
+                visualStyle={[
+                  styles.actionVisual,
+                  { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+                ]}
+              >
+                <PenIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+              </IconButton>
+            ) : item.state === 'uploading' ? (
+              <View
+                style={[styles.uploadingIndicator, { backgroundColor: theme.backgroundSurface }]}
+              >
+                <ActivityIndicator
+                  accessibilityLabel={`첨부 이미지 ${itemNumber} 업로드 중`}
+                  color={theme.foregroundPrimary}
+                />
+              </View>
+            ) : (
+              <IconButton
+                accessibilityLabel={`${itemNumber}번째 이미지 업로드 다시 시도`}
+                disabled={disabled}
+                feedback="opacity"
+                onPress={() => onRetry(item)}
+                style={styles.retryAction}
+                visualSize={actionVisualSize}
+                visualStyle={[
+                  styles.actionVisual,
+                  { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+                ]}
+              >
+                <RefreshCwIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+              </IconButton>
+            )}
+
+            {ready && (item.altText.trim() || sensitiveMedia) ? (
+              <View style={styles.statuses}>
+                {item.altText.trim() ? (
+                  <StatusButton
+                    accessibilityLabel={`첨부 이미지 ${itemNumber} ALT 편집`}
+                    disabled={disabled}
+                    onPress={() => onEdit(item.key, 'alt')}
+                  >
+                    <Text style={[styles.statusText, { color: theme.foregroundPrimary }]}>ALT</Text>
+                  </StatusButton>
+                ) : null}
+                {sensitiveMedia ? (
+                  <StatusButton
+                    accessibilityLabel={`첨부 이미지 ${itemNumber} 민감한 이미지 설정 편집`}
+                    disabled={disabled}
+                    onPress={() => onEdit(item.key, 'sensitive')}
+                  >
+                    <FlagIcon color={theme.foregroundPrimary} size={iconSizes[16]} />
+                    <Text style={[styles.statusText, { color: theme.foregroundPrimary }]}>
+                      민감
+                    </Text>
+                  </StatusButton>
+                ) : null}
+              </View>
+            ) : null}
+
+            {failed ? (
+              <View
+                accessibilityRole="alert"
+                style={[
+                  styles.failureBadge,
+                  {
+                    backgroundColor: theme.feedbackDangerSubtle,
+                    borderColor: theme.feedbackDangerBorder,
+                  },
+                ]}
+              >
+                <Text style={[styles.statusText, { color: theme.feedbackDangerOnSubtle }]}>
+                  업로드 실패
+                </Text>
+              </View>
+            ) : null}
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+function StatusButton({
+  accessibilityLabel,
+  children,
+  disabled,
+  onPress,
+}: {
+  readonly accessibilityLabel: string;
+  readonly children: React.ReactNode;
+  readonly disabled: boolean;
+  readonly onPress: () => void;
+}) {
+  const theme = useTheme();
+
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.statusTarget,
+        { opacity: disabled ? 0.45 : pressed ? 0.7 : 1 },
+      ]}
+    >
+      <View
+        style={[
+          styles.statusVisual,
+          { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+        ]}
+      >
+        {children}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  gallery: { height: itemSize, width: '100%' },
+  galleryContent: { gap: space[8] },
+  item: {
+    borderRadius: radius[12],
+    borderWidth: borderWidths[1],
+    height: itemSize,
+    overflow: 'hidden',
+    position: 'relative',
+    width: itemSize,
+  },
+  previewTarget: { height: '100%', width: '100%' },
+  preview: { height: '100%', width: '100%' },
+  pendingPreview: { opacity: 0.18 },
+  pressed: { opacity: 0.84 },
+  actionVisual: {
+    borderRadius: radius.full,
+    borderWidth: borderWidths[1],
+  },
+  removeAction: { left: space[4], position: 'absolute', top: space[4], zIndex: 2 },
+  editAction: { position: 'absolute', right: space[4], top: space[4], zIndex: 2 },
+  uploadingIndicator: {
+    alignItems: 'center',
+    borderRadius: radius.full,
+    height: space[48],
+    justifyContent: 'center',
+    left: '50%',
+    marginLeft: -space[24],
+    marginTop: -space[24],
+    position: 'absolute',
+    top: '50%',
+    width: space[48],
+  },
+  retryAction: {
+    left: '50%',
+    marginLeft: -actionVisualSize / 2,
+    marginTop: -actionVisualSize / 2,
+    position: 'absolute',
+    top: '50%',
+  },
+  statuses: {
+    alignItems: 'center',
+    bottom: space[4],
+    flexDirection: 'row',
+    gap: space[4],
+    left: space[4],
+    position: 'absolute',
+  },
+  statusTarget: {
+    alignItems: 'center',
+    height: statusTargetHeight,
+    justifyContent: 'center',
+  },
+  statusVisual: {
+    alignItems: 'center',
+    borderRadius: radius.full,
+    borderWidth: borderWidths[1],
+    flexDirection: 'row',
+    gap: space[4],
+    height: statusVisualHeight,
+    justifyContent: 'center',
+    paddingHorizontal: space[8],
+  },
+  statusText: textStyles.uiCopyM,
+  failureBadge: {
+    borderRadius: radius.full,
+    borderWidth: borderWidths[1],
+    bottom: space[4],
+    height: statusVisualHeight,
+    justifyContent: 'center',
+    left: space[4],
+    paddingHorizontal: space[8],
+    position: 'absolute',
+  },
+});

--- a/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
+++ b/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
@@ -1,0 +1,205 @@
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ProfilePicker } from '@/components/profile/ProfilePicker';
+import { Avatar } from '@/components/ui/Avatar';
+import { useTheme } from '@/theme/ThemeProvider';
+import { spacing, typography } from '@/theme/tokens';
+import type { ProfilePickerProfile } from '@/components/profile/ProfilePicker';
+
+export type PostComposerProfileSwitcherSurface = 'overlay' | 'rail';
+
+type Props = Readonly<{
+  onSelectProfile: (id: string) => void | Promise<void>;
+  profiles: readonly ProfilePickerProfile[];
+  selectedProfileId: string;
+  surface: PostComposerProfileSwitcherSurface;
+}>;
+
+export function PostComposerProfileSwitcher({
+  onSelectProfile,
+  profiles,
+  selectedProfileId: initialSelectedProfileId,
+  surface,
+}: Props) {
+  const theme = useTheme();
+  const rootRef = useRef<View>(null);
+  const pickerRef = useRef<View>(null);
+  const triggerRef = useRef<View>(null);
+  const pendingRef = useRef(false);
+  const operationVersionRef = useRef(0);
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedProfileId, setSelectedProfileId] = useState(initialSelectedProfileId);
+  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId);
+
+  useEffect(() => {
+    setSelectedProfileId(initialSelectedProfileId);
+  }, [initialSelectedProfileId]);
+
+  const focusTrigger = useCallback(() => {
+    if (Platform.OS === 'web') {
+      setTimeout(() => triggerRef.current?.focus(), 0);
+      return;
+    }
+    triggerRef.current?.focus();
+  }, []);
+
+  const dismiss = useCallback(() => {
+    operationVersionRef.current += 1;
+    pendingRef.current = false;
+    setPending(false);
+    setError(null);
+    setOpen(false);
+    focusTrigger();
+  }, [focusTrigger]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !open) {
+      return;
+    }
+
+    const root = rootRef.current as unknown as HTMLElement | null;
+    const ownerDocument = root?.ownerDocument;
+    if (!root || !ownerDocument) {
+      return;
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!root.contains(event.target as Node)) {
+        dismiss();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      event.preventDefault();
+      dismiss();
+    };
+
+    ownerDocument.addEventListener('pointerdown', onPointerDown);
+    ownerDocument.addEventListener('keydown', onKeyDown);
+    return () => {
+      ownerDocument.removeEventListener('pointerdown', onPointerDown);
+      ownerDocument.removeEventListener('keydown', onKeyDown);
+    };
+  }, [dismiss, open]);
+
+  const selectProfile = (id: string) => {
+    if (pendingRef.current) {
+      return;
+    }
+
+    pendingRef.current = true;
+    setPending(true);
+    setError(null);
+    const operationVersion = operationVersionRef.current;
+
+    void Promise.resolve()
+      .then(() => onSelectProfile(id))
+      .then(
+        () => {
+          if (operationVersion !== operationVersionRef.current) {
+            return;
+          }
+          setSelectedProfileId(id);
+          setOpen(false);
+          setPending(false);
+          pendingRef.current = false;
+          operationVersionRef.current += 1;
+          focusTrigger();
+        },
+        () => {
+          if (operationVersion !== operationVersionRef.current) {
+            return;
+          }
+          setError('프로필을 전환하지 못했습니다.');
+          setPending(false);
+          pendingRef.current = false;
+        },
+      );
+  };
+
+  return (
+    <View ref={rootRef} style={styles.root}>
+      <Pressable
+        accessibilityLabel="작성 프로필"
+        accessibilityRole="button"
+        accessibilityState={{ busy: pending, disabled: pending, expanded: open }}
+        aria-busy={pending}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        disabled={pending}
+        onPress={() => {
+          setError(null);
+          setOpen((value) => !value);
+        }}
+        ref={triggerRef}
+        style={({ pressed }) => [
+          styles.trigger,
+          { backgroundColor: pressed ? theme.surface : 'transparent', opacity: pending ? 0.5 : 1 },
+        ]}
+      >
+        <Avatar
+          imageUri={selectedProfile?.avatar?.url}
+          label={selectedProfile?.displayName ?? '프로필'}
+          size={40}
+        />
+        <View style={styles.triggerCopy}>
+          <Text numberOfLines={1} style={[styles.triggerName, { color: theme.text }]}>
+            {selectedProfile?.displayName ?? '프로필 선택'}
+          </Text>
+          {selectedProfile ? (
+            <Text numberOfLines={1} style={[styles.triggerHandle, { color: theme.textSecondary }]}>
+              {selectedProfile.relativeHandle}
+            </Text>
+          ) : null}
+        </View>
+        {open ? (
+          <ChevronUpIcon color={theme.textSecondary} size={16} />
+        ) : (
+          <ChevronDownIcon color={theme.textSecondary} size={16} />
+        )}
+      </Pressable>
+      {open ? (
+        <View style={styles.pickerLayer}>
+          <ProfilePicker
+            busy={pending}
+            footer={
+              error ? (
+                <Text accessibilityRole="alert" style={[styles.error, { color: theme.danger }]}>
+                  {error}
+                </Text>
+              ) : null
+            }
+            onSelect={selectProfile}
+            pickerRef={pickerRef}
+            profiles={profiles}
+            selectedProfileId={selectedProfileId}
+            showDivider={false}
+            surface={surface === 'rail' ? 'compact' : 'full'}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { position: 'relative', zIndex: 20 },
+  trigger: {
+    alignItems: 'center',
+    borderRadius: 10,
+    flexDirection: 'row',
+    gap: spacing.sm,
+    maxWidth: '100%',
+    padding: spacing.xs,
+  },
+  triggerCopy: { flex: 1, minWidth: 0 },
+  triggerName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
+  triggerHandle: { fontFamily: 'SUIT', ...typography.sm },
+  pickerLayer: { left: 0, position: 'absolute', top: 48, zIndex: 30 },
+  error: { fontFamily: 'SUIT', padding: spacing.sm, ...typography.xsm },
+});

--- a/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
+++ b/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
@@ -45,14 +45,17 @@ export function PostComposerProfileSwitcher({
     triggerRef.current?.focus();
   }, []);
 
-  const dismiss = useCallback(() => {
-    operationVersionRef.current += 1;
-    pendingRef.current = false;
-    setPending(false);
-    setError(null);
-    setOpen(false);
-    focusTrigger();
-  }, [focusTrigger]);
+  const dismiss = useCallback(
+    (restoreFocus: boolean) => {
+      operationVersionRef.current += 1;
+      setError(null);
+      setOpen(false);
+      if (restoreFocus) {
+        focusTrigger();
+      }
+    },
+    [focusTrigger],
+  );
 
   useEffect(() => {
     if (Platform.OS !== 'web' || !open) {
@@ -67,7 +70,7 @@ export function PostComposerProfileSwitcher({
 
     const onPointerDown = (event: PointerEvent) => {
       if (!root.contains(event.target as Node)) {
-        dismiss();
+        dismiss(false);
       }
     };
     const onKeyDown = (event: KeyboardEvent) => {
@@ -75,7 +78,7 @@ export function PostComposerProfileSwitcher({
         return;
       }
       event.preventDefault();
-      dismiss();
+      dismiss(true);
     };
 
     ownerDocument.addEventListener('pointerdown', onPointerDown);
@@ -85,6 +88,11 @@ export function PostComposerProfileSwitcher({
       ownerDocument.removeEventListener('keydown', onKeyDown);
     };
   }, [dismiss, open]);
+
+  const releaseDismissedSelection = () => {
+    pendingRef.current = false;
+    setPending(false);
+  };
 
   const selectProfile = (id: string) => {
     if (pendingRef.current) {
@@ -101,6 +109,7 @@ export function PostComposerProfileSwitcher({
       .then(
         () => {
           if (operationVersion !== operationVersionRef.current) {
+            releaseDismissedSelection();
             return;
           }
           setSelectedProfileId(id);
@@ -112,6 +121,7 @@ export function PostComposerProfileSwitcher({
         },
         () => {
           if (operationVersion !== operationVersionRef.current) {
+            releaseDismissedSelection();
             return;
           }
           setError('프로필을 전환하지 못했습니다.');
@@ -130,9 +140,12 @@ export function PostComposerProfileSwitcher({
           accessibilityState={{ busy: pending, disabled: pending, expanded: open }}
           aria-busy={pending}
           aria-expanded={open}
-          disabled={pending}
+          disabled={pending && open}
           hitSlop={4}
           onPress={() => {
+            if (pendingRef.current) {
+              return;
+            }
             setError(null);
             setOpen((value) => !value);
           }}

--- a/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
+++ b/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
@@ -130,7 +130,6 @@ export function PostComposerProfileSwitcher({
         accessibilityState={{ busy: pending, disabled: pending, expanded: open }}
         aria-busy={pending}
         aria-expanded={open}
-        aria-haspopup="menu"
         disabled={pending}
         onPress={() => {
           setError(null);

--- a/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
+++ b/apps/app/src/components/post/PostComposerProfileSwitcher.tsx
@@ -1,4 +1,3 @@
-import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react-native';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { ProfilePicker } from '@/components/profile/ProfilePicker';
@@ -124,28 +123,34 @@ export function PostComposerProfileSwitcher({
 
   return (
     <View ref={rootRef} style={styles.root}>
-      <Pressable
-        accessibilityLabel="작성 프로필"
-        accessibilityRole="button"
-        accessibilityState={{ busy: pending, disabled: pending, expanded: open }}
-        aria-busy={pending}
-        aria-expanded={open}
-        disabled={pending}
-        onPress={() => {
-          setError(null);
-          setOpen((value) => !value);
-        }}
-        ref={triggerRef}
-        style={({ pressed }) => [
-          styles.trigger,
-          { backgroundColor: pressed ? theme.surface : 'transparent', opacity: pending ? 0.5 : 1 },
-        ]}
-      >
-        <Avatar
-          imageUri={selectedProfile?.avatar?.url}
-          label={selectedProfile?.displayName ?? '프로필'}
-          size={40}
-        />
+      <View style={styles.trigger}>
+        <Pressable
+          accessibilityLabel="작성 프로필"
+          accessibilityRole="button"
+          accessibilityState={{ busy: pending, disabled: pending, expanded: open }}
+          aria-busy={pending}
+          aria-expanded={open}
+          disabled={pending}
+          hitSlop={4}
+          onPress={() => {
+            setError(null);
+            setOpen((value) => !value);
+          }}
+          ref={triggerRef}
+          style={({ pressed }) => [
+            styles.avatarTrigger,
+            {
+              backgroundColor: pressed ? theme.surface : 'transparent',
+              opacity: pending ? 0.5 : 1,
+            },
+          ]}
+        >
+          <Avatar
+            imageUri={selectedProfile?.avatar?.url}
+            label={selectedProfile?.displayName ?? '프로필'}
+            size={40}
+          />
+        </Pressable>
         <View style={styles.triggerCopy}>
           <Text numberOfLines={1} style={[styles.triggerName, { color: theme.text }]}>
             {selectedProfile?.displayName ?? '프로필 선택'}
@@ -156,12 +161,7 @@ export function PostComposerProfileSwitcher({
             </Text>
           ) : null}
         </View>
-        {open ? (
-          <ChevronUpIcon color={theme.textSecondary} size={16} />
-        ) : (
-          <ChevronDownIcon color={theme.textSecondary} size={16} />
-        )}
-      </Pressable>
+      </View>
       {open ? (
         <View style={styles.pickerLayer}>
           <ProfilePicker
@@ -190,12 +190,11 @@ const styles = StyleSheet.create({
   root: { position: 'relative', zIndex: 20 },
   trigger: {
     alignItems: 'center',
-    borderRadius: 10,
     flexDirection: 'row',
-    gap: spacing.sm,
+    gap: spacing.md,
     maxWidth: '100%',
-    padding: spacing.xs,
   },
+  avatarTrigger: { borderRadius: 999 },
   triggerCopy: { flex: 1, minWidth: 0 },
   triggerName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
   triggerHandle: { fontFamily: 'SUIT', ...typography.sm },

--- a/apps/app/src/components/post/PostComposerTarget.tsx
+++ b/apps/app/src/components/post/PostComposerTarget.tsx
@@ -11,7 +11,7 @@ import {
   TriangleAlertIcon,
   XIcon,
 } from 'lucide-react-native';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { Circle, Svg } from 'react-native-svg';
 import { Button } from '@/components/ui/Button';
@@ -112,6 +112,11 @@ export function PostComposerTarget({
 }: PostComposerTargetProps) {
   const theme = useTheme();
   const [visibilityOpen, setVisibilityOpen] = useState(false);
+  useEffect(() => {
+    if (submitting) {
+      setVisibilityOpen(false);
+    }
+  }, [submitting]);
   const selectedVisibility =
     visibilityOptions.find((option) => option.value === visibility) ?? visibilityOptions[1];
   const SelectedVisibilityIcon = selectedVisibility.icon;
@@ -146,7 +151,7 @@ export function PostComposerTarget({
             <Pressable
               accessibilityLabel={`공개 범위: ${selectedVisibility.label}`}
               accessibilityRole="button"
-              accessibilityState={{ expanded: visibilityOpen }}
+              accessibilityState={{ expanded: visibilityOpen && !submitting }}
               disabled={submitting}
               onPress={() => setVisibilityOpen((open) => !open)}
               style={({ pressed }) => [
@@ -169,7 +174,7 @@ export function PostComposerTarget({
                 {selectedVisibility.label}
               </Text>
             </Pressable>
-            {visibilityOpen ? (
+            {visibilityOpen && !submitting ? (
               <VisibilityMenu
                 onChange={(value) => {
                   onVisibilityChange(value);
@@ -347,6 +352,11 @@ export function MobileFullscreenComposerShellCandidate({
   const theme = useTheme();
   const [bodyFocused, setBodyFocused] = useState(false);
   const [visibilityOpen, setVisibilityOpen] = useState(false);
+  useEffect(() => {
+    if (submitting) {
+      setVisibilityOpen(false);
+    }
+  }, [submitting]);
   const selectedVisibility =
     visibilityOptions.find((option) => option.value === visibility) ?? visibilityOptions[1];
   const disabled =
@@ -394,7 +404,7 @@ export function MobileFullscreenComposerShellCandidate({
         <Pressable
           accessibilityLabel={`공개 범위: ${selectedVisibility.label}`}
           accessibilityRole="button"
-          accessibilityState={{ expanded: visibilityOpen }}
+          accessibilityState={{ expanded: visibilityOpen && !submitting }}
           disabled={submitting}
           onPress={() => setVisibilityOpen((open) => !open)}
           style={({ pressed }) => [
@@ -415,7 +425,7 @@ export function MobileFullscreenComposerShellCandidate({
             <ChevronDownIcon color={theme.foregroundPrimary} size={iconSizes[16]} strokeWidth={2} />
           </View>
         </Pressable>
-        {visibilityOpen ? (
+        {visibilityOpen && !submitting ? (
           <VisibilityMenu
             alignRight
             onChange={(value) => {
@@ -695,7 +705,7 @@ function ComposerTool({
   children,
   disabled,
   onPress,
-  selected = false,
+  selected,
 }: {
   accessibilityLabel: string;
   children: ReactNode;
@@ -707,7 +717,7 @@ function ComposerTool({
   return (
     <IconButton
       accessibilityLabel={accessibilityLabel}
-      accessibilityState={{ selected }}
+      accessibilityState={selected === undefined ? undefined : { selected }}
       aria-pressed={selected}
       disabled={disabled}
       feedback="opacity"

--- a/apps/app/src/components/post/PostComposerTarget.tsx
+++ b/apps/app/src/components/post/PostComposerTarget.tsx
@@ -1,0 +1,771 @@
+import {
+  ChartNoAxesColumnIncreasingIcon,
+  ChevronDownIcon,
+  ExpandIcon,
+  GlobeIcon,
+  ImagePlusIcon,
+  LockIcon,
+  MoonIcon,
+  SmileIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from 'lucide-react-native';
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Button } from '@/components/ui/Button';
+import { IconButton } from '@/components/ui/IconButton';
+import { TextArea, TextField } from '@/components/ui/TextField';
+import { useElevation, useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/tokens';
+import { PostComposerMediaItemsTarget } from './PostComposerMediaItemsTarget';
+import type { LucideIcon } from 'lucide-react-native';
+import type { ReactNode } from 'react';
+import type { ComposerMediaItem } from './PostComposerMediaControls';
+
+export type PostComposerTargetVisibility = 'FOLLOWERS' | 'PUBLIC' | 'UNLISTED';
+
+export type PostComposerTargetProps = Readonly<{
+  author: ReactNode;
+  body: string;
+  contentWarning: string;
+  contentWarningExpanded: boolean;
+  error?: string;
+  items: readonly ComposerMediaItem[];
+  onBodyChange: (value: string) => void;
+  onContentWarningChange: (value: string) => void;
+  onContentWarningToggle: () => void;
+  onEmojiAction: () => void;
+  onExpand: () => void;
+  onMediaAction: () => void;
+  onMediaEdit: (itemId: string, tool: 'alt' | 'sensitive') => void;
+  onMediaRemove: (itemId: string) => void;
+  onMediaRetry: (itemId: string) => void;
+  onPollAction: () => void;
+  onSubmit: () => void;
+  onVisibilityChange: (value: PostComposerTargetVisibility) => void;
+  remaining: number;
+  sensitiveMedia: boolean;
+  showCWAction?: boolean;
+  showEmojiAction?: boolean;
+  showMediaAction?: boolean;
+  showPollAction?: boolean;
+  showSubmit?: boolean;
+  submitting?: boolean;
+  surface: 'overlay' | 'rail';
+  visibility: PostComposerTargetVisibility;
+}>;
+
+export type MobileFullscreenComposerShellCandidateProps = Omit<
+  PostComposerTargetProps,
+  'onExpand' | 'showSubmit' | 'surface'
+> &
+  Readonly<{ keyboard?: boolean; onOverlayClose: () => void }>;
+
+const visibilityOptions: ReadonlyArray<{
+  description: string;
+  icon: LucideIcon;
+  label: string;
+  value: PostComposerTargetVisibility;
+}> = [
+  { description: '모두가 볼 수 있어요.', icon: GlobeIcon, label: '공개', value: 'PUBLIC' },
+  {
+    description: '모두가 볼 수 있지만 검색되지 않아요.',
+    icon: MoonIcon,
+    label: '조용한 공개',
+    value: 'UNLISTED',
+  },
+  { description: '팔로워만 볼 수 있어요.', icon: LockIcon, label: '팔로워만', value: 'FOLLOWERS' },
+];
+
+export function PostComposerTarget({
+  author,
+  body,
+  contentWarning,
+  contentWarningExpanded,
+  error,
+  items,
+  onBodyChange,
+  onContentWarningChange,
+  onContentWarningToggle,
+  onEmojiAction,
+  onExpand,
+  onMediaAction,
+  onMediaEdit,
+  onMediaRemove,
+  onMediaRetry,
+  onPollAction,
+  onSubmit,
+  onVisibilityChange,
+  remaining,
+  sensitiveMedia,
+  showCWAction = true,
+  showEmojiAction = true,
+  showMediaAction = true,
+  showPollAction = true,
+  showSubmit = true,
+  submitting = false,
+  surface,
+  visibility,
+}: PostComposerTargetProps) {
+  const theme = useTheme();
+  const [visibilityOpen, setVisibilityOpen] = useState(false);
+  const selectedVisibility =
+    visibilityOptions.find((option) => option.value === visibility) ?? visibilityOptions[1];
+  const SelectedVisibilityIcon = selectedVisibility.icon;
+  const disabled =
+    submitting ||
+    items.some((item) => item.state !== 'ready') ||
+    (body.trim().length === 0 && items.length === 0) ||
+    remaining < 0;
+
+  return (
+    <View
+      accessibilityLabel="게시물 작성"
+      style={[
+        styles.root,
+        surface === 'rail' ? styles.rail : styles.overlay,
+        { backgroundColor: theme.backgroundCanvas },
+      ]}
+      testID="post-composer-target"
+    >
+      {author}
+      <View
+        style={[
+          styles.editor,
+          {
+            backgroundColor: theme.backgroundElevated,
+            borderColor: error ? theme.feedbackDangerBorder : theme.borderDefault,
+          },
+        ]}
+      >
+        <View style={styles.header}>
+          <View style={styles.visibilityControl}>
+            <Pressable
+              accessibilityLabel={`공개 범위: ${selectedVisibility.label}`}
+              accessibilityRole="button"
+              accessibilityState={{ expanded: visibilityOpen }}
+              disabled={submitting}
+              onPress={() => setVisibilityOpen((open) => !open)}
+              style={({ pressed }) => [
+                styles.visibilityTrigger,
+                {
+                  backgroundColor: pressed ? theme.statePressed : theme.backgroundSurface,
+                  borderColor: theme.borderDefault,
+                },
+              ]}
+            >
+              <SelectedVisibilityIcon
+                color={theme.foregroundPrimary}
+                size={iconSizes[16]}
+                strokeWidth={2}
+              />
+              <Text
+                numberOfLines={1}
+                style={[styles.visibilityLabel, { color: theme.foregroundPrimary }]}
+              >
+                {selectedVisibility.label}
+              </Text>
+            </Pressable>
+            {visibilityOpen ? (
+              <VisibilityMenu
+                onChange={(value) => {
+                  onVisibilityChange(value);
+                  setVisibilityOpen(false);
+                }}
+                value={visibility}
+              />
+            ) : null}
+          </View>
+          {surface === 'rail' ? (
+            <IconButton
+              accessibilityLabel="Composer 확장"
+              disabled={submitting}
+              feedback="opacity"
+              onPress={onExpand}
+              targetSize={40}
+              visualSize={32}
+            >
+              <ExpandIcon color={theme.foregroundPrimary} size={iconSizes[20]} strokeWidth={2} />
+            </IconButton>
+          ) : null}
+        </View>
+
+        {contentWarningExpanded ? (
+          <View style={styles.contentWarning}>
+            <TextField
+              accessibilityLabel="콘텐츠 경고"
+              editable={!submitting}
+              onChangeText={onContentWarningChange}
+              placeholder="경고 문구를 입력하세요"
+              style={styles.contentWarningField}
+              value={contentWarning}
+            />
+          </View>
+        ) : null}
+
+        <View style={[styles.content, items.length > 0 ? styles.mediaContent : styles.textContent]}>
+          <TextArea
+            accessibilityLabel="게시물 내용"
+            editable={!submitting}
+            onChangeText={onBodyChange}
+            placeholder="무슨 일이 일어나고 있나요?"
+            style={[
+              styles.body,
+              items.length > 0 ? styles.mediaBody : styles.textBody,
+              { backgroundColor: theme.backgroundElevated, color: theme.foregroundPrimary },
+            ]}
+            value={body}
+          />
+          <PostComposerMediaItemsTarget
+            disabled={submitting}
+            media={items}
+            onEdit={onMediaEdit}
+            onRemove={onMediaRemove}
+            onRetry={(item) => onMediaRetry(item.key)}
+            sensitiveMedia={sensitiveMedia}
+          />
+          {error ? (
+            <Text
+              accessibilityRole="alert"
+              style={[styles.error, { color: theme.feedbackDangerOnSubtle }]}
+            >
+              {error}
+            </Text>
+          ) : null}
+        </View>
+
+        <View style={styles.footer}>
+          <View style={styles.tools}>
+            {showMediaAction ? (
+              <ComposerTool
+                accessibilityLabel="이미지 추가"
+                disabled={submitting}
+                onPress={onMediaAction}
+              >
+                <ImagePlusIcon
+                  color={theme.foregroundPrimary}
+                  size={iconSizes[20]}
+                  strokeWidth={2}
+                />
+              </ComposerTool>
+            ) : null}
+            {showPollAction ? (
+              <ComposerTool
+                accessibilityLabel="투표 추가"
+                disabled={submitting}
+                onPress={onPollAction}
+              >
+                <ChartNoAxesColumnIncreasingIcon
+                  color={theme.foregroundPrimary}
+                  size={iconSizes[20]}
+                  strokeWidth={2}
+                />
+              </ComposerTool>
+            ) : null}
+            {showCWAction ? (
+              <ComposerTool
+                accessibilityLabel={`콘텐츠 경고 ${contentWarningExpanded ? '끄기' : '켜기'}`}
+                disabled={submitting}
+                onPress={onContentWarningToggle}
+                selected={contentWarningExpanded}
+              >
+                <TriangleAlertIcon
+                  color={theme.foregroundPrimary}
+                  size={iconSizes[20]}
+                  strokeWidth={2}
+                />
+              </ComposerTool>
+            ) : null}
+            {showEmojiAction ? (
+              <ComposerTool
+                accessibilityLabel="이모지 추가"
+                disabled={submitting}
+                onPress={onEmojiAction}
+              >
+                <SmileIcon color={theme.foregroundPrimary} size={iconSizes[20]} strokeWidth={2} />
+              </ComposerTool>
+            ) : null}
+          </View>
+          <View style={styles.submit}>
+            <Text
+              accessibilityLabel={`남은 글자 수 ${remaining.toLocaleString('ko-KR')}자`}
+              accessibilityLiveRegion="polite"
+              style={[
+                styles.remaining,
+                {
+                  color: remaining < 0 ? theme.feedbackDangerOnSubtle : theme.foregroundSecondary,
+                },
+              ]}
+            >
+              {remaining.toLocaleString('ko-KR')}
+            </Text>
+            {showSubmit ? (
+              <Button
+                disabled={disabled}
+                loading={submitting}
+                loadingText="게시 중"
+                onPress={onSubmit}
+                size="compact"
+              >
+                게시
+              </Button>
+            ) : null}
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function MobileFullscreenComposerShellCandidate({
+  author,
+  body,
+  contentWarning,
+  contentWarningExpanded,
+  error,
+  items,
+  keyboard = false,
+  onBodyChange,
+  onContentWarningChange,
+  onContentWarningToggle,
+  onEmojiAction,
+  onMediaAction,
+  onMediaEdit,
+  onMediaRemove,
+  onMediaRetry,
+  onOverlayClose,
+  onPollAction,
+  onSubmit,
+  onVisibilityChange,
+  remaining,
+  sensitiveMedia,
+  showCWAction = true,
+  showEmojiAction = true,
+  showMediaAction = true,
+  showPollAction = true,
+  submitting = false,
+  visibility,
+}: MobileFullscreenComposerShellCandidateProps) {
+  const theme = useTheme();
+  const selectedVisibility =
+    visibilityOptions.find((option) => option.value === visibility) ?? visibilityOptions[1];
+  const disabled =
+    submitting ||
+    items.some((item) => item.state !== 'ready') ||
+    (body.trim().length === 0 && items.length === 0) ||
+    remaining < 0;
+  const nextVisibility =
+    visibilityOptions[
+      (visibilityOptions.indexOf(selectedVisibility) + 1) % visibilityOptions.length
+    ].value;
+  const textHeight = keyboard
+    ? items.length > 0
+      ? 100
+      : contentWarningExpanded
+        ? 216
+        : 264
+    : items.length > 0
+      ? 424
+      : contentWarningExpanded
+        ? 552
+        : 600;
+
+  return (
+    <View
+      accessibilityLabel="모바일 글쓰기 Candidate"
+      style={[styles.mobileShell, { backgroundColor: theme.backgroundCanvas }]}
+      testID="mobile-fullscreen-composer-candidate"
+    >
+      <View style={[styles.mobileHeader, { borderBottomColor: theme.borderSubtle }]}>
+        <View style={styles.mobileLeadingSlot}>
+          <IconButton
+            accessibilityLabel="글쓰기 닫기"
+            disabled={submitting}
+            feedback="opacity"
+            onPress={onOverlayClose}
+            targetSize={44}
+          >
+            <XIcon color={theme.foregroundPrimary} size={iconSizes[24]} strokeWidth={2} />
+          </IconButton>
+        </View>
+        <Text
+          accessibilityRole="header"
+          style={[styles.mobileTitle, { color: theme.foregroundPrimary }]}
+        >
+          글쓰기
+        </Text>
+        <View style={styles.mobileTrailingSlot}>
+          <Button disabled={disabled} loading={submitting} onPress={onSubmit} size="compact">
+            게시
+          </Button>
+        </View>
+      </View>
+
+      <Pressable
+        accessibilityLabel={`공개 범위: ${selectedVisibility.label}`}
+        accessibilityRole="button"
+        disabled={submitting}
+        onPress={() => onVisibilityChange(nextVisibility)}
+        style={({ pressed }) => [
+          styles.mobileVisibility,
+          {
+            backgroundColor: pressed ? theme.statePressed : theme.backgroundCanvas,
+            borderColor: theme.borderSubtle,
+          },
+        ]}
+      >
+        <Text style={[styles.mobileVisibilityCaption, { color: theme.foregroundSecondary }]}>
+          공개 범위
+        </Text>
+        <View style={styles.mobileVisibilityValue}>
+          <Text style={[styles.visibilityOptionLabel, { color: theme.foregroundPrimary }]}>
+            {selectedVisibility.label}
+          </Text>
+          <ChevronDownIcon color={theme.foregroundPrimary} size={iconSizes[16]} strokeWidth={2} />
+        </View>
+      </Pressable>
+
+      <View style={styles.mobileComposerBody}>
+        {author}
+        {contentWarningExpanded ? (
+          <TextField
+            accessibilityLabel="콘텐츠 경고"
+            editable={!submitting}
+            onChangeText={onContentWarningChange}
+            placeholder="경고 문구를 입력하세요"
+            style={styles.mobileContentWarning}
+            value={contentWarning}
+          />
+        ) : null}
+        <TextArea
+          accessibilityLabel="게시물 내용"
+          editable={!submitting}
+          onChangeText={onBodyChange}
+          placeholder="무슨 일이 일어나고 있나요?"
+          style={[
+            styles.mobileBody,
+            {
+              backgroundColor: theme.backgroundCanvas,
+              color: theme.foregroundPrimary,
+              height: textHeight,
+            },
+          ]}
+          value={body}
+        />
+        {error ? (
+          <Text
+            accessibilityRole="alert"
+            style={[styles.error, { color: theme.feedbackDangerOnSubtle }]}
+          >
+            {error}
+          </Text>
+        ) : null}
+      </View>
+
+      {items.length > 0 ? (
+        <View style={styles.mobileMediaShelf}>
+          <PostComposerMediaItemsTarget
+            disabled={submitting}
+            media={items}
+            onEdit={onMediaEdit}
+            onRemove={onMediaRemove}
+            onRetry={(item) => onMediaRetry(item.key)}
+            sensitiveMedia={sensitiveMedia}
+          />
+        </View>
+      ) : null}
+
+      <View style={[styles.mobileFooter, { borderTopColor: theme.borderSubtle }]}>
+        <View style={styles.tools}>
+          {showMediaAction ? (
+            <ComposerTool
+              accessibilityLabel="이미지 추가"
+              disabled={submitting}
+              onPress={onMediaAction}
+            >
+              <ImagePlusIcon color={theme.foregroundPrimary} size={iconSizes[20]} strokeWidth={2} />
+            </ComposerTool>
+          ) : null}
+          {showPollAction ? (
+            <ComposerTool
+              accessibilityLabel="투표 추가"
+              disabled={submitting}
+              onPress={onPollAction}
+            >
+              <ChartNoAxesColumnIncreasingIcon
+                color={theme.foregroundPrimary}
+                size={iconSizes[20]}
+                strokeWidth={2}
+              />
+            </ComposerTool>
+          ) : null}
+          {showCWAction ? (
+            <ComposerTool
+              accessibilityLabel={`콘텐츠 경고 ${contentWarningExpanded ? '끄기' : '켜기'}`}
+              disabled={submitting}
+              onPress={onContentWarningToggle}
+              selected={contentWarningExpanded}
+            >
+              <TriangleAlertIcon
+                color={theme.foregroundPrimary}
+                size={iconSizes[20]}
+                strokeWidth={2}
+              />
+            </ComposerTool>
+          ) : null}
+          {showEmojiAction ? (
+            <ComposerTool
+              accessibilityLabel="이모지 추가"
+              disabled={submitting}
+              onPress={onEmojiAction}
+            >
+              <SmileIcon color={theme.foregroundPrimary} size={iconSizes[20]} strokeWidth={2} />
+            </ComposerTool>
+          ) : null}
+        </View>
+        <Text
+          accessibilityLabel={`남은 글자 수 ${remaining.toLocaleString('ko-KR')}자`}
+          accessibilityLiveRegion="polite"
+          style={[
+            styles.remaining,
+            { color: remaining < 0 ? theme.feedbackDangerOnSubtle : theme.foregroundSecondary },
+          ]}
+        >
+          {remaining.toLocaleString('ko-KR')}
+        </Text>
+      </View>
+      {keyboard ? <IllustrativeKeyboard /> : null}
+    </View>
+  );
+}
+
+function IllustrativeKeyboard() {
+  const theme = useTheme();
+  return (
+    <View
+      accessibilityElementsHidden
+      aria-hidden
+      importantForAccessibility="no-hide-descendants"
+      style={[
+        styles.keyboard,
+        { backgroundColor: theme.backgroundSurface, borderColor: theme.borderSubtle },
+      ]}
+      testID="illustrative-system-keyboard"
+    >
+      {[342, 326, 286, 168].map((width) => (
+        <View
+          key={width}
+          style={[
+            styles.keyboardRow,
+            { backgroundColor: theme.backgroundElevated, borderColor: theme.borderSubtle, width },
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+function VisibilityMenu({
+  onChange,
+  value,
+}: {
+  onChange: (value: PostComposerTargetVisibility) => void;
+  value: PostComposerTargetVisibility;
+}) {
+  const theme = useTheme();
+  const elevation = useElevation();
+  return (
+    <View
+      accessibilityLabel="공개 범위 선택"
+      accessibilityRole="radiogroup"
+      style={[
+        styles.visibilityMenu,
+        elevation.floating,
+        { backgroundColor: theme.backgroundElevated, borderColor: theme.borderDefault },
+      ]}
+    >
+      {visibilityOptions.map((option) => {
+        const Icon = option.icon;
+        const selected = option.value === value;
+        return (
+          <Pressable
+            accessibilityLabel={option.label}
+            accessibilityRole="radio"
+            accessibilityState={{ checked: selected }}
+            key={option.value}
+            onPress={() => onChange(option.value)}
+            style={({ pressed }) => [
+              styles.visibilityOption,
+              {
+                backgroundColor: selected
+                  ? theme.stateSelectedSurface
+                  : pressed
+                    ? theme.statePressed
+                    : 'transparent',
+              },
+            ]}
+          >
+            <Icon color={theme.foregroundSecondary} size={iconSizes[16]} strokeWidth={2} />
+            <View style={styles.visibilityOptionCopy}>
+              <Text style={[styles.visibilityOptionLabel, { color: theme.foregroundPrimary }]}>
+                {option.label}
+              </Text>
+              <Text style={[styles.visibilityDescription, { color: theme.foregroundSecondary }]}>
+                {option.description}
+              </Text>
+            </View>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function ComposerTool({
+  accessibilityLabel,
+  children,
+  disabled,
+  onPress,
+  selected = false,
+}: {
+  accessibilityLabel: string;
+  children: ReactNode;
+  disabled: boolean;
+  onPress: () => void;
+  selected?: boolean;
+}) {
+  const theme = useTheme();
+  return (
+    <IconButton
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ selected }}
+      aria-pressed={selected}
+      disabled={disabled}
+      feedback="opacity"
+      onPress={onPress}
+      visualSize={32}
+      visualStyle={[
+        styles.toolVisual,
+        { backgroundColor: selected ? theme.stateSelectedSurface : 'transparent' },
+      ]}
+    >
+      {children}
+    </IconButton>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: { borderWidth: borderWidths[0], padding: space[0] },
+  content: { gap: space[12], paddingHorizontal: space[12] },
+  contentWarning: { paddingBottom: space[12] },
+  contentWarningField: { borderRadius: radius[0] },
+  editor: { borderRadius: radius[12], borderWidth: borderWidths[1], overflow: 'visible' },
+  error: textStyles.uiCopyM,
+  footer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    height: 64,
+    justifyContent: 'space-between',
+    padding: space[12],
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    height: 64,
+    justifyContent: 'space-between',
+    padding: space[12],
+    zIndex: 10,
+  },
+  mediaBody: { minHeight: 236 },
+  mediaContent: { minHeight: 404 },
+  mobileBody: { borderWidth: borderWidths[0], minHeight: 0, padding: space[0] },
+  mobileComposerBody: {
+    flex: 1,
+    gap: space[4],
+    overflow: 'hidden',
+    paddingBottom: space[8],
+    paddingHorizontal: space[16],
+    paddingTop: space[16],
+  },
+  mobileContentWarning: { borderRadius: radius[0], minHeight: 44 },
+  mobileFooter: {
+    alignItems: 'center',
+    borderTopWidth: borderWidths[1],
+    flexDirection: 'row',
+    height: 64,
+    justifyContent: 'space-between',
+    paddingHorizontal: space[16],
+    paddingVertical: space[12],
+  },
+  mobileHeader: {
+    alignItems: 'center',
+    borderBottomWidth: borderWidths[1],
+    flexDirection: 'row',
+    height: 64,
+    paddingHorizontal: space[16],
+  },
+  mobileLeadingSlot: { alignItems: 'flex-start', width: 72 },
+  mobileMediaShelf: { height: 156, paddingHorizontal: space[16] },
+  mobileShell: { height: 844, overflow: 'hidden', width: 390 },
+  mobileTitle: { flex: 1, textAlign: 'center', ...textStyles.uiHeadingS },
+  mobileTrailingSlot: { alignItems: 'flex-end', width: 84 },
+  mobileVisibility: {
+    alignItems: 'center',
+    borderBottomWidth: borderWidths[1],
+    borderTopWidth: borderWidths[1],
+    flexDirection: 'row',
+    height: 48,
+    justifyContent: 'space-between',
+    paddingHorizontal: space[16],
+  },
+  mobileVisibilityCaption: textStyles.uiCopyM,
+  mobileVisibilityValue: { alignItems: 'center', flexDirection: 'row', gap: space[8] },
+  keyboard: {
+    alignItems: 'center',
+    borderTopWidth: borderWidths[1],
+    gap: space[12],
+    height: 336,
+    justifyContent: 'center',
+  },
+  keyboardRow: { borderRadius: radius[8], borderWidth: borderWidths[1], height: 44 },
+  overlay: { maxWidth: 600, width: '100%' },
+  rail: { width: 326 },
+  remaining: { width: 40, ...textStyles.uiCopyS },
+  root: { gap: space[16], padding: space[16] },
+  submit: { alignItems: 'center', flexDirection: 'row', gap: space[8] },
+  textBody: { minHeight: 184 },
+  textContent: { minHeight: 184 },
+  tools: { alignItems: 'center', flexDirection: 'row', gap: space[4] },
+  toolVisual: { borderRadius: radius[8] },
+  visibilityControl: { position: 'relative', zIndex: 12 },
+  visibilityDescription: textStyles.uiCopyS,
+  visibilityLabel: { width: 66, ...textStyles.uiLabelM },
+  visibilityMenu: {
+    borderRadius: radius[12],
+    borderWidth: borderWidths[1],
+    left: 0,
+    overflow: 'hidden',
+    position: 'absolute',
+    top: 44,
+    width: 240,
+  },
+  visibilityOption: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: space[8],
+    padding: space[12],
+  },
+  visibilityOptionCopy: { flex: 1 },
+  visibilityOptionLabel: textStyles.uiLabelM,
+  visibilityTrigger: {
+    alignItems: 'center',
+    borderRadius: radius[8],
+    borderWidth: borderWidths[1],
+    flexDirection: 'row',
+    gap: space[4],
+    height: 40,
+    justifyContent: 'center',
+    paddingHorizontal: space[16],
+    width: 120,
+  },
+});

--- a/apps/app/src/components/post/PostComposerTarget.tsx
+++ b/apps/app/src/components/post/PostComposerTarget.tsx
@@ -379,7 +379,12 @@ export function MobileFullscreenComposerShellCandidate({
           글쓰기
         </Text>
         <View style={styles.mobileTrailingSlot}>
-          <Button disabled={disabled} loading={submitting} onPress={onSubmit} size="compact">
+          <Button
+            disabled={disabled}
+            loading={submitting}
+            onPress={onSubmit}
+            style={styles.mobileSubmitButton}
+          >
             게시
           </Button>
         </View>
@@ -471,7 +476,7 @@ export function MobileFullscreenComposerShellCandidate({
       </View>
 
       {items.length > 0 ? (
-        <View style={styles.mobileMediaShelf}>
+        <View style={styles.mobileMediaShelf} testID="mobile-composer-media-shelf">
           <PostComposerMediaItemsTarget
             disabled={submitting}
             media={items}
@@ -483,7 +488,10 @@ export function MobileFullscreenComposerShellCandidate({
         </View>
       ) : null}
 
-      <View style={[styles.mobileFooter, { borderTopColor: theme.borderSubtle }]}>
+      <View
+        style={[styles.mobileFooter, { borderTopColor: theme.borderSubtle }]}
+        testID="mobile-composer-footer"
+      >
         <View style={styles.tools}>
           {showMediaAction ? (
             <ComposerTool
@@ -776,6 +784,7 @@ const styles = StyleSheet.create({
   mobileLeadingSlot: { alignItems: 'flex-start', width: 72 },
   mobileMediaShelf: { height: 164, paddingBottom: space[8], paddingHorizontal: space[16] },
   mobileShell: { height: 844, overflow: 'hidden', width: 390 },
+  mobileSubmitButton: { minWidth: 72, width: 72 },
   mobileTitle: { flex: 1, textAlign: 'center', ...textStyles.uiHeadingS },
   mobileTrailingSlot: { alignItems: 'flex-end', width: 84 },
   mobileVisibilityControl: { position: 'relative', zIndex: 12 },
@@ -801,7 +810,7 @@ const styles = StyleSheet.create({
   overlay: { maxWidth: 600, width: '100%' },
   progressRing: { height: 20, width: 20 },
   rail: { width: 326 },
-  remaining: { width: 40, ...textStyles.uiCopyS },
+  remaining: { width: 40, ...textStyles.uiCopyS, textAlign: 'right' },
   root: { gap: space[16], padding: space[16] },
   submit: { alignItems: 'center', flexDirection: 'row', gap: space[8] },
   textBody: { minHeight: 184 },

--- a/apps/app/src/components/post/PostComposerTarget.tsx
+++ b/apps/app/src/components/post/PostComposerTarget.tsx
@@ -1,3 +1,4 @@
+import { postBodyMaxLength } from '@kosmo/core/validation/post-policy';
 import {
   ChartNoAxesColumnIncreasingIcon,
   ChevronDownIcon,
@@ -12,6 +13,7 @@ import {
 } from 'lucide-react-native';
 import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Circle, Svg } from 'react-native-svg';
 import { Button } from '@/components/ui/Button';
 import { IconButton } from '@/components/ui/IconButton';
 import { TextArea, TextField } from '@/components/ui/TextField';
@@ -299,14 +301,9 @@ export function PostComposerTarget({
             >
               {remaining.toLocaleString('ko-KR')}
             </Text>
+            {surface === 'overlay' ? <ProgressRing remaining={remaining} /> : null}
             {showSubmit ? (
-              <Button
-                disabled={disabled}
-                loading={submitting}
-                loadingText="게시 중"
-                onPress={onSubmit}
-                size="compact"
-              >
+              <Button disabled={disabled} loading={submitting} onPress={onSubmit} size="compact">
                 게시
               </Button>
             ) : null}
@@ -355,18 +352,6 @@ export function MobileFullscreenComposerShellCandidate({
     items.some((item) => item.state !== 'ready') ||
     (body.trim().length === 0 && items.length === 0) ||
     remaining < 0;
-  const textHeight = keyboard
-    ? items.length > 0
-      ? 100
-      : contentWarningExpanded
-        ? 216
-        : 264
-    : items.length > 0
-      ? 424
-      : contentWarningExpanded
-        ? 552
-        : 600;
-
   return (
     <View
       accessibilityLabel="모바일 글쓰기 Candidate"
@@ -425,6 +410,7 @@ export function MobileFullscreenComposerShellCandidate({
         </Pressable>
         {visibilityOpen ? (
           <VisibilityMenu
+            alignRight
             onChange={(value) => {
               onVisibilityChange(value);
               setVisibilityOpen(false);
@@ -434,7 +420,7 @@ export function MobileFullscreenComposerShellCandidate({
         ) : null}
       </View>
 
-      <View style={styles.mobileComposerBody}>
+      <View style={styles.mobileComposerBody} testID="mobile-composer-body">
         {author}
         {contentWarningExpanded ? (
           <TextField
@@ -446,21 +432,23 @@ export function MobileFullscreenComposerShellCandidate({
             value={contentWarning}
           />
         ) : null}
-        <TextArea
-          accessibilityLabel="게시물 내용"
-          editable={!submitting}
-          onChangeText={onBodyChange}
-          placeholder="무슨 일이 일어나고 있나요?"
-          style={[
-            styles.mobileBody,
-            {
-              backgroundColor: theme.backgroundCanvas,
-              color: theme.foregroundPrimary,
-              height: textHeight,
-            },
-          ]}
-          value={body}
-        />
+        <View style={styles.mobileEditor}>
+          <TextArea
+            accessibilityLabel="게시물 내용"
+            editable={!submitting}
+            onChangeText={onBodyChange}
+            placeholder="무슨 일이 일어나고 있나요?"
+            style={[
+              styles.mobileBody,
+              {
+                backgroundColor: theme.backgroundCanvas,
+                color: theme.foregroundPrimary,
+                flex: 1,
+              },
+            ]}
+            value={body}
+          />
+        </View>
         {error ? (
           <Text
             accessibilityRole="alert"
@@ -532,18 +520,68 @@ export function MobileFullscreenComposerShellCandidate({
             </ComposerTool>
           ) : null}
         </View>
-        <Text
-          accessibilityLabel={`남은 글자 수 ${remaining.toLocaleString('ko-KR')}자`}
-          accessibilityLiveRegion="polite"
-          style={[
-            styles.remaining,
-            { color: remaining < 0 ? theme.feedbackDangerOnSubtle : theme.foregroundSecondary },
-          ]}
-        >
-          {remaining.toLocaleString('ko-KR')}
-        </Text>
+        <View style={styles.submit}>
+          <Text
+            accessibilityLabel={`남은 글자 수 ${remaining.toLocaleString('ko-KR')}자`}
+            accessibilityLiveRegion="polite"
+            style={[
+              styles.remaining,
+              { color: remaining < 0 ? theme.feedbackDangerOnSubtle : theme.foregroundSecondary },
+            ]}
+          >
+            {remaining.toLocaleString('ko-KR')}
+          </Text>
+          <ProgressRing remaining={remaining} />
+        </View>
       </View>
       {keyboard ? <IllustrativeKeyboard /> : null}
+    </View>
+  );
+}
+
+function ProgressRing({ remaining }: { remaining: number }) {
+  const theme = useTheme();
+  const usedRatio = Math.min(1, Math.max(0, (postBodyMaxLength - remaining) / postBodyMaxLength));
+  const radius = 9;
+  const circumference = 2 * Math.PI * radius;
+  const color =
+    remaining <= 0
+      ? theme.feedbackDangerBorder
+      : remaining <= 100
+        ? theme.feedbackWarningBorder
+        : theme.stateSelectedBorder;
+
+  return (
+    <View
+      accessible={false}
+      accessibilityElementsHidden
+      aria-hidden
+      importantForAccessibility="no-hide-descendants"
+      style={styles.progressRing}
+      testID="post-composer-progress-ring"
+    >
+      <Svg height={20} viewBox="0 0 20 20" width={20}>
+        <Circle
+          cx={10}
+          cy={10}
+          fill="none"
+          r={radius}
+          stroke={theme.borderSubtle}
+          strokeWidth={2}
+        />
+        <Circle
+          cx={10}
+          cy={10}
+          fill="none"
+          r={radius}
+          stroke={color}
+          strokeDasharray={[circumference, circumference]}
+          strokeDashoffset={circumference * (1 - usedRatio)}
+          strokeLinecap="round"
+          strokeWidth={2}
+          transform="rotate(-90 10 10)"
+        />
+      </Svg>
     </View>
   );
 }
@@ -575,9 +613,11 @@ function IllustrativeKeyboard() {
 }
 
 function VisibilityMenu({
+  alignRight = false,
   onChange,
   value,
 }: {
+  alignRight?: boolean;
   onChange: (value: PostComposerTargetVisibility) => void;
   value: PostComposerTargetVisibility;
 }) {
@@ -589,6 +629,7 @@ function VisibilityMenu({
       accessibilityRole="radiogroup"
       style={[
         styles.visibilityMenu,
+        alignRight ? styles.visibilityMenuRight : styles.visibilityMenuLeft,
         elevation.floating,
         { backgroundColor: theme.backgroundElevated, borderColor: theme.borderDefault },
       ]}
@@ -690,13 +731,14 @@ const styles = StyleSheet.create({
   mobileBody: { borderWidth: borderWidths[0], minHeight: 0, padding: space[0] },
   mobileComposerBody: {
     flex: 1,
-    gap: space[4],
-    overflow: 'hidden',
+    gap: space[8],
+    overflow: 'visible',
     paddingBottom: space[8],
     paddingHorizontal: space[16],
     paddingTop: space[16],
   },
   mobileContentWarning: { borderRadius: radius[0], minHeight: 44 },
+  mobileEditor: { flex: 1, minHeight: 0 },
   mobileFooter: {
     alignItems: 'center',
     borderTopWidth: borderWidths[1],
@@ -739,6 +781,7 @@ const styles = StyleSheet.create({
   },
   keyboardRow: { borderRadius: radius[8], borderWidth: borderWidths[1], height: 44 },
   overlay: { maxWidth: 600, width: '100%' },
+  progressRing: { height: 20, width: 20 },
   rail: { width: 326 },
   remaining: { width: 40, ...textStyles.uiCopyS },
   root: { gap: space[16], padding: space[16] },
@@ -753,12 +796,13 @@ const styles = StyleSheet.create({
   visibilityMenu: {
     borderRadius: radius[12],
     borderWidth: borderWidths[1],
-    left: 0,
     overflow: 'hidden',
     position: 'absolute',
     top: 44,
     width: 240,
   },
+  visibilityMenuLeft: { left: 0 },
+  visibilityMenuRight: { right: 0 },
   visibilityOption: {
     alignItems: 'center',
     flexDirection: 'row',

--- a/apps/app/src/components/post/PostComposerTarget.tsx
+++ b/apps/app/src/components/post/PostComposerTarget.tsx
@@ -12,7 +12,7 @@ import {
   XIcon,
 } from 'lucide-react-native';
 import { useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { Circle, Svg } from 'react-native-svg';
 import { Button } from '@/components/ui/Button';
 import { IconButton } from '@/components/ui/IconButton';
@@ -22,6 +22,7 @@ import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/toke
 import { PostComposerMediaItemsTarget } from './PostComposerMediaItemsTarget';
 import type { LucideIcon } from 'lucide-react-native';
 import type { ReactNode } from 'react';
+import type { TextStyle } from 'react-native';
 import type { ComposerMediaItem } from './PostComposerMediaControls';
 
 export type PostComposerTargetVisibility = 'FOLLOWERS' | 'PUBLIC' | 'UNLISTED';
@@ -344,6 +345,7 @@ export function MobileFullscreenComposerShellCandidate({
   visibility,
 }: MobileFullscreenComposerShellCandidateProps) {
   const theme = useTheme();
+  const [bodyFocused, setBodyFocused] = useState(false);
   const [visibilityOpen, setVisibilityOpen] = useState(false);
   const selectedVisibility =
     visibilityOptions.find((option) => option.value === visibility) ?? visibilityOptions[1];
@@ -432,18 +434,28 @@ export function MobileFullscreenComposerShellCandidate({
             value={contentWarning}
           />
         ) : null}
-        <TextArea
+        <TextInput
           accessibilityLabel="게시물 내용"
-          containerStyle={styles.mobileEditor}
           editable={!submitting}
+          multiline
+          onBlur={() => setBodyFocused(false)}
           onChangeText={onBodyChange}
+          onFocus={() => setBodyFocused(true)}
           placeholder="무슨 일이 일어나고 있나요?"
+          placeholderTextColor={submitting ? theme.stateDisabledForeground : theme.foregroundMuted}
           style={[
             styles.mobileBody,
             {
               backgroundColor: theme.backgroundCanvas,
               color: theme.foregroundPrimary,
-              flex: 1,
+              ...(bodyFocused
+                ? ({
+                    outlineColor: theme.stateFocusRing,
+                    outlineOffset: 2,
+                    outlineStyle: 'solid',
+                    outlineWidth: borderWidths[2],
+                  } as unknown as TextStyle)
+                : undefined),
             },
           ]}
           value={body}
@@ -727,7 +739,15 @@ const styles = StyleSheet.create({
   },
   mediaBody: { minHeight: 236 },
   mediaContent: { minHeight: 404 },
-  mobileBody: { borderWidth: borderWidths[0], minHeight: 0, padding: space[0] },
+  mobileBody: {
+    borderRadius: radius[12],
+    borderWidth: borderWidths[0],
+    flex: 1,
+    minHeight: 0,
+    padding: space[0],
+    textAlignVertical: 'top',
+    ...textStyles.contentM,
+  },
   mobileComposerBody: {
     flex: 1,
     gap: space[8],
@@ -737,7 +757,6 @@ const styles = StyleSheet.create({
     paddingTop: space[16],
   },
   mobileContentWarning: { borderRadius: radius[0], minHeight: 44 },
-  mobileEditor: { flex: 1, minHeight: 0 },
   mobileFooter: {
     alignItems: 'center',
     borderTopWidth: borderWidths[1],

--- a/apps/app/src/components/post/PostComposerTarget.tsx
+++ b/apps/app/src/components/post/PostComposerTarget.tsx
@@ -432,23 +432,22 @@ export function MobileFullscreenComposerShellCandidate({
             value={contentWarning}
           />
         ) : null}
-        <View style={styles.mobileEditor}>
-          <TextArea
-            accessibilityLabel="게시물 내용"
-            editable={!submitting}
-            onChangeText={onBodyChange}
-            placeholder="무슨 일이 일어나고 있나요?"
-            style={[
-              styles.mobileBody,
-              {
-                backgroundColor: theme.backgroundCanvas,
-                color: theme.foregroundPrimary,
-                flex: 1,
-              },
-            ]}
-            value={body}
-          />
-        </View>
+        <TextArea
+          accessibilityLabel="게시물 내용"
+          containerStyle={styles.mobileEditor}
+          editable={!submitting}
+          onChangeText={onBodyChange}
+          placeholder="무슨 일이 일어나고 있나요?"
+          style={[
+            styles.mobileBody,
+            {
+              backgroundColor: theme.backgroundCanvas,
+              color: theme.foregroundPrimary,
+              flex: 1,
+            },
+          ]}
+          value={body}
+        />
         {error ? (
           <Text
             accessibilityRole="alert"

--- a/apps/app/src/components/post/PostComposerTarget.tsx
+++ b/apps/app/src/components/post/PostComposerTarget.tsx
@@ -347,6 +347,7 @@ export function MobileFullscreenComposerShellCandidate({
   visibility,
 }: MobileFullscreenComposerShellCandidateProps) {
   const theme = useTheme();
+  const [visibilityOpen, setVisibilityOpen] = useState(false);
   const selectedVisibility =
     visibilityOptions.find((option) => option.value === visibility) ?? visibilityOptions[1];
   const disabled =
@@ -354,10 +355,6 @@ export function MobileFullscreenComposerShellCandidate({
     items.some((item) => item.state !== 'ready') ||
     (body.trim().length === 0 && items.length === 0) ||
     remaining < 0;
-  const nextVisibility =
-    visibilityOptions[
-      (visibilityOptions.indexOf(selectedVisibility) + 1) % visibilityOptions.length
-    ].value;
   const textHeight = keyboard
     ? items.length > 0
       ? 100
@@ -401,29 +398,41 @@ export function MobileFullscreenComposerShellCandidate({
         </View>
       </View>
 
-      <Pressable
-        accessibilityLabel={`공개 범위: ${selectedVisibility.label}`}
-        accessibilityRole="button"
-        disabled={submitting}
-        onPress={() => onVisibilityChange(nextVisibility)}
-        style={({ pressed }) => [
-          styles.mobileVisibility,
-          {
-            backgroundColor: pressed ? theme.statePressed : theme.backgroundCanvas,
-            borderColor: theme.borderSubtle,
-          },
-        ]}
-      >
-        <Text style={[styles.mobileVisibilityCaption, { color: theme.foregroundSecondary }]}>
-          공개 범위
-        </Text>
-        <View style={styles.mobileVisibilityValue}>
-          <Text style={[styles.visibilityOptionLabel, { color: theme.foregroundPrimary }]}>
-            {selectedVisibility.label}
+      <View style={styles.mobileVisibilityControl}>
+        <Pressable
+          accessibilityLabel={`공개 범위: ${selectedVisibility.label}`}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: visibilityOpen }}
+          disabled={submitting}
+          onPress={() => setVisibilityOpen((open) => !open)}
+          style={({ pressed }) => [
+            styles.mobileVisibility,
+            {
+              backgroundColor: pressed ? theme.statePressed : theme.backgroundCanvas,
+              borderColor: theme.borderSubtle,
+            },
+          ]}
+        >
+          <Text style={[styles.mobileVisibilityCaption, { color: theme.foregroundSecondary }]}>
+            공개 범위
           </Text>
-          <ChevronDownIcon color={theme.foregroundPrimary} size={iconSizes[16]} strokeWidth={2} />
-        </View>
-      </Pressable>
+          <View style={styles.mobileVisibilityValue}>
+            <Text style={[styles.visibilityOptionLabel, { color: theme.foregroundPrimary }]}>
+              {selectedVisibility.label}
+            </Text>
+            <ChevronDownIcon color={theme.foregroundPrimary} size={iconSizes[16]} strokeWidth={2} />
+          </View>
+        </Pressable>
+        {visibilityOpen ? (
+          <VisibilityMenu
+            onChange={(value) => {
+              onVisibilityChange(value);
+              setVisibilityOpen(false);
+            }}
+            value={visibility}
+          />
+        ) : null}
+      </View>
 
       <View style={styles.mobileComposerBody}>
         {author}
@@ -705,10 +714,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: space[16],
   },
   mobileLeadingSlot: { alignItems: 'flex-start', width: 72 },
-  mobileMediaShelf: { height: 156, paddingHorizontal: space[16] },
+  mobileMediaShelf: { height: 164, paddingBottom: space[8], paddingHorizontal: space[16] },
   mobileShell: { height: 844, overflow: 'hidden', width: 390 },
   mobileTitle: { flex: 1, textAlign: 'center', ...textStyles.uiHeadingS },
   mobileTrailingSlot: { alignItems: 'flex-end', width: 84 },
+  mobileVisibilityControl: { position: 'relative', zIndex: 12 },
   mobileVisibility: {
     alignItems: 'center',
     borderBottomWidth: borderWidths[1],

--- a/apps/app/src/components/profile/ProfilePicker.tsx
+++ b/apps/app/src/components/profile/ProfilePicker.tsx
@@ -1,0 +1,180 @@
+import { CheckIcon } from 'lucide-react-native';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { UnreadDot } from '@/components/shell/UnreadDot';
+import { Avatar } from '@/components/ui/Avatar';
+import { useElevation, useTheme } from '@/theme/ThemeProvider';
+import { space, spacing, typography } from '@/theme/tokens';
+import type { ReactNode, Ref } from 'react';
+import type { ViewStyle } from 'react-native';
+
+export type ProfilePickerSurface = 'compact' | 'drawer' | 'full';
+
+export type ProfilePickerProfile = Readonly<{
+  avatar?: Readonly<{ url: string | null | undefined }> | null;
+  displayName: string;
+  id: string;
+  relativeHandle: string;
+  unreadNotificationCount?: number;
+}>;
+
+type Props = Readonly<{
+  busy?: boolean;
+  footer?: ReactNode;
+  onSelect: (id: string) => void;
+  pickerRef?: Ref<View>;
+  profiles: readonly ProfilePickerProfile[];
+  selectedProfileId?: string | null;
+  showDivider?: boolean;
+  surface: ProfilePickerSurface;
+}>;
+
+const webCompactPickerBounds = {
+  maxHeight: 'min(430px, calc(100vh - 32px))',
+} as unknown as ViewStyle;
+const webFullPickerBounds = {
+  maxHeight: 'min(430px, calc(100vh - 276px))',
+} as unknown as ViewStyle;
+const webDrawerPickerBounds = {
+  maxHeight: 'min(430px, calc(100vh - 206px))',
+} as unknown as ViewStyle;
+
+export function ProfilePicker({
+  busy = false,
+  footer,
+  onSelect,
+  pickerRef,
+  profiles,
+  selectedProfileId,
+  showDivider = true,
+  surface,
+}: Props) {
+  const theme = useTheme();
+  const elevation = useElevation();
+  const redesignedWeb = Platform.OS === 'web' && surface !== 'drawer';
+  const scrollableWebPicker = Platform.OS === 'web';
+  const surfaceBounds = !scrollableWebPicker
+    ? undefined
+    : surface === 'compact'
+      ? webCompactPickerBounds
+      : surface === 'drawer'
+        ? webDrawerPickerBounds
+        : webFullPickerBounds;
+  const profileOptions = profiles.map((profile) => {
+    const selected = selectedProfileId === profile.id;
+    const hasUnread = (profile.unreadNotificationCount ?? 0) > 0;
+
+    return (
+      <Pressable
+        aria-checked={Platform.OS === 'web' && !redesignedWeb ? selected : undefined}
+        aria-pressed={redesignedWeb ? selected : undefined}
+        accessibilityLabel={`${profile.displayName}, ${profile.relativeHandle}${hasUnread ? ', 읽지 않은 알림 있음' : ''}`}
+        accessibilityRole={redesignedWeb ? 'button' : Platform.OS === 'web' ? undefined : 'radio'}
+        accessibilityState={
+          redesignedWeb ? { disabled: busy } : { checked: selected, disabled: busy }
+        }
+        disabled={busy}
+        key={profile.id}
+        onPress={() => onSelect(profile.id)}
+        role={Platform.OS === 'web' && !redesignedWeb ? ('menuitemradio' as 'radio') : undefined}
+        style={({ pressed }) => [
+          styles.profile,
+          !selected ? styles.unselectedProfile : undefined,
+          {
+            backgroundColor: selected || pressed ? theme.surface : 'transparent',
+            opacity: busy ? 0.5 : 1,
+          },
+        ]}
+      >
+        <View style={styles.profileAvatar}>
+          <Avatar
+            imageUri={profile.avatar?.url}
+            label={profile.displayName}
+            size={selected ? 48 : 32}
+          />
+          {hasUnread ? (
+            <UnreadDot style={styles.profileUnreadDot} testID="profile-switcher-unread-dot" />
+          ) : null}
+        </View>
+        <View style={styles.profileLabel}>
+          <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
+            {profile.displayName}
+          </Text>
+          <Text numberOfLines={1} style={[styles.handle, { color: theme.textSecondary }]}>
+            {profile.relativeHandle}
+          </Text>
+        </View>
+        {selected ? <CheckIcon color={theme.text} size={16} /> : null}
+      </Pressable>
+    );
+  });
+
+  return (
+    <View
+      ref={pickerRef}
+      style={[
+        styles.menu,
+        scrollableWebPicker ? styles.redesignedMenu : undefined,
+        surfaceBounds,
+        Platform.OS === 'web' ? elevation.floating : elevation.overlay,
+        { backgroundColor: theme.card, borderColor: theme.border },
+      ]}
+    >
+      <View
+        accessibilityLabel="프로필 전환"
+        accessibilityRole={Platform.OS === 'web' ? undefined : 'menu'}
+        role={Platform.OS === 'web' && !redesignedWeb ? 'menu' : undefined}
+        style={scrollableWebPicker ? styles.redesignedMenuRegion : styles.menuItems}
+      >
+        {scrollableWebPicker ? (
+          <ScrollView
+            accessibilityLabel="전환할 프로필 목록"
+            contentContainerStyle={styles.profileListContent}
+            role="group"
+            style={styles.profileList}
+          >
+            {profileOptions}
+          </ScrollView>
+        ) : (
+          profileOptions
+        )}
+        {showDivider ? <View style={[styles.divider, { backgroundColor: theme.border }]} /> : null}
+        {footer}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  menu: {
+    borderRadius: 14,
+    borderWidth: 1,
+    padding: 6,
+    width: 280,
+  },
+  redesignedMenu: { overflow: 'hidden' },
+  menuItems: { gap: space[0] },
+  redesignedMenuRegion: { flexShrink: 1, minHeight: 0 },
+  profileList: { flexShrink: 1, minHeight: 0 },
+  profileListContent: { gap: space[0] },
+  profile: {
+    alignItems: 'center',
+    borderRadius: 10,
+    flexDirection: 'row',
+    gap: 10,
+    padding: spacing.sm,
+  },
+  unselectedProfile: { paddingVertical: space[8] },
+  profileAvatar: { position: 'relative' },
+  profileUnreadDot: {
+    height: 12,
+    position: 'absolute',
+    right: -2,
+    top: -2,
+    width: 12,
+    zIndex: 1,
+  },
+  profileLabel: { flex: 1, minWidth: 0 },
+  displayName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
+  handle: { fontFamily: 'SUIT', ...typography.sm },
+  divider: { height: 1, marginVertical: space[4], width: '100%' },
+});

--- a/apps/app/src/components/profile/ProfilePicker.tsx
+++ b/apps/app/src/components/profile/ProfilePicker.tsx
@@ -20,6 +20,7 @@ export type ProfilePickerProfile = Readonly<{
 type Props = Readonly<{
   busy?: boolean;
   footer?: ReactNode;
+  menuFooter?: ReactNode;
   onSelect: (id: string) => void;
   pickerRef?: Ref<View>;
   profiles: readonly ProfilePickerProfile[];
@@ -41,6 +42,7 @@ const webDrawerPickerBounds = {
 export function ProfilePicker({
   busy = false,
   footer,
+  menuFooter,
   onSelect,
   pickerRef,
   profiles,
@@ -137,9 +139,16 @@ export function ProfilePicker({
         ) : (
           profileOptions
         )}
-        {showDivider ? <View style={[styles.divider, { backgroundColor: theme.border }]} /> : null}
-        {footer}
+        {showDivider ? (
+          <View
+            accessibilityRole={Platform.OS === 'web' ? undefined : 'none'}
+            role={Platform.OS === 'web' ? 'separator' : undefined}
+            style={[styles.divider, { backgroundColor: theme.border }]}
+          />
+        ) : null}
+        {menuFooter}
       </View>
+      {footer ? <View style={styles.pickerFooter}>{footer}</View> : null}
     </View>
   );
 }
@@ -154,6 +163,7 @@ const styles = StyleSheet.create({
   redesignedMenu: { overflow: 'hidden' },
   menuItems: { gap: space[0] },
   redesignedMenuRegion: { flexShrink: 1, minHeight: 0 },
+  pickerFooter: { flexShrink: 0 },
   profileList: { flexShrink: 1, minHeight: 0 },
   profileListContent: { gap: space[0] },
   profile: {

--- a/apps/app/src/components/reaction/FullReactionPicker.tsx
+++ b/apps/app/src/components/reaction/FullReactionPicker.tsx
@@ -237,7 +237,12 @@ function ReactionSection({
   );
   return (
     <View style={styles.section} testID={testID}>
-      <Text style={[styles.sectionTitle, { color: theme.foregroundPrimary }]}>{title}</Text>
+      <Text
+        accessibilityRole="header"
+        style={[styles.sectionTitle, { color: theme.foregroundPrimary }]}
+      >
+        {title}
+      </Text>
       <View style={[styles.grid, mobile ? styles.mobileGrid : styles.webGrid]}>
         {rows.map((row, rowIndex) => (
           <View

--- a/apps/app/src/components/reaction/FullReactionPicker.tsx
+++ b/apps/app/src/components/reaction/FullReactionPicker.tsx
@@ -1,0 +1,351 @@
+import { Search } from 'lucide-react-native';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useElevation, useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/tokens';
+import { ReactionPendingSpinner } from './ReactionPendingSpinner';
+import type React from 'react';
+
+export type FullReactionPickerOption = Readonly<{
+  category: string;
+  categoryLabel: string;
+  emoji: string;
+  id: string;
+  keywords?: ReadonlyArray<string>;
+  label: string;
+  quick?: boolean;
+  recent?: boolean;
+}>;
+
+export type FullReactionPickerProps = {
+  activeCategory: string;
+  onCategoryChange: (category: string) => void;
+  onQueryChange: (query: string) => void;
+  onSelect: (option: FullReactionPickerOption) => void;
+  options: ReadonlyArray<FullReactionPickerOption>;
+  presentation?: 'mobile' | 'web';
+  query: string;
+  selectedValues?: ReadonlyArray<string>;
+  loading?: boolean;
+};
+
+const categoryIcons: Readonly<Record<string, string>> = {
+  activities: '🎉',
+  expressions: '😀',
+  gestures: '👋',
+  nature: '🌿',
+  symbols: '♡',
+};
+
+export function FullReactionPicker({
+  activeCategory,
+  onCategoryChange,
+  onQueryChange,
+  onSelect,
+  options,
+  presentation = 'web',
+  query,
+  selectedValues = [],
+  loading = false,
+}: FullReactionPickerProps): React.ReactElement {
+  const theme = useTheme();
+  const elevation = useElevation();
+  const mobile = presentation === 'mobile';
+  const categories = Array.from(
+    new Map(options.map((option) => [option.category, option.categoryLabel])).entries(),
+    ([id, label]) => ({ id, label }),
+  );
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const searchResults = options.filter((option) =>
+    [option.emoji, option.label, ...(option.keywords ?? [])]
+      .join(' ')
+      .toLocaleLowerCase()
+      .includes(normalizedQuery),
+  );
+  const state = loading
+    ? 'loading'
+    : normalizedQuery.length === 0
+      ? 'browse'
+      : searchResults.length > 0
+        ? 'searchResults'
+        : 'empty';
+  const picker = (
+    <View
+      accessibilityLabel="반응 선택"
+      accessibilityViewIsModal
+      role={Platform.OS === 'web' ? 'dialog' : undefined}
+      style={[
+        mobile ? styles.mobileSheet : styles.webDialog,
+        mobile ? { height: state === 'browse' ? 480 : 720 } : elevation.overlay,
+        { backgroundColor: theme.backgroundElevated, borderColor: theme.borderDefault },
+      ]}
+      testID={mobile ? 'full-reaction-picker-sheet' : undefined}
+    >
+      {mobile ? (
+        <>
+          <View style={[styles.dragHandle, { backgroundColor: theme.borderStrong }]} />
+          <Text
+            accessibilityRole="header"
+            style={[styles.mobileTitle, { color: theme.foregroundPrimary }]}
+          >
+            반응 선택
+          </Text>
+        </>
+      ) : null}
+      <SearchField onChange={onQueryChange} value={query} />
+      {state === 'loading' ? (
+        <View
+          accessibilityLabel="반응을 불러오는 중"
+          accessibilityLiveRegion="polite"
+          accessibilityState={{ busy: true }}
+          aria-busy
+          role={Platform.OS === 'web' ? 'status' : undefined}
+          style={styles.state}
+        >
+          <View style={mobile ? styles.mobileSpinner : styles.webSpinner}>
+            <ReactionPendingSpinner />
+          </View>
+        </View>
+      ) : state === 'empty' ? (
+        <View accessibilityLiveRegion="polite" style={styles.state}>
+          <Text style={[styles.emptyTitle, { color: theme.foregroundPrimary }]}>
+            검색 결과가 없어요
+          </Text>
+          <Text style={[styles.emptyDescription, { color: theme.foregroundSecondary }]}>
+            다른 이름이나 이모지로 검색해 보세요.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+          testID={mobile ? 'full-reaction-picker-scroll' : undefined}
+        >
+          {state === 'searchResults' ? (
+            <>
+              <Text style={[styles.resultCount, { color: theme.foregroundSecondary }]}>
+                ‘{query}’ 검색 결과 {searchResults.length}개
+              </Text>
+              <ReactionSection
+                mobile={mobile}
+                onSelect={onSelect}
+                options={searchResults}
+                selectedValues={selectedValues}
+                title="반응"
+              />
+            </>
+          ) : (
+            <>
+              <ReactionSection
+                mobile={mobile}
+                onSelect={onSelect}
+                options={options.filter((option) => option.quick)}
+                selectedValues={selectedValues}
+                title="빠른 반응"
+              />
+              <ReactionSection
+                mobile={mobile}
+                onSelect={onSelect}
+                options={options.filter((option) => option.recent)}
+                selectedValues={selectedValues}
+                title="최근 사용"
+              />
+              <View style={styles.categories}>
+                {categories.map((category) => {
+                  const selected = category.id === activeCategory;
+                  return (
+                    <Pressable
+                      accessibilityLabel={`${category.label} category 보기`}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected }}
+                      key={category.id}
+                      onPress={() => onCategoryChange(category.id)}
+                      style={({ pressed }) => [
+                        styles.category,
+                        {
+                          backgroundColor: selected
+                            ? theme.stateSelectedSurface
+                            : pressed
+                              ? theme.statePressed
+                              : 'transparent',
+                          borderColor: selected ? theme.stateSelectedBorder : 'transparent',
+                        },
+                      ]}
+                    >
+                      <Text style={styles.categoryIcon}>{categoryIcons[category.id] ?? '•'}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+              {categories.map((category) => (
+                <ReactionSection
+                  key={category.id}
+                  mobile={mobile}
+                  onSelect={onSelect}
+                  options={options.filter((option) => option.category === category.id)}
+                  selectedValues={selectedValues}
+                  title={category.label}
+                />
+              ))}
+            </>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+
+  return mobile ? (
+    <View style={[styles.mobileRoot, { backgroundColor: theme.overlayScrim }]}>{picker}</View>
+  ) : (
+    picker
+  );
+}
+
+function SearchField({ onChange, value }: { onChange: (value: string) => void; value: string }) {
+  const theme = useTheme();
+  return (
+    <View
+      style={[
+        styles.search,
+        { backgroundColor: theme.backgroundSurface, borderColor: theme.borderDefault },
+      ]}
+    >
+      <Search color={theme.foregroundSecondary} size={iconSizes[20]} strokeWidth={2} />
+      <TextInput
+        accessibilityLabel="반응 검색"
+        autoCapitalize="none"
+        autoCorrect={false}
+        onChangeText={onChange}
+        placeholder="반응 검색"
+        placeholderTextColor={theme.foregroundMuted}
+        role={Platform.OS === 'web' ? 'searchbox' : undefined}
+        style={[styles.searchInput, { color: theme.foregroundPrimary }]}
+        value={value}
+      />
+    </View>
+  );
+}
+
+function ReactionSection({
+  mobile,
+  onSelect,
+  options,
+  selectedValues,
+  title,
+}: {
+  mobile: boolean;
+  onSelect: (option: FullReactionPickerOption) => void;
+  options: ReadonlyArray<FullReactionPickerOption>;
+  selectedValues: ReadonlyArray<string>;
+  title: string;
+}) {
+  const theme = useTheme();
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.sectionTitle, { color: theme.foregroundPrimary }]}>{title}</Text>
+      <View style={[styles.grid, mobile ? styles.mobileGrid : styles.webGrid]}>
+        {options.map((option) => {
+          const selected = selectedValues.includes(option.id);
+          return (
+            <Pressable
+              accessibilityLabel={`${option.label} ${option.emoji}`}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              aria-pressed={selected}
+              key={option.id}
+              onPress={() => onSelect(option)}
+              style={mobile ? styles.mobileReactionTarget : styles.webReactionTarget}
+            >
+              {({ pressed }) => (
+                <View
+                  style={[
+                    styles.reaction,
+                    mobile ? styles.mobileReaction : styles.webReaction,
+                    {
+                      backgroundColor: selected
+                        ? theme.stateSelectedSurface
+                        : pressed
+                          ? theme.statePressed
+                          : 'transparent',
+                      borderColor: selected ? theme.stateSelectedBorder : 'transparent',
+                    },
+                  ]}
+                >
+                  <Text style={mobile ? styles.mobileEmoji : styles.webEmoji}>{option.emoji}</Text>
+                </View>
+              )}
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  categories: { flexDirection: 'row', justifyContent: 'space-between' },
+  category: {
+    alignItems: 'center',
+    borderRadius: radius[8],
+    borderWidth: borderWidths[1],
+    height: 40,
+    justifyContent: 'center',
+    width: 40,
+  },
+  categoryIcon: { fontSize: 20, lineHeight: 24 },
+  dragHandle: { alignSelf: 'center', borderRadius: radius.full, height: 4, width: 32 },
+  emptyDescription: textStyles.uiCopyM,
+  emptyTitle: textStyles.uiLabelL,
+  grid: { flexDirection: 'row', flexWrap: 'wrap' },
+  mobileEmoji: { fontSize: 24, lineHeight: 32 },
+  mobileGrid: { gap: 0 },
+  mobileReaction: { height: 44, width: 44 },
+  mobileReactionTarget: { alignItems: 'center', height: 48, justifyContent: 'center', width: 48 },
+  mobileRoot: { flex: 1, justifyContent: 'flex-end', minHeight: 844 },
+  mobileSheet: {
+    borderTopLeftRadius: radius[24],
+    borderTopRightRadius: radius[24],
+    borderWidth: borderWidths[1],
+    gap: space[12],
+    maxWidth: 390,
+    paddingBottom: space[24],
+    paddingHorizontal: space[16],
+    paddingTop: space[12],
+    width: '100%',
+  },
+  mobileSpinner: { transform: [{ scale: 1.5 }] },
+  mobileTitle: { textAlign: 'left', ...textStyles.uiLabelL },
+  reaction: {
+    alignItems: 'center',
+    borderRadius: radius[12],
+    borderWidth: borderWidths[1],
+    justifyContent: 'center',
+  },
+  scrollContent: { gap: space[16], paddingBottom: space[8] },
+  resultCount: textStyles.uiCopyS,
+  search: {
+    alignItems: 'center',
+    borderRadius: radius[12],
+    borderWidth: borderWidths[1],
+    flexDirection: 'row',
+    gap: space[8],
+    height: 44,
+    paddingHorizontal: space[12],
+  },
+  searchInput: { flex: 1, padding: 0, ...textStyles.uiCopyM },
+  section: { gap: space[8] },
+  sectionTitle: textStyles.uiLabelM,
+  state: { alignItems: 'center', flex: 1, gap: space[8], justifyContent: 'center' },
+  webDialog: {
+    borderRadius: radius[16],
+    borderWidth: borderWidths[1],
+    gap: space[16],
+    height: 624,
+    padding: space[16],
+    width: 360,
+  },
+  webEmoji: { fontSize: 20, lineHeight: 24 },
+  webGrid: { gap: space[8] },
+  webReaction: { height: 32, width: 32 },
+  webReactionTarget: { height: 32, width: 32 },
+  webSpinner: { transform: [{ scale: 1.25 }] },
+});

--- a/apps/app/src/components/reaction/FullReactionPicker.tsx
+++ b/apps/app/src/components/reaction/FullReactionPicker.tsx
@@ -1,4 +1,5 @@
 import { Search } from 'lucide-react-native';
+import { useEffect, useRef } from 'react';
 import { Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useElevation, useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/tokens';
@@ -17,6 +18,7 @@ export type FullReactionPickerOption = Readonly<{
 }>;
 
 export type FullReactionPickerProps = {
+  onClose: () => void;
   onQueryChange: (query: string) => void;
   onSelect: (option: FullReactionPickerOption) => void;
   options: ReadonlyArray<FullReactionPickerOption>;
@@ -27,6 +29,7 @@ export type FullReactionPickerProps = {
 };
 
 export function FullReactionPicker({
+  onClose,
   onQueryChange,
   onSelect,
   options,
@@ -38,6 +41,7 @@ export function FullReactionPicker({
   const theme = useTheme();
   const elevation = useElevation();
   const mobile = presentation === 'mobile';
+  const pickerRef = useRef<View>(null);
   const categories = Array.from(
     new Map(options.map((option) => [option.category, option.categoryLabel])).entries(),
     ([id, label]) => ({ id, label }),
@@ -56,10 +60,32 @@ export function FullReactionPicker({
       : searchResults.length > 0
         ? 'searchResults'
         : 'empty';
+  useEffect(() => {
+    if (mobile) {
+      return;
+    }
+
+    const ownerDocument = (pickerRef.current as unknown as HTMLElement | null)?.ownerDocument;
+    if (!ownerDocument) {
+      return;
+    }
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    };
+    ownerDocument.addEventListener('keyup', onKeyUp, true);
+    return () => ownerDocument.removeEventListener('keyup', onKeyUp, true);
+  }, [mobile, onClose]);
   const picker = (
     <View
       accessibilityLabel="반응 선택"
       accessibilityViewIsModal
+      onAccessibilityEscape={onClose}
+      ref={pickerRef}
       role={Platform.OS === 'web' ? 'dialog' : undefined}
       style={[
         mobile ? styles.mobileSheet : styles.webDialog,
@@ -177,6 +203,7 @@ function SearchField({ onChange, value }: { onChange: (value: string) => void; v
         accessibilityLabel="반응 검색"
         autoCapitalize="none"
         autoCorrect={false}
+        autoFocus={Platform.OS === 'web'}
         onChangeText={onChange}
         placeholder="반응 검색"
         placeholderTextColor={theme.foregroundMuted}

--- a/apps/app/src/components/reaction/FullReactionPicker.tsx
+++ b/apps/app/src/components/reaction/FullReactionPicker.tsx
@@ -17,8 +17,6 @@ export type FullReactionPickerOption = Readonly<{
 }>;
 
 export type FullReactionPickerProps = {
-  activeCategory: string;
-  onCategoryChange: (category: string) => void;
   onQueryChange: (query: string) => void;
   onSelect: (option: FullReactionPickerOption) => void;
   options: ReadonlyArray<FullReactionPickerOption>;
@@ -28,17 +26,7 @@ export type FullReactionPickerProps = {
   loading?: boolean;
 };
 
-const categoryIcons: Readonly<Record<string, string>> = {
-  activities: '🎉',
-  expressions: '😀',
-  gestures: '👋',
-  nature: '🌿',
-  symbols: '♡',
-};
-
 export function FullReactionPicker({
-  activeCategory,
-  onCategoryChange,
   onQueryChange,
   onSelect,
   options,
@@ -145,37 +133,11 @@ export function FullReactionPicker({
               <ReactionSection
                 mobile={mobile}
                 onSelect={onSelect}
-                options={options.filter((option) => option.recent)}
+                options={options.filter((option) => option.recent).slice(0, mobile ? 14 : 16)}
                 selectedValues={selectedValues}
+                testID="full-reaction-section-recent"
                 title="최근 사용"
               />
-              <View style={styles.categories}>
-                {categories.map((category) => {
-                  const selected = category.id === activeCategory;
-                  return (
-                    <Pressable
-                      accessibilityLabel={`${category.label} category 보기`}
-                      accessibilityRole="button"
-                      accessibilityState={{ selected }}
-                      key={category.id}
-                      onPress={() => onCategoryChange(category.id)}
-                      style={({ pressed }) => [
-                        styles.category,
-                        {
-                          backgroundColor: selected
-                            ? theme.stateSelectedSurface
-                            : pressed
-                              ? theme.statePressed
-                              : 'transparent',
-                          borderColor: selected ? theme.stateSelectedBorder : 'transparent',
-                        },
-                      ]}
-                    >
-                      <Text style={styles.categoryIcon}>{categoryIcons[category.id] ?? '•'}</Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
               {categories.map((category) => (
                 <ReactionSection
                   key={category.id}
@@ -183,6 +145,7 @@ export function FullReactionPicker({
                   onSelect={onSelect}
                   options={options.filter((option) => option.category === category.id)}
                   selectedValues={selectedValues}
+                  testID={`full-reaction-section-${category.id}`}
                   title={category.label}
                 />
               ))}
@@ -230,72 +193,84 @@ function ReactionSection({
   onSelect,
   options,
   selectedValues,
+  testID,
   title,
 }: {
   mobile: boolean;
   onSelect: (option: FullReactionPickerOption) => void;
   options: ReadonlyArray<FullReactionPickerOption>;
   selectedValues: ReadonlyArray<string>;
+  testID?: string;
   title: string;
 }) {
   const theme = useTheme();
+  const columns = mobile ? 7 : 8;
+  const rows = Array.from({ length: Math.ceil(options.length / columns) }, (_, index) =>
+    options.slice(index * columns, (index + 1) * columns),
+  );
   return (
-    <View style={styles.section}>
+    <View style={styles.section} testID={testID}>
       <Text style={[styles.sectionTitle, { color: theme.foregroundPrimary }]}>{title}</Text>
       <View style={[styles.grid, mobile ? styles.mobileGrid : styles.webGrid]}>
-        {options.map((option) => {
-          const selected = selectedValues.includes(option.id);
-          return (
-            <Pressable
-              accessibilityLabel={`${option.label} ${option.emoji}`}
-              accessibilityRole="button"
-              accessibilityState={{ selected }}
-              aria-pressed={selected}
-              key={option.id}
-              onPress={() => onSelect(option)}
-              style={mobile ? styles.mobileReactionTarget : styles.webReactionTarget}
-            >
-              {({ pressed }) => (
-                <View
-                  style={[
-                    styles.reaction,
-                    mobile ? styles.mobileReaction : styles.webReaction,
-                    {
-                      backgroundColor: selected
-                        ? theme.stateSelectedSurface
-                        : pressed
-                          ? theme.statePressed
-                          : 'transparent',
-                      borderColor: selected ? theme.stateSelectedBorder : 'transparent',
-                    },
-                  ]}
+        {rows.map((row, rowIndex) => (
+          <View
+            key={rowIndex}
+            style={[
+              styles.gridRow,
+              mobile ? styles.mobileGrid : styles.webGrid,
+              row.length === columns ? styles.fullGridRow : styles.partialGridRow,
+            ]}
+            testID={testID ? `${testID}-row-${rowIndex}` : undefined}
+          >
+            {row.map((option) => {
+              const selected = selectedValues.includes(option.id);
+              return (
+                <Pressable
+                  accessibilityLabel={`${option.label} ${option.emoji}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected }}
+                  aria-pressed={selected}
+                  key={option.id}
+                  onPress={() => onSelect(option)}
+                  style={mobile ? styles.mobileReactionTarget : styles.webReactionTarget}
                 >
-                  <Text style={mobile ? styles.mobileEmoji : styles.webEmoji}>{option.emoji}</Text>
-                </View>
-              )}
-            </Pressable>
-          );
-        })}
+                  {({ pressed }) => (
+                    <View
+                      style={[
+                        styles.reaction,
+                        mobile ? styles.mobileReaction : styles.webReaction,
+                        {
+                          backgroundColor: selected
+                            ? theme.stateSelectedSurface
+                            : pressed
+                              ? theme.statePressed
+                              : 'transparent',
+                          borderColor: selected ? theme.stateSelectedBorder : 'transparent',
+                        },
+                      ]}
+                    >
+                      <Text style={mobile ? styles.mobileEmoji : styles.webEmoji}>
+                        {option.emoji}
+                      </Text>
+                    </View>
+                  )}
+                </Pressable>
+              );
+            })}
+          </View>
+        ))}
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  categories: { flexDirection: 'row', justifyContent: 'space-between' },
-  category: {
-    alignItems: 'center',
-    borderRadius: radius[8],
-    borderWidth: borderWidths[1],
-    height: 40,
-    justifyContent: 'center',
-    width: 40,
-  },
-  categoryIcon: { fontSize: 20, lineHeight: 24 },
   dragHandle: { alignSelf: 'center', borderRadius: radius.full, height: 4, width: 32 },
   emptyDescription: textStyles.uiCopyM,
   emptyTitle: textStyles.uiLabelL,
-  grid: { flexDirection: 'row', flexWrap: 'wrap' },
+  fullGridRow: { justifyContent: 'space-between' },
+  grid: { flexDirection: 'column' },
+  gridRow: { flexDirection: 'row' },
   mobileEmoji: { fontSize: 24, lineHeight: 32 },
   mobileGrid: { gap: 0 },
   mobileReaction: { height: 44, width: 44 },
@@ -314,6 +289,7 @@ const styles = StyleSheet.create({
   },
   mobileSpinner: { transform: [{ scale: 1.5 }] },
   mobileTitle: { textAlign: 'left', ...textStyles.uiLabelL },
+  partialGridRow: { justifyContent: 'flex-start' },
   reaction: {
     alignItems: 'center',
     borderRadius: radius[12],
@@ -340,6 +316,7 @@ const styles = StyleSheet.create({
     borderWidth: borderWidths[1],
     gap: space[16],
     height: 624,
+    maxHeight: '100%',
     padding: space[16],
     width: 360,
   },

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -64,7 +64,6 @@ const ProfileSwitcherFragment = graphql`
           id
           url
         }
-        ...ProfileNameBlock_profile
       }
     }
   }
@@ -363,74 +362,74 @@ export function ProfileSwitcher({
       busy={busy}
       footer={
         <>
-          {!creating ? (
-            <Pressable
-              accessibilityLabel="새 프로필 추가"
-              accessibilityRole={redesignedWeb || Platform.OS !== 'web' ? 'button' : undefined}
-              disabled={busy}
-              onPress={() => {
-                setCreating(true);
-                setFieldError(null);
-                setOperationErrorState(null);
-              }}
-              role={Platform.OS === 'web' && !redesignedWeb ? 'menuitem' : undefined}
-              style={({ pressed }) => [
-                styles.addProfile,
-                {
-                  backgroundColor: pressed ? theme.surface : 'transparent',
-                  opacity: busy ? 0.5 : 1,
-                },
-              ]}
+          {creating ? (
+            <View
+              accessibilityLabel="새 프로필 만들기"
+              role={Platform.OS === 'web' ? 'form' : undefined}
+              style={styles.createForm}
             >
-              <View style={styles.addIcon}>
-                <PlusIcon color={theme.text} size={18} strokeWidth={2.25} />
-              </View>
-              <Text style={[styles.addLabel, { color: theme.text }]}>새 프로필 추가</Text>
-            </Pressable>
-          ) : null}
-          <View style={styles.pickerFooter}>
-            {creating ? (
-              <View
-                accessibilityLabel="새 프로필 만들기"
-                role={Platform.OS === 'web' ? 'form' : undefined}
-                style={styles.createForm}
-              >
-                <View style={styles.createRow}>
-                  <View style={styles.inputField}>
-                    <TextField
-                      accessibilityLabel="프로필 핸들"
-                      autoCapitalize="none"
-                      autoCorrect={false}
-                      editable={!busy}
-                      error={fieldError ?? undefined}
-                      onChangeText={setHandle}
-                      onSubmitEditing={createProfile}
-                      placeholder="새 프로필 핸들"
-                      style={styles.input}
-                      value={handle}
-                    />
-                  </View>
-                  <Button
-                    disabled={busy}
-                    loading={busy}
-                    onPress={createProfile}
-                    style={styles.createButton}
-                  >
-                    만들기
-                  </Button>
+              <View style={styles.createRow}>
+                <View style={styles.inputField}>
+                  <TextField
+                    accessibilityLabel="프로필 핸들"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    editable={!busy}
+                    error={fieldError ?? undefined}
+                    onChangeText={setHandle}
+                    onSubmitEditing={createProfile}
+                    placeholder="새 프로필 핸들"
+                    style={styles.input}
+                    value={handle}
+                  />
                 </View>
-                <Text style={[styles.help, { color: theme.textSecondary }]}>
-                  영문, 숫자, 밑줄(_)만 사용할 수 있어요.
-                </Text>
+                <Button
+                  disabled={busy}
+                  loading={busy}
+                  onPress={createProfile}
+                  style={styles.createButton}
+                >
+                  만들기
+                </Button>
               </View>
-            ) : null}
-            {operationError ? (
-              <Text accessibilityRole="alert" style={[styles.error, { color: theme.danger }]}>
-                {operationError}
+              <Text style={[styles.help, { color: theme.textSecondary }]}>
+                영문, 숫자, 밑줄(_)만 사용할 수 있어요.
               </Text>
-            ) : null}
-          </View>
+            </View>
+          ) : null}
+          {operationError ? (
+            <Text accessibilityRole="alert" style={[styles.error, { color: theme.danger }]}>
+              {operationError}
+            </Text>
+          ) : null}
         </>
+      }
+      menuFooter={
+        !creating ? (
+          <Pressable
+            accessibilityLabel="새 프로필 추가"
+            accessibilityRole={redesignedWeb || Platform.OS !== 'web' ? 'button' : undefined}
+            disabled={busy}
+            onPress={() => {
+              setCreating(true);
+              setFieldError(null);
+              setOperationErrorState(null);
+            }}
+            role={Platform.OS === 'web' && !redesignedWeb ? 'menuitem' : undefined}
+            style={({ pressed }) => [
+              styles.addProfile,
+              {
+                backgroundColor: pressed ? theme.surface : 'transparent',
+                opacity: busy ? 0.5 : 1,
+              },
+            ]}
+          >
+            <View style={styles.addIcon}>
+              <PlusIcon color={theme.text} size={18} strokeWidth={2.25} />
+            </View>
+            <Text style={[styles.addLabel, { color: theme.text }]}>새 프로필 추가</Text>
+          </Pressable>
+        ) : null
       }
       onSelect={selectProfile}
       pickerRef={pickerRef}
@@ -709,7 +708,6 @@ const styles = StyleSheet.create({
   countLink: { flexDirection: 'row', gap: spacing.sm },
   count: { fontFamily: 'SUIT', ...typography.sm },
   countLabel: { fontFamily: 'SUIT', ...typography.sm },
-  pickerFooter: { flexShrink: 0 },
   backdrop: {
     alignItems: 'center',
     flex: 1,

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -1,26 +1,17 @@
 import { localProfileHandleSchema, profileHandlePolicyErrorMessage } from '@kosmo/core/validation';
 import { usePathname } from 'expo-router';
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon, PlusIcon } from 'lucide-react-native';
+import { ChevronDownIcon, ChevronUpIcon, PlusIcon } from 'lucide-react-native';
 import { useEffect, useRef, useState } from 'react';
-import {
-  Image,
-  Modal,
-  Platform,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import { Image, Modal, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment, useMutation } from 'react-relay';
 import { trackAnalytics } from '@/analytics/client';
-import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
+import { ProfilePicker } from '@/components/profile/ProfilePicker';
 import { Avatar } from '@/components/ui/Avatar';
 import { Button } from '@/components/ui/Button';
 import { TextField } from '@/components/ui/TextField';
 import { useRelayActor } from '@/relay/RelayActorProvider';
-import { useElevation, useTheme } from '@/theme/ThemeProvider';
-import { layoutRecipes, radii, space, spacing, textStyles, typography } from '@/theme/tokens';
+import { useTheme } from '@/theme/ThemeProvider';
+import { layoutRecipes, radii, spacing, textStyles, typography } from '@/theme/tokens';
 import { useNavigationGuard } from './NavigationGuardContext';
 import { NavigationLink } from './NavigationLink';
 import {
@@ -28,7 +19,6 @@ import {
   getProfileEditActionTargetMetrics,
   profileEditActionLabelColor,
 } from './shellLayout';
-import { UnreadDot } from './UnreadDot';
 import type { ViewStyle } from 'react-native';
 import type { ProfileSwitcher_query$key } from './__generated__/ProfileSwitcher_query.graphql';
 import type { ProfileSwitcherCreateProfileMutation } from './__generated__/ProfileSwitcherCreateProfileMutation.graphql';
@@ -123,15 +113,6 @@ const CreateProfileMutation = graphql`
 
 export type ProfileSwitcherSurface = 'compact' | 'drawer' | 'full';
 
-const webCompactPickerBounds = {
-  maxHeight: 'min(430px, calc(100vh - 32px))',
-} as unknown as ViewStyle;
-const webFullPickerBounds = {
-  maxHeight: 'min(430px, calc(100vh - 276px))',
-} as unknown as ViewStyle;
-const webDrawerPickerBounds = {
-  maxHeight: 'min(430px, calc(100vh - 206px))',
-} as unknown as ViewStyle;
 const countFormatter = new Intl.NumberFormat('en', {
   maximumFractionDigits: 1,
   notation: 'compact',
@@ -179,7 +160,6 @@ export function ProfileSwitcher({
   surface,
 }: Props) {
   const theme = useTheme();
-  const elevation = useElevation();
   const pathname = usePathname();
   const data = useFragment(ProfileSwitcherFragment, query);
   const { resetActor } = useRelayActor();
@@ -205,7 +185,6 @@ export function ProfileSwitcher({
   const fullWeb = Platform.OS === 'web' && surface === 'full';
   const mobileWebDrawer = Platform.OS === 'web' && surface === 'drawer';
   const redesignedWeb = Platform.OS === 'web' && surface !== 'drawer';
-  const scrollableWebPicker = Platform.OS === 'web';
   const open = controlledOpen ?? internalOpen;
   const webExpandedChevron = Platform.OS === 'web' && open;
   const setOpen = (nextOpen: boolean) => {
@@ -379,159 +358,86 @@ export function ProfileSwitcher({
     action();
   };
 
-  const surfaceBounds = !scrollableWebPicker
-    ? undefined
-    : surface === 'compact'
-      ? webCompactPickerBounds
-      : surface === 'drawer'
-        ? webDrawerPickerBounds
-        : webFullPickerBounds;
-  const profileOptions = profiles.map((profile) => {
-    const selected = active?.id === profile.id;
-    const hasUnread = profile.unreadNotificationCount > 0;
-    return (
-      <Pressable
-        aria-checked={Platform.OS === 'web' && !redesignedWeb ? selected : undefined}
-        aria-pressed={redesignedWeb ? selected : undefined}
-        accessibilityLabel={`${profile.displayName}, ${profile.relativeHandle}${hasUnread ? ', 읽지 않은 알림 있음' : ''}`}
-        accessibilityRole={redesignedWeb ? 'button' : Platform.OS === 'web' ? undefined : 'radio'}
-        accessibilityState={
-          redesignedWeb ? { disabled: busy } : { checked: selected, disabled: busy }
-        }
-        disabled={busy}
-        key={profile.id}
-        onPress={() => selectProfile(profile.id)}
-        role={Platform.OS === 'web' && !redesignedWeb ? ('menuitemradio' as 'radio') : undefined}
-        style={({ pressed }) => [
-          styles.profile,
-          !selected ? styles.unselectedProfile : undefined,
-          {
-            backgroundColor: selected || pressed ? theme.surface : 'transparent',
-            opacity: busy ? 0.5 : 1,
-          },
-        ]}
-      >
-        <View style={styles.profileAvatar}>
-          <Avatar
-            imageUri={profile.avatar?.url}
-            label={profile.displayName}
-            size={selected ? 48 : 32}
-          />
-          {hasUnread ? (
-            <UnreadDot style={styles.profileUnreadDot} testID="profile-switcher-unread-dot" />
-          ) : null}
-        </View>
-        <ProfileNameBlock profile={profile} style={styles.profileLabel} />
-        {selected ? <CheckIcon color={theme.text} size={16} /> : null}
-      </Pressable>
-    );
-  });
   const pickerContent = (
-    <View
-      ref={pickerRef}
-      style={[
-        styles.menu,
-        scrollableWebPicker ? styles.redesignedMenu : undefined,
-        surfaceBounds,
-        Platform.OS === 'web' ? elevation.floating : elevation.overlay,
-        { backgroundColor: theme.card, borderColor: theme.border },
-      ]}
-    >
-      <View
-        accessibilityLabel="프로필 전환"
-        accessibilityRole={Platform.OS === 'web' ? undefined : 'menu'}
-        role={Platform.OS === 'web' && !redesignedWeb ? 'menu' : undefined}
-        style={scrollableWebPicker ? styles.redesignedMenuRegion : styles.menuItems}
-      >
-        {scrollableWebPicker ? (
-          <ScrollView
-            accessibilityLabel="전환할 프로필 목록"
-            contentContainerStyle={styles.profileListContent}
-            role="group"
-            style={styles.profileList}
-          >
-            {profileOptions}
-          </ScrollView>
-        ) : (
-          profileOptions
-        )}
-
-        <View
-          accessibilityRole={Platform.OS === 'web' ? undefined : 'none'}
-          role={Platform.OS === 'web' ? 'separator' : undefined}
-          style={[styles.divider, { backgroundColor: theme.border }]}
-        />
-
-        {!creating ? (
-          <Pressable
-            accessibilityLabel="새 프로필 추가"
-            accessibilityRole={redesignedWeb || Platform.OS !== 'web' ? 'button' : undefined}
-            disabled={busy}
-            onPress={() => {
-              setCreating(true);
-              setFieldError(null);
-              setOperationErrorState(null);
-            }}
-            role={Platform.OS === 'web' && !redesignedWeb ? 'menuitem' : undefined}
-            style={({ pressed }) => [
-              styles.addProfile,
-              {
-                backgroundColor: pressed ? theme.surface : 'transparent',
-                opacity: busy ? 0.5 : 1,
-              },
-            ]}
-          >
-            <View style={styles.addIcon}>
-              <PlusIcon color={theme.text} size={18} strokeWidth={2.25} />
-            </View>
-            <Text style={[styles.addLabel, { color: theme.text }]}>새 프로필 추가</Text>
-          </Pressable>
-        ) : null}
-      </View>
-
-      <View style={styles.pickerFooter}>
-        {creating ? (
-          <View
-            accessibilityLabel="새 프로필 만들기"
-            role={Platform.OS === 'web' ? 'form' : undefined}
-            style={styles.createForm}
-          >
-            <View style={styles.createRow}>
-              <View style={styles.inputField}>
-                <TextField
-                  accessibilityLabel="프로필 핸들"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  editable={!busy}
-                  error={fieldError ?? undefined}
-                  onChangeText={setHandle}
-                  onSubmitEditing={createProfile}
-                  placeholder="새 프로필 핸들"
-                  style={styles.input}
-                  value={handle}
-                />
+    <ProfilePicker
+      busy={busy}
+      footer={
+        <>
+          {!creating ? (
+            <Pressable
+              accessibilityLabel="새 프로필 추가"
+              accessibilityRole={redesignedWeb || Platform.OS !== 'web' ? 'button' : undefined}
+              disabled={busy}
+              onPress={() => {
+                setCreating(true);
+                setFieldError(null);
+                setOperationErrorState(null);
+              }}
+              role={Platform.OS === 'web' && !redesignedWeb ? 'menuitem' : undefined}
+              style={({ pressed }) => [
+                styles.addProfile,
+                {
+                  backgroundColor: pressed ? theme.surface : 'transparent',
+                  opacity: busy ? 0.5 : 1,
+                },
+              ]}
+            >
+              <View style={styles.addIcon}>
+                <PlusIcon color={theme.text} size={18} strokeWidth={2.25} />
               </View>
-              <Button
-                disabled={busy}
-                loading={busy}
-                onPress={createProfile}
-                style={styles.createButton}
+              <Text style={[styles.addLabel, { color: theme.text }]}>새 프로필 추가</Text>
+            </Pressable>
+          ) : null}
+          <View style={styles.pickerFooter}>
+            {creating ? (
+              <View
+                accessibilityLabel="새 프로필 만들기"
+                role={Platform.OS === 'web' ? 'form' : undefined}
+                style={styles.createForm}
               >
-                만들기
-              </Button>
-            </View>
-            <Text style={[styles.help, { color: theme.textSecondary }]}>
-              영문, 숫자, 밑줄(_)만 사용할 수 있어요.
-            </Text>
+                <View style={styles.createRow}>
+                  <View style={styles.inputField}>
+                    <TextField
+                      accessibilityLabel="프로필 핸들"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      editable={!busy}
+                      error={fieldError ?? undefined}
+                      onChangeText={setHandle}
+                      onSubmitEditing={createProfile}
+                      placeholder="새 프로필 핸들"
+                      style={styles.input}
+                      value={handle}
+                    />
+                  </View>
+                  <Button
+                    disabled={busy}
+                    loading={busy}
+                    onPress={createProfile}
+                    style={styles.createButton}
+                  >
+                    만들기
+                  </Button>
+                </View>
+                <Text style={[styles.help, { color: theme.textSecondary }]}>
+                  영문, 숫자, 밑줄(_)만 사용할 수 있어요.
+                </Text>
+              </View>
+            ) : null}
+            {operationError ? (
+              <Text accessibilityRole="alert" style={[styles.error, { color: theme.danger }]}>
+                {operationError}
+              </Text>
+            ) : null}
           </View>
-        ) : null}
-        {operationError ? (
-          <Text accessibilityRole="alert" style={[styles.error, { color: theme.danger }]}>
-            {operationError}
-          </Text>
-        ) : null}
-      </View>
-    </View>
+        </>
+      }
+      onSelect={selectProfile}
+      pickerRef={pickerRef}
+      profiles={profiles}
+      selectedProfileId={active?.id}
+      surface={surface}
+    />
   );
 
   const triggerCopy = !compact ? (
@@ -803,17 +709,6 @@ const styles = StyleSheet.create({
   countLink: { flexDirection: 'row', gap: spacing.sm },
   count: { fontFamily: 'SUIT', ...typography.sm },
   countLabel: { fontFamily: 'SUIT', ...typography.sm },
-  menu: {
-    borderRadius: 14,
-    borderWidth: 1,
-    padding: 6,
-    width: 280,
-  },
-  redesignedMenu: { overflow: 'hidden' },
-  menuItems: { gap: space[0] },
-  redesignedMenuRegion: { flexShrink: 1, minHeight: 0 },
-  profileList: { flexShrink: 1, minHeight: 0 },
-  profileListContent: { gap: space[0] },
   pickerFooter: { flexShrink: 0 },
   backdrop: {
     alignItems: 'center',
@@ -822,25 +717,6 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
   },
   nativeMenu: { width: 280 },
-  profile: {
-    alignItems: 'center',
-    borderRadius: 10,
-    flexDirection: 'row',
-    gap: 10,
-    padding: spacing.sm,
-  },
-  unselectedProfile: { paddingVertical: space[8] },
-  profileAvatar: { position: 'relative' },
-  profileUnreadDot: {
-    height: 12,
-    position: 'absolute',
-    right: -2,
-    top: -2,
-    width: 12,
-    zIndex: 1,
-  },
-  profileLabel: { flex: 1, minWidth: 0 },
-  divider: { height: 1, marginVertical: space[4], width: '100%' },
   createForm: { ...layoutRecipes.labelSupportStack, padding: spacing.xs },
   createRow: { alignItems: 'flex-start', flexDirection: 'row', gap: spacing.sm },
   inputField: { flex: 1, minWidth: 0 },

--- a/apps/app/src/components/ui/TextField.tsx
+++ b/apps/app/src/components/ui/TextField.tsx
@@ -2,10 +2,9 @@ import { forwardRef, useId, useState } from 'react';
 import { Platform, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, layoutRecipes, radius, space, textStyles } from '@/theme/tokens';
-import type { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
+import type { TextInputProps, TextStyle } from 'react-native';
 
 type TextFieldProps = TextInputProps & {
-  containerStyle?: StyleProp<ViewStyle>;
   error?: string;
   label?: string;
 };
@@ -13,7 +12,6 @@ type TextFieldProps = TextInputProps & {
 export const TextField = forwardRef<TextInput, TextFieldProps>(function TextField(
   {
     accessibilityHint,
-    containerStyle,
     editable = true,
     error,
     label,
@@ -34,7 +32,7 @@ export const TextField = forwardRef<TextInput, TextFieldProps>(function TextFiel
       : {};
 
   return (
-    <View style={[styles.wrapper, containerStyle]}>
+    <View style={styles.wrapper}>
       {label ? (
         <Text style={[styles.label, { color: theme.foregroundPrimary }]}>{label}</Text>
       ) : null}

--- a/apps/app/src/components/ui/TextField.tsx
+++ b/apps/app/src/components/ui/TextField.tsx
@@ -2,9 +2,10 @@ import { forwardRef, useId, useState } from 'react';
 import { Platform, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, layoutRecipes, radius, space, textStyles } from '@/theme/tokens';
-import type { TextInputProps, TextStyle } from 'react-native';
+import type { StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
 
 type TextFieldProps = TextInputProps & {
+  containerStyle?: StyleProp<ViewStyle>;
   error?: string;
   label?: string;
 };
@@ -12,6 +13,7 @@ type TextFieldProps = TextInputProps & {
 export const TextField = forwardRef<TextInput, TextFieldProps>(function TextField(
   {
     accessibilityHint,
+    containerStyle,
     editable = true,
     error,
     label,
@@ -32,7 +34,7 @@ export const TextField = forwardRef<TextInput, TextFieldProps>(function TextFiel
       : {};
 
   return (
-    <View style={styles.wrapper}>
+    <View style={[styles.wrapper, containerStyle]}>
       {label ? (
         <Text style={[styles.label, { color: theme.foregroundPrimary }]}>{label}</Text>
       ) : null}

--- a/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
@@ -38,6 +38,7 @@ const meta = {
     presentation: 'web',
     selectedKey: 'media-1',
     sensitiveMedia: false,
+    showImageEditPreview: false,
     tool: 'alt',
   },
   argTypes: {
@@ -56,11 +57,16 @@ const meta = {
     presentation: { control: 'inline-radio', options: ['web', 'mobile'] },
     selectedKey: { control: 'select', options: editorMedia.map(({ key }) => key) },
     sensitiveMedia: { control: 'boolean' },
+    showImageEditPreview: {
+      control: 'boolean',
+      name: '미래 이미지 편집 미리보기',
+    },
     tool: { control: 'inline-radio', options: ['alt', 'sensitive'] },
   },
   component: ComposerMediaEditor,
   excludeStories: [
     'InteractionContract',
+    'FutureImageEditPreviewContract',
     'MobileAltKeyboardGeometryContract',
     'MobileDefaultGeometryContract',
     'MobileSensitiveGeometryContract',
@@ -183,10 +189,7 @@ export const InteractionContract: Story = {
       '노을빛 밤하늘 아래 모인 사람들',
     );
     expect(canvas.getByText('1 / 2')).toBeVisible();
-    expect(canvas.getByRole('tab', { name: '이미지 편집 (준비 중)' })).toHaveAttribute(
-      'aria-disabled',
-      'true',
-    );
+    expect(canvas.queryByRole('tab', { name: '이미지 편집 (준비 중)' })).toBeNull();
 
     await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 선택' }));
     expect(args.onSelectMedia).toHaveBeenLastCalledWith('media-2');
@@ -208,6 +211,17 @@ export const InteractionContract: Story = {
     expect(args.onClose).toHaveBeenCalledOnce();
   },
   render: (args) => <WebEditorStory {...args} />,
+};
+
+export const FutureImageEditPreviewContract: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole('tab', { name: '이미지 편집 (준비 중)' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  },
+  render: (args) => <WebEditorStory {...args} showImageEditPreview />,
 };
 
 export const MobileDefaultGeometryContract: Story = {

--- a/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
@@ -32,6 +32,7 @@ const meta = {
     onBack: fn(),
     onClose: fn(),
     onDone: fn(),
+    onPreviewPress: fn(),
     onSelectMedia: fn(),
     onSensitiveMediaChange: fn(),
     onToolChange: fn(),
@@ -51,6 +52,7 @@ const meta = {
     onBack: { action: 'back', control: false },
     onClose: { action: 'close', control: false },
     onDone: { action: 'done', control: false },
+    onPreviewPress: { action: 'previewPress', control: false },
     onSelectMedia: { action: 'selectMedia', control: false },
     onSensitiveMediaChange: { action: 'sensitiveMediaChange', control: false },
     onToolChange: { action: 'toolChange', control: false },
@@ -71,16 +73,33 @@ const meta = {
     'MobileDefaultGeometryContract',
     'MobileSensitiveGeometryContract',
     'MobileToolInteractionContract',
+    'ControlsContract',
     'editorMedia',
   ],
-  parameters: { layout: 'centered' },
+  parameters: {
+    controls: {
+      include: [
+        'media',
+        'mobileState',
+        'selectedKey',
+        'sensitiveMedia',
+        'showImageEditPreview',
+        'tool',
+      ],
+    },
+    layout: 'centered',
+  },
   title: 'KOSMO/Components/Composer Media Editor',
 } satisfies Meta<typeof ComposerMediaEditor>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = { render: (args) => <WebEditorStory {...args} /> };
+export const Playground: Story = {
+  render: (args, context) => (
+    <ViewportAwareEditor {...args} mobile={context.globals.viewport?.value === 'kosmoMobile'} />
+  ),
+};
 
 export const Sensitive: Story = {
   args: { sensitiveMedia: true, tool: 'sensitive' },
@@ -183,6 +202,14 @@ function WebEditorStory(props: ComposerMediaEditorProps) {
     <View style={{ width: 920 }}>
       <InteractiveEditor {...props} />
     </View>
+  );
+}
+
+function ViewportAwareEditor({ mobile, ...props }: ComposerMediaEditorProps & { mobile: boolean }) {
+  return mobile ? (
+    <InteractiveEditor {...props} presentation="mobile" />
+  ) : (
+    <WebEditorStory {...props} presentation="web" />
   );
 }
 
@@ -305,4 +332,42 @@ export const MobileToolInteractionContract: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '대체 텍스트 편집' }));
     expect(canvas.getByRole('textbox', { name: '이미지 설명' })).toHaveValue('작성한 설명');
   },
+};
+
+export const WideImagePreviewContract: Story = {
+  ...Playground,
+  args: { mobileState: 'default', presentation: 'web' },
+  globals: { viewport: { isRotated: false, value: 'kosmoFull' } },
+  parameters: { layout: 'centered' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const preview = canvas.getAllByRole('img', { name: '선택한 첨부 이미지 1 미리보기' })[0];
+    expect(preview.firstElementChild).toHaveStyle({ backgroundSize: 'contain' });
+  },
+};
+
+export const PlaygroundMobileViewportContract: Story = {
+  ...Playground,
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  parameters: { layout: 'fullscreen' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByTestId('mobile-composer-media-editor')).toBeVisible();
+    expect(canvas.queryByTestId('web-composer-media-editor')).toBeNull();
+  },
+};
+
+export const ControlsContract: Story = {
+  play: async () => {
+    expect(meta.parameters?.controls?.include).toEqual([
+      'media',
+      'mobileState',
+      'selectedKey',
+      'sensitiveMedia',
+      'showImageEditPreview',
+      'tool',
+    ]);
+    expect(meta.parameters?.controls?.include).not.toContain('presentation');
+  },
+  render: (args) => <WebEditorStory {...args} />,
 };

--- a/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { ComposerMediaEditor } from '@/components/post/ComposerMediaEditor';
+import ogImage from '../../../public/og-default.png?url';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComposerMediaEditorProps } from '@/components/post/ComposerMediaEditor';
+import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
+
+export const editorMedia: readonly ComposerMediaItem[] = [
+  {
+    altText: '노을빛 밤하늘 아래 모인 사람들',
+    asset: { height: 390, uri: ogImage, width: 560 },
+    key: 'media-1',
+    mediaId: 'media-1',
+    state: 'ready',
+  },
+  {
+    altText: '',
+    asset: { height: 390, uri: ogImage, width: 560 },
+    key: 'media-2',
+    mediaId: 'media-2',
+    state: 'ready',
+  },
+];
+
+const meta = {
+  args: {
+    media: editorMedia,
+    mobileState: undefined,
+    onAltTextChange: fn(),
+    onBack: fn(),
+    onClose: fn(),
+    onDone: fn(),
+    onSelectMedia: fn(),
+    onSensitiveMediaChange: fn(),
+    onToolChange: fn(),
+    presentation: 'web',
+    selectedKey: 'media-1',
+    sensitiveMedia: false,
+    tool: 'alt',
+  },
+  argTypes: {
+    media: { control: 'object' },
+    mobileState: {
+      control: 'select',
+      options: ['default', 'altKeyboard', 'sensitive'],
+    },
+    onAltTextChange: { action: 'altTextChange', control: false },
+    onBack: { action: 'back', control: false },
+    onClose: { action: 'close', control: false },
+    onDone: { action: 'done', control: false },
+    onSelectMedia: { action: 'selectMedia', control: false },
+    onSensitiveMediaChange: { action: 'sensitiveMediaChange', control: false },
+    onToolChange: { action: 'toolChange', control: false },
+    presentation: { control: 'inline-radio', options: ['web', 'mobile'] },
+    selectedKey: { control: 'select', options: editorMedia.map(({ key }) => key) },
+    sensitiveMedia: { control: 'boolean' },
+    tool: { control: 'inline-radio', options: ['alt', 'sensitive'] },
+  },
+  component: ComposerMediaEditor,
+  excludeStories: [
+    'InteractionContract',
+    'MobileAltKeyboardGeometryContract',
+    'MobileDefaultGeometryContract',
+    'MobileSensitiveGeometryContract',
+    'MobileToolInteractionContract',
+    'editorMedia',
+  ],
+  parameters: { layout: 'centered' },
+  title: 'KOSMO/Components/Composer Media Editor',
+} satisfies Meta<typeof ComposerMediaEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = { render: (args) => <WebEditorStory {...args} /> };
+
+export const Sensitive: Story = {
+  args: { sensitiveMedia: true, tool: 'sensitive' },
+  render: (args) => <WebEditorStory {...args} />,
+};
+
+export const CompactWebAlt: Story = {
+  render: (args) => (
+    <View style={{ width: 720 }}>
+      <ComposerMediaEditor {...args} />
+    </View>
+  ),
+};
+
+export const MobileDefault: Story = {
+  args: { mobileState: 'default', presentation: 'mobile' },
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  parameters: { layout: 'fullscreen' },
+  render: (args) => <InteractiveEditor {...args} />,
+};
+
+export const MobileAltKeyboard: Story = {
+  args: { mobileState: 'altKeyboard', presentation: 'mobile' },
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  parameters: { layout: 'fullscreen' },
+  render: (args) => <InteractiveEditor {...args} />,
+};
+
+export const MobileSensitive: Story = {
+  args: {
+    mobileState: 'sensitive',
+    presentation: 'mobile',
+    sensitiveMedia: true,
+    tool: 'sensitive',
+  },
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  parameters: { layout: 'fullscreen' },
+  render: (args) => <InteractiveEditor {...args} />,
+};
+
+function InteractiveEditor(props: ComposerMediaEditorProps) {
+  const [media, setMedia] = useState(props.media);
+  const [mobileState, setMobileState] = useState(props.mobileState);
+  const [selectedKey, setSelectedKey] = useState(props.selectedKey);
+  const [sensitiveMedia, setSensitiveMedia] = useState(props.sensitiveMedia);
+  const [tool, setTool] = useState(props.tool);
+
+  useEffect(() => setMedia(props.media), [props.media]);
+  useEffect(() => setMobileState(props.mobileState), [props.mobileState]);
+  useEffect(() => setSelectedKey(props.selectedKey), [props.selectedKey]);
+  useEffect(() => setSensitiveMedia(props.sensitiveMedia), [props.sensitiveMedia]);
+  useEffect(() => setTool(props.tool), [props.tool]);
+
+  return (
+    <ComposerMediaEditor
+      {...props}
+      media={media}
+      mobileState={mobileState}
+      onAltTextChange={(key, altText) => {
+        props.onAltTextChange(key, altText);
+        setMedia((items) => items.map((item) => (item.key === key ? { ...item, altText } : item)));
+      }}
+      onSelectMedia={(key) => {
+        props.onSelectMedia(key);
+        setSelectedKey(key);
+      }}
+      onSensitiveMediaChange={(value) => {
+        props.onSensitiveMediaChange(value);
+        setSensitiveMedia(value);
+      }}
+      onToolChange={(value) => {
+        props.onToolChange(value);
+        setTool(value);
+        if (props.presentation === 'mobile') {
+          setMobileState(value === 'alt' ? 'altKeyboard' : 'sensitive');
+        }
+      }}
+      selectedKey={selectedKey}
+      sensitiveMedia={sensitiveMedia}
+      tool={tool}
+    />
+  );
+}
+
+function WebEditorStory(props: ComposerMediaEditorProps) {
+  return (
+    <View style={{ width: 920 }}>
+      <InteractiveEditor {...props} />
+    </View>
+  );
+}
+
+export const InteractionContract: Story = {
+  play: async ({ args, canvasElement }) => {
+    args.onAltTextChange.mockClear();
+    args.onBack.mockClear();
+    args.onClose.mockClear();
+    args.onDone.mockClear();
+    args.onSelectMedia.mockClear();
+    args.onSensitiveMediaChange.mockClear();
+    args.onToolChange.mockClear();
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByRole('heading', { name: '미디어 편집' })).toBeVisible();
+    expect(canvas.getByRole('textbox', { name: '이미지 설명' })).toHaveValue(
+      '노을빛 밤하늘 아래 모인 사람들',
+    );
+    expect(canvas.getByText('1 / 2')).toBeVisible();
+    expect(canvas.getByRole('tab', { name: '이미지 편집 (준비 중)' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 선택' }));
+    expect(args.onSelectMedia).toHaveBeenLastCalledWith('media-2');
+    expect(canvas.getByRole('textbox', { name: '이미지 설명' })).toHaveValue('');
+
+    await userEvent.type(canvas.getByRole('textbox', { name: '이미지 설명' }), '두 번째 이미지');
+    expect(args.onAltTextChange).toHaveBeenLastCalledWith('media-2', '두 번째 이미지');
+
+    await userEvent.click(canvas.getByRole('tab', { name: '민감도' }));
+    expect(args.onToolChange).toHaveBeenLastCalledWith('sensitive');
+    await userEvent.click(canvas.getByRole('switch', { name: '민감한 이미지' }));
+    expect(args.onSensitiveMediaChange).toHaveBeenLastCalledWith(true);
+
+    await userEvent.click(canvas.getByRole('button', { name: '완료' }));
+    expect(args.onDone).toHaveBeenCalledOnce();
+    await userEvent.click(canvas.getByRole('button', { name: '미디어 편집에서 뒤로' }));
+    expect(args.onBack).toHaveBeenCalledOnce();
+    await userEvent.click(canvas.getByRole('button', { name: '미디어 편집 닫기' }));
+    expect(args.onClose).toHaveBeenCalledOnce();
+  },
+  render: (args) => <WebEditorStory {...args} />,
+};
+
+export const MobileDefaultGeometryContract: Story = {
+  ...MobileDefault,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByTestId('mobile-composer-media-editor')).toHaveStyle({
+      height: '844px',
+      width: '390px',
+    });
+    expect(canvas.queryByTestId('mobile-composer-media-editor-tool-sheet')).toBeNull();
+    expect(canvas.queryByTestId('mobile-composer-media-editor-keyboard')).toBeNull();
+  },
+};
+
+export const MobileAltKeyboardGeometryContract: Story = {
+  ...MobileAltKeyboard,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByTestId('mobile-composer-media-editor-tool-sheet')).toHaveStyle({
+      height: '176px',
+    });
+    expect(canvas.getByTestId('mobile-composer-media-editor-keyboard')).toHaveStyle({
+      height: '336px',
+    });
+  },
+};
+
+export const MobileSensitiveGeometryContract: Story = {
+  ...MobileSensitive,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByTestId('mobile-composer-media-editor-tool-sheet')).toHaveStyle({
+      height: '184px',
+    });
+    expect(canvas.queryByTestId('mobile-composer-media-editor-keyboard')).toBeNull();
+  },
+};
+
+export const MobileToolInteractionContract: Story = {
+  ...MobileDefault,
+  play: async ({ args, canvasElement }) => {
+    args.onToolChange.mockClear();
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: '대체 텍스트 편집' }));
+
+    expect(args.onToolChange).toHaveBeenLastCalledWith('alt');
+    expect(canvas.getByTestId('mobile-composer-media-editor-tool-sheet')).toHaveStyle({
+      height: '176px',
+    });
+    expect(canvas.getByTestId('mobile-composer-media-editor-keyboard')).toHaveStyle({
+      height: '336px',
+    });
+  },
+};

--- a/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
@@ -170,6 +170,7 @@ function InteractiveEditor(props: ComposerMediaEditorProps) {
         props.presentation === 'mobile' && mobileState === 'altKeyboard'
           ? () => {
               setMobileState('default');
+              props.onPreviewPress?.();
             }
           : undefined
       }
@@ -304,6 +305,7 @@ export const MobileSensitiveGeometryContract: Story = {
 export const MobileToolInteractionContract: Story = {
   ...MobileDefault,
   play: async ({ args, canvasElement }) => {
+    args.onPreviewPress?.mockClear();
     args.onToolChange.mockClear();
     const canvas = within(canvasElement);
 
@@ -322,6 +324,7 @@ export const MobileToolInteractionContract: Story = {
     await userEvent.clear(altText);
     await userEvent.type(altText, '작성한 설명');
     await userEvent.click(canvas.getByRole('button', { name: '선택한 첨부 이미지 1 미리보기' }));
+    expect(args.onPreviewPress).toHaveBeenCalledOnce();
     expect(canvas.queryByTestId('mobile-composer-media-editor-keyboard')).toBeNull();
 
     await userEvent.click(canvas.getByRole('button', { name: '대체 텍스트 편집' }));

--- a/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
@@ -231,6 +231,12 @@ export const InteractionContract: Story = {
     );
     expect(canvas.getByText('1 / 2')).toBeVisible();
     expect(canvas.queryByRole('tab', { name: '이미지 편집 (준비 중)' })).toBeNull();
+    expect(
+      getComputedStyle(canvas.getByTestId('composer-media-editor-gallery')).borderTopWidth,
+    ).toBe('0px');
+    expect(
+      getComputedStyle(canvas.getByTestId('composer-media-editor-footer')).borderTopWidth,
+    ).toBe('0px');
 
     await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 선택' }));
     expect(args.onSelectMedia).toHaveBeenLastCalledWith('media-2');

--- a/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
@@ -147,6 +147,13 @@ function InteractiveEditor(props: ComposerMediaEditorProps) {
         props.onSelectMedia(key);
         setSelectedKey(key);
       }}
+      onPreviewPress={
+        props.presentation === 'mobile' && mobileState === 'altKeyboard'
+          ? () => {
+              setMobileState('default');
+            }
+          : undefined
+      }
       onSensitiveMediaChange={(value) => {
         props.onSensitiveMediaChange(value);
         setSensitiveMedia(value);
@@ -155,7 +162,13 @@ function InteractiveEditor(props: ComposerMediaEditorProps) {
         props.onToolChange(value);
         setTool(value);
         if (props.presentation === 'mobile') {
-          setMobileState(value === 'alt' ? 'altKeyboard' : 'sensitive');
+          setMobileState((current) =>
+            value === 'alt' && current === 'altKeyboard'
+              ? 'default'
+              : value === 'alt'
+                ? 'altKeyboard'
+                : 'sensitive',
+          );
         }
       }}
       selectedKey={selectedKey}
@@ -270,11 +283,26 @@ export const MobileToolInteractionContract: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '대체 텍스트 편집' }));
 
     expect(args.onToolChange).toHaveBeenLastCalledWith('alt');
+    expect(canvas.getByRole('button', { name: '대체 텍스트 편집' })).toHaveTextContent('ALT');
     expect(canvas.getByTestId('mobile-composer-media-editor-tool-sheet')).toHaveStyle({
       height: '176px',
     });
     expect(canvas.getByTestId('mobile-composer-media-editor-keyboard')).toHaveStyle({
       height: '336px',
     });
+
+    const altText = canvas.getByRole('textbox', { name: '이미지 설명' });
+    await userEvent.clear(altText);
+    await userEvent.type(altText, '작성한 설명');
+    await userEvent.click(canvas.getByRole('button', { name: '선택한 첨부 이미지 1 미리보기' }));
+    expect(canvas.queryByTestId('mobile-composer-media-editor-keyboard')).toBeNull();
+
+    await userEvent.click(canvas.getByRole('button', { name: '대체 텍스트 편집' }));
+    expect(canvas.getByTestId('mobile-composer-media-editor-keyboard')).toBeVisible();
+    expect(canvas.getByRole('textbox', { name: '이미지 설명' })).toHaveValue('작성한 설명');
+    await userEvent.click(canvas.getByRole('button', { name: '대체 텍스트 편집' }));
+    expect(canvas.queryByTestId('mobile-composer-media-editor-keyboard')).toBeNull();
+    await userEvent.click(canvas.getByRole('button', { name: '대체 텍스트 편집' }));
+    expect(canvas.getByRole('textbox', { name: '이미지 설명' })).toHaveValue('작성한 설명');
   },
 };

--- a/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.stories.tsx
@@ -73,7 +73,6 @@ const meta = {
     'MobileDefaultGeometryContract',
     'MobileSensitiveGeometryContract',
     'MobileToolInteractionContract',
-    'ControlsContract',
     'editorMedia',
   ],
   parameters: {
@@ -364,19 +363,4 @@ export const PlaygroundMobileViewportContract: Story = {
     expect(canvas.getByTestId('mobile-composer-media-editor')).toBeVisible();
     expect(canvas.queryByTestId('web-composer-media-editor')).toBeNull();
   },
-};
-
-export const ControlsContract: Story = {
-  play: async () => {
-    expect(meta.parameters?.controls?.include).toEqual([
-      'media',
-      'mobileState',
-      'selectedKey',
-      'sensitiveMedia',
-      'showImageEditPreview',
-      'tool',
-    ]);
-    expect(meta.parameters?.controls?.include).not.toContain('presentation');
-  },
-  render: (args) => <WebEditorStory {...args} />,
 };

--- a/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
@@ -1,0 +1,23 @@
+import baseMeta, {
+  InteractionContract as interactionContract,
+  MobileAltKeyboardGeometryContract as mobileAltKeyboardGeometryContract,
+  MobileDefaultGeometryContract as mobileDefaultGeometryContract,
+  MobileSensitiveGeometryContract as mobileSensitiveGeometryContract,
+  MobileToolInteractionContract as mobileToolInteractionContract,
+} from './ComposerMediaEditor.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Components/Composer Media Editor/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const MobileAltKeyboardGeometryContract: Story = mobileAltKeyboardGeometryContract;
+export const MobileDefaultGeometryContract: Story = mobileDefaultGeometryContract;
+export const MobileSensitiveGeometryContract: Story = mobileSensitiveGeometryContract;
+export const MobileToolInteractionContract: Story = mobileToolInteractionContract;

--- a/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
@@ -1,10 +1,13 @@
 import baseMeta, {
+  ControlsContract as controlsContract,
   FutureImageEditPreviewContract as futureImageEditPreviewContract,
   InteractionContract as interactionContract,
   MobileAltKeyboardGeometryContract as mobileAltKeyboardGeometryContract,
   MobileDefaultGeometryContract as mobileDefaultGeometryContract,
   MobileSensitiveGeometryContract as mobileSensitiveGeometryContract,
   MobileToolInteractionContract as mobileToolInteractionContract,
+  PlaygroundMobileViewportContract as playgroundMobileViewportContract,
+  WideImagePreviewContract as wideImagePreviewContract,
 } from './ComposerMediaEditor.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -23,3 +26,6 @@ export const MobileAltKeyboardGeometryContract: Story = mobileAltKeyboardGeometr
 export const MobileDefaultGeometryContract: Story = mobileDefaultGeometryContract;
 export const MobileSensitiveGeometryContract: Story = mobileSensitiveGeometryContract;
 export const MobileToolInteractionContract: Story = mobileToolInteractionContract;
+export const ControlsContract: Story = controlsContract;
+export const PlaygroundMobileViewportContract: Story = playgroundMobileViewportContract;
+export const WideImagePreviewContract: Story = wideImagePreviewContract;

--- a/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
@@ -1,4 +1,5 @@
 import baseMeta, {
+  FutureImageEditPreviewContract as futureImageEditPreviewContract,
   InteractionContract as interactionContract,
   MobileAltKeyboardGeometryContract as mobileAltKeyboardGeometryContract,
   MobileDefaultGeometryContract as mobileDefaultGeometryContract,
@@ -17,6 +18,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const InteractionContract: Story = interactionContract;
+export const FutureImageEditPreviewContract: Story = futureImageEditPreviewContract;
 export const MobileAltKeyboardGeometryContract: Story = mobileAltKeyboardGeometryContract;
 export const MobileDefaultGeometryContract: Story = mobileDefaultGeometryContract;
 export const MobileSensitiveGeometryContract: Story = mobileSensitiveGeometryContract;

--- a/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
+++ b/apps/app/src/stories/components/ComposerMediaEditor.tests.stories.tsx
@@ -1,5 +1,4 @@
 import baseMeta, {
-  ControlsContract as controlsContract,
   FutureImageEditPreviewContract as futureImageEditPreviewContract,
   InteractionContract as interactionContract,
   MobileAltKeyboardGeometryContract as mobileAltKeyboardGeometryContract,
@@ -26,6 +25,5 @@ export const MobileAltKeyboardGeometryContract: Story = mobileAltKeyboardGeometr
 export const MobileDefaultGeometryContract: Story = mobileDefaultGeometryContract;
 export const MobileSensitiveGeometryContract: Story = mobileSensitiveGeometryContract;
 export const MobileToolInteractionContract: Story = mobileToolInteractionContract;
-export const ControlsContract: Story = controlsContract;
 export const PlaygroundMobileViewportContract: Story = playgroundMobileViewportContract;
 export const WideImagePreviewContract: Story = wideImagePreviewContract;

--- a/apps/app/src/stories/components/FullReactionPicker.stories.tsx
+++ b/apps/app/src/stories/components/FullReactionPicker.stories.tsx
@@ -261,6 +261,7 @@ export const recentLimitOptions: readonly FullReactionPickerOption[] = Array.fro
 
 const meta = {
   args: {
+    onClose: fn(),
     onQueryChange: fn(),
     onSelect: fn(),
     options: reactionOptions,
@@ -270,6 +271,7 @@ const meta = {
     loading: false,
   },
   argTypes: {
+    onClose: { action: 'close', control: false },
     onQueryChange: { action: 'queryChange', control: false },
     onSelect: { action: 'select', control: false },
     options: { control: 'object' },

--- a/apps/app/src/stories/components/FullReactionPicker.stories.tsx
+++ b/apps/app/src/stories/components/FullReactionPicker.stories.tsx
@@ -1,0 +1,434 @@
+import { useEffect, useState } from 'react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { FullReactionPicker } from '@/components/reaction/FullReactionPicker';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type {
+  FullReactionPickerOption,
+  FullReactionPickerProps,
+} from '@/components/reaction/FullReactionPicker';
+
+export const reactionOptions: readonly FullReactionPickerOption[] = [
+  {
+    category: 'expressions',
+    categoryLabel: '표정과 감정',
+    emoji: '🥹',
+    id: 'moved',
+    keywords: ['감동', '눈물'],
+    label: '감동',
+    quick: true,
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '❤️',
+    id: 'heart-red',
+    keywords: ['하트', '사랑'],
+    label: '빨간 하트',
+    quick: true,
+    recent: true,
+  },
+  {
+    category: 'activities',
+    categoryLabel: '활동',
+    emoji: '🎉',
+    id: 'party',
+    keywords: ['축하'],
+    label: '축하',
+    quick: true,
+  },
+  {
+    category: 'expressions',
+    categoryLabel: '표정과 감정',
+    emoji: '👀',
+    id: 'eyes',
+    keywords: ['눈', '보기'],
+    label: '지켜보기',
+    quick: true,
+  },
+  {
+    category: 'nature',
+    categoryLabel: '동물과 자연',
+    emoji: '☘️',
+    id: 'clover',
+    keywords: ['행운', '클로버'],
+    label: '행운',
+    quick: true,
+  },
+  {
+    category: 'nature',
+    categoryLabel: '동물과 자연',
+    emoji: '🌈',
+    id: 'rainbow',
+    keywords: ['무지개'],
+    label: '무지개',
+    quick: true,
+  },
+  {
+    category: 'expressions',
+    categoryLabel: '표정과 감정',
+    emoji: '😂',
+    id: 'laugh',
+    keywords: ['웃음'],
+    label: '웃음',
+    recent: true,
+  },
+  {
+    category: 'nature',
+    categoryLabel: '동물과 자연',
+    emoji: '🔥',
+    id: 'fire',
+    keywords: ['불꽃'],
+    label: '불꽃',
+    recent: true,
+  },
+  {
+    category: 'gestures',
+    categoryLabel: '사람과 몸짓',
+    emoji: '👏',
+    id: 'clap',
+    keywords: ['박수'],
+    label: '박수',
+    recent: true,
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '✨',
+    id: 'sparkles',
+    keywords: ['반짝임'],
+    label: '반짝임',
+    recent: true,
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '💯',
+    id: 'hundred',
+    keywords: ['최고'],
+    label: '최고',
+    recent: true,
+  },
+  {
+    category: 'expressions',
+    categoryLabel: '표정과 감정',
+    emoji: '😍',
+    id: 'heart-eyes',
+    keywords: ['하트', '사랑'],
+    label: '하트 눈',
+    recent: true,
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '🩷',
+    id: 'heart-pink',
+    keywords: ['하트'],
+    label: '분홍 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '🧡',
+    id: 'heart-orange',
+    keywords: ['하트'],
+    label: '주황 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '💛',
+    id: 'heart-yellow',
+    keywords: ['하트'],
+    label: '노란 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '💚',
+    id: 'heart-green',
+    keywords: ['하트'],
+    label: '초록 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '💙',
+    id: 'heart-blue',
+    keywords: ['하트'],
+    label: '파란 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '💜',
+    id: 'heart-purple',
+    keywords: ['하트'],
+    label: '보라 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '🤎',
+    id: 'heart-brown',
+    keywords: ['하트'],
+    label: '갈색 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '🖤',
+    id: 'heart-black',
+    keywords: ['하트'],
+    label: '검정 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '🤍',
+    id: 'heart-white',
+    keywords: ['하트'],
+    label: '하얀 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '🩶',
+    id: 'heart-gray',
+    keywords: ['하트'],
+    label: '회색 하트',
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '💔',
+    id: 'heart-broken',
+    keywords: ['하트'],
+    label: '깨진 하트',
+  },
+  {
+    category: 'gestures',
+    categoryLabel: '사람과 몸짓',
+    emoji: '👋',
+    id: 'wave',
+    keywords: ['인사'],
+    label: '손 흔들기',
+  },
+  {
+    category: 'gestures',
+    categoryLabel: '사람과 몸짓',
+    emoji: '🤚',
+    id: 'raised-back-hand',
+    keywords: ['손'],
+    label: '손등 들기',
+  },
+  {
+    category: 'gestures',
+    categoryLabel: '사람과 몸짓',
+    emoji: '🖐️',
+    id: 'hand',
+    keywords: ['손'],
+    label: '손바닥',
+  },
+  {
+    category: 'gestures',
+    categoryLabel: '사람과 몸짓',
+    emoji: '🖖',
+    id: 'vulcan',
+    keywords: ['인사'],
+    label: '벌컨 인사',
+  },
+  {
+    category: 'gestures',
+    categoryLabel: '사람과 몸짓',
+    emoji: '🫶',
+    id: 'heart-hands',
+    keywords: ['하트', '손'],
+    label: '하트 손',
+  },
+];
+
+const meta = {
+  args: {
+    activeCategory: 'expressions',
+    onCategoryChange: fn(),
+    onQueryChange: fn(),
+    onSelect: fn(),
+    options: reactionOptions,
+    presentation: 'web',
+    query: '',
+    selectedValues: [],
+    loading: false,
+  },
+  argTypes: {
+    activeCategory: {
+      control: 'select',
+      options: ['expressions', 'gestures', 'nature', 'activities', 'symbols'],
+    },
+    onCategoryChange: { action: 'categoryChange', control: false },
+    onQueryChange: { action: 'queryChange', control: false },
+    onSelect: { action: 'select', control: false },
+    options: { control: 'object' },
+    presentation: { control: 'inline-radio', options: ['web', 'mobile'] },
+    query: { control: 'text' },
+    selectedValues: { control: 'object' },
+    loading: { control: 'boolean' },
+  },
+  component: FullReactionPicker,
+  excludeStories: [
+    'InteractionContract',
+    'LoadingContract',
+    'MobileBrowseGeometryContract',
+    'MobileExpandedGeometryContract',
+    'reactionOptions',
+  ],
+  parameters: { layout: 'centered' },
+  title: 'KOSMO/Components/Full Reaction Picker',
+} satisfies Meta<typeof FullReactionPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = { render: (args) => <InteractivePicker {...args} /> };
+export const WebBrowse: Story = {};
+export const WebSearchResults: Story = { args: { query: '하트' } };
+export const WebEmpty: Story = { args: { query: '존재하지않음' } };
+export const WebLoading: Story = { args: { loading: true } };
+
+const mobileGlobals = { viewport: { isRotated: false, value: 'kosmoMobile' } } as const;
+const mobileParameters = { layout: 'fullscreen' } as const;
+
+export const MobileBrowse: Story = {
+  args: { presentation: 'mobile' },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+};
+export const MobileScrolled: Story = {
+  ...MobileBrowse,
+  play: async ({ canvasElement }) => {
+    const scroll = within(canvasElement).getByTestId('full-reaction-picker-scroll');
+    (
+      scroll as HTMLElement & {
+        scrollTo(options: { animated: boolean; y: number }): void;
+      }
+    ).scrollTo({ animated: false, y: 160 });
+    expect(scroll.scrollTop).toBeGreaterThan(0);
+  },
+};
+export const MobileSearchResults: Story = {
+  args: { presentation: 'mobile', query: '하트' },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+};
+export const MobileEmpty: Story = {
+  args: { presentation: 'mobile', query: '존재하지않음' },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+};
+export const MobileLoading: Story = {
+  args: { presentation: 'mobile', loading: true },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+};
+
+function InteractivePicker(props: FullReactionPickerProps) {
+  const [activeCategory, setActiveCategory] = useState(props.activeCategory);
+  const [query, setQuery] = useState(props.query);
+  const [selectedValues, setSelectedValues] = useState(props.selectedValues ?? []);
+
+  useEffect(() => setActiveCategory(props.activeCategory), [props.activeCategory]);
+  useEffect(() => setQuery(props.query), [props.query]);
+  useEffect(() => setSelectedValues(props.selectedValues ?? []), [props.selectedValues]);
+
+  return (
+    <FullReactionPicker
+      {...props}
+      activeCategory={activeCategory}
+      onCategoryChange={(category) => {
+        props.onCategoryChange(category);
+        setActiveCategory(category);
+      }}
+      onQueryChange={(value) => {
+        props.onQueryChange(value);
+        setQuery(value);
+      }}
+      onSelect={(option) => {
+        props.onSelect(option);
+        setSelectedValues((values) =>
+          values.includes(option.id)
+            ? values.filter((value) => value !== option.id)
+            : [...values, option.id],
+        );
+      }}
+      query={query}
+      selectedValues={selectedValues}
+    />
+  );
+}
+
+export const InteractionContract: Story = {
+  play: async ({ args, canvasElement }) => {
+    args.onCategoryChange.mockClear();
+    args.onQueryChange.mockClear();
+    args.onSelect.mockClear();
+    const canvas = within(canvasElement);
+    const search = canvas.getByRole('searchbox', { name: '반응 검색' });
+
+    expect(canvas.getByRole('dialog', { name: '반응 선택' })).toHaveStyle({
+      height: '624px',
+      width: '360px',
+    });
+    expect(canvas.getByText('빠른 반응')).toBeVisible();
+    expect(canvas.getByText('최근 사용')).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: '사람과 몸짓 category 보기' }));
+    expect(args.onCategoryChange).toHaveBeenLastCalledWith('gestures');
+
+    await userEvent.click(canvas.getAllByRole('button', { name: '빨간 하트 ❤️' })[0]);
+    expect(args.onSelect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ emoji: '❤️', id: 'heart-red' }),
+    );
+
+    await userEvent.type(search, '하트');
+    expect(args.onQueryChange).toHaveBeenLastCalledWith('하트');
+    expect(canvas.getByText('‘하트’ 검색 결과 14개')).toBeVisible();
+    expect(canvas.getByText('반응')).toBeVisible();
+
+    await userEvent.clear(search);
+    await userEvent.type(search, '❤️');
+    expect(canvas.getByRole('button', { name: '빨간 하트 ❤️' })).toBeVisible();
+
+    await userEvent.clear(search);
+    await userEvent.type(search, '존재하지않음');
+    expect(canvas.getByText('검색 결과가 없어요')).toBeVisible();
+    expect(canvas.getByText('다른 이름이나 이모지로 검색해 보세요.')).toBeVisible();
+  },
+  render: (args) => <InteractivePicker {...args} />,
+};
+
+export const LoadingContract: Story = {
+  args: { loading: true },
+  globals: { reduceMotion: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByLabelText('반응을 불러오는 중')).toHaveAttribute('aria-busy', 'true');
+    expect(canvas.getByText('···')).toBeVisible();
+  },
+};
+
+export const MobileBrowseGeometryContract: Story = {
+  ...MobileBrowse,
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).getByTestId('full-reaction-picker-sheet')).toHaveStyle({
+      height: '480px',
+    });
+  },
+};
+
+export const MobileExpandedGeometryContract: Story = {
+  ...MobileSearchResults,
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).getByTestId('full-reaction-picker-sheet')).toHaveStyle({
+      height: '720px',
+    });
+  },
+};

--- a/apps/app/src/stories/components/FullReactionPicker.stories.tsx
+++ b/apps/app/src/stories/components/FullReactionPicker.stories.tsx
@@ -420,8 +420,9 @@ export const InteractionContract: Story = {
       height: '624px',
       width: '360px',
     });
-    expect(canvas.getByText('빠른 반응')).toBeVisible();
-    expect(canvas.getByText('최근 사용')).toBeVisible();
+    expect(canvas.getByRole('heading', { name: '빠른 반응' })).toBeVisible();
+    expect(canvas.getByRole('heading', { name: '최근 사용' })).toBeVisible();
+    expect(canvas.getByRole('heading', { name: '표정과 감정' })).toBeVisible();
     expect(canvas.queryByRole('button', { name: /category 보기/ })).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getAllByRole('button', { name: '빨간 하트 ❤️' })[0]);

--- a/apps/app/src/stories/components/FullReactionPicker.stories.tsx
+++ b/apps/app/src/stories/components/FullReactionPicker.stories.tsx
@@ -247,10 +247,20 @@ export const reactionOptions: readonly FullReactionPickerOption[] = [
   },
 ];
 
+export const recentLimitOptions: readonly FullReactionPickerOption[] = Array.from(
+  { length: 18 },
+  (_, index) => ({
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '😀',
+    id: `recent-${index + 1}`,
+    label: `최근 ${index + 1}`,
+    recent: true,
+  }),
+);
+
 const meta = {
   args: {
-    activeCategory: 'expressions',
-    onCategoryChange: fn(),
     onQueryChange: fn(),
     onSelect: fn(),
     options: reactionOptions,
@@ -260,11 +270,6 @@ const meta = {
     loading: false,
   },
   argTypes: {
-    activeCategory: {
-      control: 'select',
-      options: ['expressions', 'gestures', 'nature', 'activities', 'symbols'],
-    },
-    onCategoryChange: { action: 'categoryChange', control: false },
     onQueryChange: { action: 'queryChange', control: false },
     onSelect: { action: 'select', control: false },
     options: { control: 'object' },
@@ -277,9 +282,14 @@ const meta = {
   excludeStories: [
     'InteractionContract',
     'LoadingContract',
+    'MobileGridGeometryContract',
+    'MobileRecentGridContract',
     'MobileBrowseGeometryContract',
     'MobileExpandedGeometryContract',
+    'RecentGridContract',
+    'WebGridGeometryContract',
     'reactionOptions',
+    'recentLimitOptions',
   ],
   parameters: { layout: 'centered' },
   title: 'KOSMO/Components/Full Reaction Picker',
@@ -330,23 +340,55 @@ export const MobileLoading: Story = {
   parameters: mobileParameters,
 };
 
+export const RecentGridContract: Story = {
+  args: { options: recentLimitOptions },
+  play: async ({ canvasElement }) => {
+    const section = within(canvasElement).getByTestId('full-reaction-section-recent');
+    expect(within(section).getAllByRole('button')).toHaveLength(16);
+  },
+};
+
+export const MobileRecentGridContract: Story = {
+  ...MobileBrowse,
+  args: { options: recentLimitOptions, presentation: 'mobile' },
+  play: async ({ canvasElement }) => {
+    const section = within(canvasElement).getByTestId('full-reaction-section-recent');
+    expect(within(section).getAllByRole('button')).toHaveLength(14);
+  },
+};
+
+export const MobileGridGeometryContract: Story = {
+  ...MobileBrowse,
+  play: async ({ canvasElement }) => {
+    const section = within(canvasElement).getByTestId('full-reaction-section-symbols');
+    const rows = within(section).getAllByTestId(/^full-reaction-section-symbols-row-/);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(getComputedStyle(row).justifyContent).toBe('space-between');
+    }
+  },
+};
+
+export const WebGridGeometryContract: Story = {
+  play: async ({ canvasElement }) => {
+    const section = within(canvasElement).getByTestId('full-reaction-section-symbols');
+    const rows = within(section).getAllByTestId(/^full-reaction-section-symbols-row-/);
+    expect(rows).toHaveLength(2);
+    expect(getComputedStyle(rows[0]).justifyContent).toBe('space-between');
+    expect(getComputedStyle(rows[1]).justifyContent).toBe('flex-start');
+  },
+};
+
 function InteractivePicker(props: FullReactionPickerProps) {
-  const [activeCategory, setActiveCategory] = useState(props.activeCategory);
   const [query, setQuery] = useState(props.query);
   const [selectedValues, setSelectedValues] = useState(props.selectedValues ?? []);
 
-  useEffect(() => setActiveCategory(props.activeCategory), [props.activeCategory]);
   useEffect(() => setQuery(props.query), [props.query]);
   useEffect(() => setSelectedValues(props.selectedValues ?? []), [props.selectedValues]);
 
   return (
     <FullReactionPicker
       {...props}
-      activeCategory={activeCategory}
-      onCategoryChange={(category) => {
-        props.onCategoryChange(category);
-        setActiveCategory(category);
-      }}
       onQueryChange={(value) => {
         props.onQueryChange(value);
         setQuery(value);
@@ -367,7 +409,6 @@ function InteractivePicker(props: FullReactionPickerProps) {
 
 export const InteractionContract: Story = {
   play: async ({ args, canvasElement }) => {
-    args.onCategoryChange.mockClear();
     args.onQueryChange.mockClear();
     args.onSelect.mockClear();
     const canvas = within(canvasElement);
@@ -379,9 +420,7 @@ export const InteractionContract: Story = {
     });
     expect(canvas.getByText('빠른 반응')).toBeVisible();
     expect(canvas.getByText('최근 사용')).toBeVisible();
-
-    await userEvent.click(canvas.getByRole('button', { name: '사람과 몸짓 category 보기' }));
-    expect(args.onCategoryChange).toHaveBeenLastCalledWith('gestures');
+    expect(canvas.queryByRole('button', { name: /category 보기/ })).not.toBeInTheDocument();
 
     await userEvent.click(canvas.getAllByRole('button', { name: '빨간 하트 ❤️' })[0]);
     expect(args.onSelect).toHaveBeenLastCalledWith(

--- a/apps/app/src/stories/components/FullReactionPicker.tests.stories.tsx
+++ b/apps/app/src/stories/components/FullReactionPicker.tests.stories.tsx
@@ -1,0 +1,21 @@
+import baseMeta, {
+  InteractionContract as interactionContract,
+  LoadingContract as loadingContract,
+  MobileBrowseGeometryContract as mobileBrowseGeometryContract,
+  MobileExpandedGeometryContract as mobileExpandedGeometryContract,
+} from './FullReactionPicker.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Components/Full Reaction Picker/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const LoadingContract: Story = loadingContract;
+export const MobileBrowseGeometryContract: Story = mobileBrowseGeometryContract;
+export const MobileExpandedGeometryContract: Story = mobileExpandedGeometryContract;

--- a/apps/app/src/stories/components/FullReactionPicker.tests.stories.tsx
+++ b/apps/app/src/stories/components/FullReactionPicker.tests.stories.tsx
@@ -3,6 +3,10 @@ import baseMeta, {
   LoadingContract as loadingContract,
   MobileBrowseGeometryContract as mobileBrowseGeometryContract,
   MobileExpandedGeometryContract as mobileExpandedGeometryContract,
+  MobileGridGeometryContract as mobileGridGeometryContract,
+  MobileRecentGridContract as mobileRecentGridContract,
+  RecentGridContract as recentGridContract,
+  WebGridGeometryContract as webGridGeometryContract,
 } from './FullReactionPicker.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -17,5 +21,9 @@ type Story = StoryObj<typeof meta>;
 
 export const InteractionContract: Story = interactionContract;
 export const LoadingContract: Story = loadingContract;
+export const MobileGridGeometryContract: Story = mobileGridGeometryContract;
 export const MobileBrowseGeometryContract: Story = mobileBrowseGeometryContract;
 export const MobileExpandedGeometryContract: Story = mobileExpandedGeometryContract;
+export const MobileRecentGridContract: Story = mobileRecentGridContract;
+export const RecentGridContract: Story = recentGridContract;
+export const WebGridGeometryContract: Story = webGridGeometryContract;

--- a/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
@@ -54,7 +54,10 @@ const meta = {
   },
   component: PostComposerMediaItemsTarget,
   excludeStories: ['InteractionContract', 'mixedMedia'],
-  parameters: { layout: 'padded' },
+  parameters: {
+    controls: { exclude: ['onEdit', 'onRemove', 'onRetry'] },
+    layout: 'padded',
+  },
   title: 'KOSMO/Components/Post Composer Media Items',
 } satisfies Meta<typeof PostComposerMediaItemsTarget>;
 

--- a/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
@@ -1,0 +1,111 @@
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { PostComposerMediaItemsTarget } from '@/components/post/PostComposerMediaItemsTarget';
+import ogImage from '../../../public/og-default.png?url';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
+
+const mediaAsset = { height: 156, uri: ogImage, width: 156 };
+
+export const mixedMedia: readonly ComposerMediaItem[] = [
+  { altText: '', asset: mediaAsset, key: 'uploading', state: 'uploading' },
+  {
+    altText: '밤하늘 아래 모인 사람들',
+    asset: mediaAsset,
+    key: 'ready-with-alt',
+    mediaId: 'media-ready-with-alt',
+    state: 'ready',
+  },
+  {
+    altText: '',
+    asset: mediaAsset,
+    failure: { reason: 'transient', stage: 'transfer' },
+    key: 'failed',
+    state: 'failed',
+  },
+  {
+    altText: '',
+    asset: mediaAsset,
+    key: 'ready-without-alt',
+    mediaId: 'media-ready-without-alt',
+    state: 'ready',
+  },
+];
+
+const meta = {
+  args: {
+    disabled: false,
+    media: mixedMedia,
+    onEdit: fn(),
+    onRemove: fn(),
+    onRetry: fn(),
+    sensitiveMedia: true,
+  },
+  argTypes: {
+    disabled: { control: 'boolean' },
+    media: { control: 'object' },
+    onEdit: { action: 'edit', control: false },
+    onRemove: { action: 'remove', control: false },
+    onRetry: { action: 'retry', control: false },
+    sensitiveMedia: { control: 'boolean' },
+  },
+  component: PostComposerMediaItemsTarget,
+  excludeStories: ['InteractionContract', 'mixedMedia'],
+  parameters: { layout: 'padded' },
+  title: 'KOSMO/Components/Post Composer Media Items',
+} satisfies Meta<typeof PostComposerMediaItemsTarget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Uploading: Story = {
+  args: { media: [mixedMedia[0]], sensitiveMedia: false },
+};
+
+export const Ready: Story = {
+  args: { media: [mixedMedia[1], mixedMedia[3]] },
+};
+
+export const Failed: Story = {
+  args: { media: [mixedMedia[2]], sensitiveMedia: false },
+};
+
+export const InteractionContract: Story = {
+  play: async ({ args, canvasElement }) => {
+    args.onEdit.mockClear();
+    args.onRemove.mockClear();
+    args.onRetry.mockClear();
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByLabelText('첨부 이미지 1, 업로드 중')).toHaveStyle({
+      height: '156px',
+      width: '156px',
+    });
+    expect(canvas.getByLabelText('첨부 이미지 2, 업로드 완료')).toBeVisible();
+    expect(canvas.getByLabelText('첨부 이미지 3, 업로드 실패')).toBeVisible();
+    expect(canvas.getByText('업로드 실패')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '첨부 이미지 2 ALT 편집' })).toBeVisible();
+    expect(canvas.getAllByRole('button', { name: /민감한 이미지 설정 편집/ })).toHaveLength(2);
+
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 대체 텍스트 편집' }));
+    expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'alt');
+
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 편집' }));
+    expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'alt');
+
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 ALT 편집' }));
+    expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'alt');
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: '첨부 이미지 2 민감한 이미지 설정 편집' }),
+    );
+    expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'sensitive');
+
+    await userEvent.click(canvas.getByRole('button', { name: '3번째 이미지 업로드 다시 시도' }));
+    expect(args.onRetry).toHaveBeenLastCalledWith(mixedMedia[2]);
+
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 1 제거' }));
+    expect(args.onRemove).toHaveBeenLastCalledWith('uploading');
+  },
+};

--- a/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
@@ -1,8 +1,12 @@
+import { useEffect, useState } from 'react';
 import { expect, fn, userEvent, within } from 'storybook/test';
+import { ComposerMediaEditor } from '@/components/post/ComposerMediaEditor';
 import { PostComposerMediaItemsTarget } from '@/components/post/PostComposerMediaItemsTarget';
 import ogImage from '../../../public/og-default.png?url';
+import { ComposerOverlayFixture } from '../fixtures/ComposerOverlayFixture';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
+import type { PostComposerMediaItemsTargetProps } from '@/components/post/PostComposerMediaItemsTarget';
 
 const mediaAsset = { height: 156, uri: ogImage, width: 156 };
 
@@ -57,7 +61,9 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = {};
+export const Playground: Story = {
+  render: (args) => <InteractiveMediaItems {...args} />,
+};
 
 export const Uploading: Story = {
   args: { media: [mixedMedia[0]], sensitiveMedia: false },
@@ -71,12 +77,73 @@ export const Failed: Story = {
   args: { media: [mixedMedia[2]], sensitiveMedia: false },
 };
 
+function InteractiveMediaItems(props: PostComposerMediaItemsTargetProps) {
+  const [media, setMedia] = useState(props.media);
+  const [sensitiveMedia, setSensitiveMedia] = useState(props.sensitiveMedia);
+  const [editor, setEditor] = useState<{ key: string; tool: 'alt' | 'sensitive' } | null>(null);
+  const [selectedKey, setSelectedKey] = useState(props.media[0]?.key ?? '');
+  const [tool, setTool] = useState<'alt' | 'sensitive'>('alt');
+
+  useEffect(() => setMedia(props.media), [props.media]);
+  useEffect(() => setSensitiveMedia(props.sensitiveMedia), [props.sensitiveMedia]);
+
+  return (
+    <>
+      <PostComposerMediaItemsTarget
+        {...props}
+        media={media}
+        onEdit={(key, nextTool) => {
+          props.onEdit(key, nextTool);
+          setEditor({ key, tool: nextTool });
+          setSelectedKey(key);
+          setTool(nextTool);
+        }}
+        onRemove={(key) => {
+          props.onRemove(key);
+          setMedia((current) => current.filter((item) => item.key !== key));
+        }}
+        onRetry={props.onRetry}
+        sensitiveMedia={sensitiveMedia}
+      />
+      <ComposerOverlayFixture
+        accessibilityLabel="미디어 편집"
+        maxWidth={920}
+        onRequestClose={() => setEditor(null)}
+        visible={editor !== null}
+      >
+        {editor ? (
+          <ComposerMediaEditor
+            media={media.filter((item) => item.state === 'ready')}
+            onAltTextChange={(key, altText) => {
+              setMedia((current) =>
+                current.map((item) => (item.key === key ? { ...item, altText } : item)),
+              );
+            }}
+            onBack={() => setEditor(null)}
+            onClose={() => setEditor(null)}
+            onDone={() => setEditor(null)}
+            onSelectMedia={(key) => setSelectedKey(key)}
+            onSensitiveMediaChange={setSensitiveMedia}
+            onToolChange={setTool}
+            presentation="web"
+            selectedKey={selectedKey}
+            sensitiveMedia={sensitiveMedia}
+            showImageEditPreview={false}
+            tool={tool}
+          />
+        ) : null}
+      </ComposerOverlayFixture>
+    </>
+  );
+}
+
 export const InteractionContract: Story = {
   play: async ({ args, canvasElement }) => {
     args.onEdit.mockClear();
     args.onRemove.mockClear();
     args.onRetry.mockClear();
     const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
 
     expect(canvas.getByLabelText('첨부 이미지 1, 업로드 중')).toHaveStyle({
       height: '156px',
@@ -90,17 +157,39 @@ export const InteractionContract: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 대체 텍스트 편집' }));
     expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'alt');
+    let dialog = page.getByRole('dialog', { name: '미디어 편집' });
+    expect(dialog).toBeVisible();
+    expect(within(dialog).getByRole('heading', { name: '미디어 편집' })).toBeVisible();
+    expect(within(dialog).getByRole('textbox', { name: '이미지 설명' })).toHaveValue(
+      '밤하늘 아래 모인 사람들',
+    );
+    await userEvent.type(within(dialog).getByRole('textbox', { name: '이미지 설명' }), ' 추가');
+    await userEvent.click(within(dialog).getByRole('button', { name: '완료' }));
+    expect(page.queryByRole('dialog', { name: '미디어 편집' })).toBeNull();
 
     await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 편집' }));
     expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'alt');
+    dialog = page.getByRole('dialog', { name: '미디어 편집' });
+    expect(within(dialog).getByRole('textbox', { name: '이미지 설명' })).toHaveValue(
+      '밤하늘 아래 모인 사람들 추가',
+    );
+    await userEvent.click(within(dialog).getByRole('button', { name: '미디어 편집에서 뒤로' }));
+    expect(page.queryByRole('dialog', { name: '미디어 편집' })).toBeNull();
 
     await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 ALT 편집' }));
     expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'alt');
+    dialog = page.getByRole('dialog', { name: '미디어 편집' });
+    await userEvent.click(within(dialog).getByRole('button', { name: '미디어 편집 닫기' }));
+    expect(page.queryByRole('dialog', { name: '미디어 편집' })).toBeNull();
 
     await userEvent.click(
       canvas.getByRole('button', { name: '첨부 이미지 2 민감한 이미지 설정 편집' }),
     );
     expect(args.onEdit).toHaveBeenLastCalledWith('ready-with-alt', 'sensitive');
+    dialog = page.getByRole('dialog', { name: '미디어 편집' });
+    expect(within(dialog).getByRole('switch', { name: '민감한 이미지' })).toBeVisible();
+    await userEvent.click(within(dialog).getByRole('button', { name: '완료' }));
+    expect(page.queryByRole('dialog', { name: '미디어 편집' })).toBeNull();
 
     await userEvent.click(canvas.getByRole('button', { name: '3번째 이미지 업로드 다시 시도' }));
     expect(args.onRetry).toHaveBeenLastCalledWith(mixedMedia[2]);
@@ -108,4 +197,5 @@ export const InteractionContract: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 1 제거' }));
     expect(args.onRemove).toHaveBeenLastCalledWith('uploading');
   },
+  render: (args) => <InteractiveMediaItems {...args} />,
 };

--- a/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.stories.tsx
@@ -80,7 +80,7 @@ export const Failed: Story = {
 function InteractiveMediaItems(props: PostComposerMediaItemsTargetProps) {
   const [media, setMedia] = useState(props.media);
   const [sensitiveMedia, setSensitiveMedia] = useState(props.sensitiveMedia);
-  const [editor, setEditor] = useState<{ key: string; tool: 'alt' | 'sensitive' } | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState(props.media[0]?.key ?? '');
   const [tool, setTool] = useState<'alt' | 'sensitive'>('alt');
 
@@ -94,7 +94,7 @@ function InteractiveMediaItems(props: PostComposerMediaItemsTargetProps) {
         media={media}
         onEdit={(key, nextTool) => {
           props.onEdit(key, nextTool);
-          setEditor({ key, tool: nextTool });
+          setEditorOpen(true);
           setSelectedKey(key);
           setTool(nextTool);
         }}
@@ -108,10 +108,10 @@ function InteractiveMediaItems(props: PostComposerMediaItemsTargetProps) {
       <ComposerOverlayFixture
         accessibilityLabel="미디어 편집"
         maxWidth={920}
-        onRequestClose={() => setEditor(null)}
-        visible={editor !== null}
+        onRequestClose={() => setEditorOpen(false)}
+        visible={editorOpen}
       >
-        {editor ? (
+        {editorOpen ? (
           <ComposerMediaEditor
             media={media.filter((item) => item.state === 'ready')}
             onAltTextChange={(key, altText) => {
@@ -119,9 +119,9 @@ function InteractiveMediaItems(props: PostComposerMediaItemsTargetProps) {
                 current.map((item) => (item.key === key ? { ...item, altText } : item)),
               );
             }}
-            onBack={() => setEditor(null)}
-            onClose={() => setEditor(null)}
-            onDone={() => setEditor(null)}
+            onBack={() => setEditorOpen(false)}
+            onClose={() => setEditorOpen(false)}
+            onDone={() => setEditorOpen(false)}
             onSelectMedia={(key) => setSelectedKey(key)}
             onSensitiveMediaChange={setSensitiveMedia}
             onToolChange={setTool}

--- a/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
@@ -48,9 +48,25 @@ export const HorizontalReachabilityContract: Story = {
     const laterItemAction = within(gallery).getByRole('button', {
       name: '첨부 이미지 4 편집',
     });
+    const previousButton = within(canvasElement).getByRole('button', {
+      name: '첨부 이미지 갤러리 이전',
+    });
+    const nextButton = within(canvasElement).getByRole('button', {
+      name: '첨부 이미지 갤러리 다음',
+    });
 
-    expect(getComputedStyle(gallery).scrollbarWidth).toBe('auto');
+    expect(getComputedStyle(gallery).scrollbarWidth).toBe('none');
     expect(gallery.scrollWidth).toBeGreaterThan(gallery.clientWidth);
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).not.toBeDisabled();
+    const initialArrowScrollLeft = gallery.scrollLeft;
+    await userEvent.click(nextButton);
+    expect(gallery.scrollLeft).toBeGreaterThan(initialArrowScrollLeft);
+    expect(previousButton).not.toBeDisabled();
+    for (let index = 0; index < 8 && !nextButton.hasAttribute('disabled'); index += 1) {
+      await userEvent.click(nextButton);
+    }
+    expect(nextButton).toBeDisabled();
     await userEvent.click(firstAction);
     const initialScrollLeft = gallery.scrollLeft;
     for (let index = 0; index < 12 && document.activeElement !== laterItemAction; index += 1) {

--- a/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
@@ -1,5 +1,5 @@
 import { View } from 'react-native';
-import { expect, fn, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 import { PostComposerMediaItemsTarget } from '@/components/post/PostComposerMediaItemsTarget';
 import baseMeta, {
   InteractionContract as interactionContract,
@@ -44,9 +44,19 @@ export const HorizontalReachabilityContract: Story = {
   ),
   play: async ({ canvasElement }) => {
     const gallery = within(canvasElement).getByLabelText('첨부 이미지 갤러리, 4개');
+    const firstAction = within(gallery).getByRole('button', { name: '첨부 이미지 1 제거' });
+    const laterItemAction = within(gallery).getByRole('button', {
+      name: '첨부 이미지 4 편집',
+    });
 
+    expect(getComputedStyle(gallery).scrollbarWidth).toBe('auto');
     expect(gallery.scrollWidth).toBeGreaterThan(gallery.clientWidth);
-    gallery.scrollLeft = gallery.scrollWidth;
-    expect(gallery.scrollLeft).toBeGreaterThan(0);
+    await userEvent.click(firstAction);
+    const initialScrollLeft = gallery.scrollLeft;
+    for (let index = 0; index < 12 && document.activeElement !== laterItemAction; index += 1) {
+      await userEvent.tab();
+    }
+    expect(laterItemAction).toHaveFocus();
+    expect(gallery.scrollLeft).toBeGreaterThan(initialScrollLeft);
   },
 };

--- a/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
@@ -1,5 +1,9 @@
+import { View } from 'react-native';
+import { expect, fn, within } from 'storybook/test';
+import { PostComposerMediaItemsTarget } from '@/components/post/PostComposerMediaItemsTarget';
 import baseMeta, {
   InteractionContract as interactionContract,
+  mixedMedia,
 } from './PostComposerMediaItems.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -13,3 +17,36 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const InteractionContract: Story = interactionContract;
+
+export const ControlsContract: Story = {
+  play: async () => {
+    const controls = baseMeta.parameters?.controls;
+
+    expect(controls?.exclude).toEqual(['onEdit', 'onRemove', 'onRetry']);
+    expect(baseMeta.argTypes?.onEdit?.action).toBe('edit');
+    expect(baseMeta.argTypes?.onRemove?.action).toBe('remove');
+    expect(baseMeta.argTypes?.onRetry?.action).toBe('retry');
+  },
+};
+
+export const HorizontalReachabilityContract: Story = {
+  render: () => (
+    <View style={{ width: 320 }}>
+      <PostComposerMediaItemsTarget
+        disabled={false}
+        media={mixedMedia}
+        onEdit={fn()}
+        onRemove={fn()}
+        onRetry={fn()}
+        sensitiveMedia
+      />
+    </View>
+  ),
+  play: async ({ canvasElement }) => {
+    const gallery = within(canvasElement).getByLabelText('첨부 이미지 갤러리, 4개');
+
+    expect(gallery.scrollWidth).toBeGreaterThan(gallery.clientWidth);
+    gallery.scrollLeft = gallery.scrollWidth;
+    expect(gallery.scrollLeft).toBeGreaterThan(0);
+  },
+};

--- a/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
@@ -1,0 +1,15 @@
+import baseMeta, {
+  InteractionContract as interactionContract,
+} from './PostComposerMediaItems.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Components/Post Composer Media Items/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;

--- a/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
+++ b/apps/app/src/stories/components/PostComposerMediaItems.tests.stories.tsx
@@ -18,17 +18,6 @@ type Story = StoryObj<typeof meta>;
 
 export const InteractionContract: Story = interactionContract;
 
-export const ControlsContract: Story = {
-  play: async () => {
-    const controls = baseMeta.parameters?.controls;
-
-    expect(controls?.exclude).toEqual(['onEdit', 'onRemove', 'onRetry']);
-    expect(baseMeta.argTypes?.onEdit?.action).toBe('edit');
-    expect(baseMeta.argTypes?.onRemove?.action).toBe('remove');
-    expect(baseMeta.argTypes?.onRetry?.action).toBe('retry');
-  },
-};
-
 export const HorizontalReachabilityContract: Story = {
   render: () => (
     <View style={{ width: 320 }}>

--- a/apps/app/src/stories/fixtures/ComposerOverlayFixture.tsx
+++ b/apps/app/src/stories/fixtures/ComposerOverlayFixture.tsx
@@ -34,9 +34,12 @@ export function ComposerOverlayFixture({
         <View
           accessibilityViewIsModal
           key={maxWidth}
+          testID="composer-overlay-surface"
           style={[styles.surface, { backgroundColor: theme.backgroundSurface, maxWidth }]}
         >
-          {children}
+          <View testID="composer-overlay-scroll" style={styles.scroll}>
+            {children}
+          </View>
         </View>
       </View>
     </Modal>
@@ -54,7 +57,8 @@ const styles = StyleSheet.create({
   surface: {
     borderRadius: radius[16],
     maxHeight: '85dvh' as never,
-    overflow: 'auto' as never,
+    overflow: 'hidden' as never,
     width: '100%',
   },
+  scroll: { maxHeight: '85dvh' as never, overflow: 'auto' as never, width: '100%' },
 });

--- a/apps/app/src/stories/fixtures/ComposerOverlayFixture.tsx
+++ b/apps/app/src/stories/fixtures/ComposerOverlayFixture.tsx
@@ -1,0 +1,59 @@
+import { Modal, StyleSheet, View } from 'react-native';
+import { useTheme } from '@/theme/ThemeProvider';
+import { radius, space } from '@/theme/tokens';
+import type { ReactNode } from 'react';
+
+type ComposerOverlayFixtureProps = Readonly<{
+  accessibilityLabel: string;
+  children: ReactNode;
+  maxWidth: number;
+  onRequestClose: () => void;
+  visible: boolean;
+}>;
+
+export function ComposerOverlayFixture({
+  accessibilityLabel,
+  children,
+  maxWidth,
+  onRequestClose,
+  visible,
+}: ComposerOverlayFixtureProps) {
+  const theme = useTheme();
+
+  return (
+    <Modal
+      accessibilityLabel={accessibilityLabel}
+      accessibilityViewIsModal
+      animationType="none"
+      onRequestClose={onRequestClose}
+      role="dialog"
+      transparent
+      visible={visible}
+    >
+      <View style={[styles.backdrop, { backgroundColor: theme.overlayScrim }]}>
+        <View
+          accessibilityViewIsModal
+          style={[styles.surface, { backgroundColor: theme.backgroundSurface, maxWidth }]}
+        >
+          {children}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    padding: space[24],
+    width: '100vw' as never,
+  },
+  surface: {
+    borderRadius: radius[16],
+    maxHeight: '85dvh' as never,
+    overflow: 'hidden',
+    width: '100%',
+  },
+});

--- a/apps/app/src/stories/fixtures/ComposerOverlayFixture.tsx
+++ b/apps/app/src/stories/fixtures/ComposerOverlayFixture.tsx
@@ -33,6 +33,7 @@ export function ComposerOverlayFixture({
       <View style={[styles.backdrop, { backgroundColor: theme.overlayScrim }]}>
         <View
           accessibilityViewIsModal
+          key={maxWidth}
           style={[styles.surface, { backgroundColor: theme.backgroundSurface, maxWidth }]}
         >
           {children}
@@ -53,7 +54,7 @@ const styles = StyleSheet.create({
   surface: {
     borderRadius: radius[16],
     maxHeight: '85dvh' as never,
-    overflow: 'hidden',
+    overflow: 'auto' as never,
     width: '100%',
   },
 });

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -304,6 +304,7 @@ function InteractiveComposer({
   ...props
 }: PostComposerTargetProps & { keyboard?: boolean; mobile?: boolean }) {
   const theme = useTheme();
+  const composerProps = { ...props, showPollAction: false };
   const [body, setBody] = useState(props.body);
   const [contentWarning, setContentWarning] = useState(props.contentWarning);
   const [contentWarningExpanded, setContentWarningExpanded] = useState(
@@ -466,7 +467,7 @@ function InteractiveComposer({
     <View style={styles.composition}>
       {mobile ? (
         <MobileFullscreenComposerShellCandidate
-          {...props}
+          {...composerProps}
           body={body}
           contentWarning={contentWarning}
           contentWarningExpanded={contentWarningExpanded}
@@ -512,7 +513,7 @@ function InteractiveComposer({
         />
       ) : (
         <PostComposerTarget
-          {...props}
+          {...composerProps}
           body={body}
           contentWarning={contentWarning}
           contentWarningExpanded={contentWarningExpanded}
@@ -611,7 +612,7 @@ function InteractiveComposer({
                 </IconButton>
               </View>
               <PostComposerTarget
-                {...props}
+                {...composerProps}
                 body={body}
                 contentWarning={contentWarning}
                 contentWarningExpanded={contentWarningExpanded}

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -328,8 +328,8 @@ function InteractiveComposer({
   } | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerQuery, setPickerQuery] = useState('');
-  const [activeCategory, setActiveCategory] = useState('expressions');
   const [pickerPosition, setPickerPosition] = useState({
+    height: 624,
     left: space[8] as number,
     top: space[8] as number,
   });
@@ -366,15 +366,23 @@ function InteractiveComposer({
 
     const bounds = trigger.getBoundingClientRect();
     const panelWidth = 360;
-    const panelHeight = 624;
+    const preferredPanelHeight = 624;
     const gap = space[8];
+    const panelHeight = Math.min(
+      preferredPanelHeight,
+      Math.max(0, storyWindow.innerHeight - gap * 2),
+    );
     const maxLeft = Math.max(gap, storyWindow.innerWidth - panelWidth - gap);
+    const maxTop = Math.max(gap, storyWindow.innerHeight - panelHeight - gap);
     setPickerPosition({
+      height: panelHeight,
       left: Math.min(Math.max(gap, bounds.right - panelWidth), maxLeft),
-      top:
+      top: Math.min(
         storyWindow.innerHeight - bounds.bottom >= panelHeight + gap
           ? bounds.bottom + gap
           : Math.max(gap, bounds.top - panelHeight - gap),
+        maxTop,
+      ),
     });
   }, [mobile, pickerOpen]);
 
@@ -400,13 +408,15 @@ function InteractiveComposer({
           styles.pickerPanel,
           mobile
             ? styles.mobilePickerPanel
-            : { left: pickerPosition.left, top: pickerPosition.top },
+            : {
+                height: pickerPosition.height,
+                left: pickerPosition.left,
+                top: pickerPosition.top,
+              },
         ]}
         testID="post-composer-emoji-picker"
       >
         <FullReactionPicker
-          activeCategory={activeCategory}
-          onCategoryChange={setActiveCategory}
           onQueryChange={setPickerQuery}
           onSelect={(option) => {
             const value = `${body}${option.emoji}`;
@@ -757,7 +767,10 @@ export const MobileCandidateContract: Story = {
     });
     expect(canvas.getByRole('heading', { name: '글쓰기' })).toBeVisible();
     expect(canvas.getByRole('button', { name: '글쓰기 닫기' })).toBeVisible();
+    const submit = canvas.getByRole('button', { name: '게시' });
     expect(canvas.getAllByRole('button', { name: '게시' })).toHaveLength(1);
+    expect(submit.getBoundingClientRect().height).toBe(40);
+    expect(submit.getBoundingClientRect().width).toBe(72);
     expect(canvas.getByLabelText('남은 글자 수 500자')).toBeVisible();
     expect(canvas.getByTestId('post-composer-progress-ring')).toBeVisible();
     expect(canvas.queryByRole('button', { name: 'Composer 확장' })).not.toBeInTheDocument();
@@ -818,9 +831,11 @@ export const OverlayProgressRingContract: Story = {
   args: { body: '오버레이 진행률', items: [], remaining: 250, surface: 'overlay' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const remaining = canvas.getByLabelText(/남은 글자 수 \d+자/);
     const ring = canvas.getByTestId('post-composer-progress-ring');
     const submit = canvas.getByRole('button', { name: '게시' });
 
+    expect(getComputedStyle(remaining).textAlign).toBe('right');
     expect(ring).toBeVisible();
     expect(ring).toHaveAttribute('aria-hidden', 'true');
     expect(ring.querySelectorAll('circle')).toHaveLength(2);
@@ -864,13 +879,11 @@ export const MobileMediaFooterGeometryContract: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const gallery = canvas.getByLabelText('첨부 이미지 갤러리, 1개');
-    const shelf = gallery.parentElement;
-    const footer = shelf?.nextElementSibling;
+    const shelf = canvas.getByTestId('mobile-composer-media-shelf');
+    const footer = canvas.getByTestId('mobile-composer-footer');
 
-    expect(shelf).not.toBeNull();
-    expect(footer).not.toBeNull();
     expect(shelf).toHaveStyle({ height: '164px', paddingBottom: '8px' });
-    expect(footer!.getBoundingClientRect().top - gallery.getBoundingClientRect().bottom).toBe(8);
+    expect(footer.getBoundingClientRect().top - gallery.getBoundingClientRect().bottom).toBe(8);
   },
 };
 
@@ -879,13 +892,11 @@ export const MobileKeyboardMediaFooterGeometryContract: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const gallery = canvas.getByLabelText('첨부 이미지 갤러리, 1개');
-    const shelf = gallery.parentElement;
-    const footer = shelf?.nextElementSibling;
+    const shelf = canvas.getByTestId('mobile-composer-media-shelf');
+    const footer = canvas.getByTestId('mobile-composer-footer');
 
-    expect(shelf).not.toBeNull();
-    expect(footer).not.toBeNull();
     expect(shelf).toHaveStyle({ height: '164px', paddingBottom: '8px' });
-    expect(footer!.getBoundingClientRect().top - gallery.getBoundingClientRect().bottom).toBe(8);
+    expect(footer.getBoundingClientRect().top - gallery.getBoundingClientRect().bottom).toBe(8);
   },
 };
 

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -11,6 +11,7 @@ import { Avatar } from '@/components/ui/Avatar';
 import { useTheme } from '@/theme/ThemeProvider';
 import { space, textStyles } from '@/theme/tokens';
 import ogImage from '../../../public/og-default.png?url';
+import { ComposerOverlayFixture } from '../fixtures/ComposerOverlayFixture';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
 import type { PostComposerTargetProps } from '@/components/post/PostComposerTarget';
@@ -245,9 +246,9 @@ function InteractiveComposer({
     props.contentWarningExpanded,
   );
   const [items, setItems] = useState(props.items);
-  const [surface, setSurface] = useState(props.surface);
   const [visibility, setVisibility] = useState(props.visibility);
   const [sensitiveMedia, setSensitiveMedia] = useState(props.sensitiveMedia);
+  const [overlayOpen, setOverlayOpen] = useState(false);
   const [editor, setEditor] = useState<{ key: string; tool: 'alt' | 'sensitive' } | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerQuery, setPickerQuery] = useState('');
@@ -260,11 +261,36 @@ function InteractiveComposer({
     [props.contentWarningExpanded],
   );
   useEffect(() => setItems(props.items), [props.items]);
-  useEffect(() => setSurface(props.surface), [props.surface]);
   useEffect(() => setVisibility(props.visibility), [props.visibility]);
   useEffect(() => setSensitiveMedia(props.sensitiveMedia), [props.sensitiveMedia]);
 
-  if (editor) {
+  const closeOverlay = () => {
+    setEditor(null);
+    setOverlayOpen(false);
+    setPickerOpen(false);
+  };
+
+  const picker = pickerOpen ? (
+    <View style={mobile ? styles.mobilePicker : styles.picker}>
+      <FullReactionPicker
+        activeCategory={activeCategory}
+        onCategoryChange={setActiveCategory}
+        onQueryChange={setPickerQuery}
+        onSelect={(option) => {
+          const value = `${body}${option.emoji}`;
+          props.onBodyChange(value);
+          setBody(value);
+          setPickerOpen(false);
+        }}
+        options={reactionOptions}
+        presentation={mobile ? 'mobile' : 'web'}
+        query={pickerQuery}
+        selectedValues={[]}
+      />
+    </View>
+  ) : null;
+
+  if (mobile && editor) {
     return (
       <ComposerMediaEditor
         media={items.filter((item) => item.state === 'ready')}
@@ -282,6 +308,7 @@ function InteractiveComposer({
         presentation={mobile ? 'mobile' : 'web'}
         selectedKey={editor.key}
         sensitiveMedia={sensitiveMedia}
+        showImageEditPreview={false}
         tool={editor.tool}
       />
     );
@@ -355,11 +382,12 @@ function InteractiveComposer({
           }}
           onExpand={() => {
             props.onExpand();
-            setSurface('overlay');
+            setOverlayOpen(true);
           }}
           onMediaEdit={(key, tool) => {
             props.onMediaEdit(key, tool);
             setEditor({ key, tool });
+            setOverlayOpen(true);
           }}
           onMediaRemove={(key) => {
             props.onMediaRemove(key);
@@ -371,35 +399,96 @@ function InteractiveComposer({
             setVisibility(value);
           }}
           sensitiveMedia={sensitiveMedia}
-          surface={surface}
+          surface={props.surface}
           visibility={visibility}
         />
       )}
-      {pickerOpen ? (
-        <View style={mobile ? styles.mobilePicker : styles.picker}>
-          <FullReactionPicker
-            activeCategory={activeCategory}
-            onCategoryChange={setActiveCategory}
-            onQueryChange={setPickerQuery}
-            onSelect={(option) => {
-              const value = `${body}${option.emoji}`;
-              props.onBodyChange(value);
-              setBody(value);
-              setPickerOpen(false);
-            }}
-            options={reactionOptions}
-            presentation={mobile ? 'mobile' : 'web'}
-            query={pickerQuery}
-            selectedValues={[]}
-          />
-        </View>
-      ) : null}
+      {!mobile && overlayOpen ? (
+        <ComposerOverlayFixture
+          accessibilityLabel="글쓰기"
+          maxWidth={editor ? 920 : 600}
+          onRequestClose={closeOverlay}
+          visible
+        >
+          {editor ? (
+            <ComposerMediaEditor
+              media={items.filter((item) => item.state === 'ready')}
+              onAltTextChange={(key, altText) => {
+                setItems((current) =>
+                  current.map((item) => (item.key === key ? { ...item, altText } : item)),
+                );
+              }}
+              onBack={() => setEditor(null)}
+              onClose={closeOverlay}
+              onDone={() => setEditor(null)}
+              onSelectMedia={(key) =>
+                setEditor((current) => (current ? { ...current, key } : current))
+              }
+              onSensitiveMediaChange={setSensitiveMedia}
+              onToolChange={(tool) =>
+                setEditor((current) => (current ? { ...current, tool } : current))
+              }
+              presentation="web"
+              selectedKey={editor.key}
+              sensitiveMedia={sensitiveMedia}
+              showImageEditPreview={false}
+              tool={editor.tool}
+            />
+          ) : (
+            <View style={styles.overlayContent}>
+              <PostComposerTarget
+                {...props}
+                body={body}
+                contentWarning={contentWarning}
+                contentWarningExpanded={contentWarningExpanded}
+                items={items}
+                onBodyChange={(value) => {
+                  props.onBodyChange(value);
+                  setBody(value);
+                }}
+                onContentWarningChange={(value) => {
+                  props.onContentWarningChange(value);
+                  setContentWarning(value);
+                }}
+                onContentWarningToggle={() => {
+                  props.onContentWarningToggle();
+                  setContentWarningExpanded((expanded) => !expanded);
+                }}
+                onEmojiAction={() => {
+                  props.onEmojiAction();
+                  setPickerOpen(true);
+                }}
+                onMediaEdit={(key, tool) => {
+                  props.onMediaEdit(key, tool);
+                  setEditor({ key, tool });
+                }}
+                onMediaRemove={(key) => {
+                  props.onMediaRemove(key);
+                  setItems((current) => current.filter((item) => item.key !== key));
+                }}
+                onMediaRetry={(key) => props.onMediaRetry(key)}
+                onVisibilityChange={(value) => {
+                  props.onVisibilityChange(value);
+                  setVisibility(value);
+                }}
+                sensitiveMedia={sensitiveMedia}
+                surface="overlay"
+                visibility={visibility}
+              />
+              {picker}
+            </View>
+          )}
+        </ComposerOverlayFixture>
+      ) : (
+        picker
+      )}
     </View>
   );
 }
 
 export const InteractionContract: Story = {
   play: async ({ args, canvasElement }) => {
+    args.onBodyChange.mockClear();
     args.onContentWarningChange.mockClear();
     args.onContentWarningToggle.mockClear();
     args.onEmojiAction.mockClear();
@@ -408,35 +497,56 @@ export const InteractionContract: Story = {
     args.onMediaRemove.mockClear();
     args.onMediaRetry.mockClear();
     const canvas = within(canvasElement);
-    const body = canvas.getByRole('textbox', { name: '게시물 내용' });
+    const page = within(canvasElement.ownerDocument.body);
+    const railBody = canvas.getByRole('textbox', { name: '게시물 내용' });
 
     await userEvent.click(canvas.getByRole('button', { name: 'Composer 확장' }));
     expect(args.onExpand).toHaveBeenCalledOnce();
-    expect(canvas.queryByRole('button', { name: 'Composer 확장' })).not.toBeInTheDocument();
-    expect(body).toHaveValue('오늘의 코스모 이야기를 나눠보세요.');
+    expect(railBody).toBeInTheDocument();
+    expect(canvas.getByRole('button', { name: 'Composer 확장' })).toBeInTheDocument();
 
-    await userEvent.click(canvas.getByRole('button', { name: '콘텐츠 경고 켜기' }));
+    const dialog = page.getByRole('dialog', { name: '글쓰기' });
+    expect(dialog).toBeVisible();
+    expect(page.getAllByRole('dialog')).toHaveLength(1);
+    expect(within(dialog).queryByRole('button', { name: 'Composer 확장' })).toBeNull();
+    const body = within(dialog).getByRole('textbox', { name: '게시물 내용' });
+    expect(body).toHaveValue('오늘의 코스모 이야기를 나눠보세요.');
+    await userEvent.type(body, ' 오버레이');
+    expect(args.onBodyChange).toHaveBeenLastCalledWith(
+      '오늘의 코스모 이야기를 나눠보세요. 오버레이',
+    );
+
+    await userEvent.click(within(dialog).getByRole('button', { name: '콘텐츠 경고 켜기' }));
     expect(args.onContentWarningToggle).toHaveBeenCalledOnce();
-    await userEvent.type(canvas.getByRole('textbox', { name: '콘텐츠 경고' }), '스포일러');
+    await userEvent.type(within(dialog).getByRole('textbox', { name: '콘텐츠 경고' }), '스포일러');
     expect(args.onContentWarningChange).toHaveBeenLastCalledWith('스포일러');
 
-    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 편집' }));
+    await userEvent.click(within(dialog).getByRole('button', { name: '첨부 이미지 2 편집' }));
     expect(args.onMediaEdit).toHaveBeenLastCalledWith('ready', 'alt');
-    expect(canvas.getByRole('heading', { name: '미디어 편집' })).toBeVisible();
-    await userEvent.click(canvas.getByRole('button', { name: '완료' }));
+    expect(within(dialog).getByRole('heading', { name: '미디어 편집' })).toBeVisible();
+    await userEvent.click(within(dialog).getByRole('button', { name: '완료' }));
+    expect(within(dialog).getByRole('textbox', { name: '게시물 내용' })).toHaveValue(
+      '오늘의 코스모 이야기를 나눠보세요. 오버레이',
+    );
 
-    await userEvent.click(canvas.getByRole('button', { name: '3번째 이미지 업로드 다시 시도' }));
+    await userEvent.click(
+      within(dialog).getByRole('button', { name: '3번째 이미지 업로드 다시 시도' }),
+    );
     expect(args.onMediaRetry).toHaveBeenLastCalledWith('failed');
-    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 1 제거' }));
+    await userEvent.click(within(dialog).getByRole('button', { name: '첨부 이미지 1 제거' }));
     expect(args.onMediaRemove).toHaveBeenLastCalledWith('uploading');
 
-    await userEvent.click(canvas.getByRole('button', { name: '이모지 추가' }));
+    await userEvent.click(within(dialog).getByRole('button', { name: '이모지 추가' }));
     expect(args.onEmojiAction).toHaveBeenCalledOnce();
-    expect(canvas.getByRole('dialog', { name: '반응 선택' })).toBeVisible();
-    await userEvent.click(canvas.getAllByRole('button', { name: '빨간 하트 ❤️' })[0]);
-    expect(canvas.getByRole('textbox', { name: '게시물 내용' })).toHaveValue(
-      '오늘의 코스모 이야기를 나눠보세요.❤️',
+    expect(page.getByRole('dialog', { name: '반응 선택' })).toBeVisible();
+    await userEvent.click(page.getAllByRole('button', { name: '빨간 하트 ❤️' })[0]);
+    expect(within(dialog).getByRole('textbox', { name: '게시물 내용' })).toHaveValue(
+      '오늘의 코스모 이야기를 나눠보세요. 오버레이❤️',
     );
+
+    await userEvent.keyboard('{Escape}');
+    expect(page.queryByRole('dialog', { name: '글쓰기' })).toBeNull();
+    expect(railBody).toHaveValue('오늘의 코스모 이야기를 나눠보세요. 오버레이❤️');
   },
   render: (args) => <InteractiveComposer {...args} />,
 };
@@ -497,4 +607,5 @@ const styles = StyleSheet.create({
     zIndex: 20,
   },
   picker: { position: 'absolute', right: 0, top: 72, zIndex: 20 },
+  overlayContent: { width: '100%' },
 });

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -152,6 +152,7 @@ const meta = {
   },
   component: PostComposerTarget,
   excludeStories: [
+    'ActionSemanticsContract',
     'InteractionContract',
     'MobileCandidateContract',
     'MobileKeyboardMediaFooterGeometryContract',
@@ -167,6 +168,7 @@ const meta = {
     'RailProgressRingContract',
     'SubmittingSpinnerContract',
     'SubmittingPickerContract',
+    'SubmittingVisibilityContract',
     'composerMedia',
   ],
   parameters: { controls: { disable: true }, layout: 'centered' },
@@ -794,6 +796,21 @@ export const PendingMediaContract: Story = {
   },
 };
 
+export const ActionSemanticsContract: Story = {
+  args: { body: 'Composer 동작 의미 검증', items: [], showPollAction: true, surface: 'rail' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    for (const name of ['이미지 추가', '투표 추가', '이모지 추가']) {
+      expect(canvas.getByRole('button', { name })).not.toHaveAttribute('aria-pressed');
+    }
+    expect(canvas.getByRole('button', { name: '콘텐츠 경고 켜기' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  },
+};
+
 export const MobileCandidateContract: Story = {
   ...MobileEmpty,
   play: async ({ canvasElement }) => {
@@ -930,6 +947,29 @@ export const SubmittingPickerContract: Story = {
     expect(canvas.getByRole('button', { name: '게시' })).toBeDisabled();
     expect(body).toHaveValue('제출 전 이모지 선택');
     expect(args.onBodyChange).not.toHaveBeenCalled();
+    expect(args.onSubmit).toHaveBeenCalledOnce();
+  },
+};
+
+export const SubmittingVisibilityContract: Story = {
+  ...Playground,
+  args: { body: '제출 전 공개 범위', items: [], surface: 'rail' },
+  render: (args) => <SubmittingPickerComposer {...args} />,
+  play: async ({ args, canvasElement }) => {
+    args.onSubmit.mockClear();
+    args.onVisibilityChange.mockClear();
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: '공개 범위: 조용한 공개' }));
+    expect(canvas.getByRole('radiogroup', { name: '공개 범위 선택' })).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: '게시' }));
+    await waitFor(() =>
+      expect(canvas.queryByRole('radiogroup', { name: '공개 범위 선택' })).toBeNull(),
+    );
+
+    expect(canvas.getByRole('button', { name: '공개 범위: 조용한 공개' })).toBeDisabled();
+    expect(args.onVisibilityChange).not.toHaveBeenCalled();
     expect(args.onSubmit).toHaveBeenCalledOnce();
   },
 };

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -1,9 +1,9 @@
 import { normalizePostContentPlainText } from '@kosmo/core/post-content';
 import { postBodyMaxLength } from '@kosmo/core/validation/post-policy';
 import { XIcon } from 'lucide-react-native';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { ComposerMediaEditor } from '@/components/post/ComposerMediaEditor';
 import {
   MobileFullscreenComposerShellCandidate,
@@ -166,6 +166,7 @@ const meta = {
     'ProgressRingToneContract',
     'RailProgressRingContract',
     'SubmittingSpinnerContract',
+    'SubmittingPickerContract',
     'composerMedia',
   ],
   parameters: { controls: { disable: true }, layout: 'centered' },
@@ -328,6 +329,7 @@ function InteractiveComposer({
   } | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerQuery, setPickerQuery] = useState('');
+  const pickerTriggerRef = useRef<HTMLElement | null>(null);
   const [pickerPosition, setPickerPosition] = useState({
     height: 624,
     left: space[8] as number,
@@ -337,6 +339,18 @@ function InteractiveComposer({
     postBodyMaxLength -
     normalizePostContentPlainText(body).length -
     normalizePostContentPlainText(contentWarning).length;
+  const closePicker = useCallback(() => {
+    setPickerOpen(false);
+    pickerTriggerRef.current?.focus();
+  }, []);
+  const togglePicker = () => {
+    props.onEmojiAction();
+    if (pickerOpen) {
+      closePicker();
+    } else {
+      setPickerOpen(true);
+    }
+  };
 
   useEffect(() => setBody(props.body), [props.body]);
   useEffect(() => setContentWarning(props.contentWarning), [props.contentWarning]);
@@ -347,6 +361,11 @@ function InteractiveComposer({
   useEffect(() => setItems(props.items), [props.items]);
   useEffect(() => setVisibility(props.visibility), [props.visibility]);
   useEffect(() => setSensitiveMedia(props.sensitiveMedia), [props.sensitiveMedia]);
+  useEffect(() => {
+    if (props.submitting) {
+      setPickerOpen(false);
+    }
+  }, [props.submitting]);
   useEffect(() => {
     if (mobile || !pickerOpen || typeof document === 'undefined') {
       return;
@@ -363,6 +382,7 @@ function InteractiveComposer({
     if (!trigger || !storyWindow) {
       return;
     }
+    pickerTriggerRef.current = trigger;
 
     const bounds = trigger.getBoundingClientRect();
     const panelWidth = 360;
@@ -385,20 +405,20 @@ function InteractiveComposer({
       ),
     });
   }, [mobile, pickerOpen]);
-
   const closeOverlay = () => {
     setEditor(null);
     setOverlayOpen(false);
     setPickerOpen(false);
   };
 
-  const picker = pickerOpen ? (
+  const shouldShowPicker = pickerOpen && !props.submitting;
+  const picker = shouldShowPicker ? (
     <View pointerEvents="box-none" style={mobile ? styles.mobilePicker : styles.pickerLayer}>
       {!mobile ? (
         <Pressable
           accessibilityLabel="반응 선택 닫기"
           accessibilityRole="button"
-          onPress={() => setPickerOpen(false)}
+          onPress={closePicker}
           style={styles.pickerDismiss}
         />
       ) : null}
@@ -417,12 +437,16 @@ function InteractiveComposer({
         testID="post-composer-emoji-picker"
       >
         <FullReactionPicker
+          onClose={closePicker}
           onQueryChange={setPickerQuery}
           onSelect={(option) => {
+            if (props.submitting) {
+              return;
+            }
             const value = `${body}${option.emoji}`;
             props.onBodyChange(value);
             setBody(value);
-            setPickerOpen(false);
+            closePicker();
           }}
           options={reactionOptions}
           presentation={mobile ? 'mobile' : 'web'}
@@ -503,10 +527,7 @@ function InteractiveComposer({
             props.onContentWarningToggle();
             setContentWarningExpanded((expanded) => !expanded);
           }}
-          onEmojiAction={() => {
-            props.onEmojiAction();
-            setPickerOpen(true);
-          }}
+          onEmojiAction={togglePicker}
           onMediaEdit={(key, tool) => {
             props.onMediaEdit(key, tool);
             setEditor({
@@ -548,10 +569,7 @@ function InteractiveComposer({
             props.onContentWarningToggle();
             setContentWarningExpanded((expanded) => !expanded);
           }}
-          onEmojiAction={() => {
-            props.onEmojiAction();
-            setPickerOpen(true);
-          }}
+          onEmojiAction={togglePicker}
           onExpand={() => {
             props.onExpand();
             setOverlayOpen(true);
@@ -647,10 +665,7 @@ function InteractiveComposer({
                   props.onContentWarningToggle();
                   setContentWarningExpanded((expanded) => !expanded);
                 }}
-                onEmojiAction={() => {
-                  props.onEmojiAction();
-                  setPickerOpen(true);
-                }}
+                onEmojiAction={togglePicker}
                 onMediaEdit={(key, tool) => {
                   props.onMediaEdit(key, tool);
                   setEditor({
@@ -680,6 +695,21 @@ function InteractiveComposer({
         picker
       )}
     </View>
+  );
+}
+
+function SubmittingPickerComposer(props: PostComposerTargetProps) {
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <InteractiveComposer
+      {...props}
+      onSubmit={() => {
+        props.onSubmit();
+        setSubmitting(true);
+      }}
+      submitting={submitting}
+    />
   );
 }
 
@@ -738,6 +768,13 @@ export const InteractionContract: Story = {
     await userEvent.click(within(dialog).getByRole('button', { name: '이모지 추가' }));
     expect(args.onEmojiAction).toHaveBeenCalledOnce();
     expect(page.getByRole('dialog', { name: '반응 선택' })).toBeVisible();
+    page.getAllByRole('button', { name: '감동 🥹' })[0].focus();
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(page.queryByRole('dialog', { name: '반응 선택' })).toBeNull());
+    expect(page.getByRole('dialog', { name: '글쓰기' })).toBeVisible();
+    expect(within(dialog).getByRole('button', { name: '이모지 추가' })).toHaveFocus();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: '이모지 추가' }));
     await userEvent.click(page.getAllByRole('button', { name: '빨간 하트 ❤️' })[0]);
     expect(within(dialog).getByRole('textbox', { name: '게시물 내용' })).toHaveValue(
       '오늘의 코스모 이야기를 나눠보세요. 오버레이❤️',
@@ -871,6 +908,29 @@ export const SubmittingSpinnerContract: Story = {
     expect(submit).toBeDisabled();
     expect(canvas.getByLabelText('게시 처리 중')).toBeVisible();
     expect(canvas.queryByText('게시 중')).toBeNull();
+  },
+};
+
+export const SubmittingPickerContract: Story = {
+  ...Playground,
+  args: { body: '제출 전 이모지 선택', items: [], surface: 'rail' },
+  render: (args) => <SubmittingPickerComposer {...args} />,
+  play: async ({ args, canvasElement }) => {
+    args.onBodyChange.mockClear();
+    args.onSubmit.mockClear();
+    const canvas = within(canvasElement);
+    const body = canvas.getByRole('textbox', { name: '게시물 내용' });
+
+    await userEvent.click(canvas.getByRole('button', { name: '이모지 추가' }));
+    expect(await canvas.findByTestId('post-composer-emoji-picker')).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: '게시' }));
+    await waitFor(() => expect(canvas.queryByTestId('post-composer-emoji-picker')).toBeNull());
+
+    expect(canvas.getByRole('button', { name: '게시' })).toBeDisabled();
+    expect(body).toHaveValue('제출 전 이모지 선택');
+    expect(args.onBodyChange).not.toHaveBeenCalled();
+    expect(args.onSubmit).toHaveBeenCalledOnce();
   },
 };
 

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -159,7 +159,6 @@ const meta = {
     'MobileMediaFooterGeometryContract',
     'MobilePlaygroundContract',
     'PendingMediaContract',
-    'StateContract',
     'composerMedia',
   ],
   parameters: { controls: { disable: true }, layout: 'centered' },
@@ -177,7 +176,6 @@ export const Playground: Story = {
         'body',
         'contentWarning',
         'contentWarningExpanded',
-        'error',
         'sensitiveMedia',
         'showCWAction',
         'showEmojiAction',
@@ -189,7 +187,7 @@ export const Playground: Story = {
       ],
     },
   },
-  render: (args) => <InteractiveComposer {...args} />,
+  render: (args) => <InteractiveComposer {...args} showPollAction={false} />,
 };
 
 export const RailEmptyPublic: Story = {
@@ -819,15 +817,6 @@ export const MobileKeyboardContract: Story = {
     expect(within(canvasElement).getByTestId('illustrative-system-keyboard')).toHaveStyle({
       height: '336px',
     });
-  },
-};
-
-export const StateContract: Story = {
-  args: { error: '게시글을 작성하지 못했습니다.', items: [] },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    expect(canvas.getByRole('alert')).toHaveTextContent('게시글을 작성하지 못했습니다.');
-    expect(canvas.getByRole('button', { name: '게시' })).toBeEnabled();
   },
 };
 

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -1,3 +1,4 @@
+import { XIcon } from 'lucide-react-native';
 import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { expect, fn, userEvent, within } from 'storybook/test';
@@ -8,11 +9,13 @@ import {
 } from '@/components/post/PostComposerTarget';
 import { FullReactionPicker } from '@/components/reaction/FullReactionPicker';
 import { Avatar } from '@/components/ui/Avatar';
+import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
-import { space, textStyles } from '@/theme/tokens';
+import { borderWidths, iconSizes, space, textStyles } from '@/theme/tokens';
 import ogImage from '../../../public/og-default.png?url';
 import { ComposerOverlayFixture } from '../fixtures/ComposerOverlayFixture';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComposerMediaEditorMobileState } from '@/components/post/ComposerMediaEditor';
 import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
 import type { PostComposerTargetProps } from '@/components/post/PostComposerTarget';
 
@@ -148,7 +151,10 @@ const meta = {
   excludeStories: [
     'InteractionContract',
     'MobileCandidateContract',
+    'MobileKeyboardMediaFooterGeometryContract',
     'MobileKeyboardContract',
+    'MobileMediaFooterGeometryContract',
+    'MobilePlaygroundContract',
     'PendingMediaContract',
     'StateContract',
     'composerMedia',
@@ -194,6 +200,13 @@ export const CompactOverlay: Story = {
 const mobileGlobals = { viewport: { isRotated: false, value: 'kosmoMobile' } } as const;
 const mobileParameters = { layout: 'fullscreen' } as const;
 
+export const MobilePlayground: Story = {
+  args: { items: readyComposerMedia, surface: 'overlay' },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+  render: (args) => <InteractiveComposer {...args} mobile />,
+};
+
 export const MobileEmpty: Story = {
   args: { body: '', items: [], remaining: 500, surface: 'overlay' },
   globals: mobileGlobals,
@@ -202,10 +215,7 @@ export const MobileEmpty: Story = {
 };
 
 export const MobileMedia: Story = {
-  args: { items: readyComposerMedia, surface: 'overlay' },
-  globals: mobileGlobals,
-  parameters: mobileParameters,
-  render: (args) => <InteractiveComposer {...args} mobile />,
+  ...MobilePlayground,
 };
 
 export const MobileCW: Story = {
@@ -240,6 +250,7 @@ function InteractiveComposer({
   mobile = false,
   ...props
 }: PostComposerTargetProps & { keyboard?: boolean; mobile?: boolean }) {
+  const theme = useTheme();
   const [body, setBody] = useState(props.body);
   const [contentWarning, setContentWarning] = useState(props.contentWarning);
   const [contentWarningExpanded, setContentWarningExpanded] = useState(
@@ -249,7 +260,11 @@ function InteractiveComposer({
   const [visibility, setVisibility] = useState(props.visibility);
   const [sensitiveMedia, setSensitiveMedia] = useState(props.sensitiveMedia);
   const [overlayOpen, setOverlayOpen] = useState(false);
-  const [editor, setEditor] = useState<{ key: string; tool: 'alt' | 'sensitive' } | null>(null);
+  const [editor, setEditor] = useState<{
+    key: string;
+    mobileState: ComposerMediaEditorMobileState;
+    tool: 'alt' | 'sensitive';
+  } | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerQuery, setPickerQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState('expressions');
@@ -294,6 +309,7 @@ function InteractiveComposer({
     return (
       <ComposerMediaEditor
         media={items.filter((item) => item.state === 'ready')}
+        mobileState={editor.mobileState}
         onAltTextChange={(key, altText) => {
           setItems((current) =>
             current.map((item) => (item.key === key ? { ...item, altText } : item)),
@@ -302,9 +318,31 @@ function InteractiveComposer({
         onBack={() => setEditor(null)}
         onClose={() => setEditor(null)}
         onDone={() => setEditor(null)}
+        onPreviewPress={
+          editor.mobileState === 'altKeyboard'
+            ? () =>
+                setEditor((current) => (current ? { ...current, mobileState: 'default' } : current))
+            : undefined
+        }
         onSelectMedia={(key) => setEditor((current) => (current ? { ...current, key } : current))}
         onSensitiveMediaChange={setSensitiveMedia}
-        onToolChange={(tool) => setEditor((current) => (current ? { ...current, tool } : current))}
+        onToolChange={(tool) =>
+          setEditor((current) => {
+            if (!current) {
+              return current;
+            }
+            return {
+              ...current,
+              mobileState:
+                tool === 'sensitive'
+                  ? 'sensitive'
+                  : current.mobileState === 'altKeyboard'
+                    ? 'default'
+                    : 'altKeyboard',
+              tool,
+            };
+          })
+        }
         presentation={mobile ? 'mobile' : 'web'}
         selectedKey={editor.key}
         sensitiveMedia={sensitiveMedia}
@@ -342,7 +380,11 @@ function InteractiveComposer({
           }}
           onMediaEdit={(key, tool) => {
             props.onMediaEdit(key, tool);
-            setEditor({ key, tool });
+            setEditor({
+              key,
+              mobileState: tool === 'alt' ? 'altKeyboard' : 'sensitive',
+              tool,
+            });
           }}
           onMediaRemove={(key) => {
             props.onMediaRemove(key);
@@ -386,7 +428,11 @@ function InteractiveComposer({
           }}
           onMediaEdit={(key, tool) => {
             props.onMediaEdit(key, tool);
-            setEditor({ key, tool });
+            setEditor({
+              key,
+              mobileState: tool === 'alt' ? 'altKeyboard' : 'sensitive',
+              tool,
+            });
             setOverlayOpen(true);
           }}
           onMediaRemove={(key) => {
@@ -436,6 +482,22 @@ function InteractiveComposer({
             />
           ) : (
             <View style={styles.overlayContent}>
+              <View style={[styles.overlayHeader, { borderColor: theme.borderSubtle }]}>
+                <Text
+                  accessibilityRole="header"
+                  style={[styles.overlayTitle, { color: theme.foregroundPrimary }]}
+                >
+                  글쓰기
+                </Text>
+                <IconButton
+                  accessibilityLabel="글쓰기 닫기"
+                  onPress={closeOverlay}
+                  style={styles.overlayClose}
+                  targetSize={40}
+                >
+                  <XIcon color={theme.foregroundPrimary} size={iconSizes[20]} strokeWidth={2} />
+                </IconButton>
+              </View>
               <PostComposerTarget
                 {...props}
                 body={body}
@@ -460,7 +522,11 @@ function InteractiveComposer({
                 }}
                 onMediaEdit={(key, tool) => {
                   props.onMediaEdit(key, tool);
-                  setEditor({ key, tool });
+                  setEditor({
+                    key,
+                    mobileState: tool === 'alt' ? 'altKeyboard' : 'sensitive',
+                    tool,
+                  });
                 }}
                 onMediaRemove={(key) => {
                   props.onMediaRemove(key);
@@ -508,6 +574,8 @@ export const InteractionContract: Story = {
     const dialog = page.getByRole('dialog', { name: '글쓰기' });
     expect(dialog).toBeVisible();
     expect(page.getAllByRole('dialog')).toHaveLength(1);
+    expect(within(dialog).getByRole('heading', { name: '글쓰기' })).toBeVisible();
+    expect(within(dialog).getByRole('button', { name: '글쓰기 닫기' })).toBeVisible();
     expect(within(dialog).queryByRole('button', { name: 'Composer 확장' })).toBeNull();
     const body = within(dialog).getByRole('textbox', { name: '게시물 내용' });
     expect(body).toHaveValue('오늘의 코스모 이야기를 나눠보세요.');
@@ -544,7 +612,7 @@ export const InteractionContract: Story = {
       '오늘의 코스모 이야기를 나눠보세요. 오버레이❤️',
     );
 
-    await userEvent.keyboard('{Escape}');
+    await userEvent.click(within(dialog).getByRole('button', { name: '글쓰기 닫기' }));
     expect(page.queryByRole('dialog', { name: '글쓰기' })).toBeNull();
     expect(railBody).toHaveValue('오늘의 코스모 이야기를 나눠보세요. 오버레이❤️');
   },
@@ -571,6 +639,62 @@ export const MobileCandidateContract: Story = {
     expect(canvas.getAllByRole('button', { name: '게시' })).toHaveLength(1);
     expect(canvas.getByLabelText('남은 글자 수 500자')).toBeVisible();
     expect(canvas.queryByRole('button', { name: 'Composer 확장' })).not.toBeInTheDocument();
+  },
+};
+
+export const MobilePlaygroundContract: Story = {
+  ...MobilePlayground,
+  play: async ({ args, canvasElement }) => {
+    args.onVisibilityChange.mockClear();
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: '공개 범위: 조용한 공개' }));
+
+    const menu = canvas.getByRole('radiogroup', { name: '공개 범위 선택' });
+    expect(within(menu).getAllByRole('radio')).toHaveLength(3);
+
+    await userEvent.click(within(menu).getByRole('radio', { name: '공개' }));
+    expect(args.onVisibilityChange).toHaveBeenLastCalledWith('PUBLIC');
+    expect(canvas.getByRole('button', { name: '공개 범위: 공개' })).toBeVisible();
+    expect(canvas.queryByRole('radiogroup', { name: '공개 범위 선택' })).toBeNull();
+
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 1 편집' }));
+    expect(canvas.getByRole('heading', { name: '미디어 편집' })).toBeVisible();
+    expect(canvas.getByTestId('mobile-composer-media-editor-keyboard')).toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '선택한 첨부 이미지 1 미리보기' }));
+    expect(canvas.queryByTestId('mobile-composer-media-editor-keyboard')).toBeNull();
+    await userEvent.click(canvas.getByRole('button', { name: '완료' }));
+    expect(canvas.getByRole('heading', { name: '글쓰기' })).toBeVisible();
+  },
+};
+
+export const MobileMediaFooterGeometryContract: Story = {
+  ...MobilePlayground,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const gallery = canvas.getByLabelText('첨부 이미지 갤러리, 1개');
+    const shelf = gallery.parentElement;
+    const footer = shelf?.nextElementSibling;
+
+    expect(shelf).not.toBeNull();
+    expect(footer).not.toBeNull();
+    expect(shelf).toHaveStyle({ height: '164px', paddingBottom: '8px' });
+    expect(footer!.getBoundingClientRect().top - gallery.getBoundingClientRect().bottom).toBe(8);
+  },
+};
+
+export const MobileKeyboardMediaFooterGeometryContract: Story = {
+  ...MobileKeyboardMedia,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const gallery = canvas.getByLabelText('첨부 이미지 갤러리, 1개');
+    const shelf = gallery.parentElement;
+    const footer = shelf?.nextElementSibling;
+
+    expect(shelf).not.toBeNull();
+    expect(footer).not.toBeNull();
+    expect(shelf).toHaveStyle({ height: '164px', paddingBottom: '8px' });
+    expect(footer!.getBoundingClientRect().top - gallery.getBoundingClientRect().bottom).toBe(8);
   },
 };
 
@@ -606,6 +730,15 @@ const styles = StyleSheet.create({
     top: 0,
     zIndex: 20,
   },
+  overlayClose: { position: 'absolute', right: space[16], top: space[12] },
   picker: { position: 'absolute', right: 0, top: 72, zIndex: 20 },
   overlayContent: { width: '100%' },
+  overlayHeader: {
+    alignItems: 'center',
+    borderBottomWidth: borderWidths[1],
+    height: 64,
+    justifyContent: 'center',
+    width: '100%',
+  },
+  overlayTitle: textStyles.uiHeadingS,
 });

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -156,6 +156,8 @@ const meta = {
     'MobileCandidateContract',
     'MobileKeyboardMediaFooterGeometryContract',
     'MobileKeyboardContract',
+    'MobileKeyboardCWEditorGeometryContract',
+    'MobileKeyboardMediaEditorGeometryContract',
     'MobileMediaFooterGeometryContract',
     'MobilePlaygroundContract',
     'MobileFlexLayoutContract',
@@ -887,6 +889,26 @@ export const MobileKeyboardMediaFooterGeometryContract: Story = {
   },
 };
 
+export const MobileKeyboardMediaEditorGeometryContract: Story = {
+  ...MobileKeyboardMedia,
+  play: async ({ canvasElement }) => {
+    expectMobileEditorFitsMediaShelf(canvasElement);
+  },
+};
+
+export const MobileKeyboardCWEditorGeometryContract: Story = {
+  ...MobileKeyboardCW,
+  args: {
+    contentWarning: '스포일러가 포함되어 있어요.',
+    contentWarningExpanded: true,
+    items: readyComposerMedia,
+    surface: 'overlay',
+  },
+  play: async ({ canvasElement }) => {
+    expectMobileEditorFitsMediaShelf(canvasElement);
+  },
+};
+
 export const MobileKeyboardContract: Story = {
   ...MobileKeyboardMedia,
   play: async ({ canvasElement }) => {
@@ -895,6 +917,20 @@ export const MobileKeyboardContract: Story = {
     });
   },
 };
+
+function expectMobileEditorFitsMediaShelf(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  const editor = canvas.getByRole('textbox', { name: '게시물 내용' });
+  const editorOuter = editor.parentElement;
+  const shelf = canvas.getByLabelText('첨부 이미지 갤러리, 1개').parentElement;
+
+  expect(editorOuter).not.toBeNull();
+  expect(getComputedStyle(editorOuter!).flexGrow).toBe('1');
+  expect(shelf).not.toBeNull();
+  expect(editorOuter!.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+    shelf!.getBoundingClientRect().top,
+  );
+}
 
 const styles = StyleSheet.create({
   author: { alignItems: 'center', flexDirection: 'row', gap: space[12] },

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -1,0 +1,500 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { ComposerMediaEditor } from '@/components/post/ComposerMediaEditor';
+import {
+  MobileFullscreenComposerShellCandidate,
+  PostComposerTarget,
+} from '@/components/post/PostComposerTarget';
+import { FullReactionPicker } from '@/components/reaction/FullReactionPicker';
+import { Avatar } from '@/components/ui/Avatar';
+import { useTheme } from '@/theme/ThemeProvider';
+import { space, textStyles } from '@/theme/tokens';
+import ogImage from '../../../public/og-default.png?url';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
+import type { PostComposerTargetProps } from '@/components/post/PostComposerTarget';
+
+const mediaAsset = { height: 390, uri: ogImage, width: 560 };
+
+export const composerMedia: readonly ComposerMediaItem[] = [
+  { altText: '', asset: mediaAsset, key: 'uploading', state: 'uploading' },
+  {
+    altText: '노을빛 밤하늘 아래 모인 사람들',
+    asset: mediaAsset,
+    key: 'ready',
+    mediaId: 'media-ready',
+    state: 'ready',
+  },
+  {
+    altText: '',
+    asset: mediaAsset,
+    failure: { reason: 'transient', stage: 'transfer' },
+    key: 'failed',
+    state: 'failed',
+  },
+];
+
+const readyComposerMedia = composerMedia.filter((item) => item.state === 'ready');
+const onMobileClose = fn();
+
+const reactionOptions = [
+  {
+    category: 'expressions',
+    categoryLabel: '표정과 감정',
+    emoji: '🥹',
+    id: 'moved',
+    keywords: ['감동'],
+    label: '감동',
+    quick: true,
+  },
+  {
+    category: 'symbols',
+    categoryLabel: '기호',
+    emoji: '❤️',
+    id: 'heart-red',
+    keywords: ['하트', '사랑'],
+    label: '빨간 하트',
+    quick: true,
+    recent: true,
+  },
+  {
+    category: 'gestures',
+    categoryLabel: '사람과 몸짓',
+    emoji: '👏',
+    id: 'clap',
+    keywords: ['박수'],
+    label: '박수',
+    recent: true,
+  },
+] as const;
+
+function Author() {
+  const theme = useTheme();
+  return (
+    <View style={styles.author}>
+      <Avatar label="코스모 작가" />
+      <View style={styles.authorCopy}>
+        <Text style={[styles.authorName, { color: theme.foregroundPrimary }]}>코스모 작가</Text>
+        <Text style={[styles.authorHandle, { color: theme.foregroundSecondary }]}>@kosmo</Text>
+      </View>
+    </View>
+  );
+}
+
+const meta = {
+  args: {
+    author: <Author />,
+    body: '오늘의 코스모 이야기를 나눠보세요.',
+    contentWarning: '',
+    contentWarningExpanded: false,
+    error: undefined,
+    items: composerMedia,
+    onBodyChange: fn(),
+    onContentWarningChange: fn(),
+    onContentWarningToggle: fn(),
+    onEmojiAction: fn(),
+    onExpand: fn(),
+    onMediaAction: fn(),
+    onMediaEdit: fn(),
+    onMediaRemove: fn(),
+    onMediaRetry: fn(),
+    onPollAction: fn(),
+    onSubmit: fn(),
+    onVisibilityChange: fn(),
+    remaining: 450,
+    sensitiveMedia: false,
+    showCWAction: true,
+    showEmojiAction: true,
+    showMediaAction: true,
+    showPollAction: true,
+    showSubmit: true,
+    submitting: false,
+    surface: 'rail',
+    visibility: 'UNLISTED',
+  },
+  argTypes: {
+    author: { control: false },
+    body: { control: 'text' },
+    contentWarning: { control: 'text' },
+    contentWarningExpanded: { control: 'boolean' },
+    error: { control: 'text' },
+    items: { control: 'object' },
+    onBodyChange: { action: 'bodyChange', control: false },
+    onContentWarningChange: { action: 'contentWarningChange', control: false },
+    onContentWarningToggle: { action: 'contentWarningToggle', control: false },
+    onEmojiAction: { action: 'emojiAction', control: false },
+    onExpand: { action: 'expand', control: false },
+    onMediaAction: { action: 'mediaAction', control: false },
+    onMediaEdit: { action: 'mediaEdit', control: false },
+    onMediaRemove: { action: 'mediaRemove', control: false },
+    onMediaRetry: { action: 'mediaRetry', control: false },
+    onPollAction: { action: 'pollAction', control: false },
+    onSubmit: { action: 'submit', control: false },
+    onVisibilityChange: { action: 'visibilityChange', control: false },
+    remaining: { control: { max: 500, min: -10, step: 1, type: 'range' } },
+    sensitiveMedia: { control: 'boolean' },
+    showCWAction: { control: 'boolean' },
+    showEmojiAction: { control: 'boolean' },
+    showMediaAction: { control: 'boolean' },
+    showPollAction: { control: 'boolean' },
+    showSubmit: { control: 'boolean' },
+    submitting: { control: 'boolean' },
+    surface: { control: 'inline-radio', options: ['rail', 'overlay'] },
+    visibility: { control: 'select', options: ['PUBLIC', 'UNLISTED', 'FOLLOWERS'] },
+  },
+  component: PostComposerTarget,
+  excludeStories: [
+    'InteractionContract',
+    'MobileCandidateContract',
+    'MobileKeyboardContract',
+    'PendingMediaContract',
+    'StateContract',
+    'composerMedia',
+  ],
+  parameters: { layout: 'centered' },
+  title: 'KOSMO/Patterns/Post Composer Target',
+} satisfies Meta<typeof PostComposerTarget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = { render: (args) => <InteractiveComposer {...args} /> };
+
+export const RailEmptyPublic: Story = {
+  args: { body: '', items: [], remaining: 500, surface: 'rail', visibility: 'PUBLIC' },
+};
+
+export const RailFilledUnlistedCW: Story = {
+  args: { contentWarning: '스포일러가 포함되어 있어요.', contentWarningExpanded: true, items: [] },
+};
+
+export const OverlayMediaFollowers: Story = {
+  args: { surface: 'overlay', visibility: 'FOLLOWERS' },
+  render: (args) => (
+    <View style={{ width: 600 }}>
+      <InteractiveComposer {...args} />
+    </View>
+  ),
+};
+
+export const Submitting: Story = { args: { items: [], submitting: true } };
+export const Error: Story = { args: { error: '게시글을 작성하지 못했습니다.', items: [] } };
+
+export const CompactOverlay: Story = {
+  args: { surface: 'overlay' },
+  render: (args) => (
+    <View style={{ width: 480 }}>
+      <InteractiveComposer {...args} />
+    </View>
+  ),
+};
+
+const mobileGlobals = { viewport: { isRotated: false, value: 'kosmoMobile' } } as const;
+const mobileParameters = { layout: 'fullscreen' } as const;
+
+export const MobileEmpty: Story = {
+  args: { body: '', items: [], remaining: 500, surface: 'overlay' },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+  render: (args) => <InteractiveComposer {...args} mobile />,
+};
+
+export const MobileMedia: Story = {
+  args: { items: readyComposerMedia, surface: 'overlay' },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+  render: (args) => <InteractiveComposer {...args} mobile />,
+};
+
+export const MobileCW: Story = {
+  args: {
+    contentWarning: '스포일러가 포함되어 있어요.',
+    contentWarningExpanded: true,
+    items: [],
+    surface: 'overlay',
+  },
+  globals: mobileGlobals,
+  parameters: mobileParameters,
+  render: (args) => <InteractiveComposer {...args} mobile />,
+};
+
+export const MobileKeyboardEmpty: Story = {
+  ...MobileEmpty,
+  render: (args) => <InteractiveComposer {...args} keyboard mobile />,
+};
+
+export const MobileKeyboardMedia: Story = {
+  ...MobileMedia,
+  render: (args) => <InteractiveComposer {...args} keyboard mobile />,
+};
+
+export const MobileKeyboardCW: Story = {
+  ...MobileCW,
+  render: (args) => <InteractiveComposer {...args} keyboard mobile />,
+};
+
+function InteractiveComposer({
+  keyboard = false,
+  mobile = false,
+  ...props
+}: PostComposerTargetProps & { keyboard?: boolean; mobile?: boolean }) {
+  const [body, setBody] = useState(props.body);
+  const [contentWarning, setContentWarning] = useState(props.contentWarning);
+  const [contentWarningExpanded, setContentWarningExpanded] = useState(
+    props.contentWarningExpanded,
+  );
+  const [items, setItems] = useState(props.items);
+  const [surface, setSurface] = useState(props.surface);
+  const [visibility, setVisibility] = useState(props.visibility);
+  const [sensitiveMedia, setSensitiveMedia] = useState(props.sensitiveMedia);
+  const [editor, setEditor] = useState<{ key: string; tool: 'alt' | 'sensitive' } | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerQuery, setPickerQuery] = useState('');
+  const [activeCategory, setActiveCategory] = useState('expressions');
+
+  useEffect(() => setBody(props.body), [props.body]);
+  useEffect(() => setContentWarning(props.contentWarning), [props.contentWarning]);
+  useEffect(
+    () => setContentWarningExpanded(props.contentWarningExpanded),
+    [props.contentWarningExpanded],
+  );
+  useEffect(() => setItems(props.items), [props.items]);
+  useEffect(() => setSurface(props.surface), [props.surface]);
+  useEffect(() => setVisibility(props.visibility), [props.visibility]);
+  useEffect(() => setSensitiveMedia(props.sensitiveMedia), [props.sensitiveMedia]);
+
+  if (editor) {
+    return (
+      <ComposerMediaEditor
+        media={items.filter((item) => item.state === 'ready')}
+        onAltTextChange={(key, altText) => {
+          setItems((current) =>
+            current.map((item) => (item.key === key ? { ...item, altText } : item)),
+          );
+        }}
+        onBack={() => setEditor(null)}
+        onClose={() => setEditor(null)}
+        onDone={() => setEditor(null)}
+        onSelectMedia={(key) => setEditor((current) => (current ? { ...current, key } : current))}
+        onSensitiveMediaChange={setSensitiveMedia}
+        onToolChange={(tool) => setEditor((current) => (current ? { ...current, tool } : current))}
+        presentation={mobile ? 'mobile' : 'web'}
+        selectedKey={editor.key}
+        sensitiveMedia={sensitiveMedia}
+        tool={editor.tool}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.composition}>
+      {mobile ? (
+        <MobileFullscreenComposerShellCandidate
+          {...props}
+          body={body}
+          contentWarning={contentWarning}
+          contentWarningExpanded={contentWarningExpanded}
+          items={items}
+          keyboard={keyboard}
+          onBodyChange={(value) => {
+            props.onBodyChange(value);
+            setBody(value);
+          }}
+          onContentWarningChange={(value) => {
+            props.onContentWarningChange(value);
+            setContentWarning(value);
+          }}
+          onContentWarningToggle={() => {
+            props.onContentWarningToggle();
+            setContentWarningExpanded((expanded) => !expanded);
+          }}
+          onEmojiAction={() => {
+            props.onEmojiAction();
+            setPickerOpen(true);
+          }}
+          onMediaEdit={(key, tool) => {
+            props.onMediaEdit(key, tool);
+            setEditor({ key, tool });
+          }}
+          onMediaRemove={(key) => {
+            props.onMediaRemove(key);
+            setItems((current) => current.filter((item) => item.key !== key));
+          }}
+          onMediaRetry={(key) => props.onMediaRetry(key)}
+          onOverlayClose={onMobileClose}
+          onVisibilityChange={(value) => {
+            props.onVisibilityChange(value);
+            setVisibility(value);
+          }}
+          sensitiveMedia={sensitiveMedia}
+          visibility={visibility}
+        />
+      ) : (
+        <PostComposerTarget
+          {...props}
+          body={body}
+          contentWarning={contentWarning}
+          contentWarningExpanded={contentWarningExpanded}
+          items={items}
+          onBodyChange={(value) => {
+            props.onBodyChange(value);
+            setBody(value);
+          }}
+          onContentWarningChange={(value) => {
+            props.onContentWarningChange(value);
+            setContentWarning(value);
+          }}
+          onContentWarningToggle={() => {
+            props.onContentWarningToggle();
+            setContentWarningExpanded((expanded) => !expanded);
+          }}
+          onEmojiAction={() => {
+            props.onEmojiAction();
+            setPickerOpen(true);
+          }}
+          onExpand={() => {
+            props.onExpand();
+            setSurface('overlay');
+          }}
+          onMediaEdit={(key, tool) => {
+            props.onMediaEdit(key, tool);
+            setEditor({ key, tool });
+          }}
+          onMediaRemove={(key) => {
+            props.onMediaRemove(key);
+            setItems((current) => current.filter((item) => item.key !== key));
+          }}
+          onMediaRetry={(key) => props.onMediaRetry(key)}
+          onVisibilityChange={(value) => {
+            props.onVisibilityChange(value);
+            setVisibility(value);
+          }}
+          sensitiveMedia={sensitiveMedia}
+          surface={surface}
+          visibility={visibility}
+        />
+      )}
+      {pickerOpen ? (
+        <View style={mobile ? styles.mobilePicker : styles.picker}>
+          <FullReactionPicker
+            activeCategory={activeCategory}
+            onCategoryChange={setActiveCategory}
+            onQueryChange={setPickerQuery}
+            onSelect={(option) => {
+              const value = `${body}${option.emoji}`;
+              props.onBodyChange(value);
+              setBody(value);
+              setPickerOpen(false);
+            }}
+            options={reactionOptions}
+            presentation={mobile ? 'mobile' : 'web'}
+            query={pickerQuery}
+            selectedValues={[]}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export const InteractionContract: Story = {
+  play: async ({ args, canvasElement }) => {
+    args.onContentWarningChange.mockClear();
+    args.onContentWarningToggle.mockClear();
+    args.onEmojiAction.mockClear();
+    args.onExpand.mockClear();
+    args.onMediaEdit.mockClear();
+    args.onMediaRemove.mockClear();
+    args.onMediaRetry.mockClear();
+    const canvas = within(canvasElement);
+    const body = canvas.getByRole('textbox', { name: '게시물 내용' });
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Composer 확장' }));
+    expect(args.onExpand).toHaveBeenCalledOnce();
+    expect(canvas.queryByRole('button', { name: 'Composer 확장' })).not.toBeInTheDocument();
+    expect(body).toHaveValue('오늘의 코스모 이야기를 나눠보세요.');
+
+    await userEvent.click(canvas.getByRole('button', { name: '콘텐츠 경고 켜기' }));
+    expect(args.onContentWarningToggle).toHaveBeenCalledOnce();
+    await userEvent.type(canvas.getByRole('textbox', { name: '콘텐츠 경고' }), '스포일러');
+    expect(args.onContentWarningChange).toHaveBeenLastCalledWith('스포일러');
+
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 2 편집' }));
+    expect(args.onMediaEdit).toHaveBeenLastCalledWith('ready', 'alt');
+    expect(canvas.getByRole('heading', { name: '미디어 편집' })).toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '완료' }));
+
+    await userEvent.click(canvas.getByRole('button', { name: '3번째 이미지 업로드 다시 시도' }));
+    expect(args.onMediaRetry).toHaveBeenLastCalledWith('failed');
+    await userEvent.click(canvas.getByRole('button', { name: '첨부 이미지 1 제거' }));
+    expect(args.onMediaRemove).toHaveBeenLastCalledWith('uploading');
+
+    await userEvent.click(canvas.getByRole('button', { name: '이모지 추가' }));
+    expect(args.onEmojiAction).toHaveBeenCalledOnce();
+    expect(canvas.getByRole('dialog', { name: '반응 선택' })).toBeVisible();
+    await userEvent.click(canvas.getAllByRole('button', { name: '빨간 하트 ❤️' })[0]);
+    expect(canvas.getByRole('textbox', { name: '게시물 내용' })).toHaveValue(
+      '오늘의 코스모 이야기를 나눠보세요.❤️',
+    );
+  },
+  render: (args) => <InteractiveComposer {...args} />,
+};
+
+export const PendingMediaContract: Story = {
+  args: { body: '업로드 중인 미디어가 있어요.', items: composerMedia },
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).getByRole('button', { name: '게시' })).toBeDisabled();
+  },
+};
+
+export const MobileCandidateContract: Story = {
+  ...MobileEmpty,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByTestId('mobile-fullscreen-composer-candidate')).toHaveStyle({
+      height: '844px',
+      width: '390px',
+    });
+    expect(canvas.getByRole('heading', { name: '글쓰기' })).toBeVisible();
+    expect(canvas.getByRole('button', { name: '글쓰기 닫기' })).toBeVisible();
+    expect(canvas.getAllByRole('button', { name: '게시' })).toHaveLength(1);
+    expect(canvas.getByLabelText('남은 글자 수 500자')).toBeVisible();
+    expect(canvas.queryByRole('button', { name: 'Composer 확장' })).not.toBeInTheDocument();
+  },
+};
+
+export const MobileKeyboardContract: Story = {
+  ...MobileKeyboardMedia,
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).getByTestId('illustrative-system-keyboard')).toHaveStyle({
+      height: '336px',
+    });
+  },
+};
+
+export const StateContract: Story = {
+  args: { error: '게시글을 작성하지 못했습니다.', items: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole('alert')).toHaveTextContent('게시글을 작성하지 못했습니다.');
+    expect(canvas.getByRole('button', { name: '게시' })).toBeEnabled();
+  },
+};
+
+const styles = StyleSheet.create({
+  author: { alignItems: 'center', flexDirection: 'row', gap: space[12] },
+  authorCopy: { flex: 1 },
+  authorHandle: textStyles.uiCopyM,
+  authorName: textStyles.uiLabelL,
+  composition: { alignItems: 'center', width: '100%' },
+  mobilePicker: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 20,
+  },
+  picker: { position: 'absolute', right: 0, top: 72, zIndex: 20 },
+});

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -1,6 +1,8 @@
+import { normalizePostContentPlainText } from '@kosmo/core/post-content';
+import { postBodyMaxLength } from '@kosmo/core/validation/post-policy';
 import { XIcon } from 'lucide-react-native';
 import { useEffect, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { expect, fn, userEvent, within } from 'storybook/test';
 import { ComposerMediaEditor } from '@/components/post/ComposerMediaEditor';
 import {
@@ -10,6 +12,7 @@ import {
 import { FullReactionPicker } from '@/components/reaction/FullReactionPicker';
 import { Avatar } from '@/components/ui/Avatar';
 import { IconButton } from '@/components/ui/IconButton';
+import { useToast } from '@/components/ui/ToastProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, iconSizes, space, textStyles } from '@/theme/tokens';
 import ogImage from '../../../public/og-default.png?url';
@@ -111,7 +114,7 @@ const meta = {
     showCWAction: true,
     showEmojiAction: true,
     showMediaAction: true,
-    showPollAction: true,
+    showPollAction: false,
     showSubmit: true,
     submitting: false,
     surface: 'rail',
@@ -123,7 +126,7 @@ const meta = {
     contentWarning: { control: 'text' },
     contentWarningExpanded: { control: 'boolean' },
     error: { control: 'text' },
-    items: { control: 'object' },
+    items: { control: false },
     onBodyChange: { action: 'bodyChange', control: false },
     onContentWarningChange: { action: 'contentWarningChange', control: false },
     onContentWarningToggle: { action: 'contentWarningToggle', control: false },
@@ -136,12 +139,12 @@ const meta = {
     onPollAction: { action: 'pollAction', control: false },
     onSubmit: { action: 'submit', control: false },
     onVisibilityChange: { action: 'visibilityChange', control: false },
-    remaining: { control: { max: 500, min: -10, step: 1, type: 'range' } },
+    remaining: { control: false },
     sensitiveMedia: { control: 'boolean' },
     showCWAction: { control: 'boolean' },
     showEmojiAction: { control: 'boolean' },
     showMediaAction: { control: 'boolean' },
-    showPollAction: { control: 'boolean' },
+    showPollAction: { control: false },
     showSubmit: { control: 'boolean' },
     submitting: { control: 'boolean' },
     surface: { control: 'inline-radio', options: ['rail', 'overlay'] },
@@ -159,14 +162,35 @@ const meta = {
     'StateContract',
     'composerMedia',
   ],
-  parameters: { layout: 'centered' },
+  parameters: { controls: { disable: true }, layout: 'centered' },
   title: 'KOSMO/Patterns/Post Composer Target',
 } satisfies Meta<typeof PostComposerTarget>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = { render: (args) => <InteractiveComposer {...args} /> };
+export const Playground: Story = {
+  parameters: {
+    controls: {
+      disable: false,
+      include: [
+        'body',
+        'contentWarning',
+        'contentWarningExpanded',
+        'error',
+        'sensitiveMedia',
+        'showCWAction',
+        'showEmojiAction',
+        'showMediaAction',
+        'showSubmit',
+        'submitting',
+        'surface',
+        'visibility',
+      ],
+    },
+  },
+  render: (args) => <InteractiveComposer {...args} />,
+};
 
 export const RailEmptyPublic: Story = {
   args: { body: '', items: [], remaining: 500, surface: 'rail', visibility: 'PUBLIC' },
@@ -186,7 +210,23 @@ export const OverlayMediaFollowers: Story = {
 };
 
 export const Submitting: Story = { args: { items: [], submitting: true } };
-export const Error: Story = { args: { error: '게시글을 작성하지 못했습니다.', items: [] } };
+export const Error: Story = {
+  args: { body: '미디어 업로드 실패를 확인할 본문', error: undefined, items: [composerMedia[2]] },
+};
+
+export const SubmitFailure: Story = {
+  args: { body: '제출 실패를 확인할 본문', error: undefined, items: [], surface: 'rail' },
+  render: (args) => <SubmitFailureComposer {...args} />,
+};
+
+export const RailMedia: Story = {
+  args: { body: '세 장 미디어 접근성 확인', items: composerMedia, surface: 'rail' },
+  render: (args) => (
+    <View style={styles.railMediaFixture} testID="post-composer-rail-media-reachability">
+      <InteractiveComposer {...args} />
+    </View>
+  ),
+};
 
 export const CompactOverlay: Story = {
   args: { surface: 'overlay' },
@@ -199,6 +239,7 @@ export const CompactOverlay: Story = {
 
 const mobileGlobals = { viewport: { isRotated: false, value: 'kosmoMobile' } } as const;
 const mobileParameters = { layout: 'fullscreen' } as const;
+const submitFailureMessage = '게시글을 작성하지 못했습니다. 잠시 후 다시 시도해 주세요.';
 
 export const MobilePlayground: Story = {
   args: { items: readyComposerMedia, surface: 'overlay' },
@@ -245,6 +286,20 @@ export const MobileKeyboardCW: Story = {
   render: (args) => <InteractiveComposer {...args} keyboard mobile />,
 };
 
+function SubmitFailureComposer(props: PostComposerTargetProps) {
+  const { showToast } = useToast();
+
+  return (
+    <InteractiveComposer
+      {...props}
+      onSubmit={() => {
+        props.onSubmit();
+        showToast(submitFailureMessage, { tone: 'danger' });
+      }}
+    />
+  );
+}
+
 function InteractiveComposer({
   keyboard = false,
   mobile = false,
@@ -268,6 +323,14 @@ function InteractiveComposer({
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerQuery, setPickerQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState('expressions');
+  const [pickerPosition, setPickerPosition] = useState({
+    left: space[8] as number,
+    top: space[8] as number,
+  });
+  const remaining =
+    postBodyMaxLength -
+    normalizePostContentPlainText(body).length -
+    normalizePostContentPlainText(contentWarning).length;
 
   useEffect(() => setBody(props.body), [props.body]);
   useEffect(() => setContentWarning(props.contentWarning), [props.contentWarning]);
@@ -278,6 +341,36 @@ function InteractiveComposer({
   useEffect(() => setItems(props.items), [props.items]);
   useEffect(() => setVisibility(props.visibility), [props.visibility]);
   useEffect(() => setSensitiveMedia(props.sensitiveMedia), [props.sensitiveMedia]);
+  useEffect(() => {
+    if (mobile || !pickerOpen || typeof document === 'undefined') {
+      return;
+    }
+
+    const triggers = Array.from(
+      document.querySelectorAll<HTMLElement>('[aria-label="이모지 추가"]'),
+    ).filter((element) => {
+      const bounds = element.getBoundingClientRect();
+      return bounds.width > 0 && bounds.height > 0;
+    });
+    const trigger = triggers[triggers.length - 1];
+    const storyWindow = trigger?.ownerDocument.defaultView;
+    if (!trigger || !storyWindow) {
+      return;
+    }
+
+    const bounds = trigger.getBoundingClientRect();
+    const panelWidth = 360;
+    const panelHeight = 624;
+    const gap = space[8];
+    const maxLeft = Math.max(gap, storyWindow.innerWidth - panelWidth - gap);
+    setPickerPosition({
+      left: Math.min(Math.max(gap, bounds.right - panelWidth), maxLeft),
+      top:
+        storyWindow.innerHeight - bounds.bottom >= panelHeight + gap
+          ? bounds.bottom + gap
+          : Math.max(gap, bounds.top - panelHeight - gap),
+    });
+  }, [mobile, pickerOpen]);
 
   const closeOverlay = () => {
     setEditor(null);
@@ -286,22 +379,41 @@ function InteractiveComposer({
   };
 
   const picker = pickerOpen ? (
-    <View style={mobile ? styles.mobilePicker : styles.picker}>
-      <FullReactionPicker
-        activeCategory={activeCategory}
-        onCategoryChange={setActiveCategory}
-        onQueryChange={setPickerQuery}
-        onSelect={(option) => {
-          const value = `${body}${option.emoji}`;
-          props.onBodyChange(value);
-          setBody(value);
-          setPickerOpen(false);
-        }}
-        options={reactionOptions}
-        presentation={mobile ? 'mobile' : 'web'}
-        query={pickerQuery}
-        selectedValues={[]}
-      />
+    <View pointerEvents="box-none" style={mobile ? styles.mobilePicker : styles.pickerLayer}>
+      {!mobile ? (
+        <Pressable
+          accessibilityLabel="반응 선택 닫기"
+          accessibilityRole="button"
+          onPress={() => setPickerOpen(false)}
+          style={styles.pickerDismiss}
+        />
+      ) : null}
+      <View
+        pointerEvents="box-none"
+        style={[
+          styles.pickerPanel,
+          mobile
+            ? styles.mobilePickerPanel
+            : { left: pickerPosition.left, top: pickerPosition.top },
+        ]}
+        testID="post-composer-emoji-picker"
+      >
+        <FullReactionPicker
+          activeCategory={activeCategory}
+          onCategoryChange={setActiveCategory}
+          onQueryChange={setPickerQuery}
+          onSelect={(option) => {
+            const value = `${body}${option.emoji}`;
+            props.onBodyChange(value);
+            setBody(value);
+            setPickerOpen(false);
+          }}
+          options={reactionOptions}
+          presentation={mobile ? 'mobile' : 'web'}
+          query={pickerQuery}
+          selectedValues={[]}
+        />
+      </View>
     </View>
   ) : null;
 
@@ -361,6 +473,7 @@ function InteractiveComposer({
           contentWarning={contentWarning}
           contentWarningExpanded={contentWarningExpanded}
           items={items}
+          remaining={remaining}
           keyboard={keyboard}
           onBodyChange={(value) => {
             props.onBodyChange(value);
@@ -406,6 +519,7 @@ function InteractiveComposer({
           contentWarning={contentWarning}
           contentWarningExpanded={contentWarningExpanded}
           items={items}
+          remaining={remaining}
           onBodyChange={(value) => {
             props.onBodyChange(value);
             setBody(value);
@@ -504,6 +618,7 @@ function InteractiveComposer({
                 contentWarning={contentWarning}
                 contentWarningExpanded={contentWarningExpanded}
                 items={items}
+                remaining={remaining}
                 onBodyChange={(value) => {
                   props.onBodyChange(value);
                   setBody(value);
@@ -731,7 +846,18 @@ const styles = StyleSheet.create({
     zIndex: 20,
   },
   overlayClose: { position: 'absolute', right: space[16], top: space[12] },
-  picker: { position: 'absolute', right: 0, top: 72, zIndex: 20 },
+  pickerDismiss: { ...StyleSheet.absoluteFill, backgroundColor: 'transparent' },
+  pickerLayer: {
+    bottom: 0,
+    left: 0,
+    position: 'fixed' as never,
+    right: 0,
+    top: 0,
+    zIndex: 20,
+  },
+  pickerPanel: { position: 'absolute', zIndex: 1 },
+  mobilePickerPanel: { bottom: 0, left: 0, position: 'absolute', right: 0, top: 0 },
+  railMediaFixture: { maxWidth: 326, width: '100%' },
   overlayContent: { width: '100%' },
   overlayHeader: {
     alignItems: 'center',

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -921,13 +921,11 @@ export const MobileKeyboardContract: Story = {
 function expectMobileEditorFitsMediaShelf(canvasElement: HTMLElement) {
   const canvas = within(canvasElement);
   const editor = canvas.getByRole('textbox', { name: '게시물 내용' });
-  const editorOuter = editor.parentElement;
   const shelf = canvas.getByLabelText('첨부 이미지 갤러리, 1개').parentElement;
 
-  expect(editorOuter).not.toBeNull();
-  expect(getComputedStyle(editorOuter!).flexGrow).toBe('1');
+  expect(getComputedStyle(editor).flexGrow).toBe('1');
   expect(shelf).not.toBeNull();
-  expect(editorOuter!.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+  expect(editor.getBoundingClientRect().bottom).toBeLessThanOrEqual(
     shelf!.getBoundingClientRect().top,
   );
 }

--- a/apps/app/src/stories/patterns/PostComposer.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.stories.tsx
@@ -158,7 +158,12 @@ const meta = {
     'MobileKeyboardContract',
     'MobileMediaFooterGeometryContract',
     'MobilePlaygroundContract',
+    'MobileFlexLayoutContract',
+    'OverlayProgressRingContract',
     'PendingMediaContract',
+    'ProgressRingToneContract',
+    'RailProgressRingContract',
+    'SubmittingSpinnerContract',
     'composerMedia',
   ],
   parameters: { controls: { disable: true }, layout: 'centered' },
@@ -752,7 +757,21 @@ export const MobileCandidateContract: Story = {
     expect(canvas.getByRole('button', { name: '글쓰기 닫기' })).toBeVisible();
     expect(canvas.getAllByRole('button', { name: '게시' })).toHaveLength(1);
     expect(canvas.getByLabelText('남은 글자 수 500자')).toBeVisible();
+    expect(canvas.getByTestId('post-composer-progress-ring')).toBeVisible();
     expect(canvas.queryByRole('button', { name: 'Composer 확장' })).not.toBeInTheDocument();
+  },
+};
+
+export const MobileFlexLayoutContract: Story = {
+  ...MobileEmpty,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = canvas.getByTestId('mobile-composer-body');
+    const editor = canvas.getByRole('textbox', { name: '게시물 내용' });
+
+    expect(body).toHaveStyle({ gap: '8px' });
+    expect(getComputedStyle(body).overflow).toBe('visible');
+    expect(getComputedStyle(editor).flexGrow).toBe('1');
   },
 };
 
@@ -765,7 +784,9 @@ export const MobilePlaygroundContract: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '공개 범위: 조용한 공개' }));
 
     const menu = canvas.getByRole('radiogroup', { name: '공개 범위 선택' });
+    const trigger = canvas.getByRole('button', { name: '공개 범위: 조용한 공개' });
     expect(within(menu).getAllByRole('radio')).toHaveLength(3);
+    expect(menu.getBoundingClientRect().right).toBe(trigger.getBoundingClientRect().right);
 
     await userEvent.click(within(menu).getByRole('radio', { name: '공개' }));
     expect(args.onVisibilityChange).toHaveBeenLastCalledWith('PUBLIC');
@@ -779,6 +800,60 @@ export const MobilePlaygroundContract: Story = {
     expect(canvas.queryByTestId('mobile-composer-media-editor-keyboard')).toBeNull();
     await userEvent.click(canvas.getByRole('button', { name: '완료' }));
     expect(canvas.getByRole('heading', { name: '글쓰기' })).toBeVisible();
+  },
+};
+
+export const RailProgressRingContract: Story = {
+  ...Playground,
+  args: { body: '레일 진행률', items: [], remaining: 250, surface: 'rail' },
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).queryByTestId('post-composer-progress-ring')).toBeNull();
+  },
+};
+
+export const OverlayProgressRingContract: Story = {
+  ...Playground,
+  args: { body: '오버레이 진행률', items: [], remaining: 250, surface: 'overlay' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const ring = canvas.getByTestId('post-composer-progress-ring');
+    const submit = canvas.getByRole('button', { name: '게시' });
+
+    expect(ring).toBeVisible();
+    expect(ring).toHaveAttribute('aria-hidden', 'true');
+    expect(ring.querySelectorAll('circle')).toHaveLength(2);
+    expect(ring.querySelectorAll('circle')[1]).toHaveAttribute('stroke', '#AE8512');
+    expect(ring.parentElement?.lastElementChild).toBe(submit);
+  },
+};
+
+export const ProgressRingToneContract: Story = {
+  ...Playground,
+  render: (args) => (
+    <View style={{ gap: space[16] }}>
+      <PostComposerTarget {...args} body="일반" items={[]} remaining={250} surface="overlay" />
+      <PostComposerTarget {...args} body="경고" items={[]} remaining={100} surface="overlay" />
+      <PostComposerTarget {...args} body="위험" items={[]} remaining={0} surface="overlay" />
+    </View>
+  ),
+  play: async ({ canvasElement }) => {
+    const rings = within(canvasElement).getAllByTestId('post-composer-progress-ring');
+    expect(rings).toHaveLength(3);
+    expect(rings[0].querySelectorAll('circle')[1]).toHaveAttribute('stroke', '#AE8512');
+    expect(rings[1].querySelectorAll('circle')[1]).toHaveAttribute('stroke', '#CF6D2F');
+    expect(rings[2].querySelectorAll('circle')[1]).toHaveAttribute('stroke', '#B42318');
+  },
+};
+
+export const SubmittingSpinnerContract: Story = {
+  ...Submitting,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const submit = canvas.getByRole('button', { name: '게시' });
+
+    expect(submit).toBeDisabled();
+    expect(canvas.getByLabelText('게시 처리 중')).toBeVisible();
+    expect(canvas.queryByText('게시 중')).toBeNull();
   },
 };
 

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -2,15 +2,20 @@ import { expect, userEvent, within } from 'storybook/test';
 import baseMeta, {
   InteractionContract as interactionContract,
   MobileCandidateContract as mobileCandidateContract,
+  MobileFlexLayoutContract as mobileFlexLayoutContract,
   MobileKeyboardContract as mobileKeyboardContract,
   MobileKeyboardMediaFooterGeometryContract as mobileKeyboardMediaFooterGeometryContract,
   MobileMediaFooterGeometryContract as mobileMediaFooterGeometryContract,
   MobilePlayground as mobilePlaygroundStory,
   MobilePlaygroundContract as mobilePlaygroundContract,
+  OverlayProgressRingContract as overlayProgressRingContract,
   PendingMediaContract as pendingMediaContract,
   Playground as playgroundContract,
+  ProgressRingToneContract as progressRingToneContract,
   RailMedia as railMediaStory,
+  RailProgressRingContract as railProgressRingContract,
   SubmitFailure as submitFailureStory,
+  SubmittingSpinnerContract as submittingSpinnerContract,
 } from './PostComposer.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -30,7 +35,12 @@ export const MobileCandidateContract: Story = mobileCandidateContract;
 export const MobileKeyboardContract: Story = mobileKeyboardContract;
 export const MobileMediaFooterGeometryContract: Story = mobileMediaFooterGeometryContract;
 export const MobilePlaygroundContract: Story = mobilePlaygroundContract;
+export const MobileFlexLayoutContract: Story = mobileFlexLayoutContract;
+export const OverlayProgressRingContract: Story = overlayProgressRingContract;
 export const PendingMediaContract: Story = pendingMediaContract;
+export const ProgressRingToneContract: Story = progressRingToneContract;
+export const RailProgressRingContract: Story = railProgressRingContract;
+export const SubmittingSpinnerContract: Story = submittingSpinnerContract;
 
 export const ControlsContract: Story = {
   play: async () => {

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import baseMeta, {
   InteractionContract as interactionContract,
   MobileCandidateContract as mobileCandidateContract,
@@ -17,6 +17,7 @@ import baseMeta, {
   RailMedia as railMediaStory,
   RailProgressRingContract as railProgressRingContract,
   SubmitFailure as submitFailureStory,
+  SubmittingPickerContract as submittingPickerContract,
   SubmittingSpinnerContract as submittingSpinnerContract,
 } from './PostComposer.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -45,6 +46,7 @@ export const OverlayProgressRingContract: Story = overlayProgressRingContract;
 export const PendingMediaContract: Story = pendingMediaContract;
 export const ProgressRingToneContract: Story = progressRingToneContract;
 export const RailProgressRingContract: Story = railProgressRingContract;
+export const SubmittingPickerContract: Story = submittingPickerContract;
 export const SubmittingSpinnerContract: Story = submittingSpinnerContract;
 
 export const ControlsContract: Story = {
@@ -110,7 +112,7 @@ export const SubmitFailureToastContract: Story = {
   },
 };
 
-export const EmojiOutsideDismissContract: Story = {
+export const EmojiPickerLifecycleContract: Story = {
   ...playgroundContract,
   args: { body: '이모지 위치를 확인할 본문', items: [], surface: 'rail' },
   globals: { viewport: { isRotated: false, value: 'postComposerPicker' } },
@@ -127,11 +129,12 @@ export const EmojiOutsideDismissContract: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', { name: '이모지 추가' }));
+    const trigger = canvas.getByRole('button', { name: '이모지 추가' });
+    await userEvent.click(trigger);
 
     const picker = await canvas.findByTestId('post-composer-emoji-picker');
-    const trigger = canvas.getByRole('button', { name: '이모지 추가' });
     expect(picker).toBeVisible();
+    await waitFor(() => expect(canvas.getByRole('searchbox', { name: '반응 검색' })).toHaveFocus());
     expect(picker.getBoundingClientRect().right).toBeLessThanOrEqual(
       canvasElement.ownerDocument.defaultView!.innerWidth,
     );
@@ -142,8 +145,22 @@ export const EmojiOutsideDismissContract: Story = {
       trigger.getBoundingClientRect().bottom,
     );
 
+    const [reaction] = canvas.getAllByRole('button', { name: '감동 🥹' });
+    reaction.focus();
+    expect(reaction).toHaveFocus();
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(canvas.queryByTestId('post-composer-emoji-picker')).toBeNull());
+    expect(trigger).toHaveFocus();
+
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    await waitFor(() => expect(canvas.queryByTestId('post-composer-emoji-picker')).toBeNull());
+    expect(trigger).toHaveFocus();
+
+    await userEvent.click(trigger);
     await userEvent.click(canvas.getByRole('button', { name: '반응 선택 닫기' }));
     expect(canvas.queryByTestId('post-composer-emoji-picker')).toBeNull();
+    expect(trigger).toHaveFocus();
   },
 };
 

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -3,6 +3,9 @@ import baseMeta, {
   InteractionContract as interactionContract,
   MobileCandidateContract as mobileCandidateContract,
   MobileKeyboardContract as mobileKeyboardContract,
+  MobileKeyboardMediaFooterGeometryContract as mobileKeyboardMediaFooterGeometryContract,
+  MobileMediaFooterGeometryContract as mobileMediaFooterGeometryContract,
+  MobilePlaygroundContract as mobilePlaygroundContract,
   PendingMediaContract as pendingMediaContract,
   StateContract as stateContract,
 } from './PostComposer.stories';
@@ -18,8 +21,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const InteractionContract: Story = interactionContract;
+export const MobileKeyboardMediaFooterGeometryContract: Story =
+  mobileKeyboardMediaFooterGeometryContract;
 export const MobileCandidateContract: Story = mobileCandidateContract;
 export const MobileKeyboardContract: Story = mobileKeyboardContract;
+export const MobileMediaFooterGeometryContract: Story = mobileMediaFooterGeometryContract;
+export const MobilePlaygroundContract: Story = mobilePlaygroundContract;
 export const PendingMediaContract: Story = pendingMediaContract;
 export const StateContract: Story = stateContract;
 

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -1,3 +1,4 @@
+import { expect, userEvent, within } from 'storybook/test';
 import baseMeta, {
   InteractionContract as interactionContract,
   MobileCandidateContract as mobileCandidateContract,
@@ -21,3 +22,40 @@ export const MobileCandidateContract: Story = mobileCandidateContract;
 export const MobileKeyboardContract: Story = mobileKeyboardContract;
 export const PendingMediaContract: Story = pendingMediaContract;
 export const StateContract: Story = stateContract;
+
+export const ShortViewportContract: Story = {
+  ...interactionContract,
+  globals: { viewport: { isRotated: false, value: 'postComposerShort' } },
+  parameters: {
+    viewport: {
+      options: {
+        postComposerShort: {
+          name: 'Post Composer short',
+          styles: { height: '380px', width: '600px' },
+          type: 'tablet',
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Composer 확장' }));
+
+    const dialog = page.getByRole('dialog', { name: '글쓰기' });
+    const getSurface = () =>
+      dialog.firstElementChild?.firstElementChild?.firstElementChild as HTMLElement | null;
+    const surface = getSurface();
+
+    expect(surface).not.toBeNull();
+    expect(getComputedStyle(surface!).overflowY).toBe('auto');
+    expect(surface!.scrollHeight).toBeGreaterThan(surface!.clientHeight);
+    surface!.scrollTop = surface!.scrollHeight;
+    expect(surface!.scrollTop).toBeGreaterThan(0);
+
+    await userEvent.click(within(dialog).getByRole('button', { name: '첨부 이미지 2 편집' }));
+    expect(within(dialog).getByRole('heading', { name: '미디어 편집' })).toBeVisible();
+    expect(getSurface()!.scrollTop).toBe(0);
+  },
+};

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -9,7 +9,6 @@ import baseMeta, {
   PendingMediaContract as pendingMediaContract,
   Playground as playgroundContract,
   RailMedia as railMediaStory,
-  StateContract as stateContract,
   SubmitFailure as submitFailureStory,
 } from './PostComposer.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -31,11 +30,13 @@ export const MobileKeyboardContract: Story = mobileKeyboardContract;
 export const MobileMediaFooterGeometryContract: Story = mobileMediaFooterGeometryContract;
 export const MobilePlaygroundContract: Story = mobilePlaygroundContract;
 export const PendingMediaContract: Story = pendingMediaContract;
-export const StateContract: Story = stateContract;
 
 export const ControlsContract: Story = {
   play: async () => {
     expect(baseMeta.parameters?.controls).toMatchObject({ disable: true });
+    const playgroundControls = playgroundContract.parameters?.controls;
+    expect(playgroundControls).toHaveProperty('include');
+    expect(playgroundControls?.include).not.toContain('error');
     expect(baseMeta.argTypes?.author?.control).toBe(false);
     expect(baseMeta.argTypes?.items?.control).toBe(false);
     expect(baseMeta.argTypes?.remaining?.control).toBe(false);
@@ -65,6 +66,14 @@ export const PollActionHiddenContract: Story = {
   },
 };
 
+export const PlaygroundPollOverrideContract: Story = {
+  ...playgroundContract,
+  args: { body: 'Playground Poll override', items: [], showPollAction: true, surface: 'rail' },
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).queryByRole('button', { name: '투표 추가' })).toBeNull();
+  },
+};
+
 export const SubmitFailureToastContract: Story = {
   ...submitFailureStory,
   play: async ({ canvasElement }) => {
@@ -80,6 +89,18 @@ export const SubmitFailureToastContract: Story = {
 export const EmojiOutsideDismissContract: Story = {
   ...playgroundContract,
   args: { body: '이모지 위치를 확인할 본문', items: [], surface: 'rail' },
+  globals: { viewport: { isRotated: false, value: 'postComposerPicker' } },
+  parameters: {
+    viewport: {
+      options: {
+        postComposerPicker: {
+          name: 'Post Composer picker',
+          styles: { height: '1200px', width: '600px' },
+          type: 'tablet',
+        },
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole('button', { name: '이모지 추가' }));
@@ -92,6 +113,9 @@ export const EmojiOutsideDismissContract: Story = {
     );
     expect(picker.getBoundingClientRect().right).toBeGreaterThanOrEqual(
       trigger.getBoundingClientRect().left,
+    );
+    expect(picker.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      trigger.getBoundingClientRect().bottom,
     );
 
     await userEvent.click(canvas.getByRole('button', { name: '반응 선택 닫기' }));

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -7,7 +7,10 @@ import baseMeta, {
   MobileMediaFooterGeometryContract as mobileMediaFooterGeometryContract,
   MobilePlaygroundContract as mobilePlaygroundContract,
   PendingMediaContract as pendingMediaContract,
+  Playground as playgroundContract,
+  RailMedia as railMediaStory,
   StateContract as stateContract,
+  SubmitFailure as submitFailureStory,
 } from './PostComposer.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -30,6 +33,85 @@ export const MobilePlaygroundContract: Story = mobilePlaygroundContract;
 export const PendingMediaContract: Story = pendingMediaContract;
 export const StateContract: Story = stateContract;
 
+export const ControlsContract: Story = {
+  play: async () => {
+    expect(baseMeta.parameters?.controls).toMatchObject({ disable: true });
+    expect(baseMeta.argTypes?.author?.control).toBe(false);
+    expect(baseMeta.argTypes?.items?.control).toBe(false);
+    expect(baseMeta.argTypes?.remaining?.control).toBe(false);
+    expect(baseMeta.argTypes?.showPollAction?.control).toBe(false);
+  },
+};
+
+export const DerivedRemainingContract: Story = {
+  ...playgroundContract,
+  args: {
+    body: ' 본문 ',
+    contentWarning: ' 경고 ',
+    items: [],
+    remaining: 500,
+    surface: 'rail',
+  },
+  play: async ({ canvasElement }) => {
+    expect(await within(canvasElement).findByLabelText('남은 글자 수 496자')).toBeVisible();
+  },
+};
+
+export const PollActionHiddenContract: Story = {
+  ...playgroundContract,
+  args: { body: '게시할 본문', items: [], surface: 'rail' },
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).queryByRole('button', { name: '투표 추가' })).toBeNull();
+  },
+};
+
+export const SubmitFailureToastContract: Story = {
+  ...submitFailureStory,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '게시' }));
+    expect(await canvas.findByRole('alert')).toHaveTextContent(
+      '게시글을 작성하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+    );
+    expect(canvas.queryByText('제출 실패를 확인할 본문')).toBeInTheDocument();
+  },
+};
+
+export const EmojiOutsideDismissContract: Story = {
+  ...playgroundContract,
+  args: { body: '이모지 위치를 확인할 본문', items: [], surface: 'rail' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '이모지 추가' }));
+
+    const picker = await canvas.findByTestId('post-composer-emoji-picker');
+    const trigger = canvas.getByRole('button', { name: '이모지 추가' });
+    expect(picker).toBeVisible();
+    expect(picker.getBoundingClientRect().right).toBeLessThanOrEqual(
+      canvasElement.ownerDocument.defaultView!.innerWidth,
+    );
+    expect(picker.getBoundingClientRect().right).toBeGreaterThanOrEqual(
+      trigger.getBoundingClientRect().left,
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: '반응 선택 닫기' }));
+    expect(canvas.queryByTestId('post-composer-emoji-picker')).toBeNull();
+  },
+};
+
+export const RailMediaReachabilityContract: Story = {
+  ...railMediaStory,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const fixture = canvas.getByTestId('post-composer-rail-media-reachability');
+    const gallery = within(fixture).getByLabelText('첨부 이미지 갤러리, 3개');
+
+    expect(gallery.scrollWidth).toBeGreaterThan(gallery.clientWidth);
+    gallery.scrollLeft = gallery.scrollWidth;
+    expect(gallery.scrollLeft).toBeGreaterThan(0);
+  },
+};
+
 export const ShortViewportContract: Story = {
   ...interactionContract,
   globals: { viewport: { isRotated: false, value: 'postComposerShort' } },
@@ -51,18 +133,18 @@ export const ShortViewportContract: Story = {
     await userEvent.click(canvas.getByRole('button', { name: 'Composer 확장' }));
 
     const dialog = page.getByRole('dialog', { name: '글쓰기' });
-    const getSurface = () =>
-      dialog.firstElementChild?.firstElementChild?.firstElementChild as HTMLElement | null;
-    const surface = getSurface();
+    const scroll = within(dialog).getByTestId('composer-overlay-scroll');
 
-    expect(surface).not.toBeNull();
-    expect(getComputedStyle(surface!).overflowY).toBe('auto');
-    expect(surface!.scrollHeight).toBeGreaterThan(surface!.clientHeight);
-    surface!.scrollTop = surface!.scrollHeight;
-    expect(surface!.scrollTop).toBeGreaterThan(0);
+    expect(getComputedStyle(within(dialog).getByTestId('composer-overlay-surface')).overflow).toBe(
+      'hidden',
+    );
+    expect(getComputedStyle(scroll).overflowY).toBe('auto');
+    expect(scroll.scrollHeight).toBeGreaterThan(scroll.clientHeight);
+    scroll.scrollTop = scroll.scrollHeight;
+    expect(scroll.scrollTop).toBeGreaterThan(0);
 
     await userEvent.click(within(dialog).getByRole('button', { name: '첨부 이미지 2 편집' }));
     expect(within(dialog).getByRole('heading', { name: '미디어 편집' })).toBeVisible();
-    expect(getSurface()!.scrollTop).toBe(0);
+    expect(within(dialog).getByTestId('composer-overlay-scroll').scrollTop).toBe(0);
   },
 };

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -5,6 +5,7 @@ import baseMeta, {
   MobileKeyboardContract as mobileKeyboardContract,
   MobileKeyboardMediaFooterGeometryContract as mobileKeyboardMediaFooterGeometryContract,
   MobileMediaFooterGeometryContract as mobileMediaFooterGeometryContract,
+  MobilePlayground as mobilePlaygroundStory,
   MobilePlaygroundContract as mobilePlaygroundContract,
   PendingMediaContract as pendingMediaContract,
   Playground as playgroundContract,
@@ -69,6 +70,14 @@ export const PollActionHiddenContract: Story = {
 export const PlaygroundPollOverrideContract: Story = {
   ...playgroundContract,
   args: { body: 'Playground Poll override', items: [], showPollAction: true, surface: 'rail' },
+  play: async ({ canvasElement }) => {
+    expect(within(canvasElement).queryByRole('button', { name: '투표 추가' })).toBeNull();
+  },
+};
+
+export const MobilePlaygroundPollOverrideContract: Story = {
+  ...mobilePlaygroundStory,
+  args: { items: [], showPollAction: true, surface: 'overlay' },
   play: async ({ canvasElement }) => {
     expect(within(canvasElement).queryByRole('button', { name: '투표 추가' })).toBeNull();
   },

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -4,6 +4,8 @@ import baseMeta, {
   MobileCandidateContract as mobileCandidateContract,
   MobileFlexLayoutContract as mobileFlexLayoutContract,
   MobileKeyboardContract as mobileKeyboardContract,
+  MobileKeyboardCWEditorGeometryContract as mobileKeyboardCWEditorGeometryContract,
+  MobileKeyboardMediaEditorGeometryContract as mobileKeyboardMediaEditorGeometryContract,
   MobileKeyboardMediaFooterGeometryContract as mobileKeyboardMediaFooterGeometryContract,
   MobileMediaFooterGeometryContract as mobileMediaFooterGeometryContract,
   MobilePlayground as mobilePlaygroundStory,
@@ -33,6 +35,9 @@ export const MobileKeyboardMediaFooterGeometryContract: Story =
   mobileKeyboardMediaFooterGeometryContract;
 export const MobileCandidateContract: Story = mobileCandidateContract;
 export const MobileKeyboardContract: Story = mobileKeyboardContract;
+export const MobileKeyboardCWEditorGeometryContract: Story = mobileKeyboardCWEditorGeometryContract;
+export const MobileKeyboardMediaEditorGeometryContract: Story =
+  mobileKeyboardMediaEditorGeometryContract;
 export const MobileMediaFooterGeometryContract: Story = mobileMediaFooterGeometryContract;
 export const MobilePlaygroundContract: Story = mobilePlaygroundContract;
 export const MobileFlexLayoutContract: Story = mobileFlexLayoutContract;

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -191,6 +191,18 @@ export const ShortViewportContract: Story = {
     scroll.scrollTop = scroll.scrollHeight;
     expect(scroll.scrollTop).toBeGreaterThan(0);
 
+    await userEvent.click(within(dialog).getByRole('button', { name: '이모지 추가' }));
+    const picker = page.getByTestId('post-composer-emoji-picker');
+    const pickerGap = 8;
+    expect(picker).toHaveStyle({
+      height: `${canvasElement.ownerDocument.defaultView!.innerHeight - pickerGap * 2}px`,
+    });
+    expect(picker.getBoundingClientRect().top).toBeGreaterThanOrEqual(pickerGap);
+    expect(picker.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      canvasElement.ownerDocument.defaultView!.innerHeight - pickerGap,
+    );
+    await userEvent.click(page.getByRole('button', { name: '반응 선택 닫기' }));
+
     await userEvent.click(within(dialog).getByRole('button', { name: '첨부 이미지 2 편집' }));
     expect(within(dialog).getByRole('heading', { name: '미디어 편집' })).toBeVisible();
     expect(within(dialog).getByTestId('composer-overlay-scroll').scrollTop).toBe(0);

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -1,5 +1,6 @@
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import baseMeta, {
+  ActionSemanticsContract as actionSemanticsContract,
   InteractionContract as interactionContract,
   MobileCandidateContract as mobileCandidateContract,
   MobileFlexLayoutContract as mobileFlexLayoutContract,
@@ -19,6 +20,7 @@ import baseMeta, {
   SubmitFailure as submitFailureStory,
   SubmittingPickerContract as submittingPickerContract,
   SubmittingSpinnerContract as submittingSpinnerContract,
+  SubmittingVisibilityContract as submittingVisibilityContract,
 } from './PostComposer.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -31,6 +33,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const ActionSemanticsContract: Story = actionSemanticsContract;
 export const InteractionContract: Story = interactionContract;
 export const MobileKeyboardMediaFooterGeometryContract: Story =
   mobileKeyboardMediaFooterGeometryContract;
@@ -48,6 +51,7 @@ export const ProgressRingToneContract: Story = progressRingToneContract;
 export const RailProgressRingContract: Story = railProgressRingContract;
 export const SubmittingPickerContract: Story = submittingPickerContract;
 export const SubmittingSpinnerContract: Story = submittingSpinnerContract;
+export const SubmittingVisibilityContract: Story = submittingVisibilityContract;
 
 export const ControlsContract: Story = {
   play: async () => {

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -1,0 +1,23 @@
+import baseMeta, {
+  InteractionContract as interactionContract,
+  MobileCandidateContract as mobileCandidateContract,
+  MobileKeyboardContract as mobileKeyboardContract,
+  PendingMediaContract as pendingMediaContract,
+  StateContract as stateContract,
+} from './PostComposer.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Patterns/Post Composer Target/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const MobileCandidateContract: Story = mobileCandidateContract;
+export const MobileKeyboardContract: Story = mobileKeyboardContract;
+export const PendingMediaContract: Story = pendingMediaContract;
+export const StateContract: Story = stateContract;

--- a/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposer.tests.stories.tsx
@@ -53,19 +53,6 @@ export const SubmittingPickerContract: Story = submittingPickerContract;
 export const SubmittingSpinnerContract: Story = submittingSpinnerContract;
 export const SubmittingVisibilityContract: Story = submittingVisibilityContract;
 
-export const ControlsContract: Story = {
-  play: async () => {
-    expect(baseMeta.parameters?.controls).toMatchObject({ disable: true });
-    const playgroundControls = playgroundContract.parameters?.controls;
-    expect(playgroundControls).toHaveProperty('include');
-    expect(playgroundControls?.include).not.toContain('error');
-    expect(baseMeta.argTypes?.author?.control).toBe(false);
-    expect(baseMeta.argTypes?.items?.control).toBe(false);
-    expect(baseMeta.argTypes?.remaining?.control).toBe(false);
-    expect(baseMeta.argTypes?.showPollAction?.control).toBe(false);
-  },
-};
-
 export const DerivedRemainingContract: Story = {
   ...playgroundContract,
   args: {

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -1,6 +1,6 @@
 import { normalizePostContentPlainText } from '@kosmo/core/post-content';
 import { postBodyMaxLength } from '@kosmo/core/validation/post-policy';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { PostComposerProfileSwitcher } from '@/components/post/PostComposerProfileSwitcher';
@@ -31,25 +31,88 @@ const draftMedia = [composerMedia[1]] as readonly ComposerMediaItem[];
 const globalProfile = composerProfiles[0]!;
 
 type ComposerProfileFixtureProps = Readonly<{
+  body: string;
+  contentWarning: string;
+  contentWarningExpanded: boolean;
+  items: readonly ComposerMediaItem[];
   onSelectProfile?: (id: string) => void | Promise<void>;
+  selectedProfileId: string;
+  sensitiveMedia: boolean;
+  surface: 'overlay' | 'rail';
+  switching: boolean;
+}>;
+
+type SelectionFixtureProps = Readonly<{
+  onSelectProfile: (id: string) => void | Promise<void>;
   surface: 'overlay' | 'rail';
 }>;
 
+const defaultFixtureArgs = {
+  body: '프로필을 바꿔도 유지되는 본문',
+  contentWarning: '콘텐츠 경고',
+  contentWarningExpanded: true,
+  items: draftMedia,
+  selectedProfileId: globalProfile.id,
+  sensitiveMedia: true,
+  surface: 'rail',
+  switching: false,
+} satisfies Omit<ComposerProfileFixtureProps, 'onSelectProfile'>;
+
 export function ComposerProfileFixture({
+  body: initialBody,
+  contentWarning: initialContentWarning,
+  contentWarningExpanded: initialContentWarningExpanded,
+  items: initialItems,
   onSelectProfile = async () => undefined,
+  selectedProfileId: initialSelectedProfileId,
+  sensitiveMedia: initialSensitiveMedia,
   surface,
+  switching,
 }: ComposerProfileFixtureProps) {
   const theme = useTheme();
-  const [body, setBody] = useState('프로필을 바꿔도 유지되는 본문');
-  const [contentWarning, setContentWarning] = useState('콘텐츠 경고');
-  const [contentWarningExpanded, setContentWarningExpanded] = useState(true);
-  const [items, setItems] = useState(draftMedia);
-  const sensitiveMedia = true;
+  const switchingRef = useRef(switching);
+  const resolveSelectionRef = useRef<(() => void) | null>(null);
+  const [body, setBody] = useState(initialBody);
+  const [contentWarning, setContentWarning] = useState(initialContentWarning);
+  const [contentWarningExpanded, setContentWarningExpanded] = useState(
+    initialContentWarningExpanded,
+  );
+  const [items, setItems] = useState(initialItems);
+  const [sensitiveMedia, setSensitiveMedia] = useState(initialSensitiveMedia);
   const [visibility, setVisibility] = useState<'FOLLOWERS' | 'PUBLIC' | 'UNLISTED'>('UNLISTED');
   const remaining =
     postBodyMaxLength -
     normalizePostContentPlainText(body).length -
     normalizePostContentPlainText(contentWarning).length;
+
+  useEffect(() => setBody(initialBody), [initialBody]);
+  useEffect(() => setContentWarning(initialContentWarning), [initialContentWarning]);
+  useEffect(
+    () => setContentWarningExpanded(initialContentWarningExpanded),
+    [initialContentWarningExpanded],
+  );
+  useEffect(() => setItems(initialItems), [initialItems]);
+  useEffect(() => setSensitiveMedia(initialSensitiveMedia), [initialSensitiveMedia]);
+  useEffect(() => {
+    switchingRef.current = switching;
+    if (!switching) {
+      resolveSelectionRef.current?.();
+      resolveSelectionRef.current = null;
+    }
+  }, [switching]);
+
+  const selectProfile = async (id: string) => {
+    await onSelectProfile(id);
+    if (switchingRef.current) {
+      await new Promise<void>((resolve) => {
+        if (!switchingRef.current) {
+          resolve();
+          return;
+        }
+        resolveSelectionRef.current = resolve;
+      });
+    }
+  };
 
   return (
     <View
@@ -70,9 +133,9 @@ export function ComposerProfileFixture({
       <PostComposerTarget
         author={
           <PostComposerProfileSwitcher
-            onSelectProfile={onSelectProfile}
+            onSelectProfile={selectProfile}
             profiles={composerProfiles}
-            selectedProfileId={globalProfile.id}
+            selectedProfileId={initialSelectedProfileId}
             surface={surface}
           />
         }
@@ -102,22 +165,17 @@ export function ComposerProfileFixture({
   );
 }
 
-function DeferredSelectionFixture({
-  onSelectProfile,
-  surface,
-}: Required<ComposerProfileFixtureProps>) {
-  const resolveRef = useRef<(() => void) | null>(null);
-  const deferSelection = (id: string) =>
-    new Promise<void>((resolve, reject) => {
-      resolveRef.current = () => {
-        resolveRef.current = null;
-        void Promise.resolve(onSelectProfile(id)).then(resolve, reject);
-      };
-    });
+function DeferredSelectionFixture({ onSelectProfile, surface }: SelectionFixtureProps) {
+  const [switching, setSwitching] = useState(true);
 
   return (
     <>
-      <ComposerProfileFixture onSelectProfile={deferSelection} surface={surface} />
+      <ComposerProfileFixture
+        {...defaultFixtureArgs}
+        onSelectProfile={onSelectProfile}
+        surface={surface}
+        switching={switching}
+      />
       <Pressable
         accessibilityLabel="지연된 프로필 전환 완료"
         accessibilityRole="button"
@@ -125,7 +183,7 @@ function DeferredSelectionFixture({
           event.preventDefault();
           event.stopPropagation();
         }}
-        onPress={() => resolveRef.current?.()}
+        onPress={() => setSwitching(false)}
       >
         <Text>지연된 프로필 전환 완료</Text>
       </Pressable>
@@ -133,23 +191,39 @@ function DeferredSelectionFixture({
   );
 }
 
-function FailingSelectionFixture({
-  onSelectProfile,
-  surface,
-}: Required<ComposerProfileFixtureProps>) {
+function FailingSelectionFixture({ onSelectProfile, surface }: SelectionFixtureProps) {
   const failSelection = async (id: string) => {
     await onSelectProfile(id);
     throw new Error('selection failed');
   };
 
-  return <ComposerProfileFixture onSelectProfile={failSelection} surface={surface} />;
+  return (
+    <ComposerProfileFixture
+      {...defaultFixtureArgs}
+      onSelectProfile={failSelection}
+      surface={surface}
+    />
+  );
 }
 
 const meta = {
-  args: { onSelectProfile: fn(), surface: 'rail' },
+  args: { ...defaultFixtureArgs, onSelectProfile: fn() },
   argTypes: {
+    body: { control: 'text' },
+    contentWarning: { control: 'text' },
+    contentWarningExpanded: { control: 'boolean' },
+    items: { control: 'object' },
     onSelectProfile: { action: 'selectProfile', control: false },
+    selectedProfileId: {
+      control: 'select',
+      options: composerProfiles.map((profile) => profile.id),
+    },
+    sensitiveMedia: { control: 'boolean' },
     surface: { control: 'inline-radio', options: ['rail', 'overlay'] },
+    switching: {
+      control: 'boolean',
+      description: '선택한 프로필 전환을 완료하지 않고 전환 중 상태로 유지합니다.',
+    },
   },
   component: ComposerProfileFixture,
   excludeStories: [
@@ -167,7 +241,19 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {
   parameters: {
-    controls: { disable: false, include: ['surface'] },
+    controls: {
+      disable: false,
+      include: [
+        'selectedProfileId',
+        'body',
+        'contentWarning',
+        'contentWarningExpanded',
+        'items',
+        'sensitiveMedia',
+        'switching',
+        'surface',
+      ],
+    },
   },
 };
 
@@ -184,6 +270,16 @@ export const Dark: Story = {
 };
 
 export const InteractionContract: Story = {
+  args: {
+    body: 'Controls에서 설정한 본문',
+    contentWarning: 'Controls에서 설정한 경고',
+    contentWarningExpanded: true,
+    items: composerMedia,
+    selectedProfileId: 'profile-remote',
+    sensitiveMedia: false,
+    switching: false,
+    surface: 'rail',
+  },
   play: async ({ args, canvasElement }) => {
     args.onSelectProfile?.mockClear();
     const canvas = within(canvasElement);
@@ -195,25 +291,25 @@ export const InteractionContract: Story = {
     expect(target.getBoundingClientRect().width).toBeCloseTo(326, 0);
     expect(trigger).not.toHaveAttribute('aria-haspopup');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
-    expect(contentWarning).toHaveValue('콘텐츠 경고');
-    expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
-    expect(canvas.getByRole('button', { name: '첨부 이미지 1 ALT 편집' })).toBeVisible();
+    expect(body).toHaveValue('Controls에서 설정한 본문');
+    expect(contentWarning).toHaveValue('Controls에서 설정한 경고');
+    expect(canvas.getByLabelText('첨부 이미지 갤러리, 3개')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '첨부 이미지 2 ALT 편집' })).toBeVisible();
     expect(
-      canvas.getByRole('button', { name: '첨부 이미지 1 민감한 이미지 설정 편집' }),
-    ).toBeVisible();
+      canvas.queryByRole('button', { name: '첨부 이미지 2 민감한 이미지 설정 편집' }),
+    ).not.toBeInTheDocument();
 
-    await userEvent.click(canvas.getByText('코스모 작가', { exact: true }));
+    await userEvent.click(canvas.getByText('먼 우주의 사용자', { exact: true }));
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    await userEvent.click(canvas.getByText('@kosmo', { exact: true }));
+    await userEvent.click(canvas.getByText('@remote', { exact: true }));
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    await userEvent.click(canvas.getByLabelText('코스모 작가 프로필 이미지'));
+    await userEvent.click(canvas.getByLabelText('먼 우주의 사용자 프로필 이미지'));
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
     const picker = await canvas.findByLabelText('프로필 전환');
-    const selected = within(picker).getByRole('button', { name: '코스모 작가, @kosmo' });
+    const kosmo = within(picker).getByRole('button', { name: '코스모 작가, @kosmo' });
     const remote = within(picker).getByRole('button', { name: '먼 우주의 사용자, @remote' });
-    expect(selected).toHaveAttribute('aria-pressed', 'true');
-    expect(remote).toHaveAttribute('aria-pressed', 'false');
+    expect(kosmo).toHaveAttribute('aria-pressed', 'false');
+    expect(remote).toHaveAttribute('aria-pressed', 'true');
 
     await userEvent.click(body);
     expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
@@ -221,25 +317,23 @@ export const InteractionContract: Story = {
 
     await userEvent.click(trigger);
     const reopenedPicker = await canvas.findByLabelText('프로필 전환');
-    const reopenedRemote = within(reopenedPicker).getByRole('button', {
-      name: '먼 우주의 사용자, @remote',
+    const reopenedKosmo = within(reopenedPicker).getByRole('button', {
+      name: '코스모 작가, @kosmo',
     });
 
-    await userEvent.click(reopenedRemote);
-    await waitFor(() =>
-      expect(canvas.getByText('먼 우주의 사용자', { exact: true })).toBeVisible(),
-    );
+    await userEvent.click(reopenedKosmo);
+    await waitFor(() => expect(canvas.getByText('코스모 작가', { exact: true })).toBeVisible());
     expect(args.onSelectProfile).toHaveBeenCalledOnce();
-    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
+    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-kosmo');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     await waitFor(() => expect(trigger).toHaveFocus());
-    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
-    expect(contentWarning).toHaveValue('콘텐츠 경고');
-    expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
-    expect(canvas.getByRole('button', { name: '첨부 이미지 1 ALT 편집' })).toBeVisible();
+    expect(body).toHaveValue('Controls에서 설정한 본문');
+    expect(contentWarning).toHaveValue('Controls에서 설정한 경고');
+    expect(canvas.getByLabelText('첨부 이미지 갤러리, 3개')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '첨부 이미지 2 ALT 편집' })).toBeVisible();
     expect(
-      canvas.getByRole('button', { name: '첨부 이미지 1 민감한 이미지 설정 편집' }),
-    ).toBeVisible();
+      canvas.queryByRole('button', { name: '첨부 이미지 2 민감한 이미지 설정 편집' }),
+    ).not.toBeInTheDocument();
     expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
   },
 };
@@ -261,11 +355,10 @@ export const PendingSelectionContract: Story = {
     expect(trigger).toHaveAttribute('aria-busy', 'true');
     expect(remote).toBeDisabled();
     expect(canvas.getByRole('button', { name: '코스모 작가, @kosmo' })).toBeDisabled();
-    expect(args.onSelectProfile).not.toHaveBeenCalled();
-
-    await userEvent.click(canvas.getByRole('button', { name: '지연된 프로필 전환 완료' }));
     await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
     expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
+
+    await userEvent.click(canvas.getByRole('button', { name: '지연된 프로필 전환 완료' }));
     await waitFor(() => expect(trigger).not.toBeDisabled());
     await waitFor(() => expect(trigger).toHaveFocus());
   },
@@ -328,7 +421,8 @@ export const CancelSelectionContract: Story = {
       within(picker).getByRole('button', { name: '먼 우주의 사용자, @remote' }),
     );
     expect(trigger).toBeDisabled();
-    expect(args.onSelectProfile).not.toHaveBeenCalled();
+    await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
+    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
 
     await userEvent.keyboard('{Escape}');
     expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
@@ -352,8 +446,6 @@ export const CancelSelectionContract: Story = {
     expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
 
     await userEvent.click(canvas.getByRole('button', { name: '지연된 프로필 전환 완료' }));
-    await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
-    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
     await waitFor(() => expect(trigger).not.toBeDisabled());
     await waitFor(() => expect(body).toHaveFocus());
     expect(trigger).toHaveAttribute('aria-expanded', 'false');

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -121,6 +121,10 @@ function DeferredSelectionFixture({
       <Pressable
         accessibilityLabel="지연된 프로필 전환 완료"
         accessibilityRole="button"
+        onPointerDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
         onPress={() => resolveRef.current?.()}
       >
         <Text>지연된 프로필 전환 완료</Text>
@@ -211,7 +215,17 @@ export const InteractionContract: Story = {
     expect(selected).toHaveAttribute('aria-pressed', 'true');
     expect(remote).toHaveAttribute('aria-pressed', 'false');
 
-    await userEvent.click(remote);
+    await userEvent.click(body);
+    expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
+    await waitFor(() => expect(body).toHaveFocus());
+
+    await userEvent.click(trigger);
+    const reopenedPicker = await canvas.findByLabelText('프로필 전환');
+    const reopenedRemote = within(reopenedPicker).getByRole('button', {
+      name: '먼 우주의 사용자, @remote',
+    });
+
+    await userEvent.click(reopenedRemote);
     await waitFor(() =>
       expect(canvas.getByText('먼 우주의 사용자', { exact: true })).toBeVisible(),
     );
@@ -319,6 +333,15 @@ export const CancelSelectionContract: Story = {
     await userEvent.keyboard('{Escape}');
     expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
     await waitFor(() => expect(trigger).toHaveFocus());
+    expect(trigger).not.toBeDisabled();
+    expect(trigger).toHaveAttribute('aria-busy', 'true');
+
+    trigger.click();
+    expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
+
+    await userEvent.click(body);
+    await waitFor(() => expect(body).toHaveFocus());
+
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
     expect(contentWarning).toHaveValue('콘텐츠 경고');
     expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
@@ -331,6 +354,8 @@ export const CancelSelectionContract: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '지연된 프로필 전환 완료' }));
     await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
     expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
+    await waitFor(() => expect(trigger).not.toBeDisabled());
+    await waitFor(() => expect(body).toHaveFocus());
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
     expect(contentWarning).toHaveValue('콘텐츠 경고');

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -237,7 +237,7 @@ export const PendingSelectionContract: Story = {
     await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
     expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
     await waitFor(() => expect(trigger).not.toBeDisabled());
-    expect(trigger).toHaveFocus();
+    await waitFor(() => expect(trigger).toHaveFocus());
   },
 };
 
@@ -270,7 +270,7 @@ export const FailureAndCancelContract: Story = {
 
     await userEvent.keyboard('{Escape}');
     expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
-    expect(trigger).toHaveFocus();
+    await waitFor(() => expect(trigger).toHaveFocus());
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
     expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
   },

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -257,7 +257,6 @@ export const Playground: Story = {
   },
 };
 
-export const Rail: Story = { args: { surface: 'rail' } };
 export const Overlay: Story = { args: { surface: 'overlay' } };
 export const Mobile390: Story = {
   args: { surface: 'overlay' },

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -140,7 +140,12 @@ const meta = {
     surface: { control: 'inline-radio', options: ['rail', 'overlay'] },
   },
   component: ComposerProfileFixture,
-  excludeStories: ['InteractionContract', 'PendingSelectionContract', 'FailureAndCancelContract'],
+  excludeStories: [
+    'CancelSelectionContract',
+    'FailureAndCancelContract',
+    'InteractionContract',
+    'PendingSelectionContract',
+  ],
   parameters: { layout: 'centered' },
   title: 'KOSMO/Patterns/Post Composer Profile Switcher',
 } satisfies Meta<typeof ComposerProfileFixture>;
@@ -174,7 +179,7 @@ export const InteractionContract: Story = {
     const body = canvas.getByRole('textbox', { name: '게시물 내용' });
     const contentWarning = canvas.getByRole('textbox', { name: '콘텐츠 경고' });
 
-    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).not.toHaveAttribute('aria-haspopup');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
     expect(contentWarning).toHaveValue('콘텐츠 경고');
@@ -268,6 +273,64 @@ export const FailureAndCancelContract: Story = {
     expect(trigger).toHaveFocus();
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
     expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
+  },
+};
+
+export const CancelSelectionContract: Story = {
+  args: { onSelectProfile: fn(), surface: 'overlay' },
+  render: (args) => (
+    <DeferredSelectionFixture onSelectProfile={args.onSelectProfile!} surface={args.surface!} />
+  ),
+  play: async ({ args, canvasElement }) => {
+    args.onSelectProfile?.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '작성 프로필' });
+    const body = canvas.getByRole('textbox', { name: '게시물 내용' });
+    const contentWarning = canvas.getByRole('textbox', { name: '콘텐츠 경고' });
+
+    await userEvent.click(trigger);
+    const picker = await canvas.findByLabelText('프로필 전환');
+    await userEvent.click(
+      within(picker).getByRole('button', { name: '먼 우주의 사용자, @remote' }),
+    );
+    expect(trigger).toBeDisabled();
+    expect(args.onSelectProfile).not.toHaveBeenCalled();
+
+    await userEvent.keyboard('{Escape}');
+    expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(trigger).toHaveTextContent('코스모 작가');
+    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
+    expect(contentWarning).toHaveValue('콘텐츠 경고');
+    expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '첨부 이미지 1 ALT 편집' })).toBeVisible();
+    expect(
+      canvas.getByRole('button', { name: '첨부 이미지 1 민감한 이미지 설정 편집' }),
+    ).toBeVisible();
+    expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
+
+    await userEvent.click(canvas.getByRole('button', { name: '지연된 프로필 전환 완료' }));
+    await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
+    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
+    expect(trigger).toHaveTextContent('코스모 작가');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
+    expect(contentWarning).toHaveValue('콘텐츠 경고');
+    expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '첨부 이미지 1 ALT 편집' })).toBeVisible();
+    expect(
+      canvas.getByRole('button', { name: '첨부 이미지 1 민감한 이미지 설정 편집' }),
+    ).toBeVisible();
+    expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
+
+    await userEvent.click(trigger);
+    const pickerAfterLateResolve = await canvas.findByLabelText('프로필 전환');
+    expect(
+      within(pickerAfterLateResolve).getByRole('button', { name: '코스모 작가, @kosmo' }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      within(pickerAfterLateResolve).getByRole('button', { name: '먼 우주의 사용자, @remote' }),
+    ).toHaveAttribute('aria-pressed', 'false');
   },
 };
 

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -1,0 +1,279 @@
+import { normalizePostContentPlainText } from '@kosmo/core/post-content';
+import { postBodyMaxLength } from '@kosmo/core/validation/post-policy';
+import { useRef, useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { PostComposerProfileSwitcher } from '@/components/post/PostComposerProfileSwitcher';
+import { PostComposerTarget } from '@/components/post/PostComposerTarget';
+import { useTheme } from '@/theme/ThemeProvider';
+import { spacing, typography } from '@/theme/tokens';
+import { composerMedia } from './PostComposer.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComposerMediaItem } from '@/components/post/PostComposerMediaControls';
+import type { ProfilePickerProfile } from '@/components/profile/ProfilePicker';
+
+export const composerProfiles: readonly ProfilePickerProfile[] = [
+  {
+    avatar: null,
+    displayName: '코스모 작가',
+    id: 'profile-kosmo',
+    relativeHandle: '@kosmo',
+  },
+  {
+    avatar: null,
+    displayName: '먼 우주의 사용자',
+    id: 'profile-remote',
+    relativeHandle: '@remote',
+  },
+];
+
+const draftMedia = [composerMedia[1]] as readonly ComposerMediaItem[];
+const globalProfile = composerProfiles[0]!;
+
+type ComposerProfileFixtureProps = Readonly<{
+  onSelectProfile?: (id: string) => void | Promise<void>;
+  surface: 'overlay' | 'rail';
+}>;
+
+export function ComposerProfileFixture({
+  onSelectProfile = async () => undefined,
+  surface,
+}: ComposerProfileFixtureProps) {
+  const theme = useTheme();
+  const [body, setBody] = useState('프로필을 바꿔도 유지되는 본문');
+  const [contentWarning, setContentWarning] = useState('콘텐츠 경고');
+  const [contentWarningExpanded, setContentWarningExpanded] = useState(true);
+  const [items, setItems] = useState(draftMedia);
+  const sensitiveMedia = true;
+  const [visibility, setVisibility] = useState<'FOLLOWERS' | 'PUBLIC' | 'UNLISTED'>('UNLISTED');
+  const remaining =
+    postBodyMaxLength -
+    normalizePostContentPlainText(body).length -
+    normalizePostContentPlainText(contentWarning).length;
+
+  return (
+    <View style={styles.fixture}>
+      <View accessibilityLabel="전역 활성 프로필" style={styles.globalProfile}>
+        <Text style={[styles.globalLabel, { color: theme.textSecondary }]}>전역 활성 프로필</Text>
+        <Text style={[styles.globalName, { color: theme.text }]}>
+          {globalProfile.displayName} {globalProfile.relativeHandle}
+        </Text>
+      </View>
+      <PostComposerTarget
+        author={
+          <PostComposerProfileSwitcher
+            onSelectProfile={onSelectProfile}
+            profiles={composerProfiles}
+            selectedProfileId={globalProfile.id}
+            surface={surface}
+          />
+        }
+        body={body}
+        contentWarning={contentWarning}
+        contentWarningExpanded={contentWarningExpanded}
+        items={items}
+        onBodyChange={setBody}
+        onContentWarningChange={setContentWarning}
+        onContentWarningToggle={() => setContentWarningExpanded((value) => !value)}
+        onEmojiAction={fn()}
+        onExpand={fn()}
+        onMediaAction={fn()}
+        onMediaEdit={fn()}
+        onMediaRemove={(itemId) => setItems((value) => value.filter((item) => item.key !== itemId))}
+        onMediaRetry={fn()}
+        onPollAction={fn()}
+        onSubmit={fn()}
+        onVisibilityChange={setVisibility}
+        remaining={remaining}
+        sensitiveMedia={sensitiveMedia}
+        showPollAction={false}
+        surface={surface}
+        visibility={visibility}
+      />
+    </View>
+  );
+}
+
+function DeferredSelectionFixture({
+  onSelectProfile,
+  surface,
+}: Required<ComposerProfileFixtureProps>) {
+  const resolveRef = useRef<(() => void) | null>(null);
+  const deferSelection = (id: string) =>
+    new Promise<void>((resolve, reject) => {
+      resolveRef.current = () => {
+        resolveRef.current = null;
+        void Promise.resolve(onSelectProfile(id)).then(resolve, reject);
+      };
+    });
+
+  return (
+    <>
+      <ComposerProfileFixture onSelectProfile={deferSelection} surface={surface} />
+      <Pressable
+        accessibilityLabel="지연된 프로필 전환 완료"
+        accessibilityRole="button"
+        onPress={() => resolveRef.current?.()}
+      >
+        <Text>지연된 프로필 전환 완료</Text>
+      </Pressable>
+    </>
+  );
+}
+
+function FailingSelectionFixture({
+  onSelectProfile,
+  surface,
+}: Required<ComposerProfileFixtureProps>) {
+  const failSelection = async (id: string) => {
+    await onSelectProfile(id);
+    throw new Error('selection failed');
+  };
+
+  return <ComposerProfileFixture onSelectProfile={failSelection} surface={surface} />;
+}
+
+const meta = {
+  args: { onSelectProfile: fn(), surface: 'rail' },
+  argTypes: {
+    onSelectProfile: { action: 'selectProfile', control: false },
+    surface: { control: 'inline-radio', options: ['rail', 'overlay'] },
+  },
+  component: ComposerProfileFixture,
+  excludeStories: ['InteractionContract', 'PendingSelectionContract', 'FailureAndCancelContract'],
+  parameters: { layout: 'centered' },
+  title: 'KOSMO/Patterns/Post Composer Profile Switcher',
+} satisfies Meta<typeof ComposerProfileFixture>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  parameters: {
+    controls: { disable: false, include: ['surface'] },
+  },
+};
+
+export const Rail: Story = { args: { surface: 'rail' } };
+export const Overlay: Story = { args: { surface: 'overlay' } };
+export const Mobile390: Story = {
+  args: { surface: 'overlay' },
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+  parameters: { layout: 'fullscreen' },
+};
+export const Dark: Story = {
+  args: { surface: 'overlay' },
+  globals: { theme: 'dark' },
+};
+
+export const InteractionContract: Story = {
+  play: async ({ args, canvasElement }) => {
+    args.onSelectProfile?.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '작성 프로필' });
+    const body = canvas.getByRole('textbox', { name: '게시물 내용' });
+    const contentWarning = canvas.getByRole('textbox', { name: '콘텐츠 경고' });
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
+    expect(contentWarning).toHaveValue('콘텐츠 경고');
+    expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '첨부 이미지 1 ALT 편집' })).toBeVisible();
+    expect(
+      canvas.getByRole('button', { name: '첨부 이미지 1 민감한 이미지 설정 편집' }),
+    ).toBeVisible();
+
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const picker = await canvas.findByLabelText('프로필 전환');
+    const selected = within(picker).getByRole('button', { name: '코스모 작가, @kosmo' });
+    const remote = within(picker).getByRole('button', { name: '먼 우주의 사용자, @remote' });
+    expect(selected).toHaveAttribute('aria-pressed', 'true');
+    expect(remote).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(remote);
+    await waitFor(() => expect(trigger).toHaveTextContent('먼 우주의 사용자'));
+    expect(args.onSelectProfile).toHaveBeenCalledOnce();
+    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
+    expect(contentWarning).toHaveValue('콘텐츠 경고');
+    expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
+    expect(canvas.getByRole('button', { name: '첨부 이미지 1 ALT 편집' })).toBeVisible();
+    expect(
+      canvas.getByRole('button', { name: '첨부 이미지 1 민감한 이미지 설정 편집' }),
+    ).toBeVisible();
+    expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
+  },
+};
+
+export const PendingSelectionContract: Story = {
+  args: { onSelectProfile: fn(), surface: 'rail' },
+  render: (args) => (
+    <DeferredSelectionFixture onSelectProfile={args.onSelectProfile!} surface={args.surface!} />
+  ),
+  play: async ({ args, canvasElement }) => {
+    args.onSelectProfile?.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '작성 프로필' });
+
+    await userEvent.click(trigger);
+    const remote = await canvas.findByRole('button', { name: '먼 우주의 사용자, @remote' });
+    await userEvent.click(remote);
+    expect(trigger).toBeDisabled();
+    expect(trigger).toHaveAttribute('aria-busy', 'true');
+    expect(remote).toBeDisabled();
+    expect(canvas.getByRole('button', { name: '코스모 작가, @kosmo' })).toBeDisabled();
+    expect(args.onSelectProfile).not.toHaveBeenCalled();
+
+    await userEvent.click(canvas.getByRole('button', { name: '지연된 프로필 전환 완료' }));
+    await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
+    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
+    await waitFor(() => expect(trigger).not.toBeDisabled());
+    expect(trigger).toHaveFocus();
+  },
+};
+
+export const FailureAndCancelContract: Story = {
+  args: { onSelectProfile: fn(), surface: 'overlay' },
+  render: (args) => (
+    <FailingSelectionFixture onSelectProfile={args.onSelectProfile!} surface={args.surface!} />
+  ),
+  play: async ({ args, canvasElement }) => {
+    args.onSelectProfile?.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '작성 프로필' });
+    const body = canvas.getByRole('textbox', { name: '게시물 내용' });
+
+    await userEvent.click(trigger);
+    const picker = await canvas.findByLabelText('프로필 전환');
+    await userEvent.click(
+      within(picker).getByRole('button', { name: '먼 우주의 사용자, @remote' }),
+    );
+    await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
+      '프로필을 전환하지 못했습니다.',
+    );
+    expect(trigger).toHaveTextContent('코스모 작가');
+    expect(within(picker).getByRole('button', { name: '코스모 작가, @kosmo' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(args.onSelectProfile).toHaveBeenCalledOnce();
+    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
+
+    await userEvent.keyboard('{Escape}');
+    expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+    expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
+    expect(canvas.getByLabelText('전역 활성 프로필')).toHaveTextContent('코스모 작가 @kosmo');
+  },
+};
+
+const styles = {
+  fixture: { gap: spacing.lg, maxWidth: 600, padding: spacing.lg, width: '100%' },
+  globalProfile: { gap: spacing.xs },
+  globalLabel: { fontFamily: 'SUIT', ...typography.xsm },
+  globalName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md },
+} as const;

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -52,7 +52,15 @@ export function ComposerProfileFixture({
     normalizePostContentPlainText(contentWarning).length;
 
   return (
-    <View style={styles.fixture}>
+    <View
+      style={[
+        styles.fixture,
+        {
+          maxWidth: '100%',
+          width: surface === 'rail' ? 326 + spacing.lg * 2 : 600 + spacing.lg * 2,
+        },
+      ]}
+    >
       <View accessibilityLabel="전역 활성 프로필" style={styles.globalProfile}>
         <Text style={[styles.globalLabel, { color: theme.textSecondary }]}>전역 활성 프로필</Text>
         <Text style={[styles.globalName, { color: theme.text }]}>
@@ -176,9 +184,11 @@ export const InteractionContract: Story = {
     args.onSelectProfile?.mockClear();
     const canvas = within(canvasElement);
     const trigger = canvas.getByRole('button', { name: '작성 프로필' });
+    const target = canvas.getByTestId('post-composer-target');
     const body = canvas.getByRole('textbox', { name: '게시물 내용' });
     const contentWarning = canvas.getByRole('textbox', { name: '콘텐츠 경고' });
 
+    expect(target.getBoundingClientRect().width).toBeCloseTo(326, 0);
     expect(trigger).not.toHaveAttribute('aria-haspopup');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
@@ -189,7 +199,11 @@ export const InteractionContract: Story = {
       canvas.getByRole('button', { name: '첨부 이미지 1 민감한 이미지 설정 편집' }),
     ).toBeVisible();
 
-    await userEvent.click(trigger);
+    await userEvent.click(canvas.getByText('코스모 작가', { exact: true }));
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(canvas.getByText('@kosmo', { exact: true }));
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(canvas.getByLabelText('코스모 작가 프로필 이미지'));
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
     const picker = await canvas.findByLabelText('프로필 전환');
     const selected = within(picker).getByRole('button', { name: '코스모 작가, @kosmo' });
@@ -198,7 +212,9 @@ export const InteractionContract: Story = {
     expect(remote).toHaveAttribute('aria-pressed', 'false');
 
     await userEvent.click(remote);
-    await waitFor(() => expect(trigger).toHaveTextContent('먼 우주의 사용자'));
+    await waitFor(() =>
+      expect(canvas.getByText('먼 우주의 사용자', { exact: true })).toBeVisible(),
+    );
     expect(args.onSelectProfile).toHaveBeenCalledOnce();
     expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
@@ -250,6 +266,10 @@ export const FailureAndCancelContract: Story = {
     args.onSelectProfile?.mockClear();
     const canvas = within(canvasElement);
     const trigger = canvas.getByRole('button', { name: '작성 프로필' });
+    expect(canvas.getByTestId('post-composer-target').getBoundingClientRect().width).toBeCloseTo(
+      600,
+      0,
+    );
     const body = canvas.getByRole('textbox', { name: '게시물 내용' });
 
     await userEvent.click(trigger);
@@ -260,7 +280,7 @@ export const FailureAndCancelContract: Story = {
     await expect(canvas.findByRole('alert')).resolves.toHaveTextContent(
       '프로필을 전환하지 못했습니다.',
     );
-    expect(trigger).toHaveTextContent('코스모 작가');
+    expect(trigger).toBeVisible();
     expect(within(picker).getByRole('button', { name: '코스모 작가, @kosmo' })).toHaveAttribute(
       'aria-pressed',
       'true',
@@ -299,7 +319,6 @@ export const CancelSelectionContract: Story = {
     await userEvent.keyboard('{Escape}');
     expect(canvas.queryByLabelText('프로필 전환')).not.toBeInTheDocument();
     await waitFor(() => expect(trigger).toHaveFocus());
-    expect(trigger).toHaveTextContent('코스모 작가');
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
     expect(contentWarning).toHaveValue('콘텐츠 경고');
     expect(canvas.getByLabelText('첨부 이미지 갤러리, 1개')).toBeVisible();
@@ -312,7 +331,6 @@ export const CancelSelectionContract: Story = {
     await userEvent.click(canvas.getByRole('button', { name: '지연된 프로필 전환 완료' }));
     await waitFor(() => expect(args.onSelectProfile).toHaveBeenCalledOnce());
     expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
-    expect(trigger).toHaveTextContent('코스모 작가');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(body).toHaveValue('프로필을 바꿔도 유지되는 본문');
     expect(contentWarning).toHaveValue('콘텐츠 경고');

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.stories.tsx
@@ -232,7 +232,7 @@ const meta = {
     'InteractionContract',
     'PendingSelectionContract',
   ],
-  parameters: { layout: 'centered' },
+  parameters: { controls: { disable: true }, layout: 'centered' },
   title: 'KOSMO/Patterns/Post Composer Profile Switcher',
 } satisfies Meta<typeof ComposerProfileFixture>;
 

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.tests.stories.tsx
@@ -1,0 +1,19 @@
+import baseMeta, {
+  FailureAndCancelContract as failureAndCancelContract,
+  InteractionContract as interactionContract,
+  PendingSelectionContract as pendingSelectionContract,
+} from './PostComposerProfileSwitcher.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Patterns/Post Composer Profile Switcher/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const PendingSelectionContract: Story = pendingSelectionContract;
+export const FailureAndCancelContract: Story = failureAndCancelContract;

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.tests.stories.tsx
@@ -1,4 +1,5 @@
 import baseMeta, {
+  CancelSelectionContract as cancelSelectionContract,
   FailureAndCancelContract as failureAndCancelContract,
   InteractionContract as interactionContract,
   PendingSelectionContract as pendingSelectionContract,
@@ -17,3 +18,4 @@ type Story = StoryObj<typeof meta>;
 export const InteractionContract: Story = interactionContract;
 export const PendingSelectionContract: Story = pendingSelectionContract;
 export const FailureAndCancelContract: Story = failureAndCancelContract;
+export const CancelSelectionContract: Story = cancelSelectionContract;

--- a/apps/app/src/stories/patterns/PostComposerProfileSwitcher.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/PostComposerProfileSwitcher.tests.stories.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 const meta = {
   ...baseMeta,
   excludeStories: [],
+  parameters: { ...baseMeta.parameters, controls: { disable: true } },
   title: 'KOSMO/Patterns/Post Composer Profile Switcher/Tests',
 } satisfies Meta;
 

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -453,6 +453,10 @@ documentation·state specimen을 두 번째 행에 둔다.
   specimen은 다섯 action을 모두 기본 `true`로 두며, Product는 아직 구현하지 않은 action을 같은
   property·capability flag로 숨긴다. 모바일 fullscreen처럼 header가 제출 action을 소유하는 consumer는
   `Show submit=false`로 footer의 Button만 숨기고 남은 글자 수 counter는 유지한다.
+- `Show progress ring`은 기본 `false`인 별도 Boolean property다. `20×20` ring은 남은 글자 수 다음, footer 제출
+  Button 앞에 놓이며 사용량의 절반을 보여 주는 source specimen만 제공한다. 실제 비율은 Product가 500자 제한에서
+  파생하고 normal·100자 이하 warning·0자 이하 danger semantic state를 적용한다. Full Overlay와 모바일 fullscreen만
+  이를 켜고, 폭이 제한된 Rail은 계속 끈다.
 - `CW active`·`Poll active`는 action 노출 여부와 별개인 modifier state다. `03 Patterns` specimen이
   Poll·Emoji action을 켜두어도 Product 기능이 준비됐다는 의미가 아니며, runtime capability·feature flag·interaction
   lifecycle은 Product가 소유한다.
@@ -483,15 +487,17 @@ documentation·state specimen을 두 번째 행에 둔다.
   geometry·event propagation·focus·navigation은 Product에서 검증한다.
 - Web footer는 Media → Poll → CW → Emoji 순서로 공용 `IconButton`의 `32×32` target과 `20×20` icon,
   action 사이 `4px` 간격을 사용한다. 글자 수 counter는 `32px`, 제출은 기존 `Button/Compact` `72×32`를 사용해
-  `Rail`의 실제 footer 폭 `270px` 안에서 한 줄로 배치한다. 이 규칙은 Web 전용이며 iOS `44pt`·Android `48dp`
-  target 계약은 유지한다.
+  `Rail`의 실제 footer 폭 `270px` 안에서 한 줄로 배치한다. Rail은 ring을 추가하지 않는다. Overlay는 도구를 왼쪽,
+  남은 글자 수 → ring → 제출을 오른쪽 그룹으로 정렬한다. 이 규칙은 Web 전용이며 iOS `44pt`·Android `48dp` target
+  계약은 유지한다.
 - Overlay 전용 attachment 편집은
   [`ComposerMediaEditor`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=5455-38985)
   component set이 `05 Post & Composer`에서 소유한다. Web source master는 `920×678`이고 같은 source의
   instance를 `720–920px`에서 resize한다. 우측 tool panel은 `280px`로 고정하고 왼쪽 preview만 남은 폭을 채우며,
   parent Overlay surface는 `min(920px, 100vw - 48px)`를 소유한다. 일반 `PostComposer Surface=Overlay` 자체의
   `600px` 폭은 유지하고, editor 진입 시 같은 parent surface 안의 내용을 교체하면서 editor 폭으로 확장한다.
-  별도 `ModalSheet`·scrim을 중첩하거나 `PostComposer`의 `State`·`Rail` variant로 추가하지 않는다.
+  별도 `ModalSheet`·scrim을 중첩하거나 `PostComposer`의 `State`·`Rail` variant로 추가하지 않는다. Overlay surface는
+  바깥 radius를 clip하고 높이가 제한될 때 content 내부만 scroll해 우측 상단 radius를 보존한다.
 - `ComposerMediaEditor`는 `Tool=Alt|Sensitive|Image Edit`를 제공한다. `Alt`가 기존 consumer를 보존하는 기본값이고,
   `Sensitive`는 어느 attachment에서 진입해도 Post Content의 공유 `sensitiveMedia`를 편집하며, 토글 결과를 모든
   attachment status pill이 함께 mirror한다. 선택한 이미지는 ALT·향후 이미지 편집을 위한 navigation context이지
@@ -504,7 +510,8 @@ documentation·state specimen을 두 번째 행에 둔다.
   attachment만 제거한다. 하단 `완료`는 현재 tool의 변경을 draft에 반영하고 Composer로 돌아가며, ALT·향후 이미지
   편집은 선택 attachment에, Sensitive는 Post 전체에 적용한다. Rail에서 편집을 시작해도 같은 Overlay의 editor
   view로 직접 전환한다.
-- `< compact` Web과 Android/iOS는 별도 fullscreen editor를 사용한다. scrim, focus trap·restore, Escape,
+- `< compact` Web과 Android/iOS는 별도 fullscreen editor를 사용한다. 모바일의 가로로 긴 preview는 잘라내지 않고
+  가용 폭 안에 `contain`한다. scrim, focus trap·restore, Escape,
   discard confirmation, viewport max-height·body scroll, safe area와 mobile keyboard avoidance lifecycle은
   Product의 상위 Overlay 구현이 소유한다.
 - `12 Exploration`에 남긴 기존 `600×624`·`SquarePen` PC editor는 `Superseded` decision history다. 새 consumer는
@@ -529,8 +536,11 @@ documentation·state specimen을 두 번째 행에 둔다.
 - 8개 variant의 `Composer body`는 40px `Author row`에 Avatar와 posting identity만 두고, CW·본문·Media·Poll
   editor는 그 아래 358px 전체 폭을 사용한다. Avatar gutter를 편집영역 전체 높이까지 유지하지 않는다.
 - 모바일 fullscreen header가 제출 action을 소유하므로 8개 조합 모두 공용 `__ComposerFooter`의
-  `Show submit=false`를 유지한다. Poll·CW 표본은 배치와 reflow evidence이며 실제 작성 기능·keyboard avoidance·
-  safe area·focus·제출 lifecycle 완료를 뜻하지 않는다.
+  `Show submit=false`, `Show progress ring=true`를 유지한다. footer는 도구를 왼쪽, 남은 글자 수 → ring을 오른쪽
+  그룹으로 정렬한다. 공개 범위 menu는 trigger의 chevron 쪽 우측 edge에 맞춘다. Poll·CW 표본은 배치와 reflow
+  evidence이며 실제 작성 기능·keyboard avoidance·safe area·focus·제출 lifecycle 완료를 뜻하지 않는다.
+- author 또는 CW block과 본문 editor 사이에는 `8px` 간격을 유지한다. editor가 남은 content 높이를 채우고 media
+  shelf는 별도 sibling으로 이어져 focus ring이 shelf 경계에서 잘리지 않는다.
 - `04 Screens - Mobile`의 [`Composer state consumers`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6771-10454)는
   Full Media·Poll·CW와 Keyboard Empty·Media·Poll·CW 7개를 연결한다. `14 Mobile composer and overlay consumers`의
   Full Empty Light/Dark까지 합치면 route 호환 FRAME 없이 8개 variant가 모두 실제 Target consumer를 가진다.

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -535,6 +535,8 @@ documentation·state specimen을 두 번째 행에 둔다.
   Full Media·Poll·CW와 Keyboard Empty·Media·Poll·CW 7개를 연결한다. `14 Mobile composer and overlay consumers`의
   Full Empty Light/Dark까지 합치면 route 호환 FRAME 없이 8개 variant가 모두 실제 Target consumer를 가진다.
   Keyboard는 illustrative geometry라 Native IME·safe-area reflow는 별도 runtime QA가 필요하다.
+- Media 조합의 attachment shelf는 `164px` 높이와 `space/8` bottom padding을 사용해 마지막 media row와 footer 사이에
+  정확히 `8px`을 둔다. Empty·Poll·CW 조합과 Desktop Composer의 spacing은 이 규칙의 영향을 받지 않는다.
 - [`Composer Dark coverage`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=5884-14199)는
   Full Web Composer overlay, Full Web thread rail Reply, Compact Web ReplyComposer modal과 전역 Mobile Composer의
   [`Reply Parent upward-scroll reveal Dark representative 5884:14891`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=5884-14891)를

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -510,8 +510,10 @@ documentation·state specimen을 두 번째 행에 둔다.
 - Web editor의 preview와 thumbnail selector, content와 footer 사이에는 가로 border를 두지 않는다. header·tool tab의
   구분선과 preview·우측 tool panel 사이 세로 border, Mobile editor의 기존 구분선은 유지한다.
 - editor header는 `44×44` hit target 안에 기존 Web `IconButton` `32×32`와 canonical `ArrowLeft`·`X`를 사용한다. Back은 draft와
-  media를 유지한 채 Composer로 돌아가고, Close는 Composer Overlay 전체를 닫는다. preview 안의 X는 해당
-  attachment만 제거한다. 하단 `완료`는 현재 tool의 변경을 draft에 반영하고 Composer로 돌아가며, ALT·향후 이미지
+  media를 유지한 채 Composer로 돌아가고, Close는 Composer Overlay 전체를 닫는다. 첨부 제거는 Composer 본문의
+  `PostComposerMediaItems` gallery에서 각 미디어 카드의 X 버튼으로 수행하며, 해당 attachment만 제거한다.
+  `ComposerMediaEditor` 내부의 선택 이미지 preview에는 첨부 제거 버튼을 제공하지 않는다.
+  하단 `완료`는 현재 tool의 변경을 draft에 반영하고 Composer로 돌아가며, ALT·향후 이미지
   편집은 선택 attachment에, Sensitive는 Post 전체에 적용한다. Rail에서 편집을 시작해도 같은 Overlay의 editor
   view로 직접 전환한다.
 - `< compact` Web과 Android/iOS는 별도 fullscreen editor를 사용한다. 모바일의 가로로 긴 preview는 잘라내지 않고

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -472,6 +472,8 @@ documentation·state specimen을 두 번째 행에 둔다.
   `ComposerMediaEditor Tool=Sensitive`로 진입해도 같은 값을 편집하며 모든 Ready attachment가 결과를 함께 표시한다.
   `__SensitiveMediaRow` source는 탐색용 candidate를 위해 보존하지만 production `PostComposerMediaItems` consumer에서는
   사용하지 않는다. attachment별 민감도는 별도 domain/API 계약이 추가될 때 도입한다.
+- gallery card는 `156×156`을 유지하고 scrollbar는 시각적으로 숨긴다. Web에서 attachment가 3개 이상이고 실제
+  overflow가 생기면 이전·다음 control로 card 단위 이동을 제공하며, Native는 기존 horizontal swipe를 사용한다.
 - Ready attachment의 우측 상단 편집 action은 canonical `Pen`을 `20×20`으로 사용하고 `Show edit action`으로
   노출을 제어한다. Rail·Overlay gallery에서는 editor 진입점을 표시하고 `ComposerMediaEditor` 내부 preview에서는
   `false`로 숨긴다. `Expand`는 Composer Rail을 Overlay로 확장하는 별도 semantic action으로 유지한다.
@@ -505,6 +507,8 @@ documentation·state specimen을 두 번째 행에 둔다.
   Product 저장·편집 기능을 의미하지 않는다. canonical `TabList`·`Tab/Underline`을 사용하고, 편집할 이미지의
   `48×48` selector는 preview 하단 중앙에서 tool tabs와 분리한다. 이 selector는 Composer 본문의
   `PostComposerMediaItems` gallery를 대체하는 컴포넌트가 아니라 editor 안의 현재 이미지 navigation이다.
+- Web editor의 preview와 thumbnail selector, content와 footer 사이에는 가로 border를 두지 않는다. header·tool tab의
+  구분선과 preview·우측 tool panel 사이 세로 border, Mobile editor의 기존 구분선은 유지한다.
 - editor header는 `44×44` hit target 안에 기존 Web `IconButton` `32×32`와 canonical `ArrowLeft`·`X`를 사용한다. Back은 draft와
   media를 유지한 채 Composer로 돌아가고, Close는 Composer Overlay 전체를 닫는다. preview 안의 X는 해당
   attachment만 제거한다. 하단 `완료`는 현재 tool의 변경을 draft에 반영하고 Composer로 돌아가며, ALT·향후 이미지
@@ -539,6 +543,9 @@ documentation·state specimen을 두 번째 행에 둔다.
   `Show submit=false`, `Show progress ring=true`를 유지한다. footer는 도구를 왼쪽, 남은 글자 수 → ring을 오른쪽
   그룹으로 정렬한다. 공개 범위 menu는 trigger의 chevron 쪽 우측 edge에 맞춘다. Poll·CW 표본은 배치와 reflow
   evidence이며 실제 작성 기능·keyboard avoidance·safe area·focus·제출 lifecycle 완료를 뜻하지 않는다.
+- header의 게시 action은 공용 `Button/Default` 높이 `40px`을 유지하고 폭만 `72px`로 제한한다. Candidate의 Web
+  rendering은 이 visual geometry를 검증하며, iOS `44pt`·Android `48dp` 실제 입력 영역은 Native runtime에서 별도로
+  검증한다.
 - author 또는 CW block과 본문 editor 사이에는 `8px` 간격을 유지한다. editor가 남은 content 높이를 채우고 media
   shelf는 별도 sibling으로 이어져 focus ring이 shelf 경계에서 잘리지 않는다.
 - `04 Screens - Mobile`의 [`Composer state consumers`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6771-10454)는

--- a/docs/design/reactions.md
+++ b/docs/design/reactions.md
@@ -46,7 +46,7 @@ Reaction Quick Picker는 현재 제공된 Reaction option을 빠르게 선택하
 
 Full Reaction Picker는 Quick Picker를 폐기하지 않고, Unicode emoji를 검색하거나 category별로 탐색해 더 많은 Reaction을 선택하는 확장 surface다. custom reaction의 데이터·asset 계약이 정해지기 전에는 별도 custom section이나 실패 화면을 추측해 추가하지 않는다.
 
-- Figma source는 `Presentation=Web | Mobile`과 `State=Browse | SearchResults | Empty | Loading`을 조합한 8 variants다. `Browse`는 검색, 빠른 반응, 최근 사용, category와 전체 emoji grid를 표시하고, `SearchResults`는 검색 결과만, `Empty`는 검색 결과 없음만, `Loading`은 spinner만 표시한다. Picker 전체 `Error` variant는 만들지 않는다.
+- Figma source는 `Presentation=Web | Mobile`과 `State=Browse | SearchResults | Empty | Loading`을 조합한 8 variants다. `Browse`는 검색, 빠른 반응, 최근 사용, category heading과 전체 emoji grid를 표시하고, `SearchResults`는 검색 결과만, `Empty`는 검색 결과 없음만, `Loading`은 spinner만 표시한다. Browse에는 category shortcut control을 두지 않으며, 최근 사용은 Web 최대 16개·Mobile 최대 14개를 아래 category grid와 같은 방식으로 표시한다. Web은 한 행에 8개, Mobile은 7개를 배치하고, 가득 찬 행은 좌우 가장자리를 맞추며 마지막 덜 찬 행은 기존 간격으로 왼쪽 정렬한다. Picker 전체 `Error` variant는 만들지 않는다.
 - Web은 trigger에 붙는 non-modal dialog를 사용한다. 열릴 때 검색 field로 focus를 옮기고 같은 trigger, `Escape`, 바깥 클릭으로 닫은 뒤 focus를 trigger에 복원한다.
 - Mobile은 modal bottom sheet를 사용한다. `Browse`의 initial height는 480, `SearchResults`·`Empty`·`Loading`의 expanded height는 720이다. `Scrolled`는 expanded sheet의 runtime scroll 위치 표본이지 별도 source variant가 아니다.
 - Mobile Screens의 [`Post action overlays and picker`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6772-10989)는
@@ -55,7 +55,7 @@ Full Reaction Picker는 Quick Picker를 폐기하지 않고, Unicode emoji를 �
   Viewer 위 Mobile sheet로 전환한다. 다른 Full Picker source state를 늘리거나 runtime focus·dismiss·keyboard
   동작 완료를 뜻하지 않는다.
 - Mobile은 열릴 때 software keyboard를 자동으로 띄우지 않고 sheet title부터 탐색한다. backdrop tap, drag dismiss, Android back으로 닫고 focus를 원래 trigger로 복원한다.
-- dialog의 접근성 이름은 `반응 선택`이다. 검색 field, category와 Reaction button은 식별 가능한 이름과 selected 상태를 제공한다. 결과 영역은 Loading에서 busy 상태와 시각적으로 숨긴 `반응을 불러오는 중` 문구를 함께 노출한다.
+- dialog의 접근성 이름은 `반응 선택`이다. 검색 field, category heading과 Reaction button은 식별 가능한 이름을 제공하고, Reaction button은 selected 상태를 제공한다. 결과 영역은 Loading에서 busy 상태와 시각적으로 숨긴 `반응을 불러오는 중` 문구를 함께 노출한다.
 - spinner는 `motion/duration/loading-cycle` 800ms마다 linear하게 회전한다. reduced motion에서는 회전을 제거하고 정적인 `···`로 대체한다.
 - sticky header·category, grid scroll, safe area, software keyboard, Web keyboard, VoiceOver·TalkBack의 실제 focus·dismiss·reflow는 Production runtime QA에서 검증한다.
 

--- a/docs/design/reactions.md
+++ b/docs/design/reactions.md
@@ -122,7 +122,7 @@ Full Reaction Picker는 Quick Picker를 폐기하지 않고, Unicode emoji를 �
 ## 컴포넌트 경계
 
 - `ReactionSelector`는 Quick Picker의 플랫폼별 presentation만 소유한다.
-- `FullReactionPicker`는 Unicode-first 검색·category 탐색과 Web dialog·Mobile sheet presentation을 소유한다. custom reaction의 asset·data·API와 runtime fetch·cache는 소유하지 않는다.
+- `FullReactionPicker`는 Unicode-first 검색·category 탐색과 Web dialog·Mobile sheet presentation을 소유한다. Web에서 이를 여는 composition은 trigger와 open state를 소유하고 같은 trigger·`Escape`·바깥 클릭 dismiss 및 trigger focus 복원을 연결한다. custom reaction의 asset·data·API와 runtime fetch·cache는 소유하지 않는다.
 - private `ReactionAction`과 `ReactionPopover`는 Action Bar trigger와 anchored popover를 소유한다.
 - private `PostReactionController`는 한 Post의 toggle 상태와 mutation/cache 동작을 소유한다.
 - private `__ReactionSummaryItem`은 Web 32px·iOS 44pt·Android 48dp의 reaction, selected, `+N` item presentation을 소유한다.


### PR DESCRIPTION
## 무엇을 변경했나요

- 기존 shell의 프로필 선택 UI를 mutation-free `ProfilePicker`로 추출하고, 기존 전역 Profile 전환/analytics/resetActor 동작은 그대로 유지했습니다.
- Composer 전용 controlled `PostComposerProfileSwitcher`를 추가해 작성 actor만 전환하도록 했습니다.
- Rail 초기 상태는 Playground에서 제공하고, Overlay·Mobile 390·Dark 대표 스토리를 제공합니다.
- 중복 Rail story를 제거하고 Tests의 Controls를 비활성화했습니다.
- 정상 선택, pending, 실패/Escape, pending 취소 뒤 늦은 resolve까지 4개 interaction 계약을 추가했습니다.
- Profile 전환 전후에 본문, CW, 미디어/ALT, 민감 콘텐츠 상태가 유지되는 fixture를 포함했습니다.

## 왜 변경했나요

[PROD-859](https://linear.app/byulmaru/issue/PROD-859)의 범위대로 Composer 작성 Profile 전환 상태를 공용 UI와 Storybook 검증 표면으로 먼저 이관합니다. 런타임 연결 전에 Figma 기준의 시각 상태와 상호작용 계약을 독립적으로 검토할 수 있게 합니다.

## 이번 PR의 주요 결정

- Composer에서 바뀌는 값은 작성 actor뿐이며 전역 active Profile은 변경하지 않습니다.
- 새 picker/variant를 만들지 않고 기존 Figma ProfileSwitcher 구조를 재사용했습니다.
- body/CW/media/ALT/sensitive 상태는 actor 전환과 분리해 보존합니다.
- 이 PR은 Target/Storybook presentation까지만 담당하며 실제 `/compose`, RightRail, Relay/API/cache/session 연결은 PROD-810으로 남깁니다.

### Figma 기준

- [Composer Overlay](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4508-31048)
- [Composer Rail](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4508-31051)
- [ProfileSwitcher source](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1929-2082)

## Storybook Preview

- 제공: @yeeun-uwu 로컬 Mac의 Tailscale Serve
- 기간: 이 PR의 Storybook 리뷰가 끝날 때까지
- 접근: 동일 tailnet 계정/기기 필요
- Exact head: `prod-859@4fcc710bc39ce0926c4848e7c3b80adbe635daca`
- 기존 공유 Preview는 상위 작업이 관리합니다. 현재 Stack 최상단은 [PR #763](https://github.com/byulmaru/kosmo/pull/763)이며, 이번 두 Storybook 정리는 공유 Preview에 아직 반영됐다고 보장하지 않습니다.
- [Playground](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-post-composer-profile-switcher--playground)
- [Overlay](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-post-composer-profile-switcher--overlay)
- [Mobile 390](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-post-composer-profile-switcher--mobile-390)
- [Dark](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-post-composer-profile-switcher--dark)

## 검증

### 이번 Storybook 정리 (`4fcc710b`)

- 기존 interaction 4/4, 정적 Storybook 빌드, ESLint·Prettier 및 diff 검사 통과
- 생성된 index에서 중복 Rail 제거와 Playground 유지 확인

### 이전 구현 검증 기록

- `vitest ... PostComposerProfileSwitcher.tests.stories.tsx`: 4/4 통과
- `pnpm --filter @kosmo/app lint:tsc`: 통과
- `pnpm --filter @kosmo/app build-storybook`: 통과
- `pnpm --filter @kosmo/app test:storybook`: 재실행 68/68 files, 561/561 tests 통과
  - 첫 실행은 변경 범위 밖 기존 `Slider.stories.tsx > Playground` interaction이 1회 실패(560/561)했고 동일 HEAD 재실행은 통과했습니다.
- Browser QA: Rail/Overlay/Mobile 390/Dark, actor 변경과 draft 보존, Escape 닫기와 trigger focus 복원 확인
- 독립 구현 리뷰 및 수정 후 재검토: 차단 finding 없음

## 범위 밖 / 남은 위험

- Native runtime 검증은 포함하지 않습니다. Mobile 390은 RNW 대표 상태입니다.
- route/data/Relay/API/mutation/cache/permission/session 및 전역 active Profile 변경은 포함하지 않습니다.
- 기존 전체 Storybook의 Slider interaction flake는 이 PR에서 수정하지 않습니다.

## Stack

- GitHub Stack [#716](https://github.com/byulmaru/kosmo/stacks/716)
- parent: [#730 `prod-854`](https://github.com/byulmaru/kosmo/pull/730)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

