### PR TITLE
리뷰에 테스트 검증 전담 서브에이전트를 추가한다

### DIFF
--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-review-coach
-description: Review implementation work before publication or inspect another author’s GitHub pull request as the human decision-maker’s evidence-gathering partner. Distinguish implementation self-review from external PR review using user intent, thread provenance, PR authorship, and Linear ownership; delegate bounded correctness and optional ponytail passes while the main agent maps responsibilities, execution flow, public contracts, production callers, and test-only seams. Use for implementation self-review, PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
+description: Review implementation work before publication or inspect another author’s GitHub pull request as the human decision-maker’s evidence-gathering partner. Distinguish implementation self-review from external PR review using user intent, thread provenance, PR authorship, and Linear ownership; delegate bounded correctness and test-evidence passes plus an optional ponytail pass while the main agent maps responsibilities, execution flow, public contracts, production callers, and test-only seams. Use for implementation self-review, PR review, 재리뷰, 구조 또는 책임 분리 검토, review comment drafting, request-changes decisions, scope-splitting feedback, or review-thread cleanup.
 ---
 
 # GitHub Review Coach
@@ -61,14 +61,23 @@ Use thread-aware GitHub reads when resolution or inline context matters. Do not 
 
 ### 3. Start delegated evidence review
 
-After fixing the review mode, exact snapshot, ownership evidence, and repository guidance, spawn one review subagent before drawing conclusions.
+After fixing the review mode, exact snapshot, ownership evidence, and repository guidance, spawn one correctness subagent before drawing conclusions; when the review includes changed tests or changed runtime behavior, also spawn a dedicated test-evidence subagent in parallel.
 
-- Assign one subagent a bounded correctness surface such as contracts, authorization, transactions, persistence, concurrency, fixtures, tests, or unresolved-thread regressions.
-- When the `ponytail:ponytail-review` skill is available, spawn a second subagent in parallel and assign it to find only deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
-- When the ponytail skill is unavailable, continue with the single correctness subagent.
+- Assign the correctness subagent a bounded non-test surface such as contracts, authorization, transactions, persistence, concurrency, or unresolved-thread regressions; the correctness pass does not own test-evidence review.
+- When applicable, assign the dedicated test-evidence subagent to inspect changed tests and tests covering changed behavior. When neither changed tests nor changed runtime behavior is in scope, explicitly report test evidence not applicable; when runtime behavior changed but relevant tests are absent, report the contract-specific coverage gap instead of treating it as not applicable, and do not invent work.
+- The test-evidence subagent assesses test evidence for the reviewed behavior using these criteria:
+  - Would the test fail if the changed behavior were broken? Check for vacuous or skipped conditional assertions, async assertions or completion that are neither awaited nor returned, and swallowed errors; do not flag valid returned promises.
+  - Do mocks and stubs leave the system under test's policy and state transformation in the test? A mock may replace an external boundary, but must not replace the policy or transformation being claimed.
+  - Does the test cover relevant failure or boundary states and verify the resulting post-state and required side effects?
+  - Are ordering, shared state, time, randomness, and completion controlled deterministically rather than by arbitrary sleeps or timing assumptions?
+  - Are fixtures realistic, and are expected values derived independently rather than computed by the same system under test?
+- Apply `Audit assertion targets` as part of this pass.
+- The test-evidence pass does not require mutation testing, mandate broad suites or 100% coverage, or add tests solely to satisfy this checklist; use the narrowest meaningful check.
+- When the `ponytail:ponytail-review` skill is available, spawn an additional subagent in parallel and assign it to find only deletable code, speculative abstractions without a current caller, avoidable dependencies, duplicated native behavior, and scope that belongs with a later caller.
 - When multiple subagents run, divide work by independent responsibility or execution-flow slices. Do not assign overlapping whole-PR rereads merely to increase agent count.
 - Give every subagent the same repository, review mode, exact snapshot, applicable guidance, and a bounded question. For external review include PR number, base SHA, and head SHA. For self-review provide raw artifacts rather than implementation rationale or the expected conclusion.
 - Require exact file/line evidence, the path or invariant checked, confirmed findings separated from suspicions, the smallest relevant validation and its result, and an explicit no-finding result when the assigned surface is sound.
+- Require the test-evidence report to name each concrete missed regression or failure mode and state the smallest fix and the meaningful coverage that remains.
 - Forbid subagents from GitHub writes, code edits, product-policy decisions, severity decisions, and final review recommendations.
 
 While they run, the main agent must independently trace and share a compact responsibility map and execution-flow summary. Do not wait idle and do not delegate this synthesis. The main agent owns freshness checks, final verification, deduplication, severity, drafting, and every GitHub write.

--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -117,6 +117,12 @@ Treat a mandatory application lifecycle exposed as an optional or replaceable ca
 
 Prefer the smallest relevant check that can disprove or confirm a concern. Do not run broad test suites merely to appear thorough.
 
+#### Audit assertion targets
+
+For tests in the review scope, always trace each assertion's input and observed target; do not judge it by `.toBe` or `.toEqual` syntax alone. Flag tests that only inspect source-file strings, compare an imported config or meta object with hard-coded expected values, or pin internal DOM structure or SVG node counts without exercising the behavior. The existence of config acceptance does not make equality against the config object a user-behavior test.
+
+Preserve tests that exercise real behavior with meaningful inputs and observe outputs, state transitions, callback wiring, accessibility behavior, or rendered geometry, including user interaction where applicable. For a weak test, recommend the smallest suitable remedy: delete it if it adds no meaningful behavioral coverage, or replace it with the smallest behavior check needed for the contract. Ground that choice in the test's location, affected behavior, and coverage remaining after deletion. Do not add tests that merely mirror this guidance.
+
 ### 5. Reconcile and classify evidence
 
 Treat subagent reports as evidence, not conclusions. Verify their cited lines against the exact reviewed snapshot; in external review, this includes the shared head SHA. Merge duplicates only when they have the same root cause and requested fix, and preserve independently actionable fixes. A ponytail observation is not a blocker without a concrete current cost, absent caller, duplicated behavior, or scope/verification mismatch.

--- a/.codex/skills/gh-review-coach/SKILL.md
+++ b/.codex/skills/gh-review-coach/SKILL.md
@@ -119,7 +119,7 @@ Prefer the smallest relevant check that can disprove or confirm a concern. Do no
 
 #### Audit assertion targets
 
-For tests in the review scope, always trace each assertion's input and observed target; do not judge it by `.toBe` or `.toEqual` syntax alone. Flag tests that only inspect source-file strings, compare an imported config or meta object with hard-coded expected values, or pin internal DOM structure or SVG node counts without exercising the behavior. The existence of config acceptance does not make equality against the config object a user-behavior test.
+For tests in the review scope, always trace each assertion's input and observed target; do not judge it by `.toBe` or `.toEqual` syntax alone. Check for tests that only inspect source-file strings, compare an imported config or meta object with hard-coded expected values, or pin internal DOM structure or SVG node counts without exercising the behavior. The existence of config acceptance does not make equality against the config object a user-behavior test.
 
 Preserve tests that exercise real behavior with meaningful inputs and observe outputs, state transitions, callback wiring, accessibility behavior, or rendered geometry, including user interaction where applicable. For a weak test, recommend the smallest suitable remedy: delete it if it adds no meaningful behavioral coverage, or replace it with the smallest behavior check needed for the contract. Ground that choice in the test's location, affected behavior, and coverage remaining after deletion. Do not add tests that merely mirror this guidance.
 


### PR DESCRIPTION
## 무엇을 변경했는지

변경된 테스트나 런타임 동작이 있으면 테스트 검증 전담 서브에이전트를 정확성 검토와 병렬로 실행합니다.

- 동작이 깨졌을 때 실패하는지: 실행되지 않는 assertion, 완료를 기다리지 않는 비동기 검증, 삼켜진 오류를 확인합니다.
- mock 경계: 검증 대상의 정책·상태 변환 자체를 mock으로 대체하지 않는지 확인합니다.
- 실패·경계 조건: 계약에 중요한 실패 후 상태와 외부 효과를 검증하는지 확인합니다.
- 독립성·재현성: 순서·공유 상태·시간·무작위성·완료 조건에 의존한 불안정성을 확인합니다.
- fixture·기대값: 현실적인 상태를 사용하고, 같은 검증 대상에서 기대값을 계산해 버그를 공유하지 않는지 확인합니다.

기존 assertion 관찰 대상 지침도 적용합니다. 소스 문자열·설정 객체·내부 DOM/SVG 구조만 비교하는 테스트를 점검하되, 실제 입력·출력·상태 전이·callback·접근성·렌더 geometry 검증은 보존합니다. 변경 동작에 테스트가 없으면 계약별 검증 공백을 보고하고, 위치·영향·남는 검증을 근거로 가장 작은 조치를 제안합니다.

## 왜 변경했는지

테스트가 통과한다는 사실만으로 변경 동작이 검증됐다고 판단하는 누락을 줄이기 위해서입니다. 전담 역할이 구체적으로 놓치는 회귀와 검증 범위를 확인하고, 메인 에이전트가 결과를 종합합니다.

## 이번 PR의 주요 결정

사용자 요청에 따라 테스트 검증을 별도 서브에이전트 역할로 분리했습니다. 일반 정확성 검토에 맡기는 방식보다 책임을 명확히 하되, 관련 변경이 없는 리뷰에서는 전담 에이전트를 생략합니다. 광범위한 테스트 실행이나 체크리스트만을 위한 테스트 추가는 요구하지 않습니다.

Stack: main -> review-test-observation-guidance

## 어떻게 확인할 수 있는지

- Skill Creator `quick_validate.py` 통과
- `git diff --check` 통과
- Luna `criteria_check`의 요구사항·오탐 검토 및 Ponytail `minimality`의 최종 최소성 검토 완료

## 아직 어떤 문제가 남았는지

실제 PR 리뷰에서 새 역할을 실행한 결과는 아직 검증하지 않았습니다. PR #730의 수정·리뷰 제출은 이번 작업에 포함하지 않습니다.
