### PR TITLE
네이티브에서도 알림 모두 읽음과 미확인 표시를 제공한다

### DIFF
--- a/apps/app/src/components/notification/NotificationList.tsx
+++ b/apps/app/src/components/notification/NotificationList.tsx
@@ -314,10 +314,7 @@ function NotificationPageHeader() {
     '알림';
 
   return shellOwnsHeader ? null : (
-    <PageHeader
-      title="알림"
-      trailing={Platform.OS === 'web' ? <NotificationReadAllAction /> : undefined}
-    />
+    <PageHeader title="알림" trailing={<NotificationReadAllAction />} />
   );
 }
 

--- a/apps/app/src/components/notification/NotificationList.tsx
+++ b/apps/app/src/components/notification/NotificationList.tsx
@@ -1,5 +1,5 @@
 import { usePathname, useSegments } from 'expo-router';
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import {
   Platform,
   RefreshControl,
@@ -9,12 +9,11 @@ import {
   useWindowDimensions,
   View,
 } from 'react-native';
-import { graphql, useMutation, usePaginationFragment } from 'react-relay';
+import { graphql, usePaginationFragment } from 'react-relay';
 import { PageHeader } from '@/components/PageHeader';
 import { getWebMobileShellHeader } from '@/components/shell/shellLayout';
 import { Button } from '@/components/ui/Button';
 import { Skeleton, StateView } from '@/components/ui/StateView';
-import { useToast } from '@/components/ui/ToastProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import { spacing } from '@/theme/tokens';
 import {
@@ -26,27 +25,11 @@ import {
 } from './NotificationListItem';
 import { NotificationReadAllAction, useNotificationReadAll } from './NotificationReadAllContext';
 import type { NotificationList_profile$key } from './__generated__/NotificationList_profile.graphql';
-import type { NotificationListMarkAllReadMutation } from './__generated__/NotificationListMarkAllReadMutation.graphql';
 import type { NotificationListNextPageQuery } from './__generated__/NotificationListNextPageQuery.graphql';
 
 type NotificationListProps = {
   profile: NotificationList_profile$key;
 };
-
-const notificationListMarkAllReadMutation = graphql`
-  mutation NotificationListMarkAllReadMutation($ids: [ID!]!) {
-    markNotificationRead(input: { ids: $ids }) {
-      notifications {
-        id
-        readAt
-      }
-      recipientProfiles {
-        id
-        unreadNotificationCount
-      }
-    }
-  }
-`;
 
 const notificationListFragment = graphql`
   fragment NotificationList_profile on Profile
@@ -87,77 +70,16 @@ export function NotificationList({ profile }: NotificationListProps) {
     NotificationListNextPageQuery,
     NotificationList_profile$key
   >(notificationListFragment, profile);
-  const { invoke, register } = useNotificationReadAll();
-  const { showToast } = useToast();
-  const [commitMarkAllRead, isMarkAllReadInFlight] =
-    useMutation<NotificationListMarkAllReadMutation>(notificationListMarkAllReadMutation);
+  const { publishUnreadIds } = useNotificationReadAll();
   const [loadError, setLoadError] = useState(false);
   const [refreshing, startTransition] = useTransition();
-  const [readAllPending, setReadAllPending] = useState(false);
-  const readAllInFlight = useRef(false);
-  const mounted = useRef(false);
-  const currentUnreadIds = useRef<ReadonlyArray<string>>([]);
-  const unreadNotificationIds = pagination.data.notifications.edges.flatMap(({ node }) =>
-    node.readAt === null ? [node.id] : [],
-  );
-  currentUnreadIds.current = unreadNotificationIds;
-  const markAllRead = useCallback(() => {
-    if (readAllInFlight.current || readAllPending || isMarkAllReadInFlight) {
-      return;
-    }
-
-    const ids = currentUnreadIds.current;
-    if (ids.length === 0) {
-      return;
-    }
-
-    readAllInFlight.current = true;
-    setReadAllPending(true);
-    const handleFailure = () => {
-      readAllInFlight.current = false;
-      if (!mounted.current) {
-        return;
-      }
-      setReadAllPending(false);
-      showToast('알림을 모두 읽지 못했어요.', {
-        action: { label: '다시 시도', onPress: invoke },
-        tone: 'danger',
-      });
-    };
-    commitMarkAllRead({
-      onCompleted: (response, errors) => {
-        if (errors?.length || response.markNotificationRead == null) {
-          handleFailure();
-          return;
-        }
-        readAllInFlight.current = false;
-        if (mounted.current) {
-          setReadAllPending(false);
-        }
-      },
-      onError: handleFailure,
-      variables: { ids: [...ids] },
-    });
-  }, [commitMarkAllRead, invoke, isMarkAllReadInFlight, readAllPending, showToast]);
-
-  useEffect(() => {
-    mounted.current = true;
-    return () => {
-      mounted.current = false;
-      readAllInFlight.current = false;
-    };
-  }, []);
+  const { edges } = pagination.data.notifications;
 
   useEffect(
-    () =>
-      register({
-        busy: readAllPending || isMarkAllReadInFlight,
-        disabled: readAllPending || isMarkAllReadInFlight || unreadNotificationIds.length === 0,
-        onPress: markAllRead,
-      }),
-    [isMarkAllReadInFlight, markAllRead, readAllPending, register, unreadNotificationIds.length],
+    () => publishUnreadIds(edges.flatMap(({ node }) => (node.readAt === null ? [node.id] : []))),
+    [edges, publishUnreadIds],
   );
-  const notifications = pagination.data.notifications.edges.flatMap(({ node }) => {
+  const notifications = edges.flatMap(({ node }) => {
     if (node.__typename === 'FollowNotification' && node.follow) {
       return <NotificationListItem key={node.id} notification={node.follow} />;
     }

--- a/apps/app/src/components/notification/NotificationListItem.tsx
+++ b/apps/app/src/components/notification/NotificationListItem.tsx
@@ -289,15 +289,10 @@ function NotificationRow({
       onPointerLeave={web ? () => setHovered(false) : undefined}
       style={[
         styles.root,
-        web ? styles.webRoot : undefined,
         {
-          backgroundColor: hovered
-            ? theme.surface
-            : web && unread
-              ? theme.primarySubtle
-              : theme.card,
+          backgroundColor: hovered ? theme.surface : unread ? theme.primarySubtle : theme.card,
           borderBottomColor: theme.border,
-          borderLeftColor: web ? (unread ? theme.primary : 'transparent') : undefined,
+          borderLeftColor: unread ? theme.primary : 'transparent',
         },
       ]}
     >
@@ -351,15 +346,12 @@ const styles = StyleSheet.create({
   root: {
     alignItems: 'flex-start',
     borderBottomWidth: 1,
+    borderLeftWidth: 4,
     flexDirection: 'row',
     gap: spacing.md,
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.lg,
-  },
-  webRoot: {
-    borderLeftWidth: 4,
     paddingLeft: spacing.md,
     paddingRight: spacing.lg,
+    paddingVertical: spacing.lg,
   },
   content: { flex: 1, gap: spacing.sm, minWidth: 0 },
   kind: {

--- a/apps/app/src/components/notification/NotificationListItemView.tsx
+++ b/apps/app/src/components/notification/NotificationListItemView.tsx
@@ -81,7 +81,7 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
         onPointerEnter={() => setHovered(true)}
         onPointerLeave={() => setHovered(false)}
         style={{
-          backgroundColor: web && unread ? theme.actionPrimarySubtle : 'transparent',
+          backgroundColor: unread ? theme.actionPrimarySubtle : 'transparent',
         }}
         testID="notification-item-surface"
       >
@@ -101,7 +101,7 @@ export function NotificationListItemView(props: NotificationListItemViewProps) {
         ) : (
           <NotificationTarget {...props} />
         )}
-        {web && unread ? (
+        {unread ? (
           <View style={[styles.unreadRail, { backgroundColor: theme.actionPrimaryBase }]} />
         ) : null}
       </View>

--- a/apps/app/src/components/notification/NotificationReadAllContext.tsx
+++ b/apps/app/src/components/notification/NotificationReadAllContext.tsx
@@ -21,6 +21,7 @@ type PublishedUnreadIds = Readonly<{
 }>;
 
 type NotificationReadAllContextValue = Readonly<{
+  getCurrentTarget: () => ReadonlyArray<string> | null;
   publishUnreadIds: (unreadIds: ReadonlyArray<string>) => () => void;
   unreadIds: ReadonlyArray<string>;
 }>;
@@ -45,22 +46,40 @@ const markAllReadMutation = graphql`
 
 export function NotificationReadAllProvider({ children }: PropsWithChildren): ReactNode {
   const actorLifecycleKey = useRelayActorLifecycleKey();
+  const actorLifecycleKeyRef = useRef(actorLifecycleKey);
+  actorLifecycleKeyRef.current = actorLifecycleKey;
   const [publishedUnreadIds, setPublishedUnreadIds] = useState<PublishedUnreadIds | null>(null);
+  const publishedUnreadIdsRef = useRef<PublishedUnreadIds | null>(null);
   const publishUnreadIds = useCallback(
     (unreadIds: ReadonlyArray<string>) => {
       const next = { actorLifecycleKey, unreadIds };
+      publishedUnreadIdsRef.current = next;
       setPublishedUnreadIds(next);
       return () => {
+        if (publishedUnreadIdsRef.current !== next) {
+          return;
+        }
+        publishedUnreadIdsRef.current = null;
         setPublishedUnreadIds((current) => (current === next ? null : current));
       };
     },
     [actorLifecycleKey],
   );
+  const getCurrentTarget = useCallback(() => {
+    const current = publishedUnreadIdsRef.current;
+    return actorLifecycleKeyRef.current === actorLifecycleKey &&
+      current?.actorLifecycleKey === actorLifecycleKey
+      ? current.unreadIds
+      : null;
+  }, [actorLifecycleKey]);
   const unreadIds =
     publishedUnreadIds?.actorLifecycleKey === actorLifecycleKey
       ? publishedUnreadIds.unreadIds
       : noUnreadIds;
-  const value = useMemo(() => ({ publishUnreadIds, unreadIds }), [publishUnreadIds, unreadIds]);
+  const value = useMemo(
+    () => ({ getCurrentTarget, publishUnreadIds, unreadIds }),
+    [getCurrentTarget, publishUnreadIds, unreadIds],
+  );
 
   return (
     <NotificationReadAllContext.Provider value={value}>
@@ -80,44 +99,36 @@ export function useNotificationReadAll() {
 }
 
 export function NotificationReadAllAction() {
-  const { unreadIds } = useNotificationReadAll();
+  const { getCurrentTarget, unreadIds } = useNotificationReadAll();
   const { showToast } = useToast();
   const [commitMarkAllRead, isMarkAllReadInFlight] =
     useMutation<NotificationListMarkAllReadMutation>(markAllReadMutation);
   const readAllInFlight = useRef(false);
-  const mounted = useRef(false);
-  const failureToastCleanup = useRef<(() => void) | null>(null);
-  const retryRef = useRef<() => void>(() => undefined);
 
   useEffect(() => {
-    mounted.current = true;
     return () => {
-      mounted.current = false;
       readAllInFlight.current = false;
-      failureToastCleanup.current?.();
-      failureToastCleanup.current = null;
-      retryRef.current = () => undefined;
     };
   }, []);
 
   const markAllRead = useCallback(() => {
-    if (!mounted.current || readAllInFlight.current || isMarkAllReadInFlight) {
+    const target = getCurrentTarget();
+    if (!target || readAllInFlight.current || isMarkAllReadInFlight) {
       return;
     }
 
-    if (unreadIds.length === 0) {
+    if (target.length === 0) {
       return;
     }
 
     readAllInFlight.current = true;
     const handleFailure = () => {
       readAllInFlight.current = false;
-      if (!mounted.current) {
+      if (!getCurrentTarget()?.length) {
         return;
       }
-      failureToastCleanup.current?.();
-      failureToastCleanup.current = showToast('알림을 모두 읽지 못했어요.', {
-        action: { label: '다시 시도', onPress: () => retryRef.current() },
+      showToast('알림을 모두 읽지 못했어요.', {
+        action: { label: '다시 시도', onPress: markAllRead },
         tone: 'danger',
       });
     };
@@ -130,10 +141,9 @@ export function NotificationReadAllAction() {
         readAllInFlight.current = false;
       },
       onError: handleFailure,
-      variables: { ids: [...unreadIds] },
+      variables: { ids: [...target] },
     });
-  }, [commitMarkAllRead, isMarkAllReadInFlight, showToast, unreadIds]);
-  retryRef.current = markAllRead;
+  }, [commitMarkAllRead, getCurrentTarget, isMarkAllReadInFlight, showToast]);
 
   return (
     <Button

--- a/apps/app/src/components/notification/NotificationReadAllContext.tsx
+++ b/apps/app/src/components/notification/NotificationReadAllContext.tsx
@@ -1,54 +1,66 @@
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Platform } from 'react-native';
+import { graphql, useMutation } from 'react-relay';
 import { Button } from '@/components/ui/Button';
+import { useToast } from '@/components/ui/ToastProvider';
+import { useRelayActorLifecycleKey } from '@/relay/RelayActorProvider';
 import type { PropsWithChildren, ReactNode } from 'react';
+import type { NotificationListMarkAllReadMutation } from './__generated__/NotificationListMarkAllReadMutation.graphql';
 
-export type NotificationReadAllAction = Readonly<{
-  busy: boolean;
-  disabled: boolean;
-  onPress: () => void;
-}>;
-
-type Registration = Readonly<{
-  action: NotificationReadAllAction;
-  token: object;
+type PublishedUnreadIds = Readonly<{
+  actorLifecycleKey: string;
+  unreadIds: ReadonlyArray<string>;
 }>;
 
 type NotificationReadAllContextValue = Readonly<{
-  action: NotificationReadAllAction;
-  invoke: () => void;
-  register: (action: NotificationReadAllAction) => () => void;
+  publishUnreadIds: (unreadIds: ReadonlyArray<string>) => () => void;
+  unreadIds: ReadonlyArray<string>;
 }>;
 
-const disabledAction: NotificationReadAllAction = {
-  busy: false,
-  disabled: true,
-  onPress: () => undefined,
-};
-
 const NotificationReadAllContext = createContext<NotificationReadAllContextValue | null>(null);
+const noUnreadIds: ReadonlyArray<string> = [];
+
+const markAllReadMutation = graphql`
+  mutation NotificationListMarkAllReadMutation($ids: [ID!]!) {
+    markNotificationRead(input: { ids: $ids }) {
+      notifications {
+        id
+        readAt
+      }
+      recipientProfiles {
+        id
+        unreadNotificationCount
+      }
+    }
+  }
+`;
 
 export function NotificationReadAllProvider({ children }: PropsWithChildren): ReactNode {
-  const [registration, setRegistration] = useState<Registration | null>(null);
-  const registrationRef = useRef<Registration | null>(null);
-  const register = useCallback((action: NotificationReadAllAction) => {
-    const token = {};
-    const next = { action, token };
-    registrationRef.current = next;
-    setRegistration(next);
-    return () => {
-      if (registrationRef.current?.token !== token) {
-        return;
-      }
-      registrationRef.current = null;
-      setRegistration(null);
-    };
-  }, []);
-  const invoke = useCallback(() => registrationRef.current?.action.onPress(), []);
-  const value = useMemo(
-    () => ({ action: registration?.action ?? disabledAction, invoke, register }),
-    [invoke, register, registration?.action],
+  const actorLifecycleKey = useRelayActorLifecycleKey();
+  const [publishedUnreadIds, setPublishedUnreadIds] = useState<PublishedUnreadIds | null>(null);
+  const publishUnreadIds = useCallback(
+    (unreadIds: ReadonlyArray<string>) => {
+      const next = { actorLifecycleKey, unreadIds };
+      setPublishedUnreadIds(next);
+      return () => {
+        setPublishedUnreadIds((current) => (current === next ? null : current));
+      };
+    },
+    [actorLifecycleKey],
   );
+  const unreadIds =
+    publishedUnreadIds?.actorLifecycleKey === actorLifecycleKey
+      ? publishedUnreadIds.unreadIds
+      : noUnreadIds;
+  const value = useMemo(() => ({ publishUnreadIds, unreadIds }), [publishUnreadIds, unreadIds]);
 
   return (
     <NotificationReadAllContext.Provider value={value}>
@@ -68,16 +80,72 @@ export function useNotificationReadAll() {
 }
 
 export function NotificationReadAllAction() {
-  const { action } = useNotificationReadAll();
+  const { unreadIds } = useNotificationReadAll();
+  const { showToast } = useToast();
+  const [commitMarkAllRead, isMarkAllReadInFlight] =
+    useMutation<NotificationListMarkAllReadMutation>(markAllReadMutation);
+  const readAllInFlight = useRef(false);
+  const mounted = useRef(false);
+  const failureToastCleanup = useRef<(() => void) | null>(null);
+  const retryRef = useRef<() => void>(() => undefined);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      readAllInFlight.current = false;
+      failureToastCleanup.current?.();
+      failureToastCleanup.current = null;
+      retryRef.current = () => undefined;
+    };
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    if (!mounted.current || readAllInFlight.current || isMarkAllReadInFlight) {
+      return;
+    }
+
+    if (unreadIds.length === 0) {
+      return;
+    }
+
+    readAllInFlight.current = true;
+    const handleFailure = () => {
+      readAllInFlight.current = false;
+      if (!mounted.current) {
+        return;
+      }
+      failureToastCleanup.current?.();
+      failureToastCleanup.current = showToast('알림을 모두 읽지 못했어요.', {
+        action: { label: '다시 시도', onPress: () => retryRef.current() },
+        tone: 'danger',
+      });
+    };
+    commitMarkAllRead({
+      onCompleted: (response, errors) => {
+        if (errors?.length || response.markNotificationRead == null) {
+          handleFailure();
+          return;
+        }
+        readAllInFlight.current = false;
+      },
+      onError: handleFailure,
+      variables: { ids: [...unreadIds] },
+    });
+  }, [commitMarkAllRead, isMarkAllReadInFlight, showToast, unreadIds]);
+  retryRef.current = markAllRead;
 
   return (
     <Button
       accessibilityLabel="모두 읽음"
-      accessibilityState={{ busy: action.busy, disabled: action.disabled }}
-      aria-busy={action.busy || undefined}
-      disabled={action.disabled}
+      accessibilityState={{
+        busy: isMarkAllReadInFlight,
+        disabled: isMarkAllReadInFlight || unreadIds.length === 0,
+      }}
+      aria-busy={isMarkAllReadInFlight || undefined}
+      disabled={isMarkAllReadInFlight || unreadIds.length === 0}
       hitSlop={Platform.OS === 'web' ? undefined : 4}
-      onPress={action.onPress}
+      onPress={markAllRead}
       tone="secondary"
     >
       모두 읽음

--- a/apps/app/src/components/notification/NotificationReadAllContext.tsx
+++ b/apps/app/src/components/notification/NotificationReadAllContext.tsx
@@ -70,16 +70,13 @@ export function useNotificationReadAll() {
 export function NotificationReadAllAction() {
   const { action } = useNotificationReadAll();
 
-  if (Platform.OS !== 'web') {
-    return null;
-  }
-
   return (
     <Button
       accessibilityLabel="모두 읽음"
       accessibilityState={{ busy: action.busy, disabled: action.disabled }}
       aria-busy={action.busy || undefined}
       disabled={action.disabled}
+      hitSlop={Platform.OS === 'web' ? undefined : 4}
       onPress={action.onPress}
       tone="secondary"
     >

--- a/apps/app/src/components/shell/UniversalShell.tsx
+++ b/apps/app/src/components/shell/UniversalShell.tsx
@@ -352,7 +352,11 @@ function UniversalShellContent() {
                   leading={mobileShellHeader.leading === 'back' ? backButton : menuButton}
                   title={mobileShellHeader.title}
                   trailing={
-                    mobileShellHeader.title === '알림' ? <NotificationReadAllAction /> : undefined
+                    mobileShellHeader.title === '알림' ? (
+                      <RelayActorBoundary>
+                        <NotificationReadAllAction />
+                      </RelayActorBoundary>
+                    ) : undefined
                   }
                 />
               ) : (

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -3,6 +3,8 @@
 PROD-884는 `NotificationListItemView`와 `KOSMO/Patterns/Notification List Item` Storybook을
 소유한다. 이 컴포넌트는 표시용 입력과 이동 callback을 받고, 기존 Notification runtime은 그대로 둔다.
 PROD-811이 실제 목록 연결, Relay projection·그룹 집계, 읽음 처리, 권한과 navigation 통합을 소유한다.
+PROD-930은 production Notification runtime에서 플랫폼별로 나뉘었던 `모두 읽음` action과 Read/Unread
+표시를 Web·iOS·Android에서 같은 계약으로 제공하며, 현재 로드된 ID와 기존 API/Relay 수렴 경계를 유지한다.
 
 ## Canonical source
 
@@ -31,11 +33,11 @@ API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는�
   Web inset은 좌 12px·우 16px, Native는 좌우 8px, kind/content gap은 12px이다.
   Reply에는 별도 알림 header나 그 header의 최소 높이를 두지 않는다. 게시글 내부 링크와 action의
   플랫폼별 접근성 target은 기존 Post 계약을 유지한다.
-- Web Read 배경은 투명, Unread는 Figma가 사용하는 `actionPrimarySubtle`과 4px
-  `actionPrimaryBase` rail이다. Hover는 기존 배경 위에 `stateHover`를 얹으며 Unread의 primary 배경을
-  지우지 않는다. 따라서 Read와 Unread의 hover 색상이 구분된다. keyboard focus는 `stateFocusRing`이다.
-  이는 unread 전용 semantic token 신설이 아니다. Native는 Default 표시를 사용하되 접근 가능한 이름에
-  unread 정보를 유지한다.
+- Read 배경은 투명, Unread는 Figma가 사용하는 `actionPrimarySubtle`과 4px
+  `actionPrimaryBase` rail이다. 모든 플랫폼에서 이 Read/Unread 기본 표시와 접근 가능한 Unread 상태를
+  유지한다. Web hover는 기존 배경 위에 `stateHover`를 얹으며 Unread의 primary 배경을 지우지 않는다.
+  따라서 Read와 Unread의 hover 색상이 구분된다. keyboard focus는 `stateFocusRing`이다. 이는 unread
+  전용 semantic token 신설이 아니다.
 - Reaction/Repost는 요약 헤더·한 줄 미리보기·썸네일을 하나의 이동 target으로 취급한다.
   hover·읽음 배경과 읽음 rail은 알림 전체에 적용한다. Reply도 게시글 전체를 하나의 알림 surface로
   표시하며 게시글 위에서 전체 hover 배경이 유지된다. 별도 header 이동 링크는 없으며 Post 내부 링크·

--- a/docs/design/page-header.md
+++ b/docs/design/page-header.md
@@ -15,9 +15,9 @@
 - `text` variant에서 leading action과 제목 사이에는 `spacing.lg`(`16px`)를 두어 `24px` 아이콘과 제목의 시각 간격을 약 `26px`로 유지한다. `brand` variant의 대칭 action slot에는 이 간격을 적용하지 않는다.
 - `trailing` prop은 `text` variant 제목과 분리되어 헤더 오른쪽 끝에 정렬되는 화면별 action을 받는다. trailing action은 자기 touch target, 접근 가능한 이름과 disabled 상태를 소유하며, action 유무에 따라 제목 heading이나 헤더 높이를 바꾸지 않는다.
 
-### Web 알림 모두 읽음
+### 알림 모두 읽음
 
-- Web `/notifications`의 trailing action은 기존 공용 `Button`의 secondary 표현(흰 배경과 `border` 색상 테두리)으로 `모두 읽음` 텍스트를 표시한다. `<768px` 모바일 Web에서는 `UniversalShell`이, compact/full Web에서는 알림 route가 소유한 `PageHeader`가 렌더링한다. Android/iOS에는 이 action을 표시하지 않는다.
+- 모든 플랫폼의 `/notifications` trailing action은 기존 공용 `Button`의 secondary 표현(흰 배경과 `border` 색상 테두리)으로 `모두 읽음` 텍스트를 표시한다. `<768px` 모바일 Web에서는 `UniversalShell`이, compact/full Web과 Android/iOS에서는 알림 route가 소유한 `PageHeader`가 렌더링한다.
 - action은 클릭 시점에 현재 Relay connection에 로드된 unread Notification ID만 처리하며, 아직 로드하지 않았거나 요청 이후 새로 도착한 Notification을 처리하기 위해 추가 page를 먼저 가져오지 않는다.
 - 현재 로드된 unread item이 없거나 요청 중이면 action을 disabled 처리하고 접근성 상태에도 반영한다.
 - 성공 뒤 처리된 item은 목록에 남고 Unread 강조만 제거된다. 전역 인디케이터는 서버 count로 수렴하므로 아직 처리하지 않은 unread item이 있으면 `모두 읽음` 성공 뒤에도 남을 수 있다.
@@ -58,7 +58,7 @@ Web `/search`는 모든 breakpoint에서 중앙 컬럼 최상단에 높이 `64px
   `< compact`에서 `UniversalShell`은 기본 메뉴 전용 헤더 대신 drawer action과 가장자리 스와이프만 제공한다.
 - `<768px` 모바일 Web `/compose`, `/notifications`와 `/settings` root: `UniversalShell`이 메뉴 버튼과 텍스트 제목을 하나의 app bar로 렌더링한다. `/notifications`에서는 같은 app bar가 `모두 읽음` trailing action도 소유하고, Settings 내부 category·detail destination에서는 같은 위치에 뒤로가기와 현재 destination 제목을 렌더링한다. route의 loading, error, empty와 content 상태는 셸 헤더 아래에서 전환하며 자체 PageHeader를 렌더링하지 않는다.
 - `<768px` 모바일 Web 게시글 상세: `UniversalShell`이 기존 `router.back()` 동작을 사용하는 뒤로가기 버튼과 `게시글` 제목을 하나의 app bar로 렌더링한다. route는 별도 sticky PageHeader와 그 offset을 만들지 않는다.
-- Android/iOS의 알림·글쓰기·게시글 상세와 compact/full Web: 모바일 Web 셸 헤더가 없으므로 route 또는 화면의 최상위 scroll content가 기존 텍스트·뒤로가기 헤더를 소유한다. Native 게시글 상세에서는 `PostDetailFrame`이 첫 번째 sticky child를 계속 소유한다.
+- Android/iOS의 알림·글쓰기·게시글 상세와 compact/full Web: 모바일 Web 셸 헤더가 없으므로 route 또는 화면의 최상위 scroll content가 기존 텍스트·뒤로가기 헤더를 소유한다. `/notifications`는 같은 위치에 `모두 읽음` trailing action도 소유한다. Native 게시글 상세에서는 `PostDetailFrame`이 첫 번째 sticky child를 계속 소유한다.
 - Current compact/full Web의 `/[profileHandle]/followers`·`following`은 상위 Profile layout의
   `ProfileHero`를 유지하고 그 아래에 목록 영역을 렌더링한다.
 - Target compact/full Web과 Android/iOS의 `/[profileHandle]/followers`·`following`은 각 독립 route가

--- a/docs/design/page-header.md
+++ b/docs/design/page-header.md
@@ -18,12 +18,19 @@
 ### 알림 모두 읽음
 
 - 모든 플랫폼의 `/notifications` trailing action은 기존 공용 `Button`의 secondary 표현(흰 배경과 `border` 색상 테두리)으로 `모두 읽음` 텍스트를 표시한다. `<768px` 모바일 Web에서는 `UniversalShell`이, compact/full Web과 Android/iOS에서는 알림 route가 소유한 `PageHeader`가 렌더링한다.
+- Shell app bar의 header·menu 위치와 layout은 `UniversalShell`이 계속 소유하고, 목록 query·pagination은 알림 목록이 소유한다.
+- `모두 읽음` action은 mutation·pending·error·retry를 소유하며, 현재 loaded unread ID snapshot만 최소 Context bridge로 전달받는다.
 - action은 클릭 시점에 현재 Relay connection에 로드된 unread Notification ID만 처리하며, 아직 로드하지 않았거나 요청 이후 새로 도착한 Notification을 처리하기 위해 추가 page를 먼저 가져오지 않는다.
 - 현재 로드된 unread item이 없거나 요청 중이면 action을 disabled 처리하고 접근성 상태에도 반영한다.
 - 성공 뒤 처리된 item은 목록에 남고 Unread 강조만 제거된다. 전역 인디케이터는 서버 count로 수렴하므로 아직 처리하지 않은 unread item이 있으면 `모두 읽음` 성공 뒤에도 남을 수 있다.
 - pending 또는 실패 중에는 item 강조와 전역 인디케이터를 낙관적으로 제거하지 않는다. 실패하면 기존 앱
   toast로 `알림을 모두 읽지 못했어요.`와 `다시 시도` action을 제공하고, 재시도 시점의 current Relay
   connection에 로드된 unread Notification ID를 다시 수집한다.
+- 중복 입력 차단은 하나의 Action instance가 살아 있는 동안의 연속 입력으로 한정하며, 전역 coordinator 없이
+  action lifetime 밖의 pending·retry·ID batch 실행 상태를 이어가지 않는다. Web breakpoint 전환이나
+  동일 Profile에서 breakpoint 전환으로 새 instance가 생기면 현재 loaded ID를 다시 요청할 수 있고, 이
+  재요청은 서버의 idempotent Read 수렴에 맡긴다. actor·route 변경으로 lifetime이 끝나면 이전 ID
+  snapshot·pending·retry를 이어가지 않고, action이 자신이 등록한 실패 toast retry를 정리한다.
 
 ## Web 검색 헤더
 

--- a/docs/design/page-header.md
+++ b/docs/design/page-header.md
@@ -27,10 +27,12 @@
   toast로 `알림을 모두 읽지 못했어요.`와 `다시 시도` action을 제공하고, 재시도 시점의 current Relay
   connection에 로드된 unread Notification ID를 다시 수집한다.
 - 중복 입력 차단은 하나의 Action instance가 살아 있는 동안의 연속 입력으로 한정하며, 전역 coordinator 없이
-  action lifetime 밖의 pending·retry·ID batch 실행 상태를 이어가지 않는다. Web breakpoint 전환이나
-  동일 Profile에서 breakpoint 전환으로 새 instance가 생기면 현재 loaded ID를 다시 요청할 수 있고, 이
-  재요청은 서버의 idempotent Read 수렴에 맡긴다. actor·route 변경으로 lifetime이 끝나면 이전 ID
-  snapshot·pending·retry를 이어가지 않고, action이 자신이 등록한 실패 toast retry를 정리한다.
+  action lifetime 밖의 pending·ID batch 실행 상태를 이어가지 않는다. 동일 Profile에서 pending 중 Web
+  breakpoint 전환으로 새 instance가 생기면 현재 loaded ID를 다시 요청할 수 있고, 이 재요청은 서버의
+  idempotent Read 수렴에 맡긴다.
+- 동일 actor에서 Home 등 다른 route를 방문한 뒤 `/notifications`로 돌아오면 남아 있는 실패 toast의 retry는
+  새로 로드된 current ID로 실행한다. actor 변경으로 lifetime이 끝나면 이전 ID snapshot·pending·retry를
+  새 actor에 이어가지 않는다.
 
 ## Web 검색 헤더
 

--- a/openspec/specs/notification/spec.md
+++ b/openspec/specs/notification/spec.md
@@ -596,6 +596,8 @@ API는 kind별 source가 존재하고 source에서 파생한 Recipient가 저장
 
 **Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/design/page-header.md`, `docs/design/colors.md`, `docs/design/breakpoints.md`, `PROD-703`, `PROD-679`, `PROD-930` — 모든 지원 플랫폼의 `/notifications`는 현재 Relay connection에 로드된 unread Notification만 지정 ID 일괄 Read로 처리하는 `모두 읽음` action을 제공하고, 서버 payload로 목록과 전역 인디케이터를 수렴시켜야 한다(MUST).
 
+Shell header·menu 위치와 layout은 `UniversalShell`이, 목록 query·pagination은 알림 목록이, action mutation·pending·error·retry는 action이 소유해야 한다(MUST). Action에는 현재 loaded unread ID snapshot만 최소 Context bridge로 전달해야 한다(MUST).
+
 #### Scenario: 플랫폼별 header action 소유권
 
 - **WHEN** 사용자가 지원 플랫폼에서 `/notifications`를 연다
@@ -606,7 +608,7 @@ API는 kind별 source가 존재하고 source에서 파생한 Recipient가 저장
 
 - **WHEN** 현재 Relay connection에 loaded unread Notification이 하나 이상 있고 Read 요청이 pending이 아니다
 - **THEN** `모두 읽음` action은 활성화된다
-- **AND** loaded unread가 없거나 요청 중이면 disabled와 접근성 disabled 상태를 함께 제공하고 중복 요청을 시작하지 않는다
+- **AND** loaded unread가 없거나 요청 중이면 disabled와 접근성 disabled 상태를 함께 제공하고, 동일 Action instance의 연속 입력으로 중복 요청을 시작하지 않는다
 
 #### Scenario: 현재 로드된 unread ID만 처리
 
@@ -630,6 +632,8 @@ API는 kind별 source가 존재하고 source에서 파생한 Recipient가 저장
 - **AND** 실패한 요청 전의 Unread 강조와 전역 인디케이터를 유지하고 사용자가 다시 시도할 수 있게 한다
 - **AND** 실패하면 기존 앱 toast로 `알림을 모두 읽지 못했어요.`와 `다시 시도` action을 제공한다
 - **AND** toast의 재시도는 실행 시점의 current Relay connection에서 loaded unread ID를 다시 수집한다
+- **AND** 동일 Profile에서 Web breakpoint 전환으로 새 Action instance가 생기면 현재 loaded ID를 다시 요청할 수 있고, 이 재요청은 서버의 idempotent Read 수렴에 맡긴다
+- **AND** actor·route 변경으로 Action lifetime이 끝나면 이전 ID snapshot·pending·retry를 이어가지 않고, action이 등록한 실패 toast retry를 정리한다
 
 #### Scenario: Web 상태와 수직 검증
 

--- a/openspec/specs/notification/spec.md
+++ b/openspec/specs/notification/spec.md
@@ -632,8 +632,9 @@ Shell header·menu 위치와 layout은 `UniversalShell`이, 목록 query·pagina
 - **AND** 실패한 요청 전의 Unread 강조와 전역 인디케이터를 유지하고 사용자가 다시 시도할 수 있게 한다
 - **AND** 실패하면 기존 앱 toast로 `알림을 모두 읽지 못했어요.`와 `다시 시도` action을 제공한다
 - **AND** toast의 재시도는 실행 시점의 current Relay connection에서 loaded unread ID를 다시 수집한다
-- **AND** 동일 Profile에서 Web breakpoint 전환으로 새 Action instance가 생기면 현재 loaded ID를 다시 요청할 수 있고, 이 재요청은 서버의 idempotent Read 수렴에 맡긴다
-- **AND** actor·route 변경으로 Action lifetime이 끝나면 이전 ID snapshot·pending·retry를 이어가지 않고, action이 등록한 실패 toast retry를 정리한다
+- **AND** 동일 Profile에서 pending 중 Web breakpoint 전환으로 새 Action instance가 생기면 현재 loaded ID를 다시 요청할 수 있고, 이 재요청은 서버의 idempotent Read 수렴에 맡긴다
+- **AND** 동일 actor에서 Home 등 다른 route를 방문한 뒤 `/notifications`로 돌아오면 남아 있는 실패 toast의 retry를 새로 로드된 current ID로 실행한다
+- **AND** actor 변경으로 Action lifetime이 끝나면 이전 ID snapshot·pending·retry를 새 actor에 이어가지 않으며, 이전 toast retry를 새 actor에서 실행하지 않는다
 
 #### Scenario: Web 상태와 수직 검증
 

--- a/openspec/specs/notification/spec.md
+++ b/openspec/specs/notification/spec.md
@@ -252,7 +252,7 @@ API는 kind별 source가 존재하고 source에서 파생한 Recipient가 저장
 
 ### Requirement: Selected Profile Follow Notification 목록 UI
 
-**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/breakpoints.md`, `docs/design/colors.md`, `PROD-277`, `PROD-372`, `PROD-541`, `PROD-680`, `PROD-703` — 클라이언트는 selected Profile의 visible Follow Notification을 모바일과 Web에서 같은 단일 목록으로 제공하고 Relay connection과 actor cache를 Profile별로 격리해야 한다(MUST).
+**Authority / Provenance:** `docs/design/accessibility.md`, `docs/design/breakpoints.md`, `docs/design/colors.md`, `PROD-277`, `PROD-372`, `PROD-541`, `PROD-680`, `PROD-703`, `PROD-930` — 클라이언트는 selected Profile의 visible Follow Notification을 모든 지원 플랫폼에서 같은 단일 목록으로 제공하고 Relay connection과 actor cache를 Profile별로 격리해야 한다(MUST).
 
 #### Scenario: 단일 Follow item 표시와 Profile link
 
@@ -272,10 +272,10 @@ API는 kind별 source가 존재하고 source에서 파생한 Recipient가 저장
 #### Scenario: Read와 Unread 표시
 
 - **WHEN** Follow item의 `readAt`이 `null`이다
-- **THEN** Web item은 토큰 기반의 분명한 좌측 상태선, 은은한 배경과 접근성 Unread 상태를 제공한다
-- **AND** `readAt`이 존재하면 Web item은 Unread 좌측 상태선·배경 강조·접근성 Unread 상태를 제공하지 않는다
+- **THEN** 각 지원 플랫폼의 item은 토큰 기반의 분명한 좌측 상태선, 은은한 배경과 접근성 Unread 상태를 제공한다
+- **AND** `readAt`이 존재하면 각 지원 플랫폼의 item은 Unread 좌측 상태선·배경 강조·접근성 Unread 상태를 제공하지 않는다
 - **AND** Web pointer hover 중에는 기존 `surface` 배경을 사용하며 Unread item의 좌측 상태선은 유지한다
-- **AND** hover가 없는 native 화면은 Read 상태와 관계없이 `card` 기본 배경을 유지한다
+- **AND** hover가 없는 native 화면도 Read/Unread 기본 표시와 접근성 상태를 유지한다
 
 #### Scenario: Profile 이동과 Read side effect 분리
 
@@ -456,20 +456,20 @@ API는 kind별 source가 존재하고 source에서 파생한 Recipient가 저장
 - **AND** 남은 Notification row는 source가 없으므로 모든 API 표면에서 숨겨진다
 - **AND** retry, cron, queue, backfill 또는 bulk cleanup은 이번 capability에 포함하지 않는다
 
-### Requirement: Selected Profile Web Notification Unread 시각 상태
+### Requirement: Selected Profile Notification Unread 시각 상태
 
-**Authority / Provenance:** `docs/design/colors.md`, `docs/design/accessibility.md`, `PROD-680`, `PROD-703` — 클라이언트는 selected Profile의 Web 알림 목록에서 visible Notification item의 Read와 Unread 상태를 시각·접근성 정보로 일관되게 구분해야 한다(MUST).
+**Authority / Provenance:** `docs/design/colors.md`, `docs/design/accessibility.md`, `PROD-680`, `PROD-703`, `PROD-930` — 클라이언트는 selected Profile의 알림 목록에서 visible Notification item의 Read와 Unread 상태를 모든 지원 플랫폼에서 시각·접근성 정보로 일관되게 구분해야 한다(MUST).
 
-#### Scenario: Web Unread 기본 표시
+#### Scenario: Unread 기본 표시
 
-- **WHEN** Web 알림 목록의 visible Notification item이 `readAt = null`이고 pointer hover 중이 아니다
+- **WHEN** 알림 목록의 visible Notification item이 `readAt = null`이고 pointer hover 중이 아니다
 - **THEN** item은 토큰 기반의 분명한 좌측 상태선과 은은한 배경으로 Unread임을 표시한다
 - **AND** 기존 접근성 Unread 설명을 함께 제공해 상태를 색만으로 전달하지 않는다
 - **AND** 텍스트, icon과 link는 배경 강조와 독립적으로 기존 가독성과 상호작용을 유지한다
 
-#### Scenario: Web Read 기본 표시
+#### Scenario: Read 기본 표시
 
-- **WHEN** Web 알림 목록의 visible Notification item에 `readAt`이 존재하고 pointer hover 중이 아니다
+- **WHEN** 알림 목록의 visible Notification item에 `readAt`이 존재하고 pointer hover 중이 아니다
 - **THEN** item은 Unread 좌측 상태선과 배경 강조를 표시하지 않는다
 - **AND** 접근성 Unread 설명을 제공하지 않는다
 - **AND** Read와 Unread 전환 전후에 item 콘텐츠의 수평 정렬이 움직이지 않는다
@@ -592,15 +592,15 @@ API는 kind별 source가 존재하고 source에서 파생한 Recipient가 저장
 - **THEN** API는 item을 page limit 전 connection과 Unread count에서 제외한다
 - **AND** Node는 `null`을 반환하고 `markNotificationRead(input: { ids })`는 해당 ID를 조용히 제외하며 generic Notification으로 대신 노출하지 않는다
 
-### Requirement: 현재 로드된 Web Notification 일괄 Read action
+### Requirement: 현재 로드된 Notification 일괄 Read action
 
-**Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/design/page-header.md`, `docs/design/colors.md`, `docs/design/breakpoints.md`, `PROD-703`, `PROD-679` — Web `/notifications`는 현재 Relay connection에 로드된 unread Notification만 지정 ID 일괄 Read로 처리하는 `모두 읽음` action을 제공하고, 서버 payload로 목록과 전역 인디케이터를 수렴시켜야 한다(MUST).
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/design/page-header.md`, `docs/design/colors.md`, `docs/design/breakpoints.md`, `PROD-703`, `PROD-679`, `PROD-930` — 모든 지원 플랫폼의 `/notifications`는 현재 Relay connection에 로드된 unread Notification만 지정 ID 일괄 Read로 처리하는 `모두 읽음` action을 제공하고, 서버 payload로 목록과 전역 인디케이터를 수렴시켜야 한다(MUST).
 
-#### Scenario: Web header action 소유권
+#### Scenario: 플랫폼별 header action 소유권
 
-- **WHEN** 사용자가 Web `/notifications`를 연다
-- **THEN** `<768px` 모바일 Web에서는 `UniversalShell` app bar가, compact/full Web에서는 route의 `PageHeader`가 `모두 읽음` trailing text action을 렌더링한다
-- **AND** Android/iOS 화면에는 이 action을 렌더링하지 않는다
+- **WHEN** 사용자가 지원 플랫폼에서 `/notifications`를 연다
+- **THEN** `<768px` 모바일 Web에서는 `UniversalShell` app bar가, compact/full Web과 Android/iOS에서는 route의 `PageHeader`가 `모두 읽음` trailing text action을 렌더링한다
+- **AND** 각 플랫폼은 같은 loaded unread ID, mutation input과 payload 수렴 계약을 사용한다
 
 #### Scenario: action enabled와 pending 상태
 


### PR DESCRIPTION
## 무엇을 변경했는지

- iOS·Android 알림 화면에도 `모두 읽음` action을 표시합니다.
- Web·Native 알림 행에서 `readAt = null`인 미확인 상태를 같은 배경과 좌측 상태선으로 표시합니다.
- Native action의 touch target과 접근성 이름·상태를 플랫폼 기준에 맞춥니다.
- 기존 책임 경계를 유지하면서 분리합니다. Shell은 기존 header·menu·layout을 소유하고, List는 query·페이지네이션·현재 대상 ID를 소유하며, `NotificationReadAllAction`은 mutation·pending·error·retry를 소유합니다.
- Context는 List가 action에 현재 대상 ID를 전달하는 최소 data bridge만 유지합니다. command register/invoke/token과 중복 pending 상태는 제거했습니다.
- Stack: `main` → `PROD-930`

## 왜 변경했는지

Slack에서 보고된 iOS 알림 화면은 플랫폼 분기 때문에 `모두 읽음`과 미확인 상태 표시가 빠져 있었습니다. Jiyu 결정에 따라 기존 Web-only 제한을 폐기하고 iOS·Android에서도 같은 알림 상태와 action을 제공합니다.

## 이번 PR의 주요 결정

- 기존 `markNotificationRead(input: { ids })` 계약과 현재 Relay connection에 로드된 unread ID만 처리하는 범위를 유지합니다. 서버 전체 unread 확장이나 추가 page fetch는 포함하지 않습니다.
- `NotificationReadAllAction`이 mutation의 pending·error·retry 상태를 관리하고, 성공 시 기존 목록·unread count 수렴 동작을 유지합니다. route remount 뒤에도 실패 retry가 동작하도록 detached retry callback의 toast 수명을 보존합니다.
- Shell·List·`NotificationReadAllAction` 사이의 기존 UI·데이터 책임을 바꾸지 않고, Context에는 현재 대상 ID bridge만 둡니다. Context가 mutation 명령이나 pending 상태를 관리하지 않습니다.
- 동일 actor에서 Home 등 다른 route를 방문한 뒤 `/notifications`로 돌아오면 남아 있는 실패 toast retry를 새로 로드된 current ID로 실행하고, actor 변경 뒤 남은 retry는 guard에서 무해하게 종료합니다.
- Native action은 iOS·Android touch target을 충족하도록 기존 Button에 Native hit slop을 적용합니다.

## 어떻게 확인할 수 있는지

- 앞선 커밋 검증: 기존 app unit 489개, app Storybook 699개, OpenSpec strict validation 74개 통과
- 이번 retry 수정 후 검증: `Notifications.stories.tsx` focused 25개, Relay compiler(noWatchman), TypeScript `tsc --noEmit`, ESLint, Prettier, diff check 통과
- 최신 head `f611fdb77c1eb36568c8365ba76a20ba1b1a0ad5`의 [Test run 34329143233](https://github.com/byulmaru/kosmo/actions/runs/34329143233): Web E2E 3개 shard를 포함한 14개 job 전체 성공. 별도 Lint·Semgrep 검사도 성공.
- 새 테스트는 추가하지 않았습니다.

## 아직 어떤 문제가 남았는지

- 실제 iOS·Android 기기 또는 simulator에서 VoiceOver·TalkBack, font scaling과 Native touch/focus 경계는 아직 검증하지 않았습니다.
- 로컬 Web E2E는 Docker Compose가 없는 환경이라 실행하지 못했습니다.
- 같은 Profile에서 pending 중 Web 768px breakpoint 전환으로 새 Action이 생긴 후 다시 누르면 현재 loaded ID에 대한 추가 `markNotificationRead` 요청이 발생할 수 있습니다. 서버는 [`coalesce(readAt, now())`](https://github.com/byulmaru/kosmo/blob/main/apps/api/src/graphql/resolvers/notification/mutation/mark-read.ts#L29-L32)로 이를 멱등 처리하며 concurrent 요청은 기존 [`notification.test.ts`](https://github.com/byulmaru/kosmo/blob/main/apps/api/tests/integration/graphql/notification.test.ts#L1550-L1573)가 같은 `readAt`과 unread count `0`을 검증합니다. 전역 pending 전달이나 registry는 추가하지 않았습니다.

Fixes [PROD-930](https://linear.app/byulmaru/issue/PROD-930)

[Slack 원문](https://byulmaru.slack.com/archives/C0ARDKUFUDT/p1788934753599059)
