### PR TITLE
Fedify 테스트의 Temporal 포트 재할당 충돌을 줄인다

### DIFF
--- a/apps/worker/src/temporal-test-server.ts
+++ b/apps/worker/src/temporal-test-server.ts
@@ -4,13 +4,17 @@ import { TestWorkflowEnvironment } from '@temporalio/testing';
 
 const host = process.env.HOST?.trim() || '127.0.0.1';
 const healthPort = Number(process.env.PORT);
-const temporalPort = Number(process.env.TEMPORAL_PORT);
+const temporalPortValue = process.env.TEMPORAL_PORT?.trim();
+const temporalPort = temporalPortValue ? Number(temporalPortValue) : undefined;
 const namespace = process.env.TEMPORAL_NAMESPACE?.trim();
 
 if (!Number.isInteger(healthPort) || healthPort < 1 || healthPort > 65_535) {
   throw new Error('PORT must be an integer between 1 and 65535');
 }
-if (!Number.isInteger(temporalPort) || temporalPort < 1 || temporalPort > 65_535) {
+if (
+  temporalPort !== undefined &&
+  (!Number.isInteger(temporalPort) || temporalPort < 1 || temporalPort > 65_535)
+) {
   throw new Error('TEMPORAL_PORT must be an integer between 1 and 65535');
 }
 if (!namespace) {
@@ -27,7 +31,8 @@ const environment = await TestWorkflowEnvironment.createLocal({
   },
 });
 const healthServer = createServer((request, response) => {
-  response.writeHead(request.url === '/health' ? 200 : 404).end();
+  const isHealth = request.url === '/health';
+  response.writeHead(isHealth ? 200 : 404).end(isHealth ? environment.address : undefined);
 });
 
 try {

--- a/packages/core/temporal/test-runtime.ts
+++ b/packages/core/temporal/test-runtime.ts
@@ -26,14 +26,9 @@ export const startTestTemporalRuntime = async (): Promise<void> => {
 async function startRuntime(): Promise<void> {
   const host = '127.0.0.1';
   const namespace = process.env.TEMPORAL_NAMESPACE?.trim() || 'test';
-  const [temporalPort, healthPort, workerPort] = await Promise.all([
-    findFreePort(host),
-    findFreePort(host),
-    findFreePort(host),
-  ]);
-  const address = `${host}:${temporalPort}`;
+  const [healthPort, workerPort] = await Promise.all([findFreePort(host), findFreePort(host)]);
   const databaseUrl = process.env.DATABASE_URL ?? defaultDatabaseUrl;
-  const workerEnvironment = {
+  const workerEnvironment: NodeJS.ProcessEnv = {
     ...process.env,
     DATABASE_URL: databaseUrl,
     // Keep the Worker and Core Activities on the disposable test database even
@@ -43,7 +38,6 @@ async function startRuntime(): Promise<void> {
     NODE_ENV: process.env.NODE_ENV ?? 'test',
     PORT: String(workerPort),
     PUBLIC_ORIGIN: process.env.PUBLIC_ORIGIN ?? 'http://127.0.0.1:4173',
-    TEMPORAL_ADDRESS: address,
     TEMPORAL_NAMESPACE: namespace,
   };
   const server = spawn(process.execPath, ['--import', 'tsx', 'src/temporal-test-server.ts'], {
@@ -51,7 +45,7 @@ async function startRuntime(): Promise<void> {
     env: {
       ...workerEnvironment,
       PORT: String(healthPort),
-      TEMPORAL_PORT: String(temporalPort),
+      TEMPORAL_PORT: undefined,
     },
     // Keep startup failures visible in CI and avoid keeping the parent alive
     // with a long-lived stderr pipe after the children are unref'ed.
@@ -60,7 +54,11 @@ async function startRuntime(): Promise<void> {
   let worker: ChildProcess | undefined;
 
   try {
-    await waitForChildHealth(`http://${host}:${healthPort}/health`, server, startupTimeoutMs);
+    workerEnvironment.TEMPORAL_ADDRESS = await waitForChildHealth(
+      `http://${host}:${healthPort}/health`,
+      server,
+      startupTimeoutMs,
+    );
     worker = spawn(process.execPath, ['--import', 'tsx', 'src/index.ts'], {
       cwd: workerDirectory,
       env: workerEnvironment,
@@ -75,7 +73,7 @@ async function startRuntime(): Promise<void> {
     throw error;
   }
 
-  process.env.TEMPORAL_ADDRESS = address;
+  process.env.TEMPORAL_ADDRESS = workerEnvironment.TEMPORAL_ADDRESS;
   process.env.TEMPORAL_NAMESPACE = namespace;
 
   // Keep the test process from being held open by child handles. The exit
@@ -112,7 +110,7 @@ async function findFreePort(host: string): Promise<number> {
   return port;
 }
 
-async function waitForHealth(url: string, child: ChildProcess, timeoutMs: number): Promise<void> {
+async function waitForHealth(url: string, child: ChildProcess, timeoutMs: number): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
 
@@ -126,7 +124,7 @@ async function waitForHealth(url: string, child: ChildProcess, timeoutMs: number
     try {
       const response = await fetch(url);
       if (response.ok) {
-        return;
+        return (await response.text()).trim();
       }
       lastError = new Error(`HTTP ${response.status}`);
     } catch (error) {
@@ -147,8 +145,8 @@ async function waitForChildHealth(
   url: string,
   child: ChildProcess,
   timeoutMs: number,
-): Promise<void> {
-  await Promise.race([
+): Promise<string> {
+  return Promise.race([
     waitForHealth(url, child, timeoutMs),
     new Promise<never>((_, reject) => {
       child.once('error', (error) => {


### PR DESCRIPTION
## 무엇을 변경했는지

Temporal SDK가 테스트 서버 포트를 선택하게 하고, 기존 health 응답으로 실제 주소를 받아 Worker와 테스트 클라이언트에 전달합니다. Web E2E의 명시적 포트 설정은 유지합니다.

## 왜 변경했는지

#760의 [Fedify 실패 로그](https://github.com/byulmaru/kosmo/actions/runs/34004774141/job/101409861732)는 Temporal 서버의 `bind: address already in use`를 보여줍니다. 직접 빈 포트를 골랐다가 닫는 코드가 SDK의 Linux TIME_WAIT 재할당 방어를 우회하므로 기본 할당 경로를 복구합니다. 당시 포트 점유 프로세스는 확인되지 않았습니다.

#773은 로컬 개발용 Temporal 실행만 변경해 이 CI 경로를 해결하지 않습니다.

## 이번 PR의 주요 결정

새 제품 계약이나 durable decision은 없습니다. 테스트 인프라 수정으로 새 OpenSpec은 만들지 않았으며, 재시도·skip·assertion 완화도 추가하지 않았습니다.

## 어떻게 확인할 수 있는지

- `2400636d7`의 [CI](https://github.com/byulmaru/kosmo/actions/runs/34074642800): Fedify·Core·API·Worker, Web E2E 세 shard를 포함한 전체 PR 검사 16개 통과.
- 로컬: 동적·고정 포트 서버 smoke, 실제 parent runtime을 포함한 Fedify `follow-delivery` 2개, Worker/Fedify 타입 검사와 ESLint·Prettier 통과. 전체 DB 테스트는 로컬 PostgreSQL/Docker 환경이 없어 CI로 확인했습니다.
- Luna `fix_owner`가 구현·실행 검증, `ci_evidence`가 동작 보존 검토, `minimality`가 Ponytail 검토를 담당했습니다.

## 아직 어떤 문제가 남았는지

SDK도 모든 외부 포트 선점을 막지는 못합니다. 이 수정은 기존 코드가 우회하던 재할당 방어를 복구합니다.

Stack: `main -> ci-temporal-random-port` (1-layer Stack)
