### PR TITLE
iOS 배포 성공 후 중복 검사로 실패하지 않게 한다

### DIFF
--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -77,7 +77,7 @@ platform :ios do
     )
   end
 
-  private_lane :write_testflight_summary do |uploaded_build:|
+  private_lane :write_testflight_summary do |app_version:, build_number:|
     summary_path = ENV['GITHUB_STEP_SUMMARY']
     return unless summary_path && !summary_path.empty?
 
@@ -85,7 +85,7 @@ platform :ios do
       file.puts('## iOS TestFlight internal testing')
       file.puts
       file.puts("- Bundle: `#{BUNDLE_IDENTIFIER}`")
-      file.puts("- Version: `#{uploaded_build.app_version} (#{uploaded_build.version})`")
+      file.puts("- Version: `#{app_version} (#{build_number})`")
       file.puts('- Processing: completed')
       file.puts('- TestFlight group: `Internal Testers`')
       file.puts("- Source: `#{ENV.fetch('GITHUB_SHA', 'local')}`")
@@ -185,8 +185,7 @@ platform :ios do
       api_key = load_apple_api_key
       app = Spaceship::ConnectAPI::App.find(BUNDLE_IDENTIFIER)
       matching_groups = (app&.get_beta_groups || []).select { |group| group.name == 'Internal Testers' }
-      internal_group = matching_groups.first
-      UI.user_error!('TestFlight group "Internal Testers" must exist exactly once as an internal group.') unless matching_groups.one? && internal_group.is_internal_group == true
+      UI.user_error!('TestFlight group "Internal Testers" must exist exactly once as an internal group.') unless matching_groups.one? && matching_groups.first.is_internal_group == true
 
       ipa_path = build_app(
         clean: true,
@@ -215,6 +214,7 @@ platform :ios do
       )
       ipa_path = File.expand_path(ipa_path.to_s)
       UI.user_error!("Fastlane did not produce a signed IPA at #{ipa_path}.") unless File.file?(ipa_path) && File.size?(ipa_path)
+      app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(ipa_path)
 
       upload_to_testflight(
         api_key: api_key,
@@ -226,21 +226,7 @@ platform :ios do
         skip_waiting_for_build_processing: false,
       )
 
-      uploaded_build = Spaceship::ConnectAPI::Build.all(
-        app_id: app.id,
-        build_number: build_number,
-        platform: Spaceship::ConnectAPI::Platform::IOS,
-        processing_states: Spaceship::ConnectAPI::Build::ProcessingState::VALID,
-      ).find do |build|
-        build.processing_state == Spaceship::ConnectAPI::Build::ProcessingState::VALID &&
-          build.bundle_id == BUNDLE_IDENTIFIER &&
-          build.version == build_number
-      end
-      UI.user_error!('Uploaded IPA was not found as a valid App Store Connect build.') unless uploaded_build
-      UI.user_error!('Uploaded App Store Connect build is not ready for internal testing.') unless uploaded_build.ready_for_internal_testing?
-      UI.user_error!('Uploaded App Store Connect build was not assigned to Internal Testers.') unless internal_group.fetch_builds.any? { |build| build.id == uploaded_build.id }
-
-      write_testflight_summary(uploaded_build: uploaded_build)
+      write_testflight_summary(app_version: app_version, build_number: build_number)
     rescue StandardError => error
       primary_error = error
     ensure


### PR DESCRIPTION
## 무엇을 변경했는지

- TestFlight 내부 배포가 끝난 뒤 실행하던 App Store Connect 빌드 재조회와 readiness 검증을 제거했습니다.
- Internal Testers 그룹 재조회·재검증도 제거했습니다.
- 업로드 대상 IPA에서 확인한 앱 버전과 workflow에서 확보한 빌드 번호를 사용해 GitHub Step Summary를 작성하도록 정리했습니다.

## 왜 변경했는지

Run 34084279307은 App Store Connect 업로드와 processing, Internal testers 배포까지 성공했지만, 배포 후 `ready_for_internal_testing?` 검증이 이미 `IN_BETA_TESTING` 상태가 된 빌드를 준비 전으로 판단해 exit code 1을 반환했습니다. 그 결과 실제 배포는 완료됐는데 Actions만 실패로 표시되고 요약 작성에도 도달하지 못했습니다.

## 이번 PR의 주요 결정

사용자가 배포 후 중복 검증을 제거하고 요약만 남기도록 결정했습니다. `upload_to_testflight`가 processing 대기와 내부 그룹 배포를 담당하므로 같은 결과를 배포 후 다시 원격 조회하지 않습니다. 업로드 전 Internal Testers 그룹 존재 검증은 유지했습니다. 별도 이슈는 생성하지 않았습니다.

## 어떻게 확인할 수 있는지

- `ruby -c apps/app/fastlane/Fastfile`
- `actionlint .github/workflows/ios-app-store-connect-upload.yml`
- `git diff --check`
- test_evidence worker가 Fastlane lane 검증을 성공했습니다.
- 실제 App Store Connect 업로드는 재실행하지 않았습니다.
- 로컬에는 bundle exec 및 CocoaPods 잠금 의존성이 설치되어 있지 않아 전체 Fastlane 실행은 수행하지 않았습니다.

## 아직 어떤 문제가 남았는지

실제 iOS CI 업로드는 다음 정상 실행에서 수정 결과를 확인해야 합니다.

Stack: `main -> fix-ios-upload-success-status`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>