### PR TITLE
순수 Repost의 Quote Source 표시 정책을 정본 문서로 확정한다

### DIFF
--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -125,6 +125,38 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
   간격을 공유한다. Repost의 Profile link 의미와 Reply의 비대화형 텍스트 의미는 각 변형이 따로 소유하며,
   공용 행이 링크 여부를 추론하지 않는다.
 
+## Source가 Quote인 순수 Repost
+
+이 절은 [PROD-828](https://linear.app/byulmaru/issue/PROD-828)의 `X(Twitter) 방식대로`라는 표시 방향을
+구체화한다. Domain Gate 전환 승인 상태는
+[ADR 0027](../domain/decisions/0027-repost-of-quote-source-presentation.md)에서 추적한다. 제품 결정과 현재 UI에
+반영된 범위를 구분한다.
+
+- A가 B의 Quote를 Repost하고 B가 C의 Post를 인용했다면, `A님이 재게시함`, B의 표준 Author·생성 시각·Content,
+  C의 Source preview, Action Bar 순서로 표시한다. B의 Quote를 별도 Source 카드 안에 다시 감싸지 않는다.
+- preview는 B를 기준으로 한 단계다. C도 Quote이면 C의 Author·생성 시각·Content까지만 보여주며, C가
+  인용한 Post는 추가로 표시하거나 이를 대신하는 placeholder·별도 CTA를 두지 않는다. Quote와 Reply+Quote를
+  직접 표시할 때도 같은 preview 깊이를 사용한다.
+- 바깥 목록 항목이 article, 카드 padding과 row divider를 한 번만 소유한다. B의 표준 행과 C의 preview에
+  article이나 전체 게시글 renderer를 재귀적으로 중첩하지 않는다. C의 preview border는 인용 관계를 구분하는
+  기존 Quote 표현으로 유지한다.
+- A의 attribution은 A의 Profile로, B의 Author는 B의 Profile로 이동한다. B의 본문 shortcut·생성 시각과
+  순수 Repost ID 직접 진입은 B의 canonical Post 상세로 이동한다. C의 Author는 C의 Profile로, C의 본문
+  shortcut·생성 시각은 C의 canonical Post 상세로 이동한다. B의 직접 관계를 C로 평탄화하지 않는다.
+- C의 preview는 기존 Source preview 입력 경계를 따른다. Author·생성 시각은 각각 독립 Link이고, 본문은
+  pointer·touch shortcut을 제공한다. 본문 shortcut을 별도 접근성 Link나 keyboard focus 대상으로 중복하지
+  않는다. 본문의 외부 Link는 자신의 URL만 열며 preview 전체와 빈 padding을 하나의 Link로 감싸지 않는다.
+- Action Bar와 Reaction Summary는 C의 preview 뒤에 한 번만 배치하며 모든 navigation target의 sibling으로
+  둔다. Repost·Reaction·Bookmark·More와 Summary는 B를 대상으로 하고, Reply는 바깥 contentless Repost의
+  기존 binding과 disabled 상태를 유지한다. C에 별도의 Action Bar를 붙이지 않는다.
+- B를 조회할 수 있고 C가 unavailable이면 C의 preview를 생략하고 B의 Content와 Repost 항목을 유지한다.
+  B 자체를 조회할 수 없으면 기존 Post Eligibility에 따라 순수 Repost 항목을 표시하지 않는다. preview의
+  Content Warning·Media 표현과 조회 범위는 각 대상의 기존 계약을 따른다.
+- 순수 Repost의 별도 상세 화면은 만들지 않는다. B 상세로 replace redirect한 뒤에는 B의 기존 Quote 상세와
+  C의 한 단계 preview를 사용하며, A의 attribution이나 바깥 Repost의 Reply 상태를 B 상세로 전달하지 않는다.
+- Web과 공용 Native presentation은 같은 표시·이동 계약을 사용한다. Web Storybook·runtime 검증과 Native의
+  실제 touch·VoiceOver·TalkBack 검증은 구분하며, Native runtime 관찰은 출시 gate에 남긴다.
+
 ## Repost action menu
 
 - Mobile Target consumer section [`6772:10989`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6772-10989)은

--- a/docs/domain/decisions/0027-repost-of-quote-source-presentation.md
+++ b/docs/domain/decisions/0027-repost-of-quote-source-presentation.md
@@ -1,0 +1,91 @@
+# ADR 0027: Repost of Quote Source Presentation
+
+## 상태
+
+Accepted
+
+2026-09-08 PROD-828 Spec 대화에서 사람이 `X(Twitter) 방식대로`를 선택했다. 같은 task에서
+`PROD-828 Domain Gate 승인`으로 이 ADR의 구체 적용안과 후속 책임을 다음 gate의 입력으로 사용하는 것을
+명시적으로 승인했다. 이 승인은 PROD-922의 Issue Gate나 이후 OpenSpec Gate 승인을 대신하지 않는다.
+
+## 날짜
+
+2026-09-08
+
+## 승인 근거
+
+- 승인자: 현재 task의 사용자 정혜주
+- 승인 문구: `PROD-828 Domain Gate 승인`
+- 승인 대상: 이 ADR의 결정안, canonical Post·Post Action Bar 반영과 PROD-922의 후속 책임
+- 다음 gate: PROD-922 Issue Gate
+- 포함하지 않은 승인: PROD-922 Issue Gate, OpenSpec Gate, 구현·배포
+
+## 맥락
+
+순수 Repost의 직접 Source는 Content가 있는 Quote일 수 있다. 재게시한 Quote의 본문만 보여주면
+인용 원문을 전제로 쓴 내용을 목록에서 이해하기 어렵다. 반면 Source 관계를 계속 펼치면 목록 항목이
+끝없이 깊어지고, 작성자·이동 대상과 접근성 구조를 구분하기 어려워진다.
+
+PROD-828은 이 표시 깊이를 결정하는 Domain Gate다. 저장·생성·취소·Notification이나 순수 Repost의 canonical
+이동 대상을 다시 결정하지 않으며, 기존 `add-post-reposts` archive를 소유하지 않는다.
+
+## 결정안
+
+- Repost attribution 아래에는 직접 Source Quote의 Author와 Content를 주된 게시 내용으로 표시한다.
+- 해당 Quote가 직접 인용한 조회 가능한 Source를 한 단계 preview로 함께 표시한다. Content 없는 Repost를
+  거치는 것은 Quote의 인용 맥락을 숨길 이유가 되지 않는다.
+- preview 대상도 Quote이면 그 대상의 Author와 Content까지만 표시한다. 그 아래 Source를 재귀적으로
+  표시하거나 이를 대신하는 placeholder·별도 진입 안내는 추가하지 않는다.
+- 각 Source를 조회할 수 있는지 독립적으로 판정한다. Quote가 인용한 Source를 표시할 수 없어도 Quote 자체를
+  조회할 수 있으면 Quote의 Content와 이를 재게시한 항목은 유지한다.
+- 순수 Repost의 본문·생성 시각·직접 상세 URL과 Repost·Reaction·Bookmark·More의 대상은 직접 Source
+  Quote다. preview의 본문·생성 시각만 그 preview 대상의 상세로 이동한다. 각 Author는 자신의 Profile로
+  이동한다. 기존 직접 관계를 더 깊은 Source로 평탄화하지 않는다.
+- 순수 Repost 목록의 Reply는 바깥 contentless Post의 기존 disabled 계약을 유지한다. Quote 상세로
+  이동한 뒤의 Reply는 Quote 자체의 기존 정책을 따른다.
+- 목록 항목 하나의 article과 Action Bar 하나를 유지하며, preview 안에 전체 게시글 renderer·article·Link를
+  재귀적으로 중첩하지 않는다. 상세한 입력·배치 경계는 canonical 디자인 문서가 소유한다.
+
+## 고려한 대안
+
+| 대안                                          | 이점                                                            | 감수할 결과                                       | 판단                          |
+| --------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------- | ----------------------------- |
+| Quote 본문과 직접 인용 Source preview 한 단계 | 재게시한 Quote의 맥락을 일반 Quote와 같은 방식으로 읽을 수 있다 | 현재 목록에 preview를 추가하고 회귀 검증해야 한다 | 사람이 선택한 X 방식의 적용안 |
+| Quote 본문만 표시                             | 현재 목록 구현을 유지하고 항목 높이를 줄인다                    | 인용 원문은 Quote 상세에 들어가야 확인할 수 있다  | 선택하지 않음                 |
+| Source 관계를 여러 단계 재귀 표시             | 더 많은 인용 맥락을 한 항목에서 제공한다                        | 항목 높이·조회 범위·이동·접근성 구조가 복잡해진다 | 선택하지 않음                 |
+
+## 근거와 적용 범위
+
+- [PROD-828](https://linear.app/byulmaru/issue/PROD-828)의 현재 Domain Gate 범위와 2026-09-08 사람의 표시 방향
+  선택을 제품 결정의 근거로 사용한다.
+- [X Repost FAQ](https://help.x.com/en/using-x/repost-faqs)는 재게시가 원 게시물의 작성자·내용을 유지하고
+  재게시자 표시로 구분된다고 설명한다. [X의 Repost·Quote 안내](https://help.x.com/en/using-x/how-to-repost)는
+  Quote가 공유한 Post를 참조한다고 설명한다.
+- 한 단계 cutoff와 KOSMO의 article·Link·Reply 정책은 X 문서에서 그대로 가져온 계약이 아니다. 기존
+  KOSMO 계약과 사람의 표시 방향을 결합한 이번 적용안이며, X의 모든 플랫폼·비공개 상태·세부 UI를 복제한다는
+  의미로 사용하지 않는다. X의 실제 runtime은 이번 조사에서 직접 관찰하지 않았다.
+- [ADR 0014](./0014-post-structure-relations.md)의 관계 조합,
+  [Post](../objects/post.md)의 직접 참조·조회 정책과
+  [Post Action Bar](../../design/post-action-bar.md)의 입력·대상 계약을 유지한다.
+
+## 후속 책임과 완료 경계
+
+PROD-828은 canonical 문서·이 결정안·후속 책임 정렬과 승인 근거를 소유한다.
+[PROD-922](https://linear.app/byulmaru/issue/PROD-922)는 preview 표시, 필요한 fragment 소비,
+Storybook·실제 화면 검증과 새 OpenSpec의 통합 검증·동기화·archive를 소유한다. PROD-922는 Backlog 초안이며
+PROD-828에 blocked 관계로 연결해 초안을 검토했다. Domain Gate 승인 뒤 이 blocker를 해제했으며 부모·자식
+계층을 새로 만들지 않았다. PROD-922의 Issue Gate가 승인되기 전에는 새 OpenSpec을 생성하지 않는다.
+
+기존 `add-post-reposts` archive와 완료된 PROD-389·PROD-415·PROD-505를 다시 열거나 과거 기록을 덮어쓰지
+않는다. 현재 `post-repost-ui` 명세가 PROD-828로 미룬 조합은 후속 구현 이슈의 새 change에서 구체화한다.
+PROD-670·PROD-904의 게시 활동 목록, PROD-431의 Quote 작성, federation·Quote 알림은 이 결정의 구현 범위가
+아니다. 원격 Quote의 승인·철회·resolution과 Source 반환 정책은 PROD-792가 계속 소유하며, PROD-922는
+반환된 nullable Source를 소비한다.
+
+## 문서 반영
+
+- [Post](../objects/post.md)는 Source가 Quote인 순수 Repost의 표시 깊이와 기존 조회 정책을 정의한다.
+- [Post Action Bar](../../design/post-action-bar.md#source가-quote인-순수-repost)는 표시 순서, article·Link,
+  Action Bar와 상세 진입 경계를 정의한다.
+- [검토 기록](../records/2026-09-08-repost-of-quote-display-review.md)은 현재 구현 차이, 검증 공백과 승인
+  대상을 기록한다.

--- a/docs/domain/objects/post.md
+++ b/docs/domain/objects/post.md
@@ -128,6 +128,15 @@ Reply·Quote·Repost 작성은 각 입력 Parent·Source Post의 Author Profile�
   이동하거나 replace redirect한다. Repost 자체의 별도 상세 화면은 표시하지 않는다.
 - Content와 Repost Source가 있는 Quote는 Quote 자체의 canonical Post 상세를 유지하고, Quote 안의 Source
   preview를 활성화했을 때만 Source의 canonical Post route로 이동한다.
+- 순수 Repost의 직접 Repost Source가 Quote이면 재게시한 Quote의 Author와 Content를 주된 표시 대상으로
+  유지하고, 그 Quote가 직접 참조한 조회 가능한 Source를 preview로 함께 표시한다. Content 없는 Repost를
+  거치는 것만으로 Quote의 Source preview를 생략하지 않는다.
+- Quote의 Source preview는 표시 중인 Content Post를 기준으로 한 단계까지만 제공한다. preview 대상이
+  Quote여도 그 대상의 Author와 Content까지만 표시하고, 그 아래 Source나 이를 대신하는 placeholder·별도
+  진입 안내를 추가하지 않는다. 각 Source의 조회 정책은 독립적으로 적용한다.
+- 이 표시 깊이와 이동 대상의 구분은 [ADR 0027](../decisions/0027-repost-of-quote-source-presentation.md)과
+  [Post Action Bar의 Source가 Quote인 순수 Repost](../../design/post-action-bar.md#source가-quote인-순수-repost)를
+  따른다. PROD-828의 Domain Gate 전환 승인은 해당 ADR에서 별도로 추적한다.
 - Post의 Repost 수는 해당 Post를 Repost Source로 직접 참조하면서 Content와 Reply Parent가 없는 eligible
   Active Repost만 포함하고 Quote는 포함하지 않는다.
 

--- a/docs/domain/records/2026-09-08-repost-of-quote-display-review.md
+++ b/docs/domain/records/2026-09-08-repost-of-quote-display-review.md
@@ -1,0 +1,88 @@
+# 순수 Repost의 Quote Source 표시 검토
+
+이 문서는 2026-09-08 PROD-828의 조사와 결정 검토 기록이다. 현재 canonical 계약은 Post 객체와 디자인
+문서, 승인된 ADR을 기준으로 읽는다. 이번 적용안은 사람이 선택한 표시 방향을 반영했으며 같은 task에서
+`PROD-828 Domain Gate 승인`으로 다음 gate의 입력이 되었다.
+
+## 요청과 선택
+
+- 요청: PROD-828에 `openspec-propose`와 `kosmo-spec-workflow` 적용.
+- 최신 Linear 본문: PROD-828은 표시 깊이의 Domain Gate이며 OpenSpec·구현·기존 archive를 소유하지 않는다.
+- 사람의 선택: PROD-828 Spec 대화에서 `X(Twitter) 방식대로`.
+- Domain Gate 승인: 같은 task에서 `PROD-828 Domain Gate 승인`.
+- 적용안: A의 Repost attribution 아래 B의 Quote 본문과 C의 Source preview를 함께 표시한다. C가 Quote여도
+  그 아래 D는 표시하지 않는다. preview 깊이는 Content가 있는 주된 표시 대상 B를 기준으로 센다.
+- X 공식 문서에서 확인한 범위와 KOSMO 적용안의 구분은
+  [ADR 0027](../decisions/0027-repost-of-quote-source-presentation.md#근거와-적용-범위)에 기록했다.
+
+## Authority 확인
+
+| 근거                                                             | 확인 결과                                                                                                                               |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| PROD-828, 조회 당시 updated `2026-09-07T09:48:30.859Z`, 댓글 0개 | Domain Gate이고 표시 깊이는 미결정이었다. 현재 대화의 선택과 후속 책임을 본문에 갱신했다.                                               |
+| Post 객체·ADR 0014                                               | Repost와 Quote는 Content·Reply Parent·Repost Source의 조합이며 Source를 평탄화하지 않는다.                                              |
+| Post Action Bar                                                  | 본문·시간·직접 URL은 direct Source로 이동한다. social action은 Source, 순수 Repost Reply는 바깥 contentless Post를 기준으로 disabled다. |
+| PROD-415의 2026-07-25·2026-07-27 댓글                            | Source Quote의 preview 생략·유지 설명이 함께 존재한다. 2026-08-24 분리된 PROD-828의 최종 승인 근거로 사용하지 않았다.                   |
+| PROD-389·archived add-post-reposts                               | PROD-828의 표시 결정을 후속 범위로 남겼다. 기존 archive 완료를 이번 결정의 승인으로 해석하지 않았다.                                    |
+| PROD-431                                                         | 로컬 Quote 작성과 기존 Quote presentation 회귀를 소유한다. pure Repost wrapper의 추가 preview는 PROD-922가 맡는다.                      |
+| PROD-792                                                         | 원격 Quote의 승인·철회·조회 가능성에 따른 Source 반환을 소유한다. UI는 반환된 nullable Source만 소비한다.                               |
+| PROD-670·PROD-904                                                | 게시 활동 목록은 별도 Backlog 범위다. 표시 깊이 구현이나 archive 책임을 배정하지 않았다.                                                |
+
+## 현재 구현 증거
+
+기준은 main commit `4417b2a8a1a11796ae41adc9921686e1a3e4fe25`다. 아래 행 번호는 이 commit의 읽기
+증거이며, 실행 검증 결과를 뜻하지 않는다.
+
+| 경로·위치                                                         | 관찰한 동작                                                                                           | 적용안과의 차이                                                                                      |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `apps/app/src/components/post/PostListItem.tsx:233`               | outer article·attribution 뒤 `PostListRow post={source}`를 표시한다.                                  | B 본문 뒤 C preview가 필요하다. B의 표준 행·단일 article은 유지한다.                                 |
+| `apps/app/src/components/post/PostListItem.tsx:311`               | 표준 행은 Author·본문·Action Surface를 표시한다.                                                      | C preview의 소비와 Action Surface 앞 배치가 필요하다.                                                |
+| `apps/app/src/components/post/PostSourcePresentationView.tsx:45`  | preview fragment는 대상의 Content·Profile을 읽고 그 아래 Source를 읽지 않는다.                        | C를 leaf preview로 소비하는 기존 경계를 재사용할 수 있다. 구체 구현 수단은 후속 OpenSpec에서 정한다. |
+| `apps/app/src/app/(tabs)/(post)/[profileHandle]/[postId].tsx:148` | 순수 Repost ID 직접 접근은 direct Source로 replace redirect한다.                                      | 기존 동작을 유지하고 B가 Quote인 경우를 회귀 검증한다.                                               |
+| `apps/app/src/stories/patterns/Posts.stories.tsx:4008`            | `PureRepostOfQuote`는 B 본문만 표시하고 C 본문을 숨기는 현재 동작을 검증한다.                         | C 표시·D cutoff 기대값으로 변경해야 한다.                                                            |
+| `apps/app/src/stories/patterns/Posts.stories.tsx:3383`            | production integration은 Quote-of-Quote의 preview와 pure Repost-of-Quote의 표준 행을 별도로 확인한다. | 두 경로를 혼동하지 않고 pure Repost의 C 표시만 보완해야 한다.                                        |
+| `apps/app/src/stories/screens/Bookmarks.stories.tsx:509`          | `RepostQuoteUsesOneSourceDepth`의 pure Repost fixture는 C preview를 표시하지 않는다.                  | 기존 소비 경로의 기대값을 정렬하되 Bookmark 후보 정책은 바꾸지 않는다.                               |
+
+## 적용안 검토 목록
+
+| 항목       | 결과                                                                                   |
+| ---------- | -------------------------------------------------------------------------------------- |
+| 표시 순서  | `A님이 재게시함` → B의 표준 Author·생성 시각·Content → C preview → Summary·Action Bar  |
+| 깊이       | B를 기준으로 preview 한 단계. C가 Quote여도 D·placeholder·별도 CTA는 생략              |
+| 접근성     | 바깥 article 하나, C preview의 독립 Profile·시간 Link, 외부 Link와 본문 shortcut 분리  |
+| 이동       | B 본문·시간·Repost URL은 B 상세, C preview 본문·시간은 C 상세, Author는 각각의 Profile |
+| Action Bar | B의 social action과 Summary를 한 번 표시. 바깥 Repost Reply disabled 유지              |
+| 조회 실패  | C unavailable이면 B 유지·C 생략, B unavailable이면 기존 Repost 제외                    |
+| 상세       | Repost 자체 상세 없이 B로 replace redirect. B 상세의 기존 Quote·Reply 계약 적용        |
+| 제외       | Quote 작성·알림·federation·게시 활동 목록·저장 Mutation·기존 archive                   |
+
+## 후속 이슈와 검증 책임
+
+[PROD-922](https://linear.app/byulmaru/issue/PROD-922)를 Backlog 초안으로 생성하고 Domain Gate 검토 중
+PROD-828에 blocked 관계로 연결했다. Domain Gate 승인 뒤 이 blocker를 해제했다. 담당자는 정혜주이며
+부모·자식 계층은 추가하지 않았다.
+
+- PROD-828은 이번 canonical 문서·ADR·책임 정렬과 Domain Gate 승인을 소유한다.
+- PROD-922는 공용 UI·fragment 소비, 목록·상세·route·action 통합 검증, 새 OpenSpec의 delta 동기화와
+  전체 완료 후 archive를 소유한다. Spec만을 위한 별도 이슈나 archive만을 위한 이슈는 만들지 않는다.
+- 다음 단계는 PROD-922의 Issue Gate에서 범위와 책임을 검토하는 것이다. Issue Gate 승인 전에는
+  `show-reposted-quote-source-preview` 후보 change를 생성하지 않는다.
+- A→B→C와 A→B→C→D, C/B unavailable, 각 Author·B·C·외부 URL 이동, article·Action Bar 하나, Reply
+  disabled, Repost URL replace redirect를 실행 결과로 확인한다.
+- Home·Profile의 공용 목록, 기존 Bookmark fixture와 Quote·Reply+Quote 목록·상세·thread를 회귀
+  검증한다. 화면과 내부 관계가 제공하지 않는 새로운 후보·Source·Reply 관계는 추론하지 않는다.
+- 현재 데이터 모델과 Source field를 사용하므로 DB migration·backfill은 계획하지 않는다. schema 변경이
+  필요하다는 증거가 생기면 후속 이슈와 해당 gate에서 범위를 다시 판단한다.
+- rollout은 preview를 소비하는 UI의 통상 배포로 계획한다. 문제가 생기면 preview 표시 변경을 되돌릴 수
+  있으며 저장 관계·canonical URL·mutation target은 바꾸지 않는다. 서버의 Source 노출 정책을 우회하는
+  fallback은 만들지 않는다.
+
+## 검증 공백과 승인 상태
+
+이번 조사에서는 코드·fragment·fixture·assertion을 읽었으며 Storybook, Web 화면, Native touch·VoiceOver·TalkBack은
+실행하지 않았다. 기존 테스트 파일의 존재를 통과 증거로 사용하지 않는다. 현재 runtime과 제품 전체의 접근성
+준수를 주장하지 않는다.
+
+사람이 `PROD-828 Domain Gate 승인`으로 구체 적용안과 후속 책임을 다음 gate의 입력으로 사용하는 것을
+승인했다. 이 승인은 PROD-922의 Issue Gate나 OpenSpec Gate를 포함하지 않는다. 다음 단계는 PROD-922의
+Issue Gate이며 현재 task에서 구현은 시작하지 않는다.


### PR DESCRIPTION
## 무엇을 변경했는지

- `docs/domain/objects/post.md`에 direct Source가 Quote인 순수 Repost의 한 단계 preview와 nullable 조회 정책을 기록했습니다.
- `docs/design/post-action-bar.md`에 표시 순서, 단일 article·Action Bar, navigation·Link·Reply 예외를 기록했습니다.
- ADR 0027과 2026-09-08 검토 기록에 결정·근거·현재 구현 차이·후속 책임을 남겼습니다.
- Stack: `main -> PROD-828`

## 왜 변경했는지

PROD-828 Domain Gate에서 선택한 `X(Twitter) 방식대로` 적용안을 canonical 문서로 확정해 후속 구현 이슈가 같은 표시·이동 계약을 사용하도록 했습니다.

## 이번 PR의 주요 결정

- A → B(Quote) → C를 표시하되 C 아래 D는 표시하지 않습니다.
- B를 주된 표시 대상으로 유지하고 B의 action·summary·직접 이동 대상을 보존합니다.
- UI 구현과 `show-reposted-quote-source-preview` OpenSpec은 PROD-922 소유로 남겼습니다.
- 별도 durable decision은 ADR 0027로 기록했으며 승인 문구는 `PROD-828 Domain Gate 승인`입니다.

## 어떻게 확인할 수 있는지

- `git diff --check HEAD^ HEAD`
- 문서 diff에서 4개 파일만 변경된 것을 확인했습니다.
- `origin/PROD-828`은 최신 `main` 위에 push되어 있습니다.

## 아직 어떤 문제가 남았는지

PROD-922가 UI·fragment·Storybook·통합 검증과 `show-reposted-quote-source-preview` OpenSpec의 완료·archive를 후속으로 담당합니다. 이 PR은 Domain Gate 문서만 소유하며 Native runtime 검증은 수행하지 않았습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>