### PR TITLE
답글 알림에서 답글 본문과 게시글 동작을 제공한다

### DIFF
--- a/apps/app/src/components/notification/NotificationList.tsx
+++ b/apps/app/src/components/notification/NotificationList.tsx
@@ -11,6 +11,9 @@ import {
 } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 import { PageHeader } from '@/components/PageHeader';
+import { PostActionAuthenticationProvider } from '@/components/post/PostActionAuthentication';
+import { PostMediaViewerHostProvider } from '@/components/post/PostMediaViewerHost';
+import { PostReplyCoordinatorProvider } from '@/components/post/PostReplyCoordinator';
 import { getWebMobileShellHeader } from '@/components/shell/shellLayout';
 import { Button } from '@/components/ui/Button';
 import { Skeleton, StateView } from '@/components/ui/StateView';
@@ -35,6 +38,7 @@ const notificationListFragment = graphql`
   fragment NotificationList_profile on Profile
   @argumentDefinitions(count: { type: "Int", defaultValue: 20 }, cursor: { type: "String" })
   @refetchable(queryName: "NotificationListNextPageQuery") {
+    ...ReplyComposerSurface_profile
     notifications(first: $count, after: $cursor)
       @connection(key: "NotificationList_notifications") {
       edges {
@@ -126,50 +130,60 @@ export function NotificationList({ profile }: NotificationListProps) {
   };
 
   return (
-    <ScrollView
-      contentContainerStyle={styles.root}
-      refreshControl={
-        Platform.OS === 'web' ? undefined : (
-          <RefreshControl onRefresh={refresh} refreshing={refreshing} tintColor={theme.text} />
-        )
-      }
-    >
-      <NotificationPageHeader />
-      {notifications.length ? (
-        notifications
-      ) : (
-        <StateView
-          description="새로운 팔로우, 팔로우 요청, 답글, 반응 또는 재게시 알림이 생기면 여기에 표시돼요."
-          style={styles.state}
-          title="아직 알림이 없어요"
-        />
-      )}
-      {pagination.hasNext || loadError ? (
-        loadError ? (
-          <StateView
-            actionLabel="다시 시도"
-            alert
-            onAction={loadMore}
-            style={[styles.pagination, { borderColor: theme.border }]}
-            title="알림을 더 불러오지 못했어요"
-          />
-        ) : (
-          <View style={[styles.pagination, { borderColor: theme.border }]}>
-            <Button
-              accessibilityState={{
-                busy: pagination.isLoadingNext,
-                disabled: pagination.isLoadingNext,
-              }}
-              disabled={pagination.isLoadingNext}
-              onPress={loadMore}
-              tone="secondary"
-            >
-              {pagination.isLoadingNext ? '불러오는 중' : '더 불러오기'}
-            </Button>
-          </View>
-        )
-      ) : null}
-    </ScrollView>
+    <PostActionAuthenticationProvider>
+      <PostReplyCoordinatorProvider key={pagination.data.id} owner="list" profile={pagination.data}>
+        <PostMediaViewerHostProvider>
+          <ScrollView
+            contentContainerStyle={styles.root}
+            refreshControl={
+              Platform.OS === 'web' ? undefined : (
+                <RefreshControl
+                  onRefresh={refresh}
+                  refreshing={refreshing}
+                  tintColor={theme.text}
+                />
+              )
+            }
+          >
+            <NotificationPageHeader />
+            {notifications.length ? (
+              notifications
+            ) : (
+              <StateView
+                description="새로운 팔로우, 팔로우 요청, 답글, 반응 또는 재게시 알림이 생기면 여기에 표시돼요."
+                style={styles.state}
+                title="아직 알림이 없어요"
+              />
+            )}
+            {pagination.hasNext || loadError ? (
+              loadError ? (
+                <StateView
+                  actionLabel="다시 시도"
+                  alert
+                  onAction={loadMore}
+                  style={[styles.pagination, { borderColor: theme.border }]}
+                  title="알림을 더 불러오지 못했어요"
+                />
+              ) : (
+                <View style={[styles.pagination, { borderColor: theme.border }]}>
+                  <Button
+                    accessibilityState={{
+                      busy: pagination.isLoadingNext,
+                      disabled: pagination.isLoadingNext,
+                    }}
+                    disabled={pagination.isLoadingNext}
+                    onPress={loadMore}
+                    tone="secondary"
+                  >
+                    {pagination.isLoadingNext ? '불러오는 중' : '더 불러오기'}
+                  </Button>
+                </View>
+              )
+            ) : null}
+          </ScrollView>
+        </PostMediaViewerHostProvider>
+      </PostReplyCoordinatorProvider>
+    </PostActionAuthenticationProvider>
   );
 }
 
@@ -190,7 +204,7 @@ export function NotificationListState({
           <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
             {[0, 1, 2].map((item) => (
               <View key={item} style={[styles.skeletonItem, { borderColor: theme.border }]}>
-                <Skeleton circular height={28} width={28} />
+                <Skeleton circular height={48} width={48} />
                 <View style={styles.skeletonContent}>
                   <View style={styles.skeletonAvatarRow}>
                     <Skeleton circular height={28} width={28} />

--- a/apps/app/src/components/notification/NotificationListItem.test.ts
+++ b/apps/app/src/components/notification/NotificationListItem.test.ts
@@ -19,6 +19,7 @@ const readAt = '2026-07-21T12:00:00Z';
 type NotificationTypename =
   | 'FollowNotification'
   | 'FollowRequestNotification'
+  | 'ReplyNotification'
   | 'RepostNotification';
 
 function createEnvironment(typename: NotificationTypename = 'FollowNotification') {
@@ -106,6 +107,16 @@ describe('NotificationListItem Read cache', () => {
       requireRecord(environment, notificationId).__typename,
       'FollowRequestNotification',
     );
+    assert.equal(requireRecord(environment, notificationId).readAt, readAt);
+    assert.equal(requireRecord(environment, recipientId).unreadNotificationCount, 1);
+  });
+
+  it('normalizes a Reply Notification and Recipient Profile', () => {
+    const environment = createEnvironment('ReplyNotification');
+
+    commitReadPayload(environment, 'ReplyNotification');
+
+    assert.equal(requireRecord(environment, notificationId).__typename, 'ReplyNotification');
     assert.equal(requireRecord(environment, notificationId).readAt, readAt);
     assert.equal(requireRecord(environment, recipientId).unreadNotificationCount, 1);
   });

--- a/apps/app/src/components/notification/NotificationListItem.tsx
+++ b/apps/app/src/components/notification/NotificationListItem.tsx
@@ -1,13 +1,10 @@
-import { Link } from 'expo-router';
-import { MessageCircle, Repeat2, Smile, UserPlus } from 'lucide-react-native';
-import { useState } from 'react';
-import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { isPostContentDocumentV1 } from '@kosmo/core/post-content';
+import { useCallback } from 'react';
 import { graphql, useFragment, useMutation } from 'react-relay';
-import { Avatar } from '@/components/ui/Avatar';
 import { formatTimelineTimestamp } from '@/lib/date';
-import { useTheme } from '@/theme/ThemeProvider';
-import { fontFamilies, radii, spacing, typography } from '@/theme/tokens';
-import type { Href } from 'expo-router';
+import { NotificationListItemView } from './NotificationListItemView';
+import { ReplyNotificationPost } from './ReplyNotificationPost';
+import type { PostMediaItem } from '@/components/post/PostMediaImage';
 import type { FollowRequestNotificationListItem_notification$key } from './__generated__/FollowRequestNotificationListItem_notification.graphql';
 import type { NotificationListItem_notification$key } from './__generated__/NotificationListItem_notification.graphql';
 import type { NotificationListItemMarkReadMutation } from './__generated__/NotificationListItemMarkReadMutation.graphql';
@@ -19,24 +16,13 @@ type NotificationListItemProps = {
   notification: NotificationListItem_notification$key;
 };
 
-type NotificationRowProps = {
-  action: string;
-  avatarUrl: string | null | undefined;
-  destination: string;
-  href: Href;
-  id: string;
-  kind: 'follow' | 'followRequest' | 'reaction' | 'reply' | 'repost';
-  name: string;
-  readAt: string | null | undefined;
-  timestamp: string;
-};
-
 const notificationFragment = graphql`
   fragment NotificationListItem_notification on FollowNotification {
     id
     createdAt
     readAt
     profile {
+      id
       displayName
       handle
       relativeHandle
@@ -63,21 +49,46 @@ const notificationListItemMarkReadMutation = graphql`
   }
 `;
 
+function useNotificationRead() {
+  const [commitMarkRead] = useMutation<NotificationListItemMarkReadMutation>(
+    notificationListItemMarkReadMutation,
+  );
+  return useCallback(
+    (id: string) => {
+      commitMarkRead({
+        onError: () => undefined,
+        variables: { ids: [id] },
+      });
+    },
+    [commitMarkRead],
+  );
+}
+
+function actor(profile: {
+  avatar?: { url: string | null | undefined } | null;
+  displayName: string;
+  handle: string;
+  id: string;
+}) {
+  return {
+    avatarUrl: profile.avatar?.url,
+    id: profile.id,
+    name: profile.displayName || profile.handle,
+  };
+}
+
 export function NotificationListItem({ notification }: NotificationListItemProps) {
   const data = useFragment(notificationFragment, notification);
-  const name = data.profile.displayName || data.profile.handle;
+  const markRead = useNotificationRead();
 
   return (
-    <NotificationRow
-      action="팔로우했습니다"
-      avatarUrl={data.profile.avatar?.url}
-      destination="프로필"
-      href={`/${data.profile.relativeHandle}` as Href}
-      id={data.id}
+    <NotificationListItemView
+      actors={[actor(data.profile)]}
+      href={`/${data.profile.relativeHandle}`}
       kind="follow"
-      name={name}
-      readAt={data.readAt}
+      onNavigate={() => markRead(data.id)}
       timestamp={formatTimelineTimestamp(data.createdAt)}
+      unread={data.readAt === null}
     />
   );
 }
@@ -88,6 +99,7 @@ const followRequestNotificationFragment = graphql`
     createdAt
     readAt
     profile {
+      id
       displayName
       handle
       relativeHandle
@@ -105,19 +117,16 @@ export function FollowRequestNotificationListItem({
   notification: FollowRequestNotificationListItem_notification$key;
 }) {
   const data = useFragment(followRequestNotificationFragment, notification);
-  const name = data.profile.displayName || data.profile.handle;
+  const markRead = useNotificationRead();
 
   return (
-    <NotificationRow
-      action="팔로우를 요청했습니다"
-      avatarUrl={data.profile.avatar?.url}
-      destination="프로필"
-      href={`/${data.profile.relativeHandle}` as Href}
-      id={data.id}
+    <NotificationListItemView
+      actors={[actor(data.profile)]}
+      href="/follow-requests"
       kind="followRequest"
-      name={name}
-      readAt={data.readAt}
+      onNavigate={() => markRead(data.id)}
       timestamp={formatTimelineTimestamp(data.createdAt)}
+      unread={data.readAt === null}
     />
   );
 }
@@ -127,8 +136,8 @@ const reactionNotificationFragment = graphql`
     id
     createdAt
     readAt
-    type
     profile {
+      id
       displayName
       handle
       avatar {
@@ -140,6 +149,16 @@ const reactionNotificationFragment = graphql`
       id
       profile {
         relativeHandle
+      }
+      content {
+        bodyText
+        contentWarning
+        document
+        media {
+          id
+          altText
+          url
+        }
       }
     }
   }
@@ -151,19 +170,17 @@ export function ReactionNotificationListItem({
   notification: ReactionNotificationListItem_notification$key;
 }) {
   const data = useFragment(reactionNotificationFragment, notification);
-  const name = data.profile.displayName || data.profile.handle;
+  const markRead = useNotificationRead();
 
   return (
-    <NotificationRow
-      action={`${data.type} 반응을 남겼습니다`}
-      avatarUrl={data.profile.avatar?.url}
-      destination="게시글"
-      href={`/${data.post.profile.relativeHandle}/${data.post.id}` as Href}
-      id={data.id}
+    <NotificationListItemView
+      actors={[actor(data.profile)]}
+      href={`/${data.post.profile.relativeHandle}/${data.post.id}`}
       kind="reaction"
-      name={name}
-      readAt={data.readAt}
+      onNavigate={() => markRead(data.id)}
+      preview={toPreview(data.post)}
       timestamp={formatTimelineTimestamp(data.createdAt)}
+      unread={data.readAt === null}
     />
   );
 }
@@ -171,21 +188,9 @@ export function ReactionNotificationListItem({
 const replyNotificationFragment = graphql`
   fragment ReplyNotificationListItem_notification on ReplyNotification {
     id
-    createdAt
     readAt
-    profile {
-      displayName
-      handle
-      avatar {
-        id
-        url
-      }
-    }
     post {
-      id
-      profile {
-        relativeHandle
-      }
+      ...ReplyNotificationPost_post
     }
   }
 `;
@@ -196,19 +201,12 @@ export function ReplyNotificationListItem({
   notification: ReplyNotificationListItem_notification$key;
 }) {
   const data = useFragment(replyNotificationFragment, notification);
-  const name = data.profile.displayName || data.profile.handle;
+  const markRead = useNotificationRead();
+
   return (
-    <NotificationRow
-      action="답글을 남겼습니다"
-      avatarUrl={data.profile.avatar?.url}
-      destination="게시글"
-      href={`/${data.post.profile.relativeHandle}/${data.post.id}` as Href}
-      id={data.id}
-      kind="reply"
-      name={name}
-      readAt={data.readAt}
-      timestamp={formatTimelineTimestamp(data.createdAt)}
-    />
+    <NotificationListItemView kind="reply" unread={data.readAt === null}>
+      <ReplyNotificationPost onActivate={() => markRead(data.id)} post={data.post} />
+    </NotificationListItemView>
   );
 }
 
@@ -218,6 +216,7 @@ const repostNotificationFragment = graphql`
     createdAt
     readAt
     profile {
+      id
       displayName
       handle
       avatar {
@@ -229,6 +228,16 @@ const repostNotificationFragment = graphql`
       id
       profile {
         relativeHandle
+      }
+      content {
+        bodyText
+        contentWarning
+        document
+        media {
+          id
+          altText
+          url
+        }
       }
     }
   }
@@ -240,147 +249,55 @@ export function RepostNotificationListItem({
   notification: RepostNotificationListItem_notification$key;
 }) {
   const data = useFragment(repostNotificationFragment, notification);
-  const name = data.profile.displayName || data.profile.handle;
+  const markRead = useNotificationRead();
 
   return (
-    <NotificationRow
-      action="게시물을 재게시했습니다"
-      avatarUrl={data.profile.avatar?.url}
-      destination="게시글"
-      href={`/${data.post.profile.relativeHandle}/${data.post.id}` as Href}
-      id={data.id}
+    <NotificationListItemView
+      actors={[actor(data.profile)]}
+      href={`/${data.post.profile.relativeHandle}/${data.post.id}`}
       kind="repost"
-      name={name}
-      readAt={data.readAt}
+      onNavigate={() => markRead(data.id)}
+      preview={toPreview(data.post)}
       timestamp={formatTimelineTimestamp(data.createdAt)}
+      unread={data.readAt === null}
     />
   );
 }
 
-function NotificationRow({
-  action,
-  avatarUrl,
-  destination,
-  href,
-  id,
-  kind,
-  name,
-  readAt,
-  timestamp,
-}: NotificationRowProps) {
-  const theme = useTheme();
-  const [hovered, setHovered] = useState(false);
-  const [commitMarkRead] = useMutation<NotificationListItemMarkReadMutation>(
-    notificationListItemMarkReadMutation,
-  );
-  const web = Platform.OS === 'web';
-  const unread = readAt === null;
-  const unreadDescription = unread ? ' 읽지 않은 알림.' : '';
-  const markRead = () => {
-    commitMarkRead({
-      onError: () => undefined,
-      variables: { ids: [id] },
-    });
+function toPreview(post: {
+  content:
+    | {
+        bodyText: string;
+        contentWarning: string | null | undefined;
+        document: unknown;
+        media:
+          | ReadonlyArray<{
+              altText: string | null | undefined;
+              id: string;
+              url: string | null | undefined;
+            }>
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
+}) {
+  const content = post.content;
+  if (!content) {
+    return null;
+  }
+
+  return {
+    bodyText: content.bodyText,
+    contentWarning: content.contentWarning ?? null,
+    media:
+      content.media?.map<PostMediaItem>(({ altText, id, url }) => ({
+        altText: altText ?? null,
+        id,
+        url: url ?? null,
+      })) ?? null,
+    sensitiveMedia: isPostContentDocumentV1(content.document)
+      ? content.document.body.attrs?.sensitiveMedia === true
+      : false,
   };
-
-  return (
-    <View
-      onPointerEnter={web ? () => setHovered(true) : undefined}
-      onPointerLeave={web ? () => setHovered(false) : undefined}
-      style={[
-        styles.root,
-        {
-          backgroundColor: hovered ? theme.surface : unread ? theme.primarySubtle : theme.card,
-          borderBottomColor: theme.border,
-          borderLeftColor: unread ? theme.primary : 'transparent',
-        },
-      ]}
-    >
-      <View
-        accessibilityElementsHidden
-        importantForAccessibility="no-hide-descendants"
-        style={[styles.kind, { backgroundColor: theme.primary }]}
-      >
-        {kind === 'follow' || kind === 'followRequest' ? (
-          <UserPlus color={theme.text} size={18} strokeWidth={2} />
-        ) : kind === 'reaction' ? (
-          <Smile color={theme.text} size={18} strokeWidth={2} />
-        ) : kind === 'reply' ? (
-          <MessageCircle color={theme.text} size={18} strokeWidth={2} />
-        ) : (
-          <Repeat2 color={theme.text} size={18} strokeWidth={2} />
-        )}
-      </View>
-      <View style={styles.content}>
-        <View style={styles.avatarRow}>
-          <Link asChild href={href}>
-            <Pressable
-              accessibilityLabel={`${name} ${destination}로 이동.${unreadDescription}`}
-              accessibilityRole="link"
-              onPress={markRead}
-              style={styles.avatarLink}
-            >
-              <Avatar imageUri={avatarUrl} label={name} size={28} />
-            </Pressable>
-          </Link>
-          <Text style={[styles.time, { color: theme.textSecondary }]}>{timestamp}</Text>
-        </View>
-        <Link asChild href={href}>
-          <Pressable
-            accessibilityLabel={`${name}님이 ${action}. ${timestamp}.${unreadDescription} ${destination}로 이동`}
-            accessibilityRole="link"
-            onPress={markRead}
-            style={styles.copyLink}
-          >
-            <Text style={[styles.copy, { color: theme.text }]}>
-              <Text style={styles.name}>{name}</Text>님이 {action}
-            </Text>
-          </Pressable>
-        </Link>
-      </View>
-    </View>
-  );
 }
-
-const styles = StyleSheet.create({
-  root: {
-    alignItems: 'flex-start',
-    borderBottomWidth: 1,
-    borderLeftWidth: 4,
-    flexDirection: 'row',
-    gap: spacing.md,
-    paddingLeft: spacing.md,
-    paddingRight: spacing.lg,
-    paddingVertical: spacing.lg,
-  },
-  content: { flex: 1, gap: spacing.sm, minWidth: 0 },
-  kind: {
-    alignItems: 'center',
-    borderRadius: radii.full,
-    height: 28,
-    justifyContent: 'center',
-    width: 28,
-  },
-  avatarRow: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    height: 28,
-    justifyContent: 'space-between',
-  },
-  avatarLink: {
-    alignItems: 'center',
-    height: 44,
-    justifyContent: 'center',
-    margin: -spacing.sm,
-    width: 44,
-  },
-  copyLink: {
-    flex: 1,
-    marginVertical: -spacing.md,
-    minWidth: 0,
-    paddingVertical: spacing.md,
-  },
-  copy: { fontFamily: fontFamilies.ui, ...typography.sm },
-  name: { fontFamily: fontFamilies.ui, fontWeight: '700' },
-  time: { fontFamily: fontFamilies.ui, ...typography.xsm },
-});

--- a/apps/app/src/components/notification/NotificationListItemView.tsx
+++ b/apps/app/src/components/notification/NotificationListItemView.tsx
@@ -192,7 +192,7 @@ function NotificationTarget(props: GroupedNotificationProps) {
       }}
       onPointerDown={() => setFocusVisible(false)}
       onPress={blocked ? undefined : onNavigate}
-      style={[
+      style={StyleSheet.flatten([
         styles.target,
         {
           outlineColor: theme.stateFocusRing,
@@ -201,7 +201,7 @@ function NotificationTarget(props: GroupedNotificationProps) {
           outlineWidth: focusVisible ? 2 : 0,
           opacity: blocked ? 0.5 : 1,
         } as ViewStyle,
-      ]}
+      ])}
     >
       <View style={[styles.row, web && styles.webRow]}>
         <View

--- a/apps/app/src/components/notification/ReplyNotificationPost.tsx
+++ b/apps/app/src/components/notification/ReplyNotificationPost.tsx
@@ -1,4 +1,4 @@
-import { Link, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { MessageCircle } from 'lucide-react-native';
 import { useCallback } from 'react';
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
@@ -41,7 +41,13 @@ const ReplyNotificationPostFragment = graphql`
 `;
 
 /** Recipient-relative Reply presentation, composed inside NotificationListItemView. */
-export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificationPost_post$key }) {
+export function ReplyNotificationPost({
+  onActivate,
+  post: postKey,
+}: {
+  onActivate?: () => void;
+  post: ReplyNotificationPost_post$key;
+}) {
   const post = useFragment(ReplyNotificationPostFragment, postKey);
   const theme = useTheme();
   const router = useRouter();
@@ -51,6 +57,7 @@ export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificati
   const detailHref = `/${post.profile.relativeHandle}/${post.id}` as const;
   const onMediaOpen = useCallback<PostMediaOpenHandler>(
     (selectedIndex, originControl) => {
+      onActivate?.();
       openViewer({
         mediaOwnerPostId: post.id,
         originControl,
@@ -58,7 +65,7 @@ export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificati
         surfacePostId: post.id,
       });
     },
-    [openViewer, post.id],
+    [onActivate, openViewer, post.id],
   );
 
   if (!post.content) {
@@ -68,7 +75,7 @@ export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificati
   return (
     <>
       <View role="article" style={styles.root} testID="reply-notification-post">
-        <Link asChild href={profileHref}>
+        <NavigationLink href={profileHref} onNavigate={onActivate}>
           <Pressable
             aria-hidden
             accessibilityElementsHidden
@@ -84,10 +91,10 @@ export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificati
               size={48}
             />
           </Pressable>
-        </Link>
+        </NavigationLink>
         <View style={styles.content}>
           <View style={styles.header}>
-            <NavigationLink href={profileHref}>
+            <NavigationLink href={profileHref} onNavigate={onActivate}>
               <Pressable
                 accessibilityRole="link"
                 style={styles.author}
@@ -104,13 +111,13 @@ export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificati
                 </Text>
               </Pressable>
             </NavigationLink>
-            <Link asChild href={detailHref}>
+            <NavigationLink href={detailHref} onNavigate={onActivate}>
               <Pressable accessibilityRole="link" style={styles.timeLink}>
                 <Text style={[styles.time, { color: theme.foregroundSecondary }]}>
                   {formatTimelineTimestamp(post.createdAt)}
                 </Text>
               </Pressable>
-            </Link>
+            </NavigationLink>
           </View>
           <View style={styles.reasonRow}>
             <View
@@ -130,7 +137,10 @@ export function ReplyNotificationPost({ post: postKey }: { post: ReplyNotificati
           </View>
           <View style={styles.bodyLink}>
             <PostBody
-              onBodyPress={() => router.push(detailHref)}
+              onBodyPress={() => {
+                onActivate?.();
+                router.push(detailHref);
+              }}
               onMediaOpen={onMediaOpen}
               post={post}
             />

--- a/apps/app/src/stories/screens/Notifications.stories.tsx
+++ b/apps/app/src/stories/screens/Notifications.stories.tsx
@@ -2,7 +2,7 @@ import { usePathname } from 'expo-router';
 import { useState } from 'react';
 import { Text } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fireEvent, fn, screen, userEvent, waitFor, within } from 'storybook/test';
 import NotificationsScreen from '@/app/(tabs)/(protected)/notifications';
 import {
   NotificationList,
@@ -11,6 +11,8 @@ import {
 import { NotificationReadAllProvider } from '@/components/notification/NotificationReadAllContext';
 import { Button } from '@/components/ui/Button';
 import { useRelayActor } from '@/relay/RelayActorProvider';
+import { SessionProvider } from '@/session/SessionProvider';
+import { colors } from '@/theme/tokens';
 import {
   followNotification,
   followRequestNotification,
@@ -23,6 +25,7 @@ import {
 } from '../fixtures';
 import { Catalog, Section } from '../StoryFrame';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { RequestParameters, Variables } from 'relay-runtime';
 import type { NotificationsStoriesQuery as NotificationsStoriesQueryType } from './__generated__/NotificationsStoriesQuery.graphql';
 
 const unreadFollowerAvatarUrl =
@@ -56,6 +59,16 @@ const notificationRecipient = profile({
   id: 'notification-profile-content',
   relativeHandle: '@recipient',
 });
+const notificationReplyMedia = {
+  __typename: 'Media' as const,
+  altText: '답글 첨부 이미지',
+  id: 'notification-reply-media',
+  url: unreadFollowerAvatarUrl,
+};
+
+function notificationPost(options: Parameters<typeof post>[0] = {}) {
+  return { ...post(options), viewerReactions: [] };
+}
 
 const emptyProfile = notificationsProfile([], {}, { id: 'notification-profile-empty' });
 const contentProfile = notificationsProfile(
@@ -73,18 +86,27 @@ const contentProfile = notificationsProfile(
     followNotification({ id: 'notification-long', profile: longFollower }),
     reactionNotification({
       id: 'notification-reaction',
-      post: post({ id: 'notification-related-post', profile: notificationRecipient }),
+      post: notificationPost({ id: 'notification-related-post', profile: notificationRecipient }),
       profile: unreadFollower,
       type: '🎉',
     }),
     replyNotification({
       id: 'notification-reply',
-      post: post({ id: 'notification-reply-post', profile: notificationRecipient }),
+      post: notificationPost({
+        bodyText: '알림에서 바로 확인할 수 있는 답글 본문입니다.',
+        contentWarning: '답글 내용에 주의가 필요합니다.',
+        id: 'notification-reply-post',
+        media: [notificationReplyMedia],
+        profile: unreadFollower,
+      }),
       profile: unreadFollower,
     }),
     repostNotification({
       id: 'notification-repost',
-      post: post({ id: 'notification-repost-related-post', profile: notificationRecipient }),
+      post: notificationPost({
+        id: 'notification-repost-related-post',
+        profile: notificationRecipient,
+      }),
       profile: readFollower,
     }),
   ],
@@ -96,8 +118,21 @@ const paginationProfile = notificationsProfile(
   { hasNext: true },
   { id: 'notification-profile-pagination' },
 );
+const profileSwitchReplyNotification = replyNotification({
+  id: 'notification-profile-a-reply',
+  post: notificationPost({
+    bodyText: '프로필 전환 중인 답글 본문입니다.',
+    id: 'notification-profile-a-reply-post',
+    media: [notificationReplyMedia],
+    profile: unreadFollower,
+  }),
+  profile: unreadFollower,
+});
 const profileA = notificationsProfile(
-  [followNotification({ id: 'notification-item-profile-a', profile: unreadFollower })],
+  [
+    followNotification({ id: 'notification-item-profile-a', profile: unreadFollower }),
+    profileSwitchReplyNotification,
+  ],
   {},
   { id: 'notification-profile-a' },
 );
@@ -146,6 +181,18 @@ function requireProfile(profiles: ReadonlyArray<ProfileNode>, index: number): Pr
   return result;
 }
 
+function notificationSurface(link: HTMLElement): HTMLElement {
+  const surface = link.closest<HTMLElement>('[data-testid="notification-item-surface"]');
+  if (!surface) {
+    throw new Error('Notification target is missing its presentation surface.');
+  }
+  return surface;
+}
+
+function storyColors(theme: unknown) {
+  return theme === 'dark' ? colors.dark : colors.light;
+}
+
 function NotificationCatalog() {
   const profiles = useStoryProfiles();
 
@@ -191,6 +238,14 @@ function ReadNavigationList() {
   );
 }
 
+function AuthenticatedReadNavigationList() {
+  return (
+    <SessionProvider>
+      <ReadNavigationList />
+    </SessionProvider>
+  );
+}
+
 const readMutationResponse = {
   markNotificationRead: {
     notifications: [
@@ -209,6 +264,27 @@ const readMutationResponse = {
     ],
   },
 };
+
+const replyReadMutationResponse = {
+  markNotificationRead: {
+    notifications: [
+      {
+        __typename: 'ReplyNotification',
+        id: 'notification-reply',
+        readAt: '2026-07-21T12:00:00Z',
+      },
+    ],
+    recipientProfiles: [
+      {
+        __typename: 'Profile',
+        id: 'notification-profile-content',
+        unreadNotificationCount: 1,
+      },
+    ],
+  },
+};
+
+const notificationMutationRequest = fn<(operationName: string, variables: Variables) => void>();
 
 const repostReadMutationResponse = {
   markNotificationRead: {
@@ -268,10 +344,10 @@ function ProfileSwitchList() {
   const profileNode = requireProfile(profiles, selected);
 
   return (
-    <>
+    <SessionProvider>
       <Button onPress={() => setSelected((current) => (current === 3 ? 4 : 3))}>프로필 전환</Button>
       <NotificationList key={profileNode.id} profile={profileNode.notificationList!} />
-    </>
+    </SessionProvider>
   );
 }
 
@@ -317,8 +393,9 @@ async function verifyReadAllFailure(canvasElement: HTMLElement) {
 }
 
 export const StatesAndFollowItems: Story = {
-  play: ({ canvasElement }) => {
+  play: ({ canvasElement, globals }) => {
     const canvas = within(canvasElement);
+    const theme = storyColors(globals.theme);
     for (const avatar of canvas.getAllByLabelText('별빛 여행자 프로필 이미지')) {
       expect(avatar.querySelector('img')).toHaveAttribute('src', unreadFollowerAvatarUrl);
     }
@@ -334,36 +411,31 @@ export const StatesAndFollowItems: Story = {
     const readCopyLink = canvas.getByRole('link', {
       name: /은하 기록자님이 팔로우했습니다/,
     });
-    const unreadRow = unreadCopyLink.parentElement?.parentElement;
-    const readRow = readCopyLink.parentElement?.parentElement;
+    const unreadRow = notificationSurface(unreadCopyLink);
+    const readRow = notificationSurface(readCopyLink);
 
     expect(unreadCopyLink).toBeVisible();
     expect(unreadRow).not.toBeNull();
     expect(readRow).not.toBeNull();
-    expect(getComputedStyle(unreadRow!).backgroundColor).toBe('rgba(252, 231, 154, 0.3)');
-    expect(getComputedStyle(unreadRow!).borderLeftColor).toBe('rgb(252, 231, 154)');
-    expect(getComputedStyle(unreadRow!).borderLeftWidth).toBe('4px');
-    expect(getComputedStyle(unreadRow!).paddingLeft).toBe('12px');
-    expect(getComputedStyle(readRow!).backgroundColor).toBe('rgb(255, 255, 255)');
-    expect(getComputedStyle(readRow!).borderLeftColor).toBe('rgba(0, 0, 0, 0)');
-    expect(getComputedStyle(readRow!).borderLeftWidth).toBe('4px');
-    expect(getComputedStyle(readRow!).paddingLeft).toBe('12px');
-    expect(unreadRow!.firstElementChild!.getBoundingClientRect().left).toBe(
-      readRow!.firstElementChild!.getBoundingClientRect().left,
+    expect(unreadRow).toHaveStyle({ backgroundColor: theme.actionPrimarySubtle });
+    expect(getComputedStyle(readRow).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(unreadRow.firstElementChild!.getBoundingClientRect().left).toBe(
+      readRow.firstElementChild!.getBoundingClientRect().left,
     );
     expect(
       canvas.getByRole('link', { name: /새 요청자님이 팔로우를 요청했습니다/ }),
-    ).toHaveAttribute('href', '/@requester');
+    ).toHaveAttribute('href', '/follow-requests');
     expect(canvasElement.querySelector('a[href="/@starlight"]')).toBeInTheDocument();
     expect(
-      canvas.getByRole('link', { name: /별빛 여행자님이 🎉 반응을 남겼습니다/ }),
+      canvas.getByRole('link', { name: /별빛 여행자님이 이 게시글에 반응했습니다/ }),
     ).toHaveAttribute('href', '/@recipient/notification-related-post');
-    expect(canvas.getByRole('link', { name: /별빛 여행자님이 답글을 남겼습니다/ })).toHaveAttribute(
+    expect(canvas.getByTestId('notification-post-author')).toHaveAttribute('href', '/@starlight');
+    expect(canvas.getByRole('link', { name: '5분 전' })).toHaveAttribute(
       'href',
-      '/@recipient/notification-reply-post',
+      '/@starlight/notification-reply-post',
     );
     expect(
-      canvas.getByRole('link', { name: /은하 기록자님이 게시물을 재게시했습니다/ }),
+      canvas.getByRole('link', { name: /은하 기록자님이 이 게시글을 재게시했습니다/ }),
     ).toHaveAttribute('href', '/@recipient/notification-repost-related-post');
   },
 };
@@ -392,8 +464,9 @@ export const NextPageFailureAndRetry: Story = {
 };
 
 export const HeaderAndWebRefreshPolicy: Story = {
-  play: ({ canvasElement }) => {
+  play: ({ canvasElement, globals }) => {
     const canvas = within(canvasElement);
+    const theme = storyColors(globals.theme);
     const heading = canvas.getByRole('heading', { name: '알림' });
     const action = canvas.getByRole('button', { name: '모두 읽음' });
     const headerRect = heading.parentElement!.getBoundingClientRect();
@@ -403,8 +476,8 @@ export const HeaderAndWebRefreshPolicy: Story = {
     expect(heading).toBeVisible();
     expect(headerRect.height).toBe(64);
     expect(headerRect.right - actionRect.right).toBe(16);
-    expect(actionStyle.backgroundColor).toBe('rgb(250, 250, 251)');
-    expect(actionStyle.borderColor).toBe('rgb(223, 223, 229)');
+    expect(action).toHaveStyle({ backgroundColor: theme.actionSecondaryBase });
+    expect(action).toHaveStyle({ borderColor: theme.actionSecondaryBorder });
     expect(actionStyle.borderWidth).toBe('1px');
     expect(canvas.queryByRole('button', { name: '알림 설정 (준비 중)' })).not.toBeInTheDocument();
     expect(canvas.queryByText('KOSMO')).not.toBeInTheDocument();
@@ -432,7 +505,7 @@ export const ReadAllLoadedUnread: Story = {
     await userEvent.click(action);
 
     await expect(
-      canvas.findByRole('link', { name: '별빛 여행자 프로필로 이동.' }),
+      canvas.findByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ }),
     ).resolves.toBeVisible();
     expect(
       canvas.getByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ }),
@@ -512,7 +585,7 @@ export const ReadAllPendingAndFailureRetry: Story = {
 
     await userEvent.click(canvas.getByRole('button', { name: '다시 시도' }));
     await expect(
-      canvas.findByRole('link', { name: '별빛 여행자 프로필로 이동.' }),
+      canvas.findByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ }),
     ).resolves.toBeVisible();
   },
   render: () => <RefreshList />,
@@ -522,19 +595,13 @@ export const KeyboardFocusableProfileLink: Story = {
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ });
-    const unreadAvatarLink = canvas.getByRole('link', {
-      name: '별빛 여행자 프로필로 이동. 읽지 않은 알림.',
-    });
-    const readAvatarLink = canvas.getByRole('link', {
-      name: '은하 기록자 프로필로 이동.',
-    });
-
     link.focus();
     expect(link).toHaveFocus();
     expect(link).toHaveAttribute('href', '/@starlight');
-    expect(unreadAvatarLink).toHaveAttribute('href', '/@starlight');
-    expect(readAvatarLink).toHaveAttribute('href', '/@galaxy');
-    expect(readAvatarLink).not.toHaveAccessibleName(/읽지 않은 알림/);
+    expect(link).toHaveAccessibleName(/읽지 않은 알림/);
+    expect(
+      canvas.getByRole('link', { name: /은하 기록자님이 팔로우했습니다/ }),
+    ).not.toHaveAccessibleName(/읽지 않은 알림/);
   },
   render: () => <RefreshList />,
 };
@@ -546,18 +613,20 @@ export const ReadSuccessNormalizesAndNavigates: Story = {
     await userEvent.click(canvas.getByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ }));
     await expect(canvas.findByText('/@starlight')).resolves.toBeVisible();
     await expect(
-      canvas.findByRole('link', { name: '별빛 여행자 프로필로 이동.' }),
+      canvas.findByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ }),
     ).resolves.toBeVisible();
     const readCopyLink = await canvas.findByRole('link', {
       name: /별빛 여행자님이 팔로우했습니다/,
     });
-    const readRow = readCopyLink.parentElement?.parentElement;
+    const readRow = notificationSurface(readCopyLink);
 
     expect(readRow).not.toBeNull();
-    expect(getComputedStyle(readRow!).backgroundColor).toBe('rgb(246, 246, 246)');
-    expect(getComputedStyle(readRow!).borderLeftColor).toBe('rgba(0, 0, 0, 0)');
+    expect(getComputedStyle(readRow).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(readRow.querySelector('[data-testid="notification-hover-overlay"]')).toBeInTheDocument();
     await userEvent.unhover(readCopyLink);
-    expect(getComputedStyle(readRow!).backgroundColor).toBe('rgb(255, 255, 255)');
+    expect(
+      readRow.querySelector('[data-testid="notification-hover-overlay"]'),
+    ).not.toBeInTheDocument();
   },
   render: () => <ReadNavigationList />,
 };
@@ -567,13 +636,13 @@ export const RepostReadNormalizesAndNavigates: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(
-      canvas.getByRole('link', { name: /은하 기록자님이 게시물을 재게시했습니다/ }),
+      canvas.getByRole('link', { name: /은하 기록자님이 이 게시글을 재게시했습니다/ }),
     );
     await expect(
       canvas.findByText('/@recipient/notification-repost-related-post'),
     ).resolves.toBeVisible();
     await expect(
-      canvas.findByRole('link', { name: '은하 기록자 게시글로 이동.' }),
+      canvas.findByRole('link', { name: /은하 기록자님이 이 게시글을 재게시했습니다/ }),
     ).resolves.toBeVisible();
   },
   render: () => <ReadNavigationList />,
@@ -581,50 +650,49 @@ export const RepostReadNormalizesAndNavigates: Story = {
 
 export const ReadPendingDoesNotBlockAvatarNavigation: Story = {
   parameters: { relay: { mutationLoading: true } },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, globals }) => {
     const canvas = within(canvasElement);
+    const theme = storyColors(globals.theme);
     await userEvent.click(
-      canvas.getByRole('link', {
-        name: '별빛 여행자 프로필로 이동. 읽지 않은 알림.',
-      }),
+      canvas.getByRole('link', { name: /별빛 여행자님이 팔로우했습니다.*읽지 않은 알림/ }),
     );
     await expect(canvas.findByText('/@starlight')).resolves.toBeVisible();
-    expect(
-      canvas.getByRole('link', {
-        name: '별빛 여행자 프로필로 이동. 읽지 않은 알림.',
-      }),
-    ).toBeVisible();
+    expect(canvas.getByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ })).toBeVisible();
     const unreadCopyLink = canvas.getByRole('link', {
       name: /별빛 여행자님이 팔로우했습니다.*읽지 않은 알림/,
     });
-    const unreadRow = unreadCopyLink.parentElement?.parentElement;
+    const unreadRow = notificationSurface(unreadCopyLink);
 
     expect(unreadRow).not.toBeNull();
-    expect(getComputedStyle(unreadRow!).backgroundColor).toBe('rgb(246, 246, 246)');
-    expect(getComputedStyle(unreadRow!).borderLeftColor).toBe('rgb(252, 231, 154)');
+    expect(unreadRow).toHaveStyle({ backgroundColor: theme.actionPrimarySubtle });
+    expect(
+      unreadRow.querySelector('[data-testid="notification-hover-overlay"]'),
+    ).toBeInTheDocument();
     await userEvent.unhover(unreadCopyLink);
-    expect(getComputedStyle(unreadRow!).backgroundColor).toBe('rgba(252, 231, 154, 0.3)');
+    expect(
+      unreadRow.querySelector('[data-testid="notification-hover-overlay"]'),
+    ).not.toBeInTheDocument();
   },
   render: () => <ReadNavigationList />,
 };
 
 export const ReadNetworkErrorDoesNotBlockCopyNavigation: Story = {
   parameters: { relay: { mutationError: 'Read failed' } },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, globals }) => {
     const canvas = within(canvasElement);
+    const theme = storyColors(globals.theme);
     await userEvent.click(canvas.getByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ }));
     await expect(canvas.findByText('/@starlight')).resolves.toBeVisible();
     expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
     const unreadCopyLink = canvas.getByRole('link', {
       name: /별빛 여행자님이 팔로우했습니다.*읽지 않은 알림/,
     });
-    const unreadRow = unreadCopyLink.parentElement?.parentElement;
+    const unreadRow = notificationSurface(unreadCopyLink);
 
     expect(unreadRow).not.toBeNull();
-    expect(getComputedStyle(unreadRow!).backgroundColor).toBe('rgb(246, 246, 246)');
-    expect(getComputedStyle(unreadRow!).borderLeftColor).toBe('rgb(252, 231, 154)');
+    expect(unreadRow).toHaveStyle({ backgroundColor: theme.actionPrimarySubtle });
     await userEvent.unhover(unreadCopyLink);
-    expect(getComputedStyle(unreadRow!).backgroundColor).toBe('rgba(252, 231, 154, 0.3)');
+    expect(unreadRow).toHaveStyle({ backgroundColor: theme.actionPrimarySubtle });
   },
   render: () => <ReadNavigationList />,
 };
@@ -645,20 +713,139 @@ export const ReadGraphQLErrorDoesNotBlockNavigation: Story = {
   render: () => <ReadNavigationList />,
 };
 
+export const ReplyContentAndProtectedActions: Story = {
+  parameters: {
+    relay: {
+      mutationRequestObserver: (request: RequestParameters, variables: Variables) =>
+        notificationMutationRequest(request.name, variables),
+      operationResponses: {
+        SessionProviderQuery: {
+          data: {
+            currentSession: {
+              id: 'notification-session',
+              selectedProfile: { id: 'notification-profile-content' },
+            },
+            me: { id: 'notification-account', name: 'Notification Story' },
+          },
+        },
+      },
+    },
+    controls: { disable: true },
+  },
+  play: async ({ canvasElement }) => {
+    notificationMutationRequest.mockClear();
+    const canvas = within(canvasElement);
+
+    await expect(canvas.findByTestId('post-content-warning')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByRole('button', { name: '내용 보기' }));
+    await expect(
+      canvas.findByText('알림에서 바로 확인할 수 있는 답글 본문입니다.'),
+    ).resolves.toBeVisible();
+    expect(canvas.getByText('/notifications')).toBeVisible();
+    expect(notificationMutationRequest).not.toHaveBeenCalledWith(
+      'NotificationListItemMarkReadMutation',
+      expect.anything(),
+    );
+
+    const replyButton = canvas.getByRole('button', { name: '답글' });
+    await waitFor(() => expect(replyButton).not.toHaveAttribute('aria-disabled', 'true'));
+    await userEvent.click(replyButton);
+    const composer = await screen.findByRole('dialog', { name: '답글 쓰기' });
+    await expect(composer).toBeVisible();
+    expect(canvas.getByText('/notifications')).toBeVisible();
+    expect(notificationMutationRequest).not.toHaveBeenCalledWith(
+      'NotificationListItemMarkReadMutation',
+      expect.anything(),
+    );
+    await userEvent.click(within(composer).getByRole('button', { name: '닫기' }));
+    const confirm = await screen.findByRole('alertdialog', { name: '답글 작성을 취소할까요?' });
+    await userEvent.click(within(confirm).getByRole('button', { name: '작성 취소' }));
+    await expect(screen.queryByRole('dialog', { name: '답글 쓰기' })).not.toBeInTheDocument();
+    expect(canvas.getByText('/notifications')).toBeVisible();
+    expect(replyButton).toHaveFocus();
+    expect(notificationMutationRequest).not.toHaveBeenCalledWith(
+      'NotificationListItemMarkReadMutation',
+      expect.anything(),
+    );
+  },
+  render: () => <AuthenticatedReadNavigationList />,
+};
+
+export const ReplyAuthorActivationReadsOnce: Story = {
+  parameters: {
+    relay: {
+      mutationRequestObserver: (request: RequestParameters, variables: Variables) =>
+        notificationMutationRequest(request.name, variables),
+      mutationResponse: replyReadMutationResponse,
+    },
+    controls: { disable: true },
+  },
+  play: async ({ canvasElement }) => {
+    notificationMutationRequest.mockClear();
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '내용 보기' }));
+    await expect(
+      canvas.findByText('알림에서 바로 확인할 수 있는 답글 본문입니다.'),
+    ).resolves.toBeVisible();
+    expect(canvas.getByText('/notifications')).toBeVisible();
+    expect(notificationMutationRequest).not.toHaveBeenCalledWith(
+      'NotificationListItemMarkReadMutation',
+      expect.anything(),
+    );
+
+    const detailPath = '/@starlight/notification-reply-post';
+    const activations = [
+      { target: canvas.getByTestId('notification-post-author'), path: '/@starlight' },
+      { target: canvas.getByRole('link', { name: '5분 전' }), path: detailPath },
+      { target: canvas.getByTestId('post-list-row-body'), path: detailPath },
+      {
+        target: canvas.getByTestId('post-media-open-notification-reply-media'),
+        path: detailPath,
+        opensViewer: true,
+      },
+    ];
+
+    for (const activation of activations) {
+      notificationMutationRequest.mockClear();
+      await userEvent.click(activation.target);
+      await expect(canvas.findByText(activation.path)).resolves.toBeVisible();
+      if (activation.opensViewer) {
+        await expect(screen.findByTestId('post-media-viewer-dialog')).resolves.toBeVisible();
+      }
+      expect(notificationMutationRequest).toHaveBeenCalledTimes(1);
+      expect(notificationMutationRequest).toHaveBeenCalledWith(
+        'NotificationListItemMarkReadMutation',
+        { ids: ['notification-reply'] },
+      );
+
+      if (activation.target === activations[0]!.target) {
+        await waitFor(() => expect(canvas.queryByText('읽지 않은 알림')).not.toBeInTheDocument());
+      }
+
+      if (activation.opensViewer) {
+        await userEvent.click(screen.getByTestId('post-media-viewer-close'));
+        await expect(screen.queryByTestId('post-media-viewer-dialog')).not.toBeInTheDocument();
+      }
+    }
+  },
+  render: () => <ReadNavigationList />,
+};
+
 export const FigmaFollowRowHierarchy: Story = {
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const followLink = canvas.getByRole('link', {
+      name: /별빛 여행자님이 팔로우했습니다/,
+    });
+    const surface = notificationSurface(followLink);
     const avatar = canvas.getAllByLabelText('별빛 여행자 프로필 이미지')[0];
-    const avatarLink = avatar?.closest('a');
-    let content = avatarLink?.parentElement;
-    while (content && !content.previousElementSibling) {
-      content = content.parentElement;
-    }
-    const kindIcon = content?.previousElementSibling;
+    const kindIcon = surface.querySelector('svg')?.parentElement;
     const copyLink = canvas.getByRole('link', {
       name: /별빛 여행자님이 팔로우했습니다/,
     });
-    const copy = copyLink.querySelector('[dir="auto"]');
+    const copy = [...copyLink.querySelectorAll<HTMLElement>('[dir="auto"]')].find((element) =>
+      element.textContent?.includes('팔로우했습니다'),
+    );
     const timestamp = canvas.getAllByText('5분 전')[0];
 
     expect(kindIcon).not.toBeNull();
@@ -668,8 +855,8 @@ export const FigmaFollowRowHierarchy: Story = {
 
     const kindRect = kindIcon!.getBoundingClientRect();
     const avatarRect = avatar!.getBoundingClientRect();
-    expect(kindRect.width).toBe(28);
-    expect(kindRect.height).toBe(28);
+    expect(kindRect.width).toBe(48);
+    expect(kindRect.height).toBe(48);
     expect(avatarRect.width).toBe(28);
     expect(avatarRect.height).toBe(28);
     expect(avatarRect.top).toBe(kindRect.top);
@@ -679,32 +866,24 @@ export const FigmaFollowRowHierarchy: Story = {
 };
 
 export const HoverBackgroundFeedback: Story = {
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, globals }) => {
     const canvas = within(canvasElement);
-    const avatarLink = canvas.getByRole('link', {
-      name: '별빛 여행자 프로필로 이동. 읽지 않은 알림.',
-    });
+    const theme = storyColors(globals.theme);
     const copyLink = canvas.getByRole('link', {
       name: /별빛 여행자님이 팔로우했습니다/,
     });
-    const row = copyLink.parentElement?.parentElement;
+    const row = notificationSurface(copyLink);
 
     expect(row).not.toBeNull();
-    expect(row).toHaveStyle({ backgroundColor: 'rgba(252, 231, 154, 0.3)' });
-    expect(getComputedStyle(row!).borderLeftColor).toBe('rgb(252, 231, 154)');
+    expect(row).toHaveStyle({ backgroundColor: theme.actionPrimarySubtle });
+    expect(row.querySelector('[data-testid="notification-hover-overlay"]')).not.toBeInTheDocument();
     await userEvent.hover(row!);
-    expect(row).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
-    expect(getComputedStyle(row!).borderLeftColor).toBe('rgb(252, 231, 154)');
+    expect(row).toHaveStyle({ backgroundColor: theme.actionPrimarySubtle });
+    expect(row.querySelector('[data-testid="notification-hover-overlay"]')).toBeInTheDocument();
     await userEvent.hover(copyLink);
-    expect(row).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
+    expect(row.querySelector('[data-testid="notification-hover-overlay"]')).toBeInTheDocument();
     await userEvent.unhover(copyLink);
-    expect(row).toHaveStyle({ backgroundColor: 'rgba(252, 231, 154, 0.3)' });
-    await userEvent.hover(row!);
-    expect(row).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
-    await userEvent.hover(avatarLink);
-    expect(row).toHaveStyle({ backgroundColor: 'rgb(246, 246, 246)' });
-    await userEvent.unhover(avatarLink);
-    expect(row).toHaveStyle({ backgroundColor: 'rgba(252, 231, 154, 0.3)' });
+    expect(row.querySelector('[data-testid="notification-hover-overlay"]')).not.toBeInTheDocument();
   },
   render: () => <RefreshList />,
 };
@@ -715,29 +894,60 @@ export const NonInteractiveRowAndCompactCopyLink: Story = {
       name: /별빛 여행자님이 팔로우했습니다/,
     });
     const copy = copyLink.querySelector('[dir="auto"]');
-    const row = copyLink.parentElement?.parentElement;
+    const row = notificationSurface(copyLink);
 
     expect(copy).not.toBeNull();
     expect(row).not.toBeNull();
     expect(row).not.toHaveAttribute('tabindex');
     expect(copyLink.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
     expect(copy!.getBoundingClientRect().height).toBeLessThan(44);
-    expect(row!.getBoundingClientRect().height).toBeLessThan(100);
+    expect(row.getBoundingClientRect().height).toBeLessThan(100);
   },
   render: () => <RefreshList />,
 };
 
 export const SelectedProfileSwitch: Story = {
+  parameters: {
+    relay: {
+      operationResponses: {
+        SessionProviderQuery: {
+          data: {
+            currentSession: {
+              id: 'notification-session',
+              selectedProfile: { id: 'notification-profile-a' },
+            },
+            me: { id: 'notification-account', name: 'Notification Story' },
+          },
+        },
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const switchButton = canvas.getByRole('button', { name: '프로필 전환' });
     expect(canvas.getByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ })).toBeVisible();
-    await userEvent.click(canvas.getByRole('button', { name: '프로필 전환' }));
+
+    await userEvent.click(canvas.getByRole('button', { name: '답글' }));
+    await expect(screen.findByRole('dialog', { name: '답글 쓰기' })).resolves.toBeVisible();
+    fireEvent.click(switchButton);
     await expect(
       canvas.findByRole('link', { name: /은하 기록자님이 팔로우했습니다/ }),
     ).resolves.toBeVisible();
+    expect(screen.queryByRole('dialog', { name: '답글 쓰기' })).not.toBeInTheDocument();
     expect(
       canvas.queryByRole('link', { name: /별빛 여행자님이 팔로우했습니다/ }),
     ).not.toBeInTheDocument();
+
+    await userEvent.click(switchButton);
+    await expect(canvas.findByTestId('reply-notification-post')).resolves.toBeVisible();
+    await userEvent.click(canvas.getByTestId('post-media-open-notification-reply-media'));
+    await expect(screen.findByTestId('post-media-viewer-dialog')).resolves.toBeVisible();
+
+    fireEvent.click(switchButton);
+    await expect(
+      canvas.findByRole('link', { name: /은하 기록자님이 팔로우했습니다/ }),
+    ).resolves.toBeVisible();
+    expect(screen.queryByTestId('post-media-viewer-dialog')).not.toBeInTheDocument();
   },
   render: () => <ProfileSwitchList />,
 };

--- a/apps/web/e2e/notifications.e2e.ts
+++ b/apps/web/e2e/notifications.e2e.ts
@@ -1,8 +1,10 @@
 import { db, Notifications } from '@kosmo/core/db';
+import { NotificationKind } from '@kosmo/core/enums';
 import { eq } from 'drizzle-orm';
 import {
   createE2EAccountProfile,
   createE2EFollow,
+  createE2EPost,
   createE2ESession,
   resetE2EDatabase,
   setE2ESessionCookie,
@@ -188,6 +190,74 @@ test('Local Follow 알림은 Recipient Profile별로 격리되고 Read와 Unfoll
   } finally {
     await followerContext.close();
   }
+});
+
+test('Reply 알림 본문은 작성자와 Unread를 표시하고 본문 이동에서 한 번만 Read한다', async ({
+  context,
+  page,
+}) => {
+  const recipient = await createE2ESession({
+    displayName: 'E2E Reply Recipient',
+    handle: 'e2e-reply-recipient',
+  });
+  const replyAuthor = await createE2ESession({
+    displayName: 'E2E Reply Author',
+    handle: 'e2e-reply-author',
+  });
+
+  if (!recipient.profile || !replyAuthor.profile) {
+    throw new Error('Reply Notification fixture requires local profiles.');
+  }
+
+  const parent = await createE2EPost({
+    body: 'E2E Reply parent body',
+    profileId: recipient.profile.id,
+  });
+  const reply = await createE2EPost({
+    body: 'E2E Reply notification body',
+    profileId: replyAuthor.profile.id,
+    replyParentId: parent.id,
+  });
+  const notification = await db
+    .insert(Notifications)
+    .values({
+      kind: NotificationKind.REPLY,
+      recipientProfileId: recipient.profile.id,
+      sourceId: reply.id,
+    })
+    .returning()
+    .then(([row]) => row!);
+
+  await setE2ESessionCookie(context, recipient.token);
+  await page.goto('/notifications');
+
+  const replyRow = page.getByTestId('reply-notification-post');
+  const replySurface = page.getByTestId('notification-item-surface').filter({ has: replyRow });
+  await expect(replyRow).toBeVisible();
+  await expect(replyRow.getByTestId('notification-post-author')).toContainText(
+    replyAuthor.profile.displayName,
+  );
+  await expect(replyRow.getByTestId('post-list-row-body')).toContainText(
+    'E2E Reply notification body',
+  );
+  await expect(replySurface.getByText('읽지 않은 알림')).toBeAttached();
+
+  let markReadRequestCount = 0;
+  await page.route('**/graphql', async (route) => {
+    if (
+      readGraphQLOperation(route.request().postData())?.operationName ===
+      'NotificationListItemMarkReadMutation'
+    ) {
+      markReadRequestCount += 1;
+    }
+    await route.fallback();
+  });
+
+  await replyRow.getByTestId('post-list-row-body').click();
+  await expect(page).toHaveURL(`/@${replyAuthor.profile.handle}/${toGlobalId('Post', reply.id)}`);
+  await expect.poll(() => markReadRequestCount).toBe(1);
+  await expect.poll(() => notificationReadAt(notification.id)).not.toBeNull();
+  await page.unroute('**/graphql');
 });
 
 test('Web 모두 읽음은 current loaded unread만 한 번 요청하고 실패 재시도에서 상태를 보존한다', async ({

--- a/docs/design/notifications.md
+++ b/docs/design/notifications.md
@@ -2,7 +2,7 @@
 
 PROD-884는 `NotificationListItemView`와 `KOSMO/Patterns/Notification List Item` Storybook을
 소유한다. 이 컴포넌트는 표시용 입력과 이동 callback을 받고, 기존 Notification runtime은 그대로 둔다.
-PROD-811이 실제 목록 연결, Relay projection·그룹 집계, 읽음 처리, 권한과 navigation 통합을 소유한다.
+PROD-811이 실제 목록 연결, Relay projection, 읽음 처리, 권한과 navigation 통합을 소유한다.
 PROD-930은 production Notification runtime에서 플랫폼별로 나뉘었던 `모두 읽음` action과 Read/Unread
 표시를 Web·iOS·Android에서 같은 계약으로 제공하며, 현재 로드된 ID와 기존 API/Relay 수렴 경계를 유지한다.
 
@@ -71,7 +71,9 @@ API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는�
   [Notification 도메인의 Future 계약](../domain/objects/notification.md#replymention-수신자별-분류와-중복-처리-future)을 따른다.
 - Reply 알림은 `ReplyNotificationPost`가 작성자·시각·알림 이유와 게시글 내용을 조립한다.
   `PostBody`·`PostSourcePreview`·`PostActionSurface`를 재사용하고, Reply 버튼·composer·focus 연결은
-  `usePostReplySurface`를 게시글 목록과 공유한다. `PostListItem`은 알림 종류·문구·배치를 소유하지 않는다.
+  `usePostReplySurface`를 게시글 목록과 공유한다. Reply 버튼은 `owner="list"`인 기존 Reply composer의
+  popup modal을 열며 Notification 전용 composer나 별도 popup lifecycle을 만들지 않는다. `PostListItem`은
+  알림 종류·문구·배치를 소유하지 않는다.
   기존 Post action/provider·Relay ref 계약을 따르며 action을 알림 이동 링크 안에 중첩하지 않는다.
   단일 하단 divider는 Notification wrapper가 소유한다. Reply wrapper는 `children`과 `unread`만 받고
   자식으로 `ReplyNotificationPost`를 합성한다. 게시글 identity와 이동은 이 자식이 소유하므로 wrapper에
@@ -80,6 +82,10 @@ API kind, 알림 생성 또는 runtime 통합의 완료를 의미하지 않는�
   수명을 소유하며 presentation에서 읽음 mutation·cache 또는 실패 복구 정책을 실행하지 않는다.
   Reply의 이동과 Post action 상태는 해당 Post가 소유한다. 권한 상실로 Post를 숨겨야 하면 consumer가
   전체 item을 제거해야 한다.
+- Notification 활성화에 따른 Best Effort Read는 이동이나 열기를 기다리게 하지 않는다.
+  Follow/FollowRequest/Reaction/Repost는 단일 item target 활성화에서, Reply는 작성자 Profile·시각·본문의
+  link navigation과 미디어 열기에서 각각 한 번 시작한다. Reply의 Content Warning 공개, Action Bar와 열린
+  composer의 control은 자체 동작만 수행하며 item navigation이나 Read를 함께 시작하지 않는다.
 
 ## 검증 경계
 

--- a/openspec/changes/show-reply-notification-content/.openspec.yaml
+++ b/openspec/changes/show-reply-notification-content/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-decisions
+created: 2026-09-09

--- a/openspec/changes/show-reply-notification-content/decisions.md
+++ b/openspec/changes/show-reply-notification-content/decisions.md
@@ -1,0 +1,49 @@
+## Context
+
+이 기록은 PROD-811의 Production Notification 연결을 위해 `docs/domain/objects/notification.md`, `docs/design/notifications.md`, 현재 Linear 계약과 승인된 DSN-42/PROD-884 presentation을 대조해 확정한 사용자 노출 동작을 담는다. 내부 파일·helper 선택은 `design.md`의 비규범적 지침으로 남긴다.
+
+## Decision Records
+
+### Reply는 공용 Post Action과 목록용 popup composer를 그대로 사용한다
+
+- Decision Date: 2026-09-10
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/notifications.md`, [PROD-811](https://linear.app/byulmaru/issue/PROD-811/답글-알림에서-답글-본문을-미리-볼-수-있게-한다), [DSN-42](https://linear.app/byulmaru/issue/DSN-42/figma-notificationpost-presentation을-시각-리디자인한다), [PROD-884](https://linear.app/byulmaru/issue/PROD-884/dsn-42-notification-presentation을-공용-ui와-storybook으로-이관한다)
+- Status: Active
+- Context / Problem: 승인된 Reply Notification presentation에는 공용 Post Action Bar가 있지만 PROD-811은 Notification 전용 직접 답글 기능과 Reply UI 재설계를 제외한다.
+- Decision Outcome: Reply Action Bar는 기존 Post action을 표시하고 Reply control은 기존 목록용 popup modal composer를 연다. Notification 전용 composer, popup lifecycle 또는 Reply 정책은 추가하지 않는다.
+- Alternatives Considered: Reply Action을 숨기면 승인된 Post presentation과 달라진다. Notification 전용 composer를 만들면 PROD-811의 제외 범위와 공용화 원칙을 위반한다. 기존 composer를 후속 작업까지 연결하지 않으면 이미 제공되는 목록용 popup 동작을 불필요하게 지연한다.
+- Consequences: Notification 목록은 기존 Post action 인증과 selected Profile 기반 Reply coordinator를 제공해야 한다. popup의 validation·mutation·focus lifecycle은 기존 Post 계약을 유지한다.
+- Confirmation / Follow-up: 실제 Production 목록 Storybook에서 Reply control이 popup dialog를 열고 닫은 뒤 trigger focus가 복귀하는지 검증한다.
+
+### Follow Request Notification은 관리 화면으로 이동한다
+
+- Decision Date: 2026-09-10
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/design/notifications.md`, [DSN-42](https://linear.app/byulmaru/issue/DSN-42/figma-notificationpost-presentation을-시각-리디자인한다), [PROD-811](https://linear.app/byulmaru/issue/PROD-811/답글-알림에서-답글-본문을-미리-볼-수-있게-한다)
+- Status: Active
+- Context / Problem: 승인된 Notification presentation은 Follow Request의 목적지를 요청 관리 화면으로 정했지만 legacy Production 행은 요청자 Profile로 이동한다.
+- Decision Outcome: Follow Request Notification의 단일 target은 `/follow-requests`로 이동한다.
+- Alternatives Considered: 요청자 Profile 이동을 유지하면 관리가 필요한 Notification의 canonical target과 어긋난다. inline 수락·거절 control은 현재 표시 계약에 없다.
+- Consequences: 이 결정은 active Notification spec의 `Follow Request Notification 목록과 requester Profile 활성화` requirement 중 requester Profile destination을 대체한다. 종류별 connected adapter의 target만 정렬하며 Follow Request mutation이나 관리 화면 동작은 변경하지 않는다.
+- Confirmation / Follow-up: Production 목록 interaction에서 행 activation의 route와 단건 Read 요청을 함께 검증한다.
+
+### Reply Read는 명시적인 이동과 미디어 열기에만 결속한다
+
+- Decision Date: 2026-09-10
+- Decision Class: Derived Contract
+- Authority / Provenance: `docs/domain/objects/notification.md`, `docs/design/notifications.md`, [PROD-372](https://linear.app/byulmaru/issue/PROD-372/알림-항목-읽음-상태를-best-effort로-동기화한다), [PROD-811](https://linear.app/byulmaru/issue/PROD-811/답글-알림에서-답글-본문을-미리-볼-수-있게-한다)
+- Status: Active
+- Context / Problem: Reply surface에는 여러 link와 Content Warning·Action Bar·composer control이 있어 바깥 item handler를 사용하면 navigation과 Read가 중복 실행될 수 있다.
+- Decision Outcome: Reply의 작성자 Profile, 시각과 본문 Post navigation 및 미디어 열기는 각각 한 번의 Best Effort Read를 시작한다. Content Warning 공개, Action Bar와 열린 composer의 control은 Notification navigation이나 Read를 시작하지 않는다. Read 결과는 target 동작을 지연하거나 되돌리지 않는다.
+- Alternatives Considered: 모든 pointer/press를 바깥에서 capture하면 내부 control까지 Read·navigation을 실행한다. Action Bar나 Content Warning까지 Read trigger로 취급하면 사용자가 승인한 독립 동작 경계보다 범위가 넓어진다. Reply 전체를 단일 Link로 만들면 nested interactive element가 된다.
+- Consequences: connected Notification 경계는 명시적인 activation seam으로 단건 Read를 전달해야 하며 반복 activation의 최종 상태는 기존 서버 멱등성에 맡긴다.
+- Confirmation / Follow-up: Profile/detail/body/media target은 activation당 Read 한 번과 원래 동작을, Content Warning·Action Bar·composer는 Read와 item navigation이 없음을 검증한다.
+
+## Remaining Decisions
+
+- 없음.
+
+## Superseded Decisions
+
+- 없음.

--- a/openspec/changes/show-reply-notification-content/design.md
+++ b/openspec/changes/show-reply-notification-content/design.md
@@ -1,0 +1,69 @@
+## Context
+
+PROD-884는 표시 전용 `NotificationListItemView`와 Relay 기반 `ReplyNotificationPost` 및 Storybook 계약을 만들었지만 Production 목록은 종류별 Relay adapter가 private legacy 행을 렌더링한다. Production 연결은 기존 Notification pagination·Read mutation·actor Store, Post content/privacy 정책과 Post action/reply/media provider 수명을 유지해야 한다.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 종류별 Notification fragment와 기존 서버 정책을 유지하면서 승인된 공용 presentation을 실제 목록에 연결한다.
+- Reply Post의 본문·Content Warning·미디어·Quote·Action Bar와 목록용 popup Reply composer를 기존 Post 경계로 재사용한다.
+- navigation/media open과 Best Effort Read를 결속하고 내부 control의 중복 navigation·Read를 막는다.
+- loading과 실제 Production Storybook을 새 동적 행 구조에 맞춘다.
+
+**Non-Goals:**
+
+- Notification grouping, 생성 lifecycle, API/schema, database 또는 unavailable 정책 변경
+- 새 Notification 전용 composer·media viewer·Content Warning 정책이나 popup lifecycle
+- Mention 또는 다른 Future Notification kind
+
+## Implementation Guidance
+
+### Current Constraints
+
+- `NotificationListItem.tsx`의 다섯 adapter가 종류별 Relay fragment와 단건 Read mutation의 실제 연결 경계다. private `NotificationRow`만 legacy 28px filled kind icon·분리된 Avatar/body link를 소유한다.
+- `NotificationListItemView`는 표시 전용이며 grouping, mutation과 Relay cache를 소유하지 않는다. Reply variant는 `children`과 `unread`만 받아 바깥 Link를 만들지 않는다.
+- `ReplyNotificationPost`는 `PostBody`, `PostSourcePreview`, `PostActionSurface`, `usePostReplySurface`를 사용하므로 Post action 인증, selected Profile 기반 목록 Reply coordinator와 media viewer host가 필요하다. 현재 Notification 목록 상위에는 이 provider 묶음이 없다.
+- Reply 내부에는 Profile link, Post detail link, body navigation, media viewer, Content Warning과 Action Bar가 공존한다. 바깥 capture handler나 Link wrapper는 nested navigation과 Read 중복을 만든다.
+- API는 Reply·Reaction·Repost의 visible Post를 이미 제공하고 unavailable item을 page limit 전에 숨긴다. client fallback이나 새 API field로 이 정책을 다시 구현할 필요가 없다.
+
+### Recommended Approach
+
+종류별 Relay adapter와 list dispatcher는 유지하고 각 adapter가 공용 presentation에 필요한 한 명의 actor, target과 Post preview를 투영하게 한다. 단건 Read commit은 같은 connected 경계에 남겨 non-Reply의 단일 target callback과 Reply의 명시적인 Profile/detail/body/media activation callback에서 호출한다.
+
+Reply adapter는 `NotificationListItemView kind="reply"` 안에 `ReplyNotificationPost`를 합성한다. Reply Post에는 현재 consumer가 필요한 하나의 activation callback만 추가하고 Profile/detail/body/media open에서 호출하되 Content Warning·Action Bar·composer에는 연결하지 않는다. 바깥 event capture나 Notification Link wrapper는 추가하지 않는다.
+
+Notification 목록의 selected Profile fragment에 기존 Reply composer Profile fragment를 spread하고, Post 목록이 사용하는 action authentication, `owner="list"` Reply coordinator와 media viewer host 조합을 목록 수명에 둔다. 이 조합은 Reply action을 기존 popup modal로 연결하므로 새 composer 구현이 필요 없다.
+
+Reaction·Repost adapter는 기존 Post fragment에서 body text, Content Warning document와 media를 조회해 공용 preview 입력으로 전달한다. grouping은 서버 입력이 없으므로 각 item에 한 actor만 전달한다. loading skeleton과 `KOSMO/Screens/Notifications/Catalog`의 실제 Relay fixture·interaction assertion을 새 geometry와 observable behavior에 맞춘다.
+
+### Allowed Alternatives
+
+- 단건 Read commit의 재사용은 같은 파일의 작은 hook 또는 connected wrapper로 둘 수 있다. presentation component가 Relay mutation을 소유하지 않고 한 target activation당 한 번만 실행되면 된다.
+- Post provider 묶음은 selected Profile과 Notification 목록의 수명이 일치하는 가장 가까운 route 또는 list 경계에 둘 수 있다. 앱 전역 provider로 넓히지 않는다.
+
+### Known Traps
+
+- 종류별 adapter를 제거하면 fragment colocation, target URL과 Read cache 수렴 책임까지 잃는다.
+- Reply 전체를 Link로 감싸거나 pointer event를 capture하면 Content Warning·media·Action Bar가 item navigation과 Read를 중복 실행한다.
+- `ReplyNotificationPost` 대신 `PostListItem`을 사용하면 Notification reason·배치와 원글 미리보기 제외 계약이 깨진다.
+- client에서 actor를 합치거나 unavailable Post용 generic 행을 만들면 현재 grouping 제외 범위와 서버 visibility 정책을 위반한다.
+- target presentation Storybook만 통과해도 실제 `NotificationList`의 Relay·route·provider 연결은 증명되지 않는다.
+
+## Risks / Trade-offs
+
+- [Reply Post와 media로 행 높이·렌더 비용이 증가한다] → 기존 Post presentation과 `ScrollView` pagination을 유지하고 실제 Catalog 및 지원 runtime에서 긴 본문·미디어 목록을 확인한다.
+- [명시적인 activation callback을 빠뜨리거나 두 번 호출할 수 있다] → 실제 navigation/media target별 interaction에서 mutation 요청 수와 target 동작을 함께 검증한다.
+- [selected Profile 전환 뒤 modal/viewer 상태가 남을 수 있다] → provider 수명을 actor별 Notification 목록에 결속하고 전환 검증을 유지한다.
+- [기존 active Notification spec의 legacy Follow 시각 계약과 충돌한다] → 이 change의 full modified requirement를 archive 시 active spec에 동기화한다.
+
+## Migration Plan
+
+1. 공용 presentation을 종류별 connected adapter와 Notification 목록 provider에 연결한다.
+2. loading과 실제 Production Storybook fixture·interaction을 갱신하고 Relay compiler, typecheck, 관련 unit/Storybook test와 Web 시각 QA를 수행한다.
+3. 지원 가능한 Web·iOS·Android runtime 증거를 각각 기록한다. 실행하지 못한 플랫폼은 완료로 일반화하지 않는다.
+4. 문제가 생기면 API나 저장 데이터를 되돌리지 않고 Notification consumer 연결만 이전 legacy 행으로 복구할 수 있다.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/show-reply-notification-content/proposal.md
+++ b/openspec/changes/show-reply-notification-content/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+공용 Notification presentation과 Storybook 계약은 Reply 본문·미디어·Action Bar를 포함하지만 실제 알림 목록은 아직 legacy 행을 사용해 Reply 내용을 보여주지 않는다. PROD-811은 승인된 presentation을 기존 Relay·Read·권한 경계에 연결해 알림 목록에서 Reply를 안전하게 확인할 수 있게 한다.
+
+## What Changes
+
+- Production Notification 목록이 Follow·FollowRequest·Reaction·Repost에 공용 `NotificationListItemView`를 사용하고 Reply에 `ReplyNotificationPost`를 합성한다.
+- Reply는 허용된 본문·Content Warning·미디어·Quote·공용 Post Action Bar를 표시하고, Reply action은 기존 목록용 popup composer를 재사용한다.
+- FollowRequest target을 `/follow-requests`로 정렬하고 Reaction·Repost는 기존 Post 표시 정책에 따른 한 줄 미리보기와 첫 미디어를 표시한다.
+- Notification 이동·열기와 Best Effort Read를 결속하되 Read 응답이 navigation을 막지 않게 하고, Reply의 Content Warning·Action Bar·composer control은 item navigation·Read와 독립적으로 실행한다.
+- 기존 unavailable filtering, Relay pagination·actor cache, 모두 읽음, loading/error/empty 상태를 유지하면서 loading skeleton과 실제 Production Storybook 계약을 새 행에 맞춘다.
+- Notification grouping, server GraphQL schema·resolver 변경, 새 Reply composer 또는 popup lifecycle, Post 공개 범위·Content Warning·미디어 정책 변경은 추가하지 않는다. 기존 `ReplyNotification.post`와 Post fragment를 Production consumer에서 확장해 사용한다.
+
+## Authority / Provenance
+
+- Canonical: `docs/domain/objects/notification.md`, `docs/design/notifications.md`, `docs/design/accessibility.md`, `docs/design/breakpoints.md`
+- Linear Contract: [PROD-811](https://linear.app/byulmaru/issue/PROD-811/답글-알림에서-답글-본문을-미리-볼-수-있게-한다), [DSN-42](https://linear.app/byulmaru/issue/DSN-42/figma-notificationpost-presentation을-시각-리디자인한다)
+- Linear Implementations: [PROD-811](https://linear.app/byulmaru/issue/PROD-811/답글-알림에서-답글-본문을-미리-볼-수-있게-한다); 선행 공용 UI [PROD-884](https://linear.app/byulmaru/issue/PROD-884/dsn-42-notification-presentation을-공용-ui와-storybook으로-이관한다)
+
+## Capabilities
+
+### New Capabilities
+
+없음.
+
+### Modified Capabilities
+
+- `notification`: selected Profile의 Notification 목록 presentation, Reply content, target navigation과 Read interaction 계약을 승인된 공용 UI에 맞게 변경한다.
+
+## Impact
+
+- `apps/app/src/components/notification`: 종류별 Relay adapter, 공용 presentation 합성, Reply Post, 목록 provider와 loading state
+- `apps/app/src/stories/screens/Notifications.stories.tsx`: 실제 Production 목록의 Relay fixture와 interaction 검증
+- `openspec/specs/notification/spec.md`: archive 시 새 presentation·Reply content·navigation·Read 계약으로 동기화
+- Client Relay fragment와 실제 Production query가 기존 `ReplyNotification.post`의 Post presentation field를 소비한다. Server GraphQL schema·resolver, database, Notification 생성 lifecycle과 새 dependency에는 영향이 없다.

--- a/openspec/changes/show-reply-notification-content/specs/notification/spec.md
+++ b/openspec/changes/show-reply-notification-content/specs/notification/spec.md
@@ -1,0 +1,212 @@
+## MODIFIED Requirements
+
+### Requirement: Selected Profile Follow Notification 목록 UI
+
+**Authority / Provenance:** `docs/design/notifications.md`, `docs/design/accessibility.md`, `docs/design/breakpoints.md`, `docs/design/colors.md`, `PROD-277`, `PROD-372`, `PROD-541`, `PROD-680`, `PROD-703`, `PROD-811`, `PROD-884`, `PROD-930`, `DSN-42` — 클라이언트는 selected Profile의 visible Notification을 모든 지원 플랫폼에서 같은 단일 목록과 승인된 공용 Notification presentation으로 제공하고 Relay connection과 actor cache를 Profile별로 격리해야 한다(MUST).
+
+#### Scenario: 단일 Follow item 표시와 Profile link
+
+- **WHEN** selected Profile의 connection이 Related Profile 한 명을 가진 visible Follow Notification을 반환한다
+- **THEN** 목록은 48px kind rail의 32px `UserRoundPlus`, 28px Related Profile Avatar, 상대 시각과 `OOO님이 팔로우했습니다` 문구를 공용 Notification 행에 표시한다
+- **AND** 행 전체는 `Profile.relativeHandle`의 Profile route를 가리키는 단일 link다
+- **AND** inline 맞팔로우, 빈 action 영역, snippet 또는 client가 만든 복수 사용자 aggregation을 추가하지 않는다
+
+#### Scenario: Follow Request 관리 화면 이동
+
+- **WHEN** selected Profile의 connection이 visible Follow Request Notification을 반환한다
+- **THEN** 목록은 Follow와 같은 행 구조에 `OOO님이 팔로우를 요청했습니다`를 표시한다
+- **AND** 행 전체는 요청자 Profile이 아니라 `/follow-requests` 관리 화면으로 이동한다
+- **AND** inline 수락·거절 control을 추가하지 않는다
+
+#### Scenario: Reaction과 Repost Post 미리보기
+
+- **WHEN** selected Profile의 connection이 visible Reaction 또는 Repost Notification과 조회 가능한 Related Post를 반환한다
+- **THEN** 목록은 Related Profile 요약, 상대 시각, Post 본문 한 줄과 허용된 첫 미디어의 64×64 미리보기를 하나의 Post link에 표시한다
+- **AND** Content Warning이 있으면 경고만 표시하고 본문과 미디어를 숨기며 sensitive media는 미리보기를 숨긴다
+- **AND** client는 작성자 header, Action Bar 또는 새 Post 표시 정책을 추가하지 않는다
+
+#### Scenario: Reply Post presentation
+
+- **WHEN** selected Profile의 connection이 visible Reply Notification과 조회 가능한 결과 Reply Post를 반환한다
+- **THEN** 목록은 Reply Author·상대 시각·알림 이유·본문·허용된 Content Warning과 미디어·Quote·공용 Post Action Bar를 하나의 Notification surface에 표시한다
+- **AND** 원글 미리보기, 별도 알림 header 또는 받는 사람 목록을 추가하지 않는다
+- **AND** Reply의 게시글 identity와 내부 link·control은 공용 Reply Post presentation이 소유하고 Notification wrapper는 unread surface와 divider만 소유한다
+
+#### Scenario: 알림 화면 header와 단일 목록
+
+- **WHEN** 사용자가 `/notifications` 화면을 연다
+- **THEN** 화면은 `알림` 제목을 표시하고 설정 진입 control을 시각적으로 표시하지 않는다
+- **AND** `알림 설정 (준비 중)` 또는 같은 의미의 설정 진입 control을 접근성 트리에 button이나 다른 interactive element로 노출하지 않는다
+- **AND** 설정 control 없이도 mobile과 Web에서 제목의 정렬과 header 간격을 유지한다
+- **AND** `모두`·`멘션` 탭, 단독 `모두` section heading과 날짜별 heading을 표시하지 않는다
+
+#### Scenario: Read와 Unread 표시
+
+- **WHEN** visible Notification item의 `readAt`이 `null`이다
+- **THEN** 각 지원 플랫폼의 item은 `actionPrimarySubtle` 배경, 4px `actionPrimaryBase` 좌측 상태선과 접근성 Unread 상태를 제공한다
+- **AND** `readAt`이 존재하면 각 지원 플랫폼의 item은 Unread 좌측 상태선·배경 강조·접근성 Unread 상태를 제공하지 않는다
+- **AND** Web pointer hover는 `stateHover`를 기존 배경 위에 겹쳐 Unread 배경과 좌측 상태선을 보존한다
+- **AND** hover가 없는 native 화면도 Read/Unread 기본 표시와 접근성 상태를 유지한다
+
+#### Scenario: Profile 이동과 Read side effect 분리
+
+- **WHEN** 사용자가 Follow item의 단일 link를 활성화한다
+- **THEN** 클라이언트는 Related Profile navigation과 `{ ids: [id] }` Best Effort Read를 각각 즉시 시작한다
+- **AND** Read mutation의 pending, 실패 또는 재시도는 navigation을 지연, 취소 또는 되돌리지 않는다
+- **AND** client Read mutation과 Unread count cache 갱신은 기존 지정 ID Read 계약을 유지한다
+
+#### Scenario: 성공 payload 기반 item과 Recipient count 동기화
+
+- **WHEN** item activation에서 `{ ids: [id] }`로 시작한 Read mutation이 `notifications`와 `recipientProfiles` payload로 성공한다
+- **THEN** 클라이언트는 payload가 반환한 ID를 기준으로 item의 `readAt`과 정확한 Recipient Profile의 `unreadNotificationCount`를 Relay cache에 정규화한다
+- **AND** 성공한 `readAt` 정규화로 item의 Unread 시각·접근성 상태를 제거하고 count가 0이면 기존 전역 알림 인디케이터도 제거한다
+- **AND** 현재 selected Profile을 cache target으로 다시 추론하거나 client-side count 산술, optimistic update와 성공 뒤 추가 refetch를 수행하지 않는다
+- **AND** 같은 Unread item에 대한 반복 activation 또는 동시 Read의 성공 payload는 서버가 보존한 동일 `readAt`과 일관된 visible Unread count로 수렴하고 다른 Profile cache를 변경하지 않는다
+
+#### Scenario: client Read 실패와 수렴
+
+- **WHEN** navigation 또는 media open과 독립적으로 시작한 Read mutation이 pending이거나 실패한다
+- **THEN** 클라이언트는 navigation 또는 media viewer를 유지하고 item이나 count cache를 보정하지 않는다
+- **AND** cached `readAt = null`인 동안 item의 Unread 시각·접근성 상태를 유지한다
+- **AND** 앱 수준 자동 retry나 오류 UI를 추가하지 않으며 이후 activation 또는 refetch에서 서버 source of truth로 수렴한다
+
+#### Scenario: Initial loading, error와 empty
+
+- **WHEN** selected Profile 목록의 첫 query가 진행 중이거나 실패하거나 visible edge 없이 성공한다
+- **THEN** 화면은 새 Notification 행의 geometry와 각 상태에 맞는 loading, 안전한 한국어 error와 retry, empty UI를 구분해 표시한다
+- **AND** backend error 원문이나 unavailable generic fallback을 표시하지 않는다
+
+#### Scenario: Native refresh와 다음 page
+
+- **WHEN** 사용자가 native pull-to-refresh를 실행한다
+- **THEN** 클라이언트는 selected Profile query를 다시 가져온다
+- **AND** Web은 별도 in-app refresh control을 표시하지 않고 browser의 표준 document reload를 사용한다
+- **AND** 다음 page는 20개 단위 Relay connection으로 요청하고 요청 중 중복 호출을 막는다
+- **AND** 다음 page가 실패하면 기존 item을 유지하고 같은 위치에서 재시도할 수 있다
+- **AND** route state가 edge를 수동 병합하거나 client-side filtering하지 않는다
+
+#### Scenario: selected Profile 전환
+
+- **WHEN** 사용자가 Recipient Profile A에서 B로 selected Profile을 전환한다
+- **THEN** actor별 Relay Environment와 Store가 바뀌고 목록은 Profile B를 target으로 다시 조회한다
+- **AND** Profile A의 edge, loading, error, pagination, Reply composer 또는 media viewer 상태를 Profile B 목록에 재사용하지 않는다
+
+### Requirement: Follow Request Notification 목록과 requester Profile 활성화
+
+**Authority / Provenance:** `docs/domain/objects/follow-request.md`, `docs/domain/objects/notification.md`, `docs/domain/objects/profile.md`, `docs/design/notifications.md`, `docs/design/page-header.md`, `PROD-321`, `PROD-811`, `DSN-42` — 목록은 requester Profile identity를 표시하되 item을 받은 요청 관리 화면의 target으로 활성화해야 한다(MUST).
+
+클라이언트는 selected Profile의 visible `FOLLOW_REQUEST` Notification을 기존 단일 Notification 목록, Relay/cache scope와 서버 제공 Unread badge에 포함해야 하며(MUST), item 활성화는 `/follow-requests` 관리 화면으로 이동해야 한다(MUST).
+
+#### Scenario: 목록 item 표시
+
+- **WHEN** selected Profile이 수신한 visible Follow Request Notification이 목록 connection에 포함된다
+- **THEN** 공용 Notification row의 kind 표현·상대 시각·Unread 표시 구조 안에 requester Profile identity와 팔로우 요청 의미를 표시한다
+- **AND** requester Profile의 display/handle과 조회 가능한 avatar를 source에서 파생한다
+- **AND** 받은 요청 목록의 별도 row, 승인·거절·취소 action 또는 inline 맞팔로우 control을 추가하지 않는다
+
+#### Scenario: 받은 요청 관리 화면으로 활성화
+
+- **WHEN** 사용자가 Follow Request Notification의 단일 item link를 활성화한다
+- **THEN** 클라이언트는 `/follow-requests` 관리 화면으로 이동한다
+- **AND** requester Profile route로 이동하거나 item 안에 별도 Profile navigation target을 만들지 않는다
+- **AND** 기존 목록의 Best Effort Read mutation과 Profile별 Relay cache 갱신을 적용한다
+
+#### Scenario: 목록과 Unread badge 통합
+
+- **WHEN** selected Profile에 Follow Request Notification이 Unread 상태로 존재한다
+- **THEN** 서버의 `unreadNotificationCount`가 기존 Notification 목록과 shell badge에 해당 item을 포함한다
+- **AND** 클라이언트는 목록 길이나 숨겨진 item을 이용해 count를 임의로 재계산하지 않는다
+- **AND** Profile 전환 시 다른 Profile의 item·count·badge가 노출되지 않는다
+
+#### Scenario: 빈 목록 copy 범위
+
+- **WHEN** 목록에 Follow Request Notification을 포함한 visible item이 하나도 없다
+- **THEN** 기존 Notification empty state는 요청·팔로우 알림을 포함한 Notification 의미를 설명할 수 있다
+- **AND** 받은 요청 관리 화면의 빈 상태나 승인 안내를 대신 표시하지 않는다
+
+### Requirement: Selected Profile Notification Unread 시각 상태
+
+**Authority / Provenance:** `docs/design/notifications.md`, `docs/design/colors.md`, `docs/design/accessibility.md`, `PROD-680`, `PROD-703`, `PROD-811`, `PROD-884`, `PROD-930`, `DSN-42` — 클라이언트는 selected Profile의 알림 목록에서 visible Notification item의 Read와 Unread 상태를 모든 지원 플랫폼에서 시각·접근성 정보로 일관되게 구분해야 한다(MUST).
+
+#### Scenario: Unread 기본 표시
+
+- **WHEN** 알림 목록의 visible Notification item이 `readAt = null`이고 pointer hover 중이 아니다
+- **THEN** item은 `actionPrimarySubtle` 배경과 4px `actionPrimaryBase` 좌측 상태선으로 Unread임을 표시한다
+- **AND** 접근성 Unread 설명을 함께 제공해 상태를 색만으로 전달하지 않는다
+- **AND** 텍스트, icon과 link는 배경 강조와 독립적으로 기존 가독성과 상호작용을 유지한다
+
+#### Scenario: Read 기본 표시
+
+- **WHEN** 알림 목록의 visible Notification item에 `readAt`이 존재하고 pointer hover 중이 아니다
+- **THEN** item은 Unread 좌측 상태선과 배경 강조를 표시하지 않는다
+- **AND** 접근성 Unread 설명을 제공하지 않는다
+- **AND** Read와 Unread 전환 전후에 item 콘텐츠의 수평 정렬이 움직이지 않는다
+
+#### Scenario: Web pointer hover
+
+- **WHEN** pointer가 Web 알림 목록 item 위에 있다
+- **THEN** item은 기존 Read 또는 Unread 배경 위에 `stateHover` overlay를 제공한다
+- **AND** item이 Unread이면 `actionPrimarySubtle` 배경과 좌측 상태선을 유지하고 Read이면 Unread 상태선을 표시하지 않는다
+
+#### Scenario: activation Read 성공과 전역 인디케이터 수렴
+
+- **WHEN** 사용자가 Unread item의 승인된 navigation 또는 media open target을 활성화하고 `{ ids: [id] }` Read mutation이 갱신된 `notifications`와 `recipientProfiles` payload로 성공한다
+- **THEN** navigation 또는 media open은 Read 응답과 독립적으로 즉시 진행된다
+- **AND** Relay는 payload ID를 기준으로 item의 `readAt`과 Recipient Profile의 `unreadNotificationCount`를 정규화한다
+- **AND** item의 Unread 시각·접근성 상태가 제거되고 count가 0이면 기존 전역 알림 인디케이터도 사라진다
+
+#### Scenario: activation Read pending 또는 실패
+
+- **WHEN** 사용자가 Unread item의 승인된 navigation 또는 media open target을 활성화했지만 Read mutation이 pending이거나 실패한다
+- **THEN** navigation 또는 media open은 유지된다
+- **AND** client는 item과 count cache를 보정하지 않으며 cached `readAt = null`인 동안 Unread 시각·접근성 상태를 유지한다
+
+### Requirement: Reply Notification GraphQL과 inbox 통합
+
+**Authority / Provenance:** `docs/domain/objects/notification.md`, `docs/design/notifications.md`, `docs/design/accessibility.md`, `docs/domain/objects/post.md`, `PROD-426`, `PROD-703`, `PROD-811`, `PROD-884`, `DSN-42` — API와 클라이언트는 visible Reply Notification을 기존 Notification interface·connection·Unread count·Read·badge/cache·inbox 계약에 통합하고, Recipient가 조회할 수 있는 결과 Reply의 공용 Post presentation을 제공해야 한다(MUST).
+
+#### Scenario: Reply Notification concrete object·Node
+
+- **WHEN** GraphQL schema가 Reply kind Notification을 노출한다
+- **THEN** API는 이를 Notification과 Node를 구현하는 concrete `ReplyNotification` object로 resolve한다
+- **AND** object는 Reply Author `profile`과 결과 Reply `post`를 제공한다
+- **AND** concrete global ID로 Node를 조회할 때 row kind, Recipient membership과 visible predicate를 검증하고, 실패하면 다른 type으로 재시도하지 않고 `null`을 반환한다
+
+#### Scenario: visible Recipient inbox의 Reply content
+
+- **WHEN** membership이 있는 Account가 Recipient Profile의 Notification inbox에서 visible Reply Notification을 조회한다
+- **THEN** item은 결과 Reply Post의 작성자·상대 시각·알림 이유와 조회 가능한 본문·Content Warning·미디어·Quote를 기존 Post 표시 정책으로 제공한다
+- **AND** Content Warning reveal, sensitive media와 media viewer는 공용 Post 정책을 재정의하지 않는다
+- **AND** Reply Notification은 기존 connection 정렬·pagination과 Unread count에 포함된다
+
+#### Scenario: Reply navigation과 Read side effect
+
+- **WHEN** 사용자가 Reply item의 작성자 Profile link, 시각 또는 본문 Post link, 혹은 미디어 열기를 활성화한다
+- **THEN** 클라이언트는 해당 navigation 또는 media viewer와 `{ ids: [id] }` Best Effort Read를 각각 즉시 시작한다
+- **AND** 한 번의 target activation은 Read mutation을 한 번만 시작하며 Read pending·실패·재시도가 target 동작을 지연·취소·되돌리지 않는다
+- **AND** Read 성공 payload는 item과 Recipient Profile Unread count를 같은 actor Relay Store에서 갱신한다
+
+#### Scenario: Reply 내부 control의 독립 동작
+
+- **WHEN** 사용자가 Reply item 안에서 Content Warning 공개, Action Bar 또는 열린 composer의 control을 활성화한다
+- **THEN** 해당 control은 item navigation이나 Notification Read를 함께 시작하지 않고 자신의 공용 Post 동작만 수행한다
+- **AND** control activation이 바깥 Notification target으로 전파돼 navigation 또는 Read를 중복 실행하지 않는다
+
+#### Scenario: 기존 Reply popup composer 재사용
+
+- **WHEN** selected Profile이 있는 사용자가 Reply item의 Action Bar에서 Reply control을 활성화한다
+- **THEN** 기존 `owner="list"` Reply surface는 새 Notification 전용 UI 없이 공용 popup modal composer를 연다
+- **AND** modal은 기존 focus, 닫기와 작성 취소 lifecycle을 유지한다
+- **AND** 이 연결은 Reply 작성 정책·validation·mutation 또는 popup presentation을 재정의하지 않는다
+
+#### Scenario: selected Profile 격리
+
+- **WHEN** Account가 여러 Profile membership을 가지고 하나의 Recipient Profile inbox를 조회하거나 읽는다
+- **THEN** 시스템은 대상 Profile의 Reply Notification, count, Read와 cache만 반환·갱신한다
+- **AND** 다른 selected Profile의 item, badge, Reply composer 또는 Relay Store를 변경하지 않는다
+
+#### Scenario: unavailable item
+
+- **WHEN** source Reply가 없거나 Recipient·Parent·Author 관계가 저장 계약과 다르거나 Recipient 기준 Related Post 또는 Related Profile을 조회할 수 없다
+- **THEN** API는 item을 page limit 전 connection과 Unread count에서 제외한다
+- **AND** Node는 `null`을 반환하고 `markNotificationRead(input: { ids })`는 해당 ID를 조용히 제외하며 generic Notification 또는 client fallback으로 대신 노출하지 않는다

--- a/openspec/changes/show-reply-notification-content/tasks.md
+++ b/openspec/changes/show-reply-notification-content/tasks.md
@@ -1,0 +1,46 @@
+## 1. PROD-811 Reply Notification content Production 연결
+
+**Authority / Provenance**
+
+- `docs/domain/objects/notification.md`
+- `docs/design/notifications.md`
+- `docs/design/accessibility.md`
+- `docs/design/breakpoints.md`
+- [PROD-811](https://linear.app/byulmaru/issue/PROD-811/답글-알림에서-답글-본문을-미리-볼-수-있게-한다)
+- [DSN-42](https://linear.app/byulmaru/issue/DSN-42/figma-notificationpost-presentation을-시각-리디자인한다)
+
+**Deliverable**
+
+Selected Profile의 실제 Notification 목록이 승인된 공용 presentation으로 Follow·FollowRequest·Reaction·Repost를 표시하고, Reply의 조회 가능한 본문·Content Warning·미디어·Quote·Action Bar와 기존 목록용 popup Reply composer를 제공한다. 승인된 이동·열기는 Best Effort Read와 독립적으로 함께 시작하고 내부 control은 item navigation·Read를 중복 실행하지 않는다.
+
+PROD-811 구현 PR이 이 change의 client 구현, GraphQL/Relay·Web E2E·지원 플랫폼 통합 검증, canonical·active spec 최종 동기화와 archive를 소유한다.
+
+**Guardrails**
+
+- 종류별 Notification의 기존 Relay fragment, pagination, actor Store, 지정 ID Read와 unavailable filtering을 유지한다.
+- FollowRequest target은 `/follow-requests`이며 client grouping이나 inline 수락·거절 control을 추가하지 않는다.
+- Reply 전체를 바깥 Link나 event capture handler로 감싸지 않는다.
+- Reply의 Content Warning·Action Bar·composer control은 Notification navigation·Read를 시작하지 않는다.
+- 새 API/schema, dependency, Notification 전용 composer·media viewer·Content Warning 정책과 Future kind를 추가하지 않는다.
+
+**Verification**
+
+- 테스트 코드 범위: 기존 `apps/app/src/stories/screens/Notifications.stories.tsx`의 Production Relay 목록 interaction과 `apps/web/e2e/notifications.e2e.ts`의 실제 route/Read 흐름 중 PROD-811 동작을 직접 증명하는 최소 시나리오. 기존 `apps/app/src/components/notification/NotificationListItem.test.ts`의 Relay Read normalization은 변경 없이 실행한다.
+- 테스트 필요성: FollowRequest destination, Reply 본문·보호 상태·popup composer, Profile/detail/body/media activation당 Read 1회, Content Warning·Action Bar·composer의 navigation·Read 비실행, unread/hover와 dynamic height 회귀를 관찰 가능한 UI·GraphQL 요청으로 검증한다.
+- 테스트 제외 범위: target presentation Storybook의 중복 시나리오, API/DB lifecycle coverage 확대, 새 fixture helper·test harness·snapshot·의존성, Notification grouping과 Future kind.
+- 기존 API GraphQL integration test에서 Reply Notification의 visible `post`, unavailable filtering과 Read 제외가 유지되는지 확인하고, Relay compiler 결과로 Production query가 기존 Post fragment를 소비함을 검증한다. Server schema·resolver 동작을 바꾸지 않으므로 같은 동작의 새 API 테스트는 추가하지 않는다.
+- Relay compiler, app check/test, Storybook static build와 실제 Web light/dark·compact/wide browser QA를 수행한다.
+- iOS와 Android의 실제 `/notifications`에서 긴 Reply 본문·Content Warning·미디어 행이 clipping/overlap 없이 동적으로 늘어나고, Unread 접근성 label/state, Reply popup의 focus·dismiss, 첫 20개 목록 scroll과 단일 query가 유지되는지 플랫폼별로 확인한다. 실행하지 못한 플랫폼은 미검증으로 남기고 Web 결과로 대체하지 않는다.
+
+- [x] 1.1 실제 Notification 목록에 공용 kind별 presentation과 승인된 target·Post preview를 연결하고 기존 pagination·Read·unavailable 결과를 유지한다.
+- [x] 1.2 Reply Notification에 결과 Post content와 기존 Post action·media·목록용 popup composer를 연결하고 승인된 activation별 Read 및 내부 control 독립 동작을 구현한다.
+- [x] 1.3 loading/error/empty와 selected Profile 전환 상태가 새 동적 Notification 행과 provider 수명에 맞게 동작하도록 정렬한다.
+- [x] 1.4 기존 Production Notification Storybook과 Web E2E의 최소 interaction을 갱신해 Deliverable과 Guardrails를 직접 검증한다.
+- [ ] 1.5 기존 GraphQL integration, Relay compiler, app check/test, Storybook static build와 Web browser 시각·상호작용 검증을 통과하고 iOS·Android의 dynamic height·접근성·popup·목록 성능 결과와 미검증 항목을 플랫폼별로 기록한다.
+- [ ] 1.6 PROD-811 구현 PR에서 canonical 문서·Linear·delta spec과 구현 결과를 최종 대조하고 전체 완료 증거가 충족되면 active Notification spec 동기화와 change archive를 수행한다.
+
+### 검증 기록 (2026-09-10)
+
+- Web: Notification Story 27개, Notification Relay normalization unit 6개, 실제 Notifications E2E 3개, Notification GraphQL integration 28개, Relay compiler, app TypeScript, Storybook static build를 통과했다. Light/Dark wide와 390×844 compact에서 동적 행·CW·Reply popup·취소 후 focus 복귀를 실제 브라우저로 확인했다.
+- iOS: 현재 환경에서 실제 `/notifications`를 실행하지 못했다. dynamic height·Unread 접근성·popup focus/dismiss·첫 20개 scroll/단일 query는 미검증이다.
+- Android: 현재 환경에서 실제 `/notifications`를 실행하지 못했다. dynamic height·Unread 접근성·popup focus/dismiss·첫 20개 scroll/단일 query는 미검증이다.


### PR DESCRIPTION
## 무엇을 변경했나요

- 실제 Notification 목록의 Follow·FollowRequest·Reaction·Repost를 공용 `NotificationListItemView`에 연결했습니다.
- Reply 알림에 작성자·시각·본문·Content Warning·미디어·Action Bar와 기존 목록용 popup Reply composer를 연결했습니다.
- FollowRequest 이동을 `/follow-requests`로 정렬하고, 승인된 Reply 활성화마다 이동·열기와 독립적인 Best Effort Read를 시작합니다.
- Production Storybook, Relay normalization unit, Web E2E와 설계 문서·OpenSpec을 같은 계약으로 갱신했습니다.

## 왜 변경했나요

PROD-884에서 승인한 Notification presentation이 Storybook에는 있었지만 실제 목록은 레거시 행을 사용해 Reply 본문과 기존 Post 동작을 제공하지 못했습니다. PROD-811 범위에서 공용 presentation을 실제 Relay 목록에 연결해 Storybook과 Production의 시각·상호작용 계약을 일치시킵니다.

- Linear: https://linear.app/byulmaru/issue/PROD-811/답글-알림에서-답글-본문을-미리-볼-수-있게-한다
- Stack: `main -> PROD-811`

## 이번 PR의 주요 결정

### 기존 Post popup lifecycle 재사용

- 결정자: @yeeun-uwu
- 선택: Reply 버튼은 `owner="list"`인 기존 Post Action Bar와 popup Reply composer를 재사용합니다.
- 고려한 대안: Notification 전용 composer 또는 별도 popup lifecycle
- 이유: 이미 검증된 목록용 focus·dismiss·인증 경계를 그대로 사용하고 중복 구현을 만들지 않기 위해서입니다.
- 감수한 결과: Notification은 composer 상태를 직접 소유하지 않으며 Profile 전환 시 해당 provider subtree와 함께 폐기됩니다.

### activation별 Best Effort Read

- 결정자: @yeeun-uwu
- 선택: Reply 작성자 Profile·시각·본문 이동과 미디어 열기에서 각각 Read를 한 번 시작합니다.
- 고려한 대안: Reply 전체를 하나의 Link/capture handler로 감싸기
- 이유: Content Warning·Action Bar·composer control의 자체 동작이 item navigation이나 Read를 중복 실행하지 않게 하기 위해서입니다.
- 감수한 결과: Read 실패는 이동·열기를 막지 않으며 각 activation 경계가 callback을 명시적으로 연결합니다.

### FollowRequest 관리 화면 이동

- 결정자: @yeeun-uwu
- 선택: FollowRequest 알림은 요청자 Profile 대신 `/follow-requests`로 이동합니다.
- 고려한 대안: 기존 요청자 Profile 이동 유지
- 이유: 알림에서 요청을 실제로 검토할 수 있는 관리 화면으로 연결하기 위해서입니다.
- 감수한 결과: inline 수락·거절 control이나 client grouping은 이번 범위에 추가하지 않습니다.

관련 근거: [Notification 설계](https://github.com/byulmaru/kosmo/blob/PROD-811/docs/design/notifications.md), [OpenSpec decisions](https://github.com/byulmaru/kosmo/blob/PROD-811/openspec/changes/show-reply-notification-content/decisions.md)

## 어떻게 확인할 수 있나요

- Notification Storybook interaction 27/27
- Notification Relay normalization unit 6/6
- 실제 Web Notifications E2E 3/3
- Notification GraphQL integration 28/28
- Relay compiler와 app TypeScript 통과
- Storybook static build 통과
- `pnpm exec openspec validate --all --strict` 119/119
- 실제 브라우저에서 Light/Dark wide와 390×844 compact, CW·Reply popup·취소 후 focus 복귀 확인
- 독립 구현 재검토 PASS

## 아직 어떤 문제가 남았나요

- iOS·Android 실제 `/notifications`의 dynamic height·Unread 접근성·popup focus/dismiss·첫 20개 scroll/단일 query는 미검증입니다.
- OpenSpec은 4/6입니다. Native 검증과 PR 최종 대조가 끝나기 전에는 active spec 동기화나 change archive를 수행하지 않습니다.
- Storybook Relay fixture 경고와 `pointerEvents` deprecation 경고는 비차단 상태로 남아 있습니다.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>