### PR TITLE
Profile Block의 Profile 조회와 방향별 콘텐츠 정책을 정정한다

### DIFF
--- a/docs/design/figma.md
+++ b/docs/design/figma.md
@@ -268,16 +268,17 @@ DSN-51의 플랫폼별 완료 판정은 다음처럼 Figma 확인과 runtime 검
 - [`ProfileSwitcher overlay lifecycle`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6773-11566)는
   Drawer의 ProfileSwitcher OpenLong을 기존 host·scrim·drawer 안에서 교체한 Target이다. picker 목록과 새 프로필
   추가 행은 scroll/fixed 영역을 나누고, Drawer의 primary navigation만 남은 높이를 채워 스크롤하며 divider 아래
-  footer는 바닥에 고정한다. Feedback Error는 Web exception section으로 이동했다. `blockedBy`는 별도 오류 화면이
-  아니라 기존 Profile route chrome 안에서 Target identity 없이 중앙 정렬한 actionless StateView로 통일한다.
+  footer는 바닥에 고정한다. Feedback Error는 Web exception section으로 이동했다. 차단 관계의 Profile route 표시
+  계약은 [Profile Mute·Block 디자인 계약](profile-mute-block.md#차단-관계의-직접-profile)을 따른다.
   Mobile [`6774:12067`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6774-12067),
   Compact [`7371:19453`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7371-19453),
-  Full [`7380:20771`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7380-20771) Target을 두며,
-  Target의 cover·avatar·표시 이름·handle·bio·수치·게시물·관계 action은 표시하지 않는다.
+  Full [`7380:20771`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7380-20771) Target은 당시
+  identity-free 조립의 물리 참고 자료로 유지한다.
 - 같은 section의 Mobile [`blocking 7580:14180`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7580-14180)은
-  기존 Android Dark Profile route chrome 안에서 Target identity를 제거하고, 중앙 정렬한 `StateView`에
-  `차단한 프로필입니다`와 Secondary `차단 해제`만 제공한다. Full Web [`4592:16216`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4592-16216)도
-  같은 identity-free presentation을 사용한다. 차단 해제의 data와 lifecycle은 Product 후속 범위다.
+  기존 Android Dark Profile route chrome 안의 identity-free `StateView`와 Secondary `차단 해제` 조립을 물리적 참고
+  자료로 유지한다. Full Web [`4592:16216`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4592-16216)도
+  같은 참고 범위다. Profile route의 콘텐츠 경고 문구·기간은 후속 디자인 계약에서 정하며, 차단 해제의 data와
+  lifecycle은 Product 후속 범위다.
 - 같은 section의 Mobile muted direct Profile Target [`7541:14061`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7541-14061)은
   기존 Android baseline Profile shell과 `ProfileHero.Muted=true` 상태·해제 action의 배치 근거로만 사용한다.
   이 Target에 남아 있는 `PostContent.CW=MutedCollapsed`와 Mute disclosure는 [Profile Mute 조회 정책](../domain/objects/profile-mute.md#조회-정책)과
@@ -291,8 +292,9 @@ DSN-51의 플랫폼별 완료 판정은 다음처럼 Figma 확인과 runtime 검
   `17 Composer state consumers`, `15 Mobile route and state consumers`의 Target evidence로 유지한다.
   `Assembled Target consumers + contract review · 15`는 Composer state consumer, Post content warning의 Mobile
   List/detail 4-state consumer와 moderation direct consumer의 물리 인벤토리를 기록한다. moderation 행의
-  `blocking 7580:14180`·`blockedBy 6774:12067`은 현재 Target이고, `muted 7541:14061`의 Post collapse는 대체된
-  이력이다. `Remaining Mobile contract review`는 confirmation, retained-list pagination loading과 Native/direct
+  `blocking 7580:14180`·`blockedBy 6774:12067`은 기존 route chrome·StateView 참고 Target으로 유지한다.
+  `muted 7541:14061`의 Post collapse는 대체된 이력이다. `Remaining Mobile contract review`는 confirmation,
+  retained-list pagination loading과 Native/direct
   `/feedback`의 Product/runtime 소유권만 남긴다.
 
 #### Screens 승격 결과와 남은 검증 공백
@@ -349,8 +351,9 @@ Collapsed·Revealed 시각은 유지한다. 새 `Reason=Muted`는 canonical `Vol
 
 Search Popular·Media, Profile edit, Profile Replies·Media처럼 `Candidate`·`Product not implemented`로 이미
 inventory에 등록된 항목은 누락 화면으로 다시 세지 않는다. canonical route family의 광범위한 공백은 찾지
-않았다. Mobile `blocking`·`blockedBy` identity-free state는 Target으로 조립됐고, `muted` direct consumer의
-Post collapse는 대체된 이력으로만 남는다. Mute·Block confirmation sheet 배치와 retained-list pagination
+않았다. Mobile `blocking`·`blockedBy`는 기존 identity-free StateView 조립의 물리 참고 자료로 유지하며, 현재 차단
+관계 표시는 [Profile Mute·Block 디자인 계약](profile-mute-block.md#차단-관계의-직접-profile)을 따른다. `muted` direct
+consumer의 Post collapse는 대체된 이력으로만 남는다. Mute·Block confirmation sheet 배치와 retained-list pagination
 loading은 Product/runtime 계약 전 임의 geometry를 만들지 않는다. 현재
 Native/direct `/feedback` page는 누락 화면이 아니라 호환 runtime route이며, overlay-only Target으로 이관하는
 별도 Product 계약에서 제거 여부와 Native presentation을 결정한다. Inventory의 `Remaining Mobile contract review`

--- a/docs/design/profile-mute-block.md
+++ b/docs/design/profile-mute-block.md
@@ -62,22 +62,25 @@ Profile에서 Mute·Block·해제를 실행하고 관리 목록과 제한된 Pro
 
 ## 차단 관계의 직접 Profile
 
-- 차단 관계의 direct Profile route는 [Profile Block 조회 정책](../domain/objects/profile-block.md#조회-정책)을 따르는
-  identity-free presentation이다. `blocking`·`blockedBy` 모두 Target의 identity·content·social action을 표시하지
-  않는다.
-- `blockedBy` Target은 별개 오류 화면을 만들지 않고 viewport별 기존 Profile route chrome 안의 중앙 column에
-  actionless `StateView`로 `이 프로필을 볼 수 없습니다`만 표시한다. Mobile Dark
-  [`6774:12067`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6774-12067), Compact Web Light
+- 차단 관계의 direct Profile route는 [Profile Block 조회 정책](../domain/objects/profile-block.md#조회-정책)과
+  [Profile 조회 정책](../domain/objects/profile.md#조회-정책)에 따라 기존 공개 기본 Profile 정보와 콘텐츠 상태를
+  함께 표시한다. `blocking`과 `blockedBy` 모두 Profile Node·handle route·일반 Profile 검색과 같은 기본 Profile
+  정보 범위를 사용한다.
+- `blocking` 화면에서는 Target Profile의 Post List·Post detail·첨부 Media를 기존 Post·Media 조회 정책으로
+  제공한다. Profile route는 콘텐츠 경고를 먼저 표시하고, 사용자가 확인한 뒤 해당 결과를 표시한다. 경고의
+  구체적인 문구와 표시 기간은 후속 디자인 계약에서 정한다.
+- `blockedBy` 화면에서는 Owner Profile의 기본 Profile 정보를 유지하면서 Post·Media 콘텐츠 차단 상태를 표시한다.
+  양방향 Block이면 양쪽 화면에서 콘텐츠 차단 상태를 적용하며, Profile route와 다른 API 표면은 같은 콘텐츠 정책을
+  사용한다. 차단 해제의 data와 lifecycle은 적용 Product/OpenSpec/runtime 범위다.
+- Mobile Dark [`6774:12067`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=6774-12067), Compact Web Light
   [`7371:19453`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7371-19453), Full Web Light
-  [`7380:20771`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7380-20771)이 exact evidence다.
-- `blocking`도 같은 identity-free route shell을 사용하되 action이 있는 `StateView`로 `차단한 프로필입니다`와
-  Secondary `차단 해제`를 제공한다. Mobile Dark [`7580:14180`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7580-14180)과
-  Full Web [`4592:16216`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4592-16216)이
-  Target evidence다. 차단 해제의 data와 lifecycle은 적용 Product/OpenSpec/runtime 범위다.
+  [`7380:20771`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7380-20771), Mobile Dark
+  [`7580:14180`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=7580-14180)와 Full Web
+  [`4592:16216`](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=4592-16216)은 기존 route chrome과 StateView
+  조립의 물리적 참고 자료로 유지한다. 이 Target들은 현재 기본 Profile 정보와 방향성 콘텐츠 조회 계약의 전체
+  표현을 확정하지 않는다.
 - Mobile은 MenuOnly header와 BottomTabBar, Compact는 Sidebar, Full은 Sidebar와 RightRail을 유지한다. Web 중앙
   column에는 별도 PageHeader를 두지 않는다. Sidebar와 RightRail의 로그인 Owner 정보는 차단 Target identity가
-  아니다.
-- Block 관리 목록에서 관계 관리를 위해 표시하는 최소 identity는 direct Profile route의 identity 노출 근거가
   아니다.
 
 ## 뮤트 관계의 직접 Profile

--- a/docs/domain/objects/notification.md
+++ b/docs/domain/objects/notification.md
@@ -116,14 +116,17 @@ Repost Notification의 Source Repost는 알림을 만든 원인 Repost Post다. 
 - Recipient Profile 자체를 조회할 수 없거나 필수 원인 관계가 없거나 그 관계의 Recipient가 Notification의
   Recipient와 일치하지 않거나 Recipient Profile 기준으로 Related Post 또는 Related Profile을 더 이상 조회할 수
   없는 Notification은 목록, Unread count, Node 조회와 읽음 처리에서 존재하지 않는 것으로 취급한다.
+- Recipient Profile과 Related Profile 사이에 Profile Block이 있으면 양쪽 방향의 pair 정책으로 해당 Notification을
+  목록, Unread count, Node 조회와 읽음 처리에서 숨긴다. 이 정책은 Recipient가 Related Post를 직접 조회할 수 있는
+  방향의 Post·Media 정책과 독립적으로 적용한다.
 - 필수 원인 관계가 없거나 Recipient와 일치하지 않거나 Related Post/Profile을 Recipient 기준으로 조회할 수 없게
   된 Notification은 비동기적으로 제거한다. 제거 전까지 저장 행과 Read State가 남을 수 있으며, 현재
   delivery는 모든 API 표면에서 숨기는 것으로 이 간격을 격리한다.
 - Recipient Profile 자체가 일시적으로 조회 불가인 경우에도 item은 숨기되, 복구 가능한 Recipient Profile의
   일시 비활성화·정지만으로는 Notification을 비동기 제거하지 않는다.
 - Mute가 나중에 생성되어도 기존 Notification의 존재와 Read State는 바꾸지 않는다. Profile Block은 제거된
-  Follow 객체를 직접 원인으로 가진 Notification을 제거하고, 그 밖에 조회 불가가 된 item은 위 숨김·비동기
-  제거 정책을 따른다.
+  Follow 객체를 직접 원인으로 가진 Notification을 제거하고, 그 밖에 pair 정책 또는 Related Post/Profile 조회
+  조건을 충족하지 않는 item은 위 숨김·비동기 제거 정책을 따른다.
 
 ## 확정 용어
 

--- a/docs/domain/objects/post.md
+++ b/docs/domain/objects/post.md
@@ -79,6 +79,9 @@ Source=Local, State=Ready이고 Media의 Upload Account가 행동을 요청한 A
 Profile은 Author Profile과 달라도 같은 Upload Account를 가지면 참조할 수 있다. State=Uploading인 Media는
 사용할 수 없다. Tombstone Post에는 다른 상태 전이를 적용하지 않는다.
 
+Reply·Quote·Repost 작성은 각 입력 Parent·Source Post의 Author Profile과 행동 주체 Profile 사이에 Profile Block이
+없어야 한다. 이 상호작용 조건은 Post Visibility·Post Eligibility와 별도로 양방향 적용한다.
+
 ## 권한
 
 | 권한                    | 종류      | 성립 조건                                               |
@@ -102,8 +105,10 @@ Profile은 Author Profile과 달라도 같은 Upload Account를 가지면 참조
 - Lifecycle State가 Active여야 한다.
 - Author Profile의 Lifecycle State가 Active이고 Suspension State가 Normal이어야 한다.
 - 현재 Post Content가 참조하는 Media가 Media 조회 정책을 통과해야 한다.
-- viewer Profile과 Author Profile 사이에 어느 방향으로든 Profile Block이 존재하거나, viewer가 Author Profile의
-  Instance를 Profile Domain Block한 경우 없는 것처럼 취급한다.
+- viewer Profile과 Author Profile 사이의 Profile Block은 조회 방향에 따라 적용한다. viewer가 Profile Block의
+  Owner이고 역방향 Block이 없으면 기존 Post Visibility·Post Eligibility에 따라 Post를 조회할 수 있다. viewer가
+  Profile Block의 Target이면 Post를 조회할 수 없으며, 양방향 Block이면 이 제한을 양쪽 viewer에 적용한다.
+- viewer가 Author Profile의 Instance를 Profile Domain Block한 경우 없는 것처럼 취급한다.
 - Author Profile의 Instance Safety State가 Domain Block이면 없는 것처럼 취급한다.
 - Content 없는 Repost는 Repost Source가 Tombstone이거나 조회 정책을 통과하지 못하면 후보가 아니다.
 - Quote와 Reply이면서 Quote인 Post는 Repost Source가 Tombstone이거나 조회 정책을 통과하지 못해도 자체
@@ -232,6 +237,8 @@ ActivityPub audience는 Post Visibility에서 다음과 같이 투영한다.
 - 검색 후보는 Post Visibility가 Public이고 Post Eligibility를 통과한 Post다.
 - Unlisted, Followers Only, Mentioned Profiles Post는 검색 후보가 아니다.
 - Domain Limit Instance의 Post는 공개 검색 후보에서 제외한다.
+- Profile Block 관계에서 각 viewer의 상대 Profile이 작성한 콘텐츠는 viewer 방향에 관계없이 검색 후보에서
+  제외한다.
 - Word Mute Rule과 Hashtag Mute Rule은 Search Scope를 포함한 경우에만 viewer별 결과에 적용한다.
 
 ## 확정 용어

--- a/docs/domain/objects/profile-block.md
+++ b/docs/domain/objects/profile-block.md
@@ -2,7 +2,9 @@
 
 ## 정의
 
-Profile Block은 Owner Profile과 Target Profile 사이의 조회와 상호작용을 차단하는 관계다.
+Profile Block은 Owner Profile과 Target Profile 사이의 콘텐츠 조회와 상호작용 정책을 정하는 방향성 관계다.
+Profile의 기본 정보는 Profile 조회 정책을 따르고, Post·Media 콘텐츠와 상호작용은 이 관계의 방향과 양쪽 관계
+상태를 함께 적용한다.
 
 ## 상태
 
@@ -42,11 +44,22 @@ Local Profile만 actor로 사용하며, remote ActivityPub ingress와 Block/Undo
 
 ## 조회 정책
 
-- Owner와 Target은 서로의 Profile, Post, Media와 Follow 후보를 직접 조회할 수 없다.
-- 모든 Post List와 검색 결과에서 상대 Profile의 콘텐츠를 Exclude한다.
+- Profile Node, handle route와 일반 Profile 검색은 [Profile](./profile.md)의 공개 조회 정책을 적용해 조회 가능한
+  기본 Profile 정보를 제공한다.
+- Owner Profile이 Target Profile의 Post를 직접 조회하는 경우에는 Post Visibility·Post Eligibility와 Media 조회
+  정책을 적용한다. Target Profile의 Post List, Post detail과 첨부 Media도 같은 정책을 따른다.
+- Target Profile이 Owner Profile의 Post를 조회하는 경우에는 Post와 첨부 Media를 모든 직접 API 조회 표면에서
+  제공하지 않는다. 두 Profile이 서로 Block한 경우에는 양쪽 방향의 콘텐츠 조회를 제공하지 않으며, 상대 Profile이
+  나를 Block한 상태의 콘텐츠 제한을 우선한다.
+- Home·Local·Hashtag 타임라인과 Post 콘텐츠 검색은 각 viewer가 상대 Profile의 콘텐츠를 양방향으로 필터링한다.
+  Profile Post List는 방향별 Post 조회 정책을 적용해 Owner의 Target Post 접근과 Target의 Owner Post 제한을 각각
+  적용한다.
+- Follow 후보와 Follow·Follow Request·Reply·Quote·Repost·Reaction 상호작용은 기존 양방향 Profile Block 조건을
+  유지한다.
 - 이번 Block 실행이 포착해 제거한 Follow Request/Relationship을 원인으로 가진 Notification은 필수 cleanup orchestration에서 함께 제거한다.
-  다른 기존 Notification Item은 Block action에서 동기적으로 바꾸지 않지만, 상대 Profile을 조회할 수 없어지면
-  Notification 조회에서 없는 것으로 취급하고 후속 비동기 cleanup 전까지 저장 상태가 남을 수 있다.
+  다른 기존 Notification Item은 Block action에서 동기적으로 바꾸지 않으며, Notification 조회는 Recipient·Related
+  Profile pair 정책과 Recipient 기준 Related Post/Profile 조회 정책을 적용한다. 후속 비동기 cleanup 전까지 저장
+  상태가 남을 수 있다.
 - Block 실행 중 이미 진입한 Follow transition이 cleanup 뒤 Follow/Request 또는 그 직접 원인 Notification을 남길 수 있다. Active Block 동안
   공통 정책은 이 잔존 row를 inactive/invisible로 취급한다.
   차단 뒤 모든 Notification source에 신규 생성 억제 정책을 연결하는 일은 `PROD-327`의 후속 범위다. 이 객체의 현재

--- a/docs/domain/objects/profile.md
+++ b/docs/domain/objects/profile.md
@@ -174,6 +174,8 @@ Hashtag에는 영향을 주지 않는다.
 ## 조회 정책
 
 - 공개 Profile 정보는 Lifecycle State가 Active이고 Suspension State가 Normal일 때 조회할 수 있다.
+- Profile Node, handle route와 일반 Profile 검색은 위 공개 조회 정책에 따라 기존 공개 기본 Profile 정보 범위를
+  제공한다.
 - Local Profile의 Owner와 운영자 Account는 운영에 필요한 비공개 상태를 조회할 수 있다.
 - Remote Profile은 Instance의 Safety State가 Domain Block이 아니어야 한다.
 - viewer Profile의 Profile Domain Block 대상 Instance에 속한 Remote Profile은 viewer에게 없는 것처럼 취급한다.

--- a/docs/domain/objects/reaction.md
+++ b/docs/domain/objects/reaction.md
@@ -44,6 +44,9 @@ Reaction은 Profile이 Post에 남기는 유니코드 이모지 반응이다.
 | Reaction 추가 | Profile           | Reaction  | Post, Reaction Type | Account 요청일 때 `Account.Active`, `Profile.Member` | 행동 주체가 Active/Normal Profile이고 Instance Service가 Active이며 Post 조회 정책을 통과한다 | 같은 조합의 Reaction이 없으면 생성하고, 이미 있으면 기존 Reaction을 유지한 채 멱등 성공한다       |
 | Reaction 삭제 | Profile           | Reaction  | Post, Reaction Type | Account 요청일 때 `Account.Active`, `Profile.Member` | 행동 주체가 Active/Normal Profile이고 Instance Service가 Active이다                           | 같은 Profile/Post/Type의 Reaction이 존재하면 제거하고, 없으면 상태를 바꾸지 않은 채 멱등 성공한다 |
 
+Reaction 추가는 Post 조회 정책과 별도로 행동 주체 Profile과 Post Author Profile 사이에 Profile Block이 없어야
+한다. 이 상호작용 조건은 양방향 적용한다.
+
 Reaction 삭제는 입력한 Post와 Reaction Type에서 행동 주체 Profile의 현재 관계만 식별한다. 다른 Profile이
 소유한 Reaction은 변경하지 않는다. 오래 지연된 삭제 요청이 그 사이 같은 조합으로 다시 생성된 현재 Reaction을
 제거할 수 있으며, selected Profile이 즉시 같은 Reaction을 다시 생성할 수 있는 낮은 위험의 소셜 상호작용으로

--- a/docs/domain/policies/post-list.md
+++ b/docs/domain/policies/post-list.md
@@ -60,7 +60,7 @@ Post 후보와 Control Decision을 계산하는 조회 정책이다.
 
 | Control              | Home                           | Local                      | Profile                    | Hashtag                    |
 | -------------------- | ------------------------------ | -------------------------- | -------------------------- | -------------------------- |
-| Profile Block        | Exclude                        | Exclude                    | Exclude                    | Exclude                    |
+| Profile Block        | 상대 콘텐츠 양방향 Exclude     | 상대 콘텐츠 양방향 Exclude | 방향별 Post 조회 정책 적용 | 상대 콘텐츠 양방향 Exclude |
 | Profile Mute         | Exclude                        | Exclude                    | 방문한 Profile만 예외      | Exclude                    |
 | Word Mute Rule       | Scope와 Mute Decision 적용     | Scope와 Mute Decision 적용 | Scope와 Mute Decision 적용 | Scope와 Mute Decision 적용 |
 | Hashtag Mute Rule    | Scope와 Mute Decision 적용     | Scope와 Mute Decision 적용 | Scope와 Mute Decision 적용 | Scope와 Mute Decision 적용 |
@@ -76,6 +76,12 @@ Post 후보와 Control Decision을 계산하는 조회 정책이다.
   현재 established Follow Relationship을 추가로 요구하며, pending·rejected Follow Request 또는 unfollow로
   removed된 관계와 guest에는 접근 범위를 넓히지 않는다.
 - Repost에는 Repost Author와 Source Post Author에 대한 Profile Block을 모두 적용한다.
+- Home·Local·Hashtag Post List의 상대 콘텐츠는 Profile Block 관계의 양쪽 viewer 방향에서 Exclude한다. 이 필터는
+  cursor와 page limit 전에 적용한다.
+- Profile Post List는 직접 방문한 Profile이 Profile Block의 Target이고 viewer가 Owner이며 역방향 Block이 없는
+  경우 해당 Profile의 eligible Post와 첨부 Media를 기존 Post Visibility·Post Eligibility에 따라 Include한다.
+  viewer가 Profile Block의 Target인 경우 상대 Owner의 Post와 첨부 Media를 Exclude하며, 양방향 Block이면 양쪽
+  방향에 이 제한을 적용한다.
 - Home·Local·Hashtag Post List에서 Repost Source가 있는 후보에는 바깥 Post Author와 direct Source Post
   Author의 Profile Mute를 모두 적용하고, 둘 중 하나라도 Mute Target이면 Exclude한다. Content가 있는
   Quote도 direct Source Author를 판정한다.

--- a/openspec/changes/add-profile-block/decisions.md
+++ b/openspec/changes/add-profile-block/decisions.md
@@ -45,17 +45,17 @@
 - Consequences: `PROD-821`은 required cleanup success gate, 양방향 pending/relationship, direct-cause Notification과 restart/retry idempotency를 검증한다. 기존 lifecycle과 어떻게 조합할지, 어떤 runtime 경계를 사용할지는 구현 PR의 선택으로 남긴다.
 - Confirmation / Follow-up: `PROD-821`에서 required cleanup success gate, 양방향 pending/relationship, direct-cause Notification과 restart/retry를 검증하고 Reaction을 변경하지 않는지 확인한다.
 
-### 공통 Profile Block predicate는 저장 방향과 무관하게 양쪽에 적용한다
+### Profile Block은 surface별 정책을 저장 방향과 함께 적용한다
 
-- Decision Date: 2026-09-02
+- Decision Date: 2026-09-08
 - Decision Class: Derived Contract
-- Authority / Provenance: `docs/domain/objects/profile-block.md`, `docs/domain/objects/follow-relationship.md`, `docs/domain/policies/post-list.md`, `docs/domain/decisions/0004-review-consistency-clarifications.md`, `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-822`
+- Authority / Provenance: `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/post.md`, `docs/domain/objects/follow-relationship.md`, `docs/domain/policies/post-list.md`, `docs/domain/decisions/0004-review-consistency-clarifications.md`, `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-822`
 - Status: Active
-- Context / Problem: Owner → Target row만 확인하면 Target이 Owner의 Profile·Post를 계속 조회하거나 상호작용할 수 있고, surface별 client filter는 page·Node·mutation에서 우회된다.
-- Decision Outcome: `(viewer, target)` pair에 대해 저장된 Owner → Target row를 양쪽 방향의 blocked predicate로 정규화한다. Profile/Post/Media/Follow 후보, Home/Local/Profile/Hashtag Post List, 검색과 interaction consumer는 각자 소유한 surface contract에서 이 predicate를 사용한다.
-- Alternatives Considered: Owner 방향만 검사하면 차단을 unilateral visibility로 잘못 해석한다. 각 resolver나 앱 화면에서 predicate를 복제하면 surface 누락과 actor별 불일치가 생긴다. page limit 뒤 client filter는 cursor와 보안 결과를 깨뜨린다.
-- Consequences: Profile·Post spec은 각 surface의 구체적인 Exclude/interaction 결과를, 이 결정은 대칭 predicate와 consumer 원칙을 소유한다. 기존 Post Visibility·Local PUBLIC eligibility와 cursor 계약은 유지한다.
-- Confirmation / Follow-up: `PROD-822` policy/GraphQL test에서 direct·list·search·interaction 표면을 같은 fixture로 검증한다.
+- Context / Problem: Profile 기본 정보 조회, 콘텐츠 직접 조회, 탐색 목록, 상호작용과 Notification은 서로 다른 결과를 가지므로 저장 방향만으로 하나의 표면 결과를 결정할 수 없다.
+- Decision Outcome: 저장된 Owner → Target row는 Profile Block pair를 양쪽 viewer 방향으로 평가하는 공통 관계 판정에 사용한다. Profile Node·handle route·일반 Profile 검색은 기존 Profile 조회 정책을 적용한다. Post·Media 직접 조회와 Profile Post List는 viewer 방향의 콘텐츠 정책을 적용한다. Home·Local·Hashtag Post List·Post 검색·Follow 후보·Follow/Reply/Quote/Repost/Reaction interaction·Notification은 양쪽 Profile에 대한 보호 정책을 적용한다.
+- Alternatives Considered: 모든 surface에 동일한 hidden 결과를 적용하면 Profile identity와 콘텐츠 접근의 계약이 섞인다. 각 resolver나 앱 화면에서 판정을 복제하면 surface 누락과 actor별 불일치가 생긴다. page limit 뒤 client filter는 cursor와 보안 결과를 깨뜨린다.
+- Consequences: Profile·Post·Notification spec은 각 surface의 구체 결과를 소유하고, 이 결정은 저장 방향을 양쪽 viewer 정책으로 평가하는 공통 경계만 소유한다. 기존 Profile 조회 조건, Post Visibility·Eligibility, Local PUBLIC eligibility와 cursor 계약은 유지한다.
+- Confirmation / Follow-up: `PROD-822` policy/GraphQL test에서 Profile identity, directional direct content, bilateral list/search/interaction/Notification 표면을 같은 fixture로 검증한다.
 
 ### GraphQL은 selected Local Profile actor와 중앙 application policy를 따른다
 
@@ -71,38 +71,38 @@
 
 ### 기존 Notification은 가시성으로 숨기고 source 생성 연결은 후속으로 둔다
 
-- Decision Date: 2026-09-02
+- Decision Date: 2026-09-08
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/domain/objects/profile-block.md`, `docs/domain/objects/notification.md`, `docs/domain/decisions/0002-pr-review-domain-adjustments.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, `docs/domain/decisions/0007-spec-boundary-and-state-clarifications.md`, `PROD-821`, `PROD-822`, `PROD-813`
 - Status: Active
-- Context / Problem: 차단 뒤 Related Profile/Post를 볼 수 없는 기존 Notification을 그대로 반환하면 접근 정책을 우회하지만, 모든 source를 이번 local capability에 연결하면 별도 책임과 lifecycle을 흡수한다.
-- Decision Outcome: unavailable 기존 Notification은 connection·Unread count·Node·read 처리에서 숨긴다. Block 생성으로 제거되는 Follow Request/Relationship을 직접 원인으로 하는 Notification만 821 durable cleanup에서 삭제하며, 다른 기존 Notification과 Read State는 보존한다. 모든 source의 신규 생성 suppression과 숨겨진 row의 async physical cleanup은 이 change의 task·완료 증거가 아니다.
+- Context / Problem: Profile Block pair가 있는 기존 Notification을 직접 Post 조회 방향만으로 반환하면 Notification 보호 정책을 우회하지만, 모든 source를 이번 local capability에 연결하면 별도 책임과 lifecycle을 흡수한다.
+- Decision Outcome: Profile Block pair에 연결된 기존 Notification은 connection·Unread count·Node·read 처리에서 숨긴다. 이 Notification visibility는 Recipient가 Related Post를 직접 조회할 수 있는 방향의 Post·Media policy와 독립적으로 적용한다. Block 생성으로 제거되는 Follow Request/Relationship을 직접 원인으로 하는 Notification만 821 durable cleanup에서 삭제하며, 다른 기존 Notification과 Read State는 보존한다. 모든 source의 신규 생성 suppression과 숨겨진 row의 async physical cleanup은 이 change의 task·완료 증거가 아니다.
 - Alternatives Considered: 모든 source 생성 경로를 여기서 수정하면 후속 공용 정책과 책임이 중복된다. 기존 unavailable row를 전부 삭제하면 비직접 원인 보존 계약을 위반한다. queue/worker/scan을 추가하면 별도 lifecycle이 합쳐진다.
-- Consequences: API surface는 차단 관계를 매 요청 평가하며 숨겨진 row가 남아도 사용자에게 노출하지 않는다. source suppression은 `PROD-327`, async physical cleanup은 `PROD-328`, remote ActivityPub는 `PROD-818`의 후속 boundary로 남는다.
+- Consequences: API surface는 Profile Block pair와 Recipient·Related Profile/Post 정책을 매 요청 평가하며 hidden row가 남아도 사용자에게 노출하지 않는다. source suppression은 `PROD-327`, async physical cleanup은 `PROD-328`, remote ActivityPub는 `PROD-818`의 후속 boundary로 남는다.
 - Confirmation / Follow-up: `PROD-822`에서 list/count/Node/read visibility를, `PROD-821`에서 direct-cause deletion을, `PROD-813`에서 두 후속 이슈가 완료 조건이 아님을 확인한다.
 
-### UI는 승인된 presentation과 별도 Block destination을 소비한다
+### UI는 기존 레거시 presentation과 별도 Block destination을 사용한다
 
-- Decision Date: 2026-09-02
+- Decision Date: 2026-09-08
 - Decision Class: Derived Contract
-- Authority / Provenance: 정본 `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `docs/design/accessibility.md`, `DSN-51`, `DSN-53`; 책임 이슈 `PROD-823`; 선행 presentation 구현 증거 `PROD-861` (정본 아님)
+- Authority / Provenance: 정본 `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `docs/design/accessibility.md`, `DSN-51`, `DSN-53`; 책임 이슈 `PROD-823`; 후속 UI 교체 `PROD-917`
 - Status: Active
 - Context / Problem: 공용 presentation 이관 결과를 Block runtime 계약으로 오인하거나 Mute와 Block을 하나의 목록으로 합치면 Profile Block 책임이 바뀐다.
-- Decision Outcome: `PROD-823`은 `DSN-51`·`DSN-53`과 최신 canonical이 승인한 identity-free `blocking`·`blockedBy` route presentation을 소비하고, `PROD-861` 결과는 prerequisite evidence로 참고하되 presentation 결정·이관 자체를 소유하지 않는다. Block confirmation은 Mute와 분리된 Danger·pending·실패·retry 상태를 사용하고, Settings에는 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 둔다. UI는 차단된 Profile·Post·Media·Notification을 재조회하거나 optimistic 상태로 복구하지 않는다.
-- Alternatives Considered: `PROD-861`을 이 change에 다시 포함하면 presentation·runtime lifecycle이 결합된다. Mute/Block 혼합 목록은 별도 관리 계약과 destination 상태를 잃는다. blocked 대상의 최신 detail을 다시 요청하면 visibility policy를 우회한다.
-- Consequences: DSN-53 visual result와 861 implementation은 선행 증거이고, 823은 실제 mutation·management·접근성 runtime과 protected-data guard를 완성한다. 새 범용 safety component나 Settings shell을 추가하지 않는다.
-- Confirmation / Follow-up: `PROD-823`에서 confirmation·별도 list·accessibility·viewport와 selected actor UI를 검증하고, `PROD-813`에서 플랫폼별 실제 runtime evidence를 별도로 기록한다.
+- Decision Outcome: `PROD-823`은 기존 레거시 Profile·Settings UI를 사용해 `DSN-51`·`DSN-53`과 최신 canonical이 정한 direct Profile route 계약을 구현·통합한다. 양쪽 route는 기존 Profile 조회 정책에 따른 기본 Profile 정보를 표시하고, `blocking` route는 Target의 허용된 Post·Media를 표시하기 전에 frontend 콘텐츠 경고를 제공하며, `blockedBy` route는 상대의 기본 Profile 정보와 콘텐츠 차단 상태를 표시한다. 양방향 Block에서는 양쪽 route에 콘텐츠 차단 상태를 적용하고 `blocking` route의 `차단 해제` action을 유지한다. 경고 문구와 표시 기간은 후속 디자인 계약에서 정한다. 공용 presentation 이관·Storybook 확정은 `PROD-861`의 별도 후속 범위로 관리하고, `PROD-917`의 신규 UI 교체도 후속 범위로 유지한다. Block confirmation은 Mute와 분리된 Danger·pending·실패·retry 상태를 사용하고, Settings에는 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 둔다.
+- Alternatives Considered: 공용 presentation 이관이나 신규 UI 교체를 현재 lifecycle에 결합하면 기존 레거시 UI의 구현·통합 검증과 runtime 책임이 지연된다. Mute/Block 혼합 목록은 별도 관리 계약과 destination 상태를 잃는다. 경고와 콘텐츠 상태를 별도 route 계약으로 관리하지 않으면 API 조회 정책과 presentation 책임이 섞인다.
+- Consequences: `PROD-823`은 기존 레거시 UI의 실제 mutation·management·접근성 runtime과 서버 정책에 따른 direct route 상태 수렴을 완성하고, `PROD-813`은 그 통합 결과를 검증한다. `PROD-861`과 `PROD-917`의 presentation 작업은 별도 후속 책임으로 유지하며, 새 범용 safety component나 Settings shell을 현재 change에 추가하지 않는다.
+- Confirmation / Follow-up: `PROD-823`과 `PROD-813`은 기존 레거시 UI의 구현·통합을 기준으로 confirmation·별도 list·accessibility·viewport·selected actor UI와 플랫폼별 실제 runtime evidence를 검증한다. `PROD-861`·`PROD-917`의 presentation 작업은 별도 후속 일정으로 기록한다.
 
 ### Client 상태는 selected actor 경계 안에서 서버 결과로 수렴한다
 
-- Decision Date: 2026-09-02
+- Decision Date: 2026-09-08
 - Decision Class: Implementation Choice
 - Authority / Provenance: `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `PROD-823`, `PROD-813`
 - Status: Active
-- Context / Problem: Block 성공 후 Profile·Post·Notification과 관리 목록을 그대로 두거나 Profile 전환 때 이전 actor의 상태를 재사용하면 stale visibility와 Owner 간 상태 누수가 생긴다.
-- Decision Outcome: Block·Unblock 성공 결과는 현재 selected Local Profile actor의 client 상태를 서버 확정 결과와 일치시켜야 한다. 차단으로 접근할 수 없게 된 Profile·Post·Notification은 보호된 데이터를 복구하지 않는 범위에서 수렴시키고, 실패 시 optimistic Block을 성공으로 확정하지 않는다. selected Profile/Session 전환은 이전 Owner의 Block 상태를 새 actor에 재사용하지 않으며, Unblock은 삭제된 Follow Request·Follow Relationship을 optimistic으로 복구하지 않는다.
+- Context / Problem: Block 성공 뒤 Profile 기본 정보, 콘텐츠 상태, 이미 표시 중인 timeline·Notification과 관리 목록을 서버 결과에 맞춰 갱신하지 않거나 Profile 전환 때 이전 actor의 상태를 재사용하면 stale content state와 Owner 간 상태 누수가 생긴다.
+- Decision Outcome: Block·Unblock 성공 결과는 현재 selected Local Profile actor의 client 상태를 서버 확정 결과와 일치시켜야 한다. 현재 Profile 화면과 이미 표시 중인 Home·Local·Hashtag timeline·Profile Post List·Notification은 각 surface의 서버 Profile Block 정책에 따라 숨기거나 갱신하고, Block 목록은 해당 Owner 관계를 반영한다. 실패 시 optimistic Block을 성공으로 확정하지 않으며, selected Profile/Session 전환은 각 actor의 Block 상태를 해당 actor의 결과로 격리한다. Unblock은 삭제된 Follow Request·Follow Relationship을 optimistic으로 복구하지 않는다.
 - Alternatives Considered: actor 간 상태를 공유하면 selected Profile 격리를 깨뜨린다. 모든 상태를 무조건 초기화하면 unrelated state까지 버리고 actor 경계를 과도하게 넓힐 수 있다. client-only hide는 서버 payload와 direct query 누수를 막지 못한다.
-- Consequences: `PROD-823`은 서버 결과 수렴과 actor switch 회귀를, `PROD-813`은 cross-slice UI/API 결과를 검증한다. client 상태를 갱신하는 구체 mechanism은 영향 범위에 맞춰 구현 시 정한다.
+- Consequences: `PROD-823`은 서버 결과 수렴과 actor switch 회귀를, `PROD-813`은 cross-slice UI/API 결과를 검증한다. `PROD-917`은 후속 UI 교체에서도 같은 actor·content policy 경계를 유지한다. client 상태를 갱신하는 구체 mechanism은 영향 범위에 맞춰 구현 시 정한다.
 - Confirmation / Follow-up: `PROD-823`에서 success/failure·A/B actor·Unblock no-restore 뒤 client 상태 수렴을 확인하고, `PROD-813`에서 Profile switch와 cross-slice actor 상태 격리를 E2E로 확인한다.
 
 ### 저장 schema는 additive 확장과 no-backfill rollout을 따른다

--- a/openspec/changes/add-profile-block/design.md
+++ b/openspec/changes/add-profile-block/design.md
@@ -1,11 +1,11 @@
 ## Context
 
-Profile Block은 Owner → Target 방향으로 저장하지만 조회·상호작용 정책은 양쪽에 적용되는 관계다. Block 실행이 포착한 양방향
-Follow Request·Follow Relationship과 제거된 Follow 객체의 직접 원인 Notification을 정리해야 하며, 기존 Reaction·Repost·
+Profile Block은 Owner → Target 방향으로 저장하며 Profile identity, 콘텐츠 직접 조회, 탐색 목록, 상호작용과 Notification에 surface별
+정책을 적용하는 관계다. Block 실행이 포착한 양방향 Follow Request·Follow Relationship과 제거된 Follow 객체의 직접 원인 Notification을 정리해야 하며, 기존 Reaction·Repost·
 Bookmark와 비직접 원인 Notification은 이번 action에서 변경하지 않는다.
 
 `PROD-821`은 additive 저장 관계와 durable cleanup orchestration을, `PROD-822`는 공통 policy·GraphQL을, `PROD-823`은
-승인된 presentation을 소비하는 UI·상태 수렴을, `PROD-813`은 네 slice의 cross-slice E2E·canonical sync·archive를 소유한다.
+기존 레거시 Profile·Settings UI를 사용하는 UI·상태 수렴과 통합을, `PROD-813`은 네 slice의 cross-slice E2E·canonical sync·archive를 소유한다.
 canonical `profile-block.md`는 이 결과와 durable 경계만 정하며, 각 구현 PR이 현재 코드와 검증 결과를 바탕으로 구체 수단을
 선택한다.
 
@@ -18,20 +18,22 @@ canonical `profile-block.md`는 이 결과와 durable 경계만 정하며, 각 �
   required cleanup으로 정리하며, required cleanup 완료 전에는 Block action을 성공으로 확정하지 않는다. 이미 진입한 Follow transition이 cleanup 뒤
   Follow/Request 또는 그 직접 원인 Notification을 남길 수 있지만 Active Block 동안 공통 정책에서 inactive/invisible로 취급하며, Unblock은
   현재 남아 있는 양방향 Follow/Request와 그 직접 원인 Notification을 정리한 뒤 Block을 제거하고 삭제된 관계를 복구하지 않는다.
-- Profile·Post·Media·Follow 후보와 Home·Local·Profile·Hashtag Post List·검색 및 새 로컬 상호작용에 같은 Profile Block policy를 적용한다.
+- Profile Node·handle route·일반 Profile 검색은 기존 Profile 조회 정책을 적용한다. Post·Media 직접 조회와 Profile Post List는 viewer 방향의
+  콘텐츠 정책을 적용하고, Home·Local·Hashtag Post List·Post 검색·Follow 후보·새 로컬 상호작용·Notification은 양방향 보호 정책을 적용한다.
 - selected Local Profile을 actor로 사용하는 현재 GraphQL ingress와 Owner-only management connection을 제공한다.
-- Confirmation·관리 목록·접근성 등 기존 presentation contract와 최신 canonical이 승인한 identity-free `blocking`·`blockedBy` route presentation을 소비하는
-  흐름을 제공한다. presentation 결정·이관 자체는 이 change가 소유하지 않으며, UI는 보호된 데이터를 복구하지 않는다.
+- Confirmation·관리 목록·접근성 등 기존 레거시 Profile·Settings UI와 최신 canonical이 정한 direct Profile route 계약을 구현·통합하는 흐름을 제공한다.
+  양쪽 route는 기본 Profile 정보를 표시하고, `blocking` route는 frontend 콘텐츠 경고 뒤 허용된 콘텐츠와 `차단 해제` action을 제공하며,
+  `blockedBy` route는 콘텐츠 차단 상태를 표시한다. 경고 문구·표시 기간은 후속 디자인 계약으로 남기고, `PROD-917` 신규 UI 교체는 이 change와 분리한다.
 - `PROD-813`에서 Local·Remote pair와 주요 surface의 cross-slice 결과를 검증하고 canonical·Linear·OpenSpec sync 뒤 archive한다.
 
 **Non-Goals:**
 
-- `PROD-861`이 소유하는 공용 presentation·Storybook 이관 자체.
+- 공용 presentation·Storybook 이관은 `PROD-861`의 별도 후속 범위로 관리한다.
 - 모든 Follow·Follow Request·Reply·Reaction·Repost Notification source에 신규 생성 suppression을 연결하는 `PROD-327` 작업.
 - ActivityPub Block/Undo 발신·수신과 remote delivery(`PROD-818`). 현재 remote ingress의 구현은 이 change에 포함하지 않는다.
 - 조회 불가 Notification의 schedule/event/queue/worker/scan 물리 cleanup(`PROD-328`).
 - Block 생성 시 기존 Reaction cleanup. 이 범위는 현재 action에서 정하지 않으며, 필요하면 별도 후속 계약에서 결정한다.
-- Profile Mute, Profile Domain Block, 신고·커뮤니티 관리와 차단된 Profile presentation의 결정·이관 자체.
+- Profile Mute, Profile Domain Block, 신고·커뮤니티 관리와 `PROD-917` 신규 UI 교체.
 
 ## Implementation Guidance
 
@@ -46,13 +48,14 @@ Verification을 보존하는 다른 수단을 선택할 수 있다. 그 선택�
   pair uniqueness와 self-block 거부를 보장해야 한다.
 - Block action은 필수 Follow 및 직접 원인 Notification cleanup이 유실되지 않고 재시작·일시 오류 뒤에도 완료될 수 있어야 한다. required cleanup 완료 전에는
   성공을 확정하지 않으며, 이미 처리한 효과가 보존 대상 데이터를 바꾸지 않게 한다.
-- 저장 방향과 무관한 양방향 blocked policy는 direct 조회·후보·Post list·search·interaction 결과에 적용되어야 하며, pagination/page limit 뒤 client filter가
-  policy를 대신할 수 없다.
+- 저장 방향을 양쪽 viewer 정책으로 평가하는 Profile Block 관계 판정은 surface별 계약에 적용되어야 한다. Profile identity에는 기존 Profile 조회
+  정책을, 직접 Post·Media 조회에는 viewer 방향 콘텐츠 정책을, Home·Local·Hashtag Post List·Post 검색·Follow 후보·interaction·Notification에는
+  양방향 보호 정책을 적용하고 pagination/page limit 뒤 client filter가 policy를 대신하지 않게 한다.
 - GraphQL은 selected Local Profile actor와 Owner scope를 사용하고 중앙 application policy를 호출해야 한다. ADR 0024의 경계에 따라 request-specific DB actor
   state(GUC 등)나 client-only filter로 권한·가시성을 대체하지 않는다.
-- UI는 canonical design의 기존 Button·ActionMenu·ModalSheet·Toast·SettingsItem과 기존 Profile/Settings 흐름을 재사용하고, 최신 canonical이 승인한 identity-free
-  `blocking`·`blockedBy` route presentation을 소비한다. 이 기능만을 위한 새 범용 safety component나 Settings shell을 추가하지 않으며, presentation 결정·이관 자체는
-  이 change가 소유하지 않는다.
+- UI는 canonical design의 기존 Button·ActionMenu·ModalSheet·Toast·SettingsItem과 기존 Profile/Settings 흐름을 재사용하고, 최신 canonical이 정한 direct
+  Profile route 계약을 구현·통합한다. 이 기능만을 위한 새 범용 safety component나 Settings shell을 추가하지 않으며, `PROD-861` 공용 presentation 이관·Storybook 확정과
+  `PROD-917` 신규 UI 교체는 각각 후속 범위로 관리한다.
 
 ### Implementation ownership (non-normative)
 
@@ -63,33 +66,35 @@ Verification을 보존하는 다른 수단을 선택할 수 있다. 그 선택�
 
 - Block 실행이 포착한 required cleanup이 남은 상태에서 action 성공을 확정해 부분 성공을 만들지 않는다.
 - 일시 오류·재시작에서 이미 처리한 cleanup이 중복되어 Repost·Bookmark·기존 Reaction·비직접 원인 Notification 또는 Read State를 바꾸지 않게 한다.
-- Owner → Target 한 방향만 검사해 Target이 Owner의 Profile·Post·Media·Follow 후보를 계속 보게 하지 않는다.
-- Profile route·GraphQL·list/search에서 차단된 대상의 최신 상세를 재조회하거나 client 후처리로 보호된 데이터를 복원하지 않는다.
+- Profile route는 기본 Profile 정보와 viewer 방향의 콘텐츠 상태를 기존 정책에 따라 표시하고, `blocking` route의 frontend 경고는 콘텐츠 결과 표시와
+  별도의 presentation 상태로 제공한다.
 - Block 해제 시 현재 남아 있는 양방향 Follow Request·Follow Relationship과 그 직접 원인 Notification을 먼저 정리한 뒤 Block을 제거하며, 차단 생성 때 제거된
   Follow Request·Follow Relationship을 자동 복구하지 않는다. 기존 Reaction cleanup은 현재 action에서 정하지 않는다.
 - `PROD-327` source 신규 Notification suppression, `PROD-818` federation, `PROD-328` async physical cleanup을 현재 task나 완료 증거로 끌어오지 않는다.
-- DSN-51·DSN-53/`PROD-861` presentation 결과를 API·cache·Native runtime 완료 증거로 일반화하지 않는다.
+- 기존 레거시 UI의 구현·통합 결과와 API·cache·Native runtime 결과를 `PROD-813`에서 환경별 실제 evidence로 기록한다. `PROD-861` 공용 presentation 이관·Storybook 확정과
+  `PROD-917` 신규 UI 교체는 이 change의 완료 조건과 별도 후속 범위로 관리한다.
 
 ## Risks / Trade-offs
 
 - [여러 관계 정리를 durable orchestration으로 묶으면 retry와 작업 범위가 늘어날 수 있다] → 구현 수단과 무관하게 pair 범위의 required cleanup과 재시작·일시 오류
   결과를 검증한다.
 - [orchestration이 cleanup 완료 전에 성공하거나 중단될 수 있다] → 명시적인 success gate와 restart·retry fixture로 Block 상태와 cleanup 완료를 확인한다.
-- [여러 GraphQL surface가 policy를 빠뜨릴 수 있다] → direct·connection·search·interaction consumer가 같은 양방향 결과와 cursor 전 filtering을 사용하는지
-  `PROD-822` integration test에서 검증한다.
+- [여러 GraphQL surface가 policy를 빠뜨릴 수 있다] → Profile identity, directional direct content, bilateral list/search/interaction/Notification consumer가
+  각각의 policy와 cursor 전 filtering을 사용하는지 `PROD-822` integration test에서 검증한다.
 - [mutation 뒤 client cache가 stale하거나 actor가 섞일 수 있다] → 서버 확정 결과와 selected actor 격리를 검증하고, 실패 시 optimistic 상태를 성공으로 확정하지 않는다.
 - [구버전 workload와 additive schema가 공존할 수 있다] → 기존 row 보존, rollout 중 read/write 공존과 rollback 결과를 `PROD-821`에서 확인한다.
-- [Web/Storybook 증거가 Native·federation 완료로 오인될 수 있다] → `PROD-813`에서 환경별 실제 evidence와 미검증 범위를 분리 기록한다.
+- [기존 Web 실행 결과가 Native·federation 완료로 오인될 수 있다] → `PROD-813`에서 기존 레거시 UI의 Web/iOS/Android 통합 결과와 미검증 범위를 환경별 실제 evidence로 분리 기록한다.
 
 ## Migration Plan
 
 1. `PROD-821`에서 additive Profile Block 관계와 Owner/Target·createdAt·uniqueness·referential integrity·self-block 불변식을 배포하고 기존 domain row를 변경하거나
    backfill하지 않는다.
 2. `PROD-821`에서 Block admission, durable cleanup orchestration과 required cleanup success gate를 연결하고 restart/retry·보존·no-restore 결과를 검증한다.
-3. `PROD-822`에서 common policy·GraphQL을 연결한다. Profile/Post/Media/Follow candidate와 Home·Local·Profile·Hashtag list/search 및 새 interaction은 같은
-   양방향 policy 결과를 사용한다.
-4. `PROD-823`에서 최신 canonical이 승인한 identity-free `blocking`·`blockedBy` route presentation과 Settings Block destination, selected actor 상태 수렴을 연결한다.
-   `DSN-51`·DSN-53은 presentation 근거이고 `PROD-861`은 선행 구현 증거이며, 해당 presentation의 결정·이관 자체는 이 change가 소유하지 않는다.
+3. `PROD-822`에서 surface별 policy·GraphQL을 연결한다. Profile identity는 기존 Profile 조회 정책을, 직접 Post·Media와 Profile Post List는 viewer 방향
+   콘텐츠 정책을, Home·Local·Hashtag list/search와 Follow candidate·새 interaction·Notification은 각 canonical 양방향 보호 정책을 사용한다.
+4. `PROD-823`에서 최신 canonical이 정한 direct Profile route 계약과 Settings Block destination, selected actor 상태 수렴을 기존 레거시 Profile·Settings UI에 연결한다.
+   `blocking` route의 frontend 경고와 `blockedBy` route의 콘텐츠 차단 상태를 표시하고, `PROD-861` 공용 presentation 이관·Storybook 확정과 `PROD-917` 신규 UI 교체는
+   각각 후속 범위로 유지한다.
 5. `PROD-813`에서 Local·Remote pair와 direct/list/search/interaction 및 cross-slice E2E, canonical·Linear·OpenSpec 정합성, 플랫폼별 실제 evidence를 확인한다.
    모든 declared task와 required validation 뒤에만 `add-profile-block`을 archive한다.
 6. rollback은 repository의 기존 workflow로 새 relation을 읽지 않게 처리하며, 저장된 Profile Block row를 임의 삭제하거나 차단 전 관계를 복구하지 않는다. `PROD-327`,

--- a/openspec/changes/add-profile-block/proposal.md
+++ b/openspec/changes/add-profile-block/proposal.md
@@ -17,10 +17,13 @@ Profile Block의 저장 관계, durable cleanup, 공통 조회·상호작용 정
   복구하지 않는다.
 - 기존 Reaction·Repost·Bookmark와 직접 원인이 아닌 기존 Notification 및 Read State는 이번 action에서 변경하지 않는다. 모든
   Notification source의 신규 생성 suppression은 `PROD-327`, 숨겨진 row의 async physical cleanup은 `PROD-328`의 후속 scope로 남긴다.
-- Owner/Target 사이의 Profile·Post·Media·Follow 후보 조회 차단과 Home·Local·Profile·Hashtag Post List·검색의 공통
-  Profile Block Exclude 및 새 로컬 상호작용 거부를 연결한다.
-- Profile Block 관리 목록과 확인·pending·실패·접근성·selected Profile별 상태/cache 수렴 계약을 추가한다. 최신 canonical이 승인한 identity-free
-  `blocking`·`blockedBy` route presentation을 소비하며, presentation 결정·이관 자체는 이 change가 소유하지 않는다. 보호된 데이터를 복구하지 않는다.
+- Profile Node·handle route·일반 Profile 검색에는 기존 Profile 조회 정책을 적용하고, Owner·Target 사이의 Post·Media 직접 조회와 Profile Post List에는 viewer 방향의
+  콘텐츠 정책을 적용한다. Home·Local·Hashtag Post List·Post 검색은 상대 콘텐츠를 양방향으로 필터링하며, Follow 후보·새 로컬 상호작용과 Notification은 양방향
+  보호 정책을 적용한다.
+- Profile Block 관리 목록과 확인·pending·실패·접근성·selected Profile별 상태/cache 수렴 계약을 추가한다. 기존 레거시 Profile·Settings UI에 최신 canonical이 정한 direct Profile route를
+  구현·통합해
+  기본 Profile 정보와 viewer 방향의 콘텐츠 상태를 표시하고, `blocking` route는 콘텐츠 경고 뒤 허용된 결과와 `차단 해제` action을 제공하며, `blockedBy` route는
+  콘텐츠 차단 상태를 표시한다. 경고 문구와 표시 기간은 후속 디자인 계약으로 남기고, `PROD-917`의 신규 UI 교체 범위는 이 change와 분리한다.
 - `PROD-813`은 네 slice의 cross-slice E2E, canonical·Linear·OpenSpec 동기화와 최종 archive를 소유한다.
 
 ## Authority / Provenance
@@ -40,8 +43,8 @@ Profile Block의 저장 관계, durable cleanup, 공통 조회·상호작용 정
 - Linear integration and archive owner: [PROD-813](https://linear.app/byulmaru/issue/PROD-813)
 - Linear implementation slices: [PROD-821](https://linear.app/byulmaru/issue/PROD-821),
   [PROD-822](https://linear.app/byulmaru/issue/PROD-822), [PROD-823](https://linear.app/byulmaru/issue/PROD-823)
-- Presentation authority/evidence: `DSN-51`, `DSN-53`; [PROD-861](https://linear.app/byulmaru/issue/PROD-861)은 선행 구현 증거다. 최신 canonical의
-  identity-free route presentation을 소비하며 presentation 결정·이관 자체는 이 change가 소유하지 않는다.
+- UI implementation/integration: `PROD-823`이 기존 레거시 Profile·Settings UI에 `DSN-51`, `DSN-53`과 최신 canonical이 정한 direct Profile route 계약을 구현·통합한다.
+  공용 presentation 이관·Storybook 확정은 [PROD-861](https://linear.app/byulmaru/issue/PROD-861), 신규 UI 교체는 [PROD-917](https://linear.app/byulmaru/issue/PROD-917)의 각각 후속 범위다.
 - Deferred boundaries: [PROD-327](https://linear.app/byulmaru/issue/PROD-327),
   [PROD-818](https://linear.app/byulmaru/issue/PROD-818), [PROD-328](https://linear.app/byulmaru/issue/PROD-328)
 
@@ -50,23 +53,23 @@ Profile Block의 저장 관계, durable cleanup, 공통 조회·상호작용 정
 ### New Capabilities
 
 - `profile-block`: Profile Block 저장 관계, 생성·해제, durable cleanup, 공통 symmetric policy와 로컬 API 계약
-- `profile-block-ui`: Profile action, 관리 목록, 승인된 presentation 소비와 selected Profile별 상태/cache 수렴
+- `profile-block-ui`: Profile action, 관리 목록, 기존 레거시 UI 기반 direct route 구현·통합과 selected Profile별 상태/cache 수렴
 
 ### Modified Capabilities
 
 - `data-model`: Profile Block 관계의 additive 저장 모델, uniqueness/referential integrity/self-block 불변식과 no-backfill 계약
-- `profile`: Profile object·route·검색·Follow 후보·새 Follow 입력에 Profile Block 정책 적용
-- `post`: Home·Local·Profile·Hashtag Post List, Post/Media 조회·검색과 Reply/Reaction/Repost 입력에 Profile Block 정책 적용
+- `profile`: 기존 Profile object·route·일반 검색 조회 조건 유지와 Follow 후보·새 Follow 입력에 Profile Block 정책 적용
+- `post`: 방향성 있는 Profile Post·Post/Media 조회, 양방향 Home·Local·Hashtag Post List, Post 검색과 Reply/Quote/Reaction/Repost 입력에 Profile Block 정책 적용
 - `notification`: Block으로 제거되는 Follow 객체의 직접 원인 Notification 정리와 조회 불가 기존 Notification 숨김 연결;
   source 신규 생성 suppression은 `PROD-327`에 유보
 
 ## Impact
 
-- API/Core: Profile Block 저장·삭제 action, durable cleanup orchestration, 공통 Profile/Post/Media/Follow visibility predicate,
-  GraphQL object/connection/mutation과 Node 조회 경계가 영향받는다.
+- API/Core: Profile Block 저장·삭제 action, durable cleanup orchestration, Profile identity·Post/Media·Follow visibility와
+  interaction/Notification 정책, GraphQL object/connection/mutation과 Node 조회 경계가 영향받는다.
 - Database: 기존 row를 backfill하지 않는 additive Profile Block 관계, Owner/Target uniqueness와 referential integrity가 영향받는다.
   migration/rollback safety는 design과 `PROD-821` 검증 guardrail로 다룬다.
 - App: Profile action/confirmation, Settings의 분리된 Block 목록과 selected Profile별 상태·cache 수렴이 영향받는다.
-  차단된 상세 데이터를 UI가 복구하지 않으며, 최신 canonical의 identity-free route presentation을 소비한다.
+  direct Profile route에서 기본 Profile 정보, viewer 방향 콘텐츠 상태와 frontend 경고를 기존 레거시 UI에 구현·통합하며 최신 canonical route 계약을 따른다.
 - Verification: `PROD-821 → PROD-822 → PROD-823 → PROD-813` 순서의 slice 검증과 cross-slice E2E가 필요하다.
   federation·source suppression·async cleanup runtime은 이 change에 포함하지 않는다.

--- a/openspec/changes/add-profile-block/specs/notification/spec.md
+++ b/openspec/changes/add-profile-block/specs/notification/spec.md
@@ -1,14 +1,20 @@
 ## ADDED Requirements
 
-### Requirement: Profile Block hides unavailable existing Notifications
+### Requirement: Profile Block hides paired existing Notifications
 
-**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/notification.md`, `docs/domain/decisions/0002-pr-review-domain-adjustments.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, `docs/domain/decisions/0007-spec-boundary-and-state-clarifications.md`, `PROD-822`, `PROD-813`. Profile Block 생성으로 Recipient가 Related Profile 또는 Related Post를 조회할 수 없게 된 기존 Notification은 Notification connection, Unread count, Node 조회와 읽음 처리에서 없는 것처럼 취급해야 한다(MUST). 저장 row와 Read State는 후속 cleanup 전까지 남을 수 있다(MAY).
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/notification.md`, `docs/domain/decisions/0002-pr-review-domain-adjustments.md`, `docs/domain/decisions/0005-domain-boundary-followup-clarifications.md`, `docs/domain/decisions/0007-spec-boundary-and-state-clarifications.md`, `PROD-822`, `PROD-813`. Recipient Profile과 Related Profile 사이에 Profile Block pair가 있으면 기존 Notification을 Notification connection, Unread count, Node 조회와 읽음 처리에서 숨겨야 한다(MUST). 이 Notification pair 정책은 Recipient가 Related Post를 직접 조회할 수 있는 방향의 Post·Media 정책과 독립적으로 적용해야 한다(MUST). 저장 row와 Read State는 후속 cleanup 전까지 남을 수 있다(MAY).
 
-#### Scenario: 차단으로 조회 불가가 된 기존 Notification을 숨긴다
+#### Scenario: Profile Block pair의 기존 Notification을 숨긴다
 
-- **WHEN** Profile Block이 생성된 뒤 Recipient가 상대 Profile 또는 상대 Profile의 Post를 원인으로 가진 기존 Notification을 조회한다
+- **WHEN** Recipient Profile과 Related Profile 사이에 Profile Block pair가 있고 Recipient가 해당 Notification을 조회한다
 - **THEN** 시스템은 해당 item을 목록, Unread count, Node 조회와 읽음 처리 대상에서 제외한다
 - **AND** Notification 저장 row와 Read State가 남아 있어도 API 표면에 노출하지 않는다
+
+#### Scenario: Notification pair policy와 직접 Post 조회 policy를 분리한다
+
+- **WHEN** Recipient가 Related Post를 직접 조회할 수 있는 방향의 Profile Block pair에 연결된 기존 Notification을 조회한다
+- **THEN** 시스템은 Notification pair policy에 따라 해당 item을 숨긴다
+- **AND** Related Post·Media 직접 조회 결과는 Post·Media의 viewer 방향 정책으로 별도 판정한다
 
 ### Requirement: Follow-cause Notification cleanup follows durable Profile Block cleanup
 

--- a/openspec/changes/add-profile-block/specs/post/spec.md
+++ b/openspec/changes/add-profile-block/specs/post/spec.md
@@ -1,38 +1,58 @@
 ## ADDED Requirements
 
-### Requirement: Profile Block Post and Media visibility
+### Requirement: Profile Block applies directional Post and Media access
 
-**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/post.md`, `docs/domain/objects/media.md`, `docs/domain/policies/post-list.md`, `docs/domain/decisions/0004-review-consistency-clarifications.md`, `PROD-822`. Post object·Post detail·Media relation과 Home·Local·Profile·Hashtag Post List 및 Post 검색은 Profile Block을 공통 visibility policy로 적용해야 한다(MUST). Block 관계의 상대 Profile이 Author인 Post와 상대 Profile의 Media는 양쪽 Profile의 직접 조회와 모든 해당 목록·검색 결과에서 Exclude해야 하며(MUST), Repost는 Repost Author와 Source Post Author 중 상대 Profile이 하나라도 있으면 Exclude해야 한다(MUST). 이 정책은 Post Visibility·Eligibility보다 접근 범위를 넓혀서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/post.md`, `docs/domain/objects/media.md`, `docs/domain/policies/post-list.md`, `PROD-822`. Post object·Post detail·Media relation과 Profile Post List는 기존 Post Visibility·Post Eligibility·Media 조회 정책과 Profile Block의 viewer 방향을 함께 적용해야 한다(MUST). Owner Profile이 Target Profile의 콘텐츠를 조회하는 경우에는 기존 콘텐츠 정책을 충족한 Post와 첨부 Media를 제공해야 하며(MUST), Target Profile이 Owner Profile의 콘텐츠를 조회하는 경우에는 모든 직접 콘텐츠 API 경로에 차단 정책을 적용해야 한다(MUST). 양방향 Block이면 양쪽 viewer의 직접 콘텐츠 API 경로에 차단 정책을 적용해야 한다(MUST).
 
-#### Scenario: Block된 Author의 Post와 Media를 직접 조회하지 않는다
+#### Scenario: 역방향 Block이 없을 때 Owner가 Target의 허용된 Post와 Media를 직접 조회한다
 
-- **WHEN** Owner → Target Profile Block이 존재하고 Owner 또는 Target이 상대 Author의 Post detail 또는 Media relation을 조회한다
-- **THEN** 시스템은 상대 Post와 Media를 조회 가능한 결과로 반환하지 않는다
-- **AND** Post Visibility 또는 Media policy를 우회해 차단된 대상을 복원하지 않는다
+- **WHEN** Owner → Target Profile Block이 존재하고 Target → Owner Profile Block은 없으며 Owner가 Target Profile의 Post List, Post detail 또는 첨부 Media를 조회한다
+- **THEN** 시스템은 기존 Post Visibility·Post Eligibility·Media 조회 정책을 충족하는 Target의 Post와 첨부 Media를 반환한다
+- **AND** 직접 API 조회는 같은 기존 Post·Media 정책으로 판정한다
 
-#### Scenario: Home·Profile·Hashtag·Local 목록에서 Block 대상을 제외한다
+#### Scenario: Target이 Owner의 Post와 Media를 직접 조회한다
 
-- **WHEN** Block 관계의 한쪽 Profile이 Home, Profile, Hashtag 또는 Local Post List를 조회한다
-- **THEN** 시스템은 상대 Profile이 작성한 Post를 후보에서 Exclude한다
-- **AND** 현재 목록의 cursor/page limit 계산 전에 같은 Profile Block policy를 적용한다
+- **WHEN** Owner → Target Profile Block이 존재하고 Target이 Owner Profile의 Post List, Post detail 또는 첨부 Media를 조회한다
+- **THEN** 시스템은 Profile Block의 콘텐츠 차단 정책을 적용해 해당 Post와 첨부 Media의 직접 조회 결과를 제한한다
 
-#### Scenario: Repost Author와 Source Author 양쪽 Block을 적용한다
+#### Scenario: 양방향 Block에서 양쪽 콘텐츠 조회를 제한한다
 
-- **WHEN** Repost Author 또는 Repost Source Author가 Block 관계의 상대 Profile이다
-- **THEN** 시스템은 해당 Repost를 목록·검색 후보에서 Exclude한다
-- **AND** 기존 Repost Post와 Bookmark 관계 자체를 삭제하지 않는다
+- **WHEN** 두 Profile 사이에 양방향 Profile Block이 존재하고 어느 한쪽이 상대 Profile의 Post List, Post detail 또는 첨부 Media를 조회한다
+- **THEN** 시스템은 양쪽 viewer의 직접 콘텐츠 API 경로에 Profile Block 콘텐츠 차단 정책을 적용한다
 
-### Requirement: Profile Block Post interaction boundary
+### Requirement: Profile Block filters shared content lists in both directions
 
-**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/post.md`, `docs/domain/objects/reaction.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0012-post-interaction-followup-clarifications.md`, `PROD-822`. Post surface의 새 Reply·Reaction·Repost 입력은 공통 Profile Block predicate를 적용해 차단된 pair를 거부해야 하며(MUST). 차단으로 거부된 입력은 새 Post·Reaction·Repost 저장 결과를 남겨서는 안 되고(MUST NOT), 기존 Repost Post·Bookmark는 보존해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/post.md`, `docs/domain/policies/post-list.md`, `PROD-822`. Home·Local·Hashtag Post List와 Post 콘텐츠 검색은 Profile Block 관계의 양쪽 viewer 방향에서 상대 Profile의 콘텐츠를 필터링해야 한다(MUST). Profile Post List는 방향별 Post 조회 정책에 따라 Owner → Target 콘텐츠를 제공하고 Target → Owner 콘텐츠를 제한해야 한다(MUST). 목록 필터는 기존 Post Visibility·Eligibility와 후보 정렬을 적용한 뒤 cursor·page limit 계산 전에 수행해야 한다(MUST).
+
+#### Scenario: 탐색 목록과 Post 검색에서 상대 콘텐츠를 필터링한다
+
+- **WHEN** Profile Block 관계의 한쪽 Profile이 Home, Local, Hashtag Post List 또는 Post 콘텐츠 검색을 조회한다
+- **THEN** 시스템은 상대 Profile이 작성한 콘텐츠를 해당 결과에서 양방향으로 필터링한다
+- **AND** 다음 eligible Post로 페이지를 채우고 cursor·pageInfo를 계산한다
+
+#### Scenario: Profile Post List는 viewer 방향에 따라 콘텐츠를 제공한다
+
+- **WHEN** Owner → Target Profile Block 관계만 존재하고 Target → Owner Profile Block은 없으며 어느 한쪽 Profile이 상대 Profile의 `posts` connection을 직접 조회한다
+- **THEN** Owner → Target 조회는 기존 Post Visibility·Post Eligibility를 충족하는 콘텐츠를 제공한다
+- **AND** Target → Owner 조회는 Profile Block 콘텐츠 차단 정책을 적용한다
+
+#### Scenario: Repost Author와 Source Author를 함께 판정한다
+
+- **WHEN** Home, Local, Hashtag 또는 Post 검색 후보가 Repost Source를 가지고 있다
+- **THEN** 시스템은 바깥 Post Author와 direct Source Post Author 양쪽의 Profile Block 관계를 판정한다
+- **AND** 상대 Profile과 연결된 후보를 cursor·page limit 계산 전에 필터링한다
+
+### Requirement: Profile Block protects Post interactions in both directions
+
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/post.md`, `docs/domain/objects/reaction.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0012-post-interaction-followup-clarifications.md`, `PROD-822`. Post surface의 새 Reply·Quote·Reaction·Repost 입력은 Profile Block의 양쪽 viewer 방향에 따라 거부해야 한다(MUST). Profile Block으로 거부된 입력의 기존 보존 대상 Post·Reaction·Repost·Bookmark 상태는 유지해야 한다(MUST).
 
 #### Scenario: 차단된 상대를 향한 새 Post interaction을 거부한다
 
-- **WHEN** Block 관계의 Owner 또는 Target이 상대 Profile의 Post에 Reply·Reaction·Repost를 새로 입력한다
-- **THEN** 시스템은 공통 Profile Block policy에 따라 입력을 거부한다
-- **AND** 차단 정책을 우회한 새 Post·Reaction·Repost row를 저장하지 않는다
+- **WHEN** Block 관계의 Owner 또는 Target이 상대 Profile의 Post에 Reply·Quote·Reaction·Repost를 새로 입력한다
+- **THEN** 시스템은 Profile Block interaction 정책에 따라 입력을 거부한다
+- **AND** 해당 입력의 결과로 새 Post·Reaction·Repost row를 저장하지 않는다
 
 #### Scenario: 차단과 무관한 기존 Post 상태를 보존한다
 
 - **WHEN** Profile Block을 생성하거나 해제한다
-- **THEN** 시스템은 기존 Repost Post와 Bookmark 관계를 삭제하지 않는다
+- **THEN** 시스템은 기존 Repost Post와 Bookmark 관계를 보존한다

--- a/openspec/changes/add-profile-block/specs/profile-block-ui/spec.md
+++ b/openspec/changes/add-profile-block/specs/profile-block-ui/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Profile Block action confirmation and state lifecycle
 
-**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `DSN-53`; 책임 이슈는 `PROD-823`; 선행 presentation 구현 증거는 `PROD-861` (정본 아님). Profile surface의 Block action은 Mute와 구분되는 공용 ConfirmationContent를 사용하고 Danger tone의 확인 제목·결과 설명·확정 action을 제공해야 한다(MUST). pending 동안 같은 action의 중복 입력과 dismiss를 차단하고 busy 상태를 전달해야 하며(MUST), 성공 상태는 서버 확정 결과를 사용하고 실패 시 기존 서버 상태와 제품의 공용 오류 피드백을 유지해야 한다(MUST).
+**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `DSN-53`; 책임 이슈는 `PROD-823`. Profile surface의 Block action은 Mute와 구분되는 공용 ConfirmationContent를 사용하고 Danger tone의 확인 제목·결과 설명·확정 action을 제공해야 한다(MUST). pending 동안 같은 action의 중복 입력과 dismiss를 차단하고 busy 상태를 전달해야 하며(MUST), 성공 상태는 서버 확정 결과를 사용하고 실패 시 기존 서버 상태와 제품의 공용 오류 피드백을 유지해야 한다(MUST).
 
 #### Scenario: Block 확인을 취소하면 상태를 바꾸지 않는다
 
@@ -24,7 +24,7 @@
 
 ### Requirement: Separate Profile Block management destination
 
-**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `DSN-53`; 책임 이슈는 `PROD-823`; 선행 presentation 구현 증거는 `PROD-861` (정본 아님). Settings root는 `뮤트 및 차단` 진입점에서 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 이 순서에 제공해야 하며(MUST), Block destination은 자기 heading, loading, error·retry, empty, pagination과 해제 action을 소유해야 한다(MUST). Block과 Mute를 하나의 혼합 목록이나 이 흐름만을 위한 새 Settings shell로 합쳐서는 안 된다(MUST NOT).
+**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `DSN-53`; 책임 이슈는 `PROD-823`. Settings root는 `뮤트 및 차단` 진입점에서 `뮤트한 프로필`과 `차단한 프로필`을 별도 destination으로 이 순서에 제공해야 하며(MUST), Block destination은 자기 heading, loading, error·retry, empty, pagination과 해제 action을 소유해야 한다(MUST). Block과 Mute를 하나의 혼합 목록이나 이 흐름만을 위한 새 Settings shell로 합쳐서는 안 된다(MUST NOT).
 
 #### Scenario: 차단한 프로필 목록의 독립 상태를 표시한다
 
@@ -39,15 +39,39 @@
 - **THEN** 시스템은 해당 Profile Block 해제 mutation을 실행한다
 - **AND** 성공한 Target은 현재 Block 목록에서 제거되고 다른 목록 항목의 상태는 바꾸지 않는다
 
+### Requirement: Profile Block direct route presents basic Profile and content state
+
+**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/policies/post-list.md`, `DSN-53`; 책임 이슈는 `PROD-823`, `PROD-813`; 후속 UI 교체는 `PROD-917`의 범위다. Block 관계의 direct Profile route는 기존 Profile 조회 정책에 따른 기본 Profile 정보를 표시해야 한다(MUST). `blocking` route는 기존 Post·Media 정책으로 허용된 Target 콘텐츠를 표시하기 전에 frontend 콘텐츠 경고를 제공하고, `blockedBy` route는 기본 Profile 정보와 콘텐츠 차단 상태를 표시해야 한다(MUST). 양방향 Block은 양쪽 route에 콘텐츠 차단 상태를 적용해야 한다(MUST). `차단 해제` action은 `blocking` route의 기존 관계 관리 흐름을 유지해야 하며(MUST), 경고 문구와 표시 기간은 후속 디자인 계약에서 정한다(MUST).
+
+#### Scenario: 역방향 Block이 없을 때 blocking route에서 기본 Profile과 확인 후 콘텐츠를 표시한다
+
+- **WHEN** selected Profile이 Owner이고 Target이 Owner를 차단하지 않은 상태에서 차단한 Target의 direct Profile route를 연다
+- **THEN** 시스템은 기존 Profile 조회 정책에 따른 Target의 기본 Profile 정보를 표시한다
+- **AND** frontend는 Target의 Post·Media를 표시하기 전에 콘텐츠 경고를 제공한다
+- **AND** 사용자가 확인하면 기존 Post·Media 정책으로 허용된 Target 콘텐츠를 표시한다
+- **AND** `차단 해제` action은 기존 blocking route 관계 관리 흐름으로 제공한다
+
+#### Scenario: blockedBy route에서 기본 Profile과 콘텐츠 차단 상태를 표시한다
+
+- **WHEN** selected Profile이 Target이고 차단한 Owner의 direct Profile route를 연다
+- **THEN** 시스템은 기존 Profile 조회 정책에 따른 Owner의 기본 Profile 정보를 표시한다
+- **AND** 시스템은 Owner의 Post·Media 콘텐츠에 차단 상태를 표시한다
+
+#### Scenario: 양방향 Block route에 양쪽 콘텐츠 차단 상태를 적용한다
+
+- **WHEN** 두 Profile 사이에 양방향 Profile Block이 있고 어느 한쪽이 상대의 direct Profile route를 연다
+- **THEN** 시스템은 양쪽 route에 기본 Profile 정보와 콘텐츠 차단 상태를 표시한다
+
 ### Requirement: Profile Block actor and client-state isolation
 
-**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/design/settings.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `DSN-51`, `DSN-53`; 책임 이슈는 `PROD-823`, `PROD-813`; 선행 presentation 구현 증거는 `PROD-861` (정본 아님). Block UI는 selected Profile별 actor 상태 격리를 유지해야 하며(MUST), 최신 canonical이 승인한 identity-free `blocking`·`blockedBy` route presentation을 소비하고 Target identity·이미 알고 있는 handle·content·social action을 UI 상태로 복구해서는 안 된다(MUST NOT). Block·Unblock 성공 결과는 현재 화면, Block 목록과 이미 표시 중인 unavailable 표면의 상태를 서버 정책과 일치하도록 수렴시켜야 하며(MUST), selected Profile 또는 Session 전환 시 이전 Owner의 Block 상태를 새 actor에 재사용해서는 안 된다(MUST NOT).
+**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/domain/objects/profile-block.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `DSN-51`, `DSN-53`; 책임 이슈는 `PROD-823`, `PROD-813`; 후속 UI 교체는 `PROD-917`의 범위다. Block UI는 selected Profile별 actor 상태 격리를 유지해야 하며(MUST), 기존 Profile 기본 정보와 viewer 방향에 따른 콘텐츠 상태를 최신 서버 정책과 함께 표시해야 한다(MUST). Block·Unblock 성공 결과는 현재 화면, Block 목록, 이미 표시 중인 timeline·Profile Post List와 Notification client 상태를 서버 정책과 일치하도록 수렴시켜야 하며(MUST), selected Profile 또는 Session 전환 시 각 actor의 Block 상태를 해당 actor의 결과로 격리해야 한다(MUST).
 
 #### Scenario: Block 성공 뒤 표시 중인 결과가 정책에 수렴한다
 
 - **WHEN** selected Profile이 Target을 차단하는 mutation이 성공한다
 - **THEN** 시스템은 현재 Profile 화면과 Block 목록을 서버 확정 Block 상태로 갱신한다
-- **AND** 접근할 수 없게 된 Target의 Profile·Post·Notification을 화면과 client 상태에서 제거하거나 숨긴다
+- **AND** 현재 Profile 화면은 기본 Profile 정보와 viewer 방향에 따른 콘텐츠 상태를 서버 정책에 맞춰 표시한다
+- **AND** 이미 표시 중인 Home·Local·Hashtag timeline·Profile Post List와 Notification은 각 surface의 서버 Profile Block 정책에 맞춰 숨기거나 갱신한다
 - **AND** mutation 실패 시 이전 cache를 차단된 것으로 확정하지 않는다
 
 #### Scenario: selected Profile을 전환해도 Block 상태를 섞지 않는다
@@ -61,11 +85,11 @@
 - **WHEN** Owner가 Block 목록에서 Target의 차단을 해제한다
 - **THEN** 시스템은 최신 Block 상태에 맞게 목록과 Profile surface를 갱신한다
 - **AND** 차단 생성 때 제거된 Follow 관계를 client optimistic 상태로 복구하지 않는다
-- **AND** 이후 새 요청에서만 서버가 허용한 상대 Profile·Post·상호작용이 다시 나타날 수 있다
+- **AND** 기본 Profile 정보는 기존 Profile 조회 정책에 따라 계속 표시할 수 있고, Post·상호작용은 이후 새 요청에서 서버가 허용한 경우에만 다시 나타날 수 있다
 
 ### Requirement: Profile Block interaction accessibility
 
-**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/design/accessibility.md`, `DSN-53`; 책임 이슈는 `PROD-823`; 선행 presentation 구현 증거는 `PROD-861` (정본 아님). Block confirmation과 management list는 실제 동작에 맞는 role·accessible name·current·disabled·busy 상태와 안전한 초기 focus, modal 의미, Web `Escape`·Native back 및 focus 복원을 제공해야 한다(MUST). 공용 Button, ActionMenu, ModalSheet, Toast와 SettingsItem을 재사용해야 하며(MUST), 이 흐름만을 위한 새 Toast·범용 safety component·별도 UI package를 추가해서는 안 된다(MUST NOT).
+**Authority / Provenance:** 정본은 `docs/design/profile-mute-block.md`, `docs/design/accessibility.md`, `DSN-53`; 책임 이슈는 `PROD-823`. Block confirmation과 management list는 실제 동작에 맞는 role·accessible name·current·disabled·busy 상태와 안전한 초기 focus, modal 의미, Web `Escape`·Native back 및 focus 복원을 제공해야 한다(MUST). 공용 Button, ActionMenu, ModalSheet, Toast와 SettingsItem을 재사용해야 하며(MUST), 이 흐름만을 위한 새 Toast·범용 safety component·별도 UI package를 추가해서는 안 된다(MUST NOT).
 
 #### Scenario: 확인 UI와 해제 action이 접근 가능한 이름과 상태를 제공한다
 

--- a/openspec/changes/add-profile-block/specs/profile-block/spec.md
+++ b/openspec/changes/add-profile-block/specs/profile-block/spec.md
@@ -54,25 +54,26 @@
 - **THEN** 시스템은 현재 남아 있는 양방향 Follow Request·Follow Relationship과 그 직접 원인 Notification을 정리한 뒤 Profile Block 관계를 제거한다
 - **AND** 차단 생성 때 제거된 Follow Request와 Follow Relationship을 자동으로 재생성하지 않는다
 
-### Requirement: Profile Block symmetric policy invariant
+### Requirement: Profile Block applies the policy for each surface
 
-**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/follow-relationship.md`, `docs/domain/decisions/0004-review-consistency-clarifications.md`, `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-822`. 시스템은 저장된 Owner → Target Profile Block을 임의의 viewer·target pair 양쪽에 적용되는 공통 blocked predicate로 정규화해야 한다(MUST). 이 predicate가 true인 동안 모든 policy consumer는 차단 상태를 유지해야 하며(MUST), Profile Block 관계가 사라져도 차단 생성 중 제거된 Follow Request·Follow Relationship을 자동으로 복구해서는 안 된다(MUST NOT).
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/post.md`, `docs/domain/objects/media.md`, `docs/domain/objects/notification.md`, `docs/domain/policies/post-list.md`, `docs/domain/decisions/0004-review-consistency-clarifications.md`, `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-822`. Profile Block은 저장 방향과 요청 surface를 함께 평가해야 한다(MUST). Profile Node·handle route·일반 Profile 검색은 기존 Profile 조회 정책을 적용하고, Post·Media 직접 조회는 viewer 방향에 따른 콘텐츠 정책을 적용하며, Home·Local·Hashtag Post List·Post 검색·Follow 후보·상호작용·Notification은 양쪽 Profile에 대한 보호 정책을 적용해야 한다(MUST). 각 surface는 기존 Visibility·Eligibility와 자체 lifecycle·권한 조건을 함께 적용해야 한다(MUST).
 
-#### Scenario: Block 방향과 무관하게 공통 predicate를 적용한다
+#### Scenario: Profile Block이 surface별 정책을 적용한다
 
-- **WHEN** Owner → Target Profile Block이 존재하고 Owner 또는 Target이 상대를 대상으로 하나의 policy consumer를 실행한다
-- **THEN** 시스템은 어느 요청 방향에서도 같은 pair를 blocked로 판정한다
-- **AND** consumer가 Owner 방향만 검사해 반대 방향의 정책 결정을 우회하지 않는다
+- **WHEN** Owner → Target Profile Block이 존재하고 Owner 또는 Target이 Profile identity, 직접 콘텐츠, 탐색 목록, Follow 후보, interaction 또는 Notification을 요청한다
+- **THEN** 시스템은 Profile identity에 기존 Profile 조회 정책을 적용한다
+- **AND** 직접 Post·Media 조회에는 viewer 방향의 Profile Block 콘텐츠 정책을 적용한다
+- **AND** 탐색 목록·Follow 후보·interaction·Notification에는 양방향 Profile Block 보호 정책을 적용한다
 
-#### Scenario: 차단 해제 뒤 삭제된 상태를 복구하지 않는다
+#### Scenario: 차단 해제 뒤 새 요청을 현재 정책으로 평가한다
 
 - **WHEN** Owner가 Profile Block을 해제한 뒤 양쪽 Profile이 새 요청을 실행한다
-- **THEN** 시스템은 새 요청 시점의 현재 Block predicate와 다른 정책을 평가한다
-- **AND** 차단 생성 때 제거된 Follow Request와 Follow Relationship을 자동으로 재생성하지 않는다
+- **THEN** 시스템은 새 요청 시점의 현재 Profile Block 관계와 각 surface의 기존 조회·상호작용 정책을 함께 평가한다
+- **AND** 차단 생성 때 제거된 Follow Request와 Follow Relationship은 cleanup·no-restore 계약에 따라 자동 복구하지 않는다
 
 ### Requirement: Profile Block GraphQL actor and policy boundary
 
-**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-822`, `PROD-823`. 현재 GraphQL ingress는 검증된 Session의 selected Local Profile을 actor로 사용해 Profile Block 생성·해제와 Owner 차단 목록 조회를 제공해야 한다(MUST). GraphQL resolver·loader·Node 조회·connection은 중앙 application policy를 재사용해야 하며(MUST), 요청별 DB actor state(GUC 등)·client 전용 차단 필터로 권한이나 가시성을 대체해서는 안 된다(MUST NOT). 차단 목록은 selected Local Profile이 Owner인 관계만 반환해야 하며(MUST), Target Profile의 일반 조회 가능성을 우회해 관계 관리에 필요한 최소 식별 정보만 제공해야 한다(MUST). 이 GraphQL ingress 계약을 remote ActivityPub ingress에 적용하는 것은 이 change의 범위가 아니다(MUST NOT).
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `PROD-822`, `PROD-823`. 현재 GraphQL ingress는 검증된 Session의 selected Local Profile을 actor로 사용해 Profile Block 생성·해제와 Owner 차단 목록 조회를 제공해야 한다(MUST). GraphQL resolver·loader·Node 조회·connection은 중앙 application policy를 재사용해야 하며(MUST), 차단 목록은 selected Local Profile이 Owner인 관계만 반환해야 한다(MUST). Target Profile의 기본 정보는 기존 Profile 조회 정책으로 제공하고, Post·Media와 각 목록·상호작용·Notification은 해당 surface의 Profile Block 정책을 적용해야 한다(MUST). 이 GraphQL ingress 계약을 remote ActivityPub ingress에 적용하는 것은 이 change의 범위가 아니다(MUST NOT).
 
 #### Scenario: selected Local Profile 없이 GraphQL Block operation을 실행하지 않는다
 
@@ -86,8 +87,8 @@
 - **THEN** 각 응답은 해당 시점의 selected Local Profile이 Owner인 Profile Block만 반환한다
 - **AND** Owner A의 관계가 Owner B의 목록·mutation·Node 조회 결과에 섞이지 않는다
 
-#### Scenario: GraphQL 직접 조회와 목록이 같은 Block policy를 사용한다
+#### Scenario: GraphQL 각 surface가 해당 Profile Block 정책을 사용한다
 
 - **WHEN** GraphQL client가 Profile Node, Post connection, Media relation, Follow 후보 또는 Profile Block 목록을 같은 Block 관계에 대해 요청한다
-- **THEN** 시스템은 요청 surface와 무관하게 동일한 양방향 Profile Block policy를 적용한다
-- **AND** client가 숨겨진 결과를 후처리해 상대 Profile 또는 Post를 복원할 수 있는 payload를 반환하지 않는다
+- **THEN** Profile Node는 기존 Profile 조회 정책을, Post·Media는 viewer 방향의 콘텐츠 정책을, Follow 후보는 양방향 보호 정책을 적용한다
+- **AND** Profile Block 목록은 selected Local Profile이 Owner인 관계만 반환한다

--- a/openspec/changes/add-profile-block/specs/profile/spec.md
+++ b/openspec/changes/add-profile-block/specs/profile/spec.md
@@ -1,23 +1,27 @@
 ## ADDED Requirements
 
-### Requirement: Profile Block direct Profile and search visibility
+### Requirement: Profile identity lookup uses the existing Profile policy
 
-**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/decisions/0004-review-consistency-clarifications.md`, `docs/domain/policies/post-list.md`, `PROD-822`. Profile 조회·검색과 Profile의 followers/following 후보는 Profile Block 관계를 공통 조회 정책으로 적용해야 한다(MUST). Owner → Target Block이 있으면 Owner와 Target 어느 쪽의 요청에서도 상대 Profile을 직접 조회하거나 상대 Profile을 Follow 후보로 반환해서는 안 되며(MUST NOT), 상대를 향한 새 Follow 입력도 거부해야 한다(MUST NOT). Owner가 관리하는 차단 목록은 일반 Profile 공개 조회와 구분된 Owner 전용 관계 조회로 제공해야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `PROD-822`. Profile Node, handle route와 일반 Profile 검색은 기존 Profile 조회 정책에 따라 조회 가능한 기본 Profile 정보를 제공해야 한다(MUST). Profile Lifecycle·Suspension·Instance Domain Block·Account 및 Membership에 따른 기존 조회 조건은 각 surface에서 계속 적용해야 한다(MUST).
 
-#### Scenario: Block된 상대 Profile을 직접 조회할 수 없다
+#### Scenario: Block 관계가 있어도 기존 조건을 충족한 Profile을 조회한다
 
-- **WHEN** Owner → Target Profile Block이 존재하고 Owner 또는 Target이 상대 Profile Node, route 또는 exact/partial search를 조회한다
-- **THEN** 시스템은 상대 Profile을 공개 조회 결과로 반환하지 않는다
-- **AND** Profile Block을 검사하지 않는 별도 Profile loader나 검색 경로를 사용하지 않는다
+- **WHEN** Owner → Target Profile Block이 존재하고 Owner 또는 Target이 상대 Profile Node, handle route 또는 일반 Profile 검색을 조회한다
+- **THEN** 시스템은 기존 Profile 조회 정책을 충족하는 경우 상대 Profile의 기본 정보를 반환한다
+- **AND** Profile Node·handle route·일반 Profile 검색은 동일한 기존 Profile 조회 조건을 사용한다
 
-#### Scenario: Block된 상대 Profile을 Follow 후보에서 제외한다
+### Requirement: Profile Block preserves the bilateral Follow boundary
+
+**Authority / Provenance:** `docs/domain/objects/profile-block.md`, `docs/domain/objects/profile.md`, `docs/domain/objects/follow-relationship.md`, `docs/domain/decisions/0004-review-consistency-clarifications.md`, `PROD-822`. Profile Block 관계가 있는 두 Profile 사이의 Follow 후보와 새 Follow 입력은 양방향 관계 정책을 적용해야 한다(MUST). 차단 관계가 있는 상대 Profile은 followers/following 후보에서 제외하고, 상대를 향한 새 Follow 입력은 Profile Block 정책으로 거부해야 한다(MUST).
+
+#### Scenario: Block 관계의 상대 Profile을 Follow 후보에서 제외한다
 
 - **WHEN** Block 관계의 한쪽 Profile이 followers/following 목록 또는 새 Follow 후보를 요청한다
-- **THEN** 시스템은 상대 Profile을 후보와 결과에서 제외한다
-- **AND** pending Follow Request나 과거 Follow Relationship을 현재 후보로 재구성하지 않는다
+- **THEN** 시스템은 상대 Profile을 후보 결과에서 제외한다
+- **AND** pending Follow Request와 과거 Follow Relationship은 현재 후보를 구성하는 근거로 사용하지 않는다
 
 #### Scenario: 차단된 상대를 향한 새 Follow 입력을 거부한다
 
 - **WHEN** Block 관계의 한쪽 Profile이 상대 Profile을 새로 Follow하려고 한다
-- **THEN** 시스템은 공통 Profile Block policy에 따라 입력을 거부한다
-- **AND** 새 Follow Request나 Follow Relationship을 저장하지 않는다
+- **THEN** 시스템은 Profile Block 정책에 따라 입력을 거부한다
+- **AND** 해당 입력의 결과로 새 Follow Request 또는 Follow Relationship을 저장하지 않는다

--- a/openspec/changes/add-profile-block/tasks.md
+++ b/openspec/changes/add-profile-block/tasks.md
@@ -56,6 +56,8 @@ transition이 cleanup 뒤 관계를 남길 수 있으므로, Unblock은 현재 �
 
 - `docs/domain/objects/profile-block.md`
 - `docs/domain/objects/profile.md`
+- `docs/domain/objects/post.md`
+- `docs/domain/objects/media.md`
 - `docs/domain/objects/follow-relationship.md`
 - `docs/domain/objects/notification.md`
 - `docs/domain/policies/post-list.md`
@@ -66,18 +68,20 @@ transition이 cleanup 뒤 관계를 남길 수 있으므로, Unblock은 현재 �
 
 **Deliverable**
 
-`PROD-821`의 저장 관계를 사용하는 공통 Profile Block policy와 selected Local Profile actor 기반 GraphQL mutation·Owner 관리
-connection을 제공한다. Profile/Post/Media/Follow 후보·Home/Local/Profile/Hashtag Post List·search·기존 Notification과 새 로컬
-interaction이 같은 정책을 소비하게 한다.
+`PROD-821`의 저장 관계를 사용하는 Profile Block policy와 selected Local Profile actor 기반 GraphQL mutation·Owner 관리 connection을
+제공한다. Profile identity는 기존 Profile 조회 정책을 사용하고, Post·Media direct 조회와 Profile Post List는 viewer 방향 콘텐츠 정책을
+사용하며, Home·Local·Hashtag Post List·Post search·Follow 후보·기존 Notification·새 로컬 interaction은 각 surface의 양방향 보호 정책을
+소비하게 한다.
 
 **Guardrails**
 
-- 저장 방향과 무관하게 양쪽 viewer/target을 blocked로 판정하고, 직접 조회·후보·Post list/search는 후보 반환 전에 Exclude한다. Repost는 Author와
-  Source Post Author를 모두 검사한다.
+- 저장된 Owner → Target 관계를 양쪽 viewer 방향으로 평가한다. Profile Node·handle route·일반 Profile search는 기존 Profile 조회 정책을 사용하고,
+  Post·Media direct 조회와 Profile Post List는 viewer 방향 콘텐츠 정책을 사용하며, Home·Local·Hashtag Post List·Post search·Follow 후보·interaction·
+  Notification은 양방향 보호 정책을 사용한다. Repost는 Author와 Source Post Author를 모두 검사한다.
 - Active Block은 cleanup 뒤 남은 Follow Request·Follow Relationship의 물리적 존재보다 우선하며, Follow·Reply·Reaction·Repost의 새 로컬 입력은 양쪽에서
   거부한다. page limit 뒤 client filter나 resolver별 정책 복제를 보안 경계로 사용하지 않는다.
-- 기존 unavailable Notification은 connection·Unread count·Node·read 처리에서 숨기되, `PROD-821`의 직접 원인 삭제 이외의 기존 Notification을
-  동기 삭제하거나 Read State를 바꾸지 않는다.
+- Profile Block pair의 기존 Notification은 connection·Unread count·Node·read 처리에서 숨기되, `PROD-821`의 직접 원인 삭제 이외의 기존 Notification을
+  동기 삭제하거나 Read State를 바꾸지 않는다. 이 Notification policy는 방향성 있는 Post·Media direct 조회와 독립적으로 적용한다.
 - 현재 source 신규 Notification 생성 suppression은 `PROD-327`, 비동기 물리 cleanup은 `PROD-328`에 남기며 이 그룹의 task·완료 증거로 삼지 않는다.
 - GraphQL ingress는 검증된 Session의 selected Local Profile actor 및 Owner scope를 사용하고, request-specific DB actor state나 client-only filter로
   중앙 application policy를 대체하지 않는다. remote ActivityPub ingress는 `PROD-818`에 남긴다.
@@ -85,21 +89,22 @@ interaction이 같은 정책을 소비하게 한다.
 
 **Verification**
 
-- 양쪽 요청 방향의 Profile Node·exact/partial search·Post·Media·Follow 후보와 Home/Local/Profile/Hashtag list·Post search에서 Author/Source
-  Author Exclude 및 cursor 전 필터링을 검증한다.
+- 양쪽 요청 방향의 Profile Node·handle route·일반 Profile search가 기존 Profile 조회 조건을 유지하는지, Owner → Target과 Target → Owner의 Post·Media
+  direct 조회 및 Profile Post List가 viewer 방향 정책을 따르는지 검증한다.
+- Home/Local/Hashtag list·Post search에서 양방향 Author/Source Author 보호와 cursor 전 필터링을 검증하고, Profile Post List의 viewer 방향 정책을 검증한다.
 - cleanup 뒤 남은 Follow Request·Follow Relationship의 비활성·비노출, 양쪽의 새 Follow·Reply·Reaction·Repost 거부와 기존 Post Visibility·Local PUBLIC
   eligibility 공존을 자동화된 정책·상호작용 회귀로 검증한다.
 - selected Local Profile A/B, guest·membership mismatch와 arbitrary actor ID를 GraphQL mutation·Owner connection·Node/loader에서 검증한다.
 - 차단으로 unavailable인 기존 Notification의 connection·Unread count·Node·read 숨김과 직접 원인 Follow Notification 정리 경계를 검증한다.
 
-- [ ] 2.1 `PROD-821` relation을 양방향으로 평가하고 cleanup 뒤 남은 Follow Request·Follow Relationship보다 우선하는 공통 visibility policy를 Profile/Post/Media
-      직접 조회, Follow 후보, Post list/search consumer에 연결한다.
-- [ ] 2.2 Block 확정 뒤 새 Follow commit과 Reply·Reaction·Repost 입력이 공통 Profile Block policy를 통과하지 못하도록 하고 Author·Source Author 및 cursor 전
-      Exclude를 구현한다.
+- [ ] 2.1 `PROD-821` relation을 양쪽 viewer 방향으로 평가하고 Profile identity, directional Post/Media direct 조회, bilateral Follow 후보와
+      Home/Local/Hashtag Post list/search consumer가 각 surface policy를 사용하도록 연결한다.
+- [ ] 2.2 Block 확정 뒤 새 Follow commit과 Reply·Quote·Reaction·Repost 입력에 양방향 Profile Block policy를 적용하고, Home/Local/Hashtag Post list/search의
+      Author·Source Author을 cursor 전 필터링한다.
 - [ ] 2.3 selected Local Profile actor와 Owner scope를 사용하는 Profile Block 생성·해제 mutation과 Owner 관리 connection/Node 경계를 GraphQL에 추가한다.
 - [ ] 2.4 기존 unavailable Notification의 list·Unread·Node·read 가시성 policy를 연결하고 source 신규 생성 suppression이나 async cleanup은 추가하지 않는다.
-- [ ] 2.5 양방향 policy·interaction rejection·GraphQL actor isolation·Post List consumer·Notification visibility를 검증하는 자동화된 정책·공개 계약 회귀를
-      통과시킨다.
+- [ ] 2.5 Profile identity의 기존 조회 조건, directional direct content/Profile Post List, bilateral Home/Local/Hashtag list/search·interaction·Notification policy와 GraphQL actor isolation을
+      검증하는 자동화된 정책·공개 계약 회귀를 통과시킨다.
 
 ## 3. PROD-823 — Profile Block UI·Relay 관리 흐름
 
@@ -112,40 +117,42 @@ interaction이 같은 정책을 소비하게 한다.
 - `PROD-823`
 - `DSN-51`
 - `DSN-53`
-- presentation prerequisite evidence `PROD-861` (정본 아님)
+- 후속 UI 교체 `PROD-917`
 
 **Deliverable**
 
-`PROD-822`의 서버 확정 상태와 최신 canonical이 승인한 identity-free `blocking`·`blockedBy` route presentation을 소비해 Profile Block
-confirmation·pending·실패·retry, Mute와 분리된 관리 목록과 selected Profile별 client 상태 수렴을 제공한다. presentation 결정·이관 자체는 이
-change가 소유하지 않으며 보호된 Profile·Post·Media·Notification 데이터를 UI가 복구하지 않는다.
+`PROD-822`의 서버 확정 상태와 최신 canonical이 정한 direct Profile route 계약을 기존 레거시 Profile·Settings UI에 구현·통합해 Profile Block
+confirmation·pending·실패·retry, Mute와 분리된 관리 목록과 selected Profile별 client 상태 수렴을 제공한다. 양쪽 route는 기본 Profile 정보를 표시하고, `blocking` route는
+frontend 콘텐츠 경고 뒤 허용된 콘텐츠와 `차단 해제` action을 제공하며, `blockedBy` route는 콘텐츠 차단 상태를 표시한다. `PROD-917`의
+신규 UI 교체는 후속 범위로 유지한다.
 
 **Guardrails**
 
-- 최신 canonical이 승인한 identity-free `blocking`·`blockedBy` route presentation을 소비한다. `PROD-861`은 공용 presentation 선행 구현 증거로만
-  참고하며 presentation 결정·이관 자체를 이 그룹에서 구현하거나 완료 조건으로 다시 소유하지 않는다.
+- 기존 레거시 Profile·Settings UI에 최신 canonical이 정한 direct Profile route 계약을 구현·통합한다. `blocking` route의 frontend 콘텐츠 경고와
+  `blockedBy` route의 콘텐츠 차단 상태를 표시하며, `PROD-917`의 신규 UI 교체는 후속 범위로 관리한다.
 - Block과 Mute는 별도 Settings destination으로 유지하고, Block 목록의 loading/error·retry/empty/pagination·unblock 상태를 소유한다. 차단된 상세
-  데이터를 재조회하지 않는다.
+  데이터는 각 viewer 방향 콘텐츠 정책에 따라 표시한다.
 - 기존 Button·ActionMenu·ModalSheet·Toast·SettingsItem과 canonical 접근성·viewport 계약을 재사용하고 새 범용 safety component·Settings shell을
   만들지 않는다.
-- 성공은 서버 확정 결과로 client 상태를 수렴하고 실패 시 optimistic Block을 확정하지 않는다. selected Profile/Session 전환 때 다른 Owner의
-  Block 상태를 재사용하지 않으며 Unblock 때 제거된 Follow Request·Follow Relationship을 optimistic 복구하지 않는다.
+- 성공은 서버 확정 결과로 client 상태를 수렴하고 실패 시 optimistic Block을 확정하지 않는다. selected Profile/Session 전환 때 각 actor의
+  기본 Profile 정보·콘텐츠 상태·Block 목록을 해당 actor 결과로 격리하며 Unblock 때 제거된 Follow Request·Follow Relationship을 optimistic 복구하지 않는다.
 - 저장·정책(`PROD-821`·`PROD-822`)과 전체 E2E/archive(`PROD-813`)의 책임을 이 그룹으로 옮기지 않는다.
 
 **Verification**
 
-- confirmation 취소, pending 중복/dismiss, 성공·실패·retry와 공용 presentation의 action/state를 app component/Storybook 또는 E2E로 검증한다.
+- confirmation 취소, pending 중복/dismiss, 성공·실패·retry와 기존 레거시 Profile·Settings UI의 action/state를 app component 또는 E2E로 검증한다.
 - Settings의 분리된 Block 목록에서 loading/error·retry/empty/pagination·unblock과 다른 Target 상태 보존을 검증한다.
-- selected Profile A/B와 Session 전환에서 actor별 상태 격리·서버 결과 수렴·optimistic state isolation 및 Block 성공 후 보호된 Profile/Post/Notification
-  hide를 검증한다.
+- selected Profile A/B와 Session 전환에서 actor별 상태 격리·서버 결과 수렴·optimistic state isolation 및 Block 성공 후 기본 Profile 정보,
+  viewer 방향 콘텐츠 상태와 이미 표시 중인 Home·Local·Hashtag timeline·Profile Post List·Notification client 상태의 surface별 갱신을 검증한다.
 - Web 1024/1440·Mobile 390 Light/Dark, keyboard/보조 기술, Web Escape·Native back·focus 복원과 실제 Web/iOS/Android presentation evidence를
   실행 환경별로 기록한다.
 
-- [ ] 3.1 승인된 공용 confirmation을 Profile mutation 상태에 연결해 취소·pending·실패·retry와 보호된 데이터 비복구를 구현한다.
+- [ ] 3.1 기존 공용 confirmation을 Profile mutation 상태에 연결해 취소·pending·실패·retry와 direct Profile route의 경고·콘텐츠 상태를 구현한다.
 - [ ] 3.2 Settings에 Mute와 분리된 Block 관리 destination·목록 상태·pagination·unblock action을 연결한다.
-- [ ] 3.3 selected Local Profile actor 경계 안에서 Block/Unblock 성공·실패 결과에 따라 관리 목록과 표시 중 Profile·Post·Notification 상태를
-      서버 정책에 맞게 수렴시킨다.
-- [ ] 3.4 접근성·viewport·Web/Native presentation regression과 actor 전환·Unblock no-restore 검증을 추가하고 통과시킨다.
+- [ ] 3.3 selected Local Profile actor 경계 안에서 Block/Unblock 성공·실패 결과에 따라 관리 목록과 표시 중 기본 Profile 정보·viewer 방향
+      콘텐츠 상태·Home/Local/Hashtag timeline·Profile Post List·Notification client 상태를 각 surface 서버 정책에 맞게 수렴시킨다.
+- [ ] 3.4 접근성·viewport·Web/Native direct route presentation regression과 actor 전환·Unblock no-restore를 검증하고 `PROD-917` 후속 UI
+      교체 경계를 유지한다.
 
 ## 4. PROD-813 — Profile Block cross-slice E2E·canonical sync·archive
 
@@ -160,6 +167,7 @@ change가 소유하지 않으며 보호된 Profile·Post·Media·Notification �
 - `PROD-822`
 - `PROD-823`
 - `PROD-813` 최신 본문·댓글
+- `PROD-917` 후속 UI 교체 범위
 
 **Deliverable**
 
@@ -168,21 +176,24 @@ E2E를 완료하고, 최신 canonical·Linear·OpenSpec을 동기화한 뒤 모�
 
 **Guardrails**
 
-- Local·Remote Target, 양쪽 직접 조회·list/search·새 interaction, Follow/직접 원인 Notification cleanup, 기존 Reaction·Repost/Bookmark 보존,
-  Follow 관계 Unblock 비복구와 Profile 전환 isolation을 한 완료 흐름으로 검증한다.
+- Local·Remote Target, 기존 Profile 조회 조건, viewer 방향의 직접 Post·Media 조회, 양방향 list/search·새 interaction·Notification, Follow/직접 원인
+  cleanup, 기존 Reaction·Repost/Bookmark 보존, Follow 관계 Unblock 비복구와 Profile 전환 isolation을 한 완료 흐름으로 검증한다.
 - `PROD-327`의 현재 Notification source 신규 생성 suppression, `PROD-818`의 ActivityPub Block/Undo, `PROD-328`의 async physical cleanup은 이 change의
   구현·완료 증거가 아니다.
-- `PROD-861` Storybook/presentation 결과를 API·cache·Native runtime 완료 증거로 일반화하지 않는다. 환경별 실제 증거와 미검증 범위를 분리 기록한다.
+- 기존 레거시 Profile·Settings UI의 구현·통합 결과를 API·cache·Native runtime 결과와 함께 환경별 실제 evidence로 기록한다. `PROD-917` 신규 UI 교체는
+  현재 change와 분리된 후속 범위로 유지한다.
 - 모든 declared task와 required validation, canonical·Linear 정합성이 완료되기 전에는 archive하지 않는다.
 
 **Verification**
 
-- Local/Remote Target 각각의 block·unblock, 양방향 Profile/Post/Media/Follow 후보, Post list/search, 새 interaction rejection과 cleanup/no-restore를
-  Web/API cross-slice E2E로 검증한다.
+- Local/Remote Target 각각의 block·unblock, 기존 Profile identity 조회, Owner → Target과 Target → Owner의 Post/Media direct 정책, Profile Post List viewer
+  방향 정책, 양방향 Follow 후보·Home/Local/Hashtag Post list·Post search·새 interaction·Notification과 cleanup/no-restore를 Web/API cross-slice E2E로 검증한다.
 - Web·iOS·Android와 접근성 실행 결과를 플랫폼별로 기록하고, 구현하지 않은 ActivityPub·Notification source·async cleanup 범위를 별도로 확인한다.
 - 최신 Linear 본문·관계·댓글과 canonical domain/design 문서를 다시 읽어 requirement provenance·소유권·실행 순서를 대조한다.
 - `openspec validate add-profile-block --strict`, Prettier 검사와 `git diff --check`를 통과한 뒤에만 archive gate를 진행한다.
 
-- [ ] 4.1 `PROD-821`·`PROD-822`·`PROD-823` 결과를 연결한 Local/Remote block·unblock 및 direct/list/search/interaction/cleanup cross-slice E2E를 실행한다.
-- [ ] 4.2 cross-slice UI/API 결과와 selected Profile actor 상태 격리, 보존·비복구 및 후속 범위 경계를 플랫폼별 evidence로 기록한다.
+- [ ] 4.1 `PROD-821`·`PROD-822`·`PROD-823` 결과를 연결한 Local/Remote block·unblock 및 Profile identity, directional direct content/Profile Post List,
+      bilateral Home/Local/Hashtag list·search/interaction/Notification/cleanup cross-slice E2E를 실행한다.
+- [ ] 4.2 cross-slice UI/API 결과와 selected Profile actor 상태 격리, 기본 Profile 정보·viewer 방향 콘텐츠 상태, 보존·비복구 및 `PROD-917` 후속
+      범위 경계를 플랫폼별 evidence로 기록한다.
 - [ ] 4.3 최신 canonical·Linear·OpenSpec 정합성을 확인하고 strict validation·Prettier·diff 검증과 모든 task 완료 뒤 `add-profile-block`을 archive한다.


### PR DESCRIPTION
## 무엇을 변경했는지

`docs/domain`·`docs/design`과 active `openspec/changes/add-profile-block` delta specs를 2026-09-08 확정 계약에 맞췄다. Profile Node·handle route·일반 Profile 검색은 기존 Profile 조회 정책을 따르고, 단일 A→B Block에서는 A→B Post 목록·상세·첨부 Media API를 허용한다. 차단 Owner가 Target의 프로필 화면에서 경고 확인 후 콘텐츠를 표시한다. B→A 직접 콘텐츠 API는 모든 경로에서 제한하며 mutual Block은 양쪽을 제한한다. Home·Local·Hashtag 타임라인과 Post 검색은 양방향 필터를 적용하고 Profile Post List는 viewer 방향 정책을 적용한다. Follow 후보·새 상호작용·Notification 제한은 유지한다.

기존 UI 우선 소유권은 PROD-822/#770 API·runtime(정혜주), PROD-823 기존 UI·client(정혜주), PROD-813 통합·OpenSpec(정혜주), PROD-861·917 신규 UI(이예은)로 유지한다. PROD-821/#726 저장·durable cleanup은 변경하지 않는다. GraphQL selected Local actor와 selected Local Owner 관계 ID 범위도 유지한다. runtime 코드는 포함하지 않는다. Stack은 `main` → `PROD-813-contract-correction`이다.

## 왜 변경했는지

사용자가 제공한 확인 이력은 최초 `b6192d0`의 방향 접근 제한에서 `518d1d5`의 강화 문구를 거쳐 PR #208의 canonical 문구로 이어진다. 강화 자체에 대한 별도 제품 승인 근거는 확인되지 않았다. 이번 정정은 이 역사와 현재 계약을 구분하고, 2026-09-08 사용자가 직접 확정한 상세 방향과 기존 Profile 조회 정책을 현재 근거로 삼는다. Profile identity와 콘텐츠·surface 정책을 분리해 기존 Profile 공개 조건을 유지하면서 방향별 결과를 표현한다.

## 이번 PR의 주요 결정

- 결정자: 2026-09-08 사용자
- 선택: Profile identity는 기존 조회 정책을 적용하고, Post·Media 직접 API는 A→B 허용·B→A 제한·mutual 양쪽 제한으로 판정한다. 타임라인·Post 검색은 양방향 필터를 적용한다. 프로필 경고는 표시 확인이며 유지 기간과 안내 문구는 후속 디자인에서 확정한다.
- 근거: `docs/domain/objects/profile.md`, `profile-block.md`, `post.md`, `docs/domain/policies/post-list.md`, 게시된 PROD-813·822·823·861·917·DSN-53 Linear 본문과 active OpenSpec.

기존 저장·GraphQL actor·관계 관리·알림 cleanup 경계와 기존 UI 우선 순서는 유지한다. 신규 UI·Storybook 확정과 교체 회귀는 PROD-861·917 후속 범위이며, 이 PR에서 새 projection 유지나 runtime 완료를 결정하지 않는다.

## 어떻게 확인할 수 있는지

canonical worker와 specs worker가 다음을 통과시켰다.

- `pnpm lint:prettier`
- Markdown 링크 62개 검증
- domain object 구조 검증
- 권한 명칭 검증
- `openspec validate add-profile-block --strict` PASS
- `openspec validate add-profile-mute --strict` PASS (Block 직접 조회 금지 관련 stale가 없어 기존 contract 보존, 수정 없음)
- active OpenSpec 9개 파일 Prettier PASS
- `git diff --check` PASS
- 검증 대상: 문서 8개 + active OpenSpec 9개, 총 17개 파일

이번 PR은 문서와 active OpenSpec만 다루므로 API·UI·Native runtime 완료를 주장하지 않는다. shared change의 전체 구현·통합 검증과 archive는 PROD-813의 잔여 책임으로 구분한다.

최신 head `5d320c0d3c1542b34c0e79e156fa0618634c7d84`는 CI 수정 [#801](https://github.com/byulmaru/kosmo/pull/801)이 포함된 main 위에 반영됐고, 원격 CI 16개 검사(Lint·Semgrep·Test·Web E2E)가 모두 통과했다. [Lint](https://github.com/byulmaru/kosmo/actions/runs/34231733006), [Test·Web E2E](https://github.com/byulmaru/kosmo/actions/runs/34231733077), [Semgrep](https://github.com/byulmaru/kosmo/actions/runs/34231733124).

## 아직 어떤 문제가 남았는지

- 차단 Owner가 Target 프로필에서 확인하는 경고의 유지 기간과 안내 문구는 PROD-861·917 후속 디자인에서 정한다.
- [PROD-822](https://linear.app/byulmaru/issue/PROD-822)는 PR #770(`ee0fa089`)의 일반 Profile 조회와 직접 Post API 방향을 정정하고 Notification의 양방향 pair 보호를 유지한다.
- PROD-822는 #770의 Block·Mute 대상에 기존 Profile 조회 결과를 사용하도록 정리한다. `ProfileBlockTarget`·`ProfileMuteTarget` 타입·전용 loader·별도 Target global ID를 제거하고 GraphQL schema·Relay 참조·#770 브랜치 OpenSpec을 동기화한다. 기존 Profile lifecycle·membership 권한과 Block·Mute 관계 자체의 Owner 관리·해제 ID를 유지한다.
- 최신 #802의 canonical·OpenSpec에는 전용 Target 타입·별도 ID 필수 계약이 없다. 위 정리는 #770 구현과 해당 브랜치에 남은 명세를 대상으로 하며, 구현·공개 결과 검증은 PROD-822가 소유한다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>