### PR TITLE
iOS 번들 빌드의 Node 메모리 부족을 방지한다

### DIFF
--- a/.github/workflows/ios-app-store-connect-upload.yml
+++ b/.github/workflows/ios-app-store-connect-upload.yml
@@ -109,5 +109,6 @@ jobs:
           IOS_APP_STORE_PROVISIONING_PROFILE_BASE64: ${{ steps.ios_signing.outputs.IOS_APP_STORE_PROVISIONING_PROFILE_BASE64 }}
           IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ steps.ios_signing.outputs.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
           IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ steps.ios_signing.outputs.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          NODE_OPTIONS: '--max-old-space-size=4096'
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bundle exec fastlane ios build_and_upload_ios


### PR DESCRIPTION
Stack: `main -> ios-node-heap`

## 무엇을 변경했는지

- iOS App Store Connect Upload workflow의 `Build and distribute iOS App Store IPA` step에 `NODE_OPTIONS: '--max-old-space-size=4096'`를 추가했습니다.
- iOS build, Sentry source map/dSYM 업로드, TestFlight 업로드 흐름은 기존 설정을 유지합니다.

## 왜 변경했는지

실행 [#34108881262](https://github.com/byulmaru/kosmo/actions/runs/34108881262)은 `83bd17317678a728a56a288839e5d0c7ce58370c`에서 IPA 생성과 업로드 전에 Xcode archive가 실패했습니다. 로그에서 Node 26.3.0으로 실행된 Sentry script가 약 2GiB heap 한도에 도달해 `JavaScript heap out of memory`로 종료된 것이 확인됐습니다.

## 이번 PR의 주요 결정

- Build and distribute step에만 Node old-space 한도를 4GiB로 지정합니다.
- Sentry 경로와 실패 조건, dSYM 업로드 및 TestFlight 업로드 순서는 변경하지 않습니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/ios-app-store-connect-upload.yml` 통과
- `git diff --check` 통과
- 로컬 Node `v26.3.0`에서 동일한 `NODE_OPTIONS`를 적용해 V8 heap limit `4,395,630,592` bytes를 확인

## 아직 어떤 문제가 남았는지

실제 hosted macOS runner의 Xcode archive와 TestFlight 업로드는 아직 재실행하지 않았으므로 배포 성공 여부는 후속 실행에서 확인해야 합니다.
