### PR TITLE
선택 프로필 권한을 최소 역할 기준으로 검사한다

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -13,6 +13,7 @@ import { and, eq } from 'drizzle-orm';
 import stringify from 'fast-json-stable-stringify';
 import * as R from 'remeda';
 import { visibleProfileWhere } from './profile/visibility';
+import type { AccountProfileRole } from '@kosmo/core/enums';
 import type { Context as HonoContext } from 'hono';
 
 type LoaderParams<Key, Result, SortKey, Nullability extends boolean, Many extends boolean> = {
@@ -46,12 +47,14 @@ export type SessionContext = {
     id: string;
     accountId: string;
     profileId: string | null;
+    profileRole: AccountProfileRole | null;
   };
 };
 
 export type SessionWithProfileContext = SessionContext & {
   session: {
     profileId: string;
+    profileRole: AccountProfileRole;
   };
 };
 
@@ -89,10 +92,12 @@ export const deriveContext = async (c: ServerContext): Promise<Context> => {
 
     if (session) {
       let profileId = session.activeProfileId;
+      let profileRole: AccountProfileRole | null = null;
       if (profileId) {
         await db
           .select({
             id: Profiles.id,
+            role: AccountProfiles.role,
           })
           .from(Profiles)
           .innerJoin(
@@ -113,6 +118,7 @@ export const deriveContext = async (c: ServerContext): Promise<Context> => {
           .then(first)
           .then((profile) => {
             profileId = profile?.id ?? null;
+            profileRole = profile?.role ?? null;
           });
       }
 
@@ -120,6 +126,7 @@ export const deriveContext = async (c: ServerContext): Promise<Context> => {
         id: session.id,
         accountId: session.accountId,
         profileId,
+        profileRole,
       };
     }
   }

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -46,15 +46,13 @@ export type SessionContext = {
   session: {
     id: string;
     accountId: string;
-    profileId: string | null;
-    profileRole: AccountProfileRole | null;
+    profile: { id: string; role: AccountProfileRole } | null;
   };
 };
 
 export type SessionWithProfileContext = SessionContext & {
   session: {
-    profileId: string;
-    profileRole: AccountProfileRole;
+    profile: { id: string; role: AccountProfileRole };
   };
 };
 
@@ -91,9 +89,8 @@ export const deriveContext = async (c: ServerContext): Promise<Context> => {
       .then(first);
 
     if (session) {
-      let profileId = session.activeProfileId;
-      let profileRole: AccountProfileRole | null = null;
-      if (profileId) {
+      let profile: { id: string; role: AccountProfileRole } | null = null;
+      if (session.activeProfileId) {
         await db
           .select({
             id: Profiles.id,
@@ -110,23 +107,21 @@ export const deriveContext = async (c: ServerContext): Promise<Context> => {
           .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
           .where(
             and(
-              eq(Profiles.id, profileId),
+              eq(Profiles.id, session.activeProfileId),
               visibleProfileWhere({ profile: Profiles, instance: Instances }),
             ),
           )
           .limit(1)
           .then(first)
-          .then((profile) => {
-            profileId = profile?.id ?? null;
-            profileRole = profile?.role ?? null;
+          .then((selectedProfile) => {
+            profile = selectedProfile ?? null;
           });
       }
 
       ctx.session = {
         id: session.id,
         accountId: session.accountId,
-        profileId,
-        profileRole,
+        profile,
       };
     }
   }

--- a/apps/api/src/graphql/builder.ts
+++ b/apps/api/src/graphql/builder.ts
@@ -1,3 +1,4 @@
+import { AccountProfileRoleOrder } from '@kosmo/core/enums';
 import { PermissionDeniedError, ValidationError } from '@kosmo/core/error';
 import { decodeGlobalId, encodeGlobalId } from '@kosmo/core/global-id';
 import SchemaBuilder from '@pothos/core';
@@ -8,17 +9,18 @@ import SimpleObjectsPlugin from '@pothos/plugin-simple-objects';
 import ValidationPlugin from '@pothos/plugin-validation';
 import WithInputPlugin from '@pothos/plugin-with-input';
 import * as R from 'remeda';
+import type { AccountProfileRole } from '@kosmo/core/enums';
 import type { PostContentDocumentV1 } from '@kosmo/core/post-content';
 import type { SessionContext, SessionWithProfileContext, UserContext } from '@/context';
 
 export const builder = new SchemaBuilder<{
   AuthContexts: {
     login: UserContext & SessionContext;
-    usingProfile: UserContext & SessionWithProfileContext;
+    profileRole: UserContext & SessionWithProfileContext;
   };
   AuthScopes: {
     login: boolean;
-    usingProfile: boolean;
+    profileRole: AccountProfileRole;
   };
   Context: UserContext;
   DefaultAuthStrategy: 'all';
@@ -63,7 +65,17 @@ export const builder = new SchemaBuilder<{
   scopeAuth: {
     authScopes: async (ctx) => ({
       login: !!ctx.session,
-      usingProfile: !!ctx.session?.profileId,
+      profileRole: (minimumRole) => {
+        const currentRole = ctx.session?.profileRole;
+        if (!ctx.session?.profileId || !currentRole) {
+          return false;
+        }
+
+        return (
+          AccountProfileRoleOrder.indexOf(currentRole) >=
+          AccountProfileRoleOrder.indexOf(minimumRole)
+        );
+      },
     }),
     defaultStrategy: 'all',
     runScopesOnType: true,

--- a/apps/api/src/graphql/builder.ts
+++ b/apps/api/src/graphql/builder.ts
@@ -66,13 +66,13 @@ export const builder = new SchemaBuilder<{
     authScopes: async (ctx) => ({
       login: !!ctx.session,
       profileRole: (minimumRole) => {
-        const currentRole = ctx.session?.profileRole;
-        if (!ctx.session?.profileId || !currentRole) {
+        const currentProfile = ctx.session?.profile;
+        if (!currentProfile) {
           return false;
         }
 
         return (
-          AccountProfileRoleOrder.indexOf(currentRole) >=
+          AccountProfileRoleOrder.indexOf(currentProfile.role) >=
           AccountProfileRoleOrder.indexOf(minimumRole)
         );
       },

--- a/apps/api/src/graphql/enums.ts
+++ b/apps/api/src/graphql/enums.ts
@@ -1,7 +1,9 @@
 import * as Enums from '@kosmo/core/enums';
 import { builder } from './builder';
 
-const createEnumRef = (name: keyof typeof Enums) => {
+type EnumName = Exclude<keyof typeof Enums, 'AccountProfileRoleOrder'>;
+
+const createEnumRef = (name: EnumName) => {
   builder.enumType(Enums[name], {
     name,
   });

--- a/apps/api/src/graphql/resolvers/bookmark/field/post.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/field/post.ts
@@ -1,10 +1,11 @@
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { builder } from '@/graphql/builder';
 import { Post } from '@/graphql/resolvers/post';
 import { viewerBookmarkLoader } from '../loader/viewer-bookmark';
 import { Bookmark } from '../ref';
 
 builder.objectField(Post, 'viewerBookmark', (t) =>
-  t.withAuth({ usingProfile: true }).field({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).field({
     type: Bookmark,
     nullable: true,
     unauthorizedResolver: () => null,

--- a/apps/api/src/graphql/resolvers/bookmark/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/field/profile.ts
@@ -14,7 +14,7 @@ builder.objectField(Profile, 'bookmarks', (t) =>
     {
       type: Bookmark,
       resolve: (profile, args, ctx) => {
-        if (profile.id !== ctx.session.profileId) {
+        if (profile.id !== ctx.session.profile.id) {
           throw new PermissionDeniedError('Bookmark owner is required');
         }
 

--- a/apps/api/src/graphql/resolvers/bookmark/field/profile.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/field/profile.ts
@@ -1,4 +1,5 @@
 import { Bookmarks, db, Instances, Posts, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { PermissionDeniedError } from '@kosmo/core/error';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
@@ -9,7 +10,7 @@ import { Bookmark, BookmarkConnection } from '../ref';
 import type { BookmarkRow } from '../ref';
 
 builder.objectField(Profile, 'bookmarks', (t) =>
-  t.withAuth({ usingProfile: true }).connection(
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).connection(
     {
       type: Bookmark,
       resolve: (profile, args, ctx) => {

--- a/apps/api/src/graphql/resolvers/bookmark/loader/viewer-bookmark.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/loader/viewer-bookmark.ts
@@ -8,7 +8,7 @@ export const viewerBookmarkLoader = (ctx: UserContext) =>
     name: 'bookmark.viewerBookmark',
     nullable: true,
     load: async (postIds) => {
-      if (!ctx.session?.profileId) {
+      if (!ctx.session?.profile?.id) {
         return [];
       }
 
@@ -16,7 +16,7 @@ export const viewerBookmarkLoader = (ctx: UserContext) =>
         .select(getColumns(Bookmarks))
         .from(Bookmarks)
         .where(
-          and(eq(Bookmarks.profileId, ctx.session.profileId), inArray(Bookmarks.postId, postIds)),
+          and(eq(Bookmarks.profileId, ctx.session.profile.id), inArray(Bookmarks.postId, postIds)),
         );
     },
     key: (bookmark) => bookmark?.postId ?? null,

--- a/apps/api/src/graphql/resolvers/bookmark/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/mutation/create.ts
@@ -1,4 +1,5 @@
 import { db, first, Instances, Posts, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { NotFoundError } from '@kosmo/core/error';
 import { createBookmark } from '@kosmo/core/services';
 import { and, eq } from 'drizzle-orm';
@@ -8,7 +9,7 @@ import { postAccessWhere } from '@/graphql/resolvers/post/access';
 import { Bookmark } from '../ref';
 
 builder.mutationField('createBookmark', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('CreateBookmarkPayload', {
       fields: (field) => ({
         bookmark: field.field({ type: Bookmark }),

--- a/apps/api/src/graphql/resolvers/bookmark/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/mutation/create.ts
@@ -35,7 +35,10 @@ builder.mutationField('createBookmark', (t) =>
         }
 
         return {
-          bookmark: await createBookmark({ postId: post.id, profileId: ctx.session.profileId }, tx),
+          bookmark: await createBookmark(
+            { postId: post.id, profileId: ctx.session.profile.id },
+            tx,
+          ),
         };
       }),
   }),

--- a/apps/api/src/graphql/resolvers/bookmark/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/mutation/delete.ts
@@ -1,4 +1,5 @@
 import { db } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { deleteBookmark } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
 import { Post } from '@/graphql/resolvers/post';
@@ -10,7 +11,7 @@ type DeleteBookmarkPayload = {
 };
 
 builder.mutationField('deleteBookmark', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('DeleteBookmarkPayload', {
       fields: (field) => ({
         bookmarkId: field.globalID({

--- a/apps/api/src/graphql/resolvers/bookmark/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/mutation/delete.ts
@@ -34,7 +34,7 @@ builder.mutationField('deleteBookmark', (t) =>
       const deleted = await deleteBookmark(
         {
           bookmarkId: input.id.id,
-          profileId: ctx.session.profileId,
+          profileId: ctx.session.profile.id,
         },
         db,
       );

--- a/apps/api/src/graphql/resolvers/bookmark/ref.ts
+++ b/apps/api/src/graphql/resolvers/bookmark/ref.ts
@@ -6,14 +6,14 @@ import { createObjectRef } from '@/graphql/utils';
 export type BookmarkRow = typeof Bookmarks.$inferSelect;
 
 export const Bookmark = createObjectRef<BookmarkRow>('Bookmark', (ids, ctx) => {
-  if (!ctx.session?.profileId) {
+  if (!ctx.session?.profile?.id) {
     return Promise.resolve([]);
   }
 
   return db
     .select(getColumns(Bookmarks))
     .from(Bookmarks)
-    .where(and(inArray(Bookmarks.id, ids), eq(Bookmarks.profileId, ctx.session.profileId)));
+    .where(and(inArray(Bookmarks.id, ids), eq(Bookmarks.profileId, ctx.session.profile.id)));
 });
 
 Bookmark.implement({

--- a/apps/api/src/graphql/resolvers/feedback.test.ts
+++ b/apps/api/src/graphql/resolvers/feedback.test.ts
@@ -52,7 +52,7 @@ test('선택 Profile이 없는 login session도 feedback을 제출할 수 있다
   t.mock.method(globalThis, 'fetch', fetch);
 
   const result = await graphql({
-    contextValue: { session: { accountId, id: 'session-1', profileId: null } },
+    contextValue: { session: { accountId, id: 'session-1', profile: null } },
     schema,
     source: mutation,
     variableValues: {
@@ -81,7 +81,7 @@ test('anonymous와 invalid body는 Slack 전에 거부한다', async (t) => {
     variableValues: { input: { body: 'body', kind: 'POSITIVE' } },
   });
   const empty = await graphql({
-    contextValue: { session: { accountId, id: 'session-1', profileId: null } },
+    contextValue: { session: { accountId, id: 'session-1', profile: null } },
     schema,
     source: mutation,
     variableValues: { input: { body: '   ', kind: 'POSITIVE' } },

--- a/apps/api/src/graphql/resolvers/feedback/mutation/submit.ts
+++ b/apps/api/src/graphql/resolvers/feedback/mutation/submit.ts
@@ -20,7 +20,7 @@ builder.mutationField('submitFeedback', (t) =>
     },
     resolve: async (_, { input }, ctx) =>
       deliverFeedback(
-        await resolveFeedbackIdentity(ctx.session.accountId, ctx.session.profileId, db),
+        await resolveFeedbackIdentity(ctx.session.accountId, ctx.session.profile?.id ?? null, db),
         input,
       ),
   }),

--- a/apps/api/src/graphql/resolvers/media/mutation/complete-upload.test.ts
+++ b/apps/api/src/graphql/resolvers/media/mutation/complete-upload.test.ts
@@ -9,7 +9,7 @@ test('requires an authenticated selected Profile', async () => {
 
   for (const contextValue of [
     {},
-    { session: { id: 'session', accountId: 'account', profileId: null } },
+    { session: { id: 'session', accountId: 'account', profile: null } },
   ]) {
     const result = await graphql({
       schema,

--- a/apps/api/src/graphql/resolvers/media/mutation/complete-upload.ts
+++ b/apps/api/src/graphql/resolvers/media/mutation/complete-upload.ts
@@ -1,5 +1,5 @@
 import { db, first, firstOrThrowWith, Media as MediaTable } from '@kosmo/core/db';
-import { MediaSource, MediaState } from '@kosmo/core/enums';
+import { AccountProfileRole, MediaSource, MediaState } from '@kosmo/core/enums';
 import { NotFoundError } from '@kosmo/core/error';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
@@ -14,7 +14,7 @@ const representationResponseSchema = z.object({
 const MEDIA_STORAGE_REQUEST_TIMEOUT_MS = 10_000;
 
 builder.mutationField('completeMediaUpload', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('CompleteMediaUploadPayload', {
       fields: (field) => ({
         media: field.field({ type: Media }),

--- a/apps/api/src/graphql/resolvers/media/mutation/issue-upload-url.test.ts
+++ b/apps/api/src/graphql/resolvers/media/mutation/issue-upload-url.test.ts
@@ -6,7 +6,7 @@ import { schema } from '@/graphql/schema';
 test('requires an authenticated selected Profile', async () => {
   for (const contextValue of [
     {},
-    { session: { id: 'session', accountId: 'account', profileId: null } },
+    { session: { id: 'session', accountId: 'account', profile: null } },
   ]) {
     const result = await graphql({
       schema,

--- a/apps/api/src/graphql/resolvers/media/mutation/issue-upload-url.ts
+++ b/apps/api/src/graphql/resolvers/media/mutation/issue-upload-url.ts
@@ -1,5 +1,5 @@
 import { db, firstOrThrowWith, Media as MediaTable } from '@kosmo/core/db';
-import { MediaSource, MediaState } from '@kosmo/core/enums';
+import { AccountProfileRole, MediaSource, MediaState } from '@kosmo/core/enums';
 import { z } from 'zod';
 import { builder } from '@/graphql/builder';
 import { Media } from '../ref';
@@ -13,7 +13,7 @@ const uploadResponseSchema = z.object({
 const MEDIA_STORAGE_REQUEST_TIMEOUT_MS = 10_000;
 
 builder.mutationField('issueMediaUploadUrl', (t) =>
-  t.withAuth({ usingProfile: true }).field({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).field({
     type: builder.simpleObject('IssueMediaUploadUrlPayload', {
       fields: (field) => ({
         media: field.field({ type: Media }),

--- a/apps/api/src/graphql/resolvers/media/mutation/issue-upload-url.ts
+++ b/apps/api/src/graphql/resolvers/media/mutation/issue-upload-url.ts
@@ -56,7 +56,7 @@ builder.mutationField('issueMediaUploadUrl', (t) =>
           source: MediaSource.LOCAL,
           state: MediaState.UPLOADING,
           accountId: ctx.session.accountId,
-          profileId: ctx.session.profileId,
+          profileId: ctx.session.profile.id,
           storageReference: upload.data.id,
           uploadExpiresAt: expiresAt,
         })

--- a/apps/api/src/graphql/resolvers/notification/mutation/mark-read.test.ts
+++ b/apps/api/src/graphql/resolvers/notification/mutation/mark-read.test.ts
@@ -16,7 +16,7 @@ test('silently excludes a non-Notification global ID', async () => {
     variableValues: {
       ids: [encodeGlobalId('Profile', '00000000-0000-8006-8000-000000000001')],
     },
-    contextValue: { session: { accountId: 'account', id: 'session' } },
+    contextValue: { session: { accountId: 'account', id: 'session', profile: null } },
   });
 
   assert.equal(result.errors, undefined, JSON.stringify(result.errors));

--- a/apps/api/src/graphql/resolvers/post/access/index.ts
+++ b/apps/api/src/graphql/resolvers/post/access/index.ts
@@ -16,7 +16,7 @@ export const postAccessWhere = ({
   profileMute: 'ignore' | 'exclude' | { excludeExcept: string };
 }) => {
   const accessWhere = and(postVisibilityAccessWhere({ ctx }), postRepostSourceAccessWhere({ ctx }));
-  const ownerProfileId = ctx.session?.profileId;
+  const ownerProfileId = ctx.session?.profile?.id;
   if (profileMute === 'ignore' || !ownerProfileId) {
     return accessWhere;
   }

--- a/apps/api/src/graphql/resolvers/post/access/repost-source.ts
+++ b/apps/api/src/graphql/resolvers/post/access/repost-source.ts
@@ -17,7 +17,7 @@ export const postRepostSourceAccessWhere = ({ ctx }: { ctx: UserContext }): SQL<
       profile: DirectRepostSourceProfiles,
       instance: DirectRepostSourceInstances,
     })}`,
-    viewerProfileId: ctx.session?.profileId,
+    viewerProfileId: ctx.session?.profile?.id,
     db,
   });
 

--- a/apps/api/src/graphql/resolvers/post/access/visibility.ts
+++ b/apps/api/src/graphql/resolvers/post/access/visibility.ts
@@ -11,6 +11,6 @@ export const postVisibilityAccessWhere = ({ ctx }: { ctx: UserContext }) =>
       profile: Profiles,
       instance: Instances,
     })}`,
-    viewerProfileId: ctx.session?.profileId,
+    viewerProfileId: ctx.session?.profile?.id,
     db,
   });

--- a/apps/api/src/graphql/resolvers/post/loader/repost.ts
+++ b/apps/api/src/graphql/resolvers/post/loader/repost.ts
@@ -42,7 +42,7 @@ export const viewerRepostLoader = (ctx: UserContext) =>
     name: 'post.viewerRepost',
     nullable: true,
     load: async (sourceIds) => {
-      if (!ctx.session?.profileId) {
+      if (!ctx.session?.profile?.id) {
         return [];
       }
 
@@ -51,7 +51,7 @@ export const viewerRepostLoader = (ctx: UserContext) =>
         .from(Posts)
         .where(
           and(
-            eq(Posts.profileId, ctx.session.profileId),
+            eq(Posts.profileId, ctx.session.profile.id),
             inArray(Posts.repostSourceId, sourceIds),
             eq(Posts.state, PostState.ACTIVE),
             isNull(Posts.currentContentId),

--- a/apps/api/src/graphql/resolvers/post/mutation/create.test.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { ValidationError } from '@kosmo/core/error';
 import { encodeGlobalId } from '@kosmo/core/global-id';
 import { graphql, isInputObjectType, isObjectType } from 'graphql';
@@ -71,7 +72,14 @@ test('validates createPost input before running the resolver', async () => {
         }
       `,
       variableValues: { input },
-      contextValue: { session: { profileId: '00000000-0000-8000-8000-000000000001' } },
+      contextValue: {
+        session: {
+          profile: {
+            id: '00000000-0000-8000-8000-000000000001',
+            role: AccountProfileRole.MEMBER,
+          },
+        },
+      },
     });
 
     assert.equal(result.data == null, true);

--- a/apps/api/src/graphql/resolvers/post/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.ts
@@ -79,7 +79,7 @@ builder.mutationField('createPost', (t) =>
           mediaId: mediaId.id,
         })),
         origin: 'LOCAL',
-        profileId: ctx.session.profileId,
+        profileId: ctx.session.profile.id,
         replyParentId: input.replyParentId?.id,
         visibility: input.visibility,
       });

--- a/apps/api/src/graphql/resolvers/post/mutation/create.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/create.ts
@@ -1,4 +1,4 @@
-import { PostVisibility } from '@kosmo/core/enums';
+import { AccountProfileRole, PostVisibility } from '@kosmo/core/enums';
 import { normalizePostContentPlainText } from '@kosmo/core/post-content';
 import { postContentDocumentFromTextAndMedia } from '@kosmo/core/post-content/server';
 import { createPost } from '@kosmo/core/services';
@@ -16,7 +16,7 @@ const CreatePostMediaInput = builder.inputType('CreatePostMediaInput', {
 });
 
 builder.mutationField('createPost', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('CreatePostPayload', {
       fields: (field) => ({
         post: field.field({ type: Post }),

--- a/apps/api/src/graphql/resolvers/post/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/delete.ts
@@ -1,9 +1,10 @@
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { deletePost } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
 builder.mutationField('deletePost', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('DeletePostPayload', {
       fields: (field) => ({
         postId: field.globalID({

--- a/apps/api/src/graphql/resolvers/post/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/delete.ts
@@ -24,7 +24,7 @@ builder.mutationField('deletePost', (t) =>
     },
     resolve: async (_, { input }, ctx) => {
       const result = await deletePost({
-        actorProfileId: ctx.session.profileId,
+        actorProfileId: ctx.session.profile.id,
         origin: 'LOCAL',
         postId: input.id.id,
       });

--- a/apps/api/src/graphql/resolvers/post/mutation/repost.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/repost.ts
@@ -1,9 +1,10 @@
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { repostPost } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
 import { Post } from '../ref';
 
 builder.mutationField('repostPost', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('RepostPostPayload', {
       fields: (field) => ({
         repost: field.field({ type: Post }),

--- a/apps/api/src/graphql/resolvers/post/mutation/repost.ts
+++ b/apps/api/src/graphql/resolvers/post/mutation/repost.ts
@@ -15,7 +15,7 @@ builder.mutationField('repostPost', (t) =>
     },
     resolve: async (_, { input }, ctx) => {
       const result = await repostPost({
-        actorProfileId: ctx.session.profileId,
+        actorProfileId: ctx.session.profile.id,
         origin: 'LOCAL',
         sourcePostId: input.sourceId.id,
       });

--- a/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
+++ b/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
@@ -1,4 +1,5 @@
 import { db, Instances, Posts, ProfileFollows, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, exists, getColumns, gt, isNull, lt, or } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
@@ -11,7 +12,7 @@ type PostRow = typeof Posts.$inferSelect;
 const ReplyParents = alias(Posts, 'home_timeline_reply_parent');
 
 builder.queryField('homeTimeline', (t) =>
-  t.withAuth({ usingProfile: true }).connection(
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).connection(
     {
       type: Post,
       nullable: true,

--- a/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
+++ b/apps/api/src/graphql/resolvers/post/query/home-timeline.ts
@@ -24,7 +24,7 @@ builder.queryField('homeTimeline', (t) =>
             .from(ProfileFollows)
             .where(
               and(
-                eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+                eq(ProfileFollows.followerProfileId, ctx.session.profile.id),
                 eq(ProfileFollows.followeeProfileId, Posts.profileId),
               ),
             ),
@@ -36,7 +36,7 @@ builder.queryField('homeTimeline', (t) =>
             .where(
               and(
                 eq(ReplyParents.id, Posts.replyParentId),
-                eq(ReplyParents.profileId, ctx.session.profileId),
+                eq(ReplyParents.profileId, ctx.session.profile.id),
               ),
             ),
         );
@@ -48,12 +48,12 @@ builder.queryField('homeTimeline', (t) =>
             .where(
               and(
                 eq(ReplyParents.id, Posts.replyParentId),
-                eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+                eq(ProfileFollows.followerProfileId, ctx.session.profile.id),
               ),
             ),
         );
         const homeCandidateWhere = or(
-          eq(Posts.profileId, ctx.session.profileId),
+          eq(Posts.profileId, ctx.session.profile.id),
           and(isNull(Posts.replyParentId), followeeWhere),
           replyParentIsViewerPost,
           and(followeeWhere, replyParentAuthorIsFollowee),

--- a/apps/api/src/graphql/resolvers/post/query/local-timeline.ts
+++ b/apps/api/src/graphql/resolvers/post/query/local-timeline.ts
@@ -1,5 +1,5 @@
 import { db, Instances, Posts, Profiles } from '@kosmo/core/db';
-import { PostVisibility } from '@kosmo/core/enums';
+import { AccountProfileRole, PostVisibility } from '@kosmo/core/enums';
 import { resolveConfiguredLocalInstance } from '@kosmo/core/local-instance';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, getColumns, gt, isNotNull, isNull, lt } from 'drizzle-orm';
@@ -10,7 +10,7 @@ import { Post, PostConnection } from '../ref';
 type PostRow = typeof Posts.$inferSelect;
 
 builder.queryField('localTimeline', (t) =>
-  t.withAuth({ usingProfile: true }).connection(
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).connection(
     {
       type: Post,
       nullable: true,

--- a/apps/api/src/graphql/resolvers/profile/access/follow-request.ts
+++ b/apps/api/src/graphql/resolvers/profile/access/follow-request.ts
@@ -3,7 +3,7 @@ import { eq, or } from 'drizzle-orm';
 import type { UserContext } from '@/context';
 
 export const profileFollowRequestAccessWhere = (ctx: UserContext) => {
-  const viewerProfileId = ctx.session?.profileId;
+  const viewerProfileId = ctx.session?.profile?.id;
 
   if (!viewerProfileId) {
     return undefined;

--- a/apps/api/src/graphql/resolvers/profile/access/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/access/follow.ts
@@ -30,10 +30,10 @@ export const profileFollowAccessWhere = ({
     eq(followerProfile.followPolicy, ProfileFollowPolicy.OPEN),
     eq(followeeProfile.followPolicy, ProfileFollowPolicy.OPEN),
   )!;
-  const visibleWhere = ctx.session?.profileId
+  const visibleWhere = ctx.session?.profile?.id
     ? or(
-        eq(ProfileFollows.followerProfileId, ctx.session.profileId),
-        eq(ProfileFollows.followeeProfileId, ctx.session.profileId),
+        eq(ProfileFollows.followerProfileId, ctx.session.profile.id),
+        eq(ProfileFollows.followeeProfileId, ctx.session.profile.id),
         publicFollowWhere,
       )
     : publicFollowWhere;

--- a/apps/api/src/graphql/resolvers/profile/field/follow-request.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow-request.ts
@@ -52,7 +52,7 @@ builder.objectFields(Profile, (t) => ({
     type: ProfileFollowRequest,
     nullable: true,
     resolve: (profile, args, ctx) =>
-      ctx.session?.profileId === profile.id
+      ctx.session?.profile?.id === profile.id
         ? resolveRequestConnection(ctx, profile.id, ProfileFollowRequests.followeeProfileId, args)
         : null,
   }),
@@ -60,7 +60,7 @@ builder.objectFields(Profile, (t) => ({
     type: ProfileFollowRequest,
     nullable: true,
     resolve: (profile, args, ctx) =>
-      ctx.session?.profileId === profile.id
+      ctx.session?.profile?.id === profile.id
         ? resolveRequestConnection(ctx, profile.id, ProfileFollowRequests.followerProfileId, args)
         : null,
   }),

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -1,4 +1,5 @@
 import { db, Instances, ProfileFollows, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, getColumns, gt, lt } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
@@ -114,7 +115,7 @@ builder.objectFields(Profile, (t) => ({
   }),
   followersCount: t.exposeInt('followersCount'),
   followingCount: t.exposeInt('followingCount'),
-  viewerState: t.withAuth({ usingProfile: true }).field({
+  viewerState: t.withAuth({ profileRole: AccountProfileRole.MEMBER }).field({
     type: ProfileViewerState,
     nullable: true,
     unauthorizedResolver: () => null,

--- a/apps/api/src/graphql/resolvers/profile/field/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/follow.ts
@@ -120,7 +120,7 @@ builder.objectFields(Profile, (t) => ({
     nullable: true,
     unauthorizedResolver: () => null,
     resolve: async (profile, _, ctx) => {
-      const viewerProfileId = ctx.session.profileId;
+      const viewerProfileId = ctx.session.profile.id;
       const [follow, followRequest, membership, profileMute] = await Promise.all([
         viewerFollowLoader(ctx).load(profile.id),
         viewerFollowRequestLoader(ctx).load(profile.id),

--- a/apps/api/src/graphql/resolvers/profile/field/mute.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/mute.ts
@@ -20,7 +20,7 @@ builder.objectField(Profile, 'profileMutes', (t) =>
     {
       type: ProfileMute,
       resolve: (profile, args, ctx) => {
-        if (profile.id !== ctx.session.profileId) {
+        if (profile.id !== ctx.session.profile.id) {
           throw new PermissionDeniedError('Profile mute owner is required');
         }
 

--- a/apps/api/src/graphql/resolvers/profile/field/mute.ts
+++ b/apps/api/src/graphql/resolvers/profile/field/mute.ts
@@ -1,4 +1,5 @@
 import { db, Instances, ProfileMutes, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { PermissionDeniedError } from '@kosmo/core/error';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
 import { and, asc, desc, eq, getColumns, gt, isNull, lt } from 'drizzle-orm';
@@ -15,7 +16,7 @@ builder.objectField(ProfileMute, 'targetProfile', (t) =>
 );
 
 builder.objectField(Profile, 'profileMutes', (t) =>
-  t.withAuth({ usingProfile: true }).connection(
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).connection(
     {
       type: ProfileMute,
       resolve: (profile, args, ctx) => {

--- a/apps/api/src/graphql/resolvers/profile/loader/follow-request.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow-request.ts
@@ -10,7 +10,7 @@ export const viewerFollowRequestLoader = (ctx: UserContext) =>
     name: 'profileFollowRequest.viewerFollowRequest',
     nullable: true,
     load: async (ids) => {
-      if (!ctx.session?.profileId) {
+      if (!ctx.session?.profile?.id) {
         return [];
       }
 
@@ -19,7 +19,7 @@ export const viewerFollowRequestLoader = (ctx: UserContext) =>
         .from(ProfileFollowRequests)
         .where(
           and(
-            eq(ProfileFollowRequests.followerProfileId, ctx.session.profileId),
+            eq(ProfileFollowRequests.followerProfileId, ctx.session.profile.id),
             inArray(ProfileFollowRequests.followeeProfileId, ids),
           ),
         );

--- a/apps/api/src/graphql/resolvers/profile/loader/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/follow.ts
@@ -16,7 +16,7 @@ export const viewerFollowLoader = (ctx: UserContext) =>
     name: 'profileFollow.viewerFollow',
     nullable: true,
     load: async (ids) => {
-      if (!ctx.session?.profileId) {
+      if (!ctx.session?.profile?.id) {
         return [];
       }
 
@@ -29,7 +29,7 @@ export const viewerFollowLoader = (ctx: UserContext) =>
         .innerJoin(FolloweeInstances, eq(FolloweeInstances.id, FolloweeProfiles.instanceId))
         .where(
           and(
-            eq(ProfileFollows.followerProfileId, ctx.session.profileId),
+            eq(ProfileFollows.followerProfileId, ctx.session.profile.id),
             inArray(ProfileFollows.followeeProfileId, ids),
             profileFollowAccessWhere({
               ctx,

--- a/apps/api/src/graphql/resolvers/profile/loader/mute.ts
+++ b/apps/api/src/graphql/resolvers/profile/loader/mute.ts
@@ -9,7 +9,7 @@ export const viewerProfileMuteLoader = (ctx: UserContext) =>
     name: 'profileMute.viewerProfileMute',
     nullable: true,
     load: async (targetProfileIds) => {
-      if (!ctx.session?.profileId) {
+      if (!ctx.session?.profile?.id) {
         return [];
       }
 
@@ -20,7 +20,7 @@ export const viewerProfileMuteLoader = (ctx: UserContext) =>
         .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
         .where(
           and(
-            eq(ProfileMutes.ownerProfileId, ctx.session.profileId),
+            eq(ProfileMutes.ownerProfileId, ctx.session.profile.id),
             inArray(ProfileMutes.targetProfileId, targetProfileIds),
             isNull(ProfileMutes.expiresAt),
             visibleProfileWhere({ profile: Profiles, instance: Instances }),
@@ -35,7 +35,7 @@ export const profileMuteByIdLoader = (ctx: UserContext) =>
     name: 'profileMute.byId',
     nullable: true,
     load: async (ids) => {
-      if (!ctx.session?.profileId) {
+      if (!ctx.session?.profile?.id) {
         return [];
       }
 
@@ -47,7 +47,7 @@ export const profileMuteByIdLoader = (ctx: UserContext) =>
         .where(
           and(
             inArray(ProfileMutes.id, ids),
-            eq(ProfileMutes.ownerProfileId, ctx.session.profileId),
+            eq(ProfileMutes.ownerProfileId, ctx.session.profile.id),
             isNull(ProfileMutes.expiresAt),
             visibleProfileWhere({ profile: Profiles, instance: Instances }),
           ),

--- a/apps/api/src/graphql/resolvers/profile/mutation/follow-request.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/follow-request.ts
@@ -27,7 +27,7 @@ builder.mutationField('approveProfileFollowRequest', (t) =>
     },
     resolve: (_, { input }, ctx) =>
       approveProfileFollowRequest({
-        actorProfileId: ctx.session.profileId,
+        actorProfileId: ctx.session.profile.id,
         profileFollowRequestId: input.id.id,
       }),
   }),
@@ -51,7 +51,7 @@ builder.mutationField('rejectProfileFollowRequest', (t) =>
     },
     resolve: (_, { input }, ctx) =>
       rejectProfileFollowRequest({
-        actorProfileId: ctx.session.profileId,
+        actorProfileId: ctx.session.profile.id,
         profileFollowRequestId: input.id.id,
       }),
   }),
@@ -75,7 +75,7 @@ builder.mutationField('cancelProfileFollowRequest', (t) =>
     },
     resolve: (_, { input }, ctx) =>
       cancelProfileFollowRequest({
-        actorProfileId: ctx.session.profileId,
+        actorProfileId: ctx.session.profile.id,
         profileFollowRequestId: input.id.id,
       }),
   }),

--- a/apps/api/src/graphql/resolvers/profile/mutation/follow-request.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/follow-request.ts
@@ -1,3 +1,4 @@
+import { AccountProfileRole } from '@kosmo/core/enums';
 import {
   approveProfileFollowRequest,
   cancelProfileFollowRequest,
@@ -7,7 +8,7 @@ import { builder } from '@/graphql/builder';
 import { Profile, ProfileFollow, ProfileFollowRequest } from '../ref';
 
 builder.mutationField('approveProfileFollowRequest', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('ApproveProfileFollowRequestPayload', {
       fields: (field) => ({
         followeeProfile: field.field({ type: Profile }),
@@ -33,7 +34,7 @@ builder.mutationField('approveProfileFollowRequest', (t) =>
 );
 
 builder.mutationField('rejectProfileFollowRequest', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('RejectProfileFollowRequestPayload', {
       fields: (field) => ({
         followeeProfile: field.field({ type: Profile }),
@@ -57,7 +58,7 @@ builder.mutationField('rejectProfileFollowRequest', (t) =>
 );
 
 builder.mutationField('cancelProfileFollowRequest', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('CancelProfileFollowRequestPayload', {
       fields: (field) => ({
         followerProfile: field.field({ type: Profile }),

--- a/apps/api/src/graphql/resolvers/profile/mutation/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/follow.ts
@@ -1,3 +1,4 @@
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { ConflictError } from '@kosmo/core/error';
 import { followProfile } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
@@ -18,7 +19,7 @@ const ProfileFollowResult = builder.unionType('ProfileFollowResult', {
 });
 
 builder.mutationField('followProfile', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('FollowProfilePayload', {
       fields: (field) => ({
         followeeProfile: field.field({ type: Profile }),

--- a/apps/api/src/graphql/resolvers/profile/mutation/follow.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/follow.ts
@@ -32,7 +32,7 @@ builder.mutationField('followProfile', (t) =>
     },
     resolve: async (_, { input }, ctx) => {
       const result = await followProfile({
-        followerProfileId: ctx.session.profileId,
+        followerProfileId: ctx.session.profile.id,
         followeeProfileId: input.id.id,
       }).catch((error: unknown) => {
         if (error instanceof ConflictError) {

--- a/apps/api/src/graphql/resolvers/profile/mutation/mute.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/mute.ts
@@ -15,7 +15,7 @@ builder.mutationField('muteProfile', (t) =>
     },
     resolve: async (_, { input }, ctx) => ({
       profileMute: await muteProfile({
-        ownerProfileId: ctx.session.profileId,
+        ownerProfileId: ctx.session.profile.id,
         targetProfileId: input.id.id,
       }),
     }),
@@ -40,7 +40,7 @@ builder.mutationField('unmuteProfile', (t) =>
     },
     resolve: async (_, { input }, ctx) => {
       const profileMute = await unmuteProfile({
-        ownerProfileId: ctx.session.profileId,
+        ownerProfileId: ctx.session.profile.id,
         profileMuteId: input.id.id,
       });
 

--- a/apps/api/src/graphql/resolvers/profile/mutation/mute.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/mute.ts
@@ -1,9 +1,10 @@
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { muteProfile, unmuteProfile } from '@kosmo/core/services';
 import { builder } from '@/graphql/builder';
 import { Profile, ProfileMute } from '../ref';
 
 builder.mutationField('muteProfile', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('MuteProfilePayload', {
       fields: (field) => ({
         profileMute: field.field({ type: ProfileMute }),
@@ -22,7 +23,7 @@ builder.mutationField('muteProfile', (t) =>
 );
 
 builder.mutationField('unmuteProfile', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('UnmuteProfilePayload', {
       fields: (field) => ({
         profileMuteId: field.globalID({

--- a/apps/api/src/graphql/resolvers/profile/mutation/select.test.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/select.test.ts
@@ -16,20 +16,23 @@ test('selectProfile updates the request identity before the next mutation field'
   builder.mutationField('selectProfileObservedProfileRole', (t) =>
     t.withAuth({ profileRole: AccountProfileRole.MEMBER }).field({
       type: 'String',
-      resolve: (_source, _args, context) => context.session.profileRole,
+      resolve: (_source, _args, context) => context.session.profile.role,
     }),
   );
   builder.mutationField('selectProfileObservedOwnerRole', (t) =>
     t.withAuth({ profileRole: AccountProfileRole.OWNER }).field({
       type: 'String',
-      resolve: (_source, _args, context) => context.session.profileRole,
+      resolve: (_source, _args, context) => context.session.profile.role,
     }),
   );
   const testSchema = builder.toSchema();
 
   let transactionCount = 0;
   let queryMode: 'select' | 'update' = 'select';
-  const selectedProfile = { id: selectedProfileId, profileRole: AccountProfileRole.MEMBER };
+  const selectedProfile = {
+    profile: { id: selectedProfileId },
+    role: AccountProfileRole.MEMBER,
+  };
   const chain = {
     from: () => chain,
     innerJoin: () => chain,
@@ -58,7 +61,7 @@ test('selectProfile updates the request identity before the next mutation field'
     return callback(tx as never);
   });
   const context = {
-    session: { id: sessionId, accountId: 'account-id', profileId: null, profileRole: null },
+    session: { id: sessionId, accountId: 'account-id', profile: null },
   } as unknown as UserContext;
 
   const result = await graphql({
@@ -83,8 +86,10 @@ test('selectProfile updates the request identity before the next mutation field'
   assert.equal(data?.selectProfileObservedProfileRole, AccountProfileRole.MEMBER);
   assert.equal(transactionCount, 1);
   assert.ok(context.session);
-  assert.equal(context.session.profileId, selectedProfileId);
-  assert.equal(context.session.profileRole, AccountProfileRole.MEMBER);
+  assert.deepEqual(context.session.profile, {
+    id: selectedProfileId,
+    role: AccountProfileRole.MEMBER,
+  });
 
   const ownerResult = await graphql({
     schema: testSchema,
@@ -97,7 +102,10 @@ test('selectProfile updates the request identity before the next mutation field'
 
   const ownerContext = {
     ...context,
-    session: { ...context.session, profileRole: AccountProfileRole.OWNER },
+    session: {
+      ...context.session,
+      profile: { id: selectedProfileId, role: AccountProfileRole.OWNER },
+    },
   };
   const ownerAsMemberResult = await graphql({
     schema: testSchema,
@@ -116,7 +124,7 @@ test('selectProfile updates the request identity before the next mutation field'
     source: 'mutation { selectProfileObservedProfileRole }',
     contextValue: {
       ...context,
-      session: { ...context.session, profileId: null, profileRole: null },
+      session: { ...context.session, profile: null },
     },
   });
 

--- a/apps/api/src/graphql/resolvers/profile/mutation/select.test.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/select.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { db } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { encodeGlobalId } from '@kosmo/core/global-id';
 import { graphql } from 'graphql';
 import { builder } from '@/graphql/builder';
@@ -12,17 +13,23 @@ const sessionId = '00000000-0000-8000-8000-000000000002';
 test('selectProfile updates the request identity before the next mutation field', async (t) => {
   const { schema } = await import('@/graphql/schema');
   assert.ok(schema.getMutationType()?.getFields().selectProfile);
-  builder.mutationField('selectProfileObservedUsingProfile', (t) =>
-    t.withAuth({ usingProfile: true }).field({
+  builder.mutationField('selectProfileObservedProfileRole', (t) =>
+    t.withAuth({ profileRole: AccountProfileRole.MEMBER }).field({
       type: 'String',
-      resolve: (_source, _args, context) => context.session.profileId,
+      resolve: (_source, _args, context) => context.session.profileRole,
+    }),
+  );
+  builder.mutationField('selectProfileObservedOwnerRole', (t) =>
+    t.withAuth({ profileRole: AccountProfileRole.OWNER }).field({
+      type: 'String',
+      resolve: (_source, _args, context) => context.session.profileRole,
     }),
   );
   const testSchema = builder.toSchema();
 
   let transactionCount = 0;
   let queryMode: 'select' | 'update' = 'select';
-  const selectedProfile = { id: selectedProfileId };
+  const selectedProfile = { id: selectedProfileId, profileRole: AccountProfileRole.MEMBER };
   const chain = {
     from: () => chain,
     innerJoin: () => chain,
@@ -51,7 +58,7 @@ test('selectProfile updates the request identity before the next mutation field'
     return callback(tx as never);
   });
   const context = {
-    session: { id: sessionId, accountId: 'account-id', profileId: null },
+    session: { id: sessionId, accountId: 'account-id', profileId: null, profileRole: null },
   } as unknown as UserContext;
 
   const result = await graphql({
@@ -61,7 +68,7 @@ test('selectProfile updates the request identity before the next mutation field'
         selectProfile(input: { id: "${encodeGlobalId('Profile', selectedProfileId)}" }) {
           profile { id }
         }
-        selectProfileObservedUsingProfile
+        selectProfileObservedProfileRole
       }
     `,
     contextValue: context,
@@ -70,11 +77,49 @@ test('selectProfile updates the request identity before the next mutation field'
   assert.equal(result.errors, undefined, JSON.stringify(result.errors));
   const data = result.data as {
     selectProfile?: { profile?: { id?: string } };
-    selectProfileObservedUsingProfile?: string;
+    selectProfileObservedProfileRole?: string;
   } | null;
   assert.equal(data?.selectProfile?.profile?.id, encodeGlobalId('Profile', selectedProfileId));
-  assert.equal(data?.selectProfileObservedUsingProfile, selectedProfileId);
+  assert.equal(data?.selectProfileObservedProfileRole, AccountProfileRole.MEMBER);
   assert.equal(transactionCount, 1);
   assert.ok(context.session);
   assert.equal(context.session.profileId, selectedProfileId);
+  assert.equal(context.session.profileRole, AccountProfileRole.MEMBER);
+
+  const ownerResult = await graphql({
+    schema: testSchema,
+    source: 'mutation { selectProfileObservedOwnerRole }',
+    contextValue: context,
+  });
+
+  assert.equal(ownerResult.data, null);
+  assert.match(ownerResult.errors?.[0]?.message ?? '', /Not authorized/);
+
+  const ownerContext = {
+    ...context,
+    session: { ...context.session, profileRole: AccountProfileRole.OWNER },
+  };
+  const ownerAsMemberResult = await graphql({
+    schema: testSchema,
+    source: 'mutation { selectProfileObservedProfileRole }',
+    contextValue: ownerContext,
+  });
+
+  assert.equal(ownerAsMemberResult.errors, undefined, JSON.stringify(ownerAsMemberResult.errors));
+  assert.equal(
+    ownerAsMemberResult.data?.selectProfileObservedProfileRole,
+    AccountProfileRole.OWNER,
+  );
+
+  const noProfileResult = await graphql({
+    schema: testSchema,
+    source: 'mutation { selectProfileObservedProfileRole }',
+    contextValue: {
+      ...context,
+      session: { ...context.session, profileId: null, profileRole: null },
+    },
+  });
+
+  assert.equal(noProfileResult.data, null);
+  assert.match(noProfileResult.errors?.[0]?.message ?? '', /Not authorized/);
 });

--- a/apps/api/src/graphql/resolvers/profile/mutation/select.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/select.ts
@@ -29,7 +29,7 @@ builder.mutationField('selectProfile', (t) =>
     resolve: async (_, { input }, ctx) => {
       const profile = await db.transaction(async (tx) => {
         const profile = await tx
-          .select(getColumns(Profiles))
+          .select({ ...getColumns(Profiles), profileRole: AccountProfiles.role })
           .from(Profiles)
           .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
           .leftJoin(AccountProfiles, and(eq(AccountProfiles.profileId, Profiles.id)))
@@ -54,6 +54,7 @@ builder.mutationField('selectProfile', (t) =>
       });
 
       ctx.session.profileId = profile.id;
+      ctx.session.profileRole = profile.profileRole;
       RequestCache.clearForContext(ctx);
 
       return { profile, session: ctx.session.id };

--- a/apps/api/src/graphql/resolvers/profile/mutation/select.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/select.ts
@@ -9,7 +9,7 @@ import {
 } from '@kosmo/core/db';
 import { NotFoundError } from '@kosmo/core/error';
 import { RequestCache } from '@pothos/plugin-scope-auth';
-import { and, eq, getColumns } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { builder } from '@/graphql/builder';
 import { Session } from '@/graphql/resolvers/session/ref';
 import { visibleProfileWhere } from '@/profile/visibility';
@@ -29,14 +29,19 @@ builder.mutationField('selectProfile', (t) =>
     resolve: async (_, { input }, ctx) => {
       const profile = await db.transaction(async (tx) => {
         const profile = await tx
-          .select({ ...getColumns(Profiles), profileRole: AccountProfiles.role })
+          .select({ profile: Profiles, role: AccountProfiles.role })
           .from(Profiles)
           .innerJoin(Instances, eq(Instances.id, Profiles.instanceId))
-          .leftJoin(AccountProfiles, and(eq(AccountProfiles.profileId, Profiles.id)))
+          .innerJoin(
+            AccountProfiles,
+            and(
+              eq(AccountProfiles.profileId, Profiles.id),
+              eq(AccountProfiles.accountId, ctx.session.accountId),
+            ),
+          )
           .where(
             and(
               eq(Profiles.id, input.id.id),
-              eq(AccountProfiles.accountId, ctx.session.accountId),
               visibleProfileWhere({ profile: Profiles, instance: Instances }),
             ),
           )
@@ -45,7 +50,7 @@ builder.mutationField('selectProfile', (t) =>
 
         await tx
           .update(Sessions)
-          .set({ activeProfileId: profile.id })
+          .set({ activeProfileId: profile.profile.id })
           .where(eq(Sessions.id, ctx.session.id))
           .returning()
           .then(firstOrThrow);
@@ -53,11 +58,10 @@ builder.mutationField('selectProfile', (t) =>
         return profile;
       });
 
-      ctx.session.profileId = profile.id;
-      ctx.session.profileRole = profile.profileRole;
+      ctx.session.profile = { id: profile.profile.id, role: profile.role };
       RequestCache.clearForContext(ctx);
 
-      return { profile, session: ctx.session.id };
+      return { profile: profile.profile, session: ctx.session.id };
     },
   }),
 );

--- a/apps/api/src/graphql/resolvers/profile/mutation/unfollow.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/unfollow.ts
@@ -1,5 +1,5 @@
 import { ActivityPubActors, db, firstOrThrowWith, Instances, Profiles } from '@kosmo/core/db';
-import { InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
+import { AccountProfileRole, InstanceKind, InstanceState, ProfileState } from '@kosmo/core/enums';
 import { NotFoundError } from '@kosmo/core/error';
 import { unfollowProfile } from '@kosmo/core/services';
 import { and, eq, exists, inArray, isNotNull, ne, or } from 'drizzle-orm';
@@ -11,7 +11,7 @@ const FollowerProfiles = alias(Profiles, 'unfollow_follower_profile');
 const FollowerInstances = alias(Instances, 'unfollow_follower_instance');
 
 builder.mutationField('unfollowProfile', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('UnfollowProfilePayload', {
       fields: (field) => ({
         followeeProfile: field.field({ nullable: true, type: Profile }),

--- a/apps/api/src/graphql/resolvers/profile/mutation/unfollow.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/unfollow.ts
@@ -46,7 +46,7 @@ builder.mutationField('unfollowProfile', (t) =>
                 .innerJoin(FollowerInstances, eq(FollowerInstances.id, FollowerProfiles.instanceId))
                 .where(
                   and(
-                    eq(FollowerProfiles.id, ctx.session.profileId),
+                    eq(FollowerProfiles.id, ctx.session.profile.id),
                     eq(FollowerProfiles.state, ProfileState.ACTIVE),
                     eq(FollowerInstances.kind, InstanceKind.LOCAL),
                     ne(FollowerInstances.state, InstanceState.SUSPENDED),
@@ -63,14 +63,14 @@ builder.mutationField('unfollowProfile', (t) =>
         .then(firstOrThrowWith(() => new NotFoundError('Profile not found')));
 
       const result = await unfollowProfile({
-        followerProfileId: ctx.session.profileId,
+        followerProfileId: ctx.session.profile.id,
         followeeProfileId: input.id.id,
       });
       const profiles = await db
         .select()
         .from(Profiles)
-        .where(inArray(Profiles.id, [ctx.session.profileId, input.id.id]));
-      const followerProfile = profiles.find(({ id }) => id === ctx.session.profileId);
+        .where(inArray(Profiles.id, [ctx.session.profile.id, input.id.id]));
+      const followerProfile = profiles.find(({ id }) => id === ctx.session.profile.id);
       const followeeProfile = profiles.find(({ id }) => id === input.id.id);
       if (!followerProfile || !followeeProfile) {
         throw new NotFoundError('Profile not found');

--- a/apps/api/src/graphql/resolvers/profile/mutation/update.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/update.ts
@@ -26,7 +26,7 @@ builder.mutationField('updateProfile', (t) =>
       try {
         const result = await updateProfile({
           accountId: ctx.session.accountId,
-          profileId: ctx.session.profileId,
+          profileId: ctx.session.profile.id,
           displayName: input.displayName ?? undefined,
           bio: input.bio,
           followPolicy: input.followPolicy ?? undefined,

--- a/apps/api/src/graphql/resolvers/profile/mutation/update.ts
+++ b/apps/api/src/graphql/resolvers/profile/mutation/update.ts
@@ -1,4 +1,4 @@
-import { PostVisibility, ProfileFollowPolicy } from '@kosmo/core/enums';
+import { AccountProfileRole, PostVisibility, ProfileFollowPolicy } from '@kosmo/core/enums';
 import { ValidationError } from '@kosmo/core/error';
 import { updateProfile } from '@kosmo/core/services';
 import { profileBioSchema, profileTagsInputSchema } from '@kosmo/core/validation';
@@ -7,7 +7,7 @@ import { Media } from '../../media/ref';
 import { Profile } from '../ref';
 
 builder.mutationField('updateProfile', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('UpdateProfilePayload', {
       fields: (field) => ({
         profile: field.field({ type: Profile }),

--- a/apps/api/src/graphql/resolvers/reaction/field/post.ts
+++ b/apps/api/src/graphql/resolvers/reaction/field/post.ts
@@ -1,4 +1,5 @@
 import { db, Instances, Profiles, Reactions } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { ValidationError } from '@kosmo/core/error';
 import { reactionTypeSchema } from '@kosmo/core/validation';
 import { resolveCursorConnection } from '@pothos/plugin-relay';
@@ -75,7 +76,7 @@ const reactionProfileCursorWhere = (cursor: string | undefined, direction: 'afte
 };
 
 builder.objectFields(Post, (t) => ({
-  viewerReactions: t.withAuth({ usingProfile: true }).field({
+  viewerReactions: t.withAuth({ profileRole: AccountProfileRole.MEMBER }).field({
     type: [Reaction],
     unauthorizedResolver: () => [],
     resolve: (post, _, ctx) => viewerReactionLoader(ctx).load(post.id),

--- a/apps/api/src/graphql/resolvers/reaction/loader/viewer-reaction.ts
+++ b/apps/api/src/graphql/resolvers/reaction/loader/viewer-reaction.ts
@@ -9,7 +9,7 @@ export const viewerReactionLoader = (ctx: UserContext) =>
     name: 'reaction.viewerReactions',
     many: true,
     load: async (postIds) => {
-      if (!ctx.session?.profileId) {
+      if (!ctx.session?.profile?.id) {
         return [];
       }
 
@@ -17,7 +17,7 @@ export const viewerReactionLoader = (ctx: UserContext) =>
         .select(getColumns(Reactions))
         .from(Reactions)
         .where(
-          and(eq(Reactions.profileId, ctx.session.profileId), inArray(Reactions.postId, postIds)),
+          and(eq(Reactions.profileId, ctx.session.profile.id), inArray(Reactions.postId, postIds)),
         )
         .orderBy(asc(Reactions.postId), asc(Reactions.id));
     },

--- a/apps/api/src/graphql/resolvers/reaction/mutation/add.ts
+++ b/apps/api/src/graphql/resolvers/reaction/mutation/add.ts
@@ -35,7 +35,7 @@ builder.mutationField('addReaction', (t) =>
       }
 
       const result = await addReaction({
-        actorProfileId: ctx.session.profileId,
+        actorProfileId: ctx.session.profile.id,
         origin: 'LOCAL',
         postId: post.id,
         type: input.type,

--- a/apps/api/src/graphql/resolvers/reaction/mutation/add.ts
+++ b/apps/api/src/graphql/resolvers/reaction/mutation/add.ts
@@ -1,4 +1,5 @@
 import { db, first, Instances, Posts, Profiles } from '@kosmo/core/db';
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { NotFoundError } from '@kosmo/core/error';
 import { addReaction } from '@kosmo/core/services';
 import { reactionTypeSchema } from '@kosmo/core/validation';
@@ -9,7 +10,7 @@ import { postAccessWhere } from '../../post/access';
 import { Reaction } from '../ref';
 
 builder.mutationField('addReaction', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('AddReactionPayload', {
       fields: (field) => ({
         post: field.field({ type: Post }),

--- a/apps/api/src/graphql/resolvers/reaction/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/reaction/mutation/delete.ts
@@ -1,3 +1,4 @@
+import { AccountProfileRole } from '@kosmo/core/enums';
 import { deleteReaction } from '@kosmo/core/services';
 import { reactionTypeSchema } from '@kosmo/core/validation';
 import { builder } from '@/graphql/builder';
@@ -10,7 +11,7 @@ type DeleteReactionPayload = {
 };
 
 builder.mutationField('deleteReaction', (t) =>
-  t.withAuth({ usingProfile: true }).fieldWithInput({
+  t.withAuth({ profileRole: AccountProfileRole.MEMBER }).fieldWithInput({
     type: builder.simpleObject('DeleteReactionPayload', {
       fields: (field) => ({
         reactionId: field.globalID({

--- a/apps/api/src/graphql/resolvers/reaction/mutation/delete.ts
+++ b/apps/api/src/graphql/resolvers/reaction/mutation/delete.ts
@@ -33,7 +33,7 @@ builder.mutationField('deleteReaction', (t) =>
     },
     resolve: async (_, { input }, ctx): Promise<DeleteReactionPayload> => {
       const result = await deleteReaction({
-        actorProfileId: ctx.session.profileId,
+        actorProfileId: ctx.session.profile.id,
         origin: 'LOCAL',
         postId: input.postId.id,
         type: input.type,

--- a/apps/api/src/graphql/resolvers/session/field/session.ts
+++ b/apps/api/src/graphql/resolvers/session/field/session.ts
@@ -8,6 +8,6 @@ builder.objectFields(Session, (t) => ({
   selectedProfile: t.field({
     type: Profile,
     nullable: true,
-    resolve: (_, __, ctx) => ctx.session?.profileId ?? null,
+    resolve: (_, __, ctx) => ctx.session?.profile?.id ?? null,
   }),
 }));

--- a/apps/api/tests/integration/graphql/bookmark.test.ts
+++ b/apps/api/tests/integration/graphql/bookmark.test.ts
@@ -213,7 +213,7 @@ describe('Bookmark GraphQL 경계', () => {
     assert.equal(await countBookmarks(), 0);
   });
 
-  test('usingProfile context는 사용할 수 없는 actor를 거부하고 Instance 종류를 제한하지 않는다', async () => {
+  test('profileRole context는 사용할 수 없는 actor를 거부하고 Instance 종류를 제한하지 않는다', async () => {
     const author = await createProfile('actor-check-author');
     const post = await createPost(author.id);
     const suffix = crypto.randomUUID();

--- a/apps/api/tests/integration/graphql/post.test.ts
+++ b/apps/api/tests/integration/graphql/post.test.ts
@@ -772,7 +772,7 @@ describe('Post Reply GraphQL 경계', () => {
     assert.equal(await db.$count(Posts), 0);
   });
 
-  test('usingProfile context는 사용할 수 없는 actor를 거부하고 Instance 종류를 제한하지 않는다', async () => {
+  test('profileRole context는 사용할 수 없는 actor를 거부하고 Instance 종류를 제한하지 않는다', async () => {
     const parentAuthor = await createProfile('actor-check-parent');
     const parent = await createContentPost(parentAuthor.id);
     const remoteInstance = await createInstance(InstanceKind.ACTIVITYPUB, InstanceState.ACTIVE);

--- a/docs/architecture/core-services.md
+++ b/docs/architecture/core-services.md
@@ -49,9 +49,10 @@ Account–Profile membership으로 정한다. selected Profile은 Local 또는 R
 Locality가 action의 의미일 때만 core contract에 포함한다. 결과 객체의 Local/Remote 구분이나 저장 위치를
 actor Profile의 Instance Type 조건으로 확장하지 않는다.
 
-GraphQL `usingProfile` entry point가 Active Account, selected Profile membership과 Profile 조회 가능 상태를
-보장하면 resolver와 core action은 같은 Account·membership·Profile visibility를 다시 조회하지 않는다.
-core는 검증된 Profile identity를 받아 action에 고유한 상태, 관계, 대상과 persistence 조건만 검증한다.
+GraphQL `profileRole: AccountProfileRole.MEMBER` entry point가 Active Account, selected Profile
+membership·role과 Profile 조회 가능 상태를 보장하면 resolver와 core action은 같은 Account·membership·Profile
+visibility를 다시 조회하지 않는다. core는 검증된 Profile identity를 받아 action에 고유한 상태, 관계, 대상과
+persistence 조건만 검증한다.
 
 현재 Repost caller인 Local mutation은 session과 selected Profile membership을 검증한 뒤 core action에
 `actorProfileId`와 `sourcePostId`를 전달한다. 향후 ActivityPub Repost ingress가 생기면 signature와

--- a/memory/graphql-style.md
+++ b/memory/graphql-style.md
@@ -110,6 +110,7 @@ Mutation도 필드별로 나눈다.
 - 인증 scope 부족은 resolver에서 직접 던지지 않고 `t.withAuth({ login: true })` 같은 auth 설정으로 처리한다.
 - `login`과 `profileRole` resolver는 production context가 이미 검증한 Active Account, selected Profile
   membership·role과 조회 가능 상태를 별도 actor query로 반복 검증하지 않는다. `profileRole`은
+  `session.profile: { id, role } | null`에서 현재 selected Profile의 role을 검사하며,
   `AccountProfileRole.MEMBER`처럼 필요한 최소 role을 선언하고 Owner도 통과시키며, canonical action이
   추가 조건을 명시할 때만 그 조건을 조회한다. `Media.Source=Local`처럼 생성 결과의 source가 Local이라는
   사실만으로 selected Profile의 Instance 종류를 Local로 제한하지 않는다.

--- a/memory/graphql-style.md
+++ b/memory/graphql-style.md
@@ -108,10 +108,11 @@ Mutation도 필드별로 나눈다.
 - domain error는 result union으로 반환하지 않고 GraphQL `errors[]` 경로로 전달한다.
 - Zod/Pothos validation 실패는 builder의 `validation.validationError`가 `ValidationError`로 변환한다.
 - 인증 scope 부족은 resolver에서 직접 던지지 않고 `t.withAuth({ login: true })` 같은 auth 설정으로 처리한다.
-- `login`과 `usingProfile` resolver는 production context가 이미 검증한 Active Account, selected Profile
-  membership과 조회 가능 상태를 별도 actor query로 반복 검증하지 않는다. canonical action이 추가 조건을
-  명시할 때만 그 조건을 조회한다. `Media.Source=Local`처럼 생성 결과의 source가 Local이라는 사실만으로
-  selected Profile의 Instance 종류를 Local로 제한하지 않는다.
+- `login`과 `profileRole` resolver는 production context가 이미 검증한 Active Account, selected Profile
+  membership·role과 조회 가능 상태를 별도 actor query로 반복 검증하지 않는다. `profileRole`은
+  `AccountProfileRole.MEMBER`처럼 필요한 최소 role을 선언하고 Owner도 통과시키며, canonical action이
+  추가 조건을 명시할 때만 그 조건을 조회한다. `Media.Source=Local`처럼 생성 결과의 source가 Local이라는
+  사실만으로 selected Profile의 Instance 종류를 Local로 제한하지 않는다.
 - resolver에서 환경 변수 묶음을 별도 Zod object로 다시 파싱하지 않는다. 중앙 env 모듈이 없는 현재
   runtime에서는 필요한 값을 직접 읽고 필수값 부재만 진입점에서 실패시키며, URL처럼 실제 사용 시 생성자가
   검증하는 값은 중복 schema를 두지 않는다.

--- a/packages/core/enums.ts
+++ b/packages/core/enums.ts
@@ -3,6 +3,10 @@ export const AccountProfileRole = {
   MEMBER: 'MEMBER',
 } as const;
 export type AccountProfileRole = keyof typeof AccountProfileRole;
+export const AccountProfileRoleOrder = [
+  AccountProfileRole.MEMBER,
+  AccountProfileRole.OWNER,
+] as const;
 
 export const AccountState = {
   ACTIVE: 'ACTIVE',


### PR DESCRIPTION
## 무엇을 변경했나요

- 선택 프로필 scope를 `usingProfile: true`에서 `profileRole: AccountProfileRole.MEMBER`로 전환했습니다.
- 기존 context의 AccountProfiles 조인에서 role을 함께 읽고, scope에서는 추가 조회 없이 최소 역할을 비교합니다.
- `AccountProfileRoleOrder = [MEMBER, OWNER]` const 배열을 추가했습니다.
- 선택 프로필은 `session.profile: { id, role } | null`로 표현하고, 전환 시 객체를 한 번에 교체하며 기존 scope 캐시 초기화를 유지했습니다.

## 왜 변경했나요

선택 프로필의 유효성과 멤버십 확인에 필요한 최소 역할을 함께 선언하기 위해서입니다. Member를 요구하면 Owner도 허용하며, 기존 호출부의 접근 권한과 공개 GraphQL SDL은 유지합니다.

## 이번 PR의 주요 결정

- 사용자와 합의해 별도 role scope를 추가하는 대신 usingProfile을 역할 매개변수를 받는 profileRole로 대체했습니다.
- 역할 우선순위는 const 배열 하나로 관리하고, context 생성 시 이미 조회하는 데이터를 재사용합니다.
- 사용자가 제안한 `profile: { id, role } | null` 구조로 선택 프로필 ID와 역할이 함께 존재하도록 표현합니다.
- 기존 core service의 Owner 검사와 오류 계약은 유지합니다. 기존 동작을 보존하는 내부 리팩터링으로 신규 OpenSpec은 만들지 않았습니다.

Stack: main → refactor-profile-role-scope

## 어떻게 확인할 수 있나요

- `pnpm --filter @kosmo/api lint:tsc` 통과
- `pnpm --filter @kosmo/api test:unit` 29/29 통과
- `pnpm --filter @kosmo/api lint:schema` 통과
- 변경 파일 ESLint, Prettier, diff check 통과
- Owner가 Member 요구 조건을 통과하고, Member는 Owner 요구 조건에서 거부되며, 선택 프로필이 없으면 거부되는 행동 검증 포함
- Luna scope_context가 context/scope 및 집중 테스트, profile_checks가 호출부/문서 및 API 검증을 수행했습니다. Ponytail 최종 검토를 완료했습니다.

## 아직 어떤 문제가 남았나요

로컬 PostgreSQL(127.0.0.1:54329)이 실행 중이 아니어서 DB 통합 테스트는 실행하지 못했습니다. CI 결과는 별도로 확인해야 합니다.

