### PR TITLE
Fedify 테스트 서버의 포트 사전 예약을 제거한다

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -17,6 +17,11 @@ if (import.meta.main) {
     });
     server.listen(port, host);
     await once(server, 'listening');
+    const listeningAddress = server.address();
+    if (listeningAddress === null || typeof listeningAddress === 'string') {
+      throw new Error('Unable to determine the Worker health port.');
+    }
+    process.send?.(listeningAddress.port);
 
     const terminateDuringStartup = () => {
       process.off('SIGTERM', terminateDuringStartup);

--- a/apps/worker/src/temporal-test-server.ts
+++ b/apps/worker/src/temporal-test-server.ts
@@ -8,8 +8,8 @@ const temporalPortValue = process.env.TEMPORAL_PORT?.trim();
 const temporalPort = temporalPortValue ? Number(temporalPortValue) : undefined;
 const namespace = process.env.TEMPORAL_NAMESPACE?.trim();
 
-if (!Number.isInteger(healthPort) || healthPort < 1 || healthPort > 65_535) {
-  throw new Error('PORT must be an integer between 1 and 65535');
+if (!Number.isInteger(healthPort) || healthPort < 0 || healthPort > 65_535) {
+  throw new Error('PORT must be an integer between 0 and 65535');
 }
 if (
   temporalPort !== undefined &&
@@ -38,6 +38,11 @@ const healthServer = createServer((request, response) => {
 try {
   healthServer.listen(healthPort, host);
   await once(healthServer, 'listening');
+  const address = healthServer.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Unable to determine the Temporal test health port.');
+  }
+  process.send?.(address.port);
   await Promise.race([once(process, 'SIGINT'), once(process, 'SIGTERM')]);
 } finally {
   await healthServer[Symbol.asyncDispose]();

--- a/apps/worker/src/worker.test.ts
+++ b/apps/worker/src/worker.test.ts
@@ -15,11 +15,19 @@ test('Temporal environment를 검증한다', async () => {
   assert.throws(
     () =>
       validateWorkerEnvironment({
-        PORT: '0',
+        PORT: '-1',
         TEMPORAL_ADDRESS: 'temporal.test:7233',
         TEMPORAL_NAMESPACE: 'kosmo-test',
       }),
     /PORT must be an integer/,
+  );
+  assert.equal(
+    validateWorkerEnvironment({
+      PORT: '0',
+      TEMPORAL_ADDRESS: 'temporal.test:7233',
+      TEMPORAL_NAMESPACE: 'kosmo-test',
+    }).port,
+    0,
   );
 });
 
@@ -47,12 +55,6 @@ test('Temporal connect 중 SIGTERM을 process 종료로 전달한다', { timeout
     return temporal[Symbol.asyncDispose]();
   });
 
-  const healthPortReservation = createServer();
-  healthPortReservation.listen(0, '127.0.0.1');
-  await once(healthPortReservation, 'listening');
-  const healthPort = (healthPortReservation.address() as AddressInfo).port;
-  await healthPortReservation[Symbol.asyncDispose]();
-
   const temporalPort = (temporal.address() as AddressInfo).port;
   const child = spawn(
     process.execPath,
@@ -62,15 +64,25 @@ test('Temporal connect 중 SIGTERM을 process 종료로 전달한다', { timeout
       env: {
         ...process.env,
         HOST: '127.0.0.1',
-        PORT: String(healthPort),
+        PORT: '0',
         TEMPORAL_ADDRESS: `127.0.0.1:${temporalPort}`,
         TEMPORAL_NAMESPACE: 'test',
       },
+      stdio: ['ignore', 'ignore', 'inherit', 'ipc'],
     },
   );
   t.after(() => child.kill('SIGKILL'));
 
+  const portPromise = once(child, 'message');
   await once(temporal, 'connection');
+  const [port] = await portPromise;
+  assert.equal(typeof port, 'number');
+  assert.ok(port > 0 && port <= 65_535);
+  const healthResponse = await fetch(`http://127.0.0.1:${port}/ready`);
+  assert.equal(healthResponse.status, 503);
+  if (child.connected) {
+    child.disconnect();
+  }
   child.kill('SIGTERM');
   const [code, signal] = await once(child, 'exit');
 

--- a/apps/worker/src/worker.test.ts
+++ b/apps/worker/src/worker.test.ts
@@ -21,14 +21,6 @@ test('Temporal environment를 검증한다', async () => {
       }),
     /PORT must be an integer/,
   );
-  assert.equal(
-    validateWorkerEnvironment({
-      PORT: '0',
-      TEMPORAL_ADDRESS: 'temporal.test:7233',
-      TEMPORAL_NAMESPACE: 'kosmo-test',
-    }).port,
-    0,
-  );
 });
 
 test('SDK Worker 상태를 health 응답에 그대로 반영한다', () => {

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -25,8 +25,8 @@ export function validateWorkerEnvironment(environment: NodeJS.ProcessEnv): {
   if (!namespace) {
     throw new Error('TEMPORAL_NAMESPACE is required');
   }
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    throw new Error('PORT must be an integer between 1 and 65535');
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error('PORT must be an integer between 0 and 65535');
   }
 
   return {

--- a/packages/core/temporal/test-runtime.ts
+++ b/packages/core/temporal/test-runtime.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
-import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import type { ChildProcess } from 'node:child_process';
 
@@ -26,7 +25,6 @@ export const startTestTemporalRuntime = async (): Promise<void> => {
 async function startRuntime(): Promise<void> {
   const host = '127.0.0.1';
   const namespace = process.env.TEMPORAL_NAMESPACE?.trim() || 'test';
-  const [healthPort, workerPort] = await Promise.all([findFreePort(host), findFreePort(host)]);
   const databaseUrl = process.env.DATABASE_URL ?? defaultDatabaseUrl;
   const workerEnvironment: NodeJS.ProcessEnv = {
     ...process.env,
@@ -36,7 +34,7 @@ async function startRuntime(): Promise<void> {
     FEDIFY_QUEUE_DATABASE_URL: databaseUrl,
     HOST: host,
     NODE_ENV: process.env.NODE_ENV ?? 'test',
-    PORT: String(workerPort),
+    PORT: '0',
     PUBLIC_ORIGIN: process.env.PUBLIC_ORIGIN ?? 'http://127.0.0.1:4173',
     TEMPORAL_NAMESPACE: namespace,
   };
@@ -44,16 +42,16 @@ async function startRuntime(): Promise<void> {
     cwd: workerDirectory,
     env: {
       ...workerEnvironment,
-      PORT: String(healthPort),
       TEMPORAL_PORT: undefined,
     },
     // Keep startup failures visible in CI and avoid keeping the parent alive
     // with a long-lived stderr pipe after the children are unref'ed.
-    stdio: ['ignore', 'ignore', 'inherit'],
+    stdio: ['ignore', 'ignore', 'inherit', 'ipc'],
   });
   let worker: ChildProcess | undefined;
 
   try {
+    const healthPort = await waitForChildPort(server, startupTimeoutMs);
     workerEnvironment.TEMPORAL_ADDRESS = await waitForChildHealth(
       `http://${host}:${healthPort}/health`,
       server,
@@ -62,8 +60,9 @@ async function startRuntime(): Promise<void> {
     worker = spawn(process.execPath, ['--import', 'tsx', 'src/index.ts'], {
       cwd: workerDirectory,
       env: workerEnvironment,
-      stdio: ['ignore', 'ignore', 'inherit'],
+      stdio: ['ignore', 'ignore', 'inherit', 'ipc'],
     });
+    const workerPort = await waitForChildPort(worker, startupTimeoutMs);
     await waitForChildHealth(`http://${host}:${workerPort}/ready`, worker, startupTimeoutMs);
   } catch (error) {
     terminate(server);
@@ -94,20 +93,6 @@ async function startRuntime(): Promise<void> {
     terminateChildren();
     process.exit(143);
   });
-}
-
-async function findFreePort(host: string): Promise<number> {
-  const reservation = createServer();
-  reservation.listen(0, host);
-  await once(reservation, 'listening');
-  const address = reservation.address();
-  if (address === null || typeof address === 'string') {
-    await closeServer(reservation);
-    throw new Error('Unable to determine a free local port for Temporal tests.');
-  }
-  const port = address.port;
-  await closeServer(reservation);
-  return port;
 }
 
 async function waitForHealth(url: string, child: ChildProcess, timeoutMs: number): Promise<string> {
@@ -141,6 +126,43 @@ async function waitForHealth(url: string, child: ChildProcess, timeoutMs: number
   );
 }
 
+async function waitForChildPort(child: ChildProcess, timeoutMs: number): Promise<number> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const message = await Promise.race([
+      once(child, 'message', { signal: controller.signal }).then(([value]) => value),
+      once(child, 'exit', { signal: controller.signal }).then(() => {
+        throw new Error(`Child process exited before binding a port (${formatChildExit(child)})`);
+      }),
+    ]);
+    if (
+      typeof message !== 'number' ||
+      !Number.isInteger(message) ||
+      message < 1 ||
+      message > 65_535
+    ) {
+      throw new Error(`Child process sent an invalid listening port (${formatChildExit(child)})`);
+    }
+    return message;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `Timed out waiting for child process to bind a port (${formatChildExit(child)})`,
+        { cause: error },
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    controller.abort();
+    if (child.connected) {
+      child.disconnect();
+    }
+  }
+}
+
 async function waitForChildHealth(
   url: string,
   child: ChildProcess,
@@ -171,10 +193,4 @@ function terminate(child: ChildProcess): void {
   if (child.exitCode === null && child.signalCode === null) {
     child.kill('SIGTERM');
   }
-}
-
-function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
-  return new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
 }


### PR DESCRIPTION
## 무엇을 변경했는지

테스트용 Temporal health 서버와 Worker가 `PORT=0`으로 직접 소켓을 열고, 실제 포트를 Node IPC로 부모에 전달합니다. 부모의 `findFreePort` 사전 예약을 제거하고 IPC 메시지·종료·오류·타임아웃 및 연결 정리를 처리합니다. 기존 Web E2E 고정 포트와 일반 Worker 기본값은 유지합니다.

## 왜 변경했는지

#775는 Temporal gRPC 포트의 SDK 할당만 복구했고, health·Worker 포트에는 `listen(0) → close → child listen` 경쟁 조건을 남겼습니다. #775가 포함된 #781의 [Fedify CI](https://github.com/byulmaru/kosmo/actions/runs/34096782596/job/101662100979)는 Worker의 `127.0.0.1:39789` 바인딩에서 `EADDRINUSE`로 실패했습니다(`inbound-accept-reject.test.ts`, 213 pass/1 fail).

이번에는 자식이 소켓을 보유한 상태에서 포트를 전달하므로 해당 사전 예약 간격을 없앱니다. 당시 포트를 점유한 프로세스 자체는 확인되지 않았습니다.

## 이번 PR의 주요 결정

새 제품 계약·OpenSpec은 없습니다. 표준 Node IPC와 `events.once`를 사용하고 테스트 재시도·skip·assertion 완화는 추가하지 않습니다.

## 어떻게 확인할 수 있는지

- Worker build 및 unit 3개 통과: 포트 0 허용, 음수 거부, 실제 IPC 포트의 `/ready` 응답과 SIGTERM 처리 확인.
- 최신 main 기반 Temporal child smoke 통과: IPC로 받은 health 포트에서 HTTP 200과 실제 Temporal 주소를 확인하고 정상 종료.
- 테스트 런타임 타입 검사, 변경 파일 Prettier, `git diff --check` 통과.
- `6f1be4f12`의 [CI](https://github.com/byulmaru/kosmo/actions/runs/34099979026)에서 Fedify·Core·Worker·API 및 Web E2E 세 shard를 포함한 PR 검사 16개가 모두 통과했습니다.
- Luna `fix_owner`가 구현·실행 검증, `ci_evidence`가 실패 로그·동작 검토, `minimality`가 Ponytail 검토를 담당했습니다.

## 아직 어떤 문제가 남았는지

Temporal gRPC 자체의 SDK allocator 한계는 이전과 같으며, 이 PR은 부모가 사전 예약하던 두 HTTP 포트의 경쟁 조건을 제거합니다.

Stack: `main -> fix/temporal-test-runtime-port-race` (1-layer Stack)
