### PR TITLE
[PROD-855] ProfileSwitcher unread 계약을 공용 UI와 Storybook으로 이관한다

### DIFF
--- a/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
@@ -101,7 +101,11 @@ export function ProfileSwitcherTarget({
                 accessibilityElementsHidden
                 aria-hidden
                 importantForAccessibility="no-hide-descendants"
-                style={[styles.closedUnread, { backgroundColor: theme.actionPrimaryBase }]}
+                style={[
+                  styles.closedUnread,
+                  styles.wideUnread,
+                  { backgroundColor: theme.actionPrimaryBase },
+                ]}
                 testID="profile-switcher-closed-unread"
               />
             ) : null}
@@ -222,7 +226,7 @@ const styles = StyleSheet.create({
   wideRoot: { width: 240 },
   trigger: { alignItems: 'center', flexDirection: 'row' },
   compactTrigger: { justifyContent: 'center', width: '100%' },
-  wideTrigger: { gap: space[8], width: 240 },
+  wideTrigger: { gap: space[8], position: 'relative', width: 240 },
   compactAvatar: { position: 'relative' },
   triggerName: { flex: 1, minWidth: 0, ...textStyles.uiLabelL },
   closedUnread: { borderRadius: radius.full, height: 8, width: 8 },
@@ -234,6 +238,7 @@ const styles = StyleSheet.create({
     top: -2,
     width: 12,
   },
+  wideUnread: { position: 'absolute', right: -9, top: 2 },
   menu: {
     borderRadius: radius[16],
     borderWidth: borderWidths[1],

--- a/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
@@ -1,9 +1,11 @@
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react-native';
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useEffect, useRef } from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Avatar } from '@/components/ui/Avatar';
 import { getIconButtonTargetSize } from '@/components/ui/IconButton';
 import { useElevation, useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/tokens';
+import type { ViewStyle } from 'react-native';
 import type {
   ProfilePickerProfile,
   ProfilePickerSurface,
@@ -30,12 +32,51 @@ export function ProfileSwitcherTarget({
 }: ProfileSwitcherTargetProps) {
   const theme = useTheme();
   const elevation = useElevation();
+  const menuRef = useRef<View>(null);
+  const triggerRef = useRef<View>(null);
   const compact = surface === 'compact';
   const triggerTargetSize = compact
     ? Math.max(44, getIconButtonTargetSize(Platform.OS))
     : getIconButtonTargetSize(Platform.OS);
   const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId);
   const selectedHasUnread = (selectedProfile?.unreadNotificationCount ?? 0) > 0;
+  const triggerLabel =
+    !open && selectedHasUnread ? '프로필 목록, 읽지 않은 알림 있음' : '프로필 목록';
+  const webMenuBounds =
+    Platform.OS === 'web'
+      ? ({
+          maxHeight: `min(430px, calc(100vh - ${compact ? 32 : surface === 'drawer' ? 206 : 276}px))`,
+        } as unknown as ViewStyle)
+      : undefined;
+  const ProfileList = Platform.OS === 'web' ? ScrollView : View;
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !open || surface === 'drawer') {
+      return;
+    }
+
+    const menu = menuRef.current as unknown as HTMLElement | null;
+    const trigger = triggerRef.current as unknown as HTMLElement | null;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!menu?.contains(event.target as Node) && !trigger?.contains(event.target as Node)) {
+        onOpenChange(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onOpenChange(false);
+        trigger?.focus();
+      }
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onOpenChange, open, surface]);
 
   return (
     <View
@@ -46,8 +87,9 @@ export function ProfileSwitcherTarget({
       ]}
     >
       <Pressable
+        ref={triggerRef}
         aria-expanded={open}
-        accessibilityLabel="프로필 목록"
+        accessibilityLabel={triggerLabel}
         accessibilityRole="button"
         accessibilityState={{ disabled, expanded: open }}
         disabled={disabled}
@@ -120,14 +162,21 @@ export function ProfileSwitcherTarget({
 
       {open ? (
         <View
+          ref={menuRef}
           style={[
             styles.menu,
             compact ? styles.compactMenu : styles.wideMenu,
+            Platform.OS === 'web' ? styles.webMenu : undefined,
+            webMenuBounds,
             elevation.floating,
             { backgroundColor: theme.backgroundElevated, borderColor: theme.borderDefault },
           ]}
         >
-          <View accessibilityLabel="프로필 전환" role={Platform.OS === 'web' ? 'group' : undefined}>
+          <ProfileList
+            accessibilityLabel="프로필 전환"
+            role={Platform.OS === 'web' ? 'group' : undefined}
+            style={Platform.OS === 'web' ? styles.profileList : undefined}
+          >
             {profiles.length === 0 ? (
               <Text style={[styles.empty, { color: theme.foregroundSecondary }]}>
                 프로필이 없습니다.
@@ -147,10 +196,7 @@ export function ProfileSwitcherTarget({
                     }
                     disabled={disabled}
                     key={profile.id}
-                    onPress={() => {
-                      onSelectProfile(profile.id);
-                      onOpenChange(false);
-                    }}
+                    onPress={() => onSelectProfile(profile.id)}
                     style={({ pressed }) => [
                       styles.option,
                       {
@@ -213,7 +259,7 @@ export function ProfileSwitcherTarget({
                 );
               })
             )}
-          </View>
+          </ProfileList>
         </View>
       ) : null}
     </View>
@@ -247,6 +293,8 @@ const styles = StyleSheet.create({
     width: 280,
     zIndex: 30,
   },
+  webMenu: { overflow: 'hidden' },
+  profileList: { flexShrink: 1, minHeight: 0 },
   compactMenu: { left: 56, top: 0 },
   wideMenu: { left: 0, top: 40 },
   option: {

--- a/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
@@ -1,0 +1,312 @@
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react-native';
+import { useRef } from 'react';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Avatar } from '@/components/ui/Avatar';
+import { getIconButtonTargetSize } from '@/components/ui/IconButton';
+import { useElevation, useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, iconSizes, radius, space, textStyles } from '@/theme/tokens';
+import type {
+  ProfilePickerProfile,
+  ProfilePickerSurface,
+} from '@/components/profile/ProfilePicker';
+
+export type ProfileSwitcherTargetProps = Readonly<{
+  disabled?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectProfile: (id: string) => void;
+  open: boolean;
+  profiles: readonly ProfilePickerProfile[];
+  selectedProfileId?: string | null;
+  surface: ProfilePickerSurface;
+}>;
+
+type WebOptionProps = {
+  'aria-checked': boolean;
+  onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
+  role: 'radio';
+  tabIndex: -1 | 0;
+};
+
+export function ProfileSwitcherTarget({
+  disabled = false,
+  onOpenChange,
+  onSelectProfile,
+  open,
+  profiles,
+  selectedProfileId,
+  surface,
+}: ProfileSwitcherTargetProps) {
+  const theme = useTheme();
+  const elevation = useElevation();
+  const optionRefs = useRef(new Map<string, View>());
+  const compact = surface === 'compact';
+  const triggerTargetSize = compact
+    ? Math.max(44, getIconButtonTargetSize(Platform.OS))
+    : getIconButtonTargetSize(Platform.OS);
+  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId);
+  const selectedHasUnread = (selectedProfile?.unreadNotificationCount ?? 0) > 0;
+  const tabStopId = selectedProfile?.id ?? profiles[0]?.id;
+
+  return (
+    <View
+      style={[
+        styles.root,
+        compact ? styles.compactRoot : styles.wideRoot,
+        compact ? { height: triggerTargetSize, width: triggerTargetSize } : undefined,
+      ]}
+    >
+      <Pressable
+        aria-expanded={open}
+        accessibilityLabel="프로필 목록"
+        accessibilityRole="button"
+        accessibilityState={{ disabled, expanded: open }}
+        disabled={disabled}
+        onPress={() => onOpenChange(!open)}
+        style={({ pressed }) => [
+          styles.trigger,
+          compact ? styles.compactTrigger : styles.wideTrigger,
+          { height: triggerTargetSize },
+          { opacity: disabled ? 0.5 : pressed ? 0.65 : 1 },
+        ]}
+      >
+        {compact ? (
+          <View style={styles.compactAvatar}>
+            <Avatar
+              imageUri={selectedProfile?.avatar?.url}
+              label={selectedProfile?.displayName ?? '프로필'}
+              size={40}
+            />
+            {!open && selectedHasUnread ? (
+              <View
+                accessible={false}
+                accessibilityElementsHidden
+                aria-hidden
+                importantForAccessibility="no-hide-descendants"
+                style={[
+                  styles.closedUnread,
+                  styles.compactUnread,
+                  {
+                    backgroundColor: theme.actionPrimaryBase,
+                    borderColor: theme.backgroundCanvas,
+                  },
+                ]}
+                testID="profile-switcher-closed-unread"
+              />
+            ) : null}
+          </View>
+        ) : (
+          <>
+            <Text
+              numberOfLines={1}
+              style={[
+                styles.triggerName,
+                { color: disabled ? theme.stateDisabledForeground : theme.foregroundPrimary },
+              ]}
+            >
+              {selectedProfile?.displayName ?? (profiles.length ? '프로필 선택' : '프로필')}
+            </Text>
+            {!open && selectedHasUnread ? (
+              <View
+                accessible={false}
+                accessibilityElementsHidden
+                aria-hidden
+                importantForAccessibility="no-hide-descendants"
+                style={[styles.closedUnread, { backgroundColor: theme.actionPrimaryBase }]}
+                testID="profile-switcher-closed-unread"
+              />
+            ) : null}
+            {open ? (
+              <ChevronUpIcon color={theme.foregroundSecondary} size={iconSizes[20]} />
+            ) : (
+              <ChevronDownIcon color={theme.foregroundSecondary} size={iconSizes[20]} />
+            )}
+          </>
+        )}
+      </Pressable>
+
+      {open ? (
+        <View
+          style={[
+            styles.menu,
+            compact ? styles.compactMenu : styles.wideMenu,
+            elevation.floating,
+            { backgroundColor: theme.backgroundElevated, borderColor: theme.borderDefault },
+          ]}
+        >
+          <View
+            accessibilityLabel="프로필 전환"
+            accessibilityRole="radiogroup"
+            role={Platform.OS === 'web' ? 'radiogroup' : undefined}
+          >
+            {profiles.length === 0 ? (
+              <Text style={[styles.empty, { color: theme.foregroundSecondary }]}>
+                프로필이 없습니다.
+              </Text>
+            ) : (
+              profiles.map((profile) => {
+                const selected = profile.id === selectedProfileId;
+                const hasUnread = (profile.unreadNotificationCount ?? 0) > 0;
+                const onKeyDown = (event: { key: string; preventDefault: () => void }) => {
+                  const direction =
+                    event.key === 'ArrowDown' || event.key === 'ArrowRight'
+                      ? 1
+                      : event.key === 'ArrowUp' || event.key === 'ArrowLeft'
+                        ? -1
+                        : 0;
+                  if (direction === 0 || disabled) {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  const currentIndex = profiles.findIndex(
+                    (candidate) => candidate.id === profile.id,
+                  );
+                  const target =
+                    profiles[(currentIndex + direction + profiles.length) % profiles.length];
+                  const targetRef = target ? optionRefs.current.get(target.id) : undefined;
+                  (targetRef as unknown as { focus?: () => void } | undefined)?.focus?.();
+                };
+
+                return (
+                  <Pressable
+                    accessibilityLabel={`${profile.displayName}, ${profile.relativeHandle}${hasUnread ? ', 읽지 않은 알림 있음' : ''}`}
+                    accessibilityRole="radio"
+                    accessibilityState={{ checked: selected, disabled }}
+                    disabled={disabled}
+                    key={profile.id}
+                    onPress={() => {
+                      onSelectProfile(profile.id);
+                      onOpenChange(false);
+                    }}
+                    ref={(node) => {
+                      if (node) {
+                        optionRefs.current.set(profile.id, node);
+                      } else {
+                        optionRefs.current.delete(profile.id);
+                      }
+                    }}
+                    style={({ pressed }) => [
+                      styles.option,
+                      {
+                        backgroundColor: selected
+                          ? theme.stateSelectedSurface
+                          : pressed
+                            ? theme.statePressed
+                            : 'transparent',
+                        opacity: disabled ? 0.5 : 1,
+                      },
+                    ]}
+                    {...(Platform.OS === 'web'
+                      ? ({
+                          'aria-checked': selected,
+                          onKeyDown,
+                          role: 'radio',
+                          tabIndex: disabled || profile.id !== tabStopId ? -1 : 0,
+                        } as WebOptionProps)
+                      : undefined)}
+                  >
+                    <View
+                      accessible={false}
+                      accessibilityElementsHidden
+                      aria-hidden
+                      importantForAccessibility="no-hide-descendants"
+                    >
+                      <Avatar
+                        imageUri={profile.avatar?.url}
+                        label={profile.displayName}
+                        size={40}
+                      />
+                    </View>
+                    <View style={styles.optionCopy}>
+                      <Text
+                        numberOfLines={1}
+                        style={[textStyles.uiLabelM, { color: theme.foregroundPrimary }]}
+                      >
+                        {profile.displayName}
+                      </Text>
+                      <Text
+                        numberOfLines={1}
+                        style={[textStyles.uiCopyS, { color: theme.foregroundSecondary }]}
+                      >
+                        {profile.relativeHandle}
+                      </Text>
+                    </View>
+                    <View style={styles.trailing}>
+                      {selected ? (
+                        <CheckIcon color={theme.foregroundPrimary} size={iconSizes[20]} />
+                      ) : hasUnread ? (
+                        <View
+                          accessible={false}
+                          accessibilityElementsHidden
+                          aria-hidden
+                          importantForAccessibility="no-hide-descendants"
+                          style={[styles.unreadCount, { backgroundColor: theme.actionPrimaryBase }]}
+                          testID="profile-switcher-unread-count"
+                        >
+                          <Text style={[textStyles.uiLabelS, { color: theme.actionPrimaryOnBase }]}>
+                            {(profile.unreadNotificationCount ?? 0) > 9
+                              ? '9+'
+                              : profile.unreadNotificationCount}
+                          </Text>
+                        </View>
+                      ) : null}
+                    </View>
+                  </Pressable>
+                );
+              })
+            )}
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { position: 'relative', zIndex: 20 },
+  compactRoot: {},
+  wideRoot: { width: 240 },
+  trigger: { alignItems: 'center', flexDirection: 'row' },
+  compactTrigger: { justifyContent: 'center', width: '100%' },
+  wideTrigger: { gap: space[8], width: 240 },
+  compactAvatar: { position: 'relative' },
+  triggerName: { flex: 1, minWidth: 0, ...textStyles.uiLabelL },
+  closedUnread: { borderRadius: radius.full, height: 8, width: 8 },
+  compactUnread: {
+    borderWidth: borderWidths[1],
+    height: 12,
+    position: 'absolute',
+    right: -2,
+    top: -2,
+    width: 12,
+  },
+  menu: {
+    borderRadius: radius[16],
+    borderWidth: borderWidths[1],
+    padding: space[8],
+    position: 'absolute',
+    width: 280,
+    zIndex: 30,
+  },
+  compactMenu: { left: 56, top: 0 },
+  wideMenu: { left: 0, top: 40 },
+  option: {
+    alignItems: 'center',
+    borderRadius: radius[12],
+    flexDirection: 'row',
+    gap: space[12],
+    minHeight: 60,
+    paddingHorizontal: space[12],
+    paddingVertical: space[8],
+  },
+  optionCopy: { flex: 1, minWidth: 0 },
+  trailing: { alignItems: 'center', height: 24, justifyContent: 'center', width: 24 },
+  unreadCount: {
+    alignItems: 'center',
+    borderRadius: radius.full,
+    height: 24,
+    justifyContent: 'center',
+    width: 24,
+  },
+  empty: { ...textStyles.uiCopyM, padding: space[16], textAlign: 'center' },
+});

--- a/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
@@ -1,5 +1,4 @@
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react-native';
-import { useRef } from 'react';
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { Avatar } from '@/components/ui/Avatar';
 import { getIconButtonTargetSize } from '@/components/ui/IconButton';
@@ -20,13 +19,6 @@ export type ProfileSwitcherTargetProps = Readonly<{
   surface: ProfilePickerSurface;
 }>;
 
-type WebOptionProps = {
-  'aria-checked': boolean;
-  onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
-  role: 'radio';
-  tabIndex: -1 | 0;
-};
-
 export function ProfileSwitcherTarget({
   disabled = false,
   onOpenChange,
@@ -38,14 +30,12 @@ export function ProfileSwitcherTarget({
 }: ProfileSwitcherTargetProps) {
   const theme = useTheme();
   const elevation = useElevation();
-  const optionRefs = useRef(new Map<string, View>());
   const compact = surface === 'compact';
   const triggerTargetSize = compact
     ? Math.max(44, getIconButtonTargetSize(Platform.OS))
     : getIconButtonTargetSize(Platform.OS);
   const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId);
   const selectedHasUnread = (selectedProfile?.unreadNotificationCount ?? 0) > 0;
-  const tabStopId = selectedProfile?.id ?? profiles[0]?.id;
 
   return (
     <View
@@ -133,11 +123,7 @@ export function ProfileSwitcherTarget({
             { backgroundColor: theme.backgroundElevated, borderColor: theme.borderDefault },
           ]}
         >
-          <View
-            accessibilityLabel="프로필 전환"
-            accessibilityRole="radiogroup"
-            role={Platform.OS === 'web' ? 'radiogroup' : undefined}
-          >
+          <View accessibilityLabel="프로필 전환" role={Platform.OS === 'web' ? 'group' : undefined}>
             {profiles.length === 0 ? (
               <Text style={[styles.empty, { color: theme.foregroundSecondary }]}>
                 프로필이 없습니다.
@@ -146,44 +132,20 @@ export function ProfileSwitcherTarget({
               profiles.map((profile) => {
                 const selected = profile.id === selectedProfileId;
                 const hasUnread = (profile.unreadNotificationCount ?? 0) > 0;
-                const onKeyDown = (event: { key: string; preventDefault: () => void }) => {
-                  const direction =
-                    event.key === 'ArrowDown' || event.key === 'ArrowRight'
-                      ? 1
-                      : event.key === 'ArrowUp' || event.key === 'ArrowLeft'
-                        ? -1
-                        : 0;
-                  if (direction === 0 || disabled) {
-                    return;
-                  }
-
-                  event.preventDefault();
-                  const currentIndex = profiles.findIndex(
-                    (candidate) => candidate.id === profile.id,
-                  );
-                  const target =
-                    profiles[(currentIndex + direction + profiles.length) % profiles.length];
-                  const targetRef = target ? optionRefs.current.get(target.id) : undefined;
-                  (targetRef as unknown as { focus?: () => void } | undefined)?.focus?.();
-                };
 
                 return (
                   <Pressable
+                    aria-pressed={selected}
                     accessibilityLabel={`${profile.displayName}, ${profile.relativeHandle}${hasUnread ? ', 읽지 않은 알림 있음' : ''}`}
-                    accessibilityRole="radio"
-                    accessibilityState={{ checked: selected, disabled }}
+                    accessibilityRole="button"
+                    accessibilityState={
+                      Platform.OS === 'web' ? { disabled } : { disabled, selected }
+                    }
                     disabled={disabled}
                     key={profile.id}
                     onPress={() => {
                       onSelectProfile(profile.id);
                       onOpenChange(false);
-                    }}
-                    ref={(node) => {
-                      if (node) {
-                        optionRefs.current.set(profile.id, node);
-                      } else {
-                        optionRefs.current.delete(profile.id);
-                      }
                     }}
                     style={({ pressed }) => [
                       styles.option,
@@ -196,14 +158,6 @@ export function ProfileSwitcherTarget({
                         opacity: disabled ? 0.5 : 1,
                       },
                     ]}
-                    {...(Platform.OS === 'web'
-                      ? ({
-                          'aria-checked': selected,
-                          onKeyDown,
-                          role: 'radio',
-                          tabIndex: disabled || profile.id !== tabStopId ? -1 : 0,
-                        } as WebOptionProps)
-                      : undefined)}
                   >
                     <View
                       accessible={false}

--- a/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
@@ -57,13 +57,26 @@ export function ProfileSwitcherTarget({
 
     const menu = menuRef.current as unknown as HTMLElement | null;
     const trigger = triggerRef.current as unknown as HTMLElement | null;
+    const eventComesFromModal = (event: Event) =>
+      event
+        .composedPath()
+        .some(
+          (target) => target instanceof Element && target.getAttribute('aria-modal') === 'true',
+        );
+    const modalIsPresent = () => document.querySelector('[aria-modal="true"]') !== null;
     const onPointerDown = (event: PointerEvent) => {
+      if (eventComesFromModal(event)) {
+        return;
+      }
       if (!menu?.contains(event.target as Node) && !trigger?.contains(event.target as Node)) {
         onOpenChange(false);
       }
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        if (modalIsPresent()) {
+          return;
+        }
         event.preventDefault();
         onOpenChange(false);
         trigger?.focus();

--- a/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
@@ -137,25 +137,27 @@ export function ProfileSwitcherTarget({
             >
               {selectedProfile?.displayName ?? (profiles.length ? '프로필 선택' : '프로필')}
             </Text>
-            {!open && selectedHasUnread ? (
-              <View
-                accessible={false}
-                accessibilityElementsHidden
-                aria-hidden
-                importantForAccessibility="no-hide-descendants"
-                style={[
-                  styles.closedUnread,
-                  styles.wideUnread,
-                  { backgroundColor: theme.actionPrimaryBase },
-                ]}
-                testID="profile-switcher-closed-unread"
-              />
-            ) : null}
-            {open ? (
-              <ChevronUpIcon color={theme.foregroundSecondary} size={iconSizes[20]} />
-            ) : (
-              <ChevronDownIcon color={theme.foregroundSecondary} size={iconSizes[20]} />
-            )}
+            <View style={styles.chevron}>
+              {!open && selectedHasUnread ? (
+                <View
+                  accessible={false}
+                  accessibilityElementsHidden
+                  aria-hidden
+                  importantForAccessibility="no-hide-descendants"
+                  style={[
+                    styles.closedUnread,
+                    styles.wideUnread,
+                    { backgroundColor: theme.actionPrimaryBase },
+                  ]}
+                  testID="profile-switcher-closed-unread"
+                />
+              ) : null}
+              {open ? (
+                <ChevronUpIcon color={theme.foregroundSecondary} size={iconSizes[20]} />
+              ) : (
+                <ChevronDownIcon color={theme.foregroundSecondary} size={iconSizes[20]} />
+              )}
+            </View>
           </>
         )}
       </Pressable>
@@ -280,11 +282,12 @@ const styles = StyleSheet.create({
     borderWidth: borderWidths[1],
     height: 12,
     position: 'absolute',
-    right: -2,
-    top: -2,
+    right: 0,
+    top: 0,
     width: 12,
   },
-  wideUnread: { position: 'absolute', right: -9, top: 2 },
+  chevron: { position: 'relative', height: iconSizes[20], width: iconSizes[20] },
+  wideUnread: { position: 'absolute', right: -9, top: -4 },
   menu: {
     borderRadius: radius[16],
     borderWidth: borderWidths[1],

--- a/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
@@ -208,11 +208,15 @@ export const WideClosedUnreadContract: Story = {
   args: { initialOpen: false, surface: 'full' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
     const indicator = canvas.getByTestId('profile-switcher-closed-unread');
+    const triggerBounds = trigger.getBoundingClientRect();
     const bounds = indicator.getBoundingClientRect();
 
     expect(bounds.width).toBe(8);
     expect(bounds.height).toBe(8);
+    expect(bounds.left).toBe(triggerBounds.right + 1);
+    expect(bounds.top).toBe(triggerBounds.top + 2);
     expect(indicator).toHaveAttribute('aria-hidden', 'true');
   },
 };

--- a/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
@@ -182,18 +182,18 @@ export const InteractionContract: Story = {
     expect(args.onOpenChange).toHaveBeenLastCalledWith(true);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-    const group = canvas.getByRole('radiogroup', { name: '프로필 전환' });
-    const selected = within(group).getByRole('radio', {
+    const group = canvas.getByRole('group', { name: '프로필 전환' });
+    const selected = within(group).getByRole('button', {
       name: '코스모 작가, @kosmo, 읽지 않은 알림 있음',
     });
-    const remote = within(group).getByRole('radio', {
+    const remote = within(group).getByRole('button', {
       name: '먼 우주의 사용자, @remote, 읽지 않은 알림 있음',
     });
-    expect(selected).toHaveAttribute('aria-checked', 'true');
+    expect(selected).toHaveAttribute('aria-pressed', 'true');
 
     await userEvent.tab();
     expect(selected).toHaveFocus();
-    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.tab();
     expect(remote).toHaveFocus();
     expect(args.onSelectProfile).not.toHaveBeenCalled();
 
@@ -234,11 +234,11 @@ export const OpenUnreadContract: Story = {
   args: { initialOpen: true, otherUnreadCount: 10, profileCount: 2 },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const group = canvas.getByRole('radiogroup', { name: '프로필 전환' });
-    const selected = within(group).getByRole('radio', {
+    const group = canvas.getByRole('group', { name: '프로필 전환' });
+    const selected = within(group).getByRole('button', {
       name: '코스모 작가, @kosmo, 읽지 않은 알림 있음',
     });
-    const remote = within(group).getByRole('radio', {
+    const remote = within(group).getByRole('button', {
       name: '먼 우주의 사용자, @remote, 읽지 않은 알림 있음',
     });
     const badge = within(remote).getByTestId('profile-switcher-unread-count');

--- a/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
@@ -27,6 +27,12 @@ const profiles: readonly ProfilePickerProfile[] = [
     id: 'profile-long',
     relativeHandle: '@a-very-long-profile-handle',
   },
+  ...Array.from({ length: 5 }, (_, index) => ({
+    avatar: null,
+    displayName: `추가 프로필 ${index + 4}`,
+    id: `profile-${index + 4}`,
+    relativeHandle: `@profile-${index + 4}`,
+  })),
 ];
 
 type ProfileSwitcherFixtureProps = Readonly<{
@@ -36,6 +42,7 @@ type ProfileSwitcherFixtureProps = Readonly<{
   onSelectProfile: (id: string) => void;
   otherUnreadCount: number;
   profileCount: number;
+  selectionOutcome: 'failure' | 'success';
   selectedProfileId: string;
   selectedUnreadCount: number;
   surface: ProfilePickerSurface;
@@ -48,6 +55,7 @@ export function ProfileSwitcherFixture({
   onSelectProfile,
   otherUnreadCount,
   profileCount,
+  selectionOutcome,
   selectedProfileId: initialSelectedProfileId,
   selectedUnreadCount,
   surface,
@@ -89,8 +97,12 @@ export function ProfileSwitcherFixture({
           onOpenChange(nextOpen);
         }}
         onSelectProfile={(id) => {
-          setSelectedProfileId(id);
           onSelectProfile(id);
+          if (selectionOutcome === 'success') {
+            setSelectedProfileId(id);
+            setOpen(false);
+            onOpenChange(false);
+          }
         }}
         open={open}
         profiles={visibleProfiles}
@@ -109,6 +121,7 @@ const meta = {
     onSelectProfile: fn(),
     otherUnreadCount: 10,
     profileCount: 3,
+    selectionOutcome: 'success',
     selectedProfileId: 'profile-kosmo',
     selectedUnreadCount: 1,
     surface: 'full',
@@ -119,7 +132,8 @@ const meta = {
     onOpenChange: { action: 'open', control: false },
     onSelectProfile: { action: 'selectProfile', control: false },
     otherUnreadCount: { control: 'select', options: [0, 1, 9, 10] },
-    profileCount: { control: { max: 3, min: 0, step: 1, type: 'range' } },
+    profileCount: { control: { max: profiles.length, min: 0, step: 1, type: 'range' } },
+    selectionOutcome: { control: false },
     selectedProfileId: {
       control: 'select',
       options: profiles.map((profile) => profile.id),
@@ -132,8 +146,12 @@ const meta = {
     'CompactClosedUnreadContract',
     'InteractionContract',
     'OpenUnreadContract',
+    'OutsideDismissContract',
     'ProfileSwitcherFixture',
+    'SelectionFailureContract',
     'WideClosedUnreadContract',
+    'EscapeDismissContract',
+    'LongListContract',
   ],
   parameters: { layout: 'centered' },
   title: 'KOSMO/Patterns/Profile Switcher',
@@ -167,6 +185,7 @@ export const Empty: Story = {
 export const LongContent: Story = {
   args: { initialOpen: true, selectedProfileId: 'profile-long' },
 };
+export const LongList: Story = { args: { initialOpen: true, profileCount: profiles.length } };
 export const Disabled: Story = { args: { disabled: true } };
 
 export const InteractionContract: Story = {
@@ -175,7 +194,9 @@ export const InteractionContract: Story = {
     args.onOpenChange.mockClear();
     args.onSelectProfile.mockClear();
     const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+    const trigger = canvas.getByRole('button', {
+      name: '프로필 목록, 읽지 않은 알림 있음',
+    });
 
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     await userEvent.click(trigger);
@@ -204,11 +225,84 @@ export const InteractionContract: Story = {
   },
 };
 
+export const SelectionFailureContract: Story = {
+  args: { initialOpen: true, profileCount: 2, selectionOutcome: 'failure' },
+  play: async ({ args, canvasElement }) => {
+    args.onOpenChange.mockClear();
+    args.onSelectProfile.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+    const group = canvas.getByRole('group', { name: '프로필 전환' });
+    const remote = within(group).getByRole('button', {
+      name: '먼 우주의 사용자, @remote, 읽지 않은 알림 있음',
+    });
+
+    await userEvent.click(remote);
+
+    expect(args.onSelectProfile).toHaveBeenCalledWith('profile-remote');
+    expect(args.onOpenChange).not.toHaveBeenCalled();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(group).toBeInTheDocument();
+  },
+};
+
+export const EscapeDismissContract: Story = {
+  args: { initialOpen: true },
+  play: async ({ args, canvasElement }) => {
+    args.onOpenChange.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(args.onOpenChange).toHaveBeenCalledWith(false);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveFocus();
+  },
+};
+
+export const OutsideDismissContract: Story = {
+  args: { initialOpen: true },
+  play: async ({ args, canvasElement }) => {
+    args.onOpenChange.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+
+    await userEvent.click(canvasElement);
+
+    expect(args.onOpenChange).toHaveBeenCalledWith(false);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  },
+};
+
+export const LongListContract: Story = {
+  args: { initialOpen: true, profileCount: profiles.length },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('group', { name: '프로필 전환' });
+    const lastProfile = within(group).getByRole('button', {
+      name: '추가 프로필 8, @profile-8, 읽지 않은 알림 있음',
+    });
+
+    expect(group.scrollHeight).toBeGreaterThan(group.clientHeight);
+    expect(group.clientHeight).toBeLessThanOrEqual(430);
+
+    lastProfile.focus();
+
+    const groupBounds = group.getBoundingClientRect();
+    const lastProfileBounds = lastProfile.getBoundingClientRect();
+    expect(lastProfile).toHaveFocus();
+    expect(lastProfileBounds.bottom).toBeLessThanOrEqual(groupBounds.bottom);
+  },
+};
+
 export const WideClosedUnreadContract: Story = {
   args: { initialOpen: false, surface: 'full' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+    const trigger = canvas.getByRole('button', {
+      name: '프로필 목록, 읽지 않은 알림 있음',
+    });
     const indicator = canvas.getByTestId('profile-switcher-closed-unread');
     const triggerBounds = trigger.getBoundingClientRect();
     const bounds = indicator.getBoundingClientRect();

--- a/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { ProfileSwitcherTarget } from '@/components/shell/ProfileSwitcherTarget';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type {
+  ProfilePickerProfile,
+  ProfilePickerSurface,
+} from '@/components/profile/ProfilePicker';
+
+const profiles: readonly ProfilePickerProfile[] = [
+  {
+    avatar: null,
+    displayName: '코스모 작가',
+    id: 'profile-kosmo',
+    relativeHandle: '@kosmo',
+  },
+  {
+    avatar: null,
+    displayName: '먼 우주의 사용자',
+    id: 'profile-remote',
+    relativeHandle: '@remote',
+  },
+  {
+    avatar: null,
+    displayName: '아주 긴 이름을 가진 세 번째 프로필',
+    id: 'profile-long',
+    relativeHandle: '@a-very-long-profile-handle',
+  },
+];
+
+type ProfileSwitcherFixtureProps = Readonly<{
+  disabled: boolean;
+  initialOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectProfile: (id: string) => void;
+  otherUnreadCount: number;
+  profileCount: number;
+  selectedProfileId: string;
+  selectedUnreadCount: number;
+  surface: ProfilePickerSurface;
+}>;
+
+export function ProfileSwitcherFixture({
+  disabled,
+  initialOpen,
+  onOpenChange,
+  onSelectProfile,
+  otherUnreadCount,
+  profileCount,
+  selectedProfileId: initialSelectedProfileId,
+  selectedUnreadCount,
+  surface,
+}: ProfileSwitcherFixtureProps) {
+  const availableProfiles = profiles.slice(0, profileCount);
+  const fallbackProfileId = availableProfiles[0]?.id ?? null;
+  const [open, setOpen] = useState(initialOpen);
+  const [selectedProfileId, setSelectedProfileId] = useState(
+    availableProfiles.some((profile) => profile.id === initialSelectedProfileId)
+      ? initialSelectedProfileId
+      : fallbackProfileId,
+  );
+  const visibleProfiles = availableProfiles.map((profile) => ({
+    ...profile,
+    unreadNotificationCount:
+      profile.id === selectedProfileId ? selectedUnreadCount : otherUnreadCount,
+  }));
+
+  useEffect(() => {
+    setSelectedProfileId(
+      availableProfiles.some((profile) => profile.id === initialSelectedProfileId)
+        ? initialSelectedProfileId
+        : fallbackProfileId,
+    );
+  }, [fallbackProfileId, initialSelectedProfileId, profileCount]);
+
+  return (
+    <View
+      style={{
+        minHeight: open ? 340 : 96,
+        padding: 24,
+        width: surface === 'compact' ? 360 : 320,
+      }}
+    >
+      <ProfileSwitcherTarget
+        disabled={disabled}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          onOpenChange(nextOpen);
+        }}
+        onSelectProfile={(id) => {
+          setSelectedProfileId(id);
+          onSelectProfile(id);
+        }}
+        open={open}
+        profiles={visibleProfiles}
+        selectedProfileId={selectedProfileId}
+        surface={surface}
+      />
+    </View>
+  );
+}
+
+const meta = {
+  args: {
+    disabled: false,
+    initialOpen: false,
+    onOpenChange: fn(),
+    onSelectProfile: fn(),
+    otherUnreadCount: 10,
+    profileCount: 3,
+    selectedProfileId: 'profile-kosmo',
+    selectedUnreadCount: 1,
+    surface: 'full',
+  },
+  argTypes: {
+    disabled: { control: 'boolean' },
+    initialOpen: { control: false },
+    onOpenChange: { action: 'open', control: false },
+    onSelectProfile: { action: 'selectProfile', control: false },
+    otherUnreadCount: { control: 'select', options: [0, 1, 9, 10] },
+    profileCount: { control: { max: 3, min: 0, step: 1, type: 'range' } },
+    selectedProfileId: {
+      control: 'select',
+      options: profiles.map((profile) => profile.id),
+    },
+    selectedUnreadCount: { control: 'select', options: [0, 1, 9, 10] },
+    surface: { control: 'inline-radio', options: ['full', 'compact', 'drawer'] },
+  },
+  component: ProfileSwitcherFixture,
+  excludeStories: [
+    'CompactClosedUnreadContract',
+    'InteractionContract',
+    'OpenUnreadContract',
+    'ProfileSwitcherFixture',
+    'WideClosedUnreadContract',
+  ],
+  parameters: { layout: 'centered' },
+  title: 'KOSMO/Patterns/Profile Switcher',
+} satisfies Meta<typeof ProfileSwitcherFixture>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  parameters: {
+    controls: {
+      disable: false,
+      include: [
+        'surface',
+        'selectedProfileId',
+        'profileCount',
+        'selectedUnreadCount',
+        'otherUnreadCount',
+        'disabled',
+      ],
+    },
+  },
+};
+
+export const Compact: Story = { args: { surface: 'compact' } };
+export const Drawer: Story = { args: { surface: 'drawer' } };
+export const OpenUnreadCounts: Story = { args: { initialOpen: true } };
+export const Empty: Story = {
+  args: { initialOpen: true, profileCount: 0, selectedProfileId: '' },
+};
+export const LongContent: Story = {
+  args: { initialOpen: true, selectedProfileId: 'profile-long' },
+};
+export const Disabled: Story = { args: { disabled: true } };
+
+export const InteractionContract: Story = {
+  args: { initialOpen: false, otherUnreadCount: 9, profileCount: 2 },
+  play: async ({ args, canvasElement }) => {
+    args.onOpenChange.mockClear();
+    args.onSelectProfile.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(trigger);
+    expect(args.onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const group = canvas.getByRole('radiogroup', { name: '프로필 전환' });
+    const selected = within(group).getByRole('radio', {
+      name: '코스모 작가, @kosmo, 읽지 않은 알림 있음',
+    });
+    const remote = within(group).getByRole('radio', {
+      name: '먼 우주의 사용자, @remote, 읽지 않은 알림 있음',
+    });
+    expect(selected).toHaveAttribute('aria-checked', 'true');
+
+    await userEvent.tab();
+    expect(selected).toHaveFocus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(remote).toHaveFocus();
+    expect(args.onSelectProfile).not.toHaveBeenCalled();
+
+    await userEvent.keyboard('{Enter}');
+    expect(args.onSelectProfile).toHaveBeenLastCalledWith('profile-remote');
+    expect(args.onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  },
+};
+
+export const WideClosedUnreadContract: Story = {
+  args: { initialOpen: false, surface: 'full' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const indicator = canvas.getByTestId('profile-switcher-closed-unread');
+    const bounds = indicator.getBoundingClientRect();
+
+    expect(bounds.width).toBe(8);
+    expect(bounds.height).toBe(8);
+    expect(indicator).toHaveAttribute('aria-hidden', 'true');
+  },
+};
+
+export const CompactClosedUnreadContract: Story = {
+  args: { initialOpen: false, surface: 'compact' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const indicator = canvas.getByTestId('profile-switcher-closed-unread');
+    const bounds = indicator.getBoundingClientRect();
+
+    expect(bounds.width).toBe(12);
+    expect(bounds.height).toBe(12);
+    expect(getComputedStyle(indicator).borderTopWidth).toBe('1px');
+  },
+};
+
+export const OpenUnreadContract: Story = {
+  args: { initialOpen: true, otherUnreadCount: 10, profileCount: 2 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('radiogroup', { name: '프로필 전환' });
+    const selected = within(group).getByRole('radio', {
+      name: '코스모 작가, @kosmo, 읽지 않은 알림 있음',
+    });
+    const remote = within(group).getByRole('radio', {
+      name: '먼 우주의 사용자, @remote, 읽지 않은 알림 있음',
+    });
+    const badge = within(remote).getByTestId('profile-switcher-unread-count');
+    const bounds = badge.getBoundingClientRect();
+
+    expect(within(selected).queryByTestId('profile-switcher-unread-count')).not.toBeInTheDocument();
+    expect(badge).toHaveTextContent('9+');
+    expect(bounds.width).toBe(24);
+    expect(bounds.height).toBe(24);
+    expect(canvas.queryByTestId('profile-switcher-closed-unread')).not.toBeInTheDocument();
+  },
+};

--- a/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
@@ -128,12 +128,12 @@ const meta = {
   },
   argTypes: {
     disabled: { control: 'boolean' },
-    initialOpen: { control: false },
-    onOpenChange: { action: 'open', control: false },
-    onSelectProfile: { action: 'selectProfile', control: false },
+    initialOpen: { control: false, table: { disable: true } },
+    onOpenChange: { action: 'open', control: false, table: { disable: true } },
+    onSelectProfile: { action: 'selectProfile', control: false, table: { disable: true } },
     otherUnreadCount: { control: 'select', options: [0, 1, 9, 10] },
     profileCount: { control: { max: profiles.length, min: 0, step: 1, type: 'range' } },
-    selectionOutcome: { control: false },
+    selectionOutcome: { control: false, table: { disable: true } },
     selectedProfileId: {
       control: 'select',
       options: profiles.map((profile) => profile.id),
@@ -144,6 +144,7 @@ const meta = {
   component: ProfileSwitcherFixture,
   excludeStories: [
     'CompactClosedUnreadContract',
+    'DrawerClosedUnreadContract',
     'InteractionContract',
     'OpenUnreadContract',
     'OutsideDismissContract',
@@ -304,26 +305,41 @@ export const WideClosedUnreadContract: Story = {
       name: '프로필 목록, 읽지 않은 알림 있음',
     });
     const indicator = canvas.getByTestId('profile-switcher-closed-unread');
+    const chevron = trigger.querySelector('svg');
+    expect(chevron).not.toBeNull();
     const triggerBounds = trigger.getBoundingClientRect();
+    const chevronBounds = chevron!.getBoundingClientRect();
     const bounds = indicator.getBoundingClientRect();
 
     expect(bounds.width).toBe(8);
     expect(bounds.height).toBe(8);
-    expect(bounds.left).toBe(triggerBounds.right + 1);
-    expect(bounds.top).toBe(triggerBounds.top + 2);
+    expect(chevronBounds.width).toBe(20);
+    expect(chevronBounds.height).toBe(20);
+    expect(bounds.left).toBe(chevronBounds.right + 1);
+    expect(bounds.top).toBe(chevronBounds.top - 4);
+    expect(bounds.left).toBeGreaterThan(triggerBounds.right);
     expect(indicator).toHaveAttribute('aria-hidden', 'true');
   },
+};
+
+export const DrawerClosedUnreadContract: Story = {
+  args: { initialOpen: false, surface: 'drawer' },
+  play: WideClosedUnreadContract.play,
 };
 
 export const CompactClosedUnreadContract: Story = {
   args: { initialOpen: false, surface: 'compact' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const avatar = canvas.getByLabelText('코스모 작가 프로필 이미지');
     const indicator = canvas.getByTestId('profile-switcher-closed-unread');
+    const avatarBounds = avatar.getBoundingClientRect();
     const bounds = indicator.getBoundingClientRect();
 
     expect(bounds.width).toBe(12);
     expect(bounds.height).toBe(12);
+    expect(bounds.left).toBe(avatarBounds.left + 28);
+    expect(bounds.top).toBe(avatarBounds.top);
     expect(getComputedStyle(indicator).borderTopWidth).toBe('1px');
   },
 };

--- a/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
@@ -1,0 +1,21 @@
+import baseMeta, {
+  CompactClosedUnreadContract as compactClosedUnreadContract,
+  InteractionContract as interactionContract,
+  OpenUnreadContract as openUnreadContract,
+  WideClosedUnreadContract as wideClosedUnreadContract,
+} from './ProfileSwitcher.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Patterns/Profile Switcher/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const WideClosedUnreadContract: Story = wideClosedUnreadContract;
+export const CompactClosedUnreadContract: Story = compactClosedUnreadContract;
+export const OpenUnreadContract: Story = openUnreadContract;

--- a/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
@@ -1,7 +1,11 @@
 import baseMeta, {
   CompactClosedUnreadContract as compactClosedUnreadContract,
+  EscapeDismissContract as escapeDismissContract,
   InteractionContract as interactionContract,
+  LongListContract as longListContract,
   OpenUnreadContract as openUnreadContract,
+  OutsideDismissContract as outsideDismissContract,
+  SelectionFailureContract as selectionFailureContract,
   WideClosedUnreadContract as wideClosedUnreadContract,
 } from './ProfileSwitcher.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -9,6 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 const meta = {
   ...baseMeta,
   excludeStories: [],
+  parameters: { ...baseMeta.parameters, controls: { disable: true } },
   title: 'KOSMO/Patterns/Profile Switcher/Tests',
 } satisfies Meta;
 
@@ -16,6 +21,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const InteractionContract: Story = interactionContract;
+export const SelectionFailureContract: Story = selectionFailureContract;
+export const EscapeDismissContract: Story = escapeDismissContract;
+export const OutsideDismissContract: Story = outsideDismissContract;
+export const LongListContract: Story = longListContract;
 export const WideClosedUnreadContract: Story = wideClosedUnreadContract;
 export const CompactClosedUnreadContract: Story = compactClosedUnreadContract;
 export const OpenUnreadContract: Story = openUnreadContract;

--- a/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
@@ -1,3 +1,8 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { ProfileEditDiscardDialog } from '@/components/profile/ProfileEditDiscardDialog';
+import { ProfileSwitcherTarget } from '@/components/shell/ProfileSwitcherTarget';
 import baseMeta, {
   CompactClosedUnreadContract as compactClosedUnreadContract,
   DrawerClosedUnreadContract as drawerClosedUnreadContract,
@@ -10,6 +15,10 @@ import baseMeta, {
   WideClosedUnreadContract as wideClosedUnreadContract,
 } from './ProfileSwitcher.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type {
+  ProfilePickerProfile,
+  ProfilePickerSurface,
+} from '@/components/profile/ProfilePicker';
 
 const meta = {
   ...baseMeta,
@@ -21,6 +30,84 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const nestedModalProfiles = [
+  {
+    avatar: null,
+    displayName: '코스모 작가',
+    id: 'profile-kosmo',
+    relativeHandle: '@kosmo',
+  },
+  {
+    avatar: null,
+    displayName: '먼 우주의 사용자',
+    id: 'profile-remote',
+    relativeHandle: '@remote',
+  },
+] satisfies readonly ProfilePickerProfile[];
+
+function NestedModalProfileSwitcherStory({ surface }: Readonly<{ surface: ProfilePickerSurface }>) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  return (
+    <View style={{ minHeight: 340, padding: 24, width: surface === 'compact' ? 360 : 320 }}>
+      <ProfileSwitcherTarget
+        onOpenChange={setPickerOpen}
+        onSelectProfile={() => setDialogOpen(true)}
+        open={pickerOpen}
+        profiles={nestedModalProfiles}
+        selectedProfileId="profile-kosmo"
+        surface={surface}
+      />
+      <ProfileEditDiscardDialog
+        onContinue={() => setDialogOpen(false)}
+        onDiscard={() => setDialogOpen(false)}
+        visible={dialogOpen}
+      />
+    </View>
+  );
+}
+
+async function assertNestedModalDismissal(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  const body = within(canvasElement.ownerDocument.body);
+  const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+
+  await userEvent.click(trigger);
+  const picker = await canvas.findByRole('group', { name: '프로필 전환' });
+  await userEvent.click(within(picker).getByRole('button', { name: '먼 우주의 사용자, @remote' }));
+
+  const dialog = await body.findByRole('dialog', { name: '변경사항을 버릴까요?' });
+  expect(dialog).toHaveAttribute('aria-modal', 'true');
+  expect(picker).toBeVisible();
+
+  await userEvent.click(within(dialog).getByText('변경사항을 버릴까요?', { exact: true }));
+  expect(picker).toBeVisible();
+  await userEvent.click(within(dialog).getByRole('button', { name: '계속 편집' }));
+  await waitFor(() =>
+    expect(body.queryByRole('dialog', { name: '변경사항을 버릴까요?' })).not.toBeInTheDocument(),
+  );
+  expect(picker).toBeVisible();
+
+  await userEvent.click(within(picker).getByRole('button', { name: '먼 우주의 사용자, @remote' }));
+  const escapeDialog = await body.findByRole('dialog', { name: '변경사항을 버릴까요?' });
+  const continueButton = within(escapeDialog).getByRole('button', { name: '계속 편집' });
+  continueButton.focus();
+  expect(continueButton).toHaveFocus();
+
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() =>
+    expect(body.queryByRole('dialog', { name: '변경사항을 버릴까요?' })).not.toBeInTheDocument(),
+  );
+  expect(picker).toBeVisible();
+  expect(trigger).not.toHaveFocus();
+
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => expect(canvas.queryByRole('group', { name: '프로필 전환' })).toBeNull());
+  expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  expect(trigger).toHaveFocus();
+}
+
 export const InteractionContract: Story = interactionContract;
 export const SelectionFailureContract: Story = selectionFailureContract;
 export const EscapeDismissContract: Story = escapeDismissContract;
@@ -30,3 +117,13 @@ export const WideClosedUnreadContract: Story = wideClosedUnreadContract;
 export const DrawerClosedUnreadContract: Story = drawerClosedUnreadContract;
 export const CompactClosedUnreadContract: Story = compactClosedUnreadContract;
 export const OpenUnreadContract: Story = openUnreadContract;
+
+export const NestedModalDismissContract: Story = {
+  play: ({ canvasElement }) => assertNestedModalDismissal(canvasElement),
+  render: () => <NestedModalProfileSwitcherStory surface="full" />,
+};
+
+export const NestedModalDismissCompactContract: Story = {
+  play: ({ canvasElement }) => assertNestedModalDismissal(canvasElement),
+  render: () => <NestedModalProfileSwitcherStory surface="compact" />,
+};

--- a/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.tests.stories.tsx
@@ -1,5 +1,6 @@
 import baseMeta, {
   CompactClosedUnreadContract as compactClosedUnreadContract,
+  DrawerClosedUnreadContract as drawerClosedUnreadContract,
   EscapeDismissContract as escapeDismissContract,
   InteractionContract as interactionContract,
   LongListContract as longListContract,
@@ -26,5 +27,6 @@ export const EscapeDismissContract: Story = escapeDismissContract;
 export const OutsideDismissContract: Story = outsideDismissContract;
 export const LongListContract: Story = longListContract;
 export const WideClosedUnreadContract: Story = wideClosedUnreadContract;
+export const DrawerClosedUnreadContract: Story = drawerClosedUnreadContract;
 export const CompactClosedUnreadContract: Story = compactClosedUnreadContract;
 export const OpenUnreadContract: Story = openUnreadContract;

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -151,25 +151,18 @@ Web profile picker는 breakpoint별 사이드바 구조에 맞는 surface를 사
 
 ### Profile별 Unread 표시
 
-Profile picker는 Account가 접근할 수 있는 각 Profile에 visible Unread 알림이 있는지를 Web·Android·iOS의
-같은 Profile option에서 표시한다. selected Profile도 같은 표시 대상이며, 이 상태는 오른쪽의 기존 선택
-check와 별개다.
-
-- Unread가 있는 Profile은 아바타 우상단에 숫자 없는 `12` logical unit(Web CSS px·iOS pt·Android dp) dot을
-  겹쳐 표시한다. dot은 semantic `accent` color token을 사용하며 Profile option의 행 폭, label,
-  pointer·touch target과 기존 selected check를 밀지 않는다.
-- dot 자체는 접근성 트리와 focus 순서에서 숨긴다. Profile option의 accessible name은 기존 표시 이름과
-  handle을 유지하고 Unread가 있을 때만 `읽지 않은 알림 있음`을 덧붙인다. 정확한 count는 시각적 UI나
-  accessible name에 포함하지 않는다.
-- 각 Profile option의 서버 제공 `unreadNotificationCount`가 양수일 때만 dot을 표시한다. count가 `0`이거나
-  Profile option을 표시할 수 없으면 잘못된 dot을 표시하지 않는다.
-- Profile 전환 성공 뒤 알림 목록과 셸 badge는 기존 actor 전환과 서버 재조회 계약에 따라 새 selected Profile
-  상태로 수렴한다.
-- 다른 Profile의 알림 내용이나 정확한 count를 현재 화면에 노출하거나, Profile을 자동 전환하거나, 알림을
-  자동으로 읽음 처리하지 않는다. Push, OS app icon badge와 realtime delivery도 이 표시가 변경하지 않는다.
-- 이 `12` logical unit Profile avatar dot은 아래의 알림 navigation icon용 `8px` dot과 서로 다른 컴포넌트
-  계약이다. 기존 셸 badge의 geometry, 실제 count accessible name과 selected Profile 격리 계약은 변경하지
-  않는다.
+- **Current:** Production Profile picker는 Web·Android·iOS의 각 Profile option 아바타 우상단에
+  `unreadNotificationCount > 0`이면 숫자 없는 `12` logical unit semantic `accent` dot을 표시한다. dot 자체는
+  접근성 트리에서 숨기고 option의 accessible name에만 `읽지 않은 알림 있음`을 덧붙이며, 정확한 count와
+  알림 내용은 노출하지 않는다. Profile 전환 뒤의 actor·서버 재조회, 셸 badge, Push·OS badge와 realtime
+  lifecycle은 기존 runtime 계약을 유지한다.
+- **Target:** DSN-40 Figma와 PROD-855의 `ProfileSwitcherTarget`은 닫힌 `full`·`drawer` trigger에 `8px`
+  `action/primary/base` dot, 닫힌 `compact` avatar에 canvas `1px` halo를 둔 `12px` dot을 표시한다. 열리면 닫힌
+  indicator를 숨기고 non-selected Profile row 오른쪽에 `24px` 숫자 badge를 표시해 `1`~`9`는 실제 값,
+  `10` 이상은 `9+`로 축약한다. selected row는 count badge 대신 기존 check를 표시해 두 요소가 겹치지 않게
+  한다. indicator와 badge는 접근성 트리에서 숨기고 Profile option의 accessible name은 정확한 count 대신
+  `읽지 않은 알림 있음`만 유지한다. 이 Target은 Storybook 검토 표면이며 Production runtime 연결과 unread
+  data·Relay·badge lifecycle 이관은 PROD-786이 소유한다.
 
 ## 알림 Unread badge
 

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -146,7 +146,8 @@ Web profile picker는 breakpoint별 사이드바 구조에 맞는 surface를 사
 - full·compact Web에서 프로필 선택·생성 실패는 picker와 오류를 유지하고 생성 실패는 입력값도 유지한다.
   trigger 재실행, full·compact 바깥 pointer close 또는 `Escape`처럼 사용자가 명시적으로 닫으면 `open=false`,
   `creating=false`, 빈 handle과 오류 없음으로 초기화한다. 바깥 pointer close는 이벤트 기본 동작을 막지 않아
-  pointer 대상의 브라우저 기본 focus를 따른다. `Escape`는 trigger focus를 복원한다. mobile Web drawer의
+  pointer 대상의 브라우저 기본 focus를 따른다. `Escape`는 trigger focus를 복원한다. Target도 상위 modal 내부
+  pointer 이벤트와 modal이 떠 있는 동안의 `Escape`로 picker를 닫거나 trigger로 focus를 옮기지 않는다. mobile Web drawer의
   chevron 표시 외 close transition과 Android/iOS의 기존 상태 동작은 이 계약으로 바꾸지 않는다.
 
 ### Profile별 Unread 표시

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -161,7 +161,8 @@ Web profile picker는 breakpoint별 사이드바 구조에 맞는 surface를 사
   indicator를 숨기고 non-selected Profile row 오른쪽에 `24px` 숫자 badge를 표시해 `1`~`9`는 실제 값,
   `10` 이상은 `9+`로 축약한다. selected row는 count badge 대신 기존 check를 표시해 두 요소가 겹치지 않게
   한다. indicator와 badge는 접근성 트리에서 숨기고 Profile option의 accessible name은 정확한 count 대신
-  `읽지 않은 알림 있음`만 유지한다. 이 Target은 Storybook 검토 표면이며 Production runtime 연결과 unread
+  `읽지 않은 알림 있음`만 유지한다. full·drawer chevron은 기존 20px를 유지하고 dot은 chevron 우상단 기준 `right: -9px`, `top: -4px`,
+  compact dot은 40px avatar 기준 `right: 0`, `top: 0`으로 배치한다. 이 Target은 Storybook 검토 표면이며 Production runtime 연결과 unread
   data·Relay·badge lifecycle 이관은 PROD-786이 소유한다.
 
 ## 알림 Unread badge


### PR DESCRIPTION
## 무엇을 변경했나요

- Figma 기준 ProfileSwitcher Target 표현을 production presentational component로 추가했습니다.
- 닫힌 Full/Drawer의 8px unread dot, Compact의 12px dot와 1px canvas halo를 반영했습니다.
- 열린 목록은 unread 0 숨김, 1–9 표시, 10 이상 `9+`, 선택된 Profile의 check 표시 계약을 반영했습니다.
- 시각적 unread 표시는 접근성 트리에서 숨기고, 프로필 버튼의 accessible name에는 boolean unread 상태만 제공합니다.
- Playground와 Compact, Drawer, Open unread, Empty, Long content, Long List, Disabled 스토리 및 interaction 테스트를 추가했습니다.
- `breakpoints.md`에는 기존 runtime인 Current와 이번 Storybook Target만 구분해 기록했습니다.

- 선택 성공 후 닫기, Full/Compact Web Escape·바깥 클릭 dismiss와 focus 복원, 닫힌 trigger의 unread 접근성 이름, 최대 430px 내부 목록 스크롤을 반영했습니다.

- 상위 모달 내부 pointer 이벤트와 모달이 열린 동안의 Escape는 picker dismiss에서 제외했습니다. 실제 `ProfileEditDiscardDialog`를 사용한 Full·Compact 회귀 테스트로 모달만 닫힌 뒤 picker 유지 및 다음 Escape의 focus 복원을 확인했습니다.

## 왜 변경했나요

[PROD-855](https://linear.app/byulmaru/issue/PROD-855)의 범위대로 DSN-40에서 정리한 ProfileSwitcher unread 표현을 runtime 연결 전에 공용 UI와 Storybook 검증 표면으로 먼저 이관합니다.

## 이번 PR의 주요 결정

- 기존 shell `ProfileSwitcher`와 공용 `ProfilePicker`의 runtime 동작은 변경하지 않습니다.
- Web 프로필 항목은 기존 문서 계약대로 기본 Tab 순서의 button과 pressed 상태를 사용합니다.
- 이 PR은 Target presentation과 Storybook까지만 담당합니다.
- route/data/Relay/API/mutation/cache 및 unread 수명주기 연결은 PROD-786의 runtime 범위로 남깁니다.
- OpenSpec은 변경하지 않습니다.

### Figma 기준

- [ProfileSwitcher source](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1929-2082)
- [DSN-40](https://linear.app/byulmaru/issue/DSN-40)

## Storybook Preview

- 제공: @yeeun-uwu 로컬 Mac의 Tailscale Serve
- 기간: 이 PR의 Storybook 리뷰가 끝날 때까지
- 접근: 동일 tailnet 계정/기기 필요
- Preview source: [PR #769](https://github.com/byulmaru/kosmo/pull/769), served commit `3c6f6dadb5b62624bfc5f252b7b7c2eea333c01e` ([빌드 출처](https://sasha-macbook-pro.tail1fdd55.ts.net/preview-provenance.json)). ProfileSwitcher 도트·Controls 정리와 상위 모달 dismiss 우선순위 수정을 포함한 최상위 Stack 빌드입니다.
- [Playground](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-profile-switcher--playground)
- [Compact](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-profile-switcher--compact)
- [Drawer](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-profile-switcher--drawer)
- [Open unread counts](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-profile-switcher--open-unread-counts)

- [Long List](https://sasha-macbook-pro.tail1fdd55.ts.net/?path=/story/kosmo-patterns-profile-switcher--long-list)

## 검증

- PR head `0ab01553`: ProfileSwitcher Storybook 2 files, 19/19 tests 및 `pnpm --filter @kosmo/app check` 통과
- Preview top `3c6f6dad`: 전체 Storybook 94 files, 693/693 tests, app check 및 build-storybook 통과
- `pnpm --filter @kosmo/app lint:tsc`: 통과
- `pnpm --filter @kosmo/app build-storybook`: 통과
- Browser QA: Light/Dark, Full/Compact/Open 시각 상태와 `group` + pressed profile button 접근성 트리 확인
- 독립 구현 리뷰 및 수정 후 재검토: 차단 finding 없음
- 최신 원격 정렬 전후 `range-diff`: PROD-855 기존 6개 패치 및 이번 모달 수정 단일 패치 동일
- [모달 dismiss Full 테스트](https://sasha-macbook-pro.tail1fdd55.ts.net/build-3c6f6dad/?path=/story/kosmo-patterns-profile-switcher-tests--nested-modal-dismiss-contract), [Compact 테스트](https://sasha-macbook-pro.tail1fdd55.ts.net/build-3c6f6dad/?path=/story/kosmo-patterns-profile-switcher-tests--nested-modal-dismiss-compact-contract)

## 범위 밖 / 남은 위험

- Android/iOS 실제 touch target과 보조기술은 검증하지 않았습니다.
- Storybook 접근성 검사는 color contrast를 제외하므로 Browser 확인만으로 전체 대비 적합성을 증명하지 않습니다.
- 실제 runtime과 unread data 연결은 포함하지 않습니다.

## Stack

- GitHub Stack [#716](https://github.com/byulmaru/kosmo/stacks/716)
- parent: [#751 `prod-859`](https://github.com/byulmaru/kosmo/pull/751)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

