### PR TITLE
PROD-901 decode-uri-component DoS 취약점을 패치한다

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN pnpm runtime set node ${NODE_VERSION} -g
 FROM base AS workspace
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 COPY apps/admin/package.json ./apps/admin/package.json
 COPY apps/api/package.json ./apps/api/package.json
 COPY apps/app/package.json ./apps/app/package.json

--- a/patches/decode-uri-component@0.5.0.patch
+++ b/patches/decode-uri-component@0.5.0.patch
@@ -1,0 +1,25 @@
+diff --git a/index.js b/index.js
+index 501f80d347a4397d473dcee1d0567b6e1f694ec7..3351a5f9fd719c8c7130c07fd9a8da9bbb7bd7b9 100644
+--- a/index.js
++++ b/index.js
+@@ -157,7 +157,7 @@ function customDecodeURIComponent(input) {
+ 	return input;
+ }
+ 
+-export default function decodeUriComponent(encodedURI) {
++module.exports = function decodeUriComponent(encodedURI) {
+ 	if (typeof encodedURI !== 'string') {
+ 		throw new TypeError(`Expected \`encodedURI\` to be of type \`string\`, got \`${typeof encodedURI}\``);
+ 	}
+diff --git a/package.json b/package.json
+index 8d01f060a3a2da1ee19861badf97d0b5db7192f6..bebb5dda3a2af3a24962b409487260836fb365a3 100644
+--- a/package.json
++++ b/package.json
+@@ -10,7 +10,6 @@
+ 		"email": "sam.verschueren@gmail.com",
+ 		"url": "github.com/SamVerschueren"
+ 	},
+-	"type": "module",
+ 	"exports": {
+ 		"types": "./index.d.ts",
+ 		"default": "./index.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,13 @@ overrides:
   cookie@<0.7.0: ^0.7.0
   esbuild@<0.28.1: ^0.28.1
   fbjs@3.0.5>ua-parser-js: 1.0.39
+  query-string@7.1.3>decode-uri-component: 0.5.0
   xcode@3.0.1>uuid: 11.1.1
   react-native-reanimated: 4.3.1
   react-native-worklets: 0.8.3
+
+patchedDependencies:
+  decode-uri-component@0.5.0: 98948870151581b58082ba6d11049564c999baeb94af582330a6d69f0f3ab9af
 
 importers:
 
@@ -4535,9 +4539,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
-  decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
-    engines: {node: '>=0.10'}
+  decode-uri-component@0.5.0:
+    resolution: {integrity: sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==}
+    engines: {node: '>=14.16'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -12410,7 +12414,7 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
-  decode-uri-component@0.2.2: {}
+  decode-uri-component@0.5.0(patch_hash=98948870151581b58082ba6d11049564c999baeb94af582330a6d69f0f3ab9af): {}
 
   deep-eql@5.0.2: {}
 
@@ -14710,7 +14714,7 @@ snapshots:
 
   query-string@7.1.3:
     dependencies:
-      decode-uri-component: 0.2.2
+      decode-uri-component: 0.5.0(patch_hash=98948870151581b58082ba6d11049564c999baeb94af582330a6d69f0f3ab9af)
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,5 +52,6 @@ overrides:
   'xcode@3.0.1>uuid': 11.1.1
   react-native-reanimated: 4.3.1
   react-native-worklets: 0.8.3
+# TODO(PROD-916): Remove this patch, its override, and patch file after a compatible upstream update.
 patchedDependencies:
   decode-uri-component@0.5.0: patches/decode-uri-component@0.5.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,8 +45,12 @@ overrides:
   esbuild@<0.28.1: ^0.28.1
   # Keep fbjs's declared parser without crossing into the later provenance-downgrade releases.
   'fbjs@3.0.5>ua-parser-js': 1.0.39
+  # query-string 7.1.3 is CommonJS; use the patched decoder below to preserve that contract.
+  'query-string@7.1.3>decode-uri-component': 0.5.0
   # xcode@3.0.1 requires uuid ^7 but only uses the CommonJS v4 API; uuid 11.1.1
   # preserves that API while resolving GHSA-w5hq-g745-h8pq.
   'xcode@3.0.1>uuid': 11.1.1
   react-native-reanimated: 4.3.1
   react-native-worklets: 0.8.3
+patchedDependencies:
+  decode-uri-component@0.5.0: patches/decode-uri-component@0.5.0.patch


### PR DESCRIPTION
## 무엇을 변경했나요

- `query-string@7.1.3`의 `decode-uri-component`를 안전한 `0.5.0`으로 좁게 override했습니다.
- upstream 0.5.0의 선형 디코딩 알고리즘은 그대로 두고, 기존 CommonJS 소비 계약을 유지하도록 pnpm patch로 패키지 형식만 변환했습니다.
- lockfile에서 취약한 `0.2.2`를 제거했습니다.
- Docker build의 dependency install 전에 `patches/`를 복사해 production image에서도 pnpm patch를 적용합니다.

## 왜 변경했나요

Web 번들에 포함된 `decode-uri-component@0.2.2`는 malformed percent-encoded 입력에서 지수적으로 CPU를 소모하는 CVE-2026-45822의 영향을 받습니다. 현재 Expo Router 계열을 유지하면서 취약 구현만 제거해 제품 동작과 업그레이드 범위를 최소화했습니다.

## 이번 PR의 주요 결정

- `query-string` major 업데이트는 Expo Router CommonJS 호환 범위를 벗어나므로 적용하지 않았습니다.
- patch는 `export default`를 `module.exports`로 바꾸고 `type: module`만 제거합니다. 보안 수정 알고리즘은 변경하지 않습니다.
- 제품 계약 변경이 없어 별도 OpenSpec change를 만들지 않았습니다.

## 검증

- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app test:unit` — 451 passed
- `pnpm --filter @kosmo/app build`
- production Web 번들 Chromium 직접 PoC — 1,000개 malformed token 0.4ms, 입력 보존, 정상 한글 decode 통과
- 로컬 Chromium smoke — `/`, `/search` 모두 200 및 경로 유지
- `docker build --target runtime --tag kosmo-admin-smoke .`
- Admin Image health, CSP, escaping, method, GraphQL smoke 통과

## 관련 이슈

- [PROD-901](https://linear.app/byulmaru/issue/PROD-901/decode-uri-component-cve-2026-45822의-web-런타임-dos를-패치한다)
