### PR TITLE
Dev 배포의 SHA 이미지 설정과 자동 동기화를 유지한다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -117,7 +117,33 @@ jobs:
             -p "imageDigest=${IMAGE_DIGEST}" \
             --validate
 
-          argocd --server "${ARGOCD_SERVER}" --grpc-web app sync kosmo-dev --timeout 600
+          for attempt in $(seq 1 120); do
+            if app_json="$(
+              argocd --server "${ARGOCD_SERVER}" --grpc-web app get kosmo-dev --output json
+            )" && jq -e \
+              --arg target_sha "${TARGET_SHA}" \
+              --arg image_digest "${IMAGE_DIGEST}" \
+              '
+                .spec.source.targetRevision == $target_sha
+                and any(.spec.source.helm.parameters[]?; .name == "version" and .value == $target_sha)
+                and any(.spec.source.helm.parameters[]?; .name == "imageDigest" and .value == $image_digest)
+                and .status.sync.revision == $target_sha
+                and .status.sync.status == "Synced"
+                and .status.operationState.phase == "Succeeded"
+                and .status.operationState.syncResult.revision == $target_sha
+                and .status.operationState.syncResult.source.targetRevision == $target_sha
+                and any(.status.operationState.syncResult.source.helm.parameters[]?; .name == "version" and .value == $target_sha)
+                and any(.status.operationState.syncResult.source.helm.parameters[]?; .name == "imageDigest" and .value == $image_digest)
+              ' <<<"${app_json}" >/dev/null; then
+              exit 0
+            fi
+
+            if (( attempt == 120 )); then
+              echo "::error::Argo CD did not complete a successful ${TARGET_SHA} sync with imageDigest ${IMAGE_DIGEST} after 120 bounded verification attempts."
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Restart dev workloads
         env:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  restart_dev:
-    name: Restart Dev Workloads
+  update_dev:
+    name: Update Dev Application
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04-arm
     env:
@@ -103,7 +103,7 @@ jobs:
             core.setSecret(dexToken);
             core.setOutput("token", dexToken);
 
-      - name: Sync dev application
+      - name: Update Dev Application
         env:
           ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
           IMAGE_DIGEST: ${{ steps.image.outputs.image_digest }}
@@ -116,52 +116,3 @@ jobs:
             -p "version=${TARGET_SHA}" \
             -p "imageDigest=${IMAGE_DIGEST}" \
             --validate
-
-          for attempt in $(seq 1 120); do
-            if app_json="$(
-              argocd --server "${ARGOCD_SERVER}" --grpc-web app get kosmo-dev --output json
-            )" && jq -e \
-              --arg target_sha "${TARGET_SHA}" \
-              --arg image_digest "${IMAGE_DIGEST}" \
-              '
-                .spec.source.targetRevision == $target_sha
-                and any(.spec.source.helm.parameters[]?; .name == "version" and .value == $target_sha)
-                and any(.spec.source.helm.parameters[]?; .name == "imageDigest" and .value == $image_digest)
-                and .status.sync.revision == $target_sha
-                and .status.sync.status == "Synced"
-                and .status.operationState.phase == "Succeeded"
-                and .status.operationState.syncResult.revision == $target_sha
-                and .status.operationState.syncResult.source.targetRevision == $target_sha
-                and any(.status.operationState.syncResult.source.helm.parameters[]?; .name == "version" and .value == $target_sha)
-                and any(.status.operationState.syncResult.source.helm.parameters[]?; .name == "imageDigest" and .value == $image_digest)
-              ' <<<"${app_json}" >/dev/null; then
-              exit 0
-            fi
-
-            if (( attempt == 120 )); then
-              echo "::error::Argo CD did not complete a successful ${TARGET_SHA} sync with imageDigest ${IMAGE_DIGEST} after 120 bounded verification attempts."
-              exit 1
-            fi
-            sleep 5
-          done
-
-      - name: Restart dev workloads
-        env:
-          ARGOCD_AUTH_TOKEN: ${{ steps.argocd-token.outputs.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          for rollout in kosmo-web kosmo-api; do
-            argocd --server "${ARGOCD_SERVER}" --grpc-web app actions run kosmo-dev restart \
-              --group argoproj.io \
-              --kind Rollout \
-              --namespace kosmo-dev \
-              --resource-name "${rollout}"
-          done
-
-          argocd --server "${ARGOCD_SERVER}" --grpc-web app actions run kosmo-dev restart \
-            --group apps \
-            --kind Deployment \
-            --namespace kosmo-dev \
-            --all

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -12,6 +12,8 @@
 - `byulmaru-kosmo-prod-postgresql-backups-822638974464` PostgreSQL backup bucket과 `byulmaru-kosmo-prod-postgres-backup` EKS Pod Identity role
 - Argo CD `kosmo` ApplicationSet이 생성하는 `kosmo-dev` Application과 별도 `kosmo-prod` Application의 선언
 
+`kosmo-dev`의 ApplicationSet은 기본 source와 values를 소유하고, `Deploy Dev`는 release-time `targetRevision`과 Helm `parameters`를 설정한다. ApplicationSet은 이 두 release-time 경로의 차이를 무시해 자동 sync가 배포 대상을 되돌리지 않도록 한다.
+
 Firebase를 Google Cloud 프로젝트에 추가하는 작업은 되돌릴 수 없다. 앱 리소스에는 `PREVENT` 삭제 정책을 적용한다.
 
 iOS native 배포는 App Store Connect TestFlight 하나만 사용하며, native module 변경이 없는 업데이트는 OTA로 배포한다. 저장소의 Firebase App Distribution workflow와 Fastlane 경로는 제거했다. 해당 service account의 IAM 권한과 WIF provider는 이 설정에서 비활성화·제거했지만, App Distribution API와 `PREVENT` 리소스 선언은 Terraform state의 두 단계 정리를 위해 남아 있으며 외부 리소스 정리는 별도 reviewed plan으로 진행해야 한다.

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -12,7 +12,7 @@
 - `byulmaru-kosmo-prod-postgresql-backups-822638974464` PostgreSQL backup bucket과 `byulmaru-kosmo-prod-postgres-backup` EKS Pod Identity role
 - Argo CD `kosmo` ApplicationSet이 생성하는 `kosmo-dev` Application과 별도 `kosmo-prod` Application의 선언
 
-`kosmo-dev`의 ApplicationSet은 기본 source와 values를 소유하고, `Deploy Dev`는 release-time `targetRevision`과 Helm `parameters`를 설정한다. ApplicationSet은 이 두 release-time 경로의 차이를 무시해 자동 sync가 배포 대상을 되돌리지 않도록 한다.
+`kosmo-dev`의 ApplicationSet은 기본 source와 values를 소유하고, `Deploy Dev`는 release-time `targetRevision`과 Helm `parameters`를 설정한다. ApplicationSet은 이 두 release-time 경로의 차이를 무시해 자동 sync가 배포 대상을 되돌리지 않도록 한다. Workflow 성공은 이 설정 갱신의 성공을 뜻하며, 후속 자동 sync나 rollout 완료의 증거가 아니다.
 
 Firebase를 Google Cloud 프로젝트에 추가하는 작업은 되돌릴 수 없다. 앱 리소스에는 `PREVENT` 삭제 정책을 적용한다.
 

--- a/apps/terraform/argocd.tf
+++ b/apps/terraform/argocd.tf
@@ -9,6 +9,15 @@ resource "argocd_application_set" "kosmo" {
   }
 
   spec {
+    ignore_application_differences {
+      name = "kosmo-dev"
+
+      json_pointers = [
+        "/spec/source/targetRevision",
+        "/spec/source/helm/parameters",
+      ]
+    }
+
     generator {
       list {
         elements = [

--- a/openspec/changes/share-images-across-environments/design.md
+++ b/openspec/changes/share-images-across-environments/design.md
@@ -34,7 +34,7 @@ Main Docker Build는 source full SHA의 Sentry release와 source map을 포함�
 ### Recommended Approach
 
 - Docker Build는 `sha-<full SHA>` tag를 게시하고 별도 release manifest나 digest artifact를 생성하지 않는다.
-- Dev는 triggering `head_sha`로 SHA tag를 구성해 GHCR digest를 조회·검증한 뒤 `argocd app set kosmo-dev --revision <head SHA> -p version=<head SHA> -p imageDigest=<digest>`를 실행한다. `kosmo-dev` ApplicationSet은 이 release-time source revision과 Helm parameter 차이를 무시하고 automated sync를 수행하며, workflow는 bounded status 검증으로 target SHA와 digest의 반영을 확인한다.
+- Dev는 triggering `head_sha`로 SHA tag를 구성해 GHCR digest를 조회·검증한 뒤 `argocd app set kosmo-dev --revision <head SHA> -p version=<head SHA> -p imageDigest=<digest>`를 실행한다. `kosmo-dev` ApplicationSet은 이 release-time source revision과 Helm parameter 차이를 무시하고 automated sync를 수행하며, workflow 성공은 설정 갱신까지만 의미하고 후속 sync나 rollout 완료의 증거로 간주하지 않는다.
 - Triggering Docker Build를 검사하는 Trivy도 별도 release artifact 없이 triggering `sha-<head SHA>` tag를 사용한다. 수동·정기 scan의 기존 `:main` 선택은 배포 identity가 아니므로 유지한다.
 - Production preflight는 main `Docker Build` workflow의 성공한 run 중 `head_sha == target SHA`, `event == push`, `head_branch == main`인 run을 확인한 뒤 GHCR의 `sha-<target SHA>` tag digest를 조회·검증한다. Run ID, target SHA와 조회 digest를 job outputs로 고정한다. Run 자체가 digest를 증명한다고 간주하지 않는다.
 - 승인된 production job은 checkout, Docker setup/login/build/push, Sentry build secret과 tag/digest 재조회를 갖지 않고 preflight outputs로 기존 migration-gated Argo sync를 실행한다.
@@ -51,7 +51,7 @@ Main Docker Build는 source full SHA의 Sentry release와 source map을 포함�
 - 승인 뒤 SHA tag를 다시 조회하거나 target SHA를 재해석하면 승인 정보와 실제 deploy identity가 달라질 수 있다.
 - SHA tag는 재빌드로 덮어쓸 수 있으므로 Dev와 Production이 다른 시점에 조회한 digest가 달라질 수 있다. 이는 허용된 경계이며, production은 preflight digest를 유지한다.
 - 단일 image인데 runtime 이름→digest map이나 manifest를 만들면 현재 요구되지 않는 multi-runtime 계약을 미리 고정한다.
-- `argocd app set` 직후 명시적 `argocd app sync`를 호출하면 ApplicationSet의 automated sync와 operation이 충돌할 수 있다. Dev workflow는 release-time source revision과 Helm parameter 차이를 ApplicationSet에서 무시하고 automated sync 완료를 bounded identity 검증으로 확인한다.
+- `argocd app set` 직후 명시적 `argocd app sync`를 호출하면 ApplicationSet의 automated sync와 operation이 충돌할 수 있다. Dev workflow는 release-time source revision과 Helm parameter 차이를 ApplicationSet에서 무시하고 후속 sync를 automated sync에 맡긴다. Workflow 성공은 rollout 완료 증거가 아니다.
 - Trivy용 image reference artifact를 게시하면 배포 identity가 별도 파일로 분산된다.
 
 ## Risks / Trade-offs

--- a/openspec/changes/share-images-across-environments/design.md
+++ b/openspec/changes/share-images-across-environments/design.md
@@ -34,7 +34,7 @@ Main Docker Build는 source full SHA의 Sentry release와 source map을 포함�
 ### Recommended Approach
 
 - Docker Build는 `sha-<full SHA>` tag를 게시하고 별도 release manifest나 digest artifact를 생성하지 않는다.
-- Dev는 triggering `head_sha`로 SHA tag를 구성해 GHCR digest를 조회·검증한 뒤 `argocd app set kosmo-dev --revision <head SHA> -p version=<head SHA> -p imageDigest=<digest>`를 실행한 다음 sync한다.
+- Dev는 triggering `head_sha`로 SHA tag를 구성해 GHCR digest를 조회·검증한 뒤 `argocd app set kosmo-dev --revision <head SHA> -p version=<head SHA> -p imageDigest=<digest>`를 실행한다. `kosmo-dev` ApplicationSet은 이 release-time source revision과 Helm parameter 차이를 무시하고 automated sync를 수행하며, workflow는 bounded status 검증으로 target SHA와 digest의 반영을 확인한다.
 - Triggering Docker Build를 검사하는 Trivy도 별도 release artifact 없이 triggering `sha-<head SHA>` tag를 사용한다. 수동·정기 scan의 기존 `:main` 선택은 배포 identity가 아니므로 유지한다.
 - Production preflight는 main `Docker Build` workflow의 성공한 run 중 `head_sha == target SHA`, `event == push`, `head_branch == main`인 run을 확인한 뒤 GHCR의 `sha-<target SHA>` tag digest를 조회·검증한다. Run ID, target SHA와 조회 digest를 job outputs로 고정한다. Run 자체가 digest를 증명한다고 간주하지 않는다.
 - 승인된 production job은 checkout, Docker setup/login/build/push, Sentry build secret과 tag/digest 재조회를 갖지 않고 preflight outputs로 기존 migration-gated Argo sync를 실행한다.
@@ -51,7 +51,7 @@ Main Docker Build는 source full SHA의 Sentry release와 source map을 포함�
 - 승인 뒤 SHA tag를 다시 조회하거나 target SHA를 재해석하면 승인 정보와 실제 deploy identity가 달라질 수 있다.
 - SHA tag는 재빌드로 덮어쓸 수 있으므로 Dev와 Production이 다른 시점에 조회한 digest가 달라질 수 있다. 이는 허용된 경계이며, production은 preflight digest를 유지한다.
 - 단일 image인데 runtime 이름→digest map이나 manifest를 만들면 현재 요구되지 않는 multi-runtime 계약을 미리 고정한다.
-- Dev가 `argocd app sync`만 실행하면 기존 `:main` parameter가 남아 exact digest를 소비하지 않는다.
+- `argocd app set` 직후 명시적 `argocd app sync`를 호출하면 ApplicationSet의 automated sync와 operation이 충돌할 수 있다. Dev workflow는 release-time source revision과 Helm parameter 차이를 ApplicationSet에서 무시하고 automated sync 완료를 bounded identity 검증으로 확인한다.
 - Trivy용 image reference artifact를 게시하면 배포 identity가 별도 파일로 분산된다.
 
 ## Risks / Trade-offs

--- a/openspec/changes/share-images-across-environments/specs/production-release/spec.md
+++ b/openspec/changes/share-images-across-environments/specs/production-release/spec.md
@@ -9,7 +9,7 @@ Git tag, `production` 브랜치와 일반 branch push는 canonical build를 시�
 #### Scenario: Main push canonical build와 dev deploy
 
 - **WHEN** commit이 `main`에 push되고 Docker Build가 성공한다
-- **THEN** 시스템은 `sha-<full SHA>` image tag와 Sentry release/source map을 한 번 생성하고, Dev는 triggering run의 `head_sha` tag에서 조회·검증한 digest를 Argo revision, version과 imageDigest로 설정한 뒤 자동 sync가 같은 SHA와 digest를 반영했는지 확인한다
+- **THEN** 시스템은 `sha-<full SHA>` image tag와 Sentry release/source map을 한 번 생성하고, Dev는 triggering run의 `head_sha` tag에서 조회·검증한 digest를 Argo revision, version과 imageDigest로 설정한 뒤 후속 자동 sync에 맡긴다. Workflow 성공은 rollout 완료 증거가 아니다
 
 #### Scenario: Canonical build 실패
 

--- a/openspec/changes/share-images-across-environments/specs/production-release/spec.md
+++ b/openspec/changes/share-images-across-environments/specs/production-release/spec.md
@@ -9,7 +9,7 @@ Git tag, `production` 브랜치와 일반 branch push는 canonical build를 시�
 #### Scenario: Main push canonical build와 dev deploy
 
 - **WHEN** commit이 `main`에 push되고 Docker Build가 성공한다
-- **THEN** 시스템은 `sha-<full SHA>` image tag와 Sentry release/source map을 한 번 생성하고, Dev는 triggering run의 `head_sha` tag에서 조회·검증한 digest를 Argo revision, version과 imageDigest로 설정한 뒤 sync한다
+- **THEN** 시스템은 `sha-<full SHA>` image tag와 Sentry release/source map을 한 번 생성하고, Dev는 triggering run의 `head_sha` tag에서 조회·검증한 digest를 Argo revision, version과 imageDigest로 설정한 뒤 자동 sync가 같은 SHA와 digest를 반영했는지 확인한다
 
 #### Scenario: Canonical build 실패
 


### PR DESCRIPTION
## 무엇을 변경했는지

- kosmo-dev ApplicationSet이 workflow가 설정한 targetRevision과 Helm parameters를 되돌리지 않도록 두 경로를 보존합니다.
- Dev workflow는 triggering SHA tag의 digest를 조회·검증하고 Argo revision·version·imageDigest를 설정한 뒤 종료합니다.
- 명시적 app sync, 자동 sync 완료 대기 루프, workload restart를 제거합니다.
- Terraform README와 OpenSpec에 workflow와 Argo CD의 책임을 구분합니다.

## 왜 변경했는지

[머지 후 Deploy Dev 실패](https://github.com/byulmaru/kosmo/actions/runs/34004899945)는 자동 sync와 명시 sync의 충돌로 발생했습니다. ApplicationSet이 설정을 main 기본값으로 되돌리는 문제도 확인했습니다. 이미지 digest 변경 자체로 rollout이 시작되므로 별도 restart와 이를 위한 대기는 필요하지 않습니다.

## 이번 PR의 주요 결정

- 사용자 지시에 따라 workflow는 설정 갱신 성공까지만 책임지고 자동 sync와 rollout은 Argo CD에 맡깁니다.
- workflow 성공을 실제 배포 완료 또는 health 증거로 취급하지 않습니다. 이전 polling 구현과 그 검증 근거는 이번 단순화로 대체합니다.
- kosmo-dev의 /spec/source/targetRevision 및 /spec/source/helm/parameters만 보존하며 나머지 ApplicationSet 관리와 자동 sync는 유지합니다.
- [PROD-833](https://linear.app/byulmaru/issue/PROD-833)에 변경된 책임 경계를 기록했습니다.
- Stack: main -> PROD-833-dev-sync-fix (독립 1-layer).

## 어떻게 확인할 수 있는지

- actionlint, 변경 YAML/Markdown Prettier, OpenSpec strict validation과 git diff --check를 확인합니다.
- 변경하지 않은 ApplicationSet 설정은 기존 Terraform validate와 Plan에서 두 ignore 경로를 확인했습니다.
- 삭제한 loop의 mock 검증이나 이전 head의 CI 결과는 최신 head 검증으로 재사용하지 않습니다.
- 단순 소스 문자열 검사 테스트는 추가하지 않습니다.

## 아직 어떤 문제가 남았는지

최신 head CI는 push 후 확인합니다. Terraform Apply와 실제 Dev 배포는 실행하지 않았습니다. 선행 [GCP 조건 수정 PR #766](https://github.com/byulmaru/kosmo/pull/766)을 반영하고 ApplicationSet 변경이 실제 적용되어야 설정이 보존됩니다. 실제 배포 확인과 OpenSpec archive는 별도 운영 검증으로 남깁니다.
