### PR TITLE
Android 버전 코드를 실행 순번으로 증가시킨다

### DIFF
--- a/.github/workflows/android-play-internal-distribution.yml
+++ b/.github/workflows/android-play-internal-distribution.yml
@@ -90,8 +90,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # ponytail: avoid a pre-build Play API query; replace this offset before 2086.
-          version_code=$(( $(date -u +%s) - 1577836800 ))
+          # Keep reruns on the same run number at the same version code.
+          version_code=$(( 210579434 + GITHUB_RUN_NUMBER ))
           if (( version_code < 1 || version_code > 2147483647 )); then
             echo "::error::KOSMO_ANDROID_VERSION_CODE is outside the signed 32-bit Android limit."
             exit 1

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -25,7 +25,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 
 ## Android Google Play closed testing (Alpha)
 
-`Android Google Play Alpha Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, Fastlane이 upload key로 서명한 Release AAB를 빌드해 Google Play closed testing의 Alpha track에 업로드한다. Play가 package name, versionCode, upload certificate를 검증한다. versionCode는 workflow 시작 시 UTC Unix seconds에서 `2020-01-01`을 뺀 값으로 계산하며, 첫 수동 release의 versionCode `1`보다 크고 Android signed 32-bit 범위 안에 있다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다. 기존 internal testing release는 Play Console에 남아 있으며 이 workflow가 변경하지 않는다.
+`Android Google Play Alpha Distribution`은 `main`에서만 수동 실행하는 protected workflow다. 매 실행마다 clean CNG Android project를 만들고, Fastlane이 upload key로 서명한 Release AAB를 빌드해 Google Play closed testing의 Alpha track에 업로드한다. Play가 package name, versionCode, upload certificate를 검증한다. versionCode는 고정 기준값 `210579434`에 GitHub Actions `run_number`를 더해 계산하므로 새 workflow run마다 증가하고, 같은 run의 재실행에서는 같은 값을 유지한다. 결과는 양의 정수이며 Android signed 32-bit 범위 안에 있다. 이미 업로드에 성공한 run을 재실행하면 같은 versionCode를 다시 사용하므로 새 AAB를 업로드할 수 없다. 새 versionCode가 필요하면 새 workflow run을 시작한다. Play API를 미리 조회하거나 장기 credential을 저장하지 않는다. 기존 internal testing release는 Play Console에 남아 있으며 이 workflow가 변경하지 않는다.
 
 이 앱의 Play app, Google 관리 Play App Signing, upload key는 이미 설정되어 있다. Alpha track의 첫 signed AAB는 이 workflow가 업로드한다. 앱이 아직 draft 상태인 최초 실행에서는 workflow dispatch의 `release_status`를 `draft`로 선택하고, 업로드 후 Play Console에서 Alpha release를 검토 제출한다. 앱 검토가 끝나 draft 상태를 벗어난 뒤의 실행은 기본값인 `completed`를 사용한다. Play Console에서 다음 Alpha 설정과 CI 자산을 확인한다.
 


### PR DESCRIPTION
## 무엇을 변경했는지

- Android `versionCode` 계산을 UTC Unix seconds 기반에서 고정 기준값 `210579434`와 GitHub Actions `run_number`의 합으로 변경했습니다.
- `apps/app/README.md`에 새 run마다 증가하고 같은 run 재실행에서는 동일 값을 유지하는 동작을 문서화했습니다.

## 왜 변경했는지

초 단위 시간에 의존하는 값 대신 workflow run마다 1씩 증가하는 값을 사용해 기존에 게시된 `210579434`보다 높은 versionCode를 안정적으로 생성하기 위해서입니다.

## 이번 PR의 주요 결정

- 고정 기준값 `210579434`에 `GITHUB_RUN_NUMBER`를 더하는 방식은 사용자가 승인한 결정입니다.
- 같은 run을 재실행하면 같은 versionCode를 사용하므로, 이미 업로드에 성공한 run을 다시 업로드하지 않고 새 workflow run을 시작해야 합니다.
- 기존 Android signed 32-bit 범위 검증은 유지했습니다.

## 어떻게 확인할 수 있는지

- `git diff --check`를 통과했습니다.
- workflow YAML/Bash 구문과 versionCode 계산을 확인했습니다.
- run number `6`, `7`, 동일 run 재실행 및 signed 32-bit 경계 계산을 확인했습니다.

## 아직 어떤 문제가 남아 있는지

- 이 PR에서는 실제 Android AAB 빌드·Google Play 업로드·Play Console 확인을 실행하지 않았습니다.
- 이미 업로드된 run을 재실행하면 versionCode가 같으므로 새 versionCode가 필요할 때는 새 workflow run을 시작해야 합니다.

Stack: `main -> PROD-285-version-code`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>