### PR TITLE
[PROD-895] Switch·SearchField 재사용 계약을 Storybook에서 검증한다

### DIFF
--- a/apps/app/src/stories/components/Switch.stories.tsx
+++ b/apps/app/src/stories/components/Switch.stories.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+import { Switch, Text, View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { useTheme } from '@/theme/ThemeProvider';
+import { space, textStyles } from '@/theme/tokens';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const defaultLabel = '팔로우 요청 자동 승인';
+
+type SwitchCatalogProps = {
+  disabled?: boolean;
+  label?: string;
+  onValueChange?: (value: boolean) => void;
+  value?: boolean;
+};
+
+function SwitchCatalog({
+  disabled = false,
+  label = defaultLabel,
+  onValueChange,
+  value: initialValue = false,
+}: SwitchCatalogProps) {
+  const theme = useTheme();
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => setValue(initialValue), [initialValue]);
+
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        flexDirection: 'row',
+        gap: space[12],
+        maxWidth: 320,
+        width: '100%',
+      }}
+    >
+      <Text style={[textStyles.uiCopyL, { color: theme.foregroundPrimary, flex: 1 }]}>{label}</Text>
+      <Switch
+        accessibilityLabel={label}
+        disabled={disabled}
+        onValueChange={(nextValue) => {
+          setValue(nextValue);
+          onValueChange?.(nextValue);
+        }}
+        value={value}
+      />
+    </View>
+  );
+}
+
+const meta = {
+  args: {
+    disabled: false,
+    label: defaultLabel,
+    onValueChange: fn(),
+    value: false,
+  },
+  argTypes: {
+    disabled: { control: 'boolean' },
+    label: { control: 'text' },
+    value: { control: 'boolean' },
+  },
+  component: SwitchCatalog,
+  excludeStories: ['InteractionContract', 'DisabledInteractionContract'],
+  parameters: { controls: { disable: true } },
+  title: 'KOSMO/Components/Switch',
+} satisfies Meta<typeof SwitchCatalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  parameters: {
+    controls: {
+      disable: false,
+      include: ['label', 'disabled', 'value'],
+    },
+  },
+};
+
+export const InteractionContract: Story = {
+  args: {
+    disabled: false,
+    label: defaultLabel,
+    value: false,
+  },
+  play: async ({ args, canvasElement, step }) => {
+    args.onValueChange?.mockClear();
+    const label = args.label ?? defaultLabel;
+    const toggle = within(canvasElement).getByRole('switch', { name: label });
+
+    await step('Switch 상태와 키보드 focus 확인', async () => {
+      expect(toggle).not.toBeChecked();
+      expect(toggle).not.toBeDisabled();
+      await userEvent.tab();
+      expect(toggle).toHaveFocus();
+    });
+
+    await step('click과 Space로 checked 및 callback 변경 확인', async () => {
+      await userEvent.click(toggle);
+      expect(toggle).toBeChecked();
+      expect(args.onValueChange).toHaveBeenLastCalledWith(true);
+
+      await userEvent.keyboard(' ');
+      expect(toggle).not.toBeChecked();
+      expect(args.onValueChange).toHaveBeenLastCalledWith(false);
+    });
+  },
+};
+
+export const DisabledInteractionContract: Story = {
+  args: {
+    disabled: true,
+    label: defaultLabel,
+    value: false,
+  },
+  play: async ({ args, canvasElement }) => {
+    args.onValueChange?.mockClear();
+    const toggle = within(canvasElement).getByRole('switch', { name: args.label ?? defaultLabel });
+
+    expect(toggle).not.toBeChecked();
+    expect(toggle).toBeDisabled();
+    toggle.click();
+    expect(toggle).not.toBeChecked();
+    expect(args.onValueChange).not.toHaveBeenCalled();
+  },
+};
+
+export const RepresentativeStates: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <View style={{ gap: space[16], width: '100%' }}>
+      <SwitchCatalog disabled label="비활성 꺼짐" value={false} />
+      <SwitchCatalog disabled label="비활성 켜짐" value />
+      <SwitchCatalog
+        label="팔로우 요청 자동 승인을 위한 아주 긴 Switch 레이블을 표시합니다"
+        value
+      />
+    </View>
+  ),
+};

--- a/apps/app/src/stories/components/Switch.tests.stories.tsx
+++ b/apps/app/src/stories/components/Switch.tests.stories.tsx
@@ -1,0 +1,17 @@
+import baseMeta, {
+  DisabledInteractionContract as disabledInteractionContract,
+  InteractionContract as interactionContract,
+} from './Switch.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Components/Switch/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const DisabledInteractionContract: Story = disabledInteractionContract;

--- a/apps/app/src/stories/patterns/SearchField.stories.tsx
+++ b/apps/app/src/stories/patterns/SearchField.stories.tsx
@@ -1,0 +1,199 @@
+import { SearchIcon, XIcon } from 'lucide-react-native';
+import { useEffect, useRef, useState } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { IconButton } from '@/components/ui/IconButton';
+import { TextField } from '@/components/ui/TextField';
+import { useTheme } from '@/theme/ThemeProvider';
+import { space } from '@/theme/tokens';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { TextInput } from 'react-native';
+
+type SearchFieldArgs = {
+  accessibilityLabel: string;
+  containerWidth: number;
+  disabled: boolean;
+  onBlur: () => void;
+  onChangeText: (value: string) => void;
+  onClear: () => void;
+  onFocus: () => void;
+  placeholder: string;
+  value: string;
+};
+
+// Consumer-owned composition of production primitives; no route/search lifecycle.
+function SearchFieldComposition({
+  accessibilityLabel,
+  containerWidth,
+  disabled,
+  onBlur,
+  onChangeText,
+  onClear,
+  onFocus,
+  placeholder,
+  value: initialValue,
+}: SearchFieldArgs) {
+  const theme = useTheme();
+  const inputRef = useRef<TextInput>(null);
+  const [value, setValue] = useState(initialValue);
+  useEffect(() => setValue(initialValue), [initialValue]);
+
+  return (
+    <View style={{ maxWidth: '100%', width: containerWidth }}>
+      <TextField
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="search"
+        accessibilityState={{ disabled }}
+        aria-disabled={disabled}
+        editable={!disabled}
+        onBlur={onBlur}
+        onChangeText={(next) => {
+          setValue(next);
+          onChangeText(next);
+        }}
+        onFocus={onFocus}
+        placeholder={placeholder}
+        ref={inputRef}
+        role={Platform.OS === 'web' ? 'searchbox' : undefined}
+        style={styles.input}
+        value={value}
+      />
+      <View
+        accessibilityElementsHidden
+        aria-hidden
+        importantForAccessibility="no-hide-descendants"
+        style={styles.leading}
+      >
+        <SearchIcon
+          color={disabled ? theme.stateDisabledForeground : theme.foregroundPrimary}
+          size={20}
+        />
+      </View>
+      {value.length > 0 && !disabled ? (
+        <IconButton
+          accessibilityLabel="검색 지우기"
+          onPress={() => {
+            setValue('');
+            onClear();
+            inputRef.current?.focus();
+          }}
+          style={styles.clear}
+          targetSize={32}
+        >
+          <XIcon color={theme.foregroundPrimary} size={20} />
+        </IconButton>
+      ) : null}
+    </View>
+  );
+}
+
+const meta = {
+  args: {
+    accessibilityLabel: '검색어',
+    containerWidth: 320,
+    disabled: false,
+    onBlur: fn(),
+    onChangeText: fn(),
+    onClear: fn(),
+    onFocus: fn(),
+    placeholder: '설정 검색',
+    value: '',
+  },
+  argTypes: {
+    accessibilityLabel: { control: 'text' },
+    containerWidth: { control: { max: 640, min: 240, step: 40, type: 'range' } },
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    value: { control: 'text' },
+  },
+  component: SearchFieldComposition,
+  excludeStories: ['InputClearAndFocus', 'DisabledContract'],
+  parameters: { controls: { disable: true } },
+  title: 'KOSMO/Patterns/Search Field',
+} satisfies Meta<typeof SearchFieldComposition>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  parameters: {
+    controls: {
+      disable: false,
+      include: ['accessibilityLabel', 'containerWidth', 'disabled', 'placeholder', 'value'],
+    },
+  },
+};
+
+export const RepresentativeStates: Story = {
+  render: (args) => (
+    <View style={{ gap: space[16] }}>
+      <SearchFieldComposition {...args} accessibilityLabel="입력된 검색어" value="알림" />
+      <SearchFieldComposition {...args} accessibilityLabel="비활성 빈 검색어" disabled value="" />
+      <SearchFieldComposition {...args} accessibilityLabel="비활성 검색어" disabled value="알림" />
+      <SearchFieldComposition
+        {...args}
+        accessibilityLabel="긴 검색어"
+        value="아주 긴 검색어가 입력되어도 지우기 버튼과 겹치지 않는 검색 필드"
+      />
+    </View>
+  ),
+};
+
+export const InputClearAndFocus: Story = {
+  play: async ({ args, canvasElement, step }) => {
+    args.onBlur.mockClear();
+    args.onChangeText.mockClear();
+    args.onClear.mockClear();
+    args.onFocus.mockClear();
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('searchbox', { name: args.accessibilityLabel });
+
+    await step('Empty와 keyboard focus', async () => {
+      expect(input).toHaveValue('');
+      expect(input.getBoundingClientRect().height).toBe(44);
+      expect(canvas.queryByRole('button', { name: '검색 지우기' })).toBeNull();
+      await userEvent.tab();
+      expect(input).toHaveFocus();
+      expect(args.onFocus).toHaveBeenCalled();
+      expect(getComputedStyle(input).outlineStyle).toBe('solid');
+    });
+
+    await step('Filled 입력과 clear 뒤 focus 복귀', async () => {
+      await userEvent.type(input, '알림');
+      expect(input).toHaveValue('알림');
+      expect(args.onChangeText).toHaveBeenLastCalledWith('알림');
+      await userEvent.tab();
+      const clear = canvas.getByRole('button', { name: '검색 지우기' });
+      expect(clear).toHaveFocus();
+      expect(args.onBlur).toHaveBeenCalled();
+      await userEvent.keyboard('{Enter}');
+      expect(args.onClear).toHaveBeenCalledOnce();
+      expect(input).toHaveValue('');
+      expect(input).toHaveFocus();
+      expect(canvas.queryByRole('button', { name: '검색 지우기' })).toBeNull();
+    });
+  },
+};
+
+export const DisabledContract: Story = {
+  args: { disabled: true, value: '알림' },
+  play: async ({ args, canvasElement }) => {
+    args.onChangeText.mockClear();
+    args.onClear.mockClear();
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('searchbox', { name: args.accessibilityLabel });
+    expect(input).toHaveAttribute('readonly');
+    expect(input).toHaveAttribute('aria-disabled', 'true');
+    expect(canvas.queryByRole('button', { name: '검색 지우기' })).toBeNull();
+    await userEvent.type(input, '변경');
+    expect(input).toHaveValue('알림');
+    expect(args.onChangeText).not.toHaveBeenCalled();
+    expect(args.onClear).not.toHaveBeenCalled();
+  },
+};
+
+const styles = StyleSheet.create({
+  input: { paddingLeft: space[32] + space[8], paddingRight: space[48] },
+  leading: { left: space[12], pointerEvents: 'none', position: 'absolute', top: space[12] },
+  clear: { position: 'absolute', right: space[8], top: (44 - 32) / 2 },
+});

--- a/apps/app/src/stories/patterns/SearchField.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/SearchField.tests.stories.tsx
@@ -1,0 +1,18 @@
+import baseMeta, {
+  DisabledContract as disabledContract,
+  InputClearAndFocus as inputClearAndFocus,
+} from './SearchField.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  parameters: { ...baseMeta.parameters, controls: { disable: true } },
+  title: 'KOSMO/Patterns/Search Field/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InputClearAndFocus: Story = inputClearAndFocus;
+export const DisabledContract: Story = disabledContract;

--- a/docs/design/icons.md
+++ b/docs/design/icons.md
@@ -50,6 +50,15 @@ Lucide path를 별도 SVG 묶음으로 레포에 복제하지 않는다. lockfil
 Profile 고정 action은 canonical `24×24` `Pin`을 재사용한다. attribution의 인접 label은 `고정됨`, owner
 action label은 상태에 따라 `프로필에 고정` 또는 `프로필 고정 해제`다.
 
+입력 지우기의 visual size는 각 surface의 정본을 따른다. 위 Search route 매핑은 입력 지우기 `X` `18px`와
+최근 검색 삭제 `X` `16px`, stroke `2`를 유지한다. PROD-895의
+[Figma SearchField](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3899-1389)는
+clear `X` / code export `XIcon`을 `20px`, stroke `2`, `32×32px` 버튼으로 사용한다.
+기존 `TextField`·`IconButton` 합성의 [SearchField Storybook](./settings.md#switchsearchfield-재사용-매핑-prod-895)이
+이 계약을 검증하며, Filled라도 disabled이면 clear를 숨기고 clear 뒤 입력 focus를 복귀시킨다.
+Native target은 기존 `IconButton`의 iOS `44pt`·Android `48dp` 보정을 따르며 실제 runtime QA는 별도다.
+이 차이는 승인된 surface별 크기이며 Search route를 `20px`로 바꾸거나 SearchField를 `18px`로 축소하는 근거가 아니다.
+
 `ArrowLeft`는 화면·경로 또는 overlay 안의 하위 view에서 이전 navigation state로 돌아간다. `ChevronLeft`·
 `ChevronRight`는 carousel·단계처럼 같은 view 안의 순서를 이동하거나 목록의 destination을 나타낸다. route·subview
 back에 chevron을 사용하지 않는다.

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -221,6 +221,43 @@ DSN-54는 테마 선택의 Figma 계약을, PROD-812는 production runtime과 �
 - 자동화·source/unit 결과는 실제 Web keyboard·screen reader·zoom 또는 Android·iOS runtime 접근성·
   navigation 통과 증거로 일반화하지 않는다.
 
+## Switch·SearchField 재사용 매핑 (PROD-895)
+
+Figma 이름마다 public component를 추가하지 않는다. Switch는 기존 `react-native` Switch를 사용하고,
+SearchField는 Production `TextField`·`IconButton`을 합성한다. Playground의 얇은 consumer fixture가
+입력 상태와 clear 뒤 입력 focus 복귀를 소유하며, route·검색 결과·debounce 정책은 포함하지 않는다.
+
+| Figma source                                                                               | Production 구현·consumer                                   | Storybook 표면                                                                                                 |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Switch](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3324-22405)     | `react-native` Switch                                      | `KOSMO/Components/Switch` Playground·RepresentativeStates·Tests                                                |
+| 같은 Switch                                                                                | `ProfileEditForm.tsx`의 Follow Approval                    | `screens/ProfileEdit.stories.tsx`의 `FollowPolicySwitchSubmitsEnum`·`FollowPolicyApprovalRequiredInitialState` |
+| 같은 Switch                                                                                | `PostComposerMediaControls.tsx`의 `PostComposerMediaItems` | `patterns/Posts.stories.tsx`의 `ComposerMediaStates`·`ComposerReplyMediaMutationContract`                      |
+| [SearchField](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3899-1389) | `ui/TextField.tsx`·`ui/IconButton.tsx` 합성                | `KOSMO/Patterns/Search Field` Playground·RepresentativeStates·Tests                                            |
+
+- Switch는 Off/On·Disabled와 boolean `onValueChange`를 유지한다. Figma의 40×20은 의도 표현이며
+  Web·iOS·Android의 native 렌더 크기·모양·색상 차이를 허용한다. `OPEN`/`APPROVAL_REQUIRED` 변환은
+  [ProfileEdit consumer](./profile-edit.md)의 계약이다. 민감한 이미지 Switch는 별도의 boolean 값을 전달한다.
+- SearchField는 TextField의 44px 높이·테마·focus ring을 재사용하며 Empty/Filled와
+  Default/Focused/Disabled를 표현한다. Filled라도 disabled이면 clear를 숨긴다. Focused는 실제 입력
+  focus로 도달하며 테스트 전용 state prop을 추가하지 않는다. Web 입력은 `searchbox`, Native 입력은
+  `search` 접근성 역할을 사용한다. clear는 선택 상태가 없는 버튼이며 기존 IconButton의 플랫폼 target
+  보정을 사용한다. 입력 callback과 clear callback은 별도 Actions로 관찰한다.
+- `SearchToolbar`는 별도의 toolbar다. 기존 48px 입력·Filled+Disabled의 비활성 clear 표시와
+  leading action·route focus lifecycle을 유지한다. SearchField로 rename하거나 치환하지 않는다.
+- Light/Dark는 공용 toolbar로 전환한다. 대표 상태는 disabled Off/On, Empty/Filled, 긴 label/value를
+  제공하며 자동 interaction은 Controls가 비활성화된 `*.tests.stories.tsx`에서 실행한다.
+
+2026-09-07 검증: `pnpm --filter @kosmo/app check`, 변경 story ESLint·Prettier,
+`pnpm --filter @kosmo/app build-storybook` 통과. `vitest run --project=storybook`으로 Switch·SearchField의
+main/Tests 파일 4개에서 8개 테스트와 위 표의 기존 consumer 테스트 4개가 통과했다. 기존
+`TextField.test.ts`·`IconButton.test.ts`의 단위 테스트 14개도 통과했다. 내장 Browser에서 Light/Dark,
+긴 label/value, disabled 상태와 Playground Controls·Actions를 확인했다. 기존 Posts consumer 검증에는
+Relay mock의 누락 field 경고가 남는다.
+
+Storybook의 자동 a11y 검사는 `color-contrast`를 제외하며 실제 screen reader나 Android/iOS runtime QA를
+의미하지 않는다. 해당 Settings runtime QA 소유자는 PROD-727이다. 이번에는 새 public API나 행동 계약을
+도입하지 않고 기존 계약을 검증하므로 새 OpenSpec은 만들지 않는다. Tailnet serve는 범위에서 제외한다.
+
 ## 제외 범위
 
 - Byulmaru ID Account Settings 페이지 자체와 Account 데이터 조회·입력·저장·관리 기능

--- a/docs/design/storybook.md
+++ b/docs/design/storybook.md
@@ -55,6 +55,7 @@ apps/app/src/stories/
 
 - Story는 `apps/app/src`의 실제 Production 컴포넌트나 screen을 직접 렌더링한다.
 - args를 controlled prop에 연결하거나 사용자 시나리오를 구성하는 얇은 fixture는 허용한다. Production UI, 상태 전이 또는 시각 구조를 story 전용 컴포넌트로 복제하지 않는다.
+- 승인된 이관 범위가 기존 Production primitive의 합성 가능성 검증이면, 해당 primitive를 직접 조합하는 consumer fixture도 허용한다. PROD-895의 SearchField는 기존 `TextField`·`IconButton`으로 leading icon·clear 배치, 입력 상태, disabled 시 clear 숨김과 clear 뒤 입력 focus 복귀를 검증한다. 이 범위에서는 새 public `SearchField`나 Production caller를 의무화하지 않으며, caller 부재만으로 컴포넌트 추출을 요구하지 않는다. 검증 결과는 primitive 합성과 UI 계약에 한정하고 실제 Search route·검색 결과·debounce·제품 정책의 회귀 검증으로 일반화하지 않는다. 기존 Production UI를 story 전용으로 복제해도 된다는 예외는 아니다.
 - Relay fragment component는 공용 `RelayStoryProvider`와 operation payload를 사용해 실제 fragment ref 계약을 유지한다. raw object를 generated `$key`로 cast하지 않는다.
 - 공용 Theme, Safe Area, Toast, Content Warning, Relay와 Router 환경은 `.storybook/preview.tsx`의 decorator와 mock을 재사용한다. component가 직접 소유하지 않는 provider를 일반 story마다 중복하지 않는다. 두 theme의 semantic style을 한 번에 비교하는 자동화 전용 `Tests` fixture만 명시적인 `ThemeProvider`를 중첩할 수 있다.
 - route·Relay·platform mock은 해당 story를 실행하는 데 필요한 최소 경계만 제공한다. mock 성공은 Production route, network, cache나 platform integration의 증거가 아니다.


### PR DESCRIPTION
## 무엇을 변경했나요

- React Native Switch의 Off/On·disabled와 콜백을 수동 Playground 및 별도 Tests에서 검증합니다.
- Production TextField·IconButton을 합성한 SearchField Playground와 입력·clear·focus 테스트를 추가합니다. Filled라도 disabled이면 clear를 숨깁니다.
- Figma source–component–story 매핑과 기존 ProfileEdit/Composer Switch consumer 검증, SearchToolbar와의 차이를 문서에 기록합니다.

## 왜 변경했나요

[PROD-895](https://linear.app/byulmaru/issue/PROD-895)의 기존 UI 재사용 계약을 독립적으로 검토할 수 있게 합니다. Figma [Switch](https://www.figma.com/design/Erj975S6vVP8PlHQius801?node-id=3324-22405)와 [SearchField](https://www.figma.com/design/Erj975S6vVP8PlHQius801?node-id=3899-1389)를 직접 대조했습니다.

## 이번 PR의 주요 결정

제품 계약의 신규 결정은 없습니다. PROD-895의 기존 결정에 따라 새 public wrapper 없이 Production primitive를 재사용합니다. SearchToolbar의 48px 입력과 disabled clear 표시는 유지하며, SearchField의 44px·disabled clear 숨김과 구분합니다. ProfileEdit의 Off=APPROVAL_REQUIRED, On=OPEN을 다른 Switch 정책으로 일반화하지 않습니다.

사용자 요청에 따라 main 기반 독립 PR로 진행합니다. 기존 계약 검증이므로 새 OpenSpec은 만들지 않았습니다.

Stack: main → prod-895 (1-layer).

## 어떻게 확인할 수 있나요

- 최신 main 반영 후 `pnpm --filter @kosmo/app check`, `pnpm --filter @kosmo/app build-storybook` 통과.
- 변경 파일 ESLint·Prettier 및 commit hook 통과.
- `pnpm --filter @kosmo/app exec vitest run --project=storybook src/stories/components/Switch.stories.tsx src/stories/components/Switch.tests.stories.tsx src/stories/patterns/SearchField.stories.tsx src/stories/patterns/SearchField.tests.stories.tsx`: 8개 통과.
- 기존 ProfileEdit FollowPolicy 2개와 Posts ComposerMediaStates/ComposerReplyMediaMutationContract 2개 통과. 기존 TextField·IconButton 단위 테스트 14개 통과.
- 내장 Browser에서 Light/Dark, disabled, 긴 label/value, Playground Controls·Actions를 확인했습니다. 자동 interaction은 Controls가 비활성화된 Tests로 분리했습니다.
- 구현 커밋 `0078b7365b20bbec9670fac9a5af57c83dd49539`의 로컬 독립 재리뷰: 계약·테스트 근거·불필요한 구현의 세 영역 모두 발견 사항 없음. Storybook 8개 재실행 및 GitHub CI 16개 통과.

- 문서 후속 커밋 `bfaf923011f4a7f988c232bc1d5a32270f484bb0`: 공통 Storybook 문서에 승인된 primitive 합성 fixture 범위를, icons.md에 Search route 18px와 Figma SearchField 20px·32px 버튼 차이를 명시했습니다. 독립 문서 리뷰·Prettier·diff 검사·commit hook 통과. 새 HEAD의 CI와 재리뷰는 별도 확인 대상입니다.

## Storybook 미리보기

Tailnet 전용 [Storybook](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/), HTTPS `6010` → 로컬 `6010`. 다른 PR의 기존 포트·경로와 분리했습니다.

빌드 커밋: `0078b7365b20bbec9670fac9a5af57c83dd49539`. [빌드 정보](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/preview-provenance.json). 호스트와 서버가 실행 중이고 Tailnet에 연결되어 있어야 접근할 수 있습니다.

- [KOSMO/Components/Switch / Playground](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-components-switch--playground)
- [KOSMO/Components/Switch / Representative States](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-components-switch--representative-states)
- [KOSMO/Components/Switch/Tests / Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-components-switch-tests--interaction-contract)
- [KOSMO/Components/Switch/Tests / Disabled Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-components-switch-tests--disabled-interaction-contract)
- [KOSMO/Patterns/Search Field / Playground](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-patterns-search-field--playground)
- [KOSMO/Patterns/Search Field / Representative States](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-patterns-search-field--representative-states)
- [KOSMO/Patterns/Search Field/Tests / Input Clear And Focus](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-patterns-search-field-tests--input-clear-and-focus)
- [KOSMO/Patterns/Search Field/Tests / Disabled Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6010/?path=/story/kosmo-patterns-search-field-tests--disabled-contract)

위 구현 커밋의 정적 빌드이며 Tailnet의 index·스토리 asset 일치를 확인했습니다. 후속 커밋은 디자인 문서 두 파일만 변경해 Storybook 코드와 asset은 동일합니다.

## 아직 어떤 문제가 남았나요

사람의 코드 리뷰가 남아 있습니다. GitHub 자동 보안 리뷰는 사용량 제한으로 실행되지 않았습니다. 기존 Posts consumer 검증에는 Relay mock의 누락 field 경고가 있습니다. Storybook a11y는 color-contrast를 제외하며 실제 Web screen reader·Android/iOS runtime QA는 검증하지 않았습니다. Settings runtime QA 소유자는 PROD-727로 유지합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>