### PR TITLE
Quote 동의와 연합 계약을 확정한다

### DIFF
--- a/docs/design/post-action-bar.md
+++ b/docs/design/post-action-bar.md
@@ -401,3 +401,38 @@ Post Action Bar는 Post의 Reply, Repost, Reaction, Bookmark와 More action을 �
   toast·재시도와 메뉴 keyboard·dismiss·trigger focus return을 검증한다. fixture 없는 production 메뉴에
   고정 action이 추가되지 않는지도 검증한다. 실제 요청 수명·결과 반영과 교체 확인·전용 상태 화면은
   PROD-809의 mutation·정책 구현 범위에서 검증한다.
+- 새 고정으로 기존 고정 Post가 해제되는 경우에만 교체 확인을 표시하고 제목·설명·`취소`·Primary `변경하기`가
+  정확한지, canonical `ModalSheet`와 플랫폼별 modal 의미를 재사용하는지, backdrop·platform back을 포함한
+  취소·닫기는 상태를 유지하며 단순 `프로필 고정 해제`에는 확인을 표시하지 않는지 검증한다. 교체 mutation의
+  성공·실패·동시성은 PROD-809에서 검증한다.
+
+## 인용 동의와 원문 표시
+
+[ADR 0027](../domain/decisions/0027-quote-consent-and-federation.md)의 인용 정책을 작성과 표시 흐름에 적용한다.
+
+- 이번 사이클에는 게시글별 인용 허용 설정 `모두`, `팔로워`, `본인만`을 제공한다. 새 글과 기존 글의 초기값은
+  `모두`다. Profile 기본값 설정은 PROD-925 Backlog로 분리한다.
+- 타인의 글은 Public·Unlisted이고 조회 가능한 경우에만 인용 대상으로 선택한다. 자기 Followers Only 글은
+  기존 원문 접근 범위를 유지하며 인용할 수 있다.
+- 자기 인용은 QuoteRequest 없이 허용한다. 타인의 원격 글은 `interactionPolicy`가 automatic/manual approval을
+  광고하거나, 정책이 없거나 해석되지 않는 경우에도 작성자의 본문을 pending 상태로 게시하고 QuoteRequest를
+  보낸다. 게시된 글에서 승인 전 Source를 정상 인용 카드로 표시하지 않으며, Accept와 유효한
+  QuoteAuthorization을 받은 뒤 Source를 표시한다. 거절·철회·원문 삭제 후에는 자체 본문을 유지한 채 Source를 숨긴다.
+- `interactionPolicy`는 작성 전 UI·eligibility 힌트로만 사용한다. 현재 작성자가 automatic/manual 어느 쪽에도
+  포함되지 않으면 승인이 예상되지 않는다고 안내할 수 있지만, 정책 자체를 승인 증거로 사용하지 않는다.
+- Kosmo 자체의 건별 수동 승인 UI는 제공하지 않는다. 작성자는 자기 글의 정책을 변경하거나 기존 인용 승인을
+  명시적으로 철회할 수 있다. 정책 변경과 차단만으로 기존 승인을 자동 철회하지 않는다.
+- 차단은 당사자 간 접근을 막는다. 제3자에게도 Source를 숨기는 사용자 조작은 별도 승인 철회다.
+- PROD-431은 인용 작성과 Composer를, PROD-924는 게시글별 정책·철회 조작과 승인 lifecycle 연동을 소유한다.
+  후속 설계에서는 이 조작의 진입점·오류 복구·접근성을 기존 공용 UI 계약에 맞춰 구체화한다.
+
+## 인용 작성 범위
+
+- `인용하기`는 현재 action 대상 Post를 direct Source로 선택해 공용 Composer를 연다. Source 자체가 Quote여도
+  그 Source의 Source로 대상을 바꾸지 않는다. 작성 중 preview는 한 단계만 표시한다.
+- 본문·Visibility·Content Warning·Sensitive Media·Media, pending·폐기·실패 복구는 기존 Composer를 재사용한다.
+  Source preview만으로 유효한 작성 Content를 만들지 않는다.
+- 로컬 Quote 작성에는 Reply Parent를 추가하지 않는다. Reply+Quote 작성 UI·API와 본문 링크의 인용 카드
+  전환은 2026-09-09 PROD-431 사용자 지시로 제외했다. 기존 Reply 작성과 저장된 관계의 표시 계약은 유지한다.
+- 게시 전의 Source preview와 게시 후 승인에 따른 Source 표시는 구분한다. 작성 성공은 요청한 selected Profile의
+  Relay Environment에 반영하며, 승인 대기 성공을 작성 실패로 처리하거나 Source를 낙관적으로 노출하지 않는다.

--- a/docs/domain/decisions/0017-activitypub-local-post-note.md
+++ b/docs/domain/decisions/0017-activitypub-local-post-note.md
@@ -14,6 +14,8 @@ Post Content Media node의 `Note.attachment` Image, Alt Text와 sensitive 투영
 [ADR 0022](./0022-post-content-revision-media-nodes.md)가 정의한다. 나머지 Local Note identity, HTML content,
 summary, audience와 역참조 결정은 유지한다.
 
+Quote 동의와 federation 표현은 [ADR 0027](./0027-quote-consent-and-federation.md)이 정의한다.
+
 ## 결정
 
 - Content가 있는 Local Post의 ActivityPub identity는 Author Profile이 연결된 Local Instance의 canonical
@@ -87,7 +89,7 @@ Note 역참조 권한이 독립적으로 제한하므로, Reply를 조회한 req
   유지된다.
 - Parent의 Tombstone 전이는 `inReplyTo`를 제거하지 않는다. 현재 physical delete 행동을 추가하지 않고 Reply
   Parent FK만 향후 실제 row 삭제에 대비해 `SET NULL`로 정의하며 Reply Post에는 cascade delete를 적용하지 않는다.
-- Mentioned Profiles, custom emoji, Quote 전용 federation 표현과 실제 Activity delivery는 독립 후속 계약으로
+- Mentioned Profiles, custom emoji와 실제 Activity delivery는 독립 후속 계약으로
   남는다. Media federation 표현은 [ADR 0022](./0022-post-content-revision-media-nodes.md)가 정의한다.
 
 ## 문서 반영

--- a/docs/domain/decisions/0027-quote-consent-and-federation.md
+++ b/docs/domain/decisions/0027-quote-consent-and-federation.md
@@ -37,11 +37,14 @@ Accepted
   못한다. 차단 자체가 기존 승인을 자동 철회하거나 제3자의 Source 조회를 일괄 막지는 않는다. 제3자에게도
   Source를 숨기려면 원문 작성자가 별도 승인 철회를 사용한다.
 - 원문 작성자의 명시적 철회는 QuoteAuthorization을 무효로 만들고 Delete(QuoteAuthorization)를 전달한다.
-  수신자는 철회 주체와 대상 승인의 대응을 검증한 뒤 Source를 숨긴다.
+  수신자는 철회 주체와 대상 승인의 대응을 검증한 뒤 Source를 숨긴다. 수신자가 Quote의 소유 서버라면
+  기존 Quote audience에도 같은 철회를 전달한다.
 - FEP-044f의 quote와 QuoteAuthorization을 정식 경로로 사용한다. `interactionPolicy`상 요청자가
   `automaticApproval`과 `manualApproval` 어느 쪽에도 명백히 포함되지 않으면 승인되지 않을 것으로
   예상된다는 정보를 UI·eligibility 힌트로 사용할 수 있지만, 정책 광고만으로 개별 승인을 대체하지 않는다.
-  레거시 상호운용을 지원하되 유효하지 않은 FEP Quote를 레거시 형식으로 강등하지 않는다.
+  QuoteAuthorization은 Source를 볼 수 있는 요청자에게 역참조를 허용하되 `interactingObject`를 embed하지
+  않는다. 요청자의 Source 조회 권한을 확인할 수 없으면 `interactionTarget`도 embed하지 않는다. 레거시
+  상호운용을 지원하되 유효하지 않은 FEP Quote를 레거시 형식으로 강등하지 않는다.
 - 승인된 인용은 `quoteUrl`, `quoteUri`, `_misskey_quote`와 원문 링크의 본문 fallback을 발신 표현으로
   제공한다. 승인 전·거절·철회 상태에서는 자동 생성한 표현을 숨기고 직접 작성한 본문·링크는 유지한다.
 - 저장된 Reply Parent와 Quote Source는 독립 관계이며 한쪽의 권한이 다른 쪽에 권한을 부여하지 않는다.

--- a/docs/domain/decisions/0027-quote-consent-and-federation.md
+++ b/docs/domain/decisions/0027-quote-consent-and-federation.md
@@ -1,0 +1,91 @@
+# ADR 0027: Quote Consent and Federation
+
+## 상태
+
+Accepted
+
+## 날짜
+
+2026-09-08
+
+## 근거
+
+[PROD-902](https://linear.app/byulmaru/issue/PROD-902)의 갱신된 제품 결정과 같은 날 Spec 대화에서 선택한
+게시글별 설정, 기존 Post 초기값, 차단과 명시적 승인 철회의 구분을 반영한다. 개별 정책은 확정했으며,
+문서 정렬 결과의 Domain Gate 전체 승인은 별도로 받는다.
+
+## 결정
+
+- Content가 있는 Local Post마다 `모두`, `팔로워`, `본인만` 인용 허용 정책을 제공한다. 새 Post와 기존
+  Post의 초기값은 `모두`다. `팔로워`는 established Follower와 본인, `본인만`은 본인만 허용한다.
+  허용된 요청도 Source 조회와 차단 조건을 통과해야 한다.
+- 정책 변경은 이후 요청에만 적용한다. 기존 QuoteAuthorization을 자동 철회하지 않는다.
+- Kosmo 원문은 정책에 따라 자동 승인·거절한다. Kosmo 자체의 건별 수동 승인 UI는 제공하지 않는다.
+- 자기 인용은 QuoteRequest 없이 허용한다. 타인의 원격 원문을 인용할 때는 `interactionPolicy`의
+  `automaticApproval`·`manualApproval` 여부, 정책 부재 또는 해석 실패와 관계없이 QuoteRequest를 보낸다.
+  `interactionPolicy`는 작성 전 UI·정책 힌트일 뿐 승인 근거가 아니며, 실제 승인은 원문 작성자가 발급한
+  유효한 QuoteAuthorization으로 확인한다.
+- 다른 사람의 Source는 Local·Remote 모두 Public·Unlisted만 인용할 수 있다. 타인의 Followers Only는
+  조회 가능한 팔로워라도 인용할 수 없다. 자기 Followers Only 인용은 허용하되 원문 접근 범위를 넓히지
+  않는다. Mentioned Profiles와 조회 불가 Source는 인용할 수 없다.
+- 타인의 원격 원문은 승인 대기 중에도 Quote 자체 Content를 게시하고 일반 federation 전달을 진행한다. 승인 전에는
+  Source를 정상 인용으로 노출하지 않으며 원문 서버에 별도 승인 요청을 보낸다. 유효한 승인을 받으면
+  Source와 승인을 연결하고 필요한 Update를 보낸다.
+- 거절·승인 철회·Source 삭제 후에도 Quote 자체 Content는 유지하고 Source는 비노출한다. 실패나 응답
+  부재는 승인이 아니며, 뒤늦은 응답이 더 최신의 거절·철회를 되돌려서는 안 된다.
+- 차단은 당사자 간 접근과 새로운 인용 요청·승인을 막는다. 기존 승인도 당사자 간 접근 제한을 우회하지
+  못한다. 차단 자체가 기존 승인을 자동 철회하거나 제3자의 Source 조회를 일괄 막지는 않는다. 제3자에게도
+  Source를 숨기려면 원문 작성자가 별도 승인 철회를 사용한다.
+- 원문 작성자의 명시적 철회는 QuoteAuthorization을 무효로 만들고 Delete(QuoteAuthorization)를 전달한다.
+  수신자는 철회 주체와 대상 승인의 대응을 검증한 뒤 Source를 숨긴다.
+- FEP-044f의 quote와 QuoteAuthorization을 정식 경로로 사용한다. `interactionPolicy`상 요청자가
+  `automaticApproval`과 `manualApproval` 어느 쪽에도 명백히 포함되지 않으면 승인되지 않을 것으로
+  예상된다는 정보를 UI·eligibility 힌트로 사용할 수 있지만, 정책 광고만으로 개별 승인을 대체하지 않는다.
+  레거시 상호운용을 지원하되 유효하지 않은 FEP Quote를 레거시 형식으로 강등하지 않는다.
+- 승인된 인용은 `quoteUrl`, `quoteUri`, `_misskey_quote`와 원문 링크의 본문 fallback을 발신 표현으로
+  제공한다. 승인 전·거절·철회 상태에서는 자동 생성한 표현을 숨기고 직접 작성한 본문·링크는 유지한다.
+- 저장된 Reply Parent와 Quote Source는 독립 관계이며 한쪽의 권한이 다른 쪽에 권한을 부여하지 않는다.
+  로컬 Quote 작성은 Source만 받으며 Reply+Quote 동시 작성 UI·API와 링크의 인용 카드 전환은 제외한다.
+
+## 이유와 대안
+
+게시글별 정책은 원문마다 인용 범위를 선택하게 한다. Profile 기본값은 독립적으로 제공할 수 있으므로
+이번 사이클에서 분리한다. 기존 Post도 `모두`로 시작하되 조회 권한은 그대로 적용한다.
+
+원격 승인 대기 중 전체 게시를 보류하는 대신 자체 Content를 먼저 게시한다. 인용 승인은 Source 노출에만
+적용하므로 거절이나 철회가 작성자의 본문 삭제로 이어지지 않는다.
+
+차단과 승인 철회를 분리하면 당사자 간 접근 제한과 제3자에게 보이는 인용 관계의 제거를 각각 선택할 수 있다.
+정책 변경이나 차단에 따른 일괄 자동 철회는 채택하지 않았다.
+
+## 결과와 후속 범위
+
+- [Post](../objects/post.md), [Profile Block](../objects/profile-block.md),
+  [Post Action Bar](../../design/post-action-bar.md)에 작성·설정·조회 결과를 반영한다.
+- [PROD-431](https://linear.app/byulmaru/issue/PROD-431)은 로컬 Quote 작성과 Composer를,
+  [PROD-924](https://linear.app/byulmaru/issue/PROD-924)는 게시글별 정책과 발신·승인·철회 연합을 구현한다.
+  PROD-902가 OpenSpec을 소유한다. 저장 표현, delivery와 재시도 세부는 해당 스펙의 구현 가이드를 따른다.
+- [PROD-792](https://linear.app/byulmaru/issue/PROD-792)의 원격 Quote 수신과
+  [PROD-793](https://linear.app/byulmaru/issue/PROD-793)의 Followers Only Source signed fetch 책임은 유지한다.
+  로컬 작성 제한을 원격 수신 계약의 축소로 적용하지 않는다.
+- Profile의 새 Post 인용 허용 기본값은 [PROD-925](https://linear.app/byulmaru/issue/PROD-925) Backlog에서
+  다룬다. 기존 Post와 기존 승인을 소급 변경하지 않으며 이번 사이클의 완료 조건에 포함하지 않는다.
+
+## 참고
+
+- [FEP-044f](https://fediverse.codeberg.page/fep/fep/044f/)
+- [Mastodon Quote Posts](https://docs.joinmastodon.org/user/quote-posts/)
+- [조사와 결정 기록](../records/2026-09-08-quote-federation-domain-gate.md)
+
+## 로컬 작성 범위 정정 (2026-09-09)
+
+PROD-431 Spec 대화에서 사용자가 링크 인용 기능·문서와 Reply+Quote 작성 기능 전체를 API까지 제거하도록
+지시했다. Quote 작성에서 선택적 Parent 입력과 해당 검증 요구를 제거한다. 기존 관계 조합·원격 수신·조회 표현은
+변경하지 않는다. PROD-431은 기본 Quote 작성, PROD-924는 정책·승인·발신과 공유 change의 통합·archive를 맡는다.
+
+## 원격 인용 승인 판단 정정 (2026-09-09)
+
+PROD-902 Spec 대화에서 사용자가 원격 `interactionPolicy`의 automatic/manual 여부와 관계없이 타인 원문
+인용은 QuoteRequest와 유효한 QuoteAuthorization을 거치도록 결정했다. 정책이 없거나 해석할 수 없어도
+작성자의 자체 Content를 pending 상태로 게시하고 QuoteRequest를 보낸다. 자기 인용만 요청 없이 허용하며,
+`interactionPolicy`는 작성 전 UI·정책 힌트로만 사용한다.

--- a/docs/domain/objects/post.md
+++ b/docs/domain/objects/post.md
@@ -26,10 +26,15 @@ Warning, Sensitive Media, Media 구성은 [Post Content](./post-content.md)가 �
 
 ## 속성
 
-| 속성      | 타입/nullability | 검증 정책                                | 존재 조건             | 조회 조건           | 조회 권한 |
-| --------- | ---------------- | ---------------------------------------- | --------------------- | ------------------- | --------- |
-| 생성 시각 | 시각, 필수       | 생성 결과로 기록하며 변경 불가           | 항상                  | Post 조회 정책 통과 | 없음      |
-| 삭제 시각 | 시각, nullable   | Tombstone 전이 결과로 기록하며 변경 불가 | Lifecycle이 Tombstone | Tombstone 조회 정책 | 없음      |
+| 속성           | 타입/nullability            | 검증 정책                                | 존재 조건                 | 조회 조건           | 조회 권한 |
+| -------------- | --------------------------- | ---------------------------------------- | ------------------------- | ------------------- | --------- |
+| 생성 시각      | 시각, 필수                  | 생성 결과로 기록하며 변경 불가           | 항상                      | Post 조회 정책 통과 | 없음      |
+| 삭제 시각      | 시각, nullable              | Tombstone 전이 결과로 기록하며 변경 불가 | Lifecycle이 Tombstone     | Tombstone 조회 정책 | 없음      |
+| 인용 허용 정책 | Quote Approval Policy, 필수 | 모두, 팔로워, 본인만 중 하나             | Content가 있는 Local Post | Post 조회 정책 통과 | 없음      |
+
+인용 허용 정책은 Content가 있는 Local Post에 적용하며, `모두`, `팔로워`, `본인만` 중 하나다.
+새 Post와 정책 도입 전 작성한 Local Post의 초기값은 `모두`다. 이 값은 이후 인용 요청을 판단하는 기준이며
+이미 발급한 인용 승인을 변경하지 않는다.
 
 ## 관계
 
@@ -64,15 +69,17 @@ Author Profile/Repost Source 조합에는 Lifecycle State가 Active이고 Conten
 
 ## 행동
 
-| 행동                                | 행동 주체 Profile | 대상 객체 | 입력값                                                                                               | 권한                               | 조건                                                                                                                                                                                                                                                                    | 결과                                                                                                                                                                                                                 |
-| ----------------------------------- | ----------------- | --------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Post 작성                           | Profile           | Post      | 본문, Post Visibility, Content Warning, Sensitive Media, Media 목록                                  | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이다. 본문과 Media가 모두 비어 있을 수 없으며 Media는 최대 4개다                                                                                                                                                                | Lifecycle=Active이고 Current Content가 있으며 Reply Parent와 Repost Source가 없는 Post, 첫 Post Content, Author/Hashtag 관계가 원자적으로 생성된다                                                                   |
-| Reply 작성                          | Profile           | Post      | Parent Post, 본문, Post Visibility, Content Warning, Sensitive Media, Media 목록                     | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이고 Content가 있는 Parent를 볼 수 있다. Post Visibility는 Parent와 독립적으로 행동 주체가 선택하며 본문/Media 조건은 Post 작성과 같다                                                                                          | Lifecycle=Active이고 Current Content와 입력 Reply Parent가 있으며 Repost Source가 없는 Post, 첫 Post Content, Author/Hashtag 관계가 원자적으로 생성된다                                                              |
-| Quote 작성                          | Profile           | Post      | Source Post, 선택적 Parent Post, 본문, Post Visibility, Content Warning, Sensitive Media, Media 목록 | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이고 Content가 있는 Source와 선택한 Parent를 볼 수 있다. Post Visibility는 Source/Parent와 독립적으로 선택하며 본문/Media 조건은 Post 작성과 같다                                                                               | Lifecycle=Active이고 Current Content와 Repost Source가 있으며 선택에 따라 Reply Parent도 가진 Post, 첫 Post Content, Author/Hashtag 관계가 원자적으로 생성된다                                                       |
-| Post Content 수정                   | Author Profile    | Post      | 본문, Content Warning, Sensitive Media, Media 목록                                                   | `Account.Active`, `Post.Author`    | Lifecycle State가 Active이고 Content가 있다. 새 document와 참조 Media가 [Post Content](./post-content.md)의 검증을 통과한다                                                                                                                                             | 새 immutable Post Content revision이 생성되고 Current Content가 같은 transaction에서 새 revision을 가리킨다. Post Visibility와 구조 관계는 바뀌지 않는다                                                             |
-| Repost 작성                         | Profile           | Post      | Source Post                                                                                          | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이고 Content가 있는 입력 Source를 볼 수 있다. Source Visibility는 Public, Unlisted, Followers Only 중 하나이며 같은 Author Profile/Source 조합의 Active Repost가 없다. Followers Only Source는 Source Author만 Repost할 수 있다 | Lifecycle=Active이고 Content와 Reply Parent 없이 입력 Repost Source를 직접 참조하는 Post와 Author 관계가 생성된다. Visibility는 Public/Unlisted Source이면 Unlisted, Followers Only Source이면 Followers Only가 된다 |
-| Post 삭제 (Account 요청)            | Author Profile    | Post      | 없음                                                                                                 | `Account.Active`, `Post.Author`    | Lifecycle State가 Active다                                                                                                                                                                                                                                              | Lifecycle State가 Tombstone이 되고 삭제 시각이 기록된다                                                                                                                                                              |
-| Post 삭제 (검증된 ActivityPub 요청) | Author Profile    | Post      | 없음                                                                                                 | `Post.Author`                      | Lifecycle State가 Active이고 Author Profile Origin이 Remote다. 서명 검증된 요청 Actor가 Author Profile에 연결된 저장 Actor와 같고, 요청 object가 Current Content를 가진 Post의 저장된 ActivityPub identity와 정확히 일치한다                                            | Lifecycle State가 Tombstone이 되고 삭제 시각이 기록된다                                                                                                                                                              |
+| 행동                                | 행동 주체 Profile     | 대상 객체   | 입력값                                                                           | 권한                               | 조건                                                                                                                                                                                                                                                                                                                                           | 결과                                                                                                                                                                                                                    |
+| ----------------------------------- | --------------------- | ----------- | -------------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Post 작성                           | Profile               | Post        | 본문, Post Visibility, Content Warning, Sensitive Media, Media 목록              | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이다. 본문과 Media가 모두 비어 있을 수 없으며 Media는 최대 4개다                                                                                                                                                                                                                                       | Lifecycle=Active이고 Current Content가 있으며 Reply Parent와 Repost Source가 없는 Post, 첫 Post Content, Author/Hashtag 관계가 원자적으로 생성된다                                                                      |
+| Reply 작성                          | Profile               | Post        | Parent Post, 본문, Post Visibility, Content Warning, Sensitive Media, Media 목록 | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이고 Content가 있는 Parent를 볼 수 있다. Post Visibility는 Parent와 독립적으로 행동 주체가 선택하며 본문/Media 조건은 Post 작성과 같다                                                                                                                                                                 | Lifecycle=Active이고 Current Content와 입력 Reply Parent가 있으며 Repost Source가 없는 Post, 첫 Post Content, Author/Hashtag 관계가 원자적으로 생성된다                                                                 |
+| Quote 작성                          | Profile               | Post        | Source Post, 본문, Post Visibility, Content Warning, Sensitive Media, Media 목록 | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이고 Content가 있는 Source를 볼 수 있다. Source는 아래 Quote Source 조건을 통과하며, 인용 정책이 자동 승인하거나 원격 승인 요청을 허용한다. 원격 승인 대기는 작성 거부 조건이 아니다. Post Visibility는 Source와 독립적으로 선택하되 원문 접근 범위를 넓히지 않으며 본문/Media 조건은 Post 작성과 같다 | Lifecycle=Active이고 Current Content와 입력 Source의 인용 정보를 기록하며 Reply Parent가 없는 Post, 첫 Post Content, Author/Hashtag 관계가 원자적으로 생성된다. 승인이 필요한 Source 관계는 승인 전까지 표시하지 않는다 |
+| 인용 허용 정책 변경                 | Author Profile        | Post        | 모두, 팔로워 또는 본인만                                                         | `Account.Active`, `Post.Author`    | Content가 있는 Active Local Post다                                                                                                                                                                                                                                                                                                             | 이후 요청에 적용할 정책이 변경된다. 기존 QuoteAuthorization은 유지한다                                                                                                                                                  |
+| 인용 승인 철회                      | Source Author Profile | Source Post | 승인을 철회할 Quote                                                              | `Account.Active`, `Post.Author`    | 해당 Source를 대상으로 발급한 인용 승인이 존재한다                                                                                                                                                                                                                                                                                             | 해당 승인을 무효로 만들고 Quote 자체 Content를 유지한 채 Source를 비노출한다. 원격에는 승인 철회를 전달한다                                                                                                             |
+| Post Content 수정                   | Author Profile        | Post        | 본문, Content Warning, Sensitive Media, Media 목록                               | `Account.Active`, `Post.Author`    | Lifecycle State가 Active이고 Content가 있다. 새 document와 참조 Media가 [Post Content](./post-content.md)의 검증을 통과한다                                                                                                                                                                                                                    | 새 immutable Post Content revision이 생성되고 Current Content가 같은 transaction에서 새 revision을 가리킨다. Post Visibility와 구조 관계는 바뀌지 않는다                                                                |
+| Repost 작성                         | Profile               | Post        | Source Post                                                                      | `Account.Active`, `Profile.Member` | 행동 주체는 선택된 Active/Normal Profile이고 Content가 있는 입력 Source를 볼 수 있다. Source Visibility는 Public, Unlisted, Followers Only 중 하나이며 같은 Author Profile/Source 조합의 Active Repost가 없다. Followers Only Source는 Source Author만 Repost할 수 있다                                                                        | Lifecycle=Active이고 Content와 Reply Parent 없이 입력 Repost Source를 직접 참조하는 Post와 Author 관계가 생성된다. Visibility는 Public/Unlisted Source이면 Unlisted, Followers Only Source이면 Followers Only가 된다    |
+| Post 삭제 (Account 요청)            | Author Profile        | Post        | 없음                                                                             | `Account.Active`, `Post.Author`    | Lifecycle State가 Active다                                                                                                                                                                                                                                                                                                                     | Lifecycle State가 Tombstone이 되고 삭제 시각이 기록된다                                                                                                                                                                 |
+| Post 삭제 (검증된 ActivityPub 요청) | Author Profile        | Post        | 없음                                                                             | `Post.Author`                      | Lifecycle State가 Active이고 Author Profile Origin이 Remote다. 서명 검증된 요청 Actor가 Author Profile에 연결된 저장 Actor와 같고, 요청 object가 Current Content를 가진 Post의 저장된 ActivityPub identity와 정확히 일치한다                                                                                                                   | Lifecycle State가 Tombstone이 되고 삭제 시각이 기록된다                                                                                                                                                                 |
 
 Post/Reply/Quote 작성과 Post Content 수정에서 Media node는 입력 순서를 유지한다. 모든 참조 Media는
 Source=Local, State=Ready이고 Media의 Upload Account가 행동을 요청한 Account와 같아야 한다. Media의
@@ -85,6 +92,35 @@ Reply·Quote·Repost 작성은 각 입력 Parent·Source Post의 Author Profile�
 Local 작성과 Remote 수신의 Quote는 direct Repost Source Author를 수신자로 하는
 [Quote Notification](./notification.md#quote-notification)의 원인이다. 알림의 생성 조건과 중복 처리는
 Notification이 소유하며, Quote·Reply Parent·Repost Source의 구조와 독립적인 조회 정책은 바뀌지 않는다.
+
+### Quote Source 조건과 승인
+
+- 타인의 Source는 Public 또는 Unlisted이고 Content와 조회 권한이 있어야 한다. 타인의 Followers Only
+  Source는 established Follower라도 Quote 대상으로 선택할 수 없다. 이 조건은 Local·Remote Source에
+  모두 적용한다.
+- Source Author와 Quote Author가 같으면 자기 인용이다. 자신의 Followers Only Source는 인용할 수 있지만
+  Source의 기존 접근 범위를 넓히지 않는다. Direct에 해당하는 Mentioned Profiles Source와 조회 불가
+  Source는 인용할 수 없다.
+- 로컬 Quote 작성은 Reply Parent 없이 Source를 선택한다. Reply+Quote 동시 작성 UI·API와 본문 링크의
+  인용 카드 전환은 제공하지 않는다. 기존 저장 데이터와 원격 수신에서의 독립 관계 조합·조회·표시는 유지한다.
+- `모두`는 위 조건을 통과한 Profile의 요청을 자동 승인하고, `팔로워`는 established Follower와 Source
+  Author의 요청을 자동 승인하며, `본인만`은 Source Author만 허용한다. 차단과 Source 조회 제한이 모든
+  허용 선택지에 우선한다.
+- Kosmo 원문의 건별 수동 승인 설정·승인 UI는 제공하지 않는다.
+- 자기 인용은 QuoteRequest 없이 허용한다. 타인의 원격 Source는 `interactionPolicy`가 automatic 또는
+  manual approval을 광고하거나, 정책이 없거나 유효하게 해석되지 않는 경우에도 QuoteRequest를 보낸다.
+  `interactionPolicy`는 작성 전 UI·정책 힌트로만 사용하고 승인 근거로 사용하지 않는다.
+- 타인의 원격 Quote는 자체 Content를 먼저 로컬에 게시하고 기존 Visibility에 따른 일반 전달도 수행한다.
+  승인 전에는 Source를 정상 인용으로 노출하지 않고 원문 서버에 QuoteRequest를 별도로 전달한다.
+- 검증된 승인을 받으면 승인과 Source 관계를 연결하고 이미 전달한 Quote를 갱신한다. 거절·승인 철회 또는
+  Source 삭제 시에는 Quote 자체 Content를 유지하고 Source 카드·관계는 비노출한다. 비노출을 위해 저장
+  관계를 물리적으로 제거해야 하는지는 도메인 계약으로 고정하지 않는다.
+- 전송 실패나 응답 부재를 승인으로 간주하지 않는다. 늦게 도착한 응답이나 중복 전달이 더 최신의 거절·철회를
+  무효화하지 않도록 한다. 세부 재시도와 전달 순서는 해당 lifecycle의 구현 계약에서 정한다.
+- 게시글별 인용 허용 설정의 변경은 이후 요청에만 적용한다. 기존 승인을 없애려면 별도 인용 승인 철회를
+  사용하며, 설정 변경 자체로 기존 Quote의 Source를 일괄 숨기지 않는다.
+- 차단은 당사자 간 접근과 새 인용 요청·승인을 막지만 기존 승인을 자동 철회하지 않는다. 제3자에게도
+  Source를 숨기려면 원문 작성자가 별도 승인 철회를 사용한다.
 
 ## 권한
 
@@ -117,6 +153,8 @@ Notification이 소유하며, Quote·Reply Parent·Repost Source의 구조와 �
 - Content 없는 Repost는 Repost Source가 Tombstone이거나 조회 정책을 통과하지 못하면 후보가 아니다.
 - Quote와 Reply이면서 Quote인 Post는 Repost Source가 Tombstone이거나 조회 정책을 통과하지 못해도 자체
   Content, Visibility와 Eligibility를 기준으로 후보를 유지하며 `Repost Source` 관계만 표시하지 않는다.
+- 승인 대기·거절·철회된 Source도 같은 비노출 원칙을 적용한다. 유효한 인용 승인이나 자기 인용이라는 사실은
+  viewer별 Source Visibility·Eligibility·Profile Block 검사를 대신하지 않는다.
 - Reply Parent가 Tombstone이거나 조회 정책을 통과하지 못해도 Reply 자체의 Post Eligibility는 바뀌지 않는다.
 - Post Eligibility는 Post Visibility가 허용하지 않은 viewer에게 접근 범위를 넓히지 않는다.
 
@@ -175,7 +213,7 @@ Notification이 소유하며, Quote·Reply Parent·Repost Source의 구조와 �
   중복하지 않고 document 순서대로 `attachment` Image에 투영하며 Alt Text와 조회 시점의 접근 가능한 URL·MIME
   type을 제공한다. document root의 Sensitive Media는 지원하는 ActivityPub sensitive 속성으로 투영한다. 이
   Local Note 계약은 PostContent node, mark, canonicalization 또는 validation을 다시 정의하지 않는다. Mention,
-  custom emoji와 Quote 전용 federation 속성은 이 표현에 포함하지 않는다.
+  custom emoji는 이 표현에 포함하지 않는다. Quote 전용 표현은 아래 Quote federation 정책을 따른다.
 - Reply Parent 관계가 있으면 Parent의 ActivityPub Post identity를 `inReplyTo`로 제공한다. Local Parent는
   같은 local Note URI 규칙을 사용하고 remote Parent는 저장된 ActivityPub Post URI를 사용한다. `inReplyTo`는
   requester별 Parent 조회 가능성에 따라 달라지지 않으며, Parent의 실제 표현은 Parent 자체의 역참조 권한으로
@@ -245,6 +283,32 @@ ActivityPub audience는 Post Visibility에서 다음과 같이 투영한다.
 - Local Note의 ActivityPub Tombstone, `Delete`, `Create`, `Announce`, `Like`, `EmojiReact`, `Undo` delivery와
   `emojiReactions` collection projection은 각 lifecycle과 delivery 계약이 소유한다.
 
+### Quote federation 정책
+
+- FEP-044f의 `quote`와 `QuoteAuthorization`을 정식 경로로 사용한다. 자기 인용 외에는 원문 작성자가 발급한
+  유효한 개별 승인을 검증해야 하며, `interactionPolicy` 광고만으로 승인을 대체하지 않는다.
+- Kosmo 원문에 들어오는 `QuoteRequest`는 요청 주체·인용 Post·Source의 대응과 원문 정책·조회·차단 조건을
+  확인해 자동 승인하거나 거절한다. 승인에는 `Accept`와 해당 `QuoteAuthorization`을 연결하고 거절에는
+  `Reject`를 사용한다.
+- 자기 인용은 QuoteRequest 없이 허용한다. 타인의 원격 Source를 인용하면 `interactionPolicy`의
+  automatic/manual 여부, 정책 부재 또는 해석 실패와 관계없이 원문 서버에 `QuoteRequest`를 보낸다.
+  본문만 먼저 전달한 뒤 검증된 `Accept`와 유효한 승인 객체를 받으면
+  `quote`·`quoteAuthorization`을 반영한 `Update`를 전달한다.
+- `interactionPolicy`는 작성 전 UI·eligibility 힌트로 사용할 수 있다. 요청자가
+  `automaticApproval`과 `manualApproval` 어느 쪽에도 명백히 포함되지 않으면 승인되지 않을 것으로
+  예상된다는 정보를 제공할 수 있지만, 정책 자체를 승인 증거로 사용하지 않는다.
+- 승인 전·거절·철회 상태에서는 일반 Note 표현이나 자동 생성한 레거시 호환 표현을 통해 정상 인용인 것처럼
+  Source 관계를 노출하지 않는다. Quote 작성자가 직접 작성한 Content를 Source lifecycle 때문에 삭제하지
+  않는다.
+- 명시적 인용 승인 철회는 `QuoteAuthorization`을 무효로 만들고 `Delete(QuoteAuthorization)`를 전달한다.
+  이를 수신하는 경계도 철회 주체와 승인의 대응을 검증한 뒤 Source를 비노출한다.
+- 레거시 Quote 속성의 상호운용을 지원하되 FEP 형식이 존재하지만 유효하지 않은 경우 레거시 형식으로
+  강등하지 않는다. 승인된 인용에는 `quoteUrl`, `quoteUri`, `_misskey_quote`와 원문 링크의 본문 fallback을
+  발신 표현으로 제공한다. 승인 전·거절·철회 상태에서는 자동 생성한 이 표현을 숨기되 직접 작성한 본문은
+  유지한다. PROD-902의 OpenSpec을 따라 PROD-924가 구현하고, 기존 원격 Quote 수신 책임은 PROD-792가 유지한다.
+- 기존 저장·원격 수신의 Reply+Quote는 `inReplyTo`와 Quote 관계를 독립적으로 표현한다. Source의 승인은
+  Parent 또는 다른 Source의 조회 권한이나 인용 승인을 부여하지 않는다.
+
 ### 검색
 
 - 검색 후보는 Post Visibility가 Public이고 Post Eligibility를 통과한 Post다.
@@ -284,5 +348,10 @@ ActivityPub audience는 Post Visibility에서 다음과 같이 투영한다.
 - 본문의 canonical 표현은 schema version이 식별된 document다. Plain Text는 작성 입력과 읽기·검색·접근성 projection이며 별도 canonical 저장값이 아니다.
 - 현재 document V1은 paragraph, text, hard break, 안전한 HTTP(S) link와 Media node를 지원한다. `pre`와
   일반 rich-text editor는 지원하지 않는다.
-- Mentioned Profiles audience와 ActivityPub Mention·custom emoji·Quote 전용 속성은 후속 계약에서 정의한다.
+- Mentioned Profiles audience와 ActivityPub Mention·custom emoji는 후속 계약에서 정의한다.
+- Quote 정책은 [ADR 0027](../decisions/0027-quote-consent-and-federation.md)과
+  [PROD-902](https://linear.app/byulmaru/issue/PROD-902)를 따른다. 로컬 작성은 PROD-431,
+  federation·승인 발급·철회는 PROD-924, 원격 Quote 수신·검증은 PROD-792가 구현한다.
+- 이번 사이클에는 게시글별 인용 허용 설정만 제공한다. Profile의 새 Post 인용 허용 기본값 설정은
+  [PROD-925](https://linear.app/byulmaru/issue/PROD-925)의 Backlog 범위이며 현재 출시를 막지 않는다.
 - Post Content 수정 후 원격 수신자에게 `Update(Note)`를 전달하는 lifecycle은 후속 계약에서 정의한다.

--- a/docs/domain/objects/post.md
+++ b/docs/domain/objects/post.md
@@ -287,6 +287,9 @@ ActivityPub audience는 Post Visibility에서 다음과 같이 투영한다.
 
 - FEP-044f의 `quote`와 `QuoteAuthorization`을 정식 경로로 사용한다. 자기 인용 외에는 원문 작성자가 발급한
   유효한 개별 승인을 검증해야 하며, `interactionPolicy` 광고만으로 승인을 대체하지 않는다.
+- `QuoteAuthorization` dispatcher는 Source를 조회할 수 있는 요청자에게 승인 객체를 제공한다. 승인 객체의
+  `interactingObject`는 URI 참조로만 제공하고 embed하지 않는다. 요청자의 Source 조회 권한을 확인할 수 없는
+  경우 `interactionTarget`도 embed하지 않는다.
 - Kosmo 원문에 들어오는 `QuoteRequest`는 요청 주체·인용 Post·Source의 대응과 원문 정책·조회·차단 조건을
   확인해 자동 승인하거나 거절한다. 승인에는 `Accept`와 해당 `QuoteAuthorization`을 연결하고 거절에는
   `Reject`를 사용한다.
@@ -301,7 +304,8 @@ ActivityPub audience는 Post Visibility에서 다음과 같이 투영한다.
   Source 관계를 노출하지 않는다. Quote 작성자가 직접 작성한 Content를 Source lifecycle 때문에 삭제하지
   않는다.
 - 명시적 인용 승인 철회는 `QuoteAuthorization`을 무효로 만들고 `Delete(QuoteAuthorization)`를 전달한다.
-  이를 수신하는 경계도 철회 주체와 승인의 대응을 검증한 뒤 Source를 비노출한다.
+  이를 수신하는 경계도 철회 주체와 승인의 대응을 검증한 뒤 Source를 비노출한다. 수신자가 Quote의 소유
+  서버라면 기존 Quote audience에도 검증된 `Delete(QuoteAuthorization)`을 전달한다.
 - 레거시 Quote 속성의 상호운용을 지원하되 FEP 형식이 존재하지만 유효하지 않은 경우 레거시 형식으로
   강등하지 않는다. 승인된 인용에는 `quoteUrl`, `quoteUri`, `_misskey_quote`와 원문 링크의 본문 fallback을
   발신 표현으로 제공한다. 승인 전·거절·철회 상태에서는 자동 생성한 이 표현을 숨기되 직접 작성한 본문은

--- a/docs/domain/objects/profile-block.md
+++ b/docs/domain/objects/profile-block.md
@@ -56,6 +56,9 @@ Local Profile만 actor로 사용하며, remote ActivityPub ingress와 Block/Undo
   적용한다.
 - Follow 후보와 Follow·Follow Request·Reply·Quote·Repost·Reaction 상호작용은 기존 양방향 Profile Block 조건을
   유지한다.
+- 유효한 기존 인용 승인도 당사자 간 Source 접근 제한을 우회하지 못한다. 새 QuoteRequest와 새 인용 승인은
+  차단 관계를 우선 확인한다. 차단 자체로 기존 QuoteAuthorization을 자동 철회하지 않으며, 제3자에게도
+  Source를 숨기려면 [Post](./post.md)의 명시적 인용 승인 철회를 사용한다.
 - 이번 Block 실행이 포착해 제거한 Follow Request/Relationship을 원인으로 가진 Notification은 필수 cleanup orchestration에서 함께 제거한다.
   다른 기존 Notification Item은 Block action에서 동기적으로 바꾸지 않으며, Notification 조회는 Recipient·Related
   Profile pair 정책과 Recipient 기준 Related Post/Profile 조회 정책을 적용한다. 후속 비동기 cleanup 전까지 저장

--- a/docs/domain/objects/profile.md
+++ b/docs/domain/objects/profile.md
@@ -228,3 +228,6 @@ route와 그 하위 경로도 저장된 Profile만 조회한다. 원격 lookup �
 - active Profile 선택은 Profile 객체를 바꾸지 않는 세션 동작이므로 도메인 행동에서 제외한다.
 - theme, 계정 이동, 서버 이전은 현재 범위에서 제외한다.
 - Remote Profile의 Profile Tag 수집·동기화와 ActivityPub 표현은 현재 범위에서 제외한다.
+
+- Profile의 새 Post 인용 허용 기본값 설정은 [PROD-925](https://linear.app/byulmaru/issue/PROD-925) Backlog에서
+  다룬다. 이번 사이클은 게시글별 설정만 제공하며 새 Post와 기존 Post의 초기값은 `모두`다.

--- a/docs/domain/records/2026-09-08-quote-federation-domain-gate.md
+++ b/docs/domain/records/2026-09-08-quote-federation-domain-gate.md
@@ -1,0 +1,254 @@
+# 2026-09-08 Quote 발신·승인 Domain Gate 검토
+
+## 조사 시작 시점 상태 (2026-09-08)
+
+[PROD-902](https://linear.app/byulmaru/issue/PROD-902)는 로컬 Quote 발신과 Source 작성자의 인용
+허용·승인·철회 정책을 결정하고 canonical 문서와 후속 이슈를 정렬하는 도메인 결정 이슈다.
+이 이슈의 본문은 OpenSpec 작성과 API·DB·Fedify·UI 구현을 제외한다.
+
+이 문서는 조사 근거, 이번 대화에서 선택한 항목과 남은 질문을 기록한다. 현재 canonical 계약을 대체하거나
+Domain Gate 승인을 나타내지 않는다. 정책의 적용 단위와 lifecycle까지 결정한 뒤
+[Post](../objects/post.md), 관련 객체·디자인 문서와 ADR에 반영하고 전체 결과를 승인받는다.
+후속 구현 이슈의 범위와 Issue Gate가 승인되면 해당 이슈가 필요한 OpenSpec을 작성한다.
+
+- 조사일: 2026-09-08.
+- Repository: `github.com/byulmaru/kosmo`.
+- 기준 branch: `PROD-902`, base `main`.
+- 기준 commit: `4417b2a8a1a11796ae41adc9921686e1a3e4fe25`.
+- Domain Gate: 진행 중. 인용 허용 선택지와 기본값만 대화에서 선택했다.
+- Issue Gate: 새 구현 이슈의 범위·소유권 승인 전.
+- 조사 시작 시점 OpenSpec Gate: 미착수. 이 기록은 OpenSpec이나 구현 승인 자료를 대신하지 않는다.
+
+## 독립 확인한 근거
+
+### Linear
+
+최신 본문, 관계와 전체 댓글을 OpenSpec과 독립적으로 확인했다. 아래 표는 조사 시작 시점의 snapshot이다.
+
+| 이슈                                                   | 본문 수정 시각 UTC         | 현재 책임                                                                                    | 계약 변경 댓글                      |
+| ------------------------------------------------------ | -------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------- |
+| [PROD-902](https://linear.app/byulmaru/issue/PROD-902) | `2026-09-07T08:12:00.157Z` | 발신·허용·승인·철회 Domain Gate와 canonical·이슈 정렬                                        | 없음                                |
+| [PROD-431](https://linear.app/byulmaru/issue/PROD-431) | `2026-09-07T08:12:30.488Z` | 로컬 Quote·Reply+Quote 작성 API·core·Composer, 자체 통합 검증                                | 없음                                |
+| [PROD-792](https://linear.app/byulmaru/issue/PROD-792) | `2026-09-07T09:50:08.844Z` | 원격 Quote 수신·승인 검증·Source resolution·기존 카드 표시                                   | 없음. 댓글 1개는 계약 변경이 아니다 |
+| [PROD-793](https://linear.app/byulmaru/issue/PROD-793) | `2026-09-07T09:50:15.955Z` | 미저장 Followers Only Source를 조회할 Local Follower 선택·signed fetch·저장 직전 권한 재검증 | 없음                                |
+
+조사 시작 시 PROD-792는 제외 범위의 로컬 Quote 작성과 발신을 모두 PROD-431에 연결했지만, PROD-431은
+Quote 전용 federation 발신을 명시적으로 제외했다. 이번 작업에서 PROD-792 본문을 정정해 작성은 PROD-431,
+발신 정책은 PROD-902, 발신 구현은 Domain Gate 이후 지정할 후속 구현 이슈로 구분했다.
+PROD-792의 수신 책임과 PROD-793의 signed fetch 책임, 기존 이슈 관계는 유지했다.
+
+- PROD-902에는 D1 선택과 아직 결정하지 않은 항목, 참조 정정 결과를 기록했다. 최종 확인한 수정 시각은
+  `2026-09-08T01:14:45.981Z`다.
+- PROD-792의 참조 정정 결과를 `2026-09-08T01:13:43.623Z` snapshot으로 확인했다. 동시에 진행된
+  PROD-793의 Source URI·expected author 검증 정보 전달 계약도 보존했다.
+- PROD-793은 `2026-09-08T01:13:11.059Z` 본문과 전체 댓글을 다시 확인했다. 인증된 선행 처리에서 검증한
+  Source URI와 작성자 대응이 있는 경우만 signed fetch를 수행하고, URI만으로 작성자를 추론하지 않는다.
+  이 계약은 원격 Source의 수신·조회에 적용하며 로컬 Quote 발신 지원을 뜻하지 않는다.
+- 위 PROD-793 계약의 canonical 설명은 `PROD-793` branch의 `docs/domain/objects/post.md`에서 직접
+  확인했다. 현재 PROD-902의 main 기준에는 아직 없으므로 merge된 공용 기반으로 취급하지 않는다.
+
+### Canonical 문서
+
+- [Post](../objects/post.md): Quote와 Reply+Quote의 작성·관계·Visibility·Eligibility·Source 조회,
+  ActivityPub Local Note 표현과 제외 범위.
+- [ADR 0014](../decisions/0014-post-structure-relations.md): Content, Reply Parent와 Repost Source의
+  독립 관계. Quote는 별도 Post Kind나 객체가 아니다.
+- [ADR 0017](../decisions/0017-activitypub-local-post-note.md): Local Note identity·audience·역참조,
+  Quote 전용 federation 표현의 후속 계약 경계.
+- [Profile Block](../objects/profile-block.md): 양방향 조회·상호작용 차단과 현재 cleanup 범위.
+- [Post Action Bar](../../design/post-action-bar.md): 기존 Repost 메뉴와 action target 계약.
+- [워크플로](../../../memory/issue-openspec-workflow.md): Domain → Issue → OpenSpec 순서와 gate 전환 승인.
+
+### 프로토콜 참고
+
+[FEP-044f](https://fediverse.codeberg.page/fep/fep/044f/)는 조회 시점에 Draft다. 자기 인용을 제외한 FEP
+Quote에는 개별 `QuoteAuthorization` 검증이 필요하다. `interactionPolicy.canQuote` 광고만으로 승인을
+대체하지 않는다. 요청은 `QuoteRequest`, 응답은 `Accept` 또는 `Reject`, 철회는 승인 객체의 `Delete`로
+표현한다. 승인을 기다린 뒤 게시할지, 먼저 게시하고 갱신할지는 제품이 선택할 수 있다. 이 프로토콜은
+원문 조회 권한을 추가로 부여하지 않는다.
+
+[Fedify interaction controls](https://unstable.fedify.dev/manual/interaction-controls)는
+`quoteInteraction`으로 요청·정책·승인 검증을 지원한다. 문서는 unstable 채널이며 현재 저장소 의존성은
+Fedify/vocab `2.3.0`이다. 문서의 API를 현재 설치 버전에서 사용할 수 있다고 단정하지 않는다. 정책이 없는
+대상을 허용한다고 추정하지 않으며, listener·저장·전달·제품 정책은 Kosmo가 소유한다. 의존성 추가나 버전
+변경은 후속 구현 이슈에서 호환성을 검증한다.
+
+외부 문서는 상호운용 제약과 대안의 근거다. Kosmo의 제품 기본값이나 출시 범위를 승인하는 근거는 아니다.
+
+## 기존 계약에서 유지할 기준
+
+1. Quote는 자체 Current Content와 direct Repost Source를 가진 Post다. Reply Parent는 독립적으로 함께
+   존재할 수 있고 Source를 재귀적으로 평탄화하지 않는다.
+2. 현재 로컬 Quote 작성 계약에서는 작성자가 Content가 있는 Source와 선택적 Parent를 각각 조회할 수
+   있어야 한다. Quote Visibility는 두 대상의 Visibility와 독립적으로 선택한다.
+3. Source가 Tombstone이 되거나 viewer에게 조회 불가능해도 Quote 자체 Content를 삭제하지 않는다.
+   Quote 자체 Visibility·Eligibility를 통과하면 본문을 표시하고 Source 관계의 노출을 제한한다.
+4. 승인 여부와 원문 조회 권한은 별개다. 승인된 인용도 viewer별 Source 조회 검사를 통과해야 한다.
+5. 기존 원격 수신 계약은 FEP `quote`를 우선하고, 그 속성이 없을 때만 레거시 형식을 사용한다.
+   잘못된 FEP Quote를 레거시로 강등해 승인 검증을 우회하지 않는다.
+6. 일반 Note projection·materialization은 관련 공용 경계를 재사용한다. Quote의 허용·승인 상태나
+   전용 lifecycle을 일반 Note 변환 책임으로 옮기지 않는다.
+
+2번의 로컬 작성 권한과 새 인용 허용 정책이 만나는 조건은 아직 확정하지 않았다. 게시 전에 알려진 거절을
+막을지, 허용 상태를 확인할 수 없는 경우 본문만 게시할지 결정한 뒤 PROD-431과 함께 정렬해야 한다.
+
+## 이번 대화에서 선택한 항목
+
+### D1. 인용 허용 선택지와 기본값
+
+- 상태: 선택 완료. Domain Gate 전체 승인과는 별개다.
+- 결정일: 2026-09-08.
+- 근거: 현재 `PROD-902 Spec` 대화의 첫 번째 질문에 대한 사용자 응답.
+- 선택: 모두·팔로워·본인만 자동 승인, 기본값은 모두.
+- 첫 출시에서 건별 수동 승인 기능은 포함하지 않는다.
+- 인용을 허용하더라도 기존 원문 조회 권한을 별도로 검사한다.
+- 아직 결정하지 않은 내용: 설정 소유 객체와 적용 단위, 기존 Post의 초기값, 설정 변경이 이미 발급한
+  승인에 미치는 영향. 이 선택만으로 위 항목을 확정하지 않는다.
+
+## 답변을 기다리는 질문
+
+| ID  | 결정할 내용                 | 제시한 권고안                                                             | 대안                                                 | 영향                                                        |
+| --- | --------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------- |
+| Q2  | 원격 승인 대기·거절 중 게시 | 자체 본문은 즉시 게시·전달하고 Source 카드는 승인 뒤 표시                 | 승인될 때까지 글 전체 게시·전달 보류                 | PROD-431 작성 결과, 발신 Create/Update, Composer 복구       |
+| Q3  | 첫 출시의 Source 공개 범위  | 외부 인용은 Public·Unlisted Source부터, Followers Only Source는 후속 분리 | Followers Only Source도 처음부터 양쪽 접근 권한 검증 | 발신과 승인 발급 범위, PROD-793 재사용 경계, 독립 출시 순서 |
+
+Q2와 Q3는 아직 답변하지 않은 질문이다. 권고안을 채택한 것으로 간주하지 않는다. 특히 Q3에서 Followers
+Only Source 발신을 보류하더라도 기존 로컬 Quote Visibility를 제한하거나 Quote 자체 본문의 외부 전달까지
+자동으로 금지한다는 뜻은 아니다. 후속 질문에서 외부 표현과 작성자 안내의 구체적인 동작을 정한다.
+
+## 다음 결정 항목
+
+아래 항목은 구현 수단 선택이 아니라 관찰 가능한 동작을 바꾸므로 후속 질문과 Domain Gate 검토에 포함한다.
+
+- 허용 설정의 소유: Post별 설정과 Profile의 새 Post 기본값을 모두 제공할지, 한 단위부터 제공할지.
+  기존 Post에 적용할 초기값, 이미 발급한 승인의 유지 여부도 함께 정한다.
+- 로컬 Source: 같은 서버 안에서도 같은 허용 정책을 적용할지, 자기 인용을 어떻게 처리할지,
+  기존 로컬 Quote 작성 조건을 어디까지 바꿀지.
+- 레거시 원격 Source: 인용 허용 정책이 없는 서버에 대해 Quote 발신을 지원할지, 지원한다면 어떤
+  호환 표현과 한계를 제공할지. FEP 검증 실패를 레거시 성공으로 바꾸지는 않는다.
+- 미승인·실패 상태: 작성자만 보는 pending·거절·재시도 안내, 응답 없는 요청의 처리와 명시적 거절 뒤
+  자동 재요청 여부. 네트워크 실패를 승인으로 간주하지 않는다.
+- Reply+Quote와 audience: 외부 인용을 지원하는 Quote 자체 Visibility, Source 작성자가 제한된 Quote를
+  검토하기 위해 받는 정보, Parent와 Source의 독립 권한, 레거시 fallback에 담을 URI와 본문.
+- 승인 철회: 원문 작성자의 건별 철회 조작, 철회 후 자체 Content·저장 관계·외부 표현, 오래된 승인 응답과
+  중복 전달의 처리, 철회 해제 또는 재승인 제공 여부.
+- Source 또는 Quote 삭제·차단·unfollow: 기존 승인도 철회할지, 관계를 숨기기만 할지,
+  차단 해제 뒤 승인과 Source preview를 자동으로 되살릴지.
+- 출시·기존 데이터: 이미 저장된 Quote의 처리, 기능 활성화 순서, 발신 중단 시 기존 승인·철회 처리 유지.
+  실제 운영 Quote 데이터 유무는 조사하지 않았으며 존재 여부를 추정하지 않는다.
+
+## 후속 이슈의 책임 초안
+
+이 표는 검토용 분해안이다. 새 이슈를 생성하거나 의존성·범위 변경을 승인한 상태가 아니다. 정책 답변에
+따라 독립 출시 가능성이 달라지면 이슈 수와 경계를 먼저 고친다.
+
+| 소유 이슈 또는 후보                               | 전달 결과                                                          | 검증·완료 책임                                                                                                | 의존성                                                           |
+| ------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| PROD-902                                          | 정책 질문 닫기, canonical·관련 이슈 본문 정렬, Domain Gate 승인    | 로컬·원격 Source, 승인·거절·철회·삭제·차단과 제외 범위의 정책 정합성                                          | 현재 이슈                                                        |
+| PROD-431                                          | 기존 로컬 Quote·Reply+Quote 작성 API·core·Composer 연결            | 작성 권한, 원자성, 오류 복구와 cross-layer 통합, 자신의 change 완료·archive                                   | 새 허용 정책이 작성 조건을 바꾸면 Domain Gate 결과와 정렬        |
+| 새 구현 후보: Kosmo 원문 인용 허용·승인 발급·철회 | 허용 설정, 원격 요청 검증·응답, 승인 역참조·건별 철회와 조작       | 거절·위조·조회 불가 원문·삭제·차단·중복 요청, 해당 change의 통합 검증·archive                                 | PROD-902의 승인된 정책; 로컬 작성 연결은 PROD-431과 조율         |
+| 새 구현 후보: 로컬 Quote 외부 발신                | 원격 원문 승인 요청·결과 반영, 승인 상태에 맞는 Note 표현·delivery | 로컬·원격 Source, 자기 인용, Reply+Quote, pending·거절·실패·철회·오래된 응답, 해당 change의 통합 검증·archive | PROD-431 및 승인 발급·철회 결과 중 실제로 필요한 계약            |
+| PROD-792                                          | 원격 Quote 수신·승인 검증·Source 연결·기존 카드 표시               | 기존 수신 시나리오와 보유한 resolution lifecycle                                                              | 현재 PROD-509 선행 관계 유지                                     |
+| PROD-793                                          | 미저장 Followers Only Source의 자격 있는 signed fetch              | fetch 전후 identity·Follow·audience 검증과 Source resolution                                                  | 현재 PROD-792 선행 관계 유지; outbound 지원 완료로 간주하지 않음 |
+
+두 새 구현 후보를 하나의 change로 묶을지는 양쪽을 함께 출시·검증해야 하는지에 따라 판단한다.
+파일·계층 수만으로 분리하지 않는다. 공통 통합 검증이 남으면 결과를 실제 소유할 이슈에 명시적으로
+배정하고, 마지막 이슈나 부모 이슈라는 이유로 archive 책임을 추정하지 않는다.
+
+인용 알림은 [PROD-903](https://linear.app/byulmaru/issue/PROD-903), 역방향 인용 목록은
+[PROD-904](https://linear.app/byulmaru/issue/PROD-904)의 별도 정책 범위로 유지한다. 첫 출시에서 미루기로
+정한 기능은 이유와 후속 owner를 확정해야 PROD-902를 완료할 수 있다.
+
+## 구현 조사에서 확인한 경계
+
+- `packages/core/db/tables.ts`와 `packages/core/services/post-structure.ts`에는 Quote 형태를 저장할
+  관계 조합이 있다. GraphQL Source 조회와 기존 Quote presentation도 있다.
+- `apps/api/src/graphql/resolvers/post/mutation/create.ts`와 `CreatePostInput`에는 Source 입력이 없다.
+  `repostPost`는 Content 없는 Repost를 만든다. 표시용 Quote fixture를 사용자용 작성 경로로 해석하지 않는다.
+- `packages/fedify/src/local-post-note.ts`의 Note 표현에는 Quote Source와 승인 정보가 없다.
+  `local-post-delivery.ts`의 Create/Delete 경로는 이를 사용한다. Local Quote의 승인 상태 갱신용
+  Update delivery는 현재 확인되지 않았다.
+- `packages/fedify/src/federation.ts`와 inbound Note 경로에는 QuoteRequest·승인 발급·철회 listener가 없다.
+  새 기능은 기존 Note 처리, Post 저장과 조회 경계를 재사용하되 별도 책임을 연결해야 한다.
+- API·저장 계약·migration·실행 테스트는 이번 단계에서 변경하지 않았다.
+
+## 다음 전환 조건
+
+1. 남은 정책을 결정하고 canonical 객체·정책·디자인 문서와 ADR을 정렬한다.
+2. PROD-431/792/793의 포함·제외 범위를 정렬하고 Domain Gate 검토 목록을 승인받는다.
+3. 필요한 후속 구현 이슈를 결과·의존성·검증·archive 책임으로 정리하고 Issue Gate를 승인받는다.
+4. 승인된 구현 이슈를 입력으로 OpenSpec proposal·specs·design·decisions·tasks를 작성하고 윤문·계약 대조·
+   strict validation을 수행한다. PROD-902의 이 기록만으로 해당 단계에 진입하지 않는다.
+
+## 갱신된 이슈와 후속 결정 (2026-09-08)
+
+앞선 기록은 당시 조사 상태를 보존한다. 이후 갱신된 PROD-902 본문과 Spec 대화에서 다음 결정을 추가로
+확인했다. 현재 canonical 계약은 [ADR 0027](../decisions/0027-quote-consent-and-federation.md)과
+[Post](../objects/post.md)를 따른다.
+
+- 원격 manual approval은 지원한다. 자체 Content를 먼저 게시·전달하고, 승인 전 Source는 정상 인용으로
+  노출하지 않는다. Accept와 유효한 승인 후 Source 연결·Update, Reject 후 자체 Content 유지·Source 비노출로
+  수렴한다. Kosmo 자체의 건별 수동 승인 UI는 제외한다.
+- 타인의 Source는 Public·Unlisted만 허용한다. 자기 Followers Only 인용은 원문 접근 범위를 넓히지 않는다.
+- 원문 삭제와 명시적 승인 철회 후에도 자체 Content는 유지한다. 정책 변경은 이후 요청에만 적용한다.
+- 사용자는 이번 사이클에 게시글별 설정만 제공하고 새 글은 `모두`로 시작하도록 선택했다. 기존 글도 `모두`로
+  초기화하기로 답했다. 기존 승인에는 소급 적용하지 않는다.
+- 사용자는 차단이 당사자 간 접근을 막되 기존 승인을 자동 철회하지 않도록 선택했다. 제3자에게도 Source를
+  숨기려면 별도 승인 철회를 사용한다. 이 결정으로 차단 트리거에 관한 제품 질문을 닫았다.
+- 사용자의 명시적 요청으로 [PROD-925](https://linear.app/byulmaru/issue/PROD-925)를 Backlog에 생성했다.
+  Profile의 새 Post 인용 허용 기본값을 다루며, 기존 Post·승인을 소급 변경하거나 이번 사이클을 막지 않는다.
+
+### 구현 책임과 검증
+
+| 이슈     | 책임                                                                | 완료·검증 경계                                                                                  |
+| -------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| PROD-902 | 도메인 정책과 canonical 정렬                                        | Domain Gate 승인. OpenSpec·제품 구현 제외                                                       |
+| PROD-431 | 로컬 Quote 작성 API·core·Composer                                   | Source 조건, Reply+Quote, 작성·표시 통합 검증과 담당 change 완료                                |
+| PROD-924 | 게시글별 정책, 로컬 Quote 발신, 원문 승인 발급·철회, 원격 승인 결과 | 작성부터 승인·거절·철회·삭제·차단까지 연합 통합 검증. 담당 change 전체 완료 증거와 archive 소유 |
+| PROD-792 | 원격 Quote 수신·승인 검증·표시                                      | 기존 수신 계약·테스트 유지                                                                      |
+| PROD-793 | 미저장 Followers Only Source signed fetch                           | 기존 인증된 source-author 근거 전달과 signed fetch 계약 유지                                    |
+| PROD-925 | Profile의 새 Post 인용 허용 기본값                                  | 후속 Backlog. 현재 출시 의존성 없음                                                             |
+
+PROD-924는 PROD-431의 로컬 작성 결과와 PROD-792의 수신 경계를 연결해 연합 흐름을 검증한다. 이 연결 책임에
+기존 이슈의 재구현이나 다른 change를 조기에 archive할 권한은 포함하지 않는다. OpenSpec 분할·공유 여부와
+출시 순서는 이 책임을 기준으로 Issue Gate에서 검토한다. 개별 제품 답변은 전체 Gate 승인을 대신하지 않는다.
+
+### 공식 구현 조사 근거
+
+- [Hackers’ Pub Quote inbox](https://github.com/hackers-pub/hackerspub/blob/e21745bf4657371156d8056328b5c44c3e77acdd/federation/inbox/quote.ts):
+  QuoteRequest, Accept/Reject, 승인 삭제 처리와 Source 연결·해제 후 Update 경로를 확인했다.
+- [Mastodon 명시적 철회](https://github.com/mastodon/mastodon/blob/3b6daf7ba7b49eb8b97557e6dc7877335cf5ab38/app/services/revoke_quote_service.rb)와
+  [사용자 문서](https://docs.joinmastodon.org/user/quote-posts/)는 차단과 기존 인용 제거를 구분한다.
+  일부 차단 파일에 직접 철회 호출이 없다는 사실만으로 전체 간접 호출 경로의 부재를 주장하지 않는다.
+- [FEP-044f](https://fediverse.codeberg.page/fep/fep/044f/)를 정식 승인 경로로 사용한다. 구체적인 발신 레거시 필드와
+  fallback, 저장 표현과 delivery·retry 순서는 PROD-924가 최신 공식 근거와 대조해 구현 명세에서 고정한다.
+
+### 조사 시점 Gate
+
+개별 제품 질문은 해결했다. canonical 문서와 이슈 책임 정렬 결과의 Domain Gate·Issue Gate 전체 승인은
+아직 받지 않았다. PROD-902에는 OpenSpec을 생성하지 않았으며 구현도 하지 않았다. 승인 후 PROD-924의
+구현 명세를 작성한다.
+
+## 스펙 소유권 정정과 호환 표현 확정 (2026-09-08)
+
+사용자는 현재 PROD-902 세션에서 902의 스펙을 작성하라고 명시했다. 이에 앞선 OpenSpec 제외·PROD-924로의
+스펙 작성 이동은 정정한다. PROD-902가 `define-quote-consent-and-federation`을 소유하고 PROD-431·924가
+담당 구현 task를 수행한다. PROD-924는 이 공유 change의 전체 task 완료·연합 통합 검증·spec 동기화 후
+archive를 수행한다. 이 진행 지시를 제품 구현이나 최종 Spec Gate 승인으로 취급하지 않는다.
+
+사용자는 승인된 인용에 `quoteUrl`, `quoteUri`, `_misskey_quote`와 인용 미지원 서버용 원문 링크를 제공하도록
+선택했다. 승인 대기·거절·철회 상태에서는 자동 생성한 호환 속성·본문 fallback을 숨기고 직접 작성한 본문은
+보존한다. 이 선택으로 발신 호환 표현의 제품 질문을 닫았다.
+
+## 후속 상태와 원격 승인 판단 정정 (2026-09-09)
+
+- PROD-902가 `define-quote-consent-and-federation` OpenSpec을 소유한다. PROD-431은 기본 Quote 작성,
+  PROD-924는 게시글별 정책·발신·승인·철회와 전체 통합·archive를 맡는다.
+- PROD-431의 2026-09-09 범위 정정에 따라 로컬 Reply+Quote 작성 UI·API와 링크 인용을 제외한다. 기존
+  저장 관계·원격 수신·조회 표현은 유지한다.
+- 자기 인용은 QuoteRequest 없이 허용한다. 타인의 원격 원문은 `interactionPolicy`의 automatic/manual 여부,
+  정책 부재 또는 해석 실패와 관계없이 자체 Content를 pending 상태로 게시하고 QuoteRequest를 보낸다.
+- `interactionPolicy`는 작성 전 UI·정책 힌트로만 사용한다. 실제 승인은 유효한 QuoteAuthorization으로
+  확인하며, 승인 전 Source 관계와 자동 생성 FEP·레거시 표현·본문 fallback은 정상 인용으로 노출하지 않는다.
+- 위 정정을 반영한 OpenSpec은 strict validation을 통과했고, 사용자가 2026-09-09 수정본의 Spec Gate를
+  승인했다. 제품 구현 완료나 change archive 승인은 아니다.

--- a/openspec/changes/define-quote-consent-and-federation/.openspec.yaml
+++ b/openspec/changes/define-quote-consent-and-federation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-09-08

--- a/openspec/changes/define-quote-consent-and-federation/decisions.md
+++ b/openspec/changes/define-quote-consent-and-federation/decisions.md
@@ -1,0 +1,114 @@
+## Context
+
+2026-09-08 PROD-902 최신 본문, canonical 문서와 현재 대화의 명시적 선택을 독립 확인했다.
+아래 기록은 상위 계약을 다시 정리한 Derived Contract이며 새 내부 구현 수단을 강제하지 않는다.
+Spec Gate 최종 승인은 별도이며 이 기록의 Active가 제품 구현 승인을 뜻하지 않는다.
+
+## Decision Records
+
+### D1 게시글별 자동 승인과 모두 초기값
+
+- Decision Date: 2026-09-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/profile.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+- Status: Active
+- Context / Problem: 설정 단위·기존 글 초기값과 기존 승인의 처리 기준이 필요했다.
+- Decision Outcome: 게시글별 모두·팔로워·본인만 자동 승인을 사용하고 새 글·기존 Local Post 모두 초기값을 모두로 한다. 사용자가 이번 사이클 범위를 게시글별로 선택했다.
+- Alternatives Considered: Profile 기본값은 별도 Backlog로 분리했다. 기존 글을 본인만으로 초기화하거나 기존 승인을 일괄 철회하는 방안은 선택하지 않았다.
+- Consequences: 정책 변경은 이후 요청에만 적용한다. Profile 기본값 PROD-925는 현재 완료 조건이 아니다.
+- Confirmation / Follow-up: 새/기존 글 초기값, 권한, Follow와 Follow Request 구분, 기존 승인 비소급을 검증한다.
+
+### D2 원격 승인 대기 중 본문 선게시
+
+- Decision Date: 2026-09-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-431, PROD-924.
+- Status: Active
+- Context / Problem: 원격 타인 원문 승인을 기다리는 동안 자체 본문 게시와 Source 노출을 구분해야 한다.
+- Decision Outcome: 사용자가 채택한 계약대로 본문을 먼저 게시·일반 전달하고 승인 전 Source는 정상 인용으로 노출하지 않는다. Kosmo 자체 건별 수동 승인 UI는 제외한다.
+- Alternatives Considered: 전체 게시를 승인까지 보류하거나 승인 없이 Source를 먼저 노출하는 방안은 채택하지 않았다.
+- Consequences: Accept와 유효한 승인 후 연결·Update, Reject·실패 중 본문 보존을 구분한다.
+- Confirmation / Follow-up: pending 게시·발신, 잘못된 Accept, 유효한 승인 후 같은 identity 갱신을 검증한다.
+
+### D3 타인 Source 공개 범위와 자기 인용
+
+- Decision Date: 2026-09-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-431, PROD-924.
+- Status: Active
+- Context / Problem: 조회 가능한 타인의 제한 공개 글까지 재증폭할지 결정해야 했다.
+- Decision Outcome: 타인 Local·Remote Source는 Public·Unlisted만 허용한다. 자기 Followers Only 인용은 Source 접근 범위를 유지한다.
+- Alternatives Considered: 조회 가능한 타인의 Followers Only 인용은 선택하지 않았다. Direct·Mentioned Profiles·조회 불가 Source도 제외한다.
+- Consequences: 원격 수신 PROD-792·793 계약은 별도로 유지한다. Parent와 Source의 권한은 독립이다.
+- Confirmation / Follow-up: 타인 Followers Only 거부, 자기 인용의 viewer별 접근, 기존 저장 관계의 조회를 보존한다.
+
+### D4 삭제·정책 변경·차단·철회의 서로 다른 결과
+
+- Decision Date: 2026-09-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+- Status: Active
+- Context / Problem: 원문 제어가 Quote 작성자의 본문과 제3자 조회에 미치는 범위를 정해야 했다.
+- Decision Outcome: 삭제·거절·철회 후 본문을 유지하고 Source를 숨긴다. 차단은 당사자 접근·새 요청을 막되 기존 승인을 자동 철회하지 않는다. 제3자 Source 비노출은 명시적 철회다.
+- Alternatives Considered: 정책 변경·차단에 따른 일괄 자동 철회와 Source 삭제에 따른 Quote 전체 삭제는 채택하지 않았다.
+- Consequences: 기존 승인으로 차단을 우회할 수 없고, 명시적 철회는 해당 승인을 무효화해 원격에 전달한다.
+- Confirmation / Follow-up: 당사자와 제3자의 차이, 명시적 철회, 원문 삭제, 본문 보존을 검증한다.
+
+### D5 FEP 승인과 레거시 발신 표현
+
+- Decision Date: 2026-09-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+- Status: Active
+- Context / Problem: 인용 지원 여부가 다른 서버에도 승인된 원문 참조를 전달해야 한다.
+- Decision Outcome: FEP를 정식 경로로 쓰며 승인 후 quoteUrl·quoteUri·\_misskey_quote와 원문 링크 fallback을 제공한다. 사용자가 속성 3종과 본문 링크 제공을 선택했다.
+- Alternatives Considered: 속성 3종만 제공하는 방안은 선택하지 않았다. invalid FEP를 legacy로 강등하는 방안은 승인 우회이므로 제외한다.
+- Consequences: 승인 전·거절·철회 때 자동 생성 표현을 숨기고 직접 작성한 Content·링크는 유지한다.
+- Confirmation / Follow-up: 승인 후 호환 payload와 철회 후 자동 표현 제거, 사용자 본문 보존을 검증한다.
+
+### D6 스펙 소유권과 구현·archive 책임
+
+- Decision Date: 2026-09-08
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/decisions/0027-quote-consent-and-federation.md`, `memory/issue-openspec-workflow.md`, PROD-902, PROD-431, PROD-924.
+- Status: Active
+- Context / Problem: 스펙 작성 세션을 구현 이슈로 이동하려던 해석이 사용자 요청과 달랐다.
+- Decision Outcome: 사용자 정정에 따라 PROD-902가 이 OpenSpec을 소유한다. PROD-431·924가 담당 task를 구현하며 PROD-924는 전체 선언 task와 연합 통합 검증 후 archive를 수행한다.
+- Alternatives Considered: PROD-924 소유의 별도 스펙으로 이동하거나 이슈 수만큼 계약을 복제하지 않는다.
+- Consequences: 스펙 작성과 제품 구현 승인은 별개다. PROD-792·793의 독립 change 완료를 대신 처리하지 않는다.
+- Confirmation / Follow-up: 현재 issue-scope와 task owner, 전체 완료·sync·archive 증거를 대조한다.
+
+### D7 로컬 작성 범위는 기본 Quote로 한정
+
+- Decision Date: 2026-09-09
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, `docs/design/post-action-bar.md`, PROD-431·902·924의 2026-09-09 범위 정정과 PROD-431 사용자 지시.
+- Status: Active
+- Context / Problem: 이전 미구현 작성 초안에 Reply+Quote API와 링크 인용 UX가 포함됐다.
+- Decision Outcome: 사용자가 해당 기능 전체와 문서 제거를 지시했으므로 기본 Quote 작성만 제공한다. Quote 작성에 Reply Parent를 추가하지 않으며 링크를 인용 카드로 전환하지 않는다.
+- Alternatives Considered: Reply+Quote API만 유지하거나 대체 UI를 만드는 안도 사용자가 제외했다.
+- Consequences: 기존 Reply 작성과 저장된 관계·원격 수신·조회 표현은 유지한다. 기존 PROD-431 초안은 적용 대상에서 제외하고 이 공유 change의 tasks 2~3을 사용한다. PROD-902의 이전 승인 snapshot은 이번 수정본 전체의 승인이 아니다.
+- Confirmation / Follow-up: 제외된 UI·작성 조합을 노출하지 않는지, 기본 Quote와 기존 Post·Reply의 회귀를 확인한다.
+
+### D8 원격 interactionPolicy는 승인 증거가 아닌 힌트
+
+- Decision Date: 2026-09-09
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, `docs/design/post-action-bar.md`, PROD-902의 2026-09-09 사용자 결정. 프로토콜 참고: [FEP-044f](https://fediverse.codeberg.page/fep/fep/044f/).
+- Status: Active
+- Context / Problem: 원격 `interactionPolicy`의 automatic/manual 분류나 부재·해석 실패를 QuoteRequest 발신과 실제 승인 판단에 어떻게 사용할지 확정해야 했다.
+- Decision Outcome: 자기 인용은 QuoteRequest 없이 허용한다. 타인 원문은 automatic/manual 여부와 정책 부재·해석 실패에 관계없이 자체 Content를 pending으로 게시하고 QuoteRequest를 보낸다. `interactionPolicy`는 작성 UI와 예상 eligibility의 힌트일 뿐이며, 실제 승인은 해당 Quote·Source에 결속한 유효한 QuoteAuthorization으로만 확인한다.
+- Alternatives Considered: manual 광고가 있을 때만 요청하거나 automatic 광고 자체를 승인으로 보는 방안, 정책 부재·해석 실패 시 작성을 거부하는 방안은 채택하지 않았다.
+- Consequences: 작성자가 automatic/manual 어느 쪽에도 명백히 포함되지 않으면 승인 가능성이 낮다는 안내에 사용할 수 있지만, 그 정보만으로 승인 또는 거절을 확정하지 않는다. 승인 전에는 Source와 자동 생성 FEP·legacy·fallback을 숨기며, 승인 후 같은 Post에 Source를 활성화하고 필요한 Update를 전달한다.
+- Confirmation / Follow-up: 자기 인용, automatic, manual, 정책 부재·해석 실패, 어느 집합에도 포함되지 않는 경우와 유효·무효 QuoteAuthorization을 각각 검증한다.
+
+## Remaining Decisions
+
+- 현재 범위의 미결정 제품 정책은 없다. Profile 기본값은 현재 계약의 승인 근거가 아닌 PROD-925 Backlog다.
+- 내부 저장 표현·API 이름·UI 배치·재시도 수는 design의 비규범 가이드와 기존 계약을 만족하는 범위에서 정한다.
+  공개 동작·권한·데이터·호환성에 영향을 주는 추가 선택이 드러나면 상위 결정부터 갱신한다.
+
+## Superseded Decisions
+
+- OpenSpec 안에서 대체된 기존 결정은 없다. 작성 전의 ‘PROD-902는 OpenSpec 제외, PROD-924에서 스펙 작성’
+  해석은 사용자 정정과 Linear 갱신으로 폐기했다. 현재 결정은 D6이며 당시 기록은 조사 record에 보존한다.

--- a/openspec/changes/define-quote-consent-and-federation/decisions.md
+++ b/openspec/changes/define-quote-consent-and-federation/decisions.md
@@ -49,10 +49,10 @@ Spec Gate 최종 승인은 별도이며 이 기록의 Active가 제품 구현 �
 - Authority / Provenance: `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
 - Status: Active
 - Context / Problem: 원문 제어가 Quote 작성자의 본문과 제3자 조회에 미치는 범위를 정해야 했다.
-- Decision Outcome: 삭제·거절·철회 후 본문을 유지하고 Source를 숨긴다. 차단은 당사자 접근·새 요청을 막되 기존 승인을 자동 철회하지 않는다. 제3자 Source 비노출은 명시적 철회다.
+- Decision Outcome: 삭제·거절·철회 후 본문을 유지하고 Source를 숨긴다. 차단은 당사자 접근·새 요청을 막되 기존 승인을 자동 철회하지 않는다. 제3자 Source 비노출은 명시적 철회이며, 로컬 Quote가 수신한 유효한 철회는 기존 Quote audience에도 전달한다.
 - Alternatives Considered: 정책 변경·차단에 따른 일괄 자동 철회와 Source 삭제에 따른 Quote 전체 삭제는 채택하지 않았다.
 - Consequences: 기존 승인으로 차단을 우회할 수 없고, 명시적 철회는 해당 승인을 무효화해 원격에 전달한다.
-- Confirmation / Follow-up: 당사자와 제3자의 차이, 명시적 철회, 원문 삭제, 본문 보존을 검증한다.
+- Confirmation / Follow-up: 당사자와 제3자의 차이, 명시적 철회, Quote audience 전달, 원문 삭제, 본문 보존을 검증한다.
 
 ### D5 FEP 승인과 레거시 발신 표현
 
@@ -63,8 +63,8 @@ Spec Gate 최종 승인은 별도이며 이 기록의 Active가 제품 구현 �
 - Context / Problem: 인용 지원 여부가 다른 서버에도 승인된 원문 참조를 전달해야 한다.
 - Decision Outcome: FEP를 정식 경로로 쓰며 승인 후 quoteUrl·quoteUri·\_misskey_quote와 원문 링크 fallback을 제공한다. 사용자가 속성 3종과 본문 링크 제공을 선택했다.
 - Alternatives Considered: 속성 3종만 제공하는 방안은 선택하지 않았다. invalid FEP를 legacy로 강등하는 방안은 승인 우회이므로 제외한다.
-- Consequences: 승인 전·거절·철회 때 자동 생성 표현을 숨기고 직접 작성한 Content·링크는 유지한다.
-- Confirmation / Follow-up: 승인 후 호환 payload와 철회 후 자동 표현 제거, 사용자 본문 보존을 검증한다.
+- Consequences: QuoteAuthorization 역참조는 Source 조회 권한을 적용하고 `interactingObject`를 embed하지 않는다. 권한을 확인할 수 없으면 `interactionTarget`도 embed하지 않는다. 승인 전·거절·철회 때 자동 생성 표현을 숨기고 직접 작성한 Content·링크는 유지한다.
+- Confirmation / Follow-up: 권한별 승인 객체 readback과 embed 제한, 승인 후 호환 payload와 철회 후 자동 표현 제거, 사용자 본문 보존을 검증한다.
 
 ### D6 스펙 소유권과 구현·archive 책임
 

--- a/openspec/changes/define-quote-consent-and-federation/design.md
+++ b/openspec/changes/define-quote-consent-and-federation/design.md
@@ -1,0 +1,143 @@
+## Context
+
+계약·스펙 owner는 PROD-902다. 같은 계약의 로컬 작성은 PROD-431, 게시글별 정책·발신·승인·철회와 연합
+통합 검증은 PROD-924가 맡는다. PROD-792·793의 기존 수신·signed fetch 구현을 이 change에서 복제하지 않는다.
+
+Canonical 근거는 `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`, ADR 0027과
+`docs/design/post-action-bar.md`다. 2026-09-08 사용자의 정책 선택과 스펙 소유권 정정을 Linear에서 확인했다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 게시글별 인용 허용과 원문 작성자의 철회를 실제 작성·조회·발신 결과에 일관되게 적용한다.
+- 자체 Content의 게시와 Source 인용 승인을 분리하고 원격 응답·삭제·차단 이후에도 두 결과를 구분한다.
+- 일반 Note·기존 Post·공통 dispatcher·effects 경계를 재사용하고 구현 이슈별 완료 증거를 연결한다.
+
+**Non-Goals:**
+
+- Profile 기본값 PROD-925, Kosmo 자체 건별 수동 승인 UI, 인용 알림·목록, 사용자용 본문 수정.
+- 별도 Quote durable 객체나 Kind, 기존 원격 수신·signed fetch·Repost·Profile Block UI 재구현.
+- PROD-902 세션에서 제품 코드 구현 또는 change archive.
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `packages/core/db/tables.ts`와 `packages/core/services/post-structure.ts`에는 Content·Reply Parent·Repost
+  Source 조합이 있다. Content 없는 `repostPost`는 Quote 작성 경로가 아니다.
+- `apps/api/src/graphql/resolvers/post/mutation/create.ts`의 생성 입력과 `packages/core/services/post.ts`의
+  LocalPostInput은 조사 시점에 Source 입력을 받지 않는다. PROD-431의 작성 연결이 필요하다.
+- 기존 `Post.repostSource`와 카드가 Source FK의 존재를 최종 승인으로 해석하면 pending·철회 시 원문이
+  노출된다. 조회 판단에 승인과 viewer별 Source 접근을 모두 연결해야 한다.
+- `packages/fedify/src/local-post-note.ts`에는 Quote 전용 projection이 없고 기존 Create/Delete 경로를
+  사용한다. 승인 후 Update는 이 change의 발신 lifecycle에서 연결할 부분이다.
+- 설치된 Fedify와 vocabulary는 2.3.0이다. 최신 문서의 helper 존재를 현재 dependency의 가용성으로
+  추론하지 않는다. 도입 시 package export와 공식 문서를 대조하고 의존성 변경은 pnpm CLI를 사용한다.
+- 원격 수신 저장 상태와 source-author 검증 입력은 PROD-792·793이 소유한다. 로컬 작성 제한 때문에
+  원격 Followers Only 수신 계약을 줄이지 않는다.
+
+### Recommended Approach
+
+아래는 구현 출발점이며 내부 이름이나 저장 구조를 고정하는 규범이 아니다.
+
+1. 먼저 게시글 정책과 요청 판정·조회 판정을 연결한다. 정책 값, 자기 인용, established Follow, Block과
+   Source 조회 여부를 읽는 기존 경계를 재사용한다. 초기값은 새 글·기존 글 모두 `모두`다.
+2. PROD-431은 자체 Content와 인용 대상 정보의 원자적 작성을 연결하고, 자기 인용이 아닌 원격 타인 원문은
+   `interactionPolicy`와 관계없이 Quote를 pending으로 게시한다. 요청 가능 여부와 최종 승인 여부를
+   API·클라이언트에서 혼동하지 않도록 결과를 구분한다.
+3. PROD-924는 요청에 대응하는 Quote·Source·발급자와 처리된 응답의 순서를 식별할 수 있도록 승인 정보를
+   보존한다. FK는 승인 상태가 아니므로 Source projection은 별도 승인 판정과 기존 접근 판정을 통과시킨다.
+4. 일반 Note projection을 공유해 자체 Content를 먼저 전달하고 원문 서버에 QuoteRequest를 보낸다. 자기 인용은
+   요청 없이 허용한다. 타인 원문의 `interactionPolicy`는 automatic/manual 분류나 부재·해석 실패 모두
+   사전 힌트로만 사용하며 승인 증거로 사용하지 않는다. 승인이 유효해진 뒤 같은 Post identity로 Source·승인을
+   포함한 Update를 전달한다. source-author의 Accept/Reject와 승인 객체의 대응을 검증한다.
+5. 승인된 projection에 세 호환 속성과 원문 링크 fallback을 추가한다. 같은 Source identity를 사용하고,
+   fallback은 저장된 PostContent 수정이 아닌 발신 표현으로 구성하는 접근을 권장한다. 자동 생성한 부분을
+   구분해 철회 시 제거하고 작성자 본문은 보존한다. `quote-inline`과 `RE:` 표현은 공식 구현의 참고 예시다.
+6. 명시적 철회·삭제·차단을 각각 처리한다. 철회는 승인 무효화와 원격 신호, 삭제는 기존 삭제 계약,
+   차단은 당사자 접근 제한을 담당한다. 같은 effect로 모두 묶어 기존 승인을 자동 철회하지 않는다.
+7. 기존 post-commit effects와 공통 delivery에 연결한다. commit된 자체 Content와 delivery 실패를 구분하고
+   중복·동시·stale 응답은 최신 승인 결과를 바꾸지 않도록 검증한다. 재시도 횟수나 Workflow type·ID는
+   현재 공통 runtime 정책을 확인한 뒤 정한다. PROD-792의 재시도 수를 발신에 그대로 복제하지 않는다.
+
+### Allowed Alternatives
+
+- 비노출 Source를 물리 관계에서 분리하거나 관계를 보존하고 조회에서 가릴 수 있다. 어느 방식을 택해도 요청
+  대응 검증, pending·철회 비노출, 자체 Content 보존과 기존 Post API 계약을 만족해야 한다.
+- 기존 effects 흐름에 통합하거나 별도 승인 orchestration을 연결할 수 있다. commit 이후 처리, 중복·역순
+  응답 수렴과 실패 관찰 가능성을 동일하게 증명해야 한다.
+- 저장 표현·API 이름·화면 배치의 선택이 공개 계약이나 제품 결과를 바꾸면 PROD-902 canonical·Linear·스펙을
+  먼저 정렬한다. 이 가이드를 새로운 제품 권한의 근거로 사용하지 않는다.
+
+### Known Traps
+
+- 조회 가능한 타인의 Followers Only Source를 인용 가능하다고 판단하는 것.
+- pending Quote 전체를 게시 보류하거나, 반대로 FK·legacy 속성을 보고 Source를 승인 없이 표시하는 것.
+- automatic 광고를 개별 승인으로 대체하거나 manual 광고가 없다는 이유로 QuoteRequest를 생략하는 것.
+- `interactionPolicy` 부재·해석 실패를 작성 거부로 처리하거나 다른 Source·Quote·발급자의 승인을 재사용하는 것.
+- 정책 변경·차단을 기존 승인 일괄 철회로 구현하는 것.
+- 승인 후 자동 삽입한 링크를 사용자 Content에 저장해 철회 때 본문까지 수정·삭제하는 것.
+- 지연된 Accept, 재시도 또는 삭제 뒤의 응답으로 Source 노출을 복구하는 것.
+- 기존 inbound Quote를 Local Create로 다시 발신하거나 Source URI를 delivery endpoint로 사용하는 것.
+
+## Risks / Trade-offs
+
+- 승인 대기 중 Source 없는 본문이 먼저 보인다 → 이후 같은 Post identity의 승인 결과를 반영한다.
+- 미지원 서버는 승인 철회·Update를 반영하지 않을 수 있다 → Kosmo 상태와 outbound 신호를 검증하고 다른
+  서버의 물리 삭제까지 보장한다고 주장하지 않는다.
+- FEP와 helper 구현이 변할 수 있다 → 구현 시 공식 문서·설치 버전·고정 fixture를 함께 확인한다.
+- 공유 change의 일부 PR만 완료될 수 있다 → PROD-902가 스펙을 유지하고 PROD-924는 전체 선언 task와
+  PROD-431 연동 증거가 갖춰진 뒤 archive한다. 다른 이슈의 별도 change는 그대로 둔다.
+
+## Migration Plan
+
+PROD-924가 `memory/database-migrations.md`의 additive/breaking 분류를 실제 저장 diff에 적용한다. 정책 저장
+구조와 도입 전 Local Post를 `모두`로 초기화하는 migration/backfill, 기존 승인 보존을 먼저 준비하고 정책
+판정·조회 보호를 갖춘 뒤 작성·발신을 연결한다. backfill은 정책이 이미 지정된 글과 기존 승인을 덮어쓰지 않아야 한다.
+
+이 스펙은 column 삭제·타입 축소 같은 breaking migration을 승인하지 않는다. 그런 변경이 필요하면 별도
+expand/transition/contract 경계와 rollback 근거를 상위 이슈에 반영한다. 구버전으로 되돌릴 때 승인 검증을
+잃어 Source가 노출되는 rollback은 허용하지 않는다. 이미 게시한 Content와 발급·철회 기록을 보존하면서
+새 작성·발신을 중단하거나 호환 버전으로 복구할 수 있는지 배포 전 검증한다.
+
+게시글별 정책의 구체적인 GraphQL field·mutation 이름, payload와 오류 shape는 위 공개 행동·권한·초기값을
+만족하는 범위에서 PROD-924가 구현 시 확정한다. 해당 선택과 schema·migration·backfill·rollback 증거를
+PROD-924의 구현 PR과 통합 검증에 남긴다.
+
+## PROD-431 작성 구현 가이드
+
+2026-09-09 사용자 지시로 기본 Quote 작성만 제공한다. 기존 `add-local-quote-creation` 초안은 적용하지 않는다.
+그 초안에서 전제한 타인 Followers Only 허용, 승인 상태 없는 Source 노출, migration 불필요는 현재 계약과 다르다.
+
+- API는 기존 `CreatePostInput`에 optional `repostSourceId`를 추가하는 접근을 권장한다. concrete Post global ID를
+  기존 resolver 경계에서 해석하고 core에 DB identity를 전달한다. 생략·null은 기존 Post·Reply 동작이다.
+  Source와 Parent를 함께 받는 작성 조합은 허용하지 않는다. Source 입력 자체의 shape와 기존 payload를 유지한다.
+- `packages/core/services/post.ts`의 기존 transaction에서 Media·Content와 인용 대상 정보를 기록한다.
+  Source의 Content·조회·공개 범위·정책·차단을 제출 시 다시 확인한다. 부적격 Source의 존재를 오류로 노출하지
+  않으며, transaction 실패는 Media metadata까지 rollback한다. post-commit 효과 실패는 게시 실패와 구분한다.
+- PROD-924가 소유한 정책·요청 판정·승인 상태 저장 경계를 먼저 대조한다. 승인 정보 없이 FK만 추가해 작성이나
+  조회를 배포하지 않는다. 실제 저장 표현은 양쪽 구현이 공유해야 하며 PROD-431이 임의의 두 번째 승인 모델을
+  만들지 않는다. 현재 코드에는 해당 경계가 없으므로 작업 시작 시 PROD-924의 구현·설계 상태를 확인한다.
+- menu eligibility를 순수 Repost의 계산에 그대로 종속시키지 않는다. `인용하기`는 조회 가능하고 인용 조건에 맞는
+  Content Post에서 기본 Composer를 열며 Source 자체의 direct preview를 표시한다. Reply Parent 선택·링크
+  자동 전환·새 검색기는 제공하지 않는다. 본문·Media·Content Warning·Sensitive Media·Visibility를 재사용한다.
+- `PostComposer`의 기존 요청 context generation에 Source identity를 포함하는 접근을 권장한다. selected Profile·
+  Environment·draft 전환이나 unmount 뒤 늦은 응답이 새 draft와 navigation을 변경하지 않게 한다.
+- 서버가 반환한 Post는 기존 `@prependNode`와 관리 대상 Home connection에 반영한다. 없는 connection을 합성하거나
+  Source의 Repost count·viewerRepost를 Quote 성공으로 변경하지 않는다. 성공 Post가 포함된 nullable field 오류와
+  Post 없는 실패를 구분한다. 승인 대기 성공에서는 서버의 null Source를 유지한다.
+- 승인·철회 뒤 재조회한 같은 Post identity에서 Source가 바뀌는지 확인한다. 서버 승인 lifecycle을 클라이언트에서
+  추측하거나 별도 polling·subscription 기능을 이 스펙만으로 추가하지 않는다. 기존 화면 재조회 경계를 재사용한다.
+
+## Open Questions
+
+현재 제품 정책의 미답변은 없다. 정책 API의 구체적인 field·mutation 이름, payload·오류 shape, 저장 schema,
+재시도 수와 구체 UI 배치는 PROD-924가 위 가이드와 기존 계약을 만족하도록 정하는 구현 선택이다. 의미 있는
+공개 계약·권한·데이터·호환성 변경이 필요하면 구현자가 독단으로 선택하지 않고 PROD-902의 결정을 갱신한다.
+
+공식 참고: [FEP-044f](https://fediverse.codeberg.page/fep/fep/044f/),
+[Mastodon ActivityPub](https://docs.joinmastodon.org/spec/activitypub/),
+[Hackers’ Pub Quote inbox](https://github.com/hackers-pub/hackerspub/blob/e21745bf4657371156d8056328b5c44c3e77acdd/federation/inbox/quote.ts).
+Mastodon 고정 parser는 `3b6daf7ba7b49eb8b97557e6dc7877335cf5ab38`을 조사했다. Hackers’ Pub outbound serializer
+전체의 호환 규칙을 확인했다고 주장하지 않으며, Kosmo의 발신 표현은 사용자 선택과 canonical 계약을 따른다.

--- a/openspec/changes/define-quote-consent-and-federation/proposal.md
+++ b/openspec/changes/define-quote-consent-and-federation/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+Kosmo에는 Quote 저장·표시 기반이 있지만, 로컬 작성과 원문 작성자의 동의, 외부 서버에 전달한 뒤의 승인·철회가
+하나의 계약으로 연결되어 있지 않다. PROD-902에서 확정한 제품 정책을 OpenSpec으로 남겨 작성과 federation
+구현이 같은 Source 노출·본문 보존 규칙을 따르게 한다.
+
+## What Changes
+
+- 기존 `createPost`에 Source 입력을 추가하고 Repost 메뉴에서 공용 Composer로 기본 Quote를 작성한다.
+  Reply+Quote 작성 UI·API와 링크의 인용 카드 전환은 제외한다.
+- 게시글별 인용 허용 정책 `모두 | 팔로워 | 본인만`을 제공한다. 새 글과 기존 Local Post는 `모두`로 시작하며
+  기존 승인에는 소급 적용하지 않는다.
+- 타인의 Public·Unlisted Source와 접근 범위를 넓히지 않는 자기 Followers Only 인용을 지원한다.
+- 자기 인용을 제외한 원격 타인 원문에는 `interactionPolicy`의 automatic/manual 광고나 부재·해석 실패와
+  관계없이 QuoteRequest를 보내고, 유효한 QuoteAuthorization으로 실제 승인을 확인한다.
+- 원격 승인 대기 중 자체 Content를 먼저 게시·전달하고, 승인 후 Source 연결·Update, 거절·철회·원문 삭제 후
+  본문 유지·Source 비노출을 보장한다. `interactionPolicy`는 작성 UI와 예상 eligibility의 힌트로만 사용한다.
+- FEP-044f 요청·승인 결과·명시적 철회와 레거시 상호운용을 연결한다.
+- 차단의 당사자 간 접근 제한과 제3자에게도 Source를 숨기는 명시적 승인 철회를 구분한다.
+- PROD-902가 계약과 이 OpenSpec을 소유한다. PROD-431은 작성·Composer, PROD-924는 게시글별 정책과
+  federation 구현·연합 통합 검증을 맡는다. 전체 선언 task 완료 후 archive는 PROD-924가 수행한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`,
+  `docs/domain/objects/profile.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`,
+  `docs/domain/decisions/0017-activitypub-local-post-note.md`, `docs/design/post-action-bar.md`.
+- Linear Contract: [PROD-902](https://linear.app/byulmaru/issue/PROD-902). 2026-09-08 갱신된 본문과 현재 대화의
+  정책 선택 및 “902의 스펙을 작성해야지” 지시로 기존 OpenSpec 제외·소유권 이동을 정정했다.
+- Linear Implementations: [PROD-431](https://linear.app/byulmaru/issue/PROD-431),
+  [PROD-924](https://linear.app/byulmaru/issue/PROD-924).
+- 유지되는 인접 계약: [PROD-792](https://linear.app/byulmaru/issue/PROD-792)의 원격 Quote 수신과
+  [PROD-793](https://linear.app/byulmaru/issue/PROD-793)의 Source signed fetch. 이 change에서 중복 구현하지 않는다.
+
+## Capabilities
+
+### New Capabilities
+
+- `quote-consent`: 게시글별 정책, 로컬 Quote 작성 허용, 승인과 조회 권한, 차단·철회·삭제의 제품 결과.
+- `activitypub-quote-federation`: 로컬 Quote 발신, Kosmo 원문용 승인 발급, 원격 승인 결과, 승인 후 갱신과 철회 연합.
+
+- `post-quote-composer`: 인용 메뉴, direct Source preview, 공용 작성 기능과 actor별 성공·실패 처리.
+
+### Modified Capabilities
+
+- `post`: 기존 작성 입력에 Source를 추가하고 Quote Source 반환에 인용 승인 조건을 적용한다.
+- `post-repost-ui`: 인용 항목 보류를 해제하고 기본 Quote 작성 진입을 연결한다.
+
+기존 관계 조합·일반 Create/Delete·원격 수신 계약은 유지한다.
+
+- 2026-09-09 범위 정정: PROD-431 사용자 지시에 따라 Reply+Quote 작성과 링크 인용을 제거했다.
+  현재 canonical과 Linear PROD-431·902·924의 정정 내용을 적용하며 이전 승인본을 수정본의 승인으로 간주하지 않는다.
+
+## Impact
+
+Core의 Post 작성·정책·승인 행동, API의 작성 입력과 정책·철회 조작, Composer와 게시된 Source 표시,
+Fedify의 Local Note 표현·inbox·dispatcher, effects Workflow와 통합 검증에 영향을 준다.
+실제 API 이름·저장 구조는 기존 계약을 확인한 구현 설계에서 선택하며 이 제안이 새 durable 객체를 정의하지 않는다.
+
+Profile 기본값은 PROD-925 Backlog로 제외한다. Kosmo 자체 건별 수동 승인 UI, 인용 알림·목록, 사용자용 본문 수정,
+일반 원격 Note 처리와 기존 Repost 재구현은 제외한다. 이 문서 작성은 제품 구현이나 Spec Gate 최종 승인이 아니다.

--- a/openspec/changes/define-quote-consent-and-federation/specs/activitypub-quote-federation/spec.md
+++ b/openspec/changes/define-quote-consent-and-federation/specs/activitypub-quote-federation/spec.md
@@ -1,0 +1,185 @@
+## ADDED Requirements
+
+### Requirement: FEP Quote 표현과 승인 검증
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`,
+PROD-902, PROD-924. 프로토콜 참고: [FEP-044f](https://fediverse.codeberg.page/fep/fep/044f/).
+
+시스템은 FEP-044f의 `quote`와 `QuoteAuthorization`을 정식 인용 표현으로 사용해야 한다(MUST).
+자기 인용을 제외하면 원문 작성자가 해당 Quote에 발급한 유효한 승인을 검증해야 한다(MUST).
+`interactionPolicy`의 automatic/manual 광고, 전달 성공, 임의의 승인 URI만으로 최종 승인을 인정해서는
+안 된다(MUST NOT). `interactionPolicy`는 작성 UI와 예상 eligibility의 사전 힌트로만 사용할 수 있다(MAY).
+
+#### Scenario: 승인된 로컬 Quote 발신
+
+- **WHEN** 로컬 Quote의 Source와 유효한 승인 대응을 확인한다
+- **THEN** canonical Note identity를 유지하며 FEP Source·승인 표현을 제공한다
+- **AND** 기존 Author Instance identity와 Post Visibility audience를 유지한다
+
+#### Scenario: 자기 인용
+
+- **WHEN** Source와 Quote의 작성자가 같은 Profile이다
+- **THEN** FEP 자기 인용 조건을 확인하고 기본 Quote를 표현한다
+- **AND** QuoteRequest나 별도 QuoteAuthorization을 요구하지 않는다
+- **AND** 자기 인용이 Source의 조회 권한을 넓히지 않는다
+
+### Requirement: Kosmo 원문용 인용 요청의 자동 판정
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`,
+`docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+Kosmo 원문에 들어오는 QuoteRequest는 요청 Profile·인용 Post·Source의 대응과 Source 정책·조회·차단
+조건을 검증해야 한다(MUST). 허용된 요청에는 해당 Quote·Source에 결속한 QuoteAuthorization과 Accept를
+제공하고, 허용하지 않는 요청에는 Reject로 대응해야 한다(MUST). Kosmo 자체의 건별 수동 승인 UI나
+수동 승인 정책을 추가해서는 안 된다(MUST NOT).
+
+#### Scenario: 허용된 원격 요청
+
+- **WHEN** 검증된 QuoteRequest가 현재 원문 정책과 조회·차단 조건을 통과한다
+- **THEN** 원문 작성자가 해당 Source와 Quote에 대해 발급한 승인을 Accept에 연결한다
+- **AND** 다른 Quote나 Source의 승인을 재사용하지 않는다
+
+#### Scenario: 정책 변경 또는 차단 이후 요청
+
+- **WHEN** 새 요청이 현재 정책에 맞지 않거나 두 Profile 사이에 차단이 있다
+- **THEN** 승인하지 않고 Reject로 대응한다
+- **AND** 이전에 발급한 별개 승인을 자동 철회하지 않는다
+
+#### Scenario: 위조된 요청 대응
+
+- **WHEN** 인증된 요청 주체와 인용 Post 작성자가 일치하지 않거나 요청의 Source 대응이 잘못됐다
+- **THEN** 승인을 발급하지 않고 Source 조회 제한을 우회하는 정보를 반환하지 않는다
+
+### Requirement: 원격 승인 대기 중 발신과 승인 후 Update
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`,
+`docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+자기 인용이 아닌 원격 타인 원문의 로컬 Quote는 `interactionPolicy`의 automatic/manual 분류나 부재·해석
+실패와 관계없이 자체 Content를 먼저 게시하고 일반 federation 전달을 진행해야 한다(MUST). 승인 전 Source를
+정상 인용으로 노출하지 않은 채 원문 서버에 별도 QuoteRequest를 보내야 한다(MUST).
+해당 요청의 Accept와 유효한 QuoteAuthorization을 확인한 뒤 Source·승인을 연결하고 필요한 Update를
+전달해야 한다(MUST). 이 처리에 일반 사용자용 본문 수정 기능을 추가해서는 안 된다(MUST NOT).
+
+#### Scenario: automatic approval 광고가 있는 타인 원문
+
+- **WHEN** 원격 `interactionPolicy`가 현재 작성자를 automatic approval 대상으로 광고한다
+- **THEN** 자체 Content를 pending 상태로 게시하고 원문 서버에 QuoteRequest를 보낸다
+- **AND** 광고 자체를 승인으로 보거나 유효한 QuoteAuthorization 확인을 생략하지 않는다
+
+#### Scenario: manual approval 광고가 있는 타인 원문
+
+- **WHEN** 로컬 Quote가 원격 수동 승인 요청을 기다린다
+- **THEN** 자체 Content는 기존 audience로 전달하고 원문 서버에는 QuoteRequest를 보낸다
+- **AND** 일반 Note와 자동 생성 legacy 표현에 승인된 Source 관계를 노출하지 않는다
+
+#### Scenario: interactionPolicy 부재 또는 해석 실패
+
+- **WHEN** 원격 원문의 `interactionPolicy`가 없거나 유효하게 해석되지 않는다
+- **THEN** Quote 작성을 거부하지 않고 자체 Content를 pending 상태로 게시한 뒤 QuoteRequest를 보낸다
+- **AND** Source 관계와 자동 생성 FEP·legacy·본문 fallback을 정상 인용으로 노출하지 않는다
+
+#### Scenario: 작성자가 어느 승인 대상에도 포함되지 않음
+
+- **WHEN** 유효하게 해석한 `interactionPolicy`에서 현재 작성자가 automatic/manual 어느 쪽에도 명백히 포함되지 않는다
+- **THEN** 작성 UI나 eligibility 판단은 승인 가능성이 낮다는 정보를 힌트로 사용할 수 있다
+- **AND** 그 정책만으로 Quote가 승인됐다고 보거나 QuoteAuthorization을 대체하지 않는다
+
+#### Scenario: 유효한 Accept
+
+- **WHEN** 요청 대상 원문 작성자의 Accept와 해당 Quote·Source에 대한 유효한 승인을 확인한다
+- **THEN** 같은 Quote identity에 Source·승인을 연결하고 갱신된 표현을 전달한다
+- **AND** 새 Post나 중복 Content를 만들지 않는다
+
+#### Scenario: 유효하지 않은 Accept 또는 응답 실패
+
+- **WHEN** Accept의 승인 주체·Source·Quote 대응이 틀리거나 요청에 응답이 없다
+- **THEN** Source를 승인 상태로 전환하지 않는다
+- **AND** 이미 게시한 자체 Content는 유지한다
+
+### Requirement: 거절과 철회 및 삭제 연합
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`,
+`docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+로컬 Quote에 대한 유효한 Reject 또는 승인 철회는 자체 Content를 유지한 채 Source를 비노출로 수렴시켜야
+한다(MUST). Kosmo 원문 작성자의 명시적 철회는 승인을 무효화하고 `Delete(QuoteAuthorization)`를 전달해야
+한다(MUST). 수신된 철회는 주체와 대상 승인의 대응을 검증해야 한다(MUST). Source 삭제와 Quote 자체 삭제를
+혼동하여 다른 작성자의 Content를 삭제해서는 안 된다(MUST NOT).
+
+#### Scenario: 원격 원문의 Reject 또는 승인 철회
+
+- **WHEN** 로컬 Quote에 대응하는 유효한 Reject 또는 Delete(QuoteAuthorization)을 처리한다
+- **THEN** 해당 Source·승인을 더 이상 정상 인용으로 노출하지 않는다
+- **AND** 자체 Content와 Quote identity를 유지하고 이미 발신한 표현도 필요한 갱신으로 수렴시킨다
+
+#### Scenario: Kosmo 원문 작성자의 철회
+
+- **WHEN** 원문 작성자가 자신의 Source에 발급한 기존 승인을 철회한다
+- **THEN** 해당 승인을 무효화하고 철회 신호를 원격에 전달한다
+- **AND** 차단만으로 같은 철회 신호를 자동 생성하지 않는다
+
+#### Scenario: 잘못된 철회와 Quote 삭제
+
+- **WHEN** 다른 작성자의 위조된 철회를 받거나 Quote 자체가 이미 삭제된 상태에 과거 Accept가 도착한다
+- **THEN** 잘못된 철회를 승인하지 않고 삭제된 Quote나 그 Source 노출을 복원하지 않는다
+
+### Requirement: 재전달과 역순 응답의 수렴
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`,
+PROD-902, PROD-924.
+
+중복·동시 요청과 delivery 재시도는 하나의 유효한 승인·Source 결과로 수렴해야 한다(MUST).
+뒤늦은 Accept가 더 최신 거절·철회 또는 삭제를 되돌려서는 안 된다(MUST NOT). transient 실패는 영구
+거절과 구분하고 재시도 중에도 승인 검증과 Source 비노출 조건을 유지해야 한다(MUST).
+
+#### Scenario: 중복 QuoteRequest 또는 Accept
+
+- **WHEN** 같은 의미의 요청이나 승인이 중복·동시 전달된다
+- **THEN** 중복 Post·Content·유효 승인 관계를 만들지 않고 하나의 결과로 수렴한다
+
+#### Scenario: 철회 뒤 늦은 Accept
+
+- **WHEN** 승인이 철회된 뒤 과거 요청에 대한 Accept가 늦게 도착한다
+- **THEN** 철회 상태와 Source 비노출을 유지한다
+
+#### Scenario: delivery 일시 실패
+
+- **WHEN** 승인 또는 갱신 전달에 일시적인 오류가 발생한다
+- **THEN** 이미 확정된 본문·승인 결과를 되돌리지 않고 재시도 여부와 실패를 관찰할 수 있다
+- **AND** 재전달을 이유로 이전 승인 상태로 되돌아가지 않는다
+
+### Requirement: 레거시 상호운용과 승인 우회 방지
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`,
+PROD-902, PROD-924. 기존 원격 수신 경계: PROD-792.
+
+시스템은 승인된 Quote의 레거시 발신 호환을 지원해야 한다(MUST). FEP 형식이 존재하지만 유효하지 않은
+경우 이를 레거시 인용으로 강등해서는 안 된다(MUST NOT). 승인 전·거절·철회 상태에서는 자동 생성한 호환
+표현으로 Source를 정상 인용처럼 노출해서는 안 된다(MUST NOT). 작성자가 직접 쓴 Content는 보존해야 한다(MUST).
+
+승인된 인용에는 `quoteUrl`, `quoteUri`, `_misskey_quote` 호환 속성과 원문 링크의 발신 본문 fallback을
+제공해야 한다(MUST). 자동 생성한 발신 표현은 작성자가 직접 작성한 Content와 구분해야 한다(MUST).
+
+#### Scenario: 잘못된 FEP와 legacy 속성의 동시 존재
+
+- **WHEN** FEP Quote가 유효하지 않고 legacy Quote 속성도 존재한다
+- **THEN** legacy 속성을 근거로 승인된 Source로 표시하지 않는다
+
+#### Scenario: 승인 전 자동 호환 표현
+
+- **WHEN** Quote의 승인이 대기·거절·철회 상태다
+- **THEN** 자동 생성한 legacy Source 속성이나 본문 fallback으로 정상 인용을 우회 노출하지 않는다
+- **AND** 작성자가 직접 작성한 링크와 본문을 승인 lifecycle 때문에 삭제하지 않는다
+
+#### Scenario: 승인 후 레거시 인용 표현
+
+- **WHEN** 인용이 승인되어 Source 관계를 발신할 수 있다
+- **THEN** FEP 표현과 함께 세 호환 속성이 같은 Source를 가리키고 발신 본문에도 원문 링크를 제공한다
+- **AND** 호환 표현 생성 때문에 저장된 작성자 Content를 바꾸지 않는다
+
+#### Scenario: 철회 뒤 자동 생성 fallback 제거
+
+- **WHEN** 승인된 인용이 철회되어 갱신된 표현을 전달한다
+- **THEN** 세 호환 속성과 자동 생성한 원문 링크 fallback을 비노출한다
+- **AND** 작성자가 직접 쓴 동일한 URL이나 본문은 삭제하지 않는다

--- a/openspec/changes/define-quote-consent-and-federation/specs/activitypub-quote-federation/spec.md
+++ b/openspec/changes/define-quote-consent-and-federation/specs/activitypub-quote-federation/spec.md
@@ -9,6 +9,9 @@ PROD-902, PROD-924. 프로토콜 참고: [FEP-044f](https://fediverse.codeberg.p
 자기 인용을 제외하면 원문 작성자가 해당 Quote에 발급한 유효한 승인을 검증해야 한다(MUST).
 `interactionPolicy`의 automatic/manual 광고, 전달 성공, 임의의 승인 URI만으로 최종 승인을 인정해서는
 안 된다(MUST NOT). `interactionPolicy`는 작성 UI와 예상 eligibility의 사전 힌트로만 사용할 수 있다(MAY).
+QuoteAuthorization은 Source를 볼 수 있는 당사자가 역참조할 수 있어야 한다(MUST). 승인 객체는
+`interactingObject`를 embed해서는 안 되며(MUST NOT), 요청자의 Source 조회 권한을 확인할 수 없으면
+`interactionTarget`도 embed해서는 안 된다(MUST NOT).
 
 #### Scenario: 승인된 로컬 Quote 발신
 
@@ -22,6 +25,19 @@ PROD-902, PROD-924. 프로토콜 참고: [FEP-044f](https://fediverse.codeberg.p
 - **THEN** FEP 자기 인용 조건을 확인하고 기본 Quote를 표현한다
 - **AND** QuoteRequest나 별도 QuoteAuthorization을 요구하지 않는다
 - **AND** 자기 인용이 Source의 조회 권한을 넓히지 않는다
+
+#### Scenario: 권한 있는 요청자의 승인 객체 역참조
+
+- **WHEN** Source를 조회할 수 있는 당사자가 연결된 QuoteAuthorization을 역참조한다
+- **THEN** 시스템은 해당 Quote·Source·원문 작성자에 결속한 승인 객체를 반환한다
+- **AND** `interactingObject`는 URI 참조로만 제공하고 embed하지 않는다
+- **AND** 요청자의 Source 조회 권한을 확인한 경우에만 `interactionTarget`을 embed할 수 있다
+
+#### Scenario: Source 조회 권한을 확인할 수 없는 역참조
+
+- **WHEN** QuoteAuthorization 요청자의 Source 조회 권한을 확인할 수 없다
+- **THEN** 시스템은 Source 객체를 `interactionTarget`에 embed하지 않는다
+- **AND** `interactingObject`도 embed하지 않아 Quote나 Source Content를 우회 노출하지 않는다
 
 ### Requirement: Kosmo 원문용 인용 요청의 자동 판정
 
@@ -104,14 +120,21 @@ Kosmo 원문에 들어오는 QuoteRequest는 요청 Profile·인용 Post·Source
 
 로컬 Quote에 대한 유효한 Reject 또는 승인 철회는 자체 Content를 유지한 채 Source를 비노출로 수렴시켜야
 한다(MUST). Kosmo 원문 작성자의 명시적 철회는 승인을 무효화하고 `Delete(QuoteAuthorization)`를 전달해야
-한다(MUST). 수신된 철회는 주체와 대상 승인의 대응을 검증해야 한다(MUST). Source 삭제와 Quote 자체 삭제를
-혼동하여 다른 작성자의 Content를 삭제해서는 안 된다(MUST NOT).
+한다(MUST). 수신된 철회는 주체와 대상 승인의 대응을 검증해야 한다(MUST). 수신자가 Quote의 소유 서버라면
+검증된 `Delete(QuoteAuthorization)`을 기존 Quote audience에 전달해야 한다(MUST). Source 삭제와 Quote 자체
+삭제를 혼동하여 다른 작성자의 Content를 삭제해서는 안 된다(MUST NOT).
 
 #### Scenario: 원격 원문의 Reject 또는 승인 철회
 
 - **WHEN** 로컬 Quote에 대응하는 유효한 Reject 또는 Delete(QuoteAuthorization)을 처리한다
 - **THEN** 해당 Source·승인을 더 이상 정상 인용으로 노출하지 않는다
 - **AND** 자체 Content와 Quote identity를 유지하고 이미 발신한 표현도 필요한 갱신으로 수렴시킨다
+
+#### Scenario: 수신한 승인 철회의 Quote audience 전달
+
+- **WHEN** 로컬 Quote의 소유 서버가 유효한 Delete(QuoteAuthorization)을 수신한다
+- **THEN** 해당 Source를 비노출로 전환하고 기존 Quote audience에 철회를 전달한다
+- **AND** 전달 대상별 실패가 검증된 로컬 철회 상태와 Quote 자체 Content를 되돌리지 않는다
 
 #### Scenario: Kosmo 원문 작성자의 철회
 

--- a/openspec/changes/define-quote-consent-and-federation/specs/post-quote-composer/spec.md
+++ b/openspec/changes/define-quote-consent-and-federation/specs/post-quote-composer/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: 기본 Quote 작성 진입과 입력
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`, `docs/design/reply-composer.md`, PROD-431, PROD-902. 클라이언트는 인용 메뉴의 direct Source를 가진 공용 Composer를 제공해야 한다(MUST). 기존 본문·Visibility·Content Warning·Sensitive Media·Media 검증을 재사용하고(MUST), Source preview를 작성 Content로 계산해서는 안 된다(MUST NOT). Reply+Quote 작성 UI·API와 본문 링크의 인용 카드 전환을 제공해서는 안 된다(MUST NOT).
+
+#### Scenario: 기본 작성과 Source preview
+
+- **WHEN** 인용 조건을 통과한 Post에서 `인용하기`를 선택한다
+- **THEN** 해당 Post를 direct Source로 표시하고 Reply Parent 없는 Composer를 연다
+- **AND** Source가 Quote여도 한 단계 preview만 사용하고 Source의 Source로 대상을 바꾸지 않는다
+- **AND** Source의 기존 Content Warning·Sensitive Media 가림 정책을 유지한다
+
+#### Scenario: 공용 입력 제출
+
+- **WHEN** 본문 또는 Ready Media가 있고 기존 입력 검증을 통과해 제출한다
+- **THEN** Source ID와 본문·Visibility·Content Warning·Sensitive Media·순서 있는 Media를 기존 작성 mutation으로 보낸다
+- **AND** Source 공개 범위가 사용자가 선택한 Quote Visibility를 덮어쓰지 않는다
+
+#### Scenario: 빈 작성 Content
+
+- **WHEN** Source preview만 있고 본문과 Ready Media가 모두 없다
+- **THEN** 제출할 수 없다
+- **AND** 기존 입력·업로드 오류를 수정한 뒤 제출할 수 있다
+
+### Requirement: 작성 취소와 오류 복구
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, `docs/design/reply-composer.md`, PROD-431. 클라이언트는 기존 Composer의 폐기 보호·pending·오류 복구를 유지해야 한다(MUST). 제출 중 중복 요청을 막고 실패 시 작성 내용을 보존해야 한다(MUST). 원격 승인 대기를 게시 실패로 취급해서는 안 된다(MUST NOT).
+
+#### Scenario: 취소와 focus
+
+- **WHEN** 사용자가 기존 작성 surface의 폐기 확인을 거쳐 취소한다
+- **THEN** 작성기를 닫고 Post나 connection edge를 만들지 않는다
+- **AND** Web의 menu·Composer focus와 dismiss는 기존 surface 계약을 따른다
+
+#### Scenario: 제출 중 상태와 실패
+
+- **WHEN** mutation이 진행 중이거나 생성된 Post 없이 실패한다
+- **THEN** 진행 중에는 중복 제출과 dismiss를 막고 실패하면 pending을 종료해 재시도할 수 있게 한다
+- **AND** 실패 시 본문·Media·Source 맥락을 보존하며 숨겨진 Source의 존재·Author·Content를 오류로 노출하지 않는다
+
+### Requirement: 서버 결과와 actor별 상태 반영
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `docs/design/post-action-bar.md`, PROD-431. 생성된 Post는 요청 actor의 기존 Relay Environment와 관리 대상 connection에만 반영해야 한다(MUST). 서버의 승인·Source 반환 결과를 유지하고(MUST), 늦은 응답이 다른 actor나 새 draft를 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: 승인 대기 게시 성공
+
+- **WHEN** automatic/manual 광고 또는 `interactionPolicy` 부재·해석 실패와 관계없이 자체 Content가 게시됐지만 Source 승인 대기 상태인 Post를 반환한다
+- **THEN** 같은 Post를 성공 결과로 반영하며 Source를 낙관적으로 표시하지 않는다
+- **AND** `repostCount`·`viewerRepost`를 Quote 성공 때문에 변경하지 않는다
+
+#### Scenario: 부분 오류와 actor 전환
+
+- **WHEN** 생성된 Post와 nullable field 오류가 함께 오거나 요청 뒤 actor·Environment·draft가 바뀐다
+- **THEN** 생성된 Post는 요청 Environment의 성공 결과로 처리하고 자동 재제출하지 않는다
+- **AND** 이전 요청의 완료가 새 actor Store·draft·focus·navigation을 변경하지 않는다
+
+#### Scenario: 승인과 철회 뒤 재조회
+
+- **WHEN** 승인·철회·Source 삭제 뒤 같은 Post를 다시 조회한다
+- **THEN** 기존 Post identity와 자체 Content를 유지하고 서버가 반환한 Source 또는 null을 표시한다
+- **AND** 승인 없이 저장된 Source나 이전 cache만으로 Source를 복원하지 않는다
+
+### Requirement: 작성 통합과 플랫폼 검증
+
+**Authority / Provenance:** `docs/design/post-action-bar.md`, PROD-431. 기본 Quote의 실제 Web 작성부터 API·저장·조회·표시까지 통합 검증해야 한다(MUST). Web 검사 결과를 Native runtime 완료로 일반화해서는 안 된다(MUST NOT).
+
+#### Scenario: Web 작성 release gate
+
+- **WHEN** 기본 Quote 작성 기능의 출시를 검증한다
+- **THEN** 실제 작성 E2E와 keyboard·focus·dismiss·접근성, 실패 복구·actor 격리를 확인한다
+- **AND** 기존 Post·Reply·Repost 작성·표시와 Quote of Quote·Source unavailable 회귀를 확인한다
+
+#### Scenario: Native 증거 미실행
+
+- **WHEN** Android/iOS runtime을 실행하지 않았다
+- **THEN** Native keyboard·safe area·platform back·접근성은 미검증으로 기록한다
+- **AND** Native 출시 전 별도 release gate에서 실행 증거를 확보한다

--- a/openspec/changes/define-quote-consent-and-federation/specs/post-repost-ui/spec.md
+++ b/openspec/changes/define-quote-consent-and-federation/specs/post-repost-ui/spec.md
@@ -1,0 +1,84 @@
+## MODIFIED Requirements
+
+### Requirement: selected Profile별 Repost child action
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/design/post-action-bar.md`, `PROD-389`, `PROD-414`, `PROD-431`, `PROD-432`, `PROD-433`, `PROD-471` 유니버설 앱은 공용 `PostActionBar`의 composite Post fragment가 private Repost action child fragment를 조립하게 해야 하며(MUST), child action은 viewer-independent count, selected Profile의 Active Repost 상태, 생성·취소 mutation과 interaction 상태를 같은 Relay 소유 경계에서 파생해야 한다(MUST). Repost trigger는 mutation을 즉시 실행하지 않고(MUST NOT) 항상 action menu를 열어야 한다(MUST).
+
+#### Scenario: Repost하지 않은 상태
+
+- **WHEN** 조회 Post의 `viewerRepost`가 `null`이다
+- **THEN** action은 선택되지 않은 상태와 `repostCount`를 표시한다
+- **AND** trigger를 활성화하면 `재게시하기` 항목을 가진 menu를 연다
+- **AND** 사용자가 그 항목을 선택한 뒤 Source Post에 대한 Repost 생성 mutation을 호출한다
+
+#### Scenario: 이미 Repost한 상태
+
+- **WHEN** 조회 Post의 `viewerRepost`가 Active Repost Node다
+- **THEN** action은 선택된 상태와 같은 viewer-independent `repostCount`를 표시한다
+- **AND** trigger를 활성화하면 `재게시 취소` 항목을 가진 menu를 연다
+- **AND** 사용자가 그 항목을 선택한 뒤 그 Repost Post ID에 대한 삭제 mutation을 호출한다
+
+#### Scenario: 순수 Repost의 Action Bar target
+
+- **WHEN** Content와 Reply Parent가 없고 direct Repost Source가 있는 순수 Repost 아래에 Action Bar를 표시한다
+- **THEN** Repost child는 바깥 Repost가 아니라 화면에 표시한 direct Source fragment에서 `repostCount`와 `viewerRepost`를 읽는다
+- **AND** menu 항목 선택 뒤 direct Source를 생성 target 또는 취소 상태의 기준으로 사용한다
+
+#### Scenario: platform별 Repost action menu
+
+- **WHEN** 사용자가 Web에서 Repost trigger를 활성화한다
+- **THEN** 앱은 trigger 근처에 anchored menu를 열고 바깥 pointer·focus 또는 Escape로 닫으며 Escape 뒤 trigger로 focus를 돌려보낸다
+- **AND** 방향키, Home과 End로 menu item focus를 이동할 수 있다
+- **WHEN** 사용자가 Android 또는 iOS에서 Repost trigger를 활성화한다
+- **THEN** 앱은 safe area를 고려한 bottom action sheet를 열고 backdrop·platform back action·dismiss gesture로 닫을 수 있게 한다
+- **AND** 인용 조건에 맞는 Content Post에는 `인용하기`를 제공하고 선택 시 direct Source를 가진 공용 Composer를 연다
+
+#### Scenario: pending 중 반복 입력
+
+- **WHEN** Repost 생성 또는 취소 mutation이 진행 중이다
+- **THEN** action은 pending·disabled 접근성 상태를 표시하고 반복 mutation 호출을 막는다
+- **AND** 낙관 상태가 다른 selected Profile의 Relay Store로 전파되지 않는다
+
+#### Scenario: Repost 생성 성공과 cache 동기화
+
+- **WHEN** Repost 생성 mutation이 성공한다
+- **THEN** 앱은 mutation payload의 Source Post ID, `repostCount`와 `viewerRepost` 결과로 normalized cache를 갱신한다
+- **AND** 같은 actor Store에서 그 Post를 표시하는 목록과 상세의 action 상태가 일치한다
+
+#### Scenario: PROD-414 Repost 취소 성공
+
+- **WHEN** Repost 취소 mutation이 성공한다
+- **THEN** 앱은 취소 요청을 완료하되 현재 `DeletePostPayload.postId`만으로 Source Post의 `repostCount`와 `viewerRepost` cache를 변경하지 않는다
+- **AND** client count 산술, 광범위한 invalidation, 임시 refetch·local deselect 또는 같은 Tombstone ID를 숨기는 별도 client 상태를 추가하지 않는다
+
+#### Scenario: PROD-471 Repost 취소 cache 동기화
+
+- **WHEN** PROD-471의 서버 결과 기반 취소 계약이 완료된 뒤 Repost 취소 mutation이 성공한다
+- **THEN** `DeletePostPayload.repostSource`는 nullable Source Post의 ID, 서버 확정 `repostCount`와 selected Profile별 `viewerRepost`를 반환한다
+- **AND** 앱은 이 `repostSource` 결과로 normalized Source Post cache를 갱신한다
+- **AND** 관련 없는 전체 refetch 없이 같은 actor Store의 중복 action 상태를 일치시키고 다른 actor Store에는 전파하지 않는다
+
+#### Scenario: mutation 실패
+
+- **WHEN** Repost 생성 또는 취소 mutation이 GraphQL 또는 network 오류로 실패한다
+- **THEN** child action은 pending을 종료하고 이전 서버 확정 count·선택 상태와 normalized cache를 유지한다
+- **AND** 생성 실패는 `재게시하지 못했습니다. 잠시 후 다시 시도해 주세요.`, 취소 실패는 `재게시를 취소하지 못했습니다. 잠시 후 다시 시도해 주세요.`라는 transient toast로 알린다
+- **AND** toast는 safe area와 고정 탭 바 위의 화면 하단에서 약 3초 뒤 사라지고 새 toast가 기존 toast를 교체하며 alert semantics를 제공한다
+- **AND** persistent error 상태, close·retry control 또는 성공 toast를 두지 않고 menu를 다시 열어 같은 action을 재시도할 수 있게 한다
+
+#### Scenario: child action과 PostActionBar 경계
+
+- **WHEN** Repost child action을 구현하고 검증한다
+- **THEN** `PostActionBar_post`는 `RepostAction_post`를 child fragment로 spread하고 실제 fragment ref를 private `RepostAction`까지 전달한다
+- **AND** private `RepostAction`은 `viewerRepost`에서 선택 상태, 접근성 label, 정확한 Active Repost delete identity와 create/delete mutation 종류를 함께 파생해 공통 private control을 렌더한다
+- **AND** PROD-414의 `PostListItem`·`PostLayout` surface는 actual target Post fragment ref와 action별 Repost error callback을 공급하고 Action Bar를 content grid의 마지막 sibling이자 모든 navigation link 밖에 렌더링한다
+- **AND** 최종 disabled 행동을 child에 연결할 concrete host input 또는 fragment shape, 나머지 action의 production 조립과 전체 통합 검증은 actual caller와 함께 PROD-432가 설계한다
+- **AND** 독립 공개 action leaf 또는 선택 상태·label·delete identity·mutation callback의 독립 scalar config를 만들지 않는다
+
+#### Scenario: Quote 진입과 순수 Repost 상태
+
+- **WHEN** 사용자가 인용 가능한 action target의 `인용하기`를 선택한다
+- **THEN** 메뉴를 닫고 해당 Post를 direct Source로 가진 기본 Quote 작성기를 연다
+- **AND** 이 동작만으로 Post를 생성하거나 `repostCount`·`viewerRepost`를 변경하지 않는다
+- **AND** Quote 허용 여부는 Source의 인용 정책·조회·차단 조건을 따르며 순수 Repost의 생성·취소 상태만으로 결정하지 않는다
+- **AND** 원격 `interactionPolicy`에서 작성자가 automatic/manual 어느 쪽에도 포함되지 않으면 승인 가능성이 낮다는 힌트를 표시할 수 있으나 정책 자체를 승인 증거로 사용하지 않는다

--- a/openspec/changes/define-quote-consent-and-federation/specs/post/spec.md
+++ b/openspec/changes/define-quote-consent-and-federation/specs/post/spec.md
@@ -1,0 +1,175 @@
+## MODIFIED Requirements
+
+### Requirement: Post GraphQL object
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, `docs/domain/objects/profile-block.md`, PROD-902, PROD-431, PROD-924. 기존 계약 근거: `docs/domain/decisions/0024-application-policy-and-runtime-db-boundary.md`, `docs/domain/objects/post.md`, `docs/domain/decisions/0010-post-interaction-contracts.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `PROD-389`, `PROD-402`, `PROD-403`, `PROD-777` GraphQL Post authorization과 visibility는 중앙 application policy가 집행해야 하며(MUST), PostgreSQL RLS 또는 actor GUC에 의존해서는 안 된다(MUST NOT). API는 조회 가능한 활성 게시글을 기존 GraphQL `Post` Node로 노출해야 하며 작성자 프로필, nullable 현재 콘텐츠, nullable 직접 Repost Source, viewer-independent Repost count, 현재 selected Profile의 nullable Active Repost identity, 공개 범위, 상태와 생성 시각을 제공해야 한다(MUST).
+
+이 spec의 GraphQL enum `DIRECT`는 canonical 문서의 Mentioned Profiles visibility를 나타내는 API 표현이다.
+
+Quote Source는 인용 승인 조건과 viewer별 Source 조회 조건을 모두 통과할 때만 반환해야 한다(MUST).
+승인되지 않았거나 거절·철회된 Source는 반환해서는 안 되며(MUST NOT), 자체 Content와 Post Node는
+그 Post 자체의 조회 정책을 통과하면 유지해야 한다(MUST).
+
+#### Scenario: 활성 게시글 object 조회
+
+- **WHEN** 클라이언트가 노출 가능한 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 `Post` object를 반환한다
+- **AND** `Post`는 `id`, `profile`, `content`, `repostSource`, `repostCount`, `viewerRepost`, `visibility`, `state`, `createdAt` 필드를 포함한다
+- **AND** `profile`은 게시글 작성자 프로필을 가리킨다
+- **AND** `content`는 게시글의 nullable 현재 콘텐츠를 가리킨다
+- **AND** `repostSource`는 저장된 nullable 직접 Source Post를 가리킨다
+
+#### Scenario: 조회 가능한 Source를 가진 Repost와 Quote object 조회
+
+- **WHEN** 클라이언트가 direct Source까지 조회 가능하고 Quote이면 인용 승인 조건도 통과한 Repost 또는 Quote Node를 조회한다
+- **THEN** Repost는 `content = null`과 non-null `repostSource`를 제공한다
+- **AND** Quote는 non-null `content`와 non-null `repostSource`를 제공한다
+- **AND** Reply이면서 Quote인 Post도 같은 `Post` Node에서 Reply Parent와 Repost Source를 독립적으로 제공할 수 있다
+
+#### Scenario: 공개 게시글 object 조회
+
+- **WHEN** 클라이언트가 `PUBLIC` 또는 `UNLISTED` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 Post 자체가 Post Eligibility를 통과할 때 `Post` object를 반환한다
+
+#### Scenario: 작성자 본인의 비공개 게시글 object 조회
+
+- **WHEN** 현재 active profile이 게시글 작성자이고 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 Post 자체가 Post Eligibility를 통과할 때 `Post` object를 반환한다
+
+#### Scenario: follower의 팔로워 공개 게시글 object 조회
+
+- **WHEN** 현재 active profile이 게시글 작성자를 팔로우하고 `FOLLOWERS` 공개 범위의 활성 게시글 Node를 조회한다
+- **THEN** 시스템은 Post 자체가 Post Eligibility를 통과할 때 `Post` object를 반환한다
+
+#### Scenario: 접근 권한 없는 viewer의 비공개 게시글 object 조회
+
+- **WHEN** 인증되지 않았거나, 현재 active profile이 게시글 작성자가 아니고 게시글 작성자를 팔로우하지 않는 클라이언트가 `FOLLOWERS` 또는 `DIRECT` 공개 범위의 게시글 Node를 조회한다
+- **THEN** 시스템은 해당 게시글을 GraphQL `Post` object로 노출하지 않는다
+- **AND** `DIRECT` viewer 기준 세부 접근 제어는 후속 변경에서 정의한다
+
+#### Scenario: 비활성 게시글 object 조회
+
+- **WHEN** 게시글 상태가 `ACTIVE`가 아니다
+- **THEN** 시스템은 해당 게시글을 GraphQL `Post` object로 노출하지 않는다
+
+#### Scenario: application policy가 유일한 GraphQL 권한 집행 경계임
+
+- **WHEN** GraphQL Post Node를 조회하고 application visibility/eligibility policy가 결과를 결정한다
+- **THEN** 기존 Post authorization과 visibility 결과를 반환한다
+- **AND** PostgreSQL RLS policy나 actor GUC가 없어도 같은 application policy 결과를 반환한다
+
+#### Scenario: unavailable Repost Source를 가진 Content 없는 Repost 조회
+
+- **WHEN** Content 없는 Repost의 direct Source가 Tombstone이거나 viewer 기준 Post Visibility 또는 Post Eligibility를 통과하지 못한다
+- **THEN** 시스템은 해당 Repost를 GraphQL `Post` object로 노출하지 않는다
+
+#### Scenario: unavailable Repost Source를 가진 Quote 조회
+
+- **WHEN** Content 있는 Quote 또는 Reply이면서 Quote인 Post 자체는 조회 가능하지만 direct Source는 조회할 수 없다
+- **THEN** 시스템은 Quote Post와 자체 Content를 GraphQL `Post` object로 반환한다
+- **AND** nullable `repostSource`는 `null`을 반환한다
+- **AND** direct Source의 Source가 unavailable하다는 이유로 바깥 Quote를 숨기지 않는다
+
+#### Scenario: 원격 승인 대기 또는 철회된 Quote 조회
+
+- **WHEN** Quote 자체는 조회 가능하지만 Source 승인이 대기·거절·철회 상태다
+- **THEN** 같은 Post Node와 자체 Content를 반환하고 `repostSource`는 null이다
+- **AND** Source가 저장되어 있거나 legacy 속성이 있다는 이유로 비노출을 우회하지 않는다
+
+#### Scenario: 승인된 Source와 차단된 당사자
+
+- **WHEN** 유효한 승인은 있지만 viewer와 Source Author 사이에 차단 관계가 있다
+- **THEN** Source를 반환하지 않는다
+- **AND** 차단 당사자가 아닌 제3자는 기존 승인이 명시적으로 철회되지 않았다면 자신의 Source 조회 정책으로 판정한다
+
+### Requirement: Plain Text post creation
+
+**Authority / Provenance:** `docs/domain/objects/post.md`, `docs/domain/objects/post-content.md`, `docs/domain/objects/media.md`, `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`, `docs/domain/decisions/0014-post-structure-relations.md`, `docs/domain/decisions/0022-post-content-revision-media-nodes.md`, `PROD-424`, `PROD-461`, `PROD-554`, `PROD-431`, `PROD-902`, `docs/domain/decisions/0027-quote-consent-and-federation.md` 로그인했고 active profile이 있는 사용자는 Plain Text UX의 `bodyText`, 선택적 Media item과 Sensitive Media, 선택적 concrete `Post` `replyParentId`로 versioned canonical document의 일반 Post 또는 Reply를 작성할 수 있어야 한다(MUST). 기존 입력에 선택적 concrete `Post` global ID인 `repostSourceId`를 추가해 기본 Quote를 작성할 수 있어야 한다(MUST). `repostSourceId` 생략·null은 Source 없음이며, `replyParentId`와 `repostSourceId`를 함께 지정한 작성 요청은 거부해야 한다(MUST). selected Profile은 Local 또는 Remote일 수 있으며(MUST), GraphQL `usingProfile` entry point가 보장한 Active Account, membership과 selected Profile 조회 가능 상태를 resolver가 중복 검증하면 안 된다(MUST NOT).
+
+#### Scenario: Plain Text 게시글 작성 성공
+
+- **WHEN** 로그인한 클라이언트가 active profile이 선택된 상태에서 유효한 `bodyText`, `visibility`, 최대 4개의 선택적 `{ mediaId, altText }` item과 `sensitiveMedia`로 `createPost` mutation을 호출하고 `replyParentId`와 `repostSourceId`를 생략한다
+- **THEN** 시스템은 새 `post` 행을 생성한다
+- **AND** 게시글 작성자는 현재 세션의 active profile이다
+- **AND** 게시글 상태는 `ACTIVE`이다
+- **AND** 게시글 공개 범위는 입력받은 `visibility` 값이다
+- **AND** 시스템은 새 `post_content` 행을 생성한다
+- **AND** `post.current_content_id`는 생성된 콘텐츠를 참조한다
+- **AND** Post와 첫 PostContent는 같은 transaction에서 생성되며 하나라도 실패하면 함께 rollback한다
+- **AND** Media item은 입력 순서의 V1 Media node가 되고 Sensitive Media는 document root attr가 된다
+- **AND** `post.reply_parent_id`와 `post.repost_source_id`는 `null`이다
+- **AND** mutation은 `CreatePostPayload.post`로 생성된 `Post`를 반환한다
+
+#### Scenario: Remote selected Profile로 게시글 작성
+
+- **WHEN** Active Account의 Member인 Active/Normal Remote Profile이 selected Profile인 상태에서 유효한 입력으로 `createPost`를 호출한다
+- **THEN** 시스템은 selected Profile을 Author로 하는 Post를 생성한다
+- **AND** Media의 Profile이 selected Profile과 달라도 Upload Account가 같으면 허용한다
+- **AND** selected Profile 또는 Media Profile의 Instance Type만으로 요청을 거부하지 않는다
+
+#### Scenario: Plain Text Reply 작성 성공
+
+- **WHEN** 로그인한 클라이언트가 active profile이 선택된 상태에서 유효한 `bodyText` 또는 Media item, `visibility`, 선택적 `sensitiveMedia`와 조회 가능한 contentful Parent의 concrete `Post` global ID를 `replyParentId`로 제공하고 `repostSourceId`를 생략한다
+- **THEN** 시스템은 `current_content_id`와 입력 `reply_parent_id`를 가지고 `repost_source_id`는 `null`인 Active Post를 생성한다
+- **AND** Reply의 공개 범위는 Parent와 독립적인 입력 `visibility` 값이다
+- **AND** 입력 Media item과 Sensitive Media는 일반 Post와 같은 PostContent document 계약을 따른다
+- **AND** mutation은 일반 Post와 같은 `CreatePostPayload.post`로 생성된 단일 `Post`를 반환한다
+
+#### Scenario: 본문과 Media 저장 형식
+
+- **WHEN** 시스템이 Plain Text와 선택적 Media item으로 게시글 또는 Reply 콘텐츠를 저장한다
+- **THEN** 시스템은 입력 문자열을 공통 V1 Plain Text 변환 경계에 전달한다
+- **AND** trim과 line-ending normalization 뒤 paragraph content 다음에 입력 순서의 Media block node를 추가하고 summary `null`인 V1 canonical PostContent document를 저장한다
+- **AND** trim된 Plain Text가 canonical document에서 다시 동일하게 projection된다
+- **AND** persistence document의 Media node는 검증된 Media DB identity만 저장한다
+- **AND** 같은 transaction에서 Media가 nullable Alt Text를 저장하고 document root가 Sensitive Media를 저장한다
+- **AND** 시스템은 Plain Text, HTML 또는 Media ID 배열을 별도 canonical 값으로 저장하지 않는다
+
+#### Scenario: Media-only Post 또는 Reply
+
+- **WHEN** trim한 bodyText가 비어 있지만 하나 이상의 유효한 Media item이 입력된다
+- **THEN** 시스템은 빈 paragraph와 Media node를 가진 PostContent를 생성한다
+- **AND** bodyText projection은 빈 문자열이다
+
+#### Scenario: 유효하지 않은 본문과 Media 조합
+
+- **WHEN** 클라이언트가 trim한 bodyText와 Media item이 모두 없거나 summary와 body에서 파생한 authored Plain Text 합계가 500자를 초과하는 입력으로 `createPost` mutation을 호출한다
+- **THEN** 시스템은 validation code를 가진 GraphQL 오류로 요청을 거부한다
+- **AND** 게시글과 게시글 콘텐츠를 생성하지 않는다
+
+#### Scenario: 유효하지 않은 Media item
+
+- **WHEN** Media item에 중복, 5개 이상, 없는 Media, Uploading Media, Remote Media 또는 다른 Upload Account의 Media가 포함된다
+- **THEN** 시스템은 Media 존재·state·소유권 차이를 노출하지 않는 validation 오류로 요청을 거부한다
+- **AND** 게시글과 게시글 콘텐츠를 부분 저장하지 않는다
+
+#### Scenario: 인증되지 않은 작성 요청
+
+- **WHEN** 인증 session이 없는 클라이언트가 `createPost` mutation을 호출한다
+- **THEN** 시스템은 GraphQL 인증 오류로 요청을 거부한다
+- **AND** 게시글과 게시글 콘텐츠를 생성하지 않는다
+
+#### Scenario: active profile 없는 작성 요청
+
+- **WHEN** 로그인한 클라이언트가 active profile 없이 `createPost` mutation을 호출한다
+- **THEN** 시스템은 GraphQL active profile 인증 scope 오류로 요청을 거부한다
+- **AND** 게시글과 게시글 콘텐츠를 생성하지 않는다
+
+#### Scenario: 기본 Quote 입력과 작성 결과
+
+- **WHEN** 인증된 selected Profile이 유효한 본문 또는 Media와 인용 조건을 통과한 Source의 concrete Post global ID를 `repostSourceId`로 제출한다
+- **THEN** 자체 Content와 인용 대상 정보를 원자적으로 기록하고 기존 `CreatePostPayload.post`를 반환한다
+- **AND** Reply Parent는 없으며 Visibility는 Source와 독립적인 입력값이다
+- **AND** Source는 유효한 승인과 viewer 접근 조건을 모두 통과할 때만 반환한다
+
+#### Scenario: Source global ID와 접근 오류
+
+- **WHEN** Source ID가 잘못된 형식·다른 Node type이거나 Source가 조회 불가·삭제·Content 없는 상태다
+- **THEN** 요청을 거부하고 부분 작성 결과를 남기지 않는다
+- **AND** 조회 권한이 없는 Source의 존재·Author·Content를 오류로 노출하지 않는다
+
+#### Scenario: Source와 Parent 동시 입력
+
+- **WHEN** 로컬 작성 요청에 non-null `repostSourceId`와 `replyParentId`가 함께 있다
+- **THEN** 입력을 거부하고 Reply+Quote를 생성하지 않는다
+- **AND** 기존 저장 관계와 원격 수신 결과를 변경하지 않는다

--- a/openspec/changes/define-quote-consent-and-federation/specs/quote-consent/spec.md
+++ b/openspec/changes/define-quote-consent-and-federation/specs/quote-consent/spec.md
@@ -1,0 +1,163 @@
+## ADDED Requirements
+
+### Requirement: 게시글별 인용 허용 정책과 초기값
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/objects/profile.md`,
+`docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+시스템은 Content가 있는 Local Post마다 `모두`, `팔로워`, `본인만` 중 하나의 인용 허용 정책을 제공해야
+한다(MUST). 새 Post와 도입 전의 기존 Post 초기값은 `모두`여야 한다(MUST). `팔로워`는 established
+Follower와 Source Author, `본인만`은 Source Author의 요청만 자동 승인해야 한다(MUST). 인용 허용은
+Source 조회 권한을 부여해서는 안 된다(MUST NOT).
+
+#### Scenario: 새 글과 기존 글의 최초 정책
+
+- **WHEN** 정책을 처음 도입하거나 새 Content-bearing Local Post를 작성한다
+- **THEN** 별도 변경 전 인용 허용 정책은 `모두`다
+- **AND** 기존 QuoteAuthorization을 변경하거나 재발급하지 않는다
+
+#### Scenario: 팔로워 정책의 자동 승인
+
+- **WHEN** Source 정책이 `팔로워`이고 요청 Profile이 established Follower 또는 Source Author다
+- **THEN** 조회·차단·Source 대상 조건을 통과하면 자동 승인한다
+- **AND** 단순 Follow Request만 있는 Profile은 Follower로 취급하지 않는다
+
+#### Scenario: 본인만 정책과 타인 요청
+
+- **WHEN** Source 정책이 `본인만`이고 다른 Profile이 인용을 요청한다
+- **THEN** 자동 승인하지 않고 요청을 거절한다
+- **AND** Kosmo 원문용 건별 수동 승인 대기나 승인 UI를 만들지 않는다
+
+### Requirement: 작성자의 정책 변경과 비소급 적용
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`,
+`docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+인증된 Account 요청은 `Account.Active`와 행동 Profile의 `Post.Author` 사실을 확인한 뒤 Content가 있는
+Active Local Post의 정책 변경을 허용해야 한다(MUST). 새 정책은 이후 요청·승인 판단에만 적용하고 기존
+승인을 자동 철회해서는 안 된다(MUST NOT). 이번 범위에서 Profile 기본값 설정을 제공해서는 안 된다(MUST NOT).
+
+#### Scenario: 모두에서 본인만으로 변경
+
+- **WHEN** 권한이 있는 작성자가 게시글 정책을 `모두`에서 `본인만`으로 변경한다
+- **THEN** 이후 타인 요청은 새 정책으로 거절한다
+- **AND** 기존에 발급한 승인과 그 승인을 가진 Quote는 일괄 철회하지 않는다
+
+#### Scenario: 다른 Profile의 정책 변경 시도
+
+- **WHEN** 행동 Profile이 대상 Post의 Author가 아니거나 Account가 Active가 아니다
+- **THEN** 정책을 변경하지 않는다
+- **AND** 다른 selected Profile의 권한이나 설정을 재사용하지 않는다
+
+### Requirement: Quote Source의 인용 가능 범위
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`,
+PROD-902, PROD-431, PROD-924.
+
+시스템은 타인의 Local·Remote Source를 Public·Unlisted에 한정하고 Content 존재·조회·인용 정책·차단
+조건을 확인해야 한다(MUST). 타인의 Followers Only, Mentioned Profiles와 조회 불가 Source는 인용할 수
+없어야 한다(MUST). 자기 Followers Only 인용은 허용하되 Source 접근 범위를 넓혀서는 안 된다(MUST NOT).
+
+#### Scenario: 타인의 공개 Source
+
+- **WHEN** 다른 Profile의 Local 또는 Remote Public·Unlisted Source를 선택하고 모든 요청 조건을 통과한다
+- **THEN** Quote 작성 또는 원격 승인 요청을 진행할 수 있다
+
+#### Scenario: 조회 가능한 타인 Followers Only Source
+
+- **WHEN** established Follower가 타인의 Followers Only Source를 조회할 수 있어 인용을 시도한다
+- **THEN** Quote 작성을 거부한다
+- **AND** Source 조회 권한을 인용 허용으로 간주하지 않는다
+
+#### Scenario: 자기 Followers Only Source
+
+- **WHEN** Source Author가 자기 Followers Only Post를 인용한다
+- **THEN** 기존 Source 조회 범위를 유지하는 Quote를 작성할 수 있다
+- **AND** Quote를 조회할 수 있다는 사실만으로 Source를 조회하게 하지 않는다
+
+#### Scenario: 삭제되었거나 Content가 없는 Source
+
+- **WHEN** Source가 삭제·조회 불가 상태이거나 Content가 없다
+- **THEN** 작성 관계를 만들지 않고 권한 없는 Source 존재를 오류로 노출하지 않는다
+
+### Requirement: 로컬 Quote 작성
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/decisions/0014-post-structure-relations.md`,
+`docs/design/post-action-bar.md`, PROD-902, PROD-431.
+
+시스템은 Reply Parent가 없는 기존 Post에 자체 Content와 인용 대상 정보를 원자적으로 기록해야 한다(MUST).
+로컬 Reply+Quote 작성 UI·API를 제공해서는 안 되며(MUST NOT), 별도 Quote Node나 배타적인 Post Kind를
+만들어서는 안 된다(MUST NOT). 원격 승인 요청이 허용되는 상태는 최종 승인이 없어도 자체 Content 작성의
+거부 조건이 되어서는 안 된다(MUST NOT).
+
+#### Scenario: 기본 Quote 작성
+
+- **WHEN** Profile이 조건을 통과한 Source와 자체 Content를 제출한다
+- **THEN** 기존 Post에 자체 Content와 인용 대상 정보를 원자적으로 기록한다
+- **AND** Reply Parent를 추가하지 않는다
+
+#### Scenario: 작성 범위를 벗어난 관계 입력
+
+- **WHEN** 로컬 작성 요청이 Source와 Reply Parent를 함께 지정한다
+- **THEN** Reply+Quote를 생성하지 않고 입력을 거부한다
+- **AND** Post·Content·관계·Media 변경의 부분 결과를 남기지 않는다
+
+#### Scenario: 작성 실패와 재시도
+
+- **WHEN** 작성 transaction이 실패한다
+- **THEN** 부분 Post·Content·작성 관계를 남기지 않는다
+- **AND** Composer는 입력을 보존하고 오류 복구·재시도를 제공한다
+
+#### Scenario: 작성 성공의 클라이언트 반영
+
+- **WHEN** Quote 작성이 성공한다
+- **THEN** 선택한 Profile의 Relay environment와 관련 Post connection에 결과를 반영한다
+- **AND** Web과 Native의 기존 메뉴·Composer interaction 경계를 유지한다
+
+### Requirement: 승인 상태와 본문 보존
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`,
+`docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-431, PROD-924.
+
+원격 승인 대기 중에도 Quote 자체 Content를 게시해야 하며(MUST), Source는 정상 인용으로 노출해서는
+안 된다(MUST NOT). 검증된 승인 후에만 Source를 연결·표시하고 거절·철회·원문 삭제 후에는 자체 Content를
+유지한 채 Source를 숨겨야 한다(MUST). 승인 여부와 무관하게 Source 조회·차단 정책을 적용해야 한다(MUST).
+
+#### Scenario: 원격 타인 원문의 승인 대기
+
+- **WHEN** 자기 인용이 아닌 원격 원문의 QuoteAuthorization을 아직 확인하지 못했다
+- **THEN** 자체 Content는 로컬에 게시되며 게시된 Source 카드는 승인 전까지 숨긴다
+- **AND** `interactionPolicy`의 automatic/manual 광고나 부재·해석 실패를 승인 증거로 취급하지 않는다
+
+#### Scenario: 거절 또는 승인 철회
+
+- **WHEN** 해당 Quote의 유효한 거절이나 승인 철회를 처리한다
+- **THEN** 자체 Content를 유지하고 Source를 비노출한다
+- **AND** 저장된 Source 관계의 존재만으로 정상 Quote 표시를 복원하지 않는다
+
+#### Scenario: 원문 삭제
+
+- **WHEN** Source가 삭제된다
+- **THEN** Quote 자체의 조회 정책을 통과하는 본문은 유지한다
+- **AND** Source 카드·관계를 숨기며 Quote 전체를 연쇄 삭제하지 않는다
+
+### Requirement: 차단과 명시적 승인 철회의 구분
+
+**Authority / Provenance:** 이 요구사항은 반드시 준수해야 한다(MUST). 근거: `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`,
+`docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+차단 관계는 당사자의 새 인용 요청·새 승인과 Source 접근보다 우선해야 한다(MUST). 차단 자체로 기존
+승인을 자동 철회하거나 제3자의 Source를 일괄 숨겨서는 안 된다(MUST NOT). 인증된 원문 작성자가 기존
+승인을 명시적으로 철회하면 승인에 의존하는 Source를 비노출해야 한다(MUST).
+
+#### Scenario: 차단 뒤 새 요청과 기존 승인
+
+- **WHEN** 이미 승인된 Quote의 두 Profile 사이에 차단 관계를 만든다
+- **THEN** 당사자 간 Source 접근과 새 요청·승인을 막는다
+- **AND** 기존 승인은 자동 철회하지 않으며 제3자는 자신의 Source 조회 정책에 따라 조회한다
+
+#### Scenario: 제3자에게도 인용 원문 숨기기
+
+- **WHEN** Active Account의 Source Author가 해당 Source에 발급한 승인을 명시적으로 철회한다
+- **THEN** 승인을 무효로 만들고 제3자에게도 해당 승인에 따른 Source를 표시하지 않는다
+- **AND** Quote 작성자의 본문은 유지한다

--- a/openspec/changes/define-quote-consent-and-federation/tasks.md
+++ b/openspec/changes/define-quote-consent-and-federation/tasks.md
@@ -106,15 +106,18 @@ Kosmo 원문이 요청을 정책대로 자동 승인·거절하고 작성자가 
 
 - 1번 정책과 기존 Follow·Block·조회 경계를 사용한다.
 - 요청 Profile·Quote·Source·승인 발급자 대응을 검증한다. 정책 변경·차단은 기존 승인을 자동 철회하지 않는다.
+- QuoteAuthorization dispatcher는 Source 조회 권한을 적용하고 `interactingObject`를 embed하지 않는다.
+  요청자의 Source 조회 권한을 확인할 수 없으면 `interactionTarget`도 embed하지 않는다.
 - 명시적 철회는 Source만 숨기고 Quote 자체 본문을 보존한다.
 
 **Verification**
 
 - 정상·위조·차단·정책상 거부 요청, 중복 승인, 작성자 철회 권한, 제3자 비노출과 본문 보존을 검증한다.
+- 권한별 QuoteAuthorization dispatcher/readback과 `interactingObject`·`interactionTarget` embed 제한을 검증한다.
 
-- [ ] 4.1 Kosmo 원문 QuoteRequest의 검증·자동 Accept/Reject·승인 발급을 연결한다.
+- [ ] 4.1 Kosmo 원문 QuoteRequest의 검증·자동 Accept/Reject·승인 발급과 권한 기반 QuoteAuthorization dispatcher를 연결한다.
 - [ ] 4.2 작성자의 명시적 승인 철회 조작과 승인 무효화·원격 철회 전달을 연결한다.
-- [ ] 4.3 요청 대응·중복·철회 권한과 차단/명시적 철회의 다른 결과를 검증한다.
+- [ ] 4.3 요청 대응·중복·철회 권한, 승인 객체 readback·embed 제한과 차단/명시적 철회의 다른 결과를 검증한다.
 
 ## 5. PROD-924 로컬 Quote 발신과 원격 승인 결과
 
@@ -133,15 +136,17 @@ QuoteRequest와 유효한 QuoteAuthorization을 통해 같은 Quote의 Source �
 - 2번 작성 결과와 기존 canonical identity·audience·공통 delivery를 사용한다.
 - automatic/manual 광고와 정책 부재·해석 실패 모두 별도 QuoteRequest를 보내고, 유효한 Accept·승인 후 Update를 지킨다.
 - `interactionPolicy`는 UI·예상 eligibility의 힌트일 뿐 승인 증거가 아니다. 승인 전 Source와 자동 생성 호환 표현을 숨긴다.
+- 유효한 원격 철회를 수신하면 Source를 숨기고 기존 Quote audience에 `Delete(QuoteAuthorization)`을 전달한다.
 - 원격 Quote 수신 PROD-792를 중복 구현하거나 일반 사용자용 본문 수정을 추가하지 않는다.
 
 **Verification**
 
 - local/remote Source, 자기 인용, automatic/manual, 정책 부재·해석 실패, 어느 집합에도 포함되지 않는 경우,
   valid/invalid Accept, Reject, source delete와 동일 identity Update를 확인한다. 발신 payload와 최종 Source 조회를 함께 검증한다.
+- 유효·위조 철회 수신, 기존 Quote audience forwarding과 대상별 전달 실패 뒤의 상태 보존을 검증한다.
 
 - [ ] 5.1 승인된 Quote projection과 pending 본문 선발신·원격 요청을 연결한다.
-- [ ] 5.2 로컬 Quote의 원격 Accept/Reject·승인 철회를 검증해 Source와 필요한 Update를 연결한다.
+- [ ] 5.2 로컬 Quote의 원격 Accept/Reject·승인 철회를 검증해 Source·필요한 Update와 기존 Quote audience 철회 전달을 연결한다.
 - [ ] 5.3 일반 Post·Reply·Repost identity/audience 회귀와 승인 전 Source 비노출을 검증한다.
 - [ ] 5.4 자기 인용의 요청 생략과 원격 타인 원문의 정책별 QuoteRequest·pending·승인 증거 경계를 검증한다.
 
@@ -190,11 +195,12 @@ PROD-431·924의 작성·정책·승인·발신 결과가 하나의 사용자 �
 
 **Verification**
 
-- 작성→pending 게시·전달→Accept→Source 표시→명시적 철회→제3자 Source 비노출과 자체 Content 보존을 확인한다.
+- 작성→pending 게시·전달→Accept→Source 표시→명시적 철회→Quote audience 철회 전달→제3자 Source 비노출과
+  자체 Content 보존을 확인한다.
 - 타인 Followers Only 거부·자기 인용 접근, 차단 당사자/제3자 차이, 원문 삭제와 legacy 수신을 통합 확인한다.
 - 실제 schema diff의 초기화·기존 승인 보존·배포 순서와 rollback 시 Source 접근 보호를 확인한다.
 
-- [ ] 7.1 PROD-431 작성과 승인·발신·원격 수신 경계를 연결하는 연합 통합 검증을 수행한다.
+- [ ] 7.1 PROD-431 작성과 승인·발신·원격 수신·철회 audience forwarding 경계를 연결하는 연합 통합 검증을 수행한다.
 - [ ] 7.2 기존 데이터·승인 보존, 출시·복구 시 접근 보호와 플랫폼별 필요한 release 증거를 확인한다.
 - [ ] 7.3 최신 canonical·Linear·OpenSpec과 전체 구현 결과를 대조하고 미완료 범위가 없음을 확인한다.
 - [ ] 7.4 전체 선언 task 완료 후 delta spec 동기화·archive와 archive 후 validation을 수행한다.

--- a/openspec/changes/define-quote-consent-and-federation/tasks.md
+++ b/openspec/changes/define-quote-consent-and-federation/tasks.md
@@ -1,0 +1,200 @@
+## 1. PROD-924 게시글별 정책과 초기값
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`, `docs/domain/objects/profile.md`,
+  `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+**Deliverable**
+
+새 글과 기존 글의 인용 허용 정책을 게시글별로 조회·변경하고 요청에 적용할 수 있다. 구체적인 GraphQL
+field·mutation 이름, payload와 오류 shape는 이 공개 행동을 지키는 범위에서 PROD-924가 구현 시 확정한다.
+
+**Guardrails**
+
+- 모두·팔로워·본인만, 초기값 모두와 기존 승인 비소급을 유지한다.
+- Active Account와 Post Author 권한을 확인한다. Profile 기본값·건별 수동 승인 UI는 포함하지 않는다.
+- PROD-924가 정책 저장, 기존 Local Post 초기화, 기존 승인 보존과 rollback 접근 보호를 함께 소유한다.
+
+**Verification**
+
+- 새/기존 Post 초기값, 정책 변경 권한과 selected Profile 격리, 기존 승인 보존을 검증한다.
+- 실제 schema diff와 migration/backfill, rollback 후 Source 접근 보호, 확정한 GraphQL 계약을 구현 PR에 기록한다.
+
+- [ ] 1.1 새 글과 기존 글의 정책 조회·초기화 및 정책 변경을 연결한다.
+- [ ] 1.2 작성자가 게시글별 정책을 변경하는 사용자 조작과 오류 복구를 제공한다.
+- [ ] 1.3 초기값·권한·변경 비소급·기존 데이터 보존을 검증한다.
+- [ ] 1.4 PROD-924가 정책 API 형태와 저장 schema를 확정하고 기존 Local Post를 `모두`로 초기화하는 migration/backfill 및 rollback 접근 보호를 검증한다.
+
+## 2. PROD-431 기본 Quote 작성 API와 core
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`, `docs/domain/decisions/0014-post-structure-relations.md`,
+  `docs/domain/decisions/0019-selected-profile-authorization-boundary.md`,
+  `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-431·902의 2026-09-09 정정, PROD-924.
+
+**Deliverable**
+
+인용 조건을 통과한 Source와 자체 Content로 기본 Quote를 원자적으로 작성하고 기존 Post payload로 조회한다.
+
+**Guardrails**
+
+- 선행: 1번 정책과 PROD-924의 승인 상태·요청 판정 저장 경계를 공유한다. Source FK만으로 승인 여부를 판단하지 않는다.
+- 타인의 Local·Remote Source는 Public·Unlisted, 자기 Followers Only는 원문 접근 유지 조건을 따른다.
+- Reply+Quote 작성은 제공하지 않는다. 기존 Post·Reply 입력과 저장 관계·원격 수신·조회는 보존한다.
+- 원격 승인 대기는 작성 실패가 아니다. 부분 결과와 권한 없는 Source 정보가 남지 않게 한다.
+- Quote 전용 Node·Kind를 추가하거나 정책·승인 lifecycle을 두 번째 모델로 재구현하지 않는다.
+
+**Verification**
+
+- core DB test로 Source Content·조회·삭제·정책·차단·공개 범위와 Media metadata rollback을 확인한다.
+- 실제 mutation으로 작성한 Post를 다시 조회한다. fixture 직접 삽입만으로 작성 성공을 증명하지 않는다.
+- global ID type·인증·selected Profile, Source 생략·null, Source/Parent 동시 입력 거부, 기존 Post·Reply 회귀를 확인한다.
+- Media-only·Content Warning·Sensitive Media·독립 Visibility와 commit 뒤 effect 실패의 게시 결과 보존을 확인한다.
+- 정책·승인 저장 구현이 없으면 mock만으로 production 연결 완료를 주장하지 않고 의존성으로 기록한다.
+
+- [ ] 2.1 기존 작성 입력에 Source를 연결하고 기본 Quote와 기존 Post·Reply의 입력 범위를 구분한다.
+- [ ] 2.2 Source 조건·정책·차단을 검증하고 Content·인용 대상 정보·Media·Hashtag의 원자적 작성을 연결한다.
+- [ ] 2.3 요청 가능한 원격 Quote의 본문 선게시와 승인 전 Source 비노출을 공유 승인 경계에 연결한다.
+- [ ] 2.4 core/API의 거부·rollback·readback·입력 호환과 기존 작성 효과 회귀를 검증한다.
+
+## 3. PROD-431 Composer와 승인에 따른 Post 조회
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`, `docs/design/post-action-bar.md`, `docs/design/reply-composer.md`,
+  `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-431·902의 2026-09-09 정정, PROD-924.
+
+**Deliverable**
+
+인용 메뉴에서 기본 Quote를 작성하고, 게시된 Post의 Source를 승인과 viewer 접근 조건에 맞게 표시한다.
+
+**Guardrails**
+
+- 선행: 2번 작성 결과와 PROD-924의 승인 상태 경계를 사용한다.
+- 기본 Quote는 Source만 받는다. 링크 인용과 Reply+Quote 진입·API·성공 검증을 추가하지 않는다.
+- 기존 메뉴·Composer·direct preview·입력 검증·폐기 보호와 selected Profile별 Environment를 재사용한다.
+- 승인 대기·거절·철회 Source는 숨기되 자체 Content를 유지한다. Source와 Quote 자체 Eligibility를 구분한다.
+- Quote 성공을 Source Repost count·선택 상태로 표현하지 않는다. 없는 connection이나 다른 actor Store를 갱신하지 않는다.
+
+**Verification**
+
+- 실제 Relay operation 기반 Storybook에서 메뉴·preview·취소·제출·pending·실패·재시도와 Media/CW 가림을 확인한다.
+- 성공·부분 오류·Post 없는 실패, connection 미로드·중복 완료·actor/Environment 전환·unmount 뒤 늦은 응답을 확인한다.
+- 승인 대기·유효 승인·거절·철회·Source 삭제·차단 당사자/제3자의 Post readback과 Source null·카드 상태를 확인한다.
+- Web 실제 Quote 작성 E2E와 keyboard/focus/dismiss/accessibility를 확인한다. Native runtime은 별도 release gate다.
+- PROD-431은 작성 cross-layer 증거를 제공하고 PROD-924는 이를 실제 연합 lifecycle과 연결해 전체 change를 검증한다.
+
+- [ ] 3.1 인용 메뉴와 direct Source를 가진 공용 Composer의 기본 작성·취소·제출·오류 복구를 연결한다.
+- [ ] 3.2 승인과 viewer 접근을 Source 조회에 적용하고 같은 Post identity의 본문·Source 표시를 검증한다.
+- [ ] 3.3 요청 actor의 작성 성공 cache와 늦은 응답 격리·기존 presentation 회귀를 검증한다.
+- [ ] 3.4 Web 작성 E2E·접근성 증거와 API 선배포·접근 보호 rollback 및 Native 미검증 범위를 기록한다.
+
+## 4. PROD-924 Kosmo 원문의 자동 승인과 명시적 철회
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`, `docs/design/post-action-bar.md`,
+  `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+**Deliverable**
+
+Kosmo 원문이 요청을 정책대로 자동 승인·거절하고 작성자가 기존 승인을 명시적으로 철회할 수 있다.
+
+**Guardrails**
+
+- 1번 정책과 기존 Follow·Block·조회 경계를 사용한다.
+- 요청 Profile·Quote·Source·승인 발급자 대응을 검증한다. 정책 변경·차단은 기존 승인을 자동 철회하지 않는다.
+- 명시적 철회는 Source만 숨기고 Quote 자체 본문을 보존한다.
+
+**Verification**
+
+- 정상·위조·차단·정책상 거부 요청, 중복 승인, 작성자 철회 권한, 제3자 비노출과 본문 보존을 검증한다.
+
+- [ ] 4.1 Kosmo 원문 QuoteRequest의 검증·자동 Accept/Reject·승인 발급을 연결한다.
+- [ ] 4.2 작성자의 명시적 승인 철회 조작과 승인 무효화·원격 철회 전달을 연결한다.
+- [ ] 4.3 요청 대응·중복·철회 권한과 차단/명시적 철회의 다른 결과를 검증한다.
+
+## 5. PROD-924 로컬 Quote 발신과 원격 승인 결과
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`, `docs/domain/decisions/0017-activitypub-local-post-note.md`,
+  `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+**Deliverable**
+
+자기 인용은 요청 없이 허용하고, 원격 타인 원문은 `interactionPolicy`와 관계없이 본문을 먼저 전달한 뒤
+QuoteRequest와 유효한 QuoteAuthorization을 통해 같은 Quote의 Source 표현을 수렴시킨다.
+
+**Guardrails**
+
+- 2번 작성 결과와 기존 canonical identity·audience·공통 delivery를 사용한다.
+- automatic/manual 광고와 정책 부재·해석 실패 모두 별도 QuoteRequest를 보내고, 유효한 Accept·승인 후 Update를 지킨다.
+- `interactionPolicy`는 UI·예상 eligibility의 힌트일 뿐 승인 증거가 아니다. 승인 전 Source와 자동 생성 호환 표현을 숨긴다.
+- 원격 Quote 수신 PROD-792를 중복 구현하거나 일반 사용자용 본문 수정을 추가하지 않는다.
+
+**Verification**
+
+- local/remote Source, 자기 인용, automatic/manual, 정책 부재·해석 실패, 어느 집합에도 포함되지 않는 경우,
+  valid/invalid Accept, Reject, source delete와 동일 identity Update를 확인한다. 발신 payload와 최종 Source 조회를 함께 검증한다.
+
+- [ ] 5.1 승인된 Quote projection과 pending 본문 선발신·원격 요청을 연결한다.
+- [ ] 5.2 로컬 Quote의 원격 Accept/Reject·승인 철회를 검증해 Source와 필요한 Update를 연결한다.
+- [ ] 5.3 일반 Post·Reply·Repost identity/audience 회귀와 승인 전 Source 비노출을 검증한다.
+- [ ] 5.4 자기 인용의 요청 생략과 원격 타인 원문의 정책별 QuoteRequest·pending·승인 증거 경계를 검증한다.
+
+## 6. PROD-924 레거시 발신과 재전달 수렴
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`, `docs/domain/decisions/0027-quote-consent-and-federation.md`, PROD-902, PROD-924.
+
+**Deliverable**
+
+승인된 인용을 레거시 서버에 전달하고 재시도·역순 응답 이후에도 최신 승인 결과를 유지한다.
+
+**Guardrails**
+
+- 4·5번 lifecycle을 기반으로 quoteUrl·quoteUri·\_misskey_quote와 승인 후 본문 링크를 제공한다.
+- pending·거절·철회 때 자동 표현만 숨기고 직접 작성한 본문을 유지한다. invalid FEP를 legacy로 강등하지 않는다.
+- 중복·동시·stale 처리로 철회된 Source나 삭제된 Quote를 복구하지 않는다.
+
+**Verification**
+
+- 승인 후 세 속성·원문 링크, 철회 후 자동 표현 제거, 직접 쓴 동일 URL 보존을 payload로 확인한다.
+- 중복 요청·승인, 동시 철회, 늦은 Accept, 일시 실패·재전달의 상태 수렴과 실패 관찰을 검증한다.
+
+- [ ] 6.1 승인 조건에 따른 세 호환 속성과 발신 본문 fallback을 연결한다.
+- [ ] 6.2 중복·동시·역순 응답 및 delivery 실패·재시도를 최신 상태에 수렴시킨다.
+- [ ] 6.3 공식 구현에 근거한 compatibility fixture와 상태·본문 보존 회귀를 검증한다.
+
+## 7. PROD-924 전체 연합 통합 검증과 change 완료
+
+**Authority / Provenance**
+
+- `docs/domain/objects/post.md`, `docs/domain/objects/profile-block.md`,
+  `docs/domain/decisions/0027-quote-consent-and-federation.md`, `memory/issue-openspec-workflow.md`,
+  PROD-902, PROD-431, PROD-924.
+
+**Deliverable**
+
+PROD-431·924의 작성·정책·승인·발신 결과가 하나의 사용자 흐름으로 동작하고 전체 change 완료를 증명한다.
+
+**Guardrails**
+
+- 1~6번 전체 task 완료와 인접 PROD-792 수신 경계 연동 증거가 필요하다.
+- PROD-793의 기존 signed fetch 계약을 축소하지 않는다. PROD-925는 현재 완료 조건이 아니다.
+- 일부 PR 완료만으로 archive하지 않으며 다른 이슈의 독립 change도 대신 archive하지 않는다.
+
+**Verification**
+
+- 작성→pending 게시·전달→Accept→Source 표시→명시적 철회→제3자 Source 비노출과 자체 Content 보존을 확인한다.
+- 타인 Followers Only 거부·자기 인용 접근, 차단 당사자/제3자 차이, 원문 삭제와 legacy 수신을 통합 확인한다.
+- 실제 schema diff의 초기화·기존 승인 보존·배포 순서와 rollback 시 Source 접근 보호를 확인한다.
+
+- [ ] 7.1 PROD-431 작성과 승인·발신·원격 수신 경계를 연결하는 연합 통합 검증을 수행한다.
+- [ ] 7.2 기존 데이터·승인 보존, 출시·복구 시 접근 보호와 플랫폼별 필요한 release 증거를 확인한다.
+- [ ] 7.3 최신 canonical·Linear·OpenSpec과 전체 구현 결과를 대조하고 미완료 범위가 없음을 확인한다.
+- [ ] 7.4 전체 선언 task 완료 후 delta spec 동기화·archive와 archive 후 validation을 수행한다.


### PR DESCRIPTION
## 무엇을 변경했는지

- PROD-902가 소유하는 `define-quote-consent-and-federation` OpenSpec과 canonical 문서를 추가·정렬했습니다.
- QuoteAuthorization의 Source 권한 기반 역참조와 embed 제한, 수신 철회의 기존 Quote audience 전달 계약을 보강했습니다.
- PR #817의 9월 9일 공유 spec 정정 중 기본 Quote 범위와 Reply+Quote 작성 UI·API 및 링크 인용 제외를 반영했습니다. PROD-431 구현 코드와 고유 변경은 포함하지 않았습니다.
- 자기 인용 외 모든 원격 타인 원문은 `interactionPolicy`의 automatic/manual 여부나 부재·해석 실패와 관계없이 QuoteRequest를 보내고, 유효한 QuoteAuthorization으로 승인 여부를 확인하도록 확정했습니다.
- 승인 전에는 자체 Content만 pending 상태로 게시·유지하고 Source 관계와 자동 생성 FEP·레거시 표현·fallback을 숨깁니다. 승인 후 같은 Post identity에 Source를 활성화하고 필요한 Update를 전달합니다.
- 게시글별 정책 API의 구체 형태와 저장 schema, migration/backfill/rollback 책임을 PROD-924에 명시했습니다.
- Stack: main -> PROD-902

## 왜 변경했는지

Quote 저장·표시 기반, 원문 작성자의 동의, 원격 승인·철회가 하나의 검증 가능한 계약으로 연결되어 있지 않았습니다. 이 PR은 제품 구현을 추가하는 PR이 아니라 Quote consent/federation 계약과 구현 경계를 OpenSpec으로 확정하는 변경입니다.

PROD-431은 Quote 작성 API·core·Composer를 담당합니다. PROD-924는 정책 저장, federation, 승인·철회 lifecycle과 전체 연합 통합 검증 및 전체 task 완료 후 archive를 담당합니다.

## 이번 PR의 주요 결정

### 원격 interactionPolicy는 승인 증거가 아닌 힌트로 사용

- 결정자: PROD-902 사용자 승인
- 선택: 자기 인용만 QuoteRequest 없이 허용하고, 타인 원문은 interactionPolicy와 관계없이 QuoteRequest와 유효한 QuoteAuthorization을 거칩니다.
- 고려한 대안: manual approval 광고가 있을 때만 요청하거나 automatic 광고 자체를 승인으로 취급하고, 정책 부재·해석 실패 시 작성을 거부하는 방안
- 이유: FEP-044f의 개별 승인 경계를 지키고 정책 광고와 실제 승인을 분리하기 위해서입니다.
- 감수한 결과: automatic 광고가 있어도 승인 응답 전까지 Source가 없는 pending Content가 먼저 보입니다.
- 관련 근거: `docs/domain/decisions/0027-quote-consent-and-federation.md`, `openspec/changes/define-quote-consent-and-federation/decisions.md`

### 구현 책임 분리

- 결정자: PROD-902 사용자 승인
- 선택: OpenSpec owner는 PROD-902에 유지하고 PROD-431과 PROD-924가 각각 담당 task를 구현합니다.
- 고려한 대안: PR #817/PROD-431을 canonical OpenSpec 수정 branch로 전환하는 방안
- 이유: 계약 소유권과 구현 slice의 책임을 분리하면서 PR #817의 구현·승인 snapshot을 보존하기 위해서입니다.
- 감수한 결과: 이 PR만 merge되어도 제품 기능은 완료되지 않으며 후속 구현과 전체 통합 검증이 필요합니다.
- 관련 근거: `openspec/changes/define-quote-consent-and-federation/tasks.md`

## 어떻게 확인할 수 있는지

- 승인 OpenSpec 산출물과 conflict 해결 후 산출물의 요구사항·결정·task 의미를 대조
- `openspec validate define-quote-consent-and-federation --strict --no-interactive`
- 저장소 Prettier 3.8.3과 동일 config/plugin으로 변경 문서 검사
- `git diff --check`
- OpenSpec 구성: 19 requirements, 87 scenarios, 8 active decisions, 26 implementation tasks
- 최신 main 재배치 후 GitHub mergeable 상태와 17개 변경 파일 확인

## 아직 어떤 문제가 남았는지

- 26개 제품 구현 task는 완료 처리하지 않았고 OpenSpec change도 archive하지 않았습니다.
- `docs/domain/objects/post.md`는 최신 main의 Quote Notification 계약과 PROD-902의 Quote 승인 계약을 함께 유지했습니다.
- `docs/domain/objects/profile-block.md`는 최신 main의 방향별 조회 정책을 유지하고, 기존 인용 승인이 차단을 우회하거나 자동 철회되지 않는 PROD-902 계약을 결합했습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

