### PR TITLE
[PROD-894] SelectTrigger·ColorWell을 공용 UI와 Storybook으로 이관한다

### DIFF
--- a/apps/app/src/components/ui/ColorPickerPanel.tsx
+++ b/apps/app/src/components/ui/ColorPickerPanel.tsx
@@ -91,7 +91,7 @@ function normalizeValue(value: ColorPickerValue): ColorPickerValue {
   };
 }
 
-function hsbToHex(value: ColorPickerValue): string {
+export function hsbToHex(value: ColorPickerValue): string {
   const normalized = normalizeValue(value);
   const hue = normalized.hue === 360 ? 0 : normalized.hue;
   const saturation = normalized.saturation / 100;
@@ -120,7 +120,7 @@ function hsbToHex(value: ColorPickerValue): string {
   return `#${channel(red)}${channel(green)}${channel(blue)}`;
 }
 
-function hexToHsb(rawText: string): ColorPickerValue | null {
+export function hexToHsb(rawText: string): ColorPickerValue | null {
   const match = /^#([0-9a-f]{6})$/i.exec(rawText);
   if (!match) {
     return null;

--- a/apps/app/src/components/ui/ColorWell.tsx
+++ b/apps/app/src/components/ui/ColorWell.tsx
@@ -32,11 +32,7 @@ export function ColorWell({
         };
         setFocusVisible(Platform.OS !== 'web' || Boolean(target.matches?.(':focus-visible')));
       }}
-      onPress={() => {
-        if (!disabled) {
-          onPress();
-        }
-      }}
+      onPress={onPress}
       {...(Platform.OS === 'web' ? { onPointerDown: () => setFocusVisible(false) } : {})}
       style={Platform.OS === 'web' ? { outlineStyle: 'solid', outlineWidth: 0 } : undefined}
       targetSize={48}

--- a/apps/app/src/components/ui/ColorWell.tsx
+++ b/apps/app/src/components/ui/ColorWell.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+import { IconButton } from '@/components/ui/IconButton';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, radius } from '@/theme/tokens';
+
+export type ColorWellProps = {
+  accessibilityLabel: string;
+  color?: string;
+  disabled?: boolean;
+  onPress: () => void;
+};
+
+export function ColorWell({
+  accessibilityLabel,
+  color,
+  disabled = false,
+  onPress,
+}: ColorWellProps) {
+  const theme = useTheme();
+  const [focusVisible, setFocusVisible] = useState(false);
+  const selectedColor = color || theme.actionPrimaryBase;
+
+  return (
+    <IconButton
+      accessibilityLabel={`${accessibilityLabel}: ${selectedColor}`}
+      disabled={disabled}
+      onBlur={() => setFocusVisible(false)}
+      onFocus={(event) => {
+        const target = event.currentTarget as unknown as {
+          matches?: (selector: string) => boolean;
+        };
+        setFocusVisible(Platform.OS !== 'web' || Boolean(target.matches?.(':focus-visible')));
+      }}
+      onPress={() => {
+        if (!disabled) {
+          onPress();
+        }
+      }}
+      {...(Platform.OS === 'web' ? { onPointerDown: () => setFocusVisible(false) } : {})}
+      style={Platform.OS === 'web' ? { outlineStyle: 'solid', outlineWidth: 0 } : undefined}
+      targetSize={48}
+      visualSize={40}
+      visualStyle={(state) => ({
+        backgroundColor: disabled
+          ? theme.stateDisabledSurface
+          : state.pressed
+            ? theme.statePressed
+            : (state as { hovered?: boolean }).hovered
+              ? theme.stateHover
+              : 'transparent',
+        borderColor: !disabled && focusVisible ? theme.stateFocusRing : 'transparent',
+        borderRadius: radius[8],
+        borderWidth: borderWidths[2],
+      })}
+    >
+      <View
+        style={[
+          styles.swatch,
+          {
+            backgroundColor: selectedColor,
+            borderColor: disabled ? theme.borderDisabled : theme.foregroundMuted,
+          },
+        ]}
+      />
+    </IconButton>
+  );
+}
+
+const styles = StyleSheet.create({
+  swatch: { width: 32, height: 32, borderRadius: radius[8], borderWidth: borderWidths[1] },
+});

--- a/apps/app/src/components/ui/SelectTrigger.tsx
+++ b/apps/app/src/components/ui/SelectTrigger.tsx
@@ -1,0 +1,173 @@
+import { ChevronDown, ChevronUp } from 'lucide-react-native';
+import { useId, useState } from 'react';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, radius, space, textStyles } from '@/theme/tokens';
+import type { Ref } from 'react';
+
+export type SelectTriggerProps = {
+  accessibilityLabel: string;
+  controlRef?: Ref<View>;
+  error?: string;
+  onPress: () => void;
+  placeholder?: string;
+  value?: string;
+} & (
+  | { controls: string; disabled?: false; open: true }
+  | { controls?: string; disabled?: boolean; open?: false }
+);
+
+export function SelectTrigger({
+  accessibilityLabel,
+  controlRef,
+  controls,
+  disabled = false,
+  error,
+  onPress,
+  open = false,
+  placeholder = '선택하세요',
+  value,
+}: SelectTriggerProps) {
+  const theme = useTheme();
+  const errorId = useId();
+  const [focusVisible, setFocusVisible] = useState(false);
+  const expanded = !disabled && open && Boolean(controls);
+  const displayedValue = value || placeholder;
+  const Chevron = expanded ? ChevronUp : ChevronDown;
+
+  return (
+    <View style={styles.wrapper}>
+      <Pressable
+        accessibilityLabel={`${accessibilityLabel}: ${displayedValue}`}
+        accessibilityRole="button"
+        accessibilityHint={Platform.OS !== 'web' ? error : undefined}
+        accessibilityState={{ disabled, expanded }}
+        disabled={disabled}
+        ref={controlRef}
+        onBlur={() => setFocusVisible(false)}
+        onFocus={(event) => {
+          const target = event.currentTarget as unknown as {
+            matches?: (selector: string) => boolean;
+          };
+          setFocusVisible(Platform.OS !== 'web' || Boolean(target.matches?.(':focus-visible')));
+        }}
+        onPress={() => {
+          if (!disabled) {
+            onPress();
+          }
+        }}
+        style={[
+          styles.target,
+          Platform.OS === 'web' ? { outlineStyle: 'solid', outlineWidth: 0 } : undefined,
+        ]}
+        {...(Platform.OS === 'web'
+          ? {
+              onPointerDown: () => setFocusVisible(false),
+              'aria-haspopup': 'listbox' as const,
+              'aria-expanded': expanded,
+              'aria-controls': expanded ? controls : undefined,
+              'aria-describedby': error ? errorId : undefined,
+              'aria-invalid': Boolean(error),
+            }
+          : {})}
+      >
+        {(state) => (
+          <>
+            {!disabled && focusVisible ? (
+              <View
+                pointerEvents="none"
+                style={[
+                  styles.focusRing,
+                  { borderColor: error ? theme.feedbackDangerBorder : theme.stateFocusRing },
+                ]}
+              />
+            ) : null}
+            <View
+              style={[
+                styles.surface,
+                {
+                  backgroundColor: disabled ? theme.stateDisabledSurface : theme.backgroundSurface,
+                  borderColor: disabled
+                    ? theme.borderDisabled
+                    : error
+                      ? theme.feedbackDangerBorder
+                      : theme.borderDefault,
+                },
+              ]}
+            >
+              {!disabled && !focusVisible && (state as { hovered?: boolean }).hovered ? (
+                <View
+                  pointerEvents="none"
+                  style={[StyleSheet.absoluteFill, { backgroundColor: theme.stateHover }]}
+                />
+              ) : null}
+              <Text
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                style={[
+                  styles.value,
+                  {
+                    color: disabled
+                      ? theme.stateDisabledForeground
+                      : value
+                        ? theme.foregroundPrimary
+                        : theme.foregroundMuted,
+                  },
+                ]}
+              >
+                {displayedValue}
+              </Text>
+              <View
+                accessibilityElementsHidden
+                importantForAccessibility="no-hide-descendants"
+                aria-hidden
+                style={styles.chevron}
+              >
+                <Chevron
+                  size={24}
+                  color={disabled ? theme.stateDisabledForeground : theme.foregroundPrimary}
+                />
+              </View>
+            </View>
+          </>
+        )}
+      </Pressable>
+      {error ? (
+        <Text
+          nativeID={errorId}
+          accessibilityLiveRegion="polite"
+          style={[styles.error, { color: theme.feedbackDangerOnSubtle }]}
+        >
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: { minWidth: 0, width: '100%', gap: space[8] },
+  target: { height: 48, minWidth: 0 },
+  surface: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space[8],
+    paddingHorizontal: space[12],
+    borderWidth: borderWidths[1],
+    borderRadius: radius[12],
+    overflow: 'hidden',
+  },
+  value: { ...textStyles.uiCopyL, flex: 1, minWidth: 0 },
+  chevron: { width: 24, height: 24 },
+  focusRing: {
+    position: 'absolute',
+    top: -4,
+    bottom: -4,
+    left: -4,
+    right: -4,
+    borderRadius: radius[12],
+    borderWidth: borderWidths[2],
+  },
+  error: textStyles.uiCopyS,
+});

--- a/apps/app/src/components/ui/SelectTrigger.tsx
+++ b/apps/app/src/components/ui/SelectTrigger.tsx
@@ -51,11 +51,7 @@ export function SelectTrigger({
           };
           setFocusVisible(Platform.OS !== 'web' || Boolean(target.matches?.(':focus-visible')));
         }}
-        onPress={() => {
-          if (!disabled) {
-            onPress();
-          }
-        }}
+        onPress={onPress}
         style={[
           styles.target,
           Platform.OS === 'web' ? { outlineStyle: 'solid', outlineWidth: 0 } : undefined,

--- a/apps/app/src/stories/components/ColorWell.stories.tsx
+++ b/apps/app/src/stories/components/ColorWell.stories.tsx
@@ -1,0 +1,86 @@
+import { View } from 'react-native';
+import { expect, fireEvent, fn, userEvent, waitFor, within } from 'storybook/test';
+import { ColorWell } from '@/components/ui/ColorWell';
+import { colors } from '@/theme/tokens';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'KOSMO/Components/Color Well',
+  component: ColorWell,
+  args: { accessibilityLabel: '강조 색상', color: '', disabled: false, onPress: fn() },
+  argTypes: {
+    accessibilityLabel: { control: 'text' },
+    color: { control: 'color' },
+    disabled: { control: 'boolean' },
+    onPress: { control: false },
+  },
+  excludeStories: ['InteractionContract'],
+} satisfies Meta<typeof ColorWell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const RepresentativeStates: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 16 }}>
+      <ColorWell {...args} color="#347AC2" />
+      <ColorWell {...args} color="#347AC2" disabled />
+      <ColorWell
+        {...args}
+        color="#FFFFFF"
+        accessibilityLabel="아주 긴 이름을 가진 프로필의 배경 색상"
+      />
+    </View>
+  ),
+};
+
+export const InteractionContract: Story = {
+  args: { color: '#347AC2' },
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View>
+      <ColorWell {...args} />
+      <ColorWell {...args} accessibilityLabel="비활성 색상" disabled />
+    </View>
+  ),
+  play: async ({ args, canvasElement, globals }) => {
+    args.onPress.mockClear();
+    const user = userEvent.setup();
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: '강조 색상: #347AC2' });
+    const disabled = canvas.getByRole('button', { name: '비활성 색상: #347AC2' });
+    expect(button.getBoundingClientRect().width).toBe(48);
+    expect(button.getBoundingClientRect().height).toBe(48);
+    const surface = button.firstElementChild as HTMLElement;
+    const swatch = surface.firstElementChild as HTMLElement;
+    expect(surface.getBoundingClientRect().width).toBe(40);
+    expect(swatch.getBoundingClientRect().width).toBe(32);
+    expect(swatch).toHaveStyle({ backgroundColor: '#347AC2' });
+    const theme = colors[globals.theme === 'dark' ? 'dark' : 'light'];
+    expect(button).not.toHaveAttribute('aria-pressed');
+    expect(button).not.toHaveAttribute('aria-selected');
+    await user.tab();
+    expect(button).toHaveFocus();
+    expect(surface).toHaveStyle({ borderColor: theme.stateFocusRing });
+    await user.keyboard('{Enter}');
+    expect(args.onPress).toHaveBeenCalledOnce();
+    expect(surface).toHaveStyle({ borderColor: theme.stateFocusRing });
+    await user.unhover(button);
+    await user.hover(button);
+    await user.pointer({ target: button, keys: '[MouseLeft>]' });
+    await waitFor(() => expect(surface).toHaveStyle({ backgroundColor: theme.statePressed }));
+    await user.pointer({ target: button, keys: '[/MouseLeft]' });
+    await waitFor(() => expect(surface).toHaveStyle({ backgroundColor: theme.stateHover }));
+    await user.click(button);
+    expect(args.onPress).toHaveBeenCalledTimes(3);
+    expect(disabled).toHaveAttribute('aria-disabled', 'true');
+    expect(disabled.firstElementChild?.firstElementChild).toHaveStyle({
+      backgroundColor: '#347AC2',
+    });
+    await fireEvent.click(disabled);
+    expect(args.onPress).toHaveBeenCalledTimes(3);
+  },
+};

--- a/apps/app/src/stories/components/ColorWell.stories.tsx
+++ b/apps/app/src/stories/components/ColorWell.stories.tsx
@@ -1,13 +1,54 @@
+import { useState } from 'react';
 import { View } from 'react-native';
 import { expect, fireEvent, fn, userEvent, waitFor, within } from 'storybook/test';
+import { ColorPickerPanel, hexToHsb, hsbToHex } from '@/components/ui/ColorPickerPanel';
 import { ColorWell } from '@/components/ui/ColorWell';
 import { colors } from '@/theme/tokens';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ColorWellProps } from '@/components/ui/ColorWell';
+
+const fallbackValue = { brightness: 76, hue: 210, saturation: 64 };
+
+function ColorWellCatalog({ color = '#4684C2', ...args }: ColorWellProps) {
+  const initialValue = hexToHsb(color) ?? fallbackValue;
+  const [committedValue, setCommittedValue] = useState(initialValue);
+  const [draftValue, setDraftValue] = useState(initialValue);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View style={{ gap: 12, width: 360 }}>
+      <ColorWell
+        {...args}
+        color={hsbToHex(committedValue)}
+        onPress={() => {
+          setDraftValue(committedValue);
+          setOpen((current) => !current);
+          args.onPress();
+        }}
+      />
+      {open ? (
+        <ColorPickerPanel
+          onCancel={() => {
+            setDraftValue(committedValue);
+            setOpen(false);
+          }}
+          onChange={setDraftValue}
+          onCommit={(value) => {
+            setCommittedValue(value);
+            setOpen(false);
+          }}
+          title="강조 색상 선택"
+          value={draftValue}
+        />
+      ) : null}
+    </View>
+  );
+}
 
 const meta = {
   title: 'KOSMO/Components/Color Well',
-  component: ColorWell,
-  args: { accessibilityLabel: '강조 색상', color: '', disabled: false, onPress: fn() },
+  component: ColorWellCatalog,
+  args: { accessibilityLabel: '강조 색상', color: '#4684C2', disabled: false, onPress: fn() },
   argTypes: {
     accessibilityLabel: { control: 'text' },
     color: { control: 'color' },
@@ -20,7 +61,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = {};
+export const Playground: Story = {
+  render: (args) => (
+    <ColorWellCatalog key={`${args.accessibilityLabel}:${args.color}:${args.disabled}`} {...args} />
+  ),
+};
 
 export const RepresentativeStates: Story = {
   parameters: { controls: { disable: true } },

--- a/apps/app/src/stories/components/ColorWell.tests.stories.tsx
+++ b/apps/app/src/stories/components/ColorWell.tests.stories.tsx
@@ -1,4 +1,11 @@
-import baseMeta, { InteractionContract as interactionContract } from './ColorWell.stories';
+import { expect, userEvent, within } from 'storybook/test';
+import baseMeta, {
+  InteractionContract as interactionContract,
+  Playground as playground,
+} from './ColorWell.stories';
+import type { StoryObj } from '@storybook/react-vite';
+
+type Story = StoryObj<typeof baseMeta>;
 
 export default {
   ...baseMeta,
@@ -9,3 +16,21 @@ export default {
 
 export const InteractionContract = interactionContract;
 export const DarkInteractionContract = { ...interactionContract, globals: { theme: 'dark' } };
+export const PlaygroundInteractionContract: Story = {
+  ...playground,
+  parameters: { controls: { disable: true } },
+  play: async ({ args, canvasElement }) => {
+    args.onPress.mockClear();
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: '강조 색상: #4684C2' }));
+    expect(canvas.getByRole('heading', { name: '강조 색상 선택' })).toBeVisible();
+    await userEvent.clear(canvas.getByRole('textbox', { name: 'HEX 색상' }));
+    await userEvent.type(canvas.getByRole('textbox', { name: 'HEX 색상' }), '#123456');
+    await userEvent.click(canvas.getByRole('button', { name: '적용' }));
+
+    expect(canvas.getByRole('button', { name: '강조 색상: #123456' })).toBeVisible();
+    expect(canvas.queryByRole('heading', { name: '강조 색상 선택' })).not.toBeInTheDocument();
+    expect(args.onPress).toHaveBeenCalledOnce();
+  },
+};

--- a/apps/app/src/stories/components/ColorWell.tests.stories.tsx
+++ b/apps/app/src/stories/components/ColorWell.tests.stories.tsx
@@ -1,0 +1,11 @@
+import baseMeta, { InteractionContract as interactionContract } from './ColorWell.stories';
+
+export default {
+  ...baseMeta,
+  excludeStories: [],
+  parameters: { controls: { disable: true } },
+  title: 'KOSMO/Components/Color Well/Tests',
+};
+
+export const InteractionContract = interactionContract;
+export const DarkInteractionContract = { ...interactionContract, globals: { theme: 'dark' } };

--- a/apps/app/src/stories/components/ColorWell.tests.stories.tsx
+++ b/apps/app/src/stories/components/ColorWell.tests.stories.tsx
@@ -25,12 +25,23 @@ export const PlaygroundInteractionContract: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: '강조 색상: #4684C2' }));
     expect(canvas.getByRole('heading', { name: '강조 색상 선택' })).toBeVisible();
+    const hexInput = canvas.getByRole('textbox', { name: 'HEX 색상' });
+    await userEvent.clear(hexInput);
+    await userEvent.type(hexInput, '#123456');
+    await userEvent.click(canvas.getByRole('button', { name: '취소' }));
+
+    const originalTrigger = canvas.getByRole('button', { name: '강조 색상: #4684C2' });
+    expect(originalTrigger).toBeVisible();
+    expect(canvas.queryByRole('heading', { name: '강조 색상 선택' })).not.toBeInTheDocument();
+
+    await userEvent.click(originalTrigger);
+    expect(canvas.getByRole('textbox', { name: 'HEX 색상' })).toHaveValue('#4684C2');
     await userEvent.clear(canvas.getByRole('textbox', { name: 'HEX 색상' }));
     await userEvent.type(canvas.getByRole('textbox', { name: 'HEX 색상' }), '#123456');
     await userEvent.click(canvas.getByRole('button', { name: '적용' }));
 
     expect(canvas.getByRole('button', { name: '강조 색상: #123456' })).toBeVisible();
     expect(canvas.queryByRole('heading', { name: '강조 색상 선택' })).not.toBeInTheDocument();
-    expect(args.onPress).toHaveBeenCalledOnce();
+    expect(args.onPress).toHaveBeenCalledTimes(2);
   },
 };

--- a/apps/app/src/stories/components/SelectTrigger.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.stories.tsx
@@ -27,7 +27,6 @@ function SelectTriggerCatalog({ open, disabled, ...args }: CatalogProps) {
     <View style={{ gap: 8, width: '100%', maxWidth: 320, padding: 4 }}>
       <SelectTrigger
         {...args}
-        onPress={args.onPress}
         {...(expanded ? { open: true, controls } : { open: false, disabled })}
       />
       {expanded ? (

--- a/apps/app/src/stories/components/SelectTrigger.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.stories.tsx
@@ -1,0 +1,156 @@
+import { useId } from 'react';
+import { View } from 'react-native';
+import { expect, fireEvent, fn, userEvent, within } from 'storybook/test';
+import { ListboxOption } from '@/components/ui/ListboxOption';
+import { SelectTrigger } from '@/components/ui/SelectTrigger';
+import { colors } from '@/theme/tokens';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+type CatalogProps = {
+  accessibilityLabel: string;
+  disabled: boolean;
+  error: string;
+  onPress: () => void;
+  open: boolean;
+  placeholder: string;
+  value: string;
+};
+
+function SelectTriggerCatalog({ open, disabled, ...args }: CatalogProps) {
+  const controls = useId();
+  const expanded = open && !disabled;
+  return (
+    <View style={{ gap: 8, width: '100%', maxWidth: 320, padding: 4 }}>
+      <SelectTrigger
+        {...args}
+        {...(expanded ? { open: true, controls } : { open: false, disabled })}
+      />
+      {expanded ? (
+        <View
+          nativeID={controls}
+          {...({ role: 'listbox' } as unknown as { role?: never })}
+          accessibilityLabel={args.accessibilityLabel}
+        >
+          <ListboxOption
+            label={args.value || args.placeholder}
+            selected={Boolean(args.value)}
+            onSelect={args.onPress}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const meta = {
+  title: 'KOSMO/Components/Select Trigger',
+  component: SelectTriggerCatalog,
+  args: {
+    accessibilityLabel: '공개 범위',
+    disabled: false,
+    error: '',
+    onPress: fn(),
+    open: false,
+    placeholder: '선택하세요',
+    value: '',
+  },
+  argTypes: {
+    accessibilityLabel: { control: 'text' },
+    disabled: { control: 'boolean' },
+    error: { control: 'text' },
+    open: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    value: { control: 'text' },
+    onPress: { control: false },
+  },
+  render: (args) => <SelectTriggerCatalog {...args} />,
+  excludeStories: ['InteractionContract', 'OpenContract'],
+} satisfies Meta<CatalogProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const RepresentativeStates: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View style={{ gap: 16, width: '100%', maxWidth: 320 }}>
+      <SelectTriggerCatalog {...args} value="팔로워에게만 공개" />
+      <SelectTriggerCatalog {...args} error="공개 범위를 선택하세요." />
+      <SelectTriggerCatalog {...args} disabled value="비공개" />
+      <SelectTriggerCatalog
+        {...args}
+        value="선택한 프로필을 팔로우하고 있는 모든 사용자에게만 공개하는 아주 긴 선택값"
+        accessibilityLabel="이름이 아주 긴 프로필의 기본 게시물 공개 범위"
+      />
+    </View>
+  ),
+};
+
+export const InteractionContract: Story = {
+  args: {
+    error: '공개 범위를 선택하세요.',
+    value: '선택한 프로필을 팔로우하고 있는 모든 사용자에게만 공개하는 아주 긴 선택값',
+  },
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <View>
+      <SelectTriggerCatalog {...args} />
+      <SelectTriggerCatalog {...args} accessibilityLabel="비활성 공개 범위" disabled />
+    </View>
+  ),
+  play: async ({ args, canvasElement, globals }) => {
+    args.onPress.mockClear();
+    const user = userEvent.setup();
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', {
+      name: `${args.accessibilityLabel}: ${args.value}`,
+    });
+    expect(button).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(button).not.toHaveAttribute('aria-pressed');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).not.toHaveAttribute('aria-controls');
+    expect(button).toHaveAttribute('aria-invalid', 'true');
+    expect(button).toHaveAccessibleDescription(args.error);
+    expect(button.getBoundingClientRect().height).toBe(48);
+    await user.hover(button);
+    expect(button.firstElementChild?.firstElementChild).toHaveStyle({
+      backgroundColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].stateHover,
+    });
+    await user.unhover(button);
+    await user.tab();
+    expect(button).toHaveFocus();
+    expect(button.firstElementChild).toHaveStyle({
+      borderColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].feedbackDangerBorder,
+    });
+    await user.keyboard('{Enter}');
+    expect(args.onPress).toHaveBeenCalledOnce();
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    await user.keyboard(' ');
+    expect(args.onPress).toHaveBeenCalledTimes(2);
+    const disabled = canvas.getByRole('button', { name: `비활성 공개 범위: ${args.value}` });
+    expect(disabled).toHaveAttribute('aria-disabled', 'true');
+    await fireEvent.click(disabled);
+    expect(args.onPress).toHaveBeenCalledTimes(2);
+  },
+};
+
+export const OpenContract: Story = {
+  args: { open: true, value: '팔로워에게만 공개' },
+  parameters: { controls: { disable: true } },
+  play: async ({ args, canvasElement, globals }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', {
+      name: `${args.accessibilityLabel}: ${args.value}`,
+    });
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(canvas.getByRole('listbox')).toHaveAttribute('id', button.getAttribute('aria-controls'));
+    expect(canvas.getByRole('option')).toHaveAttribute('aria-selected', 'true');
+    await userEvent.tab();
+    expect(button).toHaveFocus();
+    expect(button.firstElementChild).toHaveStyle({
+      borderColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].stateFocusRing,
+    });
+  },
+};

--- a/apps/app/src/stories/components/SelectTrigger.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.stories.tsx
@@ -1,5 +1,5 @@
-import { useId } from 'react';
-import { View } from 'react-native';
+import { useId, useRef, useState } from 'react';
+import { Platform, View } from 'react-native';
 import { expect, fireEvent, fn, userEvent, within } from 'storybook/test';
 import { ListboxOption } from '@/components/ui/ListboxOption';
 import { SelectTrigger } from '@/components/ui/SelectTrigger';
@@ -10,19 +10,41 @@ type CatalogProps = {
   accessibilityLabel: string;
   disabled: boolean;
   error: string;
+  interactive?: boolean;
   onPress: () => void;
   open: boolean;
   placeholder: string;
   value: string;
 };
 
-function SelectTriggerCatalog({ open, disabled, ...args }: CatalogProps) {
+function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: CatalogProps) {
   const controls = useId();
-  const expanded = open && !disabled;
+  const controlRef = useRef<View>(null);
+  const [currentOpen, setCurrentOpen] = useState(open);
+  const [currentValue, setCurrentValue] = useState(args.value);
+  const expanded = currentOpen && !disabled;
+  const choices = ['전체 공개', '팔로워에게만 공개', '비공개'];
+
+  const focusTrigger = () => {
+    if (Platform.OS === 'web') {
+      requestAnimationFrame(() => {
+        (controlRef.current as unknown as HTMLElement | null)?.focus();
+      });
+    }
+  };
+
   return (
     <View style={{ gap: 8, width: '100%', maxWidth: 320, padding: 4 }}>
       <SelectTrigger
         {...args}
+        controlRef={controlRef}
+        value={currentValue}
+        onPress={() => {
+          if (interactive) {
+            setCurrentOpen((current) => !current);
+          }
+          args.onPress();
+        }}
         {...(expanded ? { open: true, controls } : { open: false, disabled })}
       />
       {expanded ? (
@@ -31,11 +53,26 @@ function SelectTriggerCatalog({ open, disabled, ...args }: CatalogProps) {
           {...({ role: 'listbox' } as unknown as { role?: never })}
           accessibilityLabel={args.accessibilityLabel}
         >
-          <ListboxOption
-            label={args.value || args.placeholder}
-            selected={Boolean(args.value)}
-            onSelect={args.onPress}
-          />
+          {interactive ? (
+            choices.map((choice) => (
+              <ListboxOption
+                key={choice}
+                label={choice}
+                selected={currentValue === choice}
+                onSelect={() => {
+                  setCurrentValue(choice);
+                  setCurrentOpen(false);
+                  focusTrigger();
+                }}
+              />
+            ))
+          ) : (
+            <ListboxOption
+              label={args.value || args.placeholder}
+              selected={Boolean(args.value)}
+              onSelect={args.onPress}
+            />
+          )}
         </View>
       ) : null}
     </View>
@@ -49,6 +86,7 @@ const meta = {
     accessibilityLabel: '공개 범위',
     disabled: false,
     error: '',
+    interactive: false,
     onPress: fn(),
     open: false,
     placeholder: '선택하세요',
@@ -58,6 +96,7 @@ const meta = {
     accessibilityLabel: { control: 'text' },
     disabled: { control: 'boolean' },
     error: { control: 'text' },
+    interactive: { control: false },
     open: { control: 'boolean' },
     placeholder: { control: 'text' },
     value: { control: 'text' },
@@ -70,7 +109,15 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = {};
+export const Playground: Story = {
+  render: (args) => (
+    <SelectTriggerCatalog
+      key={`${args.accessibilityLabel}:${args.disabled}:${args.error}:${args.open}:${args.placeholder}:${args.value}`}
+      {...args}
+      interactive
+    />
+  ),
+};
 
 export const RepresentativeStates: Story = {
   parameters: { controls: { disable: true } },

--- a/apps/app/src/stories/components/SelectTrigger.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.stories.tsx
@@ -1,9 +1,10 @@
-import { useId, useRef, useState } from 'react';
+import { Fragment, useId, useRef, useState } from 'react';
 import { Platform, View } from 'react-native';
 import { expect, fireEvent, fn, userEvent, within } from 'storybook/test';
 import { ListboxOption } from '@/components/ui/ListboxOption';
 import { SelectTrigger } from '@/components/ui/SelectTrigger';
-import { colors } from '@/theme/tokens';
+import { useElevation, useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, colors, radius, space } from '@/theme/tokens';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 type CatalogProps = {
@@ -18,6 +19,8 @@ type CatalogProps = {
 };
 
 function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: CatalogProps) {
+  const elevation = useElevation();
+  const theme = useTheme();
   const controls = useId();
   const controlRef = useRef<View>(null);
   const [currentOpen, setCurrentOpen] = useState(open);
@@ -52,19 +55,40 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
           nativeID={controls}
           {...({ role: 'listbox' } as unknown as { role?: never })}
           accessibilityLabel={args.accessibilityLabel}
+          style={[
+            elevation.floating,
+            {
+              backgroundColor: theme.backgroundElevated,
+              borderColor: theme.borderDefault,
+              borderRadius: radius[12],
+              borderWidth: borderWidths[1],
+              gap: space[4],
+              padding: space[4],
+            },
+          ]}
         >
           {interactive ? (
-            choices.map((choice) => (
-              <ListboxOption
-                key={choice}
-                label={choice}
-                selected={currentValue === choice}
-                onSelect={() => {
-                  setCurrentValue(choice);
-                  setCurrentOpen(false);
-                  focusTrigger();
-                }}
-              />
+            choices.map((choice, index) => (
+              <Fragment key={choice}>
+                {index > 0 ? (
+                  <View
+                    testID="select-trigger-option-divider"
+                    style={{
+                      borderTopColor: theme.borderSubtle,
+                      borderTopWidth: borderWidths[1],
+                    }}
+                  />
+                ) : null}
+                <ListboxOption
+                  label={choice}
+                  selected={currentValue === choice}
+                  onSelect={() => {
+                    setCurrentValue(choice);
+                    setCurrentOpen(false);
+                    focusTrigger();
+                  }}
+                />
+              </Fragment>
             ))
           ) : (
             <ListboxOption

--- a/apps/app/src/stories/components/SelectTrigger.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.stories.tsx
@@ -6,6 +6,9 @@ import { SelectTrigger } from '@/components/ui/SelectTrigger';
 import { useElevation, useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, colors, radius, space } from '@/theme/tokens';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { KeyboardEvent } from 'react';
+
+const choices = ['전체 공개', '팔로워에게만 공개', '비공개'];
 
 type CatalogProps = {
   accessibilityLabel: string;
@@ -25,8 +28,16 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
   const controlRef = useRef<View>(null);
   const [currentOpen, setCurrentOpen] = useState(open);
   const [currentValue, setCurrentValue] = useState(args.value);
+  const [activeIndex, setActiveIndex] = useState(Math.max(0, choices.indexOf(args.value)));
   const expanded = currentOpen && !disabled;
-  const choices = ['전체 공개', '팔로워에게만 공개', '비공개'];
+
+  const optionId = (index: number) => `${controls}-option-${index}`;
+
+  const focusOption = (index: number) => {
+    if (Platform.OS === 'web') {
+      requestAnimationFrame(() => document.getElementById(optionId(index))?.focus());
+    }
+  };
 
   const focusTrigger = () => {
     if (Platform.OS === 'web') {
@@ -34,6 +45,35 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
         (controlRef.current as unknown as HTMLElement | null)?.focus();
       });
     }
+  };
+
+  const close = () => {
+    setCurrentOpen(false);
+    focusTrigger();
+  };
+
+  const select = (choice: string) => {
+    setCurrentValue(choice);
+    close();
+  };
+
+  const handleListboxKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (!interactive) {
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      return;
+    }
+    event.preventDefault();
+    const direction = event.key === 'ArrowDown' ? 1 : -1;
+    const nextIndex = (activeIndex + direction + choices.length) % choices.length;
+    setActiveIndex(nextIndex);
+    focusOption(nextIndex);
   };
 
   return (
@@ -44,7 +84,13 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
         value={currentValue}
         onPress={() => {
           if (interactive) {
-            setCurrentOpen((current) => !current);
+            const nextOpen = !currentOpen;
+            setCurrentOpen(nextOpen);
+            if (nextOpen) {
+              const nextIndex = Math.max(0, choices.indexOf(currentValue));
+              setActiveIndex(nextIndex);
+              focusOption(nextIndex);
+            }
           }
           args.onPress();
         }}
@@ -53,7 +99,10 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
       {expanded ? (
         <View
           nativeID={controls}
-          {...({ role: 'listbox' } as unknown as { role?: never })}
+          {...({
+            role: 'listbox',
+            ...(Platform.OS === 'web' ? { onKeyDown: handleListboxKeyDown } : {}),
+          } as unknown as { role?: never })}
           accessibilityLabel={args.accessibilityLabel}
           style={[
             elevation.floating,
@@ -80,14 +129,12 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
                   />
                 ) : null}
                 <ListboxOption
+                  active={activeIndex === index}
                   label={choice}
+                  nativeID={optionId(index)}
                   selected={currentValue === choice}
                   style={{ borderRadius: radius[8] }}
-                  onSelect={() => {
-                    setCurrentValue(choice);
-                    setCurrentOpen(false);
-                    focusTrigger();
-                  }}
+                  onSelect={() => select(choice)}
                 />
               </Fragment>
             ))

--- a/apps/app/src/stories/components/SelectTrigger.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.stories.tsx
@@ -82,6 +82,7 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
                 <ListboxOption
                   label={choice}
                   selected={currentValue === choice}
+                  style={{ borderRadius: radius[8] }}
                   onSelect={() => {
                     setCurrentValue(choice);
                     setCurrentOpen(false);
@@ -94,6 +95,7 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
             <ListboxOption
               label={args.value || args.placeholder}
               selected={Boolean(args.value)}
+              style={{ borderRadius: radius[8] }}
               onSelect={args.onPress}
             />
           )}

--- a/apps/app/src/stories/components/SelectTrigger.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.stories.tsx
@@ -1,108 +1,39 @@
-import { Fragment, useId, useRef, useState } from 'react';
-import { Platform, View } from 'react-native';
+import { useId } from 'react';
+import { View } from 'react-native';
 import { expect, fireEvent, fn, userEvent, within } from 'storybook/test';
 import { ListboxOption } from '@/components/ui/ListboxOption';
 import { SelectTrigger } from '@/components/ui/SelectTrigger';
 import { useElevation, useTheme } from '@/theme/ThemeProvider';
 import { borderWidths, colors, radius, space } from '@/theme/tokens';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { KeyboardEvent } from 'react';
-
-const choices = ['전체 공개', '팔로워에게만 공개', '비공개'];
 
 type CatalogProps = {
   accessibilityLabel: string;
   disabled: boolean;
   error: string;
-  interactive?: boolean;
   onPress: () => void;
   open: boolean;
   placeholder: string;
   value: string;
 };
 
-function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: CatalogProps) {
+function SelectTriggerCatalog({ open, disabled, ...args }: CatalogProps) {
   const elevation = useElevation();
   const theme = useTheme();
   const controls = useId();
-  const controlRef = useRef<View>(null);
-  const [currentOpen, setCurrentOpen] = useState(open);
-  const [currentValue, setCurrentValue] = useState(args.value);
-  const [activeIndex, setActiveIndex] = useState(Math.max(0, choices.indexOf(args.value)));
-  const expanded = currentOpen && !disabled;
-
-  const optionId = (index: number) => `${controls}-option-${index}`;
-
-  const focusOption = (index: number) => {
-    if (Platform.OS === 'web') {
-      requestAnimationFrame(() => document.getElementById(optionId(index))?.focus());
-    }
-  };
-
-  const focusTrigger = () => {
-    if (Platform.OS === 'web') {
-      requestAnimationFrame(() => {
-        (controlRef.current as unknown as HTMLElement | null)?.focus();
-      });
-    }
-  };
-
-  const close = () => {
-    setCurrentOpen(false);
-    focusTrigger();
-  };
-
-  const select = (choice: string) => {
-    setCurrentValue(choice);
-    close();
-  };
-
-  const handleListboxKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-    if (!interactive) {
-      return;
-    }
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      close();
-      return;
-    }
-    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
-      return;
-    }
-    event.preventDefault();
-    const direction = event.key === 'ArrowDown' ? 1 : -1;
-    const nextIndex = (activeIndex + direction + choices.length) % choices.length;
-    setActiveIndex(nextIndex);
-    focusOption(nextIndex);
-  };
+  const expanded = open && !disabled;
 
   return (
     <View style={{ gap: 8, width: '100%', maxWidth: 320, padding: 4 }}>
       <SelectTrigger
         {...args}
-        controlRef={controlRef}
-        value={currentValue}
-        onPress={() => {
-          if (interactive) {
-            const nextOpen = !currentOpen;
-            setCurrentOpen(nextOpen);
-            if (nextOpen) {
-              const nextIndex = Math.max(0, choices.indexOf(currentValue));
-              setActiveIndex(nextIndex);
-              focusOption(nextIndex);
-            }
-          }
-          args.onPress();
-        }}
+        onPress={args.onPress}
         {...(expanded ? { open: true, controls } : { open: false, disabled })}
       />
       {expanded ? (
         <View
           nativeID={controls}
-          {...({
-            role: 'listbox',
-            ...(Platform.OS === 'web' ? { onKeyDown: handleListboxKeyDown } : {}),
-          } as unknown as { role?: never })}
+          {...({ role: 'listbox' } as unknown as { role?: never })}
           accessibilityLabel={args.accessibilityLabel}
           style={[
             elevation.floating,
@@ -116,36 +47,12 @@ function SelectTriggerCatalog({ open, disabled, interactive = false, ...args }: 
             },
           ]}
         >
-          {interactive ? (
-            choices.map((choice, index) => (
-              <Fragment key={choice}>
-                {index > 0 ? (
-                  <View
-                    testID="select-trigger-option-divider"
-                    style={{
-                      borderTopColor: theme.borderSubtle,
-                      borderTopWidth: borderWidths[1],
-                    }}
-                  />
-                ) : null}
-                <ListboxOption
-                  active={activeIndex === index}
-                  label={choice}
-                  nativeID={optionId(index)}
-                  selected={currentValue === choice}
-                  style={{ borderRadius: radius[8] }}
-                  onSelect={() => select(choice)}
-                />
-              </Fragment>
-            ))
-          ) : (
-            <ListboxOption
-              label={args.value || args.placeholder}
-              selected={Boolean(args.value)}
-              style={{ borderRadius: radius[8] }}
-              onSelect={args.onPress}
-            />
-          )}
+          <ListboxOption
+            label={args.value || args.placeholder}
+            selected={Boolean(args.value)}
+            style={{ borderRadius: radius[8] }}
+            onSelect={args.onPress}
+          />
         </View>
       ) : null}
     </View>
@@ -159,7 +66,6 @@ const meta = {
     accessibilityLabel: '공개 범위',
     disabled: false,
     error: '',
-    interactive: false,
     onPress: fn(),
     open: false,
     placeholder: '선택하세요',
@@ -169,7 +75,6 @@ const meta = {
     accessibilityLabel: { control: 'text' },
     disabled: { control: 'boolean' },
     error: { control: 'text' },
-    interactive: { control: false },
     open: { control: 'boolean' },
     placeholder: { control: 'text' },
     value: { control: 'text' },
@@ -182,15 +87,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Playground: Story = {
-  render: (args) => (
-    <SelectTriggerCatalog
-      key={`${args.accessibilityLabel}:${args.disabled}:${args.error}:${args.open}:${args.placeholder}:${args.value}`}
-      {...args}
-      interactive
-    />
-  ),
-};
+export const Playground: Story = {};
 
 export const RepresentativeStates: Story = {
   parameters: { controls: { disable: true } },

--- a/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
@@ -1,7 +1,12 @@
+import { expect, userEvent, within } from 'storybook/test';
 import baseMeta, {
   InteractionContract as interactionContract,
   OpenContract as openContract,
+  Playground as playground,
 } from './SelectTrigger.stories';
+import type { StoryObj } from '@storybook/react-vite';
+
+type Story = StoryObj<typeof baseMeta>;
 
 export default {
   ...baseMeta,
@@ -13,3 +18,20 @@ export default {
 export const InteractionContract = interactionContract;
 export const DarkInteractionContract = { ...interactionContract, globals: { theme: 'dark' } };
 export const OpenContract = openContract;
+export const PlaygroundInteractionContract: Story = {
+  ...playground,
+  parameters: { controls: { disable: true } },
+  play: async ({ args, canvasElement }) => {
+    args.onPress.mockClear();
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '공개 범위: 선택하세요' });
+
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await userEvent.click(canvas.getByRole('option', { name: '팔로워에게만 공개' }));
+
+    expect(canvas.getByRole('button', { name: '공개 범위: 팔로워에게만 공개' })).toHaveFocus();
+    expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(args.onPress).toHaveBeenCalledOnce();
+  },
+};

--- a/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
@@ -1,13 +1,7 @@
-import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { colors, elevations } from '@/theme/tokens';
 import baseMeta, {
   InteractionContract as interactionContract,
   OpenContract as openContract,
-  Playground as playground,
 } from './SelectTrigger.stories';
-import type { StoryObj } from '@storybook/react-vite';
-
-type Story = StoryObj<typeof baseMeta>;
 
 export default {
   ...baseMeta,
@@ -19,53 +13,3 @@ export default {
 export const InteractionContract = interactionContract;
 export const DarkInteractionContract = { ...interactionContract, globals: { theme: 'dark' } };
 export const OpenContract = openContract;
-export const PlaygroundInteractionContract: Story = {
-  ...playground,
-  parameters: { controls: { disable: true } },
-  play: async ({ args, canvasElement, globals }) => {
-    args.onPress.mockClear();
-    const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: '공개 범위: 선택하세요' });
-
-    await userEvent.click(trigger);
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    expect(canvas.getByRole('listbox')).toHaveStyle({
-      ...elevations[globals.theme === 'dark' ? 'dark' : 'light'].floating,
-      backgroundColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].backgroundElevated,
-      borderColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].borderDefault,
-      borderRadius: '12px',
-      borderWidth: '1px',
-      gap: '4px',
-      padding: '4px',
-    });
-    const dividers = canvas.getAllByTestId('select-trigger-option-divider');
-    expect(dividers).toHaveLength(2);
-    dividers.forEach((divider) =>
-      expect(divider).toHaveStyle({
-        borderTopColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].borderSubtle,
-        borderTopWidth: '1px',
-      }),
-    );
-    const publicOption = canvas.getByRole('option', { name: '전체 공개' });
-    const followerOption = canvas.getByRole('option', { name: '팔로워에게만 공개' });
-    expect(followerOption).toHaveStyle({ borderRadius: '8px' });
-    await waitFor(() => expect(publicOption).toHaveFocus());
-    await userEvent.keyboard('{ArrowDown}');
-    await waitFor(() => expect(followerOption).toHaveFocus());
-    await userEvent.keyboard('{Enter}');
-
-    const selectedTrigger = canvas.getByRole('button', { name: '공개 범위: 팔로워에게만 공개' });
-    expect(selectedTrigger).toHaveFocus();
-    expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
-    expect(args.onPress).toHaveBeenCalledOnce();
-
-    await userEvent.click(selectedTrigger);
-    await waitFor(() =>
-      expect(canvas.getByRole('option', { name: '팔로워에게만 공개' })).toHaveFocus(),
-    );
-    await userEvent.keyboard('{Escape}');
-    expect(selectedTrigger).toHaveFocus();
-    expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
-    expect(args.onPress).toHaveBeenCalledTimes(2);
-  },
-};

--- a/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { colors, elevations } from '@/theme/tokens';
 import baseMeta, {
   InteractionContract as interactionContract,
@@ -46,12 +46,26 @@ export const PlaygroundInteractionContract: Story = {
         borderTopWidth: '1px',
       }),
     );
+    const publicOption = canvas.getByRole('option', { name: '전체 공개' });
     const followerOption = canvas.getByRole('option', { name: '팔로워에게만 공개' });
     expect(followerOption).toHaveStyle({ borderRadius: '8px' });
-    await userEvent.click(followerOption);
+    await waitFor(() => expect(publicOption).toHaveFocus());
+    await userEvent.keyboard('{ArrowDown}');
+    await waitFor(() => expect(followerOption).toHaveFocus());
+    await userEvent.keyboard('{Enter}');
 
-    expect(canvas.getByRole('button', { name: '공개 범위: 팔로워에게만 공개' })).toHaveFocus();
+    const selectedTrigger = canvas.getByRole('button', { name: '공개 범위: 팔로워에게만 공개' });
+    expect(selectedTrigger).toHaveFocus();
     expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
     expect(args.onPress).toHaveBeenCalledOnce();
+
+    await userEvent.click(selectedTrigger);
+    await waitFor(() =>
+      expect(canvas.getByRole('option', { name: '팔로워에게만 공개' })).toHaveFocus(),
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(selectedTrigger).toHaveFocus();
+    expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(args.onPress).toHaveBeenCalledTimes(2);
   },
 };

--- a/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
@@ -1,4 +1,5 @@
 import { expect, userEvent, within } from 'storybook/test';
+import { colors, elevations } from '@/theme/tokens';
 import baseMeta, {
   InteractionContract as interactionContract,
   OpenContract as openContract,
@@ -21,13 +22,30 @@ export const OpenContract = openContract;
 export const PlaygroundInteractionContract: Story = {
   ...playground,
   parameters: { controls: { disable: true } },
-  play: async ({ args, canvasElement }) => {
+  play: async ({ args, canvasElement, globals }) => {
     args.onPress.mockClear();
     const canvas = within(canvasElement);
     const trigger = canvas.getByRole('button', { name: '공개 범위: 선택하세요' });
 
     await userEvent.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(canvas.getByRole('listbox')).toHaveStyle({
+      ...elevations[globals.theme === 'dark' ? 'dark' : 'light'].floating,
+      backgroundColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].backgroundElevated,
+      borderColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].borderDefault,
+      borderRadius: '12px',
+      borderWidth: '1px',
+      gap: '4px',
+      padding: '4px',
+    });
+    const dividers = canvas.getAllByTestId('select-trigger-option-divider');
+    expect(dividers).toHaveLength(2);
+    dividers.forEach((divider) =>
+      expect(divider).toHaveStyle({
+        borderTopColor: colors[globals.theme === 'dark' ? 'dark' : 'light'].borderSubtle,
+        borderTopWidth: '1px',
+      }),
+    );
     await userEvent.click(canvas.getByRole('option', { name: '팔로워에게만 공개' }));
 
     expect(canvas.getByRole('button', { name: '공개 범위: 팔로워에게만 공개' })).toHaveFocus();

--- a/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
@@ -46,7 +46,9 @@ export const PlaygroundInteractionContract: Story = {
         borderTopWidth: '1px',
       }),
     );
-    await userEvent.click(canvas.getByRole('option', { name: '팔로워에게만 공개' }));
+    const followerOption = canvas.getByRole('option', { name: '팔로워에게만 공개' });
+    expect(followerOption).toHaveStyle({ borderRadius: '8px' });
+    await userEvent.click(followerOption);
 
     expect(canvas.getByRole('button', { name: '공개 범위: 팔로워에게만 공개' })).toHaveFocus();
     expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();

--- a/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
+++ b/apps/app/src/stories/components/SelectTrigger.tests.stories.tsx
@@ -1,0 +1,15 @@
+import baseMeta, {
+  InteractionContract as interactionContract,
+  OpenContract as openContract,
+} from './SelectTrigger.stories';
+
+export default {
+  ...baseMeta,
+  excludeStories: [],
+  parameters: { controls: { disable: true } },
+  title: 'KOSMO/Components/Select Trigger/Tests',
+};
+
+export const InteractionContract = interactionContract;
+export const DarkInteractionContract = { ...interactionContract, globals: { theme: 'dark' } };
+export const OpenContract = openContract;

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -614,10 +614,9 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   placeholder를 접근성 이름으로 조합하고, `error`가 있으면 오류 문구를 함께 렌더링해 Web의 `aria-describedby`와
   Native의 hint에 연결한다. hover와 focus는 실제 입력에서 유도하며 error+focus와 open+focus를 지원한다.
 - `open: true`는 `controls` ID를 필수로 요구하고 disabled와 조합할 수 없다. consumer가 실제 listbox의
-  존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook Playground의 최소 consumer fixture는
-  트리거 클릭으로 세 옵션을 열고 내부 option은 radius 8과 `borderSubtle` 1px 구분선으로 구분한다. Web은 현재
-  옵션에 focus를 옮기고 Arrow key로 active option을 이동하며 Enter로 선택하거나 Escape로 닫은 뒤 trigger에 focus를
-  돌려준다. Production 트리거 자체는 내부 open 상태를 만들지 않는다.
+  존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook의 open 표본은 연결된 listbox ID와 현재 option을
+  렌더링해 trigger의 popup 메타데이터만 검증한다. 실제 목록 탐색·dismiss·focus 복귀는 구현하지 않으며 Production
+  trigger 자체도 내부 open 상태를 만들지 않는다.
 - ColorWell은 기존 IconButton의 48×48 target과 40×40 interaction surface를 재사용하며 32×32 swatch만
   선택 색상으로 채운다. 기본 색상은 `actionPrimaryBase`이고 disabled에서도 선택 색상을 보존한다.
   이름과 색상 값을 함께 읽고 일반 button action으로 동작하며 selected·pressed toggle 상태를 노출하지 않는다.
@@ -630,10 +629,9 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   실제 popup/picker lifecycle, 설정 route·저장·API, Web screen reader·Android/iOS runtime QA는 이 이관의
   완료 증거가 아니며 실제 Settings runtime QA는 PROD-727에 남는다.
 - 2026-09-09 검증: 앱 Relay·TypeScript 검사, 변경 파일 ESLint·Prettier, Storybook static build와 관련
-  Storybook 4개 파일의 11개 테스트가 통과했다. Tests는 Light/Dark의 ColorWell 크기·색상·focus·pressed→hover 복귀,
-  SelectTrigger의 error+focus·open+focus·ARIA 연결, disabled 콜백 차단과 두 Playground consumer의 keyboard 선택·Escape
-  dismiss·적용·취소·focus 복귀를 다룬다. 내장 Browser에서
-  대표 Light/Dark·긴 값과 수동 open Controls·Actions를 확인했다. 실제 Native runtime과 screen reader는
+  Storybook 4개 파일의 10개 테스트가 통과했다. Tests는 Light/Dark의 ColorWell 크기·색상·focus·pressed→hover 복귀와
+  Playground 적용·취소, SelectTrigger의 error+focus·open+focus·ARIA 연결과 disabled 콜백 차단을 다룬다. 내장
+  Browser에서 대표 Light/Dark·긴 값과 수동 open Controls·Actions를 확인했다. 실제 Native runtime과 screen reader는
   미검증이며 자동 a11y에서 제외된 color-contrast를 포함한 전체 WCAG 적합성을 주장하지 않는다.
 
 SearchField, Switch와 Tabs는 기존 공용 source를 재사용한다. 이 계약은 설정용 control의 조합 가능성까지만 다루며

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -615,8 +615,9 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   Native의 hint에 연결한다. hover와 focus는 실제 입력에서 유도하며 error+focus와 open+focus를 지원한다.
 - `open: true`는 `controls` ID를 필수로 요구하고 disabled와 조합할 수 없다. consumer가 실제 listbox의
   존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook Playground의 최소 consumer fixture는
-  트리거 클릭으로 세 옵션을 열고 내부 option은 radius 8과 `borderSubtle` 1px 구분선으로 구분하며, 선택한 값을
-  반영한 뒤 닫고 focus를 돌려준다. Production 트리거 자체는 내부 open 상태를 만들지 않는다.
+  트리거 클릭으로 세 옵션을 열고 내부 option은 radius 8과 `borderSubtle` 1px 구분선으로 구분한다. Web은 현재
+  옵션에 focus를 옮기고 Arrow key로 active option을 이동하며 Enter로 선택하거나 Escape로 닫은 뒤 trigger에 focus를
+  돌려준다. Production 트리거 자체는 내부 open 상태를 만들지 않는다.
 - ColorWell은 기존 IconButton의 48×48 target과 40×40 interaction surface를 재사용하며 32×32 swatch만
   선택 색상으로 채운다. 기본 색상은 `actionPrimaryBase`이고 disabled에서도 선택 색상을 보존한다.
   이름과 색상 값을 함께 읽고 일반 button action으로 동작하며 selected·pressed toggle 상태를 노출하지 않는다.
@@ -630,8 +631,8 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   완료 증거가 아니며 실제 Settings runtime QA는 PROD-727에 남는다.
 - 2026-09-09 검증: 앱 Relay·TypeScript 검사, 변경 파일 ESLint·Prettier, Storybook static build와 관련
   Storybook 4개 파일의 11개 테스트가 통과했다. Tests는 Light/Dark의 ColorWell 크기·색상·focus·pressed→hover 복귀,
-  SelectTrigger의 error+focus·open+focus·ARIA 연결, disabled 콜백 차단과 두 Playground consumer의 선택·적용·취소·focus
-  복귀를 다룬다. 내장 Browser에서
+  SelectTrigger의 error+focus·open+focus·ARIA 연결, disabled 콜백 차단과 두 Playground consumer의 keyboard 선택·Escape
+  dismiss·적용·취소·focus 복귀를 다룬다. 내장 Browser에서
   대표 Light/Dark·긴 값과 수동 open Controls·Actions를 확인했다. 실제 Native runtime과 screen reader는
   미검증이며 자동 a11y에서 제외된 color-contrast를 포함한 전체 WCAG 적합성을 주장하지 않는다.
 

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -614,12 +614,16 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   placeholder를 접근성 이름으로 조합하고, `error`가 있으면 오류 문구를 함께 렌더링해 Web의 `aria-describedby`와
   Native의 hint에 연결한다. hover와 focus는 실제 입력에서 유도하며 error+focus와 open+focus를 지원한다.
 - `open: true`는 `controls` ID를 필수로 요구하고 disabled와 조합할 수 없다. consumer가 실제 listbox의
-  존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook의 open Control은 ID가 연결된 최소
-  ListboxOption composition도 함께 표시한다. 트리거를 누르는 것만으로 내부 open 상태를 만들지 않는다.
+  존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook Playground의 최소 consumer fixture는
+  트리거 클릭으로 세 옵션을 열고, 선택한 값을 반영한 뒤 닫고 focus를 돌려준다. Production 트리거 자체는
+  내부 open 상태를 만들지 않는다.
 - ColorWell은 기존 IconButton의 48×48 target과 40×40 interaction surface를 재사용하며 32×32 swatch만
   선택 색상으로 채운다. 기본 색상은 `actionPrimaryBase`이고 disabled에서도 선택 색상을 보존한다.
   이름과 색상 값을 함께 읽고 일반 button action으로 동작하며 selected·pressed toggle 상태를 노출하지 않는다.
   ColorPickerPanel의 기존 swatch는 패널 내부의 비대화형 현재값 표시이므로 이 트리거로 재사용하지 않는다.
+- Storybook Playground의 최소 consumer fixture는 ColorWell에서 기존 ColorPickerPanel을 열고, Cancel은
+  draft를 버리며 Apply는 선택 색상을 ColorWell에 반영한다. 이 fixture 상태는 Production picker lifecycle의
+  구현 완료 증거가 아니다.
 - 기존 Figma 계약을 적용하는 이관으로 새 OpenSpec은 만들지 않는다. 별도 Tests에서 접근성 이름·값·오류 연결,
   disabled 콜백 차단, 키보드 활성화·focus와 open 연결을 검증한다. Light/Dark는 공용 toolbar를 사용한다.
   실제 popup/picker lifecycle, 설정 route·저장·API, Web screen reader·Android/iOS runtime QA는 이 이관의

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -615,8 +615,8 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   Native의 hint에 연결한다. hover와 focus는 실제 입력에서 유도하며 error+focus와 open+focus를 지원한다.
 - `open: true`는 `controls` ID를 필수로 요구하고 disabled와 조합할 수 없다. consumer가 실제 listbox의
   존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook Playground의 최소 consumer fixture는
-  트리거 클릭으로 세 옵션을 열고, 선택한 값을 반영한 뒤 닫고 focus를 돌려준다. Production 트리거 자체는
-  내부 open 상태를 만들지 않는다.
+  트리거 클릭으로 세 옵션을 열고 `borderSubtle` 1px 구분선으로 옵션을 구분하며, 선택한 값을 반영한 뒤 닫고
+  focus를 돌려준다. Production 트리거 자체는 내부 open 상태를 만들지 않는다.
 - ColorWell은 기존 IconButton의 48×48 target과 40×40 interaction surface를 재사용하며 32×32 swatch만
   선택 색상으로 채운다. 기본 색상은 `actionPrimaryBase`이고 disabled에서도 선택 색상을 보존한다.
   이름과 색상 값을 함께 읽고 일반 button action으로 동작하며 selected·pressed toggle 상태를 노출하지 않는다.

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -603,6 +603,33 @@ documentation·state specimen을 두 번째 행에 둔다.
 - MultiSelect combobox는 검색 결과가 없는 상태와 현재 입력으로 새 태그를 만드는 action을 [`Create` specimen](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4025-10133)으로 검증한다.
 - [`ColorPickerPanel`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3819-8600)은 Light/Dark semantic preview와 비차단 대비 경고를 함께 제공한다.
 
+PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이관한다.
+
+| Figma source                                                                                               | Production component                           | Storybook                                                                   |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------- |
+| [SelectTrigger `3509:24655`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3509-24655) | `apps/app/src/components/ui/SelectTrigger.tsx` | `KOSMO/Components/Select Trigger`의 Playground·RepresentativeStates와 Tests |
+| [ColorWell `3693:1271`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3693-1271)       | `apps/app/src/components/ui/ColorWell.tsx`     | `KOSMO/Components/Color Well`의 Playground·RepresentativeStates와 Tests     |
+
+- SelectTrigger는 48px 높이, 가변 폭, 한 줄 말줄임과 전체 접근 가능한 값을 제공한다. label과 현재 value 또는
+  placeholder를 접근성 이름으로 조합하고, `error`가 있으면 오류 문구를 함께 렌더링해 Web의 `aria-describedby`와
+  Native의 hint에 연결한다. hover와 focus는 실제 입력에서 유도하며 error+focus와 open+focus를 지원한다.
+- `open: true`는 `controls` ID를 필수로 요구하고 disabled와 조합할 수 없다. consumer가 실제 listbox의
+  존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook의 open Control은 ID가 연결된 최소
+  ListboxOption composition도 함께 표시한다. 트리거를 누르는 것만으로 내부 open 상태를 만들지 않는다.
+- ColorWell은 기존 IconButton의 48×48 target과 40×40 interaction surface를 재사용하며 32×32 swatch만
+  선택 색상으로 채운다. 기본 색상은 `actionPrimaryBase`이고 disabled에서도 선택 색상을 보존한다.
+  이름과 색상 값을 함께 읽고 일반 button action으로 동작하며 selected·pressed toggle 상태를 노출하지 않는다.
+  ColorPickerPanel의 기존 swatch는 패널 내부의 비대화형 현재값 표시이므로 이 트리거로 재사용하지 않는다.
+- 기존 Figma 계약을 적용하는 이관으로 새 OpenSpec은 만들지 않는다. 별도 Tests에서 접근성 이름·값·오류 연결,
+  disabled 콜백 차단, 키보드 활성화·focus와 open 연결을 검증한다. Light/Dark는 공용 toolbar를 사용한다.
+  실제 popup/picker lifecycle, 설정 route·저장·API, Web screen reader·Android/iOS runtime QA는 이 이관의
+  완료 증거가 아니며 실제 Settings runtime QA는 PROD-727에 남는다.
+- 2026-09-08 검증: 앱 Relay·TypeScript 검사, 변경 파일 ESLint·Prettier, Storybook static build와 관련
+  Storybook 4개 파일의 9개 테스트가 통과했다. Tests는 Light/Dark의 ColorWell 크기·색상·focus·pressed→hover 복귀,
+  SelectTrigger의 error+focus·open+focus·ARIA 연결과 disabled 콜백 차단을 다룬다. 내장 Browser에서
+  대표 Light/Dark·긴 값과 수동 open Controls·Actions를 확인했다. 실제 Native runtime과 screen reader는
+  미검증이며 자동 a11y에서 제외된 color-contrast를 포함한 전체 WCAG 적합성을 주장하지 않는다.
+
 SearchField, Switch와 Tabs는 기존 공용 source를 재사용한다. 이 계약은 설정용 control의 조합 가능성까지만 다루며
 설정 IA, route, 저장 방식, frontend lifecycle은 포함하지 않는다.
 

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -628,9 +628,10 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   disabled 콜백 차단, 키보드 활성화·focus와 open 연결을 검증한다. Light/Dark는 공용 toolbar를 사용한다.
   실제 popup/picker lifecycle, 설정 route·저장·API, Web screen reader·Android/iOS runtime QA는 이 이관의
   완료 증거가 아니며 실제 Settings runtime QA는 PROD-727에 남는다.
-- 2026-09-08 검증: 앱 Relay·TypeScript 검사, 변경 파일 ESLint·Prettier, Storybook static build와 관련
-  Storybook 4개 파일의 9개 테스트가 통과했다. Tests는 Light/Dark의 ColorWell 크기·색상·focus·pressed→hover 복귀,
-  SelectTrigger의 error+focus·open+focus·ARIA 연결과 disabled 콜백 차단을 다룬다. 내장 Browser에서
+- 2026-09-09 검증: 앱 Relay·TypeScript 검사, 변경 파일 ESLint·Prettier, Storybook static build와 관련
+  Storybook 4개 파일의 11개 테스트가 통과했다. Tests는 Light/Dark의 ColorWell 크기·색상·focus·pressed→hover 복귀,
+  SelectTrigger의 error+focus·open+focus·ARIA 연결, disabled 콜백 차단과 두 Playground consumer의 선택·적용·취소·focus
+  복귀를 다룬다. 내장 Browser에서
   대표 Light/Dark·긴 값과 수동 open Controls·Actions를 확인했다. 실제 Native runtime과 screen reader는
   미검증이며 자동 a11y에서 제외된 color-contrast를 포함한 전체 WCAG 적합성을 주장하지 않는다.
 

--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -615,8 +615,8 @@ PROD-894는 다음 두 트리거를 Production 공용 UI와 Storybook으로 이�
   Native의 hint에 연결한다. hover와 focus는 실제 입력에서 유도하며 error+focus와 open+focus를 지원한다.
 - `open: true`는 `controls` ID를 필수로 요구하고 disabled와 조합할 수 없다. consumer가 실제 listbox의
   존재·값·선택·keyboard·dismiss·focus 복귀를 소유한다. Storybook Playground의 최소 consumer fixture는
-  트리거 클릭으로 세 옵션을 열고 `borderSubtle` 1px 구분선으로 옵션을 구분하며, 선택한 값을 반영한 뒤 닫고
-  focus를 돌려준다. Production 트리거 자체는 내부 open 상태를 만들지 않는다.
+  트리거 클릭으로 세 옵션을 열고 내부 option은 radius 8과 `borderSubtle` 1px 구분선으로 구분하며, 선택한 값을
+  반영한 뒤 닫고 focus를 돌려준다. Production 트리거 자체는 내부 open 상태를 만들지 않는다.
 - ColorWell은 기존 IconButton의 48×48 target과 40×40 interaction surface를 재사용하며 32×32 swatch만
   선택 색상으로 채운다. 기본 색상은 `actionPrimaryBase`이고 disabled에서도 선택 색상을 보존한다.
   이름과 색상 값을 함께 읽고 일반 button action으로 동작하며 selected·pressed toggle 상태를 노출하지 않는다.


### PR DESCRIPTION
## 무엇을 변경했는지

- SelectTrigger와 ColorWell을 실제 Production 공용 UI로 추가하고, 수동 Playground와 자동 Tests를 분리했습니다.
- SelectTrigger의 전체 접근성 값·오류 설명·open 연결, ColorWell의 48/40/32px 구조와 상태 피드백을 구현했습니다.
- ColorWell Playground는 기존 ColorPickerPanel의 취소·적용을 연결했습니다. SelectTrigger Playground는 Controls로 trigger props를 검토하고, open 표본은 연결된 listbox ID와 selected metadata를 보여줍니다.
- Figma source–component–story 매핑과 검증 범위를 `docs/design/figma.md`에 기록했습니다.

## 왜 변경했는지

[PROD-894](https://linear.app/byulmaru/issue/PROD-894)의 두 트리거를 Settings 화면과 독립적으로 재사용하고 검토할 수 있게 합니다. Controls나 Actions 패널을 열지 않아도 Playground에서 두 트리거의 실제 소비 흐름을 직접 확인할 수 있습니다. 기존 PROD-862 Stack에 연결하지 않고 main 기반 1-layer Stack으로 진행합니다.

## 이번 PR의 주요 결정

[SelectTrigger 정본](https://www.figma.com/design/Erj975S6vVP8PlHQius801?node-id=3509-24655), [ColorWell 정본](https://www.figma.com/design/Erj975S6vVP8PlHQius801?node-id=3693-1271)과 PROD-894 범위를 적용했으며 새 OpenSpec은 만들지 않았습니다. Production trigger의 open/value/picker lifecycle은 consumer가 소유합니다. Playground는 Production props를 넓히지 않고 Controls/Actions와 open metadata 표본만 제공합니다. 실제 listbox 탐색·dismiss·focus 복귀는 범위에 포함하지 않습니다.

## 어떻게 확인할 수 있는지

- `pnpm --filter @kosmo/app check` 통과.
- `pnpm --filter @kosmo/app exec vitest run --project=storybook src/stories/components/SelectTrigger src/stories/components/ColorWell` — 4개 파일, 10개 테스트 통과.
- `pnpm --filter @kosmo/app build-storybook`, 변경 파일 ESLint·Prettier와 `git diff --check` 통과.
- Light/Dark, disabled, 전체 접근성 값, 오류 연결, 키보드·focus, hover·pressed, 실제 listbox ID 연결을 확인했습니다.
- 6017 내장 Browser에서 ColorWell의 HEX 미리보기·취소·적용과 SelectTrigger의 expanded·controls·연결된 listbox ID·selected metadata를 직접 확인했습니다. 독립 구현 리뷰도 통과했습니다.
- 현재 head `d6b6a0dbb`의 [GitHub CI 16개](https://github.com/byulmaru/kosmo/pull/799/checks)가 모두 통과했습니다.

### Tailnet Storybook 프리뷰

현재 PR 커밋 `d6b6a0dbb`에서 빌드했습니다. Tailnet 연결이 필요하며 별도 HTTPS 6017 포트에서 제공합니다.

| 컴포넌트 | 스토리 |
| --- | --- |
| Color Well | [Playground](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-color-well--playground) |
| Color Well | [Representative States](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-color-well--representative-states) |
| Color Well/Tests | [Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-color-well-tests--interaction-contract) |
| Color Well/Tests | [Dark Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-color-well-tests--dark-interaction-contract) |
| Color Well/Tests | [Playground Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-color-well-tests--playground-interaction-contract) |
| Select Trigger | [Playground](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-select-trigger--playground) |
| Select Trigger | [Representative States](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-select-trigger--representative-states) |
| Select Trigger/Tests | [Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-select-trigger-tests--interaction-contract) |
| Select Trigger/Tests | [Dark Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-select-trigger-tests--dark-interaction-contract) |
| Select Trigger/Tests | [Open Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-select-trigger-tests--open-contract) |
| Select Trigger/Tests | [Playground Interaction Contract](https://sasha-macbook-pro.tail1fdd55.ts.net:6017/?path=/story/kosmo-components-select-trigger-tests--playground-interaction-contract) |

## 아직 어떤 문제가 남았는지

PR 범위 안의 알려진 문제는 없습니다. Production의 실제 popup/picker 통합·설정 route·저장·API는 범위 밖입니다. Web screen reader·Android/iOS runtime은 미검증이며 Settings runtime QA는 PROD-727에 남습니다. 자동 a11y의 color-contrast 제외를 포함한 전체 WCAG 적합성을 주장하지 않습니다.

Stack: main → prod-894

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>





