### PR TITLE
CI의 mise 다운로드 404를 방지한다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -54,6 +54,7 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: false
+          version: '2026.9.2'
 
       - name: Set up Java
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.0.0

--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: false
           version: '2026.9.2'
 
       - name: Set up Java

--- a/.github/workflows/ios-app-store-connect-upload.yml
+++ b/.github/workflows/ios-app-store-connect-upload.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: '2026.9.2'
 
       - name: Cache pnpm store
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: true
           version: '2026.9.2'
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: true
+          version: '2026.9.2'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,6 +39,7 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: true
+          version: '2026.9.2'
           mise_toml: |
             [tools]
             python = "3.12"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: true
           version: '2026.9.2'
           mise_toml: |
             [tools]

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -307,6 +307,7 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           cache: false
+          version: '2026.9.2'
           tool_versions: |
             aws-cli 2.35.14
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -306,7 +306,6 @@ jobs:
       - name: Setup AWS CLI
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          cache: false
           version: '2026.9.2'
           tool_versions: |
             aws-cli 2.35.14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,6 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: true
           version: '2026.9.2'
 
       - name: Get pnpm store directory
@@ -161,7 +160,6 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          cache: true
           version: '2026.9.2'
 
       - name: Get pnpm store directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: true
+          version: '2026.9.2'
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -161,6 +162,7 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: true
+          version: '2026.9.2'
 
       - name: Get pnpm store directory
         id: pnpm-store


### PR DESCRIPTION
## 무엇을 변경했는지

GitHub Actions의 jdx/mise-action 7개 호출에 mise 버전 2026.9.2를 고정하고, GitHub-hosted runner의 명시적인 cache 입력 6개를 제거해 기본 캐시 동작을 사용하도록 했습니다.

## 왜 변경했는지

기존 CI 실패는 Lint 실행에서 mise 다운로드가 공개되지 않은 최신 버전으로 해석되어 404가 발생한 사례였습니다. 실패 기록: https://github.com/byulmaru/kosmo/actions/runs/34216704051

요청에 따라 GitHub-hosted runner는 action의 기본 캐시 설정을 사용하도록 정리했습니다.

## 주요 결정

- 모든 mise 호출이 GitHub-hosted runner에서 실행되는 것을 확인해 `cache: true`와 `cache: false`를 모두 제거했습니다.
- self-hosted runner에는 기존 명시 설정을 유지하는 원칙을 적용했지만, 현재 7개 호출에는 해당 대상이 없습니다.
- 액션 버전과 워크플로 실행 구조는 변경하지 않았습니다.

## 검증

- `actionlint .github/workflows/*.yml`
- 수정된 워크플로 6개 Prettier 검사
- `git diff --check`
- runner 선언과 대표 CI 로그로 GitHub-hosted 실행 확인
- 명시적 버전 사용 시 최신 버전 조회를 생략하고 버전이 포함된 별도 캐시 키를 사용하는 동작 확인

## 남은 문제

원격 CI 결과 확인이 남아 있습니다. mise 버전은 이후 명시적으로 갱신해야 합니다.

Stack: main -> ci-mise-2026-9-2

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
