### PR TITLE
iOS 배포 중 공용 DNS가 끊기지 않게 한다

### DIFF
--- a/.github/workflows/ios-app-store-connect-upload.yml
+++ b/.github/workflows/ios-app-store-connect-upload.yml
@@ -90,6 +90,12 @@ jobs:
             secret/data/kosmo/prod/ios-signing APPLE_API_ISSUER_ID | APPLE_API_ISSUER_ID ;
             secret/data/kosmo/prod/ios-signing APPLE_API_KEY_P8_BASE64 | APPLE_API_KEY_P8_BASE64
 
+      - name: Disconnect Tailscale after loading Vault secrets
+        run: |
+          sudo -E tailscale logout
+          networksetup -setdnsservers Ethernet Empty
+          networksetup -setsearchdomains Ethernet Empty
+
       - name: Build and distribute iOS App Store IPA
         working-directory: apps/app
         env:


### PR DESCRIPTION
## 무엇을 변경했나요

- Vault에서 iOS 서명 비밀을 읽은 직후 Tailscale에서 로그아웃합니다.
- Tailscale Action이 macOS에 설정한 DNS 서버와 검색 도메인을 기본값으로 복구합니다.

## 왜 변경했나요

iOS App Store Connect Upload run 33732362299의 두 실행에서 Vault와 서명 준비는 성공했지만, Tailscale Action이 시스템 DNS를 100.100.100.100으로 변경한 뒤 api.appstoreconnect.apple.com 조회가 동일하게 실패했습니다. 첫 실행에서는 signed IPA 업로드까지 성공했지만 processing 확인에서 실패했고, 두 번째 실행은 최초 App Store Connect API 조회에서 실패했습니다.

Tailscale 공식 이슈 #315가 같은 macOS DNS 강제 변경 문제를 기록하고 있습니다: https://github.com/tailscale/github-action/issues/315

## 이번 PR의 주요 결정

### Vault 비밀을 읽은 뒤 Tailscale 연결을 종료한다

- 결정자: @robin-maki
- 선택: Vault 로드 직후 Tailscale에서 로그아웃하고 macOS DNS를 복구합니다.
- 고려한 대안: Tailscale 연결을 유지한 채 DNS만 복구하거나, Fastlane에 재시도를 추가합니다.
- 이유: 이후 빌드와 App Store Connect 업로드에는 tailnet 접근이 필요하지 않아 연결과 DNS 변경을 함께 종료하는 것이 가장 작은 권한 경계입니다.
- 감수한 결과: Tailscale Action의 job 종료 후 cleanup이 로그아웃과 DNS 복구를 한 번 더 시도합니다.
- 관련 근거: PROD-876 live run 33732362299와 tailscale/github-action#315

## 어떻게 확인할 수 있나요

- `actionlint .github/workflows/ios-app-store-connect-upload.yml`
- `pnpm exec prettier --check .github/workflows/ios-app-store-connect-upload.yml`
- `git diff --check`
- Ponytail read-only 검토에서 추가 삭제 대상이나 회귀 없음

## 아직 어떤 문제가 남았나요

- 실제 GitHub-hosted macOS에서 App Store Connect processing과 Internal Testers 할당까지 완료되는지는 이 변경이 main에 반영된 뒤 workflow를 다시 실행해 확인해야 합니다.

Stack: main -> prod-876-tailscale-dns

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>