### PR TITLE
ProfileSwitcher의 최신 unread 표시를 Production에 동기화한다

### DIFF
--- a/apps/app/src/components/profile/ProfilePicker.tsx
+++ b/apps/app/src/components/profile/ProfilePicker.tsx
@@ -1,9 +1,8 @@
 import { CheckIcon } from 'lucide-react-native';
 import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { UnreadDot } from '@/components/shell/UnreadDot';
 import { Avatar } from '@/components/ui/Avatar';
 import { useElevation, useTheme } from '@/theme/ThemeProvider';
-import { fontFamilies, space, spacing, typography } from '@/theme/tokens';
+import { fontFamilies, radius, space, spacing, textStyles, typography } from '@/theme/tokens';
 import type { ReactNode, Ref } from 'react';
 import type { ViewStyle } from 'react-native';
 
@@ -87,16 +86,11 @@ export function ProfilePicker({
           },
         ]}
       >
-        <View style={styles.profileAvatar}>
-          <Avatar
-            imageUri={profile.avatar?.url}
-            label={profile.displayName}
-            size={selected ? 48 : 32}
-          />
-          {hasUnread ? (
-            <UnreadDot style={styles.profileUnreadDot} testID="profile-switcher-unread-dot" />
-          ) : null}
-        </View>
+        <Avatar
+          imageUri={profile.avatar?.url}
+          label={profile.displayName}
+          size={selected ? 48 : 32}
+        />
         <View style={styles.profileLabel}>
           <Text numberOfLines={1} style={[styles.displayName, { color: theme.text }]}>
             {profile.displayName}
@@ -105,7 +99,22 @@ export function ProfilePicker({
             {profile.relativeHandle}
           </Text>
         </View>
-        {selected ? <CheckIcon color={theme.text} size={16} /> : null}
+        {selected ? (
+          <CheckIcon color={theme.text} size={16} />
+        ) : hasUnread ? (
+          <View
+            accessible={false}
+            accessibilityElementsHidden
+            aria-hidden
+            importantForAccessibility="no-hide-descendants"
+            style={[styles.unreadCount, { backgroundColor: theme.actionPrimaryBase }]}
+            testID="profile-switcher-unread-count"
+          >
+            <Text style={[textStyles.uiLabelS, { color: theme.actionPrimaryOnBase }]}>
+              {(profile.unreadNotificationCount ?? 0) > 9 ? '9+' : profile.unreadNotificationCount}
+            </Text>
+          </View>
+        ) : null}
       </Pressable>
     );
   });
@@ -174,17 +183,15 @@ const styles = StyleSheet.create({
     padding: spacing.sm,
   },
   unselectedProfile: { paddingVertical: space[8] },
-  profileAvatar: { position: 'relative' },
-  profileUnreadDot: {
-    height: 12,
-    position: 'absolute',
-    right: -2,
-    top: -2,
-    width: 12,
-    zIndex: 1,
-  },
   profileLabel: { flex: 1, minWidth: 0 },
   displayName: { fontFamily: fontFamilies.ui, fontWeight: '700', ...typography.md },
   handle: { fontFamily: fontFamilies.ui, ...typography.sm },
+  unreadCount: {
+    alignItems: 'center',
+    borderRadius: radius.full,
+    height: 24,
+    justifyContent: 'center',
+    width: 24,
+  },
   divider: { height: 1, marginVertical: space[4], width: '100%' },
 });

--- a/apps/app/src/components/shell/ProfileSwitcher.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcher.tsx
@@ -12,9 +12,12 @@ import { TextField } from '@/components/ui/TextField';
 import { useRelayActor } from '@/relay/RelayActorProvider';
 import { useTheme } from '@/theme/ThemeProvider';
 import {
+  borderWidths,
   fontFamilies,
+  iconSizes,
   layoutRecipes,
   radii,
+  radius,
   spacing,
   textStyles,
   typography,
@@ -186,6 +189,9 @@ export function ProfileSwitcher({
   const canEditSelectedProfile =
     active?.instance.kind === 'LOCAL' && active.viewerState?.membership?.role === 'OWNER';
   const profiles = data.me?.profiles ?? [];
+  const otherHasUnread = profiles.some(
+    (profile) => profile.id !== active?.id && profile.unreadNotificationCount > 0,
+  );
   const busy = selecting || creatingProfile;
   const compact = surface === 'compact';
   const fullWeb = Platform.OS === 'web' && surface === 'full';
@@ -451,18 +457,36 @@ export function ProfileSwitcher({
       <Text numberOfLines={1} style={[styles.triggerName, { color: theme.text }]}>
         {active?.displayName ?? (profiles.length ? '프로필 선택' : '프로필')}
       </Text>
-      {webExpandedChevron ? (
-        <ChevronUpIcon color={theme.textSecondary} size={16} />
-      ) : (
-        <ChevronDownIcon color={theme.textSecondary} size={16} />
-      )}
+      <View style={styles.chevron}>
+        {!open && otherHasUnread ? (
+          <View
+            accessible={false}
+            accessibilityElementsHidden
+            aria-hidden
+            importantForAccessibility="no-hide-descendants"
+            style={[
+              styles.closedUnread,
+              styles.wideUnread,
+              { backgroundColor: theme.actionPrimaryBase },
+            ]}
+            testID="profile-switcher-closed-unread"
+          />
+        ) : null}
+        {webExpandedChevron ? (
+          <ChevronUpIcon color={theme.textSecondary} size={iconSizes[20]} />
+        ) : (
+          <ChevronDownIcon color={theme.textSecondary} size={iconSizes[20]} />
+        )}
+      </View>
     </>
   ) : null;
   const trigger = (
     <Pressable
       ref={triggerRef}
       aria-expanded={open}
-      accessibilityLabel="프로필 목록"
+      accessibilityLabel={
+        !open && otherHasUnread ? '프로필 목록, 읽지 않은 알림 있음' : '프로필 목록'
+      }
       accessibilityRole="button"
       accessibilityState={{ expanded: open }}
       onPress={() => (open ? dismissPicker() : setOpen(true))}
@@ -474,7 +498,26 @@ export function ProfileSwitcher({
       ]}
     >
       {compact ? (
-        <Avatar imageUri={active?.avatar?.url} label={active?.displayName ?? '?'} size={40} />
+        <View style={styles.compactAvatar}>
+          <Avatar imageUri={active?.avatar?.url} label={active?.displayName ?? '?'} size={40} />
+          {!open && otherHasUnread ? (
+            <View
+              accessible={false}
+              accessibilityElementsHidden
+              aria-hidden
+              importantForAccessibility="no-hide-descendants"
+              style={[
+                styles.closedUnread,
+                styles.compactUnread,
+                {
+                  backgroundColor: theme.actionPrimaryBase,
+                  borderColor: theme.backgroundCanvas,
+                },
+              ]}
+              testID="profile-switcher-closed-unread"
+            />
+          ) : null}
+        </View>
       ) : null}
       {fullWeb || mobileWebDrawer ? (
         <View style={styles.webTriggerContent}>{triggerCopy}</View>
@@ -661,6 +704,7 @@ const styles = StyleSheet.create({
   fullRoot: { alignSelf: 'stretch' },
   trigger: { alignItems: 'center', flexDirection: 'row' },
   compactTrigger: { height: 44, justifyContent: 'center', width: 44 },
+  compactAvatar: { position: 'relative' },
   fullTrigger: { alignSelf: 'flex-start', gap: spacing.sm, height: 42, maxWidth: '100%' },
   webProfileTrigger: { marginBottom: -spacing.sm },
   webTriggerContent: {
@@ -676,6 +720,17 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     ...typography.xl,
   },
+  closedUnread: { borderRadius: radius.full, height: 8, width: 8 },
+  compactUnread: {
+    borderWidth: borderWidths[1],
+    height: 12,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    width: 12,
+  },
+  chevron: { height: iconSizes[20], position: 'relative', width: iconSizes[20] },
+  wideUnread: { position: 'absolute', right: -9, top: -4 },
   webMenu: { position: 'absolute', width: 280, zIndex: 30 },
   compactMenuPosition: { left: 72, top: 0 },
   drawerMenuPosition: { left: 0, top: 190 },

--- a/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
+++ b/apps/app/src/components/shell/ProfileSwitcherTarget.tsx
@@ -39,9 +39,10 @@ export function ProfileSwitcherTarget({
     ? Math.max(44, getIconButtonTargetSize(Platform.OS))
     : getIconButtonTargetSize(Platform.OS);
   const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId);
-  const selectedHasUnread = (selectedProfile?.unreadNotificationCount ?? 0) > 0;
-  const triggerLabel =
-    !open && selectedHasUnread ? '프로필 목록, 읽지 않은 알림 있음' : '프로필 목록';
+  const otherHasUnread = profiles.some(
+    (profile) => profile.id !== selectedProfileId && (profile.unreadNotificationCount ?? 0) > 0,
+  );
+  const triggerLabel = !open && otherHasUnread ? '프로필 목록, 읽지 않은 알림 있음' : '프로필 목록';
   const webMenuBounds =
     Platform.OS === 'web'
       ? ({
@@ -121,7 +122,7 @@ export function ProfileSwitcherTarget({
               label={selectedProfile?.displayName ?? '프로필'}
               size={40}
             />
-            {!open && selectedHasUnread ? (
+            {!open && otherHasUnread ? (
               <View
                 accessible={false}
                 accessibilityElementsHidden
@@ -151,7 +152,7 @@ export function ProfileSwitcherTarget({
               {selectedProfile?.displayName ?? (profiles.length ? '프로필 선택' : '프로필')}
             </Text>
             <View style={styles.chevron}>
-              {!open && selectedHasUnread ? (
+              {!open && otherHasUnread ? (
                 <View
                   accessible={false}
                   accessibilityElementsHidden

--- a/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
+++ b/apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx
@@ -123,7 +123,7 @@ const meta = {
     profileCount: 3,
     selectionOutcome: 'success',
     selectedProfileId: 'profile-kosmo',
-    selectedUnreadCount: 1,
+    selectedUnreadCount: 0,
     surface: 'full',
   },
   argTypes: {
@@ -206,12 +206,13 @@ export const InteractionContract: Story = {
 
     const group = canvas.getByRole('group', { name: '프로필 전환' });
     const selected = within(group).getByRole('button', {
-      name: '코스모 작가, @kosmo, 읽지 않은 알림 있음',
+      name: '코스모 작가, @kosmo',
     });
     const remote = within(group).getByRole('button', {
       name: '먼 우주의 사용자, @remote, 읽지 않은 알림 있음',
     });
     expect(selected).toHaveAttribute('aria-pressed', 'true');
+    expect(within(remote).getByTestId('profile-switcher-unread-count')).toHaveTextContent('9');
 
     await userEvent.tab();
     expect(selected).toHaveFocus();
@@ -341,6 +342,7 @@ export const CompactClosedUnreadContract: Story = {
     expect(bounds.left).toBe(avatarBounds.left + 28);
     expect(bounds.top).toBe(avatarBounds.top);
     expect(getComputedStyle(indicator).borderTopWidth).toBe('1px');
+    expect(getComputedStyle(indicator).borderTopColor).toBe('rgb(255, 255, 255)');
   },
 };
 
@@ -350,7 +352,7 @@ export const OpenUnreadContract: Story = {
     const canvas = within(canvasElement);
     const group = canvas.getByRole('group', { name: '프로필 전환' });
     const selected = within(group).getByRole('button', {
-      name: '코스모 작가, @kosmo, 읽지 않은 알림 있음',
+      name: '코스모 작가, @kosmo',
     });
     const remote = within(group).getByRole('button', {
       name: '먼 우주의 사용자, @remote, 읽지 않은 알림 있음',

--- a/apps/app/src/stories/patterns/Shell.stories.tsx
+++ b/apps/app/src/stories/patterns/Shell.stories.tsx
@@ -98,6 +98,7 @@ const longProfileEditCopyQuery = {
     selectedProfile: selectedProfileWithLongDisplayName,
   }),
 };
+const selectedProfileWithoutUnread = { ...selectedProfile, unreadNotificationCount: 0 };
 const selectedProfileWithUnread = { ...selectedProfile, unreadNotificationCount: 1 };
 const secondProfileWithLargeUnread = { ...secondProfile, unreadNotificationCount: 127 };
 const profileWithoutUnread = profile({
@@ -110,7 +111,14 @@ const profileWithoutUnread = profile({
 const profileSwitcherUnreadQuery = {
   ...query,
   ...shellQuery({
-    profiles: [selectedProfileWithUnread, secondProfileWithLargeUnread, profileWithoutUnread],
+    profiles: [selectedProfileWithoutUnread, secondProfileWithLargeUnread, profileWithoutUnread],
+    selectedProfile: selectedProfileWithoutUnread,
+  }),
+};
+const profileSwitcherSelectedOnlyUnreadQuery = {
+  ...query,
+  ...shellQuery({
+    profiles: [selectedProfileWithUnread, secondProfile],
     selectedProfile: selectedProfileWithUnread,
   }),
 };
@@ -236,6 +244,28 @@ function ProfileSwitcherStory() {
     <SessionProvider>
       <View style={{ maxWidth: 360 }}>
         <ProfileSwitcher query={data.query} surface="full" />
+      </View>
+    </SessionProvider>
+  );
+}
+
+function CompactProfileSwitcherStory() {
+  const data = useShellStoryData();
+  return (
+    <SessionProvider>
+      <View style={{ width: 80 }}>
+        <ProfileSwitcher query={data.query} surface="compact" />
+      </View>
+    </SessionProvider>
+  );
+}
+
+function DrawerProfileSwitcherStory() {
+  const data = useShellStoryData();
+  return (
+    <SessionProvider>
+      <View style={{ width: 280 }}>
+        <ProfileSwitcher query={data.query} surface="drawer" />
       </View>
     </SessionProvider>
   );
@@ -1004,10 +1034,29 @@ export const ProfileSwitcherUnreadPresence: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('button', { name: '프로필 목록' }));
+    const trigger = canvas.getByRole('button', {
+      name: '프로필 목록, 읽지 않은 알림 있음',
+    });
+    const closedIndicator = canvas.getByTestId('profile-switcher-closed-unread');
+    const chevron = trigger.querySelector('svg');
+
+    expect(chevron).not.toBeNull();
+    expect(closedIndicator).toHaveAttribute('aria-hidden', 'true');
+    expect(closedIndicator.getBoundingClientRect().width).toBe(8);
+    expect(closedIndicator.getBoundingClientRect().height).toBe(8);
+    expect(chevron!.getBoundingClientRect().width).toBe(20);
+    expect(chevron!.getBoundingClientRect().height).toBe(20);
+    expect(closedIndicator.getBoundingClientRect().left).toBe(
+      chevron!.getBoundingClientRect().right + 1,
+    );
+    expect(closedIndicator.getBoundingClientRect().top).toBe(
+      chevron!.getBoundingClientRect().top - 4,
+    );
+
+    await userEvent.click(trigger);
     const list = await canvas.findByLabelText('전환할 프로필 목록');
     const selectedOption = within(list).getByRole('button', {
-      name: `${selectedProfile.displayName}, ${selectedProfile.relativeHandle}, 읽지 않은 알림 있음`,
+      name: `${selectedProfile.displayName}, ${selectedProfile.relativeHandle}`,
     });
     const unreadOption = await within(list).findByRole('button', {
       name: `${secondProfile.displayName}, ${secondProfile.relativeHandle}, 읽지 않은 알림 있음`,
@@ -1015,24 +1064,96 @@ export const ProfileSwitcherUnreadPresence: Story = {
     const noUnreadOption = within(list).getByRole('button', {
       name: `${profileWithoutUnread.displayName}, ${profileWithoutUnread.relativeHandle}`,
     });
-    const selectedDot = within(selectedOption).getByTestId('profile-switcher-unread-dot');
-    const unreadDot = within(unreadOption).getByTestId('profile-switcher-unread-dot');
+    const unreadCount = within(unreadOption).getByTestId('profile-switcher-unread-count');
 
     expect(selectedOption).toHaveAttribute('aria-pressed', 'true');
     expect(unreadOption).toHaveAttribute('aria-pressed', 'false');
     expect(noUnreadOption).toHaveAttribute('aria-pressed', 'false');
-    expect(within(noUnreadOption).queryByTestId('profile-switcher-unread-dot')).toBeNull();
+    expect(within(selectedOption).queryByTestId('profile-switcher-unread-count')).toBeNull();
+    expect(within(noUnreadOption).queryByTestId('profile-switcher-unread-count')).toBeNull();
     expect(noUnreadOption).not.toHaveAccessibleName(/읽지 않은 알림 있음/);
-    expect(selectedDot).toHaveAttribute('aria-hidden', 'true');
-    expect(unreadDot).toHaveAttribute('aria-hidden', 'true');
-    expect(selectedDot).toHaveStyle({ height: '12px', width: '12px' });
-    expect(unreadDot).toHaveStyle({ height: '12px', width: '12px' });
-    expect(selectedOption).not.toHaveAccessibleName(/1/);
+    expect(unreadCount).toHaveAttribute('aria-hidden', 'true');
+    expect(unreadCount).toHaveTextContent('9+');
+    expect(unreadCount).toHaveStyle({ height: '24px', width: '24px' });
     expect(unreadOption).not.toHaveAccessibleName(/127/);
     expect(unreadOption.getBoundingClientRect().height).toBe(60);
-    expect(unreadDot.getBoundingClientRect().right).toBeLessThanOrEqual(
+    expect(unreadCount.getBoundingClientRect().right).toBeLessThanOrEqual(
       unreadOption.getBoundingClientRect().right,
     );
+    expect(canvas.queryByTestId('profile-switcher-closed-unread')).toBeNull();
+  },
+  render: () => <ProfileSwitcherStory />,
+};
+
+export const ProfileSwitcherCompactUnreadPresence: Story = {
+  parameters: {
+    relay: { data: profileSwitcherUnreadQuery },
+  },
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', {
+      name: '프로필 목록, 읽지 않은 알림 있음',
+    });
+    const avatar = within(trigger).getByLabelText(`${selectedProfile.displayName} 프로필 이미지`);
+    const indicator = within(trigger).getByTestId('profile-switcher-closed-unread');
+    const avatarBounds = avatar.getBoundingClientRect();
+    const indicatorBounds = indicator.getBoundingClientRect();
+
+    expect(indicator).toHaveAttribute('aria-hidden', 'true');
+    expect(indicatorBounds.width).toBe(12);
+    expect(indicatorBounds.height).toBe(12);
+    expect(indicatorBounds.left).toBe(avatarBounds.left + 28);
+    expect(indicatorBounds.top).toBe(avatarBounds.top);
+    expect(getComputedStyle(indicator).borderTopWidth).toBe('1px');
+    expect(getComputedStyle(indicator).borderTopColor).toBe('rgb(255, 255, 255)');
+  },
+  render: () => <CompactProfileSwitcherStory />,
+};
+
+export const ProfileSwitcherDrawerUnreadPresence: Story = {
+  parameters: {
+    relay: { data: profileSwitcherUnreadQuery },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', {
+      name: '프로필 목록, 읽지 않은 알림 있음',
+    });
+    const indicator = canvas.getByTestId('profile-switcher-closed-unread');
+
+    expect(indicator.getBoundingClientRect().width).toBe(8);
+    expect(indicator.getBoundingClientRect().height).toBe(8);
+    await userEvent.click(trigger);
+
+    const list = await canvas.findByLabelText('전환할 프로필 목록');
+    const unreadOption = within(list).getByRole('menuitemradio', {
+      name: `${secondProfile.displayName}, ${secondProfile.relativeHandle}, 읽지 않은 알림 있음`,
+    });
+    expect(within(unreadOption).getByTestId('profile-switcher-unread-count')).toHaveTextContent(
+      '9+',
+    );
+    expect(canvas.queryByTestId('profile-switcher-closed-unread')).toBeNull();
+  },
+  render: () => <DrawerProfileSwitcherStory />,
+};
+
+export const ProfileSwitcherSelectedOnlyUnread: Story = {
+  parameters: {
+    relay: { data: profileSwitcherSelectedOnlyUnreadQuery },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '프로필 목록' });
+
+    expect(canvas.queryByTestId('profile-switcher-closed-unread')).toBeNull();
+    await userEvent.click(trigger);
+
+    const list = await canvas.findByLabelText('전환할 프로필 목록');
+    const selectedOption = within(list).getByRole('button', {
+      name: `${selectedProfile.displayName}, ${selectedProfile.relativeHandle}, 읽지 않은 알림 있음`,
+    });
+    expect(selectedOption.querySelector('svg')).not.toBeNull();
+    expect(within(selectedOption).queryByTestId('profile-switcher-unread-count')).toBeNull();
   },
   render: () => <ProfileSwitcherStory />,
 };

--- a/apps/web/e2e/profile-switcher.e2e.ts
+++ b/apps/web/e2e/profile-switcher.e2e.ts
@@ -13,7 +13,7 @@ test.beforeEach(async () => {
   await resetE2EDatabase();
 });
 
-test('다른 Profile의 Unread dot에서 전환하면 기존 badge와 알림 목록이 새 actor에 수렴한다', async ({
+test('다른 Profile의 Unread badge에서 전환하면 기존 badge와 알림 목록이 새 actor에 수렴한다', async ({
   browser,
   context,
   page,
@@ -52,7 +52,11 @@ test('다른 Profile의 Unread dot에서 전환하면 기존 badge와 알림 목
 
     await page.reload();
     await expect(page.getByRole('progressbar')).toHaveCount(0);
-    await openProfileSwitcher(page);
+    const trigger = page.getByRole('button', {
+      name: '프로필 목록, 읽지 않은 알림 있음',
+    });
+    await expect(trigger.getByTestId('profile-switcher-closed-unread')).toBeVisible();
+    await trigger.click();
 
     const list = page.getByLabel('전환할 프로필 목록');
     const unreadOption = list.getByRole('button', {
@@ -63,10 +67,11 @@ test('다른 Profile의 Unread dot에서 전환하면 기존 badge와 알림 목
     });
 
     await expect(unreadOption).toBeVisible();
-    await expect(unreadOption.getByTestId('profile-switcher-unread-dot')).toBeVisible();
+    await expect(unreadOption.getByTestId('profile-switcher-unread-count')).toHaveText('1');
     await expect(unreadOption).not.toHaveAccessibleName(/1개/);
     await expect(selectedOption).toHaveAttribute('aria-pressed', 'true');
-    await expect(selectedOption.getByTestId('profile-switcher-unread-dot')).toHaveCount(0);
+    await expect(selectedOption.getByTestId('profile-switcher-unread-count')).toHaveCount(0);
+    await expect(page.getByTestId('profile-switcher-closed-unread')).toHaveCount(0);
 
     const selectResponse = waitForGraphQLOperation(page, 'ProfileSwitcherSelectProfileMutation');
     await unreadOption.click();

--- a/docs/design/breakpoints.md
+++ b/docs/design/breakpoints.md
@@ -152,19 +152,15 @@ Web profile picker는 breakpoint별 사이드바 구조에 맞는 surface를 사
 
 ### Profile별 Unread 표시
 
-- **Current:** Production Profile picker는 Web·Android·iOS의 각 Profile option 아바타 우상단에
-  `unreadNotificationCount > 0`이면 숫자 없는 `12` logical unit semantic `accent` dot을 표시한다. dot 자체는
-  접근성 트리에서 숨기고 option의 accessible name에만 `읽지 않은 알림 있음`을 덧붙이며, 정확한 count와
-  알림 내용은 노출하지 않는다. Profile 전환 뒤의 actor·서버 재조회, 셸 badge, Push·OS badge와 realtime
-  lifecycle은 기존 runtime 계약을 유지한다.
-- **Target:** DSN-40 Figma와 PROD-855의 `ProfileSwitcherTarget`은 닫힌 `full`·`drawer` trigger에 `8px`
-  `action/primary/base` dot, 닫힌 `compact` avatar에 canvas `1px` halo를 둔 `12px` dot을 표시한다. 열리면 닫힌
-  indicator를 숨기고 non-selected Profile row 오른쪽에 `24px` 숫자 badge를 표시해 `1`~`9`는 실제 값,
+- Production ProfileSwitcher는 닫힌 `full`·`drawer` trigger에 `8px` `action/primary/base` dot, 닫힌
+  `compact` avatar에 canvas `1px` halo를 둔 `12px` dot을 표시한다. indicator의 source는 selected Profile을
+  제외한 Profile 중 `unreadNotificationCount > 0`인 항목의 존재 여부다. 열리면 닫힌 indicator를 숨기고
+  non-selected Profile row 오른쪽에 `24px` 숫자 badge를 표시해 `1`~`9`는 실제 값,
   `10` 이상은 `9+`로 축약한다. selected row는 count badge 대신 기존 check를 표시해 두 요소가 겹치지 않게
   한다. indicator와 badge는 접근성 트리에서 숨기고 Profile option의 accessible name은 정확한 count 대신
   `읽지 않은 알림 있음`만 유지한다. full·drawer chevron은 기존 20px를 유지하고 dot은 chevron 우상단 기준 `right: -9px`, `top: -4px`,
-  compact dot은 40px avatar 기준 `right: 0`, `top: 0`으로 배치한다. 이 Target은 Storybook 검토 표면이며 Production runtime 연결과 unread
-  data·Relay·badge lifecycle 이관은 PROD-786이 소유한다.
+  compact dot은 40px avatar 기준 `right: 0`, `top: 0`으로 배치한다. Profile 전환 뒤의 actor·서버 재조회,
+  selected Profile 셸 badge, 알림 목록, Push·OS badge와 realtime lifecycle은 기존 runtime 계약을 유지한다.
 
 ## 알림 Unread badge
 

--- a/openspec/changes/show-profile-switcher-unread-presence/decisions.md
+++ b/openspec/changes/show-profile-switcher-unread-presence/decisions.md
@@ -1,65 +1,63 @@
 ## Context
 
-이 로그는 `PROD-643`과 `docs/design/breakpoints.md`의 Profile picker Unread 표시·접근성 계약을 구현 가능한
-경계로 기록한다. 기존 selected Profile 셸 badge의 독립 계약도 함께 반영한다.
+이 로그는 PROD-643에서 시작한 Profile picker Unread 표시를 DSN-40·PROD-855·PROD-786의 최신
+ProfileSwitcher 계약으로 갱신한다. selected Profile 셸 badge와 Profile 전환 lifecycle은 독립 계약으로 유지한다.
 
 ## Decision Records
 
-### selected Profile을 포함한 avatar 우상단 12-unit 존재 표시
+### 닫힌 trigger는 Other Unread 존재만 표시한다
 
-- Decision Date: 2026-08-04
+- Decision Date: 2026-09-09
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/breakpoints.md`, `docs/design/accessibility.md`,
-  `docs/design/colors.md`, `PROD-643`
+  `docs/design/colors.md`, `DSN-40`, `PROD-786`
 - Status: Active
-- Context / Problem: 사용자는 Profile을 전환하기 전에 다른 Profile에 Unread가 있는지 알 수 없으며, selected
-  Profile도 picker option으로 같은 상태를 일관되게 보여야 한다.
-- Decision Outcome: Web·Android·iOS의 selected/non-selected Profile option 아바타 우상단에
-  `unreadNotificationCount > 0`일 때만 숫자 없는 12 logical unit `accent` dot을 표시한다. dot은 행 geometry와
-  기존 selected check를 바꾸지 않는다.
-- Alternatives Considered: 8px dot은 기존 navigation icon badge와 구분이 약해 거절했다. option 행 끝 표시는
-  selected check와 경쟁해 거절했다. selected Profile 제외는 picker 내부 일관성을 깨므로 거절했다.
-- Consequences: 32px와 48px avatar 모두에서 overlay geometry를 검증해야 하며 compact, drawer, full,
-  Android, iOS surface에서 layout 회귀를 확인해야 한다.
-- Confirmation / Follow-up: Storybook visual/interaction과 platform별 수동 QA에서 위치·크기·행 target을 확인한다.
+- Context / Problem: 사용자는 picker를 열기 전에 다른 Profile의 Unread 존재를 알아야 하지만 selected Profile의
+  Unread는 기존 shell notification badge가 이미 표시한다.
+- Decision Outcome: selected Profile을 제외한 접근 가능한 Profile 중 `unreadNotificationCount > 0`인 항목이
+  하나라도 있을 때만 닫힌 trigger indicator를 표시한다. `full`·`drawer`는 20px chevron 옆 8px
+  `action/primary/base` dot, `compact`는 40px avatar 우상단의 canvas 1px halo가 있는 12px dot을 사용한다.
+  picker가 열리면 닫힌 indicator를 숨긴다.
+- Alternatives Considered: selected Profile count 사용은 기존 shell badge와 중복되고 Other Unread 목적을
+  충족하지 못해 제외했다. 모든 count를 합산하거나 client에서 보정하는 방식은 Profile별 서버 ownership을
+  흐려 제외했다.
+- Consequences: selected Profile에만 Unread가 있으면 ProfileSwitcher closed indicator는 숨겨지고 기존 shell
+  badge만 남는다.
+- Confirmation / Follow-up: selected count `0`, other count 양수 fixture와 실제 Shell query로 source와
+  open/closed 중복 방지를 검증한다.
 
-### dot은 숨기고 option에 boolean 접근성 상태를 추가한다
+### 열린 picker는 non-selected 행에 숫자 badge를 표시한다
 
-- Decision Date: 2026-08-04
+- Decision Date: 2026-09-09
 - Decision Class: Derived Contract
-- Authority / Provenance: `docs/design/breakpoints.md`, `docs/design/accessibility.md`, `PROD-643`
+- Authority / Provenance: `docs/design/breakpoints.md`, `docs/design/colors.md`, `DSN-40`, `PROD-786`
 - Status: Active
-- Context / Problem: 숫자 없는 시각 dot을 별도 accessibility element로 노출하면 중복 focus가 생기고, 다른
-  Profile의 정확한 count를 읽으면 승인 범위를 넘어선다.
-- Decision Outcome: dot은 접근성 트리와 focus 순서에서 숨긴다. Profile option accessible name은 기존 display
-  name과 handle을 유지하고 Unread가 있을 때만 `읽지 않은 알림 있음`을 추가한다. selected/disabled state와
-  option role은 독립적으로 유지한다.
-- Alternatives Considered: exact count 읽기는 이번 picker의 존재 표시 범위를 넘어 거절했다. dot 자체 label은
-  중복 탐색을 만들므로 거절했다. 시각 표시만 제공하는 방식은 screen reader 사용자가 상태를 알 수 없어 거절했다.
-- Consequences: Profile option이 명시적 accessible name을 갖게 되므로 기존 role·selected state가 덮이지 않는지
-  Web screen reader, TalkBack, VoiceOver에서 확인해야 한다.
-- Confirmation / Follow-up: 큰 count가 숫자로 읽히지 않는지와 dot이 별도 element가 아닌지를 자동화하고,
-  platform 수동 QA에서 읽기 순서를 확인한다.
+- Context / Problem: 최신 picker는 Profile별 Unread 존재뿐 아니라 작은 범위의 count를 비교할 수 있어야 하며,
+  selected 행의 기존 check와 trailing geometry를 보존해야 한다.
+- Decision Outcome: Unread가 있는 non-selected Profile 행 오른쪽 24px slot에 `1`~`9` 또는 `9+` badge를
+  표시한다. selected 행은 count와 무관하게 기존 check만 표시하고 count `0`인 non-selected 행은 slot을 비운다.
+  badge는 `action/primary/base`, `action/primary/on-base`, `ui/label/s`를 사용한다.
+- Alternatives Considered: avatar dot은 최신 숫자 계약을 표현하지 못해 supersede했다. selected 행에 badge와
+  check를 함께 표시하는 방식은 canonical 계약과 trailing geometry를 깨므로 제외했다.
+- Consequences: 시각적 `9+`는 실제 count의 축약이며 data나 접근성 값을 변경하지 않는다.
+- Confirmation / Follow-up: 0·1·9·10 이상과 selected/non-selected 조합을 Storybook과 Web E2E에서 검증한다.
 
-### picker 존재 상태와 기존 8px 셸 badge를 분리한다
+### 정확한 count 표시는 presentation에 한정하고 기존 lifecycle을 유지한다
 
-- Decision Date: 2026-08-04
+- Decision Date: 2026-09-09
 - Decision Class: Derived Contract
 - Authority / Provenance: `docs/design/breakpoints.md`, `docs/design/accessibility.md`,
-  `docs/design/colors.md`, `PROD-643`
+  `docs/domain/objects/notification.md`, `PROD-643`, `PROD-786`
 - Status: Active
-- Context / Problem: 기존 navigation badge는 selected Profile의 8px dot과 실제 count accessible name을
-  제공하지만, picker는 모든 Profile의 12-unit dot과 boolean accessible name을 요구한다.
-- Decision Outcome: picker는 기존 셸 badge 컴포넌트와 controller를 재사용하지 않는다. 두 dot은
-  `accent`·원형·접근성 숨김만 presentation-only `UnreadDot`으로 공유하고, 표시 조건·geometry·selector와
-  accessible name은 각 호출부가 소유한다. Profile 선택 성공 뒤 기존 `resetActor`, 셸 badge와 알림 목록의
-  서버 재조회 수렴 계약은 변경하지 않는다.
-- Alternatives Considered: 기존 badge에 size와 mode를 추가하는 일반화는 서로 다른 표시와 접근성 계약을 한
-  컴포넌트에 결합해 거절했다. picker 존재 표시를 셸 badge count로 사용하는 방식은 exact count와 selected
-  Profile 격리를 잃어 거절했다.
-- Consequences: 작은 semantic primitive가 추가되지만 두 consumer의 geometry와 접근성 label 계약은 분리된다.
-- Confirmation / Follow-up: 기존 badge 자동 검증을 유지하고 Profile 전환 E2E에서 새 actor의 badge와 알림 목록
-  수렴을 확인한다.
+- Context / Problem: 숫자 badge가 새 data fetch, Profile 격리 변경 또는 중복 accessibility element를 만들면
+  기존 알림 수렴 계약을 깨뜨릴 수 있다.
+- Decision Outcome: 기존 `ProfileSwitcher_query.me.profiles[].unreadNotificationCount`만 사용한다. closed
+  indicator와 open badge 자체는 접근성 트리에서 숨기고 Profile option에는 count 없는
+  `읽지 않은 알림 있음`만 추가한다. Profile 생성·선택, navigation guard, actor reset, selected Profile shell
+  badge와 알림 목록 수렴을 변경하지 않는다.
+- Alternatives Considered: 별도 picker refresh와 exact count announcement는 승인 범위 밖이므로 제외했다.
+- Consequences: shell query 재실행 전에는 표시가 서버 최신 상태와 시차가 날 수 있으며 기존 Relay 수렴에 맡긴다.
+- Confirmation / Follow-up: Profile 전환 E2E와 기존 notification regression을 유지한다.
 
 ## Remaining Decisions
 
@@ -67,17 +65,28 @@
 
 ## Superseded Decisions
 
+### selected Profile을 포함한 avatar 우상단 12-unit 존재 표시
+
+- Original Decision Date: 2026-08-04
+- Superseded Date: 2026-09-09
+- Previous Outcome: 열린 picker의 selected/non-selected Profile avatar 우상단에 숫자 없는 12-unit dot을
+  표시한다.
+- Superseded By: 닫힌 Other Unread indicator와 열린 non-selected 숫자 badge 계약.
+- Reason: DSN-40과 PROD-786이 ProfileSwitcher의 최신 closed·opened presentation을 확정했다.
+
+### picker 존재 상태와 기존 8px 셸 badge의 avatar-dot presentation 공유
+
+- Original Decision Date: 2026-08-04
+- Superseded Date: 2026-09-09
+- Previous Outcome: picker와 shell badge가 `UnreadDot` primitive의 원형·색·접근성 숨김을 공유한다.
+- Superseded By: ProfilePicker의 24px 숫자 badge와 closed trigger별 indicator markup.
+- Reason: 최신 picker는 숫자와 `action/primary` tokens를 사용하므로 기존 숫자 없는 avatar dot primitive와
+  presentation 계약이 다르다.
+
 ### 별도 Unread query와 last-success request lifecycle
 
 - Original Decision Date: 2026-08-04
 - Superseded Date: 2026-08-05
-- Decision Class: Implementation Choice
-- Previous Outcome: picker open마다 별도 non-suspending Relay query를 실행하고, 임시 Store의 boolean
-  last-success snapshot과 Account·environment·generation·request-version guard로 결과를 관리한다.
-- Superseded By: 기존 `ProfileSwitcher_query`가 소유한 `me.profiles[].unreadNotificationCount`를 선언해
-  option에서 양수 여부를 직접 표시한다.
-- Reason: 원래 Linear 제품 요구사항은 별도 refresh lifecycle을 요구하지 않았고, PR #506 리뷰에서 해당 필드가
-  Account가 접근 가능한 Profile Node의 정상 데이터이며 기존 Relay fragment·Store lifecycle을 재사용할 수
-  있음이 확인됐다.
-- Consequences: 전용 query, 임시 Environment/Store, last-success snapshot, request identity helper와 lifecycle
-  테스트를 제거한다. dot은 기존 shell query가 다시 실행될 때 최신 서버 상태로 수렴한다.
+- Previous Outcome: picker open마다 별도 query와 last-success snapshot을 관리한다.
+- Superseded By: 기존 `ProfileSwitcher_query.me.profiles[].unreadNotificationCount` 재사용.
+- Reason: 새 lifecycle 없이 기존 Relay ownership으로 요구사항을 충족할 수 있다.

--- a/openspec/changes/show-profile-switcher-unread-presence/design.md
+++ b/openspec/changes/show-profile-switcher-unread-presence/design.md
@@ -1,87 +1,85 @@
 ## Context
 
-`ProfileSwitcher`는 기존 셸 query의 `ProfileSwitcher_query` fragment에서 Account가 접근할 수 있는
-`me.profiles`와 각 Profile option을 읽는다. PROD-643은 이 option에 서버가 이미 제공하는
-`Profile.unreadNotificationCount`의 양수 여부를 표시하되, 정확한 count나 다른 Profile의 알림 내용을 노출하지
-않는다.
+`ProfileSwitcher_query`는 Account가 접근할 수 있는 `me.profiles`와 각 Profile의 서버 제공
+`unreadNotificationCount`를 이미 읽는다. PROD-643은 이 값을 열린 picker의 avatar dot에 연결했고,
+PROD-855는 DSN-40의 최신 closed·opened presentation을 `ProfileSwitcherTarget`과 Storybook에 구현했다.
+PROD-786은 새 query나 상태 lifecycle 없이 이 최신 presentation을 실제 `ProfileSwitcher`와 공용
+`ProfilePicker`에 연결한다.
 
-기존 selected Profile 알림 badge는 현재 actor의 count와 알림 목록을 소유한다. picker의 12-unit boolean dot은
-그 8px badge와 표시·접근성 목적과 geometry가 다르므로 badge component·controller 계약을 재사용하지
-않는다. 단, 두 dot의 `accent`·원형·접근성 숨김 invariant만 presentation-only primitive로 공유한다.
+`ProfilePicker`는 Shell ProfileSwitcher와 Post Composer가 공유한다. Composer fixture는 Unread count를
+전달하지 않으므로 badge가 나타나지 않아야 하며, 이번 변경은 Composer의 선택·실패·focus 동작을 바꾸지 않는다.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- selected/non-selected option 모두에 12 logical unit `accent` dot과 count 없는 접근성 상태를 제공한다.
-- count `0` 또는 표시할 수 없는 Profile에는 잘못된 dot을 표시하지 않는다.
-- 기존 Profile 선택 mutation, actor reset, 8px 셸 badge와 알림 목록 수렴을 보존한다.
-- 기존 Relay fragment와 Store lifecycle을 그대로 사용한다.
+- 닫힌 trigger에서 selected Profile을 제외한 Other Unread 존재를 표시한다.
+- 열린 picker에서 non-selected Profile의 정확한 count를 `1`~`9` 또는 `9+`로 표시한다.
+- indicator·badge를 접근성 트리에서 숨기고 option에는 boolean Unread 상태만 전달한다.
+- 기존 Profile 생성·선택, navigation guard, actor reset과 selected Profile 알림 격리를 보존한다.
 
 **Non-Goals:**
 
 - GraphQL schema·resolver, DB·migration 또는 dependency를 변경하지 않는다.
-- 다른 Profile의 알림 내용·정확한 count를 표시하지 않는다.
-- picker open 전용 refresh, retry, last-success snapshot 또는 request identity lifecycle을 추가하지 않는다.
-- 기존 `UnreadNotificationBadge`의 8px geometry나 실제 count 접근성 계약을 변경하지 않는다.
-- Profile 자동 전환·자동 읽음 처리, push·OS app icon badge 또는 realtime delivery를 추가하지 않는다.
-- picker의 breakpoint별 surface, 목록 scroll, 선택·생성 흐름을 다시 설계하지 않는다.
+- picker open 전용 refresh, retry, snapshot 또는 request identity lifecycle을 추가하지 않는다.
+- selected Profile 셸 badge, 알림 목록, Push·OS badge 또는 realtime delivery를 재구현하지 않는다.
+- ProfileSwitcher 전체 구조를 Target으로 교체하거나 ProfilePicker 공개 API를 미래 용도로 일반화하지 않는다.
 
 ## Implementation Guidance
 
 ### Current Constraints
 
-- `ProfileSwitcher_query`가 이미 `me.profiles`의 identity, label과 avatar를 소유한다.
-- `Profile.unreadNotificationCount`는 Account–Profile membership으로 접근 권한을 확인하는 기존 non-null
-  필드이며 schema·resolver 변경이 필요 없다.
-- Profile option은 surface에 따라 Web button·`menuitemradio` 또는 Native radio semantics를 사용한다.
-  Unread 접근성 이름을 추가하면서 selected/disabled state와 role을 덮어쓰면 안 된다.
+- `ProfileSwitcher_query.me.profiles[].unreadNotificationCount`는 이미 Relay artifact에 포함돼 있다.
+- `ProfileSwitcher`는 profile summary, create form, navigation guard, modal과 actor reset을 함께 소유하지만
+  `ProfileSwitcherTarget`은 presentation-only trigger와 list만 소유한다.
+- 닫힌 indicator는 selected Profile의 shell badge와 중복되지 않도록 `profile.id !== selectedProfileId`인
+  Profile만 검사해야 한다.
+- selected row는 기존 check를 유지하고 count badge를 동시에 표시하지 않는다.
 
 ### Recommended Approach
 
-1. 기존 `ProfileSwitcher_query`의 `me.profiles` selection에 `unreadNotificationCount`를 선언한다.
-2. 각 option에서 `profile.unreadNotificationCount > 0`만 계산해 12-unit dot과 boolean 접근성 이름에 사용한다.
-   별도 local snapshot이나 network lifecycle은 두지 않는다.
-3. dot은 avatar wrapper 안의 absolute upper-right overlay로 두고 `accent` token과 원형 radius를 사용한다.
-   모든 접근성 platform에서 dot 자체를 숨긴다.
-4. presentation-only `UnreadDot`은 `accent`·원형·접근성 숨김만 소유한다. picker와 셸 badge
-   호출부는 각각 표시 조건, 12/8px geometry, offset, test selector와 accessible name을 계속 소유한다.
-5. 기존 display name과 relative handle을 유지하고, Unread가 있을 때만 `읽지 않은 알림 있음`을 option 이름에
-   추가한다. selected/disabled state, role, press handler와 check는 그대로 둔다.
-6. Storybook에서 0·양수·큰 count, selected/non-selected, geometry와 접근성 이름을 검증한다. Web E2E에서는 최신
-   shell query를 받은 뒤 다른 Profile의 dot을 확인하고 선택해 기존 actor 재조회와 셸 badge·알림 목록 수렴을
-   검증한다.
+1. Target과 Production trigger 모두 `profiles.some(profile.id !== selectedProfileId && count > 0)`에서
+   Other Unread를 파생한다.
+2. 닫힌 non-compact trigger의 20px chevron wrapper에 8px dot을 배치하고 compact avatar wrapper에는
+   canvas 1px halo가 있는 12px dot을 배치한다. `open=true`이면 둘 다 렌더링하지 않는다.
+3. `ProfilePicker`의 기존 avatar dot을 제거하고 trailing 24px slot에서 non-selected 행의 숫자 badge 또는
+   selected check 중 하나만 렌더링한다.
+4. count가 양수인 option의 accessible name은 기존 boolean 문구를 유지하고 indicator·badge 자체는 숨긴다.
+5. Target Storybook은 selected count `0`, other count 양수 fixture로 closed indicator의 source를 검증한다.
+   Production Shell Storybook과 Web E2E는 closed indicator → open numeric badge → 기존 actor·notification
+   수렴을 검증한다.
 
 ### Allowed Alternatives
 
-- 공통 `UnreadDot` primitive는 semantic presentation invariant만 공유할 수 있다. 12 logical unit picker dot과
-  8px 셸 badge의 geometry·test selector·visibility·accessible name 계약을 primitive prop으로 일반화하지
-  않아야 한다.
+- 같은 semantic token과 geometry를 유지한다면 indicator·badge의 작은 presentation helper를 재사용할 수 있다.
+  현재 consumer 수와 단순 markup만으로 별도 public component를 만들 필요는 없다.
 
 ### Known Traps
 
-- selected Profile badge의 count를 모든 option에 복사하면 Profile별 상태가 섞인다.
-- exact count를 option label에 넣거나 dot을 accessible element로 남기면 승인 범위 밖 숫자 또는 중복 상태를 읽는다.
-- option 행 끝에 dot을 배치하면 selected check와 경쟁하거나 행 geometry를 바꿀 수 있다.
-- unread 표시를 이유로 기존 Profile 선택·actor reset 흐름을 변경하면 알림 목록과 셸 badge 수렴이 깨진다.
+- selected Profile count로 closed indicator를 계산하면 Other Unread가 없을 때 selected shell badge와 중복되고,
+  다른 Profile에만 Unread가 있을 때 표시가 누락된다.
+- selected row에 badge와 check를 함께 표시하면 canonical trailing geometry와 충돌한다.
+- exact count를 accessible name에 넣거나 badge를 accessible element로 남기면 시각적 축약과 중복 announcement가
+  생긴다.
+- Target을 Production component 전체와 교체하면 create form, profile summary, modal과 navigation guard lifecycle을
+  잃는다.
 
 ## Risks / Trade-offs
 
-- 기존 shell query가 다시 실행되기 전까지 Profile option의 count가 최신 서버 상태와 시차가 날 수 있다. 이 dot은
-  상태 전이를 수행하는 control이 아니라 보조 존재 표시이며, 별도 picker refresh 비용과 lifecycle 복잡도를
-  추가하지 않는 쪽을 선택한다.
-- 12-unit overlay가 작은 avatar에서 경계를 벗어나거나 clip될 수 있다. compact, drawer, full, Android, iOS
-  surface에서 위치와 행 geometry를 확인한다.
+- 기존 shell query가 다시 실행되기 전까지 count에 시차가 날 수 있다. 별도 refresh lifecycle을 추가하지 않고
+  기존 Relay source of truth에 수렴한다.
+- `ProfilePicker`가 공유 component이므로 Composer 회귀 가능성이 있다. Unread count가 없는 Composer에서는
+  빈 trailing slot만 남고 선택·focus 동작은 유지되는지 기존 Storybook 검증으로 확인한다.
 
 ## Migration Plan
 
-1. Storybook fixture가 기존 shell fragment의 count만으로 0·양수·큰 count 표시를 검증하게 한다.
-2. `ProfileSwitcher_query`에 count를 추가하고 별도 query·snapshot·request guard를 제거한다.
-3. Relay artifact를 갱신하고 app type/Storybook 검증을 실행한다.
-4. Web E2E에서 최신 shell query 이후 dot → Profile 선택 → 기존 badge·알림 목록 수렴을 확인한다.
-5. Web keyboard/screen reader, Android TalkBack, iOS VoiceOver에서 option 이름·selected state·touch target을 확인한다.
-6. 문제가 있으면 fragment field와 picker presentation만 되돌린다. schema와 셸 badge는 변경하지 않으므로 데이터
-   migration은 필요 없다.
+1. OpenSpec의 PROD-643 avatar-dot 계약을 최신 canonical·PROD-786 계약으로 supersede한다.
+2. Target의 Other Unread 계산을 바로잡고 Storybook fixture를 정렬한다.
+3. Production trigger와 ProfilePicker presentation을 최소 변경한다.
+4. Relay/type, Storybook tests/build, targeted Web E2E와 OpenSpec strict validation을 실행한다.
+5. Web에서 full·compact closed/open geometry와 keyboard·focus를 시각·상호작용 확인한다. Android/iOS runtime과
+   assistive technology를 실행하지 못하면 미확인으로 남기고 change를 archive하지 않는다.
+6. 문제가 있으면 presentation과 tests/spec 변경만 되돌린다. data migration은 없다.
 
 ## Open Questions
 

--- a/openspec/changes/show-profile-switcher-unread-presence/proposal.md
+++ b/openspec/changes/show-profile-switcher-unread-presence/proposal.md
@@ -1,25 +1,29 @@
 ## Why
 
-현재 알림 badge는 selected Profile의 Unread 상태만 보여 주므로 여러 Profile에 접근하는 사용자는 다른 Profile에
-Unread 알림이 생겼는지 전환 전에는 알 수 없다. 기존 selected Profile 셸 badge와 알림 목록의 격리 계약을
-유지하면서 Profile picker 안에서 각 Profile의 Unread 존재만 알려야 한다.
+PROD-643은 열린 Profile picker의 숫자 없는 Unread 존재 dot을 Production에 연결했다. 이후 DSN-40과
+PROD-855는 닫힌 trigger의 Other Unread indicator와 열린 non-selected 행의 숫자 badge를 최신 공용 UI
+계약으로 확정했다. 기존 Profile별 `unreadNotificationCount`와 Profile 전환 lifecycle은 유지하면서 이 최신
+표시 계약을 실제 Web·Android·iOS ProfileSwitcher에 동기화해야 한다.
 
 ## What Changes
 
-- selected Profile을 포함해 Unread가 있는 Profile option의 아바타 우상단에 숫자 없는 `12` logical unit
-  `accent` dot을 표시한다.
-- dot은 접근성 트리와 focus 순서에서 숨기고 Profile option의 accessible name에 정확한 count 대신
-  `읽지 않은 알림 있음`만 추가한다.
-- 각 Profile option의 서버 제공 `unreadNotificationCount`가 양수인지 여부만 사용하고, count가 `0`이거나
-  option을 표시할 수 없으면 잘못된 dot을 표시하지 않는다.
-- 기존 Profile 선택 mutation, actor reset, selected Profile의 8px 셸 badge와 알림 목록 수렴 계약은 유지한다.
+- 닫힌 `full`·`drawer` trigger는 다른 Profile에 Unread가 있을 때 chevron 옆에 8px action-primary dot을
+  표시한다.
+- 닫힌 `compact` trigger는 같은 조건에서 avatar 우상단에 canvas 1px halo가 있는 12px dot을 표시한다.
+- picker가 열리면 닫힌 indicator를 숨기고, Unread가 있는 non-selected Profile 행 오른쪽에 24px 숫자 badge를
+  표시한다. `1`~`9`는 실제 값, `10` 이상은 `9+`로 표시하며 selected 행은 기존 check를 유지한다.
+- indicator와 badge는 접근성 트리에서 숨기고, Profile option의 accessible name에는 정확한 count 대신
+  `읽지 않은 알림 있음`만 유지한다.
+- 기존 Profile 선택·생성, navigation guard, actor reset, selected Profile 셸 badge와 알림 목록 수렴 계약은
+  변경하지 않는다.
 
 ## Authority / Provenance
 
 - Canonical: `docs/design/breakpoints.md`, `docs/design/accessibility.md`, `docs/design/colors.md`,
   `docs/domain/objects/notification.md`
-- Linear Contract: `PROD-643`
-- Linear Implementations: `PROD-643`
+- Linear Contract: `PROD-643`, `DSN-40`, `PROD-786`
+- Storybook·공용 UI 선행 구현: `PROD-855`
+- Production 구현·통합 검증: `PROD-786`
 
 ## Capabilities
 
@@ -29,12 +33,13 @@ Unread 알림이 생겼는지 전환 전에는 알 수 없다. 기존 selected P
 
 ### Modified Capabilities
 
-- `web-app-shell`: Profile picker의 Profile별 Unread 존재 표시와 접근성 계약을 추가한다.
+- `web-app-shell`: ProfileSwitcher의 닫힌 Other Unread indicator와 열린 Profile별 숫자 badge 계약을 추가한다.
 
 ## Impact
 
-- Profile picker 표시: `apps/app/src/components/shell/ProfileSwitcher.tsx`
-- Relay 생성 산출물: 기존 ProfileSwitcher fragment와 이를 포함하는 query artifact
-- 가장 가까운 자동 검증: `apps/app/src/stories/patterns/Shell.stories.tsx`,
-  `apps/web/e2e/profile-switcher.e2e.ts`
-- GraphQL schema, resolver, DB·migration, 패키지 dependency와 기존 셸 badge 구현은 변경하지 않는다.
+- Production 표시: `apps/app/src/components/shell/ProfileSwitcher.tsx`,
+  `apps/app/src/components/profile/ProfilePicker.tsx`
+- 공용 UI 정합성: `apps/app/src/components/shell/ProfileSwitcherTarget.tsx`
+- 검증: `apps/app/src/stories/patterns/ProfileSwitcher.stories.tsx`,
+  `apps/app/src/stories/patterns/Shell.stories.tsx`, `apps/web/e2e/profile-switcher.e2e.ts`
+- GraphQL schema·resolver, DB·migration, package dependency와 기존 셸 badge controller는 변경하지 않는다.

--- a/openspec/changes/show-profile-switcher-unread-presence/specs/web-app-shell/spec.md
+++ b/openspec/changes/show-profile-switcher-unread-presence/specs/web-app-shell/spec.md
@@ -1,78 +1,107 @@
 ## ADDED Requirements
 
-### Requirement: Profile picker의 Profile별 Unread 존재 표시
+### Requirement: 닫힌 ProfileSwitcher의 Other Unread 표시
 
-Profile picker는 접근 가능한 각 Profile의 visible Unread 존재 여부를 표시해야 한다(MUST).
+ProfileSwitcher는 picker를 열기 전에 selected Profile을 제외한 접근 가능한 Profile의 visible Unread 존재를 표시해야 한다(MUST).
 
 **Authority / Provenance:** `docs/design/breakpoints.md`, `docs/design/accessibility.md`,
-`docs/design/colors.md`, `docs/domain/objects/notification.md`, `PROD-643` — Profile picker는 Account가
-접근할 수 있는 각 Profile에 visible Unread 알림이 있는지를 selected Profile을 포함한 같은 Profile option에
-표시해야 한다(MUST). 서버 제공 `Profile.unreadNotificationCount`가 양수인 option은 아바타 우상단에 숫자 없는
-`12` logical unit(Web CSS px·iOS pt·Android dp) `accent` dot을 표시해야 한다(MUST). dot은 Profile option의
-행 폭, label, pointer·touch target과 기존 selected check의 배치를 바꾸지 않아야 하며(MUST), 다른 Profile의
-알림 내용이나 정확한 count를 노출하거나 Profile을 자동 전환하거나 알림을 읽음 처리해서는 안 된다(MUST NOT).
+`docs/design/colors.md`, `docs/domain/objects/notification.md`, `DSN-40`, `PROD-786` — selected Profile이 아닌
+Profile 중 서버 제공 `unreadNotificationCount`가 양수인 항목이 하나라도 있으면 닫힌 trigger는 Other Unread
+indicator를 표시해야 한다(MUST). `full`·`drawer`는 20px chevron 옆에 8px `action/primary/base` dot을,
+`compact`는 40px avatar 우상단에 `background/canvas` 1px halo가 있는 12px dot을 사용해야 한다(MUST).
+picker가 열리면 닫힌 indicator를 중복 표시해서는 안 된다(MUST NOT).
 
-#### Scenario: Show unread presence for selected and non-selected Profiles
+#### Scenario: Show Other Unread on a closed full or drawer trigger
 
-- **GIVEN** Account가 접근할 수 있는 selected Profile과 non-selected Profile의 `unreadNotificationCount`가 모두 양수다
-- **WHEN** 사용자가 Web·Android·iOS 중 하나에서 Profile picker를 연다
-- **THEN** 시스템은 두 Profile option의 아바타 우상단에 각각 숫자 없는 `12` logical unit `accent` dot을 표시한다
-- **AND** selected Profile의 기존 check는 그대로 유지된다
+- **GIVEN** selected Profile의 `unreadNotificationCount`는 `0`이고 non-selected Profile의 count는 양수다
+- **WHEN** `full` 또는 `drawer` ProfileSwitcher가 닫혀 있다
+- **THEN** trigger는 `읽지 않은 알림 있음`을 포함한 accessible name을 가진다
+- **AND** 20px chevron 우상단의 지정 위치에 8px action-primary dot을 표시한다
+- **AND** dot은 별도 accessibility element로 노출되지 않는다
 
-#### Scenario: Hide a zero or unavailable Profile state
+#### Scenario: Show Other Unread on a closed compact trigger
 
-- **GIVEN** Profile option의 `unreadNotificationCount`가 `0`이거나 해당 option을 표시할 수 없다
-- **WHEN** 시스템이 Profile picker를 렌더링한다
-- **THEN** 시스템은 해당 Profile의 아바타에 Unread dot을 표시하지 않는다
+- **GIVEN** non-selected Profile의 `unreadNotificationCount`가 양수다
+- **WHEN** `compact` ProfileSwitcher가 닫혀 있다
+- **THEN** 40px selected Profile avatar 우상단에 canvas 1px halo가 있는 12px action-primary dot을 표시한다
+- **AND** avatar와 trigger의 layout·pointer·touch target을 바꾸지 않는다
 
-#### Scenario: Keep a large count numberless
+#### Scenario: Ignore selected-only Unread
 
-- **GIVEN** Profile의 `unreadNotificationCount`가 `127`이다
-- **WHEN** 시스템이 Profile option을 렌더링한다
-- **THEN** 시스템은 다른 양수 count와 같은 숫자 없는 `12` logical unit dot을 표시한다
-- **AND** 시각적 UI와 accessible name 어디에도 `127`을 노출하지 않는다
+- **GIVEN** selected Profile에만 Unread가 있고 모든 non-selected Profile의 count는 `0`이다
+- **WHEN** ProfileSwitcher가 닫혀 있다
+- **THEN** ProfileSwitcher trigger는 Other Unread indicator를 표시하지 않는다
+- **AND** selected Profile의 기존 notification shell badge 계약은 그대로 유지된다
 
-#### Scenario: Preserve the Profile option layout and action
+#### Scenario: Hide the closed indicator while open
 
-- **WHEN** Unread dot이 있는 Profile option을 렌더링하거나 사용자가 해당 option을 선택한다
-- **THEN** dot은 아바타 위에 겹쳐 표시되고 option의 label, hit target과 selected check를 밀지 않는다
-- **AND** 기존 Profile 선택 mutation과 actor 전환 동작을 그대로 실행한다
+- **GIVEN** non-selected Profile에 Unread가 있어 닫힌 indicator가 표시됐다
+- **WHEN** 사용자가 ProfileSwitcher를 연다
+- **THEN** 닫힌 trigger indicator는 사라진다
+- **AND** trigger의 기존 expanded 상태와 picker focus·dismiss lifecycle을 유지한다
 
-#### Scenario: Converge the selected Profile notification surfaces
+### Requirement: 열린 Profile picker의 숫자 Unread badge
 
-- **GIVEN** non-selected Profile의 picker option에 Unread dot이 표시되어 있다
-- **WHEN** 사용자가 해당 Profile을 선택하고 actor 전환이 성공한다
-- **THEN** 기존 selected Profile 셸 badge와 알림 목록은 선택한 Profile의 서버 상태로 수렴한다
-- **AND** picker의 숫자 없는 존재 표시를 정확한 badge count나 알림 목록 데이터로 사용하지 않는다
+열린 Profile picker는 Unread가 있는 non-selected Profile의 count를 trailing 숫자 badge로 표시해야 한다(MUST).
 
-### Requirement: Profile picker Unread 접근성
+**Authority / Provenance:** `docs/design/breakpoints.md`, `docs/design/accessibility.md`,
+`docs/design/colors.md`, `docs/domain/objects/notification.md`, `DSN-40`, `PROD-786` — badge는 24 logical unit
+원형 `action/primary/base` surface와 `action/primary/on-base` `ui/label/s` text를 사용해야 한다(MUST).
+`1`~`9`는 실제 숫자를, `10` 이상은 `9+`를 표시해야 하며(MUST), count `0`인 행에는 표시하지 않아야 한다
+(MUST NOT). selected 행은 count badge 대신 기존 check를 유지해야 한다(MUST).
 
-Profile picker의 Unread 표시는 기존 Profile option 안에서 중복 없이 접근 가능해야 한다(MUST).
+#### Scenario: Show counts from one through nine
 
-**Authority / Provenance:** `docs/design/breakpoints.md`, `docs/design/accessibility.md`, `PROD-643` —
-Profile Unread dot은 접근성 트리와 focus 순서에서 숨겨야 하며(MUST), 별도 접근성 element나 control로 노출해서는
-안 된다(MUST NOT). Profile option의 accessible name은 기존 표시 이름과 handle을 유지하고, 해당 Profile에
-Unread가 있을 때만 count 없는 `읽지 않은 알림 있음` 상태를 추가해야 한다(MUST). 기존 selected state와 option
-동작은 각 platform의 현재 접근성 계약을 유지해야 한다(MUST).
+- **GIVEN** non-selected Profile의 `unreadNotificationCount`가 `N`이고 `1 <= N <= 9`다
+- **WHEN** 사용자가 Profile picker를 연다
+- **THEN** 해당 행 오른쪽의 24 logical unit badge에 `N`을 표시한다
 
-#### Scenario: Announce boolean unread presence once
+#### Scenario: Cap a large count at nine plus
+
+- **GIVEN** non-selected Profile의 `unreadNotificationCount`가 `10` 이상이다
+- **WHEN** 사용자가 Profile picker를 연다
+- **THEN** 해당 행의 24 logical unit badge에 `9+`를 표시한다
+- **AND** 서버 count나 Relay record를 변경하지 않는다
+
+#### Scenario: Keep the selected check instead of a count badge
+
+- **GIVEN** selected Profile의 `unreadNotificationCount`가 양수다
+- **WHEN** 사용자가 Profile picker를 연다
+- **THEN** selected 행은 기존 check를 표시한다
+- **AND** 같은 trailing slot에 숫자 badge를 함께 표시하지 않는다
+
+#### Scenario: Hide zero Unread
+
+- **GIVEN** non-selected Profile의 `unreadNotificationCount`가 `0`이다
+- **WHEN** 사용자가 Profile picker를 연다
+- **THEN** 해당 행에 Unread badge를 표시하지 않는다
+
+### Requirement: ProfileSwitcher Unread 접근성과 lifecycle 보존
+
+ProfileSwitcher의 Unread presentation은 기존 Profile option 의미와 Profile 전환 수렴을 유지해야 한다(MUST).
+
+**Authority / Provenance:** `docs/design/breakpoints.md`, `docs/design/accessibility.md`,
+`docs/domain/objects/notification.md`, `PROD-643`, `PROD-786` — closed indicator와 open badge는 접근성 트리와
+focus 순서에서 숨겨야 하며(MUST), Profile option의 accessible name은 기존 표시 이름·handle과 count 없는
+`읽지 않은 알림 있음` 상태만 전달해야 한다(MUST). 기존 Profile 생성·선택, navigation guard, actor reset,
+selected Profile shell badge와 알림 목록 수렴을 변경해서는 안 된다(MUST NOT).
+
+#### Scenario: Announce boolean Unread once
 
 - **GIVEN** Profile의 `unreadNotificationCount`가 양수다
 - **WHEN** screen reader가 해당 Profile option을 탐색한다
-- **THEN** option은 기존 표시 이름과 handle에 `읽지 않은 알림 있음`을 더한 하나의 accessible name으로 노출된다
-- **AND** dot은 별도 focus 대상이나 중복 accessibility element로 노출되지 않는다
-- **AND** 정확한 Unread count는 읽지 않는다
+- **THEN** option은 이름·handle과 `읽지 않은 알림 있음`을 하나의 accessible name으로 전달한다
+- **AND** 정확한 count와 badge 자체는 별도로 읽지 않는다
 
-#### Scenario: Preserve the existing name without unread
+#### Scenario: Preserve selected state independently
 
-- **GIVEN** Profile의 `unreadNotificationCount`가 `0`이거나 해당 option을 표시할 수 없다
-- **WHEN** screen reader가 Profile picker를 탐색한다
-- **THEN** 표시된 option은 기존 표시 이름과 handle만 포함하는 accessible name을 유지한다
-- **AND** `읽지 않은 알림 있음`을 읽지 않는다
+- **WHEN** screen reader가 selected Profile option을 탐색한다
+- **THEN** 기존 selected state와 선택 동작을 유지한다
+- **AND** Unread 상태가 check의 의미를 대체하지 않는다
 
-#### Scenario: Preserve selected state independently from unread
+#### Scenario: Converge after Profile selection
 
-- **GIVEN** selected Profile에 Unread가 있다
-- **WHEN** screen reader가 해당 Profile option을 탐색한다
-- **THEN** option은 기존 selected 상태와 `읽지 않은 알림 있음` 상태를 함께 전달한다
-- **AND** Unread 상태는 selected check의 의미나 선택 동작을 대체하지 않는다
+- **GIVEN** non-selected Profile의 숫자 badge가 표시돼 있다
+- **WHEN** 사용자가 해당 Profile을 선택하고 actor 전환이 성공한다
+- **THEN** 기존 selected Profile shell badge와 알림 목록은 선택한 Profile의 서버 상태로 수렴한다
+- **AND** picker badge를 shell badge count나 알림 목록 데이터로 사용하지 않는다

--- a/openspec/changes/show-profile-switcher-unread-presence/tasks.md
+++ b/openspec/changes/show-profile-switcher-unread-presence/tasks.md
@@ -1,114 +1,116 @@
-## 1. PROD-643 기존 Profile 데이터 소유권 재사용
+## 1. 기존 data ownership 보존
 
 **Authority / Provenance**
 
-- `docs/design/breakpoints.md`
 - `docs/domain/objects/notification.md`
 - `PROD-643`
+- `PROD-786`
 
 **Deliverable**
 
-Profile picker는 기존 `ProfileSwitcher_query`가 소유한 각 Profile의 서버 제공
-`unreadNotificationCount`에서 Unread 존재 여부를 직접 파생한다. picker open 전용 query·Store·request
-lifecycle을 추가하지 않는다.
+ProfileSwitcher는 기존 shell query와 Relay Store의 Profile별 `unreadNotificationCount`를 그대로 사용한다.
 
 **Guardrails**
 
-- 기존 `me.profiles` fragment selection에 count를 선언하고 `> 0` boolean만 표시한다.
-- exact count를 UI 상태나 accessible name으로 노출하지 않는다.
-- GraphQL schema·resolver, DB·migration와 package dependency를 변경하지 않는다.
+- 별도 query, snapshot, client-side count 보정, schema·resolver·DB 변경을 추가하지 않는다.
+- selected Profile shell badge와 notification lifecycle을 변경하지 않는다.
 
 **Verification**
 
-- 테스트 코드 범위: `apps/app/src/stories/patterns/Shell.stories.tsx`의 가장 가까운 ProfileSwitcher interaction에서
-  기존 shell fragment fixture의 0·양수·큰 count가 올바른 boolean 표시로 이어지는지 검증한다.
-- Relay artifact와 app type check에서 기존 fragment consumer가 count를 제공하는지 확인한다.
-- 별도 request lifecycle unit test, fixture, helper와 retry/error 조합은 제외한다.
+- 기존 fragment와 generated artifact에서 Profile별 count ownership을 확인한다.
+- Profile 전환 E2E에서 기존 actor·shell badge·알림 목록 수렴을 유지한다.
 
-- [x] 1.1 `ProfileSwitcher_query`의 `me.profiles`에 `unreadNotificationCount`를 선언하고 option에서
-      `> 0`으로 직접 파생한다.
-- [x] 1.2 별도 Unread query, 임시 Relay Environment/Store, last-success snapshot, request identity helper와
-      전용 unit/interaction test를 제거한다.
-- [x] 1.3 Relay artifact를 갱신하고 app type check를 통과시킨다.
+- [x] 1.1 `ProfileSwitcher_query.me.profiles[].unreadNotificationCount`와 기존 Relay ownership을 재사용한다.
+- [x] 1.2 별도 query·snapshot·client count 보정과 schema·DB·dependency 변경을 추가하지 않는다.
 
-## 2. PROD-643 12-unit avatar dot과 접근성
+## 2. PROD-786 계약 정렬
 
 **Authority / Provenance**
 
 - `docs/design/breakpoints.md`
 - `docs/design/accessibility.md`
 - `docs/design/colors.md`
-- `PROD-643`
+- `DSN-40`
+- `PROD-786`
 
 **Deliverable**
 
-Web·Android·iOS의 selected/non-selected Profile option은 Unread가 있을 때 avatar 우상단에 숫자 없는 12 logical
-unit `accent` dot을 표시하며, screen reader는 기존 Profile 이름·handle과 boolean Unread 상태를 하나의 option으로
-읽는다.
+기존 PROD-643 avatar-dot 계약을 닫힌 Other Unread indicator와 열린 non-selected 숫자 badge 계약으로
+supersede하고 Production 이관 상태를 canonical 문서에 반영한다.
 
 **Guardrails**
 
-- dot은 option의 행 폭, label, pointer·touch target과 selected check를 밀지 않는다.
-- dot은 접근성 트리와 focus 순서에서 숨기고 별도 control로 만들지 않는다.
-- exact count는 시각적 UI와 accessible name에 노출하지 않는다.
-- 기존 selected state, role, disabled state, 선택 mutation·actor reset과 8px 셸 badge 구현을 변경하지 않는다.
+- selected 행은 기존 check를 유지한다.
+- Profile 생성·선택·actor lifecycle과 excluded Push·realtime·OS badge 범위를 넓히지 않는다.
 
 **Verification**
 
-- 테스트 코드 범위: `apps/app/src/stories/patterns/Shell.stories.tsx`의 가장 가까운 ProfileSwitcher interaction에
-  selected/non-selected, 0/양수/큰 count, 접근성 이름, dot 숨김과 layout 불변을 유지한다.
-- Web visual/interaction 자동 검증에 더해 Web·Android·iOS 수동 시각 QA에서 12-unit dot의 우상단 위치·크기,
-  avatar clipping과 행 geometry 불변을 확인하고, Android TalkBack과 iOS VoiceOver에서 접근성 이름, selected
-  state와 touch target을 확인한다.
-- exact count 표시, 새 알림 content UI, push·realtime·OS badge 검증은 승인 범위 밖이므로 추가하지 않는다.
+- proposal, delta spec, design, decisions와 tasks가 같은 closed·opened 계약을 설명하는지 확인한다.
+- OpenSpec strict validation과 formatting을 통과한다.
 
-- [x] 2.1 Profile option avatar의 12 logical unit `accent` dot을 selected/non-selected와 모든 surface에서 행
-      geometry를 바꾸지 않게 표시한다.
-- [x] 2.2 dot을 모든 platform의 접근성 트리에서 숨기고 option의 기존 이름·handle에 boolean
-      `읽지 않은 알림 있음`만 조건부로 추가한다.
-- [x] 2.3 0·양수·큰 count, selected/non-selected, 기존 check·hit target과 접근성 상태를 Storybook
-      interaction/visual fixture로 검증한다.
-- [ ] 2.4 Web·Android·iOS 적용 surface에서 12-unit dot의 위치·크기, avatar clipping과 행 geometry를 수동
-      시각 확인하고, Web keyboard/screen reader, Android TalkBack과 iOS VoiceOver QA를 실행하며 확인하지 못한
-      platform 항목을 명시한다.
+- [x] 2.1 OpenSpec proposal·spec·design·decisions·tasks를 PROD-786 provenance와 최신 계약으로 정렬한다.
+- [x] 2.2 `docs/design/breakpoints.md`의 Profile별 Unread 상태를 Production current로 갱신한다.
 
-## 3. PROD-643 Profile 전환 수렴과 완료 검증
+## 3. 공용 UI와 Production 동기화
 
 **Authority / Provenance**
 
 - `docs/design/breakpoints.md`
-- `docs/design/accessibility.md`
-- `docs/domain/objects/notification.md`
-- `PROD-643`
+- `PROD-855`
+- `PROD-786`
 
 **Deliverable**
 
-다른 Profile의 picker Unread dot에서 Profile을 선택한 뒤 기존 actor 전환, selected Profile 8px 셸 badge와 알림
-목록이 새 Profile의 서버 상태로 수렴하며, PROD-643 범위의 자동·수동 검증과 OpenSpec 정합성 근거가 완료된다.
+Target과 실제 ProfileSwitcher가 같은 Other Unread source, closed indicator와 open numeric badge를 사용한다.
 
 **Guardrails**
 
-- picker 존재 표시를 셸 badge의 exact count나 알림 목록 데이터로 재사용하지 않는다.
-- 기존 Profile 선택 mutation, navigation guard, actor reset과 selected Profile 알림 격리 계약을 보존한다.
-- passing automation과 실행하지 못한 Web·Android·iOS runtime QA를 별도 근거로 보고한다.
-- 이 change는 PROD-643의 전체 선언 범위와 검증이 끝난 뒤에만 archive한다.
+- closed source는 selected Profile을 제외한다.
+- open 상태에는 closed indicator를 표시하지 않는다.
+- ProfilePicker의 selected check, label, hit target, 선택 handler와 Post Composer 동작을 유지한다.
 
 **Verification**
 
-- 테스트 코드 범위: `apps/web/e2e/profile-switcher.e2e.ts`에 최신 shell query 이후 다른 Profile의 dot 확인 →
-  Profile 선택 → 새 actor query와 selected Profile 셸 badge·알림 목록 수렴을 검증하는 최소 경로를 유지한다.
-- `@kosmo/app` unit·type/Relay·Storybook tests/build, targeted Web profile-switcher E2E와 기존 API notification
-  integration test를 실행한다.
-- 전체 OpenSpec strict validation, formatting/diff check와 독립 누락 검토를 통과한다.
-- 새 API/DB/dependency 동작이 없으므로 별도 API·DB 구현 test와 dependency audit 확장은 제외한다.
+- 테스트 코드 범위: `ProfileSwitcher.stories.tsx`, `Shell.stories.tsx`, `profile-switcher.e2e.ts`의 기존
+  ProfileSwitcher 계약.
+- 테스트 필요성: Other Unread source, full·compact geometry, open 중복 방지, 1~9·9+ badge와 actor 수렴.
+- 테스트 제외 범위: 새 fixture/helper/harness, 관련 없는 ProfilePicker consumer 조합과 coverage 확대.
 
-- [ ] 3.1 최신 shell query 이후 다른 Profile의 picker dot 확인부터 선택, 새 actor의 기존 셸 badge·알림 목록
-      수렴까지 Web E2E로 검증한다.
-- [x] 3.2 기존 selected Profile badge와 notification integration 회귀 test를 실행해 Profile 격리가 유지됨을
-      확인한다.
-- [ ] 3.3 app unit·Relay/type check·Storybook test/build와 targeted Web E2E를 실행하고 실패를 해소한다.
-- [x] 3.4 canonical 문서, Linear `PROD-643`, delta spec, decisions와 구현을 교차 확인하고 OpenSpec strict
-      validation·formatting/diff check를 통과시킨다.
-- [x] 3.5 독립 구현 리뷰에서 scope·Relay data ownership·접근성·검증 누락이 없는지 확인하고 actionable
-      finding을 반영한다.
-- [ ] 3.6 전체 task와 필요한 runtime QA 근거가 완료된 뒤 change를 main spec과 동기화하고 archive한다.
+- [x] 3.1 `ProfileSwitcherTarget`의 closed indicator를 selected count가 아닌 Other Unread에서 파생한다.
+- [x] 3.2 Production `ProfileSwitcher`에 full·drawer 8px dot, compact 12px halo dot과 open 숨김을 연결한다.
+- [x] 3.3 `ProfilePicker`의 avatar dot을 non-selected 24px `1`~`9`·`9+` badge로 교체하고 selected check와
+      boolean accessible name을 유지한다.
+
+## 4. 검증과 완료
+
+**Authority / Provenance**
+
+- `docs/design/accessibility.md`
+- `PROD-786`
+
+**Deliverable**
+
+공용 UI와 실제 Production surface의 자동·수동 증거를 분리해 확보하고, 전체 change 완료 조건을 충족할 때만
+archive한다.
+
+**Guardrails**
+
+- Storybook 정적 증거를 Web·Android·iOS runtime 완료로 일반화하지 않는다.
+- 실행하지 못한 platform과 assistive technology는 미확인으로 명시한다.
+
+**Verification**
+
+- Target·Shell Storybook interaction, app Relay/type/unit/Storybook build, targeted Web E2E를 실행한다.
+- Web full·compact closed/open geometry, pointer·keyboard·focus를 실제 렌더에서 확인한다.
+- 독립 구현 리뷰와 OpenSpec strict validation을 통과한다.
+
+- [x] 4.1 Target과 Production Shell Storybook에서 selected `0`·other 양수, full·compact geometry, open 숨김,
+      selected check와 `1`·`9+` badge를 검증한다.
+- [x] 4.2 targeted Web E2E에서 closed indicator → open badge → Profile 선택 → 기존 shell badge·알림 목록
+      수렴을 검증한다.
+- [x] 4.3 app Relay/type/unit/Storybook tests·build와 OpenSpec strict validation을 실행하고 실패를 해소한다.
+- [ ] 4.4 Web runtime 시각·keyboard·focus QA와 가능한 Android/iOS runtime·TalkBack·VoiceOver QA를 실행해
+      결과와 미확인 항목을 기록한다.
+- [x] 4.5 독립 구현 리뷰에서 scope·data ownership·접근성·shared consumer 회귀·검증 누락을 확인하고 finding을
+      반영한다.
+- [ ] 4.6 전체 task와 필요한 runtime QA가 완료된 뒤 main spec 동기화와 archive를 수행한다.


### PR DESCRIPTION
## 무엇을 변경했나요

- 기존 Relay `ProfileSwitcher_query.me.profiles[].unreadNotificationCount`를 재사용해 닫힌 Full/Drawer trigger와 Compact avatar에 Other Unread indicator를 연결했습니다.
- 열린 picker의 non-selected Profile에 1–9 또는 9+ 숫자 badge를 표시하고, selected Profile은 기존 check를 유지합니다.
- Target, Production Shell, Storybook, Web E2E, canonical 디자인 문서와 OpenSpec 계약을 같은 동작으로 정렬했습니다.

## 왜 변경했나요

[PROD-786](https://linear.app/byulmaru/issue/PROD-786/profileswitcher의-최신-unread-표시-계약을-production에-동기화한다)의 최신 ProfileSwitcher 계약을 Production에 적용해, 사용자가 picker를 열기 전에도 다른 Profile의 unread 존재를 알고 열린 picker에서는 Profile별 count 범위를 확인할 수 있게 합니다.

## 이번 PR의 주요 결정

없음. 최신 canonical 디자인 문서와 Linear를 대조한 [OpenSpec decisions](openspec/changes/show-profile-switcher-unread-presence/decisions.md)를 변경 없이 적용했습니다. 별도 query, dependency, schema·DB 변경이나 새 lifecycle은 추가하지 않았습니다.

## 어떻게 확인할 수 있나요

- GitHub Actions 전체 성공: Lint, Semgrep, Test (App), Web E2E 3개 shard 포함
- exact head에서 app unit test, Storybook static build, 전체 Storybook 111 files / 751 tests 통과
- 관련 Storybook 2 files / 70 tests와 격리 DB 기반 `profile-switcher.e2e.ts` 7/7 통과
- `git diff --check`, OpenSpec strict validation 통과
- 독립 구현 리뷰와 Ponytail 과설계 리뷰 모두 finding 없음

## 아직 어떤 문제가 남았나요

- 로컬 `pnpm --filter @kosmo/app check`는 Relay compile 후 PR과 무관한 기존 `SettingsLinkRow.test.ts:92` 타입 오류로 중단됐습니다. ignored `.expo/types/router.d.ts`가 있는 로컬 환경에서만 재현됐고, GitHub의 clean 환경 `Test (App)`은 성공했습니다.
- 실제 app route의 Web 수동 시각·keyboard·focus QA와 Android/iOS·TalkBack·VoiceOver는 미확인입니다.
- 따라서 OpenSpec runtime QA와 archive task는 이 PR과 별개로 active 상태를 유지합니다.

Stack: main -> PROD-786

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
