### PR TITLE
Native 화면 로딩 실패 시 ErrorBoundary 참조 오류를 방지한다

### DIFF
--- a/patches/expo-router@56.2.13.patch
+++ b/patches/expo-router@56.2.13.patch
@@ -1,0 +1,27 @@
+diff --git a/build/useScreens.js b/build/useScreens.js
+index 9299061832496c67d3e83226a58f4fe33d714c69..d34170b52834b023327da942e2f3aef198ab6f9c 100644
+--- a/build/useScreens.js
++++ b/build/useScreens.js
+@@ -138,7 +138,11 @@ function useSortedScreens(order, protectedScreens, useOnlyUserDefinedScreens = f
+         return routeToScreen(value.route, value.props);
+     }), [sorted, protectedScreens]);
+ }
+-function fromImport(value, { ErrorBoundary, SuspenseFallback, ...component }) {
++function fromImport(value, routeModule) {
++    if (routeModule == null) {
++        throw new Error('Failed to load route module.');
++    }
++    const { ErrorBoundary, SuspenseFallback, ...component } = routeModule;
+     // If possible, add a more helpful display name for the component stack to improve debugging of React errors such as `Text strings must be rendered within a <Text> component.`.
+     if (component?.default && __DEV__) {
+         component.default.displayName ??= `${component.default.name ?? 'Route'}(${value.contextKey})`;
+@@ -182,6 +186,9 @@ function getQualifiedRouteComponent(value) {
+     if (import_mode_1.default === 'lazy') {
+         ScreenComponent = react_2.default.lazy(() => {
+             const res = value.loadRoute();
++            if (res == null) {
++                throw new Error('Failed to load route module.');
++            }
+             // NOTE(@kitten): React.lazy supports promise likes, which we can use to ensure that
+             // the route is synchronously available, if the `loadRoute` method returns a loaded route
+             // synchronously

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ overrides:
   react-native-reanimated: 4.3.1
   react-native-worklets: 0.8.3
 
+patchedDependencies:
+  expo-router@56.2.13: fb47bcc4111e2c6e55c9e4b8b2a58e5db294bfe45eb37a8a9bfebed0997383a3
+
 importers:
 
   .:
@@ -277,7 +280,7 @@ importers:
         version: 56.0.15(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.15)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
       expo-router:
         specifier: ~56.2.13
-        version: 56.2.13(24faa0a7552d1c8392f35296f7c53639)
+        version: 56.2.13(patch_hash=fb47bcc4111e2c6e55c9e4b8b2a58e5db294bfe45eb37a8a9bfebed0997383a3)(24faa0a7552d1c8392f35296f7c53639)
       expo-secure-store:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.14)
@@ -8980,7 +8983,7 @@ snapshots:
       ws: 8.21.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.13(24faa0a7552d1c8392f35296f7c53639)
+      expo-router: 56.2.13(patch_hash=fb47bcc4111e2c6e55c9e4b8b2a58e5db294bfe45eb37a8a9bfebed0997383a3)(24faa0a7552d1c8392f35296f7c53639)
       react-native: 0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.15)(react@19.2.3)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -9270,7 +9273,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 56.0.16(@expo/log-box@56.0.14)(expo@56.0.14)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.15)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      expo-router: 56.2.13(24faa0a7552d1c8392f35296f7c53639)
+      expo-router: 56.2.13(patch_hash=fb47bcc4111e2c6e55c9e4b8b2a58e5db294bfe45eb37a8a9bfebed0997383a3)(24faa0a7552d1c8392f35296f7c53639)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -13059,7 +13062,7 @@ snapshots:
     dependencies:
       react-native: 0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.15)(react@19.2.3)(supports-color@8.1.1)
 
-  expo-router@56.2.13(24faa0a7552d1c8392f35296f7c53639):
+  expo-router@56.2.13(patch_hash=fb47bcc4111e2c6e55c9e4b8b2a58e5db294bfe45eb37a8a9bfebed0997383a3)(24faa0a7552d1c8392f35296f7c53639):
     dependencies:
       '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.14)(react-native@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.15)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       '@expo/metro-runtime': 56.0.16(@expo/log-box@56.0.14)(expo@56.0.14)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.15)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,3 +50,5 @@ overrides:
   'xcode@3.0.1>uuid': 11.1.1
   react-native-reanimated: 4.3.1
   react-native-worklets: 0.8.3
+patchedDependencies:
+  expo-router@56.2.13: patches/expo-router@56.2.13.patch


### PR DESCRIPTION
## 무엇을 변경했는지

- Expo Router 56.2.13 패치에서 동기 및 lazy route 모듈 결과가 nullish일 때 `Failed to load route module.`을 throw하도록 했습니다.
- 기존 정상 화면 로딩, route가 제공하는 ErrorBoundary, `Try` fallback/retry와 Sentry 오류 수집 경계를 유지했습니다.
- Linear: https://linear.app/byulmaru/issue/PROD-900
- Stack: main → PROD-900

## 왜 변경했는지

Metro가 route evaluation의 최초 오류를 `ErrorUtils.reportFatalError`로 보고한 뒤 `undefined`를 반환하면 Expo Router가 `ErrorBoundary`를 구조 분해하는 과정에서 2차 TypeError를 만들었습니다. Expo CLI 56.1.18에 포함된 Metro 로더와 Expo Router 56.2.13 모듈을 실행해 이 순서를 재현했습니다. Sentry에서 관찰된 두 이벤트의 약 5ms 시간 차이만으로 최초 Intl 오류와 ErrorBoundary 오류의 인과를 확정하지 않으며, 최초 Intl 수정은 별도 PROD-899/#776 범위입니다.

## 이번 PR의 주요 결정

- 실패한 route를 EmptyRoute나 빈 성공 화면으로 대체하지 않고 명시적인 로딩 오류를 throw해 실패를 전파합니다.
- `guardedLoadModule`이 반환 전에 원래 예외를 소비하므로 Router 경계에서 원래 Error 객체를 재구성하지 않습니다. Metro의 최초 fatal report는 그대로 유지합니다.
- 오류 문자열은 고정해 새 route 경로나 개인 정보 맥락을 Sentry 이벤트에 추가하지 않습니다.

## 어떻게 확인할 수 있는지

- 실제 Metro·Router 모듈 harness: Metro 원본 fatal 1회, sync/lazy route-load 오류, 정상 route, route ErrorBoundary, Try fallback/retry를 확인했습니다.
- `CI=true pnpm --filter @kosmo/app test:unit` — 451 passed, 0 failed
- `CI=true pnpm --filter @kosmo/app exec node --experimental-test-module-mocks --import tsx --test src/observability/sentry-native.test.ts` — 3 passed, 0 failed
- `CI=true pnpm --filter @kosmo/app check` — Relay 120 reader, 77 normalization, 134 operation text compile 및 TypeScript 통과
- `CI=true pnpm lint:prettier`, patched `useScreens.js` 문법 검사, frozen lockfile 설치를 통과했습니다.
- 원본과 patched Android `ExpoRouterModule.kt`의 SHA-256이 동일함을 확인했습니다.

## 아직 어떤 문제가 남았는지

- 최초 Metro route evaluation fatal과 Intl 미지원 환경 자체는 복구하지 않으며 PROD-899/#776의 범위입니다.
- TestFlight/Hermes 실제 native 실행은 아직 확인하지 않았습니다.
- 이 PR은 merge/deploy하지 않았습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>