### PR TITLE
iOS 네이티브 컴파일 결과를 캐시로 재사용한다

### DIFF
--- a/.github/workflows/ios-app-store-connect-upload.yml
+++ b/.github/workflows/ios-app-store-connect-upload.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 60
     environment: prod
     env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
       EXPO_NO_GIT_STATUS: '1'
       SENTRY_ORG: ${{ vars.SENTRY_ORG }}
       SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
@@ -28,6 +29,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@f09c25b45002a07be2955cbe52e8cee55643f89d # v1.2.24
 
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
@@ -114,6 +118,8 @@ jobs:
           IOS_APP_STORE_PROVISIONING_PROFILE_BASE64: ${{ steps.ios_signing.outputs.IOS_APP_STORE_PROVISIONING_PROFILE_BASE64 }}
           IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ steps.ios_signing.outputs.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
           IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ steps.ios_signing.outputs.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          CCACHE_COMPILERCHECK: content
+          USE_CCACHE: '1'
           NODE_OPTIONS: '--max-old-space-size=4096'
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bundle exec fastlane ios build_and_upload_ios


### PR DESCRIPTION
Stack: `main -> ios-ccache-action`

## 무엇을 변경했는지

iOS App Store Connect Upload workflow에 ccache-action을 추가하고, Fastlane 네이티브 빌드에서 ccache를 활성화했습니다.

## 왜 변경했는지

반복적인 iOS C/C++ 컴파일 결과를 GitHub Actions 실행 간 재사용해 빌드 시간을 줄입니다.

## 주요 결정

- ccache-action은 immutable SHA로 고정했습니다.
- action의 기본 키와 timestamp 기반 restore/save 동작을 사용합니다.
- `CCACHE_DIR`을 action의 workspace `.ccache` 경로로 고정해 React Native wrapper와 action의 cache 경로를 일치시켰습니다.
- `USE_CCACHE=1`과 `CCACHE_COMPILERCHECK=content`를 Fastlane 빌드에 적용했습니다.
- 새 Expo 설정 플러그인이나 의존성은 추가하지 않았습니다.

## 검증

- `actionlint .github/workflows/ios-app-store-connect-upload.yml` 통과
- `git diff --check` 통과
- React Native ccache clang/clang++ wrapper로 C/C++를 각각 두 번 컴파일해 두 번째 실행의 cache hit 확인
- C/C++ 산출물 SHA256 동일 확인

## 남은 문제

실제 macOS runner의 iOS archive 및 TestFlight 업로드는 실행하지 않았습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>