### PR TITLE
뮤트 관리 화면의 Settings route 경계를 조립한다

### DIFF
--- a/apps/app/src/app/(tabs)/(protected)/settings/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/_layout.tsx
@@ -30,7 +30,9 @@ export function SettingsRouteLayout({ children }: { children?: ReactNode }) {
   const selected =
     root || pathname === '/settings/default-post-visibility'
       ? 'default-post-visibility'
-      : undefined;
+      : pathname === '/settings/mute-and-block' || pathname === '/settings/muted-profiles'
+        ? 'mute-and-block'
+        : undefined;
   const detailHeaderMode: SettingsDetailHeaderMode =
     layout === 'full' ? 'plain' : web && layout === 'mobile' ? 'hidden' : 'back';
 

--- a/apps/app/src/app/(tabs)/(protected)/settings/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/_layout.tsx
@@ -1,6 +1,7 @@
 import { Slot, usePathname } from 'expo-router';
 import { Platform, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { PageHeader } from '@/components/PageHeader';
+import { SettingsMuteAndBlockNavigation } from '@/components/settings/SettingsMuteAndBlockNavigation';
 import { SettingsNavigationList } from '@/components/settings/SettingsNavigationList';
 import { SettingsRouteProvider } from '@/components/settings/SettingsRouteContext';
 import { getShellLayout } from '@/components/shell/shellLayout';
@@ -27,6 +28,7 @@ export function SettingsRouteLayout({ children }: { children?: ReactNode }) {
   const web = Platform.OS === 'web';
   const layout = getShellLayout(web, width);
   const root = pathname === '/settings' || pathname === '/settings/';
+  const mutedProfiles = pathname === '/settings/muted-profiles';
   const selected =
     root || pathname === '/settings/default-post-visibility'
       ? 'default-post-visibility'
@@ -45,7 +47,11 @@ export function SettingsRouteLayout({ children }: { children?: ReactNode }) {
             testID="settings-master-pane"
           >
             <PageHeader title="설정" />
-            <SettingsNavigationList selected={selected} />
+            {mutedProfiles ? (
+              <SettingsMuteAndBlockNavigation selected="muted-profiles" />
+            ) : (
+              <SettingsNavigationList selected={selected} />
+            )}
           </View>
           <View style={styles.detailPane} testID="settings-detail-pane">
             {children}

--- a/apps/app/src/app/(tabs)/(protected)/settings/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/_layout.tsx
@@ -32,9 +32,7 @@ export function SettingsRouteLayout({ children }: { children?: ReactNode }) {
   const selected =
     root || pathname === '/settings/default-post-visibility'
       ? 'default-post-visibility'
-      : pathname === '/settings/mute-and-block' || pathname === '/settings/muted-profiles'
-        ? 'mute-and-block'
-        : undefined;
+      : undefined;
   const detailHeaderMode: SettingsDetailHeaderMode =
     layout === 'full' ? 'plain' : web && layout === 'mobile' ? 'hidden' : 'back';
 

--- a/apps/app/src/app/(tabs)/(protected)/settings/default-post-visibility.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/default-post-visibility.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'expo-router';
 import { ChevronLeftIcon } from 'lucide-react-native';
 import { StyleSheet } from 'react-native';
 import { PageHeader } from '@/components/PageHeader';
-import { returnToSettingsRoot } from '@/components/settings/settingsNavigation';
+import { returnToSettingsParent } from '@/components/settings/settingsNavigation';
 import { SettingsProfileDetail } from '@/components/settings/SettingsProfileDetail';
 import { useSettingsDetailHeaderMode } from '@/components/settings/SettingsRouteContext';
 import { IconButton } from '@/components/ui/IconButton';
@@ -16,7 +16,7 @@ export default function SettingsDefaultPostVisibilityRoute() {
     detailHeaderMode === 'back' ? (
       <IconButton
         accessibilityLabel="설정으로 돌아가기"
-        onPress={() => returnToSettingsRoot(router)}
+        onPress={() => returnToSettingsParent('/settings/default-post-visibility', router)}
         style={styles.backButton}
         targetSize={44}
       >

--- a/apps/app/src/app/(tabs)/(protected)/settings/mute-and-block.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/mute-and-block.tsx
@@ -3,7 +3,7 @@ import { ChevronLeftIcon } from 'lucide-react-native';
 import { StyleSheet } from 'react-native';
 import { PageHeader } from '@/components/PageHeader';
 import { SettingsMuteAndBlockNavigation } from '@/components/settings/SettingsMuteAndBlockNavigation';
-import { returnToSettingsRoot } from '@/components/settings/settingsNavigation';
+import { returnToSettingsParent } from '@/components/settings/settingsNavigation';
 import { useSettingsDetailHeaderMode } from '@/components/settings/SettingsRouteContext';
 import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -16,7 +16,7 @@ export default function SettingsMuteAndBlockRoute() {
     detailHeaderMode === 'back' ? (
       <IconButton
         accessibilityLabel="설정으로 돌아가기"
-        onPress={() => returnToSettingsRoot(router)}
+        onPress={() => returnToSettingsParent('/settings/mute-and-block', router)}
         style={styles.backButton}
         targetSize={44}
       >

--- a/apps/app/src/app/(tabs)/(protected)/settings/mute-and-block.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/mute-and-block.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'expo-router';
+import { ChevronLeftIcon } from 'lucide-react-native';
+import { StyleSheet } from 'react-native';
+import { PageHeader } from '@/components/PageHeader';
+import { SettingsMuteAndBlockNavigation } from '@/components/settings/SettingsMuteAndBlockNavigation';
+import { returnToSettingsRoot } from '@/components/settings/settingsNavigation';
+import { useSettingsDetailHeaderMode } from '@/components/settings/SettingsRouteContext';
+import { IconButton } from '@/components/ui/IconButton';
+import { useTheme } from '@/theme/ThemeProvider';
+
+export default function SettingsMuteAndBlockRoute() {
+  const router = useRouter();
+  const theme = useTheme();
+  const detailHeaderMode = useSettingsDetailHeaderMode();
+  const backButton =
+    detailHeaderMode === 'back' ? (
+      <IconButton
+        accessibilityLabel="설정으로 돌아가기"
+        onPress={() => returnToSettingsRoot(router)}
+        style={styles.backButton}
+        targetSize={44}
+      >
+        <ChevronLeftIcon color={theme.text} size={20} strokeWidth={2} />
+      </IconButton>
+    ) : undefined;
+
+  return (
+    <>
+      {detailHeaderMode !== 'hidden' ? (
+        <PageHeader leading={backButton} title="뮤트 및 차단" />
+      ) : null}
+      <SettingsMuteAndBlockNavigation />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  backButton: {
+    alignItems: 'center',
+    height: 44,
+    justifyContent: 'center',
+    minHeight: 44,
+    width: 44,
+  },
+});

--- a/apps/app/src/app/(tabs)/(protected)/settings/muted-profiles.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/muted-profiles.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'expo-router';
+import { ChevronLeftIcon } from 'lucide-react-native';
+import { StyleSheet } from 'react-native';
+import { PageHeader } from '@/components/PageHeader';
+import { SettingsMutedProfiles } from '@/components/settings/SettingsMutedProfiles';
+import { returnToMuteAndBlockRoot } from '@/components/settings/settingsNavigation';
+import { useSettingsDetailHeaderMode } from '@/components/settings/SettingsRouteContext';
+import { IconButton } from '@/components/ui/IconButton';
+import { useTheme } from '@/theme/ThemeProvider';
+
+export default function SettingsMutedProfilesRoute() {
+  const router = useRouter();
+  const theme = useTheme();
+  const detailHeaderMode = useSettingsDetailHeaderMode();
+  const backButton =
+    detailHeaderMode === 'back' ? (
+      <IconButton
+        accessibilityLabel="설정으로 돌아가기"
+        onPress={() => returnToMuteAndBlockRoot(router)}
+        style={styles.backButton}
+        targetSize={44}
+      >
+        <ChevronLeftIcon color={theme.text} size={20} strokeWidth={2} />
+      </IconButton>
+    ) : undefined;
+
+  return (
+    <>
+      {detailHeaderMode !== 'hidden' ? (
+        <PageHeader leading={backButton} title="뮤트한 프로필" />
+      ) : null}
+      <SettingsMutedProfiles />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  backButton: {
+    alignItems: 'center',
+    height: 44,
+    justifyContent: 'center',
+    minHeight: 44,
+    width: 44,
+  },
+});

--- a/apps/app/src/app/(tabs)/(protected)/settings/muted-profiles.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/muted-profiles.tsx
@@ -3,7 +3,7 @@ import { ChevronLeftIcon } from 'lucide-react-native';
 import { StyleSheet } from 'react-native';
 import { PageHeader } from '@/components/PageHeader';
 import { SettingsMutedProfiles } from '@/components/settings/SettingsMutedProfiles';
-import { returnToMuteAndBlockRoot } from '@/components/settings/settingsNavigation';
+import { returnToSettingsParent } from '@/components/settings/settingsNavigation';
 import { useSettingsDetailHeaderMode } from '@/components/settings/SettingsRouteContext';
 import { IconButton } from '@/components/ui/IconButton';
 import { useTheme } from '@/theme/ThemeProvider';
@@ -16,7 +16,7 @@ export default function SettingsMutedProfilesRoute() {
     detailHeaderMode === 'back' ? (
       <IconButton
         accessibilityLabel="뮤트 및 차단으로 돌아가기"
-        onPress={() => returnToMuteAndBlockRoot(router)}
+        onPress={() => returnToSettingsParent('/settings/muted-profiles', router)}
         style={styles.backButton}
         targetSize={44}
       >

--- a/apps/app/src/app/(tabs)/(protected)/settings/muted-profiles.tsx
+++ b/apps/app/src/app/(tabs)/(protected)/settings/muted-profiles.tsx
@@ -15,7 +15,7 @@ export default function SettingsMutedProfilesRoute() {
   const backButton =
     detailHeaderMode === 'back' ? (
       <IconButton
-        accessibilityLabel="설정으로 돌아가기"
+        accessibilityLabel="뮤트 및 차단으로 돌아가기"
         onPress={() => returnToMuteAndBlockRoot(router)}
         style={styles.backButton}
         targetSize={44}

--- a/apps/app/src/components/profile/MutedProfileList.tsx
+++ b/apps/app/src/components/profile/MutedProfileList.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Button } from '@/components/ui/Button';
 import { StateView } from '@/components/ui/StateView';
 import { useToast } from '@/components/ui/ToastProvider';
-import { useTheme } from '@/theme/ThemeProvider';
-import { borderWidths, space, textStyles } from '@/theme/tokens';
+import { space } from '@/theme/tokens';
 import { ProfileListItemContent } from './ProfileListItemContent';
 import { ProfileMuteAction } from './ProfileMuteAction';
 import type { ProfileMuteFeedback } from './ProfileMuteAction';
@@ -22,22 +21,10 @@ export type MutedProfileListState =
 type Props = {
   onFeedback?: (feedback: ProfileMuteFeedback & { profileId: string }) => void;
   onUnmute: (profileId: string) => Promise<void>;
-  showHeading?: boolean;
-  scrollable?: boolean;
   state: MutedProfileListState;
 };
 
-export function MutedProfileList({
-  onFeedback,
-  onUnmute,
-  scrollable = true,
-  showHeading = true,
-  state,
-}: Props) {
-  const theme = useTheme();
-  const headingRef = useRef<View>(null);
-  const listRef = useRef<View>(null);
-  const focusAfterUnmute = useRef(false);
+export function MutedProfileList({ onFeedback, onUnmute, state }: Props) {
   const { showToast } = useToast();
   const loadError =
     state.status === 'error'
@@ -62,39 +49,14 @@ export function MutedProfileList({
         action: {
           label: '다시 시도',
           onPress: () => {
-            (headingRef.current ?? listRef.current)?.focus();
             retryRef.current?.();
           },
         },
       });
     }
   }, [errorMessage, showToast]);
-  useEffect(() => {
-    if (focusAfterUnmute.current) {
-      (headingRef.current ?? listRef.current)?.focus();
-      focusAfterUnmute.current = false;
-    }
-  }, [state]);
-  const content = (
-    <View
-      accessibilityLabel="뮤트한 프로필"
-      ref={listRef}
-      style={styles.root}
-      tabIndex={-1}
-      testID="muted-profile-list"
-    >
-      {showHeading ? (
-        <View accessibilityRole="header" ref={headingRef} tabIndex={-1}>
-          <Text
-            style={[
-              styles.heading,
-              { color: theme.foregroundPrimary, borderColor: theme.borderDefault },
-            ]}
-          >
-            뮤트한 프로필
-          </Text>
-        </View>
-      ) : null}
+  return (
+    <View accessibilityLabel="뮤트한 프로필" style={styles.root} testID="muted-profile-list">
       {state.status === 'loading' ? (
         <StateView loading title="뮤트한 프로필을 불러오는 중입니다." />
       ) : state.status === 'error' ? (
@@ -120,7 +82,6 @@ export function MutedProfileList({
                 muted
                 onChangeMuted={() => onUnmute(profile.id)}
                 onFeedback={(feedback) => {
-                  focusAfterUnmute.current = feedback.status === 'success';
                   onFeedback?.({ ...feedback, profileId: profile.id });
                 }}
                 profileId={profile.id}
@@ -147,15 +108,9 @@ export function MutedProfileList({
       )}
     </View>
   );
-  return scrollable ? (
-    <ScrollView contentContainerStyle={styles.root}>{content}</ScrollView>
-  ) : (
-    content
-  );
 }
 const styles = StyleSheet.create({
   root: { flexGrow: 1, width: '100%' },
-  heading: { ...textStyles.uiHeadingM, borderBottomWidth: borderWidths[1], padding: space[16] },
   row: { height: 64, paddingVertical: 0 },
   pagination: { alignItems: 'center', padding: space[16] },
 });

--- a/apps/app/src/components/profile/MutedProfileList.tsx
+++ b/apps/app/src/components/profile/MutedProfileList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Button } from '@/components/ui/Button';
 import { StateView } from '@/components/ui/StateView';
+import { useToast } from '@/components/ui/ToastProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, space, textStyles } from '@/theme/tokens';
 import { ProfileListItemContent } from './ProfileListItemContent';
@@ -42,6 +43,37 @@ export function MutedProfileList({
   const headingRef = useRef<View>(null);
   const listRef = useRef<View>(null);
   const [unmuteFocusRevision, setUnmuteFocusRevision] = useState(0);
+  const { showToast } = useToast();
+  const loadError =
+    state.status === 'error'
+      ? state
+      : state.status === 'loaded' && state.pagination.status === 'error'
+        ? state.pagination
+        : null;
+  const errorMessage = loadError
+    ? state.status === 'error'
+      ? '뮤트한 프로필을 불러오지 못했어요'
+      : '프로필을 더 불러오지 못했어요'
+    : null;
+  const retry = loadError?.onRetry;
+  const retryRef = useRef(retry);
+  useEffect(() => {
+    retryRef.current = retry;
+  }, [retry]);
+  useEffect(() => {
+    if (errorMessage) {
+      return showToast(errorMessage, {
+        tone: 'danger',
+        action: {
+          label: '다시 시도',
+          onPress: () => {
+            (headingRef.current ?? listRef.current)?.focus();
+            retryRef.current?.();
+          },
+        },
+      });
+    }
+  }, [errorMessage, showToast]);
   useEffect(() => {
     if (unmuteFocusRevision > 0) {
       (headingRef.current ?? listRef.current)?.focus();
@@ -70,12 +102,11 @@ export function MutedProfileList({
       {state.status === 'loading' ? (
         <StateView loading title="뮤트한 프로필을 불러오는 중입니다." />
       ) : state.status === 'error' ? (
-        <StateView
-          actionLabel="다시 시도"
-          alert
-          onAction={state.onRetry}
-          title="뮤트한 프로필을 불러오지 못했어요"
-        />
+        <View style={styles.pagination}>
+          <Button onPress={state.onRetry} tone="secondary">
+            다시 시도
+          </Button>
+        </View>
       ) : state.profiles.length === 0 && state.pagination.status === 'end' ? (
         <StateView title="뮤트한 프로필이 없어요" />
       ) : (
@@ -105,12 +136,11 @@ export function MutedProfileList({
             </ProfileListItemContent>
           ))}
           {state.pagination.status === 'error' ? (
-            <StateView
-              actionLabel="다시 시도"
-              alert
-              onAction={state.pagination.onRetry}
-              title="프로필을 더 불러오지 못했어요"
-            />
+            <View style={styles.pagination}>
+              <Button onPress={state.pagination.onRetry} tone="secondary">
+                더 불러오기
+              </Button>
+            </View>
           ) : state.pagination.status === 'loading' ? (
             <StateView loading title="프로필을 더 불러오는 중입니다." />
           ) : state.pagination.status === 'more' ? (

--- a/apps/app/src/components/profile/MutedProfileList.tsx
+++ b/apps/app/src/components/profile/MutedProfileList.tsx
@@ -1,15 +1,19 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Button } from '@/components/ui/Button';
 import { StateView } from '@/components/ui/StateView';
-import { useToast } from '@/components/ui/ToastProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, space, textStyles } from '@/theme/tokens';
 import { ProfileListItemContent } from './ProfileListItemContent';
 import { ProfileMuteAction } from './ProfileMuteAction';
 import type { ProfileMuteFeedback } from './ProfileMuteAction';
 
-export type MutedProfile = { id: string; displayName: string; avatarUri?: string | null };
+export type MutedProfile = {
+  id: string;
+  displayName: string;
+  avatarUri?: string | null;
+  relativeHandle?: string | null;
+};
 type Pagination =
   | { status: 'end' }
   | { status: 'loading' }
@@ -22,70 +26,56 @@ export type MutedProfileListState =
 type Props = {
   onFeedback?: (feedback: ProfileMuteFeedback & { profileId: string }) => void;
   onUnmute: (profileId: string) => Promise<void>;
+  showHeading?: boolean;
+  scrollable?: boolean;
   state: MutedProfileListState;
 };
 
-export function MutedProfileList({ onFeedback, onUnmute, state }: Props) {
+export function MutedProfileList({
+  onFeedback,
+  onUnmute,
+  scrollable = true,
+  showHeading = true,
+  state,
+}: Props) {
   const theme = useTheme();
   const headingRef = useRef<View>(null);
-  const focusAfterUnmute = useRef(false);
-  const { showToast } = useToast();
-  const loadError =
-    state.status === 'error'
-      ? state
-      : state.status === 'loaded' && state.pagination.status === 'error'
-        ? state.pagination
-        : null;
-  const errorMessage = loadError
-    ? state.status === 'error'
-      ? '뮤트한 프로필을 불러오지 못했어요'
-      : '프로필을 더 불러오지 못했어요'
-    : null;
-  const retry = loadError?.onRetry;
-  const retryRef = useRef(retry);
+  const listRef = useRef<View>(null);
+  const [unmuteFocusRevision, setUnmuteFocusRevision] = useState(0);
   useEffect(() => {
-    retryRef.current = retry;
-  }, [retry]);
-  useEffect(() => {
-    if (errorMessage) {
-      return showToast(errorMessage, {
-        tone: 'danger',
-        action: {
-          label: '다시 시도',
-          onPress: () => {
-            headingRef.current?.focus();
-            retryRef.current?.();
-          },
-        },
-      });
+    if (unmuteFocusRevision > 0) {
+      (headingRef.current ?? listRef.current)?.focus();
     }
-  }, [errorMessage, showToast]);
-  useEffect(() => {
-    if (focusAfterUnmute.current) {
-      headingRef.current?.focus();
-      focusAfterUnmute.current = false;
-    }
-  }, [state]);
-  return (
-    <ScrollView contentContainerStyle={styles.root}>
-      <View accessibilityRole="header" ref={headingRef} tabIndex={-1}>
-        <Text
-          style={[
-            styles.heading,
-            { color: theme.foregroundPrimary, borderColor: theme.borderDefault },
-          ]}
-        >
-          뮤트한 프로필
-        </Text>
-      </View>
+  }, [unmuteFocusRevision]);
+  const content = (
+    <View
+      accessibilityLabel="뮤트한 프로필"
+      ref={listRef}
+      style={styles.root}
+      tabIndex={-1}
+      testID="muted-profile-list"
+    >
+      {showHeading ? (
+        <View accessibilityRole="header" ref={headingRef} tabIndex={-1}>
+          <Text
+            style={[
+              styles.heading,
+              { color: theme.foregroundPrimary, borderColor: theme.borderDefault },
+            ]}
+          >
+            뮤트한 프로필
+          </Text>
+        </View>
+      ) : null}
       {state.status === 'loading' ? (
         <StateView loading title="뮤트한 프로필을 불러오는 중입니다." />
       ) : state.status === 'error' ? (
-        <View style={styles.pagination}>
-          <Button onPress={state.onRetry} tone="secondary">
-            다시 시도
-          </Button>
-        </View>
+        <StateView
+          actionLabel="다시 시도"
+          alert
+          onAction={state.onRetry}
+          title="뮤트한 프로필을 불러오지 못했어요"
+        />
       ) : state.profiles.length === 0 && state.pagination.status === 'end' ? (
         <StateView title="뮤트한 프로필이 없어요" />
       ) : (
@@ -96,6 +86,7 @@ export function MutedProfileList({ onFeedback, onUnmute, state }: Props) {
               avatarLabel={profile.displayName}
               avatarUri={profile.avatarUri}
               displayName={profile.displayName}
+              relativeHandle={profile.relativeHandle ?? undefined}
               style={styles.row}
             >
               <ProfileMuteAction
@@ -103,7 +94,9 @@ export function MutedProfileList({ onFeedback, onUnmute, state }: Props) {
                 muted
                 onChangeMuted={() => onUnmute(profile.id)}
                 onFeedback={(feedback) => {
-                  focusAfterUnmute.current = feedback.status === 'success';
+                  if (feedback.status === 'success') {
+                    setUnmuteFocusRevision((revision) => revision + 1);
+                  }
                   onFeedback?.({ ...feedback, profileId: profile.id });
                 }}
                 profileId={profile.id}
@@ -112,11 +105,12 @@ export function MutedProfileList({ onFeedback, onUnmute, state }: Props) {
             </ProfileListItemContent>
           ))}
           {state.pagination.status === 'error' ? (
-            <View style={styles.pagination}>
-              <Button onPress={state.pagination.onRetry} tone="secondary">
-                더 불러오기
-              </Button>
-            </View>
+            <StateView
+              actionLabel="다시 시도"
+              alert
+              onAction={state.pagination.onRetry}
+              title="프로필을 더 불러오지 못했어요"
+            />
           ) : state.pagination.status === 'loading' ? (
             <StateView loading title="프로필을 더 불러오는 중입니다." />
           ) : state.pagination.status === 'more' ? (
@@ -128,7 +122,12 @@ export function MutedProfileList({ onFeedback, onUnmute, state }: Props) {
           ) : null}
         </>
       )}
-    </ScrollView>
+    </View>
+  );
+  return scrollable ? (
+    <ScrollView contentContainerStyle={styles.root}>{content}</ScrollView>
+  ) : (
+    content
   );
 }
 const styles = StyleSheet.create({

--- a/apps/app/src/components/profile/MutedProfileList.tsx
+++ b/apps/app/src/components/profile/MutedProfileList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Button } from '@/components/ui/Button';
 import { StateView } from '@/components/ui/StateView';
@@ -9,12 +9,7 @@ import { ProfileListItemContent } from './ProfileListItemContent';
 import { ProfileMuteAction } from './ProfileMuteAction';
 import type { ProfileMuteFeedback } from './ProfileMuteAction';
 
-export type MutedProfile = {
-  id: string;
-  displayName: string;
-  avatarUri?: string | null;
-  relativeHandle?: string | null;
-};
+export type MutedProfile = { id: string; displayName: string; avatarUri?: string | null };
 type Pagination =
   | { status: 'end' }
   | { status: 'loading' }
@@ -42,7 +37,7 @@ export function MutedProfileList({
   const theme = useTheme();
   const headingRef = useRef<View>(null);
   const listRef = useRef<View>(null);
-  const [unmuteFocusRevision, setUnmuteFocusRevision] = useState(0);
+  const focusAfterUnmute = useRef(false);
   const { showToast } = useToast();
   const loadError =
     state.status === 'error'
@@ -75,10 +70,11 @@ export function MutedProfileList({
     }
   }, [errorMessage, showToast]);
   useEffect(() => {
-    if (unmuteFocusRevision > 0) {
+    if (focusAfterUnmute.current) {
       (headingRef.current ?? listRef.current)?.focus();
+      focusAfterUnmute.current = false;
     }
-  }, [unmuteFocusRevision]);
+  }, [state]);
   const content = (
     <View
       accessibilityLabel="뮤트한 프로필"
@@ -117,7 +113,6 @@ export function MutedProfileList({
               avatarLabel={profile.displayName}
               avatarUri={profile.avatarUri}
               displayName={profile.displayName}
-              relativeHandle={profile.relativeHandle ?? undefined}
               style={styles.row}
             >
               <ProfileMuteAction
@@ -125,9 +120,7 @@ export function MutedProfileList({
                 muted
                 onChangeMuted={() => onUnmute(profile.id)}
                 onFeedback={(feedback) => {
-                  if (feedback.status === 'success') {
-                    setUnmuteFocusRevision((revision) => revision + 1);
-                  }
+                  focusAfterUnmute.current = feedback.status === 'success';
                   onFeedback?.({ ...feedback, profileId: profile.id });
                 }}
                 profileId={profile.id}

--- a/apps/app/src/components/settings/SettingsMuteAndBlockNavigation.tsx
+++ b/apps/app/src/components/settings/SettingsMuteAndBlockNavigation.tsx
@@ -1,0 +1,23 @@
+import { StyleSheet, View } from 'react-native';
+import { layoutRecipes } from '@/theme/tokens';
+import { SettingsLinkRow } from './SettingsLinkRow';
+
+export function SettingsMuteAndBlockNavigation({ selected }: { selected?: 'muted-profiles' }) {
+  return (
+    <View
+      accessibilityLabel="뮤트 및 차단 목록"
+      role="navigation"
+      style={[layoutRecipes.listStack, styles.root]}
+    >
+      <SettingsLinkRow
+        accessibilityLabel="뮤트한 프로필 관리 열기"
+        href="/settings/muted-profiles"
+        label="뮤트한 프로필"
+        primary
+        selected={selected === 'muted-profiles'}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({ root: { width: '100%' } });

--- a/apps/app/src/components/settings/SettingsMutedProfiles.tsx
+++ b/apps/app/src/components/settings/SettingsMutedProfiles.tsx
@@ -1,0 +1,14 @@
+import { MutedProfileList } from '@/components/profile/MutedProfileList';
+
+const noopUnmute = () => Promise.resolve();
+
+export function SettingsMutedProfiles() {
+  return (
+    <MutedProfileList
+      onUnmute={noopUnmute}
+      scrollable={false}
+      showHeading={false}
+      state={{ status: 'loading' }}
+    />
+  );
+}

--- a/apps/app/src/components/settings/SettingsMutedProfiles.tsx
+++ b/apps/app/src/components/settings/SettingsMutedProfiles.tsx
@@ -3,12 +3,5 @@ import { MutedProfileList } from '@/components/profile/MutedProfileList';
 const noopUnmute = () => Promise.resolve();
 
 export function SettingsMutedProfiles() {
-  return (
-    <MutedProfileList
-      onUnmute={noopUnmute}
-      scrollable={false}
-      showHeading={false}
-      state={{ status: 'loading' }}
-    />
-  );
+  return <MutedProfileList onUnmute={noopUnmute} state={{ status: 'loading' }} />;
 }

--- a/apps/app/src/components/settings/SettingsNavigationList.test.ts
+++ b/apps/app/src/components/settings/SettingsNavigationList.test.ts
@@ -55,7 +55,7 @@ mock.module(new URL('../../theme/ThemeProvider.tsx', import.meta.url), {
 } as unknown as Parameters<typeof mock.module>[1]);
 
 let SettingsNavigationList: ComponentType<{
-  selected?: 'default-post-visibility' | 'mute-and-block';
+  selected?: 'default-post-visibility';
 }>;
 let renderer: ReactTestRenderer | null = null;
 
@@ -71,11 +71,11 @@ afterEach(async () => {
 });
 
 describe('SettingsNavigationList', () => {
-  it('승인된 외부 Account와 내부 Profile entry만 이 순서로 제공한다', async () => {
+  it('실제 데이터가 연결된 설정 진입점만 제공한다', async () => {
     await render();
 
     const links = rendered('Pressable');
-    assert.equal(links.length, 3);
+    assert.equal(links.length, 2);
     assert.equal(
       links[0].props.accessibilityLabel,
       'Byulmaru ID Account Settings 외부 서비스로 이동',
@@ -83,9 +83,7 @@ describe('SettingsNavigationList', () => {
     assert.equal(links[0].props.href, 'https://id.byulmaru.co');
     assert.equal(links[1].props.accessibilityLabel, '게시물 기본 공개 범위 설정 열기');
     assert.equal(links[1].props.href, '/settings/default-post-visibility');
-    assert.equal(links[2].props.accessibilityLabel, '뮤트 및 차단 설정 열기');
-    assert.equal(links[2].props.href, '/settings/mute-and-block');
-    assert.deepEqual(texts(), ['계정 설정', '게시물 기본 공개 범위', '뮤트 및 차단']);
+    assert.deepEqual(texts(), ['계정 설정', '게시물 기본 공개 범위']);
   });
 
   it('full master가 표시한 내부 detail만 current destination으로 전달한다', async () => {
@@ -95,17 +93,9 @@ describe('SettingsNavigationList', () => {
     assert.equal(internal.props['aria-current'], 'page');
     assert.deepEqual(internal.props.accessibilityState, { selected: true });
   });
-
-  it('뮤트 및 차단 master destination을 current로 표시한다', async () => {
-    await render('mute-and-block');
-
-    const internal = rendered('Pressable')[2];
-    assert.equal(internal.props['aria-current'], 'page');
-    assert.deepEqual(internal.props.accessibilityState, { selected: true });
-  });
 });
 
-async function render(selected?: 'default-post-visibility' | 'mute-and-block') {
+async function render(selected?: 'default-post-visibility') {
   await act(async () => {
     renderer = create(createElement(SettingsNavigationList, { selected }));
   });

--- a/apps/app/src/components/settings/SettingsNavigationList.test.ts
+++ b/apps/app/src/components/settings/SettingsNavigationList.test.ts
@@ -54,7 +54,9 @@ mock.module(new URL('../../theme/ThemeProvider.tsx', import.meta.url), {
   },
 } as unknown as Parameters<typeof mock.module>[1]);
 
-let SettingsNavigationList: ComponentType<{ selected?: 'default-post-visibility' }>;
+let SettingsNavigationList: ComponentType<{
+  selected?: 'default-post-visibility' | 'mute-and-block';
+}>;
 let renderer: ReactTestRenderer | null = null;
 
 before(async () => {
@@ -73,7 +75,7 @@ describe('SettingsNavigationList', () => {
     await render();
 
     const links = rendered('Pressable');
-    assert.equal(links.length, 2);
+    assert.equal(links.length, 3);
     assert.equal(
       links[0].props.accessibilityLabel,
       'Byulmaru ID Account Settings 외부 서비스로 이동',
@@ -81,7 +83,9 @@ describe('SettingsNavigationList', () => {
     assert.equal(links[0].props.href, 'https://id.byulmaru.co');
     assert.equal(links[1].props.accessibilityLabel, '게시물 기본 공개 범위 설정 열기');
     assert.equal(links[1].props.href, '/settings/default-post-visibility');
-    assert.deepEqual(texts(), ['계정 설정', '게시물 기본 공개 범위']);
+    assert.equal(links[2].props.accessibilityLabel, '뮤트 및 차단 설정 열기');
+    assert.equal(links[2].props.href, '/settings/mute-and-block');
+    assert.deepEqual(texts(), ['계정 설정', '게시물 기본 공개 범위', '뮤트 및 차단']);
   });
 
   it('full master가 표시한 내부 detail만 current destination으로 전달한다', async () => {
@@ -91,9 +95,17 @@ describe('SettingsNavigationList', () => {
     assert.equal(internal.props['aria-current'], 'page');
     assert.deepEqual(internal.props.accessibilityState, { selected: true });
   });
+
+  it('뮤트 및 차단 master destination을 current로 표시한다', async () => {
+    await render('mute-and-block');
+
+    const internal = rendered('Pressable')[2];
+    assert.equal(internal.props['aria-current'], 'page');
+    assert.deepEqual(internal.props.accessibilityState, { selected: true });
+  });
 });
 
-async function render(selected?: 'default-post-visibility') {
+async function render(selected?: 'default-post-visibility' | 'mute-and-block') {
   await act(async () => {
     renderer = create(createElement(SettingsNavigationList, { selected }));
   });

--- a/apps/app/src/components/settings/SettingsNavigationList.tsx
+++ b/apps/app/src/components/settings/SettingsNavigationList.tsx
@@ -3,7 +3,7 @@ import { layoutRecipes } from '@/theme/tokens';
 import { ByulmaruIdAccountSettingsEntry } from './ByulmaruIdAccountSettingsEntry';
 import { SettingsLinkRow } from './SettingsLinkRow';
 
-type SettingsDestination = 'default-post-visibility';
+type SettingsDestination = 'default-post-visibility' | 'mute-and-block';
 
 export function SettingsNavigationList({ selected }: { selected?: SettingsDestination }) {
   const current = selected === 'default-post-visibility';
@@ -21,6 +21,13 @@ export function SettingsNavigationList({ selected }: { selected?: SettingsDestin
         label="게시물 기본 공개 범위"
         primary
         selected={current}
+      />
+      <SettingsLinkRow
+        accessibilityLabel="뮤트 및 차단 설정 열기"
+        href="/settings/mute-and-block"
+        label="뮤트 및 차단"
+        primary
+        selected={selected === 'mute-and-block'}
       />
     </View>
   );

--- a/apps/app/src/components/settings/SettingsNavigationList.tsx
+++ b/apps/app/src/components/settings/SettingsNavigationList.tsx
@@ -3,7 +3,7 @@ import { layoutRecipes } from '@/theme/tokens';
 import { ByulmaruIdAccountSettingsEntry } from './ByulmaruIdAccountSettingsEntry';
 import { SettingsLinkRow } from './SettingsLinkRow';
 
-type SettingsDestination = 'default-post-visibility' | 'mute-and-block';
+type SettingsDestination = 'default-post-visibility';
 
 export function SettingsNavigationList({ selected }: { selected?: SettingsDestination }) {
   const current = selected === 'default-post-visibility';
@@ -21,13 +21,6 @@ export function SettingsNavigationList({ selected }: { selected?: SettingsDestin
         label="게시물 기본 공개 범위"
         primary
         selected={current}
-      />
-      <SettingsLinkRow
-        accessibilityLabel="뮤트 및 차단 설정 열기"
-        href="/settings/mute-and-block"
-        label="뮤트 및 차단"
-        primary
-        selected={selected === 'mute-and-block'}
       />
     </View>
   );

--- a/apps/app/src/components/settings/SettingsRoutes.test.ts
+++ b/apps/app/src/components/settings/SettingsRoutes.test.ts
@@ -71,6 +71,17 @@ mock.module(new URL('./SettingsProfileDetail.tsx', import.meta.url), {
     SettingsProfileDetail: () => createElement('SettingsProfileDetail'),
   },
 } as unknown as Parameters<typeof mock.module>[1]);
+mock.module(new URL('./SettingsMuteAndBlockNavigation.tsx', import.meta.url), {
+  exports: {
+    SettingsMuteAndBlockNavigation: (props: Record<string, unknown>) =>
+      createElement('SettingsMuteAndBlockNavigation', props),
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
+mock.module(new URL('./SettingsMutedProfiles.tsx', import.meta.url), {
+  exports: {
+    SettingsMutedProfiles: () => createElement('SettingsMutedProfiles'),
+  },
+} as unknown as Parameters<typeof mock.module>[1]);
 mock.module(new URL('../../theme/ThemeProvider.tsx', import.meta.url), {
   exports: { useTheme: () => ({ border: '#333333', text: '#111111' }) },
 } as unknown as Parameters<typeof mock.module>[1]);
@@ -84,6 +95,8 @@ mock.module(new URL('../../session/SessionProvider.tsx', import.meta.url), {
 } as unknown as Parameters<typeof mock.module>[1]);
 
 let SettingsDefaultPostVisibilityRoute: ComponentType;
+let SettingsMuteAndBlockRoute: ComponentType;
+let SettingsMutedProfilesRoute: ComponentType;
 let SettingsLayout: ComponentType;
 let SettingsRoute: ComponentType;
 let ProtectedLayout: ComponentType;
@@ -97,6 +110,10 @@ before(async () => {
   ({ default: SettingsRoute } = await import('../../app/(tabs)/(protected)/settings/index'));
   ({ default: SettingsDefaultPostVisibilityRoute } =
     await import('../../app/(tabs)/(protected)/settings/default-post-visibility'));
+  ({ default: SettingsMuteAndBlockRoute } =
+    await import('../../app/(tabs)/(protected)/settings/mute-and-block'));
+  ({ default: SettingsMutedProfilesRoute } =
+    await import('../../app/(tabs)/(protected)/settings/muted-profiles'));
   ({ default: ProtectedLayout } = await import('../../app/(tabs)/(protected)/_layout'));
 });
 
@@ -151,6 +168,28 @@ describe('Settings routes', () => {
     assert.equal(rendered('SettingsNavigationList')[0].props.selected, 'default-post-visibility');
     assert.equal(rendered('Pressable').length, 0);
     assert.equal(rendered('SettingsProfileDetail').length, 1);
+  });
+
+  it('full Web mute category는 완료된 관리 entry와 공통 master를 연결한다', async () => {
+    await renderRoute('/settings/mute-and-block', SettingsMuteAndBlockRoute);
+
+    assert.deepEqual(
+      rendered('PageHeader').map((node) => node.props.title),
+      ['설정', '뮤트 및 차단'],
+    );
+    assert.equal(rendered('SettingsNavigationList')[0].props.selected, 'mute-and-block');
+    assert.equal(rendered('SettingsMuteAndBlockNavigation').length, 1);
+  });
+
+  it('full Web muted profile detail은 공통 master의 mute category를 선택한다', async () => {
+    await renderRoute('/settings/muted-profiles', SettingsMutedProfilesRoute);
+
+    assert.deepEqual(
+      rendered('PageHeader').map((node) => node.props.title),
+      ['설정', '뮤트한 프로필'],
+    );
+    assert.equal(rendered('SettingsNavigationList')[0].props.selected, 'mute-and-block');
+    assert.equal(rendered('SettingsMutedProfiles').length, 1);
   });
 
   it('compact Web root는 선택 없는 root 목록부터 표시한다', async () => {

--- a/apps/app/src/components/settings/SettingsRoutes.test.ts
+++ b/apps/app/src/components/settings/SettingsRoutes.test.ts
@@ -170,14 +170,14 @@ describe('Settings routes', () => {
     assert.equal(rendered('SettingsProfileDetail').length, 1);
   });
 
-  it('full Web mute category는 완료된 관리 entry와 공통 master를 연결한다', async () => {
+  it('full Web mute category는 데이터 연결 전에 master entry를 선택하지 않는다', async () => {
     await renderRoute('/settings/mute-and-block', SettingsMuteAndBlockRoute);
 
     assert.deepEqual(
       rendered('PageHeader').map((node) => node.props.title),
       ['설정', '뮤트 및 차단'],
     );
-    assert.equal(rendered('SettingsNavigationList')[0].props.selected, 'mute-and-block');
+    assert.equal(rendered('SettingsNavigationList')[0].props.selected, undefined);
     assert.equal(rendered('SettingsMuteAndBlockNavigation').length, 1);
   });
 
@@ -298,7 +298,8 @@ describe('Settings routes', () => {
     );
 
     await act(async () => header.props.leading.props.onPress());
-    assert.equal(backCalls, 1);
+    assert.equal(backCalls, 0);
+    assert.deepEqual(replacedPaths, ['/settings']);
   });
 
   it('compact Web detail은 route-owned back header로 Settings root를 연다', async () => {
@@ -337,7 +338,8 @@ describe('Settings routes', () => {
     assert.equal(style.width, 44);
     assert.deepEqual(back.props.hitSlop, { bottom: 2, left: 2, right: 2, top: 2 });
     await act(async () => back.props.onPress());
-    assert.equal(backCalls, 1);
+    assert.equal(backCalls, 0);
+    assert.deepEqual(replacedPaths, ['/settings']);
   });
 
   it('Native root는 route-owned 설정 heading을 표시한다', async () => {

--- a/apps/app/src/components/settings/SettingsRoutes.test.ts
+++ b/apps/app/src/components/settings/SettingsRoutes.test.ts
@@ -188,8 +188,51 @@ describe('Settings routes', () => {
       rendered('PageHeader').map((node) => node.props.title),
       ['설정', '뮤트한 프로필'],
     );
-    assert.equal(rendered('SettingsNavigationList')[0].props.selected, 'mute-and-block');
+    assert.equal(rendered('SettingsNavigationList').length, 0);
+    assert.equal(rendered('SettingsMuteAndBlockNavigation').length, 1);
+    assert.equal(rendered('SettingsMuteAndBlockNavigation')[0].props.selected, 'muted-profiles');
+    assert.equal(
+      byTestId('settings-master-pane').findAll(
+        (node) => (node.type as unknown) === 'SettingsMuteAndBlockNavigation',
+      ).length,
+      1,
+    );
+    assert.equal(
+      byTestId('settings-detail-pane').findAll(
+        (node) => (node.type as unknown) === 'SettingsMutedProfiles',
+      ).length,
+      1,
+    );
     assert.equal(rendered('SettingsMutedProfiles').length, 1);
+  });
+
+  it('compact Web muted profile detail은 parent으로 돌아가는 caller label과 navigation을 사용한다', async () => {
+    width = 768;
+    await renderRoute('/settings/muted-profiles', SettingsMutedProfilesRoute);
+
+    const back = rendered('PageHeader')[0].props.leading;
+    assert.equal(back.props.accessibilityLabel, '뮤트 및 차단으로 돌아가기');
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { replace: (href: string) => locationReplacements.push(href) },
+    });
+    await act(async () => back.props.onPress());
+    assert.equal(backCalls, 0);
+    assert.deepEqual(locationReplacements, ['/settings/mute-and-block']);
+  });
+
+  it('Native muted profile detail은 parent label과 replace navigation을 사용한다', async () => {
+    platform = 'android';
+    width = 390;
+    await renderRoute('/settings/muted-profiles', SettingsMutedProfilesRoute);
+
+    const back = rendered('Pressable').find(
+      (node) => node.props.accessibilityLabel === '뮤트 및 차단으로 돌아가기',
+    );
+    assert.ok(back);
+    await act(async () => back.props.onPress());
+    assert.equal(backCalls, 0);
+    assert.deepEqual(replacedPaths, ['/settings/mute-and-block']);
   });
 
   it('compact Web root는 선택 없는 root 목록부터 표시한다', async () => {

--- a/apps/app/src/components/settings/settingsNavigation.test.ts
+++ b/apps/app/src/components/settings/settingsNavigation.test.ts
@@ -4,7 +4,12 @@ import type { ImperativeRouter } from 'expo-router';
 
 type SettingsNavigationRouter = Pick<ImperativeRouter, 'back'>;
 
+let returnToMuteAndBlockRoot: (router: Pick<ImperativeRouter, 'replace'>) => void;
 let returnToSettingsRoot: (router: SettingsNavigationRouter) => void;
+let returnToSettingsParent: (
+  pathname: string,
+  router: Pick<ImperativeRouter, 'back' | 'replace'>,
+) => void;
 let platform: 'ios' | 'web' = 'web';
 const originalLocation = Object.getOwnPropertyDescriptor(globalThis, 'location');
 
@@ -19,7 +24,8 @@ mock.module('react-native', {
 } as unknown as Parameters<typeof mock.module>[1]);
 
 before(async () => {
-  ({ returnToSettingsRoot } = await import('./settingsNavigation'));
+  ({ returnToMuteAndBlockRoot, returnToSettingsParent, returnToSettingsRoot } =
+    await import('./settingsNavigation'));
 });
 
 afterEach(() => {
@@ -54,5 +60,30 @@ describe('Settings detail back navigation', () => {
     returnToSettingsRoot({ back: () => (backCalls += 1) });
 
     assert.equal(backCalls, 1);
+  });
+
+  it('중첩된 Native detail은 바로 위 mute category를 명시적으로 연다', () => {
+    platform = 'ios';
+    const replaced: string[] = [];
+
+    returnToMuteAndBlockRoot({ replace: (href) => replaced.push(String(href)) });
+
+    assert.deepEqual(replaced, ['/settings/mute-and-block']);
+  });
+
+  it('Muted profiles의 shell back은 바로 위 mute category를 연다', () => {
+    const replaced: string[] = [];
+
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { replace: (href: string) => replaced.push(href) },
+    });
+
+    returnToSettingsParent('/settings/muted-profiles', {
+      back: () => {},
+      replace: (href) => replaced.push(String(href)),
+    });
+
+    assert.deepEqual(replaced, ['/settings/mute-and-block']);
   });
 });

--- a/apps/app/src/components/settings/settingsNavigation.test.ts
+++ b/apps/app/src/components/settings/settingsNavigation.test.ts
@@ -1,15 +1,8 @@
 import assert from 'node:assert/strict';
 import { afterEach, before, describe, it, mock } from 'node:test';
-import type { ImperativeRouter } from 'expo-router';
+import type { returnToSettingsParent as ReturnToSettingsParent } from './settingsNavigation';
 
-type SettingsNavigationRouter = Pick<ImperativeRouter, 'back' | 'replace'>;
-
-let returnToMuteAndBlockRoot: (router: Pick<ImperativeRouter, 'replace'>) => void;
-let returnToSettingsRoot: (router: SettingsNavigationRouter) => void;
-let returnToSettingsParent: (
-  pathname: string,
-  router: Pick<ImperativeRouter, 'back' | 'replace'>,
-) => void;
+let returnToSettingsParent: typeof ReturnToSettingsParent;
 let platform: 'ios' | 'web' = 'web';
 const originalLocation = Object.getOwnPropertyDescriptor(globalThis, 'location');
 
@@ -24,8 +17,7 @@ mock.module('react-native', {
 } as unknown as Parameters<typeof mock.module>[1]);
 
 before(async () => {
-  ({ returnToMuteAndBlockRoot, returnToSettingsParent, returnToSettingsRoot } =
-    await import('./settingsNavigation'));
+  ({ returnToSettingsParent } = await import('./settingsNavigation'));
 });
 
 afterEach(() => {
@@ -39,7 +31,6 @@ afterEach(() => {
 
 describe('Settings detail back navigation', () => {
   it('Web은 document location을 Settings root로 replace한다', () => {
-    let backCalls = 0;
     const replaced: string[] = [];
 
     Object.defineProperty(globalThis, 'location', {
@@ -47,23 +38,21 @@ describe('Settings detail back navigation', () => {
       value: { replace: (href: string) => replaced.push(href) },
     });
 
-    returnToSettingsRoot({ back: () => (backCalls += 1), replace: () => {} });
+    returnToSettingsParent('/settings/mute-and-block', {
+      replace: () => {},
+    });
 
-    assert.equal(backCalls, 0);
     assert.deepEqual(replaced, ['/settings']);
   });
 
   it('Native는 이전 history와 무관하게 Settings root를 연다', () => {
     platform = 'ios';
-    let backCalls = 0;
     const replaced: string[] = [];
 
-    returnToSettingsRoot({
-      back: () => (backCalls += 1),
+    returnToSettingsParent('/settings/default-post-visibility', {
       replace: (href) => replaced.push(String(href)),
     });
 
-    assert.equal(backCalls, 0);
     assert.deepEqual(replaced, ['/settings']);
   });
 
@@ -71,7 +60,9 @@ describe('Settings detail back navigation', () => {
     platform = 'ios';
     const replaced: string[] = [];
 
-    returnToMuteAndBlockRoot({ replace: (href) => replaced.push(String(href)) });
+    returnToSettingsParent('/settings/muted-profiles', {
+      replace: (href) => replaced.push(String(href)),
+    });
 
     assert.deepEqual(replaced, ['/settings/mute-and-block']);
   });
@@ -85,7 +76,6 @@ describe('Settings detail back navigation', () => {
     });
 
     returnToSettingsParent('/settings/muted-profiles', {
-      back: () => {},
       replace: (href) => replaced.push(String(href)),
     });
 

--- a/apps/app/src/components/settings/settingsNavigation.test.ts
+++ b/apps/app/src/components/settings/settingsNavigation.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, before, describe, it, mock } from 'node:test';
 import type { ImperativeRouter } from 'expo-router';
 
-type SettingsNavigationRouter = Pick<ImperativeRouter, 'back'>;
+type SettingsNavigationRouter = Pick<ImperativeRouter, 'back' | 'replace'>;
 
 let returnToMuteAndBlockRoot: (router: Pick<ImperativeRouter, 'replace'>) => void;
 let returnToSettingsRoot: (router: SettingsNavigationRouter) => void;
@@ -47,19 +47,24 @@ describe('Settings detail back navigation', () => {
       value: { replace: (href: string) => replaced.push(href) },
     });
 
-    returnToSettingsRoot({ back: () => (backCalls += 1) });
+    returnToSettingsRoot({ back: () => (backCalls += 1), replace: () => {} });
 
     assert.equal(backCalls, 0);
     assert.deepEqual(replaced, ['/settings']);
   });
 
-  it('Native는 router back으로 route-owned stack을 닫는다', () => {
+  it('Native는 이전 history와 무관하게 Settings root를 연다', () => {
     platform = 'ios';
     let backCalls = 0;
+    const replaced: string[] = [];
 
-    returnToSettingsRoot({ back: () => (backCalls += 1) });
+    returnToSettingsRoot({
+      back: () => (backCalls += 1),
+      replace: (href) => replaced.push(String(href)),
+    });
 
-    assert.equal(backCalls, 1);
+    assert.equal(backCalls, 0);
+    assert.deepEqual(replaced, ['/settings']);
   });
 
   it('중첩된 Native detail은 바로 위 mute category를 명시적으로 연다', () => {

--- a/apps/app/src/components/settings/settingsNavigation.ts
+++ b/apps/app/src/components/settings/settingsNavigation.ts
@@ -2,6 +2,8 @@ import { Platform } from 'react-native';
 import type { ImperativeRouter } from 'expo-router';
 
 type SettingsNavigationRouter = Pick<ImperativeRouter, 'back'>;
+type SettingsParentNavigationRouter = Pick<ImperativeRouter, 'back' | 'replace'>;
+type NestedSettingsNavigationRouter = Pick<ImperativeRouter, 'replace'>;
 
 export function returnToSettingsRoot(router: SettingsNavigationRouter) {
   if (Platform.OS === 'web') {
@@ -9,4 +11,20 @@ export function returnToSettingsRoot(router: SettingsNavigationRouter) {
   } else {
     router.back();
   }
+}
+
+export function returnToMuteAndBlockRoot(router: NestedSettingsNavigationRouter) {
+  if (Platform.OS === 'web') {
+    globalThis.location.replace('/settings/mute-and-block');
+  } else {
+    router.replace('/settings/mute-and-block');
+  }
+}
+
+export function returnToSettingsParent(pathname: string, router: SettingsParentNavigationRouter) {
+  if (pathname === '/settings/muted-profiles') {
+    return returnToMuteAndBlockRoot(router);
+  }
+
+  return returnToSettingsRoot(router);
 }

--- a/apps/app/src/components/settings/settingsNavigation.ts
+++ b/apps/app/src/components/settings/settingsNavigation.ts
@@ -1,30 +1,15 @@
 import { Platform } from 'react-native';
 import type { ImperativeRouter } from 'expo-router';
 
-type SettingsNavigationRouter = Pick<ImperativeRouter, 'back' | 'replace'>;
-type SettingsParentNavigationRouter = Pick<ImperativeRouter, 'back' | 'replace'>;
-type NestedSettingsNavigationRouter = Pick<ImperativeRouter, 'replace'>;
+type SettingsNavigationRouter = Pick<ImperativeRouter, 'replace'>;
 
-export function returnToSettingsRoot(router: SettingsNavigationRouter) {
+export function returnToSettingsParent(pathname: string, router: SettingsNavigationRouter) {
+  const parentPath =
+    pathname === '/settings/muted-profiles' ? '/settings/mute-and-block' : '/settings';
+
   if (Platform.OS === 'web') {
-    globalThis.location.replace('/settings');
+    globalThis.location.replace(parentPath);
   } else {
-    router.replace('/settings');
+    router.replace(parentPath);
   }
-}
-
-export function returnToMuteAndBlockRoot(router: NestedSettingsNavigationRouter) {
-  if (Platform.OS === 'web') {
-    globalThis.location.replace('/settings/mute-and-block');
-  } else {
-    router.replace('/settings/mute-and-block');
-  }
-}
-
-export function returnToSettingsParent(pathname: string, router: SettingsParentNavigationRouter) {
-  if (pathname === '/settings/muted-profiles') {
-    return returnToMuteAndBlockRoot(router);
-  }
-
-  return returnToSettingsRoot(router);
 }

--- a/apps/app/src/components/settings/settingsNavigation.ts
+++ b/apps/app/src/components/settings/settingsNavigation.ts
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 import type { ImperativeRouter } from 'expo-router';
 
-type SettingsNavigationRouter = Pick<ImperativeRouter, 'back'>;
+type SettingsNavigationRouter = Pick<ImperativeRouter, 'back' | 'replace'>;
 type SettingsParentNavigationRouter = Pick<ImperativeRouter, 'back' | 'replace'>;
 type NestedSettingsNavigationRouter = Pick<ImperativeRouter, 'replace'>;
 
@@ -9,7 +9,7 @@ export function returnToSettingsRoot(router: SettingsNavigationRouter) {
   if (Platform.OS === 'web') {
     globalThis.location.replace('/settings');
   } else {
-    router.back();
+    router.replace('/settings');
   }
 }
 

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -24,7 +24,7 @@ import { useSafeAreaPadding } from '@/components/ui/useSafeAreaPadding';
 import { RelayActorBoundary } from '@/relay/RelayActorProvider';
 import { useElevation, useTheme } from '@/theme/ThemeProvider';
 import { spacing } from '@/theme/tokens';
-import { returnToSettingsRoot } from '../settings/settingsNavigation';
+import { returnToSettingsParent } from '../settings/settingsNavigation';
 import { BottomTabBar } from './BottomTabBar';
 import { NavigationGuardProvider } from './NavigationGuardContext';
 import {
@@ -258,7 +258,9 @@ function UniversalShellContent() {
   const backButton = (
     <IconButton
       accessibilityLabel="뒤로 가기"
-      onPress={() => (isSettingsRoute(pathname) ? returnToSettingsRoot(router) : router.back())}
+      onPress={() =>
+        isSettingsRoute(pathname) ? returnToSettingsParent(pathname, router) : router.back()
+      }
       style={styles.menuButton}
       targetSize={44}
       visualSize={44}

--- a/apps/app/src/components/shell/shellLayout.test.ts
+++ b/apps/app/src/components/shell/shellLayout.test.ts
@@ -78,6 +78,14 @@ describe('getShellLayout', () => {
       leading: 'back',
       title: '게시물 기본 공개 범위',
     });
+    assert.deepEqual(getWebMobileShellHeader(true, 390, '/settings/mute-and-block', []), {
+      leading: 'back',
+      title: '뮤트 및 차단',
+    });
+    assert.deepEqual(getWebMobileShellHeader(true, 390, '/settings/muted-profiles', []), {
+      leading: 'back',
+      title: '뮤트한 프로필',
+    });
     assert.equal(getWebMobileShellHeader(true, 390, '/bookmarks', []), null);
     assert.equal(getWebMobileShellHeader(true, 390, '/search', []), null);
     assert.equal(getWebMobileShellHeader(true, 390, '/@writer/followers', []), null);

--- a/apps/app/src/components/shell/shellLayout.ts
+++ b/apps/app/src/components/shell/shellLayout.ts
@@ -34,7 +34,14 @@ export function getShellLayout(web: boolean, width: number) {
 
 export type WebMobileShellHeader = Readonly<{
   leading: 'back' | 'menu';
-  title: '게시글' | '게시물 기본 공개 범위' | '글쓰기' | '설정' | '알림';
+  title:
+    | '게시글'
+    | '게시물 기본 공개 범위'
+    | '글쓰기'
+    | '뮤트 및 차단'
+    | '뮤트한 프로필'
+    | '설정'
+    | '알림';
 }>;
 
 export function isSettingsRoute(pathname: string) {
@@ -77,6 +84,12 @@ export function getWebMobileShellHeader(
   }
   if (pathname === '/settings/default-post-visibility') {
     return { leading: 'back', title: '게시물 기본 공개 범위' };
+  }
+  if (pathname === '/settings/mute-and-block') {
+    return { leading: 'back', title: '뮤트 및 차단' };
+  }
+  if (pathname === '/settings/muted-profiles') {
+    return { leading: 'back', title: '뮤트한 프로필' };
   }
 
   if (routeSegments.at(-2) === '[profileHandle]' && routeSegments.at(-1) === '[postId]') {

--- a/apps/app/src/stories/patterns/MutedProfileList.stories.tsx
+++ b/apps/app/src/stories/patterns/MutedProfileList.stories.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { fn } from 'storybook/test';
 import { MutedProfileList } from '@/components/profile/MutedProfileList';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, space, textStyles } from '@/theme/tokens';
 import appleTouchIconUrl from '../../../public/apple-touch-icon.png?url';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -27,12 +29,21 @@ function Fixture({
   onLoadMore,
   onFeedback,
 }: Props) {
+  const theme = useTheme();
+  const headingRef = useRef<View>(null);
+  const focusAfterRemoval = useRef(false);
   const [removed, setRemoved] = useState<string[]>([]);
   const [requestState, setRequestState] = useState<Props['state'] | 'end' | null>(null);
   useEffect(() => {
     setRemoved([]);
     setRequestState(null);
   }, [state, outcome, displayName]);
+  useEffect(() => {
+    if (focusAfterRemoval.current) {
+      headingRef.current?.focus();
+      focusAfterRemoval.current = false;
+    }
+  }, [removed]);
   useEffect(() => {
     if (outcome === 'pending' || (requestState !== 'loading' && requestState !== 'loadingMore')) {
       return;
@@ -52,6 +63,7 @@ function Fixture({
   }, [requestState, outcome]);
   const visibleState = requestState ?? state;
   const retry = () => {
+    headingRef.current?.focus();
     onRetry();
     setRequestState(visibleState === 'error' ? 'loading' : 'loadingMore');
   };
@@ -59,11 +71,22 @@ function Fixture({
     .map((p, index) => ({ ...p, displayName: index ? p.displayName : displayName }))
     .filter((p) => !removed.includes(p.id));
   return (
-    <View style={{ width: '100%', maxWidth: 640 }}>
+    <ScrollView contentContainerStyle={styles.content} style={styles.frame}>
+      <View accessibilityRole="header" ref={headingRef} tabIndex={-1}>
+        <Text
+          style={[
+            styles.heading,
+            { color: theme.foregroundPrimary, borderColor: theme.borderDefault },
+          ]}
+        >
+          뮤트한 프로필
+        </Text>
+      </View>
       <MutedProfileList
         onFeedback={(event) => {
           onFeedback(event);
           if (event.status === 'success') {
+            focusAfterRemoval.current = true;
             setRemoved((current) => [...current, event.profileId]);
           }
         }}
@@ -101,9 +124,15 @@ function Fixture({
                 }
         }
       />
-    </View>
+    </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  content: { flexGrow: 1, width: '100%' },
+  frame: { maxWidth: 640, width: '100%' },
+  heading: { ...textStyles.uiHeadingM, borderBottomWidth: borderWidths[1], padding: space[16] },
+});
 const meta = {
   args: {
     state: 'loaded',

--- a/apps/app/src/stories/patterns/MutedProfileList.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/MutedProfileList.tests.stories.tsx
@@ -34,6 +34,17 @@ export const TargetGeometryContract: Story = {
   },
 };
 
+export const CompositionOwnershipContract: Story = {
+  ...unmute,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const heading = canvas.getByRole('heading', { name: '뮤트한 프로필' });
+    const list = canvas.getByTestId('muted-profile-list');
+
+    expect(list.contains(heading)).toBe(false);
+  },
+};
+
 export const UnmuteContract: Story = {
   ...unmute,
   play: async ({ args, canvasElement }) => {

--- a/docs/design/profile-mute-block.md
+++ b/docs/design/profile-mute-block.md
@@ -142,7 +142,9 @@ Profile에서 Mute·Block·해제를 실행하고 관리 목록과 제한된 Pro
 
 `ProfileMuteAction`은 기존 ActionMenu·ModalSheet·ConfirmationContent·ToastProvider를 재사용한다.
 확인과 pending/dismiss, 오류 피드백은 공용 UI 경계에서 제공하며 실제 요청은 callback으로 전달한다.
-관리 목록은 `MutedProfileList`, 행 표시는 기존 Relay `ProfileListItem`과 공유하는 `ProfileListItemContent`를 사용한다.
+관리 목록은 본문·상태·행·pagination을 소유하는 `MutedProfileList`, 행 표시는 기존 Relay `ProfileListItem`과
+공유하는 `ProfileListItemContent`를 사용한다. 화면과 Storybook은 목록 밖의 heading·scroll container와
+해제 성공 후 heading focus를 소유한다.
 Relay 행은 `identity`로 기존 `ProfileNameBlock`을 전달하고, 관리 목록은 이름·핸들 기본 표시를 사용한다.
 행의 action은 `children`으로 합성하며, FollowButton의 Web·Native 크기 선택은 Relay wrapper가 유지한다.
 `ProfileHero.mute.muted`에는 서버 확정 상태를 전달하고, loading에서는 메뉴·상태행을 표시하지 않는다.


### PR DESCRIPTION
## 무엇을 변경했는지

- `뮤트 및 차단`과 `뮤트한 프로필` Settings route·layout·heading 경계를 조립했습니다.
- full Web의 muted profiles 화면에서 category 하위 navigation을 master pane에 배치했습니다.
- compact Web과 Native의 중첩 화면이 이전 history와 무관하게 명시적 Settings parent로 이동하도록 맞췄습니다.
- `MutedProfileList`는 본문·상태·행·pagination만 소유하고, 화면과 Storybook이 heading·scroll·focus 구성을 소유하도록 분리했습니다.
- 실제 데이터가 연결되기 전에 미완성 관리 화면이 노출되지 않도록 Settings root 진입점은 #796 레이어로 옮겼습니다.

## 왜 변경했는지

PROD-814의 Relay 데이터 연결을 검토하기 전에 Settings route와 화면 조립 경계를 독립적으로 확인할 수 있게 분리했습니다. 다만 #795만 반영된 상태에서는 사용자가 조회나 해제를 완료할 수 없으므로, 관리 진입점은 실제 기능을 소유하는 #796에서 공개합니다.

## 이번 PR의 주요 결정

### route 조립과 기능 공개 시점 분리

- 결정자: @hyeju
- 선택: #795는 Settings route·layout·heading·명시적 parent 이동과 목록 본문 경계를 소유하고, #796은 실제 조회·상태·action 연결과 진입점 공개를 소유합니다. heading·scroll·해제 성공 후 focus는 목록의 mode prop이 아니라 각 화면과 Storybook의 바깥 구성에서 관리합니다.
- 고려한 대안: 데이터 연결 전에 loading-only 화면을 Settings에 노출하거나, 목록 컴포넌트에 heading·scroll 표시 옵션을 유지하는 방식
- 이유: 화면 경계 리뷰는 분리하면서도 사용자에게 완료되지 않은 destination을 공개하지 않고, 부모가 자식의 화면 구성을 알고 끄는 결합을 남기지 않기 위해서입니다.
- 감수한 결과: #795만 반영된 상태에서는 뮤트 관리 진입점이 표시되지 않으며, #796 적용 후 완성된 기능과 함께 공개됩니다.
- 관련 근거: Linear PROD-814, `docs/design/settings.md`, `docs/design/profile-mute-block.md`

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app exec node --experimental-test-module-mocks --import tsx --test src/components/settings/SettingsNavigationList.test.ts src/components/settings/settingsNavigation.test.ts src/components/settings/SettingsRoutes.test.ts` — 23 passed
- `pnpm --filter @kosmo/app check`
- `pnpm --filter @kosmo/app exec vitest run --project=storybook src/stories/patterns/MutedProfileList.tests.stories.tsx` — 8 passed
- GitHub 필수 CI

## 아직 어떤 문제가 남았는지

- 실제 Relay 조회·mutation·cache·pagination, selected Profile 격리, Settings 진입점 공개는 다음 `PROD-814-data` PR #796에서 연결합니다.
- Android·iOS screen reader와 실제 기기 history/focus 이동은 후속 Native 검증에서 확인합니다.
- Stack: `main -> PROD-814-ui -> PROD-814-data`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
