### PR TITLE
iOS Native 이미지 업로드의 Blob 변환 실패를 수정한다

### DIFF
--- a/apps/app/src/components/media/imageUpload.test.ts
+++ b/apps/app/src/components/media/imageUpload.test.ts
@@ -148,6 +148,43 @@ beforeEach(() => {
   createManipulatorContext = () => installManipulator({ height: 100, width: 100 }).context;
 });
 
+test('uploads identical normalized bytes when native Blob creation from ArrayBuffer is unsupported', async (t) => {
+  const bytes = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0, 255, 128, 0x57, 0x45, 0x42, 0x50]);
+  const normalizedUri = 'file:///cache/normalized.webp';
+  const manipulator = installManipulator({ height: 100, width: 100, resultUri: normalizedUri });
+  const readResponse = new Response(bytes, { status: 200 });
+  const blob = t.mock.method(readResponse, 'blob', async () => {
+    throw new Error("Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported");
+  });
+  const calls: string[] = [];
+  t.mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input) === normalizedUri) {
+      calls.push('read');
+      return readResponse;
+    }
+    calls.push('put');
+    assert.equal(init?.method, 'PUT');
+    assert.deepEqual(init?.headers, { 'content-type': 'image/webp' });
+    assert.deepEqual(new Uint8Array(await new Request(String(input), init).arrayBuffer()), bytes);
+    assert.equal(manipulator.contextReleased(), true);
+    return new Response(null, { status: 204 });
+  });
+  const result = await uploadImage({
+    asset: createAsset(),
+    issue: async () => ({ mediaId: 'media-native', uploadUrl: 'https://upload.example/native' }),
+    complete: async (mediaId) => {
+      assert.equal(mediaId, 'media-native');
+      calls.push('complete');
+    },
+    isActive: () => true,
+  });
+  assert.equal(result, 'media-native');
+  assert.deepEqual(calls, ['read', 'put', 'complete']);
+  assert.equal(blob.mock.callCount(), 0);
+  assert.deepEqual(manipulator.saveOptions, [{ compress: 0.8, format: 'webp' }]);
+  assert.equal(captureCalls.length, 0);
+});
+
 test('releases only Web object URL previews', () => {
   const released: string[] = [];
 
@@ -171,7 +208,7 @@ test('issues, uploads normalized WebP bytes, and completes in order', async (t) 
         return new Response(normalizedBlob, { status: 200 });
       }
       calls.push(`${init?.method}:${String(input)}`);
-      assert.equal(await (init?.body as Blob).text(), 'normalized-webp');
+      assert.equal(await new Response(init?.body).text(), 'normalized-webp');
       assert.deepEqual(init?.headers, { 'content-type': 'image/webp' });
       return new Response(null, { status: 204 });
     },
@@ -208,7 +245,7 @@ test('issues, uploads normalized WebP bytes, and completes in order', async (t) 
   assert.equal(captureCalls.length, 0);
 });
 
-test('reads the normalized Blob and uses WebP content type for small images', async (t) => {
+test('reads the normalized bytes and uses WebP content type for small images', async (t) => {
   const normalizedBlob = new Blob(['normalized-webp'], { type: 'image/webp' });
   const manipulator = installManipulator({ height: 800, width: 1200 });
   const calls: Array<{ readonly body?: BodyInit | null; readonly headers?: HeadersInit }> = [];
@@ -235,8 +272,7 @@ test('reads the normalized Blob and uses WebP content type for small images', as
   assert.equal(manipulator.renderCount(), 1);
   assert.deepEqual(manipulator.saveOptions, [{ compress: 0.8, format: 'webp' }]);
   assert.deepEqual(calls[0], { body: undefined, headers: undefined });
-  assert.equal(await (calls[1]?.body as Blob).text(), 'normalized-webp');
-  assert.equal((calls[1]?.body as Blob).type, 'image/webp');
+  assert.equal(await new Response(calls[1]?.body).text(), 'normalized-webp');
   assert.deepEqual(calls[1]?.headers, { 'content-type': 'image/webp' });
 });
 
@@ -350,7 +386,7 @@ for (const testCase of [
   });
 }
 
-test('releases a WebP object URL after reading its upload Blob', async (t) => {
+test('releases a WebP object URL after reading its upload bytes', async (t) => {
   const normalizedUri = 'blob:https://kosmo.example/normalized';
   const manipulator = installManipulator({
     height: 800,
@@ -435,7 +471,7 @@ test('turns image conversion failures into transfer failures', async (t) => {
   });
 });
 
-test('captures normalized Blob read failures with a safe operation and status', async (t) => {
+test('captures normalized image read failures with a safe operation and status', async (t) => {
   installManipulator({ height: 100, width: 100 });
   t.mock.method(globalThis, 'fetch', async (input: RequestInfo | URL) => {
     assert.equal(String(input), 'file:///cache/normalized.webp');
@@ -462,7 +498,7 @@ test('captures normalized Blob read failures with a safe operation and status', 
   });
 });
 
-test('captures normalized Blob fetch rejections as read failures', async (t) => {
+test('captures normalized image fetch rejections as read failures', async (t) => {
   installManipulator({ height: 100, width: 100 });
   t.mock.method(globalThis, 'fetch', async (input: RequestInfo | URL) => {
     assert.equal(String(input), 'file:///cache/normalized.webp');
@@ -492,11 +528,11 @@ test('captures normalized Blob fetch rejections as read failures', async (t) => 
   });
 });
 
-test('captures normalized Blob body rejections as read failures', async (t) => {
+test('captures normalized ArrayBuffer body rejections as read failures', async (t) => {
   installManipulator({ height: 100, width: 100 });
   const response = new Response(null, { status: 200 });
-  response.blob = async () => {
-    throw new Error('private normalized Blob detail');
+  response.arrayBuffer = async () => {
+    throw new Error('private normalized ArrayBuffer detail');
   };
   t.mock.method(globalThis, 'fetch', async (input: RequestInfo | URL) => {
     assert.equal(String(input), 'file:///cache/normalized.webp');
@@ -514,7 +550,7 @@ test('captures normalized Blob body rejections as read failures', async (t) => {
       error instanceof ImageUploadError &&
       error.observation?.operation === 'read' &&
       error.failure.reason === 'transient' &&
-      !error.message.includes('private normalized Blob detail'),
+      !error.message.includes('private normalized ArrayBuffer detail'),
   );
   assert.deepEqual(captureCalls[0]?.context, {
     operation: 'read',
@@ -819,7 +855,7 @@ for (const boundary of [
   'issue',
   'normalize',
   'read-fetch',
-  'read-blob',
+  'read-body',
   'put',
   'complete',
 ] as const) {
@@ -839,8 +875,8 @@ for (const boundary of [
         throw original;
       }
       const response = new Response(new Blob(['webp']), { status: 200 });
-      if (boundary === 'read-blob' && !init) {
-        response.blob = async () => {
+      if (boundary === 'read-body' && !init) {
+        response.arrayBuffer = async () => {
           throw original;
         };
       }
@@ -883,7 +919,7 @@ for (const boundary of [
           operation: boundary.startsWith('read-') ? 'read' : boundary,
           reason: 'transient',
           stage,
-          ...(boundary === 'read-blob' ? { status: 200 } : {}),
+          ...(boundary === 'read-body' ? { status: 200 } : {}),
         });
         return true;
       },

--- a/apps/app/src/components/media/imageUpload.test.ts
+++ b/apps/app/src/components/media/imageUpload.test.ts
@@ -148,43 +148,6 @@ beforeEach(() => {
   createManipulatorContext = () => installManipulator({ height: 100, width: 100 }).context;
 });
 
-test('uploads identical normalized bytes when native Blob creation from ArrayBuffer is unsupported', async (t) => {
-  const bytes = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0, 255, 128, 0x57, 0x45, 0x42, 0x50]);
-  const normalizedUri = 'file:///cache/normalized.webp';
-  const manipulator = installManipulator({ height: 100, width: 100, resultUri: normalizedUri });
-  const readResponse = new Response(bytes, { status: 200 });
-  const blob = t.mock.method(readResponse, 'blob', async () => {
-    throw new Error("Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported");
-  });
-  const calls: string[] = [];
-  t.mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
-    if (String(input) === normalizedUri) {
-      calls.push('read');
-      return readResponse;
-    }
-    calls.push('put');
-    assert.equal(init?.method, 'PUT');
-    assert.deepEqual(init?.headers, { 'content-type': 'image/webp' });
-    assert.deepEqual(new Uint8Array(await new Request(String(input), init).arrayBuffer()), bytes);
-    assert.equal(manipulator.contextReleased(), true);
-    return new Response(null, { status: 204 });
-  });
-  const result = await uploadImage({
-    asset: createAsset(),
-    issue: async () => ({ mediaId: 'media-native', uploadUrl: 'https://upload.example/native' }),
-    complete: async (mediaId) => {
-      assert.equal(mediaId, 'media-native');
-      calls.push('complete');
-    },
-    isActive: () => true,
-  });
-  assert.equal(result, 'media-native');
-  assert.deepEqual(calls, ['read', 'put', 'complete']);
-  assert.equal(blob.mock.callCount(), 0);
-  assert.deepEqual(manipulator.saveOptions, [{ compress: 0.8, format: 'webp' }]);
-  assert.equal(captureCalls.length, 0);
-});
-
 test('releases only Web object URL previews', () => {
   const released: string[] = [];
 
@@ -197,7 +160,11 @@ test('releases only Web object URL previews', () => {
 
 test('issues, uploads normalized WebP bytes, and completes in order', async (t) => {
   const calls: string[] = [];
-  const normalizedBlob = new Blob(['normalized-webp'], { type: 'image/webp' });
+  const bytes = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0, 255, 128, 0x57, 0x45, 0x42, 0x50]);
+  const readResponse = new Response(bytes, { status: 200 });
+  t.mock.method(readResponse, 'blob', async () => {
+    throw new Error("Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported");
+  });
   const manipulator = installManipulator({ height: 2000, width: 4000 });
   const put = t.mock.method(
     globalThis,
@@ -205,10 +172,10 @@ test('issues, uploads normalized WebP bytes, and completes in order', async (t) 
     async (input: RequestInfo | URL, init?: RequestInit) => {
       if (String(input) === 'file:///cache/normalized.webp') {
         calls.push('read-normalized');
-        return new Response(normalizedBlob, { status: 200 });
+        return readResponse;
       }
       calls.push(`${init?.method}:${String(input)}`);
-      assert.equal(await new Response(init?.body).text(), 'normalized-webp');
+      assert.deepEqual(new Uint8Array(await new Request(String(input), init).arrayBuffer()), bytes);
       assert.deepEqual(init?.headers, { 'content-type': 'image/webp' });
       return new Response(null, { status: 204 });
     },

--- a/apps/app/src/components/media/imageUpload.ts
+++ b/apps/app/src/components/media/imageUpload.ts
@@ -40,7 +40,7 @@ function getImageResizeDimensions(
   };
 }
 
-async function createNormalizedImageBlob(asset: ImagePickerAsset): Promise<Blob> {
+async function createNormalizedImageBody(asset: ImagePickerAsset): Promise<ArrayBuffer> {
   let context: ImageManipulatorContext | undefined;
   let sourceImage: ImageRef | undefined;
   let normalizedImage: ImageRef | undefined;
@@ -101,7 +101,7 @@ async function createNormalizedImageBlob(asset: ImagePickerAsset): Promise<Blob>
       );
     }
     try {
-      return await response.blob();
+      return await response.arrayBuffer();
     } catch (error) {
       throw new ImageUploadError(
         { reason: 'transient', stage: 'transfer' },
@@ -187,7 +187,7 @@ export async function uploadImage({
       return null;
     }
 
-    const body = await createNormalizedImageBlob(asset);
+    const body = await createNormalizedImageBody(asset);
     operation = 'put';
     const response = await fetch(issued.uploadUrl, {
       body,

--- a/apps/app/src/components/profile/ProfileEditRoute.test.ts
+++ b/apps/app/src/components/profile/ProfileEditRoute.test.ts
@@ -328,10 +328,6 @@ const mockSuccessfulUploadFetch = () =>
     }
     assert.equal(init?.method, 'PUT');
     assert.deepEqual(init?.headers, { 'content-type': 'image/webp' });
-    assert.deepEqual(
-      new Uint8Array(await new Request(String(input), init).arrayBuffer()),
-      new TextEncoder().encode('normalized-webp'),
-    );
     return new Response(null, { status: 204 });
   });
 

--- a/apps/app/src/components/profile/ProfileEditRoute.test.ts
+++ b/apps/app/src/components/profile/ProfileEditRoute.test.ts
@@ -328,7 +328,10 @@ const mockSuccessfulUploadFetch = () =>
     }
     assert.equal(init?.method, 'PUT');
     assert.deepEqual(init?.headers, { 'content-type': 'image/webp' });
-    assert.equal((init?.body as Blob).type, 'image/webp');
+    assert.deepEqual(
+      new Uint8Array(await new Request(String(input), init).arrayBuffer()),
+      new TextEncoder().encode('normalized-webp'),
+    );
     return new Response(null, { status: 204 });
   });
 

--- a/docs/design/media-upload-errors.md
+++ b/docs/design/media-upload-errors.md
@@ -61,7 +61,7 @@ accessible name에 사용하지 않는다.
 ## 처리된 실패의 Sentry 관측
 
 - Post Composer와 Profile 편집은 각자 실패를 capture하지 않고, 두 흐름이 공유하는 이미지 업로드 경계에서 처리된 실패를 공통 Web·Native Sentry 수집 진입점으로 한 번만 전달한다.
-- 실패 event에는 이 문서의 공통 오류 모델에서 안전하게 구성한 `stage`·`reason`과 `operation`을 context로 전달한다. `operation`은 `issue`, `normalize`, `read`, `put`, `complete` 중 하나이며, `transfer` 단계 안에서 정규화·normalized Blob read·signed PUT을 구분한다. 공통 업로드 경계에서 직접 확인할 수 있는 normalized-image read/PUT 응답이 있는 실패에만 숫자 `status`를 추가하고, `unsupported_image`, `content_type_mismatch`, `size_limit_exceeded`, `pixel_limit_exceeded`, `dimension_limit_exceeded`, `invalid_image` 중 하나인 경우에만 machine-readable `code`를 추가한다.
+- 실패 event에는 이 문서의 공통 오류 모델에서 안전하게 구성한 `stage`·`reason`과 `operation`을 context로 전달한다. `operation`은 `issue`, `normalize`, `read`, `put`, `complete` 중 하나이며, `transfer` 단계 안에서 정규화·정규화된 이미지 byte 읽기·signed PUT을 구분한다. 공통 업로드 경계에서 직접 확인할 수 있는 normalized-image read/PUT 응답이 있는 실패에만 숫자 `status`를 추가하고, `unsupported_image`, `content_type_mismatch`, `size_limit_exceeded`, `pixel_limit_exceeded`, `dimension_limit_exceeded`, `invalid_image` 중 하나인 경우에만 machine-readable `code`를 추가한다.
 - 성공, 비활성 항목의 `null` 결과와 명시적 no-op은 Sentry 처리된 실패 event를 만들지 않는다.
 - Sentry capture 실패는 원래 업로드 오류, 실패 항목 보존, 오류 UI와 재시도 동작을 바꾸지 않는다.
 - 업로드에서 실제 발생한 Error는 직접 capture에 전달하거나 기존 UI 분류 wrapper의 표준 `cause` chain에 원본 객체를 연결하여 원래 message·stack·cause를 모든 오류 단계에서 보존한다. 기존 UI 분류 wrapper는 유지할 수 있지만, 원본 오류 연결 없이 수집만을 위한 일반 메시지의 새 Error로 대체하거나 복제·전역 정제하지 않는다. 이 진단 정보는 Sentry에서 사용하며 사용자-facing 오류 분류와 안내 문구는 기존 정책을 유지한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- 정규화된 이미지 결과를 ArrayBuffer로 읽어 signed PUT에 전달합니다.
- 기존 성공 테스트에 Native Blob 미지원 조건과 바이너리 바이트 보존 검증을 통합했습니다. 프로필의 Blob 타입 가정과 중복 바이트 검증은 제거하고 PUT·Content-Type 검증을 유지했습니다.
- Stack: main → PROD-934

## 왜 변경했는지

- iOS Native의 Expo response.blob()이 React Native에서 지원하지 않는 ArrayBuffer 기반 Blob 생성을 시도해 PUT 전에 실패했습니다.
- [Sentry KOSMO-7M](https://byulmaru.sentry.io/issues/7721395797/)에서 operation=read, status=200과 원본 오류를 확인했습니다.
- [PROD-934](https://linear.app/byulmaru/issue/PROD-934)

## 이번 PR의 주요 결정

- 기존 정규화 WebP 바이트 전송 계약을 복구합니다. 새로운 제품 결정이나 OpenSpec은 없습니다.
- 새 의존성·Blob polyfill·플랫폼 분기 없이 지원되는 ArrayBuffer body를 사용합니다.
- 기존 2048px/품질 0.8 WebP, image/webp 헤더, 업로드 순서, cleanup 및 Sentry 원본 오류 보존을 유지합니다.
- 근거: PROD-881, openspec/specs/image-upload-normalization/spec.md, docs/domain/objects/media.md, docs/design/media-upload-errors.md.

## 어떻게 확인할 수 있는지

- 통합한 성공 테스트가 격리된 기존 Blob 구현에서 실패함을 재확인했습니다.
- 중복 테스트 통합 후 업로드 관련 테스트 44/44, 프로필 테스트 13/13, 전체 앱 unit 515/515 통과.
- TypeScript, ESLint, Prettier, git diff --check 및 기본 커밋 검사 통과.
- Maxwell 구현·검증, Newton 독립 전체 테스트, Mill Expo→iOS 전송 경로 검토, Chandrasekhar Ponytail 최소성 검토 완료.

## 아직 어떤 문제가 남았는지

- 실제 iOS 기기에서 수정본 업로드 성공 및 배포 후 Sentry 확인은 미실행입니다.
- Web 배포 버전 불일치·iOS Web 업로드 실패·Sentry source map 문제는 이번 범위에서 제외합니다.
- 이 PR은 배포나 자동 merge를 수행하지 않습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>