### PR TITLE
ProfileHero의 프로필 정보 겹침을 막는다

### DIFF
--- a/apps/app/src/components/profile/ProfileHero.tsx
+++ b/apps/app/src/components/profile/ProfileHero.tsx
@@ -304,7 +304,7 @@ const styles = StyleSheet.create({
     borderWidth: space[4],
   },
   action: { alignItems: 'flex-end', justifyContent: 'center', width: 96 },
-  identity: { flex: 0 },
+  identity: { flex: -1 },
   bio: { marginTop: space[12], ...textStyles.uiCopyL },
   tags: { flexDirection: 'row', flexWrap: 'wrap', gap: space[8], marginTop: space[12] },
   tagTarget: {

--- a/apps/app/src/stories/patterns/ProfileHero.tests.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileHero.tests.stories.tsx
@@ -64,7 +64,7 @@ export const CenterGeometryContract: Story = {
 };
 
 export const MobileGeometryContract: Story = {
-  args: { containerWidth: 390 },
+  args: { containerWidth: 390, profileId: 'profile-hero-no-bio' },
   globals: { viewport: { isRotated: false, value: 'kosmoMobile' } },
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -79,7 +79,14 @@ export const MobileGeometryContract: Story = {
     expect(followRect.left - moreRect.right).toBeCloseTo(16, 0);
     expect(followRect.top).toBeCloseTo(moreRect.top, 0);
     expect(canvas.getByTestId('profile-hero-surface').getBoundingClientRect().width).toBe(390);
-    expect(canvas.getByLabelText('프로필 히어로 프로필 이미지')).toBeVisible();
+    expect(canvas.getByLabelText('소개 없는 히어로 프로필 이미지')).toBeVisible();
+    const handle = canvas.getByText('@no-bio');
+    const identity = handle.parentElement;
+    expect(identity).toBeInstanceOf(HTMLElement);
+    expect(getComputedStyle(identity as HTMLElement).flexBasis).toBe('auto');
+    const handleRect = handle.getBoundingClientRect();
+    const countsRect = canvas.getByRole('link', { name: /팔로잉/ }).getBoundingClientRect();
+    expect(countsRect.top - handleRect.bottom).toBeCloseTo(12, 0);
   },
 };
 


### PR DESCRIPTION
## 무엇을 변경했나요

- `ProfileHero`에서 `ProfileNameBlock`의 `flex: 0` override를 `flex: -1`로 바꿔 이름·핸들이 실제 콘텐츠 높이를 차지하게 했습니다.
- 기존 `ProfileHero` Tests story에 bio가 없는 회귀 fixture를 추가하고, Web computed `flex-basis: auto`와 핸들–관계 수치 간격 `12px`를 검증합니다.

## 왜 변경했나요

Production `kos.moe` 프로필에서 이름·핸들이 following/follower 수치와 겹쳤습니다. 공용 `ProfileNameBlock`의 기본 `flex: 1`을 Hero가 `flex: 0`으로 덮으면서 React Native Web에서 basis가 `0%`가 되어, 텍스트는 그려지지만 identity가 레이아웃 높이에 반영되지 않은 것이 원인이었습니다.

공용 컴포넌트나 다른 소비처는 바꾸지 않고 문제가 생긴 Hero override 한 줄만 바로잡았습니다. RNW와 Native 모두 `flex: -1`을 content-based basis, grow 0, shrink 1로 처리합니다.

## 어떻게 확인할 수 있나요

- [x] ProfileHero Storybook: 10/10
- [x] 앱 unit: 521/521
- [x] 전체 Storybook: 111 files / 748 tests
- [x] Storybook 정적 빌드: 3,121 modules
- [x] 변경 파일 ESLint / Prettier / `git diff --check`
- [x] Browser QA: 1400×900에서 이름 → 핸들 → 소개 → 관계 수치가 겹치지 않고, 소개·관계 수치 앞 간격이 각각 `12px`임을 측정
- [x] 독립 구현 리뷰 PASS
- [ ] `pnpm --filter @kosmo/app check`
  - Relay 생성은 reader 130 / normalization 85 / operation 144까지 통과했습니다.
  - TypeScript는 이번 변경 밖의 `SettingsLinkRow.test.ts:92` 기존 타입 오류에서 중단됩니다.

## 아직 어떤 문제가 남았나요

- 실제 Android/iOS 기기에서 긴 이름·소개 조합의 최종 Yoga 배치는 확인하지 않았습니다.
- Tests story의 computed-style 검사는 현재 RNW DOM 구조에 일부 결합됩니다.

Stack: main -> PROD-785-profilehero-hotfix -> PROD-785 (#806, Draft)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
