### PR TITLE
AI 도구가 적용할 KOSMO 저장소 보안 정책을 정의한다

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,12 @@ namespace, Vault path, PostgreSQL cluster와 Temporal namespace를 사용하지�
   cloud metadata, cluster·관리 surface로 우회하지 않게 한다.
 - secret과 session credential은 server·secure device storage 경계에 유지하고 client
   bundle, telemetry, 로그와 오류 응답에 노출하지 않는다.
-- transaction rollback, replay와 retry가 중복 상태 변경이나 delivery를 만들지 않아야
-  한다. 외부 side effect는 선언된 commit 경계를 지키고 idempotency를 유지한다.
+- transaction rollback, replay와 retry가 domain state transition을 중복 적용해서는 안
+  된다. 외부 side effect는 선언된 commit 경계를 지키고 각 capability가 정의한 멱등
+  계약을 유지한다.
+- ActivityPub delivery retry는 같은 stable Activity ID를 사용한다. Queue acknowledgement가
+  모호한 경우 cross-system exactly-once를 요구하지 않으며, 같은 Activity ID의 중복
+  delivery는 수신 측의 멱등 처리로 의미상 수렴한다.
 - 신뢰하지 않는 입력의 크기·복잡도·fan-out과 처리량을 제한해 parsing, query, queue,
   workflow 또는 storage 자원을 고갈시키지 않는다.
 - GraphQL의 사용자별 권한은 중앙 application policy가 적용하며 runtime database role은
@@ -138,5 +142,7 @@ source와 live evidence에 맞게 재검토한다.
 
 ## 보안 연락처
 
-보안 관련 연락은 공개 Issue나 Pull Request 대신
-[hello@byulmaru.co](mailto:hello@byulmaru.co)로 보내며 제목에 `[Security] KOSMO`를 포함한다.
+외부에서 발견한 미공개 취약점은 공개 Issue나 Pull Request 대신
+[hello@byulmaru.co](mailto:hello@byulmaru.co)로 제보하며 제목에 `[Security] KOSMO`를
+포함한다. 사용자가 요청한 저장소 변경·Pull Request 리뷰에서 발견한 regression과
+finding은 해당 협업 흐름에 기록한다.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,104 +1,142 @@
 # Security Policy
 
-## 지원 범위
-
-KOSMO는 `main`의 최신 코드, 현재 공식적으로 운영되는 Dev·Production 배포와
-공식 배포 중인 클라이언트 빌드를 지원합니다.
-
-오래된 커밋, 개인 포크 또는 임의로 수정된 배포에서만 발생하는 문제는 지원 범위가
-아닙니다. 다만 같은 문제가 지원 중인 코드나 배포에도 영향을 준다면 제보 대상입니다.
-
-## 취약점 제보
-
-보안 취약점은 공개 Issue나 Pull Request 대신
-[hello@byulmaru.co](mailto:hello@byulmaru.co)로 비공개 제보해 주세요.
-
-- 제목에 `[Security] KOSMO`를 포함해 주세요.
-- 영향받는 구성 요소와 버전 또는 커밋을 알려 주세요.
-- 재현 조건, 예상 영향과 최소한의 재현 자료를 포함해 주세요.
-- 불필요한 개인정보, 실제 사용자 데이터와 비밀 값은 보내지 마세요.
-- 사전 협의 없이 Production 서비스에 부하를 주거나 데이터를 변경하지 마세요.
+이 문서는 KOSMO 저장소를 변경하거나 검토하는 AI 코딩·보안 도구가 적용할 저장소 보안
+정책이다. 시스템 경계, 신뢰 가정, 반드시 유지할 속성, finding 판정 기준과 알려진 제한을
+정의한다. 저장소 설정은 운영 상태의 증거가 아니며, 이 문서는 명령 실행이나 외부 상태
+변경을 승인하지 않는다.
 
 ## 시스템과 범위
 
-이 정책은 다음 저장소 구성 요소와 그 공식 배포 구성을 다룹니다.
+정책은 현재 작업 tree와 기준 branch의 다음 구성 요소와 공식 배포 구성을 다룬다.
 
-- Web 클라이언트와 BFF, GraphQL API 및 Admin
-- iOS·Android 클라이언트
-- ActivityPub endpoint, Fedify queue와 consumer
-- Temporal Worker와 외부 side effect
-- PostgreSQL 데이터와 migration
-- Media Storage Service, OIDC 등 외부 서비스 연동
-- 빌드, CI, 컨테이너, Helm과 release workflow
+- Web 클라이언트와 BFF, GraphQL API 및 iOS·Android 클라이언트
+- ActivityPub endpoint, Fedify queue·consumer와 Temporal Worker
+- Admin Console과 Tailscale ingress
+- PostgreSQL 데이터·migration·backup
+- Media Storage Service, OIDC, Sentry와 feedback 등 외부 연동
+- 빌드, CI, 컨테이너, Helm, Terraform과 release·mobile signing workflow
 
-보호 대상에는 계정과 세션, Profile과 콘텐츠의 접근 범위, 미디어, 서비스 자격 증명,
-데이터 무결성과 서비스 가용성이 포함됩니다.
+중요 자산은 Account와 Session, Profile membership, 콘텐츠와 visibility, federation
+identity·private key·delivery state, 미디어, 데이터베이스·backup, service credential,
+배포·서명 권한, 사용자 데이터와 서비스 가용성이다.
+
+Web·API·native client와 ActivityPub은 외부 입력에 노출된다. Admin Console은 public
+surface가 아니라 Tailscale 접근 경계 뒤의 내부 surface다. Dev와 Production은 별도
+namespace, Vault path, PostgreSQL cluster와 Temporal namespace를 사용하지만, 저장소
+구성만으로 live 격리나 별도 물리 control plane을 증명하지 않는다.
 
 ## 위협 모델과 신뢰 경계
 
-HTTP·GraphQL 요청, OIDC callback 입력, 업로드, ActivityPub payload와 remote document,
-외부 서비스 응답 및 저장된 원격 콘텐츠는 신뢰하지 않는 입력으로 취급합니다.
+다음 입력과 주체는 신뢰하지 않는다.
 
-주요 경계는 클라이언트와 Web/API, federation ingress와 Fedify consumer,
-애플리케이션과 PostgreSQL·Temporal·외부 서비스, 그리고 source와 CI·배포 artifact
-사이입니다. 운영자가 관리하는 설정과 secret store는 신뢰하지만, 그 경계를 통과하는
-값은 용도와 형식에 맞게 검증해야 합니다.
+- 인증되지 않은 Web·GraphQL·OIDC·ActivityPub 요청
+- 권한 경계를 넘으려는 인증 사용자와 custom native client
+- 올바르게 서명했더라도 악의적이거나 손상된 federation server
+- 업로드, remote document·media, 외부 서비스 응답과 저장된 원격 콘텐츠
+- dependency, registry, GitHub Action, build tool, runner와 배포 artifact
+- 침해된 workload가 같은 환경의 credential·database·service로 이동하는 경로
+
+운영자가 관리하는 설정, secret store, Tailscale policy와 cluster control plane은 현재
+아키텍처의 신뢰 가정이다. 그 경계를 통과하는 값은 용도와 형식에 맞게 검증해야 하며,
+실제 설정을 확인하지 않고 control이 적용됐다고 가정하지 않는다.
 
 ## 보안 불변식
 
-- 인증된 identity를 확정하기 전에 사용자나 remote actor를 신뢰하지 않습니다.
-- 데이터 조회와 변경 전에 Account–Profile membership, owner 권한과 visibility 정책을
-  적용합니다.
-- ActivityPub actor, signature, 대상과 visibility를 검증하며 검증되지 않은 remote
-  identity로 상태를 변경하지 않습니다.
+- OIDC issuer·client·redirect, state와 PKCE를 검증한 뒤에만 Kosmo Session을 만든다.
+  Session은 ACTIVE Account와 ACTIVE Session에만 권한을 부여하고 logout·revocation을
+  우회해서는 안 된다.
+- 데이터 조회와 변경 전에 Account–Profile membership, owner 권한, lifecycle과
+  visibility 정책을 적용한다. 인증만으로 객체 권한을 대신하지 않는다.
+- ActivityPub signature, actor·object attribution, audience, follower 관계와 local/remote
+  경계를 검증한다. 서명된 remote input도 안전한 데이터로 간주하지 않는다.
+- Admin Console의 유일한 진입 인가는 Tailscale policy와 ingress NetworkPolicy다.
+  `Tailscale-User-*` header는 표시 metadata일 뿐 인가나 Account 매핑에 사용하지 않으며,
+  public ingress나 일반 workload의 proxy 우회를 허용하지 않는다.
 - 사용자·원격 콘텐츠는 실행 가능한 코드가 아닌 데이터로 처리하고 안전한 표현으로
-  변환합니다.
-- 업로드의 소유권, 상태와 허용된 표현을 검증하고 완료되지 않은 미디어를 게시하지
-  않습니다.
-- redirect와 outbound request가 자격 증명을 유출하거나 의도한 네트워크 경계를
-  우회하지 않게 합니다.
-- secret은 서버 경계에 유지하고 client bundle, 로그와 오류 응답에 노출하지 않습니다.
-- transaction rollback, replay와 retry가 중복 변경이나 외부 전달을 만들지 않아야
-  하며 외부 side effect는 선언된 commit 경계를 지킵니다.
-- 신뢰하지 않는 입력의 크기와 처리량을 제한하여 무제한 parsing, queue 증가 또는
-  자원 고갈을 허용하지 않습니다.
-- release artifact는 승인된 source revision과 연결되며 배포 자격 증명은 최소 권한으로
-  사용합니다.
+  변환한다.
+- Local Media는 인증된 Account·Profile에 결합하고 `UPLOADING`에서 검증된 `READY`
+  상태로 전환된 뒤에만 게시한다. 외부 storage 응답은 신뢰하지 않고 schema와 상태를
+  검증한다.
+- redirect, remote URL과 outbound request가 credential을 유출하거나 private network,
+  cloud metadata, cluster·관리 surface로 우회하지 않게 한다.
+- secret과 session credential은 server·secure device storage 경계에 유지하고 client
+  bundle, telemetry, 로그와 오류 응답에 노출하지 않는다.
+- transaction rollback, replay와 retry가 중복 상태 변경이나 delivery를 만들지 않아야
+  한다. 외부 side effect는 선언된 commit 경계를 지키고 idempotency를 유지한다.
+- 신뢰하지 않는 입력의 크기·복잡도·fan-out과 처리량을 제한해 parsing, query, queue,
+  workflow 또는 storage 자원을 고갈시키지 않는다.
+- GraphQL의 사용자별 권한은 중앙 application policy가 적용하며 runtime database role은
+  non-owner여야 한다. Migration과 Fedify queue의 별도 권한 경계를 유지한다.
+- release artifact와 mobile binary는 승인된 source revision·image digest·signing
+  workflow에 연결하고 배포 credential은 최소 권한으로 사용한다.
 
-## 제보 가능한 문제와 심각도
+## Finding 판정과 심각도
 
-지원 중인 경로에서 현실적인 공격자가 위 불변식을 위반해 기밀성, 무결성 또는
-가용성에 영향을 줄 수 있다면 제보 대상입니다. 계정 탈취, 권한 우회, 비공개 데이터
-노출, 서버 코드 실행, secret 유출, federation identity 위조, 공급망 침해, 데이터
-손실과 지속적인 서비스 거부는 높은 영향으로 평가합니다.
+AI 도구는 현재 source와 실제 caller를 따라 공격자 입력에서 보안 불변식 위반까지의
+현실적인 경로를 제시해야 한다. 테스트는 의도와 실패 예시의 근거이지 control이 실제로
+동작한다는 증명은 아니다. 운영 설정, 배포 상태와 외부 서비스 control은 현재 근거
+없이 확인된 사실로 취급하지 않는다.
 
-심각도는 필요한 권한과 사용자 상호작용, 공격자 도달 가능성, 영향받는 사용자·instance
-범위, 자동화·지속 가능성과 복구 비용을 함께 고려합니다.
+Scanner 또는 Dependabot 알림만으로 finding이나 안전성이 확정되지는 않는다. 실제 버전,
+공격자 입력, runtime·build·CI 도달 경로와 영향을 확인한다. 개발 의존성이라는 이유만으로
+제외하지 않고, 반대로 위험해 보이는 primitive만으로 취약점을 주장하지 않는다.
 
-Scanner 또는 Dependabot 알림만으로 실제 영향이나 안전성이 확정되지는 않습니다.
-해당 버전, 공격자 입력, runtime·build·CI 경로와 보안 통제 영향을 확인합니다.
-개발 의존성이라는 이유만으로 제외하지 않습니다.
+심각도는 필요한 권한과 사용자 상호작용, 공격 비용, 영향받는 사용자·instance 범위,
+기밀성·무결성·가용성 영향, 자동화·지속 가능성과 복구 비용으로 정한다. 다음 결과는
+현재 경로가 입증되면 높은 심각도로 본다.
 
-## 범위 밖 항목과 수용 위험
+- 계정 탈취, 다른 Account·Profile의 private/direct 데이터 접근 또는 권한 없는 변경
+- public runtime code execution, credential·private key·database backup 유출
+- federation identity 위조, private network SSRF 또는 durable queue·workflow corruption
+- 승인 경계를 우회한 production·signed mobile artifact 배포
+- 낮은 비용으로 반복 가능한 데이터 손실 또는 광범위한 서비스 거부
 
-다음 항목만으로는 취약점으로 보지 않습니다.
+## 범위 밖 항목과 수용 경계
 
-- 지원 중인 코드나 배포에 영향을 주지 않는 오래된 revision 또는 수정된 포크의 문제
+다음 항목만으로는 finding으로 보지 않는다.
+
+- 현재 지원되는 source·배포에 영향을 주지 않는 오래된 revision이나 수정된 포크
 - 현실적인 도달 경로와 보안 영향이 없는 이론적 문제
-- KOSMO의 연동 방식이나 설정에 결함이 없는 외부 서비스 자체의 문제
-- 공식 CI·배포에는 영향을 주지 않고, 문서와 다르게 외부에 노출한 로컬 개발 환경만의
-  문제
+- KOSMO의 설정·credential·연동에 결함이 없는 AWS 등 외부 provider 자체의 문제
+- 공식 CI·배포에 영향을 주지 않고 문서와 다르게 외부 노출한 로컬 개발 환경만의 문제
+- public analytics key·Sentry DSN, 예상된 public ActivityPub·profile·media 데이터처럼
+  원래 공개되는 값 자체
 
-현재 저장소 전체에 적용되는 별도의 수용 위험은 없습니다. 수용 위험을 추가하려면
-영향 범위, 근거, 보완 통제, 책임자와 재검토 조건을 함께 기록해야 합니다.
+Admin Console v1은 Tailscale와 NetworkPolicy를 application-level 인증 대신 사용하는
+all-or-nothing read boundary다. Node·kubelet 권한을 이미 가진 운영 주체는 현재 모델의
+신뢰된 infrastructure다. Application 인증이 없다는 사실만으로는 finding이 아니지만,
+일반 workload나 public network가 이 경계를 우회하면 finding이다.
+
+여기에 명시되지 않은 위험을 임의로 수용된 위험으로 추론하지 않는다. 새로운 수용 위험은
+영향 범위, 근거, 보완 통제, 책임자와 재검토 조건을 함께 기록해야 한다.
 
 ## 알려진 제한과 보완 통제
 
-GraphQL의 사용자별 visibility와 owner 권한은 PostgreSQL RLS가 아니라 중앙
-application policy가 적용합니다. Runtime은 shared non-owner database role을 사용하고,
-PostgreSQL constraint와 분리된 migration·Fedify queue 권한이 구조적 경계를 보완합니다.
-Application policy를 우회할 수 있는 경로는 제보 대상이지만 RLS가 없다는 사실만으로는
-취약점이 아닙니다.
+- 장기 로그인 유지는 제품 의도다. 현재 Session에는 server-enforced absolute·idle expiry가
+  없고 Web cookie는 장기 유지되며, ACTIVE state와 명시적 logout·revocation이 이를
+  보완한다. 이 제한은 영구 불변식이나 일괄 제외 근거가 아니다. Token 탈취·재사용,
+  revocation 우회 또는 과도한 blast radius 경로는 여전히 finding이다.
+- GraphQL의 viewer별 visibility와 owner 권한은 PostgreSQL RLS가 아니라 중앙 application
+  policy가 적용한다. Shared non-owner runtime role과 database constraint가 구조적 경계를
+  보완한다. RLS 부재 자체는 finding이 아니지만 application policy 우회는 finding이다.
+- KOSMO는 Media 발급·완료의 인증, 소유권, state와 외부 응답 검증을 책임진다. Upload byte
+  decoding, type·size·quota, object isolation과 serving header는 이 저장소 밖 storage
+  service·provider 책임이며 여기서 control 적용을 주장하지 않는다. AWS 자체 결함은 범위
+  밖이지만 KOSMO의 잘못된 grant·permission·configuration과 신뢰 검증은 범위 안이다.
+- 저장소에서 GraphQL depth·cost limiter나 distributed request rate limiter가 확인되지
+  않는다. 외부 edge control을 추정하지 말고, finding은 재현 가능한 자원 영향과 경로로
+  판단한다.
+- Semgrep, Trivy, Nuclei와 Dependabot은 검토 신호를 제공하지만 안전성을 증명하거나 개별
+  알림의 자동 제외를 정당화하지 않는다.
 
-Semgrep, Trivy, Nuclei와 Dependabot은 검토 신호를 제공하며 안전성을 증명하거나 개별
-알림의 자동 제외를 정당화하지 않습니다.
+## 재검토 조건
+
+OIDC·Session 정책, Admin ingress·mutation, Media Storage 계약, 새 ActivityPub activity나
+remote fetch, runtime Secret·database role, analytics·telemetry, GraphQL query·rate limit,
+GitHub workflow·runner·Environment, release·mobile signing 경계가 바뀌면 이 정책을 현재
+source와 live evidence에 맞게 재검토한다.
+
+## 보안 연락처
+
+보안 관련 연락은 공개 Issue나 Pull Request 대신
+[hello@byulmaru.co](mailto:hello@byulmaru.co)로 보내며 제목에 `[Security] KOSMO`를 포함한다.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,104 @@
+# Security Policy
+
+## 지원 범위
+
+KOSMO는 `main`의 최신 코드, 현재 공식적으로 운영되는 Dev·Production 배포와
+공식 배포 중인 클라이언트 빌드를 지원합니다.
+
+오래된 커밋, 개인 포크 또는 임의로 수정된 배포에서만 발생하는 문제는 지원 범위가
+아닙니다. 다만 같은 문제가 지원 중인 코드나 배포에도 영향을 준다면 제보 대상입니다.
+
+## 취약점 제보
+
+보안 취약점은 공개 Issue나 Pull Request 대신
+[hello@byulmaru.co](mailto:hello@byulmaru.co)로 비공개 제보해 주세요.
+
+- 제목에 `[Security] KOSMO`를 포함해 주세요.
+- 영향받는 구성 요소와 버전 또는 커밋을 알려 주세요.
+- 재현 조건, 예상 영향과 최소한의 재현 자료를 포함해 주세요.
+- 불필요한 개인정보, 실제 사용자 데이터와 비밀 값은 보내지 마세요.
+- 사전 협의 없이 Production 서비스에 부하를 주거나 데이터를 변경하지 마세요.
+
+## 시스템과 범위
+
+이 정책은 다음 저장소 구성 요소와 그 공식 배포 구성을 다룹니다.
+
+- Web 클라이언트와 BFF, GraphQL API 및 Admin
+- iOS·Android 클라이언트
+- ActivityPub endpoint, Fedify queue와 consumer
+- Temporal Worker와 외부 side effect
+- PostgreSQL 데이터와 migration
+- Media Storage Service, OIDC 등 외부 서비스 연동
+- 빌드, CI, 컨테이너, Helm과 release workflow
+
+보호 대상에는 계정과 세션, Profile과 콘텐츠의 접근 범위, 미디어, 서비스 자격 증명,
+데이터 무결성과 서비스 가용성이 포함됩니다.
+
+## 위협 모델과 신뢰 경계
+
+HTTP·GraphQL 요청, OIDC callback 입력, 업로드, ActivityPub payload와 remote document,
+외부 서비스 응답 및 저장된 원격 콘텐츠는 신뢰하지 않는 입력으로 취급합니다.
+
+주요 경계는 클라이언트와 Web/API, federation ingress와 Fedify consumer,
+애플리케이션과 PostgreSQL·Temporal·외부 서비스, 그리고 source와 CI·배포 artifact
+사이입니다. 운영자가 관리하는 설정과 secret store는 신뢰하지만, 그 경계를 통과하는
+값은 용도와 형식에 맞게 검증해야 합니다.
+
+## 보안 불변식
+
+- 인증된 identity를 확정하기 전에 사용자나 remote actor를 신뢰하지 않습니다.
+- 데이터 조회와 변경 전에 Account–Profile membership, owner 권한과 visibility 정책을
+  적용합니다.
+- ActivityPub actor, signature, 대상과 visibility를 검증하며 검증되지 않은 remote
+  identity로 상태를 변경하지 않습니다.
+- 사용자·원격 콘텐츠는 실행 가능한 코드가 아닌 데이터로 처리하고 안전한 표현으로
+  변환합니다.
+- 업로드의 소유권, 상태와 허용된 표현을 검증하고 완료되지 않은 미디어를 게시하지
+  않습니다.
+- redirect와 outbound request가 자격 증명을 유출하거나 의도한 네트워크 경계를
+  우회하지 않게 합니다.
+- secret은 서버 경계에 유지하고 client bundle, 로그와 오류 응답에 노출하지 않습니다.
+- transaction rollback, replay와 retry가 중복 변경이나 외부 전달을 만들지 않아야
+  하며 외부 side effect는 선언된 commit 경계를 지킵니다.
+- 신뢰하지 않는 입력의 크기와 처리량을 제한하여 무제한 parsing, queue 증가 또는
+  자원 고갈을 허용하지 않습니다.
+- release artifact는 승인된 source revision과 연결되며 배포 자격 증명은 최소 권한으로
+  사용합니다.
+
+## 제보 가능한 문제와 심각도
+
+지원 중인 경로에서 현실적인 공격자가 위 불변식을 위반해 기밀성, 무결성 또는
+가용성에 영향을 줄 수 있다면 제보 대상입니다. 계정 탈취, 권한 우회, 비공개 데이터
+노출, 서버 코드 실행, secret 유출, federation identity 위조, 공급망 침해, 데이터
+손실과 지속적인 서비스 거부는 높은 영향으로 평가합니다.
+
+심각도는 필요한 권한과 사용자 상호작용, 공격자 도달 가능성, 영향받는 사용자·instance
+범위, 자동화·지속 가능성과 복구 비용을 함께 고려합니다.
+
+Scanner 또는 Dependabot 알림만으로 실제 영향이나 안전성이 확정되지는 않습니다.
+해당 버전, 공격자 입력, runtime·build·CI 경로와 보안 통제 영향을 확인합니다.
+개발 의존성이라는 이유만으로 제외하지 않습니다.
+
+## 범위 밖 항목과 수용 위험
+
+다음 항목만으로는 취약점으로 보지 않습니다.
+
+- 지원 중인 코드나 배포에 영향을 주지 않는 오래된 revision 또는 수정된 포크의 문제
+- 현실적인 도달 경로와 보안 영향이 없는 이론적 문제
+- KOSMO의 연동 방식이나 설정에 결함이 없는 외부 서비스 자체의 문제
+- 공식 CI·배포에는 영향을 주지 않고, 문서와 다르게 외부에 노출한 로컬 개발 환경만의
+  문제
+
+현재 저장소 전체에 적용되는 별도의 수용 위험은 없습니다. 수용 위험을 추가하려면
+영향 범위, 근거, 보완 통제, 책임자와 재검토 조건을 함께 기록해야 합니다.
+
+## 알려진 제한과 보완 통제
+
+GraphQL의 사용자별 visibility와 owner 권한은 PostgreSQL RLS가 아니라 중앙
+application policy가 적용합니다. Runtime은 shared non-owner database role을 사용하고,
+PostgreSQL constraint와 분리된 migration·Fedify queue 권한이 구조적 경계를 보완합니다.
+Application policy를 우회할 수 있는 경로는 제보 대상이지만 RLS가 없다는 사실만으로는
+취약점이 아닙니다.
+
+Semgrep, Trivy, Nuclei와 Dependabot은 검토 신호를 제공하며 안전성을 증명하거나 개별
+알림의 자동 제외를 정당화하지 않습니다.


### PR DESCRIPTION
## 무엇을 변경했나요

- 저장소 루트 SECURITY.md를 AI 코딩·보안 도구가 읽는 정책으로 재구성했습니다.
- 현재 시스템 자산, 공격자 입력, 신뢰 경계와 보안 불변식을 구체화했습니다.
- finding 판정·심각도, 범위 밖 항목, 알려진 제한과 재검토 조건을 정의했습니다.
- 외부 제보 안내는 hello@byulmaru.co 연락처만 문서 끝에 남겼습니다.

## 왜 변경했나요

기존 초안은 외부 취약점 제보 안내의 비중이 컸습니다. 이 저장소에서는 AI 도구가 실제 caller와 현재 source를 따라 보안 경계를 검토하고, scanner 알림이나 저장소 설정만으로 위험·안전성을 단정하지 않게 하는 정책이 더 중요합니다.

2026-09-03의 e6b71f1 기준으로 작성된 기존 Codex Cloud 위협 모델을 현재 main 기준 코드와 대조했습니다. 전체 snapshot을 복사하지 않고 현재도 유효하며 owner 결정이 확인된 경계만 정책에 반영했습니다.

## 이번 PR의 주요 결정

### 장기 로그인은 제품 의도지만 무기한 세션을 영구 불변식으로 만들지 않는다

- 현재 Session에는 server-enforced absolute·idle expiry가 없고 Web cookie는 장기 유지됩니다.
- ACTIVE state와 logout·revocation을 보완 통제로 기록했습니다.
- Token 탈취·재사용과 revocation 우회는 계속 finding 대상입니다.

### Admin Console은 Tailscale와 NetworkPolicy를 인가 경계로 사용한다

- Tailscale 접근 정책과 ingress NetworkPolicy가 v1의 유일한 진입 인가입니다.
- Tailscale-User-* header는 표시 metadata이며 Account 인가에 사용하지 않습니다.
- 앱 인증 부재 자체는 finding이 아니지만 public network나 일반 workload의 우회는 finding입니다.

### KOSMO와 Media Storage·AWS 책임을 분리한다

- KOSMO는 upload 발급·완료의 인증, 소유권, 상태와 외부 응답 검증을 책임집니다.
- 저장소 밖 storage service·provider의 byte 처리와 AWS 자체 결함은 이 정책이 보장하거나 평가하지 않습니다.
- 잘못된 grant, permission, configuration과 신뢰 검증은 KOSMO 범위에 남습니다.

### AI 도구는 현재 경로와 근거로 finding을 판단한다

- 테스트와 scanner는 신호이지 실제 control의 증명이 아닙니다.
- 개발 의존성을 일괄 제외하지 않고 runtime·build·CI 도달 경로를 확인합니다.
- live control은 현재 외부 증거 없이 적용됐다고 가정하지 않습니다.

## 어떻게 확인했나요

- 첨부 위협 모델의 기준 SHA와 현재 source 차이 확인
- Session, Admin, Media, GraphQL, federation, 배포 경계의 현재 코드·문서 대조
- 설치된 Prettier로 SECURITY.md 형식 검사
- Codex Security policy resolver로 루트 정책 chain 확인
- whitespace 검사와 승인 후보의 byte-for-byte 일치 확인

## 아직 남은 작업은 무엇인가요

- 첨부한 전체 위협 모델은 오래된 GitHub 운영 snapshot과 이미 변경된 구현을 포함하므로 저장소에 그대로 추가하지 않았습니다.
- 현재 설정에서 PostHog 수집은 비활성화됐지만 기존 OpenPanel 개인정보·운영 문서는 별도의 정합성 검토가 필요합니다.
- 문서 변경이므로 runtime 동작 테스트는 수행하지 않았으며 PR CI가 새 commit에 대해 다시 실행됩니다.

Stack: main -> codex/security-policy