### PR TITLE
통합 배포 workflow의 Vault role을 맞춘다

### DIFF
--- a/.github/workflows/native-store-distribution.yml
+++ b/.github/workflows/native-store-distribution.yml
@@ -125,7 +125,7 @@ jobs:
           url: ${{ vars.VAULT_ADDR }}
           path: github-actions
           method: jwt
-          role: kosmo-android-play
+          role: kosmo-native-store-distribution
           jwtGithubAudience: ${{ vars.VAULT_GITHUB_ACTIONS_AUDIENCE }}
           exportEnv: false
           secrets: |
@@ -349,7 +349,7 @@ jobs:
           url: ${{ vars.VAULT_ADDR }}
           path: github-actions
           method: jwt
-          role: kosmo-ios-testflight
+          role: kosmo-native-store-distribution
           jwtGithubAudience: ${{ vars.VAULT_GITHUB_ACTIONS_AUDIENCE }}
           exportEnv: false
           secrets: |

--- a/apps/app/README.md
+++ b/apps/app/README.md
@@ -39,7 +39,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `GCP_WORKLOAD_IDENTITY_PROVIDER` | variable | `terraform output -raw android_play_workload_identity_provider` |
 | `ANDROID_RELEASE_KEY_ALIAS`      | variable | upload key 생성 시 사용한 alias                                 |
 
-4. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. 운영자가 Vault CLI/UI에서 사용하는 KV v2 logical path는 `secret/kosmo/prod/android-play`다. Workflow와 Vault ACL policy에서 사용하는 KV v2 API path는 `secret/data/kosmo/prod/android-play`이며, `/data/`는 CLI/UI logical path에 포함하지 않는다. 다음 field를 만들고, `kosmo-android-play` GitHub OIDC role이 이 API path를 읽도록 한다.
+4. upload keystore와 두 password는 GitHub에 저장하지 않고 Vault에 저장한다. 운영자가 Vault CLI/UI에서 사용하는 KV v2 logical path는 `secret/kosmo/prod/android-play`다. Workflow와 Vault ACL policy에서 사용하는 KV v2 API path는 `secret/data/kosmo/prod/android-play`이며, `/data/`는 CLI/UI logical path에 포함하지 않는다. 다음 field를 만들고, `kosmo-native-store-distribution` GitHub OIDC role이 이 API path를 읽도록 한다.
 
 | Field                             | 값                                 |
 | --------------------------------- | ---------------------------------- |
@@ -47,7 +47,7 @@ Native projects are generated with `expo prebuild --clean`; they are not source-
 | `ANDROID_RELEASE_STORE_PASSWORD`  | upload keystore password           |
 | `ANDROID_RELEASE_KEY_PASSWORD`    | upload key password                |
 
-`Native Store Distribution`의 Android job은 조직 수준 `VAULT_ADDR`와 `VAULT_GITHUB_ACTIONS_AUDIENCE`, 저장소 수준 `TAILSCALE_OAUTH_CLIENT_ID`와 `TAILSCALE_AUDIENCE`를 사용한다. Vault tailnet에 접속한 뒤 GitHub OIDC JWT로 `kosmo-android-play` role을 인증하고 실행 중에만 서명 값을 읽는다. Vault role과 policy는 `prod` Environment의 이 workflow만 해당 경로를 읽도록 제한해야 한다.
+`Native Store Distribution`의 Android job은 조직 수준 `VAULT_ADDR`와 `VAULT_GITHUB_ACTIONS_AUDIENCE`, 저장소 수준 `TAILSCALE_OAUTH_CLIENT_ID`와 `TAILSCALE_AUDIENCE`를 사용한다. Vault tailnet에 접속한 뒤 GitHub OIDC JWT로 `kosmo-native-store-distribution` role을 인증하고 실행 중에만 서명 값을 읽는다. Vault role과 policy는 `prod` Environment의 이 workflow만 해당 경로를 읽도록 제한해야 한다.
 
 upload key 예시는 다음과 같다. password는 명령행이나 저장소에 넣지 말고 `keytool` prompt에서 입력한다.
 
@@ -81,7 +81,7 @@ base64 결과와 password는 shell history, 저장소, GitHub 로그에 남기�
 5. App Store Connect의 Users and Access → Integrations → App Store Connect API → Team Keys에서 App Manager 권한의 Team API key를 만든다. P8 파일은 생성 시 한 번만 다운로드할 수 있으므로 즉시 Vault에 넣고, 저장소·로그·artifact에는 남기지 않는다.
 6. 앱의 TestFlight → Internal Testing에서 정확히 `Internal Testers` group을 만들고 `Enable automatic distribution`을 끈 manual distribution group으로 설정한 뒤, 해당 그룹에 App Store Connect 사용자 tester를 추가한다. workflow가 build를 이 그룹에 명시적으로 할당하므로 자동 배포 group으로 설정하지 않는다. 외부 tester나 Firebase group은 이 workflow의 대상이 아니다.
 
-Kubernetes의 `kosmo-ios-testflight` role과 read-only policy가 적용된 뒤, Vault 관리자 UI/CLI에서 다음 six fields를 KV v2 logical path `secret/kosmo/prod/ios-signing`에 기록한다. workflow와 ACL이 사용하는 API path는 `secret/data/kosmo/prod/ios-signing`이며, `/data/`는 UI/CLI logical path에 쓰지 않는다.
+Kubernetes의 `kosmo-native-store-distribution` role과 read-only policy가 적용된 뒤, Vault 관리자 UI/CLI에서 다음 six fields를 KV v2 logical path `secret/kosmo/prod/ios-signing`에 기록한다. workflow와 ACL이 사용하는 API path는 `secret/data/kosmo/prod/ios-signing`이며, `/data/`는 UI/CLI logical path에 쓰지 않는다.
 
 | Field                                       | 값                                |
 | ------------------------------------------- | --------------------------------- |
@@ -104,7 +104,7 @@ GitHub Actions에서는 새 environment를 만들지 않고 기존 `prod`를 사
 
 ### Rotation and revoke
 
-새 certificate/profile/API key를 준비한 뒤 해당 Vault field만 교체하고 TestFlight upload와 processing을 확인한 다음 이전 asset을 revoke한다. API key는 수정할 수 없으므로 새 App Manager Team key를 만들고 세 ID/P8 field를 함께 교체한다. 노출이 의심되면 확인을 기다리지 말고 이전 API key와 certificate를 Apple에서 revoke하고, 필요하면 `kosmo-ios-testflight` role/policy를 검토된 Terraform 변경으로 비활성화한다.
+새 certificate/profile/API key를 준비한 뒤 해당 Vault field만 교체하고 TestFlight upload와 processing을 확인한 다음 이전 asset을 revoke한다. API key는 수정할 수 없으므로 새 App Manager Team key를 만들고 세 ID/P8 field를 함께 교체한다. 노출이 의심되면 확인을 기다리지 말고 이전 API key와 certificate를 Apple에서 revoke하고, 필요하면 `kosmo-native-store-distribution` role/policy를 검토된 Terraform 변경으로 비활성화한다.
 
 ## Validation
 


### PR DESCRIPTION
## 무엇을 변경했는지

- `.github/workflows/native-store-distribution.yml`의 Android/iOS Vault JWT role을 `kosmo-native-store-distribution`으로 맞췄습니다.
- `apps/app/README.md`의 Android/iOS 운영 role 참조를 동일한 통합 role로 갱신했습니다.
- Android/iOS가 읽는 Vault secret path(`secret/data/kosmo/prod/android-play`, `secret/data/kosmo/prod/ios-signing`)와 나머지 배포 동작은 유지했습니다.

## 왜 변경했는지

Kubernetes PR #97이 기존 `kosmo-android-play`와 `kosmo-ios-testflight` role/policy를 `kosmo-native-store-distribution` 통합 role/policy로 교체한 뒤, 기존 workflow는 삭제된 Android role을 요청했습니다. 그 결과 [Native Store Distribution run 34325933261](https://github.com/byulmaru/kosmo/actions/runs/34325933261)에서 Android와 iOS가 Vault credential 로딩 단계에서 `role could not be found`로 실패했습니다.

## 이번 PR의 주요 결정

- Android와 iOS job 모두 Kubernetes에 적용된 canonical role `kosmo-native-store-distribution`을 사용합니다.
- 플랫폼별 secret path와 field mapping은 통합 role의 read-only policy와 맞물리므로 변경하지 않았습니다.
- version code/build number, workflow claim, cache, build/upload, cleanup 동작은 이 role 정합성 수정의 범위를 벗어나므로 유지했습니다.

## 어떻게 확인할 수 있는지

- 최신 `main`(`21f131167`)에서 새 1-layer Stack `main -> PROD-287-vault-role`로 변경했습니다.
- `actionlint .github/workflows/native-store-distribution.yml` 통과
- `git diff --check` 통과
- workflow에 새 role 참조가 정확히 2곳(Android/iOS) 존재하고, README의 기존 role 참조 4곳이 모두 통합 role로 갱신됐는지 assertion 통과
- 실제 Android/iOS Store 재실행과 secret 값 조회는 수행하지 않았습니다.

## 아직 어떤 문제가 남아 있는지

- 이 PR에서는 실제 `workflow_dispatch`, Android AAB 업로드, iOS TestFlight 업로드를 수행하지 않았습니다.
- merge 후 `prod` Environment 승인과 실제 Vault JWT allow/deny 및 Store 업로드 결과를 별도 운영 gate에서 확인해야 합니다.

Stack: `main -> PROD-287-vault-role`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>