### PR TITLE
iOS 배포 완료 후 요약 작성이 실패하지 않게 한다

### DIFF
--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -77,7 +77,7 @@ platform :ios do
     )
   end
 
-  private_lane :write_testflight_summary do |uploaded_build|
+  private_lane :write_testflight_summary do |uploaded_build:|
     summary_path = ENV['GITHUB_STEP_SUMMARY']
     return unless summary_path && !summary_path.empty?
 
@@ -236,7 +236,7 @@ platform :ios do
       UI.user_error!('Uploaded App Store Connect build is not ready for internal testing.') unless uploaded_build.ready_for_internal_testing?
       UI.user_error!('Uploaded App Store Connect build was not assigned to Internal Testers.') unless internal_group.fetch_builds.any? { |build| build.id == uploaded_build.id }
 
-      write_testflight_summary(uploaded_build)
+      write_testflight_summary(uploaded_build: uploaded_build)
     rescue StandardError => error
       primary_error = error
     ensure


### PR DESCRIPTION
## 무엇을 변경했나요

- TestFlight summary private lane이 업로드된 build를 keyword option으로 받도록 수정합니다.
- summary 호출부도 동일한 keyword hash 계약으로 맞춥니다.

## 왜 변경했나요

iOS App Store Connect Upload run 33739706497에서 signed IPA 빌드와 업로드, Apple processing, Internal Testers 배포까지 모두 성공했습니다. 이후 마지막 summary 호출이 build 객체를 positional argument로 전달해 Fastlane 2.237.0의 `Parameters for a lane must always be a hash` 오류로 job과 deployment만 실패했습니다.

## 이번 PR의 주요 결정

### 완료된 배포는 다시 실행하지 않고 summary 호출만 고친다

- 결정자: @robin-maki
- 선택: 기존 summary를 유지하면서 private lane 입력과 호출을 keyword hash로 맞춥니다.
- 고려한 대안: summary를 삭제하거나 실패한 workflow를 그대로 재실행합니다.
- 이유: 배포 결과와 운영 요약을 보존하면서 확인된 호출 계약 오류만 수정하는 최소 변경입니다.
- 감수한 결과: 이 PR은 이미 성공한 build 33739706497001을 다시 업로드하지 않습니다.
- 관련 근거: PROD-876 live run 33739706497

## 어떻게 확인할 수 있나요

- Ruby 3.4.10 `ruby -c apps/app/fastlane/Fastfile`
- Fastlane 2.237.0 keyword lane 호출 semantics 확인
- `git diff --check`
- Ponytail read-only 검토에서 추가 삭제 대상이나 회귀 없음

## 아직 어떤 문제가 남았나요

- 다음 iOS workflow 실행에서 Actions summary까지 포함한 job 전체 성공을 확인해야 합니다. build 33739706497001의 App Store Connect processing 및 Internal Testers 배포 자체는 이미 확인됐습니다.

Stack: main -> prod-876-fastlane-summary

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>