### PR TITLE
Checkbox와 SegmentedControl을 공용 UI와 Storybook으로 이관한다

### DIFF
--- a/apps/app/src/components/ui/Checkbox.test.ts
+++ b/apps/app/src/components/ui/Checkbox.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { before, beforeEach, mock, test } from 'node:test';
+import { createElement } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ElementType, ReactNode } from 'react';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import type * as CheckboxModule from './Checkbox';
+
+const mockModule = (specifier: string | URL, exports: object) =>
+  mock.module(specifier, { exports } as unknown as Parameters<typeof mock.module>[1]);
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let platformOS: 'android' | 'ios' | 'web' = 'web';
+const PressableHost = 'Pressable' as unknown as ElementType;
+const ViewHost = 'View' as unknown as ElementType;
+
+mockModule(createRequire(import.meta.url).resolve('lucide-react-native'), { Check: 'Check' });
+mockModule('react-native', {
+  Platform: {
+    get OS() {
+      return platformOS;
+    },
+  },
+  Pressable: ({ children, ...props }: { children?: ReactNode | ((state: object) => ReactNode) }) =>
+    createElement(
+      PressableHost,
+      props,
+      typeof children === 'function' ? children({ hovered: false, pressed: false }) : children,
+    ),
+  StyleSheet: {
+    absoluteFillObject: { bottom: 0, left: 0, position: 'absolute', right: 0, top: 0 },
+    create: <T>(styles: T) => styles,
+  },
+  View: ViewHost,
+});
+mockModule('@/theme/ThemeProvider', {
+  useTheme: () => ({
+    actionPrimaryBase: 'primary',
+    actionPrimaryDisabled: 'primary-disabled',
+    actionPrimaryHover: 'primary-hover',
+    actionPrimaryOnBase: 'on-primary',
+    actionPrimaryOnDisabled: 'on-disabled',
+    actionPrimaryPressed: 'primary-pressed',
+    backgroundSurface: 'surface',
+    borderDisabled: 'border-disabled',
+    borderStrong: 'border-strong',
+    stateDisabledSurface: 'disabled-surface',
+    stateFocusRing: 'focus-ring',
+    stateHover: 'hover',
+    statePressed: 'pressed',
+  }),
+});
+mockModule('@/theme/tokens', {
+  borderWidths: { 1: 1, 2: 2 },
+  iconSizes: { 20: 20 },
+  radius: { 4: 4, 8: 8, full: 999 },
+});
+
+let Checkbox: typeof CheckboxModule.Checkbox | undefined;
+
+before(async () => {
+  Checkbox = (await import('./Checkbox')).Checkbox;
+});
+
+beforeEach(() => {
+  platformOS = 'web';
+});
+
+function renderCheckbox(
+  checked: CheckboxModule.CheckboxValue,
+  onCheckedChange: (next: boolean) => void = () => undefined,
+  disabled = false,
+) {
+  assert.ok(Checkbox);
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(
+      createElement(Checkbox!, {
+        accessibilityLabel: '모두 선택',
+        checked,
+        disabled,
+        onCheckedChange,
+      }),
+    );
+  });
+  assert.ok(renderer);
+  return renderer.root.findByType(PressableHost);
+}
+
+test('Checkbox exposes false, true, and mixed checked states and emits the next boolean', () => {
+  const changes: boolean[] = [];
+
+  for (const [checked, next] of [
+    [false, true],
+    [true, false],
+    ['mixed', true],
+  ] as const) {
+    const checkbox = renderCheckbox(checked, (value) => changes.push(value));
+    assert.equal(checkbox.props.accessibilityRole, 'checkbox');
+    assert.equal(checkbox.props['aria-checked'], checked);
+    assert.deepEqual(checkbox.props.accessibilityState, { checked, disabled: false });
+    act(() => checkbox.props.onPress());
+    assert.equal(changes.at(-1), next);
+  }
+});
+
+test('Checkbox preserves its visual box and supplies the Native target deficit as hit slop', () => {
+  for (const [platform, hitSlop] of [
+    ['web', undefined],
+    ['ios', 6],
+    ['android', 8],
+  ] as const) {
+    platformOS = platform;
+    const checkbox = renderCheckbox(false);
+    assert.equal(checkbox.props.hitSlop, hitSlop);
+    assert.deepEqual(checkbox.props.style, {
+      alignItems: 'center',
+      height: 32,
+      justifyContent: 'center',
+      width: 32,
+    });
+  }
+});
+
+test('Disabled Checkbox does not emit a change', () => {
+  const changes: boolean[] = [];
+  const checkbox = renderCheckbox(false, (value) => changes.push(value), true);
+
+  assert.equal(checkbox.props.disabled, true);
+  assert.equal(checkbox.props['aria-disabled'], true);
+  act(() => checkbox.props.onPress());
+  assert.deepEqual(changes, []);
+});

--- a/apps/app/src/components/ui/Checkbox.test.ts
+++ b/apps/app/src/components/ui/Checkbox.test.ts
@@ -106,22 +106,52 @@ test('Checkbox exposes false, true, and mixed checked states and emits the next 
   }
 });
 
-test('Checkbox preserves its visual box and supplies the Native target deficit as hit slop', () => {
-  for (const [platform, hitSlop] of [
-    ['web', undefined],
-    ['ios', 6],
-    ['android', 8],
+test('Checkbox preserves its visual box inside the platform target size', () => {
+  for (const [platform, targetSize] of [
+    ['web', 32],
+    ['ios', 44],
+    ['android', 48],
   ] as const) {
     platformOS = platform;
     const checkbox = renderCheckbox(false);
-    assert.equal(checkbox.props.hitSlop, hitSlop);
-    assert.deepEqual(checkbox.props.style, {
+    assert.deepEqual(checkbox.props.style, [
+      {
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+      { height: targetSize, width: targetSize },
+    ]);
+    const [visual, indicator] = checkbox.findAllByType(ViewHost);
+    assert.deepEqual(visual.props.style, {
       alignItems: 'center',
       height: 32,
       justifyContent: 'center',
       width: 32,
     });
+    assert.equal(indicator.props.style[0].height, 20);
+    assert.equal(indicator.props.style[0].width, 20);
   }
+});
+
+test('Web keyboard toggles Checkbox once and ignores repeated Space', () => {
+  const changes: boolean[] = [];
+  const checkbox = renderCheckbox(false, (value) => changes.push(value));
+  let prevented = 0;
+
+  for (const repeat of [false, true]) {
+    act(() =>
+      checkbox.props.onKeyDown({
+        key: ' ',
+        preventDefault: () => {
+          prevented += 1;
+        },
+        repeat,
+      }),
+    );
+  }
+
+  assert.equal(prevented, 2);
+  assert.deepEqual(changes, [true]);
 });
 
 test('Disabled Checkbox does not emit a change', () => {

--- a/apps/app/src/components/ui/Checkbox.tsx
+++ b/apps/app/src/components/ui/Checkbox.tsx
@@ -1,0 +1,163 @@
+import { Check } from 'lucide-react-native';
+import { useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, iconSizes, radius } from '@/theme/tokens';
+import type { ViewStyle } from 'react-native';
+
+export type CheckboxValue = boolean | 'mixed';
+
+export type CheckboxProps = {
+  accessibilityLabel: string;
+  checked: CheckboxValue;
+  disabled?: boolean;
+  onCheckedChange: (checked: boolean) => void;
+};
+
+type WebCheckboxProps = {
+  'aria-checked': CheckboxValue;
+  'aria-disabled': boolean;
+  onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
+  onPointerDown: () => void;
+  role: 'checkbox';
+};
+
+export function Checkbox({
+  accessibilityLabel,
+  checked,
+  disabled = false,
+  onCheckedChange,
+}: CheckboxProps) {
+  const theme = useTheme();
+  const [focusVisible, setFocusVisible] = useState(false);
+  const web = Platform.OS === 'web';
+  const hitSlop = web ? undefined : Platform.OS === 'ios' ? 6 : 8;
+  const toggle = () => {
+    if (!disabled) {
+      onCheckedChange(checked !== true);
+    }
+  };
+
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked, disabled }}
+      disabled={disabled}
+      hitSlop={hitSlop}
+      onBlur={() => setFocusVisible(false)}
+      onFocus={(event) => {
+        const target = event.currentTarget as unknown as {
+          matches?: (selector: string) => boolean;
+        };
+        setFocusVisible(!web || Boolean(target.matches?.(':focus-visible')));
+      }}
+      onPress={toggle}
+      style={styles.root}
+      {...(web
+        ? ({
+            'aria-checked': checked,
+            'aria-disabled': disabled,
+            onKeyDown: (event) => {
+              if (event.key === ' ' || event.key === 'Spacebar') {
+                event.preventDefault();
+                toggle();
+              }
+            },
+            onPointerDown: () => setFocusVisible(false),
+            role: 'checkbox',
+          } as WebCheckboxProps)
+        : undefined)}
+    >
+      {(state) => {
+        const webState = state as { hovered?: boolean };
+        const hovered = web && Boolean(webState.hovered);
+        const activeColor = disabled
+          ? theme.actionPrimaryDisabled
+          : state.pressed
+            ? theme.actionPrimaryPressed
+            : hovered
+              ? theme.actionPrimaryHover
+              : theme.actionPrimaryBase;
+        const foreground = disabled ? theme.actionPrimaryOnDisabled : theme.actionPrimaryOnBase;
+
+        return (
+          <>
+            {hovered || state.pressed ? (
+              <View
+                style={[
+                  styles.stateLayer,
+                  { backgroundColor: state.pressed ? theme.statePressed : theme.stateHover },
+                ]}
+              />
+            ) : null}
+            {focusVisible ? (
+              <View style={[styles.focusRing, { borderColor: theme.stateFocusRing }]} />
+            ) : null}
+            <View
+              style={[
+                styles.indicator,
+                checked === false
+                  ? {
+                      backgroundColor: disabled
+                        ? theme.stateDisabledSurface
+                        : theme.backgroundSurface,
+                      borderColor: disabled ? theme.borderDisabled : theme.borderStrong,
+                      borderWidth: borderWidths[1],
+                    }
+                  : { backgroundColor: activeColor },
+              ]}
+            >
+              {checked === true ? (
+                <Check color={foreground} size={iconSizes[20]} strokeWidth={2} />
+              ) : checked === 'mixed' ? (
+                <View style={[styles.mixed, { backgroundColor: foreground }]} />
+              ) : null}
+            </View>
+          </>
+        );
+      }}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    alignItems: 'center',
+    height: 32,
+    justifyContent: 'center',
+    width: 32,
+  },
+  stateLayer: {
+    bottom: 0,
+    borderRadius: radius[8],
+    left: 0,
+    pointerEvents: 'none',
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  focusRing: {
+    borderRadius: radius[8],
+    borderWidth: borderWidths[2],
+    bottom: 2,
+    left: 2,
+    pointerEvents: 'none',
+    position: 'absolute',
+    right: 2,
+    top: 2,
+  } as ViewStyle,
+  indicator: {
+    alignItems: 'center',
+    borderRadius: radius[4],
+    height: iconSizes[20],
+    justifyContent: 'center',
+    pointerEvents: 'none',
+    width: iconSizes[20],
+  },
+  mixed: {
+    borderRadius: radius.full,
+    height: 2,
+    width: 10,
+  },
+});

--- a/apps/app/src/components/ui/Checkbox.tsx
+++ b/apps/app/src/components/ui/Checkbox.tsx
@@ -17,7 +17,7 @@ export type CheckboxProps = {
 type WebCheckboxProps = {
   'aria-checked': CheckboxValue;
   'aria-disabled': boolean;
-  onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
+  onKeyDown: (event: { key: string; preventDefault: () => void; repeat: boolean }) => void;
   onPointerDown: () => void;
   role: 'checkbox';
 };
@@ -31,7 +31,7 @@ export function Checkbox({
   const theme = useTheme();
   const [focusVisible, setFocusVisible] = useState(false);
   const web = Platform.OS === 'web';
-  const hitSlop = web ? undefined : Platform.OS === 'ios' ? 6 : 8;
+  const targetSize = web ? 32 : Platform.OS === 'ios' ? 44 : 48;
   const toggle = () => {
     if (!disabled) {
       onCheckedChange(checked !== true);
@@ -44,7 +44,6 @@ export function Checkbox({
       accessibilityRole="checkbox"
       accessibilityState={{ checked, disabled }}
       disabled={disabled}
-      hitSlop={hitSlop}
       onBlur={() => setFocusVisible(false)}
       onFocus={(event) => {
         const target = event.currentTarget as unknown as {
@@ -53,7 +52,7 @@ export function Checkbox({
         setFocusVisible(!web || Boolean(target.matches?.(':focus-visible')));
       }}
       onPress={toggle}
-      style={styles.root}
+      style={[styles.root, { height: targetSize, width: targetSize }]}
       {...(web
         ? ({
             'aria-checked': checked,
@@ -61,7 +60,9 @@ export function Checkbox({
             onKeyDown: (event) => {
               if (event.key === ' ' || event.key === 'Spacebar') {
                 event.preventDefault();
-                toggle();
+                if (!event.repeat) {
+                  toggle();
+                }
               }
             },
             onPointerDown: () => setFocusVisible(false),
@@ -82,7 +83,7 @@ export function Checkbox({
         const foreground = disabled ? theme.actionPrimaryOnDisabled : theme.actionPrimaryOnBase;
 
         return (
-          <>
+          <View style={styles.visual}>
             {hovered || state.pressed ? (
               <View
                 style={[
@@ -114,7 +115,7 @@ export function Checkbox({
                 <View style={[styles.mixed, { backgroundColor: foreground }]} />
               ) : null}
             </View>
-          </>
+          </View>
         );
       }}
     </Pressable>
@@ -123,6 +124,10 @@ export function Checkbox({
 
 const styles = StyleSheet.create({
   root: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  visual: {
     alignItems: 'center',
     height: 32,
     justifyContent: 'center',

--- a/apps/app/src/components/ui/SegmentedControl.test.ts
+++ b/apps/app/src/components/ui/SegmentedControl.test.ts
@@ -210,7 +210,7 @@ test('SegmentedControl exposes a radiogroup with exactly one selected radio', ()
   );
 });
 
-test('Arrow keys move focus and selection with wrapping', () => {
+test('Arrow keys move focus and selection while Space activates the focused option once', () => {
   const changes: string[] = [];
   const renderer = renderControl({ onValueChange: (value) => changes.push(value) });
   const first = radios(renderer)[0];
@@ -222,12 +222,20 @@ test('Arrow keys move focus and selection with wrapping', () => {
       preventDefault: () => {
         prevented = true;
       },
+      repeat: false,
     }),
   );
 
   assert.equal(prevented, true);
   assert.deepEqual(changes, ['three']);
   assert.deepEqual(focusedLabels, ['옵션 3']);
+
+  const second = radios(renderer)[1];
+  act(() => {
+    second.props.onKeyDown({ key: ' ', preventDefault: () => undefined, repeat: false });
+    second.props.onKeyDown({ key: ' ', preventDefault: () => undefined, repeat: true });
+  });
+  assert.deepEqual(changes, ['three', 'two']);
 });
 
 test('Selection pill stretch stays subtle across distance and direction', () => {

--- a/apps/app/src/components/ui/SegmentedControl.test.ts
+++ b/apps/app/src/components/ui/SegmentedControl.test.ts
@@ -1,0 +1,326 @@
+import assert from 'node:assert/strict';
+import { before, beforeEach, mock, test } from 'node:test';
+import { createElement, forwardRef, useImperativeHandle } from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ElementType, ReactNode, Ref } from 'react';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import type * as SegmentedControlModule from './SegmentedControl';
+
+const mockModule = (specifier: string | URL, exports: object) =>
+  mock.module(specifier, { exports } as unknown as Parameters<typeof mock.module>[1]);
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type PressableProps = {
+  accessibilityLabel?: string;
+  children?: ReactNode | ((state: object) => ReactNode);
+};
+
+const focusedLabels: string[] = [];
+const timingCalls: {
+  duration: number;
+  easing: string;
+  toValue: number;
+  useNativeDriver: boolean;
+}[] = [];
+const PressableHost = forwardRef<{ focus: () => void }, PressableProps>(function PressableMock(
+  { children, ...props },
+  ref: Ref<{ focus: () => void }>,
+) {
+  useImperativeHandle(ref, () => ({
+    focus: () => focusedLabels.push(props.accessibilityLabel ?? ''),
+  }));
+  return createElement(
+    'Pressable',
+    props,
+    typeof children === 'function' ? children({ hovered: false, pressed: false }) : children,
+  );
+});
+const ViewHost = 'View' as unknown as ElementType;
+
+let platformOS: 'ios' | 'web' = 'web';
+let reducedMotion = false;
+
+class AnimatedValueMock {
+  value: number;
+
+  constructor(value: number) {
+    this.value = value;
+  }
+
+  setValue(value: number) {
+    this.value = value;
+  }
+
+  stopAnimation(callback?: (value: number) => void) {
+    callback?.(this.value);
+  }
+}
+
+type AnimationMock = { start: () => void; stop: () => void };
+
+mockModule('react-native', {
+  Animated: {
+    Value: AnimatedValueMock,
+    View: ViewHost,
+    parallel: (animations: AnimationMock[]): AnimationMock => ({
+      start: () => animations.forEach((animation) => animation.start()),
+      stop: () => animations.forEach((animation) => animation.stop()),
+    }),
+    sequence: (animations: AnimationMock[]): AnimationMock => ({
+      start: () => animations.forEach((animation) => animation.start()),
+      stop: () => animations.forEach((animation) => animation.stop()),
+    }),
+    timing: (
+      value: AnimatedValueMock,
+      config: { duration: number; easing: string; toValue: number; useNativeDriver: boolean },
+    ): AnimationMock => {
+      timingCalls.push(config);
+      return { start: () => value.setValue(config.toValue), stop: () => undefined };
+    },
+  },
+  Easing: { bezier: () => 'standard-easing' },
+  Platform: {
+    get OS() {
+      return platformOS;
+    },
+  },
+  Pressable: PressableHost,
+  StyleSheet: { create: <T>(styles: T) => styles },
+  Text: 'Text',
+  View: ViewHost,
+});
+mockModule('@/theme/ThemeProvider', {
+  useReducedMotion: () => reducedMotion,
+  useTheme: () => ({
+    backgroundSurface: 'surface',
+    borderDefault: 'border',
+    borderDisabled: 'border-disabled',
+    foregroundPrimary: 'foreground',
+    stateDisabledForeground: 'disabled-foreground',
+    stateDisabledSurface: 'disabled-surface',
+    stateFocusRing: 'focus-ring',
+    stateHover: 'hover',
+    statePressed: 'pressed',
+    stateSelectedBorder: 'selected-border',
+    stateSelectedSurface: 'selected-surface',
+  }),
+});
+mockModule('@/theme/tokens', {
+  borderWidths: { 1: 1, 2: 2 },
+  motion: {
+    duration: { standard: 200 },
+    easingPoints: { standard: [0.17, 0.73, 0.14, 1] },
+  },
+  radius: { 8: 8, 12: 12 },
+  space: { 8: 8, 12: 12 },
+  textStyles: { uiLabelM: { fontSize: 14, lineHeight: 20 } },
+});
+
+let SegmentedControl: typeof SegmentedControlModule.SegmentedControl | undefined;
+
+before(async () => {
+  SegmentedControl = (await import('./SegmentedControl')).SegmentedControl;
+});
+
+beforeEach(() => {
+  focusedLabels.length = 0;
+  timingCalls.length = 0;
+  platformOS = 'web';
+  reducedMotion = false;
+});
+
+const options = [
+  { label: '옵션 1', value: 'one' },
+  { label: '옵션 2', value: 'two' },
+  { label: '옵션 3', value: 'three' },
+] as const;
+
+function renderControl({
+  disabled = false,
+  onValueChange = () => undefined,
+  value = 'one',
+}: {
+  disabled?: boolean;
+  onValueChange?: (value: string) => void;
+  value?: string;
+} = {}) {
+  assert.ok(SegmentedControl);
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(
+      createElement(SegmentedControl!, {
+        accessibilityLabel: '표시 방식',
+        disabled,
+        onValueChange,
+        options,
+        value,
+      }),
+    );
+  });
+  assert.ok(renderer);
+  return renderer;
+}
+
+function radios(renderer: ReactTestRenderer) {
+  return renderer.root.findAllByType(PressableHost);
+}
+
+function layOutItems(renderer: ReactTestRenderer) {
+  act(() => {
+    radios(renderer).forEach((item, index) =>
+      item.props.onLayout({
+        nativeEvent: { layout: { height: 48, width: 100, x: index * 100, y: 0 } },
+      }),
+    );
+  });
+}
+
+function selectionFrame(renderer: ReactTestRenderer) {
+  const selection = renderer.root.find(
+    (node) => node.type === ViewHost && node.props.pointerEvents === 'none',
+  );
+  const frame = selection.props.style.at(-1) as {
+    left: AnimatedValueMock;
+    width: AnimatedValueMock;
+  };
+  return { left: frame.left.value, width: frame.width.value };
+}
+
+test('SegmentedControl exposes a radiogroup with exactly one selected radio', () => {
+  const renderer = renderControl({ value: 'missing' });
+  const group = renderer.root.findByType(ViewHost);
+  const items = radios(renderer);
+
+  assert.equal(group.props.accessibilityRole, 'radiogroup');
+  assert.equal(group.props.role, 'radiogroup');
+  assert.equal(group.props.style[0].width, 320);
+  assert.equal(items.length, 3);
+  assert.equal(
+    items.every((item) => item.props.style.flex === 1),
+    true,
+  );
+  assert.deepEqual(
+    items.map((item) => item.props.accessibilityState.checked),
+    [true, false, false],
+  );
+  assert.deepEqual(
+    items.map((item) => item.props.tabIndex),
+    [0, -1, -1],
+  );
+});
+
+test('Arrow keys move focus and selection with wrapping', () => {
+  const changes: string[] = [];
+  const renderer = renderControl({ onValueChange: (value) => changes.push(value) });
+  const first = radios(renderer)[0];
+  let prevented = false;
+
+  act(() =>
+    first.props.onKeyDown({
+      key: 'ArrowLeft',
+      preventDefault: () => {
+        prevented = true;
+      },
+    }),
+  );
+
+  assert.equal(prevented, true);
+  assert.deepEqual(changes, ['three']);
+  assert.deepEqual(focusedLabels, ['옵션 3']);
+});
+
+test('Selection pill stretch stays subtle across distance and direction', () => {
+  const renderer = renderControl();
+  layOutItems(renderer);
+
+  act(() => {
+    renderer.update(
+      createElement(SegmentedControl!, {
+        accessibilityLabel: '표시 방식',
+        onValueChange: () => undefined,
+        options,
+        value: 'three',
+      }),
+    );
+  });
+
+  assert.deepEqual(
+    timingCalls.map(({ duration, easing, toValue, useNativeDriver }) => ({
+      duration,
+      easing,
+      toValue,
+      useNativeDriver,
+    })),
+    [
+      { duration: 60, easing: 'standard-easing', toValue: 4, useNativeDriver: false },
+      { duration: 60, easing: 'standard-easing', toValue: 100, useNativeDriver: false },
+      { duration: 140, easing: 'standard-easing', toValue: 204, useNativeDriver: false },
+      { duration: 140, easing: 'standard-easing', toValue: 92, useNativeDriver: false },
+    ],
+  );
+  assert.deepEqual(selectionFrame(renderer), { left: 204, width: 92 });
+
+  timingCalls.length = 0;
+  act(() => {
+    renderer.update(
+      createElement(SegmentedControl!, {
+        accessibilityLabel: '표시 방식',
+        onValueChange: () => undefined,
+        options,
+        value: 'one',
+      }),
+    );
+  });
+
+  assert.deepEqual(
+    timingCalls.map(({ duration, toValue }) => ({ duration, toValue })),
+    [
+      { duration: 60, toValue: 196 },
+      { duration: 60, toValue: 100 },
+      { duration: 140, toValue: 4 },
+      { duration: 140, toValue: 92 },
+    ],
+  );
+  assert.deepEqual(selectionFrame(renderer), { left: 4, width: 92 });
+});
+
+test('Reduced motion moves the selection pill immediately', () => {
+  reducedMotion = true;
+  const renderer = renderControl();
+  layOutItems(renderer);
+
+  act(() => {
+    renderer.update(
+      createElement(SegmentedControl!, {
+        accessibilityLabel: '표시 방식',
+        onValueChange: () => undefined,
+        options,
+        value: 'two',
+      }),
+    );
+  });
+
+  assert.deepEqual(timingCalls, []);
+  assert.deepEqual(selectionFrame(renderer), { left: 104, width: 92 });
+});
+
+test('Disabled SegmentedControl has no tab stop or change callback', () => {
+  const changes: string[] = [];
+  const renderer = renderControl({
+    disabled: true,
+    onValueChange: (value) => changes.push(value),
+  });
+  const items = radios(renderer);
+
+  assert.equal(
+    items.every((item) => item.props.disabled),
+    true,
+  );
+  assert.equal(
+    items.every((item) => item.props.tabIndex === -1),
+    true,
+  );
+  act(() => items[1]?.props.onPress());
+  assert.deepEqual(changes, []);
+});

--- a/apps/app/src/components/ui/SegmentedControl.tsx
+++ b/apps/app/src/components/ui/SegmentedControl.tsx
@@ -37,7 +37,7 @@ type WebGroupProps = { role: 'radiogroup' };
 type WebRadioProps = {
   'aria-checked': boolean;
   'aria-disabled': boolean;
-  onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
+  onKeyDown: (event: { key: string; preventDefault: () => void; repeat: boolean }) => void;
   onPointerDown: () => void;
   role: 'radio';
   tabIndex: -1 | 0;
@@ -71,14 +71,26 @@ function SegmentedControlItem<Value extends string>({
   const web = Platform.OS === 'web';
   optionRefs.set(option.value, optionRef);
 
-  const onKeyDown = (event: { key: string; preventDefault: () => void }) => {
+  const onKeyDown = (event: { key: string; preventDefault: () => void; repeat: boolean }) => {
+    if (disabled || !web) {
+      return;
+    }
+
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      if (!event.repeat) {
+        onValueChange(option.value);
+      }
+      return;
+    }
+
     const direction =
       event.key === 'ArrowRight' || event.key === 'ArrowDown'
         ? 1
         : event.key === 'ArrowLeft' || event.key === 'ArrowUp'
           ? -1
           : 0;
-    if (disabled || !web || direction === 0) {
+    if (direction === 0) {
       return;
     }
 

--- a/apps/app/src/components/ui/SegmentedControl.tsx
+++ b/apps/app/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useRef, useState } from 'react';
+import { Animated, Easing, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useReducedMotion, useTheme } from '@/theme/ThemeProvider';
+import { borderWidths, motion, radius, space, textStyles } from '@/theme/tokens';
+import type { RefObject } from 'react';
+import type { LayoutChangeEvent, ViewStyle } from 'react-native';
+
+export type SegmentedControlOption<Value extends string> = Readonly<{
+  accessibilityLabel?: string;
+  label: string;
+  value: Value;
+}>;
+
+export type SegmentedControlOptions<Value extends string> =
+  | readonly [SegmentedControlOption<Value>, SegmentedControlOption<Value>]
+  | readonly [
+      SegmentedControlOption<Value>,
+      SegmentedControlOption<Value>,
+      SegmentedControlOption<Value>,
+    ]
+  | readonly [
+      SegmentedControlOption<Value>,
+      SegmentedControlOption<Value>,
+      SegmentedControlOption<Value>,
+      SegmentedControlOption<Value>,
+    ];
+
+export type SegmentedControlProps<Value extends string> = {
+  accessibilityLabel: string;
+  disabled?: boolean;
+  onValueChange: (value: Value) => void;
+  options: SegmentedControlOptions<Value>;
+  value: Value;
+};
+
+type WebGroupProps = { role: 'radiogroup' };
+type WebRadioProps = {
+  'aria-checked': boolean;
+  'aria-disabled': boolean;
+  onKeyDown: (event: { key: string; preventDefault: () => void }) => void;
+  onPointerDown: () => void;
+  role: 'radio';
+  tabIndex: -1 | 0;
+};
+
+type SegmentedControlItemProps<Value extends string> = {
+  disabled: boolean;
+  index: number;
+  onLayout: (event: LayoutChangeEvent) => void;
+  onValueChange: (value: Value) => void;
+  option: SegmentedControlOption<Value>;
+  optionRefs: Map<Value, RefObject<View | null>>;
+  options: SegmentedControlOptions<Value>;
+  selectedValue: Value;
+};
+
+function SegmentedControlItem<Value extends string>({
+  disabled,
+  index,
+  onLayout,
+  onValueChange,
+  option,
+  optionRefs,
+  options,
+  selectedValue,
+}: SegmentedControlItemProps<Value>) {
+  const theme = useTheme();
+  const optionRef = useRef<View>(null);
+  const [focusVisible, setFocusVisible] = useState(false);
+  const selected = option.value === selectedValue;
+  const web = Platform.OS === 'web';
+  optionRefs.set(option.value, optionRef);
+
+  const onKeyDown = (event: { key: string; preventDefault: () => void }) => {
+    const direction =
+      event.key === 'ArrowRight' || event.key === 'ArrowDown'
+        ? 1
+        : event.key === 'ArrowLeft' || event.key === 'ArrowUp'
+          ? -1
+          : 0;
+    if (disabled || !web || direction === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    const target = options[(index + direction + options.length) % options.length];
+    onValueChange(target.value);
+    const targetRef = optionRefs.get(target.value)?.current as unknown as {
+      focus?: () => void;
+    } | null;
+    targetRef?.focus?.();
+  };
+
+  return (
+    <Pressable
+      accessibilityLabel={option.accessibilityLabel ?? option.label}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected, disabled }}
+      disabled={disabled}
+      onLayout={onLayout}
+      onBlur={() => setFocusVisible(false)}
+      onFocus={(event) => {
+        const target = event.currentTarget as unknown as {
+          matches?: (selector: string) => boolean;
+        };
+        setFocusVisible(!web || Boolean(target.matches?.(':focus-visible')));
+      }}
+      onPress={() => {
+        if (!disabled) {
+          onValueChange(option.value);
+        }
+      }}
+      ref={optionRef}
+      style={styles.item}
+      {...(web
+        ? ({
+            'aria-checked': selected,
+            'aria-disabled': disabled,
+            onKeyDown,
+            onPointerDown: () => setFocusVisible(false),
+            role: 'radio',
+            tabIndex: disabled || !selected ? -1 : 0,
+          } as WebRadioProps)
+        : undefined)}
+    >
+      {(state) => {
+        const hovered = web && Boolean((state as { hovered?: boolean }).hovered);
+        return (
+          <>
+            {hovered || state.pressed ? (
+              <View
+                style={[
+                  styles.stateLayer,
+                  { backgroundColor: state.pressed ? theme.statePressed : theme.stateHover },
+                ]}
+              />
+            ) : null}
+            {focusVisible ? (
+              <View style={[styles.focusRing, { borderColor: theme.stateFocusRing }]} />
+            ) : null}
+            <Text
+              numberOfLines={1}
+              style={[
+                styles.label,
+                { color: disabled ? theme.stateDisabledForeground : theme.foregroundPrimary },
+              ]}
+            >
+              {option.label}
+            </Text>
+          </>
+        );
+      }}
+    </Pressable>
+  );
+}
+
+export function SegmentedControl<Value extends string>({
+  accessibilityLabel,
+  disabled = false,
+  onValueChange,
+  options,
+  value,
+}: SegmentedControlProps<Value>) {
+  const theme = useTheme();
+  const reducedMotion = useReducedMotion();
+  const optionRefs = useRef(new Map<Value, RefObject<View | null>>()).current;
+  const selectionLeft = useRef(new Animated.Value(0)).current;
+  const selectionWidth = useRef(new Animated.Value(0)).current;
+  const previousValue = useRef<Value | undefined>(undefined);
+  const [frames, setFrames] = useState<Partial<Record<Value, { left: number; width: number }>>>({});
+  const selectedValue = options.some((option) => option.value === value) ? value : options[0].value;
+  const web = Platform.OS === 'web';
+  const selectedFrame = frames[selectedValue];
+
+  useEffect(() => {
+    if (!selectedFrame) {
+      return;
+    }
+
+    const targetLeft = selectedFrame.left + 4;
+    const targetWidth = selectedFrame.width - 8;
+    const valueChanged =
+      previousValue.current !== undefined && previousValue.current !== selectedValue;
+    previousValue.current = selectedValue;
+
+    if (reducedMotion || !valueChanged) {
+      selectionLeft.stopAnimation();
+      selectionWidth.stopAnimation();
+      selectionLeft.setValue(targetLeft);
+      selectionWidth.setValue(targetWidth);
+      return;
+    }
+
+    let cancelled = false;
+    let animation: Animated.CompositeAnimation | undefined;
+    selectionLeft.stopAnimation((currentLeft) => {
+      selectionWidth.stopAnimation((currentWidth) => {
+        if (cancelled) {
+          return;
+        }
+
+        const currentRight = currentLeft + currentWidth;
+        const stretchedWidth = targetWidth + space[8];
+        const stretchDuration = motion.duration.standard * 0.3;
+        const settleDuration = motion.duration.standard - stretchDuration;
+        const easing = Easing.bezier(...motion.easingPoints.standard);
+        const movingRight = targetLeft > currentLeft;
+        animation = Animated.sequence([
+          Animated.parallel([
+            Animated.timing(selectionLeft, {
+              duration: stretchDuration,
+              easing,
+              toValue: movingRight ? currentLeft : currentRight - stretchedWidth,
+              useNativeDriver: false,
+            }),
+            Animated.timing(selectionWidth, {
+              duration: stretchDuration,
+              easing,
+              toValue: stretchedWidth,
+              useNativeDriver: false,
+            }),
+          ]),
+          Animated.parallel([
+            Animated.timing(selectionLeft, {
+              duration: settleDuration,
+              easing,
+              toValue: targetLeft,
+              useNativeDriver: false,
+            }),
+            Animated.timing(selectionWidth, {
+              duration: settleDuration,
+              easing,
+              toValue: targetWidth,
+              useNativeDriver: false,
+            }),
+          ]),
+        ]);
+        animation.start();
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      animation?.stop();
+    };
+  }, [reducedMotion, selectedFrame, selectedValue, selectionLeft, selectionWidth]);
+
+  return (
+    <View
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="radiogroup"
+      accessibilityState={{ disabled }}
+      style={[
+        styles.root,
+        {
+          backgroundColor: disabled ? theme.stateDisabledSurface : theme.backgroundSurface,
+          borderColor: disabled ? theme.borderDisabled : theme.borderDefault,
+        },
+      ]}
+      {...(web ? ({ role: 'radiogroup' } as WebGroupProps) : undefined)}
+    >
+      {selectedFrame ? (
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.selection,
+            {
+              backgroundColor: theme.stateSelectedSurface,
+              borderColor: theme.stateSelectedBorder,
+              left: selectionLeft,
+              width: selectionWidth,
+            },
+          ]}
+        />
+      ) : null}
+      {options.map((option, index) => (
+        <SegmentedControlItem
+          disabled={disabled}
+          index={index}
+          key={option.value}
+          onLayout={(event) => {
+            const { width, x: left } = event.nativeEvent.layout;
+            setFrames((current) => {
+              const previous = current[option.value];
+              return previous?.left === left && previous.width === width
+                ? current
+                : { ...current, [option.value]: { left, width } };
+            });
+          }}
+          onValueChange={onValueChange}
+          option={option}
+          optionRefs={optionRefs}
+          options={options}
+          selectedValue={selectedValue}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    borderRadius: radius[12],
+    borderWidth: borderWidths[1],
+    flexDirection: 'row',
+    height: 48,
+    width: 320,
+  },
+  item: {
+    alignItems: 'center',
+    flex: 1,
+    height: 48,
+    justifyContent: 'center',
+    paddingHorizontal: space[12],
+  },
+  selection: {
+    borderRadius: radius[8],
+    borderWidth: borderWidths[1],
+    bottom: 4,
+    pointerEvents: 'none',
+    position: 'absolute',
+    top: 4,
+  } as ViewStyle,
+  stateLayer: {
+    borderRadius: radius[8],
+    bottom: 4,
+    left: 4,
+    pointerEvents: 'none',
+    position: 'absolute',
+    right: 4,
+    top: 4,
+  } as ViewStyle,
+  focusRing: {
+    borderRadius: radius[12],
+    borderWidth: borderWidths[2],
+    bottom: 2,
+    left: 2,
+    pointerEvents: 'none',
+    position: 'absolute',
+    right: 2,
+    top: 2,
+  } as ViewStyle,
+  label: {
+    ...textStyles.uiLabelM,
+    maxWidth: '100%',
+    textAlign: 'center',
+  },
+});

--- a/apps/app/src/stories/components/Checkbox.stories.tsx
+++ b/apps/app/src/stories/components/Checkbox.stories.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { Text, View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { Checkbox } from '@/components/ui/Checkbox';
+import { useTheme } from '@/theme/ThemeProvider';
+import { space, textStyles } from '@/theme/tokens';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { CheckboxValue } from '@/components/ui/Checkbox';
+
+const defaultLabel = '모두 선택';
+
+type CheckboxCatalogProps = {
+  checked?: CheckboxValue;
+  disabled?: boolean;
+  label?: string;
+  onCheckedChange?: (checked: boolean) => void;
+};
+
+function CheckboxCatalog({
+  checked: initialChecked = false,
+  disabled = false,
+  label = defaultLabel,
+  onCheckedChange,
+}: CheckboxCatalogProps) {
+  const theme = useTheme();
+  const [checked, setChecked] = useState<CheckboxValue>(initialChecked);
+
+  useEffect(() => setChecked(initialChecked), [initialChecked]);
+
+  return (
+    <View style={{ alignItems: 'center', flexDirection: 'row', gap: space[8] }}>
+      <Checkbox
+        accessibilityLabel={label}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={(next) => {
+          setChecked(next);
+          onCheckedChange?.(next);
+        }}
+      />
+      <Text style={[textStyles.uiCopyM, { color: theme.foregroundPrimary, flexShrink: 1 }]}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const meta = {
+  args: {
+    checked: false,
+    disabled: false,
+    label: defaultLabel,
+    onCheckedChange: fn(),
+  },
+  argTypes: {
+    checked: { control: 'select', options: [false, true, 'mixed'] },
+    disabled: { control: 'boolean' },
+    label: { control: 'text' },
+  },
+  component: CheckboxCatalog,
+  excludeStories: ['InteractionContract', 'DisabledInteractionContract'],
+  parameters: { controls: { disable: true } },
+  render: (args) => <CheckboxCatalog key={String(args.checked)} {...args} />,
+  title: 'KOSMO/Components/Checkbox',
+} satisfies Meta<typeof CheckboxCatalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  parameters: {
+    controls: { disable: false, include: ['checked', 'disabled', 'label'] },
+  },
+};
+
+export const InteractionContract: Story = {
+  args: { checked: 'mixed', disabled: false, label: defaultLabel },
+  play: async ({ args, canvasElement, step }) => {
+    args.onCheckedChange?.mockClear();
+    const checkbox = within(canvasElement).getByRole('checkbox', { name: defaultLabel });
+
+    await step('mixed 상태와 keyboard focus 확인', async () => {
+      expect(checkbox).toHaveAttribute('aria-checked', 'mixed');
+      await userEvent.tab();
+      expect(checkbox).toHaveFocus();
+    });
+
+    await step('Space로 checked 상태와 callback 변경', async () => {
+      await userEvent.keyboard(' ');
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+      expect(args.onCheckedChange).toHaveBeenLastCalledWith(true);
+    });
+  },
+};
+
+export const DisabledInteractionContract: Story = {
+  args: { checked: true, disabled: true, label: defaultLabel },
+  play: async ({ args, canvasElement }) => {
+    args.onCheckedChange?.mockClear();
+    const checkbox = within(canvasElement).getByRole('checkbox', { name: defaultLabel });
+
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    expect(checkbox).toHaveAttribute('aria-disabled', 'true');
+    checkbox.click();
+    expect(args.onCheckedChange).not.toHaveBeenCalled();
+  },
+};
+
+export const RepresentativeStates: Story = {
+  render: () => (
+    <View style={{ gap: space[12] }}>
+      <CheckboxCatalog checked={false} label="선택 안 됨" />
+      <CheckboxCatalog checked label="선택됨" />
+      <CheckboxCatalog checked="mixed" label="일부 선택됨" />
+      <CheckboxCatalog checked disabled label="비활성 선택됨" />
+      <CheckboxCatalog
+        checked="mixed"
+        label="그룹에 포함된 항목 중 일부만 선택되었음을 알리는 아주 긴 레이블"
+      />
+    </View>
+  ),
+};

--- a/apps/app/src/stories/components/Checkbox.tests.stories.tsx
+++ b/apps/app/src/stories/components/Checkbox.tests.stories.tsx
@@ -1,0 +1,17 @@
+import baseMeta, {
+  DisabledInteractionContract as disabledInteractionContract,
+  InteractionContract as interactionContract,
+} from './Checkbox.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Components/Checkbox/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const DisabledInteractionContract: Story = disabledInteractionContract;

--- a/apps/app/src/stories/components/SegmentedControl.stories.tsx
+++ b/apps/app/src/stories/components/SegmentedControl.stories.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import { SegmentedControl } from '@/components/ui/SegmentedControl';
+import { space } from '@/theme/tokens';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { SegmentedControlOptions } from '@/components/ui/SegmentedControl';
+
+type SegmentValue = string;
+const defaultLabels = ['옵션 1', '옵션 2', '옵션 3', '옵션 4'];
+
+function makeOptions(labels: string[], optionCount: number): SegmentedControlOptions<SegmentValue> {
+  const count = Math.max(2, Math.min(4, optionCount));
+  return Array.from({ length: count }, (_, index) => ({
+    label: labels[index]?.trim() || defaultLabels[index],
+    value: `option-${index + 1}`,
+  })) as unknown as SegmentedControlOptions<SegmentValue>;
+}
+
+type SegmentedControlCatalogProps = {
+  accessibilityLabel?: string;
+  disabled?: boolean;
+  initialItem?: number;
+  onValueChange?: (value: SegmentValue) => void;
+  optionCount?: number;
+  optionLabels?: string[];
+};
+
+function SegmentedControlCatalog({
+  accessibilityLabel = '표시 방식',
+  disabled = false,
+  initialItem = 1,
+  onValueChange,
+  optionCount = 3,
+  optionLabels = defaultLabels,
+}: SegmentedControlCatalogProps) {
+  const options = makeOptions(optionLabels, optionCount);
+  const initialValue = options[Math.max(0, Math.min(initialItem - 1, options.length - 1))].value;
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => setValue(initialValue), [initialValue]);
+
+  return (
+    <View style={{ maxWidth: 320, width: '100%' }}>
+      <SegmentedControl
+        accessibilityLabel={accessibilityLabel}
+        disabled={disabled}
+        onValueChange={(next) => {
+          setValue(next);
+          onValueChange?.(next);
+        }}
+        options={options}
+        value={value}
+      />
+    </View>
+  );
+}
+
+const meta = {
+  args: {
+    accessibilityLabel: '표시 방식',
+    disabled: false,
+    initialItem: 1,
+    onValueChange: fn(),
+    optionCount: 3,
+    optionLabels: defaultLabels,
+  },
+  argTypes: {
+    accessibilityLabel: { control: 'text' },
+    disabled: { control: 'boolean' },
+    initialItem: { control: { max: 4, min: 1, step: 1, type: 'number' } },
+    optionCount: { control: { max: 4, min: 2, step: 1, type: 'range' } },
+    optionLabels: { control: 'object' },
+  },
+  component: SegmentedControlCatalog,
+  excludeStories: ['InteractionContract', 'DisabledInteractionContract'],
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <SegmentedControlCatalog
+      key={JSON.stringify([args.initialItem, args.optionCount, args.optionLabels])}
+      {...args}
+    />
+  ),
+  title: 'KOSMO/Components/Segmented Control',
+} satisfies Meta<typeof SegmentedControlCatalog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  parameters: {
+    controls: {
+      disable: false,
+      include: ['accessibilityLabel', 'disabled', 'initialItem', 'optionCount', 'optionLabels'],
+    },
+  },
+};
+
+export const InteractionContract: Story = {
+  args: { disabled: false, initialItem: 1, optionCount: 3, optionLabels: defaultLabels },
+  play: async ({ args, canvasElement, step }) => {
+    args.onValueChange?.mockClear();
+    const group = within(canvasElement).getByRole('radiogroup', { name: '표시 방식' });
+    const radios = within(group).getAllByRole('radio');
+
+    await step('정확히 하나의 선택과 tab stop 확인', async () => {
+      expect(radios).toHaveLength(3);
+      expect(radios.filter((radio) => radio.getAttribute('aria-checked') === 'true')).toHaveLength(
+        1,
+      );
+      expect(radios[0]).toBeChecked();
+      await userEvent.tab();
+      expect(radios[0]).toHaveFocus();
+    });
+
+    await step('방향키로 focus와 선택을 함께 이동', async () => {
+      await userEvent.keyboard('{ArrowRight}');
+      expect(radios[1]).toHaveFocus();
+      expect(radios[1]).toBeChecked();
+      expect(args.onValueChange).toHaveBeenLastCalledWith('option-2');
+    });
+
+    await step('포인터로 선택 변경', async () => {
+      await userEvent.click(radios[2]);
+      expect(radios[2]).toBeChecked();
+      expect(args.onValueChange).toHaveBeenLastCalledWith('option-3');
+    });
+  },
+};
+
+export const DisabledInteractionContract: Story = {
+  args: { disabled: true, initialItem: 2, optionCount: 3, optionLabels: defaultLabels },
+  play: async ({ args, canvasElement }) => {
+    args.onValueChange?.mockClear();
+    const radios = within(
+      within(canvasElement).getByRole('radiogroup', { name: '표시 방식' }),
+    ).getAllByRole('radio');
+
+    expect(radios[1]).toBeChecked();
+    for (const radio of radios) {
+      expect(radio).toHaveAttribute('aria-disabled', 'true');
+      expect(radio).toHaveAttribute('tabindex', '-1');
+    }
+    radios[0].click();
+    expect(args.onValueChange).not.toHaveBeenCalled();
+  },
+};
+
+export const RepresentativeStates: Story = {
+  render: () => {
+    const longOptions = [
+      { label: '시스템 설정에 맞추기', value: 'system' },
+      { label: '라이트', value: 'light' },
+      { label: '다크', value: 'dark' },
+    ] satisfies SegmentedControlOptions<string>;
+    const counts = [2, 3, 4] as const;
+
+    return (
+      <View style={{ gap: space[16], maxWidth: 320, width: '100%' }}>
+        {counts.map((count) => {
+          const options = makeOptions(defaultLabels, count);
+          return (
+            <SegmentedControl
+              accessibilityLabel={`${count}개 옵션`}
+              key={count}
+              onValueChange={() => undefined}
+              options={options}
+              value={options.at(-1)!.value}
+            />
+          );
+        })}
+        <SegmentedControl
+          accessibilityLabel="긴 레이블"
+          onValueChange={() => undefined}
+          options={longOptions}
+          value="system"
+        />
+        <SegmentedControl
+          accessibilityLabel="비활성 표시 방식"
+          disabled
+          onValueChange={() => undefined}
+          options={longOptions}
+          value="dark"
+        />
+      </View>
+    );
+  },
+};

--- a/apps/app/src/stories/components/SegmentedControl.tests.stories.tsx
+++ b/apps/app/src/stories/components/SegmentedControl.tests.stories.tsx
@@ -1,0 +1,17 @@
+import baseMeta, {
+  DisabledInteractionContract as disabledInteractionContract,
+  InteractionContract as interactionContract,
+} from './SegmentedControl.stories';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  ...baseMeta,
+  excludeStories: [],
+  title: 'KOSMO/Components/Segmented Control/Tests',
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InteractionContract: Story = interactionContract;
+export const DisabledInteractionContract: Story = disabledInteractionContract;

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -281,7 +281,7 @@ Checkbox와 SegmentedControl은 실제 Settings route나 저장 정책에 연결
 
 - Checkbox는 `false`·`true`·`mixed` checked 상태와 필수 accessible name을 제공한다. `mixed`는
   indeterminate/group summary 전용이며 activation은 `true`를 요청한다. 32×32 root와 20×20 indicator를
-  유지하고 Native에서는 iOS 44×44pt·Android 48×48dp target의 부족분을 hit slop으로 보충한다.
+  유지하고 Native host 자체는 iOS 44×44pt·Android 48×48dp target을 제공한다.
 - SegmentedControl은 타입에서 2–4개 option만 받고, 유효하지 않은 controlled value도 첫 option으로
   정규화해 정확히 하나의 radio를 선택한다. Web은 선택 항목 하나만 Tab stop으로 두고 방향키가 focus와
   선택을 함께 순환 이동한다. 320px × 48px root 안에서 option은 같은 폭을 나누고 긴 label은 줄인다.
@@ -294,6 +294,11 @@ Checkbox와 SegmentedControl은 실제 Settings route나 저장 정책에 연결
   runtime QA를 계속 소유한다.
 - 새 제품 정책이나 route 계약을 만들지 않고 승인된 Figma·Linear 계약을 코드로 이관하므로 별도 OpenSpec은
   만들지 않는다.
+
+2026-09-09 검증: `pnpm --filter @kosmo/app test`로 Relay·TypeScript 검사, 단위 테스트 498개,
+Storybook static build와 Storybook 테스트 707개가 통과했다. 내장 Browser에서 SegmentedControl의 320×48
+root, 3개 option 균등 폭, 선택 이동과 최종 pill 위치를 확인했다. 실제 screen reader, iOS·Android
+touch·focus, 빠른 연속 입력의 중간 frame은 확인하지 않았으며 PROD-727 runtime QA 범위로 남긴다.
 
 ## 제외 범위
 

--- a/docs/design/settings.md
+++ b/docs/design/settings.md
@@ -266,6 +266,35 @@ Storybook의 자동 a11y 검사는 `color-contrast`를 제외하며 실제 scree
 의미하지 않는다. 해당 Settings runtime QA 소유자는 PROD-727이다. 이번에는 새 public API나 행동 계약을
 도입하지 않고 기존 계약을 검증하므로 새 OpenSpec은 만들지 않는다. Tailnet serve는 범위에서 제외한다.
 
+## Checkbox·SegmentedControl 매핑 (PROD-893)
+
+Checkbox와 SegmentedControl은 실제 Settings route나 저장 정책에 연결하지 않고 재사용 가능한 Production
+공용 UI로 제공한다. 두 컴포넌트의 controlled value와 callback까지만 소유하며 label 배치, group summary의
+데이터 lifecycle과 제품별 선택 정책은 consumer가 소유한다.
+
+| Figma source                                                                                      | Production 구현                      | Storybook 표면                                                             |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
+| [Checkbox](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3435-7529)           | `ui/Checkbox.tsx`                    | `KOSMO/Components/Checkbox` Playground·RepresentativeStates·Tests          |
+| [SegmentedControl/2](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3455-7525) | `ui/SegmentedControl.tsx`의 2개 옵션 | `KOSMO/Components/Segmented Control` Playground·RepresentativeStates·Tests |
+| [SegmentedControl/3](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3457-7465) | 같은 컴포넌트의 3개 옵션             | 같은 표면                                                                  |
+| [SegmentedControl/4](https://www.figma.com/design/Erj975S6vVP8PlHQius801/KOSMO?node-id=3459-7609) | 같은 컴포넌트의 4개 옵션             | 같은 표면                                                                  |
+
+- Checkbox는 `false`·`true`·`mixed` checked 상태와 필수 accessible name을 제공한다. `mixed`는
+  indeterminate/group summary 전용이며 activation은 `true`를 요청한다. 32×32 root와 20×20 indicator를
+  유지하고 Native에서는 iOS 44×44pt·Android 48×48dp target의 부족분을 hit slop으로 보충한다.
+- SegmentedControl은 타입에서 2–4개 option만 받고, 유효하지 않은 controlled value도 첫 option으로
+  정규화해 정확히 하나의 radio를 선택한다. Web은 선택 항목 하나만 Tab stop으로 두고 방향키가 focus와
+  선택을 함께 순환 이동한다. 320px × 48px root 안에서 option은 같은 폭을 나누고 긴 label은 줄인다.
+  selected는 항목마다 border를 다시 만들지 않고 하나의 pill이 이동 방향으로 최대 8px만 60ms 동안
+  늘어난 뒤 140ms 동안 목표 항목에 정착한다. 시각 전환은 `motion/duration/standard` 200ms와
+  `motion/easing/standard`를 사용하고 accessible selected 상태는 즉시 갱신하며 reduced motion에서는 최종
+  pill 위치를 즉시 표시한다.
+- Light/Dark는 semantic theme token과 Storybook toolbar를 사용한다. Storybook 자동화와 Web 시각 검토는
+  실제 screen reader, iOS·Android touch/focus 또는 Settings runtime 완료 증거가 아니며 PROD-727이 해당
+  runtime QA를 계속 소유한다.
+- 새 제품 정책이나 route 계약을 만들지 않고 승인된 Figma·Linear 계약을 코드로 이관하므로 별도 OpenSpec은
+  만들지 않는다.
+
 ## 제외 범위
 
 - Byulmaru ID Account Settings 페이지 자체와 Account 데이터 조회·입력·저장·관리 기능


### PR DESCRIPTION
## 무엇

- Checkbox와 SegmentedControl을 공용 UI 컴포넌트로 추가했습니다.
- Playground와 Tests Story를 추가해 상태, 키보드 조작, Actions, 포커스 동작을 검증합니다.
- Settings 화면에서 추후 공용 컴포넌트를 사용할 수 있도록 스토리를 추가했습니다.

## 왜

PROD-893 범위의 설정 컨트롤을 재사용 가능한 공용 UI와 Storybook 계약으로 분리해, 화면 구현과 상호작용 검증의 기준을 일치시키기 위해서입니다.

## 주요 결정

- Stack: `main → prod-893`
- SegmentedControl 선택 이동은 최대 8px, 60ms 이동 후 140ms 복귀 모션을 사용합니다.
- Checkbox 자체에는 별도의 모션 계약을 추가하지 않았습니다.
- Checkbox의 Native 터치 호스트는 iOS 44px, Android 48px이고 시각 크기는 32px로 유지합니다.
- Web에서는 32px 호스트와 32px 시각 크기를 사용합니다.
- Space/Spacebar 키의 반복 입력은 Checkbox와 SegmentedControl 모두 무시합니다.

## 확인

- 집중 단위 테스트: 9/9 통과
- 앱 단위 테스트: 498/498 통과
- Storybook 테스트: 707/707 통과
- Storybook 정적 빌드 및 타입 검사 통과
- localhost와 Tailnet Preview의 정적 빌드 해시 일치 확인
- Browser Preview에서 Checkbox의 Web 크기와 Space 선택 동작 확인
- 독립 구현 재검토: 차단 이슈 없음

## 남은 문제

- 실제 스크린 리더 환경과 iOS·Android 런타임은 이 PR에서 확인하지 않았습니다.
- SegmentedControl을 매우 빠르게 반대 방향으로 전환할 때의 중간 프레임은 PROD-727 런타임 QA에서 확인합니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>