### PR TITLE
iOS 배포에서 ccache가 실제 컴파일에 사용되도록 한다

### DIFF
--- a/.github/workflows/native-store-distribution.yml
+++ b/.github/workflows/native-store-distribution.yml
@@ -379,4 +379,8 @@ jobs:
           USE_CCACHE: '1'
           NODE_OPTIONS: '--max-old-space-size=4096'
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: bundle exec fastlane ios build_and_upload_ios
+        run: |
+          # Xcode does not export custom build settings to compiler processes.
+          CCACHE_BINARY="$(command -v ccache)"
+          export CCACHE_BINARY
+          bundle exec fastlane ios build_and_upload_ios


### PR DESCRIPTION
## 무엇을 변경했는지

- iOS Fastlane 실행 전에 `command -v ccache` 결과를 `CCACHE_BINARY` 환경변수로 전달합니다.
- Stack: main → PROD-933 (독립 1-layer)
- 관련 이슈: https://linear.app/byulmaru/issue/PROD-933 (Android는 PROD-932에서 별도 진행)

## 왜 변경했는지

성공 Native Store Distribution run 34329459620의 iOS job은 ccache 객체가 0개라 캐시 저장을 생략했습니다. RN 0.85.3은 `CCACHE_BINARY`를 Xcode build setting에 지정하지만 compiler 프로세스 환경에는 전달되지 않았습니다. RN wrapper의 `exec $CCACHE_BINARY clang`은 값이 없으면 clang을 직접 실행합니다.

Xcode 26.6의 unsigned 최소 프로젝트에서 동일한 wrapper/build setting을 적용하면 ccache 호출이 없었고, 환경변수 하나만 추가하면 C/C++ 두 건을 저장했습니다. 따라서 compiler 미인식 경고만으로 wrapper 미호출을 추정하던 가설은 배제했습니다.

## 이번 PR의 주요 결정

사용자가 승인한 iOS 캐시 개선 범위에서 확인된 환경변수 누락만 수정합니다. 표준 launcher 전환이나 SDK patch는 필요하지 않아 추가하지 않습니다. 기존 CNG, Vault, 서명 cleanup, TestFlight 및 Sentry 실패 전파는 그대로 유지합니다.

## 어떻게 확인할 수 있는지

- Xcode 26.6 (17F113), RN 0.85.3 wrapper를 사용하는 unsigned iPhoneOS C/C++ static library 재현
- 기존 설정: 빌드 성공, ccache 호출 없음
- CCACHE_BINARY 환경변수 전달 후 cold build: 2 cacheable calls / 2 misses, 객체 저장
- 같은 프로젝트 clean warm build: 2 direct hits 추가
- 캐시 비활성화 빌드와 warm 빌드의 두 `.o` SHA-256 동일
- actionlint 및 git diff --check 통과
- [RN wrapper](https://github.com/facebook/react-native/blob/v0.85.3/packages/react-native/scripts/xcode/ccache-clang.sh), [RN build settings](https://github.com/facebook/react-native/blob/v0.85.3/packages/react-native/scripts/cocoapods/utils.rb)

## 아직 어떤 문제가 남았는지

실제 hosted archive의 캐시 저장·hit·시간 절감은 미검증입니다. workflow dispatch 및 Store 업로드는 수행하지 않았으며 cold/warm 배포 실행은 별도 승인 대상입니다. 기존 Xcode compiler 미인식 경고는 남지만 로컬 재현에서 캐시 저장·재사용을 막지 않았습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>