### PR TITLE
비활성화한 WIF provider가 Terraform 적용을 막지 않게 한다

### DIFF
--- a/apps/terraform/main.tf
+++ b/apps/terraform/main.tf
@@ -132,7 +132,7 @@ resource "google_iam_workload_identity_pool_provider" "kosmo" {
   attribute_mapping = {
     "google.subject" = "assertion.sub"
   }
-  attribute_condition = "false"
+  attribute_condition = "assertion.sub == '__retired__' && false"
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"


### PR DESCRIPTION
## 무엇을 변경했는지

- 비활성화한 Firebase WIF provider의 attribute condition 한 줄에 OIDC sub claim 참조를 추가합니다.
- 조건은 `assertion.sub == '__retired__' && false`로 항상 거부하며 disabled와 PREVENT는 유지합니다.

## 왜 변경했는지

[#741](https://github.com/byulmaru/kosmo/pull/741)의 retirement 설정에 들어간 단독 `false` 조건이 [main Terraform Apply](https://github.com/byulmaru/kosmo/actions/runs/34004771396/job/101409854648)에서 claim 참조 부재로 HTTP 400을 반환했습니다. 기존 권한 제거 의도를 유지하면서 API가 요구한 claim 참조를 복구합니다.

## 이번 PR의 주요 결정

- 조건을 삭제해 허용 범위를 넓히지 않고 항상 거부하는 결과를 유지합니다.
- 리소스 제거, IAM 권한 복원, TestFlight 배포 동작 변경은 하지 않습니다.
- 기존 [PROD-876](https://linear.app/byulmaru/issue/PROD-876)의 retirement 후속 수정이며 새 제품 계약은 없습니다.
- Stack: main -> PROD-876-wif-condition-fix (독립 1-layer).

## 어떻게 확인할 수 있는지

- Terraform init -backend=false, fmt, validate 통과.
- git diff --check와 Ponytail 검토 통과.
- exact head `79d916faa3eaaedcddd0a9f96743e9f574f04f59`에서 CI 17개 통과, Terraform Apply만 예상 skip. [Test](https://github.com/byulmaru/kosmo/actions/runs/34007241854), [Terraform Plan](https://github.com/byulmaru/kosmo/actions/runs/34007241861/job/101416606319).
- exact head `79d916faa3eaaedcddd0a9f96743e9f574f04f59`의 Terraform Plan 통과: 0 add / 1 change / 0 destroy. 저장된 plan에서도 WIF provider의 새 조건, disabled=true, PREVENT 유지 확인.
- 단순 소스 문자열 검사 테스트는 추가하지 않았습니다.

## 아직 어떤 문제가 남았는지

Terraform validate와 Plan은 Google API의 실제 조건 업데이트 수용을 증명하지 않습니다. merge 후 reviewed Apply에서 확인해야 합니다. 이번 작업에서는 Apply, 배포, workflow dispatch 또는 재실행을 하지 않았습니다. GCP 리소스의 2단계 정리는 별도 범위로 유지합니다.
