### PR TITLE
fast-uri 보안 패치를 적용한다

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@opentelemetry/sdk-metrics@<2.8.0': ^2.8.0
+  ajv@8.20.0>fast-uri: 3.1.7
   '@react-native/metro-config': 0.85.3
   '@typescript-eslint/scope-manager': 8.62.1
   '@typescript-eslint/type-utils': 8.62.1
@@ -5322,8 +5323,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -11879,7 +11880,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13297,7 +13298,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,8 @@ allowBuilds:
   protobufjs: false
   unrs-resolver: true
 minimumReleaseAgeExclude:
+  # fast-uri 3.1.7 fixes CVE-2026-75899 and its follow-up advisories.
+  - fast-uri@3.1.7
   # Temporal 1.22.0 clears GHSA-4w2j-m93h-cj5j from the bundled Rust lockfile.
   - '@temporalio/activity@1.22.0'
   - '@temporalio/client@1.22.0'
@@ -32,6 +34,8 @@ minimumReleaseAgeExclude:
   - '@temporalio/workflow@1.22.0'
 overrides:
   '@opentelemetry/sdk-metrics@<2.8.0': ^2.8.0
+  # Ajv accepts fast-uri 3.x, so keep the security override within its declared range.
+  'ajv@8.20.0>fast-uri': 3.1.7
   # Expo Router exposes broad native peers; align every peer snapshot with SDK 56 / RN 0.85.
   '@react-native/metro-config': 0.85.3
   # eslint-react 5.11.3 accepts 8.62.1; avoid newer incomplete registry dependency graphs.


### PR DESCRIPTION
## 변경

- Ajv 8.20.0이 사용하는 `fast-uri`를 3.1.7로 한정 override했습니다.
- 7일 release-age 정책을 보안 릴리스 3.1.7에만 예외 적용했습니다.
- lockfile에서 취약한 3.1.5를 제거했습니다.

## 이유

production 이미지의 Trivy가 `fast-uri@3.1.5`에서 CVE-2026-75899를 계속 탐지합니다. 애플리케이션에서 확인된 직접 공격 경로는 없지만, 런타임 이미지의 취약 패키지를 제거하고 향후 간접 사용 위험을 막습니다.

## 주요 결정

- CVE-2026-75899의 최소 수정 버전은 3.1.6이지만, 3.1.6도 후속 advisory의 영향 범위라 3.x 최신 수정 버전인 3.1.7을 선택했습니다.
- Ajv의 선언 범위 `^3.0.1` 안에서 `ajv@8.20.0>fast-uri` 경로만 override했습니다.
- Linear 이슈·OpenSpec·애플리케이션 코드·Trivy ignore는 추가하지 않았습니다.

## 확인

- `pnpm install --frozen-lockfile --reporter=append-only`
- `pnpm why fast-uri -r --prod` — 3.1.7 단일 버전과 worker production 의존 경로 확인
- 설치된 `fast-uri/package.json` — 3.1.7 확인
- `pnpm audit --prod --json` — fast-uri 및 대상 advisory 일치 항목 없음
- 독립 구현 검토 — 발견 사항 없음

## 남은 문제

- 새 production 이미지를 빌드한 뒤 CI의 Trivy 결과에서 3.1.5 부재를 확인해야 합니다.
- production audit에는 이 변경과 무관한 기존 취약점 29건(Moderate 7, High 22)이 남아 있습니다.