### PR TITLE
Native 목록에서 정리된 스크롤 이벤트를 다시 읽지 않게 한다

### DIFF
--- a/apps/app/src/components/pagination/PaginationScrollView.test.ts
+++ b/apps/app/src/components/pagination/PaginationScrollView.test.ts
@@ -133,6 +133,51 @@ describe('PaginationScrollView', () => {
     assert.equal(contentHeight, 960);
   });
 
+  it('registration 전 Native event가 정리돼도 layout과 scroll metric을 replay한다', async () => {
+    await act(async () => {
+      renderer = create(renderOwner(false));
+    });
+    assert.ok(renderer);
+
+    const scrollView = renderer.root.findAll((node) => (node.type as unknown) === 'ScrollView')[0];
+    assert.ok(scrollView);
+    const layoutEvent = { nativeEvent: { layout: { height: 240 } } };
+    const scrollEvent = {
+      nativeEvent: {
+        contentOffset: { y: 24 },
+        contentSize: { height: 960 },
+        layoutMeasurement: { height: 320 },
+      },
+    };
+
+    scrollView.props.onLayout(layoutEvent);
+    (layoutEvent as unknown as { nativeEvent: null }).nativeEvent = null;
+
+    await act(async () => {
+      renderer?.update(renderOwner(true));
+    });
+
+    assert.equal(layoutHeight, 240);
+
+    await act(async () => {
+      renderer?.update(renderOwner(false));
+    });
+    const unregisteredScrollView = renderer.root.findAll(
+      (node) => (node.type as unknown) === 'ScrollView',
+    )[0];
+    assert.ok(unregisteredScrollView);
+    unregisteredScrollView.props.onScroll(scrollEvent);
+    (scrollEvent as unknown as { nativeEvent: null }).nativeEvent = null;
+
+    await act(async () => {
+      renderer?.update(renderOwner(true));
+    });
+
+    assert.equal(contentHeight, 960);
+    assert.equal(layoutHeight, 320);
+    assert.equal(scrollOffset, 24);
+  });
+
   it('owner가 바뀌면 이전 metric을 새 registration에 재생하지 않는다', async () => {
     await act(async () => {
       renderer = create(renderOwner(false, 'owner-a'));

--- a/apps/app/src/components/pagination/PaginationScrollView.tsx
+++ b/apps/app/src/components/pagination/PaginationScrollView.tsx
@@ -4,6 +4,8 @@ import type { ScrollViewProps } from 'react-native';
 import type { UseAutomaticPaginationResult } from './useAutomaticPagination';
 
 type NativeScrollProps = UseAutomaticPaginationResult['nativeScrollProps'];
+type NativeLayoutEvent = Parameters<NativeScrollProps['onLayout']>[0];
+type NativeScrollEvent = Parameters<NativeScrollProps['onScroll']>[0];
 type Registration = Readonly<{ id: symbol; props: NativeScrollProps }>;
 type ActiveRegistration = Registration & Readonly<{ ownerKey: string }>;
 type Register = (registration: Registration) => () => void;
@@ -28,6 +30,20 @@ function recordLatestEvent(events: LatestEvent[], event: LatestEvent) {
     events.splice(previousIndex, 1);
   }
   events.push(event);
+}
+
+function snapshotLayoutEvent(event: NativeLayoutEvent): NativeLayoutEvent {
+  return { nativeEvent: { layout: { height: event.nativeEvent.layout.height } } };
+}
+
+function snapshotScrollEvent(event: NativeScrollEvent): NativeScrollEvent {
+  return {
+    nativeEvent: {
+      contentOffset: { y: event.nativeEvent.contentOffset.y },
+      contentSize: { height: event.nativeEvent.contentSize.height },
+      layoutMeasurement: { height: event.nativeEvent.layoutMeasurement.height },
+    },
+  };
 }
 
 export function PaginationScrollView({
@@ -57,7 +73,10 @@ export function PaginationScrollView({
   );
   const onLayout = useCallback(
     (...args: Parameters<NativeScrollProps['onLayout']>) => {
-      recordLatestEvent(latestEventsRef.current, { args, type: 'layout' });
+      recordLatestEvent(latestEventsRef.current, {
+        args: [snapshotLayoutEvent(args[0])],
+        type: 'layout',
+      });
       const registration = registrationRef.current;
       const handler =
         registration?.ownerKey === paginationOwnerKey ? registration.props.onLayout : undefined;
@@ -69,7 +88,10 @@ export function PaginationScrollView({
   );
   const onScroll = useCallback(
     (...args: Parameters<NativeScrollProps['onScroll']>) => {
-      recordLatestEvent(latestEventsRef.current, { args, type: 'scroll' });
+      recordLatestEvent(latestEventsRef.current, {
+        args: [snapshotScrollEvent(args[0])],
+        type: 'scroll',
+      });
       const registration = registrationRef.current;
       const handler =
         registration?.ownerKey === paginationOwnerKey ? registration.props.onScroll : undefined;


### PR DESCRIPTION
## 무엇을 변경했는지

- `PaginationScrollView`가 registration 전에 받은 Native `onLayout`/`onScroll` 이벤트에서 레이아웃 높이, 스크롤 위치, 콘텐츠 높이, viewport 높이를 즉시 복사하도록 했습니다.
- React Native가 callback 이벤트의 `nativeEvent`를 정리한 뒤에도 registration 시 최신 layout/scroll metric을 안전하게 replay합니다.
- 정리된 layout 이벤트와 scroll 이벤트를 각각 replay하는 회귀 테스트를 추가했습니다.

## 왜 변경했는지

[KOSMO-7H Sentry 이슈](https://byulmaru.sentry.io/issues/7717149306/)의 `Cannot read property 'layout' of null`은 실제 `ScrollView`를 소유한 부모가 Native event를 전달한 뒤 자식 pagination registration이 늦게 발생하는 경로에서 나타났습니다. React Native Fabric이 dispatch 이후 pooled event의 `nativeEvent`를 `null`로 만들 수 있으므로, registration 이후 원본 이벤트를 다시 읽는 대신 callback 시점에 필요한 scalar metric을 보존합니다.

## 이번 PR의 주요 결정

- 새 제품 동작 변경 없음. 등록 전 측정값 보존과 기존 owner/near-end/retry 계약을 유지한다.
- `nativeEvent` 전체를 보관하거나 `persist()`에 의존하지 않고 replay에 필요한 수치만 snapshot합니다. 따라서 고빈도 Native callback의 이벤트 수명에 의존하지 않습니다.

## 어떻게 확인할 수 있는지

- `CI=true pnpm --filter @kosmo/app exec node --experimental-test-module-mocks --import tsx --test src/components/pagination/PaginationScrollView.test.ts src/components/pagination/nativeScrollPagination.test.ts` — 6 passed, 0 failed
- `CI=true pnpm --filter @kosmo/app exec relay-compiler --noWatchman` — passed
- `CI=true pnpm --filter @kosmo/app exec tsc --noEmit` — passed
- `CI=true pnpm exec eslint --max-warnings 0 apps/app/src/components/pagination/PaginationScrollView.tsx apps/app/src/components/pagination/PaginationScrollView.test.ts` — passed
- `CI=true pnpm exec prettier --check apps/app/src/components/pagination/PaginationScrollView.tsx apps/app/src/components/pagination/PaginationScrollView.test.ts` — passed
- `git diff --check` — passed
- `CI=true pnpm --filter @kosmo/app check`의 기본 Watchman 경로는 sandbox의 Watchman state `fchmod` 권한 오류로 실패했고, `relay-compiler --noWatchman`와 TypeScript 검사로 같은 검증을 완료했습니다.
- 작업 소유권: `native_code`는 구현·회귀 테스트, `sentry_investigation`은 Sentry evidence/correctness, `test_evidence`는 테스트 검증, Ponytail reviewer는 minimality 검토를 담당했습니다.

## 아직 어떤 문제가 남아있는지

- 실제 iOS/Android 기기 검증은 수행하지 않았습니다.
- [KOSMO-7J Sentry 이슈](https://byulmaru.sentry.io/issues/7717149611/)의 root cause는 아직 미확정이며 이 PR에서 해결됐다고 주장하지 않습니다.
- 이 PR은 merge 또는 deploy되지 않았습니다.

Fixes [PROD-920](https://linear.app/byulmaru/issue/PROD-920)

Stack: `main -> PROD-920`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>