### PR TITLE
Android 배포에서 Gradle 캐시를 재사용한다

### DIFF
--- a/.github/workflows/native-store-distribution.yml
+++ b/.github/workflows/native-store-distribution.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.0.0
         with:
+          cache: gradle
+          cache-dependency-path: pnpm-lock.yaml
           distribution: temurin
           java-version: '17'
 
@@ -133,6 +135,12 @@ jobs:
             secret/data/kosmo/prod/android-play ANDROID_RELEASE_STORE_PASSWORD | ANDROID_RELEASE_STORE_PASSWORD ;
             secret/data/kosmo/prod/android-play ANDROID_RELEASE_KEY_PASSWORD | ANDROID_RELEASE_KEY_PASSWORD
 
+      - name: Generate clean Expo Android project
+        working-directory: apps/app
+        run: |
+          pnpm relay
+          pnpm exec expo prebuild --clean --platform android --no-install
+
       - name: Restore Android upload key
         shell: bash
         env:
@@ -190,8 +198,6 @@ jobs:
               );
 
               const keystorePath = path.join(signingDir, "upload.jks");
-              const gradleHome = path.join(signingDir, "gradle");
-              fs.mkdirSync(gradleHome, { mode: 0o700 });
               fs.writeFileSync(keystorePath, keystore, { mode: 0o600 });
 
               const properties = [
@@ -200,20 +206,17 @@ jobs:
                 `android.injected.signing.key.alias=${escapeProperty(keyAlias)}`,
                 `android.injected.signing.key.password=${escapeProperty(keyPassword)}`,
               ].join("\n");
-              const propertiesPath = path.join(gradleHome, "gradle.properties");
-              fs.writeFileSync(propertiesPath, `${properties}\n`, { mode: 0o600 });
-              fs.appendFileSync(process.env.GITHUB_ENV, `GRADLE_USER_HOME=${gradleHome}\n`);
+              const propertiesPath = path.join(
+                process.env.GITHUB_WORKSPACE,
+                "apps/app/android/gradle.properties",
+              );
+              fs.chmodSync(propertiesPath, 0o600);
+              fs.appendFileSync(propertiesPath, `\n${properties}\n`);
             } catch (error) {
               if (signingDir) fs.rmSync(signingDir, { recursive: true, force: true });
               throw error;
             }
           '
-
-      - name: Generate clean Expo Android project
-        working-directory: apps/app
-        run: |
-          pnpm relay
-          pnpm exec expo prebuild --clean --platform android --no-install
 
       - name: Authenticate to Google Cloud for Play upload
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -260,7 +260,7 @@ platform :android do
 
     gradle(
       build_type: 'Release',
-      flags: '--no-daemon',
+      flags: '--no-daemon --build-cache',
       project_dir: 'android',
       task: 'bundle',
     )


### PR DESCRIPTION
## 무엇을 변경했는지

- Android `setup-java`에 표준 Gradle 캐시와 `cache-dependency-path: pnpm-lock.yaml`을 추가했습니다.
- 임시 `GRADLE_USER_HOME` override를 제거해 실제 빌드가 `$HOME/.gradle`을 사용하게 했습니다.
- clean Expo Android prebuild 뒤 signing key를 `RUNNER_TEMP` mode `0600`으로 복원하고, 생성된 `android/gradle.properties`의 CNG 설정을 보존하면서 signing properties만 append합니다.
- Android Fastlane Gradle 실행에 `--build-cache`를 추가해 캐시 가능한 task 출력을 재사용합니다.
- 기존 `--no-daemon`, Sentry 업로드, SDK/NDK 핀과 iOS workflow는 유지했습니다.

## 왜 변경했는지

기존 signing용 임시 `GRADLE_USER_HOME` 때문에 표준 Gradle cache와 실제 빌드 경로가 분리되어 있었습니다. 서명 정보는 캐시 밖에 두고 의존성 및 캐시 가능한 task 출력을 표준 Gradle User Home에서 재사용하도록 합니다.

## 이번 PR의 주요 결정

- 사용자는 후속 검토에서 `prebuild --clean`과 기존 `setup-java` 캐시를 유지하면서 `--build-cache`를 활성화하는 방식을 선택했습니다. 네이티브 프로젝트 재생성과 컴파일 결과 재사용을 분리하며, 별도 cache provider나 configuration cache는 추가하지 않습니다.
- generated `gradle.properties`의 기존 CNG 내용을 덮어쓰지 않고 append하며, 파일과 keystore를 모두 mode `0600`으로 처리합니다.
- 기존 `if: always()` cleanup으로 generated Android project와 signing 임시 디렉터리를 제거합니다.
- 이 PR은 Android만 소유합니다. iOS ccache 개선은 별도 작업으로 분리합니다.
- 사용자가 로컬 빌드 검증은 필요 없다고 명시하여 로컬 AAB 빌드와 두 번 실행하는 `FROM-CACHE` 재현은 이번 검증 범위에서 제외했습니다.

관련 이슈: PROD-932

Stack: main -> PROD-932

## 어떻게 확인할 수 있는지

- `actionlint .github/workflows/native-store-distribution.yml` 통과
- `ruby -c apps/app/fastlane/Fastfile` 통과
- `git diff --check` 및 `git show --check` 통과
- signing/cache separation fixture 통과: 기존 properties 보존, properties/keystore mode 0600, HOME Gradle cache에 secret properties 미생성, `GRADLE_USER_HOME` override 미생성
- 정적 검토: RN 0.85.3이 사용하는 AGP 8.12.0 공식 source JAR의 `PackageBundleTask`, `FinalizeBundleTask`, `SigningConfigWriterTask`는 `@DisableCachingByDefault`입니다. 현재 AAB 생성·서명 경로에 `--build-cache`만 추가해 이 task들의 출력 캐시를 활성화하지 않습니다.
- 정적 검토: Sentry RN 8.24.0의 source-map upload는 일반 Task/Exec이고, Sentry Android Gradle Plugin 6.19.0의 native-symbol/ProGuard upload task는 캐시 비활성입니다. 이 변경으로 upload 결과를 build cache에서 재사용하지 않습니다.
- Luna store_copy가 구현·문법 검증, store_assets가 AGP 서명/패키징 검토, version_validation이 Sentry task 검토, version_minimality가 읽기 전용 최소성 검토를 수행했습니다.

## 아직 어떤 문제가 남아 있는지

- 실제 hosted runner cache hit, `FROM-CACHE`, 빌드 시간 개선 폭은 아직 측정하지 않았습니다. 정적 검토를 실제 빌드 증거로 간주하지 않습니다.
- `setup-java`는 동일 lockfile key의 exact hit에서 cache를 다시 저장하지 않습니다. 최초 저장된 task 결과는 재사용할 수 있지만, lockfile이 유지되는 동안 새 task cache가 매 실행 누적되는 구조는 아닙니다.
- 실제 Native Store workflow dispatch, Store 업로드 및 merge는 실행하지 않았습니다.
- SDK/NDK version mismatch와 production upload 상태는 이 Android cache PR의 범위 밖입니다.