### PR TITLE
최신 main의 Terraform 계획을 수동으로 적용할 수 있게 한다

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,6 +1,7 @@
 name: Terraform
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -218,15 +219,194 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ github.retention_days }}
 
-  apply:
-    name: Terraform Apply
-    if: ${{ github.event_name == 'push' }}
+  manual-plan:
+    name: Terraform Manual Plan
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04-arm
     environment: terraform-apply
 
     steps:
+      - name: Validate manual ref
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Manual Terraform recovery is allowed only for refs/heads/main; got ${GITHUB_REF}." >&2
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: byulmaru-kosmo
+          workload_identity_provider: ${{ vars.GCP_TERRAFORM_PROVIDER }}
+          service_account: ${{ vars.GCP_TERRAFORM_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
+          cleanup_credentials: true
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: tag:github-actions
+
+      - name: Authenticate to Argo CD
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const githubToken = await core.getIDToken();
+            core.setSecret(githubToken);
+
+            const response = await fetch(`https://${process.env.ARGOCD_SERVER}/api/dex/token`, {
+              method: "POST",
+              headers: {
+                authorization: `Basic ${Buffer.from("argo-cd-cli:").toString("base64")}`,
+              },
+              body: new URLSearchParams({
+                connector_id: "github-actions",
+                grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+                scope: "openid email profile federated:id",
+                requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
+                subject_token: githubToken,
+                subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
+              }),
+            });
+
+            if (!response.ok) {
+              throw new Error(`Dex token exchange failed: ${response.status} ${await response.text()}`);
+            }
+
+            const { access_token: dexToken } = await response.json();
+            if (!dexToken) {
+              throw new Error("Dex token response did not include an access token.");
+            }
+
+            core.setSecret(dexToken);
+            core.exportVariable("ARGOCD_AUTH_TOKEN", dexToken);
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: '1.15.6'
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform init
+
+      - name: Terraform validate
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform validate
+
+      - name: Terraform plan
+        working-directory: ${{ env.TF_ROOT }}
+        run: terraform plan -input=false -out=terraform.tfplan
+
+      - name: Render Terraform plan
+        working-directory: ${{ env.TF_ROOT }}
+        run: |
+          set -euo pipefail
+
+          terraform show -no-color terraform.tfplan > terraform.tfplan.txt
+          {
+            echo "TF_PLAN_EVENT_NAME=${GITHUB_EVENT_NAME}"
+            echo "TF_PLAN_COMMIT_SHA=${GITHUB_SHA}"
+          } > plan.env
+
+          plan_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          total_lines="$(wc -l < terraform.tfplan.txt)"
+          {
+            echo "## Terraform plan"
+            echo
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Workflow run: [${GITHUB_RUN_ID}](${plan_url})"
+            echo "- Apply: this run will apply this saved plan with Terraform's native stale-plan validation"
+            echo
+            echo "<details>"
+            echo "<summary>terraform show -no-color terraform.tfplan</summary>"
+            echo
+            echo '```terraform'
+            sed -n '1,600p' terraform.tfplan.txt
+            if [[ "${total_lines}" -gt 600 ]]; then
+              echo "... truncated; download the artifact for the full plan ..."
+            fi
+            echo '```'
+            echo "</details>"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Save Terraform plan
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.TF_PLAN_ARTIFACT }}
+          path: |
+            apps/terraform/terraform.tfplan
+            apps/terraform/terraform.tfplan.txt
+            apps/terraform/plan.env
+          if-no-files-found: error
+          retention-days: ${{ github.retention_days }}
+
+  apply:
+    name: Terraform Apply
+    needs: manual-plan
+    if: ${{ always() && !cancelled() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && needs.manual-plan.result == 'success')) }}
+    runs-on: ubuntu-24.04-arm
+    environment: terraform-apply
+
+    steps:
+      - name: Validate manual ref
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Manual Terraform recovery is allowed only for refs/heads/main; got ${GITHUB_REF}." >&2
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download same-run Terraform plan
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh run download "${GITHUB_RUN_ID}" --name "${TF_PLAN_ARTIFACT}" --dir "${TF_ROOT}"
+
+          plan_env() {
+            awk -F= -v key="$1" '$1 == key { print substr($0, length(key) + 2); exit }' "${TF_ROOT}/plan.env"
+          }
+
+          planned_event_name="$(plan_env TF_PLAN_EVENT_NAME)"
+          planned_commit_sha="$(plan_env TF_PLAN_COMMIT_SHA)"
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [[ "${planned_event_name}" != "workflow_dispatch" || "${planned_commit_sha}" != "${GITHUB_SHA}" || "${checked_out_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "Downloaded manual plan metadata does not match this workflow dispatch SHA." >&2
+            exit 1
+          fi
+
+          {
+            echo "TF_PLAN_SOURCE_EVENT=${planned_event_name}"
+            echo "TF_PLAN_SOURCE_COMMIT=${planned_commit_sha}"
+            echo "TF_PLAN_SOURCE_RUN_ID=${GITHUB_RUN_ID}"
+            echo "TF_PLAN_SOURCE_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "${GITHUB_ENV}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
@@ -302,6 +482,7 @@ jobs:
         run: terraform init
 
       - name: Download reviewed Terraform plan
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -366,6 +547,7 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Compare reviewed and current Terraform plans
+        if: ${{ github.event_name == 'push' }}
         working-directory: ${{ env.TF_ROOT }}
         run: |
           set -euo pipefail
@@ -432,12 +614,24 @@ jobs:
           fi
 
       - name: Summarize Terraform apply
+        if: ${{ github.event_name == 'push' }}
         run: |
           {
             echo "## Terraform apply"
             echo
             echo "The current main plan matches the reviewed plan from \`${TF_PLAN_SOURCE_EVENT}\` commit \`${TF_PLAN_SOURCE_COMMIT}\`."
             echo "Applying that reviewed saved plan."
+            echo "Terraform will perform its native stale-plan validation before changing infrastructure."
+            echo "- Plan workflow run: [${TF_PLAN_SOURCE_RUN_ID}](${TF_PLAN_SOURCE_URL})"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Summarize manual Terraform apply
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          {
+            echo "## Terraform manual apply"
+            echo
+            echo "Applying the saved Terraform plan produced earlier in this same workflow run for commit \`${TF_PLAN_SOURCE_COMMIT}\`."
             echo "Terraform will perform its native stale-plan validation before changing infrastructure."
             echo "- Plan workflow run: [${TF_PLAN_SOURCE_RUN_ID}](${TF_PLAN_SOURCE_URL})"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -219,148 +219,9 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ github.retention_days }}
 
-  manual-plan:
-    name: Terraform Manual Plan
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-24.04-arm
-    environment: terraform-apply
-
-    steps:
-      - name: Validate manual ref
-        run: |
-          set -euo pipefail
-
-          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
-            echo "Manual Terraform recovery is allowed only for refs/heads/main; got ${GITHUB_REF}." >&2
-            exit 1
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
-        with:
-          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          project_id: byulmaru-kosmo
-          workload_identity_provider: ${{ vars.GCP_TERRAFORM_PROVIDER }}
-          service_account: ${{ vars.GCP_TERRAFORM_SERVICE_ACCOUNT }}
-          create_credentials_file: true
-          export_environment_variables: true
-          cleanup_credentials: true
-
-      - name: Connect to Tailscale
-        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
-        with:
-          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
-          audience: ${{ vars.TAILSCALE_AUDIENCE }}
-          tags: tag:github-actions
-
-      - name: Authenticate to Argo CD
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const githubToken = await core.getIDToken();
-            core.setSecret(githubToken);
-
-            const response = await fetch(`https://${process.env.ARGOCD_SERVER}/api/dex/token`, {
-              method: "POST",
-              headers: {
-                authorization: `Basic ${Buffer.from("argo-cd-cli:").toString("base64")}`,
-              },
-              body: new URLSearchParams({
-                connector_id: "github-actions",
-                grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-                scope: "openid email profile federated:id",
-                requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
-                subject_token: githubToken,
-                subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
-              }),
-            });
-
-            if (!response.ok) {
-              throw new Error(`Dex token exchange failed: ${response.status} ${await response.text()}`);
-            }
-
-            const { access_token: dexToken } = await response.json();
-            if (!dexToken) {
-              throw new Error("Dex token response did not include an access token.");
-            }
-
-            core.setSecret(dexToken);
-            core.exportVariable("ARGOCD_AUTH_TOKEN", dexToken);
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-        with:
-          terraform_version: '1.15.6'
-
-      - name: Terraform init
-        working-directory: ${{ env.TF_ROOT }}
-        run: terraform init
-
-      - name: Terraform validate
-        working-directory: ${{ env.TF_ROOT }}
-        run: terraform validate
-
-      - name: Terraform plan
-        working-directory: ${{ env.TF_ROOT }}
-        run: terraform plan -input=false -out=terraform.tfplan
-
-      - name: Render Terraform plan
-        working-directory: ${{ env.TF_ROOT }}
-        run: |
-          set -euo pipefail
-
-          terraform show -no-color terraform.tfplan > terraform.tfplan.txt
-          {
-            echo "TF_PLAN_EVENT_NAME=${GITHUB_EVENT_NAME}"
-            echo "TF_PLAN_COMMIT_SHA=${GITHUB_SHA}"
-          } > plan.env
-
-          plan_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          total_lines="$(wc -l < terraform.tfplan.txt)"
-          {
-            echo "## Terraform plan"
-            echo
-            echo "- Commit: \`${GITHUB_SHA}\`"
-            echo "- Workflow run: [${GITHUB_RUN_ID}](${plan_url})"
-            echo "- Apply: this run will apply this saved plan with Terraform's native stale-plan validation"
-            echo
-            echo "<details>"
-            echo "<summary>terraform show -no-color terraform.tfplan</summary>"
-            echo
-            echo '```terraform'
-            sed -n '1,600p' terraform.tfplan.txt
-            if [[ "${total_lines}" -gt 600 ]]; then
-              echo "... truncated; download the artifact for the full plan ..."
-            fi
-            echo '```'
-            echo "</details>"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Save Terraform plan
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ env.TF_PLAN_ARTIFACT }}
-          path: |
-            apps/terraform/terraform.tfplan
-            apps/terraform/terraform.tfplan.txt
-            apps/terraform/plan.env
-          if-no-files-found: error
-          retention-days: ${{ github.retention_days }}
-
   apply:
     name: Terraform Apply
-    needs: manual-plan
-    if: ${{ always() && !cancelled() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && needs.manual-plan.result == 'success')) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04-arm
     environment: terraform-apply
 
@@ -379,34 +240,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.sha }}
-
-      - name: Download same-run Terraform plan
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          gh run download "${GITHUB_RUN_ID}" --name "${TF_PLAN_ARTIFACT}" --dir "${TF_ROOT}"
-
-          plan_env() {
-            awk -F= -v key="$1" '$1 == key { print substr($0, length(key) + 2); exit }' "${TF_ROOT}/plan.env"
-          }
-
-          planned_event_name="$(plan_env TF_PLAN_EVENT_NAME)"
-          planned_commit_sha="$(plan_env TF_PLAN_COMMIT_SHA)"
-          checked_out_sha="$(git rev-parse HEAD)"
-          if [[ "${planned_event_name}" != "workflow_dispatch" || "${planned_commit_sha}" != "${GITHUB_SHA}" || "${checked_out_sha}" != "${GITHUB_SHA}" ]]; then
-            echo "Downloaded manual plan metadata does not match this workflow dispatch SHA." >&2
-            exit 1
-          fi
-
-          {
-            echo "TF_PLAN_SOURCE_EVENT=${planned_event_name}"
-            echo "TF_PLAN_SOURCE_COMMIT=${planned_commit_sha}"
-            echo "TF_PLAN_SOURCE_RUN_ID=${GITHUB_RUN_ID}"
-            echo "TF_PLAN_SOURCE_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          } >> "${GITHUB_ENV}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
@@ -625,18 +458,7 @@ jobs:
             echo "- Plan workflow run: [${TF_PLAN_SOURCE_RUN_ID}](${TF_PLAN_SOURCE_URL})"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Summarize manual Terraform apply
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          {
-            echo "## Terraform manual apply"
-            echo
-            echo "Applying the saved Terraform plan produced earlier in this same workflow run for commit \`${TF_PLAN_SOURCE_COMMIT}\`."
-            echo "Terraform will perform its native stale-plan validation before changing infrastructure."
-            echo "- Plan workflow run: [${TF_PLAN_SOURCE_RUN_ID}](${TF_PLAN_SOURCE_URL})"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Terraform apply saved plan
+      - name: Terraform apply
         working-directory: ${{ env.TF_ROOT }}
         run: |
           set -euo pipefail
@@ -655,7 +477,11 @@ jobs:
           }
 
           trap cleanup_lock_on_cancel INT TERM
-          terraform apply -auto-approve terraform.tfplan &
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            terraform apply -auto-approve &
+          else
+            terraform apply -auto-approve terraform.tfplan &
+          fi
           terraform_pid=$!
           wait "${terraform_pid}"
 

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -60,7 +60,11 @@ terraform output -raw android_play_workload_identity_provider
 
 PR이 `main`에 병합되면 현재 main에서 plan을 새로 만들고, configuration, variables, 실제 action이 `no-op`이 아닌 resource changes, output changes와 checks가 reviewed plan과 같은지 확인한다. 이 JSON 비교는 sensitive value의 차이를 보존하되 Argo CD Application의 resource version이나 reconcile 시각처럼 실행 사이에 바뀌는 no-op 관측 상태는 제외한다. plan이 다르면 current plan을 자동 적용하지 않고 중단하며, 같으면 reviewed saved plan을 그대로 apply하므로 Terraform의 native stale-plan 검증도 유지된다. 여러 Terraform PR이 같은 merge queue 배치에 포함되어 plan이 달라지면 즉시 apply하지 않고 실패한다. 비교용 JSON은 로그나 artifact에 남기지 않고 job 안에서 삭제한다. plan과 apply는 같은 GCP 서비스 계정과 AWS role을 사용한다.
 
+Terraform workflow는 `main`에서만 `workflow_dispatch` 수동 recovery를 허용한다. 수동 Plan과 이어지는 Apply는 모두 `terraform-apply` Environment를 사용해 기존 AWS subject를 재사용하며, 수동 Plan은 선택한 `github.sha`를 checkout하고 같은 run의 saved plan만 적용한다. Plan 실패, artifact 누락 또는 SHA 불일치이면 Apply를 시작하지 않는다. PR Plan은 기존처럼 Environment 없이 실행하고, push 경로는 병합된 PR의 reviewed plan과 현재 plan을 비교하는 기존 계약을 유지한다.
+
 외부 기여자의 PR workflow는 기여 이력과 무관하게 저장소 관리자의 실행 승인을 받아야 한다. Repository의 Actions 설정에서 fork pull request 승인 정책을 `all_external_contributors`로 직접 관리하며, 조직 구성원의 PR만 자동 실행한다.
+
+Terraform CI용 `kosmo-terraform` WIF provider는 숫자 `repository_id`와 `refs/heads/main`, 또는 `pull_request`의 `base_ref == main`만 신뢰한다. 따라서 같은 repository의 main/PR workflow는 공통 provider를 사용할 수 있고, owner ID·workflow ref·Environment와 main 경로의 event 이름은 GCP condition으로 제한하지 않는다. PR 예외는 읽기 전용으로 간주하지 않으며, 이 조건 변경은 기존 main push Apply로 먼저 반영한 뒤 수동 recovery를 사용한다. AWS trust, `terraform-apply` Environment, Firebase/native-distribution provider와 다른 repository의 실행은 이 설정으로 변경되지 않는다.
 
 로컬 bootstrap 또는 복구가 필요할 때는 아래 순서로 실행한다.
 

--- a/apps/terraform/README.md
+++ b/apps/terraform/README.md
@@ -60,7 +60,7 @@ terraform output -raw android_play_workload_identity_provider
 
 PR이 `main`에 병합되면 현재 main에서 plan을 새로 만들고, configuration, variables, 실제 action이 `no-op`이 아닌 resource changes, output changes와 checks가 reviewed plan과 같은지 확인한다. 이 JSON 비교는 sensitive value의 차이를 보존하되 Argo CD Application의 resource version이나 reconcile 시각처럼 실행 사이에 바뀌는 no-op 관측 상태는 제외한다. plan이 다르면 current plan을 자동 적용하지 않고 중단하며, 같으면 reviewed saved plan을 그대로 apply하므로 Terraform의 native stale-plan 검증도 유지된다. 여러 Terraform PR이 같은 merge queue 배치에 포함되어 plan이 달라지면 즉시 apply하지 않고 실패한다. 비교용 JSON은 로그나 artifact에 남기지 않고 job 안에서 삭제한다. plan과 apply는 같은 GCP 서비스 계정과 AWS role을 사용한다.
 
-Terraform workflow는 `main`에서만 `workflow_dispatch` 수동 recovery를 허용한다. 수동 Plan과 이어지는 Apply는 모두 `terraform-apply` Environment를 사용해 기존 AWS subject를 재사용하며, 수동 Plan은 선택한 `github.sha`를 checkout하고 같은 run의 saved plan만 적용한다. Plan 실패, artifact 누락 또는 SHA 불일치이면 Apply를 시작하지 않는다. PR Plan은 기존처럼 Environment 없이 실행하고, push 경로는 병합된 PR의 reviewed plan과 현재 plan을 비교하는 기존 계약을 유지한다.
+Terraform workflow는 `main`에서만 `workflow_dispatch` 수동 recovery를 허용한다. 수동 실행은 기존 Apply job에서 선택한 `github.sha`를 checkout하고, main ref guard와 기존 AWS/GCP/Tailscale/Argo 인증·Terraform 초기화 뒤 `terraform apply -auto-approve`를 한 번 직접 실행한다. 별도 Manual Plan job, `needs`, `terraform plan`, saved plan 파일, artifact 전달과 SHA metadata 검증은 사용하지 않으며 Terraform Apply 자체의 내부 계획 계산을 사용한다. PR Plan은 기존처럼 Environment 없이 실행하고, push 경로는 병합된 PR의 reviewed plan과 현재 plan을 비교한 뒤 reviewed saved plan을 적용하는 기존 계약을 유지한다.
 
 외부 기여자의 PR workflow는 기여 이력과 무관하게 저장소 관리자의 실행 승인을 받아야 한다. Repository의 Actions 설정에서 fork pull request 승인 정책을 `all_external_contributors`로 직접 관리하며, 조직 구성원의 PR만 자동 실행한다.
 

--- a/apps/terraform/main.tf
+++ b/apps/terraform/main.tf
@@ -218,9 +218,7 @@ resource "google_iam_workload_identity_pool_provider" "terraform" {
   }
   attribute_condition = join(" && ", [
     "assertion.repository_id == '${local.github_repository_id}'",
-    "assertion.repository_owner_id == '${local.github_owner_id}'",
-    "assertion.workflow_ref.startsWith('${local.github_owner}/${local.github_repository}/.github/workflows/terraform.yml@')",
-    "((assertion.event_name == 'pull_request' && assertion.base_ref == 'main') || (assertion.event_name == 'push' && assertion.ref == 'refs/heads/main' && assertion.environment == '${local.terraform_apply_environment}'))",
+    "(assertion.ref == 'refs/heads/main' || (assertion.event_name == 'pull_request' && assertion.base_ref == 'main'))",
   ])
 
   oidc {

--- a/openspec/changes/manual-terraform-recovery/.openspec.yaml
+++ b/openspec/changes/manual-terraform-recovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-09-06

--- a/openspec/changes/manual-terraform-recovery/decisions.md
+++ b/openspec/changes/manual-terraform-recovery/decisions.md
@@ -1,0 +1,63 @@
+## Context
+
+이 decision log는 [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)의 승인된 수동 recovery 범위와 현재 Terraform 운영 context를 구현 가능한 durable choice로 정리한다. 기존 자동 apply 계약은 [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다)가 최신 authority이고, [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다)는 semantic comparison과 native stale validation의 배경이다.
+
+## Decision Records
+
+### 수동 recovery는 main의 선택된 SHA에서 Plan 후 즉시 Apply한다
+
+- Decision Date: 2026-09-07
+- Decision Class: Derived Contract
+- Authority / Provenance: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- Status: Active
+- Context / Problem: 기존 main push 자동 경로의 reviewed/current comparison이 실패했을 때, 최신 main을 운영자가 명시적으로 복구할 수 있는 경로가 필요하다. 다른 run·PR의 artifact를 고르면 reviewed plan 경계를 다시 섞을 수 있다.
+- Decision Outcome: `workflow_dispatch`는 `refs/heads/main`에서만 허용하고, 별도 target SHA나 확인 입력 없이 dispatch가 선택한 `github.sha`를 기준으로 항상 Plan을 먼저 만든 뒤 성공한 same-run saved plan만 즉시 Apply한다. Apply는 다른 run·PR artifact를 검색하지 않고 dispatch SHA와 saved plan source SHA를 확인한다.
+- Alternatives Considered: Plan-only 기본값, `confirm_apply` 입력, 별도 reviewer approval, 임의 target SHA 입력은 사용자가 선택한 항상 Plan 후 Apply와 main/선택 SHA 경계를 바꾸므로 제외한다. 기존 merged-PR/latest artifact lookup 재사용도 same-run 계약과 맞지 않아 제외한다.
+- Consequences: 수동 실행에는 별도 사람 승인 단계가 없으며, main branch policy·explicit dispatch·same-run artifact·native stale validation이 남은 보호 경계가 된다. 기존 push Apply의 job dependency 구조는 이 결정에서 고정하지 않는다.
+- Confirmation / Follow-up: workflow 실행 조건, checkout SHA와 Plan/Apply 연결을 정적 검증하고 실제 Apply 성공은 별도 운영 증거로 확인한다.
+
+### 수동 Plan과 Apply는 기존 terraform-apply Environment와 제한된 CI identity를 사용한다
+
+- Decision Date: 2026-09-07
+- Decision Class: Derived Contract
+- Authority / Provenance: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- Status: Superseded
+- Superseded By: GCP WIF는 repository와 main 또는 main 대상 PR만 신뢰한다
+- Context / Problem: 최신 main의 `kosmo-terraform` GCP provider 조건은 pull request와 Environment가 있는 main push만 허용하므로 `workflow_dispatch`의 identity가 기존 조건에 맞지 않는다. AWS role은 Environment subject를 이미 사용한다.
+- Decision Outcome: 두 수동 job 모두 `terraform-apply` Environment를 사용하고, credential 주입 전에 main ref를 확인한다. GCP `kosmo-terraform` provider에만 `workflow_dispatch + refs/heads/main + terraform-apply` 조건을 추가하며 기존 PR/push 조건과 AWS Environment subject를 유지한다.
+- Alternatives Considered: Firebase/native-distribution provider나 Firebase resource를 수정하는 방식, 새 provider·광범위한 trust·Environment 설정 변경은 승인 범위를 벗어나므로 제외한다.
+- Consequences: CI provider trust 변경은 별도 resource apply가 아니라 기존 push 자동 경로의 reviewed/current comparison을 통과한 Terraform Apply로 먼저 반영되어야 한다. 그 전에는 수동 recovery가 인증되지 않는다.
+- Confirmation / Follow-up: 구현 PR merge 후 기존 main push Apply 성공을 manual dispatch의 선행 증거로 기록한다. live GCP provider 상태는 현재 재인증 불가로 미확인인 사실을 실제 적용 증거와 구분한다.
+
+### GCP WIF는 repository와 main 또는 main 대상 PR만 신뢰한다
+
+- Decision Date: 2026-09-07
+- Decision Class: Derived Contract
+- Authority / Provenance: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- Status: Active
+- Supersedes: 수동 Plan과 Apply는 기존 terraform-apply Environment와 제한된 CI identity를 사용한다
+- Context / Problem: manual Plan/Apply의 AWS 인증에는 `terraform-apply` Environment가 계속 필요하지만, GCP WIF의 목표는 특정 workflow나 Environment가 아니라 이 repository의 main 작업과 main 대상 PR을 허용하는 것이다. PR 예외는 read-only를 보장하지 않는다.
+- Decision Outcome: `kosmo-terraform` GCP provider는 기존 `assertion.repository_id == '${local.github_repository_id}'`를 유지하고, `assertion.ref == 'refs/heads/main'` 또는 `(assertion.event_name == 'pull_request' && assertion.base_ref == 'main')`만 허용한다. owner ID, `workflow_ref`, `environment`와 비-PR event 이름은 GCP 조건에서 제한하지 않는다. GitHub issuer/provider와 service account IAM 연결은 그대로 유지하며, AWS Environment/subject는 별도 계약으로 유지한다.
+- Alternatives Considered: owner ID, workflow ref, Environment 또는 `push`/`workflow_dispatch` event를 추가로 고정하는 방식은 repository-wide main/PR 목표와 맞지 않아 제외한다. PR 예외를 제거하는 방식도 main 대상 PR Plan의 인증 계약을 깨뜨리므로 제외한다. Firebase/native-distribution WIF, service account 권한·분리, AWS Environment 설정 변경은 범위 밖이다.
+- Consequences: 다른 repository는 거부되지만 같은 repository의 main ref 작업과 main 대상 PR은 workflow, Environment, event 이름과 무관하게 GCP trust를 만족할 수 있다. main tag/feature 같은 non-PR ref는 거부된다. 기존 main push Apply가 trust 변경을 먼저 반영해야 manual path를 사용할 수 있다는 bootstrap 선행 조건과 기존 PR/push 실행 계약은 유지한다.
+- Confirmation / Follow-up: 구현 시 다른 repository 거부, main tag/feature non-PR 거부, Environment 없는 main 및 다른 workflow 허용, main 대상 PR 예외를 정적 검증한다. 실제 dispatch·Apply 또는 live trust 상태는 별도 운영 증거로 확인한다.
+
+### 기존 PR/push 자동 계약은 수동 경로와 독립적으로 보존한다
+
+- Decision Date: 2026-09-07
+- Decision Class: Derived Contract
+- Authority / Provenance: [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다), [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다), [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- Status: Active
+- Context / Problem: manual recovery를 추가하면서 reviewed PR plan과 current main plan의 의미 비교 및 mismatch fail-closed 경계를 약화시키면 기존 production safety contract가 깨진다.
+- Decision Outcome: 기존 pull request Plan, main push의 merged PR head artifact 선택, semantic comparison, mismatch 차단과 native stale validation을 그대로 유지한다. 자동 경로가 실패해도 수동 경로를 자동 시작하거나 current plan을 자동 적용하지 않는다.
+- Alternatives Considered: mismatch 시 current plan 자동 적용, 기존 comparison skip, merge-group 경로 복원은 PROD-609의 현재 계약과 충돌하므로 제외한다.
+- Consequences: 자동 경로 실패 후 운영자는 별도의 명시적 dispatch를 해야 하며, trust 선행 Apply가 실패하면 수동 경로도 사용할 수 없다.
+- Confirmation / Follow-up: PR/push event matrix와 mismatch failure path를 실행 동작 또는 workflow validator로 확인하고 소스 문자열 존재 검사는 사용하지 않는다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- `수동 Plan과 Apply는 기존 terraform-apply Environment와 제한된 CI identity를 사용한다` → `GCP WIF는 repository와 main 또는 main 대상 PR만 신뢰한다`

--- a/openspec/changes/manual-terraform-recovery/decisions.md
+++ b/openspec/changes/manual-terraform-recovery/decisions.md
@@ -1,33 +1,33 @@
 ## Context
 
-이 decision log는 [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)의 승인된 수동 recovery 범위와 현재 Terraform 운영 context를 구현 가능한 durable choice로 정리한다. 기존 자동 apply 계약은 [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다)가 최신 authority이고, [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다)는 semantic comparison과 native stale validation의 배경이다.
+이 decision log는 [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)의 최종 승인된 수동 recovery 범위와 현재 Terraform 운영 context를 구현 가능한 durable choice로 정리한다. 기존 자동 apply 계약은 [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다)가 최신 authority이고, [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다)는 semantic comparison과 native stale validation의 배경이다.
 
 ## Decision Records
 
-### 수동 recovery는 main의 선택된 SHA에서 Plan 후 즉시 Apply한다
+### 수동 recovery는 기존 Apply job에서 직접 Apply한다
+
+- Decision Date: 2026-09-07
+- Decision Class: Derived Contract
+- Authority / Provenance: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) 최종 사용자 결정
+- Status: Active
+- Supersedes: `수동 recovery는 main의 선택된 SHA에서 Plan 후 즉시 Apply한다`
+- Context / Problem: 기존 main push 자동 경로의 reviewed/current comparison이 실패했을 때, 운영자가 main에서 명시적으로 복구할 수 있는 경로가 필요하다. 별도 Plan job과 artifact 전달은 수동 경로의 복잡성을 키운다.
+- Decision Outcome: `workflow_dispatch`는 `refs/heads/main`에서만 허용하고 dispatch 당시 `github.sha`를 checkout한다. 기존 Apply job의 인증·Terraform 초기화 뒤 수동 event에서 `terraform apply -auto-approve`를 한 번 실행한다. 수동 `terraform plan`, Plan-only 입력, `confirm_apply`, saved plan 파일, artifact, `needs` 기반 Manual Plan job과 SHA metadata 전달은 두지 않는다.
+- Alternatives Considered: same-run Plan artifact 전달, 별도 Plan job, Plan-only 기본값, `confirm_apply`, 별도 reviewer approval과 임의 target SHA 입력은 최종 사용자가 선택한 기존 Apply job 직접 실행과 main 경계를 바꾸므로 제외한다.
+- Consequences: 수동 직접 Apply는 saved plan과 Terraform native stale-plan validation을 사용하지 않는다. 명시적 main dispatch, main guard, 기존 credential boundary와 state concurrency가 남은 보호 경계이며, native stale validation은 기존 push reviewed saved plan 경로에만 유지된다.
+- Confirmation / Follow-up: workflow 실행 조건과 direct Apply command를 정적 검증하고 실제 Apply 성공은 별도 운영 증거로 확인한다.
+
+### 수동 Apply는 기존 AWS Environment와 CI identity 경계를 유지한다
 
 - Decision Date: 2026-09-07
 - Decision Class: Derived Contract
 - Authority / Provenance: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
 - Status: Active
-- Context / Problem: 기존 main push 자동 경로의 reviewed/current comparison이 실패했을 때, 최신 main을 운영자가 명시적으로 복구할 수 있는 경로가 필요하다. 다른 run·PR의 artifact를 고르면 reviewed plan 경계를 다시 섞을 수 있다.
-- Decision Outcome: `workflow_dispatch`는 `refs/heads/main`에서만 허용하고, 별도 target SHA나 확인 입력 없이 dispatch가 선택한 `github.sha`를 기준으로 항상 Plan을 먼저 만든 뒤 성공한 same-run saved plan만 즉시 Apply한다. Apply는 다른 run·PR artifact를 검색하지 않고 dispatch SHA와 saved plan source SHA를 확인한다.
-- Alternatives Considered: Plan-only 기본값, `confirm_apply` 입력, 별도 reviewer approval, 임의 target SHA 입력은 사용자가 선택한 항상 Plan 후 Apply와 main/선택 SHA 경계를 바꾸므로 제외한다. 기존 merged-PR/latest artifact lookup 재사용도 same-run 계약과 맞지 않아 제외한다.
-- Consequences: 수동 실행에는 별도 사람 승인 단계가 없으며, main branch policy·explicit dispatch·same-run artifact·native stale validation이 남은 보호 경계가 된다. 기존 push Apply의 job dependency 구조는 이 결정에서 고정하지 않는다.
-- Confirmation / Follow-up: workflow 실행 조건, checkout SHA와 Plan/Apply 연결을 정적 검증하고 실제 Apply 성공은 별도 운영 증거로 확인한다.
-
-### 수동 Plan과 Apply는 기존 terraform-apply Environment와 제한된 CI identity를 사용한다
-
-- Decision Date: 2026-09-07
-- Decision Class: Derived Contract
-- Authority / Provenance: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
-- Status: Superseded
-- Superseded By: GCP WIF는 repository와 main 또는 main 대상 PR만 신뢰한다
-- Context / Problem: 최신 main의 `kosmo-terraform` GCP provider 조건은 pull request와 Environment가 있는 main push만 허용하므로 `workflow_dispatch`의 identity가 기존 조건에 맞지 않는다. AWS role은 Environment subject를 이미 사용한다.
-- Decision Outcome: 두 수동 job 모두 `terraform-apply` Environment를 사용하고, credential 주입 전에 main ref를 확인한다. GCP `kosmo-terraform` provider에만 `workflow_dispatch + refs/heads/main + terraform-apply` 조건을 추가하며 기존 PR/push 조건과 AWS Environment subject를 유지한다.
-- Alternatives Considered: Firebase/native-distribution provider나 Firebase resource를 수정하는 방식, 새 provider·광범위한 trust·Environment 설정 변경은 승인 범위를 벗어나므로 제외한다.
-- Consequences: CI provider trust 변경은 별도 resource apply가 아니라 기존 push 자동 경로의 reviewed/current comparison을 통과한 Terraform Apply로 먼저 반영되어야 한다. 그 전에는 수동 recovery가 인증되지 않는다.
-- Confirmation / Follow-up: 구현 PR merge 후 기존 main push Apply 성공을 manual dispatch의 선행 증거로 기록한다. live GCP provider 상태는 현재 재인증 불가로 미확인인 사실을 실제 적용 증거와 구분한다.
+- Context / Problem: 수동 Apply는 기존 AWS Environment subject를 계속 사용해야 하지만, GCP CI identity는 workflow 경로와 Environment에 결합하지 않는 최종 조건이 필요하다.
+- Decision Outcome: 수동 Apply job은 `terraform-apply` Environment를 사용하고 credential 주입 전에 main ref를 확인한다. GCP `kosmo-terraform` provider는 repository ID와 main ref 또는 main 대상 PR만 허용한다. AWS Environment subject와 GCP WIF 조건은 별도 경계다.
+- Alternatives Considered: Firebase/native-distribution provider나 Firebase resource 수정, 새 provider, Environment 설정 변경과 광범위한 trust는 승인 범위를 벗어나므로 제외한다.
+- Consequences: CI provider trust 변경은 기존 push 자동 경로의 reviewed/current comparison을 통과한 Terraform Apply로 먼저 반영되어야 한다. 그 전에는 수동 recovery가 인증되지 않는다.
+- Confirmation / Follow-up: 구현 PR merge 후 기존 main push Apply 성공을 manual dispatch의 선행 증거로 기록한다. live GCP provider 상태와 실제 Apply는 정적 검증과 구분한다.
 
 ### GCP WIF는 repository와 main 또는 main 대상 PR만 신뢰한다
 
@@ -35,12 +35,11 @@
 - Decision Class: Derived Contract
 - Authority / Provenance: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
 - Status: Active
-- Supersedes: 수동 Plan과 Apply는 기존 terraform-apply Environment와 제한된 CI identity를 사용한다
-- Context / Problem: manual Plan/Apply의 AWS 인증에는 `terraform-apply` Environment가 계속 필요하지만, GCP WIF의 목표는 특정 workflow나 Environment가 아니라 이 repository의 main 작업과 main 대상 PR을 허용하는 것이다. PR 예외는 read-only를 보장하지 않는다.
-- Decision Outcome: `kosmo-terraform` GCP provider는 기존 `assertion.repository_id == '${local.github_repository_id}'`를 유지하고, `assertion.ref == 'refs/heads/main'` 또는 `(assertion.event_name == 'pull_request' && assertion.base_ref == 'main')`만 허용한다. owner ID, `workflow_ref`, `environment`와 비-PR event 이름은 GCP 조건에서 제한하지 않는다. GitHub issuer/provider와 service account IAM 연결은 그대로 유지하며, AWS Environment/subject는 별도 계약으로 유지한다.
-- Alternatives Considered: owner ID, workflow ref, Environment 또는 `push`/`workflow_dispatch` event를 추가로 고정하는 방식은 repository-wide main/PR 목표와 맞지 않아 제외한다. PR 예외를 제거하는 방식도 main 대상 PR Plan의 인증 계약을 깨뜨리므로 제외한다. Firebase/native-distribution WIF, service account 권한·분리, AWS Environment 설정 변경은 범위 밖이다.
-- Consequences: 다른 repository는 거부되지만 같은 repository의 main ref 작업과 main 대상 PR은 workflow, Environment, event 이름과 무관하게 GCP trust를 만족할 수 있다. main tag/feature 같은 non-PR ref는 거부된다. 기존 main push Apply가 trust 변경을 먼저 반영해야 manual path를 사용할 수 있다는 bootstrap 선행 조건과 기존 PR/push 실행 계약은 유지한다.
-- Confirmation / Follow-up: 구현 시 다른 repository 거부, main tag/feature non-PR 거부, Environment 없는 main 및 다른 workflow 허용, main 대상 PR 예외를 정적 검증한다. 실제 dispatch·Apply 또는 live trust 상태는 별도 운영 증거로 확인한다.
+- Context / Problem: manual Apply를 위해 GCP WIF가 특정 workflow나 Environment에 묶이지 않아야 한다. PR 예외는 read-only를 보장하지 않는다.
+- Decision Outcome: `kosmo-terraform` GCP provider는 기존 `assertion.repository_id == '${local.github_repository_id}'`를 유지하고, `assertion.ref == 'refs/heads/main'` 또는 `(assertion.event_name == 'pull_request' && assertion.base_ref == 'main')`만 허용한다. owner ID, `workflow_ref`, `environment`와 비-PR event 이름은 GCP 조건에서 제한하지 않는다. GitHub issuer/provider와 service account IAM 연결, AWS Environment/subject는 그대로 유지한다.
+- Alternatives Considered: owner ID, workflow ref, Environment 또는 `push`/`workflow_dispatch` event를 추가로 고정하는 방식은 repository-wide main/PR 목표와 맞지 않아 제외한다. PR 예외 제거, Firebase/native-distribution WIF 변경과 service account 권한 분리도 범위 밖이다.
+- Consequences: 다른 repository는 거부되지만 같은 repository의 main ref 작업과 main 대상 PR은 workflow, Environment, event 이름과 무관하게 GCP trust를 만족할 수 있다. main tag/feature 같은 non-PR ref는 거부된다. 기존 main push Apply가 trust 변경을 먼저 반영해야 manual path를 사용할 수 있다.
+- Confirmation / Follow-up: 다른 repository 거부, main tag/feature non-PR 거부, Environment 없는 main 및 다른 workflow 허용, main 대상 PR 예외를 정적 검증한다. 실제 dispatch·Apply 또는 live trust 상태는 별도 운영 증거로 확인한다.
 
 ### 기존 PR/push 자동 계약은 수동 경로와 독립적으로 보존한다
 
@@ -49,15 +48,16 @@
 - Authority / Provenance: [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다), [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다), [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
 - Status: Active
 - Context / Problem: manual recovery를 추가하면서 reviewed PR plan과 current main plan의 의미 비교 및 mismatch fail-closed 경계를 약화시키면 기존 production safety contract가 깨진다.
-- Decision Outcome: 기존 pull request Plan, main push의 merged PR head artifact 선택, semantic comparison, mismatch 차단과 native stale validation을 그대로 유지한다. 자동 경로가 실패해도 수동 경로를 자동 시작하거나 current plan을 자동 적용하지 않는다.
+- Decision Outcome: 기존 pull request Plan, main push의 merged PR head artifact 선택, semantic comparison, mismatch 차단과 native stale validation을 그대로 유지한다. 자동 경로가 실패해도 수동 Apply를 자동 시작하거나 current plan을 자동 적용하지 않는다.
 - Alternatives Considered: mismatch 시 current plan 자동 적용, 기존 comparison skip, merge-group 경로 복원은 PROD-609의 현재 계약과 충돌하므로 제외한다.
-- Consequences: 자동 경로 실패 후 운영자는 별도의 명시적 dispatch를 해야 하며, trust 선행 Apply가 실패하면 수동 경로도 사용할 수 없다.
+- Consequences: 자동 경로 실패 후 운영자는 별도의 명시적 main dispatch를 해야 하며, trust 선행 Apply가 실패하면 수동 경로도 사용할 수 없다.
 - Confirmation / Follow-up: PR/push event matrix와 mismatch failure path를 실행 동작 또는 workflow validator로 확인하고 소스 문자열 존재 검사는 사용하지 않는다.
 
 ## Remaining Decisions
 
-- 없음.
+없음.
 
 ## Superseded Decisions
 
-- `수동 Plan과 Apply는 기존 terraform-apply Environment와 제한된 CI identity를 사용한다` → `GCP WIF는 repository와 main 또는 main 대상 PR만 신뢰한다`
+- `수동 recovery는 main의 선택된 SHA에서 Plan 후 즉시 Apply한다` — 최종 사용자 결정으로 별도 Manual Plan·same-run artifact·SHA metadata 전달을 제거하고 기존 Apply job 직접 Apply로 대체했다.
+- `수동 Plan과 Apply는 기존 terraform-apply Environment와 제한된 CI identity를 사용한다` — 이전 두-job 및 GCP Environment 제한 표현은 최종 사용자 결정에 따라 위 `수동 Apply는 기존 AWS Environment와 CI identity 경계를 유지한다` 및 `GCP WIF는 repository와 main 또는 main 대상 PR만 신뢰한다`로 대체했다.

--- a/openspec/changes/manual-terraform-recovery/design.md
+++ b/openspec/changes/manual-terraform-recovery/design.md
@@ -1,0 +1,73 @@
+## Context
+
+현재 `.github/workflows/terraform.yml`은 pull request에서 Plan artifact를 만들고 `main` push에서 `terraform-apply` Environment를 사용해 reviewed plan을 선택한다. Apply job은 현재 main에서 다시 만든 plan을 reviewed plan과 semantic 비교하고, 차이가 있으면 두 plan 모두 적용하지 않는다. PR #766 병합 run은 이 비교에서 중단되어 기존 artifact를 같은 run에서 재시도하는 것으로는 최신 main을 적용할 수 없었다.
+
+새 경로는 이 자동 계약을 우회하거나 완화하지 않고, 운영자가 `main`의 선택된 commit을 명시적으로 dispatch했을 때만 Plan과 Apply를 연결하는 recovery 흐름이다. 수동 Plan/Apply job은 기존 AWS `environment:terraform-apply` subject를 위해 Environment를 사용하지만, GCP CI identity는 기존 `repository_id`와 `refs/heads/main` 또는 `pull_request` + `base_ref == main`만 확인한다. owner ID, workflow ref, GCP Environment와 비-PR event 이름은 GCP 조건에서 제한하지 않으며, Firebase/native-distribution provider와 Firebase resource는 별도 소유 경계다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- main ref에서 선택된 `github.sha`를 Plan과 Apply 양쪽에 고정한다.
+- 두 job 모두 기존 `terraform-apply` Environment를 사용하고 main guard를 credential 주입보다 앞에 둔다.
+- 같은 workflow run에서 성공한 Plan artifact만 Apply하고, Plan 실패·artifact 검증 실패·Terraform stale-plan을 차단한다.
+- GCP CI provider는 기존 `repository_id`를 유지하고 `refs/heads/main` 또는 `pull_request` + `base_ref == main`만 허용한다. owner ID, workflow ref, Environment와 비-PR event 이름은 제한하지 않으며, 같은 repository의 main/PR인 다른 workflow도 GCP trust를 만족할 수 있고 PR 예외는 read-only를 보장하지 않는다는 trade-off를 기록한다.
+- 기존 push Apply의 reviewed/current semantic comparison과 Plan 출력 노출 경계를 보존한다.
+
+**Non-Goals:**
+
+- Plan-only 또는 `confirm_apply` 입력, 별도 사람 승인, target SHA/NAT/replace 입력을 추가하지 않는다.
+- 기존 자동 comparison 실패를 자동 Apply로 우회하지 않는다.
+- Firebase/native-distribution WIF, Firebase resource, Environment 설정, secret·variable 또는 Kubernetes 저장소를 변경하지 않는다.
+- 실제 dispatch, rerun, Apply 또는 live trust/resource 상태를 이 change의 정적 검증으로 주장하지 않는다.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `workflow_dispatch`에는 pull request/push처럼 선언적인 branch filter가 없으므로 수동 Plan과 Apply job 모두에서 `refs/heads/main`을 확인해야 한다. 이 확인은 AWS/GCP/Tailscale/Argo credential 단계보다 앞서야 한다.
+- Plan job을 dispatch까지 확장할 때 PR comment 전용 단계가 manual event에서 실행되지 않도록 event 조건을 분리한다.
+- 기존 push Apply job에 `needs: plan`을 바로 추가하면 push event에서 Plan job이 skipped라 Apply도 skipped될 수 있다. 반대로 무조건 `always()`를 사용하면 실패한 Plan을 우회할 위험이 있다.
+- GCP `kosmo-terraform` condition은 변경 후 `repository_id`가 일치하면서 `ref == refs/heads/main`이거나 `event_name == pull_request && base_ref == main`인 token을 허용한다. `environment`, `workflow_ref`, `repository_owner_id`와 비-PR `event_name`은 조건에 사용하지 않는다. AWS role은 기존 `environment:terraform-apply` subject를 이미 사용하므로 manual Plan/Apply에 같은 Environment를 계속 부여하되, 이를 GCP WIF 조건과 혼동하지 않는다.
+- Terraform saved plan은 state lineage/serial과 연결된다. native stale validation은 state snapshot이 바뀐 경우를 보호하지만, state에 기록되지 않은 모든 remote-only drift를 항상 검출한다는 의미는 아니다.
+
+### Recommended Approach
+
+1. workflow dispatch를 추가하고, 수동 경로가 선택한 main commit의 `github.sha`를 workflow context와 checkout에 동일하게 사용한다.
+2. 기존 PR Plan 단계의 공통 인증·Terraform 준비·Plan 렌더링을 재사용하되, manual event에서는 PR comment를 만들지 않고 same-run artifact를 저장한다. Plan artifact에는 Apply에 필요한 saved plan과 기존 허용 범위의 human-readable metadata만 포함한다.
+3. 기존 Apply job을 재사용해 Environment·credential·Terraform 준비 단계를 중복하지 않는다. Plan job을 dependency로 연결하더라도 push event에서 skipped Plan 때문에 기존 Apply가 skip되지 않도록 event와 dependency status를 함께 평가하고, manual event에서는 Plan 성공일 때만 same-run artifact 경로로 진행한다. Apply 내부의 event별 artifact/compare 분기는 기존 push semantic comparison과 manual SHA 검증을 각각 보존해야 한다.
+   기존 pull request Plan에는 `terraform-apply` Environment를 붙이지 않고 manual Plan에만 적용한다; 별도 manual-Plan job을 강제하지 않으며, 조건부 Environment 또는 별도 Plan job 중 기존 PR/push 계약과 manual same-run 계약을 충족하는 구현을 선택한다.
+4. 수동 Plan과 Apply 모두 AWS 기존 subject를 위해 `terraform-apply` Environment를 선언하고 main guard를 credentials 이전에 평가한다. Terraform CI GCP provider condition은 `repository_id`와 `ref == refs/heads/main` 또는 `event_name == pull_request && base_ref == main`만 사용한다. owner ID, workflow ref, GCP Environment와 비-PR event 이름은 제한하지 않으며, 같은 repository의 main/PR인 다른 workflow와 read-only가 아닌 PR 예외를 허용하는 trade-off를 문서화한다.
+5. CI provider trust 변경을 포함한 PR은 먼저 기존 pull request Plan과 main push reviewed/current comparison을 통과하고 실제 push Apply로 trust를 반영해야 한다. 그 선행 Apply가 실패하면 manual recovery를 시작하거나 bootstrap을 우회하지 않는다.
+6. 운영 문서에는 manual run이 사람 승인 없이 Plan 직후 Apply되는 경로이며, Environment에는 현재 required reviewer가 없고 main branch policy가 있다는 점을 구분해 적는다. 실제 수동 Apply 증거는 별도 운영 실행 기록으로 남긴다.
+
+### Allowed Alternatives
+
+없음. 기존 Apply job 재사용이 현재 Environment·credential 경계를 중복하지 않는 가장 작은 기본 경로다.
+
+### Known Traps
+
+- `workflow_dispatch`의 선택 ref를 검증하지 않고 checkout 기본값이나 임의 input을 사용하면 main-only와 SHA 고정 계약을 잃는다.
+- manual Apply가 artifact API에서 최신 artifact를 검색하면 다른 run/PR의 reviewed plan을 적용할 수 있다. same-run download와 metadata 검증을 사용해야 한다.
+- Plan과 Apply 중 한쪽만 AWS `terraform-apply` Environment를 사용하거나, GCP condition만 바꾸고 trust 선행 Apply를 생략하면 인증 경계가 비대칭이 된다.
+- Firebase/native-distribution provider를 CI provider로 잘못 해석해 disabled provider 또는 Firebase resource를 수정하면 범위를 벗어난다.
+- Terraform native stale validation을 remote-only drift 전체 검출로 설명하면 검증 보장을 과장한다.
+- plan JSON, 비교용 JSON, OIDC token, cloud secret을 summary·artifact·로그에 추가하면 기존 노출 경계를 깨뜨린다.
+
+## Risks / Trade-offs
+
+- [수동 Plan 직후 자동 Apply] → 별도 reviewer가 없는 운영 경계이므로 main branch policy, explicit dispatch, same-run SHA/artifact 검증과 Terraform stale validation에 의존한다. 운영 문서에서 사람 승인이 없음을 명확히 한다.
+- [CI trust 선행 필요] → GCP provider 변경이 main push Apply로 먼저 반영되지 않으면 manual path가 인증되지 않는다. bootstrap 순서와 실패 시 중단 조건을 문서·검증에 포함한다.
+- [repository-wide GCP trust] → `repository_id`와 main ref 또는 main 대상 PR만 확인하므로 같은 repository의 다른 workflow도 GCP trust를 만족할 수 있고, PR 예외는 read-only를 보장하지 않는다. AWS Environment/subject는 별도 경계이며, 이 wider GCP trust를 보안 강화로 표현하지 않는다.
+- [동일 state concurrency] → Plan이 state lock을 잠시 보유하므로 기존 `terraform-kosmo-state` concurrency를 유지하고 Plan 완료 뒤 Apply가 실행되게 한다.
+
+## Migration Plan
+
+1. OpenSpec Gate 승인 후 workflow, Terraform CI provider condition, 운영 문서를 함께 구현하고 actionlint/format/OpenSpec strict 및 실행 조건 검증을 수행한다.
+2. PR Plan과 기존 main push Apply가 CI trust 변경을 검토된 saved plan으로 실제 반영할 때까지 manual dispatch를 사용하지 않는다. 기존 semantic comparison 불일치가 발생하면 자동 경로의 안전한 실패로 기록하고 중단한다.
+3. trust 선행 Apply 성공 후, 별도 운영 승인 절차에 따라 main에서 manual run을 수행한다. 이 change의 PR·정적 검증은 실제 Apply 성공 증거를 대신하지 않는다.
+4. rollback이 필요하면 workflow dispatch/manual job과 GCP manual condition을 reviewed Terraform change로 되돌리고, 기존 PR/push workflow와 Firebase/native-distribution provider는 그대로 보존한다.
+
+## Open Questions
+
+없음. Issue Gate에서 manual Plan 후 즉시 Apply, main-only, same-run artifact, 좁은 CI GCP trust 추가와 기존 자동 경로 보존을 승인했다.

--- a/openspec/changes/manual-terraform-recovery/design.md
+++ b/openspec/changes/manual-terraform-recovery/design.md
@@ -1,21 +1,22 @@
 ## Context
 
-현재 `.github/workflows/terraform.yml`은 pull request에서 Plan artifact를 만들고 `main` push에서 `terraform-apply` Environment를 사용해 reviewed plan을 선택한다. Apply job은 현재 main에서 다시 만든 plan을 reviewed plan과 semantic 비교하고, 차이가 있으면 두 plan 모두 적용하지 않는다. PR #766 병합 run은 이 비교에서 중단되어 기존 artifact를 같은 run에서 재시도하는 것으로는 최신 main을 적용할 수 없었다.
+현재 `.github/workflows/terraform.yml`은 pull request에서 Plan artifact를 만들고 `main` push에서 `terraform-apply` Environment를 사용해 reviewed plan을 선택한다. Apply job은 현재 main에서 다시 만든 plan을 reviewed plan과 semantic 비교하고, 차이가 있으면 두 plan 모두 적용하지 않는다. PR #766 병합 run은 이 비교에서 중단되어 기존 자동 경로만 재시도하는 것으로는 최신 main을 운영자가 직접 복구할 수 없었다.
 
-새 경로는 이 자동 계약을 우회하거나 완화하지 않고, 운영자가 `main`의 선택된 commit을 명시적으로 dispatch했을 때만 Plan과 Apply를 연결하는 recovery 흐름이다. 수동 Plan/Apply job은 기존 AWS `environment:terraform-apply` subject를 위해 Environment를 사용하지만, GCP CI identity는 기존 `repository_id`와 `refs/heads/main` 또는 `pull_request` + `base_ref == main`만 확인한다. owner ID, workflow ref, GCP Environment와 비-PR event 이름은 GCP 조건에서 제한하지 않으며, Firebase/native-distribution provider와 Firebase resource는 별도 소유 경계다.
+새 경로는 이 자동 계약을 우회하거나 완화하지 않고, 운영자가 `main`을 명시적으로 dispatch했을 때 기존 Apply job에서 직접 Terraform Apply를 실행하는 recovery 흐름이다. 수동 Apply는 기존 AWS `environment:terraform-apply` subject를 위해 Environment를 사용하지만, GCP CI identity는 기존 `repository_id`와 `refs/heads/main` 또는 `pull_request` + `base_ref == main`만 확인한다. owner ID, workflow ref, GCP Environment와 비-PR event 이름은 GCP 조건에서 제한하지 않으며, Firebase/native-distribution provider와 Firebase resource는 별도 소유 경계다.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- main ref에서 선택된 `github.sha`를 Plan과 Apply 양쪽에 고정한다.
-- 두 job 모두 기존 `terraform-apply` Environment를 사용하고 main guard를 credential 주입보다 앞에 둔다.
-- 같은 workflow run에서 성공한 Plan artifact만 Apply하고, Plan 실패·artifact 검증 실패·Terraform stale-plan을 차단한다.
+- main ref에서 dispatch된 `github.sha`를 Apply checkout source로 사용한다.
+- 기존 Apply job을 재사용하고, manual event에서 main guard를 credential 주입보다 앞에 둔다.
+- 기존 인증·Terraform 초기화 뒤 manual event에서 `terraform apply -auto-approve`를 한 번 실행한다.
 - GCP CI provider는 기존 `repository_id`를 유지하고 `refs/heads/main` 또는 `pull_request` + `base_ref == main`만 허용한다. owner ID, workflow ref, Environment와 비-PR event 이름은 제한하지 않으며, 같은 repository의 main/PR인 다른 workflow도 GCP trust를 만족할 수 있고 PR 예외는 read-only를 보장하지 않는다는 trade-off를 기록한다.
-- 기존 push Apply의 reviewed/current semantic comparison과 Plan 출력 노출 경계를 보존한다.
+- 기존 push Apply의 reviewed/current semantic comparison, reviewed saved plan 적용과 native stale validation, PR Plan 및 출력 노출 경계를 보존한다.
 
 **Non-Goals:**
 
+- 별도 Manual Plan job, `needs` 의존성, `terraform plan`, Plan artifact, saved plan 다운로드·metadata 검증을 추가하지 않는다.
 - Plan-only 또는 `confirm_apply` 입력, 별도 사람 승인, target SHA/NAT/replace 입력을 추가하지 않는다.
 - 기존 자동 comparison 실패를 자동 Apply로 우회하지 않는다.
 - Firebase/native-distribution WIF, Firebase resource, Environment 설정, secret·variable 또는 Kubernetes 저장소를 변경하지 않는다.
@@ -25,49 +26,47 @@
 
 ### Current Constraints
 
-- `workflow_dispatch`에는 pull request/push처럼 선언적인 branch filter가 없으므로 수동 Plan과 Apply job 모두에서 `refs/heads/main`을 확인해야 한다. 이 확인은 AWS/GCP/Tailscale/Argo credential 단계보다 앞서야 한다.
-- Plan job을 dispatch까지 확장할 때 PR comment 전용 단계가 manual event에서 실행되지 않도록 event 조건을 분리한다.
-- 기존 push Apply job에 `needs: plan`을 바로 추가하면 push event에서 Plan job이 skipped라 Apply도 skipped될 수 있다. 반대로 무조건 `always()`를 사용하면 실패한 Plan을 우회할 위험이 있다.
-- GCP `kosmo-terraform` condition은 변경 후 `repository_id`가 일치하면서 `ref == refs/heads/main`이거나 `event_name == pull_request && base_ref == main`인 token을 허용한다. `environment`, `workflow_ref`, `repository_owner_id`와 비-PR `event_name`은 조건에 사용하지 않는다. AWS role은 기존 `environment:terraform-apply` subject를 이미 사용하므로 manual Plan/Apply에 같은 Environment를 계속 부여하되, 이를 GCP WIF 조건과 혼동하지 않는다.
-- Terraform saved plan은 state lineage/serial과 연결된다. native stale validation은 state snapshot이 바뀐 경우를 보호하지만, state에 기록되지 않은 모든 remote-only drift를 항상 검출한다는 의미는 아니다.
+- `workflow_dispatch`에는 pull request/push처럼 선언적인 branch filter가 없으므로 기존 Apply job의 manual 경로에서 `refs/heads/main`을 확인해야 한다. 이 확인은 AWS/GCP/Tailscale/Argo credential 단계보다 앞서야 한다.
+- 기존 Apply job을 manual event에도 실행하되, reviewed plan 다운로드와 current/reviewed semantic comparison은 `push` event에만 남긴다. PR Plan과 push의 자동 계약은 그대로 유지한다.
+- GCP `kosmo-terraform` condition은 변경 후 `repository_id`가 일치하면서 `ref == refs/heads/main`이거나 `event_name == pull_request && base_ref == main`인 token을 허용한다. `environment`, `workflow_ref`, `repository_owner_id`와 비-PR `event_name`은 조건에 사용하지 않는다. AWS role은 기존 `environment:terraform-apply` subject를 이미 사용하므로 manual Apply에 같은 Environment를 계속 부여하되, 이를 GCP WIF 조건과 혼동하지 않는다.
+- Manual Apply는 saved plan을 사용하지 않으므로 Terraform 내부에서 새 계획을 계산한다. Terraform native saved-plan stale validation은 기존 push reviewed saved plan 경로의 보장으로 설명하고 manual 직접 Apply에 전이하지 않는다.
 
 ### Recommended Approach
 
-1. workflow dispatch를 추가하고, 수동 경로가 선택한 main commit의 `github.sha`를 workflow context와 checkout에 동일하게 사용한다.
-2. 기존 PR Plan 단계의 공통 인증·Terraform 준비·Plan 렌더링을 재사용하되, manual event에서는 PR comment를 만들지 않고 same-run artifact를 저장한다. Plan artifact에는 Apply에 필요한 saved plan과 기존 허용 범위의 human-readable metadata만 포함한다.
-3. 기존 Apply job을 재사용해 Environment·credential·Terraform 준비 단계를 중복하지 않는다. Plan job을 dependency로 연결하더라도 push event에서 skipped Plan 때문에 기존 Apply가 skip되지 않도록 event와 dependency status를 함께 평가하고, manual event에서는 Plan 성공일 때만 same-run artifact 경로로 진행한다. Apply 내부의 event별 artifact/compare 분기는 기존 push semantic comparison과 manual SHA 검증을 각각 보존해야 한다.
-   기존 pull request Plan에는 `terraform-apply` Environment를 붙이지 않고 manual Plan에만 적용한다; 별도 manual-Plan job을 강제하지 않으며, 조건부 Environment 또는 별도 Plan job 중 기존 PR/push 계약과 manual same-run 계약을 충족하는 구현을 선택한다.
-4. 수동 Plan과 Apply 모두 AWS 기존 subject를 위해 `terraform-apply` Environment를 선언하고 main guard를 credentials 이전에 평가한다. Terraform CI GCP provider condition은 `repository_id`와 `ref == refs/heads/main` 또는 `event_name == pull_request && base_ref == main`만 사용한다. owner ID, workflow ref, GCP Environment와 비-PR event 이름은 제한하지 않으며, 같은 repository의 main/PR인 다른 workflow와 read-only가 아닌 PR 예외를 허용하는 trade-off를 문서화한다.
-5. CI provider trust 변경을 포함한 PR은 먼저 기존 pull request Plan과 main push reviewed/current comparison을 통과하고 실제 push Apply로 trust를 반영해야 한다. 그 선행 Apply가 실패하면 manual recovery를 시작하거나 bootstrap을 우회하지 않는다.
-6. 운영 문서에는 manual run이 사람 승인 없이 Plan 직후 Apply되는 경로이며, Environment에는 현재 required reviewer가 없고 main branch policy가 있다는 점을 구분해 적는다. 실제 수동 Apply 증거는 별도 운영 실행 기록으로 남긴다.
+1. workflow dispatch를 추가하고 기존 Apply job의 job condition이 `push`와 `workflow_dispatch`를 모두 허용하게 한다. checkout은 dispatch context의 `github.sha`를 명시적으로 사용한다.
+2. 기존 Apply job 첫 단계에 manual event의 `refs/heads/main` guard를 두고, guard 뒤의 기존 AWS/GCP/Tailscale/Argo 인증 및 Terraform init을 재사용한다.
+3. 기존 push 전용 reviewed plan 다운로드와 semantic comparison을 그대로 두고, manual event에서는 두 단계를 건너뛴다. Apply step은 manual event에 `terraform apply -auto-approve`를, push event에 기존 `terraform apply -auto-approve terraform.tfplan`을 실행한다.
+4. Terraform CI GCP provider condition은 `repository_id`와 `ref == refs/heads/main` 또는 `event_name == pull_request && base_ref == main`만 사용한다. owner ID, workflow ref, GCP Environment와 비-PR event 이름은 제한하지 않으며, PR 예외가 read-only가 아님을 문서화한다.
+5. 운영 문서에는 manual run이 별도 Plan 없이 기존 Apply job에서 직접 Apply되는 경로이며, Environment에는 현재 required reviewer가 없고 main branch policy가 있다는 점을 구분해 적는다. 실제 Apply 증거는 별도 운영 실행 기록으로 남긴다.
 
 ### Allowed Alternatives
 
-없음. 기존 Apply job 재사용이 현재 Environment·credential 경계를 중복하지 않는 가장 작은 기본 경로다.
+없음. 기존 Apply job 재사용이 현재 Environment·credential·cleanup 경계를 중복하지 않는 가장 작은 경로다.
 
 ### Known Traps
 
-- `workflow_dispatch`의 선택 ref를 검증하지 않고 checkout 기본값이나 임의 input을 사용하면 main-only와 SHA 고정 계약을 잃는다.
-- manual Apply가 artifact API에서 최신 artifact를 검색하면 다른 run/PR의 reviewed plan을 적용할 수 있다. same-run download와 metadata 검증을 사용해야 한다.
+- `workflow_dispatch`의 선택 ref를 검증하지 않거나 checkout 기본 source를 명시하지 않으면 main-only 경계를 잃을 수 있다.
+- Manual event에서 reviewed plan 다운로드나 semantic comparison을 실행하면 기존 PR/push artifact 계약을 수동 경로에 잘못 적용한다.
+- Manual event에 saved plan을 전달하려고 별도 job, `needs`, artifact 또는 metadata를 다시 추가하면 승인된 직접 Apply 범위를 벗어난다.
 - Plan과 Apply 중 한쪽만 AWS `terraform-apply` Environment를 사용하거나, GCP condition만 바꾸고 trust 선행 Apply를 생략하면 인증 경계가 비대칭이 된다.
 - Firebase/native-distribution provider를 CI provider로 잘못 해석해 disabled provider 또는 Firebase resource를 수정하면 범위를 벗어난다.
-- Terraform native stale validation을 remote-only drift 전체 검출로 설명하면 검증 보장을 과장한다.
+- Manual direct Apply에 Terraform native saved-plan stale validation이 적용된다고 설명하면 검증 보장을 과장한다.
 - plan JSON, 비교용 JSON, OIDC token, cloud secret을 summary·artifact·로그에 추가하면 기존 노출 경계를 깨뜨린다.
 
 ## Risks / Trade-offs
 
-- [수동 Plan 직후 자동 Apply] → 별도 reviewer가 없는 운영 경계이므로 main branch policy, explicit dispatch, same-run SHA/artifact 검증과 Terraform stale validation에 의존한다. 운영 문서에서 사람 승인이 없음을 명확히 한다.
+- [수동 직접 Apply] → 별도 saved plan과 native stale-plan 검증이 없는 경로이므로 main branch policy, explicit dispatch, main guard와 existing credential boundary에 의존한다. 운영 문서에서 manual event가 별도 사람 승인을 갖지 않음을 명확히 한다.
 - [CI trust 선행 필요] → GCP provider 변경이 main push Apply로 먼저 반영되지 않으면 manual path가 인증되지 않는다. bootstrap 순서와 실패 시 중단 조건을 문서·검증에 포함한다.
 - [repository-wide GCP trust] → `repository_id`와 main ref 또는 main 대상 PR만 확인하므로 같은 repository의 다른 workflow도 GCP trust를 만족할 수 있고, PR 예외는 read-only를 보장하지 않는다. AWS Environment/subject는 별도 경계이며, 이 wider GCP trust를 보안 강화로 표현하지 않는다.
-- [동일 state concurrency] → Plan이 state lock을 잠시 보유하므로 기존 `terraform-kosmo-state` concurrency를 유지하고 Plan 완료 뒤 Apply가 실행되게 한다.
+- [동일 state concurrency] → Manual Apply는 기존 `terraform-kosmo-state` concurrency를 유지해 다른 Terraform 실행과 충돌하는 위험을 줄인다.
 
 ## Migration Plan
 
 1. OpenSpec Gate 승인 후 workflow, Terraform CI provider condition, 운영 문서를 함께 구현하고 actionlint/format/OpenSpec strict 및 실행 조건 검증을 수행한다.
 2. PR Plan과 기존 main push Apply가 CI trust 변경을 검토된 saved plan으로 실제 반영할 때까지 manual dispatch를 사용하지 않는다. 기존 semantic comparison 불일치가 발생하면 자동 경로의 안전한 실패로 기록하고 중단한다.
 3. trust 선행 Apply 성공 후, 별도 운영 승인 절차에 따라 main에서 manual run을 수행한다. 이 change의 PR·정적 검증은 실제 Apply 성공 증거를 대신하지 않는다.
-4. rollback이 필요하면 workflow dispatch/manual job과 GCP manual condition을 reviewed Terraform change로 되돌리고, 기존 PR/push workflow와 Firebase/native-distribution provider는 그대로 보존한다.
+4. rollback이 필요하면 workflow dispatch/manual direct Apply 경로와 GCP CI condition을 reviewed Terraform change로 되돌리고, 기존 PR/push workflow와 Firebase/native-distribution provider는 그대로 보존한다.
 
 ## Open Questions
 
-없음. Issue Gate에서 manual Plan 후 즉시 Apply, main-only, same-run artifact, 좁은 CI GCP trust 추가와 기존 자동 경로 보존을 승인했다.
+없음. Issue Gate에서 manual direct Apply, main-only, 기존 Apply job 재사용, 좁은 CI GCP trust 추가와 기존 자동 경로 보존을 승인했다.

--- a/openspec/changes/manual-terraform-recovery/proposal.md
+++ b/openspec/changes/manual-terraform-recovery/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-PR #766 병합 뒤 Terraform 자동 apply가 reviewed PR plan과 최신 main plan의 의미 차이로 apply 전에 중단되었다. 기존 자동 경로의 안전한 불일치 차단은 유지하면서, 운영자가 선택한 최신 `main` commit을 한 번의 수동 실행에서 Plan하고 그 same-run saved plan만 Apply할 수 있는 복구 경로가 필요하다.
+PR #766 병합 뒤 Terraform 자동 apply가 reviewed PR plan과 최신 main plan의 의미 차이로 apply 전에 중단되었다. 기존 자동 경로의 안전한 불일치 차단은 유지하면서, 운영자가 `main`에서 명시적으로 수동 실행해 기존 Apply job의 Terraform 직접 적용을 수행할 수 있는 복구 경로가 필요하다.
 
 ## What Changes
 
 - 기존 Terraform workflow에 `workflow_dispatch` 수동 경로를 추가한다.
-- 수동 Plan과 Apply는 `refs/heads/main`에서만 실행하고, dispatch 시 선택된 `github.sha`를 Plan과 Apply 양쪽에서 고정한다.
-- 수동 Apply는 같은 workflow run에서 성공한 Plan이 만든 artifact만 사용하며, Plan 실패·artifact 누락·artifact 불일치 시 Apply하지 않는다.
-- 수동 Plan과 Apply job은 기존 AWS `environment:terraform-apply` subject를 위해 Environment를 계속 사용하고, Environment의 main branch policy와 Terraform native saved-plan stale validation을 유지한다. GCP WIF 조건은 Environment에 의존하지 않으며, 현재 Environment에 required reviewer가 없다는 사실을 승인 경계로 오해하지 않는다.
+- 수동 Apply는 `refs/heads/main`에서만 실행하고, dispatch 당시의 `github.sha`를 checkout한다. 실행 중 `main`을 다시 해석하지 않는다.
+- 기존 Apply job을 재사용해 기존 인증·Terraform 초기화 뒤 `terraform apply -auto-approve`를 한 번 실행한다. 수동 Plan job, `needs` 의존성, saved plan 파일, artifact 생성·전달·SHA metadata 검증은 추가하지 않는다.
+- 수동 Apply job은 기존 AWS `environment:terraform-apply` subject를 위해 Environment를 계속 사용한다. GCP WIF 조건은 Environment에 의존하지 않으며, 현재 Environment에 required reviewer가 없다는 사실을 승인 경계로 오해하지 않는다. 기존 push Apply의 Terraform native saved-plan stale validation은 그대로 유지한다.
 - Terraform CI용 `kosmo-terraform` GCP WIF 조건은 기존 `repository_id`만 고정하고 `refs/heads/main` 또는 `pull_request` + `base_ref == main`만 허용한다. owner ID, workflow ref, Environment와 비-PR event 이름은 조건에서 제한하지 않는다. 따라서 같은 repository의 main/PR인 다른 workflow도 GCP trust를 만족할 수 있고, PR 예외는 read-only를 보장하지 않는다. AWS 기존 `environment:terraform-apply` subject는 계속 재사용한다.
 - 기존 pull request Plan과 push의 reviewed/current semantic comparison 및 불일치 차단은 변경하지 않는다.
 - `apps/terraform/README.md`와 필요한 운영 설명을 수동 경로 및 trust 선행 순서에 맞춰 갱신하고, 최소 OpenSpec·위험 비례 검증을 함께 전달한다.
@@ -23,7 +23,7 @@ PR #766 병합 뒤 Terraform 자동 apply가 reviewed PR plan과 최신 main pla
 
 ### New Capabilities
 
-- `manual-terraform-recovery`: 최신 main commit을 수동으로 Plan한 뒤 같은 run의 성공한 saved plan만 Apply하는 main-only Terraform recovery 경로.
+- `manual-terraform-recovery`: main에서 기존 Apply job의 Terraform 직접 Apply를 실행하는 main-only Terraform recovery 경로.
 
 ### Modified Capabilities
 
@@ -31,7 +31,7 @@ PR #766 병합 뒤 Terraform 자동 apply가 reviewed PR plan과 최신 main pla
 
 ## Impact
 
-- `.github/workflows/terraform.yml`: 수동 dispatch, main-only guards, same-run Plan artifact와 Apply 연결, 기존 자동 경로 보존.
+- `.github/workflows/terraform.yml`: 수동 dispatch, main-only guard, 기존 Apply job의 직접 Apply 경로, 기존 자동 경로 보존.
 - `apps/terraform/main.tf`: `kosmo-terraform` GCP WIF 조건을 기존 `repository_id`와 main ref 또는 main 대상 PR 분기로 정렬한다. GitHub issuer/provider와 service account IAM 연결, Firebase/native-distribution WIF 및 Firebase 리소스는 변경하지 않는다.
 - `apps/terraform/README.md` 및 필요한 운영 문서: 수동 recovery, credential trust 선행 Apply, 검증·실제 Apply 증거의 경계를 문서화한다.
 - OpenSpec capability/spec와 workflow validation: 소스 문자열·정규식·AST 존재 검사가 아니라 실행 조건, artifact 흐름, 실패 경로와 기존 자동 경로 보존을 검증한다.

--- a/openspec/changes/manual-terraform-recovery/proposal.md
+++ b/openspec/changes/manual-terraform-recovery/proposal.md
@@ -34,4 +34,4 @@ PR #766 병합 뒤 Terraform 자동 apply가 reviewed PR plan과 최신 main pla
 - `.github/workflows/terraform.yml`: 수동 dispatch, main-only guard, 기존 Apply job의 직접 Apply 경로, 기존 자동 경로 보존.
 - `apps/terraform/main.tf`: `kosmo-terraform` GCP WIF 조건을 기존 `repository_id`와 main ref 또는 main 대상 PR 분기로 정렬한다. GitHub issuer/provider와 service account IAM 연결, Firebase/native-distribution WIF 및 Firebase 리소스는 변경하지 않는다.
 - `apps/terraform/README.md` 및 필요한 운영 문서: 수동 recovery, credential trust 선행 Apply, 검증·실제 Apply 증거의 경계를 문서화한다.
-- OpenSpec capability/spec와 workflow validation: 소스 문자열·정규식·AST 존재 검사가 아니라 실행 조건, artifact 흐름, 실패 경로와 기존 자동 경로 보존을 검증한다.
+- OpenSpec capability/spec와 workflow validation: 소스 문자열·정규식·AST 존재 검사가 아니라 실행 조건, 수동 direct Apply와 push reviewed-plan artifact 흐름, event별 실패 경로와 기존 자동 경로 보존을 검증한다.

--- a/openspec/changes/manual-terraform-recovery/proposal.md
+++ b/openspec/changes/manual-terraform-recovery/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+PR #766 병합 뒤 Terraform 자동 apply가 reviewed PR plan과 최신 main plan의 의미 차이로 apply 전에 중단되었다. 기존 자동 경로의 안전한 불일치 차단은 유지하면서, 운영자가 선택한 최신 `main` commit을 한 번의 수동 실행에서 Plan하고 그 same-run saved plan만 Apply할 수 있는 복구 경로가 필요하다.
+
+## What Changes
+
+- 기존 Terraform workflow에 `workflow_dispatch` 수동 경로를 추가한다.
+- 수동 Plan과 Apply는 `refs/heads/main`에서만 실행하고, dispatch 시 선택된 `github.sha`를 Plan과 Apply 양쪽에서 고정한다.
+- 수동 Apply는 같은 workflow run에서 성공한 Plan이 만든 artifact만 사용하며, Plan 실패·artifact 누락·artifact 불일치 시 Apply하지 않는다.
+- 수동 Plan과 Apply job은 기존 AWS `environment:terraform-apply` subject를 위해 Environment를 계속 사용하고, Environment의 main branch policy와 Terraform native saved-plan stale validation을 유지한다. GCP WIF 조건은 Environment에 의존하지 않으며, 현재 Environment에 required reviewer가 없다는 사실을 승인 경계로 오해하지 않는다.
+- Terraform CI용 `kosmo-terraform` GCP WIF 조건은 기존 `repository_id`만 고정하고 `refs/heads/main` 또는 `pull_request` + `base_ref == main`만 허용한다. owner ID, workflow ref, Environment와 비-PR event 이름은 조건에서 제한하지 않는다. 따라서 같은 repository의 main/PR인 다른 workflow도 GCP trust를 만족할 수 있고, PR 예외는 read-only를 보장하지 않는다. AWS 기존 `environment:terraform-apply` subject는 계속 재사용한다.
+- 기존 pull request Plan과 push의 reviewed/current semantic comparison 및 불일치 차단은 변경하지 않는다.
+- `apps/terraform/README.md`와 필요한 운영 설명을 수동 경로 및 trust 선행 순서에 맞춰 갱신하고, 최소 OpenSpec·위험 비례 검증을 함께 전달한다.
+
+## Authority / Provenance
+
+- Canonical: 없음. `docs/domain`과 `docs/design`을 확인했으며 적용되는 제품 도메인·UI 디자인 문서는 없다. 운영 context는 `apps/terraform/README.md`에서 확인한다.
+- Linear Contract: [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 recovery workflow, 운영 문서, 검증, 전체 정합성, OpenSpec 작성·구현·archive를 단일 이슈가 소유한다.
+- Related existing authority: [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다) — 현재 PR reviewed plan 선택과 push apply의 불일치 차단; [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다) — semantic comparison과 native stale validation의 상위 배경. PROD-609가 PROD-586의 최신 자동 경로 정리를 전달한다.
+- Linear Implementations: `PROD-898` 자체가 implementation, verification, cross-slice consistency, spec synchronization 및 completion 후 archive를 소유한다. 별도 구현·통합·archive 이슈는 없다.
+
+## Capabilities
+
+### New Capabilities
+
+- `manual-terraform-recovery`: 최신 main commit을 수동으로 Plan한 뒤 같은 run의 성공한 saved plan만 Apply하는 main-only Terraform recovery 경로.
+
+### Modified Capabilities
+
+- 없음. 기존 자동 PR/push Terraform apply 계약은 새 수동 capability와 병렬로 보존한다.
+
+## Impact
+
+- `.github/workflows/terraform.yml`: 수동 dispatch, main-only guards, same-run Plan artifact와 Apply 연결, 기존 자동 경로 보존.
+- `apps/terraform/main.tf`: `kosmo-terraform` GCP WIF 조건을 기존 `repository_id`와 main ref 또는 main 대상 PR 분기로 정렬한다. GitHub issuer/provider와 service account IAM 연결, Firebase/native-distribution WIF 및 Firebase 리소스는 변경하지 않는다.
+- `apps/terraform/README.md` 및 필요한 운영 문서: 수동 recovery, credential trust 선행 Apply, 검증·실제 Apply 증거의 경계를 문서화한다.
+- OpenSpec capability/spec와 workflow validation: 소스 문자열·정규식·AST 존재 검사가 아니라 실행 조건, artifact 흐름, 실패 경로와 기존 자동 경로 보존을 검증한다.

--- a/openspec/changes/manual-terraform-recovery/specs/manual-terraform-recovery/spec.md
+++ b/openspec/changes/manual-terraform-recovery/specs/manual-terraform-recovery/spec.md
@@ -1,27 +1,27 @@
 ## ADDED Requirements
 
-### Requirement: main에서 선택한 commit의 수동 Terraform 실행
+### Requirement: main에서 수동 Terraform Apply 실행
 
-**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — Terraform workflow는 `workflow_dispatch`로 요청한 수동 recovery를 제공해야 한다(MUST). 수동 Plan과 Apply는 `refs/heads/main`에서만 실행되어야 하며(MUST), 별도 SHA 입력이나 다른 branch/ref를 허용해서는 안 된다(MUST NOT). Dispatch event가 선택한 `github.sha`는 Plan과 Apply가 같은 실행에서 사용하는 유일한 source commit이어야 하며(MUST), Apply 단계에서 branch ref를 다시 해석해서는 안 된다(MUST NOT). Dispatch 후 `main` ref가 변경되더라도 선택된 SHA를 다시 조회하거나 재해석해서는 안 된다(MUST NOT).
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — Terraform workflow는 `workflow_dispatch`로 요청한 수동 recovery를 제공해야 한다(MUST). 수동 Apply는 `refs/heads/main`에서만 실행되어야 하며(MUST), 다른 branch/ref를 허용해서는 안 된다(MUST NOT). Dispatch event가 선택한 `github.sha`를 checkout source로 사용해야 하며(MUST), Apply 단계에서 실행 중 `main` ref를 다시 해석해서는 안 된다(MUST NOT).
 
 #### Scenario: main에서 수동 실행
 
 - **WHEN** 운영자가 Terraform workflow를 `main` ref에서 수동 실행한다
-- **THEN** Plan과 Apply는 dispatch event의 동일한 `github.sha`를 checkout하고 그 commit을 기준으로 실행한다
+- **THEN** 기존 Apply job이 dispatch event의 `github.sha`를 checkout하고 수동 Apply 경로를 실행한다
 
 #### Scenario: main 이외의 ref에서 수동 실행
 
 - **WHEN** workflow dispatch가 `main` 이외의 ref를 대상으로 요청된다
-- **THEN** cloud credential을 주입하거나 Terraform Plan/Apply를 실행하지 않고 수동 경로를 거부한다
+- **THEN** cloud credential을 주입하거나 Terraform Apply를 실행하지 않고 수동 경로를 거부한다
 
-### Requirement: 수동 경로의 cloud credential 경계
+### Requirement: 수동 Apply의 cloud credential 경계
 
-**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행한다) — 수동 Plan과 Apply job은 기존 `terraform-apply` Environment를 사용해야 하며(MUST), credential 주입 전에 main-only 조건을 확인해야 한다(MUST). Terraform CI용 `kosmo-terraform` GCP Workload Identity provider 조건은 `assertion.repository_id == '${local.github_repository_id}' && (assertion.ref == 'refs/heads/main' || (assertion.event_name == 'pull_request' && assertion.base_ref == 'main'))`이어야 한다(MUST). owner ID, `workflow_ref`, `environment`와 main 경로의 event 이름은 GCP 조건에서 제한해서는 안 된다(MUST NOT). AWS는 기존 `repo:byulmaru/kosmo:environment:terraform-apply` subject를 재사용해야 하며(MUST); 이는 GCP WIF 조건과 별도다. GitHub issuer/provider와 service account IAM 연결, Firebase/native-distribution WIF provider 및 Firebase resource의 trust·상태·삭제 정책은 변경해서는 안 된다(MUST NOT). PR 예외는 read-only 권한을 보장하지 않는다.
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 Apply job은 기존 `terraform-apply` Environment를 사용해야 하며(MUST), credential 주입 전에 main-only 조건을 확인해야 한다(MUST). Terraform CI용 `kosmo-terraform` GCP Workload Identity provider 조건은 `assertion.repository_id == '${local.github_repository_id}' && (assertion.ref == 'refs/heads/main' || (assertion.event_name == 'pull_request' && assertion.base_ref == 'main'))`이어야 한다(MUST). owner ID, `workflow_ref`, `environment`와 main 경로의 event 이름은 GCP 조건에서 제한해서는 안 된다(MUST NOT). AWS는 기존 `repo:byulmaru/kosmo:environment:terraform-apply` subject를 재사용해야 하며(MUST); 이는 GCP WIF 조건과 별도다. GitHub issuer/provider와 service account IAM 연결, Firebase/native-distribution WIF provider 및 Firebase resource의 trust·상태·삭제 정책은 변경해서는 안 된다(MUST NOT). PR 예외는 read-only 권한을 보장하지 않는다.
 
-#### Scenario: 수동 Plan과 Apply의 인증
+#### Scenario: 수동 Apply 인증
 
-- **WHEN** main dispatch의 Plan 또는 Apply job이 cloud credential을 요청한다
-- **THEN** 두 job 모두 기존 AWS `terraform-apply` Environment subject 경계 안에서 실행되고, GCP는 repository ID와 main ref 또는 main 대상 PR 조건을 사용한다
+- **WHEN** main dispatch의 Apply job이 cloud credential을 요청한다
+- **THEN** 기존 `terraform-apply` Environment subject 경계 안에서 실행되고, GCP는 repository ID와 main ref 조건을 사용한다
 
 #### Scenario: 기존 자동 Terraform 인증
 
@@ -48,60 +48,44 @@
 - **WHEN** 같은 repository의 pull request workflow가 `base_ref == main`으로 GCP credential을 요청한다
 - **THEN** `ref`가 `refs/heads/main`이 아니어도 pull request 예외로 credential 요청을 허용하며, 이 예외는 read-only 권한을 보장하지 않는다
 
-### Requirement: same-run 성공 Plan만 Apply
+### Requirement: 수동 Apply는 Terraform 직접 계획을 한 번 실행한다
 
-**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 실행은 항상 Plan을 먼저 성공시킨 뒤 그 same workflow run에서 생성된 saved plan artifact를 Apply해야 한다(MUST). Apply는 다른 run, PR 또는 저장소 artifact를 검색·선택해서는 안 되며(MUST NOT), saved plan이 생성된 dispatch `github.sha`와 현재 checkout SHA가 일치하는지 확인해야 한다(MUST). 별도 Plan-only 입력이나 `confirm_apply` 입력은 제공하지 않는다(MUST NOT).
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 실행은 기존 Apply job의 인증·Terraform 초기화 뒤 `terraform apply -auto-approve`를 한 번 실행해야 한다(MUST). 수동 경로는 별도 `terraform plan`, Plan-only 입력, `confirm_apply` 입력, saved plan 파일, Plan artifact, `needs` 기반 Manual Plan job 또는 SHA metadata 전달을 두어서는 안 된다(MUST NOT). Terraform 자체의 Apply 내부 계획 계산은 허용한다.
 
-#### Scenario: 수동 Plan 성공 후 Apply
+#### Scenario: main 수동 직접 Apply
 
-- **WHEN** main dispatch의 Plan이 성공하고 saved plan artifact가 현재 run과 선택된 SHA에 연결되어 있다
-- **THEN** Apply가 그 artifact만 내려받아 Terraform native saved-plan validation과 함께 적용한다
+- **WHEN** main dispatch가 main guard와 기존 cloud credential·Terraform 초기화를 통과한다
+- **THEN** 기존 Apply job이 `terraform apply -auto-approve`를 한 번 실행하고, 별도 Plan job이나 saved plan artifact를 조회하지 않는다
 
-#### Scenario: 다른 run의 artifact만 존재
+#### Scenario: 자동 경로 실패 뒤 명시적 recovery
 
-- **WHEN** 현재 dispatch run에 성공한 Plan artifact가 없고 다른 run에만 Plan artifact가 있다
-- **THEN** Apply를 실행하지 않고 해당 수동 실행을 실패시킨다
-
-### Requirement: Plan 실패와 stale plan의 차단
-
-**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 Apply는 Plan job의 성공에 의존해야 하며(MUST), Plan 실패·artifact 누락·artifact 검증 실패가 있으면 건너뛰어야 한다(MUST). Apply는 Terraform의 native saved-plan stale validation을 우회해서는 안 된다(MUST NOT). 수동 경로는 자동 경로가 실패했을 때 자동으로 시작되거나 current plan을 자동 적용해서는 안 되며(MUST NOT), 운영자가 명시적으로 dispatch한 recovery는 허용해야 한다(MUST).
-
-#### Scenario: Plan 실패
-
-- **WHEN** 수동 Plan이 non-zero 결과로 끝난다
-- **THEN** Apply job은 실행되지 않는다
-
-#### Scenario: 다른 Apply로 state snapshot이 변경됨
-
-- **WHEN** Plan 성공 뒤 다른 Terraform Apply가 같은 state의 lineage 또는 serial을 변경한다
-- **THEN** Terraform native saved-plan stale validation이 Apply를 거부하고 수동 경로는 state 검증을 우회하지 않는다
-
-Terraform native stale-plan validation이 state에 기록되지 않은 remote-only drift까지 항상 거부한다는 보장은 이 requirement의 범위가 아니다.
+- **WHEN** 기존 main push의 reviewed/current comparison이 실패한다
+- **THEN** 수동 Apply가 자동으로 시작되지 않으며, 운영자가 별도로 main workflow dispatch를 요청해야 한다
 
 #### Scenario: CI trust 선행 Apply 미완료
 
 - **WHEN** 제한된 GCP CI provider 조건 변경이 기존 main push 자동 경로에서 아직 성공적으로 적용되지 않았다
-- **THEN** 수동 dispatch는 bootstrap 또는 기존 자동 비교를 우회하지 않고 인증/준비 실패로 종료된다
+- **THEN** 수동 dispatch는 bootstrap을 우회하지 않고 인증/준비 실패로 종료된다
 
 ### Requirement: 기존 PR/push 자동 계약 보존
 
-**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다), [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다), [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 새 수동 capability는 기존 pull request Plan artifact 생성과 main push의 reviewed PR plan 선택·현재 main semantic comparison·불일치 차단을 변경해서는 안 된다(MUST NOT). 기존 자동 comparison이 실패하면 current plan 또는 수동 Plan을 자동 적용해서는 안 되며(MUST NOT), 운영자가 명시적으로 수동 recovery를 dispatch할 수 있어야 한다(MUST).
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다), [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다), [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 새 수동 capability는 기존 pull request Plan artifact 생성과 main push의 reviewed PR plan 선택·현재 main semantic comparison·불일치 차단을 변경해서는 안 된다(MUST NOT). 기존 자동 comparison이 실패하면 current plan 또는 수동 Apply를 자동 적용해서는 안 되며(MUST NOT), 운영자가 명시적으로 수동 recovery를 dispatch할 수 있어야 한다(MUST).
 
 #### Scenario: 기존 reviewed/current comparison 성공
 
 - **WHEN** main push에서 선택된 reviewed PR plan과 현재 main plan이 기존 semantic comparison에 통과한다
-- **THEN** 기존 자동 경로가 reviewed saved plan을 적용하고 수동 artifact 선택 로직을 사용하지 않는다
+- **THEN** 기존 자동 경로가 reviewed saved plan을 적용하고 수동 직접 Apply 경로를 사용하지 않는다
 
 #### Scenario: 기존 reviewed/current comparison 불일치
 
 - **WHEN** main push의 reviewed PR plan과 현재 main plan이 다르다
-- **THEN** 기존 자동 Apply가 실패하고 current plan 또는 다른 Plan을 자동 적용하지 않는다
+- **THEN** 기존 자동 Apply가 실패하고 current plan 또는 수동 Apply를 자동 시작하지 않는다
 
 ### Requirement: 기존 Plan 출력 노출 경계 보존
 
-**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 경로는 기존 Plan comment, workflow summary와 artifact의 노출 경계를 유지해야 한다(MUST). Terraform plan JSON, 비교용 중간 JSON 또는 cloud secret을 새 로그·artifact·summary에 노출해서는 안 된다(MUST NOT).
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 경로는 기존 Plan comment, workflow summary와 artifact의 노출 경계를 변경하지 않아야 한다(MUST). Terraform plan JSON, 비교용 중간 JSON 또는 cloud secret을 새 로그·artifact·summary에 노출해서는 안 된다(MUST NOT).
 
-#### Scenario: 수동 Plan 출력 저장
+#### Scenario: 수동 직접 Apply 출력
 
-- **WHEN** 수동 Plan이 성공한다
-- **THEN** 기존에 허용된 human-readable Plan 출력과 Apply에 필요한 saved plan만 남고 Plan JSON·비밀은 새 공개 위치에 저장되지 않는다
+- **WHEN** 수동 Apply가 성공하거나 실패한다
+- **THEN** 수동 경로는 별도 plan JSON·비교 JSON·secret을 summary나 artifact에 저장하지 않고 기존 Terraform command output 경계를 유지한다

--- a/openspec/changes/manual-terraform-recovery/specs/manual-terraform-recovery/spec.md
+++ b/openspec/changes/manual-terraform-recovery/specs/manual-terraform-recovery/spec.md
@@ -81,11 +81,11 @@
 - **WHEN** main push의 reviewed PR plan과 현재 main plan이 다르다
 - **THEN** 기존 자동 Apply가 실패하고 current plan 또는 수동 Apply를 자동 시작하지 않는다
 
-### Requirement: 기존 Plan 출력 노출 경계 보존
+### Requirement: 기존 PR Plan/push Apply 출력 경계 보존
 
-**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 경로는 기존 Plan comment, workflow summary와 artifact의 노출 경계를 변경하지 않아야 한다(MUST). Terraform plan JSON, 비교용 중간 JSON 또는 cloud secret을 새 로그·artifact·summary에 노출해서는 안 된다(MUST NOT).
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 기존 PR Plan과 push Apply의 Plan comment, workflow summary와 artifact 노출 경계를 변경해서는 안 된다(MUST). 수동 direct Apply는 Terraform command output에 새 plan JSON, 비교용 JSON 또는 cloud secret을 노출해서는 안 된다(MUST NOT).
 
 #### Scenario: 수동 직접 Apply 출력
 
 - **WHEN** 수동 Apply가 성공하거나 실패한다
-- **THEN** 수동 경로는 별도 plan JSON·비교 JSON·secret을 summary나 artifact에 저장하지 않고 기존 Terraform command output 경계를 유지한다
+- **THEN** 수동 경로의 Terraform command output에 별도 plan JSON·비교 JSON·secret을 노출하지 않는다

--- a/openspec/changes/manual-terraform-recovery/specs/manual-terraform-recovery/spec.md
+++ b/openspec/changes/manual-terraform-recovery/specs/manual-terraform-recovery/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: main에서 선택한 commit의 수동 Terraform 실행
+
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — Terraform workflow는 `workflow_dispatch`로 요청한 수동 recovery를 제공해야 한다(MUST). 수동 Plan과 Apply는 `refs/heads/main`에서만 실행되어야 하며(MUST), 별도 SHA 입력이나 다른 branch/ref를 허용해서는 안 된다(MUST NOT). Dispatch event가 선택한 `github.sha`는 Plan과 Apply가 같은 실행에서 사용하는 유일한 source commit이어야 하며(MUST), Apply 단계에서 branch ref를 다시 해석해서는 안 된다(MUST NOT). Dispatch 후 `main` ref가 변경되더라도 선택된 SHA를 다시 조회하거나 재해석해서는 안 된다(MUST NOT).
+
+#### Scenario: main에서 수동 실행
+
+- **WHEN** 운영자가 Terraform workflow를 `main` ref에서 수동 실행한다
+- **THEN** Plan과 Apply는 dispatch event의 동일한 `github.sha`를 checkout하고 그 commit을 기준으로 실행한다
+
+#### Scenario: main 이외의 ref에서 수동 실행
+
+- **WHEN** workflow dispatch가 `main` 이외의 ref를 대상으로 요청된다
+- **THEN** cloud credential을 주입하거나 Terraform Plan/Apply를 실행하지 않고 수동 경로를 거부한다
+
+### Requirement: 수동 경로의 cloud credential 경계
+
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행한다) — 수동 Plan과 Apply job은 기존 `terraform-apply` Environment를 사용해야 하며(MUST), credential 주입 전에 main-only 조건을 확인해야 한다(MUST). Terraform CI용 `kosmo-terraform` GCP Workload Identity provider 조건은 `assertion.repository_id == '${local.github_repository_id}' && (assertion.ref == 'refs/heads/main' || (assertion.event_name == 'pull_request' && assertion.base_ref == 'main'))`이어야 한다(MUST). owner ID, `workflow_ref`, `environment`와 main 경로의 event 이름은 GCP 조건에서 제한해서는 안 된다(MUST NOT). AWS는 기존 `repo:byulmaru/kosmo:environment:terraform-apply` subject를 재사용해야 하며(MUST); 이는 GCP WIF 조건과 별도다. GitHub issuer/provider와 service account IAM 연결, Firebase/native-distribution WIF provider 및 Firebase resource의 trust·상태·삭제 정책은 변경해서는 안 된다(MUST NOT). PR 예외는 read-only 권한을 보장하지 않는다.
+
+#### Scenario: 수동 Plan과 Apply의 인증
+
+- **WHEN** main dispatch의 Plan 또는 Apply job이 cloud credential을 요청한다
+- **THEN** 두 job 모두 기존 AWS `terraform-apply` Environment subject 경계 안에서 실행되고, GCP는 repository ID와 main ref 또는 main 대상 PR 조건을 사용한다
+
+#### Scenario: 기존 자동 Terraform 인증
+
+- **WHEN** pull request Plan 또는 main push Apply가 실행된다
+- **THEN** PR의 `pull_request` + `base_ref == main` 조건과 main push의 repository ID + main ref 조건이 계속 허용되고, 수동 경로를 위해 PR 조건을 완화하지 않는다
+
+#### Scenario: 다른 repository
+
+- **WHEN** 다른 repository의 OIDC token이 main ref 또는 main 대상 pull request에서 GCP credential을 요청한다
+- **THEN** `repository_id`가 일치하지 않으므로 GCP credential을 거부한다
+
+#### Scenario: main tag 또는 feature ref의 non-PR 실행
+
+- **WHEN** 같은 repository의 non-PR workflow가 tag 또는 feature branch ref에서 GCP credential을 요청한다
+- **THEN** `ref == refs/heads/main`이 아니므로 GCP credential을 거부한다
+
+#### Scenario: main의 Environment 없는 실행 또는 다른 workflow
+
+- **WHEN** 같은 repository의 workflow가 `refs/heads/main`에서 실행되고 `terraform-apply` Environment를 사용하지 않거나 Terraform workflow가 아니다
+- **THEN** GCP WIF는 Environment 또는 workflow ref를 확인하지 않으므로 credential 요청을 허용하고, AWS credential은 기존 subject로 별도 판단한다
+
+#### Scenario: main 대상 pull request 예외
+
+- **WHEN** 같은 repository의 pull request workflow가 `base_ref == main`으로 GCP credential을 요청한다
+- **THEN** `ref`가 `refs/heads/main`이 아니어도 pull request 예외로 credential 요청을 허용하며, 이 예외는 read-only 권한을 보장하지 않는다
+
+### Requirement: same-run 성공 Plan만 Apply
+
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 실행은 항상 Plan을 먼저 성공시킨 뒤 그 same workflow run에서 생성된 saved plan artifact를 Apply해야 한다(MUST). Apply는 다른 run, PR 또는 저장소 artifact를 검색·선택해서는 안 되며(MUST NOT), saved plan이 생성된 dispatch `github.sha`와 현재 checkout SHA가 일치하는지 확인해야 한다(MUST). 별도 Plan-only 입력이나 `confirm_apply` 입력은 제공하지 않는다(MUST NOT).
+
+#### Scenario: 수동 Plan 성공 후 Apply
+
+- **WHEN** main dispatch의 Plan이 성공하고 saved plan artifact가 현재 run과 선택된 SHA에 연결되어 있다
+- **THEN** Apply가 그 artifact만 내려받아 Terraform native saved-plan validation과 함께 적용한다
+
+#### Scenario: 다른 run의 artifact만 존재
+
+- **WHEN** 현재 dispatch run에 성공한 Plan artifact가 없고 다른 run에만 Plan artifact가 있다
+- **THEN** Apply를 실행하지 않고 해당 수동 실행을 실패시킨다
+
+### Requirement: Plan 실패와 stale plan의 차단
+
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 Apply는 Plan job의 성공에 의존해야 하며(MUST), Plan 실패·artifact 누락·artifact 검증 실패가 있으면 건너뛰어야 한다(MUST). Apply는 Terraform의 native saved-plan stale validation을 우회해서는 안 된다(MUST NOT). 수동 경로는 자동 경로가 실패했을 때 자동으로 시작되거나 current plan을 자동 적용해서는 안 되며(MUST NOT), 운영자가 명시적으로 dispatch한 recovery는 허용해야 한다(MUST).
+
+#### Scenario: Plan 실패
+
+- **WHEN** 수동 Plan이 non-zero 결과로 끝난다
+- **THEN** Apply job은 실행되지 않는다
+
+#### Scenario: 다른 Apply로 state snapshot이 변경됨
+
+- **WHEN** Plan 성공 뒤 다른 Terraform Apply가 같은 state의 lineage 또는 serial을 변경한다
+- **THEN** Terraform native saved-plan stale validation이 Apply를 거부하고 수동 경로는 state 검증을 우회하지 않는다
+
+Terraform native stale-plan validation이 state에 기록되지 않은 remote-only drift까지 항상 거부한다는 보장은 이 requirement의 범위가 아니다.
+
+#### Scenario: CI trust 선행 Apply 미완료
+
+- **WHEN** 제한된 GCP CI provider 조건 변경이 기존 main push 자동 경로에서 아직 성공적으로 적용되지 않았다
+- **THEN** 수동 dispatch는 bootstrap 또는 기존 자동 비교를 우회하지 않고 인증/준비 실패로 종료된다
+
+### Requirement: 기존 PR/push 자동 계약 보존
+
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다), [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다), [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 새 수동 capability는 기존 pull request Plan artifact 생성과 main push의 reviewed PR plan 선택·현재 main semantic comparison·불일치 차단을 변경해서는 안 된다(MUST NOT). 기존 자동 comparison이 실패하면 current plan 또는 수동 Plan을 자동 적용해서는 안 되며(MUST NOT), 운영자가 명시적으로 수동 recovery를 dispatch할 수 있어야 한다(MUST).
+
+#### Scenario: 기존 reviewed/current comparison 성공
+
+- **WHEN** main push에서 선택된 reviewed PR plan과 현재 main plan이 기존 semantic comparison에 통과한다
+- **THEN** 기존 자동 경로가 reviewed saved plan을 적용하고 수동 artifact 선택 로직을 사용하지 않는다
+
+#### Scenario: 기존 reviewed/current comparison 불일치
+
+- **WHEN** main push의 reviewed PR plan과 현재 main plan이 다르다
+- **THEN** 기존 자동 Apply가 실패하고 current plan 또는 다른 Plan을 자동 적용하지 않는다
+
+### Requirement: 기존 Plan 출력 노출 경계 보존
+
+**Authority / Provenance:** 적용 canonical domain/design 없음; 운영 context `apps/terraform/README.md`; [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다) — 수동 경로는 기존 Plan comment, workflow summary와 artifact의 노출 경계를 유지해야 한다(MUST). Terraform plan JSON, 비교용 중간 JSON 또는 cloud secret을 새 로그·artifact·summary에 노출해서는 안 된다(MUST NOT).
+
+#### Scenario: 수동 Plan 출력 저장
+
+- **WHEN** 수동 Plan이 성공한다
+- **THEN** 기존에 허용된 human-readable Plan 출력과 Apply에 필요한 saved plan만 남고 Plan JSON·비밀은 새 공개 위치에 저장되지 않는다

--- a/openspec/changes/manual-terraform-recovery/tasks.md
+++ b/openspec/changes/manual-terraform-recovery/tasks.md
@@ -7,24 +7,24 @@
 
 **Deliverable**
 
-`main`에서 명시적으로 dispatch한 한 workflow run이 선택된 `github.sha`로 Plan을 성공시키고, 그 same-run saved plan만 이어서 Apply하는 수동 recovery 결과.
+`main`에서 명시적으로 dispatch한 기존 Apply job이 선택된 `github.sha`를 checkout하고, 기존 인증·Terraform 초기화 뒤 직접 Apply하는 수동 recovery 결과.
 
 **Guardrails**
 
-- 수동 Plan과 Apply는 `refs/heads/main`에서만 동작하고 credential 주입 전에 ref를 확인한다.
-- 별도 target SHA, Plan-only 기본값, `confirm_apply` 입력을 추가하지 않는다.
-- Plan 실패·artifact 누락·SHA 불일치가 있으면 Apply하지 않는다.
+- 수동 Apply는 `refs/heads/main`에서만 동작하고 credential 주입 전에 ref를 확인한다.
+- 별도 target SHA, Plan-only 기본값, `confirm_apply` 입력, Manual Plan job, `needs`, saved plan artifact와 SHA metadata 전달을 추가하지 않는다.
+- 수동 경로는 `terraform apply -auto-approve`를 한 번 실행한다.
 - 기존 pull request Plan과 push reviewed/current semantic comparison 경로를 변경하거나 우회하지 않는다.
 - Plan JSON, 비교용 JSON, OIDC token과 cloud secret을 새 로그·summary·artifact에 노출하지 않는다.
 
 **Verification**
 
 - actionlint 또는 동등한 표준 workflow validator로 dispatch·PR·push event의 문법과 job 조건을 확인한다.
-- main dispatch, non-main dispatch, Plan 실패, same-run artifact 누락·SHA 불일치, push의 기존 mismatch 차단을 실행 동작 또는 검증 가능한 event matrix로 확인한다. source 문자열·정규식·AST 존재 검사는 사용하지 않는다.
+- main dispatch, non-main dispatch, 직접 Apply command와 push의 기존 mismatch 차단을 실행 동작 또는 검증 가능한 event matrix로 확인한다. source 문자열·정규식·AST 존재 검사는 사용하지 않는다.
 - 실제 workflow dispatch·rerun·Apply는 별도 운영 승인 전까지 수행하지 않으며, 정적 검증을 실제 Apply 성공으로 표현하지 않는다.
 
-- [x] 1.1 `workflow_dispatch` 수동 경로와 main-only SHA 고정을 구현한다.
-- [x] 1.2 성공한 same-run Plan artifact만 Apply하도록 Plan–Apply 의존성과 실패 차단을 구현한다.
+- [x] 1.1 `workflow_dispatch` 수동 Apply 경로와 main-only `github.sha` checkout을 구현한다.
+- [x] 1.2 기존 Apply job에서 수동 `terraform apply -auto-approve`를 한 번 실행하고 Manual Plan/artifact/needs 경로를 두지 않는다.
 - [ ] 1.3 PR/push 자동 경로와 Plan 출력 노출 경계를 보존하고 event별 실행 동작을 검증한다.
 
 ## 2. PROD-898 Terraform CI identity 선행 조건
@@ -48,11 +48,11 @@ Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 
 
 **Verification**
 
-- Terraform formatter/validator와 reviewed plan으로 CI provider 조건 변경 범위, 다른 repository·ref·PR/workflow 시나리오 및 AWS Environment 분리를 확인하고 Firebase/native-distribution resource 변경이 없음을 검토한다.
+- Terraform formatter/validator와 reviewed plan으로 CI provider만 변경되는지, 다른 repository·ref·PR/workflow 시나리오 및 AWS Environment 분리를 확인한다. Firebase/native-distribution resource 변경은 없어야 한다.
 - 기존 main push의 reviewed/current semantic comparison을 통과해 CI trust 변경을 실제 반영해야 한다는 선행 조건과, 그 증거가 없을 때 manual 경로를 사용하지 않는 운영 문서를 확인한다. 이 task에서는 실제 Apply를 수행하지 않는다.
 
 - [x] 2.1 승인된 최소 `kosmo-terraform` GCP WIF repository + main 또는 main 대상 PR condition을 구현하고 추가 owner/workflow/Environment/event 제한은 두지 않는다.
-- [x] 2.2 Manual Plan/Apply 양쪽의 `terraform-apply` Environment 및 credential 순서를 문서·workflow에 정렬한다.
+- [x] 2.2 수동 Apply의 `terraform-apply` Environment 및 credential 순서를 문서·workflow에 정렬한다.
 - [ ] 2.3 Terraform fmt/validate와 reviewed plan 범위 검토로 CI provider만 변경되는지 확인하고 trust 선행 Apply 절차를 운영 문서에 기록한다.
 
 ## 3. PROD-898 운영 문서와 OpenSpec 정합성
@@ -64,12 +64,12 @@ Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 
 
 **Deliverable**
 
-운영자가 manual Plan 후 즉시 Apply, main branch policy, same-run artifact, CI trust 선행 순서와 실제 운영 증거의 경계를 이해할 수 있는 문서와 구현·spec의 정합성.
+운영자가 main-only direct Apply, 기존 인증·초기화, push reviewed saved-plan 경로, CI trust 선행 순서와 실제 운영 증거의 경계를 이해할 수 있는 문서와 구현·spec의 정합성.
 
 **Guardrails**
 
 - `terraform-apply` Environment에 required reviewer가 없다는 현재 사실을 사람 승인으로 표현하지 않는다.
-- 기존 자동 PR/push 계약과 manual recovery의 별도 lifecycle을 섞지 않는다.
+- 기존 자동 PR/push 계약과 manual direct Apply의 별도 lifecycle을 섞지 않는다.
 - 실제 dispatch·Apply 증거가 없는 상태에서 성공을 주장하지 않는다.
 
 **Verification**
@@ -77,7 +77,7 @@ Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 
 - Markdown formatting/link validation과 OpenSpec requirement·decision·task cross-check를 수행한다.
 - 운영 문서의 포함·제외 범위가 PROD-898과 일치하고, Firebase/native-distribution WIF 보존·trust 선행 조건·실제 Apply 증거 경계가 명시되어 있는지 검토한다.
 
-- [x] 3.1 `apps/terraform/README.md` 및 필요한 운영 설명을 승인된 manual recovery 흐름과 선행 조건에 맞춰 갱신한다.
+- [x] 3.1 `apps/terraform/README.md` 및 필요한 운영 설명을 승인된 direct Apply 흐름과 선행 조건에 맞춰 갱신한다.
 - [x] 3.2 구현 diff, 운영 문서와 OpenSpec의 requirement/decision/task를 독립 대조해 누락·과장·범위 확장을 제거한다.
 
 ## 4. PROD-898 통합 검증과 완료·archive
@@ -90,7 +90,7 @@ Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 
 
 **Deliverable**
 
-수동 recovery와 기존 자동 경로를 함께 검증한 구현 PR, 정합성 확인 결과, 그리고 전체 범위가 완료된 뒤 archive 가능한 OpenSpec change.
+수동 direct Apply와 기존 자동 경로를 함께 검증한 구현 PR, 정합성 확인 결과, 그리고 전체 범위가 완료된 뒤 archive 가능한 OpenSpec change.
 
 **Guardrails**
 
@@ -101,10 +101,10 @@ Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 
 **Verification**
 
 - actionlint, Terraform fmt/validate, OpenSpec strict validation 및 저장소 표준 checks를 통과한다.
-- 독립 review에서 main-only, same-run exact artifact, Plan 실패 차단, CI trust 선행, 기존 PR/push compare 보존과 범위 제외를 확인한다.
+- 독립 review에서 main-only, direct Apply command, CI trust 선행, 기존 PR/push compare 보존과 범위 제외를 확인한다.
 - 구현 PR merge 후 CI trust 선행 Apply가 완료되었는지와 manual run을 아직 수행하지 않았다는 운영 상태를 분리해 기록한다. 이 task에서는 실제 manual dispatch·Apply를 실행하거나 그 성공을 주장하지 않는다.
 
-- [ ] 4.1 표준 workflow/Terraform/OpenSpec validation과 event·artifact·failure-path 검증을 통과시킨다.
+- [ ] 4.1 표준 workflow/Terraform/OpenSpec validation과 event·direct-Apply/failure-path 검증을 통과시킨다.
 - [x] 4.2 독립 검토 결과를 반영하고 PROD-898 전체 변경과 기존 자동 계약의 정합성을 최종 확인한다.
 - [ ] 4.3 구현 PR merge 후 CI trust 선행 Apply 요구와 manual run 미실행 상태를 분리해 기록한다.
 - [ ] 4.4 전체 requirement·task·검증·문서 sync가 완료되고 미해결 Blocked/Upstream Change Required decision이 없을 때 PROD-898이 OpenSpec change를 archive하며, 실제 manual Apply 성공은 주장하지 않는다.

--- a/openspec/changes/manual-terraform-recovery/tasks.md
+++ b/openspec/changes/manual-terraform-recovery/tasks.md
@@ -1,0 +1,110 @@
+## 1. PROD-898 수동 workflow 경로
+
+**Authority / Provenance**
+
+- [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- 운영 context: `apps/terraform/README.md`
+
+**Deliverable**
+
+`main`에서 명시적으로 dispatch한 한 workflow run이 선택된 `github.sha`로 Plan을 성공시키고, 그 same-run saved plan만 이어서 Apply하는 수동 recovery 결과.
+
+**Guardrails**
+
+- 수동 Plan과 Apply는 `refs/heads/main`에서만 동작하고 credential 주입 전에 ref를 확인한다.
+- 별도 target SHA, Plan-only 기본값, `confirm_apply` 입력을 추가하지 않는다.
+- Plan 실패·artifact 누락·SHA 불일치가 있으면 Apply하지 않는다.
+- 기존 pull request Plan과 push reviewed/current semantic comparison 경로를 변경하거나 우회하지 않는다.
+- Plan JSON, 비교용 JSON, OIDC token과 cloud secret을 새 로그·summary·artifact에 노출하지 않는다.
+
+**Verification**
+
+- actionlint 또는 동등한 표준 workflow validator로 dispatch·PR·push event의 문법과 job 조건을 확인한다.
+- main dispatch, non-main dispatch, Plan 실패, same-run artifact 누락·SHA 불일치, push의 기존 mismatch 차단을 실행 동작 또는 검증 가능한 event matrix로 확인한다. source 문자열·정규식·AST 존재 검사는 사용하지 않는다.
+- 실제 workflow dispatch·rerun·Apply는 별도 운영 승인 전까지 수행하지 않으며, 정적 검증을 실제 Apply 성공으로 표현하지 않는다.
+
+- [x] 1.1 `workflow_dispatch` 수동 경로와 main-only SHA 고정을 구현한다.
+- [x] 1.2 성공한 same-run Plan artifact만 Apply하도록 Plan–Apply 의존성과 실패 차단을 구현한다.
+- [ ] 1.3 PR/push 자동 경로와 Plan 출력 노출 경계를 보존하고 event별 실행 동작을 검증한다.
+
+## 2. PROD-898 Terraform CI identity 선행 조건
+
+**Authority / Provenance**
+
+- [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다)
+- 운영 context: `apps/terraform/README.md`
+
+**Deliverable**
+
+Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 `refs/heads/main` 또는 `pull_request` + `base_ref == main` trust를 허용하고, manual 사용 전 기존 자동 push Apply로 그 변경을 반영하는 운영 순서. owner ID, workflow ref, Environment와 main 경로의 event 이름은 GCP 조건에서 제한하지 않으며, 같은 repository의 다른 main/PR workflow와 read-only가 아닌 PR 예외를 허용한다는 trade-off를 기록한다.
+
+**Guardrails**
+
+- 새 조건은 기존 `repository_id`와 `refs/heads/main` 또는 `pull_request` + `base_ref == main`으로 제한한다. owner ID, workflow ref, Environment와 main 경로의 event 이름은 GCP 조건에 추가하지 않으며, PR 예외의 `event_name == pull_request`는 유지한다.
+- AWS 기존 `repo:byulmaru/kosmo:environment:terraform-apply` subject를 재사용한다.
+- Firebase/native-distribution WIF provider, Firebase resource, Environment 설정, secrets·variables, Kubernetes repository는 변경하지 않는다.
+- CI trust 선행 Apply가 실패하면 manual dispatch로 bootstrap을 우회하지 않는다.
+
+**Verification**
+
+- Terraform formatter/validator와 reviewed plan으로 CI provider 조건 변경 범위, 다른 repository·ref·PR/workflow 시나리오 및 AWS Environment 분리를 확인하고 Firebase/native-distribution resource 변경이 없음을 검토한다.
+- 기존 main push의 reviewed/current semantic comparison을 통과해 CI trust 변경을 실제 반영해야 한다는 선행 조건과, 그 증거가 없을 때 manual 경로를 사용하지 않는 운영 문서를 확인한다. 이 task에서는 실제 Apply를 수행하지 않는다.
+
+- [x] 2.1 승인된 최소 `kosmo-terraform` GCP WIF repository + main 또는 main 대상 PR condition을 구현하고 추가 owner/workflow/Environment/event 제한은 두지 않는다.
+- [x] 2.2 Manual Plan/Apply 양쪽의 `terraform-apply` Environment 및 credential 순서를 문서·workflow에 정렬한다.
+- [ ] 2.3 Terraform fmt/validate와 reviewed plan 범위 검토로 CI provider만 변경되는지 확인하고 trust 선행 Apply 절차를 운영 문서에 기록한다.
+
+## 3. PROD-898 운영 문서와 OpenSpec 정합성
+
+**Authority / Provenance**
+
+- [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- 운영 context: `apps/terraform/README.md`
+
+**Deliverable**
+
+운영자가 manual Plan 후 즉시 Apply, main branch policy, same-run artifact, CI trust 선행 순서와 실제 운영 증거의 경계를 이해할 수 있는 문서와 구현·spec의 정합성.
+
+**Guardrails**
+
+- `terraform-apply` Environment에 required reviewer가 없다는 현재 사실을 사람 승인으로 표현하지 않는다.
+- 기존 자동 PR/push 계약과 manual recovery의 별도 lifecycle을 섞지 않는다.
+- 실제 dispatch·Apply 증거가 없는 상태에서 성공을 주장하지 않는다.
+
+**Verification**
+
+- Markdown formatting/link validation과 OpenSpec requirement·decision·task cross-check를 수행한다.
+- 운영 문서의 포함·제외 범위가 PROD-898과 일치하고, Firebase/native-distribution WIF 보존·trust 선행 조건·실제 Apply 증거 경계가 명시되어 있는지 검토한다.
+
+- [x] 3.1 `apps/terraform/README.md` 및 필요한 운영 설명을 승인된 manual recovery 흐름과 선행 조건에 맞춰 갱신한다.
+- [ ] 3.2 구현 diff, 운영 문서와 OpenSpec의 requirement/decision/task를 독립 대조해 누락·과장·범위 확장을 제거한다.
+
+## 4. PROD-898 통합 검증과 완료·archive
+
+**Authority / Provenance**
+
+- [PROD-898](https://linear.app/byulmaru/issue/PROD-898/최신-main-terraform-계획을-수동-실행으로-적용한다)
+- [PROD-609](https://linear.app/byulmaru/issue/PROD-609/terraform-apply에서-merge-group-plan-경로를-제거한다)
+- [PROD-586](https://linear.app/byulmaru/issue/PROD-586/검토된-terraform-plan과-현재-plan이-같으면-main-apply를-허용한다)
+
+**Deliverable**
+
+수동 recovery와 기존 자동 경로를 함께 검증한 구현 PR, 정합성 확인 결과, 그리고 전체 범위가 완료된 뒤 archive 가능한 OpenSpec change.
+
+**Guardrails**
+
+- static/CI 검증과 실제 cloud Apply evidence를 분리한다.
+- source string/regex/AST 존재 검사를 테스트로 추가하지 않는다.
+- PROD-898이 소유한 구현·문서·검증·정합성·spec sync·archive를 다른 부모·자식·통합 이슈로 분산하지 않는다.
+
+**Verification**
+
+- actionlint, Terraform fmt/validate, OpenSpec strict validation 및 저장소 표준 checks를 통과한다.
+- 독립 review에서 main-only, same-run exact artifact, Plan 실패 차단, CI trust 선행, 기존 PR/push compare 보존과 범위 제외를 확인한다.
+- 구현 PR merge 후 CI trust 선행 Apply가 완료되었는지와 manual run을 아직 수행하지 않았다는 운영 상태를 분리해 기록한다. 이 task에서는 실제 manual dispatch·Apply를 실행하거나 그 성공을 주장하지 않는다.
+
+- [ ] 4.1 표준 workflow/Terraform/OpenSpec validation과 event·artifact·failure-path 검증을 통과시킨다.
+- [ ] 4.2 독립 검토 결과를 반영하고 PROD-898 전체 변경과 기존 자동 계약의 정합성을 최종 확인한다.
+- [ ] 4.3 구현 PR merge 후 CI trust 선행 Apply 요구와 manual run 미실행 상태를 분리해 기록한다.
+- [ ] 4.4 전체 requirement·task·검증·문서 sync가 완료되고 미해결 Blocked/Upstream Change Required decision이 없을 때 PROD-898이 OpenSpec change를 archive하며, 실제 manual Apply 성공은 주장하지 않는다.

--- a/openspec/changes/manual-terraform-recovery/tasks.md
+++ b/openspec/changes/manual-terraform-recovery/tasks.md
@@ -78,7 +78,7 @@ Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 
 - 운영 문서의 포함·제외 범위가 PROD-898과 일치하고, Firebase/native-distribution WIF 보존·trust 선행 조건·실제 Apply 증거 경계가 명시되어 있는지 검토한다.
 
 - [x] 3.1 `apps/terraform/README.md` 및 필요한 운영 설명을 승인된 manual recovery 흐름과 선행 조건에 맞춰 갱신한다.
-- [ ] 3.2 구현 diff, 운영 문서와 OpenSpec의 requirement/decision/task를 독립 대조해 누락·과장·범위 확장을 제거한다.
+- [x] 3.2 구현 diff, 운영 문서와 OpenSpec의 requirement/decision/task를 독립 대조해 누락·과장·범위 확장을 제거한다.
 
 ## 4. PROD-898 통합 검증과 완료·archive
 
@@ -105,6 +105,6 @@ Terraform CI용 `kosmo-terraform` GCP WIF provider가 기존 `repository_id`와 
 - 구현 PR merge 후 CI trust 선행 Apply가 완료되었는지와 manual run을 아직 수행하지 않았다는 운영 상태를 분리해 기록한다. 이 task에서는 실제 manual dispatch·Apply를 실행하거나 그 성공을 주장하지 않는다.
 
 - [ ] 4.1 표준 workflow/Terraform/OpenSpec validation과 event·artifact·failure-path 검증을 통과시킨다.
-- [ ] 4.2 독립 검토 결과를 반영하고 PROD-898 전체 변경과 기존 자동 계약의 정합성을 최종 확인한다.
+- [x] 4.2 독립 검토 결과를 반영하고 PROD-898 전체 변경과 기존 자동 계약의 정합성을 최종 확인한다.
 - [ ] 4.3 구현 PR merge 후 CI trust 선행 Apply 요구와 manual run 미실행 상태를 분리해 기록한다.
 - [ ] 4.4 전체 requirement·task·검증·문서 sync가 완료되고 미해결 Blocked/Upstream Change Required decision이 없을 때 PROD-898이 OpenSpec change를 archive하며, 실제 manual Apply 성공은 주장하지 않는다.


### PR DESCRIPTION
## 무엇을 변경했는지

- main 전용 `workflow_dispatch`에서 기존 Apply job을 재사용해 `terraform apply -auto-approve`를 직접 실행합니다.
- 별도 Manual Plan job, job 의존성, 수동 plan artifact 저장·다운로드·SHA metadata 검증을 제거했습니다.
- 기존 PR Plan과 main push의 reviewed/current plan 비교·불일치 차단·saved-plan Apply는 유지합니다.
- GCP WIF는 기존 repository ID AND (main ref OR main 대상 pull_request) 조건으로 단순화합니다. AWS trust·Environment 설정·서비스 계정 권한·Firebase/native-distribution WIF는 변경하지 않습니다.
- 운영 README와 OpenSpec을 직접 Apply 계약으로 정렬했습니다.

## 왜 변경했는지

자동 main Apply가 plan 불일치로 중단됐을 때 운영자가 명시적으로 복구할 경로를 추가합니다. 수동 실행에는 별도 Plan job과 artifact 전달이 필요 없다는 사용자 피드백에 따라 기존 인증·초기화·Apply를 재사용합니다.

## 이번 PR의 주요 결정

사용자는 수동 saved-plan 전달 대신 `terraform apply -auto-approve` 직접 실행을 선택했습니다. Terraform 내부 계획 계산은 유지하지만 별도 Plan 단계나 중간 artifact는 두지 않습니다. 수동 경로는 reviewed saved-plan 검증을 주장하지 않으며, 기존 push 경로의 검증은 그대로 유지합니다.

최신 [PROD-898](https://linear.app/byulmaru/issue/PROD-898)과 대조한 [OpenSpec decisions](https://github.com/byulmaru/kosmo/blob/PROD-898/openspec/changes/manual-terraform-recovery/decisions.md)에 이전 결정을 대체한 기록을 남겼습니다. 별도 target SHA·confirm 입력이나 새로운 인증 예외는 추가하지 않았습니다.

## 어떻게 확인할 수 있는지

- actionlint, Terraform fmt/validate, 대상 파일 Prettier, OpenSpec strict validation, git diff --check 통과.
- Ptolemy: 구현·표준 검증. Leibniz: PR/push 보존과 수동 직접 Apply 경계 검토. Arendt: 불필요한 코드·중복 제거 검토.
- 실제 수동 dispatch/rerun 및 Terraform Apply는 실행하지 않았습니다.

## 아직 어떤 문제가 남았는지

- 최신 PR CI와 reviewed plan을 확인해야 합니다.
- 병합 후 기존 main push Apply가 WIF 변경을 먼저 반영해야 합니다. 해당 선행 Apply가 실패하면 수동 recovery로 bootstrap을 우회하지 않습니다.
- 실제 수동 실행 증거와 병합 후 trust 적용 확인은 미완료입니다. 남은 OpenSpec task와 archive는 별도로 완료합니다.

Stack: main -> PROD-898
