### PR TITLE
개발·운영 DB의 1초 이상 슬로우 쿼리를 기록한다

### DIFF
--- a/apps/helm/templates/postgres-cluster.yaml
+++ b/apps/helm/templates/postgres-cluster.yaml
@@ -18,11 +18,13 @@ spec:
 {{- end }}
   resources:
 {{ toYaml .Values.postgres.resources | indent 4 }}
-{{- if eq .Values.env "prod" }}
-  serviceAccountName: kosmo-postgres-backup
   postgresql:
     parameters:
+      log_min_duration_statement: 1s
+      log_parameter_max_length: "0"
+{{ if eq .Values.env "prod" }}
       archive_timeout: 4min
+  serviceAccountName: kosmo-postgres-backup
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true


### PR DESCRIPTION
## 무엇을 변경했는지

- [PROD-928](https://linear.app/byulmaru/issue/PROD-928) 범위로 CloudNativePG Cluster의 개발·운영 공통 PostgreSQL 파라미터를 변경했습니다.
- `log_min_duration_statement: 1s`로 1초 이상 완료된 SQL을 기록합니다.
- `log_parameter_max_length: "0"`은 비오류 statement 로그의 bind parameter 값 기록만 제외하며, SQL 리터럴 마스킹 기능은 아닙니다.
- 운영 환경의 기존 `archive_timeout: 4min`과 Barman 백업 플러그인은 유지했습니다.

## 왜 변경했는지

개발·운영 DB에서 1초 이상 걸린 SQL을 PostgreSQL 로그로 확인할 수 있도록 slow-query logging을 추가합니다.

## 주요 결정

- 사용자 확정 기준에 따라 dev/prod 모두 임계치는 `1s`입니다.
- 설정은 별도 values 추상화 없이 기존 CNPG Cluster 템플릿에 최소 범위로 적용했습니다.
- 제품·API·스키마 계약 변경 없이 운영 설정만 추가하므로 새 OpenSpec은 만들지 않았습니다.
- Stack: `main -> PROD-928`

## 검증

- `helm lint apps/helm --set env=dev`
- `helm lint apps/helm --set env=prod --set imageDigest=sha256:0000000000000000000000000000000000000000000000000000000000000000`
- dev/prod `helm template` 결과에서 두 PostgreSQL 파라미터와 prod 백업 설정을 확인하고 Ruby YAML parser로 렌더 전체 문서를 파싱했습니다.
- `git diff --check`
- commit hook ESLint/Prettier
- 실제 반영 후 `kubectl logs -n <namespace> <postgres-pod> -c postgres --since=10m`으로 PostgreSQL 로그를 조회할 수 있습니다.

## 남은 문제

- 현재 Tailscale DNS 오류로 실제 Cluster의 적용 상태와 PostgreSQL 런타임 버전은 확인하지 못했습니다.
- 저장소에서 중앙 로그 수집기는 발견하지 못했고, 장기 보관·수집·대시보드는 이번 변경 범위에 포함하지 않았습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>