### PR TITLE
[PROD-884] Notification 표시 컴포넌트와 Storybook을 추가한다

### DIFF
--- a/apps/app/src/components/notification/NotificationListItemView.tsx
+++ b/apps/app/src/components/notification/NotificationListItemView.tsx
@@ -46,7 +46,7 @@ export type NotificationListItemViewProps =
   | {
       kind: 'reply';
       unread?: boolean;
-      /** Compose PostListItem with notification="reply" and showDivider={false}. */
+      /** Compose ReplyNotificationPost; this wrapper owns the divider and Read state. */
       children: ReactElement;
       actor?: never;
       actors?: never;

--- a/apps/app/src/components/notification/NotificationListItemView.tsx
+++ b/apps/app/src/components/notification/NotificationListItemView.tsx
@@ -1,0 +1,285 @@
+import { Link } from 'expo-router';
+import { Repeat2, Smile, UserRoundPlus } from 'lucide-react-native';
+import { useState } from 'react';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { PostContentPrivacyBoundary } from '@/components/post/PostContentPrivacyBoundary';
+import { PostMediaImage } from '@/components/post/PostMediaImage';
+import { Avatar } from '@/components/ui/Avatar';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, radius, space, textStyles } from '@/theme/tokens';
+import type { Href } from 'expo-router';
+import type { ReactElement } from 'react';
+import type { ViewStyle } from 'react-native';
+import type { PostMediaItem } from '@/components/post/PostMediaImage';
+
+type Actor = { id: string; name: string; avatarUrl?: string | null };
+
+type Preview = {
+  bodyText: string;
+  contentWarning: string | null;
+  media: readonly PostMediaItem[] | null;
+  sensitiveMedia: boolean;
+};
+
+type ActorSummary = {
+  actors: readonly [Actor, ...Actor[]];
+  /** Server-owned total; never infer grouping or actor order here. */
+  totalActorCount?: number;
+  actor?: never;
+  children?: never;
+};
+
+export type NotificationListItemViewProps = {
+  href: Href;
+  onNavigate?: () => void;
+  timestamp: string;
+  unread?: boolean;
+  disabled?: boolean;
+  pending?: boolean;
+} & (
+  | (ActorSummary & { kind: 'follow' | 'followRequest'; preview?: never })
+  | (ActorSummary & { kind: 'reaction' | 'repost'; preview: Preview | null })
+  | {
+      kind: 'reply';
+      actor: Actor;
+      /** Compose the existing PostListItem with showDivider={false}. */
+      children: ReactElement;
+      actors?: never;
+      totalActorCount?: never;
+      preview?: never;
+    }
+);
+
+const actions = {
+  follow: '팔로우했습니다',
+  followRequest: '팔로우를 요청했습니다',
+  reaction: '이 게시글에 반응했습니다',
+  repost: '이 게시글을 재게시했습니다',
+  reply: '답글을 남겼습니다',
+} as const;
+
+/** Presentation only. The consumer owns navigation, Read and pending state. */
+export function NotificationListItemView(props: NotificationListItemViewProps) {
+  const {
+    disabled = false,
+    href,
+    kind,
+    onNavigate,
+    pending = false,
+    timestamp,
+    unread = false,
+  } = props;
+  const theme = useTheme();
+  const web = Platform.OS === 'web';
+  const [focusVisible, setFocusVisible] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const blocked = disabled || pending;
+  const actors = kind === 'reply' ? [props.actor] : props.actors;
+  const actor = actors[0];
+  const suppliedCount = props.totalActorCount ?? actors.length;
+  const count =
+    kind === 'reply'
+      ? 1
+      : Math.max(
+          actors.length,
+          Number.isFinite(suppliedCount) ? Math.floor(suppliedCount) : actors.length,
+        );
+  const otherCount = count - 1;
+  const subject = `${actor.name}${otherCount > 0 ? ` 외 ${otherCount}명이` : '님이'}`;
+  const destination =
+    kind === 'follow' ? '프로필' : kind === 'followRequest' ? '팔로우 요청 관리 화면' : '게시글';
+  const preview = kind === 'reaction' || kind === 'repost' ? props.preview : undefined;
+  const excerpt =
+    preview === null
+      ? '게시글을 볼 수 없습니다'
+      : preview?.contentWarning
+        ? `내용 경고: ${preview.contentWarning}`
+        : preview?.bodyText;
+  const media =
+    preview && !preview.contentWarning && !preview.sensitiveMedia ? preview.media?.[0] : undefined;
+  const label = `${subject} ${actions[kind]}. ${timestamp}.${unread ? ' 읽지 않은 알림.' : ''}${excerpt ? ` ${excerpt}.` : ''}${media ? ` ${media.altText?.trim() || '첨부 이미지'}.` : ''} ${destination}${kind === 'followRequest' ? '으로' : '로'} 이동`;
+  const KindIcon = kind === 'reaction' ? Smile : kind === 'repost' ? Repeat2 : UserRoundPlus;
+  const iconColor =
+    kind === 'reaction'
+      ? theme.actionReactionBase
+      : kind === 'repost'
+        ? theme.actionRepostBase
+        : theme.foregroundSecondary;
+  const avatarStack = (
+    <View style={styles.avatars}>
+      {actors.slice(0, 3).map((item, index) => (
+        <Avatar
+          key={item.id}
+          imageUri={item.avatarUrl}
+          label={item.name}
+          size={28}
+          style={index > 0 ? styles.overlap : undefined}
+        />
+      ))}
+    </View>
+  );
+  const copy = (
+    <Text style={[styles.copy, { color: theme.foregroundPrimary }]}>
+      <Text style={textStyles.uiLabelM}>
+        {actor.name}
+        {otherCount > 0 ? ` 외 ${otherCount}명` : ''}
+      </Text>
+      {otherCount > 0 ? '이 ' : '님이 '}
+      {actions[kind]}
+    </Text>
+  );
+  const time = <Text style={[styles.time, { color: theme.foregroundSecondary }]}>{timestamp}</Text>;
+  const target = (
+    <Pressable
+      accessibilityLabel={label}
+      accessibilityRole="link"
+      accessibilityState={{ busy: pending, disabled: blocked }}
+      aria-busy={pending}
+      aria-disabled={blocked}
+      disabled={blocked}
+      onBlur={() => setFocusVisible(false)}
+      onHoverIn={() => setHovered(true)}
+      onHoverOut={() => setHovered(false)}
+      onFocus={(event) => {
+        const target = event.currentTarget as unknown as {
+          matches?: (selector: string) => boolean;
+        };
+        setFocusVisible(web && Boolean(target.matches?.(':focus-visible')));
+      }}
+      onPointerDown={() => setFocusVisible(false)}
+      onPress={blocked ? undefined : onNavigate}
+      style={[
+        styles.target,
+        {
+          outlineColor: theme.stateFocusRing,
+          outlineOffset: -2,
+          outlineStyle: focusVisible ? 'solid' : 'none',
+          outlineWidth: focusVisible ? 2 : 0,
+          opacity: blocked ? 0.5 : 1,
+        } as ViewStyle,
+      ]}
+    >
+      <View
+        style={[
+          styles.row,
+          web && styles.webRow,
+          kind === 'reply' && styles.replyRow,
+          {
+            backgroundColor:
+              web && hovered
+                ? theme.stateHover
+                : web && unread
+                  ? theme.actionPrimarySubtle
+                  : 'transparent',
+          },
+        ]}
+      >
+        <View
+          aria-hidden
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={[styles.kind, kind === 'reply' && styles.replyKind]}
+        >
+          {kind === 'reply' ? avatarStack : <KindIcon color={iconColor} size={32} />}
+        </View>
+        <View style={[styles.summary, kind === 'reply' && styles.replySummary]}>
+          {kind === 'reply' ? (
+            <>
+              {copy}
+              {time}
+            </>
+          ) : (
+            <>
+              <View style={styles.avatarAndTime}>
+                {avatarStack}
+                {time}
+              </View>
+              {copy}
+            </>
+          )}
+        </View>
+        {web && unread ? (
+          <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
+        ) : null}
+      </View>
+      {preview !== undefined ? (
+        <View style={[styles.preview, web && styles.webPreview]}>
+          <Text numberOfLines={1} style={[styles.excerpt, { color: theme.foregroundSecondary }]}>
+            {excerpt}
+          </Text>
+          {media ? (
+            <View style={styles.thumbnail}>
+              <PostMediaImage fill index={0} interactive={false} item={media} />
+            </View>
+          ) : null}
+        </View>
+      ) : null}
+    </Pressable>
+  );
+
+  return (
+    <PostContentPrivacyBoundary
+      style={[styles.root, { borderBottomColor: theme.borderSubtle }]}
+      testID="notification-list-item"
+    >
+      {blocked ? (
+        target
+      ) : (
+        <Link asChild href={href}>
+          {target}
+        </Link>
+      )}
+      {kind === 'reply' ? props.children : null}
+    </PostContentPrivacyBoundary>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { borderBottomWidth: borderWidths[1], minWidth: 0, width: '100%' },
+  target: { minWidth: 0 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: space[12],
+    paddingHorizontal: space[8],
+    paddingTop: space[16],
+    paddingBottom: space[8],
+    minHeight: 80,
+  },
+  webRow: { paddingLeft: space[12], paddingRight: space[16] },
+  kind: { alignItems: 'center', justifyContent: 'center', width: 48, height: 48, flexShrink: 0 },
+  summary: { flex: 1, minWidth: 0, gap: space[8] },
+  avatarAndTime: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: space[8],
+    minHeight: 28,
+  },
+  avatars: { alignItems: 'center', flexDirection: 'row' },
+  overlap: { marginLeft: -space[12] },
+  copy: { ...textStyles.uiCopyM, flexShrink: 1, minWidth: 0 },
+  time: { ...textStyles.uiCopyS, flexShrink: 0 },
+  replyRow: { paddingTop: space[8], minHeight: 48 },
+  replyKind: { alignItems: 'flex-end', height: 28 },
+  replySummary: { alignItems: 'center', flexDirection: 'row', minHeight: 28 },
+  preview: {
+    flexDirection: 'row',
+    gap: space[12],
+    alignItems: 'flex-start',
+    paddingLeft: space[8] + 48 + space[12],
+    paddingRight: space[8],
+    paddingBottom: space[16],
+  },
+  webPreview: { paddingLeft: space[12] + 48 + space[12], paddingRight: space[16] },
+  excerpt: { ...textStyles.contentM, flex: 1, minWidth: 0 },
+  thumbnail: { height: 64, width: 64, flexShrink: 0, borderRadius: radius[8], overflow: 'hidden' },
+  unreadRail: {
+    pointerEvents: 'none',
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: space[4],
+  },
+});

--- a/apps/app/src/components/notification/NotificationListItemView.tsx
+++ b/apps/app/src/components/notification/NotificationListItemView.tsx
@@ -29,7 +29,7 @@ type ActorSummary = {
   children?: never;
 };
 
-export type NotificationListItemViewProps = {
+type GroupedNotificationProps = {
   href: Href;
   onNavigate?: () => void;
   timestamp: string;
@@ -39,27 +39,77 @@ export type NotificationListItemViewProps = {
 } & (
   | (ActorSummary & { kind: 'follow' | 'followRequest'; preview?: never })
   | (ActorSummary & { kind: 'reaction' | 'repost'; preview: Preview | null })
+);
+
+export type NotificationListItemViewProps =
+  | GroupedNotificationProps
   | {
       kind: 'reply';
-      actor: Actor;
-      /** Compose the existing PostListItem with showDivider={false}. */
+      unread?: boolean;
+      /** Compose PostListItem with notification="reply" and showDivider={false}. */
       children: ReactElement;
+      actor?: never;
       actors?: never;
       totalActorCount?: never;
       preview?: never;
-    }
-);
+      href?: never;
+      timestamp?: never;
+      onNavigate?: never;
+      disabled?: never;
+      pending?: never;
+    };
 
 const actions = {
   follow: '팔로우했습니다',
   followRequest: '팔로우를 요청했습니다',
   reaction: '이 게시글에 반응했습니다',
   repost: '이 게시글을 재게시했습니다',
-  reply: '답글을 남겼습니다',
 } as const;
 
-/** Presentation only. The consumer owns navigation, Read and pending state. */
+/** Presentation only. The consumer owns navigation and Read state. */
 export function NotificationListItemView(props: NotificationListItemViewProps) {
+  const theme = useTheme();
+  const web = Platform.OS === 'web';
+  const unread = props.unread ?? false;
+  const [hovered, setHovered] = useState(false);
+  return (
+    <PostContentPrivacyBoundary
+      style={[styles.root, { borderBottomColor: theme.borderSubtle }]}
+      testID="notification-list-item"
+    >
+      <View
+        onPointerEnter={() => setHovered(true)}
+        onPointerLeave={() => setHovered(false)}
+        style={{
+          backgroundColor: web && unread ? theme.actionPrimarySubtle : 'transparent',
+        }}
+        testID="notification-item-surface"
+      >
+        {web && hovered ? (
+          <View
+            aria-hidden
+            pointerEvents="none"
+            style={[StyleSheet.absoluteFill, { backgroundColor: theme.stateHover }]}
+            testID="notification-hover-overlay"
+          />
+        ) : null}
+        {props.kind === 'reply' ? (
+          <>
+            {unread ? <Text style={styles.srOnly}>읽지 않은 알림</Text> : null}
+            {props.children}
+          </>
+        ) : (
+          <NotificationTarget {...props} />
+        )}
+        {web && unread ? (
+          <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
+        ) : null}
+      </View>
+    </PostContentPrivacyBoundary>
+  );
+}
+
+function NotificationTarget(props: GroupedNotificationProps) {
   const {
     disabled = false,
     href,
@@ -72,18 +122,14 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
   const theme = useTheme();
   const web = Platform.OS === 'web';
   const [focusVisible, setFocusVisible] = useState(false);
-  const [hovered, setHovered] = useState(false);
   const blocked = disabled || pending;
-  const actors = kind === 'reply' ? [props.actor] : props.actors;
+  const actors = props.actors;
   const actor = actors[0];
   const suppliedCount = props.totalActorCount ?? actors.length;
-  const count =
-    kind === 'reply'
-      ? 1
-      : Math.max(
-          actors.length,
-          Number.isFinite(suppliedCount) ? Math.floor(suppliedCount) : actors.length,
-        );
+  const count = Math.max(
+    actors.length,
+    Number.isFinite(suppliedCount) ? Math.floor(suppliedCount) : actors.length,
+  );
   const otherCount = count - 1;
   const subject = `${actor.name}${otherCount > 0 ? ` 외 ${otherCount}명이` : '님이'}`;
   const destination =
@@ -157,30 +203,21 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
         } as ViewStyle,
       ]}
     >
-      <View style={[styles.row, web && styles.webRow, kind === 'reply' && styles.replyRow]}>
+      <View style={[styles.row, web && styles.webRow]}>
         <View
           aria-hidden
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
-          style={[styles.kind, kind === 'reply' && styles.replyKind]}
+          style={styles.kind}
         >
-          {kind === 'reply' ? avatarStack : <KindIcon color={iconColor} size={32} />}
+          <KindIcon color={iconColor} size={32} />
         </View>
-        <View style={[styles.summary, kind === 'reply' && styles.replySummary]}>
-          {kind === 'reply' ? (
-            <>
-              {copy}
-              {time}
-            </>
-          ) : (
-            <>
-              <View style={styles.avatarAndTime}>
-                {avatarStack}
-                {time}
-              </View>
-              {copy}
-            </>
-          )}
+        <View style={styles.summary}>
+          <View style={styles.avatarAndTime}>
+            {avatarStack}
+            {time}
+          </View>
+          {copy}
         </View>
       </View>
       {preview !== undefined ? (
@@ -198,46 +235,19 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
     </Pressable>
   );
 
-  return (
-    <PostContentPrivacyBoundary
-      style={[styles.root, { borderBottomColor: theme.borderSubtle }]}
-      testID="notification-list-item"
-    >
-      <View
-        onPointerEnter={() => setHovered(true)}
-        onPointerLeave={() => setHovered(false)}
-        style={{
-          backgroundColor: web && unread ? theme.actionPrimarySubtle : 'transparent',
-        }}
-        testID="notification-item-surface"
-      >
-        {web && hovered ? (
-          <View
-            aria-hidden
-            pointerEvents="none"
-            style={[StyleSheet.absoluteFillObject, { backgroundColor: theme.stateHover }]}
-            testID="notification-hover-overlay"
-          />
-        ) : null}
-        {blocked ? (
-          target
-        ) : (
-          <Link asChild href={href}>
-            {target}
-          </Link>
-        )}
-        {kind === 'reply' ? props.children : null}
-        {web && unread ? (
-          <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
-        ) : null}
-      </View>
-    </PostContentPrivacyBoundary>
+  return blocked ? (
+    target
+  ) : (
+    <Link asChild href={href}>
+      {target}
+    </Link>
   );
 }
 
 const styles = StyleSheet.create({
   root: { borderBottomWidth: borderWidths[1], minWidth: 0, width: '100%' },
   target: { minWidth: 0 },
+  srOnly: { position: 'absolute', width: 1, height: 1, overflow: 'hidden', left: 0, top: 0 },
   row: {
     flexDirection: 'row',
     alignItems: 'flex-start',
@@ -261,9 +271,6 @@ const styles = StyleSheet.create({
   overlap: { marginLeft: -space[12] },
   copy: { ...textStyles.uiCopyM, flexShrink: 1, minWidth: 0 },
   time: { ...textStyles.uiCopyS, flexShrink: 0 },
-  replyRow: { paddingTop: space[8], minHeight: Platform.OS === 'android' ? 48 : 44 },
-  replyKind: { alignItems: 'flex-end', height: 28 },
-  replySummary: { alignItems: 'center', flexDirection: 'row', minHeight: 20 },
   preview: {
     flexDirection: 'row',
     gap: space[12],

--- a/apps/app/src/components/notification/NotificationListItemView.tsx
+++ b/apps/app/src/components/notification/NotificationListItemView.tsx
@@ -151,6 +151,12 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
       style={[
         styles.target,
         {
+          backgroundColor:
+            web && hovered
+              ? theme.stateHover
+              : web && unread
+                ? theme.actionPrimarySubtle
+                : 'transparent',
           outlineColor: theme.stateFocusRing,
           outlineOffset: -2,
           outlineStyle: focusVisible ? 'solid' : 'none',
@@ -159,21 +165,7 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
         } as ViewStyle,
       ]}
     >
-      <View
-        style={[
-          styles.row,
-          web && styles.webRow,
-          kind === 'reply' && styles.replyRow,
-          {
-            backgroundColor:
-              web && hovered
-                ? theme.stateHover
-                : web && unread
-                  ? theme.actionPrimarySubtle
-                  : 'transparent',
-          },
-        ]}
-      >
+      <View style={[styles.row, web && styles.webRow, kind === 'reply' && styles.replyRow]}>
         <View
           aria-hidden
           accessibilityElementsHidden
@@ -198,9 +190,6 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
             </>
           )}
         </View>
-        {web && unread ? (
-          <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
-        ) : null}
       </View>
       {preview !== undefined ? (
         <View style={[styles.preview, web && styles.webPreview]}>
@@ -213,6 +202,9 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
             </View>
           ) : null}
         </View>
+      ) : null}
+      {web && unread ? (
+        <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
       ) : null}
     </Pressable>
   );
@@ -260,16 +252,16 @@ const styles = StyleSheet.create({
   overlap: { marginLeft: -space[12] },
   copy: { ...textStyles.uiCopyM, flexShrink: 1, minWidth: 0 },
   time: { ...textStyles.uiCopyS, flexShrink: 0 },
-  replyRow: { paddingTop: space[8], minHeight: 48 },
+  replyRow: { paddingTop: space[8], minHeight: Platform.OS === 'android' ? 48 : 44 },
   replyKind: { alignItems: 'flex-end', height: 28 },
-  replySummary: { alignItems: 'center', flexDirection: 'row', minHeight: 28 },
+  replySummary: { alignItems: 'center', flexDirection: 'row', minHeight: 20 },
   preview: {
     flexDirection: 'row',
     gap: space[12],
     alignItems: 'flex-start',
     paddingLeft: space[8] + 48 + space[12],
     paddingRight: space[8],
-    paddingBottom: space[16],
+    paddingBottom: space[8],
   },
   webPreview: { paddingLeft: space[12] + 48 + space[12], paddingRight: space[16] },
   excerpt: { ...textStyles.contentM, flex: 1, minWidth: 0 },

--- a/apps/app/src/components/notification/NotificationListItemView.tsx
+++ b/apps/app/src/components/notification/NotificationListItemView.tsx
@@ -138,8 +138,6 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
       aria-disabled={blocked}
       disabled={blocked}
       onBlur={() => setFocusVisible(false)}
-      onHoverIn={() => setHovered(true)}
-      onHoverOut={() => setHovered(false)}
       onFocus={(event) => {
         const target = event.currentTarget as unknown as {
           matches?: (selector: string) => boolean;
@@ -151,12 +149,6 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
       style={[
         styles.target,
         {
-          backgroundColor:
-            web && hovered
-              ? theme.stateHover
-              : web && unread
-                ? theme.actionPrimarySubtle
-                : 'transparent',
           outlineColor: theme.stateFocusRing,
           outlineOffset: -2,
           outlineStyle: focusVisible ? 'solid' : 'none',
@@ -203,9 +195,6 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
           ) : null}
         </View>
       ) : null}
-      {web && unread ? (
-        <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
-      ) : null}
     </Pressable>
   );
 
@@ -214,14 +203,34 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
       style={[styles.root, { borderBottomColor: theme.borderSubtle }]}
       testID="notification-list-item"
     >
-      {blocked ? (
-        target
-      ) : (
-        <Link asChild href={href}>
-          {target}
-        </Link>
-      )}
-      {kind === 'reply' ? props.children : null}
+      <View
+        onPointerEnter={() => setHovered(true)}
+        onPointerLeave={() => setHovered(false)}
+        style={{
+          backgroundColor: web && unread ? theme.actionPrimarySubtle : 'transparent',
+        }}
+        testID="notification-item-surface"
+      >
+        {web && hovered ? (
+          <View
+            aria-hidden
+            pointerEvents="none"
+            style={[StyleSheet.absoluteFillObject, { backgroundColor: theme.stateHover }]}
+            testID="notification-hover-overlay"
+          />
+        ) : null}
+        {blocked ? (
+          target
+        ) : (
+          <Link asChild href={href}>
+            {target}
+          </Link>
+        )}
+        {kind === 'reply' ? props.children : null}
+        {web && unread ? (
+          <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
+        ) : null}
+      </View>
     </PostContentPrivacyBoundary>
   );
 }

--- a/apps/app/src/components/notification/ReplyNotificationPost.tsx
+++ b/apps/app/src/components/notification/ReplyNotificationPost.tsx
@@ -1,0 +1,199 @@
+import { Link, useRouter } from 'expo-router';
+import { MessageCircle } from 'lucide-react-native';
+import { useCallback } from 'react';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { graphql, useFragment } from 'react-relay';
+import { PostActionSurface } from '@/components/post/PostActionSurface';
+import { PostBody } from '@/components/post/PostBody';
+import { usePostMediaViewerHost } from '@/components/post/PostMediaViewerHost';
+import { usePostReplySurface } from '@/components/post/PostReplySurface';
+import { PostSourcePreview } from '@/components/post/PostSourcePresentationView';
+import { NavigationLink } from '@/components/shell/NavigationLink';
+import { Avatar } from '@/components/ui/Avatar';
+import { formatTimelineTimestamp } from '@/lib/date';
+import { useTheme } from '@/theme/ThemeProvider';
+import { radii, spacing, typography } from '@/theme/tokens';
+import type { PostMediaOpenHandler } from '@/components/post/PostMediaImage';
+import type { ReplyNotificationPost_post$key } from './__generated__/ReplyNotificationPost_post.graphql';
+
+const ReplyNotificationPostFragment = graphql`
+  fragment ReplyNotificationPost_post on Post {
+    id
+    createdAt
+    content {
+      id
+    }
+    profile {
+      avatar {
+        url
+      }
+      handle
+      relativeHandle
+      displayName
+    }
+    ...PostBody_post
+    ...PostActionSurface_post @alias(as: "actionSurface")
+    ...PostReplySurface_post
+    repostSource {
+      ...PostSourcePreview_source
+    }
+  }
+`;
+
+/** Recipient-relative Reply presentation, composed inside NotificationListItemView. */
+export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificationPost_post$key }) {
+  const post = useFragment(ReplyNotificationPostFragment, postKey);
+  const theme = useTheme();
+  const router = useRouter();
+  const openViewer = usePostMediaViewerHost();
+  const { reply, replySurface, owner: replyOwner } = usePostReplySurface(post);
+  const profileHref = `/${post.profile.relativeHandle}` as const;
+  const detailHref = `/${post.profile.relativeHandle}/${post.id}` as const;
+  const onMediaOpen = useCallback<PostMediaOpenHandler>(
+    (selectedIndex, originControl) => {
+      openViewer({
+        mediaOwnerPostId: post.id,
+        originControl,
+        selectedIndex,
+        surfacePostId: post.id,
+      });
+    },
+    [openViewer, post.id],
+  );
+
+  if (!post.content) {
+    return null;
+  }
+
+  return (
+    <>
+      <View role="article" style={styles.root} testID="reply-notification-post">
+        <Link asChild href={profileHref}>
+          <Pressable
+            aria-hidden
+            accessibilityElementsHidden
+            accessible={false}
+            focusable={false}
+            importantForAccessibility="no-hide-descendants"
+            style={styles.avatar}
+            tabIndex={-1}
+          >
+            <Avatar
+              imageUri={post.profile.avatar?.url}
+              label={post.profile.displayName || post.profile.handle}
+              size={48}
+            />
+          </Pressable>
+        </Link>
+        <View style={styles.content}>
+          <View style={styles.header}>
+            <NavigationLink href={profileHref}>
+              <Pressable
+                accessibilityRole="link"
+                style={styles.author}
+                testID="notification-post-author"
+              >
+                <Text numberOfLines={1} style={[styles.name, { color: theme.foregroundPrimary }]}>
+                  {post.profile.displayName}
+                </Text>
+                <Text
+                  numberOfLines={1}
+                  style={[styles.handle, { color: theme.foregroundSecondary }]}
+                >
+                  {post.profile.relativeHandle}
+                </Text>
+              </Pressable>
+            </NavigationLink>
+            <Link asChild href={detailHref}>
+              <Pressable accessibilityRole="link" style={styles.timeLink}>
+                <Text style={[styles.time, { color: theme.foregroundSecondary }]}>
+                  {formatTimelineTimestamp(post.createdAt)}
+                </Text>
+              </Pressable>
+            </Link>
+          </View>
+          <View style={styles.reasonRow}>
+            <View
+              aria-hidden
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+              style={styles.reasonIcon}
+            >
+              <MessageCircle color={theme.foregroundSecondary} size={16} />
+            </View>
+            <Text
+              testID="notification-reason"
+              style={[styles.reason, { color: theme.foregroundSecondary }]}
+            >
+              회원님의 게시글에 답글을 남겼습니다
+            </Text>
+          </View>
+          <View style={styles.bodyLink}>
+            <PostBody
+              onBodyPress={() => router.push(detailHref)}
+              onMediaOpen={onMediaOpen}
+              post={post}
+            />
+          </View>
+          {post.repostSource ? <PostSourcePreview source={post.repostSource} /> : null}
+          <PostActionSurface
+            actionBarStyle={styles.actionBar}
+            reactionSummaryStyle={styles.reactionSummary}
+            reply={reply}
+            socialActionTarget={post.actionSurface!}
+          />
+        </View>
+      </View>
+      {replySurface && replyOwner === 'detail' ? (
+        <View style={styles.detailReplySurface}>{replySurface}</View>
+      ) : (
+        replySurface
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: spacing.sm,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xs,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.md,
+    minWidth: 0,
+  },
+  avatar: { borderRadius: radii.full },
+  content: { flex: 1, gap: spacing.xs, minWidth: 0 },
+  header: {
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    gap: spacing.sm,
+    justifyContent: 'space-between',
+  },
+  author: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.xs,
+    minHeight: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
+    overflow: 'hidden',
+  },
+  name: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md, flexShrink: 1 },
+  handle: { fontFamily: 'SUIT', ...typography.sm, flex: 1, minWidth: 0 },
+  timeLink: { borderRadius: radii.sm, flexShrink: 0 },
+  time: {
+    fontFamily: 'SUIT',
+    ...typography.sm,
+    minHeight: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
+    minWidth: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
+  },
+  reasonRow: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing.xs },
+  reasonIcon: { height: 20, justifyContent: 'center' },
+  reason: { fontFamily: 'SUIT', ...typography.sm, flex: 1, minWidth: 0 },
+  bodyLink: { borderRadius: radii.sm, minWidth: 0 },
+  actionBar: { paddingTop: spacing.xs },
+  reactionSummary: { marginTop: spacing.xs },
+  detailReplySurface: { marginLeft: spacing.xxl * 2, marginRight: spacing.sm },
+});

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -1,22 +1,18 @@
 import { Link, useRouter } from 'expo-router';
 import { MessageCircle } from 'lucide-react-native';
-import { useCallback, useRef, useState } from 'react';
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
-import { NavigationLink } from '@/components/shell/NavigationLink';
 import { Avatar } from '@/components/ui/Avatar';
 import { formatTimelineTimestamp } from '@/lib/date';
 import { useTheme } from '@/theme/ThemeProvider';
 import { radii, spacing, typography } from '@/theme/tokens';
-import { usePostActionAuthentication } from './PostActionAuthentication';
 import { PostActionSurface } from './PostActionSurface';
 import { PostBody } from './PostBody';
 import { usePostMediaViewerHost } from './PostMediaViewerHost';
-import { usePostReplyBinding } from './PostReplyCoordinator';
-import { PostSourcePresentationView, PostSourcePreview } from './PostSourcePresentationView';
-import { ReplyComposerSurface } from './ReplyComposerSurface';
-import { getReplyProcessingState } from './replySurface';
+import { usePostReplySurface } from './PostReplySurface';
+import { PostSourcePresentationView } from './PostSourcePresentationView';
 import type { ReactNode } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 import type { PostListItem_post$key } from './__generated__/PostListItem_post.graphql';
@@ -51,9 +47,6 @@ const PostListRowFragment = graphql`
     }
     ...PostActionSurface_post @alias(as: "actionSurface")
     ...PostBody_post
-    repostSource {
-      ...PostSourcePreview_source
-    }
   }
 `;
 
@@ -88,7 +81,7 @@ const PostListItemFragment = graphql`
         displayName
       }
     }
-    ...ReplyComposerSurface_parent @alias(as: "replySurface")
+    ...PostReplySurface_post
     ...PostActionSurface_post @alias(as: "actionSurface")
     ...PostSourcePresentationView_post
     repostSource {
@@ -102,59 +95,20 @@ export function PostListItem({
   post: postKey,
   showDivider = true,
   showReplyAttribution = true,
-  notification,
 }: {
   post: PostListItem_post$key;
   showDivider?: boolean;
   showReplyAttribution?: boolean;
-  /** Recipient-relative presentation used only inside a Reply notification. */
-  notification?: 'reply';
 }) {
   const theme = useTheme();
   const [deleted, setDeleted] = useState(false);
   const post = useFragment(PostListItemFragment, postKey);
   const openViewer = usePostMediaViewerHost();
-  const replyBinding = usePostReplyBinding(post.id);
   const onDeleted = useCallback(() => setDeleted(true), []);
-  const replyAuthentication = usePostActionAuthentication(Boolean(post.content));
+  const { reply, replySurface, owner: replyOwner } = usePostReplySurface(post);
   const profileHref = `/${post.profile.relativeHandle}` as const;
-  const replyTriggerRef = useRef<View>(null);
-  const reply = replyBinding
-    ? {
-        accessibilityLabel: '답글',
-        controlRef: replyTriggerRef,
-        expanded: replyAuthentication.execution.kind === 'enabled' && replyBinding.expanded,
-        onPress: () => {
-          if (replyAuthentication.execution.kind === 'resolution-required') {
-            replyAuthentication.resolve(replyAuthentication.execution.reason);
-          } else if (replyAuthentication.execution.kind === 'enabled') {
-            replyBinding.onPress();
-          }
-        },
-        processing: getReplyProcessingState(
-          replyAuthentication.execution,
-          Boolean(replyBinding.profile),
-        ),
-      }
-    : undefined;
-  const replySurface =
-    replyAuthentication.execution.kind === 'enabled' &&
-    replyBinding?.profile &&
-    post.content &&
-    post.replySurface ? (
-      <ReplyComposerSurface
-        ref={replyBinding.surfaceRef}
-        onPostCreated={replyBinding.onPostCreated}
-        onRequestClose={replyBinding.onRequestClose}
-        open={replyBinding.expanded}
-        owner={replyBinding.owner}
-        parent={post.replySurface}
-        profile={replyBinding.profile}
-        triggerRef={replyTriggerRef}
-      />
-    ) : null;
   const presentedReplySurface =
-    replySurface && replyBinding?.owner === 'detail' ? (
+    replySurface && replyOwner === 'detail' ? (
       <View style={styles.detailReplySurface}>{replySurface}</View>
     ) : (
       replySurface
@@ -184,7 +138,7 @@ export function PostListItem({
     showDivider && { borderColor: theme.borderSubtle },
   ];
   const replyAttribution =
-    !notification && showReplyAttribution && post.replyParent ? (
+    showReplyAttribution && post.replyParent ? (
       <PostAttributionRow
         icon={
           <View
@@ -214,7 +168,7 @@ export function PostListItem({
     </>
   );
 
-  if (!post.repostSource || notification === 'reply') {
+  if (!post.repostSource) {
     if (!post.content) {
       return renderWithReplySurface(null);
     }
@@ -224,7 +178,6 @@ export function PostListItem({
         <PostListRow
           actionBarStyle={styles.actionBarSlot}
           onDeleted={onDeleted}
-          notification={notification}
           post={post}
           reply={reply}
         />
@@ -315,14 +268,12 @@ function PostAttributionRow({ children, icon }: { children: ReactNode; icon: Rea
 
 function PostListRow({
   actionBarStyle,
-  notification,
   onDeleted,
   post: postKey,
   reply,
   surfacePostId,
 }: {
   actionBarStyle?: StyleProp<ViewStyle>;
-  notification?: 'reply';
   onDeleted: () => void;
   post: PostListRow_post$key;
   reply?: PostActionBarProps['reply'];
@@ -367,62 +318,15 @@ function PostListRow({
       </Link>
       <View style={styles.content}>
         <View style={styles.header}>
-          {notification ? (
-            <NavigationLink href={profileHref}>
-              <Pressable
-                accessibilityRole="link"
-                style={styles.notificationAuthor}
-                testID="notification-post-author"
-              >
-                <Text
-                  numberOfLines={1}
-                  style={[styles.notificationName, { color: theme.foregroundPrimary }]}
-                >
-                  {post.profile.displayName}
-                </Text>
-                <Text
-                  numberOfLines={1}
-                  style={[styles.notificationHandle, { color: theme.foregroundSecondary }]}
-                >
-                  {post.profile.relativeHandle}
-                </Text>
-              </Pressable>
-            </NavigationLink>
-          ) : (
-            <ProfileNameBlock href={profileHref} profile={post.profile} />
-          )}
+          <ProfileNameBlock href={profileHref} profile={post.profile} />
           <Link asChild href={detailHref}>
             <Pressable accessibilityRole="link" style={styles.timeLink}>
-              <Text
-                style={[
-                  styles.time,
-                  notification && styles.notificationTime,
-                  { color: notification ? theme.foregroundSecondary : theme.textSecondary },
-                ]}
-              >
+              <Text style={[styles.time, { color: theme.textSecondary }]}>
                 {formatTimelineTimestamp(post.createdAt)}
               </Text>
             </Pressable>
           </Link>
         </View>
-        {notification ? (
-          <View style={styles.notificationReasonRow}>
-            <View
-              aria-hidden
-              accessibilityElementsHidden
-              importantForAccessibility="no-hide-descendants"
-              style={styles.notificationReasonIcon}
-            >
-              <MessageCircle color={theme.foregroundSecondary} size={16} />
-            </View>
-            <Text
-              testID="notification-reason"
-              style={[styles.notificationReason, { color: theme.foregroundSecondary }]}
-            >
-              회원님의 게시글에 답글을 남겼습니다
-            </Text>
-          </View>
-        ) : null}
         {post.content ? (
           <View style={styles.bodyLink}>
             <PostBody
@@ -431,9 +335,6 @@ function PostListRow({
               post={post}
             />
           </View>
-        ) : null}
-        {notification && post.repostSource ? (
-          <PostSourcePreview source={post.repostSource} />
         ) : null}
         <PostActionSurface
           actionBarStyle={actionBarStyle}
@@ -482,25 +383,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   timeLink: { borderRadius: radii.sm, flexShrink: 0 },
-  notificationAuthor: {
-    flex: 1,
-    minWidth: 0,
-    flexDirection: 'row',
-    alignItems: 'baseline',
-    gap: spacing.xs,
-    minHeight: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
-    overflow: 'hidden',
-  },
-  notificationName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md, flexShrink: 1 },
-  notificationHandle: { fontFamily: 'SUIT', ...typography.sm, flex: 1, minWidth: 0 },
-  notificationReasonRow: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing.xs },
-  notificationReasonIcon: { height: 20, justifyContent: 'center' },
-  notificationReason: { fontFamily: 'SUIT', ...typography.sm, flex: 1, minWidth: 0 },
-  notificationTime: {
-    minHeight: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
-    minWidth: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
-    paddingTop: 0,
-  },
   time: {
     fontFamily: 'SUIT',
     minHeight: 44,

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -1,9 +1,10 @@
 import { Link, useRouter } from 'expo-router';
 import { MessageCircle } from 'lucide-react-native';
 import { useCallback, useRef, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { ProfileNameBlock } from '@/components/profile/ProfileNameBlock';
+import { NavigationLink } from '@/components/shell/NavigationLink';
 import { Avatar } from '@/components/ui/Avatar';
 import { formatTimelineTimestamp } from '@/lib/date';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -13,7 +14,7 @@ import { PostActionSurface } from './PostActionSurface';
 import { PostBody } from './PostBody';
 import { usePostMediaViewerHost } from './PostMediaViewerHost';
 import { usePostReplyBinding } from './PostReplyCoordinator';
-import { PostSourcePresentationView } from './PostSourcePresentationView';
+import { PostSourcePresentationView, PostSourcePreview } from './PostSourcePresentationView';
 import { ReplyComposerSurface } from './ReplyComposerSurface';
 import { getReplyProcessingState } from './replySurface';
 import type { ReactNode } from 'react';
@@ -50,6 +51,9 @@ const PostListRowFragment = graphql`
     }
     ...PostActionSurface_post @alias(as: "actionSurface")
     ...PostBody_post
+    repostSource {
+      ...PostSourcePreview_source
+    }
   }
 `;
 
@@ -98,10 +102,13 @@ export function PostListItem({
   post: postKey,
   showDivider = true,
   showReplyAttribution = true,
+  notification,
 }: {
   post: PostListItem_post$key;
   showDivider?: boolean;
   showReplyAttribution?: boolean;
+  /** Recipient-relative presentation used only inside a Reply notification. */
+  notification?: 'reply';
 }) {
   const theme = useTheme();
   const [deleted, setDeleted] = useState(false);
@@ -177,7 +184,7 @@ export function PostListItem({
     showDivider && { borderColor: theme.borderSubtle },
   ];
   const replyAttribution =
-    showReplyAttribution && post.replyParent ? (
+    !notification && showReplyAttribution && post.replyParent ? (
       <PostAttributionRow
         icon={
           <View
@@ -207,7 +214,7 @@ export function PostListItem({
     </>
   );
 
-  if (!post.repostSource) {
+  if (!post.repostSource || notification === 'reply') {
     if (!post.content) {
       return renderWithReplySurface(null);
     }
@@ -217,6 +224,7 @@ export function PostListItem({
         <PostListRow
           actionBarStyle={styles.actionBarSlot}
           onDeleted={onDeleted}
+          notification={notification}
           post={post}
           reply={reply}
         />
@@ -307,12 +315,14 @@ function PostAttributionRow({ children, icon }: { children: ReactNode; icon: Rea
 
 function PostListRow({
   actionBarStyle,
+  notification,
   onDeleted,
   post: postKey,
   reply,
   surfacePostId,
 }: {
   actionBarStyle?: StyleProp<ViewStyle>;
+  notification?: 'reply';
   onDeleted: () => void;
   post: PostListRow_post$key;
   reply?: PostActionBarProps['reply'];
@@ -357,15 +367,46 @@ function PostListRow({
       </Link>
       <View style={styles.content}>
         <View style={styles.header}>
-          <ProfileNameBlock href={profileHref} profile={post.profile} />
+          {notification ? (
+            <NavigationLink href={profileHref}>
+              <Pressable
+                accessibilityRole="link"
+                style={styles.notificationAuthor}
+                testID="notification-post-author"
+              >
+                <Text numberOfLines={1} style={[styles.notificationName, { color: theme.text }]}>
+                  {post.profile.displayName}
+                </Text>
+                <Text
+                  numberOfLines={1}
+                  style={[styles.notificationHandle, { color: theme.textSecondary }]}
+                >
+                  {post.profile.relativeHandle}
+                </Text>
+              </Pressable>
+            </NavigationLink>
+          ) : (
+            <ProfileNameBlock href={profileHref} profile={post.profile} />
+          )}
           <Link asChild href={detailHref}>
             <Pressable accessibilityRole="link" style={styles.timeLink}>
-              <Text style={[styles.time, { color: theme.textSecondary }]}>
+              <Text
+                style={[
+                  styles.time,
+                  notification && styles.notificationTime,
+                  { color: theme.textSecondary },
+                ]}
+              >
                 {formatTimelineTimestamp(post.createdAt)}
               </Text>
             </Pressable>
           </Link>
         </View>
+        {notification ? (
+          <Text style={[styles.notificationReason, { color: theme.textSecondary }]}>
+            회원님의 게시글에 답글을 남겼습니다
+          </Text>
+        ) : null}
         {post.content ? (
           <View style={styles.bodyLink}>
             <PostBody
@@ -374,6 +415,9 @@ function PostListRow({
               post={post}
             />
           </View>
+        ) : null}
+        {notification && post.repostSource ? (
+          <PostSourcePreview source={post.repostSource} />
         ) : null}
         <PostActionSurface
           actionBarStyle={actionBarStyle}
@@ -422,6 +466,23 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   timeLink: { borderRadius: radii.sm, flexShrink: 0 },
+  notificationAuthor: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.xs,
+    minHeight: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
+    overflow: 'hidden',
+  },
+  notificationName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md, flexShrink: 1 },
+  notificationHandle: { fontFamily: 'SUIT', ...typography.sm, flex: 1, minWidth: 0 },
+  notificationReason: { fontFamily: 'SUIT', ...typography.sm },
+  notificationTime: {
+    minHeight: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
+    minWidth: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
+    paddingTop: 0,
+  },
   time: {
     fontFamily: 'SUIT',
     minHeight: 44,

--- a/apps/app/src/components/post/PostListItem.tsx
+++ b/apps/app/src/components/post/PostListItem.tsx
@@ -374,12 +374,15 @@ function PostListRow({
                 style={styles.notificationAuthor}
                 testID="notification-post-author"
               >
-                <Text numberOfLines={1} style={[styles.notificationName, { color: theme.text }]}>
+                <Text
+                  numberOfLines={1}
+                  style={[styles.notificationName, { color: theme.foregroundPrimary }]}
+                >
                   {post.profile.displayName}
                 </Text>
                 <Text
                   numberOfLines={1}
-                  style={[styles.notificationHandle, { color: theme.textSecondary }]}
+                  style={[styles.notificationHandle, { color: theme.foregroundSecondary }]}
                 >
                   {post.profile.relativeHandle}
                 </Text>
@@ -394,7 +397,7 @@ function PostListRow({
                 style={[
                   styles.time,
                   notification && styles.notificationTime,
-                  { color: theme.textSecondary },
+                  { color: notification ? theme.foregroundSecondary : theme.textSecondary },
                 ]}
               >
                 {formatTimelineTimestamp(post.createdAt)}
@@ -403,9 +406,22 @@ function PostListRow({
           </Link>
         </View>
         {notification ? (
-          <Text style={[styles.notificationReason, { color: theme.textSecondary }]}>
-            회원님의 게시글에 답글을 남겼습니다
-          </Text>
+          <View style={styles.notificationReasonRow}>
+            <View
+              aria-hidden
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+              style={styles.notificationReasonIcon}
+            >
+              <MessageCircle color={theme.foregroundSecondary} size={16} />
+            </View>
+            <Text
+              testID="notification-reason"
+              style={[styles.notificationReason, { color: theme.foregroundSecondary }]}
+            >
+              회원님의 게시글에 답글을 남겼습니다
+            </Text>
+          </View>
         ) : null}
         {post.content ? (
           <View style={styles.bodyLink}>
@@ -477,7 +493,9 @@ const styles = StyleSheet.create({
   },
   notificationName: { fontFamily: 'SUIT', fontWeight: '700', ...typography.md, flexShrink: 1 },
   notificationHandle: { fontFamily: 'SUIT', ...typography.sm, flex: 1, minWidth: 0 },
-  notificationReason: { fontFamily: 'SUIT', ...typography.sm },
+  notificationReasonRow: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing.xs },
+  notificationReasonIcon: { height: 20, justifyContent: 'center' },
+  notificationReason: { fontFamily: 'SUIT', ...typography.sm, flex: 1, minWidth: 0 },
   notificationTime: {
     minHeight: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,
     minWidth: Platform.OS === 'web' ? 24 : Platform.OS === 'android' ? 48 : 44,

--- a/apps/app/src/components/post/PostMediaViewerIntegration.test.ts
+++ b/apps/app/src/components/post/PostMediaViewerIntegration.test.ts
@@ -5,6 +5,8 @@ import { act, create } from 'react-test-renderer';
 import type { PropsWithChildren, ReactElement, RefObject } from 'react';
 import type { View as NativeView } from 'react-native';
 import type { ReactTestRenderer } from 'react-test-renderer';
+import type { ReplyNotificationPost_post$key } from '@/components/notification/__generated__/ReplyNotificationPost_post.graphql';
+import type { ReplyNotificationPost as ReplyNotificationPostComponent } from '@/components/notification/ReplyNotificationPost';
 import type { PostLayout_post$key } from './__generated__/PostLayout_post.graphql';
 import type { PostListItem_post$key } from './__generated__/PostListItem_post.graphql';
 import type { PostLayout as PostLayoutComponent } from './PostLayout';
@@ -95,6 +97,10 @@ mock.module('@/components/profile/ProfileNameBlock', {
     ProfileNameBlock: (props: Record<string, unknown>) =>
       createElement('ProfileNameBlock', { ...props, testID: 'profile-name-block' }),
   },
+} as unknown as Parameters<typeof mock.module>[1]);
+
+mock.module('@/components/shell/NavigationLink', {
+  exports: { NavigationLink: ({ children }: { children?: unknown }) => children },
 } as unknown as Parameters<typeof mock.module>[1]);
 
 mock.module('@/components/ui/Avatar', {
@@ -232,6 +238,7 @@ let HostProvider: typeof HostProviderComponent;
 let ScreenFallbackProvider: typeof ScreenFallbackProviderComponent;
 let PostLayout: typeof PostLayoutComponent;
 let PostListItem: typeof PostListItemComponent;
+let ReplyNotificationPost: typeof ReplyNotificationPostComponent;
 
 before(async () => {
   ({
@@ -240,6 +247,7 @@ before(async () => {
   } = await import('./PostMediaViewerHost'));
   ({ PostLayout } = await import('./PostLayout'));
   ({ PostListItem } = await import('./PostListItem'));
+  ({ ReplyNotificationPost } = await import('@/components/notification/ReplyNotificationPost'));
 });
 
 afterEach(async () => {
@@ -299,6 +307,32 @@ describe('Post Media Viewer Host production wiring', () => {
     assert.equal(viewerThread.props.mediaOwnerPostId, 'source');
     assert.equal(viewerThread.props.replyAvailable, false);
     assert.equal(viewerThread.props.replySurfacePostId, 'repost');
+  });
+
+  it('Reply 알림의 Media identity와 focus 복귀를 유지한다', async () => {
+    let focused = false;
+    const originControl = {
+      current: {
+        focus: () => {
+          focused = true;
+        },
+      },
+    };
+    const post = storyPost('reply-notification', 'reply-content');
+    queryPosts.set(post.id, hostPost(post));
+    await renderHost(
+      createElement(ReplyNotificationPost, {
+        post: post as unknown as ReplyNotificationPost_post$key,
+      }),
+    );
+    await openFromBody(originControl, 1);
+    assert.equal(queriedSurfacePostId, post.id);
+    assert.equal(currentImage().props.source.uri, 'https://media.example/reply-content-2.webp');
+    await closeViewer();
+    await act(async () => {
+      animationFrames.splice(0).forEach((callback) => callback(0));
+    });
+    assert.equal(focused, true);
   });
 
   it('Relay actor generation이 바뀌면 열린 Viewer와 이전 query projection을 닫는다', async () => {

--- a/apps/app/src/components/post/PostReplySurface.tsx
+++ b/apps/app/src/components/post/PostReplySurface.tsx
@@ -1,0 +1,60 @@
+import { useRef } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import { usePostActionAuthentication } from './PostActionAuthentication';
+import { usePostReplyBinding } from './PostReplyCoordinator';
+import { ReplyComposerSurface } from './ReplyComposerSurface';
+import { getReplyProcessingState } from './replySurface';
+import type { View } from 'react-native';
+import type { PostReplySurface_post$key } from './__generated__/PostReplySurface_post.graphql';
+import type { PostActionBarProps } from './PostActionBar';
+
+const PostReplySurfaceFragment = graphql`
+  fragment PostReplySurface_post on Post {
+    id
+    content {
+      id
+    }
+    ...ReplyComposerSurface_parent @alias(as: "replySurface")
+  }
+`;
+
+/** Share Reply execution and focus lifecycle; each consumer places its own surface. */
+export function usePostReplySurface(postKey: PostReplySurface_post$key) {
+  const post = useFragment(PostReplySurfaceFragment, postKey);
+  const binding = usePostReplyBinding(post.id);
+  const authentication = usePostActionAuthentication(Boolean(post.content));
+  const triggerRef = useRef<View>(null);
+  const reply: PostActionBarProps['reply'] = binding
+    ? {
+        accessibilityLabel: '답글',
+        controlRef: triggerRef,
+        expanded: authentication.execution.kind === 'enabled' && binding.expanded,
+        onPress: () => {
+          if (authentication.execution.kind === 'resolution-required') {
+            authentication.resolve(authentication.execution.reason);
+          } else if (authentication.execution.kind === 'enabled') {
+            binding.onPress();
+          }
+        },
+        processing: getReplyProcessingState(authentication.execution, Boolean(binding.profile)),
+      }
+    : undefined;
+  const replySurface =
+    authentication.execution.kind === 'enabled' &&
+    binding?.profile &&
+    post.content &&
+    post.replySurface ? (
+      <ReplyComposerSurface
+        ref={binding.surfaceRef}
+        onPostCreated={binding.onPostCreated}
+        onRequestClose={binding.onRequestClose}
+        open={binding.expanded}
+        owner={binding.owner}
+        parent={post.replySurface}
+        profile={binding.profile}
+        triggerRef={triggerRef}
+      />
+    ) : null;
+
+  return { reply, replySurface, owner: binding?.owner };
+}

--- a/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
@@ -407,7 +407,10 @@ export const CompositionContract: Story = {
     const reply = within(canvas.getByTestId('reply-notification'));
     const replySurface = reply.getByTestId('notification-item-surface');
     const replyPost = reply.getByTestId('post-list-standard-row');
-    await expect(reply.getByText('회원님의 게시글에 답글을 남겼습니다')).toBeVisible();
+    await expect(reply.getByTestId('notification-reason')).toBeVisible();
+    await expect(reply.getByTestId('notification-reason')).toHaveTextContent(
+      /^회원님의 게시글에 답글을 남겼습니다$/,
+    );
     await expect(reply.getAllByText('별빛여행자')).toHaveLength(1);
     await expect(reply.queryByText(/원글 작성자/)).not.toBeInTheDocument();
     await expect(reply.queryByRole('link', { name: /답글을 남겼습니다/ })).not.toBeInTheDocument();
@@ -439,7 +442,7 @@ export const ReplyLayoutContract: Story = {
     await expect(name.getBoundingClientRect().right).toBeLessThanOrEqual(
       author.getBoundingClientRect().right,
     );
-    await expect(canvas.getByText('회원님의 게시글에 답글을 남겼습니다')).toBeVisible();
+    await expect(canvas.getByTestId('notification-reason')).toBeVisible();
     await expect(canvas.getByRole('toolbar', { name: '액션 바' })).toBeVisible();
     await userEvent.tab();
     await expect(author).toHaveFocus();
@@ -474,7 +477,7 @@ export const ReplyQuoteContract: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getAllByText('회원님의 게시글에 답글을 남겼습니다')).toHaveLength(1);
+    await expect(canvas.getAllByTestId('notification-reason')).toHaveLength(1);
     await expect(canvas.getByText('답글이 인용한 게시글 본문입니다.')).toBeVisible();
     await expect(canvas.queryByText(/원글 작성자/)).not.toBeInTheDocument();
     await expect(canvas.getAllByRole('toolbar', { name: '액션 바' })).toHaveLength(1);

--- a/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
 import { View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { expect, fireEvent, fn, userEvent, within } from 'storybook/test';
+import { expect, fireEvent, fn, screen, userEvent, waitFor, within } from 'storybook/test';
 import { NotificationListItemView } from '@/components/notification/NotificationListItemView';
+import { ReplyNotificationPost } from '@/components/notification/ReplyNotificationPost';
 import { PostActionAuthenticationProvider } from '@/components/post/PostActionAuthentication';
-import { PostListItem } from '@/components/post/PostListItem';
 import { PostMediaViewerHostProvider } from '@/components/post/PostMediaViewerHost';
 import { PostReplyCoordinatorProvider } from '@/components/post/PostReplyCoordinator';
 import { SessionProvider } from '@/session/SessionProvider';
+import { getCopiedStrings, resetClipboardMock } from '../../../.storybook/mocks/postClipboard';
 import { post, profile } from '../fixtures';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { NotificationListItemViewProps } from '@/components/notification/NotificationListItemView';
@@ -68,7 +69,7 @@ function ReplyPost() {
       query NotificationListItemStoriesQuery {
         node(id: "notification-reply-post") {
           ... on Post {
-            ...PostListItem_post @alias(as: "post")
+            ...ReplyNotificationPost_post @alias(as: "post")
           }
         }
         composer: node(id: "notification-viewer") {
@@ -88,7 +89,7 @@ function ReplyPost() {
       <PostActionAuthenticationProvider>
         <PostReplyCoordinatorProvider owner="list" profile={data.composer?.replyProfile ?? null}>
           <PostMediaViewerHostProvider>
-            <PostListItem post={data.node.post} showDivider={false} notification="reply" />
+            <ReplyNotificationPost post={data.node.post} />
           </PostMediaViewerHostProvider>
         </PostReplyCoordinatorProvider>
       </PostActionAuthenticationProvider>
@@ -211,6 +212,7 @@ const meta = {
     'ProtectionContract',
     'ReplyLayoutContract',
     'ReplyQuoteContract',
+    'ReplyActionsContract',
   ],
   parameters: {
     layout: 'fullscreen',
@@ -406,7 +408,7 @@ export const CompositionContract: Story = {
     });
     const reply = within(canvas.getByTestId('reply-notification'));
     const replySurface = reply.getByTestId('notification-item-surface');
-    const replyPost = reply.getByTestId('post-list-standard-row');
+    const replyPost = reply.getByTestId('reply-notification-post');
     await expect(reply.getByTestId('notification-reason')).toBeVisible();
     await expect(reply.getByTestId('notification-reason')).toHaveTextContent(
       /^회원님의 게시글에 답글을 남겼습니다$/,
@@ -422,7 +424,7 @@ export const CompositionContract: Story = {
     await expect(reply.getByTestId('notification-hover-overlay')).toBeInTheDocument();
     const action = await reply.findByRole('button', { name: '답글' });
     await expect(action.closest('a')).toBeNull();
-    await expect(reply.getByTestId('post-list-standard-row')).toBeInTheDocument();
+    await expect(reply.getByTestId('reply-notification-post')).toBeInTheDocument();
     await expect(reply.getByRole('button', { name: /더 보기/ })).toBeInTheDocument();
     await userEvent.click(reply.getByRole('button', { name: /더 보기/ }));
     await expect(args.onNavigate).toHaveBeenCalledTimes(2);
@@ -498,5 +500,38 @@ export const ProtectionContract: Story = {
       canvas.queryByTestId('post-media-image-notification-thumbnail'),
     ).not.toBeInTheDocument();
     await expect(canvas.getAllByText(args.bodyText)).toHaveLength(1);
+  },
+};
+
+export const ReplyActionsContract: Story = {
+  args: { kind: 'reply' },
+  globals: { viewport: { isRotated: false, value: 'kosmoCompact' } },
+  parameters: {
+    controls: { disable: true },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const reply = canvas.getByRole('button', { name: '답글' });
+    await userEvent.click(reply);
+    const composer = await screen.findByRole('dialog', { name: '답글 쓰기' });
+    await expect(within(composer).getByRole('textbox', { name: '답글 본문' })).toHaveFocus();
+    await userEvent.click(within(composer).getByRole('button', { name: '닫기' }));
+    const confirm = await screen.findByRole('alertdialog', { name: '답글 작성을 취소할까요?' });
+    await userEvent.click(within(confirm).getByRole('button', { name: '작성 취소' }));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: '답글 쓰기' })).toBeNull());
+    await expect(reply).toHaveFocus();
+
+    resetClipboardMock();
+    await userEvent.click(canvas.getByRole('button', { name: '더 보기' }));
+    const menu = await screen.findByRole('menu', { name: '더 보기 메뉴' });
+    await userEvent.click(within(menu).getByRole('menuitem', { name: '링크 복사' }));
+    await waitFor(() =>
+      expect(getCopiedStrings()).toEqual([
+        `${window.location.origin}/@starlight/notification-reply-post`,
+      ]),
+    );
+    await userEvent.click(canvas.getByRole('button', { name: '더 보기' }));
+    const reopenedMenu = await screen.findByRole('menu', { name: '더 보기 메뉴' });
+    await expect(within(reopenedMenu).queryByRole('menuitem', { name: '게시글 삭제' })).toBeNull();
   },
 };

--- a/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
@@ -48,7 +48,7 @@ export type NotificationStoryArgs = {
   hasMedia: boolean;
   sensitiveMedia: boolean;
   unavailable: boolean;
-  containerWidth: number;
+  containerWidth: 'auto' | number;
   onNavigate: ReturnType<typeof fn>;
 };
 type Args = NotificationStoryArgs;
@@ -87,7 +87,7 @@ function ReplyPost() {
   );
 }
 
-function NotificationExample(args: Args) {
+export function NotificationExample(args: Args) {
   const actor = { id: 'notification-actor', name: args.name };
   const shared = {
     disabled: args.disabled,
@@ -165,7 +165,7 @@ const meta = {
     hasMedia: false,
     sensitiveMedia: false,
     unavailable: false,
-    containerWidth: 390,
+    containerWidth: 600,
     onNavigate: fn(),
   },
   argTypes: {
@@ -185,16 +185,22 @@ const meta = {
     hasMedia: { control: 'boolean' },
     sensitiveMedia: { control: 'boolean' },
     unavailable: { control: 'boolean' },
-    containerWidth: { control: { type: 'range', min: 320, max: 720, step: 10 } },
+    containerWidth: { control: 'select', options: [320, 390, 600, 720, 'auto'] },
   },
   decorators: [
     (Story, context) => (
-      <View style={{ width: context.args.containerWidth, maxWidth: '100%' }}>
+      <View
+        style={{
+          width: context.args.containerWidth === 'auto' ? '100%' : context.args.containerWidth,
+          maxWidth: '100%',
+        }}
+      >
         <Story />
       </View>
     ),
   ],
   excludeStories: [
+    'NotificationExample',
     'ActivationContract',
     'PendingContract',
     'CompositionContract',
@@ -341,16 +347,28 @@ export const CompositionContract: Story = {
   render: (args) => (
     <View>
       <View testID="reaction-notification">
-        <NotificationExample {...args} kind="reaction" grouped hasMedia />
+        <NotificationExample {...args} kind="reaction" grouped hasMedia unread />
       </View>
       <View testID="reply-notification">
         <NotificationExample {...args} kind="reply" />
       </View>
     </View>
   ),
-  play: async ({ canvasElement }) => {
+  play: async ({ args, canvasElement }) => {
+    args.onNavigate.mockClear();
     const canvas = within(canvasElement);
     const reaction = within(canvas.getByTestId('reaction-notification'));
+    const link = reaction.getByRole('link');
+    const excerpt = reaction.getByText(args.bodyText);
+    const unreadBackground = getComputedStyle(link).backgroundColor;
+    await expect(unreadBackground).not.toBe('rgba(0, 0, 0, 0)');
+    await userEvent.hover(excerpt);
+    await expect(getComputedStyle(link).backgroundColor).not.toBe(unreadBackground);
+    await userEvent.click(excerpt);
+    await expect(args.onNavigate).toHaveBeenCalledOnce();
+    await userEvent.click(reaction.getByTestId('post-media-frame-notification-thumbnail'));
+    await expect(args.onNavigate).toHaveBeenCalledTimes(2);
+    await userEvent.unhover(excerpt);
     await expect(reaction.getByText(/외 3명/)).toBeInTheDocument();
     await expect(reaction.queryByRole('button')).not.toBeInTheDocument();
     await expect(reaction.getByTestId('post-media-frame-notification-thumbnail')).toHaveStyle({

--- a/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
@@ -284,6 +284,7 @@ export const ReadAndUnavailableStates: Story = {
   parameters: { controls: { disable: true } },
   render: (args) => (
     <View>
+      <NotificationExample {...args} unread={false} name="읽은 알림" />
       <NotificationExample {...args} unread />
       <NotificationExample {...args} pending name="이동 처리 중" />
       <NotificationExample {...args} disabled name="더 이상 접근할 수 없는 알림" />
@@ -350,7 +351,7 @@ export const CompositionContract: Story = {
         <NotificationExample {...args} kind="reaction" grouped hasMedia unread />
       </View>
       <View testID="reply-notification">
-        <NotificationExample {...args} kind="reply" />
+        <NotificationExample {...args} kind="reply" unread />
       </View>
     </View>
   ),
@@ -358,12 +359,15 @@ export const CompositionContract: Story = {
     args.onNavigate.mockClear();
     const canvas = within(canvasElement);
     const reaction = within(canvas.getByTestId('reaction-notification'));
-    const link = reaction.getByRole('link');
+    const surface = reaction.getByTestId('notification-item-surface');
     const excerpt = reaction.getByText(args.bodyText);
-    const unreadBackground = getComputedStyle(link).backgroundColor;
+    const unreadBackground = getComputedStyle(surface).backgroundColor;
     await expect(unreadBackground).not.toBe('rgba(0, 0, 0, 0)');
     await userEvent.hover(excerpt);
-    await expect(getComputedStyle(link).backgroundColor).not.toBe(unreadBackground);
+    await expect(getComputedStyle(surface).backgroundColor).toBe(unreadBackground);
+    await expect(reaction.getByTestId('notification-hover-overlay')).toHaveStyle({
+      pointerEvents: 'none',
+    });
     await userEvent.click(excerpt);
     await expect(args.onNavigate).toHaveBeenCalledOnce();
     await userEvent.click(reaction.getByTestId('post-media-frame-notification-thumbnail'));
@@ -376,10 +380,19 @@ export const CompositionContract: Story = {
       height: '64px',
     });
     const reply = within(canvas.getByTestId('reply-notification'));
+    const replySurface = reply.getByTestId('notification-item-surface');
+    const replyPost = reply.getByTestId('post-list-standard-row');
+    await expect(replySurface).toContainElement(replyPost);
+    await expect(getComputedStyle(replySurface).backgroundColor).toBe(unreadBackground);
+    await userEvent.hover(replyPost);
+    await expect(getComputedStyle(replySurface).backgroundColor).toBe(unreadBackground);
+    await expect(reply.getByTestId('notification-hover-overlay')).toBeInTheDocument();
     const action = await reply.findByRole('button', { name: '답글' });
     await expect(action.closest('a')).toBeNull();
     await expect(reply.getByTestId('post-list-standard-row')).toBeInTheDocument();
     await expect(reply.getByRole('button', { name: /더 보기/ })).toBeInTheDocument();
+    await userEvent.click(reply.getByRole('button', { name: /더 보기/ }));
+    await expect(args.onNavigate).toHaveBeenCalledTimes(2);
   },
 };
 

--- a/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
@@ -1,0 +1,379 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import { expect, fireEvent, fn, userEvent, within } from 'storybook/test';
+import { NotificationListItemView } from '@/components/notification/NotificationListItemView';
+import { PostActionAuthenticationProvider } from '@/components/post/PostActionAuthentication';
+import { PostListItem } from '@/components/post/PostListItem';
+import { PostMediaViewerHostProvider } from '@/components/post/PostMediaViewerHost';
+import { PostReplyCoordinatorProvider } from '@/components/post/PostReplyCoordinator';
+import { SessionProvider } from '@/session/SessionProvider';
+import { post, profile } from '../fixtures';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { NotificationListItemViewProps } from '@/components/notification/NotificationListItemView';
+import type { NotificationListItemStoriesQuery as Query } from './__generated__/NotificationListItemStoriesQuery.graphql';
+
+const thumbnail = {
+  id: 'notification-thumbnail',
+  altText: '보라색 하늘',
+  url:
+    'data:image/svg+xml,' +
+    encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#8b7dea"/></svg>',
+    ),
+};
+const author = profile({ id: 'notification-reply-author', displayName: '코스모 사용자' });
+const replyPost = {
+  ...post({
+    id: 'notification-reply-post',
+    profile: author,
+    bodyText: '코스모에서 함께 나누고 싶은 오늘의 이야기입니다.',
+  }),
+  replyCount: 12,
+  repostCount: 3,
+  viewerReactions: [],
+};
+
+export type NotificationStoryArgs = {
+  kind: NotificationListItemViewProps['kind'];
+  name: string;
+  grouped: boolean;
+  otherActorCount: number;
+  timestamp: string;
+  unread: boolean;
+  pending: boolean;
+  disabled: boolean;
+  bodyText: string;
+  contentWarning: string;
+  hasMedia: boolean;
+  sensitiveMedia: boolean;
+  unavailable: boolean;
+  containerWidth: number;
+  onNavigate: ReturnType<typeof fn>;
+};
+type Args = NotificationStoryArgs;
+
+function ReplyPost() {
+  const data = useLazyLoadQuery<Query>(
+    graphql`
+      query NotificationListItemStoriesQuery {
+        node(id: "notification-reply-post") {
+          ... on Post {
+            ...PostListItem_post @alias(as: "post")
+          }
+        }
+        composer: node(id: "notification-viewer") {
+          ... on Profile {
+            ...ReplyComposerSurface_profile @alias(as: "replyProfile")
+          }
+        }
+      }
+    `,
+    {},
+  );
+  if (!data.node?.post) {
+    throw new Error('Reply story Post fixture is missing.');
+  }
+  return (
+    <SessionProvider>
+      <PostActionAuthenticationProvider>
+        <PostReplyCoordinatorProvider owner="list" profile={data.composer?.replyProfile ?? null}>
+          <PostMediaViewerHostProvider>
+            <PostListItem post={data.node.post} showDivider={false} showReplyAttribution={false} />
+          </PostMediaViewerHostProvider>
+        </PostReplyCoordinatorProvider>
+      </PostActionAuthenticationProvider>
+    </SessionProvider>
+  );
+}
+
+function NotificationExample(args: Args) {
+  const actor = { id: 'notification-actor', name: args.name };
+  const shared = {
+    disabled: args.disabled,
+    onNavigate: args.onNavigate,
+    pending: args.pending,
+    timestamp: args.timestamp,
+    unread: args.unread,
+  };
+  if (args.kind === 'reply') {
+    return (
+      <NotificationListItemView
+        {...shared}
+        actor={actor}
+        href="/@kosmo/notification-reply-post"
+        kind="reply"
+      >
+        <ReplyPost />
+      </NotificationListItemView>
+    );
+  }
+  const actors = args.grouped
+    ? ([
+        actor,
+        { id: 'actor-2', name: '은하 관측자' },
+        { id: 'actor-3', name: '우주 여행자' },
+      ] as const)
+    : ([actor] as const);
+  const summary = {
+    actors,
+    totalActorCount: args.grouped ? Math.max(3, (args.otherActorCount ?? 3) + 1) : 1,
+  };
+  if (args.kind === 'follow' || args.kind === 'followRequest') {
+    return (
+      <NotificationListItemView
+        {...shared}
+        {...summary}
+        href={args.kind === 'follow' ? '/@kosmo' : '/follow-requests'}
+        kind={args.kind}
+      />
+    );
+  }
+  return (
+    <NotificationListItemView
+      {...shared}
+      {...summary}
+      href="/@kosmo/notification-related-post"
+      kind={args.kind}
+      preview={
+        args.unavailable
+          ? null
+          : {
+              bodyText: args.bodyText,
+              contentWarning: args.contentWarning || null,
+              media: args.hasMedia ? [thumbnail] : [],
+              sensitiveMedia: args.sensitiveMedia,
+            }
+      }
+    />
+  );
+}
+
+const meta = {
+  title: 'KOSMO/Patterns/Notification List Item',
+  args: {
+    kind: 'follow',
+    name: '별빛 여행자',
+    grouped: false,
+    otherActorCount: 3,
+    timestamp: '5분 전',
+    unread: false,
+    pending: false,
+    disabled: false,
+    bodyText: '새 디자인 시스템을 적용한 게시글의 한 줄 미리보기입니다.',
+    contentWarning: '',
+    hasMedia: false,
+    sensitiveMedia: false,
+    unavailable: false,
+    containerWidth: 390,
+    onNavigate: fn(),
+  },
+  argTypes: {
+    kind: {
+      control: 'select',
+      options: ['follow', 'followRequest', 'reaction', 'repost', 'reply'],
+    },
+    name: { control: 'text' },
+    timestamp: { control: 'text' },
+    grouped: { control: 'boolean', if: { arg: 'kind', neq: 'reply' } },
+    otherActorCount: { control: { type: 'number', min: 2, step: 1 }, if: { arg: 'grouped' } },
+    unread: { control: 'boolean' },
+    pending: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    bodyText: { control: 'text' },
+    contentWarning: { control: 'text' },
+    hasMedia: { control: 'boolean' },
+    sensitiveMedia: { control: 'boolean' },
+    unavailable: { control: 'boolean' },
+    containerWidth: { control: { type: 'range', min: 320, max: 720, step: 10 } },
+  },
+  decorators: [
+    (Story, context) => (
+      <View style={{ width: context.args.containerWidth, maxWidth: '100%' }}>
+        <Story />
+      </View>
+    ),
+  ],
+  excludeStories: [
+    'ActivationContract',
+    'PendingContract',
+    'CompositionContract',
+    'ProtectionContract',
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    relay: {
+      operationResponses: {
+        NotificationListItemStoriesQuery: {
+          data: { node: replyPost, composer: profile({ id: 'notification-viewer' }) },
+        },
+        SessionProviderQuery: {
+          data: {
+            currentSession: {
+              id: 'notification-session',
+              selectedProfile: { id: 'notification-viewer' },
+            },
+            me: { id: 'notification-account', name: 'Story' },
+          },
+        },
+      },
+    },
+  },
+  render: (args) => <NotificationExample {...args} />,
+} satisfies Meta<Args>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const GroupedKinds: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View>
+      {(['follow', 'followRequest', 'reaction', 'repost'] as const).map((kind) => (
+        <NotificationExample
+          key={kind}
+          {...args}
+          grouped
+          kind={kind}
+          hasMedia={kind === 'repost'}
+        />
+      ))}
+    </View>
+  ),
+};
+
+export const Reply: Story = { args: { kind: 'reply' } };
+
+export const LongContent: Story = {
+  args: {
+    kind: 'reaction',
+    grouped: true,
+    name: '아주 긴 표시 이름을 사용하는 머나먼 은하의 여행자',
+    timestamp: '2026년 9월 7일',
+    bodyText: '긴 첫 번째 줄입니다. '.repeat(20) + '\n두 번째 줄입니다.',
+    hasMedia: true,
+    containerWidth: 320,
+  },
+};
+
+export const ProtectedContent: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View>
+      <NotificationExample
+        {...args}
+        kind="reaction"
+        hasMedia
+        contentWarning="내용 확인에 주의가 필요합니다"
+      />
+      <NotificationExample {...args} kind="repost" hasMedia sensitiveMedia />
+      <NotificationExample {...args} kind="reaction" unavailable />
+    </View>
+  ),
+};
+
+export const ReadAndUnavailableStates: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View>
+      <NotificationExample {...args} unread />
+      <NotificationExample {...args} pending name="이동 처리 중" />
+      <NotificationExample {...args} disabled name="더 이상 접근할 수 없는 알림" />
+    </View>
+  ),
+};
+
+export const ActivationContract: Story = {
+  args: { kind: 'followRequest' },
+  parameters: { controls: { disable: true } },
+  play: async ({ args, canvasElement }) => {
+    args.onNavigate.mockClear();
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /팔로우 요청 관리 화면으로 이동/ });
+    await expect(link).toHaveAttribute('href', '/follow-requests');
+    await expect(canvas.queryByRole('button', { name: /수락/ })).not.toBeInTheDocument();
+    await userEvent.tab();
+    await expect(link).toHaveFocus();
+    await expect(link).toHaveStyle({ outlineWidth: '2px' });
+    await userEvent.keyboard('{Enter}');
+    await expect(args.onNavigate).toHaveBeenCalledOnce();
+  },
+};
+
+function PendingExample(args: Args) {
+  const [pending, setPending] = useState(false);
+  return (
+    <NotificationListItemView
+      actors={[{ id: 'pending-actor', name: args.name }]}
+      href="/@kosmo"
+      kind="follow"
+      onNavigate={() => {
+        args.onNavigate();
+        setPending(true);
+      }}
+      pending={pending}
+      timestamp={args.timestamp}
+    />
+  );
+}
+
+export const PendingContract: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => <PendingExample {...args} />,
+  play: async ({ args, canvasElement }) => {
+    args.onNavigate.mockClear();
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('link'));
+    const pending = canvas.getByRole('link');
+    await expect(pending).toHaveAttribute('aria-busy', 'true');
+    await expect(pending).toHaveAttribute('aria-disabled', 'true');
+    await expect(pending).not.toHaveAttribute('href');
+    await expect(pending).toHaveStyle({ pointerEvents: 'none' });
+    fireEvent.click(pending);
+    await expect(args.onNavigate).toHaveBeenCalledOnce();
+  },
+};
+
+export const CompositionContract: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View>
+      <View testID="reaction-notification">
+        <NotificationExample {...args} kind="reaction" grouped hasMedia />
+      </View>
+      <View testID="reply-notification">
+        <NotificationExample {...args} kind="reply" />
+      </View>
+    </View>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const reaction = within(canvas.getByTestId('reaction-notification'));
+    await expect(reaction.getByText(/외 3명/)).toBeInTheDocument();
+    await expect(reaction.queryByRole('button')).not.toBeInTheDocument();
+    await expect(reaction.getByTestId('post-media-frame-notification-thumbnail')).toHaveStyle({
+      width: '64px',
+      height: '64px',
+    });
+    const reply = within(canvas.getByTestId('reply-notification'));
+    const action = await reply.findByRole('button', { name: '답글' });
+    await expect(action.closest('a')).toBeNull();
+    await expect(reply.getByTestId('post-list-standard-row')).toBeInTheDocument();
+    await expect(reply.getByRole('button', { name: /더 보기/ })).toBeInTheDocument();
+  },
+};
+
+export const ProtectionContract: Story = {
+  ...ProtectedContent,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('내용 경고: 내용 확인에 주의가 필요합니다')).toBeInTheDocument();
+    await expect(canvas.getByText('게시글을 볼 수 없습니다')).toBeInTheDocument();
+    await expect(
+      canvas.queryByTestId('post-media-image-notification-thumbnail'),
+    ).not.toBeInTheDocument();
+    await expect(canvas.getAllByText(args.bodyText)).toHaveLength(1);
+  },
+};

--- a/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
@@ -22,7 +22,12 @@ const thumbnail = {
       '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#8b7dea"/></svg>',
     ),
 };
-const author = profile({ id: 'notification-reply-author', displayName: '코스모 사용자' });
+const author = profile({
+  id: 'notification-reply-author',
+  displayName: '별빛여행자',
+  handle: 'starlight',
+  relativeHandle: '@starlight',
+});
 const replyPost = {
   ...post({
     id: 'notification-reply-post',
@@ -32,6 +37,10 @@ const replyPost = {
   replyCount: 12,
   repostCount: 3,
   viewerReactions: [],
+  replyParent: post({
+    id: 'notification-parent',
+    profile: profile({ displayName: '원글 작성자' }),
+  }),
 };
 
 export type NotificationStoryArgs = {
@@ -79,7 +88,7 @@ function ReplyPost() {
       <PostActionAuthenticationProvider>
         <PostReplyCoordinatorProvider owner="list" profile={data.composer?.replyProfile ?? null}>
           <PostMediaViewerHostProvider>
-            <PostListItem post={data.node.post} showDivider={false} showReplyAttribution={false} />
+            <PostListItem post={data.node.post} showDivider={false} notification="reply" />
           </PostMediaViewerHostProvider>
         </PostReplyCoordinatorProvider>
       </PostActionAuthenticationProvider>
@@ -98,12 +107,7 @@ export function NotificationExample(args: Args) {
   };
   if (args.kind === 'reply') {
     return (
-      <NotificationListItemView
-        {...shared}
-        actor={actor}
-        href="/@kosmo/notification-reply-post"
-        kind="reply"
-      >
+      <NotificationListItemView kind="reply" unread={args.unread}>
         <ReplyPost />
       </NotificationListItemView>
     );
@@ -173,13 +177,13 @@ const meta = {
       control: 'select',
       options: ['follow', 'followRequest', 'reaction', 'repost', 'reply'],
     },
-    name: { control: 'text' },
-    timestamp: { control: 'text' },
+    name: { control: 'text', if: { arg: 'kind', neq: 'reply' } },
+    timestamp: { control: 'text', if: { arg: 'kind', neq: 'reply' } },
     grouped: { control: 'boolean', if: { arg: 'kind', neq: 'reply' } },
     otherActorCount: { control: { type: 'number', min: 2, step: 1 }, if: { arg: 'grouped' } },
     unread: { control: 'boolean' },
-    pending: { control: 'boolean' },
-    disabled: { control: 'boolean' },
+    pending: { control: 'boolean', if: { arg: 'kind', neq: 'reply' } },
+    disabled: { control: 'boolean', if: { arg: 'kind', neq: 'reply' } },
     bodyText: { control: 'text' },
     contentWarning: { control: 'text' },
     hasMedia: { control: 'boolean' },
@@ -205,6 +209,8 @@ const meta = {
     'PendingContract',
     'CompositionContract',
     'ProtectionContract',
+    'ReplyLayoutContract',
+    'ReplyQuoteContract',
   ],
   parameters: {
     layout: 'fullscreen',
@@ -251,6 +257,25 @@ export const GroupedKinds: Story = {
 };
 
 export const Reply: Story = { args: { kind: 'reply' } };
+
+export const ReplyLongName: Story = {
+  args: { kind: 'reply', containerWidth: 320, unread: true },
+  parameters: {
+    relay: {
+      operationResponses: {
+        NotificationListItemStoriesQuery: {
+          data: {
+            node: {
+              ...replyPost,
+              profile: { ...author, displayName: '아주 긴 이름으로 우주를 여행하는 별빛 여행자' },
+            },
+            composer: profile({ id: 'notification-viewer' }),
+          },
+        },
+      },
+    },
+  },
+};
 
 export const LongContent: Story = {
   args: {
@@ -382,6 +407,11 @@ export const CompositionContract: Story = {
     const reply = within(canvas.getByTestId('reply-notification'));
     const replySurface = reply.getByTestId('notification-item-surface');
     const replyPost = reply.getByTestId('post-list-standard-row');
+    await expect(reply.getByText('회원님의 게시글에 답글을 남겼습니다')).toBeVisible();
+    await expect(reply.getAllByText('별빛여행자')).toHaveLength(1);
+    await expect(reply.queryByText(/원글 작성자/)).not.toBeInTheDocument();
+    await expect(reply.queryByRole('link', { name: /답글을 남겼습니다/ })).not.toBeInTheDocument();
+    await expect(reply.getByText('읽지 않은 알림')).toBeInTheDocument();
     await expect(replySurface).toContainElement(replyPost);
     await expect(getComputedStyle(replySurface).backgroundColor).toBe(unreadBackground);
     await userEvent.hover(replyPost);
@@ -393,6 +423,61 @@ export const CompositionContract: Story = {
     await expect(reply.getByRole('button', { name: /더 보기/ })).toBeInTheDocument();
     await userEvent.click(reply.getByRole('button', { name: /더 보기/ }));
     await expect(args.onNavigate).toHaveBeenCalledTimes(2);
+  },
+};
+
+export const ReplyLayoutContract: Story = {
+  ...ReplyLongName,
+  parameters: { ...ReplyLongName.parameters, controls: { disable: true } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const author = canvas.getByTestId('notification-post-author');
+    const name = within(author).getByText('아주 긴 이름으로 우주를 여행하는 별빛 여행자');
+    const handle = within(author).getByText('@starlight');
+    await expect(name.scrollWidth).toBeGreaterThan(name.clientWidth);
+    await expect(handle.getBoundingClientRect().width).toBeLessThanOrEqual(1);
+    await expect(name.getBoundingClientRect().right).toBeLessThanOrEqual(
+      author.getBoundingClientRect().right,
+    );
+    await expect(canvas.getByText('회원님의 게시글에 답글을 남겼습니다')).toBeVisible();
+    await expect(canvas.getByRole('toolbar', { name: '액션 바' })).toBeVisible();
+    await userEvent.tab();
+    await expect(author).toHaveFocus();
+    await userEvent.tab();
+    await expect(document.activeElement).toHaveAttribute(
+      'href',
+      '/@starlight/notification-reply-post',
+    );
+  },
+};
+
+export const ReplyQuoteContract: Story = {
+  args: { kind: 'reply' },
+  parameters: {
+    controls: { disable: true },
+    relay: {
+      operationResponses: {
+        NotificationListItemStoriesQuery: {
+          data: {
+            node: {
+              ...replyPost,
+              repostSource: post({
+                id: 'quoted-post',
+                bodyText: '답글이 인용한 게시글 본문입니다.',
+              }),
+            },
+            composer: profile({ id: 'notification-viewer' }),
+          },
+        },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByText('회원님의 게시글에 답글을 남겼습니다')).toHaveLength(1);
+    await expect(canvas.getByText('답글이 인용한 게시글 본문입니다.')).toBeVisible();
+    await expect(canvas.queryByText(/원글 작성자/)).not.toBeInTheDocument();
+    await expect(canvas.getAllByRole('toolbar', { name: '액션 바' })).toHaveLength(1);
   },
 };
 

--- a/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.stories.tsx
@@ -39,7 +39,7 @@ const replyPost = {
   viewerReactions: [],
   replyParent: post({
     id: 'notification-parent',
-    profile: profile({ displayName: '원글 작성자' }),
+    profile: profile({ id: 'notification-parent-author', displayName: '원글 작성자' }),
   }),
 };
 
@@ -464,10 +464,14 @@ export const ReplyQuoteContract: Story = {
           data: {
             node: {
               ...replyPost,
-              repostSource: post({
-                id: 'quoted-post',
-                bodyText: '답글이 인용한 게시글 본문입니다.',
-              }),
+              repostSource: {
+                ...post({
+                  id: 'quoted-post',
+                  profile: profile({ id: 'notification-quoted-author' }),
+                  bodyText: '답글이 인용한 게시글 본문입니다.',
+                }),
+                viewerReactions: [],
+              },
             },
             composer: profile({ id: 'notification-viewer' }),
           },

--- a/apps/app/src/stories/patterns/NotificationListItem.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.tests.stories.tsx
@@ -3,6 +3,8 @@ import baseMeta, {
   CompositionContract as composition,
   PendingContract as pending,
   ProtectionContract as protection,
+  ReplyLayoutContract as replyLayout,
+  ReplyQuoteContract as replyQuote,
 } from './NotificationListItem.stories';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { NotificationStoryArgs } from './NotificationListItem.stories';
@@ -19,3 +21,5 @@ export const ActivationContract: Story = activation;
 export const PendingContract: Story = pending;
 export const CompositionContract: Story = composition;
 export const ProtectionContract: Story = protection;
+export const ReplyLayoutContract: Story = replyLayout;
+export const ReplyQuoteContract: Story = replyQuote;

--- a/apps/app/src/stories/patterns/NotificationListItem.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.tests.stories.tsx
@@ -1,0 +1,21 @@
+import baseMeta, {
+  ActivationContract as activation,
+  CompositionContract as composition,
+  PendingContract as pending,
+  ProtectionContract as protection,
+} from './NotificationListItem.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { NotificationStoryArgs } from './NotificationListItem.stories';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Patterns/Notification List Item/Tests',
+} satisfies Meta<NotificationStoryArgs>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ActivationContract: Story = activation;
+export const PendingContract: Story = pending;
+export const CompositionContract: Story = composition;
+export const ProtectionContract: Story = protection;

--- a/apps/app/src/stories/patterns/NotificationListItem.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/NotificationListItem.tests.stories.tsx
@@ -3,6 +3,7 @@ import baseMeta, {
   CompositionContract as composition,
   PendingContract as pending,
   ProtectionContract as protection,
+  ReplyActionsContract as replyActions,
   ReplyLayoutContract as replyLayout,
   ReplyQuoteContract as replyQuote,
 } from './NotificationListItem.stories';
@@ -23,3 +24,5 @@ export const CompositionContract: Story = composition;
 export const ProtectionContract: Story = protection;
 export const ReplyLayoutContract: Story = replyLayout;
 export const ReplyQuoteContract: Story = replyQuote;
+
+export const ReplyActionsContract: Story = replyActions;

--- a/apps/app/src/stories/screens/NotificationsPresentation.stories.tsx
+++ b/apps/app/src/stories/screens/NotificationsPresentation.stories.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { PageHeader } from '@/components/PageHeader';
+import { Button } from '@/components/ui/Button';
+import { useTheme } from '@/theme/ThemeProvider';
+import itemMeta, { NotificationExample } from '../patterns/NotificationListItem.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+function NotificationsPresentation({ onNavigate }: { onNavigate: ReturnType<typeof fn> }) {
+  const theme = useTheme();
+  const [allRead, setAllRead] = useState(false);
+
+  return (
+    <View
+      style={{
+        alignSelf: 'center',
+        width: '100%',
+        maxWidth: 600,
+        minHeight: '100%',
+        borderColor: theme.borderSubtle,
+        borderLeftWidth: 1,
+        borderRightWidth: 1,
+      }}
+    >
+      <PageHeader
+        title="알림"
+        trailing={
+          <Button disabled={allRead} onPress={() => setAllRead(true)} tone="secondary">
+            모두 읽음
+          </Button>
+        }
+      />
+      {(['reaction', 'follow', 'reply', 'repost', 'followRequest'] as const).map((kind, index) => (
+        <NotificationExample
+          key={kind}
+          {...itemMeta.args}
+          kind={kind}
+          grouped={kind === 'reaction' || kind === 'repost'}
+          hasMedia={kind === 'repost'}
+          name={index % 2 === 0 ? '별빛 여행자' : '은하 관측자'}
+          timestamp={index < 2 ? '5분 전' : '1시간 전'}
+          unread={!allRead && index < 2}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </View>
+  );
+}
+
+const meta = {
+  title: 'KOSMO/Screens/Notifications/Presentation',
+  component: NotificationsPresentation,
+  args: { onNavigate: fn() },
+  parameters: {
+    layout: 'fullscreen',
+    relay: itemMeta.parameters.relay,
+    router: { pathname: '/notifications' },
+    docs: {
+      description: {
+        component:
+          'PROD-884 표시 컴포넌트를 실제 앱의 최대 600px 콘텐츠 열에 조립한 수동 검토 화면입니다. 모두 읽음은 로컬 표시 상태만 바꾸며 실제 읽음 mutation은 PROD-811 범위입니다.',
+      },
+    },
+  },
+  excludeStories: ['ReadAllContract'],
+} satisfies Meta<typeof NotificationsPresentation>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+export const Mobile: Story = {
+  globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
+};
+
+export const ReadAllContract: Story = {
+  parameters: { controls: { disable: true } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { name: '알림' })).toBeVisible();
+    await expect(canvas.getAllByRole('link', { name: /읽지 않은 알림/ })).toHaveLength(2);
+    await userEvent.click(canvas.getByRole('button', { name: '모두 읽음' }));
+    await expect(canvas.queryAllByRole('link', { name: /읽지 않은 알림/ })).toHaveLength(0);
+    await expect(canvas.getByRole('button', { name: '모두 읽음' })).toBeDisabled();
+    await expect(canvas.getByRole('toolbar', { name: '액션 바' })).toBeVisible();
+  },
+};

--- a/apps/app/src/stories/screens/NotificationsPresentation.tests.stories.tsx
+++ b/apps/app/src/stories/screens/NotificationsPresentation.tests.stories.tsx
@@ -1,0 +1,9 @@
+import baseMeta, { ReadAllContract as readAll } from './NotificationsPresentation.stories';
+
+export default {
+  ...baseMeta,
+  title: 'KOSMO/Screens/Notifications/Presentation/Tests',
+  excludeStories: [],
+};
+
+export const ReadAllContract = readAll;

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -14,6 +14,10 @@ PROD-811이 실제 목록 연결, Relay projection·그룹 집계, 읽음 처리
 2026-09-07 readback과 DSN-42 최종 결정의 현재 kind는 Follow, FollowRequest, Reaction, Repost,
 Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출하지 않는다.
 
+2026-09-08 사용자 승인으로 Reply/Mention의 Figma 표본을 아래 표시 계약으로 갱신했다.
+이 계약의 코드·Storybook·Tailnet 반영은 아직 완료되지 않았다. Mention의 디자인 승인은
+API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는다.
+
 ## 표시와 합성
 
 - Follow/FollowRequest/Reaction/Repost는 48px kind rail 안에 32px 아이콘을 표시한다. 원형 배경을
@@ -23,18 +27,19 @@ Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출
 - Follow는 프로필, FollowRequest는 `/follow-requests`가 Target destination이며 inline 수락 버튼은
   없다. 기존 runtime과 notification OpenSpec의 requester-profile 이동은 아직 교체하지 않는다.
   PROD-811에서 navigation 계약과 spec을 함께 정렬해야 한다.
-- 일반 행은 최소 80px이며 긴 이름·문구에 맞춰 높이가 늘어난다. Reply header는 Web/iOS에서 44px,
-  Android에서는 접근성 기준에 따라 48dp 최소 target을 유지한다. Web inset은 좌 12px·우 16px,
-  Native는 좌우 8px, kind/content gap은 12px이다.
+- Follow/FollowRequest/Reaction/Repost 행은 최소 80px이며 긴 이름·문구에 맞춰 높이가 늘어난다.
+  Web inset은 좌 12px·우 16px, Native는 좌우 8px, kind/content gap은 12px이다.
+  Reply에는 별도 알림 header나 그 header의 최소 높이를 두지 않는다. 게시글 내부 링크와 action의
+  플랫폼별 접근성 target은 기존 Post 계약을 유지한다.
 - Web Read 배경은 투명, Unread는 Figma가 사용하는 `actionPrimarySubtle`과 4px
   `actionPrimaryBase` rail이다. Hover는 기존 배경 위에 `stateHover`를 얹으며 Unread의 primary 배경을
   지우지 않는다. 따라서 Read와 Unread의 hover 색상이 구분된다. keyboard focus는 `stateFocusRing`이다.
   이는 unread 전용 semantic token 신설이 아니다. Native는 Default 표시를 사용하되 접근 가능한 이름에
   unread 정보를 유지한다.
 - Reaction/Repost는 요약 헤더·한 줄 미리보기·썸네일을 하나의 이동 target으로 취급한다.
-  hover·읽음 배경과 읽음 rail은 알림 전체에 적용한다. Reply도 헤더와 PostListItem을 하나의 알림
-  surface로 표시하며 게시글 위에서도 전체 hover 배경이 유지된다. 헤더 이동 링크와 Post 내부 링크·
-  Action Bar는 독립적으로 동작하고, 내부 버튼 클릭이 알림 이동을 함께 실행하지 않는다.
+  hover·읽음 배경과 읽음 rail은 알림 전체에 적용한다. Reply도 게시글 전체를 하나의 알림 surface로
+  표시하며 게시글 위에서 전체 hover 배경이 유지된다. 별도 header 이동 링크는 없으며 Post 내부 링크·
+  Action Bar는 독립적으로 동작한다. 내부 버튼 클릭이 알림 이동을 함께 실행하지 않는다.
 - Follow에는 `UserRoundPlus`, Repost에는 `Repeat2`를 사용한다. Reaction의 Figma
   `FaceSlightlySmiling`은 설치된 Lucide export에 없으므로 Figma description과 [icons.md](./icons.md)의
   기존 `Smile` fallback을 유지한다.
@@ -46,14 +51,36 @@ Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출
   가져오지 않고 프로덕션 UI의 SUIT와 본문의 Pretendard를 유지한다.
 - 미리보기의 하단 여백은 썸네일 유무와 무관하게 일반 행과 같은 8px이다.
   2026-09-07 사용자 결정에 따라 Figma Light/Dark 조합 표본과 구현을 함께 정렬했다.
-- Reply의 `children`에는 실제 `PostListItem`을 `showDivider={false}`와 필요한 attribution 설정으로
-  조합한다. Post action/provider·Relay ref는 기존 Post 계약을 따른다. 자식은 알림 이동 링크의 바깥에
-  위치해 action이 알림 이동을 함께 실행하지 않는다. 단일 하단 divider는 Notification wrapper가 소유한다.
+- Reply/Mention은 작성자 이름·핸들 → 알림 이유 → 본문·미디어 → Action Bar의 동일한 게시글
+  구성을 사용한다. 작성자 아바타·이름과 시각을 별도 알림 header에 중복 표시하지 않는다.
+  알림 안의 작성자 이름과 핸들은 한 줄에 배치하며 이름을 우선한다. 공간이 부족하면 핸들이 먼저
+  가려지고, 이름도 가용 폭을 넘으면 말줄임한다. 이 계약을 다른 Profile 표시 전체에 확대하지 않는다.
+- 둘째 줄은 답글 대상 목록이 아니라 현재 Recipient가 알림을 받은 이유다. Reply는
+  `회원님의 게시글에 답글을 남겼습니다`, Future Mention은 `회원님을 멘션했습니다`로 표시한다.
+  이 문구는 secondary 텍스트이며 Recipient 핸들을 별도 링크 색상으로 강조하지 않는다.
+  여러 Profile을 멘션한 글도 각 Recipient에게 같은 Mention 문구를 사용하며 본문의 멘션은 유지한다.
+- Reply/Mention 알림에는 원글 미리보기나 별도 받는 사람 목록을 추가하지 않는다. 결과 게시글을
+  활성화하면 해당 게시글 상세에서 대화 문맥을 확인한다. 이 제한은 Reaction/Repost의 actionless
+  미리보기에는 적용하지 않는다. 수신자별 Reply/Mention 중복 정책은
+  [Notification 도메인의 Future 계약](../domain/objects/notification.md#replymention-수신자별-분류와-중복-처리-future)을 따른다.
+- Reply는 실제 Post 컴포넌트와 기존 Action Bar를 재사용한다. Post action/provider·Relay ref는
+  기존 Post 계약을 따르며 action을 알림 이동 링크 안에 중첩하지 않는다. 단일 하단 divider는
+  Notification wrapper가 소유한다. 기존 `children`·attribution 합성 방식의 구체적 조정은 코드 반영 시
+  이 표시 계약에 맞춰 결정한다.
 - pending/disabled는 알림 이동을 차단한다. consumer가 pending 수명을 소유하며, presentation에서
   읽음 mutation·cache 또는 실패 복구 정책을 실행하지 않는다. Reply Post action의 상태는 해당 Post가
   소유한다. 권한 상실로 Post를 숨겨야 하면 consumer가 전체 item을 제거해야 한다.
 
 ## 검증 경계
+
+2026-09-08 Figma에서 Reply의 Light/Dark·긴 이름·읽음/읽지 않음 표본과 Mention의 Light/Dark
+표본을 시각 확인했다. 아래 기존 Storybook 검증은 변경 전 구현에 대한 것이므로 새 계약의 통과
+증거로 재사용하지 않는다. 코드 반영 시 중복 header 제거, 이름·핸들 overflow, 알림 이유 문구,
+원글 미리보기 부재, Action Bar의 독립 동작과 unread/hover 범위를 다시 검증해야 한다.
+
+PROD-811 통합 시 [현행 Notification OpenSpec](../../openspec/specs/notification/spec.md)의 기존
+Follow 표시 scenario(28px kind icon·image avatar와 복수 사용자 aggregation 없음)와 새 presentation의
+차이를 정렬한다. 이 문서의 target 계약만으로 기존 runtime scenario나 완료 task를 변경하지 않는다.
 
 개별 스토리 기본 폭은 실제 앱 중앙 열의 최대 폭과 같은 600px이며 좁은 화면에서는 가용 폭으로 줄어든다.
 Controls에서 320·390·600·720px 또는 전체 폭을 선택할 수 있다. LongContent만 320px를 기본값으로 쓴다.

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -27,12 +27,14 @@ Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출
   Android에서는 접근성 기준에 따라 48dp 최소 target을 유지한다. Web inset은 좌 12px·우 16px,
   Native는 좌우 8px, kind/content gap은 12px이다.
 - Web Read 배경은 투명, Unread는 Figma가 사용하는 `actionPrimarySubtle`과 4px
-  `actionPrimaryBase` rail이다. Hover는 `stateHover`, keyboard focus는 `stateFocusRing`이다.
+  `actionPrimaryBase` rail이다. Hover는 기존 배경 위에 `stateHover`를 얹으며 Unread의 primary 배경을
+  지우지 않는다. 따라서 Read와 Unread의 hover 색상이 구분된다. keyboard focus는 `stateFocusRing`이다.
   이는 unread 전용 semantic token 신설이 아니다. Native는 Default 표시를 사용하되 접근 가능한 이름에
   unread 정보를 유지한다.
 - Reaction/Repost는 요약 헤더·한 줄 미리보기·썸네일을 하나의 이동 target으로 취급한다.
-  hover·읽음 배경과 읽음 rail은 이 target 전체에 적용한다. Reply는 헤더만 알림 이동 target이며
-  아래 PostListItem과 Action Bar는 별도 상호작용 영역을 유지한다.
+  hover·읽음 배경과 읽음 rail은 알림 전체에 적용한다. Reply도 헤더와 PostListItem을 하나의 알림
+  surface로 표시하며 게시글 위에서도 전체 hover 배경이 유지된다. 헤더 이동 링크와 Post 내부 링크·
+  Action Bar는 독립적으로 동작하고, 내부 버튼 클릭이 알림 이동을 함께 실행하지 않는다.
 - Follow에는 `UserRoundPlus`, Repost에는 `Repeat2`를 사용한다. Reaction의 Figma
   `FaceSlightlySmiling`은 설치된 Lucide export에 없으므로 Figma description과 [icons.md](./icons.md)의
   기존 `Smile` fallback을 유지한다.

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -57,7 +57,11 @@ API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는�
   가려지고, 이름도 가용 폭을 넘으면 말줄임한다. 이 계약을 다른 Profile 표시 전체에 확대하지 않는다.
 - 둘째 줄은 답글 대상 목록이 아니라 현재 Recipient가 알림을 받은 이유다. Reply는
   `회원님의 게시글에 답글을 남겼습니다`, Future Mention은 `회원님을 멘션했습니다`로 표시한다.
-  이 문구는 secondary 텍스트이며 Recipient 핸들을 별도 링크 색상으로 강조하지 않는다.
+  문장 앞에 16px `MessageCircle`(Reply)·`AtSign`(Future Mention)을 두며 아이콘과 문장 전체를
+  `foregroundSecondary`(Figma `color/foreground/secondary`)로 통일한다. Light `#64646F`, Dark
+  `#A3A3A3`이며 legacy `textSecondary`는 사용하지 않는다. 알림 작성자 이름은 `foregroundPrimary`,
+  핸들과 시각은 `foregroundSecondary`를 사용한다. Info 색상, 단어별 강조나 별도 배경은 두지 않는다.
+  아이콘은 장식이며 알림 종류는 문장으로도 전달한다.
   여러 Profile을 멘션한 글도 각 Recipient에게 같은 Mention 문구를 사용하며 본문의 멘션은 유지한다.
 - Reply/Mention 알림에는 원글 미리보기나 별도 받는 사람 목록을 추가하지 않는다. 결과 게시글을
   활성화하면 해당 게시글 상세에서 대화 문맥을 확인한다. 이 제한은 Reaction/Repost의 actionless

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -23,12 +23,16 @@ Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출
 - Follow는 프로필, FollowRequest는 `/follow-requests`가 Target destination이며 inline 수락 버튼은
   없다. 기존 runtime과 notification OpenSpec의 requester-profile 이동은 아직 교체하지 않는다.
   PROD-811에서 navigation 계약과 spec을 함께 정렬해야 한다.
-- 일반 행은 최소 80px이며 긴 이름·문구에 맞춰 높이가 늘어난다. Reply header는 48px 최소 target을
-  유지한다. Web inset은 좌 12px·우 16px, Native는 좌우 8px, kind/content gap은 12px이다.
+- 일반 행은 최소 80px이며 긴 이름·문구에 맞춰 높이가 늘어난다. Reply header는 Web/iOS에서 44px,
+  Android에서는 접근성 기준에 따라 48dp 최소 target을 유지한다. Web inset은 좌 12px·우 16px,
+  Native는 좌우 8px, kind/content gap은 12px이다.
 - Web Read 배경은 투명, Unread는 Figma가 사용하는 `actionPrimarySubtle`과 4px
   `actionPrimaryBase` rail이다. Hover는 `stateHover`, keyboard focus는 `stateFocusRing`이다.
   이는 unread 전용 semantic token 신설이 아니다. Native는 Default 표시를 사용하되 접근 가능한 이름에
   unread 정보를 유지한다.
+- Reaction/Repost는 요약 헤더·한 줄 미리보기·썸네일을 하나의 이동 target으로 취급한다.
+  hover·읽음 배경과 읽음 rail은 이 target 전체에 적용한다. Reply는 헤더만 알림 이동 target이며
+  아래 PostListItem과 Action Bar는 별도 상호작용 영역을 유지한다.
 - Follow에는 `UserRoundPlus`, Repost에는 `Repeat2`를 사용한다. Reaction의 Figma
   `FaceSlightlySmiling`은 설치된 Lucide export에 없으므로 Figma description과 [icons.md](./icons.md)의
   기존 `Smile` fallback을 유지한다.
@@ -36,6 +40,10 @@ Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출
   미리보기를 표시한다. `PostMediaImage`의 로딩·실패 처리를 재사용한다. CW가 있으면 경고만 표시하고
   본문·썸네일을 숨긴다. sensitive media는 썸네일을 숨긴다. 접근할 수 없는 Post는 `preview=null`로
   전달한다. 표시 영역은 기존 `PostContentPrivacyBoundary`를 사용한다.
+- 한 줄 미리보기는 `contentM`의 16px/24px를 사용한다. Figma의 MCP 매칭용 대체 폰트를
+  가져오지 않고 프로덕션 UI의 SUIT와 본문의 Pretendard를 유지한다.
+- 미리보기의 하단 여백은 썸네일 유무와 무관하게 일반 행과 같은 8px이다.
+  2026-09-07 사용자 결정에 따라 Figma Light/Dark 조합 표본과 구현을 함께 정렬했다.
 - Reply의 `children`에는 실제 `PostListItem`을 `showDivider={false}`와 필요한 attribution 설정으로
   조합한다. Post action/provider·Relay ref는 기존 Post 계약을 따른다. 자식은 알림 이동 링크의 바깥에
   위치해 action이 알림 이동을 함께 실행하지 않는다. 단일 하단 divider는 Notification wrapper가 소유한다.
@@ -44,6 +52,11 @@ Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출
   소유한다. 권한 상실로 Post를 숨겨야 하면 consumer가 전체 item을 제거해야 한다.
 
 ## 검증 경계
+
+개별 스토리 기본 폭은 실제 앱 중앙 열의 최대 폭과 같은 600px이며 좁은 화면에서는 가용 폭으로 줄어든다.
+Controls에서 320·390·600·720px 또는 전체 폭을 선택할 수 있다. LongContent만 320px를 기본값으로 쓴다.
+`Screens/Notifications/Presentation`에는 PageHeader와 알림 5종을 조립해 목록 밀도와 읽음 상태를
+검토한다. 해당 화면의 모두 읽음은 로컬 표시 상태만 변경하며 실제 mutation 통합을 입증하지 않는다.
 
 Playground는 수동 Controls/Actions, Tests는 activation·pending 중복 실행 차단·Reply 합성·보호된
 미리보기를 검증한다. 기존 Notifications screen story는 loading/error/empty와 프로필 접근 상실 등

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -1,0 +1,54 @@
+# Notification presentation
+
+PROD-884는 `NotificationListItemView`와 `KOSMO/Patterns/Notification List Item` Storybook을
+소유한다. 이 컴포넌트는 표시용 입력과 이동 callback을 받고, 기존 Notification runtime은 그대로 둔다.
+PROD-811이 실제 목록 연결, Relay projection·그룹 집계, 읽음 처리, 권한과 navigation 통합을 소유한다.
+
+## Canonical source
+
+- [NotificationListItem 조합](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4048-10559)
+- [Follow / FollowRequest](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4129-10681)
+- [Reaction / Repost thumbnail](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4327-11389)
+- [Private NotificationRow](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=1906-1129)
+
+2026-09-07 readback과 DSN-42 최종 결정의 현재 kind는 Follow, FollowRequest, Reaction, Repost,
+Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출하지 않는다.
+
+## 표시와 합성
+
+- Follow/FollowRequest/Reaction/Repost는 48px kind rail 안에 32px 아이콘을 표시한다. 원형 배경을
+  추가하지 않는다. 아바타는 28px, 겹침은 12px이고 전달된 순서의 최대 3개를 표시한다. 전체 actor 수는
+  consumer 입력이며 컴포넌트에서 그룹을 만들지 않는다. invalid count는 전달된 actor 수 이상인 정수로
+  정규화한다. Reply는 한 명만 허용한다.
+- Follow는 프로필, FollowRequest는 `/follow-requests`가 Target destination이며 inline 수락 버튼은
+  없다. 기존 runtime과 notification OpenSpec의 requester-profile 이동은 아직 교체하지 않는다.
+  PROD-811에서 navigation 계약과 spec을 함께 정렬해야 한다.
+- 일반 행은 최소 80px이며 긴 이름·문구에 맞춰 높이가 늘어난다. Reply header는 48px 최소 target을
+  유지한다. Web inset은 좌 12px·우 16px, Native는 좌우 8px, kind/content gap은 12px이다.
+- Web Read 배경은 투명, Unread는 Figma가 사용하는 `actionPrimarySubtle`과 4px
+  `actionPrimaryBase` rail이다. Hover는 `stateHover`, keyboard focus는 `stateFocusRing`이다.
+  이는 unread 전용 semantic token 신설이 아니다. Native는 Default 표시를 사용하되 접근 가능한 이름에
+  unread 정보를 유지한다.
+- Follow에는 `UserRoundPlus`, Repost에는 `Repeat2`를 사용한다. Reaction의 Figma
+  `FaceSlightlySmiling`은 설치된 Lucide export에 없으므로 Figma description과 [icons.md](./icons.md)의
+  기존 `Smile` fallback을 유지한다.
+- Reaction/Repost는 작성자 header·Action Bar 없이 secondary 본문 한 줄과 첫 미디어의 64×64
+  미리보기를 표시한다. `PostMediaImage`의 로딩·실패 처리를 재사용한다. CW가 있으면 경고만 표시하고
+  본문·썸네일을 숨긴다. sensitive media는 썸네일을 숨긴다. 접근할 수 없는 Post는 `preview=null`로
+  전달한다. 표시 영역은 기존 `PostContentPrivacyBoundary`를 사용한다.
+- Reply의 `children`에는 실제 `PostListItem`을 `showDivider={false}`와 필요한 attribution 설정으로
+  조합한다. Post action/provider·Relay ref는 기존 Post 계약을 따른다. 자식은 알림 이동 링크의 바깥에
+  위치해 action이 알림 이동을 함께 실행하지 않는다. 단일 하단 divider는 Notification wrapper가 소유한다.
+- pending/disabled는 알림 이동을 차단한다. consumer가 pending 수명을 소유하며, presentation에서
+  읽음 mutation·cache 또는 실패 복구 정책을 실행하지 않는다. Reply Post action의 상태는 해당 Post가
+  소유한다. 권한 상실로 Post를 숨겨야 하면 consumer가 전체 item을 제거해야 한다.
+
+## 검증 경계
+
+Playground는 수동 Controls/Actions, Tests는 activation·pending 중복 실행 차단·Reply 합성·보호된
+미리보기를 검증한다. 기존 Notifications screen story는 loading/error/empty와 프로필 접근 상실 등
+현재 목록 상태와 Relay mock 검증을 유지한다. 기존 runtime story와 새 Target presentation의 완료 상태를
+혼동하지 않는다.
+
+Light/Dark와 모바일 폭은 React Native Web 검증이다. 실제 Web/iOS/Android route·권한·읽음 처리·
+grouping 완료를 입증하지 않으며, Tailnet serve 변경은 PROD-884에 포함하지 않는다.

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -15,7 +15,7 @@ PROD-811이 실제 목록 연결, Relay projection·그룹 집계, 읽음 처리
 Reply다. Mention은 Future 표본이므로 public props와 Playground에 노출하지 않는다.
 
 2026-09-08 사용자 승인으로 Reply/Mention의 Figma 표본을 아래 표시 계약으로 갱신했다.
-이 계약의 코드·Storybook·Tailnet 반영은 아직 완료되지 않았다. Mention의 디자인 승인은
+Reply 계약은 로컬 코드·Storybook에 반영했으며 Tailnet은 이전 빌드를 유지한다. Mention의 디자인 승인은
 API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는다.
 
 ## 표시와 합성
@@ -65,25 +65,31 @@ API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는�
   [Notification 도메인의 Future 계약](../domain/objects/notification.md#replymention-수신자별-분류와-중복-처리-future)을 따른다.
 - Reply는 실제 Post 컴포넌트와 기존 Action Bar를 재사용한다. Post action/provider·Relay ref는
   기존 Post 계약을 따르며 action을 알림 이동 링크 안에 중첩하지 않는다. 단일 하단 divider는
-  Notification wrapper가 소유한다. 기존 `children`·attribution 합성 방식의 구체적 조정은 코드 반영 시
-  이 표시 계약에 맞춰 결정한다.
-- pending/disabled는 알림 이동을 차단한다. consumer가 pending 수명을 소유하며, presentation에서
-  읽음 mutation·cache 또는 실패 복구 정책을 실행하지 않는다. Reply Post action의 상태는 해당 Post가
-  소유한다. 권한 상실로 Post를 숨겨야 하면 consumer가 전체 item을 제거해야 한다.
+  Notification wrapper가 소유한다. Reply wrapper는 `children`과 `unread`만 받으며, 자식은
+  `PostListItem`의 `notification="reply"`와 `showDivider={false}`로 합성한다. 게시글 identity와 이동은
+  Post가 소유하므로 wrapper에 actor·timestamp·별도 이동 props를 중복 전달하지 않는다.
+- Follow/FollowRequest/Reaction/Repost의 pending/disabled는 알림 이동을 차단한다. consumer가 pending
+  수명을 소유하며 presentation에서 읽음 mutation·cache 또는 실패 복구 정책을 실행하지 않는다.
+  Reply의 이동과 Post action 상태는 해당 Post가 소유한다. 권한 상실로 Post를 숨겨야 하면 consumer가
+  전체 item을 제거해야 한다.
 
 ## 검증 경계
 
 2026-09-08 Figma에서 Reply의 Light/Dark·긴 이름·읽음/읽지 않음 표본과 Mention의 Light/Dark
-표본을 시각 확인했다. 아래 기존 Storybook 검증은 변경 전 구현에 대한 것이므로 새 계약의 통과
-증거로 재사용하지 않는다. 코드 반영 시 중복 header 제거, 이름·핸들 overflow, 알림 이유 문구,
-원글 미리보기 부재, Action Bar의 독립 동작과 unread/hover 범위를 다시 검증해야 한다.
+표본을 시각 확인했다. 새 Reply Storybook에서 중복 header 제거, 이름·핸들 overflow, 알림 이유 문구,
+Reply Parent 미리보기 부재, Action Bar의 독립 동작과 unread/hover 범위를 다시 검증한다.
+답글 자체가 Quote를 포함하는 경우 기존 인용 내용은 유지하며 Reply Parent 미리보기와 구분한다.
+Web 자동화는 Native 실제 기기의 touch·focus 검증을 대체하지 않는다.
 
 PROD-811 통합 시 [현행 Notification OpenSpec](../../openspec/specs/notification/spec.md)의 기존
 Follow 표시 scenario(28px kind icon·image avatar와 복수 사용자 aggregation 없음)와 새 presentation의
-차이를 정렬한다. 이 문서의 target 계약만으로 기존 runtime scenario나 완료 task를 변경하지 않는다.
+차이를 정렬한다. 공통 `Web pointer hover`와 Follow 전용 `Read와 Unread 표시` scenario의 기존
+`surface` 배경도 Read/Unread 기본 배경 위에 `stateHover`를 얹는 계약으로 함께 갱신한다.
+이 문서의 target 계약만으로 기존 runtime scenario나 완료 task를 변경하지 않는다.
 
 개별 스토리 기본 폭은 실제 앱 중앙 열의 최대 폭과 같은 600px이며 좁은 화면에서는 가용 폭으로 줄어든다.
-Controls에서 320·390·600·720px 또는 전체 폭을 선택할 수 있다. LongContent만 320px를 기본값으로 쓴다.
+Controls에서 320·390·600·720px 또는 전체 폭을 선택할 수 있다. LongContent와 ReplyLongName은
+320px를 기본값으로 쓴다.
 `Screens/Notifications/Presentation`에는 PageHeader와 알림 5종을 조립해 목록 밀도와 읽음 상태를
 검토한다. 해당 화면의 모두 읽음은 로컬 표시 상태만 변경하며 실제 mutation 통합을 입증하지 않는다.
 

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -67,11 +67,13 @@ API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는�
   활성화하면 해당 게시글 상세에서 대화 문맥을 확인한다. 이 제한은 Reaction/Repost의 actionless
   미리보기에는 적용하지 않는다. 수신자별 Reply/Mention 중복 정책은
   [Notification 도메인의 Future 계약](../domain/objects/notification.md#replymention-수신자별-분류와-중복-처리-future)을 따른다.
-- Reply는 실제 Post 컴포넌트와 기존 Action Bar를 재사용한다. Post action/provider·Relay ref는
-  기존 Post 계약을 따르며 action을 알림 이동 링크 안에 중첩하지 않는다. 단일 하단 divider는
-  Notification wrapper가 소유한다. Reply wrapper는 `children`과 `unread`만 받으며, 자식은
-  `PostListItem`의 `notification="reply"`와 `showDivider={false}`로 합성한다. 게시글 identity와 이동은
-  Post가 소유하므로 wrapper에 actor·timestamp·별도 이동 props를 중복 전달하지 않는다.
+- Reply 알림은 `ReplyNotificationPost`가 작성자·시각·알림 이유와 게시글 내용을 조립한다.
+  `PostBody`·`PostSourcePreview`·`PostActionSurface`를 재사용하고, Reply 버튼·composer·focus 연결은
+  `usePostReplySurface`를 게시글 목록과 공유한다. `PostListItem`은 알림 종류·문구·배치를 소유하지 않는다.
+  기존 Post action/provider·Relay ref 계약을 따르며 action을 알림 이동 링크 안에 중첩하지 않는다.
+  단일 하단 divider는 Notification wrapper가 소유한다. Reply wrapper는 `children`과 `unread`만 받고
+  자식으로 `ReplyNotificationPost`를 합성한다. 게시글 identity와 이동은 이 자식이 소유하므로 wrapper에
+  actor·timestamp·별도 이동 props를 중복 전달하지 않는다.
 - Follow/FollowRequest/Reaction/Repost의 pending/disabled는 알림 이동을 차단한다. consumer가 pending
   수명을 소유하며 presentation에서 읽음 mutation·cache 또는 실패 복구 정책을 실행하지 않는다.
   Reply의 이동과 Post action 상태는 해당 Post가 소유한다. 권한 상실로 Post를 숨겨야 하면 consumer가

--- a/docs/domain/objects/notification.md
+++ b/docs/domain/objects/notification.md
@@ -98,6 +98,9 @@ Repost Notification의 Source Repost는 알림을 만든 원인 Repost Post다. 
 이슈와 필요한 OpenSpec scenario에 아래 정책을 연결하고 검증한다.
 
 - 분류 기준은 해당 Post가 답글인지 여부만이 아니라 각 Recipient와 원인 Post의 관계다.
+- Mention의 source와 Related Post는 Recipient를 멘션한 원인 Post이며, Related Profile은 그 Post의
+  Author Profile이다. 같은 원인 Post에서 같은 Recipient를 여러 번 멘션해도 source는 하나이며,
+  동일 source·Recipient 쌍에 Mention Notification은 최대 하나만 존재한다.
 - Recipient의 Post에 답하면서 같은 Recipient를 멘션한 경우, 같은 원인 Post에 대해 해당 Recipient에게
   Reply Notification 하나만 생성하고 Mention Notification을 중복 생성하지 않는다.
 - 타인의 Post에 답하면서 Recipient를 멘션한 경우, 해당 Recipient에게는 Mention Notification이다.

--- a/docs/domain/objects/notification.md
+++ b/docs/domain/objects/notification.md
@@ -91,6 +91,24 @@ Repost Notification의 Source Repost는 알림을 만든 원인 Repost Post다. 
 | Followee Post     | Follower Profile              | Related Post, Followee인 Related Profile, Related Follow Relationship |
 | Operational       | Account                       | 운영 메시지                                                           |
 
+### Reply/Mention 수신자별 분류와 중복 처리 (Future)
+
+2026-09-08 사용자 승인으로 확정한 후속 Mention 구현 계약이다. Mention은 도메인 Type으로
+정의되어 있으나 현재 API·알림 생성·inbox 통합의 완료를 의미하지 않는다. 후속 구현 전 담당 Linear
+이슈와 필요한 OpenSpec scenario에 아래 정책을 연결하고 검증한다.
+
+- 분류 기준은 해당 Post가 답글인지 여부만이 아니라 각 Recipient와 원인 Post의 관계다.
+- Recipient의 Post에 답하면서 같은 Recipient를 멘션한 경우, 같은 원인 Post에 대해 해당 Recipient에게
+  Reply Notification 하나만 생성하고 Mention Notification을 중복 생성하지 않는다.
+- 타인의 Post에 답하면서 Recipient를 멘션한 경우, 해당 Recipient에게는 Mention Notification이다.
+  그 글이 Reply라는 이유만으로 해당 Recipient의 Mention을 Reply로 바꾸거나 제외하지 않는다.
+- 여러 Profile이 멘션되면 각 Recipient별로 분류한다. 같은 Post가 원글 작성자에게는 Reply,
+  다른 Mentioned Profile에게는 Mention의 원인이 될 수 있다. 각 Recipient의 조회·생성 억제 정책은
+  그대로 적용한다.
+
+표시 문구와 원글 미리보기 여부는 [Notification presentation](../../design/notifications.md)이
+소유하며, 알림 UI의 구성만으로 Related Post나 Recipient 관계를 바꾸지 않는다.
+
 ## 권한
 
 | 권한                        | 종류      | 성립 조건                                                                                    |


### PR DESCRIPTION
## 무엇을 변경했는지

- Follow, FollowRequest, Reaction, Repost, Reply의 `NotificationListItemView`와 수동 Playground·자동 Tests story를 추가했습니다.
- Reply는 전용 `ReplyNotificationPost`에서 작성자 이름·핸들, 알림 이유, 본문과 Action Bar를 조립합니다. 긴 이름에서는 핸들이 먼저 숨고 이름이 말줄임됩니다.
- Reply 이유의 16px MessageCircle과 문장, 핸들·시각은 `foregroundSecondary`를 사용합니다. Figma와 실제 Web 렌더에서 Light `#64646F`, Dark `#A3A3A3`를 확인했습니다.
- `PostListItem`의 알림 전용 prop·문구·분기를 제거했습니다. `PostBody`·`PostSourcePreview`·`PostActionSurface`를 재사용하고 Reply 인증·composer·focus 연결만 `usePostReplySurface`로 공유합니다.
- 전체 알림 5종을 조립한 `Screens/Notifications/Presentation`과 표시·도메인 문서를 함께 정렬했습니다.

## 왜 변경했는지

Figma에서 승인한 알림 표시를 실제 production 컴포넌트로 검토하고, PROD-811 runtime 통합이 따를 표시 계약과 검증 표면을 제공합니다.

## 이번 PR의 주요 결정

- 결정자: @yeeun-uwu. Reply의 작성자·시각 중복 헤더를 제거하고, 게시글 안에 현재 수신자가 알림을 받은 이유를 표시합니다. 별도 받는 사람 목록과 Reply Parent 미리보기는 생략하고 기존 게시글 상세에서 문맥을 확인합니다. 답글 자체의 Quote 내용과 독립 Action Bar는 유지합니다.
- 결정자: @yeeun-uwu. 알림 이유의 아이콘과 문장 전체를 `foregroundSecondary`로 통일했습니다. 색상만으로 종류를 구분하지 않고 아이콘과 문구를 함께 사용합니다.
- [표시 계약](https://github.com/byulmaru/kosmo/blob/e11aefda0c3da0ff84e44f78e892c3039c719233/docs/design/notifications.md)과 [Notification 도메인](https://github.com/byulmaru/kosmo/blob/e11aefda0c3da0ff84e44f78e892c3039c719233/docs/domain/objects/notification.md)에 최종 결정을 기록했습니다. Mention은 Future 계약으로 남기며 public kind와 Playground에 노출하지 않습니다.

## 어떻게 확인할 수 있는지

- 2026-09-09 최신 `main`(`2b45d4745`) 위로 리베이스했습니다. 현재 head는 `e11aefda0`이며 기존 8개 커밋의 변경을 유지했습니다. 리베이스 후 Relay·TypeScript, 알림 Storybook 42/42, 미디어·상세 thread 단위 테스트 14/14 통과.
- 리베이스 전 구현 `157610217`: 알림 Storybook 42/42, 기존 Post Storybook 103/103, 미디어·상세 thread 단위 테스트 13/13 통과. 최종 fixture 정렬 후 알림 interaction 7/7도 재확인했습니다.
- 리베이스 전 구현의 Relay·TypeScript, 변경 파일 ESLint·Prettier, 정적 Storybook 빌드 및 독립 리뷰 PASS.
- 실제 수신자 표본으로 Reply composer의 open/close·focus 복귀, 링크 복사, 삭제 메뉴 부재를 검증했습니다. 알림 미디어의 Post identity·선택 index·focus 복귀와 기존 게시글 삭제 동작은 각 회귀 테스트에서 확인했습니다.
- 내장 Browser에서 Light/Dark의 실제 색상, 320px 긴 이름, 600px 전체 목록과 독립 Action Bar를 확인했습니다.
- `pnpm --filter @kosmo/app exec storybook dev --port 6008` 실행 후 `KOSMO/Screens/Notifications/Presentation/Playground`에서 알림 5종을 함께 확인할 수 있습니다. `Patterns/Notification List Item`에는 Reply, Reply Long Name, Grouped Kinds와 보호·읽음 상태 표본이 있습니다.
- 이전 [Tailnet 미리보기](https://sasha-macbook-pro.tail1fdd55.ts.net:8444/?path=/story/kosmo-screens-notifications-presentation--playground)는 `eafaa1f1` 빌드입니다. 최신 Reply 변경의 검증 근거로 사용하지 않습니다.

## 아직 어떤 문제가 남았는지

- 리베이스 후 최신 head의 원격 CI는 진행 중입니다. 이전 head의 mise 설치 파일 404 실패는 이전 실행 기록이며, 최신 CI 성공 여부는 아직 확인되지 않았습니다.
- 실제 목록 연결, Relay projection·그룹 집계, 읽음 mutation·권한·navigation 통합은 PROD-811 범위입니다. 공통 및 Follow 전용 hover OpenSpec 정렬도 PROD-811이 소유합니다.
- 실제 Native 기기의 touch·focus·assistive technology 검증과 Mention API 구현은 이번 PR 범위 밖입니다.

Linear: https://linear.app/byulmaru/issue/PROD-884

구현·검증 보조: Codex

Stack: main → prod-884 (단일 레이어)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


