### PR TITLE
iOS 빌드 캐시를 단순화하고 Tailscale 연결 시간을 줄인다

### DIFF
--- a/.github/workflows/ios-app-store-connect-upload.yml
+++ b/.github/workflows/ios-app-store-connect-upload.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Set up Ruby and Bundler
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1

--- a/.github/workflows/ios-app-store-connect-upload.yml
+++ b/.github/workflows/ios-app-store-connect-upload.yml
@@ -29,28 +29,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Connect to Tailscale for Vault
-        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
-        with:
-          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
-          audience: ${{ vars.TAILSCALE_AUDIENCE }}
-          tags: tag:github-actions
-
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
 
-      - name: Get pnpm store directory
-        id: pnpm-store
-        shell: bash
-        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
-
       - name: Cache pnpm store
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-${{ runner.os }}-${{ runner.arch }}-
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Set up Ruby and Bundler
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
@@ -88,6 +74,13 @@ jobs:
             exit 1
           fi
           echo "IOS_BUILD_NUMBER=${ios_build_number}" >> "${GITHUB_ENV}"
+
+      - name: Connect to Tailscale for Vault
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: tag:github-actions
 
       - name: Load iOS signing credentials from Vault
         id: ios_signing

--- a/.github/workflows/ios-app-store-connect-upload.yml
+++ b/.github/workflows/ios-app-store-connect-upload.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
 
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Set up Ruby and Bundler
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:


### PR DESCRIPTION
Stack: `main -> ios-pnpm-store-cache`

## 무엇을 변경했는지

- `mise` 다음에 `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020` (`v7.0.0`)의 표준 `cache: pnpm` 기능을 사용합니다.
- `node-version`을 지정하지 않아 `mise.toml`의 Node 버전을 그대로 유지합니다.
- Tailscale 연결을 Vault 사용 직전으로 옮기고, 직후의 `tailscale logout`과 DNS 초기화는 기존대로 유지합니다.
- 직접 store 경로 출력과 cache key를 관리하던 단계를 제거하고 `pnpm install --frozen-lockfile`은 유지합니다.

## 왜 변경했는지

GitHub hosted runner는 매 실행마다 새 환경에서 시작하므로 pnpm 패키지 store를 매번 다시 채워야 합니다. setup-node의 표준 pnpm 캐시를 사용하면 lockfile 기반 캐시를 재사용해 의존성 설치 시간을 줄일 수 있습니다. Tailscale은 Vault 요청에 필요한 시점에만 연결해 네트워크 세션 유지 시간을 줄입니다.

## 이번 PR의 주요 결정

- 캐시 범위는 pnpm 패키지 store로 한정하고 Xcode DerivedData, CocoaPods, CNG prebuild, clean build 동작은 변경하지 않습니다.
- 직접 cache 경로와 키를 조립하지 않고 setup-node의 표준 기능을 사용하며, 기존 frozen install 흐름을 유지합니다.
- Tailscale 연결과 Vault 요청 사이의 순서만 조정하고, Vault 직후 logout·DNS 초기화 및 action post cleanup은 보존합니다.

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/ios-app-store-connect-upload.yml` 통과
- `git diff --check` 통과
- setup-node `v7.0.0` release와 immutable SHA를 확인하고, 해당 코드에서 pnpm cache 경로 계산 및 `node-version` 미지정 시 Node 설치 생략을 확인
- 로컬 `pnpm store path --silent`가 유효한 pnpm store 경로를 반환하는 것을 확인

## 아직 어떤 문제가 남았는지

실제 hosted runner의 cache hit 여부와 설치 시간, Tailscale 세션 시간이 아직 측정되지 않았습니다. iOS archive와 TestFlight 배포도 재실행하지 않았습니다.
