### PR TITLE
개인정보처리방침 확정 전 PostHog 수집을 일시 중단한다

### DIFF
--- a/apps/app/src/analytics/client.test.ts
+++ b/apps/app/src/analytics/client.test.ts
@@ -66,6 +66,18 @@ let constructorFails = false;
 const globals = globalThis as typeof globalThis & { __KOSMO_CHANNEL__?: unknown };
 const originalChannel = globals.__KOSMO_CHANNEL__;
 const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+const mockPostHogConfig = {
+  posthogHost: 'https://posthog.example.test',
+  posthogKey: 'phc_test',
+} as const;
+
+mock.module(new URL('../config/public.ts', import.meta.url), {
+  exports: {
+    getPublicConfig: (key: keyof typeof mockPostHogConfig) =>
+      globals.__KOSMO_CHANNEL__ === 'dev' ? undefined : mockPostHogConfig[key],
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+
 Object.defineProperty(globalThis, 'document', {
   configurable: true,
   value: {},
@@ -131,9 +143,9 @@ describe('PostHog Web client', () => {
 
     assert.ok(instances[0]);
     assert.equal(initCalls.length, 1);
-    assert.equal(initCalls[0]?.token, 'phc_vYTsfHrgz8wE6wQv5kfpQM5XPBnKKjvNQgaHabb6zdsS');
+    assert.equal(initCalls[0]?.token, mockPostHogConfig.posthogKey);
     assert.deepEqual(initCalls[0]?.config, {
-      api_host: 'https://us.i.posthog.com',
+      api_host: mockPostHogConfig.posthogHost,
       defaults: '2026-05-30',
       mask_personal_data_properties: false,
     });

--- a/apps/app/src/config/public.test.ts
+++ b/apps/app/src/config/public.test.ts
@@ -65,11 +65,8 @@ describe('공개 client 설정', () => {
       assert.equal(getPublicConfig('channel'), 'prod');
       assert.equal(getPublicConfig('apiOrigin'), 'https://api.kos.moe');
       assert.equal(getPublicConfig('webOrigin'), 'https://kos.moe');
-      assert.equal(getPublicConfig('posthogHost'), 'https://us.i.posthog.com');
-      assert.equal(
-        getPublicConfig('posthogKey'),
-        'phc_vYTsfHrgz8wE6wQv5kfpQM5XPBnKKjvNQgaHabb6zdsS',
-      );
+      assert.equal(getPublicConfig('posthogHost'), undefined);
+      assert.equal(getPublicConfig('posthogKey'), undefined);
       assert.equal(getPublicConfig('oidcClientId'), '01KQM0S7HGTVJNZA6TTTK8T5NM');
       assert.equal(
         getPublicConfig('sentryDsn'),

--- a/apps/app/src/config/public.ts
+++ b/apps/app/src/config/public.ts
@@ -31,8 +31,8 @@ const publicConfigByChannel = {
     ...commonPublicConfig,
     apiOrigin: 'https://api.kos.moe',
     channel: 'prod',
-    posthogHost: 'https://us.i.posthog.com',
-    posthogKey: 'phc_vYTsfHrgz8wE6wQv5kfpQM5XPBnKKjvNQgaHabb6zdsS',
+    posthogHost: undefined,
+    posthogKey: undefined,
     webOrigin: 'https://kos.moe',
   },
 } satisfies Record<DeploymentChannel, PublicConfig>;

--- a/apps/web/e2e/analytics.e2e.ts
+++ b/apps/web/e2e/analytics.e2e.ts
@@ -71,7 +71,24 @@ test('dev channel Web runtime은 analytics 요청 없이 정상 렌더링된다'
   expect(analyticsRequests).toEqual([]);
 });
 
-test('Web runtime은 PostHog 표준 pageview·autocapture·metadata와 remote config를 유지한다', async ({
+test('prod channel Web runtime은 PostHog 설정이 비활성화되어 analytics 요청 없이 정상 렌더링된다', async ({
+  page,
+}) => {
+  const analyticsRequests: string[] = [];
+  page.on('request', (request) => {
+    if (posthogRoute.test(request.url())) {
+      analyticsRequests.push(request.url());
+    }
+  });
+
+  await page.goto('/');
+
+  await expect(page.getByRole('link', { name: '시작하기' })).toBeVisible();
+  await page.waitForTimeout(200);
+  expect(analyticsRequests).toEqual([]);
+});
+
+test.skip('TEMPORARY: 개인정보처리방침 확정 전 prod PostHog 활성화 검증을 보류한다', async ({
   page,
 }) => {
   const viewer = await createE2ESession({
@@ -254,7 +271,7 @@ test('Web runtime은 PostHog 표준 pageview·autocapture·metadata와 remote co
   expect(posthogRequests.some((url) => new URL(url).pathname.startsWith('/flags'))).toBe(true);
 });
 
-test('Account identity는 A→guest→B에서 분리되고 endpoint 실패에도 인증 흐름을 유지한다', async ({
+test.skip('TEMPORARY: 개인정보처리방침 확정 전 prod PostHog identity 검증을 보류한다', async ({
   context,
   page,
 }) => {


### PR DESCRIPTION
## 무엇을 변경했나요

- `prod` Web 공개 설정에서 PostHog project key와 ingestion host를 일시적으로 제거했습니다.
- 기존 Web adapter의 공개 설정 누락 시 no-op 경계를 그대로 사용하므로, PostHog SDK 초기화와 analytics 전송이 발생하지 않습니다.
- prod Web E2E에 analytics 무전송 검증을 추가하고, 개인정보처리방침 확정 전 실행할 수 없는 PostHog 활성화·identity E2E는 명시적으로 임시 보류했습니다.
- adapter 자체의 활성화 동작 단위 테스트는 test-only 설정 mock으로 유지했습니다.

## 왜 변경했나요

개인정보처리방침 개정이 확정될 때까지 다음 Web production build에서 PostHog 수집을 잠시 중단하기 위한 변경입니다. 이 PR에는 GitHub 공개 변수 변경이나 production 배포를 포함하지 않으므로, merge만으로 현재 운영 번들이 바뀌지 않습니다.

## 이번 PR의 주요 결정

### 공개 설정 제거로 기존 no-op 경계를 사용한다

- 결정자: 본 작업 요청자
- 선택: `prod`의 PostHog key와 host를 `undefined`로 두고 기존 adapter의 no-op 동작을 사용합니다.
- 고려한 대안: 별도 runtime enabled flag, 새 환경변수 또는 GitHub 변수 변경
- 이유: 현재 `main`의 채널별 공개 설정이 코드가 소유하는 구조이며, 이미 정의된 “key 또는 host가 없으면 no-op” 계약으로 가장 작고 되돌릴 수 있습니다.
- 감수한 결과: 다시 켜려면 설정을 복구한 뒤 새 Web production build가 필요합니다.
- 관련 근거: [PostHog Web analytics spec](https://github.com/byulmaru/kosmo/blob/main/openspec/changes/add-posthog-product-analytics/specs/web-product-analytics/spec.md), [PROD-795 개인정보처리방침 PR #714](https://github.com/byulmaru/kosmo/pull/714)

OpenSpec 문서와 PostHog dependency는 변경하지 않았습니다.

## 어떻게 확인할 수 있나요

- `CI=true pnpm --filter @kosmo/app test:unit` — 382/382 통과
- `CI=true pnpm --filter @kosmo/app check` — 통과
- `CI=true pnpm --filter @kosmo/web check` — 통과
- 관련 파일 Prettier 검사와 `git diff --check` — 통과
- `pnpm --filter @kosmo/web exec playwright test e2e/analytics.e2e.ts --list` — 4개 테스트 확인, 활성화 검증 2개는 임시 보류 상태
- `CI=true pnpm --filter @kosmo/app export:web` — Web export 성공; 운영 PostHog key/host가 `apps/app/dist`에 포함되지 않음을 확인

실제 브라우저의 prod 무전송 E2E는 로컬 환경에 Docker Compose가 없어 실행하지 못했습니다. GitHub CI에서 확인해야 합니다.

## 아직 어떤 문제가 남았나요

- 이 PR은 배포하지 않으므로 현재 production 상태는 변경하지 않습니다.
- 개인정보처리방침 확정 뒤 PostHog 설정 복구와 활성화·identity E2E 재개가 필요합니다.
- 현재 PR은 PostHog만 다루며, 이전 production 번들의 OpenPanel 중단은 별도 배포 경계의 작업입니다.

Stack: `main -> PROD-795-temporary-analytics-off`
