### PR TITLE
프로젝트 지침의 중복을 줄이고 필요한 절차만 읽도록 정리

### DIFF
--- a/.codex/instructions/codegraph-worktrees.md
+++ b/.codex/instructions/codegraph-worktrees.md
@@ -1,0 +1,22 @@
+Repository-root-relative paths and commands. Read before CodeGraph use or initialization.
+
+## CodeGraph In Linked Worktrees
+
+- For this repository, consider CodeGraph initialized only when the current worktree contains
+  `.codegraph/codegraph.db`. A `.codegraph/` directory containing only `.gitignore` is not an
+  initialized index. This rule overrides broader instructions that check only for the directory.
+- Do not run `codegraph init` in a linked worktree without user approval.
+- When the current worktree has no local index, use `git worktree list --porcelain` to find the
+  `main` checkout. If that checkout has `.codegraph/codegraph.db`, pass its absolute path as
+  CodeGraph's `projectPath` and use its graph only as a read-only structural baseline. Do not
+  hard-code a machine-specific checkout path in repository files.
+- Before using the shared baseline, run `codegraph status <main-checkout-path>` to verify that the
+  index is up to date. If freshness cannot be verified or CodeGraph reports a pending or stale
+  state, treat the entire baseline as stale and use current-worktree reads and targeted searches.
+- Before relying on the baseline graph, collect paths that differ between the baseline checkout
+  and the current worktree, plus staged, unstaged, and untracked paths in both checkouts. Treat
+  CodeGraph results for those paths, and relationships that cross them, as hints only; verify the
+  current worktree with direct reads and targeted searches.
+- If graph-shaping configuration differs or the task makes broad structural changes, state that
+  the shared baseline is not branch-exact and ask whether to initialize CodeGraph in the current
+  worktree. Otherwise, do not create a worktree-local index by default.

--- a/.codex/instructions/github-stack.md
+++ b/.codex/instructions/github-stack.md
@@ -1,0 +1,28 @@
+Repository-root-relative paths and commands. Read before branch or pull request work.
+
+## GitHub Stacked Pull Requests
+
+- Create every new pull request, including a standalone pull request, as a GitHub Stack with the
+  official `github/gh-stack` GitHub CLI extension. A standalone pull request is a one-layer Stack.
+- Before branch or pull request work, verify the extension with `gh extension list` and
+  `gh stack --version`. If it is missing, install it for the current user with
+  `gh extension install github/gh-stack`; it is a local CLI extension, not a repository dependency.
+- Start the first layer from the latest trunk with `gh stack init --base main <branch>`.
+  Add each later layer only from the current top with `gh stack add <branch>`.
+- Feature and contract branches use their Linear issue ID. A behavior-preserving simple refactor may use a descriptive branch without creating a Linear issue solely for the pull request.
+- Push tracked layers with `gh stack push` and create or update pull requests with `gh stack submit`.
+  For two or more pull requests, submit must also create or update the remote GitHub Stack object.
+  A one-layer Stack remains locally tracked and its standalone pull request has a null REST `stack`
+  field until another layer is submitted. If `gh stack` is unavailable or fails, do not fall back
+  to `gh pr create` or an ordinary unstacked pull request; report the blocker and observed
+  local/remote state, including partial branch, pull request, Stack, auto-merge, or Draft changes.
+- Do not use `gh stack submit --auto` by default. Use the interactive editor, or a narrower explicit
+  command whose title, body, Draft/Ready transitions, and affected existing pull requests have been
+  reviewed.
+- After submission, verify local Stack state with `gh stack view --json` and GitHub pull request
+  head/base/stack state with the pull request REST API. For multi-layer Stacks, a base retarget or a
+  successful branch push alone does not prove that the remote GitHub Stack object exists.
+- GitHub Stack merge is distinct from pull request auto-merge and merge queue registration. Stacked
+  pull requests currently cannot retain ordinary auto-merge; report any auto-merge removal or queue
+  state change instead of hiding it. A queued Stack may land in separate groups and is not merged
+  until GitHub reports the pull requests as merged.

--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-review-coach
-description: Review implementation work before publication or inspect another author’s GitHub pull request as the human decision-maker’s evidence-gathering partner. Distinguish implementation self-review from external PR review using user intent, thread provenance, PR authorship, and Linear ownership; delegate bounded correctness and optional ponytail passes while the main agent maps responsibilities, execution flow, public contracts, production callers, and test-only seams. Use for implementation self-review, PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
+description: 'Review implementation before publication or another author’s GitHub PR; distinguish self-review from external feedback, gather evidence, and draft or resolve review comments.'
 ---
 
 # GitHub Review Coach
@@ -166,59 +166,11 @@ Propose concrete slices rather than saying only “this PR is too large.” Stat
 
 ### 7. Record implementation self-review decisions
 
-After classifying self-review findings, distinguish a defect fix from a newly chosen important alternative. A choice is important when it changes observable behavior, public contracts, data, security, compatibility, rollout, reversibility, ownership, scope, dependencies, or the direction later implementations must follow.
+For self-review findings, read [decision recording](references/self-review-decisions.md) before fixing or recording important choices.
 
-- Update Linear first when scope, ownership, deliverables, blockers, or issue relationships change.
-- Update OpenSpec `decisions.md` before code when a durable choice or public contract shared by implementation slices changes. Record superseded decisions instead of silently overwriting them.
-- Record important implementation choices within independently verified upstream contracts in the PR body with decision-maker, choice, alternatives, reason, consequences, and links.
-- Update applicable `memory/*.md` only for reusable repository conventions, and `docs/design/*.md` for documented product or UI design decisions.
-- Do not invent a decision, rationale, or decision-maker. Ask the user when a material choice remains open. Do not create ceremonial records when the implementation merely follows an independently verified OpenSpec decision.
+### 8–10. External feedback
 
-Return a decision ledger with new decisions and their recorded locations, independently verified decisions applied unchanged, and unresolved decisions. After self-review fixes, apply the snapshot-change rule above before declaring publication readiness.
-
-### 8. Draft junior-friendly external review comments
-
-Write in Korean when the repository or user prefers Korean. Use the following order:
-
-1. **Priority and short title**
-2. **What the current code does**
-3. **Why that causes a problem**
-4. **A concrete example or execution order**
-5. **What to change**
-6. **Whether it blocks this PR or may move to a follow-up**
-
-Explain unfamiliar terms in plain language. Use `transaction`, `loader`, `fixture`, or `idempotency` only when useful, and immediately connect the term to the observable behavior.
-
-Anchor comments to the tightest changed line. Avoid preference-only feedback. Combine comments that share one root cause, but keep independently actionable fixes separate.
-
-Use repository priority rules when available. Otherwise:
-
-- `P1`: merge-blocking behavior, security, data, or API contract defect. This includes a public API that makes the PR’s mandatory invariant optional or bypassable, or a test-only input that can disable a required lifecycle in production.
-- `P2`: structural or correctness risk that should be fixed now but may be split with explicit ownership;
-- `P3`: lower-risk design or maintainability improvement;
-- `P5`: trivial cleanup.
-
-### 9. Get explicit approval before publishing external feedback
-
-Before a GitHub write:
-
-1. Show the proposed findings and open questions.
-2. Incorporate the user’s policy decisions.
-3. Re-fetch the PR head.
-4. If the head changed, stop and re-check the affected lines before publishing.
-5. State the exact PR and intended action.
-
-Decide the review body before submission. A submitted empty review body may not be editable later.
-
-- Use an empty body when inline comments are sufficient and repository rules prefer it.
-- Include a detailed body in the initial submission when requesting a PR split or explaining an overarching blocker.
-
-### 10. Clean up external review threads accurately
-
-- Resolve only feedback whose requested behavior is actually reflected in the current code or conclusively answered.
-- Do not resolve a thread merely because the author replied or moved code.
-- Keep new and unaddressed findings unresolved.
-- After publishing, verify the review state, inline comment count, body, resolved/unresolved thread state, and clean local workspace.
+For external comment drafting, publication, or thread cleanup, first read [external feedback workflow](references/external-feedback.md). GitHub writes require explicit approval; re-fetch head and stop for re-review if it changed.
 
 ## Output For Implementation Self-Review
 

--- a/.codex/skills/gh-review-coach/references/external-feedback.md
+++ b/.codex/skills/gh-review-coach/references/external-feedback.md
@@ -1,0 +1,45 @@
+Read when linked from SKILL.md. Repository paths and command working directories retain their original meaning.
+
+### 8. Draft junior-friendly external review comments
+
+Write in Korean when the repository or user prefers Korean. Use the following order:
+
+1. **Priority and short title**
+2. **What the current code does**
+3. **Why that causes a problem**
+4. **A concrete example or execution order**
+5. **What to change**
+6. **Whether it blocks this PR or may move to a follow-up**
+
+Explain unfamiliar terms in plain language. Use `transaction`, `loader`, `fixture`, or `idempotency` only when useful, and immediately connect the term to the observable behavior.
+
+Anchor comments to the tightest changed line. Avoid preference-only feedback. Combine comments that share one root cause, but keep independently actionable fixes separate.
+
+Use repository priority rules when available. Otherwise:
+
+- `P1`: merge-blocking behavior, security, data, or API contract defect. This includes a public API that makes the PR’s mandatory invariant optional or bypassable, or a test-only input that can disable a required lifecycle in production.
+- `P2`: structural or correctness risk that should be fixed now but may be split with explicit ownership;
+- `P3`: lower-risk design or maintainability improvement;
+- `P5`: trivial cleanup.
+
+### 9. Get explicit approval before publishing external feedback
+
+Before a GitHub write:
+
+1. Show the proposed findings and open questions.
+2. Incorporate the user’s policy decisions.
+3. Re-fetch the PR head.
+4. If the head changed, stop and re-check the affected lines before publishing.
+5. State the exact PR and intended action.
+
+Decide the review body before submission. A submitted empty review body may not be editable later.
+
+- Use an empty body when inline comments are sufficient and repository rules prefer it.
+- Include a detailed body in the initial submission when requesting a PR split or explaining an overarching blocker.
+
+### 10. Clean up external review threads accurately
+
+- Resolve only feedback whose requested behavior is actually reflected in the current code or conclusively answered.
+- Do not resolve a thread merely because the author replied or moved code.
+- Keep new and unaddressed findings unresolved.
+- After publishing, verify the review state, inline comment count, body, resolved/unresolved thread state, and clean local workspace.

--- a/.codex/skills/gh-review-coach/references/self-review-decisions.md
+++ b/.codex/skills/gh-review-coach/references/self-review-decisions.md
@@ -1,0 +1,15 @@
+Read when linked from SKILL.md. Repository paths and command working directories retain their original meaning.
+
+The snapshot-change rule referenced below is in [step 5 of SKILL.md](../SKILL.md#5-reconcile-and-classify-evidence).
+
+### 7. Record implementation self-review decisions
+
+After classifying self-review findings, distinguish a defect fix from a newly chosen important alternative. A choice is important when it changes observable behavior, public contracts, data, security, compatibility, rollout, reversibility, ownership, scope, dependencies, or the direction later implementations must follow.
+
+- Update Linear first when scope, ownership, deliverables, blockers, or issue relationships change.
+- Update OpenSpec `decisions.md` before code when a durable choice or public contract shared by implementation slices changes. Record superseded decisions instead of silently overwriting them.
+- Record important implementation choices within independently verified upstream contracts in the PR body with decision-maker, choice, alternatives, reason, consequences, and links.
+- Update applicable `memory/*.md` only for reusable repository conventions, and `docs/design/*.md` for documented product or UI design decisions.
+- Do not invent a decision, rationale, or decision-maker. Ask the user when a material choice remains open. Do not create ceremonial records when the implementation merely follows an independently verified OpenSpec decision.
+
+Return a decision ledger with new decisions and their recorded locations, independently verified decisions applied unchanged, and unresolved decisions. After self-review fixes, apply the snapshot-change rule above before declaring publication readiness.

--- a/.codex/skills/kosmo-design-audit/SKILL.md
+++ b/.codex/skills/kosmo-design-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kosmo-design-audit
-description: Use when reviewing or auditing KOSMO Figma components, screens, foundations, tokens, variants, states, accessibility, Light/Dark behavior, responsive layouts, or design-system drift before a Figma edit, redesign, handoff, or source-component cleanup; not for implementing or reviewing production UI code.
+description: 'Audit KOSMO Figma source components, screens, foundations, and design-system drift before edits or handoff; not production UI implementation or code review.'
 ---
 
 # KOSMO Design Audit

--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-apply-change
-description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+description: 'Implement or continue tasks from an OpenSpec change.'
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:
@@ -112,56 +112,9 @@ Implement tasks from an OpenSpec change.
    - If all done: suggest archive
    - If paused: explain why and wait for guidance
 
-**Output During Implementation**
+**Output examples**
 
-```
-## Implementing: <change-name> (schema: <schema-name>)
-
-Working on task 3/7: <task description>
-[...implementation happening...]
-✓ Task complete
-
-Working on task 4/7: <task description>
-[...implementation happening...]
-✓ Task complete
-```
-
-**Output On Completion**
-
-```
-## Implementation Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 7/7 tasks complete ✓
-
-### Completed This Session
-- [x] Task 1
-- [x] Task 2
-...
-
-All tasks complete! Ready to archive this change.
-```
-
-**Output On Pause (Issue Encountered)**
-
-```
-## Implementation Paused
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 4/7 tasks complete
-
-### Issue Encountered
-<description of the issue>
-
-**Options:**
-1. <option 1>
-2. <option 2>
-3. Other approach
-
-What would you like to do?
-```
+When reporting implementation progress, completion, or a pause, use [output examples](references/output-examples.md). Report actual change/schema, task counts, completed tasks, and any blocker/options.
 
 **Guardrails**
 

--- a/.codex/skills/openspec-apply-change/references/output-examples.md
+++ b/.codex/skills/openspec-apply-change/references/output-examples.md
@@ -1,0 +1,52 @@
+Read when linked from SKILL.md. Repository paths and command working directories retain their original meaning.
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```

--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-archive-change
-description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+description: 'Archive a completed OpenSpec change after checking its completion and spec synchronization.'
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:
@@ -112,16 +112,7 @@ Archive a completed change in the experimental workflow.
 
 **Output On Success**
 
-```
-## Archive Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
-**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
-
-All artifacts complete. All tasks complete.
-```
+When reporting successful archival, use [completion example](references/output-example.md) with actual change, schema, archive location, synchronization status, and warnings.
 
 **Guardrails**
 

--- a/.codex/skills/openspec-archive-change/references/output-example.md
+++ b/.codex/skills/openspec-archive-change/references/output-example.md
@@ -1,0 +1,14 @@
+Read when linked from SKILL.md. Repository paths and command working directories retain their original meaning.
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```

--- a/.codex/skills/openspec-explore/SKILL.md
+++ b/.codex/skills/openspec-explore/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-explore
-description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+description: 'Explore requirements, ideas, and implementation questions in the OpenSpec workflow without implementing changes.'
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:
@@ -164,111 +164,7 @@ If the user mentions a change or you detect one is relevant:
 
 ## Handling Different Entry Points
 
-**User brings a vague idea:**
-
-```
-User: I'm thinking about adding real-time collaboration
-
-You: Real-time collab is a big space. Let me think about this...
-
-      COLLABORATION SPECTRUM
-      ════════════════════════════════════════════
-
-      Awareness          Coordination         Sync
-          │                   │                 │
-          ▼                   ▼                 ▼
-      ┌────────┐         ┌────────┐        ┌────────┐
-      │Presence│         │Cursors │        │  CRDT  │
-      │  "3    │         │ Multi  │        │Conflict│
-      │online" │         │ select │        │  free  │
-      └────────┘         └────────┘        └────────┘
-          │                   │                 │
-       trivial            moderate           complex
-
-      Where's your head at?
-```
-
-**User brings a specific problem:**
-
-```
-User: The auth system is a mess
-
-You: [reads codebase]
-
-     ┌─────────────────────────────────────────────┐
-     │              CURRENT AUTH FLOW              │
-     └─────────────────────────────────────────────┘
-                        │
-          ┌─────────────┼─────────────┐
-          ▼             ▼             ▼
-     ┌─────────┐  ┌─────────┐  ┌─────────┐
-     │ Google  │  │  GitHub │  │  Email  │
-     │  OAuth  │  │  OAuth  │  │  Magic  │
-     └────┬────┘  └────┬────┘  └────┬────┘
-          │             │             │
-          └─────────────┼─────────────┘
-                        ▼
-                  ┌───────────┐
-                  │  Session  │
-                  └─────┬─────┘
-                        │
-                        ▼
-                  ┌───────────┐
-                  │   Perms   │
-                  └───────────┘
-
-     I see three tangles. Which one's burning?
-```
-
-**User is stuck mid-implementation:**
-
-```
-User: /opsx:explore add-auth-system
-      The OAuth integration is more complex than expected
-
-You: [reads change artifacts]
-
-     You're on task 4: "Implement OAuth flow"
-
-     Let me trace what's involved...
-
-     [draws diagram, explores options, suggests paths]
-
-     Want to update the design to reflect this?
-     Or add a spike task to investigate?
-```
-
-**User wants to compare options:**
-
-```
-User: Should we use Postgres or SQLite?
-
-You: Generic answer is boring. What's the context?
-
-User: A CLI tool that tracks local dev environments
-
-You: That changes everything.
-
-     ┌─────────────────────────────────────────────────┐
-     │          CLI TOOL DATA STORAGE                  │
-     └─────────────────────────────────────────────────┘
-
-     Key constraints:
-     • No daemon running
-     • Must work offline
-     • Single user
-
-                  SQLite          Postgres
-     Deployment   embedded ✓      needs server ✗
-     Offline      yes ✓           no ✗
-     Single file  yes ✓           no ✗
-
-     SQLite. Not even close.
-
-     Unless... is there a sync component?
-```
-
----
+For examples of responding to a vague idea, a concrete problem, competing options, or an implementation detour, read [conversation examples](references/conversation-examples.md). They are illustrative, not mandatory outputs.
 
 ## Ending Discovery
 

--- a/.codex/skills/openspec-explore/references/conversation-examples.md
+++ b/.codex/skills/openspec-explore/references/conversation-examples.md
@@ -1,0 +1,109 @@
+Read when linked from SKILL.md. Repository paths and command working directories retain their original meaning.
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---

--- a/.codex/skills/openspec-propose/SKILL.md
+++ b/.codex/skills/openspec-propose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-propose
-description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with specs, design, decisions, and tasks ready for implementation.
+description: 'Create an OpenSpec proposal with specs, design, and implementation tasks from a requested change.'
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,57 +3,17 @@
 ## Workspace Rules
 
 - Use `pnpm` for workspace and dependency management.
-- Use CLI commands for `package.json` dependency changes. Non-dependency fields, such as `scripts`, may be edited directly.
+- Use `pnpm add`, `pnpm remove`, `pnpm add --save-dev`, or other `pnpm` CLI commands for `package.json` dependency changes. Non-dependency fields, such as `scripts`, may be edited directly.
 - Use the Question tool when asking the user to decide between implementation options or unresolved requirements.
 - Do not add a `Co-authored-by` trailer for the agent in commits or PR descriptions. The author of record is the human running the agent; agent attribution belongs in the PR body or Linear, not in the git trailer.
 
 ## GitHub Stacked Pull Requests
 
-- Create every new pull request, including a standalone pull request, as a GitHub Stack with the
-  official `github/gh-stack` GitHub CLI extension. A standalone pull request is a one-layer Stack.
-- Before branch or pull request work, verify the extension with `gh extension list` and
-  `gh stack --version`. If it is missing, install it for the current user with
-  `gh extension install github/gh-stack`; it is a local CLI extension, not a repository dependency.
-- Start the first layer from the latest trunk with `gh stack init --base main <branch>`.
-  Add each later layer only from the current top with `gh stack add <branch>`.
-- Feature and contract branches use their Linear issue ID. A behavior-preserving simple refactor may use a descriptive branch without creating a Linear issue solely for the pull request.
-- Push tracked layers with `gh stack push` and create or update pull requests with `gh stack submit`.
-  For two or more pull requests, submit must also create or update the remote GitHub Stack object.
-  A one-layer Stack remains locally tracked and its standalone pull request has a null REST `stack`
-  field until another layer is submitted. If `gh stack` is unavailable or fails, do not fall back
-  to `gh pr create` or an ordinary unstacked pull request; report the blocker and observed
-  local/remote state, including partial branch, pull request, Stack, auto-merge, or Draft changes.
-- Do not use `gh stack submit --auto` by default. Use the interactive editor, or a narrower explicit
-  command whose title, body, Draft/Ready transitions, and affected existing pull requests have been
-  reviewed.
-- After submission, verify local Stack state with `gh stack view --json` and GitHub pull request
-  head/base/stack state with the pull request REST API. For multi-layer Stacks, a base retarget or a
-  successful branch push alone does not prove that the remote GitHub Stack object exists.
-- GitHub Stack merge is distinct from pull request auto-merge and merge queue registration. Stacked
-  pull requests currently cannot retain ordinary auto-merge; report any auto-merge removal or queue
-  state change instead of hiding it. A queued Stack may land in separate groups and is not merged
-  until GitHub reports the pull requests as merged.
+Before branch or PR work, read [GitHub Stack workflow](.codex/instructions/github-stack.md). Every new PR, including a standalone PR, uses official `github/gh-stack`. Preserve its approval, failure-stop, and local/remote verification gates.
 
 ## CodeGraph In Linked Worktrees
 
-- For this repository, consider CodeGraph initialized only when the current worktree contains
-  `.codegraph/codegraph.db`. A `.codegraph/` directory containing only `.gitignore` is not an
-  initialized index. This rule overrides broader instructions that check only for the directory.
-- Do not run `codegraph init` in a linked worktree without user approval.
-- When the current worktree has no local index, use `git worktree list --porcelain` to find the
-  `main` checkout. If that checkout has `.codegraph/codegraph.db`, pass its absolute path as
-  CodeGraph's `projectPath` and use its graph only as a read-only structural baseline. Do not
-  hard-code a machine-specific checkout path in repository files.
-- Before using the shared baseline, run `codegraph status <main-checkout-path>` to verify that the
-  index is up to date. If freshness cannot be verified or CodeGraph reports a pending or stale
-  state, treat the entire baseline as stale and use current-worktree reads and targeted searches.
-- Before relying on the baseline graph, collect paths that differ between the baseline checkout
-  and the current worktree, plus staged, unstaged, and untracked paths in both checkouts. Treat
-  CodeGraph results for those paths, and relationships that cross them, as hints only; verify the
-  current worktree with direct reads and targeted searches.
-- If graph-shaping configuration differs or the task makes broad structural changes, state that
-  the shared baseline is not branch-exact and ask whether to initialize CodeGraph in the current
-  worktree. Otherwise, do not create a worktree-local index by default.
+Before CodeGraph use or initialization in a linked worktree, read [CodeGraph worktree rules](.codex/instructions/codegraph-worktrees.md). A local `.codegraph/codegraph.db` is required for an initialized index; worktree-local initialization requires user approval.
 
 ## Review Guidelines
 
@@ -123,8 +83,3 @@
 
 - Before working on UI/product design tasks (design implementation, Figma work, style changes), check `docs/design/*.md`.
 - When a change alters a documented design decision, update the relevant `docs/design` document in the same change.
-
-## `package.json` Changes
-
-- Use `pnpm add`, `pnpm remove`, `pnpm add --save-dev`, or other `pnpm`-based CLI commands for dependency updates.
-- Non-dependency manifest fields, including `scripts`, may be edited directly.


### PR DESCRIPTION
## 변경 내용

- `AGENTS.md`의 pnpm 규칙을 한곳으로 합치고, Stack·CodeGraph의 상세 절차를 조건부 참조로 분리했습니다.
- 프로젝트 스킬 6개의 설명을 축약하고, 자기 리뷰·외부 피드백 절차와 OpenSpec 출력·대화 예시를 필요한 시점에 읽도록 연결했습니다.
- 기존 명령, 승인 경계, 완료·중단 조건, 리뷰 수량과 최신 Tests 규칙을 유지했습니다.

## 변경 이유

공유 프로젝트 지침 자체의 반복과 긴 진입점을 줄여, 현재 작업에 필요한 절차를 찾기 쉽게 합니다. 개인 로컬 지침과의 중복을 해소하려는 변경은 포함하지 않았습니다.

## 주요 결정

사용자 요청에 따라 기능·계약을 추가하지 않는 문서 정리로 한정하고, 별도 이슈나 OpenSpec 없이 설명형 브랜치로 분리했습니다. Draft 상태를 유지합니다.

Stack: `main -> codex/deduplicate-project-instructions`

## 검증

- 변경 Markdown 14개: 저장소 Prettier 3.8.3 검사, 참조 경로·앵커 및 코드 블록 검사 통과
- 스킬 6개: YAML 구문 및 description 외 메타데이터 보존 확인
- 이동 구간 7개: 포맷 공백을 제외한 원문 보존과 소스 읽기 확인
- 독립 문서 리뷰 및 `git diff --check` 통과
- 진입점 문자 수: 58,057 → 46,937자. 참조를 포함한 해당 변경 파일 총량은 59,516자이며 토큰·할당량 절감 측정은 아닙니다.

## 남은 확인

새 세션에서의 자동 스킬 선택률은 측정하지 않았습니다. 애플리케이션 코드 변경이 없어 앱 테스트·빌드는 실행하지 않았습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>